### PR TITLE
resolver: throw ERR_INVALID_PACKAGE_CONFIG for malformed package.json

### DIFF
--- a/src/resolver/dir_info.rs
+++ b/src/resolver/dir_info.rs
@@ -126,6 +126,11 @@ pub struct DirInfo {
     // ergonomics. If a write is ever added, retype to `Option<NonNull<_>>`.
     pub enclosing_package_json: Option<&'static PackageJSON>,
 
+    /// Nearest `package.json` walking up from this directory, regardless of
+    /// whether it has a `"name"` or parsed successfully. This is Node's
+    /// package-scope boundary for module-type (`"type"` field) resolution.
+    pub nearest_package_json: Option<&'static PackageJSON>,
+
     // `NonNull` (not `&'static`) so `enqueue_dependency_to_resolve` can write
     // `package_manager_package_id` back through it without a const→mut
     // provenance cast. Read via `.package_json_for_dependencies()`.
@@ -157,6 +162,7 @@ impl Default for DirInfo {
             package_json_for_browser_field: None,
             enclosing_tsconfig_json: None,
             enclosing_package_json: None,
+            nearest_package_json: None,
             package_json_for_dependencies: None,
             abs_path: b"",
             entries: Index::default(),

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -341,6 +341,14 @@ impl FileSystemPackageJsonExt for crate::fs::FileSystem {
 }
 
 impl PackageJSON {
+    /// Poisoned (unparseable / non-object) placeholder returned by `parse()`.
+    /// Distinct from a parseable object whose `"type"` is not a string, which
+    /// also sets `invalid` but retains `source_contents`.
+    #[inline]
+    pub fn is_poisoned(&self) -> bool {
+        self.invalid && self.source_contents.is_empty()
+    }
+
     pub fn parse_macros_json(
         macros: js_ast::Expr,
         log: &mut bun_ast::Log,

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -138,6 +138,11 @@ pub struct PackageJSON {
 
     pub exports: Option<ExportsMap>,
     pub imports: Option<ExportsMap>,
+
+    /// Set when the file is malformed JSON, a non-object, or has a non-string
+    /// `"type"`. Node throws `ERR_INVALID_PACKAGE_CONFIG` for `.js` files under
+    /// such a scope; the runtime loader surfaces this.
+    pub invalid: bool,
 }
 
 // hand-rolled `Default` because `#[derive(Default)]` would zero
@@ -165,6 +170,7 @@ impl Default for PackageJSON {
             browser_map: BrowserMap::default(),
             exports: None,
             imports: None,
+            invalid: false,
         }
     }
 }
@@ -506,9 +512,20 @@ impl PackageJSON {
         let contents_static: &'static [u8] = unsafe { bun_ptr::detach_lifetime(&entry_contents) };
         let json_source = bun_ast::Source::init_path_string(package_json_path, contents_static);
 
+        // An unparseable package.json is still a package scope boundary in
+        // Node (`ERR_INVALID_PACKAGE_CONFIG`); return a poisoned entry so
+        // `enclosing_package_json` stops here instead of inheriting the parent.
+        let invalid = |path: &'static [u8]| {
+            Some(PackageJSON {
+                source: bun_ast::Source::init_path_string(path, b""),
+                invalid: true,
+                ..PackageJSON::default()
+            })
+        };
+
         let parsed_json = match r.caches.json.parse_package_json(r_log, &json_source) {
             Ok(Some(v)) => v,
-            Ok(None) => return None,
+            Ok(None) => return invalid(package_json_path),
             Err(err) => {
                 if cfg!(debug_assertions) {
                     Output::print_error(format_args!(
@@ -517,16 +534,13 @@ impl PackageJSON {
                         bstr::BStr::new(err.name())
                     ));
                 }
-                return None;
+                return invalid(package_json_path);
             }
         };
         let json: js_ast::Expr = parsed_json.root;
 
         if !json.is_object() {
-            // Invalid package.json in node_modules is noisy.
-            // Let's just ignore it.
-            // (allocator.free dropped — entry.contents owned by `entry`)
-            return None;
+            return invalid(package_json_path);
         }
 
         let mut package_json = PackageJSON {
@@ -550,6 +564,7 @@ impl PackageJSON {
             side_effects: SideEffects::Unspecified,
             exports: None,
             imports: None,
+            invalid: false,
         };
         // shadow as `&Source`; the owned value is reconstructed at the bottom
         // (Source isn't `Clone`).
@@ -602,6 +617,8 @@ impl PackageJSON {
                     }
                 }
             } else {
+                // Non-string `"type"` is `ERR_INVALID_PACKAGE_CONFIG` in Node.
+                package_json.invalid = true;
                 r_log.add_warning(
                     Some(json_source),
                     type_json.loc,

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -506,9 +506,10 @@ impl PackageJSON {
         // On the success path it is *moved* (not leaked) into
         // `package_json.source_contents` at the bottom of this fn, so the heap
         // allocation lives for the life of the returned `PackageJSON`. On every
-        // early `return None` below `entry_contents` drops and frees normally, after
-        // `json_source` is already dead. `Box<[u8]>` heap address is stable
-        // across the move.
+        // early return below (the `invalid(...)` paths) `entry_contents` drops and
+        // frees normally after `json_source` is already dead; the poisoned entry's
+        // `source` uses `b""` and does not reference these bytes. `Box<[u8]>` heap
+        // address is stable across the move.
         let contents_static: &'static [u8] = unsafe { bun_ptr::detach_lifetime(&entry_contents) };
         let json_source = bun_ast::Source::init_path_string(package_json_path, contents_static);
 

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -514,7 +514,7 @@ impl PackageJSON {
 
         // An unparseable package.json is still a package scope boundary in
         // Node (`ERR_INVALID_PACKAGE_CONFIG`); return a poisoned entry so
-        // `enclosing_package_json` stops here instead of inheriting the parent.
+        // `nearest_package_json` stops here instead of inheriting the parent.
         let invalid = |path: &'static [u8]| {
             Some(PackageJSON {
                 source: bun_ast::Source::init_path_string(path, b""),
@@ -522,6 +522,12 @@ impl PackageJSON {
                 ..PackageJSON::default()
             })
         };
+
+        // `parse_package_json` short-circuits empty input to a synthetic `{}`
+        // before the parser runs; Node rejects a 0-byte file.
+        if entry_contents.is_empty() {
+            return invalid(package_json_path);
+        }
 
         let parsed_json = match r.caches.json.parse_package_json(r_log, &json_source) {
             Ok(Some(v)) => v,

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -523,12 +523,6 @@ impl PackageJSON {
             })
         };
 
-        // `parse_package_json` short-circuits empty input to a synthetic `{}`
-        // before the parser runs; Node rejects a 0-byte file.
-        if entry_contents.is_empty() {
-            return invalid(package_json_path);
-        }
-
         let parsed_json = match r.caches.json.parse_package_json(r_log, &json_source) {
             Ok(Some(v)) => v,
             Ok(None) => return invalid(package_json_path),

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6200,9 +6200,7 @@ impl<'a> Resolver<'a> {
 
             if let Some(parent_package_json) = parent_.package_json() {
                 // https://github.com/oven-sh/bun/issues/229
-                if !parent_package_json.invalid
-                    && (!parent_package_json.name.is_empty() || self.care_about_bin_folder)
-                {
+                if !parent_package_json.name.is_empty() || self.care_about_bin_folder {
                     info.enclosing_package_json = Some(parent_package_json);
                 }
 
@@ -6349,7 +6347,7 @@ impl<'a> Resolver<'a> {
                             info.package_json_for_browser_field = Some(pkg);
                         }
 
-                        if !pkg.invalid && (!pkg.name.is_empty() || self.care_about_bin_folder) {
+                        if !pkg.name.is_empty() || self.care_about_bin_folder {
                             info.enclosing_package_json = Some(pkg);
                         }
 

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6200,7 +6200,10 @@ impl<'a> Resolver<'a> {
 
             if let Some(parent_package_json) = parent_.package_json() {
                 // https://github.com/oven-sh/bun/issues/229
-                if !parent_package_json.name.is_empty() || self.care_about_bin_folder {
+                if parent_package_json.invalid
+                    || !parent_package_json.name.is_empty()
+                    || self.care_about_bin_folder
+                {
                     info.enclosing_package_json = Some(parent_package_json);
                 }
 
@@ -6342,7 +6345,10 @@ impl<'a> Resolver<'a> {
                             info.package_json_for_browser_field = Some(pkg);
                         }
 
-                        if !pkg.name.is_empty() || self.care_about_bin_folder {
+                        // An invalid package.json is still a scope boundary
+                        // (Node throws `ERR_INVALID_PACKAGE_CONFIG` rather
+                        // than inheriting the parent scope).
+                        if pkg.invalid || !pkg.name.is_empty() || self.care_about_bin_folder {
                             info.enclosing_package_json = Some(pkg);
                         }
 

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6200,9 +6200,8 @@ impl<'a> Resolver<'a> {
 
             if let Some(parent_package_json) = parent_.package_json() {
                 // https://github.com/oven-sh/bun/issues/229
-                if parent_package_json.invalid
-                    || !parent_package_json.name.is_empty()
-                    || self.care_about_bin_folder
+                if !parent_package_json.invalid
+                    && (!parent_package_json.name.is_empty() || self.care_about_bin_folder)
                 {
                     info.enclosing_package_json = Some(parent_package_json);
                 }
@@ -6220,6 +6219,7 @@ impl<'a> Resolver<'a> {
             info.enclosing_package_json = info
                 .enclosing_package_json
                 .or(parent_.enclosing_package_json);
+            info.nearest_package_json = parent_.package_json().or(parent_.nearest_package_json);
             info.package_json_for_dependencies = info
                 .package_json_for_dependencies
                 .or(parent_.package_json_for_dependencies);
@@ -6340,15 +6340,16 @@ impl<'a> Resolver<'a> {
                     };
 
                     if let Some(pkg) = info.package_json() {
+                        // Any package.json (named, nameless, or invalid) is
+                        // Node's module-type scope boundary.
+                        info.nearest_package_json = Some(pkg);
+
                         if pkg.browser_map.count() > 0 {
                             info.enclosing_browser_scope = result.index;
                             info.package_json_for_browser_field = Some(pkg);
                         }
 
-                        // An invalid package.json is still a scope boundary
-                        // (Node throws `ERR_INVALID_PACKAGE_CONFIG` rather
-                        // than inheriting the parent scope).
-                        if pkg.invalid || !pkg.name.is_empty() || self.care_about_bin_folder {
+                        if !pkg.invalid && (!pkg.name.is_empty() || self.care_about_bin_folder) {
                             info.enclosing_package_json = Some(pkg);
                         }
 

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -764,7 +764,8 @@ pub(crate) fn run_scripts_with_filter(
             bun_sys::Fd::invalid(),
             None,
             IncludeScripts::IncludeScripts,
-        ) else {
+        )
+        .filter(|p| !p.invalid) else {
             bun_core::warn!(
                 "Failed to read {}, skipping this workspace package\n",
                 bun_core::fmt::quote(&*package_json_path),

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -765,10 +765,7 @@ pub(crate) fn run_scripts_with_filter(
             None,
             IncludeScripts::IncludeScripts,
         )
-        // `invalid` is also set for a non-string `"type"` on an otherwise
-        // fully-parsed file; only the unparseable (poisoned) entries have
-        // empty `source_contents`. Scripts from the former still run.
-        .filter(|p| !p.invalid || !p.source_contents.is_empty()) else {
+        .filter(|p| !p.is_poisoned()) else {
             bun_core::warn!(
                 "Failed to read {}, skipping this workspace package\n",
                 bun_core::fmt::quote(&*package_json_path),

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -765,7 +765,10 @@ pub(crate) fn run_scripts_with_filter(
             None,
             IncludeScripts::IncludeScripts,
         )
-        .filter(|p| !p.invalid) else {
+        // `invalid` is also set for a non-string `"type"` on an otherwise
+        // fully-parsed file; only the unparseable (poisoned) entries have
+        // empty `source_contents`. Scripts from the former still run.
+        .filter(|p| !p.invalid || !p.source_contents.is_empty()) else {
             bun_core::warn!(
                 "Failed to read {}, skipping this workspace package\n",
                 bun_core::fmt::quote(&*package_json_path),

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -891,7 +891,8 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
                 bun_sys::Fd::INVALID,
                 None,
                 IncludeScripts::IncludeScripts,
-            ) else {
+            )
+            .filter(|p| !p.invalid) else {
                 continue;
             };
 

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -892,7 +892,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
                 None,
                 IncludeScripts::IncludeScripts,
             )
-            .filter(|p| !p.invalid || !p.source_contents.is_empty()) else {
+            .filter(|p| !p.is_poisoned()) else {
                 continue;
             };
 

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -892,7 +892,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
                 None,
                 IncludeScripts::IncludeScripts,
             )
-            .filter(|p| !p.invalid) else {
+            .filter(|p| !p.invalid || !p.source_contents.is_empty()) else {
                 continue;
             };
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4155,11 +4155,32 @@ unsafe fn transpile_file(
         }
         // regex /\.[jt]s$/
         if ext.len() == b".ts".len() && (ext == b".js" || ext == b".ts") {
-            // Use the package.json module type if it exists.
-            break 'brk lr
-                .package_json
-                .map(|pkg| pkg.module_type)
-                .unwrap_or(ModuleType::Unknown);
+            // Node refuses `.js` under a malformed/non-string-`"type"`
+            // package.json; falling back to content-sniffing here would
+            // silently change module semantics vs Node.
+            if let Some(pkg) = lr.package_json {
+                if pkg.invalid {
+                    let js = global_ref
+                        .err(
+                            bun_jsc::ErrCode::ERR_INVALID_PACKAGE_CONFIG,
+                            format_args!(
+                                "Invalid package config {}.",
+                                bstr::BStr::new(pkg.source.path.text)
+                            ),
+                        )
+                        .to_js();
+                    // SAFETY: per fn contract — `ret` is a valid out-param.
+                    unsafe {
+                        *ret = ErrorableResolvedSource::err(
+                            bun_core::err!("JSErrorObject"),
+                            js,
+                        );
+                    }
+                    return ptr::null_mut();
+                }
+                break 'brk pkg.module_type;
+            }
+            break 'brk ModuleType::Unknown;
         }
         // For JSX/TSX and other extensions, let the file contents decide.
         ModuleType::Unknown

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4171,10 +4171,7 @@ unsafe fn transpile_file(
                         .to_js();
                     // SAFETY: per fn contract — `ret` is a valid out-param.
                     unsafe {
-                        *ret = ErrorableResolvedSource::err(
-                            bun_core::err!("JSErrorObject"),
-                            js,
-                        );
+                        *ret = ErrorableResolvedSource::err(bun_core::err!("JSErrorObject"), js);
                     }
                     return ptr::null_mut();
                 }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1351,7 +1351,7 @@ mod vm_loader_ctx {
                     Ok(Some(dir_info)) => {
                         dir_info
                             .package_json()
-                            .or(dir_info.enclosing_package_json)
+                            .or(dir_info.nearest_package_json)
                             .map(core::ptr::from_ref::<PackageJSON>)
                     }
                     _ => None,
@@ -2754,7 +2754,7 @@ fn transpile_source_code_inner(
                                         .read_dir_info(source.path.name().dir)
                                 } {
                                     Ok(Some(dir_info)) => {
-                                        dir_info.package_json().or(dir_info.enclosing_package_json)
+                                        dir_info.package_json().or(dir_info.nearest_package_json)
                                     }
                                     _ => None,
                                 }
@@ -3028,7 +3028,7 @@ fn transpile_source_code_inner(
                                 match unsafe { (*jsc_vm).transpiler.resolver.read_dir_info(dir) } {
                                     Ok(Some(dir_info)) => dir_info
                                         .package_json()
-                                        .or(dir_info.enclosing_package_json)
+                                        .or(dir_info.nearest_package_json)
                                         .map(|p| p.module_type),
                                     _ => None,
                                 }
@@ -3922,7 +3922,7 @@ unsafe fn get_loader_and_virtual_source<'a>(
         // SAFETY: per fn contract — `transpiler.resolver` is a value field of
         // the VM; `read_dir_info` is re-entrant on the JS thread.
         match unsafe { (*jsc_vm).transpiler.resolver.read_dir_info(dir) } {
-            Ok(Some(dir_info)) => dir_info.package_json().or(dir_info.enclosing_package_json),
+            Ok(Some(dir_info)) => dir_info.package_json().or(dir_info.nearest_package_json),
             _ => None,
         }
     } else {

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -661,4 +661,30 @@ describe("bun", () => {
     expect(stderr).toContain("skipping this workspace package");
     expect(exitCode).toBe(0);
   });
+
+  test("non-string \"type\" does not stop --filter from running scripts", async () => {
+    // "type" is a module-loader concern; a non-string value must not make
+    // `bun run --filter` skip the package (npm/pnpm/yarn all run it).
+    const dir = tempDirWithFiles("filter-bad-type", {
+      packages: {
+        foo: {
+          "package.json": `{"name":"foo","type":42,"scripts":{"go":"echo built-foo"}}`,
+        },
+      },
+      "package.json": JSON.stringify({ name: "ws", workspaces: ["packages/*"] }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--filter", "*", "go"],
+      cwd: dir,
+      env: { ...bunEnv, NO_COLOR: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toContain("built-foo");
+    expect(stderr).not.toContain("Failed to read");
+    expect(stderr).not.toContain("skipping this workspace package");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -662,7 +662,7 @@ describe("bun", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("non-string \"type\" does not stop --filter from running scripts", async () => {
+  test('non-string "type" does not stop --filter from running scripts', async () => {
     // "type" is a module-loader concern; a non-string value must not make
     // `bun run --filter` skip the package (npm/pnpm/yarn all run it).
     const dir = tempDirWithFiles("filter-bad-type", {

--- a/test/cli/run/run_command.test.ts
+++ b/test/cli/run/run_command.test.ts
@@ -19,6 +19,24 @@ describe("bun", () => {
     expect(exitCode).toBe(1);
   });
 
+  test("non-string \"type\" does not hide scripts from bun run", () => {
+    // "type" is a module-loader concern; a non-string value must not make
+    // `bun run <script>` miss the package.json (npm/pnpm/yarn all run it).
+    using dir = tempDir("bad-type-scripts", {
+      "package.json": `{"name":"foo","type":42,"scripts":{"build":"echo built-ok"}}`,
+    });
+    const { exitCode, stdout, stderr } = spawnSync({
+      cwd: String(dir),
+      cmd: [bunExe(), "run", "build"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(stdout.toString()).toContain("built-ok");
+    expect(stderr.toString()).not.toMatch(/Script not found/);
+    expect(exitCode).toBe(0);
+  });
+
   test("an empty-string script value is not a runnable script", () => {
     using dir = tempDir("empty-script", {
       "package.json": JSON.stringify({ scripts: { build: "" } }),

--- a/test/cli/run/run_command.test.ts
+++ b/test/cli/run/run_command.test.ts
@@ -19,7 +19,7 @@ describe("bun", () => {
     expect(exitCode).toBe(1);
   });
 
-  test("non-string \"type\" does not hide scripts from bun run", () => {
+  test('non-string "type" does not hide scripts from bun run', () => {
     // "type" is a module-loader concern; a non-string value must not make
     // `bun run <script>` miss the package.json (npm/pnpm/yarn all run it).
     using dir = tempDir("bad-type-scripts", {

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -259,7 +259,7 @@ describe.concurrent("ERR_INVALID_PACKAGE_CONFIG", () => {
         "p.mjs": `import * as N from "./pkg/t.mjs"; console.log("ns", Object.keys(N));`,
       });
       const { stdout, stderr, exitCode } = await run(String(dir), ["p.mjs"]);
-      expect(normalizeBunSnapshot(stdout, dir)).toBe("loaded\nns [ \"x\" ]");
+      expect(normalizeBunSnapshot(stdout, dir)).toBe('loaded\nns [ "x" ]');
       expect(stderr).not.toContain("ERR_INVALID_PACKAGE_CONFIG");
       expect(exitCode).toBe(0);
     });
@@ -270,7 +270,7 @@ describe.concurrent("ERR_INVALID_PACKAGE_CONFIG", () => {
         "p.cjs": `const N = require("./pkg/t.cjs"); console.log("ns", Object.keys(N));`,
       });
       const { stdout, stderr, exitCode } = await run(String(dir), ["p.cjs"]);
-      expect(normalizeBunSnapshot(stdout, dir)).toBe("loaded\nns [ \"x\" ]");
+      expect(normalizeBunSnapshot(stdout, dir)).toBe('loaded\nns [ "x" ]');
       expect(stderr).not.toContain("ERR_INVALID_PACKAGE_CONFIG");
       expect(exitCode).toBe(0);
     });

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 
 describe("ResolveMessage", () => {
   it("position object does not segfault", async () => {
@@ -180,5 +180,143 @@ describe.concurrent("long import path overflow", () => {
     using dir = makeDir();
     // Walk-up loop indexed into a fixed [256]DirEntryResolveQueueItem
     await run(String(dir), `\`/\${"a/".repeat(300)}x\``);
+  });
+});
+
+// Node.js refuses to load any module whose format must be determined by an
+// invalid package.json (malformed JSON, non-object root, or non-string "type"),
+// throwing ERR_INVALID_PACKAGE_CONFIG. Bun previously swallowed the parse
+// error and silently fell through to content-sniffing or the parent scope.
+describe.concurrent("ERR_INVALID_PACKAGE_CONFIG", () => {
+  const invalidCases = [
+    ["malformed JSON", "{\n"],
+    ["non-object root", "42"],
+    ["non-string type", `{"name":"p","type":42}`],
+  ] as const;
+
+  function makeDir(pkgJson: string, extra: Record<string, string> = {}) {
+    return tempDir("invalid-pkg-config", {
+      "package.json": `{"name":"root"}`,
+      "pkg/package.json": pkgJson,
+      "pkg/t.js": `export const x = 7;\nconsole.log("loaded");\n`,
+      "p.mjs": `import * as N from "./pkg/t.js"; console.log("ns", Object.keys(N));`,
+      "p.cjs": `const N = require("./pkg/t.js"); console.log("ns", Object.keys(N));`,
+      "dyn.mjs": `const N = await import("./pkg/t.js"); console.log("ns", Object.keys(N));`,
+      ...extra,
+    });
+  }
+
+  async function run(dir: string, args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  describe.each(invalidCases)("%s", (_name, pkgJson) => {
+    it("static import throws ERR_INVALID_PACKAGE_CONFIG", async () => {
+      using dir = makeDir(pkgJson);
+      const { stdout, stderr, exitCode } = await run(String(dir), ["p.mjs"]);
+      expect(stdout).not.toContain("loaded");
+      expect(stderr).toContain("ERR_INVALID_PACKAGE_CONFIG");
+      expect(stderr).toContain("Invalid package config");
+      expect(stderr).toContain("package.json");
+      expect(exitCode).toBe(1);
+    });
+
+    it("entrypoint throws ERR_INVALID_PACKAGE_CONFIG", async () => {
+      using dir = makeDir(pkgJson);
+      const { stdout, stderr, exitCode } = await run(String(dir), ["pkg/t.js"]);
+      expect(stdout).not.toContain("loaded");
+      expect(stderr).toContain("ERR_INVALID_PACKAGE_CONFIG");
+      expect(exitCode).toBe(1);
+    });
+
+    it("require() throws ERR_INVALID_PACKAGE_CONFIG", async () => {
+      using dir = makeDir(pkgJson);
+      const { stdout, stderr, exitCode } = await run(String(dir), ["p.cjs"]);
+      expect(stdout).not.toContain("loaded");
+      expect(stderr).toContain("ERR_INVALID_PACKAGE_CONFIG");
+      expect(exitCode).toBe(1);
+    });
+
+    it("dynamic import() rejects with ERR_INVALID_PACKAGE_CONFIG", async () => {
+      using dir = makeDir(pkgJson);
+      const { stdout, stderr, exitCode } = await run(String(dir), ["dyn.mjs"]);
+      expect(stdout).not.toContain("loaded");
+      expect(stderr).toContain("ERR_INVALID_PACKAGE_CONFIG");
+      expect(exitCode).toBe(1);
+    });
+
+    it(".mjs under the invalid scope loads without error (format from extension)", async () => {
+      using dir = makeDir(pkgJson, {
+        "pkg/t.mjs": `export const x = 7;\nconsole.log("loaded");\n`,
+        "p.mjs": `import * as N from "./pkg/t.mjs"; console.log("ns", Object.keys(N));`,
+      });
+      const { stdout, stderr, exitCode } = await run(String(dir), ["p.mjs"]);
+      expect(normalizeBunSnapshot(stdout, dir)).toBe("loaded\nns [ \"x\" ]");
+      expect(stderr).not.toContain("ERR_INVALID_PACKAGE_CONFIG");
+      expect(exitCode).toBe(0);
+    });
+
+    it(".cjs under the invalid scope loads without error (format from extension)", async () => {
+      using dir = makeDir(pkgJson, {
+        "pkg/t.cjs": `module.exports.x = 7;\nconsole.log("loaded");\n`,
+        "p.cjs": `const N = require("./pkg/t.cjs"); console.log("ns", Object.keys(N));`,
+      });
+      const { stdout, stderr, exitCode } = await run(String(dir), ["p.cjs"]);
+      expect(normalizeBunSnapshot(stdout, dir)).toBe("loaded\nns [ \"x\" ]");
+      expect(stderr).not.toContain("ERR_INVALID_PACKAGE_CONFIG");
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  it("error is catchable and has .code", async () => {
+    using dir = makeDir("{\n", {
+      "catch.mjs": `
+        try {
+          await import("./pkg/t.js");
+          console.log("FAIL: did not throw");
+        } catch (e) {
+          console.log(JSON.stringify({ code: e.code, hasMessage: e.message.includes("package.json") }));
+        }
+      `,
+    });
+    const { stdout, exitCode } = await run(String(dir), ["catch.mjs"]);
+    expect(JSON.parse(stdout.trim())).toEqual({ code: "ERR_INVALID_PACKAGE_CONFIG", hasMessage: true });
+    expect(exitCode).toBe(0);
+  });
+
+  it("unknown string type value does NOT error (matches Node)", async () => {
+    using dir = makeDir(`{"name":"p","type":"nonsense"}`);
+    const { stdout, exitCode } = await run(String(dir), ["p.mjs"]);
+    expect(stdout).toContain("loaded");
+    expect(exitCode).toBe(0);
+  });
+
+  it("invalid package.json in a child dir poisons that scope, not the parent", async () => {
+    using dir = tempDir("invalid-pkg-config-nested", {
+      "package.json": `{"name":"root","type":"module"}`,
+      "ok.js": `console.log("parent-ok");`,
+      "sub/package.json": "{\n",
+      "sub/t.js": `console.log("child");`,
+    });
+    // Parent scope still works.
+    {
+      const { stdout, exitCode } = await run(String(dir), ["ok.js"]);
+      expect(stdout.trim()).toBe("parent-ok");
+      expect(exitCode).toBe(0);
+    }
+    // Child scope fails.
+    {
+      const { stderr, exitCode } = await run(String(dir), ["sub/t.js"]);
+      expect(stderr).toContain("ERR_INVALID_PACKAGE_CONFIG");
+      expect(exitCode).toBe(1);
+    }
   });
 });

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -190,6 +190,7 @@ describe.concurrent("long import path overflow", () => {
 describe.concurrent("ERR_INVALID_PACKAGE_CONFIG", () => {
   const invalidCases = [
     ["malformed JSON", "{\n"],
+    ["empty file", ""],
     ["non-object root", "42"],
     ["non-string type", `{"name":"p","type":42}`],
   ] as const;
@@ -317,6 +318,32 @@ describe.concurrent("ERR_INVALID_PACKAGE_CONFIG", () => {
       const { stderr, exitCode } = await run(String(dir), ["sub/t.js"]);
       expect(stderr).toContain("ERR_INVALID_PACKAGE_CONFIG");
       expect(exitCode).toBe(1);
+    }
+  });
+
+  it("valid nameless package.json between an invalid ancestor and the file is the scope boundary", async () => {
+    // A nameless `{}` or `{"type":...}` package.json is still Node's package
+    // scope boundary; an invalid grandparent above it must not poison files
+    // below it.
+    using dir = tempDir("invalid-pkg-config-mid", {
+      "package.json": `{"name":"root"}`,
+      "gp/package.json": "{\n",
+      "gp/mid/package.json": "{}",
+      "gp/mid/sub/foo.js": `console.log("ok");`,
+      "gp/mid2/package.json": `{"type":"commonjs"}`,
+      "gp/mid2/sub/foo.js": `console.log("ok2");`,
+    });
+    {
+      const { stdout, stderr, exitCode } = await run(String(dir), ["gp/mid/sub/foo.js"]);
+      expect(stderr).not.toContain("ERR_INVALID_PACKAGE_CONFIG");
+      expect(stdout.trim()).toBe("ok");
+      expect(exitCode).toBe(0);
+    }
+    {
+      const { stdout, stderr, exitCode } = await run(String(dir), ["gp/mid2/sub/foo.js"]);
+      expect(stderr).not.toContain("ERR_INVALID_PACKAGE_CONFIG");
+      expect(stdout.trim()).toBe("ok2");
+      expect(exitCode).toBe(0);
     }
   });
 });

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -188,9 +188,11 @@ describe.concurrent("long import path overflow", () => {
 // throwing ERR_INVALID_PACKAGE_CONFIG. Bun previously swallowed the parse
 // error and silently fell through to content-sniffing or the parent scope.
 describe.concurrent("ERR_INVALID_PACKAGE_CONFIG", () => {
+  // A 0-byte package.json is NOT in this matrix: Bun intentionally treats
+  // empty JSONC input as `{}` (see test/js/bun/resolve/jsonc.test.ts), so an
+  // empty package.json is a valid empty scope rather than an error.
   const invalidCases = [
     ["malformed JSON", "{\n"],
-    ["empty file", ""],
     ["non-object root", "42"],
     ["non-string type", `{"name":"p","type":42}`],
   ] as const;


### PR DESCRIPTION
## What

An invalid `package.json` (malformed JSON, non-object root, or a `"type"` field that is not a string) was silently ignored by the runtime module loader. Every `.js` file under it loaded with whatever module format content-sniffing or the nearest valid ancestor produced, with no error and no warning.

Node.js refuses the whole package scope with `ERR_INVALID_PACKAGE_CONFIG` on every load path (static import, `import()`, `require()`, entrypoint). A corrupted, half-written, or merge-conflicted `package.json` must not silently change the module semantics of every file beneath it.

## Repro

```js
// repro.mjs
import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
import { spawnSync } from "node:child_process";
const d = mkdtempSync("/tmp/badpkg-");
mkdirSync(`${d}/pkg`);
writeFileSync(`${d}/package.json`, '{"name":"root"}');
writeFileSync(`${d}/pkg/package.json`, "{\n");           // malformed
writeFileSync(`${d}/pkg/t.js`, 'export const x = 7;\nconsole.log("ran");\n');
writeFileSync(`${d}/p.mjs`, 'import * as N from "./pkg/t.js"; console.log("ns", Object.keys(N));');
for (const rt of ["node", process.execPath]) {
  const r = f => { const p = spawnSync(rt, [f], { cwd: d, encoding: "utf8" });
    return p.status === 0 ? p.stdout.trim().split("\n").pop() : (p.stderr.match(/ERR_INVALID_PACKAGE_CONFIG/)?.[0] ?? "exit " + p.status); };
  console.log(rt.split("/").pop().padEnd(8), "| import:", r("./p.mjs").padEnd(30), "| entrypoint:", r("./pkg/t.js"));
}
```

Before:
```
node     | import: ERR_INVALID_PACKAGE_CONFIG     | entrypoint: ERR_INVALID_PACKAGE_CONFIG
bun      | import: ns [ "x" ]                     | entrypoint: ran
```

After:
```
node     | import: ERR_INVALID_PACKAGE_CONFIG     | entrypoint: ERR_INVALID_PACKAGE_CONFIG
bun      | import: ERR_INVALID_PACKAGE_CONFIG     | entrypoint: ERR_INVALID_PACKAGE_CONFIG
```

Same divergence held for `{"type":42}` (schema-invalid), `42` (non-object root), across all four load paths.

## Cause

Three layers swallowed the failure:

1. `JsonCache::parse_rows` converts a JSON parse `Err` into `Ok(None)`, pushing diagnostics into the resolver log only.
2. `PackageJSON::parse` returned `None` on `Ok(None)` / non-object root, and only warned on non-string `"type"`. (A 0-byte file is intentionally left as `{}` to preserve Bun's existing JSONC-empty convention; see jsonc.test.ts.)
3. `Resolver::dir_info_uncached` did `.ok().flatten()` and cached `package_json = None`, so the parent scope was inherited for module-type resolution.

The process-lifetime `DirInfo` cache then treated the invalid file exactly like "no `package.json` here" for the rest of the process.

## Fix

- `PackageJSON` gains an `invalid: bool` field.
- `PackageJSON::parse` returns a poisoned entry (`invalid = true`, path set, everything else default) instead of `None` on parse failure / non-object root, and marks non-string `"type"` as invalid.
- `DirInfo` gains `nearest_package_json`: the first `package.json` walking up, regardless of name or validity. This is Node's actual package-scope boundary for `"type"` resolution, distinct from `enclosing_package_json` (which skips nameless entries per #229 for `bun run`/bin purposes). A valid nameless `{}` or `{"type":...}` between a poisoned ancestor and a file correctly terminates the scope.
- The runtime module-type lookups in `jsc_hooks.rs` use `nearest_package_json`. `transpile_file` throws `ERR_INVALID_PACKAGE_CONFIG` (with the offending path) when it needs the `package.json` to determine the module format of a `.js`/`.ts` file. `.mjs`/`.cjs` still load fine since their format comes from the extension, matching Node.
- `enclosing_package_json` keeps its original assignment condition. A `package.json` with a non-string `"type"` but valid `scripts` still becomes enclosing, so `bun run <script>` finds it (matches npm/pnpm/yarn). `filter_run` / `multi_run` filter out only the unparseable poisoned entries (empty `source_contents`) so the existing "skipping this workspace package" warning still fires for those while scripts from a fully-parsed entry with a bad `"type"` continue to run.

Unknown string `"type"` values (`"type":"nonsense"`) continue to be treated as unset, also matching Node.

One side effect for `bun run <script>`: when the cwd's own `package.json` is truly unparseable, bun now stops there ("Script not found") instead of silently falling through to a parent directory's scripts. npm/pnpm/yarn all refuse to fall through in that case (they error on the parse), so this brings `bun run` in line with them.

## Tests

`describe.concurrent("ERR_INVALID_PACKAGE_CONFIG")` in `test/js/bun/resolve/resolve-error.test.ts` covers the 3 invalid shapes x 4 load paths, plus negative cases (`.mjs`/`.cjs` still load, unknown string `"type"` does not error, parent scope unaffected, error is catchable with `.code`, valid nameless intermediate stops poison propagation). 14 of the 22 cases fail on main and pass with this change. Additional regression guards in `filter-workspace.test.ts` and `run_command.test.ts` cover the non-string-`"type"` + scripts case.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/filter-workspace.test.ts test/cli/run/run_command.test.ts test/js/bun/resolve/resolve-error.test.ts

<!-- robobun:evidence:end -->
