### PR TITLE
require(esm): make __esModule an own enumerable property on a null-prototype namespace

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "autobuild-preview-pr-279-c28e4183";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -116,25 +116,14 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
 
     const namespace = out;
     // In a require cycle the namespace is live while the module body is still
-    // running, so an export named `__esModule` / `module.exports` may be in TDZ.
-    let esModule, moduleExports;
+    // running, so an export named `module.exports` may be in TDZ.
+    let moduleExports;
     try {
-      esModule = namespace.__esModule;
       moduleExports = namespace["module.exports"];
     } catch {}
-    // In Bun, when __esModule is not defined, it's a CustomAccessor on the prototype.
-    // Various libraries expect __esModule to be set when using ESM from require().
-    // We don't want to always inject the __esModule export into every module,
-    // And creating an Object wrapper causes the actual exports to not be own properties.
-    // So instead of either of those, we make it so that the __esModule property can be set at runtime.
-    // It only supports "true" and undefined. Anything non-truthy is treated as undefined.
-    // https://github.com/oven-sh/bun/issues/14411
-    if (esModule === undefined) {
-      try {
-        namespace.__esModule = true;
-      } catch {
-        // https://github.com/oven-sh/bun/issues/17816
-      }
+    // Node's rule for the require(esm) interop marker.
+    if (!("__esModule" in namespace) && "default" in namespace) {
+      namespace.__esModule = true;
     }
 
     return (mod.exports = moduleExports ?? namespace);
@@ -204,25 +193,14 @@ export function requireESMFromHijackedExtension(this: JSCommonJSModule, id: stri
     throw exception;
   }
 
-  // See `overridableRequire`: TDZ-safe reads for the require-cycle case.
-  let esModule, moduleExports;
+  // See `overridableRequire`: a TDZ-safe read for the require-cycle case.
+  let moduleExports;
   try {
-    esModule = namespace.__esModule;
     moduleExports = namespace["module.exports"];
   } catch {}
-  // In Bun, when __esModule is not defined, it's a CustomAccessor on the prototype.
-  // Various libraries expect __esModule to be set when using ESM from require().
-  // We don't want to always inject the __esModule export into every module,
-  // And creating an Object wrapper causes the actual exports to not be own properties.
-  // So instead of either of those, we make it so that the __esModule property can be set at runtime.
-  // It only supports "true" and undefined. Anything non-truthy is treated as undefined.
-  // https://github.com/oven-sh/bun/issues/14411
-  if (esModule === undefined) {
-    try {
-      namespace.__esModule = true;
-    } catch {
-      // https://github.com/oven-sh/bun/issues/17816
-    }
+  // Node's rule for the require(esm) interop marker.
+  if (!("__esModule" in namespace) && "default" in namespace) {
+    namespace.__esModule = true;
   }
 
   this.exports = moduleExports ?? namespace;

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -348,13 +348,8 @@ JSModuleNamespaceObject* NodeVMModule::namespaceObject(JSC::JSGlobalObject* glob
     object = amr->getModuleNamespace(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
     if (object) {
-        // The shared module namespace structure carries an __esModule accessor for
-        // CJS interop, but a Module Namespace Exotic Object is specified to have a
-        // null [[Prototype]], which is what vm modules must expose.
-        object->setPrototypeDirect(vm, jsNull());
         namespaceObject(vm, object);
     }
-    RETURN_IF_EXCEPTION(scope, {});
 
     return object;
 }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1940,31 +1940,6 @@ extern "C" napi_env ZigGlobalObject__makeNapiEnvForFFI(Zig::GlobalObject* global
 }
 
 extern "C" JSC::EncodedJSValue CryptoObject__create(JSGlobalObject*);
-JSC_DEFINE_CUSTOM_GETTER(moduleNamespacePrototypeGetESModuleMarker, (JSGlobalObject * globalObject, JSC::EncodedJSValue encodedThisValue, PropertyName))
-{
-    JSValue thisValue = JSValue::decode(encodedThisValue);
-    JSModuleNamespaceObject* moduleNamespaceObject = dynamicDowncast<JSModuleNamespaceObject>(thisValue);
-    if (!moduleNamespaceObject || moduleNamespaceObject->m_hasESModuleMarker != WTF::TriState::True) {
-        return JSC::JSValue::encode(jsUndefined());
-    }
-
-    return JSC::JSValue::encode(jsBoolean(true));
-}
-
-JSC_DEFINE_CUSTOM_SETTER(moduleNamespacePrototypeSetESModuleMarker, (JSGlobalObject * globalObject, JSC::EncodedJSValue encodedThisValue, JSC::EncodedJSValue encodedValue, PropertyName))
-{
-    auto& vm = JSC::getVM(globalObject);
-    JSValue thisValue = JSValue::decode(encodedThisValue);
-    JSModuleNamespaceObject* moduleNamespaceObject = dynamicDowncast<JSModuleNamespaceObject>(thisValue);
-    if (!moduleNamespaceObject) {
-        return false;
-    }
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue value = JSValue::decode(encodedValue);
-    WTF::TriState triState = value.toBoolean(globalObject) ? WTF::TriState::True : WTF::TriState::False;
-    moduleNamespaceObject->m_hasESModuleMarker = triState;
-    return true;
-}
 
 namespace {
 
@@ -2294,11 +2269,6 @@ void GlobalObject::finishCreation(VM& vm)
              init.set(
                  createMemoryFootprintStructure(
                      init.vm, static_cast<Zig::GlobalObject*>(init.owner)));
-         } },
-        { OBJECT_OFFSETOF(GlobalObject, m_moduleNamespaceObjectStructure), [](const LazyProperty<JSGlobalObject, Structure>::Initializer& init) {
-             JSObject* moduleNamespacePrototype = JSC::constructEmptyObject(init.vm, init.owner->nullPrototypeObjectStructure());
-             moduleNamespacePrototype->putDirectCustomAccessor(init.vm, init.vm.propertyNames->__esModule, CustomGetterSetter::create(init.vm, moduleNamespacePrototypeGetESModuleMarker, moduleNamespacePrototypeSetESModuleMarker), PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::CustomAccessor | 0);
-             init.set(JSModuleNamespaceObject::createStructure(init.vm, init.owner, moduleNamespacePrototype));
          } },
         { OBJECT_OFFSETOF(GlobalObject, m_JSBufferSubclassStructure), [](const LazyProperty<JSGlobalObject, Structure>::Initializer& init) {
              auto scope = DECLARE_TOP_EXCEPTION_SCOPE(init.vm);
@@ -2631,8 +2601,6 @@ void GlobalObject::finishCreation(VM& vm)
                     v8::shim::GlobalInternals::createStructure(init.vm, init.owner),
                     dynamicDowncast<Zig::GlobalObject>(init.owner)));
         });
-
-    // Change prototype from null to object for synthetic modules.
 
     m_vmModuleContextMap.initLater(
         [](const Initializer<JSWeakMap>& init) {

--- a/test/js/bun/import-attributes/import-attributes.test.ts
+++ b/test/js/bun/import-attributes/import-attributes.test.ts
@@ -344,11 +344,11 @@ describe("other loaders do not crash", () => {
 });
 
 describe("?raw", () => {
-  for (const [name, fn] of [
-    ["bun run", testBunRun],
+  for (const [name, fn, expected] of [
+    ["bun run", testBunRun, {}],
     // ["bun build", testBunBuild], // TODO: bun.build doesn't support query params at all yet
-    ["bun run await import", testBunRunAwaitImport],
-    ["require", testBunRunRequire],
+    ["bun run await import", testBunRunAwaitImport, {}],
+    ["require", testBunRunRequire, { __esModule: true }],
     // ["bun build require", testBunBuildRequire], // TODO: bun.build doesn't support query params at all yet
   ] as const) {
     test(name, async () => {
@@ -357,7 +357,7 @@ describe("?raw", () => {
       await using question_raw = tempDir("import-attributes", {
         [filename]: code,
       });
-      expect(await fn(question_raw, null, filename + "?raw")).toEqual({ default: code });
+      expect(await fn(question_raw, null, filename + "?raw")).toEqual({ ...expected, default: code });
     });
   }
 });

--- a/test/js/bun/resolve/esModule.test.ts
+++ b/test/js/bun/resolve/esModule.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 // Top-level `await import(self)` is a spec-level deadlock under the new
 // pure-C++ module loader (Node prints an "unsettled top-level await" warning
@@ -10,22 +11,139 @@ test("__esModule defaults to undefined", () => {
   expect(Self.__esModule).toBeUndefined();
 });
 
-test("__esModule is settable", () => {
-  Self.__esModule = true;
-  expect(Self.__esModule).toBe(true);
-  Self.__esModule = false;
-  expect(Self.__esModule).toBe(undefined);
-  Self.__esModule = true;
-  expect(Self.__esModule).toBe(true);
-  Self.__esModule = undefined;
-});
-
-test("require of self sets __esModule", () => {
+test("require of self does not set __esModule without a default export", () => {
   expect(Self.__esModule).toBeUndefined();
   {
     const Self = require("./esModule.test.ts");
-    expect(Self.__esModule).toBe(true);
+    expect(Self.__esModule).toBeUndefined();
   }
-  expect(Self.__esModule).toBe(true);
+  expect(Self.__esModule).toBeUndefined();
   expect(Object.getOwnPropertyNames(Self)).toBeEmpty();
+});
+
+// Runs after the tests above because the marker cannot be removed again.
+test("__esModule can be set, and then behaves like a non-configurable own property", () => {
+  expect(() => {
+    Self.__esModule = false;
+  }).toThrow(TypeError);
+  expect(Object.hasOwn(Self, "__esModule")).toBe(false);
+
+  Self.__esModule = true;
+  expect(Self.__esModule).toBe(true);
+  expect(Object.getOwnPropertyDescriptor(Self, "__esModule")).toEqual({
+    value: true,
+    writable: true,
+    enumerable: true,
+    configurable: false,
+  });
+  expect(Object.getOwnPropertyNames(Self)).toEqual(["__esModule"]);
+
+  expect(() => {
+    Self.__esModule = false;
+  }).toThrow(TypeError);
+  expect(() => {
+    delete Self.__esModule;
+  }).toThrow(TypeError);
+  expect(() => Object.defineProperty(Self, "__esModule", { value: false })).toThrow(TypeError);
+  Self.__esModule = true;
+  expect(Self.__esModule).toBe(true);
+  expect(Object.hasOwn(Self, "__esModule")).toBe(true);
+});
+
+test("require(esm) defines __esModule as an own enumerable property", async () => {
+  using dir = tempDir("require-esm-esmodule", {
+    "e.mjs": "export default { d: 1 };\nexport const x = 7;\n",
+    "sorted.mjs": "export default 1; export const Alpha = 1; export const zzz = 2; export const _a = 3;\n",
+    "noDefault.mjs": "export const x = 1;\n",
+    "hasEsm.mjs": "export const __esModule = 'user-set'; export default 1;\n",
+    "hasUndefinedEsm.mjs": "export const __esModule = undefined; export default 1;\n",
+    "p.cjs": `
+const assert = require("node:assert");
+
+const n = require("./e.mjs");
+assert.deepStrictEqual(Object.getOwnPropertyNames(n).sort(), ["__esModule", "default", "x"]);
+assert.strictEqual(n.__esModule, true);
+assert.strictEqual(Object.hasOwn(n, "__esModule"), true);
+assert.strictEqual(({ ...n }).__esModule, true);
+assert.strictEqual(Object.assign({}, n).__esModule, true);
+assert.strictEqual(JSON.parse(JSON.stringify(n)).__esModule, true);
+assert.strictEqual(Object.getPrototypeOf(n), null);
+assert.deepStrictEqual(Object.getOwnPropertyDescriptor(n, "__esModule"), {
+  value: true, writable: true, enumerable: true, configurable: false,
+});
+
+// sort order matches Node (code-point sort with __esModule interleaved)
+const s = require("./sorted.mjs");
+assert.deepStrictEqual(Object.getOwnPropertyNames(s), ["Alpha", "__esModule", "_a", "default", "zzz"]);
+assert.deepStrictEqual(Object.keys(s), ["Alpha", "__esModule", "_a", "default", "zzz"]);
+
+// no default export -> no __esModule marker (matches Node)
+const nd = require("./noDefault.mjs");
+assert.deepStrictEqual(Object.getOwnPropertyNames(nd), ["x"]);
+assert.strictEqual(nd.__esModule, undefined);
+assert.strictEqual(Object.getPrototypeOf(nd), null);
+
+// module that explicitly exports __esModule keeps the user's value, even undefined
+const h = require("./hasEsm.mjs");
+assert.strictEqual(h.__esModule, "user-set");
+assert.strictEqual(Object.hasOwn(h, "__esModule"), true);
+const hu = require("./hasUndefinedEsm.mjs");
+assert.strictEqual(hu.__esModule, undefined);
+assert.deepStrictEqual(Object.getOwnPropertyNames(hu), ["__esModule", "default"]);
+assert.deepStrictEqual(Object.getOwnPropertyDescriptor(hu, "__esModule"), {
+  value: undefined, writable: true, enumerable: true, configurable: false,
+});
+
+console.log("ok");
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "p.cjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("ok\n");
+  expect(exitCode).toBe(0);
+});
+
+test("require(esm) still defines __esModule when import() materialized the namespace first", async () => {
+  using dir = tempDir("require-esm-esmodule-order", {
+    "e.mjs": "export default { d: 1 };\n",
+    "entry.mjs": `
+import assert from "node:assert";
+import { createRequire } from "node:module";
+
+const ns = await import("./e.mjs");
+assert.deepStrictEqual(Object.keys(ns), ["default"]);
+
+const n = createRequire(import.meta.url)("./e.mjs");
+assert.strictEqual(n.__esModule, true);
+assert.strictEqual(Object.hasOwn(n, "__esModule"), true);
+assert.deepStrictEqual(Object.keys(n), ["__esModule", "default"]);
+assert.strictEqual(({ ...n }).__esModule, true);
+
+console.log("ok");
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("ok\n");
+  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/resolve/require-esm-evaluating-cycle.test.ts
+++ b/test/js/bun/resolve/require-esm-evaluating-cycle.test.ts
@@ -44,9 +44,10 @@ test("require(esm) inside a require cycle returns the live namespace, not an emp
   expect(exitCode).toBe(0);
 });
 
-// The CommonJS side reads `__esModule` / `"module.exports"` off that live
-// namespace; when the module happens to export a binding by that name that is
-// still in TDZ, require() itself must not throw (reading it afterwards does).
+// The CommonJS side reads `"module.exports"` off that live namespace and checks
+// for an `__esModule` export with `in`; when the module happens to export a
+// binding by either name that is still in TDZ, require() itself must not throw
+// (reading it afterwards does).
 test("require(esm) inside a require cycle tolerates a TDZ `__esModule` export", async () => {
   using dir = tempDir("require-esm-evaluating-cycle-tdz", {
     "a.mjs": `

--- a/test/js/node/module/require-extensions.test.ts
+++ b/test/js/node/module/require-extensions.test.ts
@@ -156,7 +156,7 @@ test("wrapping an existing extension but it's secretly sync esm", () => {
       original(module, filename);
     }));
     const mod = require("./extensions-fixture/secretly_esm");
-    expect(mod).toEqual({ default: 1 });
+    expect({ ...mod }).toEqual({ __esModule: true, default: 1 });
     expect(mocked).toBeCalled();
   } finally {
     require.extensions[".cjs"] = original;


### PR DESCRIPTION
Depends on oven-sh/WebKit#279. `WEBKIT_VERSION` points at its preview build until it lands, then moves to the `autobuild-<sha>` tag that contains it.

### Problem
- `require()` of an ES module returns a namespace where `__esModule` reads `true` but is not an own property. `Object.keys`, `Object.hasOwn`, spread and `JSON.stringify` drop it, so interop helpers that clone the namespace double-wrap and callers land on `.default.default`. Node returns a null-prototype namespace with an own enumerable `__esModule: true`.
- Cause: `ZigGlobalObject.cpp` gives every namespace a custom prototype with a `__esModule` accessor over `JSModuleNamespaceObject::m_hasESModuleMarker`. The namespace's own keys are only its exports.

### Fix
- oven-sh/WebKit#279 makes the flag read as an own `{value: true, enumerable, configurable: false}` property: `getOwnPropertySlot` reports it, `getOwnPropertyNames` inserts it in sorted position, `delete` refuses it, and a truthy write sets the flag. Any other write or delete fails the way a write to an export binding fails, so the property never disappears once seen.
- This PR removes the prototype override, its accessors, and the `NodeVMModule.cpp` prototype reset that existed only because of it. `CommonJS.ts` sets the marker only when the module has a `default` export, as Node does.
- The JSC half is required. As an ordinary put, `Object.keys` still omits the marker, and if `import()` creates the non-extensible namespace before `require()` runs, the put fails and the marker is lost (table in Notes).
- Verified: `test/js/bun/resolve/esModule.test.ts`. Released bun fails 4 of 5, the bun-side change alone fails 3 of 5, this branch on `2e2aa229` + #279 (last full local run was on `c4ddc0cf`; the files this PR touches are unchanged on main since). Also the import-attributes, require-extensions, esModule-annotation and `node/vm` suites.

### Background
- A module namespace object is the exotic object behind `import * as ns`. Bun returns the same object from `require(esm)`.
- `m_hasESModuleMarker` is a Bun addition to JSC's namespace class. It records that CommonJS required the module. Until now only the prototype accessor read it.
- #39888 removes the same override for a different symptom and has no JSC half. Whichever lands first, the other rebases onto it.

<details><summary>Notes</summary>

`e.mjs` is `export default {...}; export const x = 7`.

```
                         own keys                      hasOwn  proto   configurable  import() then require()
node                     ["__esModule","default","x"]  true    null    false         marker present
released bun             ["default","x"]               false   object  n/a           reads true, not own
bun-side only, 2e2aa229  ["default","x"]               true    null    true          marker lost
this PR + WebKit#279     ["__esModule","default","x"]  true    null    false         marker present
```

`Object.keys` misses the ordinary put because JSC walks a namespace's structure properties only when the caller also asks for symbols, so spread sees it and `Object.keys` does not.

Known divergence kept: Bun hands the same object to `import *` and `require()`, Node builds a separate facade, so after a `require()` the `import *` side enumerates the marker here too. A facade is a follow-up.

Rebases: after #40519 restructured the same `CommonJS.ts` block (TDZ-safe reads in a require cycle), the merge keeps its try/catch around the `module.exports` read and drops the one around `__esModule`: the `in` checks only consult the export list and cannot hit TDZ. The branch is squashed to one commit. Rebases: the preview pin moved `ca11ae1a` -> `10b2c963` -> `1199ec14` -> `e0a11d89` -> `807c3e96` -> `50c36342` -> `55a5a693` -> `25f43ecb` -> `3330a9a4` -> `88aa0fc1` -> `b25ba771` -> `bfa7e6a3` -> `26510a18` -> `053f25f0` -> `9efc9283` -> `c28e4183` as WebKit main moved, with an identical WebKit diff each time. On the bun side the removal moved from an `initLater` call into `lazyStructureInits[]` when main refactored the file.
</details>

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 24 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/import-attributes/import-attributes.test.ts test/js/bun/resolve/esModule.test.ts test/js/node/module/require-extensions.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/resolve/esModule.test.ts:
(pass) __esModule defaults to undefined [7.06ms]
13 | 
14 | test("require of self does not set __esModule without a default export", () => {
15 |   expect(Self.__esModule).toBeUndefined();
16 |   {
17 |     const Self = require("./esModule.test.ts");
18 |     expect(Self.__esModule).toBeUndefined();
                                 ^
error: expect(received).toBeUndefined()

Received: true

      at <anonymous> (/workspace/bun/test/js/bun/resolve/esModule.test.ts:18:29)
(fail) require of self does not set __esModule without a default export [8.74ms]
24 | // Runs after the tests above because the marker cannot be removed again.
25 | test("__esModule can be set, and then behaves like a non-configurable own property", () => {
26 |   expect(() => {
27 |     Self.__esModule = false;
28 |   }).toThrow(TypeError);
29 |   expect(Object.hasOw
... (truncated)

release without fix: 6 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/js/bun/resolve/esModule.test.ts:
(pass) __esModule defaults to undefined [0.03ms]
13 | 
14 | test("require of self does not set __esModule without a default export", () => {
15 |   expect(Self.__esModule).toBeUndefined();
16 |   {
17 |     const Self = require("./esModule.test.ts");
18 |     expect(Self.__esModule).toBeUndefined();
                                 ^
error: expect(received).toBeUndefined()

Received: true

      at <anonymous> (/workspace/bun/test/js/bun/resolve/esModule.test.ts:18:29)
(fail) require of self does not set __esModule without a default export [0.19ms]
23 | 
24 | // Runs after the tests above because the marker cannot be removed again.
25 | test("__esModule can be set, and then behaves like a non-configurable own property", () => {
26 |   expect(() => {
27 |     Self.__esModule = false;
28 |   }).toThrow(TypeError);
          ^
error: expect(received).toThrow(expected)

Expected constructor: TypeError

Received function did not throw
Received value: undefined

      at <anonymous> (/workspace/bun/test/js/bun/resolve/esModule.test.ts:28:6)
(fail) __esModule can be set, and then behaves like a non
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/import-attributes/import-attributes.test.ts test/js/bun/resolve/esModule.test.ts test/js/node/module/require-extensions.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/resolve/esModule.test.ts:
(pass) __esModule defaults to undefined [7.71ms]
(pass) require of self does not set __esModule without a default export [18.70ms]
(pass) __esModule can be set, and then behaves like a non-configurable own property [14.36ms]
(pass) require(esm) defines __esModule as an own enumerable property [470.61ms]
(pass) require(esm) still defines __esModule when import() materialized the namespace first [412.91ms]

test/js/bun/import-attributes/import-attributes.test.ts:
(pass) javascript [1676.37ms]
(pass) typescript [1418.70ms]
(pass) json [1524.61ms]
(pass) jsonc [1274.73ms]
(pass) toml [1519.24ms]
(pass) yaml [1505.70ms]
(pass) tsconfig.json is assumed jsonc [846.80ms]
(pass) other loaders do not crash > webassembly [1393.17ms]
(pass) other loaders do not crash > does_not_exist [1406.61ms]
(pass) ?raw > bun run [279.80ms]
(pass) ?raw > bu
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     8e2a34fd57
  features     baseline

23 deps, 131 codegen, 1172 objects in 774ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [10.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [4.00ms]
[5/1244] fetch zlib
[zlib] up to date
[6/1244] gen ErrorCode+*.h
[7/1244] gen .bind.ts → GeneratedBindings.cpp
[8/1244] fetch tinycc
[tinycc] up to date
[9/1243] gen node-fallbacks/react-refresh.js
Bundled 1 module in 9ms

  react-refresh.js  4.81 KB  (entry point)

[10/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                       |   2 +-
 src/js/builtins/CommonJS.ts                        |  42 ++----
 src/jsc/bindings/NodeVMModule.cpp                  |   5 -
 src/jsc/bindings/ZigGlobalObject.cpp               |  32 -----
 .../import-attributes/import-attributes.test.ts    |  10 +-
 test/js/bun/resolve/esModule.test.ts               | 142 +++++++++++++++++++--
 test/js/node/module/require-extensions.test.ts     |   2 +-
 7 files changed, 147 insertions(+), 88 deletions(-)
```

</details>

**gate history** · 2 passed · 16 rejected · iteration 24

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
scripts/build/deps/webkit.ts                                 4      3      0
src/js/builtins/CommonJS.ts                                  8      8      0
src/jsc/bindings/NodeVMModule.cpp                            2      3      0
src/jsc/bindings/ZigGlobalObject.cpp                         5      4      0
test/js/bun/import-attributes/import-attributes.test.ts      3      2      0
test/js/bun/resolve/esModule.test.ts                         5      8      0
test/js/node/module/require-extensions.test.ts               1      1      0
```

</details>

<!-- robobun:evidence:end -->






