### PR TITLE
test(proxy-stress): cap memory-probe iterations on Windows to avoid ephemeral-port exhaustion

### DIFF
--- a/test/js/bun/http/proxy-stress-concurrent.test.ts
+++ b/test/js/bun/http/proxy-stress-concurrent.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isCI } from "harness";
+import { bunEnv, bunExe, isASAN, isCI, isWindows } from "harness";
 import { once } from "node:events";
 import net from "node:net";
 import { join } from "node:path";
@@ -390,8 +390,14 @@ describe("memory probe (subprocess)", () => {
     mode: MODES,
   })) {
     // ASAN inflates RSS and slows everything down; use fewer iterations
-    // there but still enough to surface a UAF.
-    const iterations = isASAN ? 300 : isCI ? 1200 : 600;
+    // there but still enough to surface a UAF. Windows is capped for a
+    // different reason: 12 concurrent subprocesses x 1200 iterations leave
+    // ~11k loopback TIME_WAIT entries (120s drain), close to the 16384-port
+    // ephemeral range, so later tests in the shard see listen(0) and
+    // connect() hand out the same few ports and hit 4-tuple collisions
+    // with those TIME_WAITs (observed as ERR_POSTGRES_CONNECTION_REFUSED /
+    // WSAENOTCONN in test/js/sql/postgres-binary-array-bounds.test.ts).
+    const iterations = isASAN || isWindows ? 300 : isCI ? 1200 : 600;
 
     test.concurrent(
       `${proxyTls ? "https" : "http"}-proxy → https-origin mode=${mode} ×${iterations}`,


### PR DESCRIPTION
## Problem

Since #33622, `test/js/sql/postgres-binary-array-bounds.test.ts` and `test/js/sql/postgres-invalid-message-length.test.ts` fail on ~80% of PR builds across every Windows lane (x64, x64-baseline, aarch64) with `ERR_POSTGRES_CONNECTION_REFUSED`. Main is unaffected because main does not run Windows test jobs.

## Root cause

`proxy-stress-concurrent.test.ts`'s `memory probe (subprocess)` block spawns 12 concurrent subprocesses that each perform 1200 proxied fetch iterations on CI. Each iteration opens two loopback TCP connections (client->proxy, proxy->origin); the active-closing side enters TIME_WAIT for ~120 s. Measured on Windows Server 2019: ~11,400 TIME_WAIT entries after a single run, against a 16,384-port ephemeral range (49152-65535).

#33622's LPT bin-packing moved this test onto the same Windows shard as the two SQL fault-injection tests (positions ~56 and ~150/151 respectively). By position 151, so few unique ports remain that `listen(0)` hands out the same port several times in a row:

```
[diag-wire] listeningServer addr={"port":50695}   (pass)
[diag-wire] listeningServer addr={"port":50695}   (again)
[diag-native] postgres on_connect_error errno=10057    <- WSAENOTCONN
```

When both the listen port and the client's auto-bound source port are recycled, the new connect's 4-tuple collides with a recent TIME_WAIT entry. Windows answers the SYN from the stale TCB (the new listen socket's accept never fires; `accepted=0`), and the client sees WSAENOTCONN from the post-connect recv probe. Reproduced in isolation by holding ~16,370 loopback connections and cycling `listen(0)`/`connect()`:

```
[0] port=49269 -> ok
[1] port=49282 -> ok
[2] port=49269 (REUSED from [0]) -> ERR_POSTGRES_CONNECTION_REFUSED
[3] port=49282 (REUSED from [1]) -> ERR_POSTGRES_CONNECTION_REFUSED
...
```

`node:net`'s own `connect()` fails identically (`ECONNREFUSED`, `accepted=0`) under the same exhaustion, so this is not a usockets-specific bug.

## Fix

Cap `iterations` to 300 on Windows (the same cap already used under ASAN). This leaves ~3,000 TIME_WAIT entries (verified locally), well under the ephemeral range, and is still enough for the RSS-growth assertion the block exists for.

## Why not SO_REUSEADDR

SO_REUSEADDR on the connecting socket does not help here: the collision is a per-4-tuple TIME_WAIT state, not a per-port bind conflict. Avoiding TIME_WAIT entirely would require `SO_LINGER` with `l_linger=0` (RST on close), which discards in-flight data.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->