### PR TITLE
require(esm): reject any top-level-await graph with ERR_REQUIRE_ASYNC_MODULE

### DIFF
--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -318,10 +318,9 @@ function loadEsmIntoCjs__dead(resolvedSpecifier: string) {
 
 $visibility = "Private";
 export function requireESM(this, resolved: string) {
-  var exports = $esmNamespaceForCjs(resolved);
-  if (exports === undefined) {
-    exports = $loadEsmIntoCjs(resolved);
-  }
+  // $esmLoadSync has its own already-evaluated fast path; going through it
+  // unconditionally lets a previously-imported TLA graph reject here too.
+  var exports = $loadEsmIntoCjs(resolved);
   if (exports === undefined) {
     throw new TypeError(`require() failed to evaluate module "${resolved}". This is an internal consistentency error.`);
   }

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -42,6 +42,7 @@
 #include "JSCommonJSExtensions.h"
 
 #include "BunProcess.h"
+#include "ErrorCode.h"
 
 namespace Bun {
 using namespace JSC;
@@ -67,6 +68,11 @@ public:
 };
 
 extern "C" BunLoaderType Bun__getDefaultLoader(JSC::JSGlobalObject*, BunString* specifier);
+
+JSC::EncodedJSValue throwRequireAsyncModuleError(JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, const WTF::String& specifier)
+{
+    return Bun::throwError(globalObject, scope, ErrorCode::ERR_REQUIRE_ASYNC_MODULE, makeString("require() async module \""_s, specifier, "\" is unsupported. use \"await import()\" instead."_s));
+}
 
 static JSC::JSPromise* rejectedInternalPromise(JSC::JSGlobalObject* globalObject, JSC::JSValue value)
 {
@@ -681,7 +687,7 @@ JSValue fetchCommonJSModule(
                 RELEASE_AND_RETURN(scope, JSValue {});
             }
             case JSPromise::Status::Pending: {
-                JSC::throwTypeError(globalObject, scope, makeString("require() async module \""_s, specifierWtfString, "\" is unsupported. use \"await import()\" instead."_s));
+                throwRequireAsyncModuleError(globalObject, scope, specifierWtfString);
                 RELEASE_AND_RETURN(scope, JSValue {});
             }
             case JSPromise::Status::Fulfilled: {
@@ -736,7 +742,7 @@ JSValue fetchCommonJSModule(
                 RELEASE_AND_RETURN(scope, JSValue {});
             }
             case JSPromise::Status::Pending: {
-                JSC::throwTypeError(globalObject, scope, makeString("require() async module \""_s, specifierWtfString, "\" is unsupported. use \"await import()\" instead."_s));
+                throwRequireAsyncModuleError(globalObject, scope, specifierWtfString);
                 RELEASE_AND_RETURN(scope, JSValue {});
             }
             case JSPromise::Status::Fulfilled: {

--- a/src/jsc/bindings/ModuleLoader.h
+++ b/src/jsc/bindings/ModuleLoader.h
@@ -91,6 +91,10 @@ public:
     bool wasModuleMock = false;
 };
 
+// Node's ERR_REQUIRE_ASYNC_MODULE: require() cannot finish loading this module
+// synchronously. Loaders detect the code to fall back to import().
+JSC::EncodedJSValue throwRequireAsyncModuleError(JSC::JSGlobalObject*, JSC::ThrowScope&, const WTF::String& specifier);
+
 JSValue fetchESMSourceCodeSync(
     Zig::GlobalObject* globalObject,
     JSString* spceifierJS,

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -699,6 +699,39 @@ static bool isModuleEvaluated(JSC::AbstractModuleRecord* record)
     return record->moduleEnvironmentMayBeNull() != nullptr;
 }
 
+// Node.js refuses require(esm) for any graph that contains top-level await
+// (v8::Module::IsGraphAsync), regardless of whether the awaited value would
+// settle on microtasks alone. [[AsyncEvaluationOrder]] is the transitive
+// summary: InnerModuleEvaluation sets it when [[HasTLA]] is true OR any
+// dependency went async, and leaves it Unset otherwise. For a record that has
+// not yet started evaluation (Linked, or Evaluating in an outer SCC) walk its
+// loaded dependencies and check [[HasTLA]] directly.
+static bool moduleGraphHasTLA(JSC::AbstractModuleRecord* root)
+{
+    if (!root)
+        return false;
+    WTF::UncheckedKeyHashSet<JSC::AbstractModuleRecord*> seen;
+    Vector<JSC::AbstractModuleRecord*, 8> stack;
+    stack.append(root);
+    while (!stack.isEmpty()) {
+        JSC::AbstractModuleRecord* module = stack.takeLast();
+        if (!seen.add(module).isNewEntry)
+            continue;
+        if (module->hasTLA())
+            return true;
+        if (!module->asyncEvaluationOrder().isUnset())
+            return true;
+        auto* cyclic = dynamicDowncast<JSC::CyclicModuleRecord>(module);
+        if (!cyclic || cyclic->status() == JSC::CyclicModuleRecord::Status::Evaluated)
+            continue;
+        for (const auto& [key, loaded] : cyclic->loadedModules()) {
+            if (auto* dep = loaded.m_module.get())
+                stack.append(dep);
+        }
+    }
+    return false;
+}
+
 JSC_DEFINE_HOST_FUNCTION(functionEsmNamespaceForCjs, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
@@ -766,6 +799,8 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
     if (auto* entry = loader->registryEntry(key)) {
         entryExistedBefore = true;
         if (isModuleEvaluated(entry->record())) {
+            if (moduleGraphHasTLA(entry->record()))
+                return Bun::throwRequireAsyncModuleError(globalObject, scope, keyString);
             auto* ns = entry->record()->getModuleNamespace(globalObject, false);
             RETURN_IF_EXCEPTION(scope, {});
             return JSValue::encode(ns);
@@ -836,6 +871,13 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
             return {};
         }
     }
+
+    // The synchronous drain diverts AsyncModuleExecutionResume, so a TLA graph
+    // that only awaits already-settled values reaches Evaluated here. Node.js
+    // rejects any TLA graph regardless, so loaders that branch on
+    // ERR_REQUIRE_ASYNC_MODULE see consistent behaviour across runtimes.
+    if (moduleGraphHasTLA(record))
+        return Bun::throwRequireAsyncModuleError(globalObject, scope, keyString);
 
     auto* ns = record->getModuleNamespace(globalObject, false);
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -812,7 +812,7 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
             WTF::Locker locker { loader->cellLock() };
             loader->removeEntry(key);
         }
-        return throwVMTypeError(globalObject, scope, makeString("require() async module \""_s, keyString, "\" is unsupported. use \"await import()\" instead."_s));
+        return Bun::throwRequireAsyncModuleError(globalObject, scope, keyString);
     }
     }
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -701,11 +701,11 @@ static bool isModuleEvaluated(JSC::AbstractModuleRecord* record)
 
 // Node.js refuses require(esm) for any graph that contains top-level await
 // (v8::Module::IsGraphAsync), regardless of whether the awaited value would
-// settle on microtasks alone. [[AsyncEvaluationOrder]] is the transitive
-// summary: InnerModuleEvaluation sets it when [[HasTLA]] is true OR any
-// dependency went async, and leaves it Unset otherwise. For a record that has
-// not yet started evaluation (Linked, or Evaluating in an outer SCC) walk its
-// loaded dependencies and check [[HasTLA]] directly.
+// settle on microtasks alone. This is a structural walk over [[HasTLA]]:
+// [[AsyncEvaluationOrder]] is a fast "yes" (set implies this subtree went
+// async) but not a valid "no" for an Evaluated record, because a parent whose
+// TLA dependency already completed in an earlier evaluation pass sees that
+// dependency's order as DONE (not an integer) and keeps its own order Unset.
 static bool moduleGraphHasTLA(JSC::AbstractModuleRecord* root)
 {
     if (!root)
@@ -722,7 +722,7 @@ static bool moduleGraphHasTLA(JSC::AbstractModuleRecord* root)
         if (!module->asyncEvaluationOrder().isUnset())
             return true;
         auto* cyclic = dynamicDowncast<JSC::CyclicModuleRecord>(module);
-        if (!cyclic || cyclic->status() == JSC::CyclicModuleRecord::Status::Evaluated)
+        if (!cyclic)
             continue;
         for (const auto& [key, loaded] : cyclic->loadedModules()) {
             if (auto* dep = loaded.m_module.get())

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -227,8 +227,17 @@ describe("require", () => {
 });
 
 describe("module", () => {
-  it("throws with require()", () => {
-    expect(() => require("my-virtual-module-async")).toThrow();
+  it("throws ERR_REQUIRE_ASYNC_MODULE with require()", () => {
+    let error: any;
+    try {
+      require("my-virtual-module-async");
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.code).toBe("ERR_REQUIRE_ASYNC_MODULE");
+    expect(error.message).toContain("my-virtual-module-async");
   });
 
   it("async module works with async import", async () => {

--- a/test/js/bun/resolve/require-esm-transitive-tla.test.ts
+++ b/test/js/bun/resolve/require-esm-transitive-tla.test.ts
@@ -28,7 +28,7 @@ test("require(esm) rejects when a transitive dependency has top-level await", as
       try {
         require("./middle.mjs");
       } catch (e) {
-        threw = e instanceof TypeError && String(e.message).includes("async module");
+        threw = e instanceof Error && e.code === "ERR_REQUIRE_ASYNC_MODULE" && String(e.message).includes("async module");
       }
       if (!threw) throw new Error("expected require(transitive-TLA) to throw");
       console.log("ok");

--- a/test/js/bun/resolve/require.test.ts
+++ b/test/js/bun/resolve/require.test.ts
@@ -1,4 +1,4 @@
-import { bunRun, tempDirWithFiles } from "harness";
+import { bunRun, tempDir, tempDirWithFiles } from "harness";
 import fs from "node:fs";
 import path from "node:path";
 const fixture = (...segs: string[]): string => path.join(import.meta.dirname, "fixtures", "require", ...segs);
@@ -40,6 +40,48 @@ describe("require(specifier)", () => {
     it.todo("require('*.html') synchronously produces a string");
     it.todo("require('*.wasm') produces a WebAssembly.Module");
     it.todo("require('*.db') wraps a sqlite file in a Database object and exports it");
+  });
+
+  describe("when specifier is an ES module whose graph uses top-level await", () => {
+    // Loaders detect `err.code === "ERR_REQUIRE_ASYNC_MODULE"` to fall back to import().
+    // https://nodejs.org/api/errors.html#err_require_async_module
+    it("throws a node-style ERR_REQUIRE_ASYNC_MODULE error", () => {
+      using dir = tempDir("require-tla", {
+        "tla.mjs": `await new Promise(resolve => setTimeout(resolve, 1));\nexport const value = 1;\n`,
+      });
+      const specifier = path.join(String(dir), "tla.mjs");
+
+      let error: any;
+      try {
+        require(specifier);
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error).not.toBeInstanceOf(TypeError);
+      expect(error.name).toBe("Error");
+      expect(error.code).toBe("ERR_REQUIRE_ASYNC_MODULE");
+      expect(error.message).toContain(require.resolve(specifier));
+    });
+
+    it("throws ERR_REQUIRE_ASYNC_MODULE when only a transitive dependency has top-level await", () => {
+      using dir = tempDir("require-transitive-tla", {
+        "leaf.mjs": `await new Promise(resolve => setTimeout(resolve, 1));\nexport const value = 1;\n`,
+        "middle.mjs": `export { value } from "./leaf.mjs";\n`,
+      });
+      const specifier = path.join(String(dir), "middle.mjs");
+
+      let error: any;
+      try {
+        require(specifier);
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.code).toBe("ERR_REQUIRE_ASYNC_MODULE");
+    });
   });
 
   describe("require.main", () => {

--- a/test/js/bun/resolve/require.test.ts
+++ b/test/js/bun/resolve/require.test.ts
@@ -120,6 +120,36 @@ describe("require(specifier)", () => {
       expect(exitCode).toBe(0);
     });
 
+    it("throws ERR_REQUIRE_ASYNC_MODULE for an intermediate module whose TLA dependency was pre-imported", async () => {
+      // An Evaluated parent whose TLA leaf completed in an earlier pass has
+      // [[AsyncEvaluationOrder]] Unset (the leaf's order is DONE, not an
+      // integer, so PendingAsyncDependencies stays 0); the graph walk must
+      // still reach the leaf's [[HasTLA]].
+      using dir = tempDir("require-tla-preimported-leaf", {
+        "leaf.mjs": `await Promise.resolve(0);\nexport const v = 1;\n`,
+        "middle.mjs": `export { v } from "./leaf.mjs";\n`,
+        "entry.cjs": `(async () => {
+          await import("./leaf.mjs");
+          try {
+            require("./middle.mjs");
+            console.log("returned");
+          } catch (e) {
+            console.log("threw", e.code ?? e.name);
+          }
+        })();`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "entry.cjs"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("threw ERR_REQUIRE_ASYNC_MODULE");
+      expect(exitCode).toBe(0);
+    });
+
     it("evaluates the graph exactly once across a rejected require() and a subsequent import()", async () => {
       using dir = tempDir("require-tla-eval-once", {
         "leaf.mjs": `globalThis.__ticks.push("leaf");\nawait Promise.resolve(0);\nexport const y = 1;\n`,

--- a/test/js/bun/resolve/require.test.ts
+++ b/test/js/bun/resolve/require.test.ts
@@ -1,4 +1,4 @@
-import { bunRun, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, bunRun, tempDir, tempDirWithFiles } from "harness";
 import fs from "node:fs";
 import path from "node:path";
 const fixture = (...segs: string[]): string => path.join(import.meta.dirname, "fixtures", "require", ...segs);
@@ -43,11 +43,19 @@ describe("require(specifier)", () => {
   });
 
   describe("when specifier is an ES module whose graph uses top-level await", () => {
-    // Loaders detect `err.code === "ERR_REQUIRE_ASYNC_MODULE"` to fall back to import().
-    // https://nodejs.org/api/errors.html#err_require_async_module
-    it("throws a node-style ERR_REQUIRE_ASYNC_MODULE error", () => {
+    // Node's require(esm) refuses any graph that contains top-level await with
+    // ERR_REQUIRE_ASYNC_MODULE, regardless of whether the awaited value would
+    // settle on microtasks alone. Loaders catch this code to fall back to
+    // import(). https://nodejs.org/api/errors.html#err_require_async_module
+    const tlaShapes = {
+      "await that needs the event loop": `await new Promise(resolve => setTimeout(resolve, 1));`,
+      "await of an already-settled promise": `await Promise.resolve(0);`,
+      "await of a non-thenable": `await 0;`,
+    };
+
+    it.each(Object.entries(tlaShapes))("throws ERR_REQUIRE_ASYNC_MODULE for %s", (_, awaitExpr) => {
       using dir = tempDir("require-tla", {
-        "tla.mjs": `await new Promise(resolve => setTimeout(resolve, 1));\nexport const value = 1;\n`,
+        "tla.mjs": `${awaitExpr}\nexport const value = 1;\n`,
       });
       const specifier = path.join(String(dir), "tla.mjs");
 
@@ -65,22 +73,87 @@ describe("require(specifier)", () => {
       expect(error.message).toContain(require.resolve(specifier));
     });
 
-    it("throws ERR_REQUIRE_ASYNC_MODULE when only a transitive dependency has top-level await", () => {
-      using dir = tempDir("require-transitive-tla", {
-        "leaf.mjs": `await new Promise(resolve => setTimeout(resolve, 1));\nexport const value = 1;\n`,
-        "middle.mjs": `export { value } from "./leaf.mjs";\n`,
+    it.each(Object.entries(tlaShapes))(
+      "throws ERR_REQUIRE_ASYNC_MODULE when a transitive dependency has %s",
+      (_, awaitExpr) => {
+        using dir = tempDir("require-transitive-tla", {
+          "leaf.mjs": `${awaitExpr}\nexport const value = 1;\n`,
+          "middle.mjs": `export { value } from "./leaf.mjs";\n`,
+        });
+        const specifier = path.join(String(dir), "middle.mjs");
+
+        let error: any;
+        try {
+          require(specifier);
+        } catch (e) {
+          error = e;
+        }
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error.code).toBe("ERR_REQUIRE_ASYNC_MODULE");
+      },
+    );
+
+    it("throws ERR_REQUIRE_ASYNC_MODULE even when the module was already evaluated via import()", async () => {
+      using dir = tempDir("require-tla-after-import", {
+        "tla.mjs": `await Promise.resolve(0);\nexport const value = 7;\n`,
+        "entry.cjs": `(async () => {
+          const ns = await import("./tla.mjs");
+          if (ns.value !== 7) throw new Error("import failed");
+          try {
+            require("./tla.mjs");
+            console.log("returned");
+          } catch (e) {
+            console.log("threw", e.code ?? e.name);
+          }
+        })();`,
       });
-      const specifier = path.join(String(dir), "middle.mjs");
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "entry.cjs"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("threw ERR_REQUIRE_ASYNC_MODULE");
+      expect(exitCode).toBe(0);
+    });
 
-      let error: any;
-      try {
-        require(specifier);
-      } catch (e) {
-        error = e;
-      }
+    it("evaluates the graph exactly once across a rejected require() and a subsequent import()", async () => {
+      using dir = tempDir("require-tla-eval-once", {
+        "leaf.mjs": `globalThis.__ticks.push("leaf");\nawait Promise.resolve(0);\nexport const y = 1;\n`,
+        "root.mjs": `import { y } from "./leaf.mjs";\nglobalThis.__ticks.push("root");\nexport const x = y + 6;\n`,
+        "entry.cjs": `globalThis.__ticks = [];
+          let code = "no-throw";
+          try { require("./root.mjs"); } catch (e) { code = e.code ?? e.name; }
+          (async () => {
+            const ns = await import("./root.mjs");
+            console.log(JSON.stringify({ code, ticks: globalThis.__ticks, x: ns.x }));
+          })();`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "entry.cjs"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({
+        code: "ERR_REQUIRE_ASYNC_MODULE",
+        ticks: ["leaf", "root"],
+        x: 7,
+      });
+      expect(exitCode).toBe(0);
+    });
 
-      expect(error).toBeInstanceOf(Error);
-      expect(error.code).toBe("ERR_REQUIRE_ASYNC_MODULE");
+    it("still loads an ES module whose graph is entirely synchronous", () => {
+      using dir = tempDir("require-esm-sync", {
+        "sync.mjs": `export const value = 42;\n`,
+      });
+      const ns = require(path.join(String(dir), "sync.mjs"));
+      expect(ns.value).toBe(42);
     });
   });
 


### PR DESCRIPTION
Node's `require(esm)` refuses any graph containing top-level await with `ERR_REQUIRE_ASYNC_MODULE`, even when every awaited value is already settled and the graph could complete on microtasks alone. Bun was more permissive than that in one case and threw the wrong error in the other, so the documented `try { require(f) } catch (e) { if (e.code === "ERR_REQUIRE_ASYNC_MODULE") return import(f) }` fallback did not work.

```js
// tla.mjs
await Promise.resolve(0);
export const x = 7;

// p.cjs
try { console.log("returned", JSON.stringify(require("./tla.mjs"))); }
catch (e) { console.log("threw", e.code ?? e.name); }
```

| runtime | `await Promise.resolve(0)` | `await new Promise(r => setTimeout(r))` |
| --- | --- | --- |
| node 26 | `threw ERR_REQUIRE_ASYNC_MODULE` | `threw ERR_REQUIRE_ASYNC_MODULE` |
| bun main | `returned {"x":7}` | `threw TypeError` (no `.code`) |
| this PR | `threw ERR_REQUIRE_ASYNC_MODULE` | `threw ERR_REQUIRE_ASYNC_MODULE` |

## Cause

`functionEsmLoadSync` drives the ESM loader through `JSModuleLoader::loadModuleSync`, which diverts the module-loader internal microtasks (including `AsyncModuleExecutionResume`, the TLA `await` continuation) onto a private queue and drains it inline. A graph whose only awaits are on already-settled promises therefore reaches `Evaluated` inside that drain, the load promise is `Fulfilled`, and the function returned the namespace. The pre-existing TLA guard only fired on a still-`Pending` load promise, and there it threw a bare `TypeError` without `.code`.

## Fix

Two commits:

- The `.code` fix from #33438 (cherry-picked): a `Bun::throwRequireAsyncModuleError` helper that routes the throw through `ErrorCode::ERR_REQUIRE_ASYNC_MODULE`, used at every "async module" throw site.
- This PR: `functionEsmLoadSync` now checks whether the graph contains top-level await before returning a namespace, in both the already-evaluated fast path and after a synchronous load completes. `moduleGraphHasTLA` is a structural DFS over `loadedModules()` checking `[[HasTLA]]` on each record (matching `v8::Module::IsGraphAsync`); a non-Unset `[[AsyncEvaluationOrder]]` is a fast "yes" but never a "no", since a parent whose TLA dependency completed in an earlier evaluation pass keeps its own order Unset. `requireESM` drops its `$esmNamespaceForCjs` fast path so a previously-imported TLA module reaches the same check; `esmLoadSync` already short-circuits the already-evaluated non-TLA case.

One deliberate difference from Node: for a graph that completes inside the synchronous drain (the `await Promise.resolve()` shape) the module body runs before the throw. A subsequent `import()` finds the module already `Evaluated` and reuses it, so each module body still runs exactly once; only the timing relative to the throw differs. Avoiding that would require gating between link and evaluate inside `moduleLoadLinkEvaluateSettled`, which is in vendored JavaScriptCore.

## Relationship to open PRs

- Supersedes #33438 (its commit is included here; the new graph check is layered on top of the same helper).
- Conflicts with #33249, which goes the other direction and makes more TLA graphs succeed under `require()`. This PR matches Node's accept/reject classification instead, so code relying on `ERR_REQUIRE_ASYNC_MODULE` to fall back to `import()` behaves the same on both runtimes.

## Verification

New tests in `test/js/bun/resolve/require.test.ts` cover direct and transitive TLA across three await shapes (`await 0`, `await Promise.resolve(0)`, `await new Promise(r => setTimeout(r, 1))`), a module already evaluated via `import()`, an intermediate module whose TLA dependency was pre-imported in a prior pass, evaluate-once across a rejected `require()` followed by `import()`, and a sanity check that a fully-synchronous ES module still loads.

```
$ bun bd test test/js/bun/resolve/require.test.ts -t "top-level await"
 10 pass, 0 fail
$ USE_SYSTEM_BUN=1 bun test test/js/bun/resolve/require.test.ts -t "top-level await"
 1 pass, 9 fail   # only the sync-graph sanity test passes on main
```

Related suites stay green: `require-esm-transitive-tla`, `require-esm-microtask-order`, `regression/issue/24387`, `esModule`, `import-meta`, `import-defer`, `plugin/plugins`, `node/module/`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 11 failed, 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts test/js/bun/resolve/require-esm-transitive-tla.test.ts test/js/bun/resolve/require.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (2be47fd0f)

test/js/bun/resolve/require-esm-transitive-tla.test.ts:
40 |     env: bunEnv,
41 |     cwd: String(dir),
42 |     stderr: "pipe",
43 |   });
44 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
45 |   expect(stderr).toBe("");
                      ^
error: expect(received).toBe(expected)

- ""
+ "3 |       try {
+ 4 |         require("./middle.mjs");
+ 5 |       } catch (e) {
+ 6 |         threw = e instanceof Error && e.code === "ERR_REQUIRE_ASYNC_MODULE" && String(e.message).includes("async module");
+ 7 |       }
+ 8 |       if (!threw) throw new Error("expected req
... (truncated)

release without fix: 4 skipped
bun test v1.4.0-canary.1 (3f9f8bec1)

test/js/bun/resolve/require-esm-transitive-tla.test.ts:
(pass) require(esm) rejects when a transitive dependency has top-level await [20.12ms]
(pass) require(esm) failing on TLA does not delete an entry an outer import() owns [36.81ms]

test/js/bun/resolve/require.test.ts:
(pass) require(specifier) > has a length of 1 [0.03ms]
(pass) require(specifier) > is a function [0.01ms]
(pass) require(specifier) > has an empty prototype [3.25ms]
(pass) require(specifier) > when specifier is a path to a non js/ts/etc file > require('obj.toml') synchronously produces an object [0.25ms]
(pass) require(specifier) > when specifier is a path to a non js/ts/etc file > require('obj.json') synchronously produces an object [0.06ms]
(pass) require(specifier) > when specifier is a path to a non js/ts/etc file > require('obj.jsonc') synchronously produces an object [0.04ms]
(pass) require(specifier) > when specifier is a path to a non js/ts/etc file > require('arr.json') synchronously produces an array [0.09ms]
(pass) require(specifier) > when specifier is a path to a non js/ts/etc file > require('arr.jsonc') synchronously produces an array [0.04ms]
(
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts test/js/bun/resolve/require-esm-transitive-tla.test.ts test/js/bun/resolve/require.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (2be47fd0f)

test/js/bun/resolve/require-esm-transitive-tla.test.ts:
(pass) require(esm) rejects when a transitive dependency has top-level await [523.62ms]
(pass) require(esm) failing on TLA does not delete an entry an outer import() owns [601.35ms]

test/js/bun/resolve/require.test.ts:
(pass) require(specifier) > has a length of 1 [1.75ms]
(pass) require(specifier) > is a function [1.05ms]
(pass) require(specifier) > has an empty prototype [2.77ms]
(pass) require(specifier) > when specifier is a path to a non js/ts/etc file > require('obj.toml') synchronously produces an object [6.48ms]
(pass) require(specifier) > when specifier is a path to
... (truncated)

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 813ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen cpp.rs (cppbind)
[2/21] gen JS modules (bundle-modules)
Preprocess modules (6779ms)
Bundle modules (66ms)
Postprocesss modules (30ms)
Bundle Functions (651ms)
Generate Code (83ms)

[7.62s] Bundled "src/js" for production
  1888 kb
  161 internal modules
  12 native modules
  90 internal functions across 19 files
[2/11] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/builtins/CommonJS.ts                        |   7 +-
 src/jsc/bindings/ModuleLoader.cpp                  |  10 +-
 src/jsc/bindings/ModuleLoader.h                    |   4 +
 src/jsc/bindings/ZigGlobalObject.cpp               |  44 +++++-
 test/js/bun/plugin/plugins.test.ts                 |  13 +-
 .../bun/resolve/require-esm-transitive-tla.test.ts |   2 +-
 test/js/bun/resolve/require.test.ts                | 147 ++++++++++++++++++++-
 7 files changed, 216 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/js/builtins/CommonJS.ts                                 1      1      0
src/jsc/bindings/ModuleLoader.cpp                           1      0      0
src/jsc/bindings/ModuleLoader.h                             0      0      0
src/jsc/bindings/ZigGlobalObject.cpp                        6      5      0
test/js/bun/plugin/plugins.test.ts                          0      0      0
test/js/bun/resolve/require-esm-transitive-tla.test.ts      0      0      0
test/js/bun/resolve/require.test.ts                         2      4      0
```

</details>

<!-- robobun:evidence:end -->
