### PR TITLE
Extend ForeignRef<T> to the rest of the owned C/C++ FFI handles

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: verify
+description: Build Bun and drive the changed code at its real surface (CLI, socket, FFI) to observe it running.
+---
+
+# Verifying a change to Bun
+
+**Build:** `bun bd` (no timeout — it can take many minutes). Exit 0 is setup, not evidence.
+
+**Drive:** `bun bd run <script.js>` builds *and* runs, forwarding args to the debug binary.
+Put driver scripts under `~/code/tmp/**` — Santa blocks unsigned executables elsewhere.
+
+## Two ways to invoke the debug build
+
+| Need | Use |
+|---|---|
+| run a script, stay in the repo | `bun bd run /path/to/drive.js` |
+| any command, from another cwd | `/Users/jarred/code/bun/build/debug/bun-debug <cmd>` |
+
+`bun bd` is a **package.json script** — it only resolves with the repo root as cwd.
+A probe that `cd`s into a temp dir must call the binary by absolute path.
+The binary refuses `bun-debug test <file>` on purpose ("use `bun bd test`"); every other
+subcommand (`pm pack`, `install`, `build`, `run`) works directly. Directory args to
+`bun-debug test` also trip a filter guard — pass explicit file paths.
+
+## Surfaces, by what you touched
+
+| Changed | Drive it with |
+|---|---|
+| `src/uws_sys/**`, `src/runtime/server/**` | `Bun.serve({port:0})` + real `fetch()`; `routes:` for static routes |
+| WebSocket / `Response::upgrade` | `Bun.serve` + `new WebSocket(...)`, echo a `Uint8Array` |
+| TLS / `SSL_CTX` | `Bun.serve({tls:{cert,key}})` + `fetch(https, {tls:{rejectUnauthorized:false}})`. Make a cert with `openssl req -x509 -newkey rsa:2048 -nodes -subj /CN=localhost -addext subjectAltName=DNS:localhost` |
+| `ConnectingSocket` (connect-failure path) | `Bun.connect()` to a port you opened then closed → `connectError` fires |
+| `src/runtime/bake/**` (dev server) | run `bun-debug index.html --port 0`, read the URL off stdout, then open `ws://host:port/_bun/hmr` |
+| `libdeflate`, `zstd`, `node:zlib` | `Bun.gzipSync`/`gunzipSync`, `Bun.zstdCompressSync`, `zlib.brotliCompress`. Feed garbage in too — it must throw, not crash |
+| `libarchive` | write side = `bun-debug pm pack`; read side = `bun-debug install ./x.tgz --no-save`, then check the extracted file exists |
+| `src/jsc/CachedBytecode.rs` | `bun-debug build x.js --bytecode --target=bun --outdir=out` then run `out/x.js` |
+| `src/tcc_sys/**` | `import { cc } from "bun:ffi"` and call a compiled C symbol |
+| Yarr `RegularExpression` | `.npmrc` with `public-hoist-pattern[]=*x*`, then `bun-debug install --dry-run` |
+| `TextCodec` | `TextDecoder`, including `{stream:true}` across a split multi-byte codepoint |
+| `JSUint8Array` | `crypto.getRandomValues(new Uint8Array(n))` (DOMJIT fast path); `ws.send(bytes)` |
+| `SourceProvider` | `new Error().stack` must contain `file:line` |
+| `Strong` / `Weak` | `WeakRef` + `Bun.gc(true)`; churn thousands of promises |
+
+## Gotchas that cost real time
+
+- **A debug assert you add is only real if it's in the binary**: `strings build/debug/bun-debug | rg '<your panic message>'`.
+- **`cargo check` is not an oracle.** It never monomorphizes, so it never evaluates
+  `const { assert!(...) }` inside a generic fn (`bun_opaque::opaque_deref*`). Finish with
+  `cargo build -p bun_bin` or `bun bd`.
+- **Generated code is built by ninja, not cargo.** `build/debug/codegen/*.rs` goes stale under
+  a bare `cargo check`. Regenerate a single file with e.g.
+  `bun src/codegen/generate-host-exports.ts build/debug/codegen`, or just run `bun bd`.
+- **Multi-file test runs share one process.** RSS/GC assertions (`gcUntilCountAtMost`,
+  "does not leak memory") and tests that mutate process globals (`buffer.kMaxLength`) fail
+  when run alongside other files even with `--isolate`. Re-run the file alone before believing it.
+- **Compare against a baseline binary, not intuition.** `~/code/bun-3` tracks `main` and usually
+  has a built `build/debug/bun-debug`. Run the same file with it to tell a regression from a
+  pre-existing flake.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,6 +1025,7 @@ dependencies = [
  "bun_ast",
  "bun_collections",
  "bun_core",
+ "bun_opaque",
  "bun_semver",
  "bun_wyhash",
  "const_format",

--- a/src/boringssl/lib.rs
+++ b/src/boringssl/lib.rs
@@ -99,7 +99,7 @@ type SslCustomVerifyCb =
 
 unsafe extern "C" {
     fn SSL_CTX_set_custom_verify(
-        ctx: *mut boring::SSL_CTX,
+        ctx: *mut boring::sys::SSL_CTX,
         mode: c_int,
         callback: SslCustomVerifyCb,
     );
@@ -114,7 +114,7 @@ unsafe extern "C" fn noop_custom_verify(
 
 /// `Send + Sync` newtype around the process-lifetime client `SSL_CTX*` so it
 /// can sit inside a `OnceLock` (raw pointers opt out of `Send`/`Sync`).
-struct CtxStore(ptr::NonNull<boring::SSL_CTX>);
+struct CtxStore(ptr::NonNull<boring::sys::SSL_CTX>);
 // SAFETY: `SSL_CTX` is internally thread-safe per BoringSSL docs (its refcount
 // and method tables are guarded by `CRYPTO_MUTEX`); we only ever bump the
 // refcount and hand it to `SSL_new`, both of which BoringSSL documents as
@@ -138,11 +138,12 @@ std::thread_local! {
 ///
 /// # Safety
 /// `ctx` must be a live `SSL_CTX*`.
-pub unsafe fn ssl_ctx_setup(ctx: *mut boring::SSL_CTX) {
+pub unsafe fn ssl_ctx_setup(ctx: *mut boring::sys::SSL_CTX) {
+    let ctx = boring::sys::SSL_CTX::opaque_ref(ctx);
     AUTO_CRYPTO_BUFFER_POOL.with(|pool| {
-        // SAFETY: caller guarantees `ctx` is a live `SSL_CTX*`; the pool pointer
-        // is either freshly returned by `CRYPTO_BUFFER_POOL_new` or a previously
-        // stored thread-local pool, and `SSL_DEFAULT_CIPHER_LIST` is a valid C string.
+        // SAFETY: the pool pointer is either freshly returned by
+        // `CRYPTO_BUFFER_POOL_new` or a previously stored thread-local pool, and
+        // `SSL_DEFAULT_CIPHER_LIST` is a valid C string.
         unsafe {
             if pool.get().is_null() {
                 pool.set(CRYPTO_BUFFER_POOL_new());
@@ -159,7 +160,7 @@ pub fn init_client() -> *mut boring::SSL {
         // Bump the refcount on every call after the first; the first call's
         // `SSL_CTX_new` already returns refcount = 1.
         if let Some(stored) = CTX_STORE.get() {
-            let _ = boring::SSL_CTX_up_ref(stored.0.as_ptr());
+            let _ = boring::SSL_CTX_up_ref(boring::sys::SSL_CTX::opaque_ref(stored.0.as_ptr()));
         }
         let ctx = CTX_STORE
             .get_or_init(|| {
@@ -167,15 +168,17 @@ pub fn init_client() -> *mut boring::SSL {
                 //   1. SSL_CTX_new(TLS_with_buffers_method())
                 //   2. setCustomVerify(noop_custom_verify) → SSL_CTX_set_custom_verify(ctx, 0, cb)
                 //   3. setup() → CRYPTO_BUFFER_POOL_new + set0_buffer_pool + set_cipher_list("ALL")
-                let ctx = boring::SSL_CTX_new(boring::TLS_with_buffers_method());
-                SSL_CTX_set_custom_verify(ctx, 0, Some(noop_custom_verify));
-                ssl_ctx_setup(ctx);
-                CtxStore(ptr::NonNull::new(ctx).expect("SSL_CTX_new"))
+                let ctx =
+                    boring::SSL_CTX::new(boring::TLS_with_buffers_method()).expect("SSL_CTX_new");
+                SSL_CTX_set_custom_verify(ctx.as_ptr(), 0, Some(noop_custom_verify));
+                ssl_ctx_setup(ctx.as_ptr());
+                // Process-lifetime: this +1 is never given back.
+                CtxStore(ctx.leak())
             })
             .0
             .as_ptr();
 
-        let ssl = boring::SSL_new(ctx);
+        let ssl = boring::SSL_new(boring::sys::SSL_CTX::opaque_ref(ctx));
         boring::SSL_set_connect_state(ssl);
 
         ssl
@@ -353,7 +356,9 @@ pub fn check_x509_server_identity(x509: &mut boring::X509, hostname: &[u8]) -> b
                     None
                 };
 
-                if let Some(names) = boring::GeneralNames::from_raw(boring::X509V3_EXT_d2i(ext)) {
+                if let Some(names) =
+                    boring::struct_stack_st_GENERAL_NAME::from_raw(boring::X509V3_EXT_d2i(ext))
+                {
                     for name in names.iter() {
                         match name.name_type {
                             boring::GEN_URI => {

--- a/src/boringssl/lib.rs
+++ b/src/boringssl/lib.rs
@@ -326,7 +326,7 @@ fn match_dns_name(pattern: &[u8], hostname: &[u8]) -> bool {
     strings::eql_case_insensitive_ascii(pattern, hostname, true)
 }
 
-pub fn check_x509_server_identity(x509: &mut boring::X509, hostname: &[u8]) -> bool {
+pub fn check_x509_server_identity(x509: &mut boring::sys::X509, hostname: &[u8]) -> bool {
     let host_is_ip = strings::is_ip_address(hostname);
     // Node.js: CN is consulted only when the certificate carries no
     // DNS / IP / URI subjectAltName entries. Track whether any were seen.
@@ -336,7 +336,7 @@ pub fn check_x509_server_identity(x509: &mut boring::X509, hostname: &[u8]) -> b
     // SAFETY: x509 is a valid &mut so non-null/aligned; all boring:: fns are
     // null-safe where documented.
     unsafe {
-        let x509: *mut boring::X509 = x509;
+        let x509: *mut boring::sys::X509 = x509;
         let index = boring::X509_get_ext_by_NID(x509, boring::NID_subject_alt_name, -1);
         if index >= 0 {
             // we can check hostname

--- a/src/boringssl_sys/boringssl.rs
+++ b/src/boringssl_sys/boringssl.rs
@@ -73,10 +73,23 @@ opaque!(
     /// `struct ssl_st` (`typedef ... SSL`).
     SSL
 );
-opaque!(
-    /// `struct ssl_ctx_st` (`typedef ... SSL_CTX`).
-    SSL_CTX
-);
+/// The C objects themselves. Only the extern declarations name these types;
+/// all Rust code uses the owning handles ([`SSL_CTX`],
+/// [`struct_stack_st_GENERAL_NAME`]) that wrap them.
+pub mod sys {
+    ::bun_opaque::opaque_ffi! {
+        /// `struct ssl_ctx_st` (`typedef ... SSL_CTX`). `&Self` is ABI-identical
+        /// to a non-null `SSL_CTX*` and carries no `noalias`/`readonly` —
+        /// BoringSSL mutates the context (refcount, session cache) through it.
+        pub struct SSL_CTX;
+    }
+    ::bun_opaque::opaque_ffi! {
+        /// `STACK_OF(GENERAL_NAME)`. `&Self` is ABI-identical to a non-null
+        /// `OPENSSL_STACK*` and carries no `noalias`/`readonly` — BoringSSL
+        /// mutates the stack's bookkeeping through it.
+        pub struct struct_stack_st_GENERAL_NAME;
+    }
+}
 opaque!(
     /// `struct crypto_buffer_pool_st` (`typedef ... CRYPTO_BUFFER_POOL`).
     CRYPTO_BUFFER_POOL
@@ -120,10 +133,6 @@ opaque!(
 opaque!(
     /// `STACK_OF(X509)` — opaque stack handle.
     struct_stack_st_X509
-);
-opaque!(
-    /// `STACK_OF(GENERAL_NAME)` — opaque stack handle.
-    struct_stack_st_GENERAL_NAME
 );
 opaque!(
     /// `struct crypto_ex_data_st` (`typedef ... CRYPTO_EX_DATA`).
@@ -284,52 +293,153 @@ unsafe extern "C" {
     fn GENERAL_NAME_free(name: *mut GENERAL_NAME);
 }
 
-/// Owns one `SSL_CTX` reference; `SSL_CTX_free`s it on drop. Construct from a
-/// pointer that already carries a +1 (`SSL_CTX_new`, `SSL_CTX_up_ref`).
-pub struct OwnedSslCtx(core::ptr::NonNull<SSL_CTX>);
+// `SSL_CTX_new` / `SSL_CTX_up_ref` hand back a `+1` on the context's
+// `CRYPTO_refcount_t`. One `SSL_CTX` handle owns exactly that one ref.
+::bun_opaque::foreign_owned!(sys::SSL_CTX, SSL_CTX_free);
 
-impl OwnedSslCtx {
-    /// Takes the +1 `raw` carries; `None` when `raw` is null.
+/// Owned handle to a BoringSSL `SSL_CTX`.
+///
+/// Holds one ref on the C refcount; `Drop` gives it back. Every method takes
+/// `&self`: the context is shared with every `SSL` created from it, and
+/// BoringSSL mutates it (refcount, session cache) through the same pointer.
+///
+/// A context borrowed from C (`SSL_get_SSL_CTX`, the weak `SSLContextCache`
+/// slot) took no ref and stays a raw `*mut sys::SSL_CTX`.
+#[repr(transparent)]
+pub struct SSL_CTX(::bun_opaque::ForeignRef<sys::SSL_CTX>);
+
+impl SSL_CTX {
+    /// Adopt a `+1` returned by C.
     ///
     /// # Safety
-    /// `raw` must be null or carry a reference the caller is giving up.
-    pub unsafe fn from_raw(raw: *mut SSL_CTX) -> Option<Self> {
-        core::ptr::NonNull::new(raw).map(Self)
+    /// `ptr` must carry exactly one ref that no other handle will release.
+    #[inline]
+    pub unsafe fn adopt(ptr: core::ptr::NonNull<sys::SSL_CTX>) -> Self {
+        // SAFETY: caller transfers the +1.
+        Self(unsafe { ::bun_opaque::ForeignRef::adopt(ptr) })
     }
 
-    pub fn as_ptr(&self) -> *mut SSL_CTX {
+    /// Adopt a nullable `+1`; `None` on null.
+    ///
+    /// # Safety
+    /// `ptr` must be null or carry a ref the caller is giving up.
+    #[inline]
+    pub unsafe fn adopt_ptr(ptr: *mut sys::SSL_CTX) -> Option<Self> {
+        // SAFETY: caller transfers the +1.
+        core::ptr::NonNull::new(ptr).map(|p| unsafe { Self::adopt(p) })
+    }
+
+    /// `SSL_CTX_new` returns a fresh `+1`; `None` on allocation failure.
+    ///
+    /// # Safety
+    /// `method` must be a live `SSL_METHOD*`.
+    pub unsafe fn new(method: *const SSL_METHOD) -> Option<Self> {
+        // SAFETY: caller contract; the result carries a fresh +1.
+        unsafe { Self::adopt_ptr(SSL_CTX_new(method)) }
+    }
+
+    /// The C pointer, still owned by `self`.
+    #[inline]
+    pub fn as_ptr(&self) -> *mut sys::SSL_CTX {
         self.0.as_ptr()
     }
 
-    /// Transfers the reference back out; the caller must free it.
-    pub fn into_raw(self) -> *mut SSL_CTX {
-        core::mem::ManuallyDrop::new(self).0.as_ptr()
+    /// Hand our `+1` to a foreign owner. Pairs with a later [`Self::adopt`].
+    #[inline]
+    pub fn leak(self) -> core::ptr::NonNull<sys::SSL_CTX> {
+        self.0.leak()
+    }
+
+    /// Take a second ref on the same context.
+    #[inline]
+    pub fn up_ref(&self) -> Self {
+        let _ = SSL_CTX_up_ref(self.raw());
+        // SAFETY: the call above added exactly the ref this handle takes.
+        unsafe { Self::adopt(self.0.as_non_null()) }
+    }
+
+    #[inline]
+    fn raw(&self) -> &sys::SSL_CTX {
+        &self.0
     }
 }
 
-impl Drop for OwnedSslCtx {
-    fn drop(&mut self) {
-        // SAFETY: we own exactly one reference, released once.
-        unsafe { SSL_CTX_free(self.0.as_ptr()) }
+// `X509V3_EXT_d2i` allocates the stack and every `GENERAL_NAME` in it, then
+// hands back the sole owner. One handle owns exactly that one allocation.
+bun_opaque::foreign_owned!(sys::struct_stack_st_GENERAL_NAME, general_name_stack_free);
+
+/// Frees every `GENERAL_NAME` element, then the stack itself.
+fn general_name_stack_free(sk: &sys::struct_stack_st_GENERAL_NAME) {
+    // SAFETY: `sk_pop_free_ex` invokes the callback once per element, so it
+    // gets `GENERAL_NAME_free` (per element), not a stack free. `as_mut_ptr`
+    // derives write provenance from the handle's `UnsafeCell` body.
+    unsafe {
+        sk_pop_free_ex(
+            sk.as_mut_ptr().cast::<OPENSSL_STACK>(),
+            Some(call_general_name_free),
+            Some(core::mem::transmute::<
+                unsafe extern "C" fn(*mut GENERAL_NAME),
+                unsafe extern "C" fn(*mut c_void),
+            >(GENERAL_NAME_free)),
+        )
     }
 }
 
-/// Owns the `STACK_OF(GENERAL_NAME)` that `X509V3_EXT_d2i` returns for a
-/// subjectAltName extension. Frees every `GENERAL_NAME` and then the stack.
-pub struct GeneralNames(core::ptr::NonNull<struct_stack_st_GENERAL_NAME>);
+/// Owned handle to the `STACK_OF(GENERAL_NAME)` that `X509V3_EXT_d2i` returns
+/// for a subjectAltName extension.
+///
+/// Holds the one allocation BoringSSL handed us; `Drop` frees the elements and
+/// then the stack. Every method takes `&self`: BoringSSL mutates the stack's
+/// bookkeeping through the same pointer, so there is no `&mut self` to have.
+#[repr(transparent)]
+pub struct struct_stack_st_GENERAL_NAME(bun_opaque::ForeignRef<sys::struct_stack_st_GENERAL_NAME>);
 
-impl GeneralNames {
+/// Ownership plumbing.
+impl struct_stack_st_GENERAL_NAME {
+    /// Adopt a stack the caller is giving up.
+    ///
+    /// # Safety
+    /// `ptr` must be live and freed by no other handle.
+    pub unsafe fn adopt(ptr: core::ptr::NonNull<sys::struct_stack_st_GENERAL_NAME>) -> Self {
+        // SAFETY: caller transfers ownership.
+        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
+    }
+
     /// Takes ownership of a `STACK_OF(GENERAL_NAME)`; `None` when `raw` is null.
     ///
     /// # Safety
     /// `raw` must be null or a stack the caller owns and does not free itself.
     pub unsafe fn from_raw(raw: *mut c_void) -> Option<Self> {
-        core::ptr::NonNull::new(raw.cast::<struct_stack_st_GENERAL_NAME>()).map(Self)
+        // SAFETY: caller contract.
+        core::ptr::NonNull::new(raw.cast::<sys::struct_stack_st_GENERAL_NAME>())
+            .map(|p| unsafe { Self::adopt(p) })
     }
 
+    /// The C pointer, still owned by `self`.
+    pub fn as_ptr(&self) -> *mut sys::struct_stack_st_GENERAL_NAME {
+        self.0.as_ptr()
+    }
+
+    /// Hand the stack to a foreign owner. Pairs with a later [`Self::adopt`].
+    pub fn leak(self) -> core::ptr::NonNull<sys::struct_stack_st_GENERAL_NAME> {
+        self.0.leak()
+    }
+
+    fn raw(&self) -> &sys::struct_stack_st_GENERAL_NAME {
+        &self.0
+    }
+
+    /// The untyped view every `sk_*` entry point takes.
+    fn stack(&self) -> *mut OPENSSL_STACK {
+        self.raw().as_mut_ptr().cast::<OPENSSL_STACK>()
+    }
+}
+
+/// Element access. `&self` throughout; BoringSSL owns the elements until `Drop`.
+impl struct_stack_st_GENERAL_NAME {
     pub fn len(&self) -> usize {
         // SAFETY: we own a live stack; `sk_num` takes it as `const OPENSSL_STACK`.
-        unsafe { sk_num(self.0.as_ptr().cast::<OPENSSL_STACK>()) }
+        unsafe { sk_num(self.stack()) }
     }
 
     pub fn is_empty(&self) -> bool {
@@ -343,11 +453,7 @@ impl GeneralNames {
         }
         // SAFETY: `i` is in bounds and the stack outlives the borrow, which is
         // tied to `&self`. BoringSSL owns the element until our `Drop`.
-        unsafe {
-            sk_value(self.0.as_ptr().cast::<OPENSSL_STACK>(), i)
-                .cast::<GENERAL_NAME>()
-                .as_ref()
-        }
+        unsafe { sk_value(self.stack(), i).cast::<GENERAL_NAME>().as_ref() }
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &GENERAL_NAME> {
@@ -355,27 +461,11 @@ impl GeneralNames {
     }
 }
 
-impl Drop for GeneralNames {
-    fn drop(&mut self) {
-        // SAFETY: `sk_pop_free_ex` invokes the callback once per element, so it
-        // gets `GENERAL_NAME_free` (per element), not a stack free.
-        unsafe {
-            sk_pop_free_ex(
-                self.0.as_ptr().cast::<OPENSSL_STACK>(),
-                Some(call_general_name_free),
-                Some(core::mem::transmute::<
-                    unsafe extern "C" fn(*mut GENERAL_NAME),
-                    unsafe extern "C" fn(*mut c_void),
-                >(GENERAL_NAME_free)),
-            )
-        }
-    }
-}
-
 /// Restores the element type erased through `OPENSSL_sk_free_func`.
 unsafe extern "C" fn call_general_name_free(free_func: OPENSSL_sk_free_func, ptr: *mut c_void) {
-    // SAFETY: `free_func` is `GENERAL_NAME_free` erased in `Drop` above; both
-    // sides are `extern "C" fn(*mut _)`, so the round-trip is ABI-sound.
+    // SAFETY: `free_func` is `GENERAL_NAME_free` erased in
+    // `general_name_stack_free` above; both sides are `extern "C" fn(*mut _)`,
+    // so the round-trip is ABI-sound.
     let f: unsafe extern "C" fn(*mut GENERAL_NAME) =
         unsafe { core::mem::transmute(free_func.expect("non-null free_func")) };
     // SAFETY: `ptr` is an element `sk_pop_free_ex` is draining from the stack.
@@ -515,7 +605,7 @@ unsafe extern "C" {
     // ── SSL ──────────────────────────────────────────────────────────────
     pub safe fn SSL_library_init() -> c_int;
     pub safe fn SSL_load_error_strings();
-    pub fn SSL_CTX_up_ref(ctx: *mut SSL_CTX) -> c_int;
+    pub safe fn SSL_CTX_up_ref(ctx: &sys::SSL_CTX) -> c_int;
     pub fn SSL_get_peer_cert_chain(ssl: *const SSL) -> *mut struct_stack_st_X509;
 
     // ── X509 ─────────────────────────────────────────────────────────────
@@ -680,19 +770,26 @@ unsafe extern "C" {
     pub fn ENGINE_free(engine: *mut ENGINE) -> c_int;
 
     // ── SSL_CTX ──────────────────────────────────────────────────────────
-    pub fn SSL_CTX_new(method: *const SSL_METHOD) -> *mut SSL_CTX;
-    pub fn SSL_CTX_free(ctx: *mut SSL_CTX);
-    pub fn SSL_CTX_get_verify_mode(ctx: *const SSL_CTX) -> c_int;
-    pub fn SSL_CTX_set_ex_data(ctx: *mut SSL_CTX, idx: c_int, data: *mut c_void) -> c_int;
-    pub fn SSL_CTX_get_ex_data(ctx: *const SSL_CTX, idx: c_int) -> *mut c_void;
-    pub fn SSL_CTX_set0_buffer_pool(ctx: *mut SSL_CTX, pool: *mut CRYPTO_BUFFER_POOL);
-    pub fn SSL_CTX_set_cipher_list(ctx: *mut SSL_CTX, str_: *const c_char) -> c_int;
+    // `&sys::SSL_CTX` is a non-null `SSL_CTX*` carrying no `noalias`/`readonly`,
+    // so shims taking only it plus scalars are `safe fn`. The rest keep an
+    // `unsafe fn` body: C dereferences the raw pointer they also carry.
+    pub fn SSL_CTX_new(method: *const SSL_METHOD) -> *mut sys::SSL_CTX;
+    // safe: decrements the intrusive refcount. A decrement is not exclusive
+    // access — other refs exist by definition — so the receiver is `&`.
+    pub safe fn SSL_CTX_free(ctx: &sys::SSL_CTX);
+    pub safe fn SSL_CTX_get_verify_mode(ctx: &sys::SSL_CTX) -> c_int;
+    // NOT `safe fn`: `data` is stashed and later dereferenced by the
+    // `CRYPTO_EX_free` callback registered for the slot.
+    pub fn SSL_CTX_set_ex_data(ctx: &sys::SSL_CTX, idx: c_int, data: *mut c_void) -> c_int;
+    pub safe fn SSL_CTX_get_ex_data(ctx: &sys::SSL_CTX, idx: c_int) -> *mut c_void;
+    pub fn SSL_CTX_set0_buffer_pool(ctx: &sys::SSL_CTX, pool: *mut CRYPTO_BUFFER_POOL);
+    pub fn SSL_CTX_set_cipher_list(ctx: &sys::SSL_CTX, str_: *const c_char) -> c_int;
 
     // ── CRYPTO_BUFFER_POOL ───────────────────────────────────────────────
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 
     // ── SSL ──────────────────────────────────────────────────────────────
-    pub fn SSL_new(ctx: *mut SSL_CTX) -> *mut SSL;
+    pub safe fn SSL_new(ctx: &sys::SSL_CTX) -> *mut SSL;
     pub fn SSL_free(ssl: *mut SSL);
     pub fn SSL_set_connect_state(ssl: *mut SSL);
     pub fn SSL_set_accept_state(ssl: *mut SSL);
@@ -712,7 +809,8 @@ unsafe extern "C" {
     pub fn SSL_set_renegotiate_mode(ssl: *mut SSL, mode: ssl_renegotiate_mode_t);
     pub fn SSL_renegotiate(ssl: *mut SSL) -> c_int;
     pub fn SSL_get_servername(ssl: *const SSL, ty: c_int) -> *const c_char;
-    pub fn SSL_get_SSL_CTX(ssl: *const SSL) -> *mut SSL_CTX;
+    // Borrowed parent context: takes no ref, so the result stays a raw pointer.
+    pub fn SSL_get_SSL_CTX(ssl: *const SSL) -> *mut sys::SSL_CTX;
     pub fn SSL_get_ex_data(ssl: *const SSL, idx: c_int) -> *mut c_void;
     pub fn SSL_set_ex_data(ssl: *mut SSL, idx: c_int, data: *mut c_void) -> c_int;
     pub fn SSL_set_tlsext_host_name(ssl: *mut SSL, name: *const c_char) -> c_int;
@@ -731,7 +829,7 @@ unsafe extern "C" {
         supported_len: c_uint,
     ) -> c_int;
     pub fn SSL_CTX_set_alpn_select_cb(
-        ctx: *mut SSL_CTX,
+        ctx: &sys::SSL_CTX,
         cb: Option<
             unsafe extern "C" fn(
                 ssl: *mut SSL,

--- a/src/boringssl_sys/boringssl.rs
+++ b/src/boringssl_sys/boringssl.rs
@@ -62,10 +62,6 @@ pub(crate) type ASN1_IA5STRING = asn1_string_st;
 // ═══════════════════════════════════════════════════════════════════════════
 
 opaque!(
-    /// `struct engine_st` (`typedef ... ENGINE`).
-    ENGINE
-);
-opaque!(
     /// `struct env_md_st` (`typedef ... EVP_MD`).
     EVP_MD
 );
@@ -74,8 +70,9 @@ opaque!(
     SSL
 );
 /// The C objects themselves. Only the extern declarations name these types;
-/// all Rust code uses the owning handles ([`SSL_CTX`],
-/// [`struct_stack_st_GENERAL_NAME`]) that wrap them.
+/// all Rust code uses the owning handles ([`SSL_CTX`], [`ENGINE`], [`X509`],
+/// [`X509_STORE`], [`X509_STORE_CTX`], [`struct_stack_st_GENERAL_NAME`]) that
+/// wrap them.
 pub mod sys {
     ::bun_opaque::opaque_ffi! {
         /// `struct ssl_ctx_st` (`typedef ... SSL_CTX`). `&Self` is ABI-identical
@@ -89,14 +86,27 @@ pub mod sys {
         /// mutates the stack's bookkeeping through it.
         pub struct struct_stack_st_GENERAL_NAME;
     }
+    ::bun_opaque::opaque_ffi! {
+        /// `struct engine_st` (`typedef ... ENGINE`). `&Self` is ABI-identical
+        /// to a non-null `ENGINE*` and carries no `noalias`/`readonly`.
+        pub struct ENGINE;
+        /// `struct x509_st` (`typedef ... X509`). `&Self` is ABI-identical to a
+        /// non-null `X509*` and carries no `noalias`/`readonly` — BoringSSL
+        /// mutates the refcount and the cached extension fields through it.
+        pub struct X509;
+        /// `struct x509_store_st` (`typedef ... X509_STORE`). `&Self` is
+        /// ABI-identical to a non-null `X509_STORE*` and carries no
+        /// `noalias`/`readonly` — BoringSSL mutates the refcount through it.
+        pub struct X509_STORE;
+        /// `struct x509_store_ctx_st` (`typedef ... X509_STORE_CTX`). `&Self` is
+        /// ABI-identical to a non-null `X509_STORE_CTX*` and carries no
+        /// `noalias`/`readonly` — BoringSSL mutates the lookup state through it.
+        pub struct X509_STORE_CTX;
+    }
 }
 opaque!(
     /// `struct crypto_buffer_pool_st` (`typedef ... CRYPTO_BUFFER_POOL`).
     CRYPTO_BUFFER_POOL
-);
-opaque!(
-    /// `struct x509_st` (`typedef ... X509`).
-    X509
 );
 opaque!(
     /// `struct X509_name_st` (`typedef ... X509_NAME`).
@@ -326,6 +336,104 @@ impl SSL_CTX {
     }
 }
 
+// ═══════════════════════════════════════════════════════════════════════════
+// Owned handles — ENGINE / X509 / X509_STORE / X509_STORE_CTX
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// `ENGINE_free` takes `*mut ENGINE` and returns `int`; `foreign_handle!` needs
+/// a `fn(&sys::ENGINE)`.
+fn engine_free_release(engine: &sys::ENGINE) {
+    // SAFETY: the handle owns the sole allocation `ENGINE_new` returned;
+    // `as_mut_ptr` derives write provenance from the `UnsafeCell` body. The
+    // `int` result is BoringSSL's OpenSSL-compat "always 1".
+    let _ = unsafe { ENGINE_free(engine.as_mut_ptr()) };
+}
+
+// `ENGINE_new` allocates and hands back the sole owner (no refcount).
+bun_opaque::foreign_handle! {
+    /// Owned handle to a BoringSSL `ENGINE`.
+    ///
+    /// Holds the one allocation `ENGINE_new` returned; `Drop` frees it. Every
+    /// method takes `&self`: BoringSSL mutates the engine through the same
+    /// pointer, so there is no `&mut self` to have.
+    ///
+    /// Every consumer (`EVP_DigestInit_ex`, `EVP_Digest`, `HMAC_Init_ex`) only
+    /// *borrows* the engine and takes a bare `*mut sys::ENGINE`, so
+    /// [`Self::as_ptr`] is the accessor those call sites want.
+    pub struct ENGINE(sys::ENGINE) via engine_free_release;
+}
+
+impl ENGINE {
+    /// `ENGINE_new` allocates a fresh engine; `None` on allocation failure.
+    pub fn new() -> Option<Self> {
+        // SAFETY: `ENGINE_new` returns a fresh, solely-owned `ENGINE*`, or null
+        // on OOM (having allocated nothing). No other handle gives that unit back.
+        unsafe { Self::adopt_ptr(ENGINE_new()) }
+    }
+}
+
+/// `X509_free` takes `*mut X509`; `foreign_handle!` needs a `fn(&sys::X509)`.
+fn x509_free_release(x509: &sys::X509) {
+    // SAFETY: the handle owns one ref on the certificate's `CRYPTO_refcount_t`;
+    // `X509_free` gives back exactly that one.
+    unsafe { X509_free(x509.as_mut_ptr()) }
+}
+
+// `d2i_X509`, `SSL_get_peer_certificate`, `X509_up_ref` and
+// `X509_STORE_CTX_get1_issuer` each hand back a `+1` on the certificate's
+// refcount. One `X509` handle owns exactly that one ref.
+bun_opaque::foreign_handle! {
+    /// Owned handle to a BoringSSL `X509` certificate.
+    ///
+    /// Holds one ref on the C refcount; `Drop` gives it back. Every method takes
+    /// `&self`: a refcount is shared by definition, and BoringSSL mutates the
+    /// certificate's cached fields through the same pointer.
+    ///
+    /// A certificate *borrowed* from a chain (`sk_X509_value`) or from the local
+    /// connection (`SSL_get_certificate`) took no ref and stays a raw
+    /// `*mut sys::X509`.
+    pub struct X509(sys::X509) via x509_free_release;
+}
+
+/// `X509_STORE_free` takes `*mut X509_STORE`.
+fn x509_store_free_release(store: &sys::X509_STORE) {
+    // SAFETY: the handle owns one ref on the store's refcount; `X509_STORE_free`
+    // gives back exactly that one.
+    unsafe { X509_STORE_free(store.as_mut_ptr()) }
+}
+
+// `us_get_shared_default_ca_store` up-refs the process-wide store before
+// returning; one handle owns exactly that one ref.
+bun_opaque::foreign_handle! {
+    /// Owned handle to a BoringSSL `X509_STORE`.
+    ///
+    /// Holds one ref on the C refcount; `Drop` gives it back. Every method takes
+    /// `&self`: the store is shared with every context that references it.
+    ///
+    /// A store *borrowed* from a context (`SSL_CTX_get_cert_store`) took no ref
+    /// and stays a raw `*mut sys::X509_STORE`. A store handed to a `set0` sink
+    /// (`SSL_set0_verify_cert_store`) is transferred, not released.
+    pub struct X509_STORE(sys::X509_STORE) via x509_store_free_release;
+}
+
+/// `X509_STORE_CTX_free` takes `*mut X509_STORE_CTX`.
+fn x509_store_ctx_free_release(ctx: &sys::X509_STORE_CTX) {
+    // SAFETY: the handle owns the sole allocation `X509_STORE_CTX_new` returned.
+    unsafe { X509_STORE_CTX_free(ctx.as_mut_ptr()) }
+}
+
+// `X509_STORE_CTX_new` allocates and hands back the sole owner (no refcount).
+bun_opaque::foreign_handle! {
+    /// Owned handle to a BoringSSL `X509_STORE_CTX`.
+    ///
+    /// Holds the one allocation `X509_STORE_CTX_new` returned; `Drop` frees it.
+    /// Every method takes `&self`: BoringSSL mutates the lookup state through
+    /// the same pointer, so there is no `&mut self` to have.
+    ///
+    /// `X509_STORE_CTX_init` only *borrows* the store and the leaf it is given.
+    pub struct X509_STORE_CTX(sys::X509_STORE_CTX) via x509_store_ctx_free_release;
+}
+
 // `X509V3_EXT_d2i` allocates the stack and every `GENERAL_NAME` in it, then
 // hands back the sole owner. One handle owns exactly that one allocation.
 // The `foreign_owned!` impl is emitted by the `foreign_handle!` invocation below.
@@ -472,7 +580,7 @@ unsafe extern "C" {
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
-        engine: *mut ENGINE,
+        engine: *mut sys::ENGINE,
     ) -> c_int;
     pub fn EVP_DigestUpdate(ctx: *mut EVP_MD_CTX, data: *const c_void, len: usize) -> c_int;
     pub fn EVP_DigestFinal(ctx: *mut EVP_MD_CTX, md_out: *mut u8, out_size: *mut c_uint) -> c_int;
@@ -492,7 +600,7 @@ unsafe extern "C" {
         md_out: *mut u8,
         md_out_size: *mut c_uint,
         type_: *const EVP_MD,
-        impl_: *mut ENGINE,
+        impl_: *mut sys::ENGINE,
     ) -> c_int;
 
     // ── HMAC ─────────────────────────────────────────────────────────────
@@ -552,12 +660,20 @@ unsafe extern "C" {
     pub fn SSL_get_peer_cert_chain(ssl: *const SSL) -> *mut struct_stack_st_X509;
 
     // ── X509 ─────────────────────────────────────────────────────────────
-    pub fn d2i_X509(out: *mut *mut X509, inp: *mut *const u8, len: c_long) -> *mut X509;
-    pub fn i2d_X509(x: *mut X509, outp: *mut *mut u8) -> c_int;
-    pub fn X509_free(x509: *mut X509);
-    pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
-    pub fn X509_get_ext_by_NID(x: *const X509, nid: c_int, lastpos: c_int) -> c_int;
-    pub fn X509_get_ext(x: *const X509, loc: c_int) -> *mut X509_EXTENSION;
+    pub fn d2i_X509(out: *mut *mut sys::X509, inp: *mut *const u8, len: c_long) -> *mut sys::X509;
+    pub fn i2d_X509(x: *mut sys::X509, outp: *mut *mut u8) -> c_int;
+    /// Decrements the certificate's refcount; frees it at zero. Backs the
+    /// [`X509`] handle's `Drop`.
+    pub fn X509_free(x509: *mut sys::X509);
+    /// Decrements the store's refcount; frees it at zero. Backs the
+    /// [`X509_STORE`] handle's `Drop`.
+    pub fn X509_STORE_free(store: *mut sys::X509_STORE);
+    /// Frees the lookup context `X509_STORE_CTX_new` allocated. Backs the
+    /// [`X509_STORE_CTX`] handle's `Drop`.
+    pub fn X509_STORE_CTX_free(ctx: *mut sys::X509_STORE_CTX);
+    pub fn X509_get_subject_name(x509: *const sys::X509) -> *mut X509_NAME;
+    pub fn X509_get_ext_by_NID(x: *const sys::X509, nid: c_int, lastpos: c_int) -> c_int;
+    pub fn X509_get_ext(x: *const sys::X509, loc: c_int) -> *mut X509_EXTENSION;
     pub fn X509_NAME_get_index_by_NID(name: *const X509_NAME, nid: c_int, lastpos: c_int) -> c_int;
     pub fn X509_NAME_get_entry(name: *const X509_NAME, loc: c_int) -> *mut X509_NAME_ENTRY;
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
@@ -573,14 +689,16 @@ unsafe extern "C" {
 // symbol — they bottom out on the untyped `sk_*` ABI above.
 // ═══════════════════════════════════════════════════════════════════════════
 
+/// Borrows the `i`th element; the stack keeps the ref, so the result names the
+/// C object (`sys::X509`), never the owning [`X509`] handle.
 #[inline]
-pub unsafe fn sk_X509_value(sk: *const struct_stack_st_X509, i: usize) -> *mut X509 {
+pub unsafe fn sk_X509_value(sk: *const struct_stack_st_X509, i: usize) -> *mut sys::X509 {
     // SAFETY: Two independent type casts, not a const→mut provenance laundering:
     //   - `sk` is reinterpreted `*const opaque -> *const OPENSSL_STACK` (const→const).
     //   - `sk_value` returns `*mut c_void` from the C heap; we narrow that to
-    //     `*mut X509` (mut→mut). Mutability originates from BoringSSL's ABI
+    //     `*mut sys::X509` (mut→mut). Mutability originates from BoringSSL's ABI
     //     (`void *sk_value(const _STACK *, size_t)`), not from `sk`.
-    unsafe { sk_value(sk.cast::<OPENSSL_STACK>(), i).cast::<X509>() }
+    unsafe { sk_value(sk.cast::<OPENSSL_STACK>(), i).cast::<sys::X509>() }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -680,21 +798,14 @@ opaque!(
     SSL_METHOD
 );
 opaque!(
-    /// `struct x509_store_st` (`typedef ... X509_STORE`).
-    X509_STORE
-);
-opaque!(
-    /// `struct x509_store_ctx_st` (`typedef ... X509_STORE_CTX`).
-    X509_STORE_CTX
-);
-opaque!(
     /// `struct rsa_st` (`typedef ... RSA`).
     RSA
 );
 
 /// `int (*SSL_verify_cb)(int preverify_ok, X509_STORE_CTX *ctx)` — verify
-/// callback type for `SSL_set_verify` / `SSL_CTX_set_verify`.
-pub type SSL_verify_cb = Option<unsafe extern "C" fn(c_int, *mut X509_STORE_CTX) -> c_int>;
+/// callback type for `SSL_set_verify` / `SSL_CTX_set_verify`. BoringSSL owns the
+/// context it passes, so the callback sees the C object, not the owning handle.
+pub type SSL_verify_cb = Option<unsafe extern "C" fn(c_int, *mut sys::X509_STORE_CTX) -> c_int>;
 
 /// `int pem_password_cb(char *buf, int size, int rwflag, void *userdata)`.
 pub(crate) type pem_password_cb =
@@ -709,8 +820,10 @@ unsafe extern "C" {
     pub safe fn TLS_with_buffers_method() -> *const SSL_METHOD;
 
     // ── ENGINE ───────────────────────────────────────────────────────────
-    pub safe fn ENGINE_new() -> *mut ENGINE;
-    pub fn ENGINE_free(engine: *mut ENGINE) -> c_int;
+    /// Allocates a fresh engine; wrapped by [`ENGINE::new`].
+    pub safe fn ENGINE_new() -> *mut sys::ENGINE;
+    /// Frees the engine. Backs the [`ENGINE`] handle's `Drop`.
+    pub fn ENGINE_free(engine: *mut sys::ENGINE) -> c_int;
 
     // ── SSL_CTX ──────────────────────────────────────────────────────────
     // `&sys::SSL_CTX` is a non-null `SSL_CTX*` carrying no `noalias`/`readonly`,
@@ -748,7 +861,9 @@ unsafe extern "C" {
     pub fn SSL_get_shutdown(ssl: *const SSL) -> c_int;
     pub fn SSL_is_init_finished(ssl: *const SSL) -> c_int;
     pub fn SSL_set_verify(ssl: *mut SSL, mode: c_int, callback: SSL_verify_cb);
-    pub fn SSL_set0_verify_cert_store(ssl: *mut SSL, store: *mut X509_STORE) -> c_int;
+    // `set0`: takes ownership of `store`. Callers hand over the unit (a leaked
+    // `X509_STORE` handle, or a raw `+1` from `us_get_shared_default_ca_store`).
+    pub fn SSL_set0_verify_cert_store(ssl: *mut SSL, store: *mut sys::X509_STORE) -> c_int;
     pub fn SSL_set_renegotiate_mode(ssl: *mut SSL, mode: ssl_renegotiate_mode_t);
     pub fn SSL_renegotiate(ssl: *mut SSL) -> c_int;
     pub fn SSL_get_servername(ssl: *const SSL, ty: c_int) -> *const c_char;
@@ -823,7 +938,7 @@ unsafe extern "C" {
         key: *const c_void,
         key_len: usize,
         md: *const EVP_MD,
-        impl_: *mut ENGINE,
+        impl_: *mut sys::ENGINE,
     ) -> c_int;
     pub fn HMAC_Update(ctx: *mut HMAC_CTX, data: *const u8, data_len: usize) -> c_int;
     pub fn HMAC_Final(ctx: *mut HMAC_CTX, out: *mut u8, out_len: *mut c_uint) -> c_int;

--- a/src/boringssl_sys/boringssl.rs
+++ b/src/boringssl_sys/boringssl.rs
@@ -295,40 +295,19 @@ unsafe extern "C" {
 
 // `SSL_CTX_new` / `SSL_CTX_up_ref` hand back a `+1` on the context's
 // `CRYPTO_refcount_t`. One `SSL_CTX` handle owns exactly that one ref.
-::bun_opaque::foreign_owned!(sys::SSL_CTX, SSL_CTX_free);
-
-/// Owned handle to a BoringSSL `SSL_CTX`.
-///
-/// Holds one ref on the C refcount; `Drop` gives it back. Every method takes
-/// `&self`: the context is shared with every `SSL` created from it, and
-/// BoringSSL mutates it (refcount, session cache) through the same pointer.
-///
-/// A context borrowed from C (`SSL_get_SSL_CTX`, the weak `SSLContextCache`
-/// slot) took no ref and stays a raw `*mut sys::SSL_CTX`.
-#[repr(transparent)]
-pub struct SSL_CTX(::bun_opaque::ForeignRef<sys::SSL_CTX>);
+bun_opaque::foreign_handle! {
+    /// Owned handle to a BoringSSL `SSL_CTX`.
+    ///
+    /// Holds one ref on the C refcount; `Drop` gives it back. Every method takes
+    /// `&self`: the context is shared with every `SSL` created from it, and
+    /// BoringSSL mutates it (refcount, session cache) through the same pointer.
+    ///
+    /// A context borrowed from C (`SSL_get_SSL_CTX`, the weak `SSLContextCache`
+    /// slot) took no ref and stays a raw `*mut sys::SSL_CTX`.
+    pub struct SSL_CTX(sys::SSL_CTX) via SSL_CTX_free;
+}
 
 impl SSL_CTX {
-    /// Adopt a `+1` returned by C.
-    ///
-    /// # Safety
-    /// `ptr` must carry exactly one ref that no other handle will release.
-    #[inline]
-    pub unsafe fn adopt(ptr: core::ptr::NonNull<sys::SSL_CTX>) -> Self {
-        // SAFETY: caller transfers the +1.
-        Self(unsafe { ::bun_opaque::ForeignRef::adopt(ptr) })
-    }
-
-    /// Adopt a nullable `+1`; `None` on null.
-    ///
-    /// # Safety
-    /// `ptr` must be null or carry a ref the caller is giving up.
-    #[inline]
-    pub unsafe fn adopt_ptr(ptr: *mut sys::SSL_CTX) -> Option<Self> {
-        // SAFETY: caller transfers the +1.
-        core::ptr::NonNull::new(ptr).map(|p| unsafe { Self::adopt(p) })
-    }
-
     /// `SSL_CTX_new` returns a fresh `+1`; `None` on allocation failure.
     ///
     /// # Safety
@@ -338,18 +317,6 @@ impl SSL_CTX {
         unsafe { Self::adopt_ptr(SSL_CTX_new(method)) }
     }
 
-    /// The C pointer, still owned by `self`.
-    #[inline]
-    pub fn as_ptr(&self) -> *mut sys::SSL_CTX {
-        self.0.as_ptr()
-    }
-
-    /// Hand our `+1` to a foreign owner. Pairs with a later [`Self::adopt`].
-    #[inline]
-    pub fn leak(self) -> core::ptr::NonNull<sys::SSL_CTX> {
-        self.0.leak()
-    }
-
     /// Take a second ref on the same context.
     #[inline]
     pub fn up_ref(&self) -> Self {
@@ -357,16 +324,11 @@ impl SSL_CTX {
         // SAFETY: the call above added exactly the ref this handle takes.
         unsafe { Self::adopt(self.0.as_non_null()) }
     }
-
-    #[inline]
-    fn raw(&self) -> &sys::SSL_CTX {
-        &self.0
-    }
 }
 
 // `X509V3_EXT_d2i` allocates the stack and every `GENERAL_NAME` in it, then
 // hands back the sole owner. One handle owns exactly that one allocation.
-bun_opaque::foreign_owned!(sys::struct_stack_st_GENERAL_NAME, general_name_stack_free);
+// The `foreign_owned!` impl is emitted by the `foreign_handle!` invocation below.
 
 /// Frees every `GENERAL_NAME` element, then the stack itself.
 fn general_name_stack_free(sk: &sys::struct_stack_st_GENERAL_NAME) {
@@ -385,27 +347,22 @@ fn general_name_stack_free(sk: &sys::struct_stack_st_GENERAL_NAME) {
     }
 }
 
-/// Owned handle to the `STACK_OF(GENERAL_NAME)` that `X509V3_EXT_d2i` returns
-/// for a subjectAltName extension.
-///
-/// Holds the one allocation BoringSSL handed us; `Drop` frees the elements and
-/// then the stack. Every method takes `&self`: BoringSSL mutates the stack's
-/// bookkeeping through the same pointer, so there is no `&mut self` to have.
-#[repr(transparent)]
-pub struct struct_stack_st_GENERAL_NAME(bun_opaque::ForeignRef<sys::struct_stack_st_GENERAL_NAME>);
-
-/// Ownership plumbing.
-impl struct_stack_st_GENERAL_NAME {
-    /// Adopt a stack the caller is giving up.
+bun_opaque::foreign_handle! {
+    /// Owned handle to the `STACK_OF(GENERAL_NAME)` that `X509V3_EXT_d2i` returns
+    /// for a subjectAltName extension.
     ///
-    /// # Safety
-    /// `ptr` must be live and freed by no other handle.
-    pub unsafe fn adopt(ptr: core::ptr::NonNull<sys::struct_stack_st_GENERAL_NAME>) -> Self {
-        // SAFETY: caller transfers ownership.
-        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
-    }
+    /// Holds the one allocation BoringSSL handed us; `Drop` frees the elements and
+    /// then the stack. Every method takes `&self`: BoringSSL mutates the stack's
+    /// bookkeeping through the same pointer, so there is no `&mut self` to have.
+    pub struct struct_stack_st_GENERAL_NAME(sys::struct_stack_st_GENERAL_NAME) via general_name_stack_free;
+}
 
+/// Ownership plumbing the macro does not emit.
+impl struct_stack_st_GENERAL_NAME {
     /// Takes ownership of a `STACK_OF(GENERAL_NAME)`; `None` when `raw` is null.
+    ///
+    /// Not [`Self::adopt_ptr`]: this takes the untyped `*mut c_void` that
+    /// `X509V3_EXT_d2i` returns and casts it here.
     ///
     /// # Safety
     /// `raw` must be null or a stack the caller owns and does not free itself.
@@ -413,20 +370,6 @@ impl struct_stack_st_GENERAL_NAME {
         // SAFETY: caller contract.
         core::ptr::NonNull::new(raw.cast::<sys::struct_stack_st_GENERAL_NAME>())
             .map(|p| unsafe { Self::adopt(p) })
-    }
-
-    /// The C pointer, still owned by `self`.
-    pub fn as_ptr(&self) -> *mut sys::struct_stack_st_GENERAL_NAME {
-        self.0.as_ptr()
-    }
-
-    /// Hand the stack to a foreign owner. Pairs with a later [`Self::adopt`].
-    pub fn leak(self) -> core::ptr::NonNull<sys::struct_stack_st_GENERAL_NAME> {
-        self.0.leak()
-    }
-
-    fn raw(&self) -> &sys::struct_stack_st_GENERAL_NAME {
-        &self.0
     }
 
     /// The untyped view every `sk_*` entry point takes.

--- a/src/bundler_jsc/analyze_jsc.rs
+++ b/src/bundler_jsc/analyze_jsc.rs
@@ -7,8 +7,6 @@
 //! higher-tier type this crate cannot depend on, and the C++ caller only needs
 //! the symbol at link time, not a particular crate.
 
-use core::ptr::NonNull;
-
 use crate::{JSGlobalObject, VM};
 
 use analyze::{ModuleInfoDeserialized, RecordKind, RequestedModuleValue, StringID};
@@ -244,15 +242,14 @@ pub mod sys {
 
 // C++ allocates (`new Identifier[len]`) and hands back the array. One
 // `IdentifierArray` handle owns that whole allocation.
-bun_opaque::foreign_owned!(sys::IdentifierArray, JSC__IdentifierArray__destroy);
-
-/// Owned handle to a C++ `JSC::Identifier[]`.
-///
-/// The pointer is the base of the array, so the handle owns every element
-/// (`delete[]`), not one. Every method takes `&self`: C++ writes elements
-/// through the same pointer, so there is no `&mut self` to have.
-#[repr(transparent)]
-pub struct IdentifierArray(bun_opaque::ForeignRef<sys::IdentifierArray>);
+bun_opaque::foreign_handle! {
+    /// Owned handle to a C++ `JSC::Identifier[]`.
+    ///
+    /// The pointer is the base of the array, so the handle owns every element
+    /// (`delete[]`), not one. Every method takes `&self`: C++ writes elements
+    /// through the same pointer, so there is no `&mut self` to have.
+    pub struct IdentifierArray(sys::IdentifierArray) via JSC__IdentifierArray__destroy;
+}
 
 unsafe extern "C" {
     safe fn JSC__IdentifierArray__create(len: usize) -> *mut sys::IdentifierArray;
@@ -270,48 +267,13 @@ unsafe extern "C" {
     );
 }
 
-/// Ownership plumbing.
-impl IdentifierArray {
-    /// Adopt an array allocated by C++.
-    ///
-    /// # Safety
-    /// `ptr` must be a live `new Identifier[]` allocation that no other handle frees.
-    #[inline]
-    pub unsafe fn adopt(ptr: NonNull<sys::IdentifierArray>) -> Self {
-        // SAFETY: caller transfers the allocation.
-        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
-    }
-
-    /// Adopt a nullable allocation; `None` on null.
-    #[inline]
-    fn adopt_ptr(ptr: *mut sys::IdentifierArray) -> Option<Self> {
-        // SAFETY: `JSC__IdentifierArray__create` returns a fresh `new[]` allocation.
-        NonNull::new(ptr).map(|p| unsafe { Self::adopt(p) })
-    }
-
-    /// The C++ pointer, still owned by `self`.
-    #[inline]
-    pub fn as_ptr(&self) -> *mut sys::IdentifierArray {
-        self.0.as_ptr()
-    }
-
-    /// Hand the allocation to a foreign owner. Pairs with a later [`Self::adopt`].
-    #[inline]
-    pub fn leak(self) -> NonNull<sys::IdentifierArray> {
-        self.0.leak()
-    }
-
-    #[inline]
-    fn raw(&self) -> &sys::IdentifierArray {
-        &self.0
-    }
-}
-
 impl IdentifierArray {
     /// `new Identifier[len]` on the C++ side.
     #[inline]
     pub fn create(len: usize) -> Self {
-        Self::adopt_ptr(JSC__IdentifierArray__create(len))
+        // SAFETY: `JSC__IdentifierArray__create` transfers a fresh `new Identifier[len]`
+        // allocation to us; no other handle frees it.
+        unsafe { Self::adopt_ptr(JSC__IdentifierArray__create(len)) }
             .expect("JSC__IdentifierArray__create returned null")
     }
 

--- a/src/bundler_jsc/analyze_jsc.rs
+++ b/src/bundler_jsc/analyze_jsc.rs
@@ -7,6 +7,8 @@
 //! higher-tier type this crate cannot depend on, and the C++ caller only needs
 //! the symbol at link time, not a particular crate.
 
+use core::ptr::NonNull;
+
 use crate::{JSGlobalObject, VM};
 
 use analyze::{ModuleInfoDeserialized, RecordKind, RequestedModuleValue, StringID};
@@ -16,7 +18,7 @@ use bun_bundler::analyze_transpiled_module as analyze;
 pub(crate) extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
     global_object: &JSGlobalObject,
     vm: &VM,
-    module_key: &IdentifierArray,
+    module_key: &sys::IdentifierArray,
     source_code: &SourceCode,
     declared_variables: &mut VariableEnvironment,
     lexical_variables: &mut VariableEnvironment,
@@ -54,13 +56,9 @@ pub(crate) extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
         return core::ptr::null_mut();
     }
 
-    let identifiers = IdentifierArray::create(strings_lens.len());
-    // SAFETY: `identifiers` is non-null (returned by `create`); the scopeguard destroys it
-    // exactly once at scope exit (on both success and early-return paths).
-    let _identifiers_guard = scopeguard::guard(identifiers, |p| unsafe {
-        IdentifierArray::destroy(p);
-    });
-    let identifiers: *mut IdentifierArray = *_identifiers_guard;
+    // Owns the array; `Drop` frees it at scope exit, on success and early returns alike.
+    let identifiers_owned = IdentifierArray::create(strings_lens.len());
+    let identifiers: &IdentifierArray = &identifiers_owned;
 
     let mut offset: usize = 0;
     for (index, &len) in strings_lens.iter().enumerate() {
@@ -69,8 +67,8 @@ pub(crate) extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
             return core::ptr::null_mut(); // error!
         }
         let sub = &strings_buf[offset..offset + len];
-        // SAFETY: `identifiers` is live for the scope of this fn (guard above).
-        unsafe { IdentifierArray::set_from_utf8(identifiers, index, vm, sub) };
+        // SAFETY: `index < strings_lens.len()`, the length the array was created with.
+        unsafe { identifiers.set_from_utf8(index, vm, sub) };
         offset += len;
     }
 
@@ -221,56 +219,108 @@ unsafe extern "C" {
     fn JSC__VariableEnvironment__add(
         environment: *mut VariableEnvironment,
         vm: *const VM,
-        identifier_array: *mut IdentifierArray,
+        identifier_array: &sys::IdentifierArray,
         identifier_index: StringID,
     );
 }
 impl VariableEnvironment {
-    // Forwards `identifier_array` to C++ without dereferencing; not_unsafe_ptr_arg_deref is a false positive on opaque-token forwarding.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     #[inline]
-    pub fn add(
-        &mut self,
-        vm: &VM,
-        identifier_array: *mut IdentifierArray,
-        identifier_index: StringID,
-    ) {
-        // SAFETY: self is a valid &mut VariableEnvironment from C++; identifier_array is live (scopeguard).
-        unsafe { JSC__VariableEnvironment__add(self, vm, identifier_array, identifier_index) }
+    pub fn add(&mut self, vm: &VM, identifier_array: &IdentifierArray, identifier_index: StringID) {
+        // SAFETY: `self` is a valid `&mut VariableEnvironment` handed over by C++.
+        unsafe { JSC__VariableEnvironment__add(self, vm, identifier_array.raw(), identifier_index) }
     }
 }
 
-bun_opaque::opaque_ffi! { pub struct IdentifierArray; }
+/// The C++ object itself. Only the extern declarations below name this type;
+/// all Rust code uses the owning [`IdentifierArray`] handle.
+pub mod sys {
+    bun_opaque::opaque_ffi! {
+        /// Base of a C array of `JSC::Identifier`. `&Self` is ABI-identical to a
+        /// non-null `JSC::Identifier*` and carries no `noalias`/`readonly` — C++
+        /// writes elements through it.
+        pub struct IdentifierArray;
+    }
+}
+
+// C++ allocates (`new Identifier[len]`) and hands back the array. One
+// `IdentifierArray` handle owns that whole allocation.
+bun_opaque::foreign_owned!(sys::IdentifierArray, JSC__IdentifierArray__destroy);
+
+/// Owned handle to a C++ `JSC::Identifier[]`.
+///
+/// The pointer is the base of the array, so the handle owns every element
+/// (`delete[]`), not one. Every method takes `&self`: C++ writes elements
+/// through the same pointer, so there is no `&mut self` to have.
+#[repr(transparent)]
+pub struct IdentifierArray(bun_opaque::ForeignRef<sys::IdentifierArray>);
+
 unsafe extern "C" {
-    fn JSC__IdentifierArray__create(len: usize) -> *mut IdentifierArray;
-    fn JSC__IdentifierArray__destroy(identifier_array: *mut IdentifierArray);
+    safe fn JSC__IdentifierArray__create(len: usize) -> *mut sys::IdentifierArray;
+    // safe: C++ takes `Identifier*` and `delete[]`s it. Freeing is not exclusive
+    // access in Rust's model, so the receiver is `&`, not `&mut`.
+    safe fn JSC__IdentifierArray__destroy(identifier_array: &sys::IdentifierArray);
+    // NOT `safe fn`: C++ writes `identifierArray[n]` with no bounds check and
+    // reads `str_[..len]`.
     fn JSC__IdentifierArray__setFromUtf8(
-        identifier_array: *mut IdentifierArray,
+        identifier_array: &sys::IdentifierArray,
         n: usize,
-        vm: *const VM,
+        vm: &VM,
         str_: *const u8,
         len: usize,
     );
 }
+
+/// Ownership plumbing.
 impl IdentifierArray {
-    #[inline]
-    pub fn create(len: usize) -> *mut IdentifierArray {
-        // SAFETY: FFI call; C++ side allocates.
-        unsafe { JSC__IdentifierArray__create(len) }
-    }
+    /// Adopt an array allocated by C++.
+    ///
     /// # Safety
-    /// `identifier_array` must be a pointer previously returned by `create` and not yet destroyed.
+    /// `ptr` must be a live `new Identifier[]` allocation that no other handle frees.
     #[inline]
-    pub unsafe fn destroy(identifier_array: *mut IdentifierArray) {
-        // SAFETY: caller contract — `identifier_array` came from `create` and has not been destroyed.
-        unsafe { JSC__IdentifierArray__destroy(identifier_array) }
+    pub unsafe fn adopt(ptr: NonNull<sys::IdentifierArray>) -> Self {
+        // SAFETY: caller transfers the allocation.
+        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
     }
-    /// # Safety
-    /// `this` must be live; `n` must be in-bounds for the array's length.
+
+    /// Adopt a nullable allocation; `None` on null.
     #[inline]
-    pub unsafe fn set_from_utf8(this: *mut IdentifierArray, n: usize, vm: &VM, str_: &[u8]) {
-        // SAFETY: caller contract — `this` is live, `n` is in bounds; `str_` is a valid slice for the call.
-        unsafe { JSC__IdentifierArray__setFromUtf8(this, n, vm, str_.as_ptr(), str_.len()) }
+    fn adopt_ptr(ptr: *mut sys::IdentifierArray) -> Option<Self> {
+        // SAFETY: `JSC__IdentifierArray__create` returns a fresh `new[]` allocation.
+        NonNull::new(ptr).map(|p| unsafe { Self::adopt(p) })
+    }
+
+    /// The C++ pointer, still owned by `self`.
+    #[inline]
+    pub fn as_ptr(&self) -> *mut sys::IdentifierArray {
+        self.0.as_ptr()
+    }
+
+    /// Hand the allocation to a foreign owner. Pairs with a later [`Self::adopt`].
+    #[inline]
+    pub fn leak(self) -> NonNull<sys::IdentifierArray> {
+        self.0.leak()
+    }
+
+    #[inline]
+    fn raw(&self) -> &sys::IdentifierArray {
+        &self.0
+    }
+}
+
+impl IdentifierArray {
+    /// `new Identifier[len]` on the C++ side.
+    #[inline]
+    pub fn create(len: usize) -> Self {
+        Self::adopt_ptr(JSC__IdentifierArray__create(len))
+            .expect("JSC__IdentifierArray__create returned null")
+    }
+
+    /// # Safety
+    /// `n` must be in-bounds for the length `self` was created with.
+    #[inline]
+    pub unsafe fn set_from_utf8(&self, n: usize, vm: &VM, str_: &[u8]) {
+        // SAFETY: caller contract — `n` is in bounds; `str_` is valid for the call.
+        unsafe { JSC__IdentifierArray__setFromUtf8(self.raw(), n, vm, str_.as_ptr(), str_.len()) }
     }
 }
 
@@ -282,7 +332,7 @@ unsafe extern "C" {
     fn JSC_JSModuleRecord__create(
         global_object: *const JSGlobalObject,
         vm: *const VM,
-        module_key: *const IdentifierArray,
+        module_key: &sys::IdentifierArray,
         source_code: *const SourceCode,
         declared_variables: *mut VariableEnvironment,
         lexical_variables: *mut VariableEnvironment,
@@ -293,56 +343,56 @@ unsafe extern "C" {
 
     fn JSC_JSModuleRecord__addIndirectExport(
         module_record: *mut JSModuleRecord,
-        identifier_array: *mut IdentifierArray,
+        identifier_array: &sys::IdentifierArray,
         export_name: StringID,
         import_name: StringID,
         module_name: StringID,
     );
     fn JSC_JSModuleRecord__addLocalExport(
         module_record: *mut JSModuleRecord,
-        identifier_array: *mut IdentifierArray,
+        identifier_array: &sys::IdentifierArray,
         export_name: StringID,
         local_name: StringID,
     );
     fn JSC_JSModuleRecord__addNamespaceExport(
         module_record: *mut JSModuleRecord,
-        identifier_array: *mut IdentifierArray,
+        identifier_array: &sys::IdentifierArray,
         export_name: StringID,
         module_name: StringID,
     );
     fn JSC_JSModuleRecord__addStarExport(
         module_record: *mut JSModuleRecord,
-        identifier_array: *mut IdentifierArray,
+        identifier_array: &sys::IdentifierArray,
         module_name: StringID,
     );
 
     fn JSC_JSModuleRecord__addRequestedModuleNullAttributesPtr(
         module_record: *mut JSModuleRecord,
-        identifier_array: *mut IdentifierArray,
+        identifier_array: &sys::IdentifierArray,
         module_name: StringID,
         phase_defer: bool,
     );
     fn JSC_JSModuleRecord__addRequestedModuleJavaScript(
         module_record: *mut JSModuleRecord,
-        identifier_array: *mut IdentifierArray,
+        identifier_array: &sys::IdentifierArray,
         module_name: StringID,
         phase_defer: bool,
     );
     fn JSC_JSModuleRecord__addRequestedModuleWebAssembly(
         module_record: *mut JSModuleRecord,
-        identifier_array: *mut IdentifierArray,
+        identifier_array: &sys::IdentifierArray,
         module_name: StringID,
         phase_defer: bool,
     );
     fn JSC_JSModuleRecord__addRequestedModuleJSON(
         module_record: *mut JSModuleRecord,
-        identifier_array: *mut IdentifierArray,
+        identifier_array: &sys::IdentifierArray,
         module_name: StringID,
         phase_defer: bool,
     );
     fn JSC_JSModuleRecord__addRequestedModuleHostDefined(
         module_record: *mut JSModuleRecord,
-        identifier_array: *mut IdentifierArray,
+        identifier_array: &sys::IdentifierArray,
         module_name: StringID,
         host_defined_import_type: StringID,
         phase_defer: bool,
@@ -350,28 +400,28 @@ unsafe extern "C" {
 
     fn JSC_JSModuleRecord__addImportEntrySingle(
         module_record: *mut JSModuleRecord,
-        identifier_array: *mut IdentifierArray,
+        identifier_array: &sys::IdentifierArray,
         import_name: StringID,
         local_name: StringID,
         module_name: StringID,
     );
     fn JSC_JSModuleRecord__addImportEntrySingleTypeScript(
         module_record: *mut JSModuleRecord,
-        identifier_array: *mut IdentifierArray,
+        identifier_array: &sys::IdentifierArray,
         import_name: StringID,
         local_name: StringID,
         module_name: StringID,
     );
     fn JSC_JSModuleRecord__addImportEntryNamespace(
         module_record: *mut JSModuleRecord,
-        identifier_array: *mut IdentifierArray,
+        identifier_array: &sys::IdentifierArray,
         import_name: StringID,
         local_name: StringID,
         module_name: StringID,
     );
     fn JSC_JSModuleRecord__addImportEntryNamespaceDefer(
         module_record: *mut JSModuleRecord,
-        identifier_array: *mut IdentifierArray,
+        identifier_array: &sys::IdentifierArray,
         import_name: StringID,
         local_name: StringID,
         module_name: StringID,
@@ -382,7 +432,7 @@ impl JSModuleRecord {
     pub(crate) fn create(
         global_object: &JSGlobalObject,
         vm: &VM,
-        module_key: &IdentifierArray,
+        module_key: &sys::IdentifierArray,
         source_code: &SourceCode,
         declared_variables: &mut VariableEnvironment,
         lexical_variables: &mut VariableEnvironment,
@@ -412,137 +462,132 @@ impl JSModuleRecord {
 trait JSModuleRecordExt {
     fn add_indirect_export(
         self,
-        ia: *mut IdentifierArray,
+        ia: &IdentifierArray,
         export_name: StringID,
         import_name: StringID,
         module_name: StringID,
     );
-    fn add_local_export(
-        self,
-        ia: *mut IdentifierArray,
-        export_name: StringID,
-        local_name: StringID,
-    );
+    fn add_local_export(self, ia: &IdentifierArray, export_name: StringID, local_name: StringID);
     fn add_namespace_export(
         self,
-        ia: *mut IdentifierArray,
+        ia: &IdentifierArray,
         export_name: StringID,
         module_name: StringID,
     );
-    fn add_star_export(self, ia: *mut IdentifierArray, module_name: StringID);
+    fn add_star_export(self, ia: &IdentifierArray, module_name: StringID);
     fn add_requested_module_null_attributes_ptr(
         self,
-        ia: *mut IdentifierArray,
+        ia: &IdentifierArray,
         module_name: StringID,
         phase_defer: bool,
     );
     fn add_requested_module_java_script(
         self,
-        ia: *mut IdentifierArray,
+        ia: &IdentifierArray,
         module_name: StringID,
         phase_defer: bool,
     );
     fn add_requested_module_web_assembly(
         self,
-        ia: *mut IdentifierArray,
+        ia: &IdentifierArray,
         module_name: StringID,
         phase_defer: bool,
     );
     fn add_requested_module_json(
         self,
-        ia: *mut IdentifierArray,
+        ia: &IdentifierArray,
         module_name: StringID,
         phase_defer: bool,
     );
     fn add_requested_module_host_defined(
         self,
-        ia: *mut IdentifierArray,
+        ia: &IdentifierArray,
         module_name: StringID,
         host_defined_import_type: StringID,
         phase_defer: bool,
     );
     fn add_import_entry_single(
         self,
-        ia: *mut IdentifierArray,
+        ia: &IdentifierArray,
         import_name: StringID,
         local_name: StringID,
         module_name: StringID,
     );
     fn add_import_entry_single_type_script(
         self,
-        ia: *mut IdentifierArray,
+        ia: &IdentifierArray,
         import_name: StringID,
         local_name: StringID,
         module_name: StringID,
     );
     fn add_import_entry_namespace(
         self,
-        ia: *mut IdentifierArray,
+        ia: &IdentifierArray,
         import_name: StringID,
         local_name: StringID,
         module_name: StringID,
     );
     fn add_import_entry_namespace_defer(
         self,
-        ia: *mut IdentifierArray,
+        ia: &IdentifierArray,
         import_name: StringID,
         local_name: StringID,
         module_name: StringID,
     );
 }
 impl JSModuleRecordExt for *mut JSModuleRecord {
-    // SAFETY (all below): `self` is the non-null pointer returned by JSC_JSModuleRecord__create;
-    // `ia` is the live IdentifierArray guarded by scopeguard for the duration of the caller.
+    // SAFETY (all below): `self` is the non-null pointer returned by JSC_JSModuleRecord__create.
     #[inline]
     fn add_indirect_export(
         self,
-        ia: *mut IdentifierArray,
+        ia: &IdentifierArray,
         export_name: StringID,
         import_name: StringID,
         module_name: StringID,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`.
         unsafe {
-            JSC_JSModuleRecord__addIndirectExport(self, ia, export_name, import_name, module_name)
+            JSC_JSModuleRecord__addIndirectExport(
+                self,
+                ia.raw(),
+                export_name,
+                import_name,
+                module_name,
+            )
         }
     }
     #[inline]
-    fn add_local_export(
-        self,
-        ia: *mut IdentifierArray,
-        export_name: StringID,
-        local_name: StringID,
-    ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
-        unsafe { JSC_JSModuleRecord__addLocalExport(self, ia, export_name, local_name) }
+    fn add_local_export(self, ia: &IdentifierArray, export_name: StringID, local_name: StringID) {
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`.
+        unsafe { JSC_JSModuleRecord__addLocalExport(self, ia.raw(), export_name, local_name) }
     }
     #[inline]
     fn add_namespace_export(
         self,
-        ia: *mut IdentifierArray,
+        ia: &IdentifierArray,
         export_name: StringID,
         module_name: StringID,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
-        unsafe { JSC_JSModuleRecord__addNamespaceExport(self, ia, export_name, module_name) }
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`.
+        unsafe { JSC_JSModuleRecord__addNamespaceExport(self, ia.raw(), export_name, module_name) }
     }
     #[inline]
-    fn add_star_export(self, ia: *mut IdentifierArray, module_name: StringID) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
-        unsafe { JSC_JSModuleRecord__addStarExport(self, ia, module_name) }
+    fn add_star_export(self, ia: &IdentifierArray, module_name: StringID) {
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`.
+        unsafe { JSC_JSModuleRecord__addStarExport(self, ia.raw(), module_name) }
     }
     #[inline]
     fn add_requested_module_null_attributes_ptr(
         self,
-        ia: *mut IdentifierArray,
+        ia: &IdentifierArray,
         module_name: StringID,
         phase_defer: bool,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`.
         unsafe {
             JSC_JSModuleRecord__addRequestedModuleNullAttributesPtr(
                 self,
-                ia,
+                ia.raw(),
                 module_name,
                 phase_defer,
             )
@@ -551,50 +596,62 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
     #[inline]
     fn add_requested_module_java_script(
         self,
-        ia: *mut IdentifierArray,
+        ia: &IdentifierArray,
         module_name: StringID,
         phase_defer: bool,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`.
         unsafe {
-            JSC_JSModuleRecord__addRequestedModuleJavaScript(self, ia, module_name, phase_defer)
+            JSC_JSModuleRecord__addRequestedModuleJavaScript(
+                self,
+                ia.raw(),
+                module_name,
+                phase_defer,
+            )
         }
     }
     #[inline]
     fn add_requested_module_web_assembly(
         self,
-        ia: *mut IdentifierArray,
+        ia: &IdentifierArray,
         module_name: StringID,
         phase_defer: bool,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`.
         unsafe {
-            JSC_JSModuleRecord__addRequestedModuleWebAssembly(self, ia, module_name, phase_defer)
+            JSC_JSModuleRecord__addRequestedModuleWebAssembly(
+                self,
+                ia.raw(),
+                module_name,
+                phase_defer,
+            )
         }
     }
     #[inline]
     fn add_requested_module_json(
         self,
-        ia: *mut IdentifierArray,
+        ia: &IdentifierArray,
         module_name: StringID,
         phase_defer: bool,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
-        unsafe { JSC_JSModuleRecord__addRequestedModuleJSON(self, ia, module_name, phase_defer) }
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`.
+        unsafe {
+            JSC_JSModuleRecord__addRequestedModuleJSON(self, ia.raw(), module_name, phase_defer)
+        }
     }
     #[inline]
     fn add_requested_module_host_defined(
         self,
-        ia: *mut IdentifierArray,
+        ia: &IdentifierArray,
         module_name: StringID,
         host_defined_import_type: StringID,
         phase_defer: bool,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`.
         unsafe {
             JSC_JSModuleRecord__addRequestedModuleHostDefined(
                 self,
-                ia,
+                ia.raw(),
                 module_name,
                 host_defined_import_type,
                 phase_defer,
@@ -604,29 +661,35 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
     #[inline]
     fn add_import_entry_single(
         self,
-        ia: *mut IdentifierArray,
+        ia: &IdentifierArray,
         import_name: StringID,
         local_name: StringID,
         module_name: StringID,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`.
         unsafe {
-            JSC_JSModuleRecord__addImportEntrySingle(self, ia, import_name, local_name, module_name)
+            JSC_JSModuleRecord__addImportEntrySingle(
+                self,
+                ia.raw(),
+                import_name,
+                local_name,
+                module_name,
+            )
         }
     }
     #[inline]
     fn add_import_entry_single_type_script(
         self,
-        ia: *mut IdentifierArray,
+        ia: &IdentifierArray,
         import_name: StringID,
         local_name: StringID,
         module_name: StringID,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`.
         unsafe {
             JSC_JSModuleRecord__addImportEntrySingleTypeScript(
                 self,
-                ia,
+                ia.raw(),
                 import_name,
                 local_name,
                 module_name,
@@ -636,16 +699,16 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
     #[inline]
     fn add_import_entry_namespace(
         self,
-        ia: *mut IdentifierArray,
+        ia: &IdentifierArray,
         import_name: StringID,
         local_name: StringID,
         module_name: StringID,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`.
         unsafe {
             JSC_JSModuleRecord__addImportEntryNamespace(
                 self,
-                ia,
+                ia.raw(),
                 import_name,
                 local_name,
                 module_name,
@@ -655,16 +718,16 @@ impl JSModuleRecordExt for *mut JSModuleRecord {
     #[inline]
     fn add_import_entry_namespace_defer(
         self,
-        ia: *mut IdentifierArray,
+        ia: &IdentifierArray,
         import_name: StringID,
         local_name: StringID,
         module_name: StringID,
     ) {
-        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`; `ia` is kept alive by the caller's scopeguard.
+        // SAFETY: `self` is the non-null record from `JSModuleRecord::create`.
         unsafe {
             JSC_JSModuleRecord__addImportEntryNamespaceDefer(
                 self,
-                ia,
+                ia.raw(),
                 import_name,
                 local_name,
                 module_name,

--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -698,10 +698,9 @@ bun_opaque::opaque_ffi! {
     /// mutates the channel on every dispatch/process call).
     pub struct Channel;
 }
-// Load-bearing: `ares_cancel`/`ares_process_fd` are declared `safe fn(&mut Channel)`
-// on the basis that re-entrant callbacks re-deriving `&mut Channel` from a raw
-// pointer cannot conflict because `Channel` claims zero bytes. If this type ever
-// gains a non-ZST field, those signatures must revert to `unsafe fn(*mut Channel)`.
+// `Channel` is `!Freeze`, so `&Channel` asserts neither `noalias` nor `readonly`;
+// c-ares owns the real object and re-enters through the same handle. If this type
+// ever gains a non-ZST field, the `safe fn(&Channel)` externs must be revisited.
 const _: () = assert!(core::mem::size_of::<Channel>() == 0);
 
 /// Implemented by the type that owns a `*mut Channel` and receives socket-
@@ -805,7 +804,7 @@ impl Channel {
 
     /// See c-ares `ares_getaddrinfo` documentation.
     pub fn get_addr_info<T: AddrInfoHandler>(
-        &mut self,
+        &self,
         host: &[u8],
         port: u16,
         hints: &[AddrInfo_hints],
@@ -833,7 +832,7 @@ impl Channel {
         // SAFETY: c-ares FFI; host/port/hints are NUL-terminated stack buffers or null; ctx outlives the channel.
         unsafe {
             ares_getaddrinfo(
-                self,
+                self.as_mut_ptr(),
                 host_ptr,
                 port_ptr,
                 hints_,
@@ -843,7 +842,7 @@ impl Channel {
         }
     }
 
-    pub fn resolve<T: ResolveHandler>(&mut self, name: &[u8], ctx: &mut T) {
+    pub fn resolve<T: ResolveHandler>(&self, name: &[u8], ctx: &mut T) {
         if name.len() >= 1023
             || name.contains(&0)
             || (name.is_empty() && !(T::LOOKUP_NAME == b"ns" || T::LOOKUP_NAME == b"soa"))
@@ -867,7 +866,7 @@ impl Channel {
         // SAFETY: c-ares FFI; name_ptr is a NUL-terminated stack buffer; ctx outlives the channel.
         unsafe {
             ares_query(
-                self,
+                self.as_mut_ptr(),
                 name_ptr,
                 NSClass::ns_c_in,
                 T::NS_TYPE,
@@ -877,7 +876,7 @@ impl Channel {
         }
     }
 
-    pub fn get_host_by_addr<T: HostentHandler>(&mut self, ip_addr: &[u8], ctx: &mut T) {
+    pub fn get_host_by_addr<T: HostentHandler>(&self, ip_addr: &[u8], ctx: &mut T) {
         // "0000:0000:0000:0000:0000:ffff:192.168.100.228".length = 45
         const BUF_SIZE: usize = 46;
         let mut addr_buf = [0u8; BUF_SIZE];
@@ -900,7 +899,7 @@ impl Channel {
                 // SAFETY: c-ares FFI; addr holds a 4-byte in_addr written by ares_inet_pton; ctx outlives the channel.
                 unsafe {
                     ares_gethostbyaddr(
-                        self,
+                        self.as_mut_ptr(),
                         addr.as_ptr().cast::<c_void>(),
                         4,
                         AF::INET,
@@ -917,7 +916,7 @@ impl Channel {
                 // SAFETY: c-ares FFI; addr holds a 16-byte in6_addr written by ares_inet_pton; ctx outlives the channel.
                 unsafe {
                     ares_gethostbyaddr(
-                        self,
+                        self.as_mut_ptr(),
                         addr.as_ptr().cast::<c_void>(),
                         16,
                         AF::INET6,
@@ -940,7 +939,7 @@ impl Channel {
     }
 
     /// https://c-ares.org/ares_getnameinfo.html
-    pub fn get_name_info<T: NameinfoHandler>(&mut self, sa: &mut sockaddr, ctx: &mut T) {
+    pub fn get_name_info<T: NameinfoHandler>(&self, sa: &mut sockaddr, ctx: &mut T) {
         let salen: ares_socklen_t = if sa.sa_family == AF::INET as _ {
             core::mem::size_of::<sockaddr_in>() as ares_socklen_t
         } else {
@@ -949,7 +948,7 @@ impl Channel {
         // SAFETY: c-ares FFI; sa is a valid sockaddr of size `salen`; ctx outlives the channel.
         unsafe {
             ares_getnameinfo(
-                self,
+                self.as_mut_ptr(),
                 std::ptr::from_ref::<sockaddr>(sa),
                 salen,
                 // node returns ENOTFOUND for addresses like 255.255.255.255:80
@@ -962,7 +961,7 @@ impl Channel {
     }
 
     #[inline]
-    pub fn process(&mut self, fd: ares_socket_t, readable: bool, writable: bool) {
+    pub fn process(&self, fd: ares_socket_t, readable: bool, writable: bool) {
         ares_process_fd(
             self,
             if readable { fd } else { ARES_SOCKET_BAD },
@@ -1027,15 +1026,11 @@ unsafe extern "C" {
     pub fn ares_destroy_options(options: *mut Options);
     pub fn ares_dup(dest: *mut Channel, src: *mut Channel) -> c_int;
     pub fn ares_destroy(channel: *mut Channel);
-    // Opaque handle by exclusive reference only — `Channel` is `!Freeze`/`!Sync`
-    // (UnsafeCell + PhantomData<*mut u8>). Note: `ares_cancel`/`ares_process_fd`
-    // synchronously invoke stored completion callbacks which may re-enter the
-    // resolver and re-derive a `&mut Channel` from a raw pointer; this is sound
-    // because `Channel` is a ZST (`UnsafeCell<[u8;0]>`), so `&mut Channel`
-    // claims zero bytes and overlapping `&mut` do not conflict under Stacked
-    // Borrows — the borrow checker does NOT gate the raw-pointer callbacks.
-    pub safe fn ares_cancel(channel: &mut Channel);
-    pub safe fn ares_set_local_ip4(channel: &mut Channel, local_ip: c_uint);
+    // Shared handle: `Channel` is `!Freeze`, so `&Channel` carries no `noalias`
+    // and no `readonly`. `ares_cancel`/`ares_process_fd` synchronously invoke
+    // completion callbacks that re-enter through the same pointer.
+    pub safe fn ares_cancel(channel: &Channel);
+    pub safe fn ares_set_local_ip4(channel: &Channel, local_ip: c_uint);
     pub fn ares_set_local_ip6(channel: *mut Channel, local_ip6: *const u8);
     pub fn ares_set_local_dev(channel: *mut Channel, local_dev_name: *const u8);
     pub fn ares_set_socket_callback(
@@ -1151,11 +1146,7 @@ unsafe extern "C" {
     ) -> *mut struct_timeval;
     // pub fn ares_process(channel: *mut Channel, read_fds: *mut fd_set, write_fds: *mut fd_set);
     // Opaque handle by exclusive reference + scalars only.
-    pub safe fn ares_process_fd(
-        channel: &mut Channel,
-        read_fd: ares_socket_t,
-        write_fd: ares_socket_t,
-    );
+    pub safe fn ares_process_fd(channel: &Channel, read_fd: ares_socket_t, write_fd: ares_socket_t);
     pub fn ares_create_query(
         name: *const c_char,
         dnsclass: c_int,

--- a/src/codegen/cppbind.ts
+++ b/src/codegen/cppbind.ts
@@ -461,7 +461,8 @@ const rustSharedTypes: Record<string, string> = {
   "JSC::JSPromise": "crate::JSPromise",
   "JSC::JSMap": "crate::JSMap",
   "JSC::CustomGetterSetter": "crate::CustomGetterSetter",
-  "JSC::SourceProvider": "crate::SourceProvider",
+  // `crate::SourceProvider` is the owning handle; the C++ object is the ZST.
+  "JSC::SourceProvider": "crate::source_provider::sys::SourceProvider",
   "JSC::CallFrame": "crate::CallFrame",
   "JSC::JSObject": "crate::JSObject",
   "JSC::JSString": "crate::JSString",
@@ -469,7 +470,7 @@ const rustSharedTypes: Record<string, string> = {
   "JSC::JSInternalPromise": "crate::JSInternalPromise",
   "WTF::StringImpl": "core::ffi::c_void",
   "WebCore::DOMURL": "crate::DOMURL",
-  "WebCore::EventLoopTask": "crate::cpp_task::CppTask",
+  "WebCore::EventLoopTask": "crate::cpp_task::sys::CppTask",
   // HTTPServerAgent / inspector types only show up in `nothrow` exports;
   // emit as opaque so the raw extern still type-checks.
   "Inspector::InspectorHTTPServerAgent": "core::ffi::c_void",

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -8,7 +8,7 @@ use crate::{
     self as http, AlpnOffer, HTTPCertError, HTTPClient, InitError, get_cert_error_from_no, h2,
 };
 use bun_boringssl::ssl_ctx_setup;
-use bun_boringssl_sys::SSL_CTX;
+use bun_boringssl_sys::sys::SSL_CTX;
 use bun_collections::{HiveArray, TaggedPtrUnion};
 use bun_core::strings;
 use bun_core::{self, Error, FeatureFlags};
@@ -1108,8 +1108,7 @@ impl<const SSL: bool> Drop for HTTPContext<SSL> {
         }
         if SSL {
             if let Some(c) = self.secure {
-                // SAFETY: we own one ref on the SSL_CTX.
-                unsafe { bun_boringssl_sys::SSL_CTX_free(c) };
+                bun_boringssl_sys::SSL_CTX_free(SSL_CTX::opaque_ref(c));
             }
         }
         // Note: `bun.default_allocator.destroy(this)` is the Box drop

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -276,25 +276,26 @@ pub struct CertCheckResumeMessage {
 }
 
 pub struct LibdeflateState {
-    pub decompressor: Option<bun_libdeflate_sys::libdeflate::OwnedDecompressor>,
-    pub compressor: Option<bun_libdeflate_sys::libdeflate::OwnedCompressor>,
+    pub decompressor: Option<bun_libdeflate_sys::libdeflate::Decompressor>,
+    pub compressor: Option<bun_libdeflate_sys::libdeflate::Compressor>,
     pub shared_buffer: [u8; 512 * 1024],
 }
 
-// SAFETY: `Option<Owned{De,}Compressor>` is `#[repr(transparent)]` over
-// `NonNull`, so all-zero = `None`; `[u8; N]` is valid at the all-zero bit
-// pattern.
+// SAFETY: `Option<Compressor>` / `Option<Decompressor>` are
+// `#[repr(transparent)]` over `NonNull`, so all-zero = `None`; `[u8; N]` is
+// valid at the all-zero bit pattern.
 unsafe impl bun_core::Zeroable for LibdeflateState {}
 
 impl LibdeflateState {
-    /// Mutable access to the libdeflate decompressor handle.
+    /// Access to the libdeflate decompressor handle. `&` suffices: libdeflate
+    /// mutates the decompressor's scratch state through a shared borrow.
     ///
     /// `decompressor` is set once in [`HttpThread::deflater`] (panics on OOM)
     /// and is never `None` after that, so the unwrap is infallible.
     #[inline]
-    pub(crate) fn decompressor_mut(&mut self) -> &mut bun_libdeflate_sys::libdeflate::Decompressor {
+    pub(crate) fn decompressor(&self) -> &bun_libdeflate_sys::libdeflate::Decompressor {
         self.decompressor
-            .as_deref_mut()
+            .as_ref()
             .expect("set in HttpThread::deflater()")
     }
 }
@@ -419,7 +420,7 @@ impl HttpThread {
 
     pub fn deflater(&mut self) -> &mut LibdeflateState {
         if self.lazy_libdeflater.is_none() {
-            let decompressor = bun_libdeflate_sys::libdeflate::OwnedDecompressor::new()
+            let decompressor = bun_libdeflate_sys::libdeflate::Decompressor::new()
                 .unwrap_or_else(|| bun_core::out_of_memory());
             let mut state: Box<LibdeflateState> = bun_core::boxed_zeroed();
             state.decompressor = Some(decompressor);

--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -313,7 +313,7 @@ impl<'a> InternalState<'a> {
                             (estimated_size as usize).saturating_sub(body_out_str.list.len()),
                         );
                         body_out_str.list.clear();
-                        let result = deflater.decompressor_mut().decompress_to_vec(
+                        let result = deflater.decompressor().decompress_to_vec(
                             buffer,
                             &mut body_out_str.list,
                             bun_libdeflate::Encoding::Gzip,
@@ -326,9 +326,11 @@ impl<'a> InternalState<'a> {
                     }
                 }
 
+                // Field access, not `deflater.decompressor()`: keeps the borrow
+                // field-split so `&mut deflater.shared_buffer` below still holds.
                 let decompressor = deflater
                     .decompressor
-                    .as_deref_mut()
+                    .as_ref()
                     .expect("set in HttpThread::deflater()");
                 let result = decompressor.decompress(
                     buffer,

--- a/src/http/compress_body.rs
+++ b/src/http/compress_body.rs
@@ -92,7 +92,7 @@ fn compress_libdeflate_fast(
     enc: bun_libdeflate_sys::libdeflate::Encoding,
     level: Option<i32>,
 ) -> Option<usize> {
-    use bun_libdeflate_sys::libdeflate::{Compressor, OwnedCompressor};
+    use bun_libdeflate_sys::libdeflate::Compressor;
 
     // Split-borrow so the compressor handle and `shared_buffer` can be used
     // together.
@@ -102,7 +102,7 @@ fn compress_libdeflate_fast(
         ..
     } = state;
     let cached = compressor.get_or_insert_with(|| {
-        OwnedCompressor::new(DEFAULT_DEFLATE_LEVEL).unwrap_or_else(|| bun_core::out_of_memory())
+        Compressor::new(DEFAULT_DEFLATE_LEVEL).unwrap_or_else(|| bun_core::out_of_memory())
     });
 
     // Bound is level-independent — use the cached handle so the slow-path
@@ -113,10 +113,10 @@ fn compress_libdeflate_fast(
 
     // Custom level → allocate a temporary compressor; the cached handle is
     // pinned to DEFAULT_DEFLATE_LEVEL.
-    let mut tmp: Option<OwnedCompressor> = None;
-    let compressor: &mut Compressor = match level {
+    let mut tmp: Option<Compressor> = None;
+    let compressor: &Compressor = match level {
         Some(l) if l != DEFAULT_DEFLATE_LEVEL => {
-            tmp.insert(OwnedCompressor::new(l).unwrap_or_else(|| bun_core::out_of_memory()))
+            tmp.insert(Compressor::new(l).unwrap_or_else(|| bun_core::out_of_memory()))
         }
         _ => cached,
     };

--- a/src/http/h3_client/ClientContext.rs
+++ b/src/http/h3_client/ClientContext.rs
@@ -40,15 +40,15 @@ static INSTANCE: bun_core::AtomicCell<Option<NonNull<ClientContext>>> =
 static LSQUIC_INIT_ONCE: std::sync::Once = std::sync::Once::new();
 
 impl ClientContext {
-    /// Mutable access to the lsquic client engine.
+    /// Access to the lsquic client engine.
     ///
     /// INVARIANT: `qctx` is set once in `get_or_create` to a fresh
     /// `us_quic_socket_context_t` and is never freed (process-lifetime, same as
-    /// this singleton). HTTP-thread only, so the `&mut` is the sole live borrow.
+    /// this singleton).
     #[inline]
-    fn qctx_mut(&mut self) -> &mut quic::Context {
+    fn qctx(&self) -> &quic::Context {
         // SAFETY: see INVARIANT above.
-        unsafe { &mut *self.qctx.as_ptr() }
+        unsafe { self.qctx.as_ref() }
     }
 
     /// Non-null pointer to the leaked process-lifetime singleton, if created.
@@ -94,11 +94,11 @@ impl ClientContext {
             qctx,
             sessions: Vec::new(),
         });
-        // Route through the existing [`qctx_mut`] / [`as_mut`] accessors (one
-        // centralised unsafe each) instead of an open-coded `qctx.as_mut()`.
+        // Route through the existing [`qctx`] / [`as_mut`] accessors (one
+        // centralised unsafe each) instead of an open-coded `qctx.as_ref()`.
         // `self_` is the freshly-boxed sole owner; callbacks don't fire until
         // the loop runs, so registering after construction is order-neutral.
-        callbacks::register(Self::as_mut(self_).qctx_mut());
+        callbacks::register(Self::as_mut(self_).qctx());
         INSTANCE.store(Some(self_));
         Some(self_)
     }
@@ -139,9 +139,9 @@ impl ClientContext {
         self.sessions.push(session);
         session_mut(session).enqueue(client);
 
-        let result =
-            self.qctx_mut()
-                .connect(host_z, port, host_z, reject, session.cast::<c_void>());
+        let result = self
+            .qctx()
+            .connect(host_z, port, host_z, reject, session.cast::<c_void>());
         match result {
             ConnectResult::Socket(qs) => {
                 session_mut(session).qsocket = NonNull::new(qs);
@@ -164,7 +164,7 @@ impl ClientContext {
                     bstr::BStr::new(hostname),
                     port,
                 );
-                let l = self.qctx_mut().r#loop();
+                let l = self.qctx().r#loop();
                 PendingConnect::register(session, pending, l.cast::<UwsLoop>());
             }
             ConnectResult::Err => {

--- a/src/http/h3_client/ClientSession.rs
+++ b/src/http/h3_client/ClientSession.rs
@@ -132,10 +132,10 @@ impl ClientSession {
             if let crate::HTTPRequestBody::Stream(s) = &mut client.state.original_request_body {
                 s.ended = ended;
             }
-            // `drain_send_body` needs `&mut Stream` and `&mut quic::Stream` at
-            // once; they are disjoint objects, so bypass `Stream::qstream_mut`.
+            // `drain_send_body` needs `&mut Stream` and `&quic::Stream` at once;
+            // they are disjoint objects, so bypass `Stream::qstream_ref`.
             if let Some(qs) = stream.qstream {
-                encode::drain_send_body(stream, quic_stream_mut(qs.as_ptr()));
+                encode::drain_send_body(stream, quic_stream_ref(qs.as_ptr()));
             }
             return;
         }
@@ -151,7 +151,7 @@ impl ClientSession {
                 continue;
             }
             if core::mem::take(&mut stream.read_paused) {
-                if let Some(qs) = stream.qstream_mut() {
+                if let Some(qs) = stream.qstream_ref() {
                     qs.want_read(true);
                 }
             }
@@ -167,7 +167,7 @@ impl ClientSession {
         }
         st.client = None;
         let request_body_done = st.request_body_done;
-        if let Some(qs) = st.qstream_mut() {
+        if let Some(qs) = st.qstream_ref() {
             qs.ext::<Stream>().set(None);
             // The success path can reach here while the request body is still
             // being written (server responded early). FIN would be a
@@ -412,16 +412,18 @@ pub(super) fn quic_socket_mut<'a>(qs: *mut quic::Socket) -> &'a mut quic::Socket
     unsafe { &mut *qs }
 }
 
-/// Upgrade a non-null `*mut quic::Stream` lsquic FFI handle to `&mut`.
+/// Upgrade a non-null `*mut quic::Stream` lsquic FFI handle to `&`.
 ///
 /// Same INVARIANT as [`quic_socket_mut`] — lsquic-owned, live for the
 /// borrow's duration (callback argument, or `Stream.qstream` set in
 /// `on_stream_open` and nulled in `on_stream_close` / `detach`), FFI
-/// allocation distinct from any Rust holder, HTTP-thread-only.
+/// allocation distinct from any Rust holder, HTTP-thread-only. `quic::Stream`
+/// is an opaque FFI ZST whose methods all take `&self`, so there is no `&mut`
+/// to hand out — lsquic mutates the real stream through the handle.
 #[inline(always)]
-pub(super) fn quic_stream_mut<'a>(s: *mut quic::Stream) -> &'a mut quic::Stream {
+pub(super) fn quic_stream_ref<'a>(s: *mut quic::Stream) -> &'a quic::Stream {
     // SAFETY: see [`quic_socket_mut`] INVARIANT.
-    unsafe { &mut *s }
+    unsafe { &*s }
 }
 
 /// Upgrade a `*mut Stream` (a `self.pending` entry, or one just removed from

--- a/src/http/h3_client/PendingConnect.rs
+++ b/src/http/h3_client/PendingConnect.rs
@@ -38,7 +38,7 @@ impl Drop for PendingConnect {
 }
 
 impl PendingConnect {
-    /// Mutable access to the owned `quic::PendingConnect` C handle.
+    /// Shared access to the owned `quic::PendingConnect` C handle.
     ///
     /// INVARIANT: `pc` is set once in [`register`] to a live
     /// `us_quic_pending_connect_t` and is consumed by exactly one of
@@ -47,9 +47,9 @@ impl PendingConnect {
     /// every caller. Centralises the raw `(*this.pc)` upgrade repeated at
     /// each consume site.
     #[inline]
-    fn pc_mut(&mut self) -> &mut quic::PendingConnect {
+    fn pc(&self) -> &quic::PendingConnect {
         // SAFETY: see INVARIANT above.
-        unsafe { &mut *self.pc }
+        unsafe { &*self.pc }
     }
 
     pub fn register(session: *mut ClientSession, pc: *mut quic::PendingConnect, l: *mut uws::Loop) {
@@ -57,14 +57,14 @@ impl PendingConnect {
         // holds one ref from construction until Drop. `session_mut` centralises
         // the backref upgrade (same invariant as the other call sites below).
         session_mut(session).ref_();
-        let mut self_ = Box::new(PendingConnect {
+        let self_ = Box::new(PendingConnect {
             session,
             pc,
             loop_ptr: l,
         });
-        // Route the addrinfo read through the existing [`pc_mut`] accessor
+        // Route the addrinfo read through the existing [`pc`] accessor
         // (centralised raw upgrade) instead of an open-coded `(*pc)` deref.
-        let addrinfo = self_.pc_mut().addrinfo();
+        let addrinfo = self_.pc().addrinfo();
         let self_ = bun_core::heap::into_raw(self_);
         // SAFETY: `self_` is the Box we just leaked above and is consumed by
         // `on_dns_resolved` (via the global cache's notify path).
@@ -80,7 +80,7 @@ impl PendingConnect {
     pub unsafe fn on_dns_resolved(this: *mut PendingConnect) {
         // SAFETY: `this` was heap-allocated in `register`; reclaim it so the Box drops at
         // end of scope — `Drop` derefs `session` and the allocation is freed.
-        let mut this = unsafe { bun_core::heap::take(this) };
+        let this = unsafe { bun_core::heap::take(this) };
         let session = this.session;
 
         // session is kept alive by the ref `this` holds for the duration of this
@@ -88,23 +88,24 @@ impl PendingConnect {
         let s = session_mut(session);
         if s.closed || s.pending.is_empty() {
             // Every waiter was aborted while DNS was in flight; don't open a
-            // connection nobody will use. `pc_mut` upgrades the owned C
+            // connection nobody will use. `pc` upgrades the owned C
             // handle; `cancel()` consumes it.
-            this.pc_mut().cancel();
+            this.pc().cancel();
             if !s.closed {
                 Self::fail_session(session, bun_core::err!("Aborted"));
             }
             return;
         }
-        // `pc_mut` upgrades the owned C handle; `resolved()` consumes it and
+        // `pc` upgrades the owned C handle; `resolved()` consumes it and
         // returns the connected quic socket or None on DNS failure.
-        let Some(qs) = this.pc_mut().resolved() else {
+        let Some(qs) = this.pc().resolved() else {
             Self::fail_session(session, bun_core::err!("DNSResolutionFailed"));
             return;
         };
-        s.qsocket = Some(NonNull::from(&mut *qs));
-        // qs.ext() returns the per-socket user storage slot for ClientSession.
-        *qs.ext::<ClientSession>() = NonNull::new(session);
+        s.qsocket = Some(qs);
+        // `ext()` hands back the per-socket user storage slot, so it needs the
+        // exclusive borrow; `opaque_mut` is the centralised non-null deref.
+        *quic::Socket::opaque_mut(qs.as_ptr()).ext::<ClientSession>() = NonNull::new(session);
     }
 
     /// DNS worker may call from off the HTTP thread; mirror

--- a/src/http/h3_client/Stream.rs
+++ b/src/http/h3_client/Stream.rs
@@ -59,16 +59,16 @@ impl Stream {
         }))
     }
 
-    /// Mutable access to the bound lsquic stream handle.
+    /// Access to the bound lsquic stream handle.
     ///
     /// INVARIANT: `qstream` is set in `callbacks::on_stream_open` and remains
     /// valid until `callbacks::on_stream_close` / `ClientSession::detach`
-    /// nulls it. HTTP-thread-only. Borrows `self` exclusively so no two live
-    /// `&mut quic::Stream` can be minted from one `Stream`.
+    /// nulls it. HTTP-thread-only. `quic::Stream` is an opaque FFI ZST, so `&`
+    /// carries no `noalias` — lsquic mutates the stream through the handle.
     #[inline]
-    pub fn qstream_mut(&mut self) -> Option<&mut quic::Stream> {
+    pub fn qstream_ref(&self) -> Option<&quic::Stream> {
         self.qstream
-            .map(|qs| super::client_session::quic_stream_mut(qs.as_ptr()))
+            .map(|qs| super::client_session::quic_stream_ref(qs.as_ptr()))
     }
 
     /// Mutable access to the owning `ClientSession`.
@@ -87,7 +87,7 @@ impl Stream {
     }
 
     pub fn abort(&mut self) {
-        if let Some(qs) = self.qstream_mut() {
+        if let Some(qs) = self.qstream_ref() {
             qs.close();
         }
     }

--- a/src/http/h3_client/callbacks.rs
+++ b/src/http/h3_client/callbacks.rs
@@ -35,13 +35,13 @@ fn qsocket_arg<'a>(qs: *mut quic::Socket) -> &'a mut quic::Socket {
     super::client_session::quic_socket_mut(qs)
 }
 
-/// Upgrade an lsquic-supplied `*mut quic::Stream` callback argument to `&mut`.
+/// Upgrade an lsquic-supplied `*mut quic::Stream` callback argument to `&`.
 /// Same INVARIANT as [`qsocket_arg`] (lsquic-owned, live for the callback,
 /// HTTP-thread-only). Routes through the shared
-/// [`client_session::quic_stream_mut`] accessor.
+/// [`client_session::quic_stream_ref`] accessor.
 #[inline(always)]
-fn qstream_arg<'a>(s: *mut quic::Stream) -> &'a mut quic::Stream {
-    super::client_session::quic_stream_mut(s)
+fn qstream_arg<'a>(s: *mut quic::Stream) -> &'a quic::Stream {
+    super::client_session::quic_stream_ref(s)
 }
 
 /// Recover the `ClientSession` from a `quic::Socket`'s ext slot.
@@ -65,16 +65,15 @@ fn session_of<'a>(qs: &mut quic::Socket) -> Option<&'a mut ClientSession> {
 /// INVARIANT: the slot is set in `on_stream_open` (and cleared in `detach`);
 /// the `Stream` is heap-owned by its `ClientSession` (`pending` list) and lives
 /// until `detach()`. HTTP-thread only, and a distinct allocation from the
-/// `quic::Stream`, so the returned `&mut` neither aliases the caller's
-/// `&mut quic::Stream` nor any other live borrow.
+/// `quic::Stream`, so the returned `&mut` does not alias any other live borrow.
 #[inline]
-fn stream_of<'a>(s: &mut quic::Stream) -> Option<&'a mut Stream> {
+fn stream_of<'a>(s: &quic::Stream) -> Option<&'a mut Stream> {
     // Route through `client_session::stream_mut` (one centralised unsafe);
     // the ext slot is `Option<NonNull<Stream>>` — same backref invariant.
     s.ext::<Stream>().get().map(|p| stream_mut(p.as_ptr()))
 }
 
-pub(crate) fn register(qctx: &mut quic::Context) {
+pub(crate) fn register(qctx: &quic::Context) {
     qctx.on_hsk_done(on_hsk_done);
     qctx.on_goaway(on_goaway);
     qctx.on_close(on_conn_close);
@@ -194,7 +193,7 @@ extern "C" fn on_stream_open(s: *mut quic::Stream, is_client: c_int) {
     };
     // `stream` is a live element of `session.pending` — `stream_mut`
     // centralises that upgrade invariant.
-    stream_mut(stream).qstream = Some(NonNull::from(&mut *s));
+    stream_mut(stream).qstream = Some(NonNull::from(s));
     s.ext::<Stream>().set(NonNull::new(stream));
     bun_core::scoped_log!(h3_client, "stream_open");
     if let Err(e) = encode::write_request(session, stream_mut(stream), s) {

--- a/src/http/h3_client/encode.rs
+++ b/src/http/h3_client/encode.rs
@@ -20,7 +20,7 @@ use crate::{HTTPClient, HTTPVerboseLevel, Protocol};
 pub fn write_request(
     session: &ClientSession,
     stream: &mut Stream,
-    qs: &mut quic::Stream,
+    qs: &quic::Stream,
 ) -> Result<(), bun_core::Error> {
     let Some(client_ptr) = stream.client else {
         return Err(err!(Aborted));
@@ -147,7 +147,7 @@ pub fn write_request(
 /// Push as much of the request body onto `qs` as flow control allows. Called
 /// from `write_request`, `callbacks.on_stream_writable`, and
 /// `ClientSession.stream_body_by_http_id` (when the JS sink delivers more bytes).
-pub(crate) fn drain_send_body(stream: &mut Stream, qs: &mut quic::Stream) {
+pub(crate) fn drain_send_body(stream: &mut Stream, qs: &quic::Stream) {
     if stream.request_body_done {
         return;
     }

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -173,8 +173,8 @@ impl<const SSL: bool> WebSocket<SSL> {
         self.message_is_compressed.set(false);
         self.deflate.replace(None);
         if let Some(s) = self.secure.take() {
-            // SAFETY: s is a valid SSL_CTX* owned by us per field invariant
-            unsafe { boringssl::c::SSL_CTX_free(s) };
+            // `s` is an owned SSL_CTX ref per the field invariant.
+            boringssl::c::SSL_CTX_free(SslCtx::opaque_ref(s));
         }
         // Detach the tunnel first so its shutdown callbacks cannot re-enter this path.
         if let Some(tunnel) = self.proxy_tunnel.take() {

--- a/src/http_jsc/websocket_client/WebSocketDeflate.rs
+++ b/src/http_jsc/websocket_client/WebSocketDeflate.rs
@@ -33,7 +33,7 @@ impl Params {
 
 #[derive(Default)]
 pub struct RareData {
-    libdeflate_decompressor: Option<libdeflate_sys::OwnedDecompressor>,
+    libdeflate_decompressor: Option<libdeflate_sys::Decompressor>,
     // PERF: a 128KB inline buffer reused as scratch for (de)compression
     // output could avoid per-call allocation — profile if hot.
 }
@@ -46,11 +46,11 @@ impl RareData {
         Vec::with_capacity(Self::STACK_BUFFER_SIZE)
     }
 
-    pub fn decompressor(&mut self) -> Option<&mut libdeflate_sys::Decompressor> {
+    pub fn decompressor(&mut self) -> Option<&libdeflate_sys::Decompressor> {
         if self.libdeflate_decompressor.is_none() {
-            self.libdeflate_decompressor = libdeflate_sys::OwnedDecompressor::new();
+            self.libdeflate_decompressor = libdeflate_sys::Decompressor::new();
         }
-        self.libdeflate_decompressor.as_deref_mut()
+        self.libdeflate_decompressor.as_ref()
     }
 }
 

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -35,7 +35,7 @@ use bun_io::KeepAlive;
 use bun_jsc::{JSGlobalObject, JsCell, VirtualMachineRef};
 use bun_picohttp as picohttp;
 use bun_ptr::ThisPtr;
-use bun_uws::{self as uws, SocketHandler, SocketKind, SslCtx};
+use bun_uws::{self as uws, SocketHandler, SocketKind};
 
 use super::cpp_websocket::CppWebSocket;
 use super::websocket_deflate as WebSocketDeflate;
@@ -87,27 +87,6 @@ enum State {
     Done,
 }
 
-/// Owned +1 reference to a `us_ssl_ctx_t` (`SSL_CTX*`); releases the ref via
-/// `SSL_CTX_free` on drop (BoringSSL decrements its internal refcount).
-/// Either dropped here, or transferred to the connected `WebSocket` via
-/// `into_raw()` after the upgrade completes.
-struct SslCtxOwned(*mut SslCtx);
-
-impl SslCtxOwned {
-    /// Transfer ownership of the retained ref to the caller without freeing.
-    fn into_raw(self) -> *mut SslCtx {
-        core::mem::ManuallyDrop::new(self).0
-    }
-}
-
-impl Drop for SslCtxOwned {
-    fn drop(&mut self) {
-        // SAFETY: `self.0` is an owned retained ref (returned with +1 by
-        // `ssl_ctx_cache_get_or_create`) that has not been transferred out.
-        unsafe { boringssl::c::SSL_CTX_free(self.0) };
-    }
-}
-
 /// WebSocket HTTP upgrade client, generic over `SSL`.
 ///
 /// Intrusive single-thread
@@ -141,7 +120,7 @@ pub struct HTTPClient<const SSL: bool> {
     /// Heap-allocated because ownership transfers to the connected
     /// `WebSocket` after the upgrade completes (so the `SSL_CTX` outlives
     /// this struct). RAII: dropping the wrapper releases the retained ref.
-    secure: Option<SslCtxOwned>,
+    secure: Option<boringssl::c::SSL_CTX>,
 
     /// Expected Sec-WebSocket-Accept value for handshake validation per RFC 6455 §4.2.2.
     /// This is base64(SHA-1(Sec-WebSocket-Key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")).
@@ -443,7 +422,8 @@ impl<const SSL: bool> HTTPClient<SSL> {
                         };
                         // Owned ref; transferred to the connected WebSocket on
                         // upgrade, freed in `deinit` if we never get that far.
-                        client_box.secure = Some(SslCtxOwned(ctx));
+                        // SAFETY: `ssl_ctx_cache_get_or_create` handed back a +1.
+                        client_box.secure = unsafe { boringssl::c::SSL_CTX::adopt_ptr(ctx) };
                         break 'brk Some(ctx);
                     }
                 }
@@ -590,7 +570,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
         }
         // ssl_config: Option<Box<SSLConfig>> — Drop runs SSLConfig::deinit + frees the box.
         self.ssl_config = None;
-        // secure: Option<SslCtxOwned> — Drop releases the ref taken in `connect`.
+        // secure: Option<SSL_CTX> — Drop releases the ref taken in `connect`.
         self.secure = None;
     }
 
@@ -1698,9 +1678,9 @@ impl<const SSL: bool> HTTPClient<SSL> {
                         } else {
                             None
                         },
-                        // ownership transferred; `into_raw` suppresses the
-                        // RAII release at fn end.
-                        saved_secure.take().map(|s| &mut *s.into_raw()),
+                        // ownership transferred; `leak` suppresses the RAII
+                        // release at fn end.
+                        saved_secure.take().map(|s| &mut *s.leak().as_ptr()),
                     )
                 };
             } else {

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -103,7 +103,7 @@ pub struct TarballStream {
     reading: Vec<u8>,
     read_pos: usize,
 
-    archive: Option<*mut lib::Archive>,
+    archive: Option<*mut lib::sys::Archive>,
 
     /// Where we are in the per-entry state machine between drain
     /// invocations. libarchive preserves everything else (filter buffers,
@@ -585,7 +585,7 @@ impl TarballStream {
     /// lifetime of the archive — see `step()` # Safety for the provenance
     /// requirement.
     unsafe fn open_archive(this: *mut Self) -> Result<(), bun_core::Error> {
-        let archive = lib::Archive::read_new();
+        let archive = lib::sys::Archive::read_new();
         let guard = scopeguard::guard(archive, |a| {
             // SAFETY: errdefer cleanup — archive is a valid handle from read_new().
             unsafe {
@@ -593,19 +593,18 @@ impl TarballStream {
                 let _ = (*a).read_free();
             }
         });
+        // SAFETY: `read_new()` asserts non-null; the handle outlives `a`.
+        let a: &lib::sys::Archive = unsafe { &*archive };
         // Bypass bidding entirely: the stream is always gzip → tar, and
         // bidding would try to read-ahead before any bytes have arrived.
         // ARCHIVE_FILTER_GZIP = 1, ARCHIVE_FORMAT_TAR = 0x30000.
-        // SAFETY: archive is a valid non-null handle from read_new(); FFI call has no other preconditions.
-        if unsafe { lib::archive_read_append_filter(archive, 1) } != 0 {
+        if lib::archive_read_append_filter(a, 1) != 0 {
             return Err(bun_core::err!("Fail"));
         }
-        // SAFETY: archive is a valid non-null handle from read_new(); FFI call has no other preconditions.
-        if unsafe { lib::archive_read_set_format(archive, 0x30000) } != 0 {
+        if lib::archive_read_set_format(a, 0x30000) != 0 {
             return Err(bun_core::err!("Fail"));
         }
-        // SAFETY: archive is a valid handle.
-        let _ = unsafe { (*archive).read_set_options(c"read_concatenated_archives") };
+        let _ = a.read_set_options(c"read_concatenated_archives");
 
         // SAFETY: archive is a valid handle; `this` outlives the archive
         // (freed only in `Drop` after `read_free`). See fn-level # Safety
@@ -613,7 +612,7 @@ impl TarballStream {
         // `&mut self`-derived pointer.
         let rc_raw: c_int = unsafe {
             lib::archive_read_open(
-                archive,
+                a,
                 this.cast::<c_void>(),
                 None,
                 Some(archive_read_callback),
@@ -644,8 +643,7 @@ impl TarballStream {
                 bun_output::scoped_log!(
                     TarballStream,
                     "archive_read_open: {}",
-                    // SAFETY: archive is a valid handle (guard not yet dropped).
-                    bstr::BStr::new(unsafe { (*archive).error_string() })
+                    bstr::BStr::new(a.error_string())
                 );
                 return Err(bun_core::err!("Fail"));
             }
@@ -927,7 +925,7 @@ impl TarballStream {
             if block.offset > self.entry_actual_offset {
                 let zero_count: usize =
                     usize::try_from(block.offset - self.entry_actual_offset).expect("int cast");
-                match lib::Archive::write_zeros_to_file(file, zero_count) {
+                match lib::sys::Archive::write_zeros_to_file(file, zero_count) {
                     lib::Result::Ok => {
                         self.entry_actual_offset = block.offset;
                     }
@@ -1231,7 +1229,7 @@ fn drain_callback(task: *mut thread_pool::Task) {
 /// in that setup, so there is no caller-side precondition to encode in the
 /// signature. The fn-pointer still coerces to the binding's expected type.
 extern "C" fn archive_read_callback(
-    _a: *mut lib::Archive,
+    _a: *mut lib::sys::Archive,
     ctx: *mut c_void,
     out_buffer: *mut *const c_void,
 ) -> lib::la_ssize_t {

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -322,7 +322,7 @@ impl ExtractTarball {
                 && esimated_output_size > 0
             {
                 use bun_libdeflate_sys::libdeflate;
-                if let Some(mut decompressor) = libdeflate::OwnedDecompressor::new() {
+                if let Some(decompressor) = libdeflate::Decompressor::new() {
                     zlib_pool.list.clear();
                     let result = decompressor.decompress_to_vec(
                         tgz_bytes,

--- a/src/install_types/Cargo.toml
+++ b/src/install_types/Cargo.toml
@@ -24,3 +24,4 @@ bun_collections.workspace = true
 bun_ast.workspace = true
 bun_semver.workspace = true
 bun_wyhash.workspace = true
+bun_opaque.workspace = true

--- a/src/install_types/NodeLinker.rs
+++ b/src/install_types/NodeLinker.rs
@@ -73,8 +73,6 @@ pub mod npm {
 // (`__bun_regex_*`) defined `#[no_mangle]` in `bun_jsc::regular_expression`.
 // ══════════════════════════════════════════════════════════════════════════
 
-use core::ptr::NonNull;
-
 use bun_alloc::Arena;
 use bun_ast as ast;
 use bun_core::escape_reg_exp::escape_reg_exp_for_package_name_matching;
@@ -94,10 +92,6 @@ pub mod sys {
     }
 }
 
-// `__bun_regex_compile` allocates and hands back the sole owning pointer. One
-// `RegularExpression` handle owns exactly that allocation.
-bun_opaque::foreign_owned!(sys::RegularExpression, __bun_regex_drop);
-
 // LAYERING: the bodies live `#[no_mangle]` in the higher-tier
 // `bun_jsc::regular_expression`; declared `extern "Rust"`, resolved at link time.
 // `&sys::RegularExpression` is ABI-identical to the pointer they take.
@@ -111,51 +105,15 @@ unsafe extern "Rust" {
     safe fn __bun_regex_drop(regex: &sys::RegularExpression);
 }
 
-/// Owned handle to a JSC `Yarr::RegularExpression`.
-///
-/// Holds the one ownership unit `__bun_regex_compile` produced; `Drop` gives it
-/// back. [`Self::matches`] takes `&self`: Yarr mutates its match state through
-/// the same pointer, so there is no `&mut self` to have.
-#[repr(transparent)]
-pub struct RegularExpression(bun_opaque::ForeignRef<sys::RegularExpression>);
-
-/// Ownership plumbing.
-impl RegularExpression {
-    /// Adopt the allocation returned by `__bun_regex_compile`.
+// `__bun_regex_compile` allocates and hands back the sole owning pointer. One
+// `RegularExpression` handle owns exactly that allocation.
+bun_opaque::foreign_handle! {
+    /// Owned handle to a JSC `Yarr::RegularExpression`.
     ///
-    /// # Safety
-    /// `ptr` must be live and carry the sole ownership unit, which no other
-    /// handle will give back.
-    #[inline]
-    pub unsafe fn adopt(ptr: NonNull<sys::RegularExpression>) -> Self {
-        // SAFETY: caller transfers ownership.
-        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
-    }
-
-    /// Adopt a nullable owning pointer; `None` on null.
-    #[inline]
-    fn adopt_ptr(ptr: *mut sys::RegularExpression) -> Option<Self> {
-        // SAFETY: `__bun_regex_compile` returns a fresh allocation or null; it
-        // already freed the handle on the invalid-pattern path.
-        NonNull::new(ptr).map(|p| unsafe { Self::adopt(p) })
-    }
-
-    /// The JSC pointer, still owned by `self`.
-    #[inline]
-    pub fn as_ptr(&self) -> *mut sys::RegularExpression {
-        self.0.as_ptr()
-    }
-
-    /// Hand our allocation to a foreign owner. Pairs with a later [`Self::adopt`].
-    #[inline]
-    pub fn leak(self) -> NonNull<sys::RegularExpression> {
-        self.0.leak()
-    }
-
-    #[inline]
-    fn raw(&self) -> &sys::RegularExpression {
-        &self.0
-    }
+    /// Holds the one ownership unit `__bun_regex_compile` produced; `Drop` gives it
+    /// back. [`Self::matches`] takes `&self`: Yarr mutates its match state through
+    /// the same pointer, so there is no `&mut self` to have.
+    pub struct RegularExpression(sys::RegularExpression) via __bun_regex_drop;
 }
 
 /// Matching. `&self`: Yarr mutates through the same pointer.
@@ -172,7 +130,10 @@ impl RegularExpression {
 /// §extern-Rust-ban).
 #[inline]
 pub(crate) fn compile_regex(pattern: BunString) -> Option<RegularExpression> {
-    RegularExpression::adopt_ptr(__bun_regex_compile(pattern))
+    // SAFETY: `__bun_regex_compile` leaks a fresh `+1` to us, or returns null on an
+    // invalid pattern — having already freed the regex it allocated, so there is
+    // nothing for us to adopt.
+    unsafe { RegularExpression::adopt_ptr(__bun_regex_compile(pattern)) }
 }
 
 pub struct PnpmMatcher {

--- a/src/install_types/NodeLinker.rs
+++ b/src/install_types/NodeLinker.rs
@@ -80,47 +80,99 @@ use bun_ast as ast;
 use bun_core::escape_reg_exp::escape_reg_exp_for_package_name_matching;
 use bun_core::{String as BunString, strings};
 
-// LAYERING: `bun_jsc::RegularExpression` (Yarr FFI) lives in a higher tier.
-// The bodies are defined `#[no_mangle]` in
-// `bun_jsc::regular_expression`; declared here as `extern "Rust"` and
-// resolved at link time.
-unsafe extern "Rust" {
-    /// Compile `pattern` with no flags. `None` ⇔ `error.InvalidRegExp`.
-    /// Performs `jsc::initialize(false)` lazily on first call.
-    fn __bun_regex_compile(pattern: BunString) -> Option<NonNull<()>>;
-    fn __bun_regex_matches(regex: NonNull<()>, input: &BunString) -> bool;
-    fn __bun_regex_drop(regex: NonNull<()>);
+// FORWARD_DECL(b0): this tier cannot name `bun_jsc::RegularExpression`, so it
+// re-declares the handle. The two ZSTs meet only at the `extern "Rust"`
+// boundary below, where both are a bare non-null pointer.
+/// The JSC object itself. Only the extern declarations below name this type;
+/// all Rust code uses the owning [`RegularExpression`] handle.
+pub mod sys {
+    bun_opaque::opaque_ffi! {
+        /// `JSC::Yarr::RegularExpression`. `&Self` is ABI-identical to a
+        /// non-null `RegularExpression*` and carries no `noalias`/`readonly` —
+        /// Yarr mutates its match state through it.
+        pub struct RegularExpression;
+    }
 }
 
-/// Owned, type-erased JSC regex; drops through the vtable.
-// FORWARD_DECL(b0): bun_jsc::RegularExpression — stored as raw NonNull<()>
-// (NOT Box<ZST>: a zero-sized opaque Box is a dangling sentinel that would
-// leak the real JSC allocation and skip its destructor).
-pub struct RegularExpression(NonNull<()>);
+// `__bun_regex_compile` allocates and hands back the sole owning pointer. One
+// `RegularExpression` handle owns exactly that allocation.
+bun_opaque::foreign_owned!(sys::RegularExpression, __bun_regex_drop);
 
+// LAYERING: the bodies live `#[no_mangle]` in the higher-tier
+// `bun_jsc::regular_expression`; declared `extern "Rust"`, resolved at link time.
+// `&sys::RegularExpression` is ABI-identical to the pointer they take.
+unsafe extern "Rust" {
+    /// Compile `pattern` with no flags. Null ⇔ `error.InvalidRegExp`.
+    /// Performs `jsc::initialize(false)` lazily on first call.
+    safe fn __bun_regex_compile(pattern: BunString) -> *mut sys::RegularExpression;
+    safe fn __bun_regex_matches(regex: &sys::RegularExpression, input: &BunString) -> bool;
+    // safe: runs the Yarr destructor + free. Giving the allocation back is not
+    // exclusive access, so the receiver is `&`, not `&mut`.
+    safe fn __bun_regex_drop(regex: &sys::RegularExpression);
+}
+
+/// Owned handle to a JSC `Yarr::RegularExpression`.
+///
+/// Holds the one ownership unit `__bun_regex_compile` produced; `Drop` gives it
+/// back. [`Self::matches`] takes `&self`: Yarr mutates its match state through
+/// the same pointer, so there is no `&mut self` to have.
+#[repr(transparent)]
+pub struct RegularExpression(bun_opaque::ForeignRef<sys::RegularExpression>);
+
+/// Ownership plumbing.
+impl RegularExpression {
+    /// Adopt the allocation returned by `__bun_regex_compile`.
+    ///
+    /// # Safety
+    /// `ptr` must be live and carry the sole ownership unit, which no other
+    /// handle will give back.
+    #[inline]
+    pub unsafe fn adopt(ptr: NonNull<sys::RegularExpression>) -> Self {
+        // SAFETY: caller transfers ownership.
+        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
+    }
+
+    /// Adopt a nullable owning pointer; `None` on null.
+    #[inline]
+    fn adopt_ptr(ptr: *mut sys::RegularExpression) -> Option<Self> {
+        // SAFETY: `__bun_regex_compile` returns a fresh allocation or null; it
+        // already freed the handle on the invalid-pattern path.
+        NonNull::new(ptr).map(|p| unsafe { Self::adopt(p) })
+    }
+
+    /// The JSC pointer, still owned by `self`.
+    #[inline]
+    pub fn as_ptr(&self) -> *mut sys::RegularExpression {
+        self.0.as_ptr()
+    }
+
+    /// Hand our allocation to a foreign owner. Pairs with a later [`Self::adopt`].
+    #[inline]
+    pub fn leak(self) -> NonNull<sys::RegularExpression> {
+        self.0.leak()
+    }
+
+    #[inline]
+    fn raw(&self) -> &sys::RegularExpression {
+        &self.0
+    }
+}
+
+/// Matching. `&self`: Yarr mutates through the same pointer.
 impl RegularExpression {
     #[inline]
     pub(crate) fn matches(&self, input: &BunString) -> bool {
-        // SAFETY: self.0 was produced by `__bun_regex_compile`.
-        unsafe { __bun_regex_matches(self.0, input) }
+        __bun_regex_matches(self.raw(), input)
     }
 }
 
-impl Drop for RegularExpression {
-    fn drop(&mut self) {
-        // SAFETY: self.0 was produced by `__bun_regex_compile`; runs JSC destructor + free.
-        unsafe { __bun_regex_drop(self.0) }
-    }
-}
-
-/// Compile `pattern` into a Yarr regex via the link-time extern. `pub` so
-/// higher-tier callers re-use this single declaration site instead of
-/// duplicating the `__bun_regex_*` extern block (one declarer per upward call,
-/// per PORTING.md §extern-Rust-ban).
+/// Compile `pattern` into a Yarr regex via the link-time extern. The single
+/// declaration site for `__bun_regex_*`, so higher-tier callers do not
+/// duplicate the extern block (one declarer per upward call, per PORTING.md
+/// §extern-Rust-ban).
 #[inline]
 pub(crate) fn compile_regex(pattern: BunString) -> Option<RegularExpression> {
-    // SAFETY: link-time extern; pattern ownership transfers.
-    unsafe { __bun_regex_compile(pattern) }.map(RegularExpression)
+    RegularExpression::adopt_ptr(__bun_regex_compile(pattern))
 }
 
 pub struct PnpmMatcher {

--- a/src/jsc/CachedBytecode.rs
+++ b/src/jsc/CachedBytecode.rs
@@ -17,15 +17,14 @@ pub mod sys {
 // `JSC::encodeCodeBlock` allocates and the C++ generator does an explicit
 // `->ref()` before leaking the pointer through the out-param, so Rust receives
 // a `+1`. One `CachedBytecode` handle owns exactly that one ref.
-bun_opaque::foreign_owned!(sys::CachedBytecode, CachedBytecode__deref);
-
-/// Owned handle to a C++ `JSC::CachedBytecode`.
-///
-/// Holds one ref on the WTF intrusive refcount; `Drop` gives it back, freeing
-/// the bytecode buffer at zero. There is no `&mut self` and no `DerefMut`: a
-/// refcount is shared by definition, and a decrement is not exclusive access.
-#[repr(transparent)]
-pub struct CachedBytecode(bun_opaque::ForeignRef<sys::CachedBytecode>);
+bun_opaque::foreign_handle! {
+    /// Owned handle to a C++ `JSC::CachedBytecode`.
+    ///
+    /// Holds one ref on the WTF intrusive refcount; `Drop` gives it back, freeing
+    /// the bytecode buffer at zero. There is no `&mut self` and no `DerefMut`: a
+    /// refcount is shared by definition, and a decrement is not exclusive access.
+    pub struct CachedBytecode(sys::CachedBytecode) via CachedBytecode__deref;
+}
 
 unsafe extern "C" {
     fn generateCachedModuleByteCodeFromSourceCode(
@@ -50,38 +49,6 @@ unsafe extern "C" {
     // refcount decrement is not exclusive access — other refs exist by
     // definition — so the receiver is `&`, not `&mut`.
     safe fn CachedBytecode__deref(this: &sys::CachedBytecode);
-}
-
-/// Ownership plumbing.
-impl CachedBytecode {
-    /// Adopt a `+1` returned by C++.
-    ///
-    /// # Safety
-    /// `ptr` must carry exactly one ref that no other handle will release.
-    #[inline]
-    pub unsafe fn adopt(ptr: NonNull<sys::CachedBytecode>) -> Self {
-        // SAFETY: caller transfers the +1.
-        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
-    }
-
-    /// Adopt a nullable `+1`; `None` on null.
-    #[inline]
-    fn adopt_ptr(ptr: Option<NonNull<sys::CachedBytecode>>) -> Option<Self> {
-        // SAFETY: the C++ generators `->ref()` before writing the out-param.
-        ptr.map(|p| unsafe { Self::adopt(p) })
-    }
-
-    /// The C++ pointer, still owned by `self`.
-    #[inline]
-    pub fn as_ptr(&self) -> *mut sys::CachedBytecode {
-        self.0.as_ptr()
-    }
-
-    /// Hand our `+1` to a foreign owner. Pairs with a later [`Self::adopt`].
-    #[inline]
-    pub fn leak(self) -> NonNull<sys::CachedBytecode> {
-        self.0.leak()
-    }
 }
 
 /// Bytecode generation. Each successful call returns the `+1` C++ handed us.
@@ -113,7 +80,11 @@ impl CachedBytecode {
             // and the slice is valid for `input_code_size` bytes until release.
             let slice =
                 unsafe { bun_core::ffi::slice(input_code_ptr.unwrap().as_ptr(), input_code_size) };
-            let handle = Self::adopt_ptr(this).expect("bytecode generated but handle is null");
+            let ptr = this.map_or(core::ptr::null_mut(), |p| p.as_ptr());
+            // SAFETY: the C++ generator `->ref()`s before writing the out-param,
+            // transferring that `+1` to us; no other handle will release it.
+            let handle =
+                unsafe { Self::adopt_ptr(ptr) }.expect("bytecode generated but handle is null");
             return Some((slice, handle));
         }
 
@@ -143,7 +114,11 @@ impl CachedBytecode {
             // and the slice is valid for `input_code_size` bytes until release.
             let slice =
                 unsafe { bun_core::ffi::slice(input_code_ptr.unwrap().as_ptr(), input_code_size) };
-            let handle = Self::adopt_ptr(this).expect("bytecode generated but handle is null");
+            let ptr = this.map_or(core::ptr::null_mut(), |p| p.as_ptr());
+            // SAFETY: the C++ generator `->ref()`s before writing the out-param,
+            // transferring that `+1` to us; no other handle will release it.
+            let handle =
+                unsafe { Self::adopt_ptr(ptr) }.expect("bytecode generated but handle is null");
             return Some((slice, handle));
         }
 

--- a/src/jsc/CachedBytecode.rs
+++ b/src/jsc/CachedBytecode.rs
@@ -3,10 +3,29 @@ use core::ptr::NonNull;
 use bun_core::String as BunString;
 use bun_options_types::Format;
 
-bun_opaque::opaque_ffi! {
-    /// Opaque FFI handle to JSC cached bytecode (a C++ `RefPtr<CachedBytecode>` payload).
-    pub struct CachedBytecode;
+/// The C++ object itself. Only the extern declarations below name this type;
+/// all Rust code uses the owning [`CachedBytecode`] handle.
+pub mod sys {
+    bun_opaque::opaque_ffi! {
+        /// `JSC::CachedBytecode`, a `WTF::RefCounted`. `&Self` is ABI-identical
+        /// to a non-null `JSC::CachedBytecode*` and carries no
+        /// `noalias`/`readonly` — C++ mutates the refcount through it.
+        pub struct CachedBytecode;
+    }
 }
+
+// `JSC::encodeCodeBlock` allocates and the C++ generator does an explicit
+// `->ref()` before leaking the pointer through the out-param, so Rust receives
+// a `+1`. One `CachedBytecode` handle owns exactly that one ref.
+bun_opaque::foreign_owned!(sys::CachedBytecode, CachedBytecode__deref);
+
+/// Owned handle to a C++ `JSC::CachedBytecode`.
+///
+/// Holds one ref on the WTF intrusive refcount; `Drop` gives it back, freeing
+/// the bytecode buffer at zero. There is no `&mut self` and no `DerefMut`: a
+/// refcount is shared by definition, and a decrement is not exclusive access.
+#[repr(transparent)]
+pub struct CachedBytecode(bun_opaque::ForeignRef<sys::CachedBytecode>);
 
 unsafe extern "C" {
     fn generateCachedModuleByteCodeFromSourceCode(
@@ -15,7 +34,7 @@ unsafe extern "C" {
         input_source_code_size: usize,
         output_byte_code: *mut Option<NonNull<u8>>,
         output_byte_code_size: *mut usize,
-        cached_bytecode: *mut Option<NonNull<CachedBytecode>>,
+        cached_bytecode: *mut Option<NonNull<sys::CachedBytecode>>,
     ) -> bool;
 
     fn generateCachedCommonJSProgramByteCodeFromSourceCode(
@@ -24,24 +43,57 @@ unsafe extern "C" {
         input_source_code_size: usize,
         output_byte_code: *mut Option<NonNull<u8>>,
         output_byte_code_size: *mut usize,
-        cached_bytecode: *mut Option<NonNull<CachedBytecode>>,
+        cached_bytecode: *mut Option<NonNull<sys::CachedBytecode>>,
     ) -> bool;
 
-    // safe: `CachedBytecode` is an `opaque_ffi!` ZST handle (`!Freeze` via
-    // `UnsafeCell`); `&mut` is ABI-identical to a non-null `*mut` and the C++
-    // refcount decrement is interior to the cell.
-    safe fn CachedBytecode__deref(this: &mut CachedBytecode);
+    // safe: C++ takes `CachedBytecode*` and calls the intrusive `->deref()`. A
+    // refcount decrement is not exclusive access — other refs exist by
+    // definition — so the receiver is `&`, not `&mut`.
+    safe fn CachedBytecode__deref(this: &sys::CachedBytecode);
 }
 
+/// Ownership plumbing.
+impl CachedBytecode {
+    /// Adopt a `+1` returned by C++.
+    ///
+    /// # Safety
+    /// `ptr` must carry exactly one ref that no other handle will release.
+    #[inline]
+    pub unsafe fn adopt(ptr: NonNull<sys::CachedBytecode>) -> Self {
+        // SAFETY: caller transfers the +1.
+        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
+    }
+
+    /// Adopt a nullable `+1`; `None` on null.
+    #[inline]
+    fn adopt_ptr(ptr: Option<NonNull<sys::CachedBytecode>>) -> Option<Self> {
+        // SAFETY: the C++ generators `->ref()` before writing the out-param.
+        ptr.map(|p| unsafe { Self::adopt(p) })
+    }
+
+    /// The C++ pointer, still owned by `self`.
+    #[inline]
+    pub fn as_ptr(&self) -> *mut sys::CachedBytecode {
+        self.0.as_ptr()
+    }
+
+    /// Hand our `+1` to a foreign owner. Pairs with a later [`Self::adopt`].
+    #[inline]
+    pub fn leak(self) -> NonNull<sys::CachedBytecode> {
+        self.0.leak()
+    }
+}
+
+/// Bytecode generation. Each successful call returns the `+1` C++ handed us.
 impl CachedBytecode {
     // SAFETY CONTRACT: the returned `&'static [u8]` actually borrows from the
-    // `CachedBytecode` handle and is invalidated when `deref()` is called. Callers own
-    // the handle and must call `deref()` (or drop via `allocator()`) to free.
+    // `CachedBytecode` handle and is invalidated when that handle is dropped.
+    // Callers must keep it alive for as long as they read the slice.
     pub fn generate_for_esm(
         source_provider_url: &mut BunString,
         input: &[u8],
-    ) -> Option<(&'static [u8], NonNull<CachedBytecode>)> {
-        let mut this: Option<NonNull<CachedBytecode>> = None;
+    ) -> Option<(&'static [u8], Self)> {
+        let mut this: Option<NonNull<sys::CachedBytecode>> = None;
 
         let mut input_code_size: usize = 0;
         let mut input_code_ptr: Option<NonNull<u8>> = None;
@@ -58,10 +110,11 @@ impl CachedBytecode {
         };
         if ok {
             // SAFETY: on success, C++ guarantees both out-params are non-null
-            // and the slice is valid for `input_code_size` bytes until deref().
+            // and the slice is valid for `input_code_size` bytes until release.
             let slice =
                 unsafe { bun_core::ffi::slice(input_code_ptr.unwrap().as_ptr(), input_code_size) };
-            return Some((slice, this.unwrap()));
+            let handle = Self::adopt_ptr(this).expect("bytecode generated but handle is null");
+            return Some((slice, handle));
         }
 
         None
@@ -70,8 +123,8 @@ impl CachedBytecode {
     pub fn generate_for_cjs(
         source_provider_url: &mut BunString,
         input: &[u8],
-    ) -> Option<(&'static [u8], NonNull<CachedBytecode>)> {
-        let mut this: Option<NonNull<CachedBytecode>> = None;
+    ) -> Option<(&'static [u8], Self)> {
+        let mut this: Option<NonNull<sys::CachedBytecode>> = None;
         let mut input_code_size: usize = 0;
         let mut input_code_ptr: Option<NonNull<u8>> = None;
         // SAFETY: out-params are valid for write; input slice valid for read.
@@ -87,47 +140,26 @@ impl CachedBytecode {
         };
         if ok {
             // SAFETY: on success, C++ guarantees both out-params are non-null
-            // and the slice is valid for `input_code_size` bytes until deref().
+            // and the slice is valid for `input_code_size` bytes until release.
             let slice =
                 unsafe { bun_core::ffi::slice(input_code_ptr.unwrap().as_ptr(), input_code_size) };
-            return Some((slice, this.unwrap()));
+            let handle = Self::adopt_ptr(this).expect("bytecode generated but handle is null");
+            return Some((slice, handle));
         }
 
         None
-    }
-
-    pub fn deref(&mut self) {
-        CachedBytecode__deref(self)
     }
 
     pub fn generate(
         format: Format,
         input: &[u8],
         source_provider_url: &mut BunString,
-    ) -> Option<(&'static [u8], NonNull<CachedBytecode>)> {
+    ) -> Option<(&'static [u8], Self)> {
         match format {
             Format::Esm => Self::generate_for_esm(source_provider_url, input),
             Format::Cjs => Self::generate_for_cjs(source_provider_url, input),
             _ => None,
         }
-    }
-}
-
-// ──────────────────────────────────────────────────────────────────────────
-// The `bun_alloc::Allocator` marker trait has no
-// `alloc`/`free` methods to dispatch through — so "free → deref" semantics
-// cannot ride the trait object. Call sites that would have freed through this
-// allocator must instead call `deref()` on the `NonNull<CachedBytecode>` handle
-// directly. `is_instance` is preserved for the vtable-identity check in
-// `bun_safety::alloc::has_ptr`.
-// ──────────────────────────────────────────────────────────────────────────
-
-impl bun_alloc::Allocator for CachedBytecode {}
-
-impl CachedBytecode {
-    /// Concrete-type identity check via the `Allocator::type_id()` hook.
-    pub fn is_instance(alloc: &dyn bun_alloc::Allocator) -> bool {
-        alloc.is::<Self>()
     }
 }
 
@@ -150,9 +182,8 @@ pub(crate) fn __bun_jsc_generate_cached_bytecode(
     crate::initialize(false);
     let (bytes, handle) = CachedBytecode::generate(format, source, source_provider_url)?;
     let owned = Box::<[u8]>::from(bytes);
-    // `handle` was just produced by C++ and is valid until deref;
-    // `CachedBytecode` is an opaque ZST handle so `opaque_mut` is the
-    // centralised zero-byte deref proof.
-    CachedBytecode__deref(CachedBytecode::opaque_mut(handle.as_ptr()));
+    // `bytes` borrows the C++ buffer; the copy above is done, so give the ref
+    // back. Dropping `handle` is the release.
+    drop(handle);
     Some(owned)
 }

--- a/src/jsc/CppTask.rs
+++ b/src/jsc/CppTask.rs
@@ -15,10 +15,6 @@ pub mod sys {
     }
 }
 
-// C++ `new EventLoopTask` (`ScriptExecutionContext::postTask*`) hands Rust the
-// sole owner. `delete` gives it back; so does `performTask` (`delete this`).
-bun_opaque::foreign_owned!(sys::CppTask, Bun__deleteEventLoopTask);
-
 #[allow(improper_ctypes)] // VirtualMachine is opaque to C++; passed as `void*`
 unsafe extern "C" {
     fn Bun__EventLoopTaskNoContext__performTask(task: *mut EventLoopTaskNoContext);
@@ -35,38 +31,18 @@ impl Taskable for sys::CppTask {
     const TAG: TaskTag = task_tag::CppTask;
 }
 
-/// Owned handle to a C++ `WebCore::EventLoopTask` — a task posted from C++,
-/// usually via `ScriptExecutionContext`.
-///
-/// Holds the sole owner of the heap task; `Drop` deletes it without running.
-/// [`Self::run`] takes `self` instead: `performTask` does `delete this`.
-#[repr(transparent)]
-pub struct CppTask(bun_opaque::ForeignRef<sys::CppTask>);
+// C++ `new EventLoopTask` (`ScriptExecutionContext::postTask*`) hands Rust the
+// sole owner. `delete` gives it back; so does `performTask` (`delete this`).
+bun_opaque::foreign_handle! {
+    /// Owned handle to a C++ `WebCore::EventLoopTask` — a task posted from C++,
+    /// usually via `ScriptExecutionContext`.
+    ///
+    /// Holds the sole owner of the heap task; `Drop` deletes it without running.
+    /// [`Self::run`] takes `self` instead: `performTask` does `delete this`.
+    pub struct CppTask(sys::CppTask) via Bun__deleteEventLoopTask;
+}
 
 impl CppTask {
-    /// Adopt the owner C++ (or the task queue) hands over.
-    ///
-    /// # Safety
-    /// `ptr` must be a live `EventLoopTask*` carrying the sole ownership unit,
-    /// which no other handle will give back.
-    #[inline]
-    pub unsafe fn adopt(ptr: NonNull<sys::CppTask>) -> Self {
-        // SAFETY: caller transfers the owner.
-        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
-    }
-
-    /// The C++ pointer, still owned by `self`.
-    #[inline]
-    pub fn as_ptr(&self) -> *mut sys::CppTask {
-        self.0.as_ptr()
-    }
-
-    /// Hand ownership to a foreign owner. Pairs with a later [`Self::adopt`].
-    #[inline]
-    pub fn leak(self) -> NonNull<sys::CppTask> {
-        self.0.leak()
-    }
-
     /// Run the task. Consumes `self`: C++ `performTask` does `delete this`,
     /// on the throwing path too, so the owner is given back exactly once.
     pub fn run(self, global: &JSGlobalObject) -> JsResult<()> {

--- a/src/jsc/CppTask.rs
+++ b/src/jsc/CppTask.rs
@@ -4,37 +4,78 @@ use crate::{JSGlobalObject, JsResult, VirtualMachineRef as VirtualMachine};
 use bun_event_loop::{TaskTag, Taskable, task_tag};
 use bun_threading::work_pool::{Task as WorkPoolTask, WorkPool};
 
+/// The C++ object itself. Only the extern declarations below name this type;
+/// all Rust code uses the owning [`CppTask`] handle.
+pub mod sys {
+    bun_opaque::opaque_ffi! {
+        /// `WebCore::EventLoopTask`. `&Self` is ABI-identical to a non-null
+        /// `WebCore::EventLoopTask*`, and carries no `noalias`/`readonly` —
+        /// C++ runs and destroys the captured `WTF::Function` through it.
+        pub struct CppTask;
+    }
+}
+
+// C++ `new EventLoopTask` (`ScriptExecutionContext::postTask*`) hands Rust the
+// sole owner. `delete` gives it back; so does `performTask` (`delete this`).
+bun_opaque::foreign_owned!(sys::CppTask, Bun__deleteEventLoopTask);
+
 #[allow(improper_ctypes)] // VirtualMachine is opaque to C++; passed as `void*`
 unsafe extern "C" {
     fn Bun__EventLoopTaskNoContext__performTask(task: *mut EventLoopTaskNoContext);
     safe fn Bun__EventLoopTaskNoContext__createdInBunVm(
         task: &EventLoopTaskNoContext,
     ) -> *mut VirtualMachine;
+    // safe: C++ `delete task`, without running it. Destroying is not exclusive
+    // access in Rust's sense, so the receiver is `&`, matching `UnsafeCell`.
+    safe fn Bun__deleteEventLoopTask(task: &sys::CppTask);
 }
 
-bun_opaque::opaque_ffi! {
-    /// A task created from C++ code, usually via ScriptExecutionContext.
-    pub struct CppTask;
-}
-
-impl Taskable for CppTask {
+// The tag describes the C++ pointee stored in `Task.ptr`, not the Rust handle.
+impl Taskable for sys::CppTask {
     const TAG: TaskTag = task_tag::CppTask;
 }
 
+/// Owned handle to a C++ `WebCore::EventLoopTask` — a task posted from C++,
+/// usually via `ScriptExecutionContext`.
+///
+/// Holds the sole owner of the heap task; `Drop` deletes it without running.
+/// [`Self::run`] takes `self` instead: `performTask` does `delete this`.
+#[repr(transparent)]
+pub struct CppTask(bun_opaque::ForeignRef<sys::CppTask>);
+
 impl CppTask {
-    pub fn run(&mut self, global: &JSGlobalObject) -> JsResult<()> {
+    /// Adopt the owner C++ (or the task queue) hands over.
+    ///
+    /// # Safety
+    /// `ptr` must be a live `EventLoopTask*` carrying the sole ownership unit,
+    /// which no other handle will give back.
+    #[inline]
+    pub unsafe fn adopt(ptr: NonNull<sys::CppTask>) -> Self {
+        // SAFETY: caller transfers the owner.
+        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
+    }
+
+    /// The C++ pointer, still owned by `self`.
+    #[inline]
+    pub fn as_ptr(&self) -> *mut sys::CppTask {
+        self.0.as_ptr()
+    }
+
+    /// Hand ownership to a foreign owner. Pairs with a later [`Self::adopt`].
+    #[inline]
+    pub fn leak(self) -> NonNull<sys::CppTask> {
+        self.0.leak()
+    }
+
+    /// Run the task. Consumes `self`: C++ `performTask` does `delete this`,
+    /// on the throwing path too, so the owner is given back exactly once.
+    pub fn run(self, global: &JSGlobalObject) -> JsResult<()> {
         crate::mark_binding!();
-        // SAFETY: self is a valid C++ EventLoopTask; global outlives the call.
-        //
-        // `Bun__performTask` is `[[ZIG_EXPORT(check_slow)]]` — the task body
-        // (a `ScriptExecutionContext::postTask` lambda) may declare its own
-        // throw scope (e.g. `JSUint8Array::create`, `JSC::call`) without an
-        // enclosing one, so we must go through the generated `cpp::` wrapper
-        // (which opens a `TopExceptionScope` and `return_if_exception`s) rather
-        // than the raw FFI. Calling the raw extern left the simulated throw
-        // unchecked, which then tripped `drainMicrotasks`'s scope ctor under
-        // `BUN_JSC_validateExceptionChecks=1`.
-        unsafe { crate::cpp::Bun__performTask(global, std::ptr::from_mut::<CppTask>(self)) }
+        let task = self.leak();
+        // The task body may open a throw scope with no enclosing one, so go through
+        // the generated `cpp::` wrapper, which opens a `TopExceptionScope`.
+        // SAFETY: `task` is the live owner we just gave up; C++ deletes it.
+        unsafe { crate::cpp::Bun__performTask(global, task.as_ptr().cast()) }
     }
 }
 

--- a/src/jsc/DOMFormData.rs
+++ b/src/jsc/DOMFormData.rs
@@ -14,36 +14,32 @@ unsafe extern "C" {
         arg0: &JSGlobalObject,
         arg1: &ZigString,
     ) -> JSValue;
-    // safe: `DOMFormData` is an `opaque_ffi!` ZST handle (`&mut` is ABI-identical
-    // to a non-null `*mut`); `arg1` is an opaque round-trip pointer C++ only
-    // forwards to `arg2` (synchronous, never retained or dereferenced as Rust data).
+    // safe: `DOMFormData` is an `opaque_ffi!` ZST handle (`&` is ABI-identical to a
+    // non-null pointer and carries no `noalias`/`readonly`); `arg1` is an opaque
+    // round-trip pointer C++ only forwards to `arg2` (synchronous, never retained).
     safe fn WebCore__DOMFormData__toQueryString(
-        arg0: &mut DOMFormData,
+        arg0: &DOMFormData,
         arg1: *mut c_void,
         arg2: extern "C" fn(arg0: *mut c_void, arg1: *mut ZigString),
     );
     safe fn WebCore__DOMFormData__fromJS(js_value0: JSValue) -> *mut DOMFormData;
-    safe fn WebCore__DOMFormData__append(
-        arg0: &mut DOMFormData,
-        arg1: &ZigString,
-        arg2: &ZigString,
-    );
+    safe fn WebCore__DOMFormData__append(arg0: &DOMFormData, arg1: &ZigString, arg2: &ZigString);
     // safe: `DOMFormData`/`JSGlobalObject` are opaque `UnsafeCell`-backed ZST
     // handles; `&ZigString` is ABI-identical to non-null `*const ZigString` and
     // C++ only reads the named struct via `toStringCopy`. `arg3` is an opaque
     // `*Blob` C++ owns (never dereferenced as Rust data) — same round-trip
     // contract as `Zig__GlobalObject__resetModuleRegistryMap`'s `map` param.
     safe fn WebCore__DOMFormData__appendBlob(
-        arg0: &mut DOMFormData,
+        arg0: &DOMFormData,
         arg1: &JSGlobalObject,
         arg2: &ZigString,
         arg3: *mut c_void,
         arg4: &ZigString,
     );
-    safe fn WebCore__DOMFormData__count(arg0: &mut DOMFormData) -> usize;
+    safe fn WebCore__DOMFormData__count(arg0: &DOMFormData) -> usize;
 
     // safe: same opaque-handle/round-trip-ctx contract as `toQueryString` above.
-    safe fn DOMFormData__forEach(this: &mut DOMFormData, ctx: *mut c_void, cb: ForEachFunction);
+    safe fn DOMFormData__forEach(this: &DOMFormData, ctx: *mut c_void, cb: ForEachFunction);
 }
 
 impl DOMFormData {
@@ -63,7 +59,7 @@ impl DOMFormData {
 
     // The closure environment is the ctx pointer; the generic trampoline
     // below unwraps it and invokes the closure.
-    pub fn to_query_string<F>(&mut self, callback: &mut F)
+    pub fn to_query_string<F>(&self, callback: &mut F)
     where
         F: FnMut(ZigString),
     {
@@ -83,23 +79,20 @@ impl DOMFormData {
         );
     }
 
-    pub fn from_js<'a>(value: JSValue) -> Option<&'a mut DOMFormData> {
-        // Returned pointer is valid while `value` is kept alive on the stack
-        // (conservative GC scan). Null → None. `DOMFormData` is an opaque ZST
-        // handle, so `opaque_mut` is the centralised zero-byte deref proof.
-        // The unbounded `'a` cannot be expressed more tightly: the cell is
-        // GC-owned, so the caller must keep `value` stack-rooted for the
-        // lifetime of the returned reference.
+    pub fn from_js<'a>(value: JSValue) -> Option<&'a DOMFormData> {
+        // Valid while `value` stays stack-rooted (conservative GC scan); null → None.
+        // `opaque_ref` is the centralised zero-byte deref proof. `'a` is unbounded
+        // because the cell is GC-owned, not borrowed from `value`.
         let p = WebCore__DOMFormData__fromJS(value);
-        (!p.is_null()).then(|| DOMFormData::opaque_mut(p))
+        (!p.is_null()).then(|| DOMFormData::opaque_ref(p))
     }
 
-    pub fn append(&mut self, name_: &ZigString, value_: &ZigString) {
+    pub fn append(&self, name_: &ZigString, value_: &ZigString) {
         WebCore__DOMFormData__append(self, name_, value_)
     }
 
     pub fn append_blob(
-        &mut self,
+        &self,
         global: &JSGlobalObject,
         name_: &ZigString,
         blob: *mut c_void,
@@ -108,7 +101,7 @@ impl DOMFormData {
         WebCore__DOMFormData__appendBlob(self, global, name_, blob, filename_);
     }
 
-    pub fn count(&mut self) -> usize {
+    pub fn count(&self) -> usize {
         WebCore__DOMFormData__count(self)
     }
 
@@ -117,7 +110,7 @@ impl DOMFormData {
     // hands it as `*mut c_void`; this fn is generic over `B` so the caller (in
     // `bun_runtime`) names the concrete `Blob` type and gets a typed `&B`
     // borrow without `bun_jsc` ever seeing the layout.
-    pub fn for_each<B, F>(&mut self, callback: &mut F)
+    pub fn for_each<B, F>(&self, callback: &mut F)
     where
         F: FnMut(ZigString, FormDataEntry<'_, B>),
     {

--- a/src/jsc/DOMURL.rs
+++ b/src/jsc/DOMURL.rs
@@ -31,17 +31,18 @@ pub enum ToFileSystemPathError {
 bun_core::named_error_set!(ToFileSystemPathError);
 
 impl DOMURL {
-    pub fn cast_<'a>(value: JSValue, vm: &'a VM) -> Option<&'a mut DOMURL> {
+    pub fn cast_<'a>(value: JSValue, vm: &'a VM) -> Option<&'a DOMURL> {
         // DOMURL is a GC-owned C++ cell; the returned reference is only valid
         // while `value` stays alive (e.g. stack-rooted for the conservative GC
         // scan) — the borrow on `vm` does not capture that.
-        // `DOMURL` is an `opaque_ffi!` ZST handle; `opaque_mut` is the
-        // centralised non-null-ZST deref proof (zero-byte `&mut` cannot alias).
+        // `DOMURL` is an `opaque_ffi!` ZST handle; `opaque_ref` is the
+        // centralised non-null-ZST deref proof. `&DOMURL` is `!Freeze`: no
+        // `noalias`/`readonly`, so C++ may mutate the cell behind it.
         let p = WebCore__DOMURL__cast_(value, vm);
-        (!p.is_null()).then(|| DOMURL::opaque_mut(p))
+        (!p.is_null()).then(|| DOMURL::opaque_ref(p))
     }
 
-    pub fn cast<'a>(value: JSValue) -> Option<&'a mut DOMURL> {
+    pub fn cast<'a>(value: JSValue) -> Option<&'a DOMURL> {
         // SAFETY: VirtualMachine::get() returns the per-thread singleton; caller is on the JS thread.
         Self::cast_(
             value,
@@ -49,17 +50,17 @@ impl DOMURL {
         )
     }
 
-    pub fn href_(&mut self, out: &mut ZigString) {
+    pub fn href_(&self, out: &mut ZigString) {
         WebCore__DOMURL__href_(self, out)
     }
 
-    pub fn href(&mut self) -> ZigString {
+    pub fn href(&self) -> ZigString {
         let mut out = ZigString::EMPTY;
         self.href_(&mut out);
         out
     }
 
-    pub fn file_system_path(&mut self) -> Result<bstr::String, ToFileSystemPathError> {
+    pub fn file_system_path(&self) -> Result<bstr::String, ToFileSystemPathError> {
         let mut error_code: c_int = 0;
         let path = WebCore__DOMURL__fileSystemPath(self, &mut error_code);
         match error_code {
@@ -72,11 +73,11 @@ impl DOMURL {
         Ok(path)
     }
 
-    pub fn pathname_(&mut self, out: &mut ZigString) {
+    pub fn pathname_(&self, out: &mut ZigString) {
         WebCore__DOMURL__pathname_(self, out)
     }
 
-    pub fn pathname(&mut self) -> ZigString {
+    pub fn pathname(&self) -> ZigString {
         let mut out = ZigString::EMPTY;
         self.pathname_(&mut out);
         out

--- a/src/jsc/Debugger.rs
+++ b/src/jsc/Debugger.rs
@@ -731,7 +731,7 @@ bun_opaque::opaque_ffi! { pub struct TestReporterHandle; }
 // by-value scalars.
 unsafe extern "C" {
     safe fn Bun__TestReporterAgentReportTestFound(
-        agent: &mut TestReporterHandle,
+        agent: &TestReporterHandle,
         call_frame: &CallFrame,
         test_id: c_int,
         name: &mut BunString,
@@ -739,7 +739,7 @@ unsafe extern "C" {
         parent_id: c_int,
     );
     safe fn Bun__TestReporterAgentReportTestFoundWithLocation(
-        agent: &mut TestReporterHandle,
+        agent: &TestReporterHandle,
         test_id: c_int,
         name: &mut BunString,
         item_type: TestType,
@@ -747,9 +747,9 @@ unsafe extern "C" {
         source_url: &mut BunString,
         line: c_int,
     );
-    safe fn Bun__TestReporterAgentReportTestStart(agent: &mut TestReporterHandle, test_id: c_int);
+    safe fn Bun__TestReporterAgentReportTestStart(agent: &TestReporterHandle, test_id: c_int);
     safe fn Bun__TestReporterAgentReportTestEnd(
-        agent: &mut TestReporterHandle,
+        agent: &TestReporterHandle,
         test_id: c_int,
         bun_test_status: TestStatus,
         elapsed: f64,
@@ -758,7 +758,7 @@ unsafe extern "C" {
 
 impl TestReporterHandle {
     pub fn report_test_found(
-        &mut self,
+        &self,
         call_frame: &CallFrame,
         test_id: i32,
         name: &mut BunString,
@@ -771,7 +771,7 @@ impl TestReporterHandle {
     }
 
     pub fn report_test_found_with_location(
-        &mut self,
+        &self,
         test_id: i32,
         name: &mut BunString,
         item_type: TestType,
@@ -784,11 +784,11 @@ impl TestReporterHandle {
         );
     }
 
-    pub fn report_test_start(&mut self, test_id: c_int) {
+    pub fn report_test_start(&self, test_id: c_int) {
         Bun__TestReporterAgentReportTestStart(self, test_id);
     }
 
-    pub fn report_test_end(&mut self, test_id: c_int, bun_test_status: TestStatus, elapsed: f64) {
+    pub fn report_test_end(&self, test_id: c_int, bun_test_status: TestStatus, elapsed: f64) {
         Bun__TestReporterAgentReportTestEnd(self, test_id, bun_test_status, elapsed);
     }
 }
@@ -827,16 +827,16 @@ pub fn test_reporter_agent_disable(_agent: *mut TestReporterHandle) {
 }
 
 impl TestReporterAgent {
-    /// Safe `&mut TestReporterHandle` accessor — `handle` is a live C++
+    /// Safe `&TestReporterHandle` accessor — `handle` is a live C++
     /// `Inspector::TestReporterAgent*` once the agent is enabled. Caller must
     /// ensure `is_enabled()` (handle != null).
     #[inline]
-    fn handle_mut(&mut self) -> &mut TestReporterHandle {
+    fn handle_ref(&self) -> &TestReporterHandle {
         debug_assert!(!self.handle.is_null());
         // Caller contract — `is_enabled()` checked; handle is a live C++ heap
         // allocation owned by the inspector backend. `TestReporterHandle` is an
-        // opaque ZST handle so the deref is the centralised `opaque_mut` proof.
-        TestReporterHandle::opaque_mut(self.handle)
+        // opaque ZST handle so the deref is the centralised `opaque_ref` proof.
+        TestReporterHandle::opaque_ref(self.handle)
     }
 
     /// Caller must ensure that it is enabled first.
@@ -851,20 +851,20 @@ impl TestReporterAgent {
         parent_id: i32,
     ) {
         bun_core::scoped_log!(TestReporterAgent, "reportTestFound");
-        self.handle_mut()
+        self.handle_ref()
             .report_test_found(call_frame, test_id, name, item_type, parent_id);
     }
 
     /// Caller must ensure that it is enabled first.
     pub fn report_test_start(&mut self, test_id: i32) {
         bun_core::scoped_log!(TestReporterAgent, "reportTestStart");
-        self.handle_mut().report_test_start(test_id);
+        self.handle_ref().report_test_start(test_id);
     }
 
     /// Caller must ensure that it is enabled first.
     pub fn report_test_end(&mut self, test_id: i32, bun_test_status: TestStatus, elapsed: f64) {
         bun_core::scoped_log!(TestReporterAgent, "reportTestEnd");
-        self.handle_mut()
+        self.handle_ref()
             .report_test_end(test_id, bun_test_status, elapsed);
     }
 
@@ -886,30 +886,27 @@ bun_opaque::opaque_ffi! { pub struct LifecycleHandle; }
 // via `UnsafeCell`); `ZigException` is a `#[repr(C)]` out-param the C++ side
 // reads/fills in-place.
 unsafe extern "C" {
-    safe fn Bun__LifecycleAgentReportReload(agent: &mut LifecycleHandle);
-    safe fn Bun__LifecycleAgentReportError(
-        agent: &mut LifecycleHandle,
-        exception: &mut ZigException,
-    );
-    safe fn Bun__LifecycleAgentPreventExit(agent: &mut LifecycleHandle);
-    safe fn Bun__LifecycleAgentStopPreventingExit(agent: &mut LifecycleHandle);
+    safe fn Bun__LifecycleAgentReportReload(agent: &LifecycleHandle);
+    safe fn Bun__LifecycleAgentReportError(agent: &LifecycleHandle, exception: &mut ZigException);
+    safe fn Bun__LifecycleAgentPreventExit(agent: &LifecycleHandle);
+    safe fn Bun__LifecycleAgentStopPreventingExit(agent: &LifecycleHandle);
 }
 
 impl LifecycleHandle {
-    pub fn prevent_exit(&mut self) {
+    pub fn prevent_exit(&self) {
         Bun__LifecycleAgentPreventExit(self)
     }
 
-    pub fn stop_preventing_exit(&mut self) {
+    pub fn stop_preventing_exit(&self) {
         Bun__LifecycleAgentStopPreventingExit(self)
     }
 
-    pub fn report_reload(&mut self) {
+    pub fn report_reload(&self) {
         bun_core::scoped_log!(LifecycleAgent, "reportReload");
         Bun__LifecycleAgentReportReload(self)
     }
 
-    pub fn report_error(&mut self, exception: &mut ZigException) {
+    pub fn report_error(&self, exception: &mut ZigException) {
         bun_core::scoped_log!(LifecycleAgent, "reportError");
         Bun__LifecycleAgentReportError(self, exception)
     }
@@ -938,15 +935,15 @@ pub fn lifecycle_agent_disable(_agent: *mut LifecycleHandle) {
 impl LifecycleAgent {
     /// Safe optional accessor — wraps the null check + raw deref.
     #[inline]
-    fn handle_mut(&mut self) -> Option<&mut LifecycleHandle> {
+    fn handle_ref(&self) -> Option<&LifecycleHandle> {
         // `handle` is null or a live C++ heap allocation owned by the inspector
         // backend. `LifecycleHandle` is an opaque ZST handle so the deref is
-        // the centralised `opaque_mut` proof.
-        core::ptr::NonNull::new(self.handle).map(|p| LifecycleHandle::opaque_mut(p.as_ptr()))
+        // the centralised `opaque_ref` proof.
+        core::ptr::NonNull::new(self.handle).map(|p| LifecycleHandle::opaque_ref(p.as_ptr()))
     }
 
     pub(crate) fn report_error(&mut self, exception: &mut ZigException) {
-        if let Some(h) = self.handle_mut() {
+        if let Some(h) = self.handle_ref() {
             h.report_error(exception);
         }
     }

--- a/src/jsc/FetchHeaders.rs
+++ b/src/jsc/FetchHeaders.rs
@@ -20,18 +20,17 @@ pub mod sys {
 
 // C++ allocates (`new WebCore::FetchHeaders` + `relaxAdoptionRequirement`) and
 // hands back a `+1`. One `FetchHeaders` handle owns exactly that one ref.
-bun_opaque::foreign_owned!(sys::FetchHeaders, WebCore__FetchHeaders__deref);
-
-/// Owned handle to a C++ `WebCore::FetchHeaders`.
-///
-/// Holds one ref on the C++ intrusive refcount; `Drop` gives it back. Every
-/// method takes `&self`: a refcount is shared by definition, and C++ mutates
-/// the headers through the same pointer, so there is no `&mut self` to have.
-///
-/// A `FetchHeaders` *borrowed* from a JS `Headers` wrapper (see [`Self::cast`])
-/// is a `ManuallyDrop<FetchHeaders>` — the JS object owns that ref, not us.
-#[repr(transparent)]
-pub struct FetchHeaders(bun_opaque::ForeignRef<sys::FetchHeaders>);
+bun_opaque::foreign_handle! {
+    /// Owned handle to a C++ `WebCore::FetchHeaders`.
+    ///
+    /// Holds one ref on the C++ intrusive refcount; `Drop` gives it back. Every
+    /// method takes `&self`: a refcount is shared by definition, and C++ mutates
+    /// the headers through the same pointer, so there is no `&mut self` to have.
+    ///
+    /// A `FetchHeaders` *borrowed* from a JS `Headers` wrapper (see [`Self::cast`])
+    /// is a `ManuallyDrop<FetchHeaders>` — the JS object owns that ref, not us.
+    pub struct FetchHeaders(sys::FetchHeaders) via WebCore__FetchHeaders__deref;
+}
 
 // `JSGlobalObject`/`VM`/`sys::FetchHeaders` are opaque `UnsafeCell`-backed ZST
 // handles, so `&T` is ABI-identical to a non-null `*const T` and C++ mutating
@@ -139,63 +138,27 @@ struct PicoHeaders {
     len: usize,
 }
 
-/// Ownership plumbing.
-impl FetchHeaders {
-    /// Adopt a `+1` returned by C++.
-    ///
-    /// # Safety
-    /// `ptr` must carry exactly one ref that no other handle will release.
-    #[inline]
-    pub unsafe fn adopt(ptr: NonNull<sys::FetchHeaders>) -> Self {
-        // SAFETY: caller transfers the +1.
-        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
-    }
-
-    /// Adopt a nullable `+1`; `None` on null.
-    #[inline]
-    fn adopt_ptr(ptr: *mut sys::FetchHeaders) -> Option<Self> {
-        // SAFETY: C++ `create*` returns a fresh +1 or null.
-        NonNull::new(ptr).map(|p| unsafe { Self::adopt(p) })
-    }
-
-    /// The C++ pointer, still owned by `self`.
-    #[inline]
-    pub fn as_ptr(&self) -> *mut sys::FetchHeaders {
-        self.0.as_ptr()
-    }
-
-    /// Hand our `+1` to a foreign owner. Pairs with a later [`Self::adopt`].
-    #[inline]
-    pub fn leak(self) -> NonNull<sys::FetchHeaders> {
-        self.0.leak()
-    }
-
-    #[inline]
-    fn raw(&self) -> &sys::FetchHeaders {
-        &self.0
-    }
-}
-
 /// Constructors. C++ allocates; every one of these returns a `+1`.
 impl FetchHeaders {
     pub fn create_empty() -> Self {
-        Self::adopt_ptr(WebCore__FetchHeaders__createEmpty())
+        // SAFETY: C++ `createEmpty` transfers a fresh `+1`, or returns null.
+        unsafe { Self::adopt_ptr(WebCore__FetchHeaders__createEmpty()) }
             .expect("WebCore__FetchHeaders__createEmpty returned null")
     }
 
     /// # Safety
     /// `uws_request` must be a live `uWS::HttpRequest*`; C++ dereferences it.
     pub unsafe fn create_from_uws(uws_request: *mut c_void) -> Self {
-        // SAFETY: caller contract.
-        Self::adopt_ptr(unsafe { WebCore__FetchHeaders__createFromUWS(uws_request) })
+        // SAFETY: caller contract; C++ `createFromUWS` transfers a fresh `+1`, or null.
+        unsafe { Self::adopt_ptr(WebCore__FetchHeaders__createFromUWS(uws_request)) }
             .expect("WebCore__FetchHeaders__createFromUWS returned null")
     }
 
     /// # Safety
     /// `h3_request` must be a live `uWS::Http3Request*`; C++ dereferences it.
     pub unsafe fn create_from_h3(h3_request: *mut c_void) -> Self {
-        // SAFETY: caller contract.
-        Self::adopt_ptr(unsafe { WebCore__FetchHeaders__createFromH3(h3_request) })
+        // SAFETY: caller contract; C++ `createFromH3` transfers a fresh `+1`, or null.
+        unsafe { Self::adopt_ptr(WebCore__FetchHeaders__createFromH3(h3_request)) }
             .expect("WebCore__FetchHeaders__createFromH3 returned null")
     }
 
@@ -212,8 +175,8 @@ impl FetchHeaders {
     /// # Safety
     /// `pico_headers` must point to a live `PicoHeaders`.
     unsafe fn create_from_pico_headers_(pico_headers: *const c_void) -> Self {
-        // SAFETY: caller contract.
-        Self::adopt_ptr(unsafe { WebCore__FetchHeaders__createFromPicoHeaders_(pico_headers) })
+        // SAFETY: caller contract; C++ `createFromPicoHeaders_` transfers a fresh `+1`, or null.
+        unsafe { Self::adopt_ptr(WebCore__FetchHeaders__createFromPicoHeaders_(pico_headers)) }
             .expect("WebCore__FetchHeaders__createFromPicoHeaders_ returned null")
     }
 
@@ -221,7 +184,8 @@ impl FetchHeaders {
     /// `Record<String, String>`. Throws on invalid input; `None` if empty.
     pub fn create_from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<Self>> {
         host_fn::from_js_host_call_generic(global, || {
-            Self::adopt_ptr(WebCore__FetchHeaders__createFromJS(global, value))
+            // SAFETY: C++ `createFromJS` transfers a fresh `+1`, or returns null.
+            unsafe { Self::adopt_ptr(WebCore__FetchHeaders__createFromJS(global, value)) }
         })
     }
 
@@ -246,13 +210,15 @@ impl FetchHeaders {
                 count,
             )
         };
-        Self::adopt_ptr(p)
+        // SAFETY: C++ `createValueNotJS` transfers a fresh `+1`, or returns null.
+        unsafe { Self::adopt_ptr(p) }
     }
 
     /// Deep-copies on the C++ side, so the result is a fresh `+1`.
     pub fn clone_this(&self, global: &JSGlobalObject) -> JsResult<Option<Self>> {
         host_fn::from_js_host_call_generic(global, || {
-            Self::adopt_ptr(WebCore__FetchHeaders__cloneThis(self.raw(), global))
+            // SAFETY: C++ `cloneThis` deep-copies and transfers a fresh `+1`, or returns null.
+            unsafe { Self::adopt_ptr(WebCore__FetchHeaders__cloneThis(self.raw(), global)) }
         })
     }
 

--- a/src/jsc/JSCScheduler.rs
+++ b/src/jsc/JSCScheduler.rs
@@ -16,13 +16,13 @@ impl Taskable for JSCDeferredWorkTask {
 
 unsafe extern "C" {
     // safe: `JSCDeferredWorkTask` is an `opaque_ffi!` ZST handle (`!Freeze`
-    // via `UnsafeCell`); `&mut` is ABI-identical to a non-null `*mut` and the
-    // C++ side consuming it is interior to the opaque cell.
-    safe fn Bun__runDeferredWork(task: &mut JSCDeferredWorkTask);
+    // via `UnsafeCell`); `&T` is ABI-identical to a non-null pointer and the
+    // C++ side consuming it mutates interior to the opaque cell.
+    safe fn Bun__runDeferredWork(task: &JSCDeferredWorkTask);
 }
 
 impl JSCDeferredWorkTask {
-    pub fn run(&mut self) -> Result<(), JsTerminated> {
+    pub fn run(&self) -> Result<(), JsTerminated> {
         // SAFETY: `VirtualMachine::get()` returns the live per-thread VM; `global` is
         // initialized during VM startup and remains valid for the VM's lifetime.
         let global_this = VirtualMachine::get().global();

--- a/src/jsc/JSObject.rs
+++ b/src/jsc/JSObject.rs
@@ -53,10 +53,7 @@ impl JSObject {
     ///
     /// This method is equivalent to `Object.create(...)` + setting properties,
     /// and is only intended for creating POJOs.
-    pub fn create<T: PojoFields>(
-        pojo: &T,
-        global: &JSGlobalObject,
-    ) -> JsResult<&'static mut JSObject> {
+    pub fn create<T: PojoFields>(pojo: &T, global: &JSGlobalObject) -> JsResult<&'static JSObject> {
         Self::create_from_struct_with_prototype::<T, false>(pojo, global)
     }
 
@@ -71,7 +68,7 @@ impl JSObject {
     pub fn create_null_proto<T: PojoFields>(
         pojo: &T,
         global: &JSGlobalObject,
-    ) -> JsResult<&'static mut JSObject> {
+    ) -> JsResult<&'static JSObject> {
         Self::create_from_struct_with_prototype::<T, true>(pojo, global)
     }
 
@@ -90,7 +87,7 @@ impl JSObject {
     fn create_from_struct_with_prototype<T: PojoFields, const NULL_PROTOTYPE: bool>(
         pojo: &T,
         global: &JSGlobalObject,
-    ) -> JsResult<&'static mut JSObject> {
+    ) -> JsResult<&'static JSObject> {
         // Rust has no field reflection; `PojoFields` impls are hand-written
         // (see trait docs) and emit an inline
         // `put(b"name", JSValue::from_any(global, &self.name)?)?;` per field.
@@ -101,12 +98,10 @@ impl JSObject {
             JSValue::create_empty_object(global, T::FIELD_COUNT)
         };
         debug_assert!(val.is_object());
-        // `val.is_object()` asserted above in debug; JSC guarantees these
-        // constructors return a JSObject cell. A cell-tagged JSValue's payload
-        // IS the cell pointer (NotCellMask bits are zero). `JSObject` is an
-        // `opaque_ffi!` ZST handle; `opaque_mut` is the centralised
-        // non-null-ZST deref proof (zero-byte `&mut` cannot alias).
-        let obj = JSObject::opaque_mut(val.0 as *mut JSObject);
+        // JSC guarantees these constructors return a JSObject cell; a cell-tagged
+        // JSValue's payload IS the cell pointer (NotCellMask bits are zero).
+        // `opaque_ref` is the centralised non-null-ZST deref proof.
+        let obj = JSObject::opaque_ref(val.0 as *const JSObject);
 
         let cell = obj.to_js();
         // Each `fromAny` result is `put()` immediately before the next field
@@ -213,7 +208,7 @@ impl JSObject {
 
     #[track_caller]
     pub fn put_record(
-        &mut self,
+        &self,
         global: &JSGlobalObject,
         key: &mut ZigString,
         values: &mut [ZigString],
@@ -232,7 +227,7 @@ impl JSObject {
     }
 
     /// This will not call getters or be observable from JavaScript.
-    pub fn get_code_property_vm_inquiry(&mut self, global: &JSGlobalObject) -> Option<JSValue> {
+    pub fn get_code_property_vm_inquiry(&self, global: &JSGlobalObject) -> Option<JSValue> {
         let v = Bun__JSObject__getCodePropertyVMInquiry(global, self);
         if v.is_empty() {
             return None;
@@ -286,7 +281,7 @@ pub(crate) type InitializeCallback =
 /// Object-initializer contract: implement `create` on your context type and
 /// pass it to `JSObject::create_with_initializer`.
 pub trait ObjectInitializer {
-    fn create(&mut self, obj: &mut JSObject, global: &JSGlobalObject) -> JsResult<()>;
+    fn create(&mut self, obj: &JSObject, global: &JSGlobalObject) -> JsResult<()>;
 }
 
 extern "C" fn initializer_call<Ctx: ObjectInitializer>(
@@ -297,7 +292,7 @@ extern "C" fn initializer_call<Ctx: ObjectInitializer>(
     // SAFETY: `this` was produced from `&mut Ctx` in `create_with_initializer`;
     // `obj` is a live JSC pointer for the duration of the callback. `global` is
     // taken by reference at the C ABI (`&T` ≡ non-null `*const T`).
-    let result = unsafe { Ctx::create(&mut *this.cast::<Ctx>(), &mut *obj, global) };
+    let result = unsafe { Ctx::create(&mut *this.cast::<Ctx>(), &*obj, global) };
     if let Err(err) = result {
         // Mirrors `host_fn::void_from_js_error` — OOM throws,
         // anything else asserts an exception is already pending.

--- a/src/jsc/JSPromise.rs
+++ b/src/jsc/JSPromise.rs
@@ -154,12 +154,12 @@ impl Strong {
     pub fn reject_without_swap(&mut self, global: &JSGlobalObject, val: JsResult<JSValue>) {
         let Some(v) = self.strong.get() else { return };
         let val = val.unwrap_or_else(|_| global.try_take_exception().unwrap());
-        let _ = JSPromise::opaque_mut(v.as_promise().unwrap()).reject(global, Ok(val));
+        let _ = JSPromise::opaque_ref(v.as_promise().unwrap()).reject(global, Ok(val));
     }
 
     pub fn resolve_without_swap(&mut self, global: &JSGlobalObject, val: JSValue) {
         let Some(v) = self.strong.get() else { return };
-        let _ = JSPromise::opaque_mut(v.as_promise().unwrap()).resolve(global, val);
+        let _ = JSPromise::opaque_ref(v.as_promise().unwrap()).resolve(global, val);
     }
 
     pub fn reject(
@@ -423,14 +423,14 @@ impl JSPromise {
     /// Fulfill an existing promise with the value.
     /// The value can be another Promise.
     /// If you want to create a new Promise that is already resolved, see `resolved_promise_value`.
-    pub fn resolve(&mut self, global: &JSGlobalObject, value: JSValue) -> Result<(), JsTerminated> {
+    pub fn resolve(&self, global: &JSGlobalObject, value: JSValue) -> Result<(), JsTerminated> {
         // `[[ZIG_EXPORT(check_slow)]]`
         crate::cpp::JSC__JSPromise__resolve(self, global, value)
             .map_err(|_| JsTerminated::JSTerminated)
     }
 
     pub fn reject(
-        &mut self,
+        &self,
         global: &JSGlobalObject,
         value: JsResult<JSValue>,
     ) -> Result<(), JsTerminated> {
@@ -456,7 +456,7 @@ impl JSPromise {
     }
 
     pub fn reject_as_handled(
-        &mut self,
+        &self,
         global: &JSGlobalObject,
         value: JSValue,
     ) -> Result<(), JsTerminated> {
@@ -470,7 +470,7 @@ impl JSPromise {
     /// of the event loop (threadpool callback) where the error would otherwise
     /// have an empty stack trace.
     pub fn reject_with_async_stack(
-        &mut self,
+        &self,
         global: &JSGlobalObject,
         value: JsResult<JSValue>,
     ) -> Result<(), JsTerminated> {
@@ -496,7 +496,7 @@ impl JSPromise {
         self.to_js()
     }
 
-    pub fn unwrap(&mut self, vm: &VM, mode: UnwrapMode) -> Unwrapped {
+    pub fn unwrap(&self, vm: &VM, mode: UnwrapMode) -> Unwrapped {
         match self.status() {
             Status::Pending => Unwrapped::Pending,
             Status::Fulfilled => Unwrapped::Fulfilled(self.result(vm)),

--- a/src/jsc/JSSecrets.rs
+++ b/src/jsc/JSSecrets.rs
@@ -1,5 +1,3 @@
-use core::ptr::NonNull;
-
 use crate::{AnyTaskJob, AnyTaskJobCtx, JSGlobalObject, JSValue, JsResult, Strong};
 
 /// The C++ object itself. Only the extern declarations below name this type;
@@ -16,16 +14,15 @@ pub mod sys {
 // C++ `SecretsJobOptions::fromJS` does a plain `new`, handing Rust the sole
 // ownership unit. `deinit` is the matching `delete`; the dtor memsets the
 // service/name/password buffers, so dropping is load-bearing, not just free.
-bun_opaque::foreign_owned!(sys::SecretsJobOptions, Bun__SecretsJobOptions__deinit);
-
-/// Owned handle to a C++ `SecretsJobOptions`.
-///
-/// Holds one heap allocation; `Drop` runs the C++ `delete`, which zeroes the
-/// secret buffers. Every method takes `&self`: the ZST is `UnsafeCell`-backed,
-/// so C++ mutates the job's result fields through `&` and there is no `&mut`
-/// exclusivity to claim — the work pool and the C++ side share the object.
-#[repr(transparent)]
-pub struct SecretsJobOptions(bun_opaque::ForeignRef<sys::SecretsJobOptions>);
+bun_opaque::foreign_handle! {
+    /// Owned handle to a C++ `SecretsJobOptions`.
+    ///
+    /// Holds one heap allocation; `Drop` runs the C++ `delete`, which zeroes the
+    /// secret buffers. Every method takes `&self`: the ZST is `UnsafeCell`-backed,
+    /// so C++ mutates the job's result fields through `&` and there is no `&mut`
+    /// exclusivity to claim — the work pool and the C++ side share the object.
+    pub struct SecretsJobOptions(sys::SecretsJobOptions) via Bun__SecretsJobOptions__deinit;
+}
 
 // safe fn: `sys::SecretsJobOptions` and `JSGlobalObject` are `opaque_ffi!` ZST
 // handles (`!Freeze` via `UnsafeCell`), so `&T` is ABI-identical to a non-null
@@ -41,47 +38,6 @@ unsafe extern "C" {
     // is `&`. Reachable only via `ForeignRef`'s `Drop`, which owns the one unit
     // it gives back — that pairing is the double-free proof.
     safe fn Bun__SecretsJobOptions__deinit(opts: &sys::SecretsJobOptions);
-}
-
-/// Ownership plumbing.
-impl SecretsJobOptions {
-    /// Adopt the allocation returned by C++ `new SecretsJobOptions`.
-    ///
-    /// # Safety
-    /// `ptr` must be live and carry the sole ownership unit — no other handle
-    /// may `delete` it.
-    #[inline]
-    pub unsafe fn adopt(ptr: NonNull<sys::SecretsJobOptions>) -> Self {
-        // SAFETY: caller transfers the sole unit.
-        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
-    }
-
-    /// Adopt a nullable owning pointer; `None` on null.
-    ///
-    /// # Safety
-    /// A non-null `ptr` must satisfy [`Self::adopt`]'s contract.
-    #[inline]
-    unsafe fn adopt_ptr(ptr: *mut sys::SecretsJobOptions) -> Option<Self> {
-        // SAFETY: caller contract.
-        NonNull::new(ptr).map(|p| unsafe { Self::adopt(p) })
-    }
-
-    /// The C++ pointer, still owned by `self`.
-    #[inline]
-    pub fn as_ptr(&self) -> *mut sys::SecretsJobOptions {
-        self.0.as_ptr()
-    }
-
-    /// Hand the allocation to a foreign owner. Pairs with a later [`Self::adopt`].
-    #[inline]
-    pub fn leak(self) -> NonNull<sys::SecretsJobOptions> {
-        self.0.leak()
-    }
-
-    #[inline]
-    fn raw(&self) -> &sys::SecretsJobOptions {
-        &self.0
-    }
 }
 
 /// Job body. `&self` throughout: C++ writes the result fields through the same

--- a/src/jsc/JSSecrets.rs
+++ b/src/jsc/JSSecrets.rs
@@ -1,38 +1,115 @@
+use core::ptr::NonNull;
+
 use crate::{AnyTaskJob, AnyTaskJobCtx, JSGlobalObject, JSValue, JsResult, Strong};
 
-// Opaque pointer to C++ SecretsJobOptions struct
-bun_opaque::opaque_ffi! { pub struct SecretsJobOptions; }
+/// The C++ object itself. Only the extern declarations below name this type;
+/// all Rust code uses the owning [`SecretsJobOptions`] handle.
+pub mod sys {
+    bun_opaque::opaque_ffi! {
+        /// C++ `SecretsJobOptions`. `&Self` is ABI-identical to a non-null
+        /// `SecretsJobOptions*` and carries no `noalias`/`readonly` — the
+        /// threadpool body writes `error`/`resultPassword`/`deleted` through it.
+        pub struct SecretsJobOptions;
+    }
+}
 
-// safe fn: `SecretsJobOptions` and `JSGlobalObject` are `opaque_ffi!` ZST
-// handles (`!Freeze` via `UnsafeCell`); `&mut`/`&` are ABI-identical to
-// non-null `*mut`/`*const` and C++ mutating job state through them is interior
-// to the cell. `deinit` consumes/frees the C++ allocation and so stays
-// `unsafe fn` (double-free precondition).
+// C++ `SecretsJobOptions::fromJS` does a plain `new`, handing Rust the sole
+// ownership unit. `deinit` is the matching `delete`; the dtor memsets the
+// service/name/password buffers, so dropping is load-bearing, not just free.
+bun_opaque::foreign_owned!(sys::SecretsJobOptions, Bun__SecretsJobOptions__deinit);
+
+/// Owned handle to a C++ `SecretsJobOptions`.
+///
+/// Holds one heap allocation; `Drop` runs the C++ `delete`, which zeroes the
+/// secret buffers. Every method takes `&self`: the ZST is `UnsafeCell`-backed,
+/// so C++ mutates the job's result fields through `&` and there is no `&mut`
+/// exclusivity to claim — the work pool and the C++ side share the object.
+#[repr(transparent)]
+pub struct SecretsJobOptions(bun_opaque::ForeignRef<sys::SecretsJobOptions>);
+
+// safe fn: `sys::SecretsJobOptions` and `JSGlobalObject` are `opaque_ffi!` ZST
+// handles (`!Freeze` via `UnsafeCell`), so `&T` is ABI-identical to a non-null
+// pointer and C++ mutating through it is interior to the cell.
 unsafe extern "C" {
-    safe fn Bun__SecretsJobOptions__runTask(ctx: &mut SecretsJobOptions, global: &JSGlobalObject);
+    safe fn Bun__SecretsJobOptions__runTask(opts: &sys::SecretsJobOptions, global: &JSGlobalObject);
     safe fn Bun__SecretsJobOptions__runFromJS(
-        ctx: &mut SecretsJobOptions,
+        opts: &sys::SecretsJobOptions,
         global: &JSGlobalObject,
         promise: JSValue,
     );
-    fn Bun__SecretsJobOptions__deinit(ctx: *mut SecretsJobOptions);
+    // safe: C++ `delete opts`. Freeing is not exclusive access, so the receiver
+    // is `&`. Reachable only via `ForeignRef`'s `Drop`, which owns the one unit
+    // it gives back — that pairing is the double-free proof.
+    safe fn Bun__SecretsJobOptions__deinit(opts: &sys::SecretsJobOptions);
 }
 
+/// Ownership plumbing.
+impl SecretsJobOptions {
+    /// Adopt the allocation returned by C++ `new SecretsJobOptions`.
+    ///
+    /// # Safety
+    /// `ptr` must be live and carry the sole ownership unit — no other handle
+    /// may `delete` it.
+    #[inline]
+    pub unsafe fn adopt(ptr: NonNull<sys::SecretsJobOptions>) -> Self {
+        // SAFETY: caller transfers the sole unit.
+        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
+    }
+
+    /// Adopt a nullable owning pointer; `None` on null.
+    ///
+    /// # Safety
+    /// A non-null `ptr` must satisfy [`Self::adopt`]'s contract.
+    #[inline]
+    unsafe fn adopt_ptr(ptr: *mut sys::SecretsJobOptions) -> Option<Self> {
+        // SAFETY: caller contract.
+        NonNull::new(ptr).map(|p| unsafe { Self::adopt(p) })
+    }
+
+    /// The C++ pointer, still owned by `self`.
+    #[inline]
+    pub fn as_ptr(&self) -> *mut sys::SecretsJobOptions {
+        self.0.as_ptr()
+    }
+
+    /// Hand the allocation to a foreign owner. Pairs with a later [`Self::adopt`].
+    #[inline]
+    pub fn leak(self) -> NonNull<sys::SecretsJobOptions> {
+        self.0.leak()
+    }
+
+    #[inline]
+    fn raw(&self) -> &sys::SecretsJobOptions {
+        &self.0
+    }
+}
+
+/// Job body. `&self` throughout: C++ writes the result fields through the same
+/// pointer, and neither call takes or gives back an ownership unit.
+impl SecretsJobOptions {
+    /// Runs OFF the JS thread; performs the platform keychain call.
+    pub fn run_task(&self, global: &JSGlobalObject) {
+        Bun__SecretsJobOptions__runTask(self.raw(), global)
+    }
+
+    /// Runs ON the JS thread; settles `promise` from the job's result fields.
+    pub fn run_from_js(&self, global: &JSGlobalObject, promise: JSValue) {
+        Bun__SecretsJobOptions__runFromJS(self.raw(), global, promise)
+    }
+}
+
+/// Owns the job options for the life of the task; both fields drop themselves,
+/// `options` before `promise`, exactly where the old hand-rolled `Drop` ran.
 pub(crate) struct SecretsCtx {
-    ctx: *mut SecretsJobOptions,
+    options: SecretsJobOptions,
     promise: Strong,
 }
 
 impl AnyTaskJobCtx for SecretsCtx {
     fn run(&mut self, global: *mut JSGlobalObject) {
-        // `ctx` is a valid C++ SecretsJobOptions* held alive until Drop;
-        // `global` is the creating VM's global pointer. Both are `opaque_ffi!`
-        // ZST handles, so `opaque_mut`/`opaque_ref` are the centralised
-        // zero-byte deref proofs (panic on null).
-        Bun__SecretsJobOptions__runTask(
-            SecretsJobOptions::opaque_mut(self.ctx),
-            JSGlobalObject::opaque_ref(global),
-        );
+        // `global` is the creating VM's global pointer, forwarded to C++ without
+        // being dereferenced here; `opaque_ref` is the zero-byte deref proof.
+        self.options.run_task(JSGlobalObject::opaque_ref(global));
     }
 
     fn then(&mut self, global: &JSGlobalObject) -> JsResult<()> {
@@ -46,32 +123,33 @@ impl AnyTaskJobCtx for SecretsCtx {
         // scope here, `drainMicrotasks`'s `TopExceptionScope` ctor asserts on the
         // unchecked simulated throw — same shape as `JSCDeferredWorkTask::run`.
         crate::validation_scope!(scope, global);
-        Bun__SecretsJobOptions__runFromJS(SecretsJobOptions::opaque_mut(self.ctx), global, promise);
+        self.options.run_from_js(global, promise);
         scope.assert_no_exception_except_termination()
-    }
-}
-
-impl Drop for SecretsCtx {
-    fn drop(&mut self) {
-        // SAFETY: `ctx` is the C++ SecretsJobOptions* passed to `create`; C++ side owns cleanup.
-        unsafe { Bun__SecretsJobOptions__deinit(self.ctx) };
-        // `promise: Strong` drops automatically.
     }
 }
 
 pub(crate) type SecretsJob = AnyTaskJob<SecretsCtx>;
 
-// Helper function for C++ to call with opaque pointer
+/// `jsSecretsGet`/`Set`/`Delete` hand over a fresh `new SecretsJobOptions`;
+/// Rust adopts it and is solely responsible for the `delete`.
+///
+/// # Safety
+/// `options` must be a live, uniquely-owned `SecretsJobOptions*`.
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn Bun__Secrets__scheduleJob(
+pub(crate) unsafe extern "C" fn Bun__Secrets__scheduleJob(
     global: &JSGlobalObject,
-    options: *mut SecretsJobOptions,
+    options: *mut sys::SecretsJobOptions,
     promise: JSValue,
 ) {
+    // SAFETY: caller contract. Non-null: every call site does
+    // `RETURN_IF_EXCEPTION` + `ASSERT(options)` after `fromJS`.
+    let options = unsafe { SecretsJobOptions::adopt_ptr(options) }
+        .expect("Bun__Secrets__scheduleJob: null SecretsJobOptions");
+    // On `Err` the job is freed, running `SecretsCtx`'s drop.
     SecretsJob::create_and_schedule(
         global,
         SecretsCtx {
-            ctx: options,
+            options,
             promise: Strong::create(promise, global),
         },
     )

--- a/src/jsc/JSUint8Array.rs
+++ b/src/jsc/JSUint8Array.rs
@@ -32,6 +32,9 @@ impl JSUint8Array {
         }
     }
 
+    /// `&mut self`, unlike the ZST-only methods above: the returned slice aliases
+    /// the typed array's real backing store, so the exclusive borrow is the only
+    /// thing preventing two live `&mut [u8]` over the same bytes.
     pub fn slice(&mut self) -> &mut [u8] {
         // Note: detached/empty JSUint8Array has ptr=null, len=0;
         // `ffi::slice_mut` tolerates `(null, 0)` so no extra guard.

--- a/src/jsc/MarkedArgumentBuffer.rs
+++ b/src/jsc/MarkedArgumentBuffer.rs
@@ -44,7 +44,7 @@ impl MarkedArgumentBuffer {
         ctx.r.unwrap()
     }
 
-    pub fn append(&mut self, value: JSValue) {
+    pub fn append(&self, value: JSValue) {
         MarkedArgumentBuffer__append(self, value)
     }
 

--- a/src/jsc/RegularExpression.rs
+++ b/src/jsc/RegularExpression.rs
@@ -16,18 +16,17 @@ pub mod sys {
 
 // C++ hands back a `new RegularExpression` (a `+1`); one `RegularExpression`
 // handle owns exactly that allocation, and `deinit` (`delete re`) gives it back.
-bun_opaque::foreign_owned!(sys::RegularExpression, Yarr__RegularExpression__deinit);
-
-/// Owned handle to a C++ `JSC::Yarr::RegularExpression`.
-///
-/// Owns one allocation; `Drop` deletes it. Every method takes `&self`: the ZST is
-/// `UnsafeCell`-backed and C++ advances the match cursor through the same pointer,
-/// so there is no `&mut self` to have.
-///
-/// A handle borrowed from a pointer someone else owns (see [`Self::borrow_leaked`])
-/// is a `ManuallyDrop<RegularExpression>` - dropping it would free their regex.
-#[repr(transparent)]
-pub struct RegularExpression(bun_opaque::ForeignRef<sys::RegularExpression>);
+bun_opaque::foreign_handle! {
+    /// Owned handle to a C++ `JSC::Yarr::RegularExpression`.
+    ///
+    /// Owns one allocation; `Drop` deletes it. Every method takes `&self`: the ZST is
+    /// `UnsafeCell`-backed and C++ advances the match cursor through the same pointer,
+    /// so there is no `&mut self` to have.
+    ///
+    /// A handle borrowed from a pointer someone else owns (see [`Self::borrow_leaked`])
+    /// is a `ManuallyDrop<RegularExpression>` - dropping it would free their regex.
+    pub struct RegularExpression(sys::RegularExpression) via Yarr__RegularExpression__deinit;
+}
 
 #[repr(u16)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -74,25 +73,9 @@ unsafe extern "C" {
     ) -> i32;
 }
 
-/// Ownership plumbing.
+/// Construction and queries. `&self` throughout: C++ mutates the match cursor
+/// through the same pointer.
 impl RegularExpression {
-    /// Adopt an allocation returned by C++.
-    ///
-    /// # Safety
-    /// `ptr` must be a live regex that no other handle will free.
-    #[inline]
-    pub unsafe fn adopt(ptr: NonNull<sys::RegularExpression>) -> Self {
-        // SAFETY: caller transfers the allocation.
-        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
-    }
-
-    /// Adopt a nullable allocation; `None` on null.
-    #[inline]
-    fn adopt_ptr(ptr: *mut sys::RegularExpression) -> Option<Self> {
-        // SAFETY: C++ `init` returns a fresh allocation or null.
-        NonNull::new(ptr).map(|p| unsafe { Self::adopt(p) })
-    }
-
     /// Borrow a regex handed to a foreign owner by [`Self::leak`].
     ///
     /// Takes **no** ownership, hence `ManuallyDrop`: dropping this would free an
@@ -106,33 +89,14 @@ impl RegularExpression {
         ManuallyDrop::new(unsafe { Self::adopt(ptr) })
     }
 
-    /// The C++ pointer, still owned by `self`.
-    #[inline]
-    pub fn as_ptr(&self) -> *mut sys::RegularExpression {
-        self.0.as_ptr()
-    }
-
-    /// Hand our allocation to a foreign owner. Pairs with a later [`Self::adopt`].
-    #[inline]
-    pub fn leak(self) -> NonNull<sys::RegularExpression> {
-        self.0.leak()
-    }
-
-    #[inline]
-    fn raw(&self) -> &sys::RegularExpression {
-        &self.0
-    }
-}
-
-/// Construction and queries. `&self` throughout: C++ mutates the match cursor
-/// through the same pointer.
-impl RegularExpression {
     /// C++ `new`s the regex. On an invalid pattern the handle drops here, so the
     /// allocation is freed before the `Err` reaches the caller.
     #[inline]
     pub fn init(pattern: BunString, flags: Flags) -> Result<Self, RegularExpressionError> {
-        let regex = Self::adopt_ptr(Yarr__RegularExpression__init(pattern, flags as u16))
-            .expect("Yarr__RegularExpression__init returned null");
+        // SAFETY: C++ `init` transfers a fresh `+1` allocation (or null) to us.
+        let regex =
+            unsafe { Self::adopt_ptr(Yarr__RegularExpression__init(pattern, flags as u16)) }
+                .expect("Yarr__RegularExpression__init returned null");
         if !regex.is_valid() {
             return Err(RegularExpressionError::InvalidRegExp);
         }

--- a/src/jsc/RegularExpression.rs
+++ b/src/jsc/RegularExpression.rs
@@ -1,9 +1,33 @@
+use core::mem::ManuallyDrop;
+use core::ptr::NonNull;
+
 use bun_core::String as BunString;
 
-bun_opaque::opaque_ffi! {
-    /// Opaque FFI handle for `JSC::Yarr::RegularExpression`.
-    pub struct RegularExpression;
+/// The C++ object itself. Only the extern declarations below name this type;
+/// all Rust code uses the owning [`RegularExpression`] handle.
+pub mod sys {
+    bun_opaque::opaque_ffi! {
+        /// `JSC::Yarr::RegularExpression`. `&Self` is ABI-identical to a non-null
+        /// `RegularExpression*`, and carries no `noalias`/`readonly` - C++ mutates
+        /// the match cursor through it.
+        pub struct RegularExpression;
+    }
 }
+
+// C++ hands back a `new RegularExpression` (a `+1`); one `RegularExpression`
+// handle owns exactly that allocation, and `deinit` (`delete re`) gives it back.
+bun_opaque::foreign_owned!(sys::RegularExpression, Yarr__RegularExpression__deinit);
+
+/// Owned handle to a C++ `JSC::Yarr::RegularExpression`.
+///
+/// Owns one allocation; `Drop` deletes it. Every method takes `&self`: the ZST is
+/// `UnsafeCell`-backed and C++ advances the match cursor through the same pointer,
+/// so there is no `&mut self` to have.
+///
+/// A handle borrowed from a pointer someone else owns (see [`Self::borrow_leaked`])
+/// is a `ManuallyDrop<RegularExpression>` - dropping it would free their regex.
+#[repr(transparent)]
+pub struct RegularExpression(bun_opaque::ForeignRef<sys::RegularExpression>);
 
 #[repr(u16)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28,71 +52,117 @@ pub enum RegularExpressionError {
 
 bun_core::named_error_set!(RegularExpressionError);
 
-// `RegularExpression` is an opaque `UnsafeCell`-backed ZST handle, so
-// `&RegularExpression` is ABI-identical to a non-null `*const` and C++ mutating
-// internal Yarr state through it is interior mutation invisible to Rust. The
-// query/compile shims are therefore declared `safe fn`; only `deinit` (which
-// frees the allocation) keeps a raw `*mut` and stays `unsafe`.
+// `&sys::RegularExpression` is ABI-identical to a non-null `RegularExpression*`
+// and carries no `noalias`; Yarr mutates through it. Every shim traffics only in
+// that plus POD, so all are `safe fn` — `deinit` releases, it is not exclusive.
 unsafe extern "C" {
-    safe fn Yarr__RegularExpression__init(pattern: BunString, flags: u16)
-    -> *mut RegularExpression;
-    fn Yarr__RegularExpression__deinit(pattern: *mut RegularExpression);
-    safe fn Yarr__RegularExpression__isValid(this: &RegularExpression) -> bool;
-    safe fn Yarr__RegularExpression__matchedLength(this: &RegularExpression) -> i32;
+    safe fn Yarr__RegularExpression__init(
+        pattern: BunString,
+        flags: u16,
+    ) -> *mut sys::RegularExpression;
+    safe fn Yarr__RegularExpression__deinit(this: &sys::RegularExpression);
+    safe fn Yarr__RegularExpression__isValid(this: &sys::RegularExpression) -> bool;
+    safe fn Yarr__RegularExpression__matchedLength(this: &sys::RegularExpression) -> i32;
     // C++: int Yarr__RegularExpression__searchRev(RegularExpression*, BunString) (bindings/RegularExpression.cpp:30)
-    safe fn Yarr__RegularExpression__searchRev(this: &RegularExpression, string: BunString) -> i32;
-    safe fn Yarr__RegularExpression__matches(this: &RegularExpression, string: BunString) -> i32;
+    safe fn Yarr__RegularExpression__searchRev(
+        this: &sys::RegularExpression,
+        string: BunString,
+    ) -> i32;
+    safe fn Yarr__RegularExpression__matches(
+        this: &sys::RegularExpression,
+        string: BunString,
+    ) -> i32;
 }
 
+/// Ownership plumbing.
 impl RegularExpression {
+    /// Adopt an allocation returned by C++.
+    ///
+    /// # Safety
+    /// `ptr` must be a live regex that no other handle will free.
     #[inline]
-    pub fn init(
-        pattern: BunString,
-        flags: Flags,
-    ) -> Result<*mut RegularExpression, RegularExpressionError> {
-        let regex = Yarr__RegularExpression__init(pattern, flags as u16);
-        // `RegularExpression` is an `opaque_ffi!` ZST handle; `opaque_mut` is
-        // the centralised non-null-ZST deref proof (panics on null, which
-        // `Yarr__RegularExpression__init` never returns).
-        if !RegularExpression::opaque_mut(regex).is_valid() {
-            // SAFETY: `regex` is a valid live Yarr handle we just allocated; consumed here.
-            unsafe { Self::destroy(regex) };
+    pub unsafe fn adopt(ptr: NonNull<sys::RegularExpression>) -> Self {
+        // SAFETY: caller transfers the allocation.
+        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
+    }
+
+    /// Adopt a nullable allocation; `None` on null.
+    #[inline]
+    fn adopt_ptr(ptr: *mut sys::RegularExpression) -> Option<Self> {
+        // SAFETY: C++ `init` returns a fresh allocation or null.
+        NonNull::new(ptr).map(|p| unsafe { Self::adopt(p) })
+    }
+
+    /// Borrow a regex handed to a foreign owner by [`Self::leak`].
+    ///
+    /// Takes **no** ownership, hence `ManuallyDrop`: dropping this would free an
+    /// allocation the leak's new owner still holds.
+    ///
+    /// # Safety
+    /// `ptr` must be live for the returned handle's lifetime.
+    #[inline]
+    pub unsafe fn borrow_leaked(ptr: NonNull<sys::RegularExpression>) -> ManuallyDrop<Self> {
+        // SAFETY: caller contract; ManuallyDrop never releases it.
+        ManuallyDrop::new(unsafe { Self::adopt(ptr) })
+    }
+
+    /// The C++ pointer, still owned by `self`.
+    #[inline]
+    pub fn as_ptr(&self) -> *mut sys::RegularExpression {
+        self.0.as_ptr()
+    }
+
+    /// Hand our allocation to a foreign owner. Pairs with a later [`Self::adopt`].
+    #[inline]
+    pub fn leak(self) -> NonNull<sys::RegularExpression> {
+        self.0.leak()
+    }
+
+    #[inline]
+    fn raw(&self) -> &sys::RegularExpression {
+        &self.0
+    }
+}
+
+/// Construction and queries. `&self` throughout: C++ mutates the match cursor
+/// through the same pointer.
+impl RegularExpression {
+    /// C++ `new`s the regex. On an invalid pattern the handle drops here, so the
+    /// allocation is freed before the `Err` reaches the caller.
+    #[inline]
+    pub fn init(pattern: BunString, flags: Flags) -> Result<Self, RegularExpressionError> {
+        let regex = Self::adopt_ptr(Yarr__RegularExpression__init(pattern, flags as u16))
+            .expect("Yarr__RegularExpression__init returned null");
+        if !regex.is_valid() {
             return Err(RegularExpressionError::InvalidRegExp);
         }
         Ok(regex)
     }
 
     #[inline]
-    pub fn is_valid(&mut self) -> bool {
-        Yarr__RegularExpression__isValid(self)
+    pub fn is_valid(&self) -> bool {
+        Yarr__RegularExpression__isValid(self.raw())
     }
 
     // Reserving `match` for a full match result.
     // #[inline]
-    // pub fn r#match(&mut self, str: BunString, start_from: i32) -> MatchResult {
+    // pub fn r#match(&self, str: BunString, start_from: i32) -> MatchResult {
     // }
 
     /// Simple boolean matcher
     #[inline]
-    pub fn matches(&mut self, str: BunString) -> bool {
-        Yarr__RegularExpression__matches(self, str) >= 0
+    pub fn matches(&self, str: BunString) -> bool {
+        Yarr__RegularExpression__matches(self.raw(), str) >= 0
     }
 
     #[inline]
-    pub fn search_rev(&mut self, str: BunString) -> i32 {
-        Yarr__RegularExpression__searchRev(self, str)
+    pub fn search_rev(&self, str: BunString) -> i32 {
+        Yarr__RegularExpression__searchRev(self.raw(), str)
     }
 
     #[inline]
-    pub fn matched_length(&mut self) -> i32 {
-        Yarr__RegularExpression__matchedLength(self)
-    }
-
-    /// Destroys the FFI-allocated handle. Caller must not use `this` afterwards.
-    #[inline]
-    pub unsafe fn destroy(this: *mut Self) {
-        // SAFETY: `this` is a valid live Yarr RegularExpression handle; consumed here.
-        unsafe { Yarr__RegularExpression__deinit(this) }
+    pub fn matched_length(&self) -> i32 {
+        Yarr__RegularExpression__matchedLength(self.raw())
     }
 }
 
@@ -105,25 +175,24 @@ impl RegularExpression {
 // ──────────────────────────────────────────────────────────────────────────
 
 #[unsafe(no_mangle)]
-pub(crate) fn __bun_regex_compile(pattern: BunString) -> Option<core::ptr::NonNull<()>> {
+pub(crate) fn __bun_regex_compile(pattern: BunString) -> Option<NonNull<()>> {
     // Initialize JSC before first compile (idempotent).
     crate::initialize(false);
-    match RegularExpression::init(pattern, Flags::None) {
-        Ok(r) => core::ptr::NonNull::new(r.cast()),
-        Err(_) => None,
-    }
+    // The allocation is leaked to the caller, which owns it until `__bun_regex_drop`.
+    RegularExpression::init(pattern, Flags::None)
+        .ok()
+        .map(|r| r.leak().cast::<()>())
 }
 
 #[unsafe(no_mangle)]
-pub(crate) fn __bun_regex_matches(regex: core::ptr::NonNull<()>, input: &BunString) -> bool {
-    // `RegularExpression` is an `opaque_ffi!` ZST handle; `opaque_mut` is the
-    // centralised non-null deref proof. `regex` was produced by
-    // `__bun_regex_compile` and remains live until `__bun_regex_drop`.
-    RegularExpression::opaque_mut(regex.as_ptr().cast()).matches(*input)
+pub(crate) fn __bun_regex_matches(regex: NonNull<()>, input: &BunString) -> bool {
+    // SAFETY: `regex` was leaked by `__bun_regex_compile` and stays live until
+    // `__bun_regex_drop`; the borrow releases nothing.
+    unsafe { RegularExpression::borrow_leaked(regex.cast()) }.matches(*input)
 }
 
 #[unsafe(no_mangle)]
-pub(crate) fn __bun_regex_drop(regex: core::ptr::NonNull<()>) {
-    // SAFETY: `regex` was produced by `__bun_regex_compile`; consumed here.
-    unsafe { RegularExpression::destroy(regex.as_ptr().cast()) }
+pub(crate) fn __bun_regex_drop(regex: NonNull<()>) {
+    // SAFETY: re-adopts the allocation leaked by `__bun_regex_compile`; `Drop` frees it.
+    drop(unsafe { RegularExpression::adopt(regex.cast()) })
 }

--- a/src/jsc/SourceProvider.rs
+++ b/src/jsc/SourceProvider.rs
@@ -1,5 +1,3 @@
-use core::ptr::NonNull;
-
 /// The C++ object itself. Only the extern declaration below names this type;
 /// all Rust code uses the owning [`SourceProvider`] handle.
 pub mod sys {
@@ -14,48 +12,21 @@ pub mod sys {
 // C++ hands Rust a `+1` by `provider->ref()`-ing into the
 // `ZigStackTrace::referenced_source_provider` out-param field
 // (`populateStackFramePosition`, ZigException.cpp). One handle owns that ref.
-bun_opaque::foreign_owned!(sys::SourceProvider, JSC__SourceProvider__deref);
-
-/// Owned handle to a C++ `JSC::SourceProvider` (a `WTF::RefCounted`).
-///
-/// Holds one ref on the intrusive refcount; `Drop` gives it back. There is no
-/// `&mut self` API and no `DerefMut`: a refcount is shared by definition, and
-/// JSC mutates the provider through the same pointer.
-///
-/// `Option<SourceProvider>` niche-optimizes to a single thin pointer, so it is
-/// exactly the ABI of the C++ `JSC::SourceProvider*` struct field.
-#[repr(transparent)]
-pub struct SourceProvider(bun_opaque::ForeignRef<sys::SourceProvider>);
+bun_opaque::foreign_handle! {
+    /// Owned handle to a C++ `JSC::SourceProvider` (a `WTF::RefCounted`).
+    ///
+    /// Holds one ref on the intrusive refcount; `Drop` gives it back. There is no
+    /// `&mut self` API and no `DerefMut`: a refcount is shared by definition, and
+    /// JSC mutates the provider through the same pointer.
+    ///
+    /// `Option<SourceProvider>` niche-optimizes to a single thin pointer, so it is
+    /// exactly the ABI of the C++ `JSC::SourceProvider*` struct field.
+    pub struct SourceProvider(sys::SourceProvider) via JSC__SourceProvider__deref;
+}
 
 unsafe extern "C" {
     // safe: C++ takes `JSC::SourceProvider*` and calls the intrusive `->deref()`.
     // A refcount decrement is not exclusive access — other refs exist by
     // definition — so the receiver is `&`, not `&mut`.
     safe fn JSC__SourceProvider__deref(provider: &sys::SourceProvider);
-}
-
-/// Ownership plumbing. `deref` is the release fn, so it lives only in `Drop`;
-/// there is no other inherent method to forward, hence no private `raw()`.
-impl SourceProvider {
-    /// Adopt a `+1` C++ wrote into an out-param.
-    ///
-    /// # Safety
-    /// `ptr` must carry exactly one ref that no other handle will release.
-    #[inline]
-    pub unsafe fn adopt(ptr: NonNull<sys::SourceProvider>) -> Self {
-        // SAFETY: caller transfers the +1.
-        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
-    }
-
-    /// The C++ pointer, still owned by `self`.
-    #[inline]
-    pub fn as_ptr(&self) -> *mut sys::SourceProvider {
-        self.0.as_ptr()
-    }
-
-    /// Hand our `+1` to a foreign owner. Pairs with a later [`Self::adopt`].
-    #[inline]
-    pub fn leak(self) -> NonNull<sys::SourceProvider> {
-        self.0.leak()
-    }
 }

--- a/src/jsc/SourceProvider.rs
+++ b/src/jsc/SourceProvider.rs
@@ -1,16 +1,61 @@
-bun_opaque::opaque_ffi! {
-    /// Opaque representation of a JavaScript source provider
-    pub struct SourceProvider;
-}
+use core::ptr::NonNull;
 
-impl SourceProvider {
-    pub fn deref(&mut self) {
-        JSC__SourceProvider__deref(self)
+/// The C++ object itself. Only the extern declaration below names this type;
+/// all Rust code uses the owning [`SourceProvider`] handle.
+pub mod sys {
+    bun_opaque::opaque_ffi! {
+        /// `JSC::SourceProvider`. `&Self` is ABI-identical to a non-null
+        /// `JSC::SourceProvider*`, and carries no `noalias`/`readonly` — C++
+        /// mutates the intrusive refcount through it.
+        pub struct SourceProvider;
     }
 }
 
+// C++ hands Rust a `+1` by `provider->ref()`-ing into the
+// `ZigStackTrace::referenced_source_provider` out-param field
+// (`populateStackFramePosition`, ZigException.cpp). One handle owns that ref.
+bun_opaque::foreign_owned!(sys::SourceProvider, JSC__SourceProvider__deref);
+
+/// Owned handle to a C++ `JSC::SourceProvider` (a `WTF::RefCounted`).
+///
+/// Holds one ref on the intrusive refcount; `Drop` gives it back. There is no
+/// `&mut self` API and no `DerefMut`: a refcount is shared by definition, and
+/// JSC mutates the provider through the same pointer.
+///
+/// `Option<SourceProvider>` niche-optimizes to a single thin pointer, so it is
+/// exactly the ABI of the C++ `JSC::SourceProvider*` struct field.
+#[repr(transparent)]
+pub struct SourceProvider(bun_opaque::ForeignRef<sys::SourceProvider>);
+
 unsafe extern "C" {
-    // safe: `SourceProvider` is an opaque `UnsafeCell`-backed ZST handle; `&mut` is
-    // ABI-identical to a non-null pointer and C++ refcount mutation is interior.
-    safe fn JSC__SourceProvider__deref(provider: &mut SourceProvider);
+    // safe: C++ takes `JSC::SourceProvider*` and calls the intrusive `->deref()`.
+    // A refcount decrement is not exclusive access — other refs exist by
+    // definition — so the receiver is `&`, not `&mut`.
+    safe fn JSC__SourceProvider__deref(provider: &sys::SourceProvider);
+}
+
+/// Ownership plumbing. `deref` is the release fn, so it lives only in `Drop`;
+/// there is no other inherent method to forward, hence no private `raw()`.
+impl SourceProvider {
+    /// Adopt a `+1` C++ wrote into an out-param.
+    ///
+    /// # Safety
+    /// `ptr` must carry exactly one ref that no other handle will release.
+    #[inline]
+    pub unsafe fn adopt(ptr: NonNull<sys::SourceProvider>) -> Self {
+        // SAFETY: caller transfers the +1.
+        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
+    }
+
+    /// The C++ pointer, still owned by `self`.
+    #[inline]
+    pub fn as_ptr(&self) -> *mut sys::SourceProvider {
+        self.0.as_ptr()
+    }
+
+    /// Hand our `+1` to a foreign owner. Pairs with a later [`Self::adopt`].
+    #[inline]
+    pub fn leak(self) -> NonNull<sys::SourceProvider> {
+        self.0.leak()
+    }
 }

--- a/src/jsc/Strong.rs
+++ b/src/jsc/Strong.rs
@@ -17,10 +17,6 @@ pub mod sys {
     }
 }
 
-// `Bun__StrongRef__new` allocates a HandleSlot from the VM's HandleSet and
-// hands back its sole owner. One `Impl` handle owns exactly that one slot.
-bun_opaque::foreign_owned!(sys::Impl, strong_ref_delete);
-
 /// A corrupted slot pointer segfaults inside JSC's `HandleBlock::handleSet`,
 /// which loses the Rust caller frame; panicking here names the exact owner.
 /// `0x10000` is Windows' null-page guard — real slots are bmalloc'd far above.
@@ -34,41 +30,14 @@ fn strong_ref_delete(slot: &sys::Impl) {
     Bun__StrongRef__delete(slot)
 }
 
-/// Owned handle to one `JSC::HandleSet` slot rooting a `JSValue`.
-///
-/// `Drop` deallocates the slot. Every method takes `&self`: JSC writes the slot
-/// through the same pointer, and deallocating it is not exclusive access.
-#[repr(transparent)]
-pub struct Impl(bun_opaque::ForeignRef<sys::Impl>);
-
-/// Ownership plumbing.
-impl Impl {
-    /// Adopt a slot allocated by C++.
+// `Bun__StrongRef__new` allocates a HandleSlot from the VM's HandleSet and
+// hands back its sole owner. One `Impl` handle owns exactly that one slot.
+bun_opaque::foreign_handle! {
+    /// Owned handle to one `JSC::HandleSet` slot rooting a `JSValue`.
     ///
-    /// # Safety
-    /// `ptr` must be a live slot that no other handle will deallocate.
-    #[inline]
-    pub unsafe fn adopt(ptr: NonNull<sys::Impl>) -> Self {
-        // SAFETY: caller transfers the allocation.
-        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
-    }
-
-    /// The slot pointer, still owned by `self`.
-    #[inline]
-    pub fn as_ptr(&self) -> *mut sys::Impl {
-        self.0.as_ptr()
-    }
-
-    /// Hand the slot to a foreign owner. Pairs with a later [`Self::adopt`].
-    #[inline]
-    pub fn leak(self) -> NonNull<sys::Impl> {
-        self.0.leak()
-    }
-
-    #[inline]
-    fn raw(&self) -> &sys::Impl {
-        &self.0
-    }
+    /// `Drop` deallocates the slot. Every method takes `&self`: JSC writes the slot
+    /// through the same pointer, and deallocating it is not exclusive access.
+    pub struct Impl(sys::Impl) via strong_ref_delete;
 }
 
 /// Slot lifecycle and access. `&self` throughout: JSC mutates the slot.

--- a/src/jsc/Strong.rs
+++ b/src/jsc/Strong.rs
@@ -6,24 +6,114 @@ use core::ptr::NonNull;
 
 use crate::{JSGlobalObject, JSValue};
 
-// Note: field renamed from `impl` (Rust keyword) to `handle`.
-pub struct Strong {
-    handle: NonNull<Impl>,
-    // NonNull<T> is already !Send + !Sync, matching the requirement that
-    // Strong must be dropped on the JS thread (HandleSet is VM-owned).
+/// The C++ allocation itself. Only the extern declarations below name this
+/// type; all Rust code uses the owning [`Impl`] handle.
+pub mod sys {
+    bun_opaque::opaque_ffi! {
+        /// A `JSC::HandleSet` slot (`JSC::JSValue*`); see StrongRef.cpp. `&Self`
+        /// is ABI-identical to a non-null slot pointer and carries no
+        /// `noalias`/`readonly` — JSC writes the slot through it.
+        pub struct Impl;
+    }
 }
+
+// `Bun__StrongRef__new` allocates a HandleSlot from the VM's HandleSet and
+// hands back its sole owner. One `Impl` handle owns exactly that one slot.
+bun_opaque::foreign_owned!(sys::Impl, strong_ref_delete);
+
+/// A corrupted slot pointer segfaults inside JSC's `HandleBlock::handleSet`,
+/// which loses the Rust caller frame; panicking here names the exact owner.
+/// `0x10000` is Windows' null-page guard — real slots are bmalloc'd far above.
+fn strong_ref_delete(slot: &sys::Impl) {
+    if cfg!(debug_assertions) {
+        assert!(
+            (std::ptr::from_ref(slot) as usize) >= 0x10000,
+            "Strong::drop: corrupted HandleSlot pointer {slot:p}"
+        );
+    }
+    Bun__StrongRef__delete(slot)
+}
+
+/// Owned handle to one `JSC::HandleSet` slot rooting a `JSValue`.
+///
+/// `Drop` deallocates the slot. Every method takes `&self`: JSC writes the slot
+/// through the same pointer, and deallocating it is not exclusive access.
+#[repr(transparent)]
+pub struct Impl(bun_opaque::ForeignRef<sys::Impl>);
+
+/// Ownership plumbing.
+impl Impl {
+    /// Adopt a slot allocated by C++.
+    ///
+    /// # Safety
+    /// `ptr` must be a live slot that no other handle will deallocate.
+    #[inline]
+    pub unsafe fn adopt(ptr: NonNull<sys::Impl>) -> Self {
+        // SAFETY: caller transfers the allocation.
+        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
+    }
+
+    /// The slot pointer, still owned by `self`.
+    #[inline]
+    pub fn as_ptr(&self) -> *mut sys::Impl {
+        self.0.as_ptr()
+    }
+
+    /// Hand the slot to a foreign owner. Pairs with a later [`Self::adopt`].
+    #[inline]
+    pub fn leak(self) -> NonNull<sys::Impl> {
+        self.0.leak()
+    }
+
+    #[inline]
+    fn raw(&self) -> &sys::Impl {
+        &self.0
+    }
+}
+
+/// Slot lifecycle and access. `&self` throughout: JSC mutates the slot.
+impl Impl {
+    /// C++ allocates the slot and hands back its sole owner.
+    pub fn init(global: &JSGlobalObject, value: JSValue) -> Self {
+        crate::mark_binding!();
+        let p = NonNull::new(Bun__StrongRef__new(global, value))
+            .expect("Bun__StrongRef__new returned null");
+        // SAFETY: freshly allocated slot, owned by nobody else.
+        unsafe { Self::adopt(p) }
+    }
+
+    pub fn get(&self) -> JSValue {
+        // The slot *is* a `JSC::JSValue`; see StrongRef.cpp.
+        // SAFETY: the slot is a live, aligned JSC::JSValue for `self`'s
+        // lifetime; `DecodedJSValue` is its `#[repr(C)]` ABI-compatible mirror.
+        unsafe { (*self.as_ptr().cast::<crate::DecodedJSValue>()).encode() }
+    }
+
+    pub fn set(&self, global: &JSGlobalObject, value: JSValue) {
+        crate::mark_binding!();
+        Bun__StrongRef__set(self.raw(), global, value);
+    }
+
+    pub fn clear(&self) {
+        crate::mark_binding!();
+        Bun__StrongRef__clear(self.raw());
+    }
+}
+
+// `ForeignRef` is !Send + !Sync, matching the requirement that Strong must be
+// dropped on the JS thread (HandleSet is VM-owned).
+#[repr(transparent)]
+pub struct Strong(Impl);
 
 impl Strong {
     /// Hold a strong reference to a JavaScript value. Released on `Drop`.
     pub fn create(value: JSValue, global: &JSGlobalObject) -> Strong {
         debug_assert!(!value.is_empty());
-        Strong {
-            handle: Impl::init(global, value),
-        }
+        Strong(Impl::init(global, value))
     }
 
     pub fn get(&self) -> JSValue {
-        let result = Impl::get(self.handle);
+        let result = self.0.get();
         debug_assert!(!result.is_empty());
         result
     }
@@ -31,67 +121,56 @@ impl Strong {
     /// Set a new value for the strong reference.
     pub fn set(&mut self, global: &JSGlobalObject, new_value: JSValue) {
         debug_assert!(!new_value.is_empty());
-        Impl::set(self.handle, global, new_value);
+        self.0.set(global, new_value);
     }
 
     /// Swap a new value for the strong reference.
     pub fn swap(&mut self, global: &JSGlobalObject, new_value: JSValue) -> JSValue {
-        let result = Impl::get(self.handle);
+        let result = self.0.get();
         self.set(global, new_value);
         result
     }
 
-    /// Adopt an `Impl` handle allocated externally (e.g. by C++ bindgen glue),
-    /// taking ownership. The handle will be destroyed on `Drop`.
+    /// Adopt a slot allocated externally (e.g. by C++ bindgen glue), taking
+    /// ownership. The slot is deallocated on `Drop`.
     ///
     /// # Safety
     /// `handle` must have been produced by `Bun__StrongRef__new` (or equivalent)
     /// and must not be owned by any other `Strong`/`Optional`.
-    pub unsafe fn adopt(handle: NonNull<Impl>) -> Strong {
-        Strong { handle }
-    }
-}
-
-impl Drop for Strong {
-    /// Release the strong reference.
-    fn drop(&mut self) {
-        // SAFETY: `self.handle` came from `Impl::init` and is consumed exactly once here.
-        unsafe { Impl::destroy(self.handle) };
+    pub unsafe fn adopt(handle: NonNull<sys::Impl>) -> Strong {
+        // SAFETY: caller transfers the allocation.
+        Strong(unsafe { Impl::adopt(handle) })
     }
 }
 
 /// Holds a strong reference to a JS value, protecting it from garbage
 /// collection. When not holding a value, the strong may still be allocated.
-// Note: field renamed from `impl` (Rust keyword) to `handle`.
-// `#[repr(transparent)]` over a single nullable pointer keeps this FFI-safe
-// when embedded in `extern "C"` structs.
+// `#[repr(transparent)]` over a niche-optimized `Option<Impl>` (one nullable
+// pointer) keeps this FFI-safe when embedded in `extern "C"` structs.
 #[repr(transparent)]
 #[derive(Default)]
-pub struct Optional {
-    handle: Option<NonNull<Impl>>,
-}
+pub struct Optional(Option<Impl>);
 
 impl Optional {
     pub const fn empty() -> Optional {
-        Optional { handle: None }
+        Optional(None)
     }
 
-    /// Adopt an `Impl` handle allocated externally (e.g. by C++ bindgen glue),
-    /// taking ownership if non-null. The handle will be destroyed on `Drop`.
+    /// Adopt a slot allocated externally (e.g. by C++ bindgen glue), taking
+    /// ownership if non-null. The slot is deallocated on `Drop`.
     ///
     /// # Safety
     /// If `Some`, `handle` must have been produced by `Bun__StrongRef__new`
     /// (or equivalent) and must not be owned by any other `Strong`/`Optional`.
-    pub unsafe fn adopt(handle: Option<NonNull<Impl>>) -> Optional {
-        Optional { handle }
+    pub unsafe fn adopt(handle: Option<NonNull<sys::Impl>>) -> Optional {
+        // SAFETY: caller transfers the allocation, if any.
+        Optional(handle.map(|p| unsafe { Impl::adopt(p) }))
     }
 
     /// Hold a strong reference to a JavaScript value. Released on `Drop` or `clear`.
     pub fn create(value: JSValue, global: &JSGlobalObject) -> Optional {
         if !value.is_empty() {
-            Optional {
-                handle: Some(Impl::init(global, value)),
-            }
+            Optional(Some(Impl::init(global, value)))
         } else {
             Optional::empty()
         }
@@ -99,8 +178,8 @@ impl Optional {
 
     /// Clears the value, but does not de-allocate the Strong reference.
     pub fn clear_without_deallocation(&mut self) {
-        let Some(r) = self.handle else { return };
-        Impl::clear(r);
+        let Some(r) = &self.0 else { return };
+        r.clear();
     }
 
     pub fn call(&mut self, global: &JSGlobalObject, args: &[JSValue]) -> JSValue {
@@ -113,8 +192,7 @@ impl Optional {
     }
 
     pub fn get(&self) -> Option<JSValue> {
-        let imp = self.handle?;
-        let result = Impl::get(imp);
+        let result = self.0.as_ref()?.get();
         if result.is_empty() {
             return None;
         }
@@ -122,20 +200,20 @@ impl Optional {
     }
 
     pub fn swap(&mut self) -> JSValue {
-        let Some(imp) = self.handle else {
+        let Some(imp) = &self.0 else {
             return JSValue::ZERO;
         };
-        let result = Impl::get(imp);
+        let result = imp.get();
         if result.is_empty() {
             return JSValue::ZERO;
         }
-        Impl::clear(imp);
+        imp.clear();
         result
     }
 
     pub fn has(&self) -> bool {
-        let Some(r) = self.handle else { return false };
-        !Impl::get(r).is_empty()
+        let Some(r) = &self.0 else { return false };
+        !r.get().is_empty()
     }
 
     pub fn try_swap(&mut self) -> Option<JSValue> {
@@ -146,97 +224,31 @@ impl Optional {
         Some(result)
     }
 
-    /// Explicit teardown. Idempotent; equivalent to dropping in place and
-    /// leaving `self` empty so `Drop` is a no-op.
+    /// Explicit teardown. Idempotent; leaves `self` empty.
     pub fn deinit(&mut self) {
-        let Some(r) = self.handle.take() else { return };
-        // SAFETY: `r` came from `Impl::init` and is consumed exactly once here.
-        unsafe { Impl::destroy(r) };
+        drop(self.0.take());
     }
 
     pub fn set(&mut self, global: &JSGlobalObject, value: JSValue) {
-        let Some(r) = self.handle else {
-            if value.is_empty() {
-                return;
-            }
-            self.handle = Some(Impl::init(global, value));
-            return;
-        };
-        Impl::set(r, global, value);
-    }
-}
-
-impl Drop for Optional {
-    /// Frees memory for the underlying Strong reference.
-    fn drop(&mut self) {
-        let Some(r) = self.handle.take() else { return };
-        // SAFETY: `r` came from `Impl::init` and is consumed exactly once here.
-        unsafe { Impl::destroy(r) };
-    }
-}
-
-bun_opaque::opaque_ffi! {
-    /// Opaque FFI handle. Backed by a `JSC::JSValue`-sized HandleSlot; see Strong.cpp.
-    pub struct Impl;
-}
-
-impl Impl {
-    pub fn init(global: &JSGlobalObject, value: JSValue) -> NonNull<Impl> {
-        crate::mark_binding!();
-        NonNull::new(Bun__StrongRef__new(global, value)).expect("Bun__StrongRef__new returned null")
-    }
-
-    pub fn get(this: NonNull<Impl>) -> JSValue {
-        // `this` is actually a pointer to a `JSC::JSValue`; see Strong.cpp.
-        // SAFETY: HandleSlot storage is a live, aligned JSC::JSValue for the
-        // lifetime of the Impl handle; `DecodedJSValue` is its `#[repr(C)]`
-        // ABI-compatible mirror.
-        unsafe { (*this.as_ptr().cast::<crate::DecodedJSValue>()).encode() }
-    }
-
-    pub fn set(this: NonNull<Impl>, global: &JSGlobalObject, value: JSValue) {
-        crate::mark_binding!();
-        Bun__StrongRef__set(Impl::opaque_ref(this.as_ptr()), global, value);
-    }
-
-    pub fn clear(this: NonNull<Impl>) {
-        crate::mark_binding!();
-        Bun__StrongRef__clear(Impl::opaque_ref(this.as_ptr()));
-    }
-
-    /// SAFETY: `this` must be a valid handle from `init`; consumed here (do not reuse).
-    pub unsafe fn destroy(this: NonNull<Impl>) {
-        crate::mark_binding!();
-        // Defensive: a corrupted slot pointer here segfaults inside JSC's
-        // HandleBlock::handleSet (the backing block is recovered by masking
-        // the slot to the block base, then `+0x10` is read), which loses the
-        // Rust caller frame. With panic=abort the crash-handler hook captures
-        // a Rust backtrace, so a `panic!` at this layer surfaces the *exact*
-        // call site that holds the corrupted Strong. The 0x10000 floor is
-        // Windows' default null-page guard; legitimate `Impl*` are bmalloc'd
-        // far above it.
-        if cfg!(debug_assertions) {
-            assert!(
-                (this.as_ptr() as usize) >= 0x10000,
-                "Strong<Impl>* corrupted ({:p}); owning struct was overwritten",
-                this.as_ptr(),
-            );
+        if let Some(r) = &self.0 {
+            r.set(global, value);
+        } else if !value.is_empty() {
+            self.0 = Some(Impl::init(global, value));
         }
-        // SAFETY: caller contract guarantees `this` is a live handle from
-        // `Bun__StrongRef__new`; ownership is transferred to C++ which frees it.
-        unsafe { Bun__StrongRef__delete(this.as_ptr()) };
     }
 }
 
-// `Impl` and `JSGlobalObject` are opaque `UnsafeCell`-backed ZST handles, so
-// `&Impl`/`&JSGlobalObject` are ABI-identical to non-null `*const T` and C++
-// mutating through them (HandleSet slot write) is interior mutation invisible
-// to Rust. `delete` consumes the C++ allocation and so stays `unsafe fn`.
+// `sys::Impl` and `JSGlobalObject` are opaque `UnsafeCell`-backed ZST handles,
+// so `&T` is ABI-identical to a non-null `*const T` and the HandleSet slot
+// write C++ performs through them is interior mutation invisible to Rust.
 unsafe extern "C" {
-    fn Bun__StrongRef__delete(this: *mut Impl);
-    safe fn Bun__StrongRef__new(global: &JSGlobalObject, value: JSValue) -> *mut Impl;
-    safe fn Bun__StrongRef__set(this: &Impl, global: &JSGlobalObject, value: JSValue);
-    safe fn Bun__StrongRef__clear(this: &Impl);
+    // safe: C++ hands the slot to `HandleSet::deallocate`. Deallocating is not
+    // exclusive access — the slot is JSC's, not Rust's — so the receiver is
+    // `&`, not `&mut`. `foreign_owned!` requires a `safe fn` here.
+    safe fn Bun__StrongRef__delete(this: &sys::Impl);
+    safe fn Bun__StrongRef__new(global: &JSGlobalObject, value: JSValue) -> *mut sys::Impl;
+    safe fn Bun__StrongRef__set(this: &sys::Impl, global: &JSGlobalObject, value: JSValue);
+    safe fn Bun__StrongRef__clear(this: &sys::Impl);
 }
 
 pub use crate::deprecated_strong as deprecated;

--- a/src/jsc/TextCodec.rs
+++ b/src/jsc/TextCodec.rs
@@ -3,23 +3,50 @@ use core::ptr::NonNull;
 use crate::mark_binding;
 use bun_core::String as BunString;
 
+/// The C++ object itself. Only the extern declarations below name this type;
+/// all Rust code uses the owning [`TextCodec`] handle.
+pub mod sys {
+    bun_opaque::opaque_ffi! {
+        /// `PAL::TextCodec`. `&Self` is ABI-identical to a non-null
+        /// `PAL::TextCodec*` (C++ spells it `void*`), and carries no
+        /// `noalias`/`readonly` — C++ mutates the codec's streaming state
+        /// (lead byte, ISO-2022-JP mode, GB18030 bytes) through it.
+        pub struct TextCodec;
+    }
+}
+
+// C++ `newTextCodec(encoding).release()` hands back the sole owning pointer;
+// `Bun__deleteTextCodec` `delete`s it. One handle owns exactly one codec.
+bun_opaque::foreign_owned!(sys::TextCodec, Bun__deleteTextCodec);
+
+/// Owned handle to a C++ `PAL::TextCodec`.
+///
+/// `Drop` deletes the codec. Every method takes `&self`: C++ mutates the codec
+/// through the same pointer, and giving the object back is not exclusive
+/// access, so there is no `&mut self` and no `DerefMut`.
+#[repr(transparent)]
+pub struct TextCodec(bun_opaque::ForeignRef<sys::TextCodec>);
+
+// `&sys::TextCodec` is ABI-identical to the `void*` the C++ shims declare. Shims
+// that also take raw `*const u8` / out-pointers stay `unsafe fn`: safe Rust can
+// forge those.
 unsafe extern "C" {
     fn Bun__createTextCodec(
         encoding_name: *const u8,
         encoding_name_len: usize,
-    ) -> Option<NonNull<TextCodec>>;
+    ) -> *mut sys::TextCodec;
     fn Bun__decodeWithTextCodec(
-        codec: *mut TextCodec,
+        codec: &sys::TextCodec,
         data: *const u8,
         length: usize,
         flush: bool,
         stop_on_error: bool,
         out_saw_error: *mut bool,
     ) -> BunString;
-    fn Bun__deleteTextCodec(codec: *mut TextCodec);
-    // safe: `TextCodec` is an `opaque_ffi!` ZST handle; `&mut` is ABI-identical
-    // to a non-null `*mut` and C++ mutating codec state is interior to the cell.
-    safe fn Bun__stripBOMFromTextCodec(codec: &mut TextCodec);
+    // safe: C++ `delete`s the codec. Handing the object back is not exclusive
+    // access as Rust sees it, so the receiver is `&`, not `&mut`.
+    safe fn Bun__deleteTextCodec(codec: &sys::TextCodec);
+    safe fn Bun__stripBOMFromTextCodec(codec: &sys::TextCodec);
     fn Bun__isEncodingSupported(encoding_name: *const u8, encoding_name_len: usize) -> bool;
     fn Bun__getCanonicalEncodingName(
         encoding_name: *const u8,
@@ -28,39 +55,64 @@ unsafe extern "C" {
     ) -> Option<NonNull<u8>>;
 }
 
-bun_opaque::opaque_ffi! {
-    /// Opaque FFI handle to a C++ PAL::TextCodec.
-    pub struct TextCodec;
-}
-
 pub struct DecodeResult {
     pub result: BunString,
     pub saw_error: bool,
 }
 
+/// Ownership plumbing.
 impl TextCodec {
-    pub fn create(encoding: &[u8]) -> Option<NonNull<TextCodec>> {
+    /// Adopt the owning pointer C++ released to us.
+    ///
+    /// # Safety
+    /// `ptr` must be a live codec that no other handle will delete.
+    #[inline]
+    pub unsafe fn adopt(ptr: NonNull<sys::TextCodec>) -> Self {
+        // SAFETY: caller transfers ownership.
+        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
+    }
+
+    /// Adopt a nullable owning pointer; `None` on null.
+    #[inline]
+    fn adopt_ptr(ptr: *mut sys::TextCodec) -> Option<Self> {
+        // SAFETY: C++ returns a freshly `new`ed codec or null.
+        NonNull::new(ptr).map(|p| unsafe { Self::adopt(p) })
+    }
+
+    /// The C++ pointer, still owned by `self`.
+    #[inline]
+    pub fn as_ptr(&self) -> *mut sys::TextCodec {
+        self.0.as_ptr()
+    }
+
+    /// Hand the codec to a foreign owner. Pairs with a later [`Self::adopt`].
+    #[inline]
+    pub fn leak(self) -> NonNull<sys::TextCodec> {
+        self.0.leak()
+    }
+
+    #[inline]
+    fn raw(&self) -> &sys::TextCodec {
+        &self.0
+    }
+}
+
+impl TextCodec {
+    /// `None` when `encoding` does not name a valid WebKit encoding.
+    pub fn create(encoding: &[u8]) -> Option<Self> {
         mark_binding!();
         // SAFETY: encoding.ptr is valid for encoding.len bytes.
-        unsafe { Bun__createTextCodec(encoding.as_ptr(), encoding.len()) }
+        Self::adopt_ptr(unsafe { Bun__createTextCodec(encoding.as_ptr(), encoding.len()) })
     }
 
-    // FFI-owned opaque; constructed/destroyed across FFI, so explicit
-    // destroy instead of `impl Drop` (cannot own a `TextCodec` by value).
-    pub unsafe fn destroy(this: *mut TextCodec) {
-        mark_binding!();
-        // SAFETY: caller guarantees `this` was returned by `create` and not yet freed.
-        unsafe { Bun__deleteTextCodec(this) }
-    }
-
-    pub fn decode(&mut self, data: &[u8], flush: bool, stop_on_error: bool) -> DecodeResult {
+    pub fn decode(&self, data: &[u8], flush: bool, stop_on_error: bool) -> DecodeResult {
         mark_binding!();
         let mut saw_error: bool = false;
-        // SAFETY: `self` is a valid live codec; `data` valid for `data.len()` bytes;
-        // `saw_error` is a valid out-pointer for the duration of the call.
+        // SAFETY: `data` valid for `data.len()` bytes; `saw_error` is a valid
+        // out-pointer for the duration of the call.
         let result = unsafe {
             Bun__decodeWithTextCodec(
-                self,
+                self.raw(),
                 data.as_ptr(),
                 data.len(),
                 flush,
@@ -72,9 +124,9 @@ impl TextCodec {
         DecodeResult { result, saw_error }
     }
 
-    pub fn strip_bom(&mut self) {
+    pub fn strip_bom(&self) {
         mark_binding!();
-        Bun__stripBOMFromTextCodec(self)
+        Bun__stripBOMFromTextCodec(self.raw())
     }
 
     pub fn is_supported(encoding: &[u8]) -> bool {

--- a/src/jsc/TextCodec.rs
+++ b/src/jsc/TextCodec.rs
@@ -17,15 +17,14 @@ pub mod sys {
 
 // C++ `newTextCodec(encoding).release()` hands back the sole owning pointer;
 // `Bun__deleteTextCodec` `delete`s it. One handle owns exactly one codec.
-bun_opaque::foreign_owned!(sys::TextCodec, Bun__deleteTextCodec);
-
-/// Owned handle to a C++ `PAL::TextCodec`.
-///
-/// `Drop` deletes the codec. Every method takes `&self`: C++ mutates the codec
-/// through the same pointer, and giving the object back is not exclusive
-/// access, so there is no `&mut self` and no `DerefMut`.
-#[repr(transparent)]
-pub struct TextCodec(bun_opaque::ForeignRef<sys::TextCodec>);
+bun_opaque::foreign_handle! {
+    /// Owned handle to a C++ `PAL::TextCodec`.
+    ///
+    /// `Drop` deletes the codec. Every method takes `&self`: C++ mutates the codec
+    /// through the same pointer, and giving the object back is not exclusive
+    /// access, so there is no `&mut self` and no `DerefMut`.
+    pub struct TextCodec(sys::TextCodec) via Bun__deleteTextCodec;
+}
 
 // `&sys::TextCodec` is ABI-identical to the `void*` the C++ shims declare. Shims
 // that also take raw `*const u8` / out-pointers stay `unsafe fn`: safe Rust can
@@ -60,49 +59,14 @@ pub struct DecodeResult {
     pub saw_error: bool,
 }
 
-/// Ownership plumbing.
-impl TextCodec {
-    /// Adopt the owning pointer C++ released to us.
-    ///
-    /// # Safety
-    /// `ptr` must be a live codec that no other handle will delete.
-    #[inline]
-    pub unsafe fn adopt(ptr: NonNull<sys::TextCodec>) -> Self {
-        // SAFETY: caller transfers ownership.
-        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
-    }
-
-    /// Adopt a nullable owning pointer; `None` on null.
-    #[inline]
-    fn adopt_ptr(ptr: *mut sys::TextCodec) -> Option<Self> {
-        // SAFETY: C++ returns a freshly `new`ed codec or null.
-        NonNull::new(ptr).map(|p| unsafe { Self::adopt(p) })
-    }
-
-    /// The C++ pointer, still owned by `self`.
-    #[inline]
-    pub fn as_ptr(&self) -> *mut sys::TextCodec {
-        self.0.as_ptr()
-    }
-
-    /// Hand the codec to a foreign owner. Pairs with a later [`Self::adopt`].
-    #[inline]
-    pub fn leak(self) -> NonNull<sys::TextCodec> {
-        self.0.leak()
-    }
-
-    #[inline]
-    fn raw(&self) -> &sys::TextCodec {
-        &self.0
-    }
-}
-
 impl TextCodec {
     /// `None` when `encoding` does not name a valid WebKit encoding.
     pub fn create(encoding: &[u8]) -> Option<Self> {
         mark_binding!();
-        // SAFETY: encoding.ptr is valid for encoding.len bytes.
-        Self::adopt_ptr(unsafe { Bun__createTextCodec(encoding.as_ptr(), encoding.len()) })
+        // SAFETY: encoding.ptr is valid for encoding.len bytes; C++
+        // `newTextCodec(encoding).release()` transfers us the sole owning
+        // pointer, or null.
+        unsafe { Self::adopt_ptr(Bun__createTextCodec(encoding.as_ptr(), encoding.len())) }
     }
 
     pub fn decode(&self, data: &[u8], flush: bool, stop_on_error: bool) -> DecodeResult {

--- a/src/jsc/URL.rs
+++ b/src/jsc/URL.rs
@@ -3,46 +3,102 @@ use core::ptr::NonNull;
 use bun_core::String;
 use bun_jsc::{JSGlobalObject, JSValue, JsResult};
 
-bun_opaque::opaque_ffi! {
-    /// Opaque handle to a WebKit `WTF::URL` allocated on the C++ side.
-    pub struct URL;
+/// The C++ object itself. Only the extern declarations below name this type;
+/// all Rust code uses the owning [`URL`] handle.
+pub mod sys {
+    bun_opaque::opaque_ffi! {
+        /// A heap-allocated WebKit `WTF::URL`. `&Self` is ABI-identical to a
+        /// non-null `WTF::URL*` and carries no `noalias`/`readonly`.
+        pub struct URL;
+    }
 }
 
-// Getters take `&URL` (non-null `*const URL` at the C ABI; BunString.cpp never
-// mutates the WTF::URL on read). `&mut String` for the in/out params is
-// ABI-identical to non-null `*mut String`. `URL__deinit` consumes the C++
-// allocation, so it keeps a raw pointer and stays `unsafe fn`.
+// C++ allocates (`new WTF::URL(...)`) and hands the allocation to Rust;
+// `URL__deinit` is an unconditional `delete`. One `URL` handle owns exactly
+// that one allocation.
+bun_opaque::foreign_owned!(sys::URL, URL__deinit);
+
+/// Owned handle to a C++ heap `WTF::URL`.
+///
+/// `Drop` `delete`s the allocation. Every method takes `&self`: the C++ side
+/// never mutates the `WTF::URL` on read, and destroying it is not exclusive
+/// access in Rust's sense.
+#[repr(transparent)]
+pub struct URL(bun_opaque::ForeignRef<sys::URL>);
+
+// Getters take `&sys::URL` (a non-null `WTF::URL*` at the C ABI; BunString.cpp
+// never mutates it on read); `&mut String` is ABI-identical to `*mut String`.
+// Every shim traffics only in those plus value types, so all are `safe fn`.
 unsafe extern "C" {
-    safe fn URL__fromJS(value: JSValue, global: &JSGlobalObject) -> *mut URL;
-    safe fn URL__fromString(input: &mut String) -> *mut URL;
-    safe fn URL__protocol(url: &URL) -> String;
-    safe fn URL__href(url: &URL) -> String;
-    safe fn URL__username(url: &URL) -> String;
-    safe fn URL__password(url: &URL) -> String;
-    safe fn URL__search(url: &URL) -> String;
-    safe fn URL__host(url: &URL) -> String;
-    safe fn URL__hostname(url: &URL) -> String;
-    safe fn URL__port(url: &URL) -> u32;
-    fn URL__deinit(url: *mut URL);
-    safe fn URL__pathname(url: &URL) -> String;
+    safe fn URL__fromJS(value: JSValue, global: &JSGlobalObject) -> *mut sys::URL;
+    safe fn URL__fromString(input: &mut String) -> *mut sys::URL;
+    safe fn URL__protocol(url: &sys::URL) -> String;
+    safe fn URL__href(url: &sys::URL) -> String;
+    safe fn URL__username(url: &sys::URL) -> String;
+    safe fn URL__password(url: &sys::URL) -> String;
+    safe fn URL__search(url: &sys::URL) -> String;
+    safe fn URL__host(url: &sys::URL) -> String;
+    safe fn URL__hostname(url: &sys::URL) -> String;
+    safe fn URL__port(url: &sys::URL) -> u32;
+    // safe: C++ `delete`s the `WTF::URL*`. Reached only through `Drop`.
+    safe fn URL__deinit(url: &sys::URL);
+    safe fn URL__pathname(url: &sys::URL) -> String;
     safe fn URL__getHrefFromJS(value: JSValue, global: &JSGlobalObject) -> String;
     safe fn URL__getHref(input: &mut String) -> String;
     safe fn URL__getFileURLString(input: &mut String) -> String;
     safe fn URL__getHrefJoin(base: &mut String, relative: &mut String) -> String;
     safe fn URL__pathFromFileURL(input: &mut String) -> String;
-    safe fn URL__hash(url: &URL) -> String;
-    safe fn URL__fragmentIdentifier(url: &URL) -> String;
+    safe fn URL__hash(url: &sys::URL) -> String;
+    safe fn URL__fragmentIdentifier(url: &sys::URL) -> String;
+}
+
+/// Ownership plumbing.
+impl URL {
+    /// Adopt a heap `WTF::URL` returned by C++.
+    ///
+    /// # Safety
+    /// `ptr` must be a live `new`-allocated `WTF::URL` that no other handle
+    /// will `delete`.
+    #[inline]
+    pub unsafe fn adopt(ptr: NonNull<sys::URL>) -> Self {
+        // SAFETY: caller transfers the allocation.
+        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
+    }
+
+    /// Adopt a nullable allocation; `None` on null (invalid URL).
+    #[inline]
+    fn adopt_ptr(ptr: *mut sys::URL) -> Option<Self> {
+        // SAFETY: the C++ `from*` shims return a fresh `new WTF::URL` or null.
+        NonNull::new(ptr).map(|p| unsafe { Self::adopt(p) })
+    }
+
+    /// The C++ pointer, still owned by `self`.
+    #[inline]
+    pub fn as_ptr(&self) -> *mut sys::URL {
+        self.0.as_ptr()
+    }
+
+    /// Hand the allocation to a foreign owner. Pairs with a later [`Self::adopt`].
+    #[inline]
+    pub fn leak(self) -> NonNull<sys::URL> {
+        self.0.leak()
+    }
+
+    #[inline]
+    fn raw(&self) -> &sys::URL {
+        &self.0
+    }
 }
 
 impl URL {
     /// Includes the leading '#'.
     pub fn hash(&self) -> String {
-        URL__hash(self)
+        URL__hash(self.raw())
     }
 
     /// Exactly the same as hash, excluding the leading '#'.
     pub fn fragment_identifier(&self) -> String {
-        URL__fragmentIdentifier(self)
+        URL__fragmentIdentifier(self.raw())
     }
 
     pub fn href_from_string(str: String) -> String {
@@ -73,40 +129,39 @@ impl URL {
         crate::call_check_slow(global, || URL__getHrefFromJS(value, global))
     }
 
+    /// C++ `new WTF::URL` on success; `None` if the URL is invalid.
     #[track_caller]
-    pub fn from_js(value: JSValue, global: &JSGlobalObject) -> JsResult<Option<NonNull<URL>>> {
-        crate::call_check_slow(global, || URL__fromJS(value, global)).map(NonNull::new)
+    pub fn from_js(value: JSValue, global: &JSGlobalObject) -> JsResult<Option<Self>> {
+        crate::call_check_slow(global, || URL__fromJS(value, global)).map(Self::adopt_ptr)
     }
 
-    pub fn from_utf8(input: &[u8]) -> Option<NonNull<URL>> {
+    pub fn from_utf8(input: &[u8]) -> Option<Self> {
         Self::from_string(String::borrow_utf8(input))
     }
 
-    pub fn from_string(str: String) -> Option<NonNull<URL>> {
+    pub fn from_string(str: String) -> Option<Self> {
         let mut input = str;
-        NonNull::new(URL__fromString(&mut input))
+        Self::adopt_ptr(URL__fromString(&mut input))
     }
-    // from_js/from_string/from_utf8 return an owned C++ heap pointer that the
-    // caller must destroy().
 
     pub fn protocol(&self) -> String {
-        URL__protocol(self)
+        URL__protocol(self.raw())
     }
 
     pub fn href(&self) -> String {
-        URL__href(self)
+        URL__href(self.raw())
     }
 
     pub fn username(&self) -> String {
-        URL__username(self)
+        URL__username(self.raw())
     }
 
     pub fn password(&self) -> String {
-        URL__password(self)
+        URL__password(self.raw())
     }
 
     pub fn search(&self) -> String {
-        URL__search(self)
+        URL__search(self.raw())
     }
 
     /// Returns the host WITHOUT the port.
@@ -118,7 +173,7 @@ impl URL {
     /// URL("http://example.com:8080").host() => "example.com"
     /// ```
     pub fn host(&self) -> String {
-        URL__host(self)
+        URL__host(self.raw())
     }
 
     /// Returns the host WITH the port.
@@ -130,23 +185,16 @@ impl URL {
     /// URL("http://example.com:8080").hostname() => "example.com:8080"
     /// ```
     pub fn hostname(&self) -> String {
-        URL__hostname(self)
+        URL__hostname(self.raw())
     }
 
     /// Returns `u32::MAX` if the port is not set. Otherwise, `port`
     /// is guaranteed to be within the `u16` range.
     pub fn port(&self) -> u32 {
-        URL__port(self)
-    }
-
-    // Kept as explicit destroy (not Drop) — URL is an opaque #[repr(C)] FFI
-    // handle constructed/destroyed across the C++ boundary.
-    pub unsafe fn destroy(this: *mut Self) {
-        // SAFETY: `this` is a valid *URL from C++; freed exactly once
-        unsafe { URL__deinit(this) }
+        URL__port(self.raw())
     }
 
     pub fn pathname(&self) -> String {
-        URL__pathname(self)
+        URL__pathname(self.raw())
     }
 }

--- a/src/jsc/URL.rs
+++ b/src/jsc/URL.rs
@@ -1,5 +1,3 @@
-use core::ptr::NonNull;
-
 use bun_core::String;
 use bun_jsc::{JSGlobalObject, JSValue, JsResult};
 
@@ -16,15 +14,14 @@ pub mod sys {
 // C++ allocates (`new WTF::URL(...)`) and hands the allocation to Rust;
 // `URL__deinit` is an unconditional `delete`. One `URL` handle owns exactly
 // that one allocation.
-bun_opaque::foreign_owned!(sys::URL, URL__deinit);
-
-/// Owned handle to a C++ heap `WTF::URL`.
-///
-/// `Drop` `delete`s the allocation. Every method takes `&self`: the C++ side
-/// never mutates the `WTF::URL` on read, and destroying it is not exclusive
-/// access in Rust's sense.
-#[repr(transparent)]
-pub struct URL(bun_opaque::ForeignRef<sys::URL>);
+bun_opaque::foreign_handle! {
+    /// Owned handle to a C++ heap `WTF::URL`.
+    ///
+    /// `Drop` `delete`s the allocation. Every method takes `&self`: the C++ side
+    /// never mutates the `WTF::URL` on read, and destroying it is not exclusive
+    /// access in Rust's sense.
+    pub struct URL(sys::URL) via URL__deinit;
+}
 
 // Getters take `&sys::URL` (a non-null `WTF::URL*` at the C ABI; BunString.cpp
 // never mutates it on read); `&mut String` is ABI-identical to `*mut String`.
@@ -50,44 +47,6 @@ unsafe extern "C" {
     safe fn URL__pathFromFileURL(input: &mut String) -> String;
     safe fn URL__hash(url: &sys::URL) -> String;
     safe fn URL__fragmentIdentifier(url: &sys::URL) -> String;
-}
-
-/// Ownership plumbing.
-impl URL {
-    /// Adopt a heap `WTF::URL` returned by C++.
-    ///
-    /// # Safety
-    /// `ptr` must be a live `new`-allocated `WTF::URL` that no other handle
-    /// will `delete`.
-    #[inline]
-    pub unsafe fn adopt(ptr: NonNull<sys::URL>) -> Self {
-        // SAFETY: caller transfers the allocation.
-        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
-    }
-
-    /// Adopt a nullable allocation; `None` on null (invalid URL).
-    #[inline]
-    fn adopt_ptr(ptr: *mut sys::URL) -> Option<Self> {
-        // SAFETY: the C++ `from*` shims return a fresh `new WTF::URL` or null.
-        NonNull::new(ptr).map(|p| unsafe { Self::adopt(p) })
-    }
-
-    /// The C++ pointer, still owned by `self`.
-    #[inline]
-    pub fn as_ptr(&self) -> *mut sys::URL {
-        self.0.as_ptr()
-    }
-
-    /// Hand the allocation to a foreign owner. Pairs with a later [`Self::adopt`].
-    #[inline]
-    pub fn leak(self) -> NonNull<sys::URL> {
-        self.0.leak()
-    }
-
-    #[inline]
-    fn raw(&self) -> &sys::URL {
-        &self.0
-    }
 }
 
 impl URL {
@@ -132,7 +91,9 @@ impl URL {
     /// C++ `new WTF::URL` on success; `None` if the URL is invalid.
     #[track_caller]
     pub fn from_js(value: JSValue, global: &JSGlobalObject) -> JsResult<Option<Self>> {
-        crate::call_check_slow(global, || URL__fromJS(value, global)).map(Self::adopt_ptr)
+        // SAFETY: `URL__fromJS` transfers a fresh `new WTF::URL` (or null) to us.
+        crate::call_check_slow(global, || URL__fromJS(value, global))
+            .map(|p| unsafe { Self::adopt_ptr(p) })
     }
 
     pub fn from_utf8(input: &[u8]) -> Option<Self> {
@@ -141,7 +102,8 @@ impl URL {
 
     pub fn from_string(str: String) -> Option<Self> {
         let mut input = str;
-        Self::adopt_ptr(URL__fromString(&mut input))
+        // SAFETY: `URL__fromString` transfers a fresh `new WTF::URL` (or null) to us.
+        unsafe { Self::adopt_ptr(URL__fromString(&mut input)) }
     }
 
     pub fn protocol(&self) -> String {

--- a/src/jsc/URLSearchParams.rs
+++ b/src/jsc/URLSearchParams.rs
@@ -12,11 +12,11 @@ bun_opaque::opaque_ffi! {
 unsafe extern "C" {
     safe fn URLSearchParams__create(global_object: &JSGlobalObject, init: &ZigString) -> JSValue;
     safe fn URLSearchParams__fromJS(value: JSValue) -> Option<NonNull<URLSearchParams>>;
-    // safe: `URLSearchParams` is an `opaque_ffi!` ZST handle (`&mut` is
-    // ABI-identical to a non-null `*mut`); `ctx` is an opaque round-trip pointer
-    // C++ only forwards to `callback` (synchronous, never retained).
+    // safe: `URLSearchParams` is an `opaque_ffi!` ZST handle (`&` is ABI-identical
+    // to a non-null pointer and carries no `noalias`/`readonly`); `ctx` is an opaque
+    // round-trip pointer C++ only forwards to `callback` (synchronous, never retained).
     safe fn URLSearchParams__toString(
-        self_: &mut URLSearchParams,
+        self_: &URLSearchParams,
         ctx: *mut c_void,
         callback: extern "C" fn(ctx: *mut c_void, str: *const ZigString),
     );
@@ -33,7 +33,7 @@ impl URLSearchParams {
         URLSearchParams__fromJS(value)
     }
 
-    pub fn to_string<Ctx>(&mut self, ctx: &mut Ctx, callback: fn(ctx: &mut Ctx, str: ZigString)) {
+    pub fn to_string<Ctx>(&self, ctx: &mut Ctx, callback: fn(ctx: &mut Ctx, str: ZigString)) {
         // A fn pointer cannot be a const generic, so pack (ctx, callback) on the
         // stack and pass the pair through the C trampoline's void* context.
         struct Wrap<'a, Ctx> {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5784,7 +5784,7 @@ impl VirtualMachine {
         });
         let code: Option<&[u8]> = if is_error_instance {
             // SAFETY: `is_error_instance` ⇒ `get_object()` is `Some`.
-            let obj = unsafe { &mut *error_instance.get_object().unwrap_unchecked() };
+            let obj = unsafe { &*error_instance.get_object().unwrap_unchecked() };
             if let Some(code_value) = obj.get_code_property_vm_inquiry(global_ref) {
                 if code_value.is_string() {
                     match code_value.to_bun_string(global_ref) {

--- a/src/jsc/Weak.rs
+++ b/src/jsc/Weak.rs
@@ -25,14 +25,13 @@ pub(crate) mod sys {
 
 // C++ `new Bun::WeakRef` hands back the allocation. One `WeakImpl` handle owns
 // exactly that one allocation; `Drop` gives it back.
-bun_opaque::foreign_owned!(sys::WeakImpl, Bun__WeakRef__delete);
-
-/// Owned handle to a C++ `Bun::WeakRef`.
-///
-/// Every method takes `&self`: C++ mutates the `JSC::Weak` slot through the
-/// same pointer, so there is no `&mut self` to have.
-#[repr(transparent)]
-pub(crate) struct WeakImpl(bun_opaque::ForeignRef<sys::WeakImpl>);
+bun_opaque::foreign_handle! {
+    /// Owned handle to a C++ `Bun::WeakRef`.
+    ///
+    /// Every method takes `&self`: C++ mutates the `JSC::Weak` slot through the
+    /// same pointer, so there is no `&mut self` to have.
+    pub(crate) struct WeakImpl(sys::WeakImpl) via Bun__WeakRef__delete;
+}
 
 // `JSGlobalObject`/`sys::WeakImpl` are ZST handles: `&T` is ABI-identical to a
 // non-null `*const T`, and C++ writing the slot through it is interior mutation.
@@ -54,31 +53,6 @@ unsafe extern "C" {
     safe fn Bun__WeakRef__clear(this: &sys::WeakImpl);
 }
 
-/// Ownership plumbing.
-impl WeakImpl {
-    /// Adopt the allocation C++ just handed back.
-    ///
-    /// # Safety
-    /// `ptr` must be a live `Bun::WeakRef` that no other handle will delete.
-    #[inline]
-    unsafe fn adopt(ptr: NonNull<sys::WeakImpl>) -> Self {
-        // SAFETY: caller transfers the allocation.
-        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
-    }
-
-    /// Adopt a nullable allocation; `None` on null.
-    #[inline]
-    fn adopt_ptr(ptr: *mut sys::WeakImpl) -> Option<Self> {
-        // SAFETY: `Bun__WeakRef__new` returns a fresh allocation or null.
-        NonNull::new(ptr).map(|p| unsafe { Self::adopt(p) })
-    }
-
-    #[inline]
-    fn raw(&self) -> &sys::WeakImpl {
-        &self.0
-    }
-}
-
 impl WeakImpl {
     fn new(
         global_this: &JSGlobalObject,
@@ -96,7 +70,8 @@ impl WeakImpl {
                 ctx.map_or(core::ptr::null_mut(), |p| p.as_ptr()),
             )
         };
-        Self::adopt_ptr(ptr).expect("Bun__WeakRef__new returned null")
+        // SAFETY: `Bun__WeakRef__new` transfers a fresh allocation, or null.
+        unsafe { Self::adopt_ptr(ptr) }.expect("Bun__WeakRef__new returned null")
     }
 
     /// Read the weakly-held `JSValue` (or `JSValue::ZERO` if collected).

--- a/src/jsc/Weak.rs
+++ b/src/jsc/Weak.rs
@@ -12,72 +12,106 @@ pub enum WeakRefType {
     PostgreSQLQueryClient = 2,
 }
 
-bun_opaque::opaque_ffi! {
-    /// Opaque FFI handle (C++ `Bun::WeakRef`).
-    pub(crate) struct WeakImpl;
-}
-
-impl WeakImpl {
-    pub(crate) fn init(
-        global_this: &JSGlobalObject,
-        value: JSValue,
-        ref_type: WeakRefType,
-        ctx: Option<NonNull<c_void>>,
-    ) -> NonNull<WeakImpl> {
-        NonNull::new(Bun__WeakRef__new(
-            global_this,
-            value,
-            ref_type,
-            ctx.map_or(core::ptr::null_mut(), |p| p.as_ptr()),
-        ))
-        .expect("Bun__WeakRef__new returned null")
-    }
-
-    /// Read the weakly-held `JSValue` (or `JSValue::ZERO` if collected).
-    ///
-    /// Safe: every `NonNull<WeakImpl>` in this crate originates from
-    /// [`WeakImpl::init`] and is held by a [`Weak<T>`] that drops it via
-    /// [`WeakImpl::destroy`] before releasing the slot — so any
-    /// `NonNull<WeakImpl>` reachable here is a live C++ `JSC::Weak` handle.
-    /// Same contract as [`crate::strong::Impl::get`].
-    pub(crate) fn get(this: NonNull<WeakImpl>) -> JSValue {
-        Bun__WeakRef__get(WeakImpl::opaque_ref(this.as_ptr()))
-    }
-
-    /// Clear the weakly-held value without freeing the handle.
-    ///
-    /// Safe for the same reason as [`WeakImpl::get`] — the handle is live by
-    /// construction; `clear` is idempotent and does not invalidate `this`.
-    pub(crate) fn clear(this: NonNull<WeakImpl>) {
-        Bun__WeakRef__clear(WeakImpl::opaque_ref(this.as_ptr()))
-    }
-
-    pub(crate) unsafe fn destroy(this: NonNull<WeakImpl>) {
-        // SAFETY: `this` is a live WeakImpl handle; consumed here.
-        unsafe { Bun__WeakRef__delete(this.as_ptr()) }
+/// The C++ object itself. Only the extern declarations below name this type;
+/// all Rust code uses the owning [`WeakImpl`] handle.
+pub(crate) mod sys {
+    bun_opaque::opaque_ffi! {
+        /// `Bun::WeakRef`. `&Self` is ABI-identical to a non-null
+        /// `Bun::WeakRef*`, and carries no `noalias`/`readonly` — C++ mutates
+        /// the `JSC::Weak` slot through it.
+        pub(crate) struct WeakImpl;
     }
 }
 
-// `WeakImpl` is an opaque `UnsafeCell`-backed ZST handle (`&WeakImpl` is
-// ABI-identical to non-null `*const WeakImpl`; C++ slot mutation is interior).
-// `new` is `safe fn`: `&JSGlobalObject` is the non-null handle proof, and `ctx`
-// is an opaque round-trip pointer C++ only stores and forwards to the finalizer
-// (never dereferenced as Rust data) — same contract as `JSC__VM__holdAPILock`.
-// `delete` consumes the allocation and so stays `unsafe fn`.
+// C++ `new Bun::WeakRef` hands back the allocation. One `WeakImpl` handle owns
+// exactly that one allocation; `Drop` gives it back.
+bun_opaque::foreign_owned!(sys::WeakImpl, Bun__WeakRef__delete);
+
+/// Owned handle to a C++ `Bun::WeakRef`.
+///
+/// Every method takes `&self`: C++ mutates the `JSC::Weak` slot through the
+/// same pointer, so there is no `&mut self` to have.
+#[repr(transparent)]
+pub(crate) struct WeakImpl(bun_opaque::ForeignRef<sys::WeakImpl>);
+
+// `JSGlobalObject`/`sys::WeakImpl` are ZST handles: `&T` is ABI-identical to a
+// non-null `*const T`, and C++ writing the slot through it is interior mutation.
+// Shims trafficking only in such refs + scalars are `safe fn`.
 unsafe extern "C" {
-    fn Bun__WeakRef__delete(this: *mut WeakImpl);
-    safe fn Bun__WeakRef__new(
+    // safe: C++ clears the slot and `delete`s the object. Destruction is not
+    // exclusive access of any Rust-visible bytes, so the receiver is `&`.
+    safe fn Bun__WeakRef__delete(this: &sys::WeakImpl);
+    // NOT `safe fn`: C++ stores `ctx` in the `JSC::Weak` and hands it to
+    // `Bun__<T>_finalize`, which dereferences it. Safe Rust can forge a
+    // `*mut c_void`, so the call itself carries the validity obligation.
+    fn Bun__WeakRef__new(
         global: &JSGlobalObject,
         value: JSValue,
         ref_type: WeakRefType,
         ctx: *mut c_void,
-    ) -> *mut WeakImpl;
-    safe fn Bun__WeakRef__get(this: &WeakImpl) -> JSValue;
-    safe fn Bun__WeakRef__clear(this: &WeakImpl);
+    ) -> *mut sys::WeakImpl;
+    safe fn Bun__WeakRef__get(this: &sys::WeakImpl) -> JSValue;
+    safe fn Bun__WeakRef__clear(this: &sys::WeakImpl);
+}
+
+/// Ownership plumbing.
+impl WeakImpl {
+    /// Adopt the allocation C++ just handed back.
+    ///
+    /// # Safety
+    /// `ptr` must be a live `Bun::WeakRef` that no other handle will delete.
+    #[inline]
+    unsafe fn adopt(ptr: NonNull<sys::WeakImpl>) -> Self {
+        // SAFETY: caller transfers the allocation.
+        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
+    }
+
+    /// Adopt a nullable allocation; `None` on null.
+    #[inline]
+    fn adopt_ptr(ptr: *mut sys::WeakImpl) -> Option<Self> {
+        // SAFETY: `Bun__WeakRef__new` returns a fresh allocation or null.
+        NonNull::new(ptr).map(|p| unsafe { Self::adopt(p) })
+    }
+
+    #[inline]
+    fn raw(&self) -> &sys::WeakImpl {
+        &self.0
+    }
+}
+
+impl WeakImpl {
+    fn new(
+        global_this: &JSGlobalObject,
+        value: JSValue,
+        ref_type: WeakRefType,
+        ctx: Option<NonNull<c_void>>,
+    ) -> Self {
+        // SAFETY: C++ only stores `ctx` and forwards it to the type's finalizer;
+        // the owner it points at outlives this handle.
+        let ptr = unsafe {
+            Bun__WeakRef__new(
+                global_this,
+                value,
+                ref_type,
+                ctx.map_or(core::ptr::null_mut(), |p| p.as_ptr()),
+            )
+        };
+        Self::adopt_ptr(ptr).expect("Bun__WeakRef__new returned null")
+    }
+
+    /// Read the weakly-held `JSValue` (or `JSValue::ZERO` if collected).
+    fn get(&self) -> JSValue {
+        Bun__WeakRef__get(self.raw())
+    }
+
+    /// Clear the weakly-held value without freeing the handle; idempotent.
+    fn clear(&self) {
+        Bun__WeakRef__clear(self.raw())
+    }
 }
 
 pub struct Weak<T> {
-    r#ref: Option<NonNull<WeakImpl>>,
+    r#ref: Option<WeakImpl>,
     global_this: Option<crate::GlobalRef>,
     _ctx: PhantomData<*mut T>,
 }
@@ -114,7 +148,7 @@ impl<T> Weak<T> {
     ) -> Self {
         if !value.is_empty() {
             return Self {
-                r#ref: Some(WeakImpl::init(
+                r#ref: Some(WeakImpl::new(
                     global_this,
                     value,
                     ref_type,
@@ -133,8 +167,7 @@ impl<T> Weak<T> {
     }
 
     pub fn get(&self) -> Option<JSValue> {
-        let r#ref = self.r#ref?;
-        let result = WeakImpl::get(r#ref);
+        let result = self.r#ref.as_ref()?.get();
         if result.is_empty() {
             return None;
         }
@@ -143,23 +176,23 @@ impl<T> Weak<T> {
     }
 
     pub fn swap(&mut self) -> JSValue {
-        let Some(r#ref) = self.r#ref else {
+        let Some(r#ref) = self.r#ref.as_ref() else {
             return JSValue::ZERO;
         };
-        let result = WeakImpl::get(r#ref);
+        let result = r#ref.get();
         if result.is_empty() {
             return JSValue::ZERO;
         }
 
-        WeakImpl::clear(r#ref);
+        r#ref.clear();
         result
     }
 
     pub fn has(&self) -> bool {
-        let Some(r#ref) = self.r#ref else {
+        let Some(r#ref) = self.r#ref.as_ref() else {
             return false;
         };
-        !WeakImpl::get(r#ref).is_empty()
+        !r#ref.get().is_empty()
     }
 
     pub fn try_swap(&mut self) -> Option<JSValue> {
@@ -172,20 +205,9 @@ impl<T> Weak<T> {
     }
 
     pub fn clear(&mut self) {
-        let Some(r#ref) = self.r#ref else {
+        let Some(r#ref) = self.r#ref.as_ref() else {
             return;
         };
-        WeakImpl::clear(r#ref);
-    }
-}
-
-impl<T> Drop for Weak<T> {
-    fn drop(&mut self) {
-        let Some(r#ref) = self.r#ref else {
-            return;
-        };
-        self.r#ref = None;
-        // SAFETY: `r#ref` was live; we just took ownership and are deleting it.
-        unsafe { WeakImpl::destroy(r#ref) };
+        r#ref.clear();
     }
 }

--- a/src/jsc/ZigException.rs
+++ b/src/jsc/ZigException.rs
@@ -72,11 +72,9 @@ impl ZigException {
             frame.deinit();
         }
 
-        if let Some(source) = self.stack.referenced_source_provider {
-            // Pointer was set by JSC (C++) and is valid until this deref releases it.
-            // `SourceProvider` is an opaque ZST handle.
-            crate::SourceProvider::opaque_mut(source.as_ptr()).deref();
-        }
+        // Gives back the `+1` C++ took in `populateStackFramePosition`. `take()`
+        // nulls the slot, so the `Holder::drop` re-entry path releases nothing.
+        drop(self.stack.referenced_source_provider.take());
     }
 
     // `ZigException__fromException` is declared in headers.h but has no C++

--- a/src/jsc/ZigStackTrace.rs
+++ b/src/jsc/ZigStackTrace.rs
@@ -1,5 +1,4 @@
 use core::ptr;
-use core::ptr::NonNull;
 
 use crate::schema_api as api;
 use bun_core::String as BunString;
@@ -21,12 +20,12 @@ pub struct ZigStackTrace {
     pub frames_len: u8,
     pub frames_cap: u8,
 
-    /// Non-null if `source_lines_*` points into data owned by a JSC::SourceProvider.
-    /// If so, then .deref must be called on it to release the memory.
+    /// `Some` if `source_lines_*` points into data owned by a `JSC::SourceProvider`.
+    /// C++ `ref()`s the provider before storing it here; `Drop` gives that ref back.
     ///
-    /// `Option<NonNull<_>>` niche-optimizes to a single thin pointer, so the
-    /// FFI layout is exactly one nullable pointer.
-    pub referenced_source_provider: Option<NonNull<SourceProvider>>,
+    /// `Option<SourceProvider>` niche-optimizes to a single thin pointer, so the
+    /// FFI layout is exactly one nullable `JSC::SourceProvider*`.
+    pub referenced_source_provider: Option<SourceProvider>,
 }
 
 impl ZigStackTrace {

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -127,7 +127,7 @@ unsafe extern "C" {
         ptr: *const c_void,
         len: usize,
     ) -> JSValue;
-    fn JSC__ArrayBuffer__asBunArrayBuffer(self_: *mut JSCArrayBuffer, out: *mut ArrayBuffer);
+    fn JSC__ArrayBuffer__asBunArrayBuffer(self_: &JSCArrayBuffer, out: *mut ArrayBuffer);
     // safe: `JSCArrayBuffer` is an `opaque_ffi!` ZST handle (`!Freeze` via
     // `UnsafeCell`); `&` is ABI-identical to a non-null `*mut` and the C++
     // `RefCounted<ArrayBuffer>` count mutation is interior to the opaque cell.
@@ -1153,7 +1153,7 @@ unsafe impl bun_ptr::ExternalSharedDescriptor for JSCArrayBuffer {
 }
 
 impl JSCArrayBuffer {
-    pub fn as_array_buffer(&mut self) -> ArrayBuffer {
+    pub fn as_array_buffer(&self) -> ArrayBuffer {
         let mut out = core::mem::MaybeUninit::<ArrayBuffer>::uninit();
         // SAFETY: C++ fully initializes `out`.
         unsafe {

--- a/src/jsc/bindgen.rs
+++ b/src/jsc/bindgen.rs
@@ -76,9 +76,10 @@ pub struct BindgenStrongAny;
 
 impl Bindgen for BindgenStrongAny {
     type ZigType = Strong;
-    // `?*jsc.Strong.Impl` — must be single-word for #[repr(C)] union placement, so
-    // `Option<NonNull<T>>` (niche-optimized), NOT `Option<*mut T>` (two words).
-    type ExternType = Option<NonNull<jsc::strong::Impl>>;
+    // `?*jsc.Strong.Impl` — the C++ HandleSlot, not the owning Rust handle. Must
+    // be single-word for #[repr(C)] union placement, so `Option<NonNull<T>>`
+    // (niche-optimized), NOT `Option<*mut T>` (two words).
+    type ExternType = Option<NonNull<jsc::strong::sys::Impl>>;
 
     fn convert_from_extern(extern_value: Self::ExternType) -> Self::ZigType {
         // SAFETY: bindgen contract — C++ passes a freshly-allocated Strong handle

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -676,9 +676,6 @@ impl EventLoop {
     /// Without this, the last worker's close-task lambda — and the
     /// `WebWorker` box reachable through its `protectedThis` — leak.
     pub fn drop_concurrent_cpp_tasks(&mut self) {
-        unsafe extern "C" {
-            fn Bun__deleteEventLoopTask(task: *mut CppTask);
-        }
         let mut iter = self.concurrent_tasks.pop_batch().iterator();
         loop {
             let node = iter.next();
@@ -690,10 +687,16 @@ impl EventLoop {
             // freeing here is sound.
             let (task, auto_delete) = unsafe { ((*node).task, (*node).auto_delete()) };
             if task.tag == bun_event_loop::task_tag::CppTask {
-                // SAFETY: every `CppTask` payload is a heap
+                // SAFETY: every `CppTask` payload is a non-null heap
                 // `WebCore::EventLoopTask*` (`ScriptExecutionContext::postTask*`
-                // → `new EventLoopTask`); we own it once popped.
-                unsafe { Bun__deleteEventLoopTask(task.ptr.cast::<CppTask>()) };
+                // → `new EventLoopTask`); we own it once popped, and `Drop`
+                // deletes it without running.
+                let task = unsafe {
+                    CppTask::adopt(NonNull::new_unchecked(
+                        task.ptr.cast::<crate::cpp_task::sys::CppTask>(),
+                    ))
+                };
+                drop(task);
             } else {
                 // Hand non-Cpp payloads to `self.tasks` so `deinit()`'s
                 // existing per-tag reclaim handles them.

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1223,8 +1223,8 @@ pub use self::js_promise::Strong as JSPromiseStrong;
 pub use self::js_promise::Status as PromiseStatus;
 
 /// `bun_ptr::RefPtr` — intrusive refcounted smart pointer. Re-exported here so
-/// `crate::RefPtr<SourceProvider>` (ZigStackTrace.rs) resolves without every
-/// submodule taking a direct `bun_ptr` dep.
+/// submodules can write `crate::RefPtr<T>` without each taking a direct
+/// `bun_ptr` dep.
 pub use bun_ptr::RefPtr;
 
 /// `bun.String` — refcounted WTF-backed string. Re-exported at the crate root

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -197,7 +197,9 @@ impl CleanupHook {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub struct RareData {
-    pub boring_ssl_engine: Option<*mut boring::ENGINE>,
+    /// Owning handle to the VM's lazily-created BoringSSL `ENGINE`; field `Drop`
+    /// calls `ENGINE_free`. Consumers borrow it via [`RareData::boring_engine`].
+    pub boring_ssl_engine: Option<boring::ENGINE>,
 
     /// Erased `*mut webcore::blob::Store` (intrusive-refcounted on the runtime
     /// side). Constructed via `__bun_stdio_blob_store_new`; high tier casts back.
@@ -667,14 +669,20 @@ impl RareData {
             .get_or_insert_with(|| Box::new(FilePollStore::init()))
     }
 
-    pub fn boring_engine(&mut self) -> *mut boring::ENGINE {
-        // The raw `ENGINE_new()` result is cached without a null check:
-        // `EVP_DigestInit_ex` tolerates a NULL engine, so OOM here degrades to
-        // "no engine" rather than crashing. Debug-assert to surface it without
-        // altering release behavior.
-        let ptr = *self
+    /// Borrows the VM-owned `ENGINE` as a raw pointer. Every consumer
+    /// (`EVP_DigestInit_ex`, `EVP_Digest`, `HMAC_Init_ex`, `SHA256::hash`) only
+    /// reads it; the `boring_ssl_engine` handle stays the owner.
+    pub fn boring_engine(&mut self) -> *mut boring::sys::ENGINE {
+        // A failed `ENGINE_new()` is not cached: `EVP_DigestInit_ex` tolerates a
+        // NULL engine, so OOM here degrades to "no engine" rather than crashing.
+        // Debug-assert to surface it without altering release behavior.
+        if self.boring_ssl_engine.is_none() {
+            self.boring_ssl_engine = boring::ENGINE::new();
+        }
+        let ptr = self
             .boring_ssl_engine
-            .get_or_insert_with(|| boring::ENGINE_new());
+            .as_ref()
+            .map_or(core::ptr::null_mut(), |engine| engine.as_ptr());
         debug_assert!(!ptr.is_null(), "ENGINE_new returned null");
         ptr
     }
@@ -1048,13 +1056,10 @@ impl Drop for RareData {
     fn drop(&mut self) {
         // temp_pipe_read_buffer / spawn_sync_event_loop_ / s3_default_client /
         // default_csrf_secret / cleanup_hooks / cron_jobs / path_buf /
-        // tls_default_ciphers:
+        // tls_default_ciphers / boring_ssl_engine (an owning `ENGINE` handle,
+        // whose Drop calls ENGINE_free):
         // all dropped automatically via field Drop.
 
-        if let Some(engine) = self.boring_ssl_engine.take() {
-            // SAFETY: engine was created by ENGINE_new.
-            unsafe { boring::ENGINE_free(engine) };
-        }
         debug_assert!(self.cron_jobs.is_empty());
 
         if let Some(s) = self.default_client_ssl_ctx.take() {

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -1058,8 +1058,8 @@ impl Drop for RareData {
         debug_assert!(self.cron_jobs.is_empty());
 
         if let Some(s) = self.default_client_ssl_ctx.take() {
-            // SAFETY: returned by ssl_ctx_cache.get_or_create_opts with +1 ref.
-            unsafe { boring::SSL_CTX_free(s) };
+            // Returned by ssl_ctx_cache.get_or_create_opts with a +1 ref.
+            boring::SSL_CTX_free(SslCtx::opaque_ref(s));
         }
         // After the default-ctx free so the tombstone callback still finds a live
         // map; ssl_ctx_cache itself lives in `RuntimeState` and is dropped there.

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -100,8 +100,10 @@ pub fn ensure_process_ipc_initialized(global: &JSGlobalObject) {
 /// This function is called on the main thread
 /// The bunVM() call will assert this
 // HOST_EXPORT(Bun__queueTask, c)
-pub fn queue_task(global: &JSGlobalObject, task: *mut crate::cpp_task::CppTask) {
+pub fn queue_task(global: &JSGlobalObject, task: *mut crate::cpp_task::sys::CppTask) {
     crate::mark_binding!();
+    // C++ hands over the sole owner; the queue holds it until `CppTask::run`
+    // or `EventLoop::drop_concurrent_cpp_tasks` gives it back.
     global
         .bun_vm()
         .event_loop_mut()
@@ -125,8 +127,9 @@ pub fn report_unhandled_error(global: &JSGlobalObject, value: JSValue) -> JSValu
 /// The main difference: we need to allocate the task & wakeup the thread
 /// We can avoid that if we run it from the main thread.
 // HOST_EXPORT(Bun__queueTaskConcurrently, c)
-pub fn queue_task_concurrently(global: &JSGlobalObject, task: *mut crate::cpp_task::CppTask) {
+pub fn queue_task_concurrently(global: &JSGlobalObject, task: *mut crate::cpp_task::sys::CppTask) {
     crate::mark_binding!();
+    // C++ hands over the sole owner; the concurrent queue holds it.
     // SAFETY: bun_vm_concurrently() yields the live VM; `event_loop()` never
     // returns null for a Bun-owned global. Called off-thread but the loop
     // wakeup is thread-safe.

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -32,14 +32,20 @@ pub mod lib {
     pub type la_int64_t = i64;
     type time_t = isize;
 
+    /// The C object itself. Only the extern declarations below name this type;
+    /// owning Rust code uses the [`Archive`] handle.
+    pub mod sys {
+        bun_opaque::opaque_ffi! {
+            /// libarchive `struct archive`. `&Self` is ABI-identical to a non-null
+            /// `struct archive*` and carries no `noalias`/`readonly` — libarchive
+            /// mutates through every call.
+            pub struct Archive;
+        }
+    }
+
     bun_opaque::opaque_ffi! {
-        /// Opaque libarchive `struct archive`. Always used behind `*mut Archive`.
-        /// Contains `UnsafeCell` so that `&Archive` does not assert immutability
-        /// (libarchive mutates through every call), making `&self -> *mut Self`
-        /// sound under Stacked Borrows.
-        pub struct Archive;
         /// Opaque libarchive `struct archive_entry`. Always used behind `*mut Entry`.
-        /// Contains `UnsafeCell` for the same reason as `Archive` — the C side
+        /// Contains `UnsafeCell` for the same reason as `sys::Archive` — the C side
         /// mutates through getter/setter calls that take `&self` here.
         pub struct Entry;
     }
@@ -70,28 +76,32 @@ pub mod lib {
     // so it is ABI-compatible with the C `int` return values.
     unsafe extern "C" {
         // read side
-        fn archive_read_new() -> *mut Archive;
-        fn archive_read_close(a: *mut Archive) -> Result;
-        fn archive_read_free(a: *mut Archive) -> Result;
-        fn archive_read_support_format_tar(a: *mut Archive) -> Result;
-        fn archive_read_support_format_gnutar(a: *mut Archive) -> Result;
-        fn archive_read_support_filter_gzip(a: *mut Archive) -> Result;
-        fn archive_read_set_options(a: *mut Archive, opts: *const c_char) -> Result;
-        fn archive_read_open_memory(a: *mut Archive, buf: *const c_void, size: usize) -> Result;
-        fn archive_read_next_header(a: *mut Archive, entry: *mut *mut Entry) -> Result;
-        fn archive_read_data(a: *mut Archive, buf: *mut c_void, size: usize) -> la_ssize_t;
+        safe fn archive_read_new() -> *mut sys::Archive;
+        safe fn archive_read_close(a: &sys::Archive) -> Result;
+        // safe: `archive_read_free` is `archive_free()` — vtable dispatch on
+        // `a->vtable->archive_free`, the one release for any `struct archive`.
+        // Freeing is not exclusive access, so the receiver is `&`, not `&mut`.
+        safe fn archive_read_free(a: &sys::Archive) -> Result;
+        safe fn archive_read_support_format_tar(a: &sys::Archive) -> Result;
+        safe fn archive_read_support_format_gnutar(a: &sys::Archive) -> Result;
+        safe fn archive_read_support_filter_gzip(a: &sys::Archive) -> Result;
+        fn archive_read_set_options(a: &sys::Archive, opts: *const c_char) -> Result;
+        fn archive_read_open_memory(a: &sys::Archive, buf: *const c_void, size: usize) -> Result;
+        fn archive_read_next_header(a: &sys::Archive, entry: *mut *mut Entry) -> Result;
+        fn archive_read_data(a: &sys::Archive, buf: *mut c_void, size: usize) -> la_ssize_t;
         fn archive_read_data_block(
-            a: *mut Archive,
+            a: &sys::Archive,
             buff: *mut *const c_void,
             size: *mut usize,
             offset: *mut la_int64_t,
         ) -> Result;
-        fn archive_error_string(a: *mut Archive) -> *const c_char;
+        safe fn archive_error_string(a: &sys::Archive) -> *const c_char;
         // streaming-read setup (used by TarballStream's resumable extractor)
-        pub fn archive_read_set_format(a: *mut Archive, code: c_int) -> c_int;
-        pub fn archive_read_append_filter(a: *mut Archive, code: c_int) -> c_int;
+        pub safe fn archive_read_set_format(a: &sys::Archive, code: c_int) -> c_int;
+        pub safe fn archive_read_append_filter(a: &sys::Archive, code: c_int) -> c_int;
+        // NOT `safe fn`: the registered callbacks dereference `client_data`.
         pub fn archive_read_open(
-            a: *mut Archive,
+            a: &sys::Archive,
             client_data: *mut c_void,
             open: Option<archive_open_callback>,
             read: Option<archive_read_callback>,
@@ -99,25 +109,25 @@ pub mod lib {
         ) -> c_int;
 
         // write side
-        fn archive_write_new() -> *mut Archive;
-        fn archive_write_free(a: *mut Archive) -> Result;
-        fn archive_write_close(a: *mut Archive) -> Result;
-        fn archive_write_set_format_pax_restricted(a: *mut Archive) -> Result;
-        fn archive_write_add_filter_gzip(a: *mut Archive) -> Result;
+        safe fn archive_write_new() -> *mut sys::Archive;
+        safe fn archive_write_free(a: &sys::Archive) -> Result;
+        safe fn archive_write_close(a: &sys::Archive) -> Result;
+        safe fn archive_write_set_format_pax_restricted(a: &sys::Archive) -> Result;
+        safe fn archive_write_add_filter_gzip(a: &sys::Archive) -> Result;
         fn archive_write_set_filter_option(
-            a: *mut Archive,
+            a: &sys::Archive,
             module: *const c_char,
             option: *const c_char,
             value: *const c_char,
         ) -> Result;
-        fn archive_write_set_options(a: *mut Archive, opts: *const c_char) -> Result;
-        fn archive_write_open_filename(a: *mut Archive, filename: *const c_char) -> Result;
-        fn archive_write_header(a: *mut Archive, entry: *mut Entry) -> Result;
-        fn archive_write_data(a: *mut Archive, data: *const c_void, size: usize) -> la_ssize_t;
-        fn archive_write_finish_entry(a: *mut Archive) -> Result;
+        fn archive_write_set_options(a: &sys::Archive, opts: *const c_char) -> Result;
+        fn archive_write_open_filename(a: &sys::Archive, filename: *const c_char) -> Result;
+        fn archive_write_header(a: &sys::Archive, entry: *mut Entry) -> Result;
+        fn archive_write_data(a: &sys::Archive, data: *const c_void, size: usize) -> la_ssize_t;
+        safe fn archive_write_finish_entry(a: &sys::Archive) -> Result;
         #[link_name = "archive_write_open2"]
         fn archive_write_open2_raw(
-            a: *mut Archive,
+            a: &sys::Archive,
             client_data: *mut c_void,
             open: Option<archive_open_callback>,
             write: Option<archive_write_callback>,
@@ -127,7 +137,7 @@ pub mod lib {
 
         // entry
         fn archive_entry_new() -> *mut Entry;
-        fn archive_entry_new2(a: *mut Archive) -> *mut Entry;
+        fn archive_entry_new2(a: &sys::Archive) -> *mut Entry;
         fn archive_entry_free(e: *mut Entry);
         fn archive_entry_clear(e: *mut Entry) -> *mut Entry;
         fn archive_entry_pathname(e: *mut Entry) -> *const c_char;
@@ -146,6 +156,74 @@ pub mod lib {
         fn archive_entry_set_mtime(e: *mut Entry, secs: time_t, nsecs: c_long);
     }
 
+    /// `ForeignOwned::release` returns `()`; libarchive's status is not actionable
+    /// once the allocation is gone.
+    fn archive_free_release(a: &sys::Archive) {
+        let _ = archive_read_free(a);
+    }
+
+    // libarchive allocates in `archive_read_new()` and hands back the object.
+    // One `Archive` handle owns exactly that one allocation.
+    bun_opaque::foreign_owned!(sys::Archive, archive_free_release);
+
+    /// Owned handle to a libarchive `struct archive` from `archive_read_new()`.
+    ///
+    /// `Drop` gives the allocation back. Every method reached through this handle
+    /// takes `&self`: libarchive mutates the archive through the same pointer, so
+    /// there is no `&mut self` to have and no `DerefMut`.
+    #[repr(transparent)]
+    pub struct Archive(bun_opaque::ForeignRef<sys::Archive>);
+
+    impl Archive {
+        /// Adopt a handle libarchive allocated.
+        ///
+        /// # Safety
+        /// `ptr` must be live and owned by no other handle.
+        #[inline]
+        pub unsafe fn adopt(ptr: core::ptr::NonNull<sys::Archive>) -> Self {
+            // SAFETY: caller transfers ownership.
+            Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
+        }
+
+        /// Adopt a nullable handle; `None` on null.
+        #[inline]
+        fn adopt_ptr(ptr: *mut sys::Archive) -> Option<Self> {
+            // SAFETY: `archive_read_new` returns a fresh allocation or null.
+            core::ptr::NonNull::new(ptr).map(|p| unsafe { Self::adopt(p) })
+        }
+
+        /// `archive_read_new()` — libarchive allocates; this handle owns it.
+        #[inline]
+        pub fn read_new() -> Self {
+            Self::adopt_ptr(sys::Archive::read_new()).expect("archive_read_new returned NULL (OOM)")
+        }
+
+        /// The C pointer, still owned by `self`.
+        #[inline]
+        pub fn as_ptr(&self) -> *mut sys::Archive {
+            self.0.as_ptr()
+        }
+
+        /// Hand the allocation to a foreign owner. Pairs with a later [`Self::adopt`].
+        #[inline]
+        pub fn leak(self) -> core::ptr::NonNull<sys::Archive> {
+            self.0.leak()
+        }
+
+        #[inline]
+        fn raw(&self) -> &sys::Archive {
+            &self.0
+        }
+    }
+
+    impl core::ops::Deref for Archive {
+        type Target = sys::Archive;
+        #[inline]
+        fn deref(&self) -> &sys::Archive {
+            self.raw()
+        }
+    }
+
     /// One block from `archive_read_data_block`. `bytes` borrows libarchive's
     /// internal buffer (valid until the next read call on the owning archive).
     pub struct Block<'a> {
@@ -154,65 +232,56 @@ pub mod lib {
         pub result: Result,
     }
 
-    impl Archive {
-        pub fn read_new() -> *mut Archive {
-            // SAFETY: FFI call with no preconditions.
-            let p = unsafe { archive_read_new() };
+    impl sys::Archive {
+        /// Raw `archive_read_new()`. Prefer [`Archive::read_new`]; this exists for
+        /// the callers that keep a `*mut sys::Archive` and free it by hand.
+        pub fn read_new() -> *mut sys::Archive {
+            let p = archive_read_new();
             // libarchive's `archive_read_new()` returns NULL on calloc failure.
-            // Every caller immediately dereferences the result (forming
-            // `&Archive`), so fail loudly here instead of invoking UB at the
-            // first accessor call.
+            // Every caller immediately dereferences the result, so fail loudly
+            // here instead of invoking UB at the first accessor call.
             assert!(!p.is_null(), "archive_read_new returned NULL (OOM)");
             p
         }
         pub fn read_close(&self) -> Result {
-            // SAFETY: self came from archive_read_new().
-            unsafe { archive_read_close(self.as_mut_ptr()) }
+            archive_read_close(self)
         }
         pub fn read_free(&self) -> Result {
-            // SAFETY: self came from archive_read_new(); not used after this.
-            unsafe { archive_read_free(self.as_mut_ptr()) }
+            archive_read_free(self)
         }
         pub fn read_support_format_tar(&self) -> Result {
-            // SAFETY: self valid.
-            unsafe { archive_read_support_format_tar(self.as_mut_ptr()) }
+            archive_read_support_format_tar(self)
         }
         pub fn read_support_format_gnutar(&self) -> Result {
-            // SAFETY: self valid.
-            unsafe { archive_read_support_format_gnutar(self.as_mut_ptr()) }
+            archive_read_support_format_gnutar(self)
         }
         pub fn read_support_filter_gzip(&self) -> Result {
-            // SAFETY: self valid.
-            unsafe { archive_read_support_filter_gzip(self.as_mut_ptr()) }
+            archive_read_support_filter_gzip(self)
         }
         pub fn read_set_options(&self, opts: &core::ffi::CStr) -> Result {
-            // SAFETY: self valid; opts is NUL-terminated.
-            unsafe { archive_read_set_options(self.as_mut_ptr(), opts.as_ptr()) }
+            // SAFETY: opts is NUL-terminated.
+            unsafe { archive_read_set_options(self, opts.as_ptr()) }
         }
         pub fn read_open_memory(&self, buf: &[u8]) -> Result {
-            // SAFETY: self valid; buf outlives the archive (caller contract,
-            // see `BufferReadStream::buf` field comment).
-            unsafe { archive_read_open_memory(self.as_mut_ptr(), buf.as_ptr().cast(), buf.len()) }
+            // SAFETY: buf outlives the archive (caller contract, see
+            // `BufferReadStream::buf` field comment).
+            unsafe { archive_read_open_memory(self, buf.as_ptr().cast(), buf.len()) }
         }
         pub fn read_next_header(&self, entry: &mut *mut Entry) -> Result {
-            // SAFETY: self valid; entry is a valid out-ptr.
-            unsafe {
-                archive_read_next_header(self.as_mut_ptr(), std::ptr::from_mut::<*mut Entry>(entry))
-            }
+            // SAFETY: entry is a valid out-ptr.
+            unsafe { archive_read_next_header(self, std::ptr::from_mut::<*mut Entry>(entry)) }
         }
         pub fn read_data(&self, buf: &mut [u8]) -> isize {
-            // SAFETY: self valid; buf writable for buf.len().
-            unsafe { archive_read_data(self.as_mut_ptr(), buf.as_mut_ptr().cast(), buf.len()) }
+            // SAFETY: buf writable for buf.len().
+            unsafe { archive_read_data(self, buf.as_mut_ptr().cast(), buf.len()) }
         }
 
         /// `archive_read_data_block` — returns `None` on EOF.
         pub fn next(&self, offset: &mut i64) -> Option<Block<'_>> {
             let mut buff: *const c_void = core::ptr::null();
             let mut size: usize = 0;
-            // SAFETY: self valid; out-ptrs are valid stack locations.
-            let r = unsafe {
-                archive_read_data_block(self.as_mut_ptr(), &raw mut buff, &raw mut size, offset)
-            };
+            // SAFETY: out-ptrs are valid stack locations.
+            let r = unsafe { archive_read_data_block(self, &raw mut buff, &raw mut size, offset) };
             if r == Result::Eof {
                 return None;
             }
@@ -346,12 +415,8 @@ pub mod lib {
             Result::Ok
         }
 
-        // `self` must be a live archive handle from `archive_{read,write}_new()`.
-        // `Archive` is `opaque_ffi!`-backed (UnsafeCell), so `&self → *mut Self`
-        // is sound; libarchive never returns null from `*_new()`.
         pub fn error_string(&self) -> &'static [u8] {
-            // SAFETY: `self` is a live archive handle.
-            let p = unsafe { archive_error_string(self.as_mut_ptr()) };
+            let p = archive_error_string(self);
             if p.is_null() {
                 return b"";
             }
@@ -363,25 +428,20 @@ pub mod lib {
         }
 
         // ── write side ─────────────────────────────────────────────────────
-        pub fn write_new() -> *mut Archive {
-            // SAFETY: FFI call with no preconditions.
-            unsafe { archive_write_new() }
+        pub fn write_new() -> *mut sys::Archive {
+            archive_write_new()
         }
         pub fn write_free(&self) -> Result {
-            // SAFETY: self came from archive_write_new(); not used after this.
-            unsafe { archive_write_free(self.as_mut_ptr()) }
+            archive_write_free(self)
         }
         pub fn write_close(&self) -> Result {
-            // SAFETY: self valid.
-            unsafe { archive_write_close(self.as_mut_ptr()) }
+            archive_write_close(self)
         }
         pub fn write_set_format_pax_restricted(&self) -> Result {
-            // SAFETY: self valid.
-            unsafe { archive_write_set_format_pax_restricted(self.as_mut_ptr()) }
+            archive_write_set_format_pax_restricted(self)
         }
         pub fn write_add_filter_gzip(&self) -> Result {
-            // SAFETY: self valid.
-            unsafe { archive_write_add_filter_gzip(self.as_mut_ptr()) }
+            archive_write_add_filter_gzip(self)
         }
         pub fn write_set_filter_option(
             &self,
@@ -389,10 +449,10 @@ pub mod lib {
             option: &ZStr,
             value: &ZStr,
         ) -> Result {
-            // SAFETY: self valid; ZStr guarantees NUL-termination.
+            // SAFETY: ZStr guarantees NUL-termination.
             unsafe {
                 archive_write_set_filter_option(
-                    self.as_mut_ptr(),
+                    self,
                     module.map_or(core::ptr::null(), |m| m.as_ptr().cast()),
                     option.as_ptr().cast(),
                     value.as_ptr().cast(),
@@ -400,25 +460,24 @@ pub mod lib {
             }
         }
         pub fn write_set_options(&self, opts: &ZStr) -> Result {
-            // SAFETY: self valid; ZStr guarantees NUL-termination.
-            unsafe { archive_write_set_options(self.as_mut_ptr(), opts.as_ptr().cast()) }
+            // SAFETY: ZStr guarantees NUL-termination.
+            unsafe { archive_write_set_options(self, opts.as_ptr().cast()) }
         }
         pub fn write_open_filename(&self, filename: &ZStr) -> Result {
-            // SAFETY: self valid; ZStr guarantees NUL-termination.
-            unsafe { archive_write_open_filename(self.as_mut_ptr(), filename.as_ptr().cast()) }
+            // SAFETY: ZStr guarantees NUL-termination.
+            unsafe { archive_write_open_filename(self, filename.as_ptr().cast()) }
         }
         pub fn write_header(&self, entry: &Entry) -> Result {
-            // SAFETY: self valid; entry came from Entry::new()/read_next_header().
+            // SAFETY: entry came from Entry::new()/read_next_header().
             // `Entry` has interior mutability so `&Entry -> *mut Entry` is sound.
-            unsafe { archive_write_header(self.as_mut_ptr(), entry.as_mut_ptr()) }
+            unsafe { archive_write_header(self, entry.as_mut_ptr()) }
         }
         pub fn write_data(&self, data: &[u8]) -> isize {
-            // SAFETY: self valid; data readable for data.len().
-            unsafe { archive_write_data(self.as_mut_ptr(), data.as_ptr().cast(), data.len()) }
+            // SAFETY: data readable for data.len().
+            unsafe { archive_write_data(self, data.as_ptr().cast(), data.len()) }
         }
         pub fn write_finish_entry(&self) -> Result {
-            // SAFETY: self valid.
-            unsafe { archive_write_finish_entry(self.as_mut_ptr()) }
+            archive_write_finish_entry(self)
         }
     }
 
@@ -462,9 +521,9 @@ pub mod lib {
         /// `archive_entry_new2(archive)` — ties the entry to the archive's
         /// charset-conversion context (preferred over `new()` when an archive
         /// is available). `archive` is a live handle from `read_new()`/`write_new()`.
-        pub fn new2(archive: &Archive) -> *mut Entry {
-            // SAFETY: `archive` is a live handle (opaque_ffi! `&self → *mut Self`).
-            unsafe { archive_entry_new2(archive.as_mut_ptr()) }
+        pub fn new2(archive: &sys::Archive) -> *mut Entry {
+            // SAFETY: `archive` is a live handle.
+            unsafe { archive_entry_new2(archive) }
         }
         pub fn free(&self) {
             // SAFETY: self came from Entry::new(); not used after this.
@@ -502,64 +561,30 @@ pub mod lib {
         }
     }
 
-    // ── RAII owners ────────────────────────────────────────────────────────
-    //
-    // The raw `*mut Archive` / `*mut Entry` constructors above mirror the C
-    // API. These thin owners pair them with the matching `*_free` on `Drop`
-    // so callers stop hand-rolling `defer { (*archive).read_free() }`.
+    // The read side is [`Archive`] (a `ForeignRef<sys::Archive>`); the write side
+    // keeps its own owner. Both free routines are the same `archive_free()` vtable
+    // entry — the pairing with `archive_write_new()` is what the type documents.
 
-    /// Owns a `*mut Archive` opened with [`Archive::read_new`]; calls
-    /// `archive_read_free` on drop. Derefs to `&Archive`.
-    pub struct ReadArchive(core::ptr::NonNull<Archive>);
-    impl ReadArchive {
-        #[inline]
-        pub fn new() -> Self {
-            Self(
-                core::ptr::NonNull::new(Archive::read_new())
-                    .expect("archive_read_new returned null"),
-            )
-        }
-        #[inline]
-        pub fn as_ptr(&self) -> *mut Archive {
-            self.0.as_ptr()
-        }
-    }
-    impl core::ops::Deref for ReadArchive {
-        type Target = Archive;
-        #[inline]
-        fn deref(&self) -> &Archive {
-            // SAFETY: handle is live until Drop; libarchive owns the storage.
-            unsafe { self.0.as_ref() }
-        }
-    }
-    impl Drop for ReadArchive {
-        #[inline]
-        fn drop(&mut self) {
-            // SAFETY: handle came from archive_read_new() and is freed exactly once.
-            let _ = unsafe { archive_read_free(self.0.as_ptr()) };
-        }
-    }
-
-    /// Owns a `*mut Archive` opened with [`Archive::write_new`]; calls
-    /// `archive_write_free` on drop. Derefs to `&Archive`.
-    pub struct WriteArchive(core::ptr::NonNull<Archive>);
+    /// Owns a `*mut sys::Archive` opened with [`sys::Archive::write_new`]; calls
+    /// `archive_write_free` on drop. Derefs to `&sys::Archive`.
+    pub struct WriteArchive(core::ptr::NonNull<sys::Archive>);
     impl WriteArchive {
         #[inline]
         pub fn new() -> Self {
             Self(
-                core::ptr::NonNull::new(Archive::write_new())
+                core::ptr::NonNull::new(sys::Archive::write_new())
                     .expect("archive_write_new returned null"),
             )
         }
         #[inline]
-        pub fn as_ptr(&self) -> *mut Archive {
+        pub fn as_ptr(&self) -> *mut sys::Archive {
             self.0.as_ptr()
         }
     }
     impl core::ops::Deref for WriteArchive {
-        type Target = Archive;
+        type Target = sys::Archive;
         #[inline]
-        fn deref(&self) -> &Archive {
+        fn deref(&self) -> &sys::Archive {
             // SAFETY: handle is live until Drop; libarchive owns the storage.
             unsafe { self.0.as_ref() }
         }
@@ -568,7 +593,7 @@ pub mod lib {
         #[inline]
         fn drop(&mut self) {
             // SAFETY: handle came from archive_write_new() and is freed exactly once.
-            let _ = unsafe { archive_write_free(self.0.as_ptr()) };
+            let _ = archive_write_free(unsafe { self.0.as_ref() });
         }
     }
 
@@ -620,7 +645,7 @@ pub mod lib {
     /// Generic result type used by [`ArchiveIterator`].
     pub enum IteratorResult<T> {
         Err {
-            archive: *mut Archive,
+            archive: *mut sys::Archive,
             message: &'static [u8],
         },
         Result(T),
@@ -628,7 +653,7 @@ pub mod lib {
 
     impl<T> IteratorResult<T> {
         #[inline]
-        pub fn init_err(arch: *mut Archive, msg: &'static [u8]) -> Self {
+        pub fn init_err(arch: *mut sys::Archive, msg: &'static [u8]) -> Self {
             Self::Err {
                 message: msg,
                 archive: arch,
@@ -643,7 +668,7 @@ pub mod lib {
     /// Iterates over the entries of an open archive, skipping entries whose
     /// file kind has its bit set in `filter`.
     pub struct ArchiveIterator {
-        pub archive: *mut Archive,
+        pub archive: *mut sys::Archive,
         // A u16 bitmask over
         // `bun_sys::FileKind` variants.
         pub filter: u16,
@@ -660,16 +685,16 @@ pub mod lib {
         ///
         /// SAFETY (invariant): `self.archive` is set to a fresh non-null
         /// handle by `Archive::read_new()` in [`init`] and remains valid
-        /// until `read_free()` in [`close`]. All `Archive` methods take
+        /// until `read_free()` in [`close`]. All `sys::Archive` methods take
         /// `&self` (FFI interior mutability), so a shared borrow suffices.
         #[inline]
-        fn archive(&self) -> &Archive {
+        fn archive(&self) -> &sys::Archive {
             // SAFETY: see doc comment — non-null for the lifetime of `self`.
             unsafe { &*self.archive }
         }
 
         pub fn init(tarball_bytes: &[u8]) -> IteratorResult<Self> {
-            let archive = Archive::read_new();
+            let archive = sys::Archive::read_new();
             // SAFETY: archive_read_new() returns a non-null handle owned by libarchive.
             let a = unsafe { &*archive };
 
@@ -766,7 +791,7 @@ pub mod lib {
         /// live handle this `NextEntry` was yielded from.
         pub fn read_entry_data(
             &self,
-            archive: &Archive,
+            archive: &sys::Archive,
         ) -> core::result::Result<IteratorResult<Box<[u8]>>, bun_core::OOM> {
             // SAFETY: self.entry is the libarchive-owned entry from read_next_header.
             let size = unsafe { (*self.entry).size() };
@@ -790,29 +815,29 @@ pub mod lib {
     }
 
     // ── write-open callback surface (libarchive `archive_write_open2`) ─────
-    pub type archive_open_callback = unsafe extern "C" fn(*mut Archive, *mut c_void) -> c_int;
+    pub type archive_open_callback = unsafe extern "C" fn(*mut sys::Archive, *mut c_void) -> c_int;
     pub type archive_read_callback =
-        unsafe extern "C" fn(*mut Archive, *mut c_void, *mut *const c_void) -> la_ssize_t;
+        unsafe extern "C" fn(*mut sys::Archive, *mut c_void, *mut *const c_void) -> la_ssize_t;
     pub type archive_write_callback =
-        unsafe extern "C" fn(*mut Archive, *mut c_void, *const c_void, usize) -> la_ssize_t;
-    pub type archive_close_callback = unsafe extern "C" fn(*mut Archive, *mut c_void) -> c_int;
-    pub type archive_free_callback = unsafe extern "C" fn(*mut Archive, *mut c_void) -> c_int;
+        unsafe extern "C" fn(*mut sys::Archive, *mut c_void, *const c_void, usize) -> la_ssize_t;
+    pub type archive_close_callback = unsafe extern "C" fn(*mut sys::Archive, *mut c_void) -> c_int;
+    pub type archive_free_callback = unsafe extern "C" fn(*mut sys::Archive, *mut c_void) -> c_int;
 
     /// `a` is a live `archive_write_new()` handle. `client_data` is forwarded
     /// opaquely to the callbacks (never dereferenced here); its lifetime must
     /// outlast the registered callbacks.
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn archive_write_open2(
-        a: &Archive,
+        a: &sys::Archive,
         client_data: *mut c_void,
         open: Option<archive_open_callback>,
         write: Option<archive_write_callback>,
         close: Option<archive_close_callback>,
         free: Option<archive_free_callback>,
     ) -> c_int {
-        // SAFETY: `a` is a live handle (`opaque_ffi!` `&self → *mut Self`);
-        // `client_data` is opaque to libarchive until a callback dereferences it.
-        unsafe { archive_write_open2_raw(a.as_mut_ptr(), client_data, open, write, close, free) }
+        // SAFETY: `client_data` is opaque to libarchive until a callback
+        // dereferences it.
+        unsafe { archive_write_open2_raw(a, client_data, open, write, close, free) }
     }
 
     /// Growing memory buffer for archive writes with libarchive callbacks.
@@ -837,7 +862,7 @@ pub mod lib {
         }
 
         pub unsafe extern "C" fn open_callback(
-            _a: *mut Archive,
+            _a: *mut sys::Archive,
             client_data: *mut c_void,
         ) -> c_int {
             // SAFETY: client_data is a *mut GrowingBuffer registered via archive_write_open2.
@@ -848,7 +873,7 @@ pub mod lib {
         }
 
         pub unsafe extern "C" fn write_callback(
-            _a: *mut Archive,
+            _a: *mut sys::Archive,
             client_data: *mut c_void,
             buff: *const c_void,
             length: usize,
@@ -869,7 +894,7 @@ pub mod lib {
         }
 
         pub unsafe extern "C" fn close_callback(
-            _a: *mut Archive,
+            _a: *mut sys::Archive,
             _client_data: *mut c_void,
         ) -> c_int {
             0
@@ -884,7 +909,7 @@ pub mod lib {
     /// Error payload for [`IterResult`]: the archive handle (for
     /// `error_string()`) plus a static description.
     pub struct IteratorError {
-        pub archive: *mut Archive,
+        pub archive: *mut sys::Archive,
         pub message: &'static [u8],
     }
     impl IteratorError {
@@ -906,6 +931,7 @@ pub mod lib {
         pub entry: *mut Entry,
         pub kind: bun_sys::FileKind,
     }
+
     impl IteratorEntry {
         /// Borrow the libarchive entry. Valid until the next `next()` call.
         #[inline]
@@ -920,7 +946,7 @@ pub mod lib {
         /// `archive` is the live handle this entry was yielded from.
         pub fn read_entry_data(
             &self,
-            archive: &Archive,
+            archive: &sys::Archive,
         ) -> core::result::Result<IterResult<Vec<u8>>, bun_core::OOM> {
             let size = self.entry().size();
             if size < 0 || size > 64 * 1024 * 1024 {
@@ -945,7 +971,7 @@ pub mod lib {
     /// Streaming reader over an in-memory tarball; yields one
     /// [`IteratorEntry`] per archive entry via [`Iterator::next`].
     pub struct Iterator {
-        pub archive: *mut Archive,
+        pub archive: *mut sys::Archive,
         // No filter field: every caller would leave it empty;
         // re-add if a caller
         // ever needs it.
@@ -955,10 +981,10 @@ pub mod lib {
         ///
         /// SAFETY (invariant): `self.archive` is set to a fresh non-null
         /// handle by `Archive::read_new()` in [`init`] and remains valid
-        /// until `read_free()` in [`deinit`]. All `Archive` methods take
+        /// until `read_free()` in [`deinit`]. All `sys::Archive` methods take
         /// `&self` (FFI interior mutability), so a shared borrow suffices.
         #[inline]
-        fn archive(&self) -> &Archive {
+        fn archive(&self) -> &sys::Archive {
             // SAFETY: see doc comment — non-null for the lifetime of `self`.
             unsafe { &*self.archive }
         }
@@ -966,8 +992,8 @@ pub mod lib {
         /// Opens `tarball_bytes` as a
         /// gzip-compressed (gnu)tar archive.
         pub fn init(tarball_bytes: &[u8]) -> IterResult<Self> {
-            let archive = Archive::read_new();
-            // SAFETY: `archive` is a fresh non-null `*mut Archive`.
+            let archive = sys::Archive::read_new();
+            // SAFETY: `archive` is a fresh non-null `*mut sys::Archive`.
             let a = unsafe { &*archive };
 
             match a.read_support_format_tar() {
@@ -1074,7 +1100,7 @@ pub mod lib {
     }
 }
 
-use lib::Archive;
+use lib::{Archive, sys};
 
 #[repr(i32)] // c_int
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1091,7 +1117,7 @@ pub struct BufferReadStream {
 
     block_size: usize,
 
-    archive: *mut Archive,
+    archive: Archive,
     reading: bool,
 }
 
@@ -1117,15 +1143,9 @@ impl BufferReadStream {
     }
 
     /// Borrow the underlying libarchive handle.
-    ///
-    /// SAFETY (invariant): `self.archive` is set to a fresh non-null handle by
-    /// `Archive::read_new()` in `init()` (asserted there) and remains valid
-    /// until `read_free()` in `Drop`. All `Archive` methods take `&self`
-    /// (FFI interior mutability), so a shared borrow is sufficient.
     #[inline]
-    fn archive(&self) -> &Archive {
-        // SAFETY: see doc comment — non-null for the lifetime of `self`.
-        unsafe { &*self.archive }
+    fn archive(&self) -> &sys::Archive {
+        &self.archive
     }
 
     /// Borrow the input buffer.
@@ -1181,7 +1201,7 @@ impl BufferReadStream {
         ctx.cast::<Self>()
     }
 
-    pub extern "C" fn archive_close_callback(_: *mut Archive, _: *mut c_void) -> c_int {
+    pub extern "C" fn archive_close_callback(_: *mut sys::Archive, _: *mut c_void) -> c_int {
         0
     }
 
@@ -1189,7 +1209,7 @@ impl BufferReadStream {
     /// libarchive C callback: `ctx_` is the `*mut BufferReadStream` registered
     /// via `archive_read_set_callback_data`; `buffer` is a non-null out-param.
     pub unsafe extern "C" fn archive_read_callback(
-        _: *mut Archive,
+        _: *mut sys::Archive,
         ctx_: *mut c_void,
         buffer: *mut *const c_void,
     ) -> lib::la_ssize_t {
@@ -1211,7 +1231,7 @@ impl BufferReadStream {
     /// libarchive C callback: `ctx_` is the `*mut BufferReadStream` registered
     /// via `archive_read_set_callback_data`.
     pub unsafe extern "C" fn archive_skip_callback(
-        _: *mut Archive,
+        _: *mut sys::Archive,
         ctx_: *mut c_void,
         offset: lib::la_int64_t,
     ) -> lib::la_int64_t {
@@ -1231,7 +1251,7 @@ impl BufferReadStream {
     /// libarchive C callback: `ctx_` is the `*mut BufferReadStream` registered
     /// via `archive_read_set_callback_data`.
     pub unsafe extern "C" fn archive_seek_callback(
-        _: *mut Archive,
+        _: *mut sys::Archive,
         ctx_: *mut c_void,
         offset: lib::la_int64_t,
         whence: c_int,
@@ -1304,8 +1324,8 @@ impl BufferReadStream {
 
 impl Drop for BufferReadStream {
     fn drop(&mut self) {
+        // The `archive` field's `Drop` runs next and calls `archive_read_free`.
         let _ = self.archive().read_close();
-        let _ = self.archive().read_free();
     }
 }
 
@@ -1557,7 +1577,7 @@ impl Archiver {
         // SAFETY: `file_buffer` outlives `stream` (stack-local, dropped at fn exit).
         let mut stream = unsafe { BufferReadStream::init(file_buffer) };
         let _ = stream.open_read();
-        let archive = stream.archive;
+        let archive: &lib::sys::Archive = &stream.archive;
 
         // Uses the bun_sys directory-fd helpers (open_dir_absolute / open_dir_at).
         let dir: Fd = 'brk: {
@@ -1581,8 +1601,7 @@ impl Archiver {
         let _close_dir_guard = scopeguard::guard(dir, |d| d.close());
 
         'loop_: loop {
-            // SAFETY: archive valid for stream lifetime
-            let r = unsafe { (*archive).read_next_header(&mut entry) };
+            let r = archive.read_next_header(&mut entry);
 
             match r {
                 lib::Result::Eof => break 'loop_,
@@ -1693,7 +1712,7 @@ impl Archiver {
         // SAFETY: `file_buffer` outlives `stream` (stack-local, dropped at fn exit).
         let mut stream = unsafe { BufferReadStream::init(file_buffer) };
         let _ = stream.open_read();
-        let archive = stream.archive;
+        let archive: &lib::sys::Archive = &stream.archive;
         let mut count: u32 = 0;
         let dir_fd = dir;
 
@@ -1711,8 +1730,7 @@ impl Archiver {
         let mut use_lseek = true;
 
         'loop_: loop {
-            // SAFETY: archive valid for stream lifetime
-            let r = unsafe { (*archive).read_next_header(&mut entry) };
+            let r = archive.read_next_header(&mut entry);
 
             match r {
                 lib::Result::Eof => break 'loop_,
@@ -2143,12 +2161,8 @@ impl Archiver {
                                             plucker_.contents.inflate(size)?;
                                             let cap = plucker_.contents.list.capacity();
                                             plucker_.contents.list.resize(cap, 0);
-                                            // SAFETY: archive valid
-                                            let read = unsafe {
-                                                (*archive).read_data(
-                                                    plucker_.contents.list.as_mut_slice(),
-                                                )
-                                            };
+                                            let read = archive
+                                                .read_data(plucker_.contents.list.as_mut_slice());
                                             plucker_.contents.inflate(
                                                 usize::try_from(read).expect("int cast"),
                                             )?;
@@ -2175,14 +2189,11 @@ impl Archiver {
                                 let mut retries_remaining: u8 = 5;
 
                                 'possibly_retry: while retries_remaining != 0 {
-                                    // SAFETY: archive valid
-                                    match unsafe {
-                                        (*archive).read_data_into_fd(
-                                            *file_handle,
-                                            &mut use_pwrite,
-                                            &mut use_lseek,
-                                        )
-                                    } {
+                                    match archive.read_data_into_fd(
+                                        *file_handle,
+                                        &mut use_pwrite,
+                                        &mut use_lseek,
+                                    ) {
                                         lib::Result::Eof => break 'loop_,
                                         lib::Result::Ok => break 'possibly_retry,
                                         lib::Result::Retry => {
@@ -2203,12 +2214,8 @@ impl Archiver {
                                         }
                                         _ => {
                                             if options.log {
-                                                // SAFETY: `archive` is the live
-                                                // `read_new()` handle this
-                                                // extraction loop is iterating.
-                                                let archive_error = slice_to_nul(
-                                                    unsafe { &*archive }.error_string(),
-                                                );
+                                                let archive_error =
+                                                    slice_to_nul(archive.error_string());
                                                 Output::err(
                                                     "libarchive error",
                                                     "extracting {}: {}",

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -164,55 +164,22 @@ pub mod lib {
 
     // libarchive allocates in `archive_read_new()` and hands back the object.
     // One `Archive` handle owns exactly that one allocation.
-    bun_opaque::foreign_owned!(sys::Archive, archive_free_release);
-
-    /// Owned handle to a libarchive `struct archive` from `archive_read_new()`.
-    ///
-    /// `Drop` gives the allocation back. Every method reached through this handle
-    /// takes `&self`: libarchive mutates the archive through the same pointer, so
-    /// there is no `&mut self` to have and no `DerefMut`.
-    #[repr(transparent)]
-    pub struct Archive(bun_opaque::ForeignRef<sys::Archive>);
+    bun_opaque::foreign_handle! {
+        /// Owned handle to a libarchive `struct archive` from `archive_read_new()`.
+        ///
+        /// `Drop` gives the allocation back. Every method reached through this handle
+        /// takes `&self`: libarchive mutates the archive through the same pointer, so
+        /// there is no `&mut self` to have and no `DerefMut`.
+        pub struct Archive(sys::Archive) via archive_free_release;
+    }
 
     impl Archive {
-        /// Adopt a handle libarchive allocated.
-        ///
-        /// # Safety
-        /// `ptr` must be live and owned by no other handle.
-        #[inline]
-        pub unsafe fn adopt(ptr: core::ptr::NonNull<sys::Archive>) -> Self {
-            // SAFETY: caller transfers ownership.
-            Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
-        }
-
-        /// Adopt a nullable handle; `None` on null.
-        #[inline]
-        fn adopt_ptr(ptr: *mut sys::Archive) -> Option<Self> {
-            // SAFETY: `archive_read_new` returns a fresh allocation or null.
-            core::ptr::NonNull::new(ptr).map(|p| unsafe { Self::adopt(p) })
-        }
-
         /// `archive_read_new()` — libarchive allocates; this handle owns it.
         #[inline]
         pub fn read_new() -> Self {
-            Self::adopt_ptr(sys::Archive::read_new()).expect("archive_read_new returned NULL (OOM)")
-        }
-
-        /// The C pointer, still owned by `self`.
-        #[inline]
-        pub fn as_ptr(&self) -> *mut sys::Archive {
-            self.0.as_ptr()
-        }
-
-        /// Hand the allocation to a foreign owner. Pairs with a later [`Self::adopt`].
-        #[inline]
-        pub fn leak(self) -> core::ptr::NonNull<sys::Archive> {
-            self.0.leak()
-        }
-
-        #[inline]
-        fn raw(&self) -> &sys::Archive {
-            &self.0
+            // SAFETY: `archive_read_new` hands back the sole ownership unit.
+            unsafe { Self::adopt_ptr(sys::Archive::read_new()) }
+                .expect("archive_read_new returned NULL (OOM)")
         }
     }
 
@@ -561,76 +528,65 @@ pub mod lib {
         }
     }
 
-    // The read side is [`Archive`] (a `ForeignRef<sys::Archive>`); the write side
-    // keeps its own owner. Both free routines are the same `archive_free()` vtable
-    // entry — the pairing with `archive_write_new()` is what the type documents.
+    // `sys::Archive` has two ownership disciplines: `archive_read_free`, claimed by
+    // its `ForeignOwned` impl and used by `Archive`, and `archive_write_free`, which
+    // names a marker. Both are the same `archive_free()` vtable entry — the pairing
+    // with `archive_write_new()` is what the type documents.
+    fn archive_write_free_release(a: &sys::Archive) {
+        let _ = archive_write_free(a);
+    }
+    bun_opaque::foreign_release!(pub WriteFree => sys::Archive, archive_write_free_release);
 
-    /// Owns a `*mut sys::Archive` opened with [`sys::Archive::write_new`]; calls
-    /// `archive_write_free` on drop. Derefs to `&sys::Archive`.
-    pub struct WriteArchive(core::ptr::NonNull<sys::Archive>);
+    bun_opaque::foreign_handle! {
+        /// Owns an archive opened with [`sys::Archive::write_new`]; `Drop` calls
+        /// `archive_write_free`. Derefs to `&sys::Archive`.
+        pub struct WriteArchive(sys::Archive) via marker WriteFree;
+    }
     impl WriteArchive {
         #[inline]
         pub fn new() -> Self {
-            Self(
-                core::ptr::NonNull::new(sys::Archive::write_new())
-                    .expect("archive_write_new returned null"),
-            )
-        }
-        #[inline]
-        pub fn as_ptr(&self) -> *mut sys::Archive {
-            self.0.as_ptr()
+            // SAFETY: `archive_write_new` hands back the sole ownership unit.
+            unsafe { Self::adopt_ptr(sys::Archive::write_new()) }
+                .expect("archive_write_new returned null")
         }
     }
     impl core::ops::Deref for WriteArchive {
         type Target = sys::Archive;
         #[inline]
         fn deref(&self) -> &sys::Archive {
-            // SAFETY: handle is live until Drop; libarchive owns the storage.
-            unsafe { self.0.as_ref() }
-        }
-    }
-    impl Drop for WriteArchive {
-        #[inline]
-        fn drop(&mut self) {
-            // SAFETY: handle came from archive_write_new() and is freed exactly once.
-            let _ = archive_write_free(unsafe { self.0.as_ref() });
+            self.raw()
         }
     }
 
-    /// Owns a `*mut Entry` created with [`Entry::new`] / [`Entry::new2`];
-    /// calls `archive_entry_free` on drop. Derefs to `&Entry`.
-    pub struct OwnedEntry(core::ptr::NonNull<Entry>);
+    fn entry_free_release(e: &Entry) {
+        // SAFETY: `e` is live and carries the unit `Drop` is giving back.
+        unsafe { archive_entry_free(e.as_mut_ptr()) };
+    }
+
+    bun_opaque::foreign_handle! {
+        /// Owns an entry created with [`Entry::new`] / [`Entry::new2`]; `Drop` calls
+        /// `archive_entry_free`. Derefs to `&Entry`.
+        pub struct OwnedEntry(Entry) via entry_free_release;
+    }
     impl OwnedEntry {
         #[inline]
         pub fn new() -> Self {
-            Self(core::ptr::NonNull::new(Entry::new()).expect("archive_entry_new returned null"))
+            // SAFETY: `archive_entry_new` hands back the sole ownership unit.
+            unsafe { Self::adopt_ptr(Entry::new()) }.expect("archive_entry_new returned null")
         }
         /// `archive` is a live handle from `read_new()`/`write_new()`.
         #[inline]
         pub fn new2(archive: &Archive) -> Self {
-            Self(
-                core::ptr::NonNull::new(Entry::new2(archive))
-                    .expect("archive_entry_new2 returned null"),
-            )
-        }
-        #[inline]
-        pub fn as_ptr(&self) -> *mut Entry {
-            self.0.as_ptr()
+            // SAFETY: `archive_entry_new2` hands back the sole ownership unit.
+            unsafe { Self::adopt_ptr(Entry::new2(archive)) }
+                .expect("archive_entry_new2 returned null")
         }
     }
     impl core::ops::Deref for OwnedEntry {
         type Target = Entry;
         #[inline]
         fn deref(&self) -> &Entry {
-            // SAFETY: handle is live until Drop; libarchive owns the storage.
-            unsafe { self.0.as_ref() }
-        }
-    }
-    impl Drop for OwnedEntry {
-        #[inline]
-        fn drop(&mut self) {
-            // SAFETY: handle came from archive_entry_new()/new2() and is freed exactly once.
-            unsafe { archive_entry_free(self.0.as_ptr()) };
+            self.raw()
         }
     }
 

--- a/src/libdeflate_sys/libdeflate.rs
+++ b/src/libdeflate_sys/libdeflate.rs
@@ -1,6 +1,5 @@
 use core::ffi::{c_int, c_uint, c_void};
 use core::mem::MaybeUninit;
-use core::ptr::NonNull;
 use std::sync::Once;
 
 #[repr(C)]
@@ -34,10 +33,6 @@ pub mod sys {
         pub struct Decompressor;
     }
 }
-
-// `libdeflate_alloc_compressor[_ex]` allocates and hands back the object. One
-// `Compressor` handle owns exactly that one allocation.
-bun_opaque::foreign_owned!(sys::Compressor, libdeflate_free_compressor);
 
 unsafe extern "C" {
     // Allocation: scalar arg, no preconditions; returns null on OOM.
@@ -110,51 +105,16 @@ pub fn load() {
     LOADED_ONCE.call_once(load_once);
 }
 
-/// Owned handle to a libdeflate compressor; `Drop` frees it.
-///
-/// Every method takes `&self`: `sys::Compressor` is `UnsafeCell`-backed, so a
-/// `&` carries no `noalias`/`readonly` and libdeflate freely mutates the
-/// compressor's scratch state through it. `#[repr(transparent)]` over `NonNull`,
-/// so `Option<Compressor>` is pointer-sized with all-zero = `None`.
-#[repr(transparent)]
-pub struct Compressor(bun_opaque::ForeignRef<sys::Compressor>);
-
-/// Ownership plumbing.
-impl Compressor {
-    /// Adopt an allocation returned by libdeflate.
+// `libdeflate_alloc_compressor[_ex]` allocates and hands back the object. One
+// `Compressor` handle owns exactly that one allocation.
+bun_opaque::foreign_handle! {
+    /// Owned handle to a libdeflate compressor; `Drop` frees it.
     ///
-    /// # Safety
-    /// `ptr` must come from `libdeflate_alloc_compressor[_ex]` and must not be
-    /// freed by any other handle.
-    #[inline]
-    pub unsafe fn adopt(ptr: NonNull<sys::Compressor>) -> Self {
-        // SAFETY: caller transfers the allocation.
-        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
-    }
-
-    /// Adopt a nullable allocation; `None` on OOM.
-    #[inline]
-    fn adopt_ptr(ptr: *mut sys::Compressor) -> Option<Self> {
-        // SAFETY: libdeflate returns a fresh allocation or null.
-        NonNull::new(ptr).map(|p| unsafe { Self::adopt(p) })
-    }
-
-    /// The libdeflate pointer, still owned by `self`.
-    #[inline]
-    pub fn as_ptr(&self) -> *mut sys::Compressor {
-        self.0.as_ptr()
-    }
-
-    /// Hand the allocation to a foreign owner. Pairs with a later [`Self::adopt`].
-    #[inline]
-    pub fn leak(self) -> NonNull<sys::Compressor> {
-        self.0.leak()
-    }
-
-    #[inline]
-    fn raw(&self) -> &sys::Compressor {
-        &self.0
-    }
+    /// Every method takes `&self`: `sys::Compressor` is `UnsafeCell`-backed, so a
+    /// `&` carries no `noalias`/`readonly` and libdeflate freely mutates the
+    /// compressor's scratch state through it. `#[repr(transparent)]` over `NonNull`,
+    /// so `Option<Compressor>` is pointer-sized with all-zero = `None`.
+    pub struct Compressor(sys::Compressor) via libdeflate_free_compressor;
 }
 
 /// Constructors. libdeflate allocates; each returns an owned handle.
@@ -162,7 +122,8 @@ impl Compressor {
     /// Allocate a compressor at `level` (0..=12). Returns `None` on OOM.
     #[inline]
     pub fn new(level: c_int) -> Option<Self> {
-        Self::adopt_ptr(libdeflate_alloc_compressor(level))
+        // SAFETY: `libdeflate_alloc_compressor` transfers the sole ownership unit, or null.
+        unsafe { Self::adopt_ptr(libdeflate_alloc_compressor(level)) }
     }
 
     /// # Safety
@@ -170,9 +131,11 @@ impl Compressor {
     /// callbacks — libdeflate writes through their return values.
     pub unsafe fn new_ex(level: c_int, options: Option<&Options>) -> Option<Self> {
         // SAFETY: caller upholds the callback contract; `Option<&T>` → `*const T` is NPO-compatible.
-        Self::adopt_ptr(unsafe {
+        let ptr = unsafe {
             libdeflate_alloc_compressor_ex(level, options.map_or(core::ptr::null(), |o| o))
-        })
+        };
+        // SAFETY: `libdeflate_alloc_compressor_ex` transfers the sole ownership unit, or null.
+        unsafe { Self::adopt_ptr(ptr) }
     }
 }
 
@@ -309,53 +272,14 @@ impl Compressor {
 
 // `libdeflate_alloc_decompressor[_ex]` allocates and hands back the object. One
 // `Decompressor` handle owns exactly that one allocation.
-bun_opaque::foreign_owned!(sys::Decompressor, libdeflate_free_decompressor);
-
-/// Owned handle to a libdeflate decompressor; `Drop` frees it.
-///
-/// Every method takes `&self`: `sys::Decompressor` is `UnsafeCell`-backed, so a
-/// `&` carries no `noalias`/`readonly` and libdeflate freely mutates the
-/// decompressor's scratch state through it. `#[repr(transparent)]` over `NonNull`,
-/// so `Option<Decompressor>` is pointer-sized with all-zero = `None`.
-#[repr(transparent)]
-pub struct Decompressor(bun_opaque::ForeignRef<sys::Decompressor>);
-
-/// Ownership plumbing.
-impl Decompressor {
-    /// Adopt an allocation returned by libdeflate.
+bun_opaque::foreign_handle! {
+    /// Owned handle to a libdeflate decompressor; `Drop` frees it.
     ///
-    /// # Safety
-    /// `ptr` must come from `libdeflate_alloc_decompressor[_ex]` and must not be
-    /// freed by any other handle.
-    #[inline]
-    pub unsafe fn adopt(ptr: NonNull<sys::Decompressor>) -> Self {
-        // SAFETY: caller transfers the allocation.
-        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
-    }
-
-    /// Adopt a nullable allocation; `None` on OOM.
-    #[inline]
-    fn adopt_ptr(ptr: *mut sys::Decompressor) -> Option<Self> {
-        // SAFETY: libdeflate returns a fresh allocation or null.
-        NonNull::new(ptr).map(|p| unsafe { Self::adopt(p) })
-    }
-
-    /// The libdeflate pointer, still owned by `self`.
-    #[inline]
-    pub fn as_ptr(&self) -> *mut sys::Decompressor {
-        self.0.as_ptr()
-    }
-
-    /// Hand the allocation to a foreign owner. Pairs with a later [`Self::adopt`].
-    #[inline]
-    pub fn leak(self) -> NonNull<sys::Decompressor> {
-        self.0.leak()
-    }
-
-    #[inline]
-    fn raw(&self) -> &sys::Decompressor {
-        &self.0
-    }
+    /// Every method takes `&self`: `sys::Decompressor` is `UnsafeCell`-backed, so a
+    /// `&` carries no `noalias`/`readonly` and libdeflate freely mutates the
+    /// decompressor's scratch state through it. `#[repr(transparent)]` over `NonNull`,
+    /// so `Option<Decompressor>` is pointer-sized with all-zero = `None`.
+    pub struct Decompressor(sys::Decompressor) via libdeflate_free_decompressor;
 }
 
 /// Constructor. libdeflate allocates; returns an owned handle.
@@ -363,7 +287,8 @@ impl Decompressor {
     /// Allocate a decompressor. Returns `None` on OOM.
     #[inline]
     pub fn new() -> Option<Self> {
-        Self::adopt_ptr(libdeflate_alloc_decompressor())
+        // SAFETY: libdeflate_alloc_decompressor transfers a fresh allocation, or null.
+        unsafe { Self::adopt_ptr(libdeflate_alloc_decompressor()) }
     }
 }
 

--- a/src/libdeflate_sys/libdeflate.rs
+++ b/src/libdeflate_sys/libdeflate.rs
@@ -20,18 +20,41 @@ impl Default for Options {
     }
 }
 
+/// The C objects themselves. Only the extern declarations below name these
+/// types; all Rust code uses the owning [`Compressor`] / [`Decompressor`] handles.
+pub mod sys {
+    bun_opaque::opaque_ffi! {
+        /// `struct libdeflate_compressor`. `&Self` is ABI-identical to a
+        /// non-null `libdeflate_compressor*` and carries no `noalias`/`readonly`
+        /// — libdeflate mutates the compressor's scratch state through it.
+        pub struct Compressor;
+        /// `struct libdeflate_decompressor`. `&Self` is ABI-identical to a
+        /// non-null `libdeflate_decompressor*` and carries no `noalias`/`readonly`
+        /// — libdeflate mutates the decompressor's scratch state through it.
+        pub struct Decompressor;
+    }
+}
+
+// `libdeflate_alloc_compressor[_ex]` allocates and hands back the object. One
+// `Compressor` handle owns exactly that one allocation.
+bun_opaque::foreign_owned!(sys::Compressor, libdeflate_free_compressor);
+
 unsafe extern "C" {
     // Allocation: scalar arg, no preconditions; returns null on OOM.
-    pub(crate) safe fn libdeflate_alloc_compressor(compression_level: c_int) -> *mut Compressor;
+    pub(crate) safe fn libdeflate_alloc_compressor(
+        compression_level: c_int,
+    ) -> *mut sys::Compressor;
     // NOT safe: `Options` carries caller-supplied `malloc_func`/`free_func`
     // callbacks that libdeflate will invoke and write through. A bogus callback
     // (constructible in 100% safe code) would cause UB inside the C library.
     pub(crate) fn libdeflate_alloc_compressor_ex(
         compression_level: c_int,
         options: *const Options,
-    ) -> *mut Compressor;
+    ) -> *mut sys::Compressor;
+    // NOT `safe fn`: `in_`/`out` are raw pointers libdeflate reads/writes. Safe
+    // Rust can forge a `*const c_void`, so the call carries the obligation.
     pub(crate) fn libdeflate_deflate_compress(
-        compressor: *mut Compressor,
+        compressor: &sys::Compressor,
         in_: *const c_void,
         in_nbytes: usize,
         out: *mut c_void,
@@ -39,34 +62,36 @@ unsafe extern "C" {
     ) -> usize;
     // Bound queries: opaque handle + scalar. The C API documents `compressor`
     // may be NULL (returns a library-wide upper bound), so expose it as
-    // `Option<&mut Compressor>` (NPO-ABI-compatible with `*mut Compressor`).
+    // `Option<&sys::Compressor>` (NPO-ABI-compatible with the raw pointer).
     pub(crate) safe fn libdeflate_deflate_compress_bound(
-        compressor: Option<&mut Compressor>,
+        compressor: Option<&sys::Compressor>,
         in_nbytes: usize,
     ) -> usize;
     pub(crate) fn libdeflate_zlib_compress(
-        compressor: *mut Compressor,
+        compressor: &sys::Compressor,
         in_: *const c_void,
         in_nbytes: usize,
         out: *mut c_void,
         out_nbytes_avail: usize,
     ) -> usize;
     pub(crate) safe fn libdeflate_zlib_compress_bound(
-        compressor: Option<&mut Compressor>,
+        compressor: Option<&sys::Compressor>,
         in_nbytes: usize,
     ) -> usize;
     pub(crate) fn libdeflate_gzip_compress(
-        compressor: *mut Compressor,
+        compressor: &sys::Compressor,
         in_: *const c_void,
         in_nbytes: usize,
         out: *mut c_void,
         out_nbytes_avail: usize,
     ) -> usize;
     pub(crate) safe fn libdeflate_gzip_compress_bound(
-        compressor: Option<&mut Compressor>,
+        compressor: Option<&sys::Compressor>,
         in_nbytes: usize,
     ) -> usize;
-    pub(crate) fn libdeflate_free_compressor(compressor: *mut Compressor);
+    // safe: C frees the allocation. Freeing is not exclusive access in Rust's
+    // model, so the receiver is `&`, as `ForeignOwned::release` requires.
+    pub(crate) safe fn libdeflate_free_compressor(compressor: &sys::Compressor);
 }
 
 fn load_once() {
@@ -85,43 +110,81 @@ pub fn load() {
     LOADED_ONCE.call_once(load_once);
 }
 
-bun_opaque::opaque_ffi! {
-    /// Opaque libdeflate compressor handle. `UnsafeCell` makes the type `!Freeze`
-    /// so a `&Compressor` does not assert immutability of the C-owned state.
-    pub struct Compressor;
+/// Owned handle to a libdeflate compressor; `Drop` frees it.
+///
+/// Every method takes `&self`: `sys::Compressor` is `UnsafeCell`-backed, so a
+/// `&` carries no `noalias`/`readonly` and libdeflate freely mutates the
+/// compressor's scratch state through it. `#[repr(transparent)]` over `NonNull`,
+/// so `Option<Compressor>` is pointer-sized with all-zero = `None`.
+#[repr(transparent)]
+pub struct Compressor(bun_opaque::ForeignRef<sys::Compressor>);
+
+/// Ownership plumbing.
+impl Compressor {
+    /// Adopt an allocation returned by libdeflate.
+    ///
+    /// # Safety
+    /// `ptr` must come from `libdeflate_alloc_compressor[_ex]` and must not be
+    /// freed by any other handle.
+    #[inline]
+    pub unsafe fn adopt(ptr: NonNull<sys::Compressor>) -> Self {
+        // SAFETY: caller transfers the allocation.
+        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
+    }
+
+    /// Adopt a nullable allocation; `None` on OOM.
+    #[inline]
+    fn adopt_ptr(ptr: *mut sys::Compressor) -> Option<Self> {
+        // SAFETY: libdeflate returns a fresh allocation or null.
+        NonNull::new(ptr).map(|p| unsafe { Self::adopt(p) })
+    }
+
+    /// The libdeflate pointer, still owned by `self`.
+    #[inline]
+    pub fn as_ptr(&self) -> *mut sys::Compressor {
+        self.0.as_ptr()
+    }
+
+    /// Hand the allocation to a foreign owner. Pairs with a later [`Self::adopt`].
+    #[inline]
+    pub fn leak(self) -> NonNull<sys::Compressor> {
+        self.0.leak()
+    }
+
+    #[inline]
+    fn raw(&self) -> &sys::Compressor {
+        &self.0
+    }
 }
 
+/// Constructors. libdeflate allocates; each returns an owned handle.
 impl Compressor {
-    pub fn alloc(compression_level: c_int) -> *mut Compressor {
-        libdeflate_alloc_compressor(compression_level)
+    /// Allocate a compressor at `level` (0..=12). Returns `None` on OOM.
+    #[inline]
+    pub fn new(level: c_int) -> Option<Self> {
+        Self::adopt_ptr(libdeflate_alloc_compressor(level))
     }
 
     /// # Safety
     /// `options.malloc_func`/`free_func` (if set) must be sound allocator
     /// callbacks — libdeflate writes through their return values.
-    pub unsafe fn alloc_ex(compression_level: c_int, options: Option<&Options>) -> *mut Compressor {
+    pub unsafe fn new_ex(level: c_int, options: Option<&Options>) -> Option<Self> {
         // SAFETY: caller upholds the callback contract; `Option<&T>` → `*const T` is NPO-compatible.
-        unsafe {
-            libdeflate_alloc_compressor_ex(
-                compression_level,
-                options.map_or(core::ptr::null(), |o| o),
-            )
-        }
+        Self::adopt_ptr(unsafe {
+            libdeflate_alloc_compressor_ex(level, options.map_or(core::ptr::null(), |o| o))
+        })
     }
+}
 
-    /// Frees the compressor. `this` must not be used afterward.
-    pub unsafe fn destroy(this: *mut Compressor) {
-        // SAFETY: caller guarantees `this` was returned by libdeflate_alloc_compressor[_ex]
-        // and is not used after this call.
-        unsafe { libdeflate_free_compressor(this) }
-    }
-
+/// Compression. `&self` throughout: libdeflate mutates through the handle.
+impl Compressor {
     /// Compresses `input` into `output` and returns the number of bytes written.
-    pub fn inflate(&mut self, input: &[u8], output: &mut [u8]) -> Result {
-        // SAFETY: self is a valid *mut Compressor; slice ptr/len pairs are valid.
+    pub fn inflate(&self, input: &[u8], output: &mut [u8]) -> Result {
+        // SAFETY: slice ptr/len pairs are valid; libdeflate reads `input` and
+        // writes at most `output.len()` bytes.
         let written = unsafe {
             libdeflate_deflate_compress(
-                self,
+                self.raw(),
                 input.as_ptr().cast::<c_void>(),
                 input.len(),
                 output.as_mut_ptr().cast::<c_void>(),
@@ -135,15 +198,15 @@ impl Compressor {
         }
     }
 
-    pub fn max_bytes_needed(&mut self, input: &[u8], encoding: Encoding) -> usize {
+    pub fn max_bytes_needed(&self, input: &[u8], encoding: Encoding) -> usize {
         match encoding {
-            Encoding::Deflate => libdeflate_deflate_compress_bound(Some(self), input.len()),
-            Encoding::Zlib => libdeflate_zlib_compress_bound(Some(self), input.len()),
-            Encoding::Gzip => libdeflate_gzip_compress_bound(Some(self), input.len()),
+            Encoding::Deflate => libdeflate_deflate_compress_bound(Some(self.raw()), input.len()),
+            Encoding::Zlib => libdeflate_zlib_compress_bound(Some(self.raw()), input.len()),
+            Encoding::Gzip => libdeflate_gzip_compress_bound(Some(self.raw()), input.len()),
         }
     }
 
-    pub fn compress(&mut self, input: &[u8], output: &mut [u8], encoding: Encoding) -> Result {
+    pub fn compress(&self, input: &[u8], output: &mut [u8], encoding: Encoding) -> Result {
         match encoding {
             Encoding::Deflate => self.inflate(input, output),
             Encoding::Zlib => self.zlib(input, output),
@@ -157,7 +220,7 @@ impl Compressor {
     /// and avoids the UB of materializing `&mut [u8]` over uninitialized bytes.
     /// On return, `output[..result.written]` is initialized.
     pub fn compress_into(
-        &mut self,
+        &self,
         input: &[u8],
         output: &mut [MaybeUninit<u8>],
         encoding: Encoding,
@@ -166,15 +229,16 @@ impl Compressor {
         let in_len = input.len();
         let out_ptr = output.as_mut_ptr().cast::<c_void>();
         let out_len = output.len();
-        // SAFETY: self is a valid *mut Compressor; ptr/len pairs are valid for the
-        // FFI contract (input read-only, output write-only for `out_len` bytes).
+        let this = self.raw();
+        // SAFETY: ptr/len pairs are valid for the FFI contract (input read-only,
+        // output write-only for `out_len` bytes).
         let written = unsafe {
             match encoding {
                 Encoding::Deflate => {
-                    libdeflate_deflate_compress(self, in_ptr, in_len, out_ptr, out_len)
+                    libdeflate_deflate_compress(this, in_ptr, in_len, out_ptr, out_len)
                 }
-                Encoding::Zlib => libdeflate_zlib_compress(self, in_ptr, in_len, out_ptr, out_len),
-                Encoding::Gzip => libdeflate_gzip_compress(self, in_ptr, in_len, out_ptr, out_len),
+                Encoding::Zlib => libdeflate_zlib_compress(this, in_ptr, in_len, out_ptr, out_len),
+                Encoding::Gzip => libdeflate_gzip_compress(this, in_ptr, in_len, out_ptr, out_len),
             }
         };
         Result {
@@ -194,12 +258,7 @@ impl Compressor {
     /// Safe replacement for the open-coded
     /// `compress_into(out.spare_capacity_mut()) + unsafe { set_len }` pattern,
     /// and for the zero-init `vec![0u8; bound]` + `truncate` form.
-    pub fn compress_to_vec(
-        &mut self,
-        input: &[u8],
-        out: &mut Vec<u8>,
-        encoding: Encoding,
-    ) -> Result {
+    pub fn compress_to_vec(&self, input: &[u8], out: &mut Vec<u8>, encoding: Encoding) -> Result {
         let result = self.compress_into(input, out.spare_capacity_mut(), encoding);
         if result.status == Status::Success {
             // SAFETY: result.written ≤ spare.len() and libdeflate has
@@ -209,11 +268,12 @@ impl Compressor {
         result
     }
 
-    pub fn zlib(&mut self, input: &[u8], output: &mut [u8]) -> Result {
-        // SAFETY: self is a valid *mut Compressor; slice ptr/len pairs are valid.
+    pub fn zlib(&self, input: &[u8], output: &mut [u8]) -> Result {
+        // SAFETY: slice ptr/len pairs are valid; libdeflate reads `input` and
+        // writes at most `output.len()` bytes.
         let result = unsafe {
             libdeflate_zlib_compress(
-                self,
+                self.raw(),
                 input.as_ptr().cast::<c_void>(),
                 input.len(),
                 output.as_mut_ptr().cast::<c_void>(),
@@ -227,11 +287,12 @@ impl Compressor {
         }
     }
 
-    pub fn gzip(&mut self, input: &[u8], output: &mut [u8]) -> Result {
-        // SAFETY: self is a valid *mut Compressor; slice ptr/len pairs are valid.
+    pub fn gzip(&self, input: &[u8], output: &mut [u8]) -> Result {
+        // SAFETY: slice ptr/len pairs are valid; libdeflate reads `input` and
+        // writes at most `output.len()` bytes.
         let result = unsafe {
             libdeflate_gzip_compress(
-                self,
+                self.raw(),
                 input.as_ptr().cast::<c_void>(),
                 input.len(),
                 output.as_mut_ptr().cast::<c_void>(),
@@ -246,70 +307,76 @@ impl Compressor {
     }
 }
 
-/// Owned RAII libdeflate compressor. Frees on drop.
+// `libdeflate_alloc_decompressor[_ex]` allocates and hands back the object. One
+// `Decompressor` handle owns exactly that one allocation.
+bun_opaque::foreign_owned!(sys::Decompressor, libdeflate_free_decompressor);
+
+/// Owned handle to a libdeflate decompressor; `Drop` frees it.
 ///
-/// `#[repr(transparent)]` over `NonNull` so `Option<OwnedCompressor>` has the
-/// same layout as `*mut Compressor` (all-zero = `None`).
+/// Every method takes `&self`: `sys::Decompressor` is `UnsafeCell`-backed, so a
+/// `&` carries no `noalias`/`readonly` and libdeflate freely mutates the
+/// decompressor's scratch state through it. `#[repr(transparent)]` over `NonNull`,
+/// so `Option<Decompressor>` is pointer-sized with all-zero = `None`.
 #[repr(transparent)]
-pub struct OwnedCompressor(NonNull<Compressor>);
+pub struct Decompressor(bun_opaque::ForeignRef<sys::Decompressor>);
 
-impl OwnedCompressor {
-    /// Allocate a compressor at `level` (0..=12). Returns `None` on OOM.
-    #[inline]
-    pub fn new(level: c_int) -> Option<Self> {
-        NonNull::new(Compressor::alloc(level)).map(Self)
-    }
-}
-
-impl core::ops::Deref for OwnedCompressor {
-    type Target = Compressor;
-    #[inline]
-    fn deref(&self) -> &Compressor {
-        // SAFETY: non-null, allocated by libdeflate, exclusively owned by `self`.
-        unsafe { self.0.as_ref() }
-    }
-}
-
-impl core::ops::DerefMut for OwnedCompressor {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Compressor {
-        // SAFETY: non-null, allocated by libdeflate, exclusively owned by `self`.
-        unsafe { self.0.as_mut() }
-    }
-}
-
-impl Drop for OwnedCompressor {
-    #[inline]
-    fn drop(&mut self) {
-        // SAFETY: allocated by `libdeflate_alloc_compressor`; freed exactly once here.
-        unsafe { libdeflate_free_compressor(self.0.as_ptr()) }
-    }
-}
-
-bun_opaque::opaque_ffi! {
-    /// Opaque libdeflate decompressor handle. `UnsafeCell` makes the type `!Freeze`.
-    pub struct Decompressor;
-}
-
+/// Ownership plumbing.
 impl Decompressor {
-    pub fn alloc() -> *mut Decompressor {
-        libdeflate_alloc_decompressor()
+    /// Adopt an allocation returned by libdeflate.
+    ///
+    /// # Safety
+    /// `ptr` must come from `libdeflate_alloc_decompressor[_ex]` and must not be
+    /// freed by any other handle.
+    #[inline]
+    pub unsafe fn adopt(ptr: NonNull<sys::Decompressor>) -> Self {
+        // SAFETY: caller transfers the allocation.
+        Self(unsafe { bun_opaque::ForeignRef::adopt(ptr) })
     }
 
-    /// Frees the decompressor. `this` must not be used afterward.
-    pub unsafe fn destroy(this: *mut Decompressor) {
-        // SAFETY: caller guarantees `this` was returned by libdeflate_alloc_decompressor[_ex]
-        // and is not used after this call.
-        unsafe { libdeflate_free_decompressor(this) }
+    /// Adopt a nullable allocation; `None` on OOM.
+    #[inline]
+    fn adopt_ptr(ptr: *mut sys::Decompressor) -> Option<Self> {
+        // SAFETY: libdeflate returns a fresh allocation or null.
+        NonNull::new(ptr).map(|p| unsafe { Self::adopt(p) })
     }
 
-    pub fn deflate(&mut self, input: &[u8], output: &mut [u8]) -> Result {
+    /// The libdeflate pointer, still owned by `self`.
+    #[inline]
+    pub fn as_ptr(&self) -> *mut sys::Decompressor {
+        self.0.as_ptr()
+    }
+
+    /// Hand the allocation to a foreign owner. Pairs with a later [`Self::adopt`].
+    #[inline]
+    pub fn leak(self) -> NonNull<sys::Decompressor> {
+        self.0.leak()
+    }
+
+    #[inline]
+    fn raw(&self) -> &sys::Decompressor {
+        &self.0
+    }
+}
+
+/// Constructor. libdeflate allocates; returns an owned handle.
+impl Decompressor {
+    /// Allocate a decompressor. Returns `None` on OOM.
+    #[inline]
+    pub fn new() -> Option<Self> {
+        Self::adopt_ptr(libdeflate_alloc_decompressor())
+    }
+}
+
+/// Decompression. `&self` throughout: libdeflate mutates through the handle.
+impl Decompressor {
+    pub fn deflate(&self, input: &[u8], output: &mut [u8]) -> Result {
         let mut actual_in_bytes_ret: usize = input.len();
         let mut actual_out_bytes_ret: usize = output.len();
-        // SAFETY: self is a valid *mut Decompressor; slice ptr/len pairs and out-params are valid.
+        // SAFETY: slice ptr/len pairs and out-params are valid; libdeflate reads
+        // `input` and writes at most `output.len()` bytes.
         let result = unsafe {
             libdeflate_deflate_decompress_ex(
-                self,
+                self.raw(),
                 input.as_ptr().cast::<c_void>(),
                 input.len(),
                 output.as_mut_ptr().cast::<c_void>(),
@@ -325,13 +392,14 @@ impl Decompressor {
         }
     }
 
-    pub fn zlib(&mut self, input: &[u8], output: &mut [u8]) -> Result {
+    pub fn zlib(&self, input: &[u8], output: &mut [u8]) -> Result {
         let mut actual_in_bytes_ret: usize = input.len();
         let mut actual_out_bytes_ret: usize = output.len();
-        // SAFETY: self is a valid *mut Decompressor; slice ptr/len pairs and out-params are valid.
+        // SAFETY: slice ptr/len pairs and out-params are valid; libdeflate reads
+        // `input` and writes at most `output.len()` bytes.
         let result = unsafe {
             libdeflate_zlib_decompress_ex(
-                self,
+                self.raw(),
                 input.as_ptr().cast::<c_void>(),
                 input.len(),
                 output.as_mut_ptr().cast::<c_void>(),
@@ -347,13 +415,14 @@ impl Decompressor {
         }
     }
 
-    pub fn gzip(&mut self, input: &[u8], output: &mut [u8]) -> Result {
+    pub fn gzip(&self, input: &[u8], output: &mut [u8]) -> Result {
         let mut actual_in_bytes_ret: usize = input.len();
         let mut actual_out_bytes_ret: usize = output.len();
-        // SAFETY: self is a valid *mut Decompressor; slice ptr/len pairs and out-params are valid.
+        // SAFETY: slice ptr/len pairs and out-params are valid; libdeflate reads
+        // `input` and writes at most `output.len()` bytes.
         let result = unsafe {
             libdeflate_gzip_decompress_ex(
-                self,
+                self.raw(),
                 input.as_ptr().cast::<c_void>(),
                 input.len(),
                 output.as_mut_ptr().cast::<c_void>(),
@@ -369,7 +438,7 @@ impl Decompressor {
         }
     }
 
-    pub fn decompress(&mut self, input: &[u8], output: &mut [u8], encoding: Encoding) -> Result {
+    pub fn decompress(&self, input: &[u8], output: &mut [u8], encoding: Encoding) -> Result {
         match encoding {
             Encoding::Deflate => self.deflate(input, output),
             Encoding::Zlib => self.zlib(input, output),
@@ -383,7 +452,7 @@ impl Decompressor {
     /// and avoids the UB of materializing `&mut [u8]` over uninitialized bytes.
     /// On `Status::Success`, `output[..result.written]` is initialized.
     pub fn decompress_into(
-        &mut self,
+        &self,
         input: &[u8],
         output: &mut [MaybeUninit<u8>],
         encoding: Encoding,
@@ -394,13 +463,13 @@ impl Decompressor {
         let out_len = output.len();
         let mut read: usize = in_len;
         let mut written: usize = out_len;
-        // SAFETY: self is a valid *mut Decompressor; ptr/len pairs are valid for the
-        // FFI contract (input read-only, output write-only for `out_len` bytes);
-        // out-params are valid `*mut usize`.
+        let this = self.raw();
+        // SAFETY: ptr/len pairs are valid for the FFI contract (input read-only,
+        // output write-only for `out_len` bytes); out-params are valid `*mut usize`.
         let status = unsafe {
             match encoding {
                 Encoding::Deflate => libdeflate_deflate_decompress_ex(
-                    self,
+                    this,
                     in_ptr,
                     in_len,
                     out_ptr,
@@ -409,7 +478,7 @@ impl Decompressor {
                     &raw mut written,
                 ),
                 Encoding::Zlib => libdeflate_zlib_decompress_ex(
-                    self,
+                    this,
                     in_ptr,
                     in_len,
                     out_ptr,
@@ -418,7 +487,7 @@ impl Decompressor {
                     &raw mut written,
                 ),
                 Encoding::Gzip => libdeflate_gzip_decompress_ex(
-                    self,
+                    this,
                     in_ptr,
                     in_len,
                     out_ptr,
@@ -448,12 +517,7 @@ impl Decompressor {
     /// `decompress_into(out.spare_capacity_mut()) + unsafe { set_len }` pattern,
     /// and for the UB-adjacent `slice_mut(ptr, capacity)` form that materialized
     /// `&mut [u8]` over uninitialized bytes.
-    pub fn decompress_to_vec(
-        &mut self,
-        input: &[u8],
-        out: &mut Vec<u8>,
-        encoding: Encoding,
-    ) -> Result {
+    pub fn decompress_to_vec(&self, input: &[u8], out: &mut Vec<u8>, encoding: Encoding) -> Result {
         let result = self.decompress_into(input, out.spare_capacity_mut(), encoding);
         if result.status == Status::Success {
             // SAFETY: result.written ≤ spare.len() and libdeflate has
@@ -471,7 +535,7 @@ impl Decompressor {
     /// `out.capacity() > max_capacity` (returned as the final
     /// `InsufficientSpace`). On success, `out.len() == result.written`.
     pub fn decompress_to_vec_grow(
-        &mut self,
+        &self,
         input: &[u8],
         out: &mut Vec<u8>,
         encoding: Encoding,
@@ -489,46 +553,6 @@ impl Decompressor {
     }
 }
 
-/// Owned RAII libdeflate decompressor. Frees on drop.
-///
-/// `#[repr(transparent)]` over `NonNull` so `Option<OwnedDecompressor>` has the
-/// same layout as `*mut Decompressor` (all-zero = `None`).
-#[repr(transparent)]
-pub struct OwnedDecompressor(NonNull<Decompressor>);
-
-impl OwnedDecompressor {
-    /// Allocate a decompressor. Returns `None` on OOM.
-    #[inline]
-    pub fn new() -> Option<Self> {
-        NonNull::new(Decompressor::alloc()).map(Self)
-    }
-}
-
-impl core::ops::Deref for OwnedDecompressor {
-    type Target = Decompressor;
-    #[inline]
-    fn deref(&self) -> &Decompressor {
-        // SAFETY: non-null, allocated by libdeflate, exclusively owned by `self`.
-        unsafe { self.0.as_ref() }
-    }
-}
-
-impl core::ops::DerefMut for OwnedDecompressor {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Decompressor {
-        // SAFETY: non-null, allocated by libdeflate, exclusively owned by `self`.
-        unsafe { self.0.as_mut() }
-    }
-}
-
-impl Drop for OwnedDecompressor {
-    #[inline]
-    fn drop(&mut self) {
-        // SAFETY: allocated by `libdeflate_alloc_decompressor`; freed exactly once here.
-        unsafe { libdeflate_free_decompressor(self.0.as_ptr()) }
-    }
-}
-
 pub struct Result {
     pub read: usize,
     pub written: usize,
@@ -543,9 +567,9 @@ pub enum Encoding {
 }
 
 unsafe extern "C" {
-    pub(crate) safe fn libdeflate_alloc_decompressor() -> *mut Decompressor;
+    pub(crate) safe fn libdeflate_alloc_decompressor() -> *mut sys::Decompressor;
     // NOT safe: `Options` carries allocator callbacks (see `libdeflate_alloc_compressor_ex`).
-    pub fn libdeflate_alloc_decompressor_ex(options: *const Options) -> *mut Decompressor;
+    pub fn libdeflate_alloc_decompressor_ex(options: *const Options) -> *mut sys::Decompressor;
 }
 
 pub(crate) const LIBDEFLATE_SUCCESS: c_uint = 0;
@@ -564,8 +588,10 @@ pub enum Status {
 }
 
 unsafe extern "C" {
+    // NOT `safe fn`: `in_`/`out` are raw pointers libdeflate reads/writes. Safe
+    // Rust can forge a `*const c_void`, so the call carries the obligation.
     pub fn libdeflate_deflate_decompress(
-        decompressor: *mut Decompressor,
+        decompressor: &sys::Decompressor,
         in_: *const c_void,
         in_nbytes: usize,
         out: *mut c_void,
@@ -573,7 +599,7 @@ unsafe extern "C" {
         actual_out_nbytes_ret: *mut usize,
     ) -> Status;
     pub(crate) fn libdeflate_deflate_decompress_ex(
-        decompressor: *mut Decompressor,
+        decompressor: &sys::Decompressor,
         in_: *const c_void,
         in_nbytes: usize,
         out: *mut c_void,
@@ -582,7 +608,7 @@ unsafe extern "C" {
         actual_out_nbytes_ret: *mut usize,
     ) -> Status;
     pub fn libdeflate_zlib_decompress(
-        decompressor: *mut Decompressor,
+        decompressor: &sys::Decompressor,
         in_: *const c_void,
         in_nbytes: usize,
         out: *mut c_void,
@@ -590,7 +616,7 @@ unsafe extern "C" {
         actual_out_nbytes_ret: *mut usize,
     ) -> Status;
     pub(crate) fn libdeflate_zlib_decompress_ex(
-        decompressor: *mut Decompressor,
+        decompressor: &sys::Decompressor,
         in_: *const c_void,
         in_nbytes: usize,
         out: *mut c_void,
@@ -599,7 +625,7 @@ unsafe extern "C" {
         actual_out_nbytes_ret: *mut usize,
     ) -> Status;
     pub fn libdeflate_gzip_decompress(
-        decompressor: *mut Decompressor,
+        decompressor: &sys::Decompressor,
         in_: *const c_void,
         in_nbytes: usize,
         out: *mut c_void,
@@ -607,7 +633,7 @@ unsafe extern "C" {
         actual_out_nbytes_ret: *mut usize,
     ) -> Status;
     pub(crate) fn libdeflate_gzip_decompress_ex(
-        decompressor: *mut Decompressor,
+        decompressor: &sys::Decompressor,
         in_: *const c_void,
         in_nbytes: usize,
         out: *mut c_void,
@@ -615,7 +641,9 @@ unsafe extern "C" {
         actual_in_nbytes_ret: *mut usize,
         actual_out_nbytes_ret: *mut usize,
     ) -> Status;
-    pub(crate) fn libdeflate_free_decompressor(decompressor: *mut Decompressor);
+    // safe: C frees the allocation. Freeing is not exclusive access in Rust's
+    // model, so the receiver is `&`, as `ForeignOwned::release` requires.
+    pub(crate) safe fn libdeflate_free_decompressor(decompressor: &sys::Decompressor);
     pub fn libdeflate_adler32(adler: u32, buffer: *const c_void, len: usize) -> u32;
     pub fn libdeflate_crc32(crc: u32, buffer: *const c_void, len: usize) -> u32;
     pub(crate) fn libdeflate_set_memory_allocator(

--- a/src/mimalloc_sys/mimalloc.rs
+++ b/src/mimalloc_sys/mimalloc.rs
@@ -110,29 +110,29 @@ bun_opaque::opaque_ffi! {
 
 impl Heap {
     #[inline]
-    pub fn delete(&mut self) {
-        // SAFETY: `self` is a live `*mut Heap` obtained from mimalloc.
-        unsafe { mi_heap_delete(self) }
+    pub fn delete(&self) {
+        // SAFETY: `self` is a live `Heap` obtained from mimalloc.
+        unsafe { mi_heap_delete(self.as_mut_ptr()) }
     }
 
     #[inline]
-    pub fn malloc(&mut self, size: usize) -> *mut c_void {
-        // SAFETY: `self` is a live `*mut Heap` obtained from mimalloc.
-        unsafe { mi_heap_malloc(self, size) }
+    pub fn malloc(&self, size: usize) -> *mut c_void {
+        // SAFETY: `self` is a live `Heap` obtained from mimalloc.
+        unsafe { mi_heap_malloc(self.as_mut_ptr(), size) }
     }
 
     #[inline]
-    pub fn calloc(&mut self, count: usize, size: usize) -> *mut c_void {
-        // SAFETY: `self` is a live `*mut Heap` obtained from mimalloc.
-        unsafe { mi_heap_calloc(self, count, size) }
+    pub fn calloc(&self, count: usize, size: usize) -> *mut c_void {
+        // SAFETY: `self` is a live `Heap` obtained from mimalloc.
+        unsafe { mi_heap_calloc(self.as_mut_ptr(), count, size) }
     }
 
     /// # Safety
     /// `p` must be null or a pointer previously allocated by this heap.
     #[inline]
-    pub unsafe fn realloc(&mut self, p: *mut c_void, newsize: usize) -> *mut c_void {
-        // SAFETY: `self` is a live `*mut Heap`; caller upholds `p` contract.
-        unsafe { mi_heap_realloc(self, p, newsize) }
+    pub unsafe fn realloc(&self, p: *mut c_void, newsize: usize) -> *mut c_void {
+        // SAFETY: `self` is a live `Heap`; caller upholds `p` contract.
+        unsafe { mi_heap_realloc(self.as_mut_ptr(), p, newsize) }
     }
 
     // `p` is only address-range-tested (never dereferenced) — there is no

--- a/src/opaque/lib.rs
+++ b/src/opaque/lib.rs
@@ -446,6 +446,34 @@ pub unsafe trait ForeignOwned: Sized {
     unsafe fn release(this: ::core::ptr::NonNull<Self>);
 }
 
+/// How a [`ForeignRef`] gives its unit back.
+///
+/// A foreign object can have more than one ownership discipline: libarchive's
+/// `struct archive` is freed by `archive_read_free` when it was opened for
+/// reading and `archive_write_free` when opened for writing. [`ForeignOwned`]
+/// admits one release per type, so the second discipline names a marker instead.
+///
+/// # Safety
+/// `release` must give back exactly one unit of `T`, exactly once per handle.
+pub unsafe trait ForeignRelease<T> {
+    /// # Safety
+    /// `this` must be live and carry a unit the caller is giving up.
+    unsafe fn release(this: ::core::ptr::NonNull<T>);
+}
+
+/// The release of `T`'s own [`ForeignOwned`] impl. The default for [`ForeignRef`],
+/// so `ForeignRef<T>` keeps meaning exactly what it did before markers existed.
+pub struct DefaultRelease;
+
+// SAFETY: forwards to `T`'s own release, whose contract is identical.
+unsafe impl<T: ForeignOwned> ForeignRelease<T> for DefaultRelease {
+    #[inline(always)]
+    unsafe fn release(this: ::core::ptr::NonNull<T>) {
+        // SAFETY: caller gives up the unit.
+        unsafe { T::release(this) }
+    }
+}
+
 /// Owned handle to a foreign object.
 ///
 /// `T` : `ForeignRef<T>` :: `Path` : `PathBuf` — the borrowed opaque and its
@@ -458,10 +486,19 @@ pub unsafe trait ForeignOwned: Sized {
 ///
 /// Not `Clone` — duplicating an ownership unit is a per-type decision. Not
 /// `Send`/`Sync` — inherited from `NonNull`.
+/// `R` selects the release; it defaults to `T`'s own [`ForeignOwned`] impl, so
+/// `ForeignRef<T>` needs no marker. Name one only for a foreign object with two
+/// ownership disciplines — see [`foreign_release!`].
 #[repr(transparent)]
-pub struct ForeignRef<T: ForeignOwned>(::core::ptr::NonNull<T>);
+pub struct ForeignRef<T, R = DefaultRelease>
+where
+    R: ForeignRelease<T>,
+{
+    ptr: ::core::ptr::NonNull<T>,
+    _r: ::core::marker::PhantomData<R>,
+}
 
-impl<T: ForeignOwned> ForeignRef<T> {
+impl<T, R: ForeignRelease<T>> ForeignRef<T, R> {
     /// Adopt an ownership unit the caller is transferring in.
     ///
     /// # Safety
@@ -469,17 +506,20 @@ impl<T: ForeignOwned> ForeignRef<T> {
     /// handle will give back.
     #[inline(always)]
     pub const unsafe fn adopt(ptr: ::core::ptr::NonNull<T>) -> Self {
-        Self(ptr)
+        Self {
+            ptr,
+            _r: ::core::marker::PhantomData,
+        }
     }
 
     #[inline(always)]
     pub const fn as_ptr(&self) -> *mut T {
-        self.0.as_ptr()
+        self.ptr.as_ptr()
     }
 
     #[inline(always)]
     pub const fn as_non_null(&self) -> ::core::ptr::NonNull<T> {
-        self.0
+        self.ptr
     }
 
     /// Hand the ownership unit to a foreign owner (a callback context, a C++
@@ -488,24 +528,24 @@ impl<T: ForeignOwned> ForeignRef<T> {
     pub fn leak(self) -> ::core::ptr::NonNull<T> {
         // `ManuallyDrop`, not `mem::forget`: `clippy::mem_forget` is denied here,
         // and forgetting a `Drop` type reads as a bug even when it is the point.
-        ::core::mem::ManuallyDrop::new(self).0
+        ::core::mem::ManuallyDrop::new(self).ptr
     }
 }
 
-impl<T: ForeignOwned> ::core::ops::Deref for ForeignRef<T> {
+impl<T, R: ForeignRelease<T>> ::core::ops::Deref for ForeignRef<T, R> {
     type Target = T;
     #[inline(always)]
     fn deref(&self) -> &T {
-        // SAFETY: `self.0` is non-null and live for `self`'s lifetime.
-        unsafe { opaque_deref_nn(self.0.as_ptr()) }
+        // SAFETY: `self.ptr` is non-null and live for `self`'s lifetime.
+        unsafe { opaque_deref_nn(self.ptr.as_ptr()) }
     }
 }
 
-impl<T: ForeignOwned> Drop for ForeignRef<T> {
+impl<T, R: ForeignRelease<T>> Drop for ForeignRef<T, R> {
     #[inline(always)]
     fn drop(&mut self) {
         // SAFETY: we own exactly one unit; `adopt`/`leak` maintain that.
-        unsafe { T::release(self.0) }
+        unsafe { R::release(self.ptr) }
     }
 }
 
@@ -527,6 +567,119 @@ macro_rules! foreign_owned {
             #[inline(always)]
             unsafe fn release(this: ::core::ptr::NonNull<Self>) {
                 $release($crate::opaque_deref(this.as_ptr()))
+            }
+        }
+    };
+}
+
+/// Declare a *second* release discipline for an already-[`ForeignOwned`] type.
+///
+/// `ForeignOwned` admits one release per type. A foreign object with two — a
+/// libarchive `struct archive` freed by `archive_read_free` or
+/// `archive_write_free` depending on how it was opened — names a marker for the
+/// other, and spells the handle `ForeignRef<T, Marker>`.
+///
+/// ```ignore
+/// foreign_release!(pub WriteFree => sys::Archive, archive_write_free_release);
+/// pub struct WriteArchive(bun_opaque::ForeignRef<sys::Archive, WriteFree>);
+/// ```
+#[macro_export]
+macro_rules! foreign_release {
+    ($(#[$m:meta])* $v:vis $marker:ident => $t:ty, $release:path) => {
+        $(#[$m])*
+        $v enum $marker {}
+        // SAFETY: `$release` gives back exactly one ownership unit of `$t`.
+        unsafe impl $crate::ForeignRelease<$t> for $marker {
+            #[inline(always)]
+            unsafe fn release(this: ::core::ptr::NonNull<$t>) {
+                $release($crate::opaque_deref(this.as_ptr()))
+            }
+        }
+    };
+}
+
+/// Emit an owning handle over an [`opaque_ffi!`] ZST: the newtype, its
+/// `ForeignOwned` impl, and the ownership plumbing every handle needs.
+///
+/// Hand-writing `adopt`/`adopt_ptr`/`as_ptr`/`leak`/`raw` per type means a
+/// missing `mem::forget` in one copy is a double-free the other copies do not
+/// reveal. Declare inherent methods in a separate `impl` block as usual.
+///
+/// ```ignore
+/// opaque_ffi! { pub struct FetchHeaders; }   // in `mod sys`
+/// foreign_handle! {
+///     /// Owned handle to a C++ `WebCore::FetchHeaders`.
+///     pub struct FetchHeaders(sys::FetchHeaders) via WebCore__FetchHeaders__deref;
+/// }
+/// ```
+///
+/// For a type with a second discipline, name the marker instead:
+/// ```ignore
+/// foreign_release!(pub WriteFree => sys::Archive, archive_write_free_release);
+/// foreign_handle! { pub struct WriteArchive(sys::Archive) via marker WriteFree; }
+/// ```
+#[macro_export]
+macro_rules! foreign_handle {
+    ($(#[$m:meta])* $v:vis struct $name:ident($sys:ty) via $release:path;) => {
+        $crate::foreign_owned!($sys, $release);
+        $crate::__foreign_handle!($(#[$m])* $v $name, $sys, $crate::ForeignRef<$sys>);
+    };
+    ($(#[$m:meta])* $v:vis struct $name:ident($sys:ty) via marker $marker:ty;) => {
+        $crate::__foreign_handle!($(#[$m])* $v $name, $sys, $crate::ForeignRef<$sys, $marker>);
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __foreign_handle {
+    ($(#[$m:meta])* $v:vis $name:ident, $sys:ty, $inner:ty) => {
+        $(#[$m])*
+        #[repr(transparent)]
+        $v struct $name($inner);
+
+        impl $name {
+            /// Adopt an ownership unit the caller is transferring in.
+            ///
+            /// # Safety
+            /// `ptr` must be live and carry the sole unit; no other handle may
+            /// give it back.
+            #[inline]
+            #[allow(dead_code)]
+            $v unsafe fn adopt(ptr: ::core::ptr::NonNull<$sys>) -> Self {
+                // SAFETY: caller transfers the sole unit.
+                Self(unsafe { <$inner>::adopt(ptr) })
+            }
+
+            /// Adopt a nullable owning pointer; `None` on null.
+            ///
+            /// # Safety
+            /// A non-null `ptr` must satisfy [`Self::adopt`]'s contract.
+            #[inline]
+            #[allow(dead_code)]
+            $v unsafe fn adopt_ptr(ptr: *mut $sys) -> ::core::option::Option<Self> {
+                // SAFETY: caller contract.
+                ::core::ptr::NonNull::new(ptr).map(|p| unsafe { Self::adopt(p) })
+            }
+
+            /// The foreign pointer, still owned by `self`.
+            #[inline]
+            #[allow(dead_code)]
+            $v fn as_ptr(&self) -> *mut $sys {
+                self.0.as_ptr()
+            }
+
+            /// Hand the unit to a foreign owner. Pairs with a later [`Self::adopt`].
+            #[inline]
+            #[allow(dead_code)]
+            $v fn leak(self) -> ::core::ptr::NonNull<$sys> {
+                self.0.leak()
+            }
+
+            /// Borrow the foreign object. `&$sys` carries no `noalias`.
+            #[inline]
+            #[allow(dead_code)]
+            fn raw(&self) -> &$sys {
+                &self.0
             }
         }
     };

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -416,7 +416,7 @@ pub struct TestOptions {
     // back-edge. High tier owns construction/destruction; this field only
     // stores the pointer. LIFETIMES.tsv says OWNED, so the high-tier setter is
     // responsible for freeing any previous value.
-    pub test_filter_regex: Option<core::ptr::NonNull<()>>, // SAFETY: erased *mut bun_jsc::RegularExpression
+    pub test_filter_regex: Option<core::ptr::NonNull<()>>, // SAFETY: erased *mut bun_jsc::regular_expression::sys::RegularExpression
     pub max_concurrency: u32,
     /// `bun test --isolate`: run each test file in a fresh global object on
     /// the same VM, force-closing leaked handles between files.
@@ -459,8 +459,9 @@ pub struct Reporters {
 }
 
 impl TestOptions {
-    /// Returns the erased `*mut bun_jsc::RegularExpression`. Caller (high tier)
-    /// casts back: `unsafe { &*ptr.cast::<bun_jsc::RegularExpression>() }`.
+    /// Returns the erased pointer to the C++ regex. Caller (high tier) casts back to
+    /// `NonNull<bun_jsc::regular_expression::sys::RegularExpression>` and borrows it
+    /// with `RegularExpression::borrow_leaked` - never to the owning handle.
     #[inline]
     pub fn test_filter_regex(&self) -> Option<core::ptr::NonNull<()>> {
         // SAFETY: erased bun_jsc::RegularExpression — see field decl.

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -130,7 +130,7 @@ impl Archive {
 }
 
 /// Configure archive for reading tar/tar.gz
-fn configure_archive_reader(archive: &libarchive::lib::Archive) {
+fn configure_archive_reader(archive: &libarchive::lib::sys::Archive) {
     let _ = archive.read_support_format_tar();
     let _ = archive.read_support_format_gnutar();
     let _ = archive.read_support_filter_gzip();
@@ -148,7 +148,7 @@ fn entry_pathname_utf8(entry: &libarchive::lib::Entry) -> Result<Vec<u8>, bun_al
 /// Count the number of files in an archive
 fn count_files_in_archive(data: &[u8]) -> u32 {
     use libarchive::lib;
-    let archive = lib::ReadArchive::new();
+    let archive = lib::Archive::read_new();
     configure_archive_reader(&archive);
 
     if archive.read_open_memory(data) != lib::Result::Ok {
@@ -302,7 +302,7 @@ fn build_tarball_from_object(global: &JSGlobalObject, obj: JSValue) -> JsResult<
     // errdefer growing_buffer.deinit() — handled by Drop on Vec<u8>
 
     let archive = lib::WriteArchive::new();
-    let archive_ref: &lib::Archive = &archive;
+    let archive_ref: &lib::sys::Archive = &archive;
 
     if archive_ref.write_set_format_pax_restricted() != lib::Result::Ok {
         return Err(global.throw_invalid_arguments(format_args!(
@@ -1140,7 +1140,7 @@ pub struct FilesContext {
 }
 
 impl FilesContext {
-    fn clone_error_string(archive: &libarchive::lib::Archive) -> Option<CString> {
+    fn clone_error_string(archive: &libarchive::lib::sys::Archive) -> Option<CString> {
         let err_str = archive.error_string();
         if err_str.is_empty() {
             return None;
@@ -1150,7 +1150,7 @@ impl FilesContext {
 
     fn do_run(&mut self) -> Result<FilesResult, bun_alloc::AllocError> {
         use libarchive::lib;
-        let archive = lib::ReadArchive::new();
+        let archive = lib::Archive::read_new();
         configure_archive_reader(&archive);
 
         if archive.read_open_memory(self.store.shared_view()) != lib::Result::Ok {
@@ -1343,8 +1343,8 @@ fn compress_gzip(data: &[u8], level: u8) -> Result<Vec<u8>, CompressError> {
     use bun_libdeflate_sys::libdeflate;
     libdeflate::load();
 
-    let mut compressor =
-        libdeflate::OwnedCompressor::new(i32::from(level)).ok_or(CompressError::GzipInitFailed)?;
+    let compressor =
+        libdeflate::Compressor::new(i32::from(level)).ok_or(CompressError::GzipInitFailed)?;
 
     let max_size = compressor.max_bytes_needed(data, libdeflate::Encoding::Gzip);
 
@@ -1429,7 +1429,7 @@ fn extract_to_disk_filtered(
     glob_patterns: Option<&[Box<[u8]>]>,
 ) -> Result<u32, bun_core::Error> {
     use libarchive::lib;
-    let archive = lib::ReadArchive::new();
+    let archive = lib::Archive::read_new();
     configure_archive_reader(&archive);
 
     if archive.read_open_memory(file_buffer) != lib::Result::Ok {

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2562,7 +2562,7 @@ pub mod JSZlib {
                 leak_list_into_uint8array(global_this, list)
             }
             Library::Libdeflate => {
-                let Some(mut decompressor) = bun_libdeflate::OwnedDecompressor::new() else {
+                let Some(decompressor) = bun_libdeflate::Decompressor::new() else {
                     drop(list);
                     return Err(global_this.throw_out_of_memory());
                 };
@@ -2701,8 +2701,7 @@ pub mod JSZlib {
                 leak_list_into_uint8array(global_this, list)
             }
             Library::Libdeflate => {
-                let Some(mut compressor) = bun_libdeflate::OwnedCompressor::new(level.unwrap_or(6))
-                else {
+                let Some(compressor) = bun_libdeflate::Compressor::new(level.unwrap_or(6)) else {
                     return Err(global_this.throw_out_of_memory());
                 };
                 let encoding = if is_gzip {

--- a/src/runtime/api/bun/SSLContextCache.rs
+++ b/src/runtime/api/bun/SSLContextCache.rs
@@ -63,7 +63,7 @@ pub struct Entry {
     /// Nulled by `bun_ssl_ctx_cache_on_free` when BoringSSL drops the last
     /// ref. Tombstoned entries are reclaimed on the next `get_or_create` for
     /// the same digest, or by the periodic compact.
-    pub ctx: Cell<*mut boringssl::SSL_CTX>,
+    pub ctx: Cell<*mut boringssl::sys::SSL_CTX>,
     /// BACKREF: the cache outlives every `Entry` it allocates (Drop clears
     /// ex_data first so the `CRYPTO_EX_free` callback never sees a dangling
     /// owner).
@@ -76,7 +76,7 @@ impl SSLContextCache {
         &mut self,
         config: &SSLConfig,
         err: &mut create_bun_socket_error_t,
-    ) -> Option<*mut boringssl::SSL_CTX> {
+    ) -> Option<*mut boringssl::sys::SSL_CTX> {
         let opts = config.as_usockets();
         self.get_or_create_digest(&opts, opts.digest(), err)
     }
@@ -87,7 +87,7 @@ impl SSLContextCache {
         &mut self,
         opts: &uws::SocketContext::BunSocketContextOptions,
         err: &mut create_bun_socket_error_t,
-    ) -> Option<*mut boringssl::SSL_CTX> {
+    ) -> Option<*mut boringssl::sys::SSL_CTX> {
         self.get_or_create_digest(opts, opts.digest(), err)
     }
 
@@ -99,7 +99,7 @@ impl SSLContextCache {
         opts: &uws::SocketContext::BunSocketContextOptions,
         d: Digest,
         err: &mut create_bun_socket_error_t,
-    ) -> Option<*mut boringssl::SSL_CTX> {
+    ) -> Option<*mut boringssl::sys::SSL_CTX> {
         {
             let _guard = self.mutex.lock_guard();
             if let Some(entry) = self.map.get(&d) {
@@ -108,8 +108,8 @@ impl SSLContextCache {
                 let entry = unsafe { &**entry };
                 let ctx = entry.ctx.get();
                 if !ctx.is_null() {
-                    // SAFETY: ctx non-null and tombstone write is serialized by this mutex.
-                    unsafe { boringssl::SSL_CTX_up_ref(ctx) };
+                    // The tombstone write is serialized by this mutex.
+                    boringssl::SSL_CTX_up_ref(boringssl::sys::SSL_CTX::opaque_ref(ctx));
                     return Some(ctx);
                 }
             }
@@ -139,21 +139,20 @@ impl SSLContextCache {
             // `bun_ssl_ctx_cache_on_free` and write this same `ctx` cell.
             let existing = entry.ctx.get();
             if !existing.is_null() {
-                // SAFETY: existing non-null; ctx is the fresh CTX we just built and own.
-                unsafe {
-                    boringssl::SSL_CTX_up_ref(existing);
-                    boringssl::SSL_CTX_free(ctx);
-                }
+                // `ctx` is the fresh CTX we just built and own; give it back.
+                boringssl::SSL_CTX_up_ref(boringssl::sys::SSL_CTX::opaque_ref(existing));
+                boringssl::SSL_CTX_free(boringssl::sys::SSL_CTX::opaque_ref(ctx));
                 return Some(existing);
             }
             // Tombstone — adopt the rebuilt CTX into the existing slot.
             // SSL_CTX_set_ex_data only fails on OOM (Bun crashes anyway), but if
             // it did, the entry would never tombstone and `entry.ctx` would dangle
             // after the CTX is freed. Don't cache it; caller still owns the ref.
-            // SAFETY: ctx is a valid SSL_CTX*; entry_ptr is a valid heap pointer.
+            // SAFETY: entry_ptr is a valid heap pointer; the CRYPTO_EX_free
+            // callback owns the eventual deref.
             if unsafe {
                 boringssl::SSL_CTX_set_ex_data(
-                    ctx,
+                    boringssl::sys::SSL_CTX::opaque_ref(ctx),
                     c::us_ssl_ctx_cache_ex_idx(),
                     entry_ptr.cast::<c_void>(),
                 )
@@ -170,10 +169,11 @@ impl SSLContextCache {
             owner: owner_ptr,
         }));
         *gop.value_ptr = entry;
-        // SAFETY: ctx is a valid SSL_CTX*; entry is a fresh non-null heap pointer.
+        // SAFETY: entry is a fresh non-null heap pointer; the CRYPTO_EX_free
+        // callback owns the eventual deref.
         if unsafe {
             boringssl::SSL_CTX_set_ex_data(
-                ctx,
+                boringssl::sys::SSL_CTX::opaque_ref(ctx),
                 c::us_ssl_ctx_cache_ex_idx(),
                 entry.cast::<c_void>(),
             )
@@ -257,10 +257,10 @@ impl Drop for SSLContextCache {
             let e = unsafe { &*entry };
             let ctx = e.ctx.get();
             if !ctx.is_null() {
-                // SAFETY: ctx non-null; clearing the ex_data slot we set.
+                // SAFETY: clearing the ex_data slot we set; null payload.
                 unsafe {
                     boringssl::SSL_CTX_set_ex_data(
-                        ctx,
+                        boringssl::sys::SSL_CTX::opaque_ref(ctx),
                         c::us_ssl_ctx_cache_ex_idx(),
                         ptr::null_mut(),
                     );

--- a/src/runtime/api/bun/SecureContext.rs
+++ b/src/runtime/api/bun/SecureContext.rs
@@ -33,7 +33,7 @@ pub use crate::generated_classes::js_SecureContext as js;
 #[bun_jsc::JsClass]
 #[repr(C)]
 pub struct SecureContext {
-    pub ctx: *mut boringssl::SSL_CTX,
+    pub ctx: *mut boringssl::sys::SSL_CTX,
     /// `BunSocketContextOptions.digest()` — exactly the fields that reach
     /// `us_ssl_ctx_from_options`. Stored so an `intern()` WeakGCMap hit (keyed by
     /// the low 64 bits) can do a full content-equality check before reusing.
@@ -331,11 +331,8 @@ impl SecureContext {
     /// `SSL_CTX_up_ref` and return — for callers that want to outlive this
     /// wrapper's GC. Most paths just pass `this.ctx` directly and let `SSL_new`
     /// take its own ref.
-    pub fn borrow(&self) -> *mut boringssl::SSL_CTX {
-        unsafe {
-            // SAFETY: self.ctx is a valid SSL_CTX* held for the lifetime of this wrapper.
-            let _ = boringssl::SSL_CTX_up_ref(self.ctx);
-        }
+    pub fn borrow(&self) -> *mut boringssl::sys::SSL_CTX {
+        let _ = boringssl::SSL_CTX_up_ref(boringssl::sys::SSL_CTX::opaque_ref(self.ctx));
         self.ctx
     }
 
@@ -380,8 +377,8 @@ impl SecureContext {
     // false positive on that contract.
     #[allow(clippy::boxed_local)]
     pub fn finalize(self: Box<Self>) {
-        // SAFETY: `ctx` was created by `SSL_CTX_new`; freed exactly once here.
-        unsafe { boringssl::SSL_CTX_free(self.ctx) };
+        // `ctx` was created by `SSL_CTX_new`; released exactly once here.
+        boringssl::SSL_CTX_free(boringssl::sys::SSL_CTX::opaque_ref(self.ctx));
     }
 
     pub fn memory_cost(&self) -> usize {

--- a/src/runtime/api/bun/x509.rs
+++ b/src/runtime/api/bun/x509.rs
@@ -1,24 +1,29 @@
-use bun_boringssl_sys::X509;
+use bun_boringssl_sys::{X509, sys};
 use bun_jsc::{JSGlobalObject, JSValue, JsResult};
 
 pub use bun_boringssl::x509::is_safe_alt_name;
 
-pub fn to_js(cert: &mut X509, global_object: &JSGlobalObject) -> JsResult<JSValue> {
+/// Borrows `cert`: C++ wraps the pointer in a non-owning `ncrypto::X509View`
+/// (`Bun__X509__toJSLegacyEncoding`), so the caller keeps its reference.
+pub fn to_js(cert: &mut sys::X509, global_object: &JSGlobalObject) -> JsResult<JSValue> {
     bun_jsc::from_js_host_call(global_object, || {
         Bun__X509__toJSLegacyEncoding(cert, global_object)
     })
 }
 
-pub(crate) fn to_js_object(cert: &mut X509, global_object: &JSGlobalObject) -> JsResult<JSValue> {
+/// Consumes `cert`: C++ moves the pointer into an owning `ncrypto::X509Pointer`
+/// (`Bun__X509__toJS`), so the handle's ref is leaked here rather than released.
+pub(crate) fn to_js_object(cert: X509, global_object: &JSGlobalObject) -> JsResult<JSValue> {
+    let cert = sys::X509::opaque_mut(cert.leak().as_ptr());
     Ok(Bun__X509__toJS(cert, global_object))
 }
 
-// `X509`/`JSGlobalObject` are opaque `repr(C)` handles; `&mut`/`&` are
+// `sys::X509`/`JSGlobalObject` are opaque `repr(C)` handles; `&mut`/`&` are
 // ABI-identical to non-null pointers, so the validity proof is in the type.
 unsafe extern "C" {
     safe fn Bun__X509__toJSLegacyEncoding(
-        cert: &mut X509,
+        cert: &mut sys::X509,
         global_object: &JSGlobalObject,
     ) -> JSValue;
-    safe fn Bun__X509__toJS(cert: &mut X509, global_object: &JSGlobalObject) -> JSValue;
+    safe fn Bun__X509__toJS(cert: &mut sys::X509, global_object: &JSGlobalObject) -> JSValue;
 }

--- a/src/runtime/api/filesystem_router.rs
+++ b/src/runtime/api/filesystem_router.rs
@@ -901,7 +901,7 @@ impl MatchedRoute {
             query: &'a mut QueryStringMap,
         }
         impl<'a> ObjectInitializer for QueryObjectCreator<'a> {
-            fn create(&mut self, obj: &mut JSObject, global: &JSGlobalObject) -> JsResult<()> {
+            fn create(&mut self, obj: &JSObject, global: &JSGlobalObject) -> JsResult<()> {
                 // Stack scratch — 256 × 16-byte fat ptr × 2 ≈ 8 KiB, well within Bun's
                 // JS-thread stack budget. A `RefCell<[&'static [u8]; 256]>` TLS slot
                 // would be unsound: `iter.next()` writes QueryStringMap-lifetime

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1706,7 +1706,10 @@ impl<const SSL: bool> bun_uws_sys::web_socket::WebSocketUpgradeServer<SSL> for D
         }
         let dw = bun_core::heap::into_raw(HmrSocket::new(this, res));
         let _ = this.active_websocket_connections.insert(dw, ());
-        let _ = res.upgrade(
+        // Fully qualified: `ResponseLike::upgrade` is also in scope for this type
+        // and would box `dw` a second time. The inherent one takes the raw pointer.
+        let _ = bun_uws_sys::NewAppResponse::<SSL>::upgrade(
+            res,
             dw,
             req.header(b"sec-websocket-key").unwrap_or(b""),
             req.header(b"sec-websocket-protocol").unwrap_or(b""),

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1730,8 +1730,8 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
         };
         // The compiled regex lives in `bun_jsc::RegularExpression` (T6); the
         // T3 `TestOptions` field is type-erased to `NonNull<()>` to break the
-        // back-edge. High tier owns construction/destruction.
-        ctx.test_options.test_filter_regex = core::ptr::NonNull::new(regex.cast::<()>());
+        // back-edge. `leak()` hands it the allocation for the process lifetime.
+        ctx.test_options.test_filter_regex = Some(regex.leak().cast::<()>());
     }
     if let Some(since) = args.option(b"--changed") {
         ctx.test_options.changed = Some(since.into());

--- a/src/runtime/cli/audit_command.rs
+++ b/src/runtime/cli/audit_command.rs
@@ -425,7 +425,7 @@ fn send_audit_request(
     body: &[u8],
 ) -> Result<Box<[u8]>, bun_alloc::AllocError> {
     libdeflate::load();
-    let mut compressor = libdeflate::OwnedCompressor::new(6).ok_or(bun_alloc::AllocError)?;
+    let compressor = libdeflate::Compressor::new(6).ok_or(bun_alloc::AllocError)?;
 
     let max_compressed_size = compressor.max_bytes_needed(body, libdeflate::Encoding::Gzip);
     let mut compressed_body = Vec::with_capacity(max_compressed_size);

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -19,7 +19,7 @@ use bun_parsers::json as JSON;
 // lift via `bun_ast::Expr::from(t2_expr)` at the call site.
 use bun_ast::{E, Expr, ExprData};
 use bun_js_printer as js_printer;
-use bun_libarchive::lib::{Archive, Entry as ArchiveEntry, Result as ArchiveStatus};
+use bun_libarchive::lib::{Entry as ArchiveEntry, Result as ArchiveStatus, sys::Archive};
 use bun_paths::{self as path, PathBuffer, SEP_STR};
 // `bun.ptr.CowString = CowSlice(u8)` — the lifetime-free struct port (init_owned/
 // borrow_subslice/length live on `cow_slice::CowSliceZ`, not on the `std::borrow::Cow`

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -12,7 +12,7 @@ use bun_dotenv as dotenv;
 use bun_http as http;
 use bun_install::lockfile::{LoadResult, LoadStep};
 use bun_install::{self as install, Lockfile, Npm, PackageManager, Subcommand};
-use bun_libarchive::lib::{Archive, ArchiveIterator, IteratorResult as ArchiveIterResult};
+use bun_libarchive::lib::{ArchiveIterator, IteratorResult as ArchiveIterResult, sys::Archive};
 use bun_parsers::json as json_mod;
 use bun_paths::resolve_path::{join_abs_string_buf_z, normalize_buf, normalize_buf_z};
 use bun_paths::{self as path, PathBuffer};

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2084,14 +2084,13 @@ impl TestCommand {
                 only: ctx.test_options.only,
                 bail: ctx.test_options.bail,
                 max_concurrency: ctx.test_options.max_concurrency,
-                // `test_filter_regex` is an erased `*mut RegularExpression` (see
-                // options_types::context); cast back to a typed `NonNull` —
-                // kept raw so `matches()` can write through it without
-                // laundering shared-ref provenance.
+                // `test_filter_regex` is an erased pointer to the C++ regex (see
+                // options_types::context); cast back to the `sys` type, not the
+                // owning handle. We only borrow it - `Arguments` leaked it.
                 filter_regex: ctx
                     .test_options
                     .test_filter_regex()
-                    .map(|p| p.cast::<jsc::RegularExpression>()),
+                    .map(|p| p.cast::<jsc::regular_expression::sys::RegularExpression>()),
                 snapshots: Snapshots {
                     update_snapshots: ctx.test_options.update_snapshots,
                     total: 0,

--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -26,18 +26,14 @@ type Digest = evp::Digest;
 const EVP_MAX_MD_SIZE_USIZE: usize = boring_ssl::EVP_MAX_MD_SIZE as usize;
 
 /// Local helper: dereference the raw `*mut VirtualMachine` to reach
-/// `RareData::boring_engine()` and cast the bun_jsc-local opaque `ENGINE`
-/// to the real `bun_boringssl_sys::ENGINE` (both name the same C struct).
+/// `RareData::boring_engine()`, which borrows the VM-owned `ENGINE` out of the
+/// owning `bun_boringssl_sys::ENGINE` handle stored on `RareData`. The result is
+/// the C object, never the handle — nothing here releases a ref.
 #[inline]
-fn boring_engine(global: &JSGlobalObject) -> *mut boring_ssl::ENGINE {
+fn boring_engine(global: &JSGlobalObject) -> *mut boring_ssl::sys::ENGINE {
     // SAFETY: `bun_vm()` returns the raw `*mut VirtualMachine` for a Bun-owned
     // global (never null, single-threaded JS heap), so deref-to-&mut is sound here.
-    global
-        .bun_vm()
-        .as_mut()
-        .rare_data()
-        .boring_engine()
-        .cast::<boring_ssl::ENGINE>()
+    global.bun_vm().as_mut().rare_data().boring_engine()
 }
 
 /// Local helper replacing `input == .blob && input.blob.isBunFile()`.
@@ -1104,7 +1100,7 @@ pub trait StaticHasher: 'static {
     fn final_(&mut self, out: &mut Self::Digest);
     /// # Safety
     /// `engine` must be null (default engine) or a live `ENGINE*`.
-    unsafe fn hash(input: &[u8], out: &mut Self::Digest, engine: *mut boring_ssl::ENGINE);
+    unsafe fn hash(input: &[u8], out: &mut Self::Digest, engine: *mut boring_ssl::sys::ENGINE);
     /// Per-monomorphization codegen module (`bun_jsc::generated::JS${NAME}`);
     /// each `impl_static_hasher!` arm binds to the typed wrapper exported by
     /// `js_class_module!` for its concrete name.
@@ -1139,9 +1135,14 @@ macro_rules! impl_static_hasher {
                 <$ty>::r#final(self, out)
             }
             #[inline]
-            unsafe fn hash(input: &[u8], out: &mut Self::Digest, engine: *mut boring_ssl::ENGINE) {
-                // `bun_sha_hmac::sha::ffi::ENGINE` re-exports `bun_boringssl_sys::ENGINE`,
-                // so the VM-owned engine pointer threads through without a cast.
+            unsafe fn hash(
+                input: &[u8],
+                out: &mut Self::Digest,
+                engine: *mut boring_ssl::sys::ENGINE,
+            ) {
+                // `bun_sha_hmac::sha::ffi::ENGINE` re-exports
+                // `bun_boringssl_sys::sys::ENGINE`, so the VM-owned engine pointer
+                // threads through without a cast.
                 // SAFETY: caller upholds `engine` validity (forwarded).
                 unsafe { <$ty>::hash(input, out, engine) }
             }

--- a/src/runtime/crypto/EVP.rs
+++ b/src/runtime/crypto/EVP.rs
@@ -170,7 +170,7 @@ impl EVP {
     pub fn init(
         algorithm: Algorithm,
         md: *const boringssl::EVP_MD,
-        engine: *mut boringssl::ENGINE,
+        engine: *mut boringssl::sys::ENGINE,
     ) -> EVP {
         bun_boringssl::load();
 
@@ -188,7 +188,7 @@ impl EVP {
     /// `engine` must be either null or a valid `ENGINE` pointer.
     // Forwards `engine` to BoringSSL without dereferencing; not_unsafe_ptr_arg_deref is a false positive on opaque-token forwarding.
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub fn reset(&mut self, engine: *mut boringssl::ENGINE) {
+    pub fn reset(&mut self, engine: *mut boringssl::sys::ENGINE) {
         // SAFETY: FFI into BoringSSL; ERR_clear_error has no preconditions. self.ctx was
         // initialized in init() and remains valid for the lifetime of EVP; self.md is a
         // static singleton.
@@ -204,7 +204,7 @@ impl EVP {
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn hash(
         &mut self,
-        engine: *mut boringssl::ENGINE,
+        engine: *mut boringssl::sys::ENGINE,
         input: &[u8],
         output: &mut [u8],
     ) -> Option<u32> {
@@ -232,7 +232,7 @@ impl EVP {
     /// `engine` must be either null or a valid `ENGINE` pointer.
     pub fn r#final<'a>(
         &mut self,
-        engine: *mut boringssl::ENGINE,
+        engine: *mut boringssl::sys::ENGINE,
         output: &'a mut [u8],
     ) -> &'a mut [u8] {
         boringssl::ERR_clear_error();
@@ -268,7 +268,7 @@ impl EVP {
 
     /// # Safety
     /// `engine` must be either null or a valid `ENGINE` pointer.
-    pub fn copy(&self, engine: *mut boringssl::ENGINE) -> Result<EVP, AllocError> {
+    pub fn copy(&self, engine: *mut boringssl::sys::ENGINE) -> Result<EVP, AllocError> {
         boringssl::ERR_clear_error();
         // SAFETY: self.md is a static singleton; caller upholds `engine`.
         let mut new = EVP::init(self.algorithm, self.md, engine);
@@ -282,7 +282,7 @@ impl EVP {
 
     /// # Safety
     /// `engine` must be either null or a valid `ENGINE` pointer.
-    pub fn by_name_and_engine(engine: *mut boringssl::ENGINE, name: &[u8]) -> Option<EVP> {
+    pub fn by_name_and_engine(engine: *mut boringssl::sys::ENGINE, name: &[u8]) -> Option<EVP> {
         if let Some(algorithm) = lookup_ignore_case(name) {
             if let Some(md) = algorithm.md() {
                 // `Algorithm::md()` lives in `bun_sha_hmac`
@@ -308,17 +308,12 @@ impl EVP {
 
     pub fn by_name(name: &ZigString, global: &JSGlobalObject) -> Option<EVP> {
         let name_str = name.to_slice();
-        // `RareData::boring_engine()` returns `*mut` to bun_jsc's local opaque `ENGINE`
-        // stub (bun_jsc has no bun_boringssl_sys dep). Both name the same C `ENGINE`
-        // struct, so cast to the real bindgen type for the FFI call.
+        // `RareData::boring_engine()` borrows the VM-owned `ENGINE` out of the
+        // owning `bun_boringssl_sys::ENGINE` handle stored on `RareData`, so it
+        // already returns `*mut boringssl::sys::ENGINE` — no cast needed.
         // SAFETY: `bun_vm()` returns the raw `*mut VirtualMachine` for a Bun-owned
         // global (never null, single-threaded JS heap), so deref-to-&mut is sound here.
-        let engine = global
-            .bun_vm()
-            .as_mut()
-            .rare_data()
-            .boring_engine()
-            .cast::<boringssl::ENGINE>();
+        let engine = global.bun_vm().as_mut().rare_data().boring_engine();
         // SAFETY: `boring_engine()` returns the VM's lazily-initialized ENGINE (valid or null).
         Self::by_name_and_engine(engine, name_str.slice())
     }

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -125,7 +125,7 @@ use crate::napi::{NapiFinalizerTask, ThreadSafeFunction, napi_async_work};
 
 use bun_jsc::PosixSignalTask;
 use bun_jsc::RuntimeTranspilerStore;
-use bun_jsc::cpp_task::CppTask;
+use bun_jsc::cpp_task::{self, CppTask};
 use bun_jsc::hot_reloader;
 use bun_jsc::jsc_scheduler::JSCDeferredWorkTask;
 
@@ -266,7 +266,15 @@ pub fn run_task(
             }
         }
         task_tag::CppTask => {
-            if let Err(err) = cast!(CppTask).run(global) {
+            // SAFETY: §Dispatch — tag identifies pointee and the pointer is a
+            // non-null `EventLoopTask*` the queue solely owns. `run` consumes
+            // it (`performTask` → `delete this`), on the error path too.
+            let task = unsafe {
+                CppTask::adopt(core::ptr::NonNull::new_unchecked(cast_ptr!(
+                    cpp_task::sys::CppTask
+                )))
+            };
+            if let Err(err) = task.run(global) {
                 report_error_or_terminate(global, err)?;
             }
         }

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -4098,7 +4098,7 @@ impl Resolver {
             if self.any_requests_pending() {
                 // SAFETY: `channel` is the live c-ares channel owned by `self`.
                 c_ares::ares_process_fd(
-                    unsafe { &mut *channel },
+                    unsafe { &*channel },
                     c_ares::ARES_SOCKET_BAD,
                     c_ares::ARES_SOCKET_BAD,
                 );
@@ -5671,7 +5671,7 @@ impl Resolver {
         {
             let ip = u32::from_be_bytes([addr[0], addr[1], addr[2], addr[3]]);
             // SAFETY: `channel` is a live handle returned by `ares_init_options`.
-            c_ares::ares_set_local_ip4(unsafe { &mut *channel }, ip);
+            c_ares::ares_set_local_ip4(unsafe { &*channel }, ip);
             return Ok(c_ares::AF::INET);
         }
 
@@ -5888,7 +5888,7 @@ impl Resolver {
     ) -> JsResult<JSValue> {
         let channel = self.get_channel_or_error(global_this)?;
         // SAFETY: `channel` is a live handle returned by `ares_init_options`.
-        c_ares::ares_cancel(unsafe { &mut *channel });
+        c_ares::ares_cancel(unsafe { &*channel });
         Ok(JSValue::UNDEFINED)
     }
 

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -275,7 +275,7 @@ impl Source {
 
     pub(crate) fn add(
         &self,
-        state: &mut TCC::State,
+        state: &TCC::State,
         current_file_for_errors: &mut ZBox,
     ) -> Result<(), bun_core::Error> {
         match self {
@@ -346,7 +346,7 @@ mod stdarg {
             static FFI_STDERRP: AtomicPtr<c_void>;
         }
 
-        pub(super) fn inject(state: &mut TCC::State) {
+        pub(super) fn inject(state: &TCC::State) {
             // Taking addresses of process-global FILE* pointers; the statics
             // live for the process and we never form a Rust reference to them
             // (only a raw `*const c_void` for tcc_add_symbol).
@@ -368,10 +368,10 @@ mod stdarg {
     #[cfg(not(target_os = "macos"))]
     mod mac {
         use super::*;
-        pub(super) fn inject(_: &mut TCC::State) {}
+        pub(super) fn inject(_: &TCC::State) {}
     }
 
-    pub(super) fn inject(state: &mut TCC::State) {
+    pub(super) fn inject(state: &TCC::State) {
         state
             .add_symbols(&[
                 // printf family
@@ -645,9 +645,7 @@ impl CompileC {
                 return Err(bun_core::err!("DeferredErrors"));
             }
         };
-        // SAFETY: `state_ptr` was just returned non-null by `TCC::State::init`;
-        // we hold the only reference for the rest of this function.
-        let state: &mut TCC::State = unsafe { &mut *state_ptr.as_ptr() };
+        let state: &TCC::State = TCC::State::opaque_ref(state_ptr.as_ptr());
 
         if let Some(compiler_rt_dir) = CompilerRT::dir() {
             if state.add_sys_include_path(compiler_rt_dir).is_err() {
@@ -2010,8 +2008,7 @@ impl Function {
             // SAFETY: we own the state
             unsafe { TCC::State::destroy(s.as_ptr()) };
         });
-        // SAFETY: `state_ptr` was just returned non-null by `TCC::State::init`.
-        let state: &mut TCC::State = unsafe { &mut *state_ptr.as_ptr() };
+        let state: &TCC::State = TCC::State::opaque_ref(state_ptr.as_ptr());
 
         if let Some(env) = napi_env {
             // `env` is the live VM-owned napi env; process-lifetime.
@@ -2134,8 +2131,7 @@ impl Function {
             // SAFETY: we own the state
             unsafe { TCC::State::destroy(s.as_ptr()) };
         });
-        // SAFETY: `state_ptr` was just returned non-null by `TCC::State::init`.
-        let state: &mut TCC::State = unsafe { &mut *state_ptr.as_ptr() };
+        let state: &TCC::State = TCC::State::opaque_ref(state_ptr.as_ptr());
 
         if self.needs_napi_env() {
             if state
@@ -2627,7 +2623,7 @@ impl CompilerRT {
         }
     }
 
-    pub(crate) fn define(state: &mut TCC::State) {
+    pub(crate) fn define(state: &TCC::State) {
         #[cfg(target_arch = "x86_64")]
         {
             state.define_symbol(zstr!("NEEDS_COMPILER_RT_FUNCTIONS"), zstr!("1"));
@@ -2671,7 +2667,7 @@ impl CompilerRT {
         ]);
     }
 
-    pub(crate) fn inject(state: &mut TCC::State) {
+    pub(crate) fn inject(state: &TCC::State) {
         state
             .add_symbol(zstr!("memset"), Self::memset as *const c_void)
             .expect("unreachable");

--- a/src/runtime/image/codec_png.rs
+++ b/src/runtime/image/codec_png.rs
@@ -8,42 +8,90 @@ use super::codecs;
 use super::quantize;
 use crate::encoded_wrap_free;
 
-bun_opaque::opaque_ffi! { pub struct spng_ctx; }
+/// The C object itself. Only the extern declarations below name this type;
+/// all Rust code uses the owning [`spng_ctx`] handle.
+pub mod sys {
+    bun_opaque::opaque_ffi! {
+        /// libspng's `spng_ctx`. `&Self` is ABI-identical to a non-null
+        /// `spng_ctx *` and carries no `noalias`/`readonly` — libspng mutates
+        /// the context's parse/encode state through it on every call.
+        pub struct spng_ctx;
+    }
+}
 
 unsafe extern "C" {
-    fn spng_ctx_new(flags: c_int) -> *mut spng_ctx;
-    fn spng_ctx_free(ctx: *mut spng_ctx);
-    fn spng_set_png_buffer(ctx: *mut spng_ctx, buf: *const u8, len: usize) -> c_int;
-    fn spng_decoded_image_size(ctx: *mut spng_ctx, fmt: c_int, out: *mut usize) -> c_int;
+    fn spng_ctx_new(flags: c_int) -> *mut sys::spng_ctx;
+    // NOT `safe fn`: this deallocates. A `safe fn` taking `&sys::spng_ctx` would
+    // let safe code free a context the handle still owns. Reached only through
+    // `spng_ctx_free_release`, below.
+    fn spng_ctx_free(ctx: *mut sys::spng_ctx);
+    fn spng_set_png_buffer(ctx: &sys::spng_ctx, buf: *const u8, len: usize) -> c_int;
+    fn spng_decoded_image_size(ctx: &sys::spng_ctx, fmt: c_int, out: *mut usize) -> c_int;
     fn spng_decode_image(
-        ctx: *mut spng_ctx,
+        ctx: &sys::spng_ctx,
         out: *mut u8,
         len: usize,
         fmt: c_int,
         flags: c_int,
     ) -> c_int;
-    fn spng_get_ihdr(ctx: *mut spng_ctx, ihdr: *mut Ihdr) -> c_int;
-    fn spng_set_ihdr(ctx: *mut spng_ctx, ihdr: *const Ihdr) -> c_int;
-    fn spng_set_plte(ctx: *mut spng_ctx, plte: *const Plte) -> c_int;
-    fn spng_set_trns(ctx: *mut spng_ctx, trns: *const Trns) -> c_int;
+    fn spng_get_ihdr(ctx: &sys::spng_ctx, ihdr: *mut Ihdr) -> c_int;
+    fn spng_set_ihdr(ctx: &sys::spng_ctx, ihdr: *const Ihdr) -> c_int;
+    fn spng_set_plte(ctx: &sys::spng_ctx, plte: *const Plte) -> c_int;
+    fn spng_set_trns(ctx: &sys::spng_ctx, trns: *const Trns) -> c_int;
     fn spng_encode_image(
-        ctx: *mut spng_ctx,
+        ctx: &sys::spng_ctx,
         img: *const u8,
         len: usize,
         fmt: c_int,
         flags: c_int,
     ) -> c_int;
-    fn spng_get_png_buffer(ctx: *mut spng_ctx, len: *mut usize, err: *mut c_int) -> *mut u8;
-    fn spng_set_option(ctx: *mut spng_ctx, opt: c_int, value: c_int) -> c_int;
+    fn spng_get_png_buffer(ctx: &sys::spng_ctx, len: *mut usize, err: *mut c_int) -> *mut u8;
+    // safe: the handle plus scalars; libspng only stores the option value.
+    safe fn spng_set_option(ctx: &sys::spng_ctx, opt: c_int, value: c_int) -> c_int;
     /// iCCP chunk read/write — PNG carries an optional ICC profile alongside
     /// the pixels for every colour type (including indexed). `spng_get_iccp`
     /// returns non-zero when the source has no iCCP (or the chunk was
     /// malformed); we treat all non-zero returns the same way — drop the
     /// profile — because the pixels are still valid and a PNG without iCCP
     /// is still a valid PNG. The `profile` pointer it hands back is owned by
-    /// the context and freed with `spng_ctx_free`; dupe out before then.
-    fn spng_get_iccp(ctx: *mut spng_ctx, iccp: *mut Iccp) -> c_int;
-    fn spng_set_iccp(ctx: *mut spng_ctx, iccp: *const Iccp) -> c_int;
+    /// the context and freed when the owning [`spng_ctx`] handle drops; dupe
+    /// out before then.
+    fn spng_get_iccp(ctx: &sys::spng_ctx, iccp: *mut Iccp) -> c_int;
+    fn spng_set_iccp(ctx: &sys::spng_ctx, iccp: *const Iccp) -> c_int;
+}
+
+/// `ForeignOwned::release` hands us `&sys::spng_ctx`; libspng's destructor takes
+/// `spng_ctx *`. `as_mut_ptr` is the sanctioned interior-mutability route to it.
+fn spng_ctx_free_release(ctx: &sys::spng_ctx) {
+    // SAFETY: reached only from `ForeignRef::drop`, which owns the sole allocation
+    // `spng_ctx_new` returned and gives it back exactly once.
+    unsafe { spng_ctx_free(ctx.as_mut_ptr()) }
+}
+
+// `spng_ctx_new` calloc's a fresh context and hands Rust the allocation. There
+// is no refcount: `spng_ctx_free` unconditionally destroys the object, so one
+// `spng_ctx` handle owns exactly that one allocation.
+bun_opaque::foreign_handle! {
+    /// Owned handle to a libspng `spng_ctx`; `Drop` frees it.
+    ///
+    /// Every method takes `&self`: `sys::spng_ctx` is `UnsafeCell`-backed, so a
+    /// `&` carries no `noalias`/`readonly` and libspng mutates the context
+    /// through it on every call — including the ones C spells as taking a
+    /// non-const `spng_ctx *`.
+    pub struct spng_ctx(sys::spng_ctx) via spng_ctx_free_release;
+}
+
+impl spng_ctx {
+    /// Allocate a context: `0` for a decoder, `SPNG_CTX_ENCODER` for an
+    /// encoder. `None` on allocation failure.
+    fn new(flags: c_int) -> Option<Self> {
+        // SAFETY: `spng_ctx_new` either returns null — for unrecognised flags,
+        // or because its `calloc` failed, in which case nothing was allocated
+        // and nothing needs freeing — or a fresh `calloc`'d context whose sole
+        // ownership unit it transfers to the caller. It frees nothing on any
+        // path, so no other handle can give this unit back.
+        unsafe { Self::adopt_ptr(spng_ctx_new(flags)) }
+    }
 }
 
 #[repr(C)]
@@ -98,36 +146,28 @@ struct Trns {
 }
 
 pub fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, codecs::Error> {
-    // SAFETY: spng_ctx_new is safe to call with any flags; null return = OOM.
-    let ctx = unsafe { spng_ctx_new(0) };
-    if ctx.is_null() {
-        return Err(codecs::Error::OutOfMemory);
-    }
-    let _ctx_guard = scopeguard::guard(ctx, |c| {
-        // SAFETY: ctx was returned non-null by spng_ctx_new and is freed exactly once here.
-        unsafe { spng_ctx_free(c) }
-    });
+    let ctx = spng_ctx::new(0).ok_or(codecs::Error::OutOfMemory)?;
 
-    // SAFETY: ctx is valid; bytes outlives the ctx (freed at end of scope).
-    if unsafe { spng_set_png_buffer(ctx, bytes.as_ptr(), bytes.len()) } != 0 {
+    // SAFETY: bytes outlives the ctx (dropped at end of scope).
+    if unsafe { spng_set_png_buffer(ctx.raw(), bytes.as_ptr(), bytes.len()) } != 0 {
         return Err(codecs::Error::DecodeFailed);
     }
     let mut ihdr = Ihdr::default();
-    // SAFETY: ctx is valid; ihdr is a valid out-ptr.
-    if unsafe { spng_get_ihdr(ctx, &raw mut ihdr) } != 0 {
+    // SAFETY: ihdr is a valid out-ptr.
+    if unsafe { spng_get_ihdr(ctx.raw(), &raw mut ihdr) } != 0 {
         return Err(codecs::Error::DecodeFailed);
     }
     codecs::guard(ihdr.width, ihdr.height, max_pixels)?;
     let mut size: usize = 0;
-    // SAFETY: ctx is valid; size is a valid out-ptr.
-    if unsafe { spng_decoded_image_size(ctx, SPNG_FMT_RGBA8, &raw mut size) } != 0 {
+    // SAFETY: size is a valid out-ptr.
+    if unsafe { spng_decoded_image_size(ctx.raw(), SPNG_FMT_RGBA8, &raw mut size) } != 0 {
         return Err(codecs::Error::DecodeFailed);
     }
     let mut out = vec![0u8; size];
-    // SAFETY: ctx is valid; out is a valid mutable buffer of `size` bytes.
+    // SAFETY: out is a valid mutable buffer of `size` bytes.
     if unsafe {
         spng_decode_image(
-            ctx,
+            ctx.raw(),
             out.as_mut_ptr(),
             out.len(),
             SPNG_FMT_RGBA8,
@@ -141,15 +181,15 @@ pub fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, codecs::
     // iCCP after decode so the chunk has definitely been parsed. A non-zero
     // return here means "no iCCP" or "iCCP was malformed" — treat both as
     // the no-profile case; the pixels are still valid RGBA. `profile` is
-    // context-owned memory, so copy it out before `spng_ctx_free` runs at
-    // function exit. Propagate OutOfMemory on allocator failure rather
+    // context-owned memory, so copy it out before `ctx` drops at function
+    // exit. Propagate OutOfMemory on allocator failure rather
     // than silently degrading colour fidelity — the pixels may be Display
     // P3 / Adobe RGB / XYB, and a "no profile" result there is a visible
     // colour shift, which is the exact bug #30197 is about.
     // SAFETY: all-zero is a valid Iccp (POD; null profile ptr is the "no profile" state).
     let mut iccp: Iccp = unsafe { bun_core::ffi::zeroed_unchecked() };
-    // SAFETY: ctx is valid; iccp is a valid out-ptr.
-    let icc: Option<Vec<u8>> = if unsafe { spng_get_iccp(ctx, &raw mut iccp) } == 0
+    // SAFETY: iccp is a valid out-ptr.
+    let icc: Option<Vec<u8>> = if unsafe { spng_get_iccp(ctx.raw(), &raw mut iccp) } == 0
         && iccp.profile_len > 0
         && !iccp.profile.is_null()
     {
@@ -177,7 +217,7 @@ pub fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, codecs::
 /// every colour type (indexed-colour palettes live in the source space
 /// too, so dropping the profile there would silently reinterpret them as
 /// sRGB, same bug #30197 was filed for).
-fn embed_iccp(ctx: *mut spng_ctx, icc_profile: Option<&[u8]>) {
+fn embed_iccp(ctx: &spng_ctx, icc_profile: Option<&[u8]>) {
     let Some(p) = icc_profile else { return };
     if p.is_empty() {
         return;
@@ -192,8 +232,8 @@ fn embed_iccp(ctx: *mut spng_ctx, icc_profile: Option<&[u8]>) {
     };
     let name = b"ICC Profile";
     iccp.profile_name[..name.len()].copy_from_slice(name);
-    // SAFETY: ctx is valid; iccp is fully initialised; libspng only reads from it.
-    let _ = unsafe { spng_set_iccp(ctx, &raw const iccp) };
+    // SAFETY: iccp is fully initialised; libspng only reads from it.
+    let _ = unsafe { spng_set_iccp(ctx.raw(), &raw const iccp) };
 }
 
 pub(crate) fn encode(
@@ -203,22 +243,15 @@ pub(crate) fn encode(
     level: i8,
     icc_profile: Option<&[u8]>,
 ) -> Result<codecs::Encoded, codecs::Error> {
-    // SAFETY: spng_ctx_new is safe to call; null return = OOM.
-    let ctx = unsafe { spng_ctx_new(SPNG_CTX_ENCODER) };
-    if ctx.is_null() {
-        return Err(codecs::Error::OutOfMemory);
-    }
-    let _ctx_guard = scopeguard::guard(ctx, |c| {
-        // SAFETY: ctx was returned non-null by spng_ctx_new and is freed exactly once here.
-        unsafe { spng_ctx_free(c) }
-    });
+    let ctx = spng_ctx::new(SPNG_CTX_ENCODER).ok_or(codecs::Error::OutOfMemory)?;
 
-    // SAFETY: ctx is valid.
-    let _ = unsafe { spng_set_option(ctx, SPNG_ENCODE_TO_BUFFER, 1) };
+    let _ = spng_set_option(ctx.raw(), SPNG_ENCODE_TO_BUFFER, 1);
     if level >= 0 {
-        // SAFETY: ctx is valid.
-        let _ =
-            unsafe { spng_set_option(ctx, SPNG_IMG_COMPRESSION_LEVEL, c_int::from(level.min(9))) };
+        let _ = spng_set_option(
+            ctx.raw(),
+            SPNG_IMG_COMPRESSION_LEVEL,
+            c_int::from(level.min(9)),
+        );
     }
     let ihdr = Ihdr {
         width: w,
@@ -227,15 +260,15 @@ pub(crate) fn encode(
         color_type: SPNG_COLOR_TYPE_TRUECOLOR_ALPHA,
         ..Default::default()
     };
-    // SAFETY: ctx is valid; ihdr is fully initialised.
-    if unsafe { spng_set_ihdr(ctx, &raw const ihdr) } != 0 {
+    // SAFETY: ihdr is fully initialised; libspng only reads from it.
+    if unsafe { spng_set_ihdr(ctx.raw(), &raw const ihdr) } != 0 {
         return Err(codecs::Error::EncodeFailed);
     }
-    embed_iccp(ctx, icc_profile);
-    // SAFETY: ctx is valid; rgba is a valid readable buffer.
+    embed_iccp(&ctx, icc_profile);
+    // SAFETY: rgba is a valid readable buffer.
     if unsafe {
         spng_encode_image(
-            ctx,
+            ctx.raw(),
             rgba.as_ptr(),
             rgba.len(),
             SPNG_FMT_PNG,
@@ -247,8 +280,8 @@ pub(crate) fn encode(
     }
     let mut len: usize = 0;
     let mut err: c_int = 0;
-    // SAFETY: ctx is valid; len/err are valid out-ptrs.
-    let buf = unsafe { spng_get_png_buffer(ctx, &raw mut len, &raw mut err) };
+    // SAFETY: len/err are valid out-ptrs.
+    let buf = unsafe { spng_get_png_buffer(ctx.raw(), &raw mut len, &raw mut err) };
     if buf.is_null() {
         return Err(codecs::Error::EncodeFailed);
     }
@@ -288,22 +321,15 @@ pub(crate) fn encode_indexed(
     )
     .map_err(|_| codecs::Error::OutOfMemory)?;
 
-    // SAFETY: spng_ctx_new is safe to call; null return = OOM.
-    let ctx = unsafe { spng_ctx_new(SPNG_CTX_ENCODER) };
-    if ctx.is_null() {
-        return Err(codecs::Error::OutOfMemory);
-    }
-    let _ctx_guard = scopeguard::guard(ctx, |c| {
-        // SAFETY: ctx was returned non-null by spng_ctx_new and is freed exactly once here.
-        unsafe { spng_ctx_free(c) }
-    });
+    let ctx = spng_ctx::new(SPNG_CTX_ENCODER).ok_or(codecs::Error::OutOfMemory)?;
 
-    // SAFETY: ctx is valid.
-    let _ = unsafe { spng_set_option(ctx, SPNG_ENCODE_TO_BUFFER, 1) };
+    let _ = spng_set_option(ctx.raw(), SPNG_ENCODE_TO_BUFFER, 1);
     if level >= 0 {
-        // SAFETY: ctx is valid.
-        let _ =
-            unsafe { spng_set_option(ctx, SPNG_IMG_COMPRESSION_LEVEL, c_int::from(level.min(9))) };
+        let _ = spng_set_option(
+            ctx.raw(),
+            SPNG_IMG_COMPRESSION_LEVEL,
+            c_int::from(level.min(9)),
+        );
     }
 
     let ihdr = Ihdr {
@@ -313,11 +339,11 @@ pub(crate) fn encode_indexed(
         color_type: SPNG_COLOR_TYPE_INDEXED,
         ..Default::default()
     };
-    // SAFETY: ctx is valid; ihdr is fully initialised.
-    if unsafe { spng_set_ihdr(ctx, &raw const ihdr) } != 0 {
+    // SAFETY: ihdr is fully initialised; libspng only reads from it.
+    if unsafe { spng_set_ihdr(ctx.raw(), &raw const ihdr) } != 0 {
         return Err(codecs::Error::EncodeFailed);
     }
-    embed_iccp(ctx, icc_profile);
+    embed_iccp(&ctx, icc_profile);
 
     let mut plte = Plte {
         n_entries: u32::from(q.colors),
@@ -340,19 +366,19 @@ pub(crate) fn encode_indexed(
         ];
         trns.type3_alpha[i] = q.palette[i * 4 + 3];
     }
-    // SAFETY: ctx is valid; plte is fully initialised.
-    if unsafe { spng_set_plte(ctx, &raw const plte) } != 0 {
+    // SAFETY: plte is fully initialised; libspng only reads from it.
+    if unsafe { spng_set_plte(ctx.raw(), &raw const plte) } != 0 {
         return Err(codecs::Error::EncodeFailed);
     }
-    // SAFETY: ctx is valid; trns is fully initialised.
-    if q.has_alpha && unsafe { spng_set_trns(ctx, &raw const trns) } != 0 {
+    // SAFETY: trns is fully initialised; libspng only reads from it.
+    if q.has_alpha && unsafe { spng_set_trns(ctx.raw(), &raw const trns) } != 0 {
         return Err(codecs::Error::EncodeFailed);
     }
 
-    // SAFETY: ctx is valid; q.indices is a valid readable buffer.
+    // SAFETY: q.indices is a valid readable buffer.
     if unsafe {
         spng_encode_image(
-            ctx,
+            ctx.raw(),
             q.indices.as_ptr(),
             q.indices.len(),
             SPNG_FMT_PNG,
@@ -365,8 +391,8 @@ pub(crate) fn encode_indexed(
 
     let mut len: usize = 0;
     let mut err: c_int = 0;
-    // SAFETY: ctx is valid; len/err are valid out-ptrs.
-    let buf = unsafe { spng_get_png_buffer(ctx, &raw mut len, &raw mut err) };
+    // SAFETY: len/err are valid out-ptrs.
+    let buf = unsafe { spng_get_png_buffer(ctx.raw(), &raw mut len, &raw mut err) };
     if buf.is_null() {
         return Err(codecs::Error::EncodeFailed);
     }

--- a/src/runtime/image/codec_webp.rs
+++ b/src/runtime/image/codec_webp.rs
@@ -82,9 +82,51 @@ struct WebPChunkIterator {
     private_: *mut c_void,
 }
 
-bun_opaque::opaque_ffi! {
-    pub(crate) struct WebPDemuxer;
-    pub(crate) struct WebPMux;
+/// The C objects themselves. Only the extern declarations below name these
+/// types; all Rust code uses the owning [`WebPDemuxer`] / [`WebPMux`] handles.
+pub(crate) mod sys {
+    bun_opaque::opaque_ffi! {
+        /// `struct WebPDemuxer` — libwebpdemux's parsed view of a RIFF file.
+        pub struct WebPDemuxer;
+        /// `struct WebPMux` — libwebpmux's in-progress RIFF container.
+        pub struct WebPMux;
+    }
+}
+
+bun_opaque::foreign_handle! {
+    /// Owned handle to a libwebpdemux `WebPDemuxer`.
+    ///
+    /// `WebPDemuxInternal` hands back the sole owner of a freshly parsed
+    /// demuxer; `Drop` gives it back with `WebPDemuxDelete`. Not refcounted, so
+    /// "one ownership unit" is the object itself.
+    pub(crate) struct WebPDemuxer(sys::WebPDemuxer) via webp_demux_delete;
+}
+
+bun_opaque::foreign_handle! {
+    /// Owned handle to a libwebpmux `WebPMux`.
+    ///
+    /// `WebPNewInternal` hands back the sole owner of a fresh, empty mux; `Drop`
+    /// gives it back with `WebPMuxDelete`. The assembled output of
+    /// [`WebPMuxAssemble`] is a separate `WebPMalloc` buffer that outlives the
+    /// mux, so dropping this handle does not invalidate it.
+    pub(crate) struct WebPMux(sys::WebPMux) via webp_mux_delete;
+}
+
+/// `ForeignOwned::release` hands us `&sys::WebPDemuxer`; libwebp's destructor
+/// takes `WebPDemuxer*`. `&` to an [`bun_opaque::opaque_ffi!`] ZST is
+/// ABI-identical to that non-null pointer, and `as_mut_ptr` is the sanctioned
+/// interior-mutability route to it.
+fn webp_demux_delete(dmux: &sys::WebPDemuxer) {
+    // SAFETY: reached only from `ForeignRef::drop`, which owns the sole unit
+    // adopted from `WebPDemuxInternal` and gives it back exactly once.
+    unsafe { WebPDemuxDelete(dmux.as_mut_ptr()) }
+}
+
+/// Same shape as [`webp_demux_delete`], for `WebPMuxDelete`.
+fn webp_mux_delete(mux: &sys::WebPMux) {
+    // SAFETY: reached only from `ForeignRef::drop`, which owns the sole unit
+    // adopted from `WebPNewInternal` and gives it back exactly once.
+    unsafe { WebPMuxDelete(mux.as_mut_ptr()) }
 }
 
 // `WebPDemux()` and `WebPMuxNew()` are `static inline` in the headers and
@@ -95,27 +137,31 @@ unsafe extern "C" {
         allow_partial: c_int,
         state: *mut c_int,
         version: c_int,
-    ) -> *mut WebPDemuxer;
-    fn WebPDemuxDelete(dmux: *mut WebPDemuxer);
-    fn WebPDemuxGetI(dmux: *const WebPDemuxer, feature: c_int) -> u32;
+    ) -> *mut sys::WebPDemuxer;
+    fn WebPDemuxDelete(dmux: *mut sys::WebPDemuxer);
+    fn WebPDemuxGetI(dmux: *const sys::WebPDemuxer, feature: c_int) -> u32;
     fn WebPDemuxGetChunk(
-        dmux: *const WebPDemuxer,
+        dmux: *const sys::WebPDemuxer,
         fourcc: *const u8,
         chunk_number: c_int,
         iter: *mut WebPChunkIterator,
     ) -> c_int;
     fn WebPDemuxReleaseChunkIterator(iter: *mut WebPChunkIterator);
 
-    fn WebPNewInternal(version: c_int) -> *mut WebPMux;
-    fn WebPMuxDelete(mux: *mut WebPMux);
-    fn WebPMuxSetImage(mux: *mut WebPMux, bitstream: *const WebPData, copy_data: c_int) -> c_int;
+    fn WebPNewInternal(version: c_int) -> *mut sys::WebPMux;
+    fn WebPMuxDelete(mux: *mut sys::WebPMux);
+    fn WebPMuxSetImage(
+        mux: *mut sys::WebPMux,
+        bitstream: *const WebPData,
+        copy_data: c_int,
+    ) -> c_int;
     fn WebPMuxSetChunk(
-        mux: *mut WebPMux,
+        mux: *mut sys::WebPMux,
         fourcc: *const u8,
         chunk_data: *const WebPData,
         copy_data: c_int,
     ) -> c_int;
-    fn WebPMuxAssemble(mux: *mut WebPMux, assembled_data: *mut WebPData) -> c_int;
+    fn WebPMuxAssemble(mux: *mut sys::WebPMux, assembled_data: *mut WebPData) -> c_int;
 }
 
 pub fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, codecs::Error> {
@@ -182,22 +228,23 @@ pub fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, codecs::
                 WEBP_DEMUX_ABI_VERSION,
             )
         };
-        if dmux.is_null() {
+        // SAFETY: `WebPDemuxInternal` is the producer: on success it transfers
+        // the sole ownership unit of a freshly parsed demuxer (nothing else
+        // holds it; `WebPDemuxDelete` is its only deallocator). On failure it
+        // returns null having already freed whatever it allocated, so there is
+        // no unit to adopt — `adopt_ptr` yields `None` and releases nothing.
+        let Some(dmux) = (unsafe { WebPDemuxer::adopt_ptr(dmux) }) else {
             break 'blk None;
-        }
-        let _free_dmux = scopeguard::guard(dmux, |d| {
-            // SAFETY: d was returned by WebPDemuxInternal above and is non-null; matching destructor.
-            unsafe { WebPDemuxDelete(d) }
-        });
+        };
         // SAFETY: dmux is a live demuxer handle.
-        if unsafe { WebPDemuxGetI(dmux, WEBP_FF_FORMAT_FLAGS) } & ICCP_FLAG == 0 {
+        if unsafe { WebPDemuxGetI(dmux.as_ptr(), WEBP_FF_FORMAT_FLAGS) } & ICCP_FLAG == 0 {
             break 'blk None;
         }
         // SAFETY: all-zero is a valid WebPChunkIterator (#[repr(C)] POD, raw ptr + ints).
         let mut iter: WebPChunkIterator =
             unsafe { core::mem::MaybeUninit::<WebPChunkIterator>::zeroed().assume_init() };
         // SAFETY: dmux is live; fourcc reads exactly 4 bytes; iter is a valid out-param.
-        if unsafe { WebPDemuxGetChunk(dmux, b"ICCP".as_ptr(), 1, &raw mut iter) } == 0 {
+        if unsafe { WebPDemuxGetChunk(dmux.as_ptr(), b"ICCP".as_ptr(), 1, &raw mut iter) } == 0 {
             break 'blk None;
         }
         let iter = scopeguard::guard(iter, |mut it| {
@@ -292,19 +339,20 @@ pub(crate) fn encode(
     });
     // SAFETY: WebPNewInternal has no preconditions.
     let mux = unsafe { WebPNewInternal(WEBP_MUX_ABI_VERSION) };
-    if mux.is_null() {
+    // SAFETY: `WebPNewInternal` is the producer: on success it transfers the
+    // sole ownership unit of a fresh, empty mux (`WebPMuxDelete` is its only
+    // deallocator). On ABI mismatch or allocation failure it returns null
+    // having allocated nothing, so `adopt_ptr` yields `None` and releases
+    // nothing. The handle's `Drop` deletes the mux on every path below.
+    let Some(mux) = (unsafe { WebPMux::adopt_ptr(mux) }) else {
         return Err(codecs::Error::OutOfMemory);
-    }
-    let _free_mux = scopeguard::guard(mux, |m| {
-        // SAFETY: m was returned by WebPNewInternal above and is non-null; matching destructor.
-        unsafe { WebPMuxDelete(m) }
-    });
+    };
     let img = WebPData {
         bytes: bitstream.as_ptr(),
         size: bitstream.len(),
     };
     // SAFETY: mux is live; img points to valid borrowed data.
-    if unsafe { WebPMuxSetImage(mux, &raw const img, 0) } != WEBP_MUX_OK {
+    if unsafe { WebPMuxSetImage(mux.as_ptr(), &raw const img, 0) } != WEBP_MUX_OK {
         return Err(codecs::Error::EncodeFailed);
     }
     let icc = WebPData {
@@ -312,12 +360,13 @@ pub(crate) fn encode(
         size: profile.len(),
     };
     // SAFETY: mux is live; fourcc reads exactly 4 bytes; icc points to valid borrowed data.
-    if unsafe { WebPMuxSetChunk(mux, b"ICCP".as_ptr(), &raw const icc, 0) } != WEBP_MUX_OK {
+    if unsafe { WebPMuxSetChunk(mux.as_ptr(), b"ICCP".as_ptr(), &raw const icc, 0) } != WEBP_MUX_OK
+    {
         return Err(codecs::Error::EncodeFailed);
     }
     let mut assembled = WebPData::default();
     // SAFETY: mux is live; assembled is a valid out-param.
-    if unsafe { WebPMuxAssemble(mux, &raw mut assembled) } != WEBP_MUX_OK {
+    if unsafe { WebPMuxAssemble(mux.as_ptr(), &raw mut assembled) } != WEBP_MUX_OK {
         // `WebPMuxAssemble` writes a half-built buffer into `assembled` even
         // on failure; its contract says `WebPDataClear` (i.e. `WebPFree`) is
         // safe to call on any return.

--- a/src/runtime/ipc_host.rs
+++ b/src/runtime/ipc_host.rs
@@ -144,9 +144,7 @@ pub(crate) fn do_send(
             match unsafe { (*listener).listener.get() } {
                 crate::socket::listener::ListenerType::Uws(socket_uws) => {
                     // may need to handle ssl case
-                    let fd = bun_opaque::opaque_deref_mut(socket_uws)
-                        .get_socket()
-                        .get_fd();
+                    let fd = bun_opaque::opaque_deref(socket_uws).get_socket().get_fd();
                     zig_handle = Some(Handle::init(fd, handle));
                 }
                 crate::socket::listener::ListenerType::NamedPipe(_named_pipe) => {}

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1614,9 +1614,8 @@ unsafe fn retroactively_report_discovered_tests(agent: *mut bun_jsc::debugger::T
     let mut max_id: i32 = 0;
 
     // Recursively report all discovered tests starting from root scope.
-    // SAFETY: `agent` is a live C++ handle (fn contract).
     retroactively_report_scope(
-        unsafe { &mut *agent },
+        TestReporterHandle::opaque_ref(agent),
         &mut active_file.collection.root_scope,
         -1,
         &mut max_id,
@@ -1628,7 +1627,7 @@ unsafe fn retroactively_report_discovered_tests(agent: *mut bun_jsc::debugger::T
     let _ = max_id;
 
     fn retroactively_report_scope(
-        agent: &mut TestReporterHandle,
+        agent: &TestReporterHandle,
         scope: &mut DescribeScope,
         parent_id: i32,
         max_id: &mut i32,

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -442,10 +442,10 @@ mod _impl {
                         self.flush as c_uint,
                     )
                 },
-                // SAFETY: state is a valid DCtx.
+                // SAFETY: state is a valid, non-null DCtx (checked above).
                 NodeMode::ZSTD_DECOMPRESS => unsafe {
                     c::ZSTD_decompressStream(
-                        self.state_ptr().cast(),
+                        c::ZSTD_DStream::opaque_ref(self.state_ptr().cast()),
                         &raw mut self.output,
                         &raw mut self.input,
                     )

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -244,7 +244,7 @@ impl FileRoute {
                 }
             }
             AnyResponse::H3(s) => {
-                let s = bun_opaque::opaque_deref_mut(s);
+                let s = bun_opaque::opaque_deref(s);
                 for (name, value) in names.iter().zip(values) {
                     s.write_header(sp_slice(*name, buf), sp_slice(*value, buf));
                 }
@@ -275,7 +275,7 @@ impl FileRoute {
                 let mut b = bun_core::fmt::ItoaBuf::new();
                 let s = bun_core::fmt::itoa(&mut b, status);
                 // S008: `h3::Response` is an `opaque_ffi!` ZST — safe deref.
-                bun_opaque::opaque_deref_mut(r).write_status(s);
+                bun_opaque::opaque_deref(r).write_status(s);
             }
         }
     }

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3632,7 +3632,7 @@ where
             self.do_write_status(status);
         }
 
-        if let Some(mut cookies) = self.cookies.take() {
+        if let Some(cookies) = self.cookies.take() {
             // SAFETY: BACKREF
             let global_this = self.server().global_this();
             let r = cookies.write(

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -76,7 +76,7 @@ impl AnyResponseExt for uws::AnyResponse {
         match self {
             uws::AnyResponse::SSL(p) => bun_opaque::opaque_deref_mut(p).has_responded(),
             uws::AnyResponse::TCP(p) => bun_opaque::opaque_deref_mut(p).has_responded(),
-            uws::AnyResponse::H3(p) => bun_opaque::opaque_deref_mut(p).has_responded(),
+            uws::AnyResponse::H3(p) => bun_opaque::opaque_deref(p).has_responded(),
         }
     }
     #[inline]
@@ -88,9 +88,7 @@ impl AnyResponseExt for uws::AnyResponse {
             uws::AnyResponse::TCP(p) => {
                 bun_opaque::opaque_deref_mut(p).override_write_offset(offset)
             }
-            uws::AnyResponse::H3(p) => {
-                bun_opaque::opaque_deref_mut(p).override_write_offset(offset)
-            }
+            uws::AnyResponse::H3(p) => bun_opaque::opaque_deref(p).override_write_offset(offset),
         }
     }
 }

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -325,7 +325,7 @@ impl ServerConfig {
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub(crate) fn apply_static_route<const SSL: bool, T>(
     server: AnyServer,
-    app: &mut uws::NewApp<SSL>,
+    app: &uws::NewApp<SSL>,
     entry: *mut T,
     path: &[u8],
     method: http_method::Optional,

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -476,7 +476,7 @@ impl StaticRoute {
                 let mut b = bun_core::fmt::ItoaBuf::new();
                 let s = bun_core::fmt::itoa(&mut b, status);
                 // S008: `h3::Response` is an `opaque_ffi!` ZST — safe deref.
-                bun_opaque::opaque_deref_mut(r).write_status(s);
+                bun_opaque::opaque_deref(r).write_status(s);
             }
         }
     }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -534,7 +534,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 let mut port = *port;
                 if let Some(listener) = self.listener {
                     // S012: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
-                    port = bun_opaque::opaque_deref_mut(listener).get_local_port() as u16;
+                    port = bun_opaque::opaque_deref(listener).get_local_port() as u16;
                 } else if Self::HAS_H3 {
                     if let Some(h3l) = self.h3_listener {
                         // S012: `h3::ListenSocket` is an `opaque_ffi!` ZST — safe deref.
@@ -1465,16 +1465,16 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
     pub fn set_flags(&self, require_host_header: bool, use_strict_method_validation: bool) {
         if let Some(app) = self.app {
-            // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-            bun_opaque::opaque_deref_mut(app)
+            // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &` deref.
+            bun_opaque::opaque_deref(app)
                 .set_flags(require_host_header, use_strict_method_validation);
         }
     }
 
     pub fn set_max_http_header_size(&self, max_header_size: u64) {
         if let Some(app) = self.app {
-            // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-            bun_opaque::opaque_deref_mut(app).set_max_http_header_size(max_header_size);
+            // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &` deref.
+            bun_opaque::opaque_deref(app).set_max_http_header_size(max_header_size);
         }
     }
 
@@ -1554,14 +1554,14 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
         if !abrupt {
             // S012: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
-            bun_opaque::opaque_deref_mut(listener).close();
+            bun_opaque::opaque_deref(listener).close();
         } else if !self.flags.contains(ServerFlags::TERMINATED) {
             if let Some(ws) = self.config.websocket.as_mut() {
                 ws.handler.app = None;
             }
             self.flags.insert(ServerFlags::TERMINATED);
-            // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-            bun_opaque::opaque_deref_mut(self.app.unwrap()).close();
+            // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &` deref.
+            bun_opaque::opaque_deref(self.app.unwrap()).close();
         }
     }
 
@@ -1660,8 +1660,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             // binding alive should not pin `dev.memory_cost()` bytes.
             if let Some(dev) = self.dev_server.take() {
                 if let Some(app) = self.app {
-                    // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                    bun_opaque::opaque_deref_mut(app).clear_routes();
+                    // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &` deref.
+                    bun_opaque::opaque_deref(app).clear_routes();
                 }
                 drop(dev); // dev.deinit()
             }
@@ -1690,8 +1690,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             self.flags.insert(ServerFlags::TERMINATED);
             let app = self.app.unwrap();
             vm.enqueue_task(bun_event_loop::ManagedTask::ManagedTask::new(app, |app| {
-                // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                bun_opaque::opaque_deref_mut(app).close();
+                // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &` deref.
+                bun_opaque::opaque_deref(app).close();
                 Ok(())
             }));
         }
@@ -1980,9 +1980,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     fn set_routes(&mut self) -> JSValue {
         use bun_http_types::Method as http_method;
         let mut route_list_value = JSValue::ZERO;
-        // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
+        // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &` deref.
         // set_routes is only called after `self.app = Some(..)` in listen().
-        let app = bun_opaque::opaque_deref_mut(self.app.unwrap());
+        let app = bun_opaque::opaque_deref(self.app.unwrap());
         let self_ptr: *mut Self = self;
         let any_server = AnyServer::from(self_ptr.cast_const());
         // reshaped for borrowck — `dev_server` is `Option<Box<..>>`;
@@ -2038,7 +2038,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         if let Some(websocket) = self.config.websocket.as_mut() {
             websocket.global_object =
                 bun_ptr::BackRef::new(bun_opaque::opaque_deref(self.global_this));
-            websocket.handler.app = Some(std::ptr::from_mut(app).cast::<c_void>());
+            websocket.handler.app = Some(app.as_mut_ptr().cast::<c_void>());
             websocket
                 .handler
                 .flags
@@ -2437,7 +2437,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // compatibility layer for specific Node API routes, even if it's not
         // the main "/*" handler.
         if has_node_http {
-            ffi::NodeHTTP_assignOnNodeJSCompat(SSL, std::ptr::from_mut(app).cast::<c_void>());
+            ffi::NodeHTTP_assignOnNodeJSCompat(SSL, app.as_mut_ptr().cast::<c_void>());
         }
 
         route_list_value
@@ -2551,8 +2551,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 // SAFETY: name_ptr/name_len were just extracted from the live
                 // `config.ssl_config.server_name` CString; valid + NUL-terminated.
                 let server_name = unsafe { bun_core::ffi::cstr(name_ptr) };
-                // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                if bun_opaque::opaque_deref_mut(app)
+                // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &` deref.
+                if bun_opaque::opaque_deref(app)
                     .add_server_name_with_options(server_name, &ssl_options)
                     .is_err()
                 {
@@ -2574,8 +2574,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
                 // SAFETY: server_name is a CStr; ZStr::from_raw upholds the NUL invariant.
                 let z = unsafe { bun_core::ZStr::from_raw(name_ptr.cast(), name_len) };
-                // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                bun_opaque::opaque_deref_mut(app).domain(z);
+                // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &` deref.
+                bun_opaque::opaque_deref(app).domain(z);
                 if throw_ssl_error_if_necessary(global) {
                     // SAFETY: `this` is the live boxed server from `init()`, uniquely owned here.
                     Self::deinit(unsafe { bun_core::heap::take(this) });
@@ -2633,8 +2633,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                         }
                     }
                 }
-                // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                if bun_opaque::opaque_deref_mut(app)
+                // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &` deref.
+                if bun_opaque::opaque_deref(app)
                     .add_server_name_with_options(sni_name, &sni_opts)
                     .is_err()
                 {
@@ -2648,8 +2648,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     Self::deinit(unsafe { bun_core::heap::take(this) });
                     return JSValue::ZERO;
                 }
-                // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                bun_opaque::opaque_deref_mut(app).domain(z);
+                // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &` deref.
+                bun_opaque::opaque_deref(app).domain(z);
                 if throw_ssl_error_if_necessary(global) {
                     // SAFETY: `this` is the live boxed server from `init()`, uniquely owned here.
                     Self::deinit(unsafe { bun_core::heap::take(this) });
@@ -3517,7 +3517,7 @@ impl AnyServer {
         any_server_dispatch!(self, |s| match s.app {
             // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` via
             // `bun_opaque::opaque_deref_mut` (const-asserted ZST/align-1).
-            Some(app) => bun_opaque::opaque_deref_mut(app).num_subscribers(topic),
+            Some(app) => bun_opaque::opaque_deref(app).num_subscribers(topic),
             // Defensive 0
             // here for the post-stop window; assert in debug to catch misuse.
             None => {
@@ -3537,8 +3537,7 @@ impl AnyServer {
         any_server_dispatch!(self, |s| match s.app {
             // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` via
             // `bun_opaque::opaque_deref_mut` (const-asserted ZST/align-1).
-            Some(app) =>
-                bun_opaque::opaque_deref_mut(app).publish(topic, message, opcode, compress),
+            Some(app) => bun_opaque::opaque_deref(app).publish(topic, message, opcode, compress),
             // Defensive for the post-stop window; assert in debug to catch misuse.
             None => {
                 debug_assert!(false, "publish on server with no app");

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1343,15 +1343,15 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         GlobalRef::from(bun_opaque::opaque_deref(self.global_this))
     }
 
-    /// `&mut` accessor for the live uws App. Only call from paths where the
+    /// `&` accessor for the live uws App. Only call from paths where the
     /// server is running (`self.app` set in `listen()`).
     #[inline]
-    fn app_mut(&mut self) -> &mut uws_sys::NewApp<SSL> {
-        // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref via
-        // const-asserted `bun_opaque::opaque_deref_mut`. `self.app` is `Some`
+    fn app_ref(&self) -> &uws_sys::NewApp<SSL> {
+        // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &` deref via
+        // const-asserted `bun_opaque::opaque_deref`. `self.app` is `Some`
         // for the lifetime of any JS-reachable `Server` (set in `listen()`,
         // freed in `deinit()` after the JS wrapper is gone).
-        bun_opaque::opaque_deref_mut(self.app.expect("server not listening"))
+        bun_opaque::opaque_deref(self.app.expect("server not listening"))
     }
 
     /// Unbounded so `deinit()` (in
@@ -1463,7 +1463,7 @@ where
         }
 
         Ok(JSValue::js_number(f64::from(
-            self.app_mut().num_subscribers(topic.slice()),
+            self.app_ref().num_subscribers(topic.slice()),
         )))
     }
 
@@ -1938,7 +1938,7 @@ where
             // `uws_sys::Request` here.
             // S008: `uws::Request` is an `opaque_ffi!` ZST — safe deref
             // (BACKREF; live while RequestContext.req is Some).
-            let r = bun_opaque::opaque_deref_mut(req_ptr.cast::<uws_sys::Request>());
+            let r = bun_opaque::opaque_deref(req_ptr.cast::<uws_sys::Request>());
             if sec_websocket_key_str.len == 0 {
                 sec_websocket_key_str =
                     ZigString::init(r.header(b"sec-websocket-key").unwrap_or(b""));
@@ -2128,7 +2128,7 @@ where
 
         // SAFETY: `on_reload` is only reachable while the server is running
         // (`self.app` set in `listen()`).
-        self.app_mut().clear_routes();
+        self.app_ref().clear_routes();
         if Self::HAS_H3 {
             if let Some(h3a) = self.h3_app {
                 bun_opaque::opaque_deref_mut(h3a).clear_routes();
@@ -2222,7 +2222,7 @@ where
             return Ok(false);
         }
         self.config = self.config.clone_for_reloading_static_routes()?;
-        self.app_mut().clear_routes();
+        self.app_ref().clear_routes();
         if Self::HAS_H3 {
             if let Some(h3a) = self.h3_app {
                 bun_opaque::opaque_deref_mut(h3a).clear_routes();
@@ -2452,7 +2452,7 @@ where
         if self.app.is_none() {
             return Ok(JSValue::UNDEFINED);
         }
-        self.app_mut().close_idle_connections();
+        self.app_ref().close_idle_connections();
         Ok(JSValue::UNDEFINED)
     }
 
@@ -2489,9 +2489,7 @@ where
 
         if let Some(listener) = self.listener {
             // S008: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
-            return JSValue::js_number(
-                bun_opaque::opaque_deref_mut(listener).get_local_port() as f64
-            );
+            return JSValue::js_number(bun_opaque::opaque_deref(listener).get_local_port() as f64);
         }
         if Self::HAS_H3 {
             if let Some(h3l) = self.h3_listener {
@@ -2537,7 +2535,7 @@ where
 
                 if let Some(listener) = self.listener {
                     // S008: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
-                    let listener = bun_opaque::opaque_deref_mut(listener);
+                    let listener = bun_opaque::opaque_deref(listener);
                     port = u16::try_from(listener.get_local_port()).expect("int cast");
 
                     let mut buf = [0u8; 64];
@@ -2600,7 +2598,7 @@ where
             if let Some(listener) = self.listener {
                 let mut buf = [0u8; 1024];
                 // S008: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
-                if let Some(addr) = bun_opaque::opaque_deref_mut(listener)
+                if let Some(addr) = bun_opaque::opaque_deref(listener)
                     .socket()
                     .remote_address(&mut buf[..1024])
                 {
@@ -3618,8 +3616,8 @@ pub(super) fn server_set_on_client_error_(
                         // S008: `us_socket_t` is an `opaque_ffi!` ZST — safe deref.
                         this.on_client_error_callback(bun_opaque::opaque_deref_mut(socket), error_code, packet);
                     }
-                    // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                    bun_opaque::opaque_deref_mut(app).on_client_error(thunk, core::ptr::from_ref::<$T>(this).cast::<c_void>().cast_mut());
+                    // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &` deref.
+                    bun_opaque::opaque_deref(app).on_client_error(thunk, core::ptr::from_ref::<$T>(this).cast::<c_void>().cast_mut());
                 }
                 return Ok(JSValue::UNDEFINED);
             }

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2051,7 +2051,7 @@ where
 
         // `CookieMapRef` releases the moved-out ref on every exit path of this
         // scope (including the `?` below) once `cookies_to_write` drops.
-        let mut cookies_to_write = upgrader.cookies.take();
+        let cookies_to_write = upgrader.cookies.take();
 
         // Write status, custom headers, and cookies in one place
         if fetch_headers_to_use.is_some() || cookies_to_write.is_some() {
@@ -2066,7 +2066,7 @@ where
                     );
                 }
             }
-            if let Some(c) = cookies_to_write.as_mut() {
+            if let Some(c) = cookies_to_write.as_ref() {
                 c.write(
                     global,
                     ResponseKind::from(SSL, false),

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -85,7 +85,7 @@ pub struct Listener {
     /// `SSL_CTX*` for accepted sockets. One owned ref; `SSL_CTX_free` on close.
     /// `SSL_new()` per-accept takes its own ref, so accepted sockets outlive a
     /// stopped listener safely.
-    pub secure_ctx: Cell<Option<NonNull<boring_sys::SSL_CTX>>>,
+    pub secure_ctx: Cell<Option<NonNull<boring_sys::sys::SSL_CTX>>>,
     pub ssl: bool,
     pub protos: Option<Box<[u8]>>,
 
@@ -335,8 +335,8 @@ impl Listener {
             // SAFETY: this is still the sole owner on the error path
             let this_owned: Box<Listener> = unsafe { bun_core::heap::take(this) };
             if let Some(c) = this_owned.secure_ctx.get() {
-                // SAFETY: FFI — secure_ctx holds one owned SSL_CTX ref from create_ssl_context
-                unsafe { boring_sys::SSL_CTX_free(c.as_ptr()) };
+                // secure_ctx holds one owned SSL_CTX ref from create_ssl_context.
+                boring_sys::SSL_CTX_free(boring_sys::sys::SSL_CTX::opaque_ref(c.as_ptr()));
             }
             // protos: Box drops automatically when Listener is dropped below
             bun_core::asan::unregister_root_region(
@@ -353,7 +353,7 @@ impl Listener {
             match ssl_cfg.as_usockets().create_ssl_context(&mut create_err) {
                 Some(ctx) => this_ref
                     .secure_ctx
-                    .set(NonNull::new(ctx.cast::<boring_sys::SSL_CTX>())),
+                    .set(NonNull::new(ctx.cast::<boring_sys::sys::SSL_CTX>())),
                 None => {
                     return Err(global.throw_value(
                         crate::socket::uws_jsc::create_bun_socket_error_to_js(create_err, global),
@@ -403,7 +403,7 @@ impl Listener {
                 });
                 if !ls.is_null() {
                     // S008: `ListenSocket` is an `opaque_ffi!` ZST — safe deref.
-                    *port = u16::try_from(bun_opaque::opaque_deref_mut(ls).get_local_port())
+                    *port = u16::try_from(bun_opaque::opaque_deref(ls).get_local_port())
                         .expect("int cast");
                 }
                 ls
@@ -496,7 +496,7 @@ impl Listener {
                     // hint for sni_cb, not load-bearing — sni_find() miss falls
                     // through to the default SSL_CTX anyway.
                     // S008: `ListenSocket` is an `opaque_ffi!` ZST — safe deref.
-                    let _ = bun_opaque::opaque_deref_mut(listen_socket).add_server_name(
+                    let _ = bun_opaque::opaque_deref(listen_socket).add_server_name(
                         server_name,
                         secure.as_ptr().cast(),
                         core::ptr::null_mut(),
@@ -513,7 +513,7 @@ impl Listener {
             // resolution suspends the handshake until resumeSNI.
             if !this_ref.handlers.on_server_name().is_empty() {
                 // S008: `ListenSocket` is an `opaque_ffi!` ZST - safe deref.
-                bun_opaque::opaque_deref_mut(listen_socket).on_server_name(us_dispatch_server_name);
+                bun_opaque::opaque_deref(listen_socket).on_server_name(us_dispatch_server_name);
             }
         }
 
@@ -613,7 +613,7 @@ impl Listener {
         }
         if let uws::InternalSocket::Connected(s) = socket.socket {
             // S008: `us_socket_t` is an `opaque_ffi!` ZST — safe deref.
-            bun_opaque::opaque_deref_mut(s).set_kind(if SSL {
+            bun_opaque::opaque_deref(s).set_kind(if SSL {
                 uws_sys::SocketKind::BunSocketTls
             } else {
                 uws_sys::SocketKind::BunSocketTcp
@@ -661,7 +661,7 @@ impl Listener {
 
         // node:tls passes the native SecureContext (already-built SSL_CTX*) — no
         // re-parse. Bun.listen({tls}) callers may still pass a raw options dict.
-        let sni_ctx: *mut boring_sys::SSL_CTX =
+        let sni_ctx: *mut boring_sys::sys::SSL_CTX =
             if let Some(sc) = tls.as_class_ref::<SecureContext>() {
                 sc.borrow()
             } else if let Some(ssl_config) = {
@@ -693,11 +693,11 @@ impl Listener {
 
         // The C SNI tree SSL_CTX_up_ref()s; drop our build/borrow ref once added.
         // S008: `ListenSocket` is an `opaque_ffi!` ZST — safe deref.
-        let ls_ref = bun_opaque::opaque_deref_mut(ls);
+        let ls_ref = bun_opaque::opaque_deref(ls);
         ls_ref.remove_server_name(server_name);
         let ok = ls_ref.add_server_name(server_name, sni_ctx.cast(), core::ptr::null_mut());
-        // SAFETY: FFI — drop the +1 ref we took via borrow()/get_or_create(); SNI tree up_ref'd its own
-        unsafe { boring_sys::SSL_CTX_free(sni_ctx) };
+        // Drop the +1 we took via borrow()/get_or_create(); the SNI tree up_ref'd its own.
+        boring_sys::SSL_CTX_free(boring_sys::sys::SSL_CTX::opaque_ref(sni_ctx));
         if !ok {
             // Old entry was already removed; failing silently would leave the
             // hostname with no SNI mapping at all. Surface it.
@@ -761,7 +761,7 @@ impl Listener {
 
         match listener {
             // S008: `ListenSocket` is an `opaque_ffi!` ZST — safe deref.
-            ListenerType::Uws(socket) => bun_opaque::opaque_deref_mut(socket).close(),
+            ListenerType::Uws(socket) => bun_opaque::opaque_deref(socket).close(),
             #[cfg(windows)]
             ListenerType::NamedPipe(named_pipe) => {
                 // SAFETY: named_pipe is the unique owner; close_pipe_and_deinit
@@ -783,7 +783,7 @@ impl Listener {
             ListenerType::Uws(socket) => {
                 Self::unlink_unix_socket_path(&self);
                 // S008: `ListenSocket` is an `opaque_ffi!` ZST — safe deref.
-                bun_opaque::opaque_deref_mut(socket).close();
+                bun_opaque::opaque_deref(socket).close();
             }
             #[cfg(windows)]
             ListenerType::NamedPipe(named_pipe) => {
@@ -837,8 +837,8 @@ impl Listener {
         // SAFETY: group was init'd in listen(); not concurrently walked.
         unsafe { uws::SocketGroup::destroy(self.group.as_ptr()) };
         if let Some(ctx) = self.secure_ctx.get() {
-            // SAFETY: FFI — secure_ctx holds one owned SSL_CTX ref; release it
-            unsafe { boring_sys::SSL_CTX_free(ctx.as_ptr()) };
+            // secure_ctx holds one owned SSL_CTX ref; release it.
+            boring_sys::SSL_CTX_free(boring_sys::sys::SSL_CTX::opaque_ref(ctx.as_ptr()));
         }
 
         // connection / protos / the handlers `Rc`: dropped with the Box below
@@ -878,7 +878,7 @@ impl Listener {
         match this.listener.get() {
             ListenerType::Uws(uws_listener) => {
                 // S008: `ListenSocket` is an `opaque_ffi!` ZST — safe deref.
-                let socket = bun_opaque::opaque_deref_mut(uws_listener).socket::<false>();
+                let socket = bun_opaque::opaque_deref(uws_listener).socket::<false>();
                 // On Windows the listening socket fd is a system-kind SOCKET
                 // handle; routing it through `.uv()` panics for anything but
                 // stdio. The sys_jsc helper branches on kind
@@ -995,7 +995,7 @@ impl Listener {
         // Resolve the prebuilt SSL_CTX before the platform branches so the Windows
         // named-pipe path can adopt it. node:tls passes the native SecureContext as
         // `tls.secureContext` so we share its already-built SSL_CTX.
-        let mut owned_ssl_ctx: Option<NonNull<boring_sys::SSL_CTX>> = None;
+        let mut owned_ssl_ctx: Option<NonNull<boring_sys::sys::SSL_CTX>> = None;
         if ssl_enabled {
             let native_sc: Option<&SecureContext> = 'blk: {
                 let Some(tls_js) = opts.get_truthy(global, "tls")? else {
@@ -1015,8 +1015,8 @@ impl Listener {
         }
         let mut ssl_ctx_guard = scopeguard::guard(owned_ssl_ctx, |c| {
             if let Some(c) = c {
-                // SAFETY: FFI — c is a live SSL_CTX* with one owned ref from borrow()/get_or_create()
-                unsafe { boring_sys::SSL_CTX_free(c.as_ptr()) };
+                // One owned ref from borrow()/get_or_create().
+                boring_sys::SSL_CTX_free(boring_sys::sys::SSL_CTX::opaque_ref(c.as_ptr()));
             }
         });
 
@@ -1249,7 +1249,7 @@ impl Listener {
                 let mut create_err = uws::create_bun_socket_error_t::none;
                 match with_ssl_ctx_cache(|cache| cache.get_or_create(ssl_cfg, &mut create_err)) {
                     Some(ctx) => {
-                        *ssl_ctx_guard = NonNull::new(ctx.cast::<boring_sys::SSL_CTX>());
+                        *ssl_ctx_guard = NonNull::new(ctx.cast::<boring_sys::sys::SSL_CTX>());
                     }
                     None => {
                         return Err(global.throw_value(
@@ -1327,7 +1327,7 @@ impl Listener {
         let mut buf = [0u8; 64];
         let mut text_buf = [0u8; 512];
         // S008: `ListenSocket` is an `opaque_ffi!` ZST — safe deref.
-        let socket_ref = bun_opaque::opaque_deref_mut(socket);
+        let socket_ref = bun_opaque::opaque_deref(socket);
         let address_bytes: &[u8] = match socket_ref.get_local_address(&mut buf) {
             Ok(b) => b,
             Err(_) => return Ok(JSValue::UNDEFINED),
@@ -1378,7 +1378,7 @@ fn connect_finish<const IS_SSL: bool>(
     connection: UnixOrHost,
     local_binding: Option<(Box<[u8]>, u16)>,
     mut ssl: Option<&mut SSLConfig>,
-    owned_ssl_ctx: Option<NonNull<boring_sys::SSL_CTX>>,
+    owned_ssl_ctx: Option<NonNull<boring_sys::sys::SSL_CTX>>,
     default_data: JSValue,
     allow_half_open: bool,
     port: Option<u16>,
@@ -1409,8 +1409,8 @@ fn connect_finish<const IS_SSL: bool>(
         prev.server_name
             .set(ssl.as_mut().and_then(|s| s.take_server_name()));
         if let Some(old) = prev.owned_ssl_ctx.get() {
-            // SAFETY: FFI — old is the previous owned SSL_CTX ref on this reused socket
-            unsafe { boring_sys::SSL_CTX_free(old) };
+            // `old` is the previous owned SSL_CTX ref on this reused socket.
+            boring_sys::SSL_CTX_free(boring_sys::sys::SSL_CTX::opaque_ref(old));
         }
         prev.owned_ssl_ctx.set(owned_ssl_ctx.map(|p| p.as_ptr()));
         prev
@@ -1567,7 +1567,7 @@ pub struct WindowsNamedPipeListeningContext {
     /// JSC_BORROW: process-lifetime singleton; `&'static` so call sites read
     /// `self.vm.is_shutting_down()` without a raw-pointer deref.
     pub vm: &'static VirtualMachine,
-    pub ctx: Option<NonNull<boring_sys::SSL_CTX>>, // server reuses the same ctx
+    pub ctx: Option<NonNull<boring_sys::sys::SSL_CTX>>, // server reuses the same ctx
 }
 
 #[cfg(not(windows))]
@@ -1692,7 +1692,7 @@ impl WindowsNamedPipeListeningContext {
             let mut err = uws::create_bun_socket_error_t::none;
             // Create SSL context using uSockets to match behavior of node.js
             match ctx_opts.create_ssl_context(&mut err) {
-                Some(ctx) => this_ref.ctx = NonNull::new(ctx.cast::<boring_sys::SSL_CTX>()),
+                Some(ctx) => this_ref.ctx = NonNull::new(ctx.cast::<boring_sys::sys::SSL_CTX>()),
                 None => return Err(bun_core::err!("InvalidOptions")),
             }
         }
@@ -1740,8 +1740,8 @@ impl WindowsNamedPipeListeningContext {
     fn deinit(mut self: Box<Self>) {
         self.listener = None;
         if let Some(ctx) = self.ctx.take() {
-            // SAFETY: the server owns the only reference to this context.
-            unsafe { boring_sys::SSL_CTX_free(ctx.as_ptr()) };
+            // The server owns the only reference to this context.
+            boring_sys::SSL_CTX_free(boring_sys::sys::SSL_CTX::opaque_ref(ctx.as_ptr()));
         }
     }
 }
@@ -1775,7 +1775,7 @@ pub(crate) extern "C" fn us_dispatch_server_name(
     }
     // The accept group's ext holds the owning `*mut Listener` for the lifetime
     // of the listen socket. S008: `ListenSocket` is an `opaque_ffi!` ZST.
-    let listener_ptr: *mut Listener = bun_opaque::opaque_deref_mut(ls).group().owner::<Listener>();
+    let listener_ptr: *mut Listener = bun_opaque::opaque_deref(ls).group().owner::<Listener>();
     if listener_ptr.is_null() {
         return core::ptr::null_mut();
     }

--- a/src/runtime/socket/SSLConfig.rs
+++ b/src/runtime/socket/SSLConfig.rs
@@ -306,8 +306,8 @@ fn handle_file(
             jsc::generated::SSLConfigFile::String(val) => SingleFile::String(val.get()),
             jsc::generated::SSLConfigFile::Buffer(val) => {
                 // SAFETY: GenVal::get() yields a non-null pointer valid for the
-                // lifetime of `generated`; we narrow it to `&mut` for the call.
-                SingleFile::Buffer(unsafe { &mut *val.get() })
+                // lifetime of `generated`.
+                SingleFile::Buffer(unsafe { &*val.get() })
             }
             jsc::generated::SSLConfigFile::File(val) => {
                 // SAFETY: opaque `GenBlob` (`*mut c_void`) is the JS class `m_ctx`
@@ -348,7 +348,7 @@ fn handle_file_array(
                 jsc::generated::SSLConfigSingleFile::Buffer(val) => {
                     // SAFETY: see `handle_file` above — non-null GenVal pointers
                     // valid for the lifetime of `generated`.
-                    SingleFile::Buffer(unsafe { &mut *val.get() })
+                    SingleFile::Buffer(unsafe { &*val.get() })
                 }
                 jsc::generated::SSLConfigSingleFile::File(val) => {
                     // SAFETY: opaque `GenBlob` (`*mut c_void`) is layout-identical
@@ -364,7 +364,7 @@ fn handle_file_array(
 
 enum SingleFile<'a> {
     String(bun_core::String),
-    Buffer(&'a mut jsc::JSCArrayBuffer),
+    Buffer(&'a jsc::JSCArrayBuffer),
     File(&'a mut crate::webcore::Blob),
 }
 

--- a/src/runtime/socket/SocketAddress.rs
+++ b/src/runtime/socket/SocketAddress.rs
@@ -209,15 +209,10 @@ impl SocketAddress {
             OwnedString::new(str)
         };
 
-        let Some(url_ptr) = URL::from_string(url_str.get()) else {
+        // Owns the C++ heap `WTF::URL`; `Drop` frees it on scope exit.
+        let Some(url) = URL::from_string(url_str.get()) else {
             return Ok(JSValue::UNDEFINED);
         };
-        // SAFETY: URL::from_string returns an owned C++ heap pointer; freed exactly once via destroy().
-        let _url_guard = scopeguard::guard(url_ptr, |p| unsafe { URL::destroy(p.as_ptr()) });
-        // `_url_guard` keeps the C++ allocation live for this scope, so the
-        // `BackRef` liveness invariant holds; `Deref` encapsulates the single
-        // `NonNull::as_ref` site.
-        let url = bun_ptr::BackRef::from(url_ptr);
         let host: BunString = url.host();
         let port_: u16 = {
             let port32 = url.port();

--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -348,13 +348,12 @@ impl UpgradedDuplex {
     /// memoised `SecureContext` can be reused on the duplex/named-pipe path.
     pub(crate) fn start_tls_with_ctx(
         &mut self,
-        ctx: *mut bun_boringssl_sys::SSL_CTX,
+        ctx: *mut bun_boringssl_sys::sys::SSL_CTX,
         is_client: bool,
     ) -> Result<(), bun_core::Error> {
         // errdefer SSL_CTX_free(ctx) — free the adopted ref on the error path only.
         let ctx_guard = scopeguard::guard(ctx, |ctx| {
-            // SAFETY: ctx is a valid SSL_CTX* with one ref adopted by this fn.
-            unsafe { bun_boringssl_sys::SSL_CTX_free(ctx) };
+            bun_boringssl_sys::SSL_CTX_free(bun_boringssl_sys::sys::SSL_CTX::opaque_ref(ctx));
         });
         let ctx_nn =
             NonNull::new(ctx).expect("caller passes a non-null SSL_CTX* with one adopted ref");

--- a/src/runtime/socket/WindowsNamedPipe.rs
+++ b/src/runtime/socket/WindowsNamedPipe.rs
@@ -718,7 +718,7 @@ impl WindowsNamedPipe {
     pub fn get_accepted_by(
         &mut self,
         server: &mut uv::Pipe,
-        ssl_ctx: Option<*mut boringssl::SSL_CTX>,
+        ssl_ctx: Option<*mut boringssl::sys::SSL_CTX>,
     ) -> bun_sys::Result<()> {
         #[cfg(windows)]
         debug_assert!(self.pipe.is_some());
@@ -751,11 +751,8 @@ impl WindowsNamedPipe {
                     });
                 }
             };
-            // ref because we are accepting will unref when wrapper deinit.
-            // SAFETY: `tls_nn` proven non-null above
-            // (`NonNull::new(tls).expect(..)`); `SSL_CTX_up_ref` only bumps the
-            // atomic refcount on a live `SSL_CTX*`.
-            let _ = unsafe { boringssl::SSL_CTX_up_ref(tls_nn.as_ptr()) };
+            // ref because we are accepting; unref'd when the wrapper deinits.
+            let _ = boringssl::SSL_CTX_up_ref(boringssl::sys::SSL_CTX::opaque_ref(tls_nn.as_ptr()));
         }
         #[cfg(windows)]
         {
@@ -814,7 +811,7 @@ impl WindowsNamedPipe {
         &mut self,
         fd: Fd,
         ssl_options: Option<SSLConfig>,
-        owned_ctx: Option<*mut boringssl::SSL_CTX>,
+        owned_ctx: Option<*mut boringssl::sys::SSL_CTX>,
     ) -> bun_sys::Result<()> {
         debug_assert!(self.pipe.is_some());
         self.flags.set_disconnected(true);
@@ -856,7 +853,7 @@ impl WindowsNamedPipe {
         &mut self,
         path: &[u8],
         ssl_options: Option<SSLConfig>,
-        owned_ctx: Option<*mut boringssl::SSL_CTX>,
+        owned_ctx: Option<*mut boringssl::sys::SSL_CTX>,
     ) -> bun_sys::Result<()> {
         debug_assert!(self.pipe.is_some());
         self.flags.set_disconnected(true);
@@ -919,7 +916,7 @@ impl WindowsNamedPipe {
         &mut self,
         _fd: Fd,
         _ssl_options: Option<SSLConfig>,
-        _owned_ctx: Option<*mut boringssl::SSL_CTX>,
+        _owned_ctx: Option<*mut boringssl::sys::SSL_CTX>,
     ) -> bun_sys::Result<()> {
         // Unreachable on POSIX — `WindowsNamedPipeContext` is aliased to `()` there;
         // this stub exists only so the module type-checks across platforms.
@@ -931,7 +928,7 @@ impl WindowsNamedPipe {
         &mut self,
         _path: &[u8],
         _ssl_options: Option<SSLConfig>,
-        _owned_ctx: Option<*mut boringssl::SSL_CTX>,
+        _owned_ctx: Option<*mut boringssl::sys::SSL_CTX>,
     ) -> bun_sys::Result<()> {
         // Unreachable on POSIX — see `open` above.
         unreachable!("WindowsNamedPipe::connect is windows-only")
@@ -948,7 +945,7 @@ impl WindowsNamedPipe {
     fn init_tls_wrapper(
         &mut self,
         ssl_options: Option<SSLConfig>,
-        owned_ctx: Option<*mut boringssl::SSL_CTX>,
+        owned_ctx: Option<*mut boringssl::sys::SSL_CTX>,
     ) -> Option<bun_sys::Result<()>> {
         let handlers = ssl_wrapper::Handlers {
             ctx: std::ptr::from_mut(self),
@@ -966,8 +963,8 @@ impl WindowsNamedPipe {
             self.wrapper = match WrapperType::init_with_ctx(ctx_nn, true, handlers) {
                 Ok(w) => Some(w),
                 Err(_) => {
-                    // SAFETY: ctx is a valid SSL_CTX* with one adopted ref
-                    unsafe { boringssl::SSL_CTX_free(ctx) };
+                    // One adopted ref, given back here.
+                    boringssl::SSL_CTX_free(boringssl::sys::SSL_CTX::opaque_ref(ctx));
                     return Some(bun_sys::Result::Err(bun_sys::Error {
                         errno: bun_sys::E::EPIPE as _,
                         syscall: bun_sys::Tag::connect,

--- a/src/runtime/socket/WindowsNamedPipeContext.rs
+++ b/src/runtime/socket/WindowsNamedPipeContext.rs
@@ -406,7 +406,7 @@ impl WindowsNamedPipeContext {
         global_this: &JSGlobalObject,
         fd: Fd,
         ssl_config: Option<SSLConfig>,
-        owned_ctx: Option<*mut boringssl::SSL_CTX>,
+        owned_ctx: Option<*mut boringssl::sys::SSL_CTX>,
         socket: SocketType,
     ) -> Result<*mut WindowsNamedPipe, bun_core::Error> {
         // TODO: reuse the same context for multiple connections when possibles
@@ -429,7 +429,7 @@ impl WindowsNamedPipeContext {
         global_this: &JSGlobalObject,
         path: &[u8],
         ssl_config: Option<SSLConfig>,
-        owned_ctx: Option<*mut boringssl::SSL_CTX>,
+        owned_ctx: Option<*mut boringssl::sys::SSL_CTX>,
         socket: SocketType,
     ) -> Result<*mut WindowsNamedPipe, bun_core::Error> {
         // TODO: reuse the same context for multiple connections when possibles

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -12,7 +12,7 @@ use bun_ptr::IntrusiveRc;
 // do NOT `use bun_boringssl_sys::SSL` here — it shadows the
 // `const SSL: bool` generic param in `NewSocket<SSL>` below, making rustc
 // resolve `<SSL>` as a type arg (E0747). Use the qualified path instead.
-use bun_boringssl_sys::SSL_CTX;
+use bun_boringssl_sys::sys::SSL_CTX;
 use bun_collections::VecExt;
 use bun_core::{self, fmt as bun_fmt};
 use bun_jsc::{self as jsc, CallFrame, JSGlobalObject, JSValue, JsRef, JsResult, SystemError};
@@ -1165,7 +1165,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             }
             if let Some(promise) = handlers.take_promise() {
                 // reject the promise on connect() error
-                let js_promise = jsc::JSPromise::opaque_mut(promise.as_promise().unwrap());
+                let js_promise = jsc::JSPromise::opaque_ref(promise.as_promise().unwrap());
                 let err_value = err.to_error_instance_with_async_stack(&global, js_promise);
                 js_promise.reject(&global, Ok(err_value))?;
             } else {
@@ -1199,7 +1199,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         } else if let Some(val) = handlers.take_promise() {
             // They've defined a `connectError` callback
             // The error is effectively handled, but we should still reject the promise.
-            let promise = jsc::JSPromise::opaque_mut(JSValue::as_promise(val).unwrap());
+            let promise = jsc::JSPromise::opaque_ref(JSValue::as_promise(val).unwrap());
             let err_ = err_for_promise
                 .take()
                 .to_error_instance_with_async_stack(&global, promise);
@@ -3051,8 +3051,8 @@ impl<const SSL: bool> NewSocket<SSL> {
             drop(connection);
         }
         if let Some(ctx) = this_ref.owned_ssl_ctx.take() {
-            // SAFETY: BoringSSL FFI; we hold one owned ref.
-            unsafe { boringssl_sys::SSL_CTX_free(ctx) };
+            // We hold one owned ref; give it back.
+            boringssl_sys::SSL_CTX_free(SSL_CTX::opaque_ref(ctx));
         }
         // SAFETY: `this` was heap-allocated in `new()`.
         drop(unsafe { bun_core::heap::take(this) });
@@ -3211,7 +3211,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         // `tls:` options. Either way `owned_ctx` holds one ref we drop in
         // deinit; SSL_new() takes its own.
         //
-        let owned_ctx: Option<boringssl_sys::OwnedSslCtx>;
+        let owned_ctx: Option<boringssl_sys::SSL_CTX>;
         let mut ssl_opts: Option<SSLConfig> = None;
         // Drop frees ssl_opts.
 
@@ -3241,8 +3241,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             };
             // `borrow()` returns a +1 ref (it calls `SSL_CTX_up_ref`).
             // SAFETY: that ref is ours to release.
-            owned_ctx =
-                unsafe { boringssl_sys::OwnedSslCtx::from_raw(sc.borrow().cast::<SSL_CTX>()) };
+            owned_ctx = unsafe { boringssl_sys::SSL_CTX::adopt_ptr(sc.borrow()) };
             // servername / ALPN still come from the surrounding tls config.
             if let Some(t) = opts.get_truthy(global, "tls")? {
                 if !t.is_boolean() {
@@ -3284,7 +3283,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             };
             owned_ctx = match cache.with_mut(|c| c.get_or_create(cfg, &mut create_err)) {
                 // SAFETY: `get_or_create` hands back a +1 ref.
-                Some(c) => unsafe { boringssl_sys::OwnedSslCtx::from_raw(c.cast::<SSL_CTX>()) },
+                Some(c) => unsafe { boringssl_sys::SSL_CTX::adopt_ptr(c) },
                 None => {
                     // us_ssl_ctx_from_options only sets *err for the CA/cipher
                     // cases; bad cert/key/DH return NULL with err==.none and the
@@ -3316,7 +3315,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         let vm = handlers.vm;
 
         // The +1 `SSL_CTX` ref transfers into `tls.owned_ssl_ctx` below.
-        let owned_ctx_taken = owned_ctx.map(|c| c.into_raw());
+        let owned_ctx_taken = owned_ctx.map(|c| c.leak().as_ptr());
 
         let cfg = ssl_opts.as_ref();
         let tls: bun_ptr::ThisPtr<TLSSocket> = TLSSocket::new(TLSSocket {
@@ -3449,7 +3448,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         tls.twin
             .set(Some(unsafe { IntrusiveRc::from_raw(raw.as_ptr()) }));
         // S008: `us_socket_t` is an `opaque_ffi!` ZST — safe deref.
-        bun_opaque::opaque_deref_mut(new_raw.as_ptr()).set_ssl_raw_tap(true);
+        bun_opaque::opaque_deref(new_raw.as_ptr()).set_ssl_raw_tap(true);
 
         let tls_js_value = tls.get_this_value(global);
         let raw_js_value = raw_ref.get_this_value(global);
@@ -3471,17 +3470,17 @@ impl<const SSL: bool> NewSocket<SSL> {
         // it before ext was repointed would have ALPN/onOpen land in the
         // dead TCPSocket.
         TLSSocket::on_open(tls, tls.socket.get());
-        bun_opaque::opaque_deref_mut(new_raw.as_ptr()).start_tls_handshake();
+        bun_opaque::opaque_deref(new_raw.as_ptr()).start_tls_handshake();
         // The socket being wrapped may have had its readable interest off (an
         // accepted socket nobody was reading yet — its ClientHello is still in
         // the kernel buffer); make sure the adopted TLS socket is reading so
         // the handshake can be driven. A no-op when it was already reading.
-        bun_opaque::opaque_deref_mut(new_raw.as_ptr()).resume();
+        bun_opaque::opaque_deref(new_raw.as_ptr()).resume();
         // Feed bytes that arrived before the upgrade (already pulled off the fd
         // by the plain-TCP layer) into the TLS engine exactly as if they had
         // just been received — for a server-side wrap this is the ClientHello.
         if !initial_data.is_empty() {
-            bun_opaque::opaque_deref_mut(new_raw.as_ptr()).tls_feed(initial_data.as_slice());
+            bun_opaque::opaque_deref(new_raw.as_ptr()).tls_feed(initial_data.as_slice());
         }
 
         let array = JSValue::create_empty_array(global, 2)?;
@@ -4130,8 +4129,8 @@ impl DuplexUpgradeContext {
         // Close raced ahead of StartTLS — drop the unconsumed config.
         self.ssl_config = None;
         if let Some(ctx) = self.owned_ctx.take() {
-            // SAFETY: BoringSSL FFI; we hold one owned ref.
-            unsafe { boringssl_sys::SSL_CTX_free(ctx) };
+            // We hold one owned ref; give it back.
+            boringssl_sys::SSL_CTX_free(SSL_CTX::opaque_ref(ctx));
         }
     }
 }
@@ -4191,7 +4190,7 @@ pub fn js_upgrade_duplex_to_tls(
     // duplex/named-pipe path shares one `SSL_CTX_new` with everyone else.
     // node:net wraps `[buntls]`'s return as `opts.tls.secureContext`; userland
     // may also pass it top-level. Same lookup as `upgradeTLS` above.
-    let mut owned_ctx: Option<boringssl_sys::OwnedSslCtx> = None;
+    let mut owned_ctx: Option<boringssl_sys::SSL_CTX> = None;
     let sc_js: JSValue = 'blk: {
         if let Some(v) = opts.get_truthy(global, "secureContext")? {
             break 'blk v;
@@ -4215,7 +4214,7 @@ pub fn js_upgrade_duplex_to_tls(
         };
         // `borrow()` returns a +1 ref (it calls `SSL_CTX_up_ref`).
         // SAFETY: that ref is ours to release.
-        owned_ctx = unsafe { boringssl_sys::OwnedSslCtx::from_raw(sc.borrow().cast::<SSL_CTX>()) };
+        owned_ctx = unsafe { boringssl_sys::SSL_CTX::adopt_ptr(sc.borrow()) };
     }
 
     // Still parse SSLConfig for servername/ALPN (those live on the JS-side
@@ -4267,7 +4266,7 @@ pub fn js_upgrade_duplex_to_tls(
     TLSSocket::data_set_cached(tls_js_value, global, default_data);
 
     // The +1 `SSL_CTX` ref transfers into `DuplexUpgradeContext.owned_ctx` below.
-    let owned_ctx_taken = owned_ctx.map(|c| c.into_raw());
+    let owned_ctx_taken = owned_ctx.map(|c| c.leak().as_ptr());
 
     // `DuplexUpgradeContext` is self-referential: `task.ctx` and
     // `upgrade.handlers.ctx` both point at the containing allocation, and

--- a/src/runtime/socket/tls_socket_functions.rs
+++ b/src/runtime/socket/tls_socket_functions.rs
@@ -17,7 +17,8 @@ use crate::api::bun_x509 as X509;
 // ──────────────────────────────────────────────────────────────────────────
 #[allow(non_camel_case_types, non_upper_case_globals)]
 pub(super) mod ffi {
-    use super::boringssl::{SSL, SSL_CTX, X509, X509_STORE, X509_STORE_CTX, struct_stack_st_X509};
+    use super::boringssl::sys::SSL_CTX;
+    use super::boringssl::{SSL, X509, X509_STORE, X509_STORE_CTX, struct_stack_st_X509};
     use core::ffi::{c_char, c_int, c_long, c_uint, c_void};
 
     // Re-export the one decl whose `*const c_char` NUL-terminated arg keeps a
@@ -544,7 +545,7 @@ pub(super) fn get_peer_certificate(
     // and released after its fields have been copied into JS values and the
     // terminal self-issued check has run.
     unsafe {
-        let mut store = ffi::SSL_CTX_get_cert_store(boringssl::SSL_CTX::opaque_ref(
+        let mut store = ffi::SSL_CTX_get_cert_store(boringssl::sys::SSL_CTX::opaque_ref(
             ffi::SSL_get_SSL_CTX(boringssl::SSL::opaque_ref(ssl_ptr)),
         ));
         // A context built without an explicit `ca` (and without requestCert,
@@ -902,11 +903,11 @@ pub(crate) fn set_key_cert(
                 ok_chain = ffi::SSL_set1_chain(ssl_ptr.cast(), chain);
             }
             if ok_cert != 1 || ok_key != 1 || ok_chain != 1 {
-                boringssl::SSL_CTX_free(ctx.cast());
+                boringssl::SSL_CTX_free(boringssl::sys::SSL_CTX::opaque_ref(ctx));
                 return Err(global.throw(format_args!("setKeyCert failed to apply the context")));
             }
         }
-        boringssl::SSL_CTX_free(ctx.cast());
+        boringssl::SSL_CTX_free(boringssl::sys::SSL_CTX::opaque_ref(ctx));
     }
     Ok(JSValue::UNDEFINED)
 }

--- a/src/runtime/socket/tls_socket_functions.rs
+++ b/src/runtime/socket/tls_socket_functions.rs
@@ -17,17 +17,52 @@ use crate::api::bun_x509 as X509;
 // ──────────────────────────────────────────────────────────────────────────
 #[allow(non_camel_case_types, non_upper_case_globals)]
 pub(super) mod ffi {
-    use super::boringssl::sys::SSL_CTX;
-    use super::boringssl::{SSL, X509, X509_STORE, X509_STORE_CTX, struct_stack_st_X509};
+    // The C objects, not the owning handles: the extern decls below traffic in
+    // `sys::X509` / `sys::X509_STORE` / `sys::X509_STORE_CTX`, and callers adopt
+    // the `+1`s into `boringssl::{X509, X509_STORE, X509_STORE_CTX}`.
+    use super::boringssl::sys::{SSL_CTX, X509, X509_STORE, X509_STORE_CTX};
+    use super::boringssl::{SSL, struct_stack_st_X509};
     use core::ffi::{c_char, c_int, c_long, c_uint, c_void};
 
     // Re-export the one decl whose `*const c_char` NUL-terminated arg keeps a
     // genuine caller precondition; the rest are re-declared `safe fn` below.
     pub(crate) use super::boringssl::SSL_set_tlsext_host_name;
 
+    /// The C object itself. Only the extern declarations below name this type;
+    /// all Rust code uses the owning [`SSL_SESSION`] handle.
+    pub(crate) mod sys {
+        bun_opaque::opaque_ffi! {
+            /// `struct ssl_session_st` (`typedef ... SSL_SESSION`). `&Self` is
+            /// ABI-identical to a non-null `SSL_SESSION*` and carries no
+            /// `noalias`/`readonly` — BoringSSL mutates the session (refcount,
+            /// ticket) through it.
+            pub struct SSL_SESSION;
+        }
+    }
+
+    /// `SSL_SESSION_free` takes `*mut SSL_SESSION`; `foreign_handle!` needs a
+    /// `fn(&sys::SSL_SESSION)`.
+    fn ssl_session_free_release(session: &sys::SSL_SESSION) {
+        // SAFETY: the handle owns one ref on the session's refcount; `as_mut_ptr`
+        // derives write provenance from the `UnsafeCell` body.
+        unsafe { SSL_SESSION_free(session.as_mut_ptr()) }
+    }
+
+    // `d2i_SSL_SESSION` parses and hands back a `+1` on the session's refcount.
+    bun_opaque::foreign_handle! {
+        /// Owned handle to a BoringSSL `SSL_SESSION`.
+        ///
+        /// Holds one ref on the C refcount; `Drop` gives it back. Every method
+        /// takes `&self`: a refcount is shared by definition.
+        ///
+        /// A session *borrowed* from a live connection (`SSL_get_session`) took
+        /// no ref and stays a raw `*mut sys::SSL_SESSION`. `SSL_set_session`
+        /// takes its *own* reference, so it borrows too.
+        pub(crate) struct SSL_SESSION(sys::SSL_SESSION) via ssl_session_free_release;
+    }
+
     // Opaque handles missing from boringssl_sys.
     bun_opaque::opaque_ffi! {
-        pub(crate) struct SSL_SESSION;
         pub(crate) struct SSL_CIPHER;
         pub(crate) struct EVP_PKEY;
         pub(crate) struct EC_KEY;
@@ -104,27 +139,32 @@ pub(super) mod ffi {
         pub(crate) safe fn SSL_get_privatekey(ssl: &SSL) -> *mut EVP_PKEY;
 
         // ── SSL_SESSION ───────────────────────────────────────────────────
-        pub(crate) safe fn SSL_get_session(ssl: &SSL) -> *mut SSL_SESSION;
+        // Borrowed from the live connection: takes no ref.
+        pub(crate) safe fn SSL_get_session(ssl: &SSL) -> *mut sys::SSL_SESSION;
         // Both handles are opaque-ZST refs (`UnsafeCell` body); BoringSSL bumps
         // `session`'s refcount internally — no caller-side precondition.
-        pub(crate) safe fn SSL_set_session(ssl: &SSL, session: &SSL_SESSION) -> c_int;
+        pub(crate) safe fn SSL_set_session(ssl: &SSL, session: &sys::SSL_SESSION) -> c_int;
+        // Releases one ref. Private: the only caller is `ssl_session_free_release`,
+        // which backs the `SSL_SESSION` handle's `Drop`.
         // SAFETY (unsafe fn): consumes a +1 reference; `session` must be uniquely owned or null.
-        pub(crate) fn SSL_SESSION_free(session: *mut SSL_SESSION);
-        // Opaque-ZST `&SSL_SESSION` + `&mut` out-params (FFI-nonnull) ⇒ no
+        fn SSL_SESSION_free(session: *mut sys::SSL_SESSION);
+        // Opaque-ZST `&sys::SSL_SESSION` + `&mut` out-params (FFI-nonnull) ⇒ no
         // caller-side precondition; BoringSSL writes a borrowed ptr/len pair.
         pub(crate) safe fn SSL_SESSION_get0_ticket(
-            session: &SSL_SESSION,
+            session: &sys::SSL_SESSION,
             out_ticket: &mut *const u8,
             out_len: &mut usize,
         );
         // SAFETY (unsafe fn): `pp` (when non-null) must point to a buffer with capacity for the encoded session.
-        pub(crate) fn i2d_SSL_SESSION(session: *mut SSL_SESSION, pp: *mut *mut u8) -> c_int;
+        pub(crate) fn i2d_SSL_SESSION(session: *mut sys::SSL_SESSION, pp: *mut *mut u8) -> c_int;
+        // Allocates and returns a fresh +1 on success; null on a parse failure,
+        // having transferred nothing (`a` is always null at our call site).
         // SAFETY (unsafe fn): `*pp` must be readable for `length` bytes.
         pub(crate) fn d2i_SSL_SESSION(
-            a: *mut *mut SSL_SESSION,
+            a: *mut *mut sys::SSL_SESSION,
             pp: *mut *const u8,
             length: c_long,
-        ) -> *mut SSL_SESSION;
+        ) -> *mut sys::SSL_SESSION;
 
         // ── SSL_CIPHER ────────────────────────────────────────────────────
         pub(crate) safe fn SSL_get_current_cipher(ssl: &SSL) -> *const SSL_CIPHER;
@@ -244,13 +284,14 @@ pub(super) mod ffi {
         // object stack and `OPENSSL_sk_num(NULL)` returns 0.
         pub(crate) fn X509_STORE_get0_objects(store: *mut X509_STORE) -> *mut c_void;
         pub(crate) fn OPENSSL_sk_num(sk: *const c_void) -> usize;
-        // The process-wide default root store; up-refs before returning, so
-        // the caller owns a reference it must release with X509_STORE_free.
+        // The process-wide default root store; up-refs before returning, so the
+        // caller owns a reference — adopted into a `boringssl::X509_STORE`, whose
+        // `Drop` calls `X509_STORE_free`.
         pub(crate) fn us_get_shared_default_ca_store() -> *mut X509_STORE;
-        pub(crate) fn X509_STORE_free(store: *mut X509_STORE);
-        // X509_STORE_CTX lifecycle for issuer lookups; `new` allocates,
-        // `init` borrows the store, `free` releases. Used to extend the peer
-        // certificate chain through the local trust store.
+        // X509_STORE_CTX lifecycle for issuer lookups; `new` allocates and `init`
+        // borrows the store. The allocation is adopted into a
+        // `boringssl::X509_STORE_CTX`, whose `Drop` calls `X509_STORE_CTX_free`.
+        // Used to extend the peer certificate chain through the local trust store.
         pub(crate) fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
         pub(crate) fn X509_STORE_CTX_init(
             ctx: *mut X509_STORE_CTX,
@@ -258,7 +299,6 @@ pub(super) mod ffi {
             x509: *mut X509,
             chain: *mut struct_stack_st_X509,
         ) -> c_int;
-        pub(crate) fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
         // Writes a +1 X509 reference to `*issuer` on success (> 0).
         pub(crate) fn X509_STORE_CTX_get1_issuer(
             issuer: *mut *mut X509,
@@ -356,8 +396,11 @@ pub(super) fn get_peer_x509_certificate(
         return Ok(JSValue::UNDEFINED);
     };
     let cert = ffi::SSL_get_peer_certificate(boringssl::SSL::opaque_ref(ssl_ptr));
-    if !cert.is_null() {
-        return X509::to_js_object(boringssl::X509::opaque_mut(cert), global);
+    // SAFETY: `SSL_get_peer_certificate` up-refs the peer leaf and hands back a
+    // fresh `+1` (or null, having released nothing). This handle is the sole
+    // owner of that ref, and `to_js_object` gives it to C++'s `X509Pointer`.
+    if let Some(cert) = unsafe { boringssl::X509::adopt_ptr(cert) } {
+        return X509::to_js_object(cert, global);
     }
     Ok(JSValue::UNDEFINED)
 }
@@ -371,10 +414,14 @@ pub(super) fn get_x509_certificate(
         return Ok(JSValue::UNDEFINED);
     };
     let cert = ffi::SSL_get_certificate(boringssl::SSL::opaque_ref(ssl_ptr));
-    if !cert.is_null() {
-        // X509_up_ref bumps the refcount before handing to JS.
-        ffi::X509_up_ref(boringssl::X509::opaque_ref(cert));
-        return X509::to_js_object(boringssl::X509::opaque_mut(cert), global);
+    if let Some(cert) = core::ptr::NonNull::new(cert) {
+        // `SSL_get_certificate` only borrows; `X509_up_ref` mints the ref the
+        // handle owns and `to_js_object` hands to C++'s `X509Pointer`.
+        ffi::X509_up_ref(boringssl::sys::X509::opaque_ref(cert.as_ptr()));
+        // SAFETY: the `X509_up_ref` above added exactly one ref, and nothing
+        // else gives it back.
+        let cert = unsafe { boringssl::X509::adopt(cert) };
+        return X509::to_js_object(cert, global);
     }
     Ok(JSValue::UNDEFINED)
 }
@@ -460,13 +507,13 @@ pub(super) fn get_peer_certificate(
 
     if abbreviated {
         if this.is_server() {
-            // SSL_get_peer_certificate returns a +1 reference; we must free it.
             // X509::to_js only borrows the pointer (X509View is non-owning).
             let cert = ffi::SSL_get_peer_certificate(boringssl::SSL::opaque_ref(ssl_ptr));
-            if !cert.is_null() {
-                // SAFETY: `c` is the +1 X509 reference returned by SSL_get_peer_certificate; we own it.
-                let _guard = scopeguard::guard(cert, |c| unsafe { boringssl::X509_free(c) });
-                return X509::to_js(boringssl::X509::opaque_mut(cert), global);
+            // SAFETY: `SSL_get_peer_certificate` hands back a fresh `+1` (or
+            // null, having released nothing). This handle is its sole owner; its
+            // `Drop` gives the ref back once `to_js` has copied what it needs.
+            if let Some(cert) = unsafe { boringssl::X509::adopt_ptr(cert) } {
+                return X509::to_js(boringssl::sys::X509::opaque_mut(cert.as_ptr()), global);
             }
         }
 
@@ -478,23 +525,29 @@ pub(super) fn get_peer_certificate(
         if cert.is_null() {
             return Ok(JSValue::UNDEFINED);
         }
-        return X509::to_js(boringssl::X509::opaque_mut(cert), global);
+        return X509::to_js(boringssl::sys::X509::opaque_mut(cert), global);
     }
 
-    let mut cert: *mut boringssl::X509 = core::ptr::null_mut();
-    if this.is_server() {
-        // SSL_get_peer_certificate returns a +1 reference; we must free it.
-        cert = ffi::SSL_get_peer_certificate(boringssl::SSL::opaque_ref(ssl_ptr));
-    }
-    let _guard = scopeguard::guard(cert, |c| {
-        if !c.is_null() {
-            // SAFETY: `c` is the +1 X509 reference returned by SSL_get_peer_certificate; we own it.
-            unsafe { boringssl::X509_free(c) };
+    // On the client path the leaf is borrowed from the chain, so there is no ref
+    // to own and this stays `None`.
+    let owned_peer: Option<boringssl::X509> = if this.is_server() {
+        // SAFETY: on the server path `SSL_get_peer_certificate` hands back a fresh
+        // `+1` (or null, having released nothing); this handle is its sole owner and
+        // its `Drop` at function exit replaces the old `scopeguard`.
+        unsafe {
+            boringssl::X509::adopt_ptr(ffi::SSL_get_peer_certificate(boringssl::SSL::opaque_ref(
+                ssl_ptr,
+            )))
         }
-    });
+    } else {
+        None
+    };
+    let cert: *mut boringssl::sys::X509 = owned_peer
+        .as_ref()
+        .map_or(core::ptr::null_mut(), |c| c.as_ptr());
 
     let cert_chain = ffi::SSL_get_peer_cert_chain(boringssl::SSL::opaque_ref(ssl_ptr));
-    let first_cert: *mut boringssl::X509 = if !cert.is_null() {
+    let first_cert: *mut boringssl::sys::X509 = if !cert.is_null() {
         cert
     } else if !cert_chain.is_null() {
         ffi::sk_X509_value(boringssl::struct_stack_st_X509::opaque_ref(cert_chain), 0)
@@ -511,13 +564,13 @@ pub(super) fn get_peer_certificate(
     // Node's getPeerCertificate(true) does. SSL_get_peer_cert_chain includes
     // the leaf on the client side but not on the server side, where the +1
     // peer certificate above is the leaf instead.
-    let first_obj = X509::to_js(boringssl::X509::opaque_mut(first_cert), global)?;
+    let first_obj = X509::to_js(boringssl::sys::X509::opaque_mut(first_cert), global)?;
     // Link each certificate to its predecessor immediately so every object in
     // the chain is reachable from the stack-rooted `first_obj` before the next
     // `X509::to_js` allocation can trigger a GC - a heap-backed Vec<JSValue>
     // is not stack-scanned.
     let mut prev_obj: JSValue = first_obj;
-    let mut last_cert: *mut boringssl::X509 = first_cert;
+    let mut last_cert: *mut boringssl::sys::X509 = first_cert;
     if !cert_chain.is_null() {
         let mut i: usize = if cert.is_null() { 1 } else { 0 };
         loop {
@@ -526,7 +579,7 @@ pub(super) fn get_peer_certificate(
             if next.is_null() {
                 break;
             }
-            let obj = X509::to_js(boringssl::X509::opaque_mut(next), global)?;
+            let obj = X509::to_js(boringssl::sys::X509::opaque_mut(next), global)?;
             prev_obj.put(global, b"issuerCertificate", obj);
             prev_obj = obj;
             last_cert = next;
@@ -539,11 +592,11 @@ pub(super) fn get_peer_certificate(
     // X509_STORE_CTX_get1_issuer to surface the root that completed
     // verification even though the peer never sent it.
     let mut last_is_self_issued = false;
-    // SAFETY: the store ctx is created, initialized against the live SSL_CTX's
-    // store, used only within this scope and freed before returning; every
-    // issuer returned by get1_issuer is a +1 reference collected in `extras`
-    // and released after its fields have been copied into JS values and the
-    // terminal self-issued check has run.
+    // SAFETY: the store ctx is created and initialized against the live SSL_CTX's
+    // store, used only within this scope, and released by its handle's `Drop`;
+    // every issuer returned by get1_issuer is a +1 reference adopted into a
+    // handle collected in `extras` and released after its fields have been
+    // copied into JS values and the terminal self-issued check has run.
     unsafe {
         let mut store = ffi::SSL_CTX_get_cert_store(boringssl::sys::SSL_CTX::opaque_ref(
             ffi::SSL_get_SSL_CTX(boringssl::SSL::opaque_ref(ssl_ptr)),
@@ -552,64 +605,68 @@ pub(super) fn get_peer_certificate(
         // which installs the shared roots) carries an empty store and the
         // issuer walk would stop at whatever the peer sent. Fall back to the
         // process-wide default roots the way Node's per-context store always
-        // contains the bundled roots. The getter up-refs, so the temporary
-        // reference is released after the walk.
-        let mut shared_store: *mut boringssl::X509_STORE = core::ptr::null_mut();
-        if store.is_null() || ffi::OPENSSL_sk_num(ffi::X509_STORE_get0_objects(store)) == 0 {
-            shared_store = ffi::us_get_shared_default_ca_store();
-            if !shared_store.is_null() {
-                store = shared_store;
-            }
+        // contains the bundled roots.
+        //
+        // SAFETY: `us_get_shared_default_ca_store` up-refs the process-wide store
+        // before returning (or returns null, having released nothing), so this
+        // handle owns exactly one ref that nothing else gives back. It outlives
+        // the borrowed `store` pointer below and drops at the end of this block.
+        let shared_store: Option<boringssl::X509_STORE> =
+            if store.is_null() || ffi::OPENSSL_sk_num(ffi::X509_STORE_get0_objects(store)) == 0 {
+                boringssl::X509_STORE::adopt_ptr(ffi::us_get_shared_default_ca_store())
+            } else {
+                None
+            };
+        if let Some(shared) = shared_store.as_ref() {
+            store = shared.as_ptr();
         }
-        let store_ctx = ffi::X509_STORE_CTX_new();
-        if !store_ctx.is_null() {
+        // SAFETY: `X509_STORE_CTX_new` allocates and hands back the sole owner,
+        // or null on OOM (having allocated nothing).
+        if let Some(store_ctx) = boringssl::X509_STORE_CTX::adopt_ptr(ffi::X509_STORE_CTX_new()) {
             if !store.is_null()
                 && ffi::X509_STORE_CTX_init(
-                    store_ctx,
+                    store_ctx.as_ptr(),
                     store,
                     core::ptr::null_mut(),
                     core::ptr::null_mut(),
                 ) == 1
             {
-                let mut extras: Vec<*mut boringssl::X509> = Vec::new();
+                let mut extras: Vec<boringssl::X509> = Vec::new();
                 // Cap the walk so a cyclic store cannot loop forever.
                 while extras.len() < 16 && ffi::X509_check_issued(last_cert, last_cert) != 0 {
-                    let mut issuer: *mut boringssl::X509 = core::ptr::null_mut();
-                    if ffi::X509_STORE_CTX_get1_issuer(&raw mut issuer, store_ctx, last_cert) <= 0
-                        || issuer.is_null()
+                    let mut issuer: *mut boringssl::sys::X509 = core::ptr::null_mut();
+                    if ffi::X509_STORE_CTX_get1_issuer(
+                        &raw mut issuer,
+                        store_ctx.as_ptr(),
+                        last_cert,
+                    ) <= 0
                     {
                         break;
                     }
-                    match X509::to_js(boringssl::X509::opaque_mut(issuer), global) {
-                        Ok(obj) => {
-                            prev_obj.put(global, b"issuerCertificate", obj);
-                            prev_obj = obj;
-                        }
-                        Err(e) => {
-                            boringssl::X509_free(issuer);
-                            for extra in extras {
-                                boringssl::X509_free(extra);
-                            }
-                            ffi::X509_STORE_CTX_free(store_ctx);
-                            if !shared_store.is_null() {
-                                ffi::X509_STORE_free(shared_store);
-                            }
-                            return Err(e);
-                        }
-                    }
+                    // SAFETY: on success (> 0) `get1_issuer` wrote a fresh `+1`
+                    // into `issuer`; this handle is its sole owner. A null slot
+                    // carries no ref, so `None` just ends the walk (this is the
+                    // old `|| issuer.is_null()` guard).
+                    let Some(issuer) = boringssl::X509::adopt_ptr(issuer) else {
+                        break;
+                    };
+                    // On the `?` path `issuer`, then `extras`, then `store_ctx`, then
+                    // `shared_store` all release on the way out — the same order the
+                    // old hand-written error path used.
+                    let obj =
+                        X509::to_js(boringssl::sys::X509::opaque_mut(issuer.as_ptr()), global)?;
+                    prev_obj.put(global, b"issuerCertificate", obj);
+                    prev_obj = obj;
+                    last_cert = issuer.as_ptr();
                     extras.push(issuer);
-                    last_cert = issuer;
                 }
                 last_is_self_issued = ffi::X509_check_issued(last_cert, last_cert) == 0;
-                for extra in extras {
-                    boringssl::X509_free(extra);
-                }
+                // `extras` drops here — after the terminal check has read
+                // `last_cert` — releasing every adopted issuer ref.
             }
-            ffi::X509_STORE_CTX_free(store_ctx);
+            // `store_ctx` drops here.
         }
-        if !shared_store.is_null() {
-            ffi::X509_STORE_free(shared_store);
-        }
+        // `shared_store` drops here.
     }
 
     // A self-issued terminal certificate references itself, like Node.
@@ -627,10 +684,12 @@ pub(super) fn get_certificate(
     let Some(ssl_ptr) = this.socket.get().ssl() else {
         return Ok(JSValue::UNDEFINED);
     };
+    // Borrowed from the connection: `SSL_get_certificate` takes no ref, and
+    // `X509::to_js` builds a non-owning `X509View`.
     let cert = ffi::SSL_get_certificate(boringssl::SSL::opaque_ref(ssl_ptr));
 
     if !cert.is_null() {
-        return X509::to_js(boringssl::X509::opaque_mut(cert), global);
+        return X509::to_js(boringssl::sys::X509::opaque_mut(cert), global);
     }
     Ok(JSValue::UNDEFINED)
 }
@@ -1172,16 +1231,18 @@ pub(super) fn set_session(
                 c_long::try_from(session_slice.len()).expect("int cast"),
             )
         };
-        if session.is_null() {
-            return Ok(JSValue::UNDEFINED);
-        }
         // SSL_set_session takes its own reference ("the caller retains ownership of |session|"),
-        // so we must release the one returned by d2i_SSL_SESSION on every path.
-        // SAFETY: `s` is the +1 SSL_SESSION reference returned by d2i_SSL_SESSION; we own it.
-        let _guard = scopeguard::guard(session, |s| unsafe { ffi::SSL_SESSION_free(s) });
+        // so the one d2i_SSL_SESSION handed us is released on every path by the
+        // handle's `Drop`.
+        // SAFETY: `d2i_SSL_SESSION` (with a null `a`) allocates and returns a
+        // fresh `+1` on success, or null on a parse failure, having transferred
+        // nothing. This handle is the sole owner of that ref.
+        let Some(session) = (unsafe { ffi::SSL_SESSION::adopt_ptr(session) }) else {
+            return Ok(JSValue::UNDEFINED);
+        };
         if ffi::SSL_set_session(
             boringssl::SSL::opaque_ref(ssl_ptr),
-            ffi::SSL_SESSION::opaque_ref(session),
+            ffi::sys::SSL_SESSION::opaque_ref(session.as_ptr()),
         ) != 1
         {
             return Err(global.throw_value(get_ssl_exception(global, b"SSL_set_session error")));
@@ -1210,7 +1271,7 @@ pub(super) fn get_tls_ticket(
     let mut length: usize = 0;
     // The pointer is only valid while the connection is in use so we need to copy it
     ffi::SSL_SESSION_get0_ticket(
-        ffi::SSL_SESSION::opaque_ref(session),
+        ffi::sys::SSL_SESSION::opaque_ref(session),
         &mut ticket,
         &mut length,
     );
@@ -1316,7 +1377,9 @@ pub(super) fn set_verify_mode(
 
 extern "C" fn always_allow_ssl_verify_callback(
     _preverify_ok: c_int,
-    _ctx: *mut boringssl::X509_STORE_CTX,
+    // BoringSSL owns the context it passes in; this is the C object, not the
+    // owning `boringssl::X509_STORE_CTX` handle.
+    _ctx: *mut boringssl::sys::X509_STORE_CTX,
 ) -> c_int {
     1
 }

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -495,8 +495,8 @@ impl UDPSocket {
     /// fields are `Cell`/`JsCell`, so a shared borrow is sufficient (R-2).
     #[inline]
     fn from_uws<'a>(socket: *mut uws::udp::Socket) -> &'a UDPSocket {
-        // `Socket` is an `opaque_ffi!` ZST — `opaque_mut` is the safe deref.
-        let user = uws::udp::Socket::opaque_mut(socket).user();
+        // `Socket` is an `opaque_ffi!` ZST — `opaque_ref` is the safe deref.
+        let user = uws::udp::Socket::opaque_ref(socket).user();
         // SAFETY: `user` was set to `*mut UDPSocket` at creation; non-null and
         // live for the callback's duration (back-ref invariant).
         unsafe { &*user.cast::<UDPSocket>() }
@@ -544,8 +544,8 @@ impl UDPSocket {
             // repeats it), so ordering is unobservable.
             this.this_value.with_mut(|r| r.downgrade());
             if let Some(socket) = this.socket.take() {
-                // `Socket` is an `opaque_ffi!` ZST — `opaque_mut` is the safe deref.
-                uws::udp::Socket::opaque_mut(socket).close();
+                // `Socket` is an `opaque_ffi!` ZST — `opaque_ref` is the safe deref.
+                uws::udp::Socket::opaque_ref(socket).close();
             }
         });
 
@@ -622,8 +622,8 @@ impl UDPSocket {
 
         if let Some(connect) = &this.config.get().connect {
             let address_z = connect.address.to_owned_slice_z();
-            // `Socket` is an `opaque_ffi!` ZST — `opaque_mut` is the safe deref.
-            let ret = uws::udp::Socket::opaque_mut(this.socket.get().unwrap())
+            // `Socket` is an `opaque_ffi!` ZST — `opaque_ref` is the safe deref.
+            let ret = uws::udp::Socket::opaque_ref(this.socket.get().unwrap())
                 .connect(address_z.as_ptr(), connect.port as u32);
             if ret != 0 {
                 if let Some(sys_err) = errno_sys(ret, bun_sys::Tag::connect) {
@@ -719,8 +719,8 @@ impl UDPSocket {
                 .to_js(global_this),
             ));
         };
-        // `Socket` is an `opaque_ffi!` ZST — `opaque_mut` is the safe deref.
-        let res = uws::udp::Socket::opaque_mut(socket).set_broadcast(enabled);
+        // `Socket` is an `opaque_ffi!` ZST — `opaque_ref` is the safe deref.
+        let res = uws::udp::Socket::opaque_ref(socket).set_broadcast(enabled);
 
         if let Some(err) = get_us_error::<true>(res, bun_sys::Tag::setsockopt) {
             return Err(global_this.throw_value(err.to_js(global_this)));
@@ -767,8 +767,8 @@ impl UDPSocket {
                 .to_js(global_this),
             ));
         };
-        // `Socket` is an `opaque_ffi!` ZST — `opaque_mut` is the safe deref.
-        let res = uws::udp::Socket::opaque_mut(socket).set_multicast_loopback(enabled);
+        // `Socket` is an `opaque_ffi!` ZST — `opaque_ref` is the safe deref.
+        let res = uws::udp::Socket::opaque_ref(socket).set_multicast_loopback(enabled);
 
         if let Some(err) = get_us_error::<true>(res, bun_sys::Tag::setsockopt) {
             return Err(global_this.throw_value(err.to_js(global_this)));
@@ -835,10 +835,10 @@ impl UDPSocket {
                     "Family mismatch between address and interface"
                 )));
             }
-            // `Socket` is an `opaque_ffi!` ZST — `opaque_mut` is the safe deref.
-            uws::udp::Socket::opaque_mut(socket).set_membership(&addr, Some(&interface), drop)
+            // `Socket` is an `opaque_ffi!` ZST — `opaque_ref` is the safe deref.
+            uws::udp::Socket::opaque_ref(socket).set_membership(&addr, Some(&interface), drop)
         } else {
-            uws::udp::Socket::opaque_mut(socket).set_membership(&addr, None, drop)
+            uws::udp::Socket::opaque_ref(socket).set_membership(&addr, None, drop)
         };
 
         if let Some(err) = get_us_error::<true>(res, bun_sys::Tag::setsockopt) {
@@ -949,15 +949,15 @@ impl UDPSocket {
                     "Family mismatch among source, group and interface addresses"
                 )));
             }
-            // `Socket` is an `opaque_ffi!` ZST — `opaque_mut` is the safe deref.
-            uws::udp::Socket::opaque_mut(socket).set_source_specific_membership(
+            // `Socket` is an `opaque_ffi!` ZST — `opaque_ref` is the safe deref.
+            uws::udp::Socket::opaque_ref(socket).set_source_specific_membership(
                 &source_addr,
                 &group_addr,
                 Some(&interface),
                 drop,
             )
         } else {
-            uws::udp::Socket::opaque_mut(socket).set_source_specific_membership(
+            uws::udp::Socket::opaque_ref(socket).set_source_specific_membership(
                 &source_addr,
                 &group_addr,
                 None,
@@ -1036,8 +1036,8 @@ impl UDPSocket {
             return Err(global_this.throw(format_args!("Socket is closed")));
         };
 
-        // `Socket` is an `opaque_ffi!` ZST — `opaque_mut` is the safe deref.
-        let res = uws::udp::Socket::opaque_mut(socket).set_multicast_interface(&addr);
+        // `Socket` is an `opaque_ffi!` ZST — `opaque_ref` is the safe deref.
+        let res = uws::udp::Socket::opaque_ref(socket).set_multicast_interface(&addr);
 
         if let Some(err) = get_us_error::<true>(res, bun_sys::Tag::setsockopt) {
             return Err(global_this.throw_value(err.to_js(global_this)));
@@ -1078,7 +1078,7 @@ impl UDPSocket {
         this: &Self,
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
-        function: fn(&mut uws::udp::Socket, i32) -> c_int,
+        function: fn(&uws::udp::Socket, i32) -> c_int,
     ) -> JsResult<JSValue> {
         if this.closed.get() {
             return Err(global_this.throw_value(
@@ -1102,8 +1102,8 @@ impl UDPSocket {
         let Some(socket) = this.socket.get() else {
             return Err(global_this.throw(format_args!("Socket is closed")));
         };
-        // `Socket` is an `opaque_ffi!` ZST — `opaque_mut` is the safe deref.
-        let res = function(uws::udp::Socket::opaque_mut(socket), ttl);
+        // `Socket` is an `opaque_ffi!` ZST — `opaque_ref` is the safe deref.
+        let res = function(uws::udp::Socket::opaque_ref(socket), ttl);
 
         if let Some(err) = get_us_error::<true>(res, bun_sys::Tag::setsockopt) {
             return Err(global_this.throw_value(err.to_js(global_this)));
@@ -1314,8 +1314,8 @@ impl UDPSocket {
         let Some(socket) = this.socket.get() else {
             return Err(global_this.throw(format_args!("Socket is closed")));
         };
-        // `Socket` is an `opaque_ffi!` ZST — `opaque_mut` is the safe deref.
-        let res = uws::udp::Socket::opaque_mut(socket).send(&payloads, &lens, &addr_ptrs);
+        // `Socket` is an `opaque_ffi!` ZST — `opaque_ref` is the safe deref.
+        let res = uws::udp::Socket::opaque_ref(socket).send(&payloads, &lens, &addr_ptrs);
         if let Some(err) = get_us_error::<true>(res, bun_sys::Tag::send) {
             return Err(global_this.throw_value(err.to_js(global_this)));
         }
@@ -1411,8 +1411,8 @@ impl UDPSocket {
         let Some(socket) = this.socket.get() else {
             return Err(global_this.throw(format_args!("Socket is closed")));
         };
-        // `Socket` is an `opaque_ffi!` ZST — `opaque_mut` is the safe deref.
-        let res = uws::udp::Socket::opaque_mut(socket).send(
+        // `Socket` is an `opaque_ffi!` ZST — `opaque_ref` is the safe deref.
+        let res = uws::udp::Socket::opaque_ref(socket).send(
             &[payload.as_ptr()],
             &[payload.len()],
             &[addr_ptr],
@@ -1582,8 +1582,8 @@ impl UDPSocket {
             // shared borrow is sound; the (idempotent) downgrade is hoisted
             // because `on_close` repeats it.
             this.this_value.with_mut(|r| r.downgrade());
-            // `Socket` is an `opaque_ffi!` ZST — `opaque_mut` is the safe deref.
-            uws::udp::Socket::opaque_mut(socket).close();
+            // `Socket` is an `opaque_ffi!` ZST — `opaque_ref` is the safe deref.
+            uws::udp::Socket::opaque_ref(socket).close();
         }
 
         Ok(JSValue::UNDEFINED)
@@ -1630,8 +1630,8 @@ impl UDPSocket {
         let Some(socket) = this.socket.get() else {
             return JSValue::UNDEFINED;
         };
-        // `Socket` is an `opaque_ffi!` ZST — `opaque_mut` is the safe deref.
-        JSValue::js_number(uws::udp::Socket::opaque_mut(socket).bound_port() as f64)
+        // `Socket` is an `opaque_ffi!` ZST — `opaque_ref` is the safe deref.
+        JSValue::js_number(uws::udp::Socket::opaque_ref(socket).bound_port() as f64)
     }
 
     fn create_sock_addr(global_this: &JSGlobalObject, address_bytes: &[u8], port: u16) -> JSValue {
@@ -1652,8 +1652,8 @@ impl UDPSocket {
         };
         let mut buf = [0u8; 64];
         let mut length: i32 = 64;
-        // `Socket` is an `opaque_ffi!` ZST — `opaque_mut` is the safe deref.
-        let socket = uws::udp::Socket::opaque_mut(socket);
+        // `Socket` is an `opaque_ffi!` ZST — `opaque_ref` is the safe deref.
+        let socket = uws::udp::Socket::opaque_ref(socket);
         socket.bound_ip(buf.as_mut_ptr(), &mut length);
 
         let address_bytes = &buf[..usize::try_from(length).expect("int cast")];
@@ -1678,8 +1678,8 @@ impl UDPSocket {
         };
         let mut buf = [0u8; 64];
         let mut length: i32 = 64;
-        // `Socket` is an `opaque_ffi!` ZST — `opaque_mut` is the safe deref.
-        uws::udp::Socket::opaque_mut(socket).remote_ip(buf.as_mut_ptr(), &mut length);
+        // `Socket` is an `opaque_ffi!` ZST — `opaque_ref` is the safe deref.
+        uws::udp::Socket::opaque_ref(socket).remote_ip(buf.as_mut_ptr(), &mut length);
 
         let address_bytes = &buf[..usize::try_from(length).expect("int cast")];
         Self::create_sock_addr(global_this, address_bytes, connect_info.port)
@@ -1805,8 +1805,8 @@ impl UDPSocket {
             return Err(global_object.throw(format_args!("Socket is closed")));
         }
 
-        // `Socket` is an `opaque_ffi!` ZST — `opaque_mut` is the safe deref.
-        if uws::udp::Socket::opaque_mut(this.socket.get().unwrap()).disconnect() == -1 {
+        // `Socket` is an `opaque_ffi!` ZST — `opaque_ref` is the safe deref.
+        if uws::udp::Socket::opaque_ref(this.socket.get().unwrap()).disconnect() == -1 {
             return Err(global_object.throw(format_args!("Failed to disconnect socket")));
         }
         this.connect_info.set(None);

--- a/src/runtime/socket/uws_dispatch.rs
+++ b/src/runtime/socket/uws_dispatch.rs
@@ -99,9 +99,9 @@ fn vt(s: *mut us_socket_t) -> &'static VTable {
 
 #[inline]
 fn vtc(c: *mut ConnectingSocket) -> &'static VTable {
-    // `ConnectingSocket` is an `opaque_ffi!` ZST — `opaque_mut` is the safe
+    // `ConnectingSocket` is an `opaque_ffi!` ZST — `opaque_ref` is the safe
     // deref (loop.c only dispatches live, non-null connecting sockets).
-    let c = ConnectingSocket::opaque_mut(c);
+    let c = ConnectingSocket::opaque_ref(c);
     let kind = c.kind();
     match kind {
         SocketKind::Invalid => {

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -423,9 +423,10 @@ impl ScopeFunctions {
                             "matches_filter \"{}\"",
                             bstr::BStr::new(bun_test.collection.filter_buffer.as_slice())
                         ));
-                        // `RegularExpression` is an `opaque_ffi!` ZST handle; `opaque_mut` is
-                        // the centralised non-null deref proof.
-                        matches_filter = RegularExpression::opaque_mut(filter_regex.as_ptr()).matches(str);
+                        // SAFETY: `filter_regex` was leaked into `TestOptions` by
+                        // `cli::Arguments` and lives for the process; the ManuallyDrop
+                        // borrow frees nothing.
+                        matches_filter = unsafe { RegularExpression::borrow_leaked(filter_regex) }.matches(str);
 
                         bun_test.collection.filter_buffer.clear();
                     }

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -6,9 +6,7 @@ use crate::cli::test_command::CommandLineReporter;
 use bun_collections::{ArrayHashMap, MultiArrayList};
 use bun_core::Output;
 use bun_jsc::virtual_machine::VirtualMachine;
-use bun_jsc::{
-    self as jsc, CallFrame, JSGlobalObject, JSValue, JsResult, RegularExpression,
-};
+use bun_jsc::{self as jsc, CallFrame, JSGlobalObject, JSValue, JsResult};
 use bun_jsc::StringJsc as _;
 use crate::timer::ElTimespec;
 
@@ -143,10 +141,10 @@ pub struct TestRunner<'a> {
     pub test_options: &'a TestOptions,
 
     /// Used for --test-name-pattern to reduce allocations.
-    /// Raw `*mut` because `RegularExpression::matches` mutates its internal
-    /// cursor through C++ — storing `&'a RegularExpression` and casting back to
-    /// `*mut` at the use site would launder shared provenance into a write (UB).
-    pub filter_regex: Option<core::ptr::NonNull<RegularExpression>>,
+    /// Points at the C++ regex (`sys`), not the owning `RegularExpression` handle:
+    /// `cli::Arguments` leaked the allocation into `TestOptions`, so this is a
+    /// non-owning borrow, taken with `RegularExpression::borrow_leaked`.
+    pub filter_regex: Option<NonNull<jsc::regular_expression::sys::RegularExpression>>,
 
     pub unhandled_errors_between_tests: u32,
     pub summary: Summary,

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1,6 +1,5 @@
 use core::cell::Cell;
 use core::ffi::c_void;
-use core::ptr::NonNull;
 
 use crate::socket::{SSLConfig, SSLConfigFromJs};
 use bun_boringssl as boringssl;
@@ -502,7 +501,8 @@ impl JSValkeyClient {
         // the case right now and I do not understand why. It will take some work in JSC to
         // understand why this is happening, but since I need to uncork valkey, I'm adding this as
         // a stop-gap.
-        let parsed_url: NonNull<URL> = 'get_url: {
+        // Owns the C++ heap `WTF::URL`; `Drop` frees it on scope exit.
+        let parsed_url: URL = 'get_url: {
             let url_slice = url_str.to_utf8();
             let url_byte_slice = url_slice.slice();
 
@@ -547,13 +547,6 @@ impl JSValkeyClient {
                 }
             }
         };
-        // SAFETY: `from_utf8` heap-allocates; release on scope exit.
-        let _parsed_url_drop =
-            scopeguard::guard(parsed_url, |p| unsafe { URL::destroy(p.as_ptr()) });
-        // `_parsed_url_drop` keeps the heap `URL` live for this scope, so the
-        // `BackRef` liveness invariant holds; `Deref` encapsulates the single
-        // `NonNull::as_ref` site.
-        let parsed_url = bun_ptr::BackRef::from(parsed_url);
 
         // Extract protocol string
         let protocol_str = parsed_url.protocol();
@@ -1288,9 +1281,9 @@ impl JSValkeyClient {
 
             if let Some(promise) = Js::connection_promise_get_cached(this_value) {
                 Js::connection_promise_set_cached(this_value, &global_object, JSValue::ZERO);
-                // `JSPromise` is an `opaque_ffi!` ZST — `opaque_mut` is the
+                // `JSPromise` is an `opaque_ffi!` ZST — `opaque_ref` is the
                 // safe deref. Cached slot held a valid JSPromise.
-                let js_promise = JSPromise::opaque_mut(promise.as_promise().unwrap());
+                let js_promise = JSPromise::opaque_ref(promise.as_promise().unwrap());
                 if self.client.get().flags.connection_promise_returns_client {
                     debug!("Resolving connection promise with client instance");
                     js_promise.resolve(&global_object, this_value)?;
@@ -1437,9 +1430,9 @@ impl JSValkeyClient {
         if !this_jsvalue.is_undefined() {
             if let Some(promise) = Js::connection_promise_get_cached(this_jsvalue) {
                 Js::connection_promise_set_cached(this_jsvalue, &global_object, JSValue::ZERO);
-                // `JSPromise` is an `opaque_ffi!` ZST — `opaque_mut` is the
+                // `JSPromise` is an `opaque_ffi!` ZST — `opaque_ref` is the
                 // safe deref. Cached slot held a valid JSPromise.
-                JSPromise::opaque_mut(promise.as_promise().unwrap())
+                JSPromise::opaque_ref(promise.as_promise().unwrap())
                     .reject(&global_object, Ok(error_value))?;
             }
         }
@@ -1736,8 +1729,8 @@ impl JSValkeyClient {
             let this_ref = unsafe { &*this };
             debug_assert!(this_ref.client.get().socket.is_closed());
             if let Some(s) = this_ref._secure.get() {
-                // SAFETY: SSL_CTX is C-refcounted; this releases our ref.
-                unsafe { boringssl::c::SSL_CTX_free(s) };
+                // SSL_CTX is C-refcounted; this releases our ref.
+                boringssl::c::SSL_CTX_free(uws::SslCtx::opaque_ref(s));
             }
             this_ref.client_mut().shutdown(None);
             this_ref.poll_ref.with_mut(|r| r.disable());

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -187,11 +187,11 @@ pub trait BlobExt {
         Self: Sized;
     fn from_url_search_params(
         global_this: &JSGlobalObject,
-        search_params: &mut jsc::URLSearchParams,
+        search_params: &jsc::URLSearchParams,
     ) -> Blob
     where
         Self: Sized;
-    fn from_dom_form_data(global_this: &JSGlobalObject, form_data: &mut jsc::DOMFormData) -> Blob
+    fn from_dom_form_data(global_this: &JSGlobalObject, form_data: &jsc::DOMFormData) -> Blob
     where
         Self: Sized;
     fn content_type(&self) -> &[u8];
@@ -859,7 +859,7 @@ impl BlobExt for Blob {
     }
     fn from_url_search_params(
         global_this: &JSGlobalObject,
-        search_params: &mut jsc::URLSearchParams,
+        search_params: &jsc::URLSearchParams,
     ) -> Blob {
         let mut converter = URLSearchParamsConverter { buf: Vec::new() };
         search_params.to_string(&mut converter, URLSearchParamsConverter::convert);
@@ -882,7 +882,7 @@ impl BlobExt for Blob {
         blob
     }
 
-    fn from_dom_form_data(global_this: &JSGlobalObject, form_data: &mut jsc::DOMFormData) -> Blob {
+    fn from_dom_form_data(global_this: &JSGlobalObject, form_data: &jsc::DOMFormData) -> Blob {
         // "----WebKitFormBoundary" (22 bytes) + 32 lowercase-hex chars of a fresh UUID.
         const BOUNDARY_PREFIX: &[u8; 22] = b"----WebKitFormBoundary";
         let mut boundary_buf = [0u8; BOUNDARY_PREFIX.len() + 32];
@@ -942,13 +942,11 @@ impl BlobExt for Blob {
             ctx.on_entry(unsafe { *name_ }, entry);
         }
         unsafe extern "C" {
-            // `this` is the `&mut DOMFormData` param (coerced); `ctx`/`cb` are
-            // stored opaquely and only used synchronously. Module-private with
-            // one call site below — no caller-side precondition remains. Kept
-            // `*mut` (not `&mut`) to match the `bun_jsc` decl and avoid
-            // `clashing_extern_declarations`.
+            // `this` is the opaque `&DOMFormData` handle; `ctx`/`cb` are stored
+            // opaquely and only used synchronously. Module-private with one call
+            // site below — no caller-side precondition remains.
             safe fn DOMFormData__forEach(
-                this: *mut jsc::DOMFormData,
+                this: &jsc::DOMFormData,
                 ctx: *mut c_void,
                 // Safe fn-ptr: `for_each_thunk` is a safe `extern "C" fn` (its
                 // body localises every raw deref individually), so the callback

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -56,17 +56,17 @@ fn set_blob_content_type(blob: &Blob, mime_type: MimeType) {
 // ────────────────────────────────────────────────────────────────────────────
 
 #[inline]
-fn as_dom_form_data<'a>(value: JSValue) -> Option<&'a mut DOMFormData> {
+fn as_dom_form_data<'a>(value: JSValue) -> Option<&'a DOMFormData> {
     // `DOMFormData` is an opaque C++ type without a `#[bun_jsc::JsClass]` derive;
     // route through the hand-written `from_js` (`DOMFormData.rs`) instead of
     // `value.as_::<DOMFormData>()`.
     DOMFormData::from_js(value)
 }
 #[inline]
-fn as_url_search_params<'a>(value: JSValue) -> Option<&'a mut URLSearchParams> {
+fn as_url_search_params<'a>(value: JSValue) -> Option<&'a URLSearchParams> {
     // See `as_dom_form_data` — opaque C++ type, hand-written `from_js`.
     // `URLSearchParams` is an opaque ZST FFI handle (S008) — safe deref.
-    URLSearchParams::from_js(value).map(|p| bun_opaque::opaque_deref_mut(p.as_ptr()))
+    URLSearchParams::from_js(value).map(|p| bun_opaque::opaque_deref(p.as_ptr()))
 }
 
 bun_core::declare_scope!(BodyValue, visible);

--- a/src/runtime/webcore/CookieMap.rs
+++ b/src/runtime/webcore/CookieMap.rs
@@ -14,7 +14,7 @@ unsafe extern "C" {
     // wraps `UnsafeCell` so `&JSGlobalObject` permits C++ interior mutation.
     // `uws_http_response` is an opaque pass-through validated by the caller.
     safe fn CookieMap__write(
-        cookie_map: &mut CookieMap,
+        cookie_map: &CookieMap,
         global_this: &JSGlobalObject,
         kind: ResponseKind,
         uws_http_response: *mut c_void,
@@ -26,8 +26,12 @@ unsafe extern "C" {
 }
 
 impl CookieMap {
+    /// `&self`, not `&mut self`: `CookieMap` is an `opaque_ffi!` ZST, so `&Self`
+    /// carries no `noalias`/`readonly` and C++ mutates the cookie store through
+    /// it. A `&mut` would assert an exclusivity that never holds — the C++ side
+    /// owns the object and other refs exist by definition.
     pub fn write(
-        &mut self,
+        &self,
         global_this: &JSGlobalObject,
         kind: ResponseKind,
         uws_http_response: *mut c_void,
@@ -40,23 +44,27 @@ impl CookieMap {
 
     // NOTE: no inherent `ref`/`deref` on `CookieMap` — `CookieMapRef` is the
     // sanctioned owner of the intrusive C++ refcount. Exposing bare refcount
-    // mutators on the pointee would let `&mut *cookie_map_ref` corrupt the
+    // mutators on the pointee would let a borrow of the pointee corrupt the
     // count relative to the ref's owned `+1` (double-unref / UAF on Drop),
     // mirroring how `RefPtr` discourages bare `ref`/`deref` on its pointee.
 }
 
-/// Intrusive smart pointer over a C++-refcounted `CookieMap`.
-///
-/// Owns exactly one strong ref: `new_ref` bumps it (for a borrowed handle)
-/// and `Drop` releases it. Mirrors `AbortSignalRef` — a raw FFI handle (opaque
-/// C++ object) cannot live inside `Box`/`Arc`, so this newtype is the
-/// sanctioned owning representation.
-///
-/// (A `+1`-transfer constructor — adopting an already-bumped raw pointer
-/// without a fresh `ref()` — is deliberately omitted until a caller needs it;
-/// every construction site in the tree goes through `new_ref`.)
-#[repr(transparent)]
-pub struct CookieMapRef(NonNull<CookieMap>);
+// The ownership unit is one tick of the C++ intrusive refcount: `CookieMap__ref`
+// adds one, `CookieMap__deref` gives one back. One `CookieMapRef` owns exactly
+// one, taken in `new_ref` and released by `ForeignRef`'s `Drop`.
+bun_opaque::foreign_handle! {
+    /// Intrusive smart pointer over a C++-refcounted `CookieMap`.
+    ///
+    /// Owns exactly one strong ref: [`CookieMapRef::new_ref`] bumps it (for a
+    /// borrowed handle) and `Drop` releases it. Mirrors `AbortSignalRef` — a raw
+    /// FFI handle (opaque C++ object) cannot live inside `Box`/`Arc`, so this
+    /// newtype is the sanctioned owning representation.
+    ///
+    /// The macro also emits `adopt`/`adopt_ptr` (`+1`-transfer constructors that
+    /// take an already-bumped pointer). No caller needs them yet: every
+    /// construction site in the tree goes through `new_ref`.
+    pub struct CookieMapRef(CookieMap) via CookieMap__deref;
+}
 
 impl CookieMapRef {
     /// Bump the refcount of a borrowed `CookieMap` and wrap it (the caller
@@ -64,12 +72,13 @@ impl CookieMapRef {
     #[inline]
     pub fn new_ref(cookie_map: &CookieMap) -> Self {
         CookieMap__ref(cookie_map);
-        Self(NonNull::from(cookie_map))
-    }
-
-    #[inline]
-    pub fn as_ptr(&self) -> *mut CookieMap {
-        self.0.as_ptr()
+        // SAFETY: the `CookieMap__ref` on the line above is the producer — it
+        // just added one strong ref to the C++ intrusive count, over and above
+        // the one `cookie_map` is borrowed from. Nothing else will give that
+        // unit back, so this handle adopts it and releases it exactly once in
+        // `Drop` (via `CookieMap__deref`). `as_mut_ptr()` returns the address of
+        // a live `&CookieMap`, hence non-null.
+        unsafe { Self::adopt(NonNull::new_unchecked(cookie_map.as_mut_ptr())) }
     }
 }
 
@@ -77,29 +86,16 @@ impl core::ops::Deref for CookieMapRef {
     type Target = CookieMap;
     #[inline]
     fn deref(&self) -> &CookieMap {
-        CookieMap::opaque_ref(self.0.as_ptr())
+        self.raw()
     }
 }
 
-impl core::ops::DerefMut for CookieMapRef {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut CookieMap {
-        CookieMap::opaque_mut(self.0.as_ptr())
-    }
-}
+// No `DerefMut`: see `CookieMap::write` — `&mut CookieMap` would assert an
+// exclusivity over a C++-owned object that is never true, and nothing needs it.
 
 impl Clone for CookieMapRef {
     #[inline]
     fn clone(&self) -> Self {
         Self::new_ref(self)
-    }
-}
-
-impl Drop for CookieMapRef {
-    #[inline]
-    fn drop(&mut self) {
-        // Held +1 ref keeps the C++ object alive until this deref; `Deref`
-        // (above) encapsulates the NonNull access.
-        CookieMap__deref(self)
     }
 }

--- a/src/runtime/webcore/Crypto.rs
+++ b/src/runtime/webcore/Crypto.rs
@@ -32,7 +32,6 @@ impl Crypto {
         array_a: &JSUint8Array,
         array_b: &JSUint8Array,
     ) -> JSValue {
-        // `JSUint8Array::slice()` takes `&mut self`; use ptr/len (`&self`) instead.
         let a_ptr = array_a.ptr();
         let b_ptr = array_b.ptr();
         let len = array_a.len();
@@ -49,8 +48,8 @@ impl Crypto {
             return JSValue::ZERO;
         }
 
-        // SAFETY: a_ptr/b_ptr are valid for `len` bytes (just obtained from JSUint8Array;
-        // `JSUint8Array::slice()` needs `&mut self`, so reconstruct the slices here).
+        // SAFETY: a_ptr/b_ptr are valid for `len` bytes. Both arrays may be the same cell,
+        // so take shared slices rather than two `slice()` results.
         // `ffi::slice` tolerates `(null, 0)` for detached/empty arrays.
         let (a, b) = unsafe {
             (
@@ -95,8 +94,8 @@ impl Crypto {
         global: &JSGlobalObject,
         array: &JSUint8Array,
     ) -> JSValue {
-        // `JSUint8Array::slice()` takes
-        // `&mut self`; use ptr()/len() (which take `&self`) to avoid the &mut requirement.
+        // `JSUint8Array::slice()` takes `&mut self`; use ptr()/len() (which take
+        // `&self`) to avoid the &mut requirement.
         // SAFETY: JSC guarantees `ptr()` is valid for `len()` writable bytes while the
         // typed-array cell is alive; `ffi::slice_mut` tolerates `(null, 0)` for detached.
         random_data(global, unsafe {

--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -212,7 +212,7 @@ pub fn to_js_from_multipart_data(
 
     struct Wrapper<'a> {
         global: &'a JSGlobalObject,
-        form: &'a mut DOMFormData,
+        form: &'a DOMFormData,
     }
 
     impl<'a> Wrapper<'a> {

--- a/src/runtime/webcore/TextDecoder.rs
+++ b/src/runtime/webcore/TextDecoder.rs
@@ -5,7 +5,6 @@ use crate::webcore::jsc::{
 use bun_core::AllocError;
 use bun_core::{OwnedString, strings};
 use core::cell::Cell;
-use core::ptr::NonNull;
 
 use jsc::StringJsc as _;
 use jsc::ZigStringJsc as _;
@@ -51,7 +50,7 @@ pub struct TextDecoder {
     // streaming state (lead byte, ISO-2022-JP mode, GB18030 first/second/third),
     // so it must live across `{stream: true}` chunks. Created lazily on first
     // decode, dropped when a flushing decode ends the stream and in `Drop`.
-    codec: Cell<Option<NonNull<TextCodec>>>,
+    codec: Cell<Option<TextCodec>>,
 
     // Read-only after construction (set in `constructor` before the JS wrapper
     // exists) — left bare.
@@ -72,16 +71,6 @@ impl Default for TextDecoder {
             ignore_bom: false,
             fatal: false,
             encoding: EncodingLabel::Utf8,
-        }
-    }
-}
-
-impl Drop for TextDecoder {
-    fn drop(&mut self) {
-        if let Some(codec) = self.codec.get_mut().take() {
-            // SAFETY: `codec` was returned by `TextCodec::create` and has not
-            // been freed (the field is cleared whenever we destroy it).
-            unsafe { TextCodec::destroy(codec.as_ptr()) }
         }
     }
 }
@@ -509,26 +498,22 @@ impl TextDecoder {
                 // so reuse the one from the previous `{stream: true}` chunk.
                 // Create it lazily on first use — matches WebKit's
                 // `if (!m_codec) m_codec = newTextCodec(...)`.
-                let codec_ptr = match self.codec.get() {
-                    Some(ptr) => ptr,
+                // Own the codec for the duration of the call and put it back
+                // below unless this decode flushes. The C++ `decode()` never
+                // calls into JS, so nothing observes the momentarily empty cell.
+                let codec = match self.codec.take() {
+                    Some(codec) => codec,
                     None => {
-                        let Some(ptr) = TextCodec::create(encoding_name) else {
+                        let Some(codec) = TextCodec::create(encoding_name) else {
                             // Fallback to empty string if codec creation fails
                             return Ok(ZigString::init(b"").to_js(global_this));
                         };
                         if !self.ignore_bom {
-                            // `TextCodec` is an opaque ZST FFI handle (S008);
-                            // `ptr` is live — safe via `opaque_deref_mut`.
-                            bun_opaque::opaque_deref_mut(ptr.as_ptr()).strip_bom();
+                            codec.strip_bom();
                         }
-                        self.codec.set(Some(ptr));
-                        ptr
+                        codec
                     }
                 };
-                // `TextCodec` is an opaque ZST FFI handle (S008); `codec_ptr`
-                // is live for this call — safe via `opaque_deref_mut`. The
-                // C++ `decode()` does not call back into JS, so no re-entrancy.
-                let codec = bun_opaque::opaque_deref_mut(codec_ptr.as_ptr());
 
                 // Decode the data
                 let result = codec.decode(buffer_slice, FLUSH, self.fatal);
@@ -543,10 +528,9 @@ impl TextDecoder {
                 // reset on flush (e.g. `m_iso2022JPDecoderState`) would leak
                 // into the next stream.
                 if FLUSH {
-                    self.codec.set(None);
-                    // SAFETY: `codec_ptr` came from `TextCodec::create` above
-                    // (or on an earlier chunk) and is freed exactly once here.
-                    unsafe { TextCodec::destroy(codec_ptr.as_ptr()) };
+                    drop(codec);
+                } else {
+                    self.codec.set(Some(codec));
                 }
 
                 // Check for errors if fatal mode is enabled

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -1570,10 +1570,10 @@ impl<'a> CopyFileWindows<'a> {
 
     pub fn throw(&mut self, err: bun_sys::Error) {
         let global_this = self.event_loop.global_ref();
-        // `swap()` returns a `&mut JSPromise` into a GC-owned cell (not into
-        // `self`), but its lifetime is elided to `&mut self`. Decay to a raw pointer so
-        // borrowck doesn't tie it to `self` across `destroy` below.
-        let promise = JSPromise::opaque_mut(self.promise.swap());
+        // `swap()` borrows a GC-owned cell (not `self`), but its lifetime is elided
+        // to `&mut self`. Decay to a raw pointer so borrowck doesn't tie it to `self`
+        // across `destroy` below.
+        let promise = JSPromise::opaque_ref(self.promise.swap());
         let err_instance = err.to_js_with_async_stack(global_this, promise);
 
         // SAFETY: VM-owned event loop is valid for the process lifetime; `enter_scope`
@@ -1662,7 +1662,7 @@ impl<'a> CopyFileWindows<'a> {
         let global_this = self.event_loop.global_ref();
         // see `throw` — re-type the GC cell via the ZST opaque deref so it
         // outlives `destroy(self)` for borrowck.
-        let promise = JSPromise::opaque_mut(self.promise.swap());
+        let promise = JSPromise::opaque_ref(self.promise.swap());
         // SAFETY: VM-owned event loop is valid for the process lifetime; `enter_scope`
         // calls enter() now and exit() on drop.
         let _guard = unsafe {

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -804,16 +804,14 @@ impl StreamResult {
                 let value = err.to_js(global_this);
                 value.ensure_still_alive();
                 *result = StreamResult::Temporary(RawSlice::EMPTY);
-                // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*mut → &mut`
-                // deref. Fresh temp `&mut` is the sole borrow across this
-                // re-entrant call (no long-lived `&mut JSPromise` held).
+                // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*mut → &` deref.
                 let _ =
-                    JSPromise::opaque_mut(promise).reject_with_async_stack(global_this, Ok(value));
+                    JSPromise::opaque_ref(promise).reject_with_async_stack(global_this, Ok(value));
                 // TODO: properly propagate exception upwards
             }
             StreamResult::Done => {
-                // S008: see reject_with_async_stack above; fresh temp `&mut`.
-                let _ = JSPromise::opaque_mut(promise).resolve(global_this, JSValue::FALSE);
+                // S008: see reject_with_async_stack above.
+                let _ = JSPromise::opaque_ref(promise).resolve(global_this, JSValue::FALSE);
                 // TODO: properly propagate exception upwards
             }
             _ => {
@@ -821,8 +819,8 @@ impl StreamResult {
                     Ok(v) => v,
                     Err(err) => {
                         *result = StreamResult::Temporary(RawSlice::EMPTY);
-                        // S008: see reject_with_async_stack above; fresh temp `&mut`.
-                        let _ = JSPromise::opaque_mut(promise).reject(global_this, Err(err));
+                        // S008: see reject_with_async_stack above.
+                        let _ = JSPromise::opaque_ref(promise).reject(global_this, Err(err));
                         // TODO: properly propagate exception upwards
                         vm.event_loop_ref().exit();
                         return;
@@ -831,8 +829,8 @@ impl StreamResult {
                 value.ensure_still_alive();
 
                 *result = StreamResult::Temporary(RawSlice::EMPTY);
-                // S008: see reject_with_async_stack above; fresh temp `&mut`.
-                let _ = JSPromise::opaque_mut(promise).resolve(global_this, value);
+                // S008: see reject_with_async_stack above.
+                let _ = JSPromise::opaque_ref(promise).resolve(global_this, value);
                 // TODO: properly propagate exception upwards
             }
         }
@@ -2014,9 +2012,9 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             bun_core::scoped_log!(HTTPServerWritableLog, "flushPromise()");
 
             let global_this = self.global_this();
-            // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `* → &`/`&mut` deref.
+            // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `* → &` deref.
             JSPromise::opaque_ref(prom).to_js().unprotect();
-            let result = JSPromise::opaque_mut(prom).resolve(
+            let result = JSPromise::opaque_ref(prom).resolve(
                 global_this,
                 JSValue::js_number(self.wrote.saturating_sub(self.wrote_at_start_of_flush) as f64),
             );
@@ -2501,8 +2499,8 @@ impl BufferAction {
         global: &JSGlobalObject,
         err: &StreamError,
     ) -> core::result::Result<(), jsc::JsTerminated> {
-        // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*mut → &mut` deref.
-        JSPromise::opaque_mut(self.swap()).reject(global, Ok(err.to_js(global)))
+        // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*mut → &` deref.
+        JSPromise::opaque_ref(self.swap()).reject(global, Ok(err.to_js(global)))
     }
 
     pub fn resolve(
@@ -2510,8 +2508,8 @@ impl BufferAction {
         global: &JSGlobalObject,
         result: JSValue,
     ) -> core::result::Result<(), jsc::JsTerminated> {
-        // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*mut → &mut` deref.
-        JSPromise::opaque_mut(self.swap()).resolve(global, result)
+        // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*mut → &` deref.
+        JSPromise::opaque_ref(self.swap()).resolve(global, result)
     }
 
     pub fn value(&self) -> JSValue {

--- a/src/sha_hmac/sha.rs
+++ b/src/sha_hmac/sha.rs
@@ -14,8 +14,14 @@ use bun_boringssl_sys as boringssl_sys;
 // identity across crates (eliminating the cross-crate opaque-pointer casts).
 // ──────────────────────────────────────────────────────────────────────────
 pub mod ffi {
+    /// The C `ENGINE` object, **not** `bun_boringssl_sys`'s owning `ENGINE`
+    /// handle: `hash(.., engine)` below only borrows the VM-owned engine pointer
+    /// (`s3_signing::credentials` passes null), so nothing here releases a unit.
+    /// Kept under the name `ENGINE` so `bun_sha_hmac::sha::ffi::ENGINE` path
+    /// consumers need no edit.
+    pub use bun_boringssl_sys::sys::ENGINE;
     pub use bun_boringssl_sys::{
-        ENGINE, EVP_Digest, EVP_DigestFinal, EVP_DigestInit, EVP_DigestUpdate, EVP_MD, EVP_MD_CTX,
+        EVP_Digest, EVP_DigestFinal, EVP_DigestInit, EVP_DigestUpdate, EVP_MD, EVP_MD_CTX,
         EVP_MD_CTX_cleanup, EVP_MD_CTX_init, EVP_blake2b256, EVP_blake2b512, EVP_md4, EVP_md5,
         EVP_md5_sha1, EVP_ripemd160, EVP_sha1, EVP_sha3_224, EVP_sha3_256, EVP_sha3_384,
         EVP_sha3_512, EVP_sha224, EVP_sha256, EVP_sha384, EVP_sha512, EVP_sha512_224,

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -311,8 +311,8 @@ impl MySQLConnection {
 
         self.auth_data = Vec::new();
         if let Some(s) = self.secure.take() {
-            // SAFETY: FFI — secure is an owned SSL_CTX* freed exactly once here
-            unsafe { bun_boringssl_sys::SSL_CTX_free(s) };
+            // `secure` is an owned SSL_CTX ref, released exactly once here.
+            bun_boringssl_sys::SSL_CTX_free(SslCtx::opaque_ref(s));
         }
         // _options_buf dropped at scope exit (Box<[u8]> frees via Drop)
     }

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -1446,8 +1446,7 @@ impl PostgresSQLConnection {
 
             // tls_config dropped by Box drop below.
             if let Some(s) = (*this).secure {
-                // SSL_CTX_free on a valid SSL_CTX*.
-                BoringSSL::c::SSL_CTX_free(s);
+                BoringSSL::c::SSL_CTX_free(uws::SslCtx::opaque_ref(s));
             }
             // Box-allocated in `call()`; ref_count is 0; reclaim.
             drop(bun_core::heap::take(this));

--- a/src/sql_jsc/shared/ConnectionCtorArgs.rs
+++ b/src/sql_jsc/shared/ConnectionCtorArgs.rs
@@ -42,8 +42,8 @@ pub(crate) type TlsGuard = scopeguard::ScopeGuard<GuardState, fn(GuardState)>;
 pub(crate) fn guard_tls(secure: Option<*mut uws::SslCtx>, tls_config: SSLConfig) -> TlsGuard {
     fn free((secure, _tls_config): GuardState) {
         if let Some(s) = secure {
-            // SAFETY: `secure` holds one `ssl_ctx_cache` reference owned by the caller.
-            unsafe { bun_boringssl_sys::SSL_CTX_free(s) };
+            // `secure` holds one `ssl_ctx_cache` reference owned by the caller.
+            bun_boringssl_sys::SSL_CTX_free(uws::SslCtx::opaque_ref(s));
         }
     }
     scopeguard::guard((secure, tls_config), free as fn(GuardState))

--- a/src/tcc_sys/tcc.rs
+++ b/src/tcc_sys/tcc.rs
@@ -136,7 +136,7 @@ pub type SymbolCallback =
     unsafe extern "C" fn(ctx: *mut c_void, name: *const c_char, val: *const Symbol);
 
 bun_opaque::opaque_ffi! {
-    /// Opaque TinyCC compilation state. Always handled via `*mut State` / `&mut State`.
+    /// Opaque TinyCC compilation state. Always handled via `*mut State` / `&State`.
     pub struct State;
 }
 
@@ -185,8 +185,7 @@ impl State {
             // SAFETY: p was returned by tcc_new and has not yet been deleted.
             unsafe { tcc_delete(p.as_ptr()) }
         });
-        // SAFETY: state_ptr is valid and uniquely owned for the duration of this fn.
-        let state: &mut State = unsafe { &mut *state_ptr.as_ptr() };
+        let state: &State = State::opaque_ref(state_ptr.as_ptr());
 
         // setOutputType has side effects that are conditional on existing
         // options, so this must be called after setOptions
@@ -232,14 +231,14 @@ impl State {
     }
 
     /// Set `CONFIG_TCCDIR` at runtime
-    pub fn set_lib_path(&mut self, path: &ZStr) {
-        // SAFETY: self is a valid *mut TCCState; path is NUL-terminated.
-        unsafe { tcc_set_lib_path(self, path.as_ptr()) }
+    pub fn set_lib_path(&self, path: &ZStr) {
+        // SAFETY: as_mut_ptr() yields a valid *mut TCCState; path is NUL-terminated.
+        unsafe { tcc_set_lib_path(self.as_mut_ptr(), path.as_ptr()) }
     }
 
     /// Set error/warning display callback
     pub fn set_error_func<Context>(
-        &mut self,
+        &self,
         error_opaque: Option<*mut Context>,
         error_func: ErrorFunc<Context>,
     ) {
@@ -253,8 +252,8 @@ impl State {
             >(error_func)
         });
         let opaque = error_opaque.map_or(core::ptr::null_mut(), |p| p.cast::<c_void>());
-        // SAFETY: self is a valid *mut TCCState.
-        unsafe { tcc_set_error_func(self, opaque, erased) }
+        // SAFETY: as_mut_ptr() yields a valid *mut TCCState.
+        unsafe { tcc_set_error_func(self.as_mut_ptr(), opaque, erased) }
     }
 
     // NOTE: get_error_func / get_error_opaque wrappers removed — the underlying
@@ -262,9 +261,9 @@ impl State {
     // libtcc.h and would fail to link if referenced.
 
     /// Set options as from command line (multiple supported)
-    pub fn set_options(&mut self, str_: &ZStr) -> Result<(), Error> {
-        // SAFETY: self is a valid *mut TCCState; str_ is NUL-terminated.
-        if unsafe { tcc_set_options(self, str_.as_ptr()) } != 0 {
+    pub fn set_options(&self, str_: &ZStr) -> Result<(), Error> {
+        // SAFETY: as_mut_ptr() yields a valid *mut TCCState; str_ is NUL-terminated.
+        if unsafe { tcc_set_options(self.as_mut_ptr(), str_.as_ptr()) } != 0 {
             return Err(Error::InvalidOptions);
         }
         Ok(())
@@ -273,18 +272,18 @@ impl State {
     // ======================== Preprocessor ========================
 
     /// Add include path
-    pub fn add_include_path(&mut self, pathname: &ZStr) -> Result<(), Error> {
-        // SAFETY: self is a valid *mut TCCState; pathname is NUL-terminated.
-        if unsafe { tcc_add_include_path(self, pathname.as_ptr()) } != 0 {
+    pub fn add_include_path(&self, pathname: &ZStr) -> Result<(), Error> {
+        // SAFETY: as_mut_ptr() yields a valid *mut TCCState; pathname is NUL-terminated.
+        if unsafe { tcc_add_include_path(self.as_mut_ptr(), pathname.as_ptr()) } != 0 {
             return Err(Error::InvalidIncludePath);
         }
         Ok(())
     }
 
     /// Add in system include path
-    pub fn add_sys_include_path(&mut self, pathname: &ZStr) -> Result<(), Error> {
-        // SAFETY: self is a valid *mut TCCState; pathname is NUL-terminated.
-        if unsafe { tcc_add_sysinclude_path(self, pathname.as_ptr()) } != 0 {
+    pub fn add_sys_include_path(&self, pathname: &ZStr) -> Result<(), Error> {
+        // SAFETY: as_mut_ptr() yields a valid *mut TCCState; pathname is NUL-terminated.
+        if unsafe { tcc_add_sysinclude_path(self.as_mut_ptr(), pathname.as_ptr()) } != 0 {
             return Err(Error::InvalidIncludePath);
         }
         Ok(())
@@ -295,9 +294,9 @@ impl State {
     /// ```c
     /// #define sym value
     /// ```
-    pub fn define_symbol(&mut self, sym: &ZStr, value: &ZStr) {
-        // SAFETY: self is a valid *mut TCCState; sym/value are NUL-terminated.
-        unsafe { tcc_define_symbol(self, sym.as_ptr(), value.as_ptr()) }
+    pub fn define_symbol(&self, sym: &ZStr, value: &ZStr) {
+        // SAFETY: as_mut_ptr() yields a valid *mut TCCState; sym/value are NUL-terminated.
+        unsafe { tcc_define_symbol(self.as_mut_ptr(), sym.as_ptr(), value.as_ptr()) }
     }
 
     /// Define multiple preprocessor symbols with integer values.
@@ -306,7 +305,7 @@ impl State {
     /// ```ignore
     /// state.define_symbols(&[("foo", 1), ("baz", 42)]);
     /// ```
-    pub fn define_symbols(&mut self, symbols: &[(&str, i64)]) {
+    pub fn define_symbols(&self, symbols: &[(&str, i64)]) {
         let mut buf = [0u8; 256];
         for &(name, value) in symbols {
             // Copy the name into the stack buffer to NUL-terminate it for the C ABI.
@@ -325,9 +324,9 @@ impl State {
             buf[val_end] = 0;
             let val_ptr = buf[val_off..].as_ptr().cast::<c_char>();
 
-            // SAFETY: self is a valid *mut TCCState; both buffer regions are NUL-terminated and
-            // outlive the FFI call (tcc_define_symbol copies its arguments).
-            unsafe { tcc_define_symbol(self, sym_ptr, val_ptr) }
+            // SAFETY: as_mut_ptr() yields a valid *mut TCCState; both buffer regions are
+            // NUL-terminated and outlive the FFI call (tcc_define_symbol copies its arguments).
+            unsafe { tcc_define_symbol(self.as_mut_ptr(), sym_ptr, val_ptr) }
         }
     }
 
@@ -336,9 +335,9 @@ impl State {
     /// ```c
     /// #undef sym
     /// ```
-    pub fn undefine_symbol(&mut self, sym: &ZStr) {
-        // SAFETY: self is a valid *mut TCCState; sym is NUL-terminated.
-        unsafe { tcc_undefine_symbol(self, sym.as_ptr()) }
+    pub fn undefine_symbol(&self, sym: &ZStr) {
+        // SAFETY: as_mut_ptr() yields a valid *mut TCCState; sym is NUL-terminated.
+        unsafe { tcc_undefine_symbol(self.as_mut_ptr(), sym.as_ptr()) }
     }
 
     // ======================== Compiling ========================
@@ -348,18 +347,18 @@ impl State {
     /// ## Errors
     /// - File not found
     /// - Syntax/formatting error
-    pub fn add_file(&mut self, filename: &ZStr) -> Result<(), Error> {
-        // SAFETY: self is a valid *mut TCCState; filename is NUL-terminated.
-        if unsafe { tcc_add_file(self, filename.as_ptr()) } != 0 {
+    pub fn add_file(&self, filename: &ZStr) -> Result<(), Error> {
+        // SAFETY: as_mut_ptr() yields a valid *mut TCCState; filename is NUL-terminated.
+        if unsafe { tcc_add_file(self.as_mut_ptr(), filename.as_ptr()) } != 0 {
             return Err(Error::CompileError);
         }
         Ok(())
     }
 
     /// Compile a string containing a C source.
-    pub fn compile_string(&mut self, buf: &ZStr) -> Result<(), Error> {
-        // SAFETY: self is a valid *mut TCCState; buf is NUL-terminated.
-        if unsafe { tcc_compile_string(self, buf.as_ptr()) } != 0 {
+    pub fn compile_string(&self, buf: &ZStr) -> Result<(), Error> {
+        // SAFETY: as_mut_ptr() yields a valid *mut TCCState; buf is NUL-terminated.
+        if unsafe { tcc_compile_string(self.as_mut_ptr(), buf.as_ptr()) } != 0 {
             return Err(Error::CompileError);
         }
         Ok(())
@@ -368,27 +367,27 @@ impl State {
     // ======================== Linking Commands ========================
 
     /// Set output type. MUST BE CALLED before any compilation
-    pub fn set_output_type(&mut self, output_type: OutputFormat) -> Result<(), Error> {
-        // SAFETY: self is a valid *mut TCCState.
-        if unsafe { tcc_set_output_type(self, output_type as c_int) } == -1 {
+    pub fn set_output_type(&self, output_type: OutputFormat) -> Result<(), Error> {
+        // SAFETY: as_mut_ptr() yields a valid *mut TCCState.
+        if unsafe { tcc_set_output_type(self.as_mut_ptr(), output_type as c_int) } == -1 {
             return Err(Error::InvalidOutputType);
         }
         Ok(())
     }
 
     /// Add a library. Equivalent to `-Lpath` option
-    pub fn add_library_path(&mut self, pathname: &ZStr) -> Result<(), Error> {
-        // SAFETY: self is a valid *mut TCCState; pathname is NUL-terminated.
-        if unsafe { tcc_add_library_path(self, pathname.as_ptr()) } != 0 {
+    pub fn add_library_path(&self, pathname: &ZStr) -> Result<(), Error> {
+        // SAFETY: as_mut_ptr() yields a valid *mut TCCState; pathname is NUL-terminated.
+        if unsafe { tcc_add_library_path(self.as_mut_ptr(), pathname.as_ptr()) } != 0 {
             return Err(Error::InvalidLibraryPath);
         }
         Ok(())
     }
 
     /// Add a library. The library name is the same as the argument of the `-l` option
-    pub fn add_library(&mut self, libraryname: &ZStr) -> Result<(), Error> {
-        // SAFETY: self is a valid *mut TCCState; libraryname is NUL-terminated.
-        if unsafe { tcc_add_library(self, libraryname.as_ptr()) } != 0 {
+    pub fn add_library(&self, libraryname: &ZStr) -> Result<(), Error> {
+        // SAFETY: as_mut_ptr() yields a valid *mut TCCState; libraryname is NUL-terminated.
+        if unsafe { tcc_add_library(self.as_mut_ptr(), libraryname.as_ptr()) } != 0 {
             return Err(Error::InvalidLibraryPath);
         }
         Ok(())
@@ -398,9 +397,10 @@ impl State {
     /// address and never dereferenced here; it must remain valid for any JIT'd
     /// code that calls it (same precondition as `add_symbols`).
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub fn add_symbol(&mut self, name: &ZStr, val: *const c_void) -> Result<(), Error> {
-        // SAFETY: self is a valid *mut TCCState; name is NUL-terminated; val is an opaque address.
-        if unsafe { tcc_add_symbol(self, name.as_ptr(), val) } != 0 {
+    pub fn add_symbol(&self, name: &ZStr, val: *const c_void) -> Result<(), Error> {
+        // SAFETY: as_mut_ptr() yields a valid *mut TCCState; name is NUL-terminated; val is an
+        // opaque address.
+        if unsafe { tcc_add_symbol(self.as_mut_ptr(), name.as_ptr(), val) } != 0 {
             return Err(Error::InvalidSymbol);
         }
         Ok(())
@@ -415,7 +415,7 @@ impl State {
     ///     ("sub", sub as *const c_void),
     /// ])?;
     /// ```
-    pub fn add_symbols(&mut self, symbols: &[(&str, *const c_void)]) -> Result<(), Error> {
+    pub fn add_symbols(&self, symbols: &[(&str, *const c_void)]) -> Result<(), Error> {
         // Copy each name into a stack buffer to NUL-terminate it for the C ABI.
         let mut buf = [0u8; 256];
         for &(name, val) in symbols {
@@ -423,9 +423,10 @@ impl State {
             debug_assert!(len < buf.len());
             buf[..len].copy_from_slice(name.as_bytes());
             buf[len] = 0;
-            // SAFETY: self is a valid *mut TCCState; buf[..=len] is NUL-terminated and outlives
-            // the FFI call (tcc_add_symbol copies the name); val is an opaque address.
-            if unsafe { tcc_add_symbol(self, buf.as_ptr().cast::<c_char>(), val) } != 0 {
+            // SAFETY: as_mut_ptr() yields a valid *mut TCCState; buf[..=len] is NUL-terminated and
+            // outlives the FFI call (tcc_add_symbol copies the name); val is an opaque address.
+            if unsafe { tcc_add_symbol(self.as_mut_ptr(), buf.as_ptr().cast::<c_char>(), val) } != 0
+            {
                 return Err(Error::InvalidSymbol);
             }
         }
@@ -433,9 +434,9 @@ impl State {
     }
 
     /// Output an executable, library or object file. DO NOT call `relocate` before.
-    pub fn output_file(&mut self, filename: &ZStr) -> Result<(), Error> {
-        // SAFETY: self is a valid *mut TCCState; filename is NUL-terminated.
-        if unsafe { tcc_output_file(self, filename.as_ptr()) } == -1 {
+    pub fn output_file(&self, filename: &ZStr) -> Result<(), Error> {
+        // SAFETY: as_mut_ptr() yields a valid *mut TCCState; filename is NUL-terminated.
+        if unsafe { tcc_output_file(self.as_mut_ptr(), filename.as_ptr()) } == -1 {
             return Err(Error::OutputError);
         }
         Ok(())
@@ -443,18 +444,18 @@ impl State {
 
     /// Link and run `main()` function and return its value. DO NOT call `relocate` before.
     /// Returns the status code returned by the program's `main()` function.
-    pub fn run(&mut self, argc: c_int, argv: *const *const c_char) -> c_int {
-        // SAFETY: self is a valid *mut TCCState; argv points to argc NUL-terminated C strings.
-        // Cast const away to match the C ABI (tcc does not mutate argv).
-        unsafe { tcc_run(self, argc, argv as *mut *mut c_char) }
+    pub fn run(&self, argc: c_int, argv: *const *const c_char) -> c_int {
+        // SAFETY: as_mut_ptr() yields a valid *mut TCCState; argv points to argc NUL-terminated C
+        // strings. Cast const away to match the C ABI (tcc does not mutate argv).
+        unsafe { tcc_run(self.as_mut_ptr(), argc, argv as *mut *mut c_char) }
     }
 
     /// Do all relocations (needed before using `get_symbol`)
     /// Memory is allocated and managed internally by TinyCC.
     /// Returns Ok on success, error on failure.
-    pub fn relocate(&mut self) -> Result<(), Error> {
-        // SAFETY: self is a valid *mut TCCState.
-        let ret = unsafe { tcc_relocate(self) };
+    pub fn relocate(&self) -> Result<(), Error> {
+        // SAFETY: as_mut_ptr() yields a valid *mut TCCState.
+        let ret = unsafe { tcc_relocate(self.as_mut_ptr()) };
         if ret < 0 {
             return Err(Error::RelocationError);
         }
@@ -462,16 +463,16 @@ impl State {
     }
 
     /// Return symbol value or NULL if not found
-    pub fn get_symbol(&mut self, name: &ZStr) -> Option<NonNull<Symbol>> {
-        // SAFETY: self is a valid *mut TCCState; name is NUL-terminated.
-        NonNull::new(unsafe { tcc_get_symbol(self, name.as_ptr()) }.cast::<Symbol>())
+    pub fn get_symbol(&self, name: &ZStr) -> Option<NonNull<Symbol>> {
+        // SAFETY: as_mut_ptr() yields a valid *mut TCCState; name is NUL-terminated.
+        NonNull::new(unsafe { tcc_get_symbol(self.as_mut_ptr(), name.as_ptr()) }.cast::<Symbol>())
     }
 
     /// Return symbol value or NULL if not found.
     /// `ctx` is forwarded opaquely to `symbol_cb`; it must be valid for every
     /// callback invocation (or null if `symbol_cb` ignores it).
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub fn list_symbols(&mut self, ctx: *mut c_void, symbol_cb: Option<SymbolCallback>) {
+    pub fn list_symbols(&self, ctx: *mut c_void, symbol_cb: Option<SymbolCallback>) {
         // SAFETY: SymbolCallback is ABI-identical to the extern's callback type
         // (`*const Symbol` vs `*const c_void` in the last param).
         let erased = symbol_cb.map(|f| unsafe {
@@ -480,7 +481,7 @@ impl State {
                 unsafe extern "C" fn(*mut c_void, *const c_char, *const c_void),
             >(f)
         });
-        // SAFETY: self is a valid *mut TCCState.
-        unsafe { tcc_list_symbols(self, ctx, erased) }
+        // SAFETY: as_mut_ptr() yields a valid *mut TCCState.
+        unsafe { tcc_list_symbols(self.as_mut_ptr(), ctx, erased) }
     }
 }

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -154,9 +154,12 @@ pub mod ssl_wrapper {
     // Re-export the canonical BoringSSL FFI surface; the lower-tier crate now
     // declares every symbol SSLWrapper needs, so the old local shim is gone.
     mod boring_sys {
-        // The C object, not the owning handle: `SSLWrapper` stores the pointer
-        // and releases it in `deinit`.
-        pub(super) use bun_boringssl::c::sys::SSL_CTX;
+        // The C objects, not the owning handles: `SSLWrapper` stores the raw
+        // `SSL_CTX*` and releases it in `deinit`; the trust store returned by
+        // `us_get_shared_default_ca_store` is handed straight to the
+        // `SSL_set0_verify_cert_store` sink (a transfer, not a release), and the
+        // `X509_STORE_CTX*` in the verify callback is owned by BoringSSL.
+        pub(super) use bun_boringssl::c::sys::{SSL_CTX, X509_STORE, X509_STORE_CTX};
         pub(super) use bun_boringssl::c::{
             BIO_ctrl_pending, BIO_free, BIO_new, BIO_read, BIO_s_mem, BIO_set_mem_eof_return,
             BIO_write, ERR_clear_error, SSL, SSL_CTX_free, SSL_CTX_get_verify_mode, SSL_ERROR_SSL,
@@ -166,7 +169,7 @@ pub mod ssl_wrapper {
             SSL_get_shutdown, SSL_get_wbio, SSL_is_init_finished, SSL_new, SSL_pending, SSL_read,
             SSL_renegotiate, SSL_set_accept_state, SSL_set_bio, SSL_set_connect_state,
             SSL_set_renegotiate_mode, SSL_set_verify, SSL_set0_verify_cert_store, SSL_shutdown,
-            SSL_write, X509_STORE, X509_STORE_CTX, ssl_renegotiate_explicit, ssl_renegotiate_never,
+            SSL_write, ssl_renegotiate_explicit, ssl_renegotiate_never,
         };
     }
 

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -34,11 +34,11 @@ pub use bun_uws_sys::response::State;
 pub use bun_uws_sys::{h3 as H3, quic, udp, vtable};
 pub type Socket = us_socket_t;
 
-/// Bare BoringSSL `SSL_CTX`. `SSL_CTX_up_ref`/`SSL_CTX_free` is the refcount;
-/// policy (verify mode, reneg limits) is encoded on the SSL_CTX itself via
-/// `us_ssl_ctx_from_options`, so there's no wrapper struct. `Option<*mut SslCtx>`
-/// is what listen/connect/adopt take.
-pub type SslCtx = bun_boringssl::c::SSL_CTX;
+/// The BoringSSL `SSL_CTX` C object. `SSL_CTX_up_ref`/`SSL_CTX_free` is the
+/// refcount; policy (verify mode, reneg limits) is encoded on the SSL_CTX itself
+/// via `us_ssl_ctx_from_options`. `Option<*mut SslCtx>` is what
+/// listen/connect/adopt take; the owning handle is `bun_boringssl::c::SSL_CTX`.
+pub type SslCtx = bun_boringssl::c::sys::SSL_CTX;
 
 /// uWS C++ `WebSocketContext<SSL,true,UserData>*`. Only ever produced by the
 /// upgrade-handler thunk and round-tripped to `uws_res_upgrade`; Rust never
@@ -154,10 +154,13 @@ pub mod ssl_wrapper {
     // Re-export the canonical BoringSSL FFI surface; the lower-tier crate now
     // declares every symbol SSLWrapper needs, so the old local shim is gone.
     mod boring_sys {
+        // The C object, not the owning handle: `SSLWrapper` stores the pointer
+        // and releases it in `deinit`.
+        pub(super) use bun_boringssl::c::sys::SSL_CTX;
         pub(super) use bun_boringssl::c::{
             BIO_ctrl_pending, BIO_free, BIO_new, BIO_read, BIO_s_mem, BIO_set_mem_eof_return,
-            BIO_write, ERR_clear_error, SSL, SSL_CTX, SSL_CTX_free, SSL_CTX_get_verify_mode,
-            SSL_ERROR_SSL, SSL_ERROR_SYSCALL, SSL_ERROR_WANT_READ, SSL_ERROR_WANT_RENEGOTIATE,
+            BIO_write, ERR_clear_error, SSL, SSL_CTX_free, SSL_CTX_get_verify_mode, SSL_ERROR_SSL,
+            SSL_ERROR_SYSCALL, SSL_ERROR_WANT_READ, SSL_ERROR_WANT_RENEGOTIATE,
             SSL_ERROR_WANT_WRITE, SSL_ERROR_ZERO_RETURN, SSL_RECEIVED_SHUTDOWN, SSL_VERIFY_NONE,
             SSL_VERIFY_PEER, SSL_do_handshake, SSL_free, SSL_get_error, SSL_get_rbio,
             SSL_get_shutdown, SSL_get_wbio, SSL_is_init_finished, SSL_new, SSL_pending, SSL_read,
@@ -383,9 +386,11 @@ pub mod ssl_wrapper {
             handlers: Handlers<T>,
         ) -> Result<Self, InitError> {
             bun_boringssl::load();
-            // SAFETY: ctx is a valid non-null SSL_CTX*; SSL_new returns null on OOM.
-            let ssl = NonNull::new(unsafe { boring_sys::SSL_new(ctx.as_ptr()) })
-                .ok_or(InitError::OutOfMemory)?;
+            // SSL_new returns null on OOM.
+            let ssl = NonNull::new(boring_sys::SSL_new(boring_sys::SSL_CTX::opaque_ref(
+                ctx.as_ptr(),
+            )))
+            .ok_or(InitError::OutOfMemory)?;
             // errdefer BoringSSL.SSL_free(ssl) — FFI cleanup on early return
             let ssl_guard = scopeguard::guard(ssl, |ssl| {
                 // SAFETY: ssl was created by SSL_new above and is solely owned by this guard until disarmed.
@@ -427,8 +432,9 @@ pub mod ssl_wrapper {
                     // accident: net.ts forced `requestCert: true` after
                     // `[buntls]` and `SSLConfig.fromJS` rebuilt the CTX with
                     // roots from that.)
-                    if boring_sys::SSL_CTX_get_verify_mode(ctx.as_ptr())
-                        == boring_sys::SSL_VERIFY_NONE
+                    if boring_sys::SSL_CTX_get_verify_mode(boring_sys::SSL_CTX::opaque_ref(
+                        ctx.as_ptr(),
+                    )) == boring_sys::SSL_VERIFY_NONE
                     {
                         boring_sys::SSL_set_verify(
                             ssl.as_ptr(),
@@ -522,8 +528,7 @@ pub mod ssl_wrapper {
             // already freed inside create_ssl_context, so SSL_CTX_free is
             // sufficient on the error path.
             let ctx_guard = scopeguard::guard(ssl_ctx, |c| {
-                // SAFETY: ssl_ctx ref was just created by create_ssl_context and not yet adopted by init_with_ctx.
-                unsafe { boring_sys::SSL_CTX_free(c.as_ptr()) };
+                boring_sys::SSL_CTX_free(boring_sys::SSL_CTX::opaque_ref(c.as_ptr()));
             });
             let this = Self::init_with_ctx(ssl_ctx, is_client, handlers)?;
             let _ = scopeguard::ScopeGuard::into_inner(ctx_guard);
@@ -799,8 +804,9 @@ pub mod ssl_wrapper {
                 unsafe { boring_sys::SSL_free(ssl.as_ptr()) };
             }
             if let Some(ctx) = self.ctx.take() {
-                // SAFETY: ctx ref was adopted in init/init_with_ctx; SSL_CTX_free decrements the C refcount and frees the SSL context and all the certificates when it hits zero.
-                unsafe { boring_sys::SSL_CTX_free(ctx.as_ptr()) };
+                // The ref adopted in init/init_with_ctx; the C refcount frees the
+                // context and all its certificates when it hits zero.
+                boring_sys::SSL_CTX_free(boring_sys::SSL_CTX::opaque_ref(ctx.as_ptr()));
             }
         }
 

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -63,16 +63,16 @@ pub type NewApp<const SSL: bool> = App<SSL>;
 macro_rules! uws_app_route_methods {
     ($($name:ident => $cfn:ident),* $(,)?) => {$(
         pub fn $name(
-            &mut self,
+            &self,
             pattern: &[u8],
             handler: c::uws_method_handler,
             user_data: *mut c_void,
         ) {
-            // SAFETY: self is a valid app; pattern outlives the call (uWS copies it).
+            // SAFETY: pattern outlives the call (uWS copies it).
             unsafe {
                 c::$cfn(
                     Self::SSL_FLAG,
-                    std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
+                    self.as_raw(),
                     pattern.as_ptr(),
                     pattern.len(),
                     handler,
@@ -87,21 +87,30 @@ impl<const SSL: bool> App<SSL> {
     pub const IS_SSL: bool = SSL;
     const SSL_FLAG: i32 = SSL as i32;
 
-    /// `&mut uws_app_s` view of self for `safe fn` shims. Both types are
+    /// Raw `uws_app_t*` with write provenance, derived through the `UnsafeCell`.
+    /// `App` is hand-written rather than `opaque_ffi!`-generated, so it needs its
+    /// own copy of the macro's accessor. `&Self` covers zero Rust-visible bytes,
+    /// so C++ mutating the app through the returned pointer cannot alias it.
+    #[inline(always)]
+    pub fn as_mut_ptr(&self) -> *mut Self {
+        self._p.get().cast::<Self>()
+    }
+
+    /// `&uws_app_s` view of self for `safe fn` shims. Both types are
     /// `#[repr(C)]` opaque ZSTs with `UnsafeCell<[u8; 0]>`, so the cast is a
     /// no-op and the reference is ABI-identical to a non-null pointer.
     #[inline]
-    fn as_raw(&mut self) -> &mut uws_app_s {
+    fn as_raw(&self) -> &uws_app_s {
         // SAFETY: `App<SSL>` and `uws_app_s` are layout-identical opaque ZSTs
-        // over the same C++ object; the borrow reborrows `&mut self`.
-        unsafe { &mut *std::ptr::from_mut::<Self>(self).cast::<uws_app_s>() }
+        // over the same C++ object; the borrow reborrows `&self`.
+        unsafe { &*std::ptr::from_ref::<Self>(self).cast::<uws_app_s>() }
     }
 
-    pub fn close(&mut self) {
+    pub fn close(&self) {
         c::uws_app_close(Self::SSL_FLAG, self.as_raw())
     }
 
-    pub fn close_idle_connections(&mut self) {
+    pub fn close_idle_connections(&self) {
         c::uws_app_close_idle(Self::SSL_FLAG, self.as_raw())
     }
 
@@ -123,7 +132,7 @@ impl<const SSL: bool> App<SSL> {
         unsafe { c::uws_app_destroy(Self::SSL_FLAG, this.cast::<uws_app_t>()) }
     }
 
-    pub fn set_flags(&mut self, require_host_header: bool, use_strict_method_validation: bool) {
+    pub fn set_flags(&self, require_host_header: bool, use_strict_method_validation: bool) {
         c::uws_app_set_flags(
             Self::SSL_FLAG,
             self.as_raw(),
@@ -132,26 +141,26 @@ impl<const SSL: bool> App<SSL> {
         )
     }
 
-    pub fn set_max_http_header_size(&mut self, max_header_size: u64) {
+    pub fn set_max_http_header_size(&self, max_header_size: u64) {
         c::uws_app_set_max_http_header_size(Self::SSL_FLAG, self.as_raw(), max_header_size)
     }
 
-    pub fn clear_routes(&mut self) {
+    pub fn clear_routes(&self) {
         c::uws_app_clear_routes(Self::SSL_FLAG, self.as_raw())
     }
 
     pub fn publish_with_options(
-        &mut self,
+        &self,
         topic: &[u8],
         message: &[u8],
         opcode: Opcode,
         compress: bool,
     ) -> SendStatus {
-        // SAFETY: self is a valid *mut uws_app_t; slices are valid for the call.
+        // SAFETY: slices are valid for the call.
         unsafe {
             c::uws_publish(
                 SSL as i32,
-                std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
+                self.as_raw(),
                 topic.as_ptr(),
                 topic.len(),
                 message.as_ptr(),
@@ -196,12 +205,12 @@ impl<const SSL: bool> App<SSL> {
     /// Alias matching uWS C++ `del()` naming (Rust `delete` is not reserved, but callers
     /// porting from uWS expect `del`).
     #[inline]
-    pub fn del(&mut self, pattern: &[u8], handler: c::uws_method_handler, user_data: *mut c_void) {
+    pub fn del(&self, pattern: &[u8], handler: c::uws_method_handler, user_data: *mut c_void) {
         self.delete(pattern, handler, user_data)
     }
 
     pub fn method(
-        &mut self,
+        &self,
         method_: Method,
         pattern: &[u8],
         handler: c::uws_method_handler,
@@ -221,23 +230,17 @@ impl<const SSL: bool> App<SSL> {
         }
     }
 
-    pub fn domain(&mut self, pattern: &ZStr) {
-        // SAFETY: pattern is NUL-terminated; self is a valid app.
-        unsafe {
-            c::uws_app_domain(
-                Self::SSL_FLAG,
-                std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
-                pattern.as_ptr().cast(),
-            )
-        }
+    pub fn domain(&self, pattern: &ZStr) {
+        // SAFETY: pattern is NUL-terminated.
+        unsafe { c::uws_app_domain(Self::SSL_FLAG, self.as_raw(), pattern.as_ptr().cast()) }
     }
 
-    pub fn run(&mut self) {
+    pub fn run(&self) {
         c::uws_app_run(Self::SSL_FLAG, self.as_raw())
     }
 
     pub fn listen(
-        &mut self,
+        &self,
         port: i32,
         handler: extern "C" fn(*mut UwsListenSocket, *mut c_void),
         user_data: *mut c_void,
@@ -253,7 +256,7 @@ impl<const SSL: bool> App<SSL> {
     }
 
     pub fn on_client_error(
-        &mut self,
+        &self,
         handler: extern "C" fn(*mut c_void, c_int, *mut us_socket_t, u8, *mut u8, c_int),
         user_data: *mut c_void,
     ) {
@@ -262,17 +265,17 @@ impl<const SSL: bool> App<SSL> {
     }
 
     pub fn listen_with_config(
-        &mut self,
+        &self,
         handler: c::uws_listen_handler,
         user_data: *mut c_void,
         config: c::uws_app_listen_config_t,
     ) {
         // Callers supply the C-ABI shim directly.
-        // SAFETY: self is a valid app; config.host (if non-null) is NUL-terminated and outlives the call.
+        // SAFETY: config.host (if non-null) is NUL-terminated and outlives the call.
         unsafe {
             c::uws_app_listen_with_config(
                 Self::SSL_FLAG,
-                std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
+                self.as_raw(),
                 config.host,
                 u16::try_from(config.port).expect("int cast"),
                 config.options,
@@ -283,18 +286,18 @@ impl<const SSL: bool> App<SSL> {
     }
 
     pub fn listen_on_unix_socket(
-        &mut self,
+        &self,
         handler: extern "C" fn(*mut UwsListenSocket, *const c_char, i32, *mut c_void),
         user_data: *mut c_void,
         domain_name: &ZStr,
         flags: i32,
     ) {
         // Callers supply the C-ABI shim directly.
-        // SAFETY: self is a valid app; domain_name is NUL-terminated.
+        // SAFETY: domain_name is NUL-terminated.
         unsafe {
             c::uws_app_listen_domain_with_options(
                 Self::SSL_FLAG,
-                std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
+                self.as_raw(),
                 domain_name.as_ptr().cast(),
                 domain_name.len(),
                 flags,
@@ -304,34 +307,29 @@ impl<const SSL: bool> App<SSL> {
         }
     }
 
-    pub fn constructor_failed(&mut self) -> bool {
+    pub fn constructor_failed(&self) -> bool {
         c::uws_constructor_failed(Self::SSL_FLAG, self.as_raw())
     }
 
-    pub fn num_subscribers(&mut self, topic: &[u8]) -> u32 {
-        // SAFETY: self is a valid app; topic valid for the call.
+    pub fn num_subscribers(&self, topic: &[u8]) -> u32 {
+        // SAFETY: topic valid for the call.
         unsafe {
-            c::uws_num_subscribers(
-                Self::SSL_FLAG,
-                std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
-                topic.as_ptr(),
-                topic.len(),
-            )
+            c::uws_num_subscribers(Self::SSL_FLAG, self.as_raw(), topic.as_ptr(), topic.len())
         }
     }
 
     pub fn publish(
-        &mut self,
+        &self,
         topic: &[u8],
         message: &[u8],
         opcode: Opcode,
         compress: bool,
     ) -> SendStatus {
-        // SAFETY: self is a valid app; slices valid for the call.
+        // SAFETY: slices valid for the call.
         unsafe {
             c::uws_publish(
                 Self::SSL_FLAG,
-                std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
+                self.as_raw(),
                 topic.as_ptr(),
                 topic.len(),
                 message.as_ptr(),
@@ -342,42 +340,32 @@ impl<const SSL: bool> App<SSL> {
         }
     }
 
-    pub fn get_native_handle(&mut self) -> *mut c_void {
+    pub fn get_native_handle(&self) -> *mut c_void {
         c::uws_get_native_handle(Self::SSL_FLAG, self.as_raw())
     }
 
-    pub fn remove_server_name(&mut self, hostname_pattern: &core::ffi::CStr) {
-        // SAFETY: self is a valid app; hostname_pattern is NUL-terminated.
+    pub fn remove_server_name(&self, hostname_pattern: &core::ffi::CStr) {
+        // SAFETY: hostname_pattern is NUL-terminated.
         unsafe {
-            c::uws_remove_server_name(
-                Self::SSL_FLAG,
-                std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
-                hostname_pattern.as_ptr(),
-            )
+            c::uws_remove_server_name(Self::SSL_FLAG, self.as_raw(), hostname_pattern.as_ptr())
         }
     }
 
-    pub fn add_server_name(&mut self, hostname_pattern: &core::ffi::CStr) {
-        // SAFETY: self is a valid app; hostname_pattern is NUL-terminated.
-        unsafe {
-            c::uws_add_server_name(
-                Self::SSL_FLAG,
-                std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
-                hostname_pattern.as_ptr(),
-            )
-        }
+    pub fn add_server_name(&self, hostname_pattern: &core::ffi::CStr) {
+        // SAFETY: hostname_pattern is NUL-terminated.
+        unsafe { c::uws_add_server_name(Self::SSL_FLAG, self.as_raw(), hostname_pattern.as_ptr()) }
     }
 
     pub fn add_server_name_with_options(
-        &mut self,
+        &self,
         hostname_pattern: &core::ffi::CStr,
         opts: &BunSocketContextOptions,
     ) -> Result<(), AddServerNameError> {
-        // SAFETY: self is a valid app; hostname_pattern is NUL-terminated.
+        // SAFETY: hostname_pattern is NUL-terminated.
         let rc = unsafe {
             c::uws_add_server_name_with_options(
                 Self::SSL_FLAG,
-                std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
+                self.as_raw(),
                 hostname_pattern.as_ptr(),
                 *opts,
             )
@@ -389,30 +377,27 @@ impl<const SSL: bool> App<SSL> {
     }
 
     pub fn missing_server_name(
-        &mut self,
+        &self,
         handler: c::uws_missing_server_handler,
         user_data: *mut c_void,
     ) {
         c::uws_missing_server_name(Self::SSL_FLAG, self.as_raw(), handler, user_data)
     }
 
-    pub fn filter(&mut self, handler: c::uws_filter_handler, user_data: *mut c_void) {
+    pub fn filter(&self, handler: c::uws_filter_handler, user_data: *mut c_void) {
         c::uws_filter(Self::SSL_FLAG, self.as_raw(), handler, user_data)
     }
 
-    pub fn ws(
-        &mut self,
-        pattern: &[u8],
-        ctx: *mut c_void,
-        id: usize,
-        behavior_: WebSocketBehavior,
-    ) {
+    pub fn ws(&self, pattern: &[u8], ctx: *mut c_void, id: usize, behavior_: WebSocketBehavior) {
         let behavior = behavior_;
-        // SAFETY: self is a valid app; pattern valid for the call; behavior is stack-local.
+        // SAFETY: pattern valid for the call; behavior is stack-local. `uws_ws`
+        // still spells its handle `*mut uws_app_t`; the app is an opaque ZST.
         unsafe {
             uws_ws(
                 Self::SSL_FLAG,
-                std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
+                std::ptr::from_ref::<Self>(self)
+                    .cast::<uws_app_t>()
+                    .cast_mut(),
                 ctx,
                 pattern.as_ptr(),
                 pattern.len(),
@@ -452,24 +437,25 @@ pub struct ListenSocket<const SSL: bool> {
 
 impl<const SSL: bool> ListenSocket<SSL> {
     #[inline]
-    pub fn close(&mut self) {
+    pub fn close(&self) {
         // S008: ListenSocket<SSL> is layout-identical to crate::ListenSocket
-        // (both ZST opaques) — safe deref via `opaque_deref_mut`.
-        bun_opaque::opaque_deref_mut(std::ptr::from_mut::<Self>(self).cast::<UwsListenSocket>())
-            .close()
+        // (both ZST opaques) — safe deref via `opaque_deref`.
+        bun_opaque::opaque_deref(std::ptr::from_ref::<Self>(self).cast::<UwsListenSocket>()).close()
     }
 
     #[inline]
-    pub fn get_local_port(&mut self) -> i32 {
+    pub fn get_local_port(&self) -> i32 {
         // S008: opaque ZST cast as above.
-        bun_opaque::opaque_deref_mut(std::ptr::from_mut::<Self>(self).cast::<UwsListenSocket>())
+        bun_opaque::opaque_deref(std::ptr::from_ref::<Self>(self).cast::<UwsListenSocket>())
             .get_local_port()
     }
 
-    pub fn socket(&mut self) -> crate::socket::NewSocketHandler<SSL> {
+    pub fn socket(&self) -> crate::socket::NewSocketHandler<SSL> {
         // SAFETY: ListenSocket<SSL> is layout-identical to us_socket_t on the C side
         // (a listen socket IS a us_socket_t).
-        crate::socket::NewSocketHandler::<SSL>::from(std::ptr::from_mut::<Self>(self).cast())
+        crate::socket::NewSocketHandler::<SSL>::from(
+            std::ptr::from_ref::<Self>(self).cast_mut().cast(),
+        )
     }
 }
 
@@ -495,14 +481,14 @@ pub mod c {
     pub(crate) type uws_missing_server_handler = Option<extern "C" fn(*const c_char, *mut c_void)>;
 
     unsafe extern "C" {
-        pub(crate) safe fn uws_app_close(ssl: i32, app: &mut uws_app_s);
-        pub(crate) safe fn uws_app_close_idle(ssl: i32, app: &mut uws_app_s);
-        // safe: `&mut uws_app_s` is ABI-identical to a non-null `*mut`;
-        // `handler`/`user_data` are stored opaquely (never dereferenced by the
-        // C++ shim itself) — no preconditions on this call.
+        pub(crate) safe fn uws_app_close(ssl: i32, app: &uws_app_s);
+        pub(crate) safe fn uws_app_close_idle(ssl: i32, app: &uws_app_s);
+        // safe: `&uws_app_s` is ABI-identical to a non-null `*mut` (the ZST is
+        // `!Freeze`, so no `noalias`/`readonly`); `handler`/`user_data` are stored
+        // opaquely (never dereferenced by the C++ shim itself).
         pub(crate) safe fn uws_app_set_on_clienterror(
             ssl: c_int,
-            app: &mut uws_app_s,
+            app: &uws_app_s,
             handler: extern "C" fn(*mut c_void, c_int, *mut us_socket_t, u8, *mut u8, c_int),
             user_data: *mut c_void,
         );
@@ -510,18 +496,18 @@ pub mod c {
         pub(crate) fn uws_app_destroy(ssl: i32, app: *mut uws_app_t);
         pub(crate) safe fn uws_app_set_flags(
             ssl: i32,
-            app: &mut uws_app_t,
+            app: &uws_app_t,
             require_host_header: bool,
             use_strict_method_validation: bool,
         );
         pub(crate) safe fn uws_app_set_max_http_header_size(
             ssl: i32,
-            app: &mut uws_app_t,
+            app: &uws_app_t,
             max_header_size: u64,
         );
         pub(crate) fn uws_app_get(
             ssl: i32,
-            app: *mut uws_app_t,
+            app: &uws_app_t,
             pattern: *const u8,
             pattern_len: usize,
             handler: uws_method_handler,
@@ -529,7 +515,7 @@ pub mod c {
         );
         pub(crate) fn uws_app_post(
             ssl: i32,
-            app: *mut uws_app_t,
+            app: &uws_app_t,
             pattern: *const u8,
             pattern_len: usize,
             handler: uws_method_handler,
@@ -537,7 +523,7 @@ pub mod c {
         );
         pub(crate) fn uws_app_options(
             ssl: i32,
-            app: *mut uws_app_t,
+            app: &uws_app_t,
             pattern: *const u8,
             pattern_len: usize,
             handler: uws_method_handler,
@@ -545,7 +531,7 @@ pub mod c {
         );
         pub(crate) fn uws_app_delete(
             ssl: i32,
-            app: *mut uws_app_t,
+            app: &uws_app_t,
             pattern: *const u8,
             pattern_len: usize,
             handler: uws_method_handler,
@@ -553,7 +539,7 @@ pub mod c {
         );
         pub(crate) fn uws_app_patch(
             ssl: i32,
-            app: *mut uws_app_t,
+            app: &uws_app_t,
             pattern: *const u8,
             pattern_len: usize,
             handler: uws_method_handler,
@@ -561,7 +547,7 @@ pub mod c {
         );
         pub(crate) fn uws_app_put(
             ssl: i32,
-            app: *mut uws_app_t,
+            app: &uws_app_t,
             pattern: *const u8,
             pattern_len: usize,
             handler: uws_method_handler,
@@ -569,7 +555,7 @@ pub mod c {
         );
         pub(crate) fn uws_app_head(
             ssl: i32,
-            app: *mut uws_app_t,
+            app: &uws_app_t,
             pattern: *const u8,
             pattern_len: usize,
             handler: uws_method_handler,
@@ -577,7 +563,7 @@ pub mod c {
         );
         pub(crate) fn uws_app_connect(
             ssl: i32,
-            app: *mut uws_app_t,
+            app: &uws_app_t,
             pattern: *const u8,
             pattern_len: usize,
             handler: uws_method_handler,
@@ -585,7 +571,7 @@ pub mod c {
         );
         pub(crate) fn uws_app_trace(
             ssl: i32,
-            app: *mut uws_app_t,
+            app: &uws_app_t,
             pattern: *const u8,
             pattern_len: usize,
             handler: uws_method_handler,
@@ -593,42 +579,42 @@ pub mod c {
         );
         pub(crate) fn uws_app_any(
             ssl: i32,
-            app: *mut uws_app_t,
+            app: &uws_app_t,
             pattern: *const u8,
             pattern_len: usize,
             handler: uws_method_handler,
             user_data: *mut c_void,
         );
-        pub(crate) safe fn uws_app_run(ssl: i32, app: &mut uws_app_t);
-        pub(crate) fn uws_app_domain(ssl: i32, app: *mut uws_app_t, domain: *const c_char);
+        pub(crate) safe fn uws_app_run(ssl: i32, app: &uws_app_t);
+        pub(crate) fn uws_app_domain(ssl: i32, app: &uws_app_t, domain: *const c_char);
         // safe: handle-only + value `port`; `handler`/`user_data` are stored
         // opaquely — no preconditions on this call.
         pub(crate) safe fn uws_app_listen(
             ssl: i32,
-            app: &mut uws_app_t,
+            app: &uws_app_t,
             port: i32,
             handler: uws_listen_handler,
             user_data: *mut c_void,
         );
         pub(crate) fn uws_app_listen_with_config(
             ssl: i32,
-            app: *mut uws_app_t,
+            app: &uws_app_t,
             host: *const c_char,
             port: u16,
             options: i32,
             handler: uws_listen_handler,
             user_data: *mut c_void,
         );
-        pub(crate) safe fn uws_constructor_failed(ssl: i32, app: &mut uws_app_t) -> bool;
+        pub(crate) safe fn uws_constructor_failed(ssl: i32, app: &uws_app_t) -> bool;
         pub(crate) fn uws_num_subscribers(
             ssl: i32,
-            app: *mut uws_app_t,
+            app: &uws_app_t,
             topic: *const u8,
             topic_length: usize,
         ) -> c_uint;
         pub(crate) fn uws_publish(
             ssl: i32,
-            app: *mut uws_app_t,
+            app: &uws_app_t,
             topic: *const u8,
             topic_length: usize,
             message: *const u8,
@@ -637,42 +623,42 @@ pub mod c {
             compress: bool,
         ) -> SendStatus;
         // safe: `uws_app_s` is an `opaque_ffi!` ZST (`UnsafeCell<[u8; 0]>`), so
-        // `&mut uws_app_s` is ABI-identical to the C `uws_app_t*` (non-null,
+        // `&uws_app_s` is ABI-identical to the C `uws_app_t*` (non-null,
         // no `noalias`/`readonly`). The C++ body only reads `app->getNativeHandle()`
         // — no preconditions beyond a live handle.
-        pub(crate) safe fn uws_get_native_handle(ssl: i32, app: &mut uws_app_s) -> *mut c_void;
+        pub(crate) safe fn uws_get_native_handle(ssl: i32, app: &uws_app_s) -> *mut c_void;
         pub(crate) fn uws_remove_server_name(
             ssl: i32,
-            app: *mut uws_app_t,
+            app: &uws_app_t,
             hostname_pattern: *const c_char,
         );
         pub(crate) fn uws_add_server_name(
             ssl: i32,
-            app: *mut uws_app_t,
+            app: &uws_app_t,
             hostname_pattern: *const c_char,
         );
         pub(crate) fn uws_add_server_name_with_options(
             ssl: i32,
-            app: *mut uws_app_t,
+            app: &uws_app_t,
             hostname_pattern: *const c_char,
             options: BunSocketContextOptions,
         ) -> i32;
         pub(crate) safe fn uws_missing_server_name(
             ssl: i32,
-            app: &mut uws_app_t,
+            app: &uws_app_t,
             handler: uws_missing_server_handler,
             user_data: *mut c_void,
         );
         pub(crate) safe fn uws_filter(
             ssl: i32,
-            app: &mut uws_app_t,
+            app: &uws_app_t,
             handler: uws_filter_handler,
             user_data: *mut c_void,
         );
 
         pub(crate) fn uws_app_listen_domain_with_options(
             ssl_flag: c_int,
-            app: *mut uws_app_t,
+            app: &uws_app_t,
             domain: *const c_char,
             pathlen: usize,
             flags: i32,
@@ -680,7 +666,7 @@ pub mod c {
             user_data: *mut c_void,
         );
 
-        pub(crate) safe fn uws_app_clear_routes(ssl_flag: c_int, app: &mut uws_app_t);
+        pub(crate) safe fn uws_app_clear_routes(ssl_flag: c_int, app: &uws_app_t);
     }
 
     #[repr(C)]

--- a/src/uws_sys/ConnectingSocket.rs
+++ b/src/uws_sys/ConnectingSocket.rs
@@ -9,7 +9,7 @@ use crate::{Loop, SocketGroup, SocketKind};
 bun_opaque::opaque_ffi! { pub struct ConnectingSocket; }
 
 impl ConnectingSocket {
-    pub fn close(&mut self) {
+    pub fn close(&self) {
         us_connecting_socket_close(self)
     }
 
@@ -17,92 +17,89 @@ impl ConnectingSocket {
     /// shared by every socket it owns;
     /// materializing `&mut SocketGroup` here would alias with other sockets'
     /// borrows of the same group.
-    pub fn group(&mut self) -> *mut SocketGroup {
+    pub fn group(&self) -> *mut SocketGroup {
         us_connecting_socket_group(self)
     }
-    pub fn raw_group(&mut self) -> *mut SocketGroup {
+    pub fn raw_group(&self) -> *mut SocketGroup {
         self.group()
     }
 
-    pub fn kind(&mut self) -> SocketKind {
+    pub fn kind(&self) -> SocketKind {
         SocketKind::from_u8(us_connecting_socket_kind(self))
     }
 
     /// Returns the owning `Loop`. Raw pointer because the loop is a shared
     /// singleton referenced by every group/socket/timer;
     /// materializing `&mut Loop` here would be aliased UB.
-    pub fn r#loop(&mut self) -> *mut Loop {
+    pub fn r#loop(&self) -> *mut Loop {
         us_connecting_socket_get_loop(self)
     }
 
+    /// `&mut self`: the returned `&mut T` aliases the socket's real trailing ext
+    /// storage, so the exclusive borrow — not the ZST receiver — is what keeps two
+    /// `&mut T` to that slot from coexisting. Caller asserts the slot was
+    /// sized/aligned for T at group creation.
     pub fn ext<T>(&mut self) -> &mut T {
-        // SAFETY: the ext slot is per-socket trailing storage inside this
-        // allocation; `&mut self` guarantees exclusive access to it for the
-        // returned borrow's lifetime. Caller asserts the slot was sized/
-        // aligned for T at group creation.
+        // SAFETY: `us_connecting_socket_ext` returns the per-socket ext slot.
         unsafe { &mut *us_connecting_socket_ext(self).cast::<T>() }
     }
 
-    pub fn get_error(&mut self) -> i32 {
+    pub fn get_error(&self) -> i32 {
         us_connecting_socket_get_error(self)
     }
 
     /// Raw `getaddrinfo(3)` return code when the name lookup itself failed;
     /// 0 for a connect failure past name resolution. A different namespace
     /// from [`Self::get_error`] (errno).
-    pub fn get_dns_error(&mut self) -> i32 {
+    pub fn get_dns_error(&self) -> i32 {
         us_connecting_socket_get_dns_error(self)
     }
 
-    pub fn get_native_handle(&mut self) -> *mut c_void {
+    pub fn get_native_handle(&self) -> *mut c_void {
         us_connecting_socket_get_native_handle(self)
     }
 
-    pub fn is_closed(&mut self) -> bool {
+    pub fn is_closed(&self) -> bool {
         us_connecting_socket_is_closed(self) == 1
     }
 
-    pub fn is_shutdown(&mut self) -> bool {
+    pub fn is_shutdown(&self) -> bool {
         us_connecting_socket_is_shut_down(self) == 1
     }
 
-    pub fn long_timeout(&mut self, seconds: c_uint) {
+    pub fn long_timeout(&self, seconds: c_uint) {
         us_connecting_socket_long_timeout(self, seconds)
     }
 
-    pub fn shutdown(&mut self) {
+    pub fn shutdown(&self) {
         us_connecting_socket_shutdown(self)
     }
 
-    pub fn shutdown_read(&mut self) {
+    pub fn shutdown_read(&self) {
         us_connecting_socket_shutdown_read(self)
     }
 
-    pub fn timeout(&mut self, seconds: c_uint) {
+    pub fn timeout(&self, seconds: c_uint) {
         us_connecting_socket_timeout(self, seconds)
     }
 }
 
-// All shims take only a non-null `us_connecting_socket_t*` plus value types.
-// `ConnectingSocket` is `#[repr(C)]` with `UnsafeCell<[u8; 0]>`, so `&mut
-// ConnectingSocket` is ABI-identical to a non-null pointer (no readonly/noalias
-// attribute). Declaring the shims with reference params and `safe fn` moves the
-// validity proof into the type signature.
+// `ConnectingSocket` is `!Freeze`, so `&ConnectingSocket` carries neither
+// `noalias` nor `readonly` and is ABI-identical to a non-null pointer. uSockets
+// re-enters through the same pointer, so no shim may claim exclusivity.
 unsafe extern "C" {
-    pub(crate) safe fn us_connecting_socket_close(s: &mut ConnectingSocket);
-    pub(crate) safe fn us_connecting_socket_group(s: &mut ConnectingSocket) -> *mut SocketGroup;
-    pub(crate) safe fn us_connecting_socket_kind(s: &mut ConnectingSocket) -> u8;
-    pub(crate) safe fn us_connecting_socket_ext(s: &mut ConnectingSocket) -> *mut c_void;
-    pub(crate) safe fn us_connecting_socket_get_error(s: &mut ConnectingSocket) -> i32;
-    pub(crate) safe fn us_connecting_socket_get_dns_error(s: &mut ConnectingSocket) -> i32;
-    pub(crate) safe fn us_connecting_socket_get_native_handle(
-        s: &mut ConnectingSocket,
-    ) -> *mut c_void;
-    pub(crate) safe fn us_connecting_socket_is_closed(s: &mut ConnectingSocket) -> i32;
-    pub(crate) safe fn us_connecting_socket_is_shut_down(s: &mut ConnectingSocket) -> i32;
-    pub(crate) safe fn us_connecting_socket_long_timeout(s: &mut ConnectingSocket, seconds: c_uint);
-    pub(crate) safe fn us_connecting_socket_shutdown(s: &mut ConnectingSocket);
-    pub(crate) safe fn us_connecting_socket_shutdown_read(s: &mut ConnectingSocket);
-    pub(crate) safe fn us_connecting_socket_timeout(s: &mut ConnectingSocket, seconds: c_uint);
-    pub(crate) safe fn us_connecting_socket_get_loop(s: &mut ConnectingSocket) -> *mut Loop;
+    pub(crate) safe fn us_connecting_socket_close(s: &ConnectingSocket);
+    pub(crate) safe fn us_connecting_socket_group(s: &ConnectingSocket) -> *mut SocketGroup;
+    pub(crate) safe fn us_connecting_socket_kind(s: &ConnectingSocket) -> u8;
+    pub(crate) safe fn us_connecting_socket_ext(s: &ConnectingSocket) -> *mut c_void;
+    pub(crate) safe fn us_connecting_socket_get_error(s: &ConnectingSocket) -> i32;
+    pub(crate) safe fn us_connecting_socket_get_dns_error(s: &ConnectingSocket) -> i32;
+    pub(crate) safe fn us_connecting_socket_get_native_handle(s: &ConnectingSocket) -> *mut c_void;
+    pub(crate) safe fn us_connecting_socket_is_closed(s: &ConnectingSocket) -> i32;
+    pub(crate) safe fn us_connecting_socket_is_shut_down(s: &ConnectingSocket) -> i32;
+    pub(crate) safe fn us_connecting_socket_long_timeout(s: &ConnectingSocket, seconds: c_uint);
+    pub(crate) safe fn us_connecting_socket_shutdown(s: &ConnectingSocket);
+    pub(crate) safe fn us_connecting_socket_shutdown_read(s: &ConnectingSocket);
+    pub(crate) safe fn us_connecting_socket_timeout(s: &ConnectingSocket, seconds: c_uint);
+    pub(crate) safe fn us_connecting_socket_get_loop(s: &ConnectingSocket) -> *mut Loop;
 }

--- a/src/uws_sys/ListenSocket.rs
+++ b/src/uws_sys/ListenSocket.rs
@@ -12,38 +12,34 @@ bun_opaque::opaque_ffi! {
 }
 
 impl ListenSocket {
-    pub fn close(&mut self) {
+    pub fn close(&self) {
         us_listen_socket_close(self)
     }
 
-    pub fn get_local_address<'a>(
-        &mut self,
-        buf: &'a mut [u8],
-    ) -> Result<&'a [u8], bun_core::Error> {
+    pub fn get_local_address<'a>(&self, buf: &'a mut [u8]) -> Result<&'a [u8], bun_core::Error> {
         self.get_socket().local_address(buf)
     }
 
-    pub fn get_local_port(&mut self) -> i32 {
+    pub fn get_local_port(&self) -> i32 {
         self.get_socket().local_port()
     }
 
-    pub fn get_socket(&mut self) -> &mut us_socket_t {
+    pub fn get_socket(&self) -> &us_socket_t {
         // S008: ListenSocket is layout-compatible with us_socket_t on the C side
         // (a listen socket IS a us_socket_t); both are `opaque_ffi!` ZSTs, so route
-        // the `*mut → &mut` pun through the const-asserted safe accessor.
-        us_socket_t::opaque_mut(std::ptr::from_mut::<ListenSocket>(self).cast::<us_socket_t>())
+        // the `*const → &` pun through the const-asserted safe accessor.
+        us_socket_t::opaque_ref(std::ptr::from_ref::<ListenSocket>(self).cast::<us_socket_t>())
     }
 
-    pub fn socket<const IS_SSL: bool>(&mut self) -> crate::socket::NewSocketHandler<IS_SSL> {
+    pub fn socket<const IS_SSL: bool>(&self) -> crate::socket::NewSocketHandler<IS_SSL> {
         // NewSocketHandler is local (crate::socket); no upward dep.
-        crate::socket::NewSocketHandler::<IS_SSL>::from(std::ptr::from_mut::<us_socket_t>(
-            self.get_socket(),
-        ))
+        // `as_mut_ptr` is the UnsafeCell route from `&self` to a write-provenance ptr.
+        crate::socket::NewSocketHandler::<IS_SSL>::from(self.as_mut_ptr().cast::<us_socket_t>())
     }
 
     /// Group accepted sockets are linked into. The group is embedded in the
     /// owner and outlives every listen socket linked into it.
-    pub fn group(&mut self) -> ParentRef<SocketGroup> {
+    pub fn group(&self) -> ParentRef<SocketGroup> {
         // SAFETY: C returns a non-null group, with write provenance, that
         // outlives this listen socket.
         unsafe { ParentRef::from_raw_mut(us_listen_socket_group(self)) }
@@ -55,7 +51,7 @@ impl ListenSocket {
         unsafe { &mut *us_listen_socket_ext(self).cast::<T>() }
     }
 
-    pub fn fd(&mut self) -> Fd {
+    pub fn fd(&self) -> Fd {
         let raw = us_listen_socket_get_fd(self);
         // SOCKET → kind=system (mask bit 63); `from_native` would store the
         // raw bits verbatim and mis-tag `INVALID_SOCKET` (~0) as kind=uv.
@@ -82,7 +78,7 @@ impl ListenSocket {
     /// a mutable pointer; accepting `&U` and const-casting would make that
     /// round-trip UB.
     pub fn add_server_name(
-        &mut self,
+        &self,
         hostname: &core::ffi::CStr,
         ssl_ctx: *mut SslCtx,
         user: *mut c_void,
@@ -94,7 +90,7 @@ impl ListenSocket {
         unsafe { us_listen_socket_add_server_name(self, hostname.as_ptr(), ssl_ctx, user) == 0 }
     }
 
-    pub fn remove_server_name(&mut self, hostname: &core::ffi::CStr) {
+    pub fn remove_server_name(&self, hostname: &core::ffi::CStr) {
         // SAFETY: self and hostname are valid for the duration of the call.
         unsafe { us_listen_socket_remove_server_name(self, hostname.as_ptr()) }
     }
@@ -103,10 +99,7 @@ impl ListenSocket {
     /// `hostname`, cast to `*mut T`. Returned as `NonNull<T>` (not `&mut T`)
     /// because the pointee is caller-owned external storage — materializing a
     /// `&mut T` here could alias the caller's own live reference to it.
-    pub fn find_server_name_userdata<T>(
-        &mut self,
-        hostname: &core::ffi::CStr,
-    ) -> Option<NonNull<T>> {
+    pub fn find_server_name_userdata<T>(&self, hostname: &core::ffi::CStr) -> Option<NonNull<T>> {
         // SAFETY: self and hostname valid; caller guarantees the stored userdata
         // is a *T.
         let p = unsafe { us_listen_socket_find_server_name_userdata(self, hostname.as_ptr()) };
@@ -114,35 +107,34 @@ impl ListenSocket {
     }
 
     pub fn on_server_name(
-        &mut self,
+        &self,
         cb: extern "C" fn(*mut ListenSocket, *const c_char, *mut c_int, *mut c_void) -> *mut c_void,
     ) {
         us_listen_socket_on_server_name(self, cb)
     }
 }
 
-// This file IS the *_sys crate, so externs live here.
-// `ListenSocket` is `#[repr(C)]` with `UnsafeCell<[u8; 0]>`, so `&mut
-// ListenSocket` is ABI-identical to a non-null pointer; value-typed shims are
-// `safe fn`. Shims with nullable raw / ctx ptr stay unsafe.
+// `ListenSocket` is `!Freeze`: `&ListenSocket` carries neither `noalias` nor
+// `readonly` and is ABI-identical to a non-null pointer, so no shim needs `&mut`.
+// Value-typed shims are `safe fn`; those with nullable raw/ctx ptrs stay unsafe.
 unsafe extern "C" {
-    safe fn us_listen_socket_close(ls: &mut ListenSocket);
-    safe fn us_listen_socket_group(ls: &mut ListenSocket) -> *mut SocketGroup;
-    safe fn us_listen_socket_ext(ls: &mut ListenSocket) -> *mut c_void;
-    safe fn us_listen_socket_get_fd(ls: &mut ListenSocket) -> LIBUS_SOCKET_DESCRIPTOR;
+    safe fn us_listen_socket_close(ls: &ListenSocket);
+    safe fn us_listen_socket_group(ls: &ListenSocket) -> *mut SocketGroup;
+    safe fn us_listen_socket_ext(ls: &ListenSocket) -> *mut c_void;
+    safe fn us_listen_socket_get_fd(ls: &ListenSocket) -> LIBUS_SOCKET_DESCRIPTOR;
     fn us_listen_socket_add_server_name(
-        ls: *mut ListenSocket,
+        ls: &ListenSocket,
         hostname: *const c_char,
         ssl_ctx: *mut SslCtx,
         user: *mut c_void,
     ) -> c_int;
-    fn us_listen_socket_remove_server_name(ls: *mut ListenSocket, hostname: *const c_char);
+    fn us_listen_socket_remove_server_name(ls: &ListenSocket, hostname: *const c_char);
     fn us_listen_socket_find_server_name_userdata(
-        ls: *mut ListenSocket,
+        ls: &ListenSocket,
         hostname: *const c_char,
     ) -> *mut c_void;
     safe fn us_listen_socket_on_server_name(
-        ls: &mut ListenSocket,
+        ls: &ListenSocket,
         cb: extern "C" fn(*mut ListenSocket, *const c_char, *mut c_int, *mut c_void) -> *mut c_void,
     );
 }

--- a/src/uws_sys/Request.rs
+++ b/src/uws_sys/Request.rs
@@ -34,7 +34,7 @@ impl AnyRequest {
     }
     pub fn set_yield(&mut self, y: bool) {
         match self {
-            Self::H1(r) => bun_opaque::opaque_deref_mut(*r).set_yield(y),
+            Self::H1(r) => bun_opaque::opaque_deref(*r).set_yield(y),
             Self::H3(r) => bun_opaque::opaque_deref_mut(*r).set_yield(y),
         }
     }
@@ -52,7 +52,7 @@ impl Request {
     pub fn get_yield(&self) -> bool {
         c::uws_req_get_yield(self)
     }
-    pub fn set_yield(&mut self, yield_: bool) {
+    pub fn set_yield(&self, yield_: bool) {
         c::uws_req_set_yield(self, yield_)
     }
     pub fn url(&self) -> &[u8] {
@@ -105,7 +105,7 @@ mod c {
     unsafe extern "C" {
         pub(super) safe fn uws_req_is_ancient(res: &Request) -> bool;
         pub(super) safe fn uws_req_get_yield(res: &Request) -> bool;
-        pub(super) safe fn uws_req_set_yield(res: &mut Request, yield_: bool);
+        pub(super) safe fn uws_req_set_yield(res: &Request, yield_: bool);
         // Out-param `dest` is a `&mut *const u8` (non-null, valid for write); the C
         // shim only stores a pointer into request-owned storage and returns its
         // length — no read-through-ptr precondition, so `safe fn`.

--- a/src/uws_sys/Response.rs
+++ b/src/uws_sys/Response.rs
@@ -90,27 +90,24 @@ impl<const SSL: bool> Response<SSL> {
     }
 
     #[inline]
-    pub fn downcast(&mut self) -> *mut c::uws_res {
-        std::ptr::from_mut::<Self>(self).cast::<c::uws_res>()
+    pub fn downcast(&self) -> *mut c::uws_res {
+        self._p.get().cast::<c::uws_res>()
     }
 
-    /// `&mut uws_res` view of self for `safe fn` shims. Both types are
-    /// `#[repr(C)]` opaque ZSTs with `UnsafeCell<[u8; 0]>`, so the cast is a
-    /// no-op and the reference is ABI-identical to the non-null pointer the C
-    /// shim expects.
+    /// `&mut uws_res` view of self for `safe fn` shims. `_p` sits at offset 0
+    /// of this `#[repr(C)]` ZST, so `UnsafeCell::get` yields self's own address
+    /// with write provenance — the sanctioned interior-mutability route.
     #[inline]
-    fn as_raw(&mut self) -> &mut c::uws_res {
-        // SAFETY: `Response<SSL>` and `c::uws_res` are layout-identical opaque
-        // ZSTs over the same C++ object; the borrow reborrows `&mut self`.
-        unsafe { &mut *std::ptr::from_mut::<Self>(self).cast::<c::uws_res>() }
+    fn as_raw(&self) -> &mut c::uws_res {
+        c::uws_res::opaque_mut(self.downcast())
     }
 
     #[inline]
-    pub fn downcast_socket(&mut self) -> *mut us_socket_t {
-        std::ptr::from_mut::<Self>(self).cast::<us_socket_t>()
+    pub fn downcast_socket(&self) -> *mut us_socket_t {
+        self._p.get().cast::<us_socket_t>()
     }
 
-    pub fn end(&mut self, data: &[u8], close_connection: bool) {
+    pub fn end(&self, data: &[u8], close_connection: bool) {
         // SAFETY: self is a live opaque uws_res handle owned by uWS; FFI call has no extra preconditions.
         unsafe {
             c::uws_res_end(
@@ -123,7 +120,7 @@ impl<const SSL: bool> Response<SSL> {
         }
     }
 
-    pub fn try_end(&mut self, data: &[u8], total: usize, close_: bool) -> bool {
+    pub fn try_end(&self, data: &[u8], total: usize, close_: bool) -> bool {
         // SAFETY: self is a live opaque uws_res handle owned by uWS; FFI call has no extra preconditions.
         unsafe {
             c::uws_res_try_end(
@@ -137,55 +134,54 @@ impl<const SSL: bool> Response<SSL> {
         }
     }
 
-    pub fn get_socket_data(&mut self) -> *mut c_void {
+    pub fn get_socket_data(&self) -> *mut c_void {
         c::uws_res_get_socket_data(Self::ssl_flag(), self.as_raw()).cast()
     }
 
-    pub fn is_connect_request(&mut self) -> bool {
+    pub fn is_connect_request(&self) -> bool {
         c::uws_res_is_connect_request(Self::ssl_flag(), self.as_raw())
     }
 
-    pub fn flush_headers(&mut self, flush_immediately: bool) {
+    pub fn flush_headers(&self, flush_immediately: bool) {
         c::uws_res_flush_headers(Self::ssl_flag(), self.as_raw(), flush_immediately)
     }
 
-    pub fn is_corked(&mut self) -> bool {
+    pub fn is_corked(&self) -> bool {
         c::uws_res_is_corked(Self::ssl_flag(), self.as_raw())
     }
 
     pub fn state(&self) -> State {
-        // SAFETY: `Response<SSL>` and `c::uws_res` are layout-identical opaque
-        // ZSTs (both `UnsafeCell<[u8; 0]>`); the reborrow is a no-op cast.
-        c::uws_res_state(Self::ssl_flag() as c_int, unsafe {
-            &*std::ptr::from_ref::<Self>(self).cast::<c::uws_res>()
-        })
+        c::uws_res_state(
+            Self::ssl_flag() as c_int,
+            c::uws_res::opaque_ref(self.downcast()),
+        )
     }
 
     pub fn should_close_connection(&self) -> bool {
         self.state().is_http_connection_close()
     }
 
-    pub fn prepare_for_sendfile(&mut self) {
+    pub fn prepare_for_sendfile(&self) {
         c::uws_res_prepare_for_sendfile(Self::ssl_flag(), self.as_raw())
     }
 
-    pub fn uncork(&mut self) {
+    pub fn uncork(&self) {
         c::uws_res_uncork(Self::ssl_flag(), self.as_raw())
     }
 
-    pub fn pause(&mut self) {
+    pub fn pause(&self) {
         c::uws_res_pause(Self::ssl_flag(), self.as_raw())
     }
 
-    pub fn resume_(&mut self) {
+    pub fn resume_(&self) {
         c::uws_res_resume(Self::ssl_flag(), self.as_raw())
     }
 
-    pub fn write_continue(&mut self) {
+    pub fn write_continue(&self) {
         c::uws_res_write_continue(Self::ssl_flag(), self.as_raw())
     }
 
-    pub fn write_status(&mut self, status: &[u8]) {
+    pub fn write_status(&self, status: &[u8]) {
         // SAFETY: self is a live opaque uws_res handle owned by uWS; FFI call has no extra preconditions.
         unsafe {
             c::uws_res_write_status(
@@ -197,7 +193,7 @@ impl<const SSL: bool> Response<SSL> {
         }
     }
 
-    pub fn write_header(&mut self, key: &[u8], value: &[u8]) {
+    pub fn write_header(&self, key: &[u8], value: &[u8]) {
         // SAFETY: self is a live opaque uws_res handle owned by uWS; FFI call has no extra preconditions.
         unsafe {
             c::uws_res_write_header(
@@ -211,7 +207,7 @@ impl<const SSL: bool> Response<SSL> {
         }
     }
 
-    pub fn write_header_int(&mut self, key: &[u8], value: u64) {
+    pub fn write_header_int(&self, key: &[u8], value: u64) {
         // SAFETY: self is a live opaque uws_res handle owned by uWS; FFI call has no extra preconditions.
         unsafe {
             c::uws_res_write_header_int(
@@ -224,11 +220,11 @@ impl<const SSL: bool> Response<SSL> {
         }
     }
 
-    pub fn end_without_body(&mut self, close_connection: bool) {
+    pub fn end_without_body(&self, close_connection: bool) {
         c::uws_res_end_without_body(Self::ssl_flag(), self.as_raw(), close_connection)
     }
 
-    pub fn end_send_file(&mut self, write_offset: u64, close_connection: bool) {
+    pub fn end_send_file(&self, write_offset: u64, close_connection: bool) {
         c::uws_res_end_sendfile(
             Self::ssl_flag(),
             self.as_raw(),
@@ -237,19 +233,19 @@ impl<const SSL: bool> Response<SSL> {
         )
     }
 
-    pub fn timeout(&mut self, seconds: u8) {
+    pub fn timeout(&self, seconds: u8) {
         c::uws_res_timeout(Self::ssl_flag(), self.as_raw(), seconds)
     }
 
-    pub fn reset_timeout(&mut self) {
+    pub fn reset_timeout(&self) {
         c::uws_res_reset_timeout(Self::ssl_flag(), self.as_raw())
     }
 
-    pub fn get_buffered_amount(&mut self) -> u64 {
+    pub fn get_buffered_amount(&self) -> u64 {
         c::uws_res_get_buffered_amount(Self::ssl_flag(), self.as_raw())
     }
 
-    pub fn write(&mut self, data: &[u8]) -> WriteResult {
+    pub fn write(&self, data: &[u8]) -> WriteResult {
         let mut len: usize = data.len();
         // SAFETY: self is a live opaque uws_res handle owned by uWS; FFI call has no extra preconditions.
         match unsafe {
@@ -265,11 +261,11 @@ impl<const SSL: bool> Response<SSL> {
         }
     }
 
-    pub fn get_write_offset(&mut self) -> u64 {
+    pub fn get_write_offset(&self) -> u64 {
         c::uws_res_get_write_offset(Self::ssl_flag(), self.as_raw())
     }
 
-    pub fn override_write_offset<T>(&mut self, offset: T)
+    pub fn override_write_offset<T>(&self, offset: T)
     where
         u64: TryFrom<T>,
         <u64 as TryFrom<T>>::Error: core::fmt::Debug,
@@ -281,19 +277,19 @@ impl<const SSL: bool> Response<SSL> {
         )
     }
 
-    pub fn has_responded(&mut self) -> bool {
+    pub fn has_responded(&self) -> bool {
         c::uws_res_has_responded(Self::ssl_flag(), self.as_raw())
     }
 
-    pub fn mark_wrote_content_length_header(&mut self) {
+    pub fn mark_wrote_content_length_header(&self) {
         c::uws_res_mark_wrote_content_length_header(Self::ssl_flag(), self.as_raw())
     }
 
-    pub fn write_mark(&mut self) {
+    pub fn write_mark(&self) {
         c::uws_res_write_mark(Self::ssl_flag(), self.as_raw())
     }
 
-    pub fn get_native_handle(&mut self) -> Fd {
+    pub fn get_native_handle(&self) -> Fd {
         #[cfg(windows)]
         {
             // on windows uSockets exposes SOCKET (uintptr-sized) as a pointer
@@ -315,7 +311,7 @@ impl<const SSL: bool> Response<SSL> {
         }
     }
 
-    pub fn get_remote_address_as_text(&mut self) -> Option<&[u8]> {
+    pub fn get_remote_address_as_text(&self) -> Option<&[u8]> {
         let mut buf: *const u8 = core::ptr::null();
         let size = c::uws_res_get_remote_address_as_text(Self::ssl_flag(), self.as_raw(), &mut buf);
         if size > 0 {
@@ -326,7 +322,7 @@ impl<const SSL: bool> Response<SSL> {
         }
     }
 
-    pub fn get_remote_socket_info(&mut self) -> Option<SocketAddress> {
+    pub fn get_remote_socket_info(&self) -> Option<SocketAddress> {
         let mut ip_ptr: *const u8 = core::ptr::null();
         let mut port: i32 = 0;
         let mut is_ipv6: bool = false;
@@ -354,7 +350,7 @@ impl<const SSL: bool> Response<SSL> {
     /// zero-sized type (function item or capture-less closure): the trampoline
     /// is monomorphized over `H` and conjures the ZST inside, so the user
     /// handler is baked in with no runtime storage.
-    pub fn on_writable<U, H>(&mut self, _handler: H, user_data: *mut U)
+    pub fn on_writable<U, H>(&self, _handler: H, user_data: *mut U)
     where
         H: Fn(*mut U, u64, &mut Response<SSL>) -> bool + Copy + 'static,
     {
@@ -390,18 +386,18 @@ impl<const SSL: bool> Response<SSL> {
         );
     }
 
-    pub fn clear_on_writable(&mut self) {
+    pub fn clear_on_writable(&self) {
         c::uws_res_clear_on_writable(Self::ssl_flag(), self.as_raw())
     }
 
     #[inline]
-    pub fn mark_needs_more(&mut self) {
+    pub fn mark_needs_more(&self) {
         if !SSL {
             c::us_socket_mark_needs_more_not_ssl(self.as_raw())
         }
     }
 
-    pub fn on_aborted<U, H>(&mut self, _handler: H, optional_data: *mut U)
+    pub fn on_aborted<U, H>(&self, _handler: H, optional_data: *mut U)
     where
         H: Fn(*mut U, &mut Response<SSL>) + Copy + 'static,
     {
@@ -432,11 +428,11 @@ impl<const SSL: bool> Response<SSL> {
         );
     }
 
-    pub fn clear_aborted(&mut self) {
+    pub fn clear_aborted(&self) {
         c::uws_res_on_aborted(Self::ssl_flag(), self.as_raw(), None, core::ptr::null_mut())
     }
 
-    pub fn on_timeout<U, H>(&mut self, _handler: H, optional_data: *mut U)
+    pub fn on_timeout<U, H>(&self, _handler: H, optional_data: *mut U)
     where
         H: Fn(*mut U, &mut Response<SSL>) + Copy + 'static,
     {
@@ -467,15 +463,15 @@ impl<const SSL: bool> Response<SSL> {
         );
     }
 
-    pub fn clear_timeout(&mut self) {
+    pub fn clear_timeout(&self) {
         c::uws_res_on_timeout(Self::ssl_flag(), self.as_raw(), None, core::ptr::null_mut())
     }
 
-    pub fn clear_on_data(&mut self) {
+    pub fn clear_on_data(&self) {
         c::uws_res_on_data(Self::ssl_flag(), self.as_raw(), None, core::ptr::null_mut())
     }
 
-    pub fn on_data<U, H>(&mut self, _handler: H, optional_data: *mut U)
+    pub fn on_data<U, H>(&self, _handler: H, optional_data: *mut U)
     where
         H: Fn(*mut U, &mut Response<SSL>, &[u8], bool) + Copy + 'static,
     {
@@ -513,12 +509,12 @@ impl<const SSL: bool> Response<SSL> {
         );
     }
 
-    pub fn end_stream(&mut self, close_connection: bool) {
+    pub fn end_stream(&self, close_connection: bool) {
         c::uws_res_end_stream(Self::ssl_flag(), self.as_raw(), close_connection)
     }
 
     /// Run `handler` while the response is corked.
-    pub fn corked<F: FnOnce()>(&mut self, f: F) {
+    pub fn corked<F: FnOnce()>(&self, f: F) {
         // Safe fn item: nested local thunk, only coerced to the C-ABI
         // fn-pointer type passed to C; body wraps its raw-ptr op explicitly.
         extern "C" fn handle<F: FnOnce()>(user_data: *mut c_void) {
@@ -536,7 +532,7 @@ impl<const SSL: bool> Response<SSL> {
         );
     }
 
-    pub fn run_corked_with_type<U>(&mut self, handler: fn(*mut U), optional_data: *mut U) {
+    pub fn run_corked_with_type<U>(&self, handler: fn(*mut U), optional_data: *mut U) {
         // cork is synchronous, so we can stack-allocate the (handler, data) pair
         // and recover it inside the trampoline.
         type Ctx<U> = (fn(*mut U), *mut U);
@@ -558,7 +554,7 @@ impl<const SSL: bool> Response<SSL> {
     }
 
     pub fn upgrade<D>(
-        &mut self,
+        &self,
         data: *mut D,
         sec_web_socket_key: &[u8],
         sec_web_socket_protocol: &[u8],

--- a/src/uws_sys/SocketContext.rs
+++ b/src/uws_sys/SocketContext.rs
@@ -6,7 +6,7 @@
 use core::ffi::{c_char, c_long};
 use core::ptr;
 
-use bun_boringssl_sys::SSL_CTX;
+use bun_boringssl_sys::sys::SSL_CTX;
 
 use crate::create_bun_socket_error_t;
 

--- a/src/uws_sys/WebSocket.rs
+++ b/src/uws_sys/WebSocket.rs
@@ -204,7 +204,7 @@ impl<const SSL_FLAG: i32> NewWebSocket<SSL_FLAG> {
 bun_opaque::opaque_ffi! { pub struct RawWebSocket; }
 
 impl RawWebSocket {
-    pub fn memory_cost(&mut self, ssl_flag: i32) -> usize {
+    pub fn memory_cost(&self, ssl_flag: i32) -> usize {
         c::uws_ws_memory_cost(ssl_flag, self)
     }
 
@@ -213,8 +213,10 @@ impl RawWebSocket {
     /// Equivalent to:
     ///
     ///   (struct us_socket_t *)socket
-    pub fn as_socket(&mut self) -> *mut Socket {
-        std::ptr::from_mut::<RawWebSocket>(self).cast::<Socket>()
+    pub fn as_socket(&self) -> *mut Socket {
+        std::ptr::from_ref::<RawWebSocket>(self)
+            .cast::<Socket>()
+            .cast_mut()
     }
 }
 
@@ -710,7 +712,7 @@ pub mod c {
     // is the socket itself (plus value types) are `safe fn`; (ptr,len) shims
     // and out-param shims stay unsafe.
     unsafe extern "C" {
-        pub(crate) safe fn uws_ws_memory_cost(ssl: i32, ws: &mut RawWebSocket) -> usize;
+        pub(crate) safe fn uws_ws_memory_cost(ssl: i32, ws: &RawWebSocket) -> usize;
         pub(crate) fn uws_ws(
             ssl: i32,
             app: *mut uws_app_t,

--- a/src/uws_sys/h3.rs
+++ b/src/uws_sys/h3.rs
@@ -17,13 +17,13 @@ use crate::thunk;
 bun_opaque::opaque_ffi! { pub struct ListenSocket; }
 
 impl ListenSocket {
-    pub fn close(&mut self) {
+    pub fn close(&self) {
         c::uws_h3_listen_socket_close(self)
     }
-    pub fn get_local_port(&mut self) -> i32 {
+    pub fn get_local_port(&self) -> i32 {
         c::uws_h3_listen_socket_port(self)
     }
-    pub fn get_local_address<'a>(&mut self, buf: &'a mut [u8]) -> Option<&'a [u8]> {
+    pub fn get_local_address<'a>(&self, buf: &'a mut [u8]) -> Option<&'a [u8]> {
         // SAFETY: self is a live FFI handle; buf ptr/len valid for write
         let n = unsafe {
             c::uws_h3_listen_socket_local_address(
@@ -49,25 +49,25 @@ impl Request {
     pub fn is_ancient(&self) -> bool {
         false
     }
-    pub fn get_yield(&mut self) -> bool {
+    pub fn get_yield(&self) -> bool {
         c::uws_h3_req_get_yield(self)
     }
-    pub fn set_yield(&mut self, y: bool) {
+    pub fn set_yield(&self, y: bool) {
         c::uws_h3_req_set_yield(self, y)
     }
-    pub fn url(&mut self) -> &[u8] {
+    pub fn url(&self) -> &[u8] {
         let mut p: *const u8 = ptr::null();
         let n = c::uws_h3_req_get_url(self, &mut p);
         // SAFETY: uws returns a pointer+len pair valid for the lifetime of the request
         unsafe { bun_core::ffi::slice(p, n) }
     }
-    pub fn method(&mut self) -> &[u8] {
+    pub fn method(&self) -> &[u8] {
         let mut p: *const u8 = ptr::null();
         let n = c::uws_h3_req_get_method(self, &mut p);
         // SAFETY: uws returns a pointer+len pair valid for the lifetime of the request
         unsafe { bun_core::ffi::slice(p, n) }
     }
-    pub fn header(&mut self, name: &[u8]) -> Option<&[u8]> {
+    pub fn header(&self, name: &[u8]) -> Option<&[u8]> {
         let mut p: *const u8 = ptr::null();
         // SAFETY: self is a live FFI handle; name ptr/len valid for read; out-ptr is a valid local
         let n = unsafe { c::uws_h3_req_get_header(self, name.as_ptr(), name.len(), &raw mut p) };
@@ -78,14 +78,14 @@ impl Request {
             Some(unsafe { bun_core::ffi::slice(p, n) })
         }
     }
-    pub fn query(&mut self, name: &[u8]) -> &[u8] {
+    pub fn query(&self, name: &[u8]) -> &[u8] {
         let mut p: *const u8 = ptr::null();
         // SAFETY: self is a live FFI handle; name ptr/len valid for read; out-ptr is a valid local
         let n = unsafe { c::uws_h3_req_get_query(self, name.as_ptr(), name.len(), &raw mut p) };
         // SAFETY: uws returns a pointer+len pair valid for the lifetime of the request
         unsafe { bun_core::ffi::slice(p, n) }
     }
-    pub fn parameter(&mut self, idx: u16) -> &[u8] {
+    pub fn parameter(&self, idx: u16) -> &[u8] {
         let mut p: *const u8 = ptr::null();
         let n = c::uws_h3_req_get_parameter(self, idx, &mut p);
         // SAFETY: uws returns a pointer+len pair valid for the lifetime of the request
@@ -97,7 +97,7 @@ impl Request {
     /// zero-sized type (function item or capture-less closure): the trampoline
     /// is monomorphized over `H` and conjures the ZST inside, so the user
     /// handler is baked in with no runtime storage.
-    pub fn for_each_header<Ctx, H>(&mut self, _cb: H, ctx: *mut Ctx)
+    pub fn for_each_header<Ctx, H>(&self, _cb: H, ctx: *mut Ctx)
     where
         H: Fn(&mut Ctx, &[u8], &[u8]) + Copy + 'static,
     {
@@ -133,24 +133,24 @@ impl Request {
 bun_opaque::opaque_ffi! { pub struct Response; }
 
 impl Response {
-    pub fn end(&mut self, data: &[u8], close_connection: bool) {
+    pub fn end(&self, data: &[u8], close_connection: bool) {
         // SAFETY: self is a live FFI handle; data ptr/len valid for read
         unsafe { c::uws_h3_res_end(self, data.as_ptr(), data.len(), close_connection) }
     }
-    pub fn try_end(&mut self, data: &[u8], total: usize, close_connection: bool) -> bool {
+    pub fn try_end(&self, data: &[u8], total: usize, close_connection: bool) -> bool {
         // SAFETY: self is a live FFI handle; data ptr/len valid for read
         unsafe { c::uws_h3_res_try_end(self, data.as_ptr(), data.len(), total, close_connection) }
     }
-    pub fn end_without_body(&mut self, close_connection: bool) {
+    pub fn end_without_body(&self, close_connection: bool) {
         c::uws_h3_res_end_without_body(self, close_connection)
     }
-    pub fn end_stream(&mut self, close_connection: bool) {
+    pub fn end_stream(&self, close_connection: bool) {
         c::uws_h3_res_end_stream(self, close_connection)
     }
-    pub fn end_send_file(&mut self, write_offset: u64, close_connection: bool) {
+    pub fn end_send_file(&self, write_offset: u64, close_connection: bool) {
         c::uws_h3_res_end_sendfile(self, write_offset, close_connection)
     }
-    pub fn write(&mut self, data: &[u8]) -> WriteResult {
+    pub fn write(&self, data: &[u8]) -> WriteResult {
         let mut len: usize = data.len();
         // SAFETY: self is a live FFI handle; data ptr valid for read; len out-ptr is a valid local
         if unsafe { c::uws_h3_res_write(self, data.as_ptr(), &raw mut len) } {
@@ -159,79 +159,79 @@ impl Response {
             WriteResult::Backpressure(len)
         }
     }
-    pub fn write_status(&mut self, status: &[u8]) {
+    pub fn write_status(&self, status: &[u8]) {
         // SAFETY: self is a live FFI handle; status ptr/len valid for read
         unsafe { c::uws_h3_res_write_status(self, status.as_ptr(), status.len()) }
     }
-    pub fn write_header(&mut self, key: &[u8], value: &[u8]) {
+    pub fn write_header(&self, key: &[u8], value: &[u8]) {
         // SAFETY: self is a live FFI handle; key/value ptr+len valid for read
         unsafe {
             c::uws_h3_res_write_header(self, key.as_ptr(), key.len(), value.as_ptr(), value.len())
         }
     }
-    pub fn write_header_int(&mut self, key: &[u8], value: u64) {
+    pub fn write_header_int(&self, key: &[u8], value: u64) {
         // SAFETY: self is a live FFI handle; key ptr/len valid for read
         unsafe { c::uws_h3_res_write_header_int(self, key.as_ptr(), key.len(), value) }
     }
-    pub fn write_mark(&mut self) {
+    pub fn write_mark(&self) {
         c::uws_h3_res_write_mark(self)
     }
-    pub fn mark_wrote_content_length_header(&mut self) {
+    pub fn mark_wrote_content_length_header(&self) {
         c::uws_h3_res_mark_wrote_content_length_header(self)
     }
-    pub fn write_continue(&mut self) {
+    pub fn write_continue(&self) {
         c::uws_h3_res_write_continue(self)
     }
-    pub fn flush_headers(&mut self, immediate: bool) {
+    pub fn flush_headers(&self, immediate: bool) {
         c::uws_h3_res_flush_headers(self, immediate)
     }
-    pub fn pause(&mut self) {
+    pub fn pause(&self) {
         c::uws_h3_res_pause(self)
     }
-    pub fn resume_(&mut self) {
+    pub fn resume_(&self) {
         c::uws_h3_res_resume(self)
     }
     #[inline]
-    pub fn resume(&mut self) {
+    pub fn resume(&self) {
         self.resume_()
     }
-    pub fn timeout(&mut self, seconds: u8) {
+    pub fn timeout(&self, seconds: u8) {
         c::uws_h3_res_timeout(self, seconds)
     }
-    pub fn reset_timeout(&mut self) {
+    pub fn reset_timeout(&self) {
         c::uws_h3_res_reset_timeout(self)
     }
-    pub fn get_write_offset(&mut self) -> u64 {
+    pub fn get_write_offset(&self) -> u64 {
         c::uws_h3_res_get_write_offset(self)
     }
-    pub fn override_write_offset(&mut self, off: u64) {
+    pub fn override_write_offset(&self, off: u64) {
         c::uws_h3_res_override_write_offset(self, off)
     }
-    pub fn get_buffered_amount(&mut self) -> u64 {
+    pub fn get_buffered_amount(&self) -> u64 {
         c::uws_h3_res_get_buffered_amount(self)
     }
-    pub fn has_responded(&mut self) -> bool {
+    pub fn has_responded(&self) -> bool {
         c::uws_h3_res_has_responded(self)
     }
-    pub fn state(&mut self) -> State {
+    pub fn state(&self) -> State {
         c::uws_h3_res_state(self)
     }
-    pub fn should_close_connection(&mut self) -> bool {
+    pub fn should_close_connection(&self) -> bool {
         self.state().is_http_connection_close()
     }
     pub fn is_corked(&self) -> bool {
         false
     }
-    pub fn uncork(&mut self) {}
+    pub fn uncork(&self) {}
     pub fn is_connect_request(&self) -> bool {
         false
     }
-    pub fn prepare_for_sendfile(&mut self) {}
-    pub fn mark_needs_more(&mut self) {}
-    pub fn get_socket_data(&mut self) -> *mut c_void {
+    pub fn prepare_for_sendfile(&self) {}
+    pub fn mark_needs_more(&self) {}
+    pub fn get_socket_data(&self) -> *mut c_void {
         c::uws_h3_res_get_socket_data(self)
     }
-    pub fn get_remote_socket_info(&mut self) -> Option<SocketAddress> {
+    pub fn get_remote_socket_info(&self) -> Option<SocketAddress> {
         let mut port: i32 = 0;
         let mut is_ipv6: bool = false;
         let mut ip_ptr: *const u8 = ptr::null();
@@ -244,11 +244,11 @@ impl Response {
         let ip = unsafe { bun_core::ffi::slice(ip_ptr, len) };
         Some(SocketAddress::new(ip, port, is_ipv6))
     }
-    pub fn force_close(&mut self) {
+    pub fn force_close(&self) {
         c::uws_h3_res_force_close(self)
     }
 
-    pub fn on_writable<UD, H>(&mut self, _handler: H, ud: *mut UD)
+    pub fn on_writable<UD, H>(&self, _handler: H, ud: *mut UD)
     where
         H: Fn(&mut UD, u64, &mut Response) -> bool + Copy + 'static,
     {
@@ -268,10 +268,10 @@ impl Response {
         }
         c::uws_h3_res_on_writable(self, Some(cb::<UD, H>), ud.cast())
     }
-    pub fn clear_on_writable(&mut self) {
+    pub fn clear_on_writable(&self) {
         c::uws_h3_res_clear_on_writable(self)
     }
-    pub fn on_aborted<UD, H>(&mut self, _handler: H, ud: *mut UD)
+    pub fn on_aborted<UD, H>(&self, _handler: H, ud: *mut UD)
     where
         H: Fn(&mut UD, &mut Response) + Copy + 'static,
     {
@@ -291,10 +291,10 @@ impl Response {
         }
         c::uws_h3_res_on_aborted(self, Some(cb::<UD, H>), ud.cast())
     }
-    pub fn clear_aborted(&mut self) {
+    pub fn clear_aborted(&self) {
         c::uws_h3_res_on_aborted(self, None, ptr::null_mut())
     }
-    pub fn on_timeout<UD, H>(&mut self, _handler: H, ud: *mut UD)
+    pub fn on_timeout<UD, H>(&self, _handler: H, ud: *mut UD)
     where
         H: Fn(&mut UD, &mut Response) + Copy + 'static,
     {
@@ -314,10 +314,10 @@ impl Response {
         }
         c::uws_h3_res_on_timeout(self, Some(cb::<UD, H>), ud.cast())
     }
-    pub fn clear_timeout(&mut self) {
+    pub fn clear_timeout(&self) {
         c::uws_h3_res_on_timeout(self, None, ptr::null_mut())
     }
-    pub fn on_data<UD, H>(&mut self, _handler: H, ud: *mut UD)
+    pub fn on_data<UD, H>(&self, _handler: H, ud: *mut UD)
     where
         H: Fn(&mut UD, &mut Response, &[u8], bool) + Copy + 'static,
     {
@@ -348,15 +348,15 @@ impl Response {
         }
         c::uws_h3_res_on_data(self, Some(cb::<UD, H>), ud.cast())
     }
-    pub fn clear_on_data(&mut self) {
+    pub fn clear_on_data(&self) {
         c::uws_h3_res_on_data(self, None, ptr::null_mut())
     }
-    pub fn corked(&mut self, handler: impl FnOnce()) {
+    pub fn corked(&self, handler: impl FnOnce()) {
         // H3 has no corking; call the handler immediately.
         let _ = self;
         handler();
     }
-    pub fn run_corked_with_type<UD>(&mut self, handler: fn(*mut UD), ud: *mut UD) {
+    pub fn run_corked_with_type<UD>(&self, handler: fn(*mut UD), ud: *mut UD) {
         // cork is synchronous, so we stack-allocate the (handler, ud) pair and
         // recover it inside the trampoline — same shape as H1's
         // `Response::run_corked_with_type` so `AnyResponse` can dispatch uniformly.
@@ -399,13 +399,13 @@ pub enum AddServerNameError {
 }
 bun_core::impl_tag_error!(AddServerNameError);
 
-/// Stamps one `pub fn $name<UD, H>(&mut self, p, ud, h)` per HTTP verb,
+/// Stamps one `pub fn $name<UD, H>(&self, p, ud, h)` per HTTP verb,
 /// each forwarding to [`App::route`] with the matching [`RouteKind`].
 /// `connect`/`trace` are intentionally omitted — h3 exposes those only via
 /// [`App::method`].
 macro_rules! h3_route_methods {
     ($($name:ident => $kind:ident),* $(,)?) => {$(
-        pub fn $name<UD, H>(&mut self, p: &[u8], ud: *mut UD, h: H)
+        pub fn $name<UD, H>(&self, p: &[u8], ud: *mut UD, h: H)
         where
             H: Fn(&mut UD, &mut Request, &mut Response) + Copy + 'static,
         {
@@ -421,7 +421,7 @@ impl App {
         if p.is_null() { None } else { Some(p) }
     }
     pub fn add_server_name_with_options(
-        &mut self,
+        &self,
         hostname: &bun_core::ZStr,
         opts: &BunSocketContextOptions,
     ) -> Result<(), AddServerNameError> {
@@ -438,14 +438,14 @@ impl App {
         // SAFETY: caller contract above
         unsafe { c::uws_h3_app_destroy(this) }
     }
-    pub fn close(&mut self) {
+    pub fn close(&self) {
         c::uws_h3_app_close(self)
     }
-    pub fn clear_routes(&mut self) {
+    pub fn clear_routes(&self) {
         c::uws_h3_app_clear_routes(self)
     }
 
-    fn route<UD, H>(which: RouteKind, this: &mut App, pattern: &[u8], ud: *mut UD, _handler: H)
+    fn route<UD, H>(which: RouteKind, this: &App, pattern: &[u8], ud: *mut UD, _handler: H)
     where
         H: Fn(&mut UD, &mut Request, &mut Response) + Copy + 'static,
     {
@@ -499,7 +499,7 @@ impl App {
         any     => Any,
     }
 
-    pub fn method<UD, H>(&mut self, m: bun_http_types::Method::Method, p: &[u8], ud: *mut UD, h: H)
+    pub fn method<UD, H>(&self, m: bun_http_types::Method::Method, p: &[u8], ud: *mut UD, h: H)
     where
         H: Fn(&mut UD, &mut Request, &mut Response) + Copy + 'static,
     {
@@ -518,7 +518,7 @@ impl App {
         }
     }
 
-    pub fn listen_with_config<UD, H>(&mut self, ud: *mut UD, _handler: H, config: &ListenConfig)
+    pub fn listen_with_config<UD, H>(&self, ud: *mut UD, _handler: H, config: &ListenConfig)
     where
         H: Fn(&mut UD, Option<&mut ListenSocket>) + Copy + 'static,
     {
@@ -595,161 +595,162 @@ mod c {
             idle_timeout_s: u32,
         ) -> *mut App;
         pub(super) fn uws_h3_app_destroy(app: *mut App);
-        pub(super) safe fn uws_h3_app_close(app: &mut App);
-        pub(super) safe fn uws_h3_app_clear_routes(app: &mut App);
+        pub(super) safe fn uws_h3_app_close(app: &App);
+        pub(super) safe fn uws_h3_app_clear_routes(app: &App);
         pub(super) fn uws_h3_app_add_server_name(
-            app: *mut App,
+            app: *const App,
             hostname: *const c_char,
             opts: BunSocketContextOptions,
         ) -> bool;
-        pub(super) safe fn uws_h3_res_write_continue(res: &mut Response);
+        pub(super) safe fn uws_h3_res_write_continue(res: &Response);
         pub(super) fn uws_h3_app_get(
-            app: *mut App,
+            app: *const App,
             p: *const u8,
             n: usize,
             h: Handler,
             ud: *mut c_void,
         );
         pub(super) fn uws_h3_app_post(
-            app: *mut App,
+            app: *const App,
             p: *const u8,
             n: usize,
             h: Handler,
             ud: *mut c_void,
         );
         pub(super) fn uws_h3_app_put(
-            app: *mut App,
+            app: *const App,
             p: *const u8,
             n: usize,
             h: Handler,
             ud: *mut c_void,
         );
         pub(super) fn uws_h3_app_delete(
-            app: *mut App,
+            app: *const App,
             p: *const u8,
             n: usize,
             h: Handler,
             ud: *mut c_void,
         );
         pub(super) fn uws_h3_app_patch(
-            app: *mut App,
+            app: *const App,
             p: *const u8,
             n: usize,
             h: Handler,
             ud: *mut c_void,
         );
         pub(super) fn uws_h3_app_head(
-            app: *mut App,
+            app: *const App,
             p: *const u8,
             n: usize,
             h: Handler,
             ud: *mut c_void,
         );
         pub(super) fn uws_h3_app_options(
-            app: *mut App,
+            app: *const App,
             p: *const u8,
             n: usize,
             h: Handler,
             ud: *mut c_void,
         );
         pub(super) fn uws_h3_app_connect(
-            app: *mut App,
+            app: *const App,
             p: *const u8,
             n: usize,
             h: Handler,
             ud: *mut c_void,
         );
         pub(super) fn uws_h3_app_trace(
-            app: *mut App,
+            app: *const App,
             p: *const u8,
             n: usize,
             h: Handler,
             ud: *mut c_void,
         );
         pub(super) fn uws_h3_app_any(
-            app: *mut App,
+            app: *const App,
             p: *const u8,
             n: usize,
             h: Handler,
             ud: *mut c_void,
         );
         pub(super) fn uws_h3_app_listen_with_config(
-            app: *mut App,
+            app: *const App,
             host: *const c_char,
             port: u16,
             options: i32,
             h: ListenHandler,
             ud: *mut c_void,
         );
-        pub(super) safe fn uws_h3_listen_socket_port(ls: &mut ListenSocket) -> i32;
+        pub(super) safe fn uws_h3_listen_socket_port(ls: &ListenSocket) -> i32;
         pub(super) fn uws_h3_listen_socket_local_address(
-            ls: *mut ListenSocket,
+            ls: *const ListenSocket,
             buf: *mut u8,
             len: c_int,
         ) -> c_int;
-        pub(super) safe fn uws_h3_listen_socket_close(ls: &mut ListenSocket);
+        pub(super) safe fn uws_h3_listen_socket_close(ls: &ListenSocket);
 
-        pub(super) safe fn uws_h3_res_state(res: &mut Response) -> State;
-        pub(super) fn uws_h3_res_end(res: *mut Response, p: *const u8, n: usize, close: bool);
-        pub(super) safe fn uws_h3_res_end_stream(res: &mut Response, close: bool);
-        pub(super) safe fn uws_h3_res_force_close(res: &mut Response);
+        pub(super) safe fn uws_h3_res_state(res: &Response) -> State;
+        pub(super) fn uws_h3_res_end(res: *const Response, p: *const u8, n: usize, close: bool);
+        pub(super) safe fn uws_h3_res_end_stream(res: &Response, close: bool);
+        pub(super) safe fn uws_h3_res_force_close(res: &Response);
         pub(super) fn uws_h3_res_try_end(
-            res: *mut Response,
+            res: *const Response,
             p: *const u8,
             n: usize,
             total: usize,
             close: bool,
         ) -> bool;
-        pub(super) safe fn uws_h3_res_end_without_body(res: &mut Response, close: bool);
-        pub(super) safe fn uws_h3_res_pause(res: &mut Response);
-        pub(super) safe fn uws_h3_res_resume(res: &mut Response);
-        pub(super) fn uws_h3_res_write_status(res: *mut Response, p: *const u8, n: usize);
+        pub(super) safe fn uws_h3_res_end_without_body(res: &Response, close: bool);
+        pub(super) safe fn uws_h3_res_pause(res: &Response);
+        pub(super) safe fn uws_h3_res_resume(res: &Response);
+        pub(super) fn uws_h3_res_write_status(res: *const Response, p: *const u8, n: usize);
         pub(super) fn uws_h3_res_write_header(
-            res: *mut Response,
+            res: *const Response,
             kp: *const u8,
             kn: usize,
             vp: *const u8,
             vn: usize,
         );
         pub(super) fn uws_h3_res_write_header_int(
-            res: *mut Response,
+            res: *const Response,
             kp: *const u8,
             kn: usize,
             v: u64,
         );
-        pub(super) safe fn uws_h3_res_mark_wrote_content_length_header(res: &mut Response);
-        pub(super) safe fn uws_h3_res_write_mark(res: &mut Response);
-        pub(super) safe fn uws_h3_res_flush_headers(res: &mut Response, immediate: bool);
-        pub(super) fn uws_h3_res_write(res: *mut Response, p: *const u8, len: *mut usize) -> bool;
-        pub(super) safe fn uws_h3_res_get_write_offset(res: &mut Response) -> u64;
-        pub(super) safe fn uws_h3_res_override_write_offset(res: &mut Response, off: u64);
-        pub(super) safe fn uws_h3_res_has_responded(res: &mut Response) -> bool;
-        pub(super) safe fn uws_h3_res_get_buffered_amount(res: &mut Response) -> u64;
-        pub(super) safe fn uws_h3_res_reset_timeout(res: &mut Response);
-        pub(super) safe fn uws_h3_res_timeout(res: &mut Response, seconds: u8);
-        pub(super) safe fn uws_h3_res_end_sendfile(res: &mut Response, off: u64, close: bool);
-        pub(super) safe fn uws_h3_res_get_socket_data(res: &mut Response) -> *mut c_void;
-        // safe: `&mut Response` is ABI-identical to a non-null `*mut`;
+        pub(super) safe fn uws_h3_res_mark_wrote_content_length_header(res: &Response);
+        pub(super) safe fn uws_h3_res_write_mark(res: &Response);
+        pub(super) safe fn uws_h3_res_flush_headers(res: &Response, immediate: bool);
+        pub(super) fn uws_h3_res_write(res: *const Response, p: *const u8, len: *mut usize)
+        -> bool;
+        pub(super) safe fn uws_h3_res_get_write_offset(res: &Response) -> u64;
+        pub(super) safe fn uws_h3_res_override_write_offset(res: &Response, off: u64);
+        pub(super) safe fn uws_h3_res_has_responded(res: &Response) -> bool;
+        pub(super) safe fn uws_h3_res_get_buffered_amount(res: &Response) -> u64;
+        pub(super) safe fn uws_h3_res_reset_timeout(res: &Response);
+        pub(super) safe fn uws_h3_res_timeout(res: &Response, seconds: u8);
+        pub(super) safe fn uws_h3_res_end_sendfile(res: &Response, off: u64, close: bool);
+        pub(super) safe fn uws_h3_res_get_socket_data(res: &Response) -> *mut c_void;
+        // safe: `&Response` is ABI-identical to a non-null pointer;
         // `cb`/`ud` are stored opaquely (never dereferenced by the C++ shim
         // itself) — no preconditions on this call. Mirrors `uws_res_on_*`.
         pub(super) safe fn uws_h3_res_on_writable(
-            res: &mut Response,
+            res: &Response,
             cb: Option<unsafe extern "C" fn(*mut Response, u64, *mut c_void) -> bool>,
             ud: *mut c_void,
         );
-        pub(super) safe fn uws_h3_res_clear_on_writable(res: &mut Response);
+        pub(super) safe fn uws_h3_res_clear_on_writable(res: &Response);
         pub(super) safe fn uws_h3_res_on_aborted(
-            res: &mut Response,
+            res: &Response,
             cb: Option<unsafe extern "C" fn(*mut Response, *mut c_void)>,
             ud: *mut c_void,
         );
         pub(super) safe fn uws_h3_res_on_timeout(
-            res: &mut Response,
+            res: &Response,
             cb: Option<unsafe extern "C" fn(*mut Response, *mut c_void)>,
             ud: *mut c_void,
         );
         pub(super) safe fn uws_h3_res_on_data(
-            res: &mut Response,
+            res: &Response,
             cb: Option<unsafe extern "C" fn(*mut Response, *const u8, usize, bool, *mut c_void)>,
             ud: *mut c_void,
         );
@@ -757,50 +758,46 @@ mod c {
         // without being dereferenced by the C++ shim itself, so the call has
         // no preconditions beyond the live opaque handle.
         pub(super) safe fn uws_h3_res_cork(
-            res: &mut Response,
+            res: &Response,
             ud: *mut c_void,
             cb: unsafe extern "C" fn(*mut c_void),
         );
         // Out-params are `&mut` (non-null, valid for write); the C shim only
         // stores into them and returns a length — no read-through precondition.
         pub(super) safe fn uws_h3_res_get_remote_address_info(
-            res: &mut Response,
+            res: &Response,
             ip: &mut *const u8,
             port: &mut i32,
             is_ipv6: &mut bool,
         ) -> usize;
 
-        pub(super) safe fn uws_h3_req_get_yield(req: &mut Request) -> bool;
-        pub(super) safe fn uws_h3_req_set_yield(req: &mut Request, y: bool);
+        pub(super) safe fn uws_h3_req_get_yield(req: &Request) -> bool;
+        pub(super) safe fn uws_h3_req_set_yield(req: &Request, y: bool);
         // Out-param `out` is `&mut *const u8` (non-null, valid for write); the C
         // shim only stores a pointer into request-owned storage and returns its
         // length — no read-through precondition, so `safe fn`.
-        pub(super) safe fn uws_h3_req_get_url(req: &mut Request, out: &mut *const u8) -> usize;
-        pub(super) safe fn uws_h3_req_get_method(req: &mut Request, out: &mut *const u8) -> usize;
+        pub(super) safe fn uws_h3_req_get_url(req: &Request, out: &mut *const u8) -> usize;
+        pub(super) safe fn uws_h3_req_get_method(req: &Request, out: &mut *const u8) -> usize;
         pub(super) fn uws_h3_req_get_header(
-            req: *mut Request,
+            req: *const Request,
             name: *const u8,
             len: usize,
             out: *mut *const u8,
         ) -> usize;
         pub(super) fn uws_h3_req_get_query(
-            req: *mut Request,
+            req: *const Request,
             name: *const u8,
             len: usize,
             out: *mut *const u8,
         ) -> usize;
         pub(super) safe fn uws_h3_req_get_parameter(
-            req: &mut Request,
+            req: &Request,
             idx: u16,
             out: &mut *const u8,
         ) -> usize;
         // safe: synchronous header iteration — `ud` is forwarded opaquely to
         // `cb` without being dereferenced by the C++ shim itself; `cb` is a
         // by-value fn pointer. No preconditions beyond the live opaque handle.
-        pub(super) safe fn uws_h3_req_for_each_header(
-            req: &mut Request,
-            cb: HeaderCb,
-            ud: *mut c_void,
-        );
+        pub(super) safe fn uws_h3_req_for_each_header(req: &Request, cb: HeaderCb, ud: *mut c_void);
     }
 }

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -31,8 +31,9 @@ pub const LIBUS_SOCKET_IPV6_ONLY: core::ffi::c_int = 8;
 pub const LIBUS_LISTEN_REUSE_ADDR: core::ffi::c_int = 16;
 pub const LIBUS_LISTEN_DISALLOW_REUSE_PORT_FAILURE: core::ffi::c_int = 32;
 
-/// BoringSSL `SSL_CTX` (alias so callers don't need a direct boringssl dep).
-pub type SslCtx = bun_boringssl_sys::SSL_CTX;
+/// The BoringSSL `SSL_CTX` C object (alias so callers don't need a direct
+/// boringssl dep). The owning handle is `bun_boringssl_sys::SSL_CTX`.
+pub type SslCtx = bun_boringssl_sys::sys::SSL_CTX;
 
 /// `struct us_bun_verify_error_t` — TLS handshake verification result.
 ///

--- a/src/uws_sys/quic/Context.rs
+++ b/src/uws_sys/quic/Context.rs
@@ -17,14 +17,13 @@ unsafe extern "C" {
         stream_ext: c_uint,
     ) -> *mut Context;
 
-    // `Context` is an `opaque_ffi!` ZST (`UnsafeCell<[u8; 0]>`), so
-    // `&mut Context` is ABI-identical to a non-null `*mut Context` with no
-    // `noalias`/`readonly` attribute. Shims taking only the handle + value
-    // types (incl. fn-pointer callbacks) are `safe fn`.
-    safe fn us_quic_socket_context_loop(ctx: &mut Context) -> *mut Loop;
+    // `&Context` is ABI-identical to a non-null `*mut Context` and carries no
+    // `noalias`/`readonly` — lsquic mutates freely through it. Shims taking only
+    // the handle + value types (incl. fn-pointer callbacks) are `safe fn`.
+    safe fn us_quic_socket_context_loop(ctx: &Context) -> *mut Loop;
 
     fn us_quic_socket_context_connect(
-        ctx: *mut Context,
+        ctx: &Context,
         host: *const c_char,
         port: c_int,
         sni: *const c_char,
@@ -35,35 +34,29 @@ unsafe extern "C" {
     ) -> c_int;
 
     safe fn us_quic_socket_context_on_hsk_done(
-        ctx: &mut Context,
+        ctx: &Context,
         cb: unsafe extern "C" fn(*mut Socket, c_int),
     );
-    safe fn us_quic_socket_context_on_goaway(
-        ctx: &mut Context,
-        cb: unsafe extern "C" fn(*mut Socket),
-    );
-    safe fn us_quic_socket_context_on_close(
-        ctx: &mut Context,
-        cb: unsafe extern "C" fn(*mut Socket),
-    );
+    safe fn us_quic_socket_context_on_goaway(ctx: &Context, cb: unsafe extern "C" fn(*mut Socket));
+    safe fn us_quic_socket_context_on_close(ctx: &Context, cb: unsafe extern "C" fn(*mut Socket));
     safe fn us_quic_socket_context_on_stream_open(
-        ctx: &mut Context,
+        ctx: &Context,
         cb: unsafe extern "C" fn(*mut Stream, c_int),
     );
     safe fn us_quic_socket_context_on_stream_headers(
-        ctx: &mut Context,
+        ctx: &Context,
         cb: unsafe extern "C" fn(*mut Stream),
     );
     safe fn us_quic_socket_context_on_stream_data(
-        ctx: &mut Context,
+        ctx: &Context,
         cb: unsafe extern "C" fn(*mut Stream, *const u8, c_uint, c_int),
     );
     safe fn us_quic_socket_context_on_stream_writable(
-        ctx: &mut Context,
+        ctx: &Context,
         cb: unsafe extern "C" fn(*mut Stream),
     );
     safe fn us_quic_socket_context_on_stream_close(
-        ctx: &mut Context,
+        ctx: &Context,
         cb: unsafe extern "C" fn(*mut Stream),
     );
 }
@@ -96,7 +89,7 @@ impl Context {
     }
 
     #[inline]
-    pub fn r#loop(&mut self) -> *mut Loop {
+    pub fn r#loop(&self) -> *mut Loop {
         // Returns a raw pointer because the Loop is shared across every
         // context/socket/timer on the thread —
         // materializing `&mut Loop` here would assert uniqueness we cannot
@@ -105,7 +98,7 @@ impl Context {
     }
 
     pub fn connect(
-        &mut self,
+        &self,
         host: &CStr,
         port: u16,
         sni: &CStr,
@@ -135,38 +128,35 @@ impl Context {
     }
 
     #[inline]
-    pub fn on_hsk_done(&mut self, cb: unsafe extern "C" fn(*mut Socket, c_int)) {
+    pub fn on_hsk_done(&self, cb: unsafe extern "C" fn(*mut Socket, c_int)) {
         us_quic_socket_context_on_hsk_done(self, cb)
     }
     #[inline]
-    pub fn on_goaway(&mut self, cb: unsafe extern "C" fn(*mut Socket)) {
+    pub fn on_goaway(&self, cb: unsafe extern "C" fn(*mut Socket)) {
         us_quic_socket_context_on_goaway(self, cb)
     }
     #[inline]
-    pub fn on_close(&mut self, cb: unsafe extern "C" fn(*mut Socket)) {
+    pub fn on_close(&self, cb: unsafe extern "C" fn(*mut Socket)) {
         us_quic_socket_context_on_close(self, cb)
     }
     #[inline]
-    pub fn on_stream_open(&mut self, cb: unsafe extern "C" fn(*mut Stream, c_int)) {
+    pub fn on_stream_open(&self, cb: unsafe extern "C" fn(*mut Stream, c_int)) {
         us_quic_socket_context_on_stream_open(self, cb)
     }
     #[inline]
-    pub fn on_stream_headers(&mut self, cb: unsafe extern "C" fn(*mut Stream)) {
+    pub fn on_stream_headers(&self, cb: unsafe extern "C" fn(*mut Stream)) {
         us_quic_socket_context_on_stream_headers(self, cb)
     }
     #[inline]
-    pub fn on_stream_data(
-        &mut self,
-        cb: unsafe extern "C" fn(*mut Stream, *const u8, c_uint, c_int),
-    ) {
+    pub fn on_stream_data(&self, cb: unsafe extern "C" fn(*mut Stream, *const u8, c_uint, c_int)) {
         us_quic_socket_context_on_stream_data(self, cb)
     }
     #[inline]
-    pub fn on_stream_writable(&mut self, cb: unsafe extern "C" fn(*mut Stream)) {
+    pub fn on_stream_writable(&self, cb: unsafe extern "C" fn(*mut Stream)) {
         us_quic_socket_context_on_stream_writable(self, cb)
     }
     #[inline]
-    pub fn on_stream_close(&mut self, cb: unsafe extern "C" fn(*mut Stream)) {
+    pub fn on_stream_close(&self, cb: unsafe extern "C" fn(*mut Stream)) {
         us_quic_socket_context_on_stream_close(self, cb)
     }
 }

--- a/src/uws_sys/quic/PendingConnect.rs
+++ b/src/uws_sys/quic/PendingConnect.rs
@@ -4,6 +4,7 @@
 //! Consumed by exactly one of `resolved()` or `cancel()`.
 
 use core::ffi::c_void;
+use core::ptr::NonNull;
 
 use crate::quic::Socket;
 
@@ -13,26 +14,29 @@ bun_opaque::opaque_ffi! {
 }
 
 // `PendingConnect` is an `opaque_ffi!` ZST (`UnsafeCell<[u8; 0]>`), so
-// `&mut PendingConnect` is ABI-identical to a non-null `*mut PendingConnect`
+// `&PendingConnect` is ABI-identical to a non-null `*mut PendingConnect`
 // with no `noalias`/`readonly` attribute — handle-only shims are `safe fn`.
 unsafe extern "C" {
-    safe fn us_quic_pending_connect_addrinfo(pc: &mut PendingConnect) -> *mut c_void;
-    safe fn us_quic_pending_connect_resolved(pc: &mut PendingConnect) -> *mut Socket;
-    safe fn us_quic_pending_connect_cancel(pc: &mut PendingConnect);
+    safe fn us_quic_pending_connect_addrinfo(pc: &PendingConnect) -> *mut c_void;
+    safe fn us_quic_pending_connect_resolved(pc: &PendingConnect) -> *mut Socket;
+    safe fn us_quic_pending_connect_cancel(pc: &PendingConnect);
 }
 
 impl PendingConnect {
-    pub fn addrinfo(&mut self) -> *mut c_void {
+    pub fn addrinfo(&self) -> *mut c_void {
         us_quic_pending_connect_addrinfo(self)
     }
 
-    pub fn resolved(&mut self) -> Option<&mut Socket> {
-        // SAFETY: C returns null or a valid `us_quic_socket_t*`; `Socket` is an
-        // opaque ZST handle so `&mut` carries no aliasing assumptions.
-        unsafe { us_quic_pending_connect_resolved(self).as_mut() }
+    /// The connected socket, or `None` if the name lookup failed.
+    ///
+    /// Returns `NonNull`, not `&mut Socket`: the socket is C-owned, and minting a
+    /// `&mut` from `&self` would let two live `&mut Socket` exist (and trips
+    /// `clippy::mut_from_ref`). Callers reborrow via `Socket::opaque_mut`.
+    pub fn resolved(&self) -> Option<NonNull<Socket>> {
+        NonNull::new(us_quic_pending_connect_resolved(self))
     }
 
-    pub fn cancel(&mut self) {
+    pub fn cancel(&self) {
         us_quic_pending_connect_cancel(self)
     }
 }

--- a/src/uws_sys/quic/Stream.rs
+++ b/src/uws_sys/quic/Stream.rs
@@ -12,23 +12,22 @@ bun_opaque::opaque_ffi! {
     pub struct Stream;
 }
 
-// `Stream` is an `opaque_ffi!` ZST (`UnsafeCell<[u8; 0]>`), so `&mut Stream` is
-// ABI-identical to a non-null `*mut Stream` with no `noalias`/`readonly`
-// attribute. Shims taking only the handle + value types are `safe fn`; the
-// (ptr,len) writers keep raw signatures.
+// `Stream` is an `opaque_ffi!` ZST (`UnsafeCell<[u8; 0]>`): `&Stream` is ABI-identical
+// to a non-null `us_quic_stream_t*` and carries no `noalias`/`readonly`, so lsquic
+// mutates through it. Handle + value-type shims are `safe fn`; (ptr,len) writers are not.
 unsafe extern "C" {
-    safe fn us_quic_stream_socket(s: &mut Stream) -> *mut Socket;
-    safe fn us_quic_stream_shutdown(s: &mut Stream);
-    safe fn us_quic_stream_close(s: &mut Stream);
-    safe fn us_quic_stream_reset(s: &mut Stream);
-    safe fn us_quic_stream_header_count(s: &mut Stream) -> c_uint;
-    safe fn us_quic_stream_header(s: &mut Stream, i: c_uint) -> *const Header;
-    safe fn us_quic_stream_ext(s: &mut Stream) -> *mut c_void;
-    fn us_quic_stream_write(s: *mut Stream, data: *const u8, len: c_uint) -> c_int;
-    safe fn us_quic_stream_want_write(s: &mut Stream, want: c_int);
-    safe fn us_quic_stream_want_read(s: &mut Stream, want: c_int);
+    safe fn us_quic_stream_socket(s: &Stream) -> *mut Socket;
+    safe fn us_quic_stream_shutdown(s: &Stream);
+    safe fn us_quic_stream_close(s: &Stream);
+    safe fn us_quic_stream_reset(s: &Stream);
+    safe fn us_quic_stream_header_count(s: &Stream) -> c_uint;
+    safe fn us_quic_stream_header(s: &Stream, i: c_uint) -> *const Header;
+    safe fn us_quic_stream_ext(s: &Stream) -> *mut c_void;
+    fn us_quic_stream_write(s: &Stream, data: *const u8, len: c_uint) -> c_int;
+    safe fn us_quic_stream_want_write(s: &Stream, want: c_int);
+    safe fn us_quic_stream_want_read(s: &Stream, want: c_int);
     fn us_quic_stream_send_headers(
-        s: *mut Stream,
+        s: &Stream,
         h: *const Header,
         n: c_uint,
         end_stream: c_int,
@@ -36,44 +35,42 @@ unsafe extern "C" {
 }
 
 impl Stream {
-    pub fn socket(&mut self) -> Option<NonNull<Socket>> {
-        // Returned as a raw pointer (not &mut) because the Socket is the *parent
-        // connection shared by every stream on it* — two live &mut Stream on the
-        // same conn calling .socket() (or a conn-level callback already holding
-        // &mut Socket) would otherwise yield aliasing &mut Socket, which is UB.
-        // Callers reborrow locally under their own SAFETY proof.
+    pub fn socket(&self) -> Option<NonNull<Socket>> {
+        // Raw pointer (not &mut) because the Socket is the *parent connection shared by
+        // every stream on it* — a conn-level callback may already hold &mut Socket, so
+        // minting one here would alias. Callers reborrow under their own SAFETY proof.
         NonNull::new(us_quic_stream_socket(self))
     }
 
-    pub fn shutdown(&mut self) {
+    pub fn shutdown(&self) {
         us_quic_stream_shutdown(self)
     }
 
-    pub fn close(&mut self) {
+    pub fn close(&self) {
         us_quic_stream_close(self)
     }
 
-    pub fn reset(&mut self) {
+    pub fn reset(&self) {
         us_quic_stream_reset(self)
     }
 
-    pub fn header_count(&mut self) -> c_uint {
+    pub fn header_count(&self) -> c_uint {
         us_quic_stream_header_count(self)
     }
 
-    pub fn header(&mut self, i: c_uint) -> Option<&Header> {
+    pub fn header(&self, i: c_uint) -> Option<&Header> {
         // SAFETY: self is a valid us_quic_stream_t; returned header borrowed from stream's header block.
         unsafe { us_quic_stream_header(self, i).as_ref() }
     }
 
-    pub fn ext<T>(&mut self) -> &Cell<Option<NonNull<T>>> {
+    pub fn ext<T>(&self) -> &Cell<Option<NonNull<T>>> {
         // SAFETY: self is a valid us_quic_stream_t; ext slot is pointer-sized & pointer-aligned,
         // and Option<NonNull<T>> has nullable-pointer layout. `Cell` is repr(transparent), so no
         // &mut into the slot is ever live across a callback that re-enters lsquic.
         unsafe { &*us_quic_stream_ext(self).cast::<Cell<Option<NonNull<T>>>>() }
     }
 
-    pub fn write(&mut self, data: &[u8]) -> c_int {
+    pub fn write(&self, data: &[u8]) -> c_int {
         // SAFETY: self is a valid us_quic_stream_t; data.ptr valid for data.len() bytes.
         unsafe {
             us_quic_stream_write(
@@ -84,15 +81,15 @@ impl Stream {
         }
     }
 
-    pub fn want_write(&mut self, want: bool) {
+    pub fn want_write(&self, want: bool) {
         us_quic_stream_want_write(self, want as c_int)
     }
 
-    pub fn want_read(&mut self, want: bool) {
+    pub fn want_read(&self, want: bool) {
         us_quic_stream_want_read(self, want as c_int)
     }
 
-    pub fn send_headers(&mut self, headers: &[Header], end_stream: bool) -> c_int {
+    pub fn send_headers(&self, headers: &[Header], end_stream: bool) -> c_int {
         // SAFETY: self is a valid us_quic_stream_t; headers.ptr valid for headers.len() entries.
         unsafe {
             us_quic_stream_send_headers(

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -122,7 +122,8 @@ impl InternalSocket {
 fn sock<'a>(p: *mut us_socket_t) -> &'a mut us_socket_t {
     bun_opaque::opaque_deref_mut(p)
 }
-/// Reborrow the `InternalSocket::Connecting` payload.
+/// Reborrow the `InternalSocket::Connecting` payload. `&mut`, mirroring `sock`:
+/// `ext` hands out a `&mut T` into the socket's real trailing ext storage.
 #[inline(always)]
 fn conn<'a>(p: *mut ConnectingSocket) -> &'a mut ConnectingSocket {
     bun_opaque::opaque_deref_mut(p)
@@ -558,8 +559,7 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
             _ => {
                 // The socket is gone; release the reference the caller handed us.
                 if !ctx.is_null() {
-                    // SAFETY: the caller passed an owned SSL_CTX reference.
-                    unsafe { bun_boringssl_sys::SSL_CTX_free(ctx) };
+                    bun_boringssl_sys::SSL_CTX_free(crate::SslCtx::opaque_ref(ctx));
                 }
             }
         }

--- a/src/uws_sys/udp.rs
+++ b/src/uws_sys/udp.rs
@@ -48,7 +48,7 @@ impl Socket {
     }
 
     pub fn send(
-        &mut self,
+        &self,
         payloads: &[*const u8],
         lengths: &[usize],
         addresses: &[*const c_void],
@@ -66,60 +66,60 @@ impl Socket {
         }
     }
 
-    pub fn user(&mut self) -> *mut c_void {
+    pub fn user(&self) -> *mut c_void {
         us_udp_socket_user(self)
     }
 
     /// Get the bound port in host byte order
-    pub fn bound_port(&mut self) -> c_int {
+    pub fn bound_port(&self) -> c_int {
         us_udp_socket_bound_port(self)
     }
 
-    pub fn bound_ip(&mut self, buf: *mut u8, length: &mut i32) {
+    pub fn bound_ip(&self, buf: *mut u8, length: &mut i32) {
         // SAFETY: buf must point to at least *length bytes; thin FFI passthrough.
         unsafe { us_udp_socket_bound_ip(self, buf, length) }
     }
 
-    pub fn remote_ip(&mut self, buf: *mut u8, length: &mut i32) {
+    pub fn remote_ip(&self, buf: *mut u8, length: &mut i32) {
         // SAFETY: buf must point to at least *length bytes; thin FFI passthrough.
         unsafe { us_udp_socket_remote_ip(self, buf, length) }
     }
 
-    pub fn close(&mut self) {
+    pub fn close(&self) {
         us_udp_socket_close(self)
     }
 
-    pub fn connect(&mut self, hostname: *const c_char, port: c_uint) -> c_int {
+    pub fn connect(&self, hostname: *const c_char, port: c_uint) -> c_int {
         // SAFETY: thin FFI passthrough; hostname must be NUL-terminated per uSockets.
         unsafe { us_udp_socket_connect(self, hostname, port) }
     }
 
-    pub fn disconnect(&mut self) -> c_int {
+    pub fn disconnect(&self) -> c_int {
         us_udp_socket_disconnect(self)
     }
 
-    pub fn set_broadcast(&mut self, enabled: bool) -> c_int {
+    pub fn set_broadcast(&self, enabled: bool) -> c_int {
         us_udp_socket_set_broadcast(self, enabled as c_int)
     }
 
-    pub fn set_unicast_ttl(&mut self, ttl: i32) -> c_int {
+    pub fn set_unicast_ttl(&self, ttl: i32) -> c_int {
         us_udp_socket_set_ttl_unicast(self, ttl as c_int)
     }
 
-    pub fn set_multicast_ttl(&mut self, ttl: i32) -> c_int {
+    pub fn set_multicast_ttl(&self, ttl: i32) -> c_int {
         us_udp_socket_set_ttl_multicast(self, ttl as c_int)
     }
 
-    pub fn set_multicast_loopback(&mut self, enabled: bool) -> c_int {
+    pub fn set_multicast_loopback(&self, enabled: bool) -> c_int {
         us_udp_socket_set_multicast_loopback(self, enabled as c_int)
     }
 
-    pub fn set_multicast_interface(&mut self, iface: &sockaddr_storage) -> c_int {
+    pub fn set_multicast_interface(&self, iface: &sockaddr_storage) -> c_int {
         us_udp_socket_set_multicast_interface(self, iface)
     }
 
     pub fn set_membership(
-        &mut self,
+        &self,
         address: &sockaddr_storage,
         iface: Option<&sockaddr_storage>,
         drop: bool,
@@ -128,7 +128,7 @@ impl Socket {
     }
 
     pub fn set_source_specific_membership(
-        &mut self,
+        &self,
         source: &sockaddr_storage,
         group: &sockaddr_storage,
         iface: Option<&sockaddr_storage>,
@@ -138,6 +138,9 @@ impl Socket {
     }
 }
 
+// `Socket` is an `opaque_ffi!` ZST: `&Socket` is ABI-identical to a non-null
+// `us_udp_socket_t*` and carries no `noalias`/`readonly` — C owns the socket and
+// mutates it through the same pointer, so no shim takes `&mut Socket`.
 unsafe extern "C" {
     fn us_create_udp_socket(
         loop_: *mut Loop,
@@ -151,26 +154,26 @@ unsafe extern "C" {
         err: *mut c_int,
         user_data: *mut c_void,
     ) -> *mut Socket;
-    fn us_udp_socket_connect(socket: *mut Socket, hostname: *const c_char, port: c_uint) -> c_int;
-    safe fn us_udp_socket_disconnect(socket: &mut Socket) -> c_int;
+    fn us_udp_socket_connect(socket: &Socket, hostname: *const c_char, port: c_uint) -> c_int;
+    safe fn us_udp_socket_disconnect(socket: &Socket) -> c_int;
     fn us_udp_socket_send(
-        socket: *mut Socket,
+        socket: &Socket,
         payloads: *const *const u8,
         lengths: *const usize,
         addresses: *const *const c_void,
         num: c_int,
     ) -> c_int;
-    safe fn us_udp_socket_user(socket: &mut Socket) -> *mut c_void;
-    safe fn us_udp_socket_bound_port(socket: &mut Socket) -> c_int;
-    fn us_udp_socket_bound_ip(socket: *mut Socket, buf: *mut u8, length: *mut i32);
-    fn us_udp_socket_remote_ip(socket: *mut Socket, buf: *mut u8, length: *mut i32);
-    safe fn us_udp_socket_close(socket: &mut Socket);
-    safe fn us_udp_socket_set_broadcast(socket: &mut Socket, enabled: c_int) -> c_int;
-    safe fn us_udp_socket_set_ttl_unicast(socket: &mut Socket, ttl: c_int) -> c_int;
-    safe fn us_udp_socket_set_ttl_multicast(socket: &mut Socket, ttl: c_int) -> c_int;
-    safe fn us_udp_socket_set_multicast_loopback(socket: &mut Socket, enabled: c_int) -> c_int;
+    safe fn us_udp_socket_user(socket: &Socket) -> *mut c_void;
+    safe fn us_udp_socket_bound_port(socket: &Socket) -> c_int;
+    fn us_udp_socket_bound_ip(socket: &Socket, buf: *mut u8, length: *mut i32);
+    fn us_udp_socket_remote_ip(socket: &Socket, buf: *mut u8, length: *mut i32);
+    safe fn us_udp_socket_close(socket: &Socket);
+    safe fn us_udp_socket_set_broadcast(socket: &Socket, enabled: c_int) -> c_int;
+    safe fn us_udp_socket_set_ttl_unicast(socket: &Socket, ttl: c_int) -> c_int;
+    safe fn us_udp_socket_set_ttl_multicast(socket: &Socket, ttl: c_int) -> c_int;
+    safe fn us_udp_socket_set_multicast_loopback(socket: &Socket, enabled: c_int) -> c_int;
     safe fn us_udp_socket_set_multicast_interface(
-        socket: &mut Socket,
+        socket: &Socket,
         iface: &sockaddr_storage,
     ) -> c_int;
     // `Option<&sockaddr_storage>` is FFI-safe (null-pointer niche → `*const`);
@@ -178,13 +181,13 @@ unsafe extern "C" {
     // arg either a reference or a niche-optimized `Option<&T>`, the validity
     // proof is in the type signature — no remaining preconditions, so `safe fn`.
     safe fn us_udp_socket_set_membership(
-        socket: &mut Socket,
+        socket: &Socket,
         address: &sockaddr_storage,
         iface: Option<&sockaddr_storage>,
         drop: c_int,
     ) -> c_int;
     safe fn us_udp_socket_set_source_specific_membership(
-        socket: &mut Socket,
+        socket: &Socket,
         source: &sockaddr_storage,
         group: &sockaddr_storage,
         iface: Option<&sockaddr_storage>,
@@ -221,7 +224,7 @@ impl PacketBuffer {
         }
     }
 
-    pub fn get_truncated(&mut self, index: c_int) -> bool {
+    pub fn get_truncated(&self, index: c_int) -> bool {
         us_udp_packet_buffer_truncated(self, index) != 0
     }
 }
@@ -233,5 +236,5 @@ unsafe extern "C" {
     ) -> *mut sockaddr_storage;
     safe fn us_udp_packet_buffer_payload(buf: &mut PacketBuffer, index: c_int) -> *mut u8;
     safe fn us_udp_packet_buffer_payload_length(buf: &mut PacketBuffer, index: c_int) -> c_int;
-    safe fn us_udp_packet_buffer_truncated(buf: &mut PacketBuffer, index: c_int) -> c_int;
+    safe fn us_udp_packet_buffer_truncated(buf: &PacketBuffer, index: c_int) -> c_int;
 }

--- a/src/uws_sys/us_socket_t.rs
+++ b/src/uws_sys/us_socket_t.rs
@@ -41,14 +41,14 @@ pub struct UsIoVec {
 }
 
 impl us_socket_t {
-    pub fn open(&mut self, is_client: bool, ip_addr: Option<&[u8]>) {
+    pub fn open(&self, is_client: bool, ip_addr: Option<&[u8]>) {
         bun_core::scoped_log!(uws, "us_socket_open({:p}, is_client: {})", self, is_client);
         if let Some(ip) = ip_addr {
             debug_assert!(ip.len() < MAX_I32);
             unsafe {
                 // SAFETY: self is a live us_socket_t; ip.ptr valid for ip.len bytes
                 let _ = c::us_socket_open(
-                    self,
+                    self.as_mut_ptr(),
                     is_client as i32,
                     ip.as_ptr(),
                     i32::try_from(ip.len().min(MAX_I32)).expect("int cast"),
@@ -57,22 +57,22 @@ impl us_socket_t {
         } else {
             unsafe {
                 // SAFETY: self is a live us_socket_t
-                let _ = c::us_socket_open(self, is_client as i32, ptr::null(), 0);
+                let _ = c::us_socket_open(self.as_mut_ptr(), is_client as i32, ptr::null(), 0);
             }
         }
     }
 
-    pub fn pause(&mut self) {
+    pub fn pause(&self) {
         bun_core::scoped_log!(uws, "us_socket_pause({:p})", self);
         c::us_socket_pause(self);
     }
 
-    pub fn resume(&mut self) {
+    pub fn resume(&self) {
         bun_core::scoped_log!(uws, "us_socket_resume({:p})", self);
         c::us_socket_resume(self);
     }
 
-    pub fn close(&mut self, code: CloseCode) {
+    pub fn close(&self, code: CloseCode) {
         bun_core::scoped_log!(
             uws,
             "us_socket_close({:p}, {})",
@@ -81,16 +81,16 @@ impl us_socket_t {
         );
         unsafe {
             // SAFETY: self is a live us_socket_t
-            let _ = c::us_socket_close(self, code, ptr::null_mut());
+            let _ = c::us_socket_close(self.as_mut_ptr(), code, ptr::null_mut());
         }
     }
 
-    pub fn shutdown(&mut self) {
+    pub fn shutdown(&self) {
         bun_core::scoped_log!(uws, "us_socket_shutdown({:p})", self);
         c::us_socket_shutdown(self);
     }
 
-    pub fn shutdown_read(&mut self) {
+    pub fn shutdown_read(&self) {
         c::us_socket_shutdown_read(self);
     }
 
@@ -163,42 +163,43 @@ impl us_socket_t {
         Ok(&buf[..usize::try_from(length).expect("int cast")])
     }
 
-    pub fn set_timeout(&mut self, seconds: u32) {
+    pub fn set_timeout(&self, seconds: u32) {
         c::us_socket_timeout(self, seconds);
     }
 
-    pub fn set_long_timeout(&mut self, minutes: u32) {
+    pub fn set_long_timeout(&self, minutes: u32) {
         c::us_socket_long_timeout(self, minutes);
     }
 
-    pub fn set_nodelay(&mut self, enabled: bool) {
+    pub fn set_nodelay(&self, enabled: bool) {
         c::us_socket_nodelay(self, enabled as c_int);
     }
 
-    pub fn set_keepalive(&mut self, enabled: bool, delay: u32) -> i32 {
+    pub fn set_keepalive(&self, enabled: bool, delay: u32) -> i32 {
         c::us_socket_keepalive(self, enabled as c_int, delay)
     }
 
     /// Set the IP type-of-service / traffic class. Returns 0 on success or a
     /// negative platform errno.
-    pub fn set_tos(&mut self, tos: i32) -> i32 {
+    pub fn set_tos(&self, tos: i32) -> i32 {
         c::us_socket_set_tos(self, tos)
     }
 
     /// Get the IP type-of-service / traffic class (>= 0) or a negative errno.
-    pub fn get_tos(&mut self) -> i32 {
+    pub fn get_tos(&self) -> i32 {
         c::us_socket_get_tos(self)
     }
 
     /// Resume a handshake suspended by an asynchronous SNICallback. `ctx`
     /// carries an owned SSL_CTX reference that the call consumes (may be
     /// null = fall through to the default context); `error` aborts instead.
-    pub fn sni_resolve(&mut self, ctx: *mut SslCtx, error: bool) {
+    pub fn sni_resolve(&self, ctx: *mut SslCtx, error: bool) {
         c::us_socket_sni_resolve(self, ctx, error as c_int);
     }
 
     /// `SSL*` if TLS, else null. Use `get_fd()` for the descriptor.
-    pub fn ssl(&mut self) -> Option<&mut bun_boringssl_sys::SSL> {
+    #[allow(clippy::mut_from_ref)]
+    pub fn ssl(&self) -> Option<&mut bun_boringssl_sys::SSL> {
         if !self.is_tls() {
             return None;
         }
@@ -213,7 +214,7 @@ impl us_socket_t {
     /// Node-compat `_handle` shape: `SSL*` for TLS sockets, fd-as-pointer for
     /// plain TCP. Consumers that want one or the other should call `ssl()` /
     /// `get_fd()` directly; this is the round-trip-to-JS form.
-    pub fn get_native_handle(&mut self) -> Option<*mut c_void> {
+    pub fn get_native_handle(&self) -> Option<*mut c_void> {
         let p = c::us_socket_get_native_handle(self);
         if p.is_null() { None } else { Some(p) }
     }
@@ -228,7 +229,7 @@ impl us_socket_t {
 
     /// Type-erased ext storage — `LIBUS_EXT_ALIGNMENT`-aligned bytes
     /// immediately after the C struct. Prefer `ext<T>()`.
-    pub fn ext_ptr(&mut self) -> *mut u8 {
+    pub fn ext_ptr(&self) -> *mut u8 {
         c::us_socket_ext(self).cast::<u8>()
     }
 
@@ -250,7 +251,7 @@ impl us_socket_t {
     /// Re-stamp the dispatch kind in place. Used after `Listener.onCreate`
     /// stashes the `NewSocket*` in ext so subsequent events skip the listener
     /// arm and route straight to `BunSocket`.
-    pub fn set_kind(&mut self, k: SocketKind) {
+    pub fn set_kind(&self, k: SocketKind) {
         c::us_socket_set_kind(self, k as u8);
     }
 
@@ -258,14 +259,22 @@ impl us_socket_t {
     /// Returns the (possibly relocated) socket; `self` is invalid after.
     // TODO: take `self` by value — it is consumed/invalidated; the returned ptr may be a different allocation
     pub fn adopt(
-        &mut self,
+        &self,
         g: &mut SocketGroup,
         k: SocketKind,
         old_ext: i32,
         new_ext: i32,
     ) -> Option<NonNull<us_socket_t>> {
         // SAFETY: self and g are live; C may realloc and return a different us_socket_t*
-        unsafe { NonNull::new(c::us_socket_adopt(self, g, k as u8, old_ext, new_ext)) }
+        unsafe {
+            NonNull::new(c::us_socket_adopt(
+                self.as_mut_ptr(),
+                g,
+                k as u8,
+                old_ext,
+                new_ext,
+            ))
+        }
     }
 
     /// `adopt` + attach a fresh `SSL*` from `ssl_ctx` (refcounted by the C
@@ -275,7 +284,7 @@ impl us_socket_t {
     /// `us_socket_upgrade_to_tls` / `wrapTLS`.
     // TODO: take `self` by value — it is consumed/invalidated; the returned ptr may be a different allocation
     pub fn adopt_tls(
-        &mut self,
+        &self,
         g: &mut SocketGroup,
         k: SocketKind,
         ssl_ctx: &mut SslCtx,
@@ -288,7 +297,7 @@ impl us_socket_t {
         // realloc and return a different us_socket_t*
         unsafe {
             NonNull::new(c::us_socket_adopt_tls(
-                self,
+                self.as_mut_ptr(),
                 g,
                 k as u8,
                 ssl_ctx,
@@ -302,14 +311,14 @@ impl us_socket_t {
 
     /// Send ClientHello. Separate from `adopt_tls` so the ext slot can be
     /// repointed before any handshake/close dispatch can fire.
-    pub fn start_tls_handshake(&mut self) {
+    pub fn start_tls_handshake(&self) {
         c::us_socket_start_tls_handshake(self);
     }
 
     /// Feed bytes that were already read off the wire (e.g. a ClientHello the
     /// plain-TCP layer consumed before the upgrade) through the same decrypt
     /// path as bytes arriving from the kernel.
-    pub fn tls_feed(&mut self, data: &[u8]) {
+    pub fn tls_feed(&self, data: &[u8]) {
         if data.is_empty() {
             return;
         }
@@ -324,7 +333,7 @@ impl us_socket_t {
             // SAFETY: `self` is a live TLS `us_socket_t`; `chunk` is valid for its
             // length, which fits in an i32 by construction.
             unsafe {
-                c::us_socket_tls_feed(self, chunk.as_ptr().cast(), chunk.len() as i32);
+                c::us_socket_tls_feed(self.as_mut_ptr(), chunk.as_ptr().cast(), chunk.len() as i32);
             }
         }
     }
@@ -332,15 +341,15 @@ impl us_socket_t {
     /// Tee inbound ciphertext to `us_dispatch_ssl_raw_tap` before `SSL_read`
     /// consumes it, so the `[raw, tls]` pair from `upgradeTLS` can surface
     /// encrypted bytes to the original net.Socket `data` listener.
-    pub fn set_ssl_raw_tap(&mut self, enabled: bool) {
+    pub fn set_ssl_raw_tap(&self, enabled: bool) {
         c::us_socket_set_ssl_raw_tap(self, enabled as c_int);
     }
 
-    pub fn write(&mut self, data: &[u8]) -> i32 {
+    pub fn write(&self, data: &[u8]) -> i32 {
         let rc = unsafe {
             // SAFETY: data.as_ptr() valid for data.len() bytes
             c::us_socket_write(
-                self,
+                self.as_mut_ptr(),
                 data.as_ptr(),
                 i32::try_from(data.len().min(MAX_I32)).expect("int cast"),
             )
@@ -350,11 +359,11 @@ impl us_socket_t {
     }
 
     #[cfg(not(windows))]
-    pub fn write_fd(&mut self, data: &[u8], file_descriptor: Fd) -> i32 {
+    pub fn write_fd(&self, data: &[u8], file_descriptor: Fd) -> i32 {
         let rc = unsafe {
             // SAFETY: data.as_ptr() valid for data.len() bytes; fd is a valid native descriptor
             c::us_socket_ipc_write_fd(
-                self,
+                self.as_mut_ptr(),
                 data.as_ptr(),
                 i32::try_from(data.len().min(MAX_I32)).expect("int cast"),
                 file_descriptor.native(),
@@ -371,18 +380,18 @@ impl us_socket_t {
         rc
     }
     #[cfg(windows)]
-    pub fn write_fd(&mut self, _data: &[u8], _file_descriptor: Fd) -> i32 {
+    pub fn write_fd(&self, _data: &[u8], _file_descriptor: Fd) -> i32 {
         // A `compile_error!` here would brick the windows build even with no
         // callers (it is evaluated at item definition), so use a runtime trap
         // instead; no current Windows call site.
         unreachable!("us_socket_t::write_fd is not implemented on Windows")
     }
 
-    pub fn write2(&mut self, first: &[u8], second: &[u8]) -> i32 {
+    pub fn write2(&self, first: &[u8], second: &[u8]) -> i32 {
         let rc = unsafe {
             // SAFETY: both slices valid for their respective lengths
             c::us_socket_write2(
-                self,
+                self.as_mut_ptr(),
                 first.as_ptr(),
                 first.len(),
                 second.as_ptr(),
@@ -404,13 +413,13 @@ impl us_socket_t {
     /// sends on platforms without it). Same closed/shutdown gating and
     /// partial-write poll handling as `raw_write`. Plain-TCP only by contract:
     /// raw writes bypass TLS framing.
-    pub fn raw_writev(&mut self, iov: &[UsIoVec]) -> i32 {
+    pub fn raw_writev(&self, iov: &[UsIoVec]) -> i32 {
         bun_core::scoped_log!(uws, "us_socket_raw_writev({:p}, {})", self, iov.len());
         // SAFETY: iov entries reference memory owned by the caller for the
         // duration of this call; the C side only reads them synchronously.
         unsafe {
             c::us_socket_raw_writev(
-                self,
+                self.as_mut_ptr(),
                 iov.as_ptr(),
                 i32::try_from(iov.len()).expect("int cast"),
             )
@@ -418,23 +427,23 @@ impl us_socket_t {
     }
 
     /// Bypass TLS — raw bytes to the fd even if `is_tls()`.
-    pub fn raw_write(&mut self, data: &[u8]) -> i32 {
+    pub fn raw_write(&self, data: &[u8]) -> i32 {
         bun_core::scoped_log!(uws, "us_socket_raw_write({:p}, {})", self, data.len());
         unsafe {
             // SAFETY: data.as_ptr() valid for data.len() bytes
             c::us_socket_raw_write(
-                self,
+                self.as_mut_ptr(),
                 data.as_ptr(),
                 i32::try_from(data.len().min(MAX_I32)).expect("int cast"),
             )
         }
     }
 
-    pub fn flush(&mut self) {
+    pub fn flush(&self) {
         c::us_socket_flush(self);
     }
 
-    pub fn send_file_needs_more(&mut self) {
+    pub fn send_file_needs_more(&self) {
         c::us_socket_sendfile_needs_more(self);
     }
 
@@ -480,7 +489,7 @@ mod c {
     // Shims that take a (ptr,len) pair, nullable raw, or transfer ownership
     // stay unsafe.
     unsafe extern "C" {
-        pub(super) safe fn us_socket_get_native_handle(s: &mut us_socket_t) -> *mut c_void;
+        pub(super) safe fn us_socket_get_native_handle(s: &us_socket_t) -> *mut c_void;
 
         pub(super) safe fn us_socket_local_port(s: &us_socket_t) -> i32;
         pub(super) safe fn us_socket_remote_port(s: &us_socket_t) -> i32;
@@ -494,27 +503,23 @@ mod c {
             buf: *mut u8,
             length: *mut i32,
         );
-        pub(super) safe fn us_socket_timeout(s: &mut us_socket_t, seconds: c_uint);
-        pub(super) safe fn us_socket_long_timeout(s: &mut us_socket_t, minutes: c_uint);
-        pub(super) safe fn us_socket_nodelay(s: &mut us_socket_t, enable: c_int);
-        pub(super) safe fn us_socket_set_tos(s: &mut us_socket_t, tos: c_int) -> c_int;
-        pub(super) safe fn us_socket_get_tos(s: &mut us_socket_t) -> c_int;
-        pub(super) safe fn us_socket_sni_resolve(
-            s: &mut us_socket_t,
-            ctx: *mut SslCtx,
-            error: c_int,
-        );
+        pub(super) safe fn us_socket_timeout(s: &us_socket_t, seconds: c_uint);
+        pub(super) safe fn us_socket_long_timeout(s: &us_socket_t, minutes: c_uint);
+        pub(super) safe fn us_socket_nodelay(s: &us_socket_t, enable: c_int);
+        pub(super) safe fn us_socket_set_tos(s: &us_socket_t, tos: c_int) -> c_int;
+        pub(super) safe fn us_socket_get_tos(s: &us_socket_t) -> c_int;
+        pub(super) safe fn us_socket_sni_resolve(s: &us_socket_t, ctx: *mut SslCtx, error: c_int);
         pub(super) safe fn us_socket_keepalive(
-            s: &mut us_socket_t,
+            s: &us_socket_t,
             enable: c_int,
             delay: c_uint,
         ) -> c_int;
 
-        pub(super) safe fn us_socket_ext(s: &mut us_socket_t) -> *mut c_void;
-        pub(super) safe fn us_socket_group(s: &mut us_socket_t) -> *mut SocketGroup;
+        pub(super) safe fn us_socket_ext(s: &us_socket_t) -> *mut c_void;
+        pub(super) safe fn us_socket_group(s: &us_socket_t) -> *mut SocketGroup;
         pub(super) safe fn us_socket_kind(s: &us_socket_t) -> u8;
-        pub(super) safe fn us_socket_set_kind(s: &mut us_socket_t, kind: u8);
-        pub(super) safe fn us_socket_set_ssl_raw_tap(s: &mut us_socket_t, enabled: c_int);
+        pub(super) safe fn us_socket_set_kind(s: &us_socket_t, kind: u8);
+        pub(super) safe fn us_socket_set_ssl_raw_tap(s: &us_socket_t, enabled: c_int);
         pub(super) safe fn us_socket_is_tls(s: &us_socket_t) -> i32;
 
         pub(super) fn us_socket_write(s: *mut us_socket_t, data: *const u8, length: i32) -> i32;
@@ -539,7 +544,7 @@ mod c {
         ) -> i32;
         pub(super) fn us_socket_raw_write(s: *mut us_socket_t, data: *const u8, length: i32)
         -> i32;
-        pub(super) safe fn us_socket_flush(s: &mut us_socket_t);
+        pub(super) safe fn us_socket_flush(s: &us_socket_t);
 
         pub(super) fn us_socket_open(
             s: *mut us_socket_t,
@@ -547,14 +552,14 @@ mod c {
             ip: *const u8,
             ip_length: i32,
         ) -> *mut us_socket_t;
-        pub(super) safe fn us_socket_pause(s: &mut us_socket_t);
-        pub(super) safe fn us_socket_resume(s: &mut us_socket_t);
+        pub(super) safe fn us_socket_pause(s: &us_socket_t);
+        pub(super) safe fn us_socket_resume(s: &us_socket_t);
         pub(super) fn us_socket_close(
             s: *mut us_socket_t,
             code: CloseCode,
             reason: *mut c_void,
         ) -> *mut us_socket_t;
-        pub(super) safe fn us_socket_shutdown(s: &mut us_socket_t);
+        pub(super) safe fn us_socket_shutdown(s: &us_socket_t);
         pub(super) safe fn us_socket_is_closed(s: &us_socket_t) -> i32;
         pub(super) fn us_socket_write_check_error(
             s: &us_socket_t,
@@ -562,9 +567,9 @@ mod c {
             length: i32,
             fatal_write_error: *mut i32,
         ) -> i32;
-        pub(super) safe fn us_socket_shutdown_read(s: &mut us_socket_t);
+        pub(super) safe fn us_socket_shutdown_read(s: &us_socket_t);
         pub(super) safe fn us_socket_is_shut_down(s: &us_socket_t) -> i32;
-        pub(super) safe fn us_socket_sendfile_needs_more(socket: &mut us_socket_t);
+        pub(super) safe fn us_socket_sendfile_needs_more(socket: &us_socket_t);
         pub(super) safe fn us_socket_get_fd(s: &us_socket_t) -> LIBUS_SOCKET_DESCRIPTOR;
         pub(super) safe fn us_socket_verify_error(s: &us_socket_t) -> us_bun_verify_error_t;
         pub(super) safe fn us_socket_get_error(s: &us_socket_t) -> c_int;
@@ -594,7 +599,7 @@ mod c {
             data: *const c_char,
             length: i32,
         ) -> *mut us_socket_t;
-        pub(super) safe fn us_socket_start_tls_handshake(s: &mut us_socket_t);
+        pub(super) safe fn us_socket_start_tls_handshake(s: &us_socket_t);
     }
 }
 

--- a/src/zstd/lib.rs
+++ b/src/zstd/lib.rs
@@ -211,28 +211,21 @@ fn free_dstream(zds: &sys::ZSTD_DStream) {
     let _ = c::ZSTD_freeDStream(zds);
 }
 
-bun_opaque::foreign_owned!(sys::ZSTD_DStream, free_dstream);
-
-/// Owned handle to a C `ZSTD_DStream` (`== ZSTD_DCtx`).
-///
-/// `Drop` frees the context. Every method takes `&self`: zstd mutates the
-/// context through the same pointer on every call, so there is no `&mut self`
-/// to have, and freeing is not exclusive access either.
-#[repr(transparent)]
-#[allow(non_camel_case_types)]
-pub struct ZSTD_DStream(bun_opaque::ForeignRef<sys::ZSTD_DStream>);
+bun_opaque::foreign_handle! {
+    /// Owned handle to a C `ZSTD_DStream` (`== ZSTD_DCtx`).
+    ///
+    /// `Drop` frees the context. Every method takes `&self`: zstd mutates the
+    /// context through the same pointer on every call, so there is no `&mut self`
+    /// to have, and freeing is not exclusive access either.
+    #[allow(non_camel_case_types)]
+    pub struct ZSTD_DStream(sys::ZSTD_DStream) via free_dstream;
+}
 
 impl ZSTD_DStream {
-    /// Adopt a fresh context from `ZSTD_createDStream()`; `None` on null.
-    #[inline]
-    fn adopt_ptr(ptr: *mut sys::ZSTD_DStream) -> Option<Self> {
-        // SAFETY: `ZSTD_createDStream` returns a solely-owned context or null.
-        core::ptr::NonNull::new(ptr).map(|p| Self(unsafe { bun_opaque::ForeignRef::adopt(p) }))
-    }
-
     /// `ZSTD_createDStream()` + `ZSTD_initDStream()`.
     pub fn create() -> core::result::Result<Self, ZstdError> {
-        let zds = Self::adopt_ptr(c::ZSTD_createDStream())
+        // SAFETY: `ZSTD_createDStream` transfers the sole ownership unit, or null.
+        let zds = unsafe { Self::adopt_ptr(c::ZSTD_createDStream()) }
             .ok_or(ZstdError::ZstdFailedToCreateInstance)?;
         zds.init();
         Ok(zds)
@@ -257,11 +250,6 @@ impl ZSTD_DStream {
     ) -> usize {
         // SAFETY: caller contract; both buffer structs are live `&mut`s.
         unsafe { c::ZSTD_decompressStream(self.raw(), &raw mut *output, &raw mut *input) }
-    }
-
-    #[inline]
-    fn raw(&self) -> &sys::ZSTD_DStream {
-        &self.0
     }
 }
 

--- a/src/zstd/lib.rs
+++ b/src/zstd/lib.rs
@@ -6,21 +6,34 @@ use bun_core::ZStr;
 // ─── FFI bindings ─────────────────────────────────────────────────────────
 // Externs stay in this crate per PORTING.md §FFI: "If your file has externs
 // and isn't already *_sys, leave them in place".
+/// The C object itself. Only the extern declarations in [`c`] name this type;
+/// all Rust code uses the owning [`ZSTD_DStream`] handle.
+#[allow(non_camel_case_types)]
+pub mod sys {
+    bun_opaque::opaque_ffi! {
+        /// `ZSTD_DStream` (`typedef ZSTD_DCtx ZSTD_DStream`) — opaque streaming
+        /// decompression context. `&Self` is ABI-identical to a non-null
+        /// `ZSTD_DStream*` and carries no `noalias`/`readonly`: zstd mutates the
+        /// context on every call.
+        pub struct ZSTD_DStream;
+    }
+}
+
 #[allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
 pub mod c {
     use core::ffi::{c_char, c_int, c_uint, c_ulonglong, c_void};
 
-    // `ZSTD_DStream` — opaque streaming-decompression context (Nomicon FFI pattern).
-    //
-    // `UnsafeCell` makes the type `!Freeze` so a `&ZSTD_DStream` does not assert
-    // immutability of the C-owned state (zstd mutates internally on every call).
+    // The decompression context lives in `crate::sys`; Rust owns it via the
+    // `crate::ZSTD_DStream` handle. Re-exported so the externs below can name it.
+    pub use crate::sys::ZSTD_DStream;
+
     bun_opaque::opaque_ffi! {
-        pub struct ZSTD_DStream;
         /// `ZSTD_CCtx` — opaque streaming-compression context.
         pub struct ZSTD_CCtx;
     }
 
-    /// `typedef ZSTD_DCtx ZSTD_DStream;` — same opaque object.
+    /// `typedef ZSTD_DCtx ZSTD_DStream;` — same opaque object. Still names the C
+    /// object, so the `*mut ZSTD_DCtx` externs below are unaffected by the handle.
     pub(crate) type ZSTD_DCtx = ZSTD_DStream;
 
     // C enums passed by value across FFI — model as `c_uint` (their declared
@@ -100,11 +113,16 @@ pub mod c {
         pub(crate) safe fn ZSTD_getErrorName(code: usize) -> *const c_char;
         pub(crate) safe fn ZSTD_defaultCLevel() -> c_int;
 
+        // Mallocs the context and hands back sole ownership, or null.
         pub(crate) safe fn ZSTD_createDStream() -> *mut ZSTD_DStream;
-        pub(crate) fn ZSTD_freeDStream(zds: *mut ZSTD_DStream) -> usize;
-        pub(crate) fn ZSTD_initDStream(zds: *mut ZSTD_DStream) -> usize;
+        // safe: `ZSTD_freeDStream` is `ZSTD_freeDCtx`. Freeing is not exclusive
+        // access, so the receiver is `&`, not `&mut`.
+        pub(crate) safe fn ZSTD_freeDStream(zds: &ZSTD_DStream) -> usize;
+        pub(crate) safe fn ZSTD_initDStream(zds: &ZSTD_DStream) -> usize;
+        // NOT `safe fn`: zstd dereferences `output->dst` / `input->src`, and both
+        // fields are `pub` raw pointers that safe Rust can forge.
         pub fn ZSTD_decompressStream(
-            zds: *mut ZSTD_DStream,
+            zds: &ZSTD_DStream,
             output: *mut ZSTD_outBuffer,
             input: *mut ZSTD_inBuffer,
         ) -> usize;
@@ -185,6 +203,67 @@ pub enum ZstdError {
 bun_core::impl_tag_error!(ZstdError);
 
 bun_core::named_error_set!(ZstdError);
+
+// `ZSTD_createDStream()` mallocs the context and hands back sole ownership. One
+// `ZSTD_DStream` handle owns exactly one such context.
+fn free_dstream(zds: &sys::ZSTD_DStream) {
+    // `ZSTD_freeDStream` is `ZSTD_freeDCtx`; its `size_t` is always 0.
+    let _ = c::ZSTD_freeDStream(zds);
+}
+
+bun_opaque::foreign_owned!(sys::ZSTD_DStream, free_dstream);
+
+/// Owned handle to a C `ZSTD_DStream` (`== ZSTD_DCtx`).
+///
+/// `Drop` frees the context. Every method takes `&self`: zstd mutates the
+/// context through the same pointer on every call, so there is no `&mut self`
+/// to have, and freeing is not exclusive access either.
+#[repr(transparent)]
+#[allow(non_camel_case_types)]
+pub struct ZSTD_DStream(bun_opaque::ForeignRef<sys::ZSTD_DStream>);
+
+impl ZSTD_DStream {
+    /// Adopt a fresh context from `ZSTD_createDStream()`; `None` on null.
+    #[inline]
+    fn adopt_ptr(ptr: *mut sys::ZSTD_DStream) -> Option<Self> {
+        // SAFETY: `ZSTD_createDStream` returns a solely-owned context or null.
+        core::ptr::NonNull::new(ptr).map(|p| Self(unsafe { bun_opaque::ForeignRef::adopt(p) }))
+    }
+
+    /// `ZSTD_createDStream()` + `ZSTD_initDStream()`.
+    pub fn create() -> core::result::Result<Self, ZstdError> {
+        let zds = Self::adopt_ptr(c::ZSTD_createDStream())
+            .ok_or(ZstdError::ZstdFailedToCreateInstance)?;
+        zds.init();
+        Ok(zds)
+    }
+
+    /// Reset the context for the next frame. Designed to be called repeatedly on
+    /// the same context; needs no cleanup in between.
+    pub fn init(&self) {
+        let _ = c::ZSTD_initDStream(self.raw());
+    }
+
+    /// One `ZSTD_decompressStream` step: 0 at a frame boundary, otherwise a
+    /// read-size hint or an error code (test with [`is_error`]).
+    ///
+    /// # Safety
+    /// `output.dst` and `input.src` must be valid for their `size` bytes; zstd
+    /// dereferences both.
+    pub unsafe fn decompress_stream(
+        &self,
+        output: &mut c::ZSTD_outBuffer,
+        input: &mut c::ZSTD_inBuffer,
+    ) -> usize {
+        // SAFETY: caller contract; both buffer structs are live `&mut`s.
+        unsafe { c::ZSTD_decompressStream(self.raw(), &raw mut *output, &raw mut *input) }
+    }
+
+    #[inline]
+    fn raw(&self) -> &sys::ZSTD_DStream {
+        &self.0
+    }
+}
 
 /// ZSTD_compress() :
 ///  Compresses `src` content as a single zstd compressed frame into already allocated `dst`.
@@ -331,7 +410,8 @@ pub struct ZstdReaderArrayList<'a> {
     // We operate on the caller's Vec directly via the `&mut` borrow.
     pub list_ptr: &'a mut Vec<u8>,
     // `list_allocator` / `allocator` params deleted — global mimalloc.
-    pub zstd: *mut c::ZSTD_DStream,
+    // `None` after `end()`, which frees the context there rather than at drop.
+    zstd: Option<ZSTD_DStream>,
     pub state: State,
     pub total_out: usize,
     pub total_in: usize,
@@ -355,17 +435,12 @@ impl<'a> ZstdReaderArrayList<'a> {
         list: &'a mut Vec<u8>,
         // list_allocator / allocator params deleted (global mimalloc).
     ) -> core::result::Result<Box<ZstdReaderArrayList<'a>>, ZstdError> {
-        let zstd = c::ZSTD_createDStream();
-        if zstd.is_null() {
-            return Err(ZstdError::ZstdFailedToCreateInstance);
-        }
-        // SAFETY: zstd is a freshly created non-null DStream.
-        let _ = unsafe { c::ZSTD_initDStream(zstd) };
+        let zstd = ZSTD_DStream::create()?;
 
         Ok(Box::new(ZstdReaderArrayList {
             input,
             list_ptr: list,
-            zstd,
+            zstd: Some(zstd),
             state: State::Uninitialized,
             total_out: 0,
             total_in: 0,
@@ -375,9 +450,8 @@ impl<'a> ZstdReaderArrayList<'a> {
 
     pub fn end(&mut self) {
         if self.state != State::End {
-            // SAFETY: self.zstd was created by ZSTD_createDStream and has not been freed
-            // (guarded by state != End).
-            let _ = unsafe { c::ZSTD_freeDStream(self.zstd) };
+            // Drops the owned context here, at the point the old free happened.
+            self.zstd = None;
             self.state = State::End;
         }
     }
@@ -426,10 +500,13 @@ impl<'a> ZstdReaderArrayList<'a> {
                 pos: 0,
             };
 
-            // SAFETY: self.zstd is a valid DStream (state != End); in_buf/out_buf point
-            // into live slices with correct sizes.
-            let rc =
-                unsafe { c::ZSTD_decompressStream(self.zstd, &raw mut out_buf, &raw mut in_buf) };
+            // SAFETY: in_buf/out_buf point into live slices with correct sizes.
+            let rc = unsafe {
+                self.zstd
+                    .as_ref()
+                    .expect("read_all after end()")
+                    .decompress_stream(&mut out_buf, &mut in_buf)
+            };
             if c::ZSTD_isError(rc) != 0 {
                 self.state = State::Error;
                 return Err(ZstdError::ZstdDecompressionError);
@@ -460,10 +537,7 @@ impl<'a> ZstdReaderArrayList<'a> {
                     return Ok(());
                 }
                 // More input available, reset for the next frame
-                // ZSTD_initDStream() safely resets the stream state without needing cleanup
-                // It's designed to be called multiple times on the same DStream object
-                // SAFETY: self.zstd is a valid DStream.
-                let _ = unsafe { c::ZSTD_initDStream(self.zstd) };
+                self.zstd.as_ref().expect("read_all after end()").init();
                 continue;
             }
 
@@ -492,12 +566,6 @@ impl<'a> ZstdReaderArrayList<'a> {
     }
 }
 
-impl Drop for ZstdReaderArrayList<'_> {
-    fn drop(&mut self) {
-        self.end();
-    }
-}
-
 // ──────────────────────────────────────────────────────────────────────────
 // StreamingDecoder
 // ──────────────────────────────────────────────────────────────────────────
@@ -508,7 +576,7 @@ impl Drop for ZstdReaderArrayList<'_> {
 /// per call, so callers can hold the decoder across multiple body chunks
 /// without lifetime erasure.
 pub struct StreamingDecoder {
-    stream: core::ptr::NonNull<c::ZSTD_DStream>,
+    stream: ZSTD_DStream,
     pub state: State,
     /// Decompression-bomb guard: `decompress` errors instead of growing the
     /// output past this many bytes. Defaults to unbounded.
@@ -517,12 +585,8 @@ pub struct StreamingDecoder {
 
 impl StreamingDecoder {
     pub fn new() -> core::result::Result<Self, ZstdError> {
-        let stream = core::ptr::NonNull::new(c::ZSTD_createDStream())
-            .ok_or(ZstdError::ZstdFailedToCreateInstance)?;
-        // SAFETY: stream is a freshly created non-null DStream.
-        let _ = unsafe { c::ZSTD_initDStream(stream.as_ptr()) };
         Ok(Self {
-            stream,
+            stream: ZSTD_DStream::create()?,
             state: State::Uninitialized,
             max_output_size: usize::MAX,
         })
@@ -575,11 +639,8 @@ impl StreamingDecoder {
                 pos: 0,
             };
 
-            // SAFETY: stream is a valid DStream (not freed); in_buf/out_buf
-            // point into live slices with correct sizes.
-            let rc = unsafe {
-                c::ZSTD_decompressStream(self.stream.as_ptr(), &raw mut out_buf, &raw mut in_buf)
-            };
+            // SAFETY: in_buf/out_buf point into live slices with correct sizes.
+            let rc = unsafe { self.stream.decompress_stream(&mut out_buf, &mut in_buf) };
             if c::ZSTD_isError(rc) != 0 {
                 self.state = State::Error;
                 return Err(ZstdError::ZstdDecompressionError);
@@ -602,8 +663,7 @@ impl StreamingDecoder {
                     return Ok(());
                 }
                 // More input available — reinitialize for the next frame.
-                // SAFETY: stream is a valid DStream.
-                let _ = unsafe { c::ZSTD_initDStream(self.stream.as_ptr()) };
+                self.stream.init();
                 continue;
             }
 
@@ -621,12 +681,5 @@ impl StreamingDecoder {
             }
         }
         Ok(())
-    }
-}
-
-impl Drop for StreamingDecoder {
-    fn drop(&mut self) {
-        // SAFETY: stream was created by ZSTD_createDStream; freed once here.
-        let _ = unsafe { c::ZSTD_freeDStream(self.stream.as_ptr()) };
     }
 }

--- a/test/internal/dead-code-escape-limits.json
+++ b/test/internal/dead-code-escape-limits.json
@@ -14,7 +14,7 @@
   "src/io/posix_event_loop.rs": 8,
   "src/jsc/PosixSignalHandle.rs": 6,
   "src/jsc_macros/lib.rs": 2,
-  "src/opaque/lib.rs": 5,
+  "src/opaque/lib.rs": 10,
   "src/patch/lib.rs": 2,
   "src/runtime/api/bun/Terminal.rs": 2,
   "src/runtime/cli/test/ChangedFilesFilter.rs": 1,


### PR DESCRIPTION
Stacked on #33820, which introduces `ForeignRef<T>` and converts `FetchHeaders`.

## What this does

Extends the owned-handle pattern to every remaining opaque FFI type that Rust holds an
ownership unit of, and generates the boilerplate instead of copying it.

**1. Owned handles for 16 more types** — each replaces a hand-rolled owner, a `scopeguard`,
or a bare raw pointer with a `#[repr(transparent)]` newtype whose `Drop` calls the C
release function. Also flips 314 `&mut self` receivers to `&self` on `opaque_ffi!` ZSTs:
those types are `UnsafeCell`-backed, so `&T` carries no `noalias` and C mutates through
it — the `&mut` asserted an exclusivity that was never true and never needed.

**2. `ForeignRef<T, R = DefaultRelease>`** — a release-marker parameter. `ForeignOwned`
admits one release per type, so an object with two ownership disciplines could not use it
twice: libarchive's `struct archive` is freed by `archive_read_free` when opened for
reading and `archive_write_free` when opened for writing, and the write side had degraded
into a bespoke owner with a hand-written `Drop`. It is now
`ForeignRef<sys::Archive, WriteFree>`. The parameter defaults, so no existing
`ForeignRef<T>` changed.

**3. `foreign_handle!`** emits the newtype plus `adopt` / `adopt_ptr` / `as_ptr` / `leak` /
`raw`. That block had been hand-copied onto 17 types; a missing `mem::forget` in one copy
is a double-free the other sixteen would not reveal. Net -437 lines.

`adopt` and `adopt_ptr` are now `unsafe`. Most hand-written copies were safe private fns,
but adopting a pointer whose ownership unit you were not given is UB, so the obligation
belongs at the call site — all 29 now carry a `SAFETY:` comment naming the producer.

**4. The remaining C handles**, converted after reading the C and C++ rather than the
names: `ENGINE`, `X509`, `X509_STORE`, `X509_STORE_CTX`, `SSL_SESSION`, `spng_ctx`,
`WebPDemuxer`, `WebPMux`, and `CookieMapRef` folded onto `ForeignRef`.

The certificate handles are careful about where the ref comes from.
`SSL_get_peer_certificate`, `X509_up_ref`, `X509_STORE_CTX_get1_issuer` and `d2i_X509`
hand over a `+1` and are adopted; `SSL_get_certificate`, `sk_X509_value` and
`SSL_CTX_get_cert_store` return borrows and stay raw pointers.
`SSL_set0_verify_cert_store` takes ownership, so that path leaks the handle rather than
dropping it.

## Two bugs this surfaced

- `cppbind` mapped `JSC::SourceProvider` to the owning handle, so the generated **safe**
  wrapper passed the address of a Rust stack slot to C++ `->deref()`. No caller today, but
  it also produced two conflicting `extern "C"` declarations of one symbol.
- Flipping `Response::upgrade` to `&self` silently moved method resolution to
  `ResponseLike::upgrade`, which boxes its argument a second time. Rust probes the receiver
  by-value first, so an inherent `&mut self` method beats a trait method there; once
  flipped it no longer matches. Only an arity mismatch made it visible.

Restores the debug-only corrupted-`HandleSlot` assert that `Strong::destroy` carried before
it became a `ForeignRef`; a bad slot otherwise faults inside JSC with no Rust frame.

## Deliberately not converted

| type | why |
|---|---|
| `AbortSignal`, `NapiEnv`, `JSCArrayBuffer` | already owned by `bun_ptr::ExternalShared`, which models ref/deref, not a single unit |
| `Blob` (standalone_graph) | the opaque decl is an erased stand-in for a type declared a tier up |
| `JSPropertyIteratorImpl` | freed by its enclosing struct's `Drop` |
| `Channel` (c-ares) | see below |
| `Loop`, `Heap`, `App` | thread/process-lifetime singletons |

`ares_destroy()` invokes `query->callback(query->arg, ARES_EDESTRUCTION, 0, NULL)` for every
pending query, and those callbacks re-enter `RefPtr::deref`. `Resolver` declares `ref_count`
before `channel`, and Rust drops fields in declaration order, so a `Drop`-based owner would
free the refcount's debug tables and then let the callbacks read them. The open-coded
teardown in `Drop for GlobalData` is load-bearing. Converting it safely means declaring
`channel` first, or keeping an explicit `drop(self.channel.take())`; left for a follow-up.

`spng_ctx_free`, `WebPDemuxDelete` and `WebPMuxDelete` stay `unsafe` externs behind a plain
wrapper: a `safe fn` taking `&sys::T` would let safe code free a context the handle owns.

## Verification

- `cargo build -p bun_bin` clean. `cargo check` is not sufficient here: it stops before
  codegen, so it never evaluates the `const { assert!(size_of::<T>() == 0) }` guards inside
  `opaque_deref*`, and a rename that turns `NonNull<X>` from "the C object" into "an 8-byte
  Rust struct" typechecks fine.
- `bun bd` clean, no warnings.
- Drove each converted subsystem end to end: TLS handshake + peer certificate + session +
  the `rejectUnauthorized` reject path, PNG and WebP encode/decode round-trips (output
  byte-identical to before), cookie get/set through `Bun.serve` routes, `bun pm pack` and
  tarball extraction, `bun:ffi cc`, `--bytecode`, `.npmrc` regex, HMR WebSocket upgrade,
  `Bun.connect` failure path. Each hammered a few hundred iterations under `Bun.gc(true)`
  to check refcount balance.
- Also adds a `verify` skill capturing the build-and-drive recipe.