### PR TITLE
timer: drive the real heap from the real clock under fake timers

### DIFF
--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -279,10 +279,11 @@ impl StatWatcherScheduler {
             return;
         }
 
-        // reschedule the timer
+        // reschedule the timer — this tag opts out of fake timers, so the
+        // deadline lives in the real heap and must be in real-clock units.
         timer_all.update(
             elt,
-            &Timespec::ms_from_now(TimespecMockMode::AllowMockedTime, i64::from(interval)),
+            &Timespec::ms_from_now(TimespecMockMode::ForceRealTime, i64::from(interval)),
         );
     }
 

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -914,8 +914,11 @@ impl All {
             // deref and fire via raw deref (mirroring `drain_timers`).
             let (min_next_sec, min_next_nsec, min_tag) =
                 unsafe { ((*min).next.sec, (*min).next.nsec, (*min).tag) };
+            // Real clock: `self.timers` is the opt-out-of-fake-timers set, all
+            // armed in real-time units. Comparing against the mocked clock made
+            // internal pacing (GC, WTFTimer, test timeouts) spin on re-arm.
             let now =
-                *maybe_now.get_or_insert_with(|| Timespec::now(TimespecMockMode::AllowMockedTime));
+                *maybe_now.get_or_insert_with(|| Timespec::now(TimespecMockMode::ForceRealTime));
 
             // bun_event_loop carries its own Timespec stub; compare field-wise.
             let min_next = Timespec {
@@ -983,7 +986,8 @@ impl All {
         let out = (|| {
             let timer = self.timers.peek()?;
             if !*has_set_now {
-                *now = Timespec::now(TimespecMockMode::AllowMockedTime);
+                // Real clock: this heap is the opt-out-of-fake-timers set.
+                *now = Timespec::now(TimespecMockMode::ForceRealTime);
                 *has_set_now = true;
             }
             // SAFETY: peek returns a live heap node

--- a/test/js/bun/test/test-timers-gc-spin-fixture.ts
+++ b/test/js/bun/test/test-timers-gc-spin-fixture.ts
@@ -1,15 +1,10 @@
 import { jest, test } from "bun:test";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 
 // https://github.com/oven-sh/bun/pull/33359#discussion_r3556322148
 test("drain_timers terminates when mocked time > CLOCK_MONOTONIC uptime", async () => {
-  const f = join(tmpdir(), `gc-spin-probe-${process.pid}.txt`);
-  await Bun.write(f, "x");
-
   // Real event-loop ticks so the GcRepeating / WTFTimer / BunTest nodes are
   // armed (real-time deadlines) before fake timers are installed.
-  for (let i = 0; i < 4; i++) await Bun.file(f).text();
+  for (let i = 0; i < 4; i++) await Bun.file(import.meta.path).text();
 
   jest.useFakeTimers();
   try {
@@ -20,7 +15,7 @@ test("drain_timers terminates when mocked time > CLOCK_MONOTONIC uptime", async 
     // `now = AllowMockedTime`, so every allow_fake_timers()==false node
     // (GC, WTFTimer, test timeout) looked overdue; those that re-arm at
     // ForceRealTime on fire were re-inserted still "overdue" and the loop spun.
-    for (let i = 0; i < 4; i++) await Bun.file(f).text();
+    for (let i = 0; i < 4; i++) await Bun.file(import.meta.path).text();
   } finally {
     jest.useRealTimers();
   }

--- a/test/js/bun/test/test-timers-gc-spin-fixture.ts
+++ b/test/js/bun/test/test-timers-gc-spin-fixture.ts
@@ -1,0 +1,28 @@
+import { jest, test } from "bun:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// https://github.com/oven-sh/bun/pull/33359#discussion_r3556322148
+test("drain_timers terminates when mocked time > CLOCK_MONOTONIC uptime", async () => {
+  const f = join(tmpdir(), `gc-spin-probe-${process.pid}.txt`);
+  await Bun.write(f, "x");
+
+  // Real event-loop ticks so the GcRepeating / WTFTimer / BunTest nodes are
+  // armed (real-time deadlines) before fake timers are installed.
+  for (let i = 0; i < 4; i++) await Bun.file(f).text();
+
+  jest.useFakeTimers();
+  try {
+    // Push the mocked monotonic clock past any plausible machine uptime
+    // (advanceTimersByTime caps at u32 ms, so loop in ~40-day chunks).
+    for (let i = 0; i < 100; i++) jest.advanceTimersByTime(40 * 24 * 3600 * 1000);
+    // A real I/O await reaches All::drain_timers. Pre-fix that loop cached
+    // `now = AllowMockedTime`, so every allow_fake_timers()==false node
+    // (GC, WTFTimer, test timeout) looked overdue; those that re-arm at
+    // ForceRealTime on fire were re-inserted still "overdue" and the loop spun.
+    for (let i = 0; i < 4; i++) await Bun.file(f).text();
+  } finally {
+    jest.useRealTimers();
+  }
+  console.log("DRAIN_OK");
+});

--- a/test/js/bun/test/test-timers.test.ts
+++ b/test/js/bun/test/test-timers.test.ts
@@ -77,24 +77,20 @@ test("setSystemTime accepts pre-epoch and epoch times and resets with no argumen
   }
 });
 
-test(
-  "real timer heap is ticked against the real clock under useFakeTimers",
-  async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", path.join(import.meta.dir, "test-timers-gc-spin-fixture.ts")],
-      env: { ...bunEnv, BUN_GC_TIMER_DISABLE: undefined, BUN_GC_TIMER_INTERVAL: undefined },
-      stdout: "pipe",
-      stderr: "pipe",
-      // Pre-fix the child spins in drain_timers at 100% CPU; bound it so the
-      // assertions below fail with a clean diff instead of a runner timeout.
-      timeout: 20_000,
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    if (exitCode !== 0) console.error(stderr);
-    expect(stdout).toContain("DRAIN_OK");
-    // null => exited on its own; non-null => killed by the spawn timeout (spun).
-    expect(proc.signalCode).toBeNull();
-    expect(exitCode).toBe(0);
-  },
-  30_000,
-);
+test("real timer heap is ticked against the real clock under useFakeTimers", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", path.join(import.meta.dir, "test-timers-gc-spin-fixture.ts")],
+    env: { ...bunEnv, BUN_GC_TIMER_DISABLE: undefined, BUN_GC_TIMER_INTERVAL: undefined },
+    stdout: "pipe",
+    stderr: "pipe",
+    // Pre-fix the child spins in drain_timers at 100% CPU; bound it so the
+    // assertions below fail with a clean diff instead of a runner timeout.
+    timeout: 20_000,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) console.error(stderr);
+  expect(stdout).toContain("DRAIN_OK");
+  // null => exited on its own; non-null => killed by the spawn timeout (spun).
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+}, 30_000);

--- a/test/js/bun/test/test-timers.test.ts
+++ b/test/js/bun/test/test-timers.test.ts
@@ -83,8 +83,8 @@ test("real timer heap is ticked against the real clock under useFakeTimers", asy
     env: { ...bunEnv, BUN_GC_TIMER_DISABLE: undefined, BUN_GC_TIMER_INTERVAL: undefined },
     stdout: "pipe",
     stderr: "pipe",
-    // Pre-fix the child spins in drain_timers at 100% CPU; bound it so the
-    // assertions below fail with a clean diff instead of a runner timeout.
+    // Pre-fix the child spins at 100% CPU; bound it so it doesn't outlive the
+    // runner by long when the parent test times out on the unfixed build.
     timeout: 20_000,
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
@@ -93,4 +93,4 @@ test("real timer heap is ticked against the real clock under useFakeTimers", asy
   // null => exited on its own; non-null => killed by the spawn timeout (spun).
   expect(proc.signalCode).toBeNull();
   expect(exitCode).toBe(0);
-}, 30_000);
+});

--- a/test/js/bun/test/test-timers.test.ts
+++ b/test/js/bun/test/test-timers.test.ts
@@ -1,3 +1,6 @@
+import { bunEnv, bunExe } from "harness";
+import path from "node:path";
+
 test("we can go back in time", () => {
   const DateBeforeMocked = Date;
   const orig = new Date();
@@ -73,3 +76,25 @@ test("setSystemTime accepts pre-epoch and epoch times and resets with no argumen
     jest.useRealTimers();
   }
 });
+
+test(
+  "real timer heap is ticked against the real clock under useFakeTimers",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", path.join(import.meta.dir, "test-timers-gc-spin-fixture.ts")],
+      env: { ...bunEnv, BUN_GC_TIMER_DISABLE: undefined, BUN_GC_TIMER_INTERVAL: undefined },
+      stdout: "pipe",
+      stderr: "pipe",
+      // Pre-fix the child spins in drain_timers at 100% CPU; bound it so the
+      // assertions below fail with a clean diff instead of a runner timeout.
+      timeout: 20_000,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) console.error(stderr);
+    expect(stdout).toContain("DRAIN_OK");
+    // null => exited on its own; non-null => killed by the spawn timeout (spun).
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);


### PR DESCRIPTION
Follow-up to #33359 ([review](https://github.com/oven-sh/bun/pull/33359#discussion_r3556322148)).

## Repro

```ts
jest.useFakeTimers();
for (let i = 0; i < 100; i++) jest.advanceTimersByTime(40 * 24 * 3600 * 1000);
await Bun.file(process.execPath).stat();   // spins at 100% CPU
```

Any `jest.advanceTimersByTime` that pushes the mocked monotonic clock past the machine's `CLOCK_MONOTONIC` uptime, followed by a real I/O await, spins `All::drain_timers` forever. Deterministic on a fresh CI container; on a developer machine it needs an advance larger than uptime.

## Cause

`All::drain_timers` and `All::get_timeout` compared `self.timers` against `Timespec::now(AllowMockedTime)`. That heap holds only `allow_fake_timers()==false` nodes (GC controller, `WTFTimer`, `bun:test` timeouts, `StatWatcherScheduler`) plus anything armed before `useFakeTimers()`, and every one of those arms its deadline with `ForceRealTime`. Once the mocked clock exceeds real uptime, every node looks overdue; any that re-arm on fire (`GcRepeating` unconditionally, `WTFTimer` when JSC's GC scheduler has more work) are re-inserted at `real_uptime + interval`, still less than the cached mocked `now`, and the drain loop never returns.

The `GcRepeating` case is new to #33359 (the GC timers were kernel timerfds before and fired on real time regardless of fake timers). The `WTFTimer` case was latent before that. Reproduces with `BUN_GC_TIMER_DISABLE=1` too, so the fix has to be at the comparison layer, not in `GarbageCollectionController::arm()`.

## Fix

`drain_timers::next()` and `get_timeout` read `ForceRealTime` for `self.timers`. The fake heap is already walked separately by `advanceTimersByTime`, so the two heaps are now ticked against their own clocks. No behavior change when fake timers are not installed (`AllowMockedTime == ForceRealTime` then).

`StatWatcherScheduler::set_timer` was the one `allow_fake_timers()==false` tag that still armed with `AllowMockedTime`; flipped to `ForceRealTime` so its deadlines are in the same units as the heap they live in. The Windows path (`ensure_uv_timer`) already used `ForceRealTime`.

## Verification

`test/js/bun/test/test-timers.test.ts` spawns a `bun test` child that advances mocked time by ~11 years and then awaits file I/O inside the fake-timer window. Without this change the child spins and is killed by the 20s spawn timeout; with it the child exits in ~35ms. Also ran `test/js/bun/test/fake-timers/` (61 pass), `test/js/node/timers/` (20 pass), `test/js/node/watch/fs.watchFile.test.ts` (9 pass), and `rust:check-all` (10/10).