### PR TITLE
webcrypto: reject JWK with duplicate key_ops on importKey/unwrapKey

### DIFF
--- a/src/jsc/bindings/webcrypto/SubtleCrypto.cpp
+++ b/src/jsc/bindings/webcrypto/SubtleCrypto.cpp
@@ -547,10 +547,24 @@ static void rejectWithException(Ref<DeferredPromise>&& passedPromise, ExceptionC
     ASSERT_NOT_REACHED();
 }
 
-static void normalizeJsonWebKey(JsonWebKey& webKey)
+// Returns false if key_ops contains duplicate entries. RFC 7517 §4.3 requires
+// "Duplicate key operation values MUST NOT be present in the array"; callers
+// reject with DataError on false.
+static bool normalizeJsonWebKey(JsonWebKey& webKey)
 {
-    // Maybe we shouldn't silently bypass duplicated usages?
-    webKey.usages = webKey.key_ops ? toCryptoKeyUsageBitmap(webKey.key_ops.value()) : 0;
+    if (!webKey.key_ops) {
+        webKey.usages = 0;
+        return true;
+    }
+    CryptoKeyUsageBitmap result = 0;
+    for (auto usage : webKey.key_ops.value()) {
+        auto bit = toCryptoKeyUsageBitmap(usage);
+        if (result & bit)
+            return false;
+        result |= bit;
+    }
+    webKey.usages = result;
+    return true;
 }
 
 // FIXME: This returns an std::optional<KeyData> and takes a promise, rather than returning an
@@ -580,8 +594,11 @@ static std::optional<KeyData> toKeyData(SubtleCrypto::KeyFormat format, SubtleCr
     case SubtleCrypto::KeyFormat::Jwk:
         return std::visit(
             WTF::makeVisitor(
-                [](JsonWebKey& webKey) -> std::optional<KeyData> {
-                    normalizeJsonWebKey(webKey);
+                [&promise](JsonWebKey& webKey) -> std::optional<KeyData> {
+                    if (!normalizeJsonWebKey(webKey)) {
+                        promise->reject(DataError, "Duplicate key operation in JWK \"key_ops\" member"_s);
+                        return std::nullopt;
+                    }
                     return KeyData { webKey };
                 },
                 [&promise](auto&) -> std::optional<KeyData> {
@@ -1321,7 +1338,11 @@ void SubtleCrypto::unwrapKey(JSC::JSGlobalObject& state, KeyFormat format, Buffe
                         promise->reject(Exception { ExistingExceptionError });
                         return;
                     }
-                    normalizeJsonWebKey(jwk);
+                    if (!normalizeJsonWebKey(jwk)) {
+                        weakThis->m_pendingPromises.remove(index);
+                        promise->reject(DataError, "Duplicate key operation in JWK \"key_ops\" member"_s);
+                        return;
+                    }
 
                     keyData = jwk;
                     break;

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -621,9 +621,13 @@ describe("JWK key_ops duplicate values", () => {
         ),
       ),
       hmac: await outcome(
-        crypto.subtle.importKey("jwk", { ...octHmac, key_ops: ["sign", "sign"] }, { name: "HMAC", hash: "SHA-256" }, true, [
-          "sign",
-        ]),
+        crypto.subtle.importKey(
+          "jwk",
+          { ...octHmac, key_ops: ["sign", "sign"] },
+          { name: "HMAC", hash: "SHA-256" },
+          true,
+          ["sign"],
+        ),
       ),
       ec: await outcome(
         crypto.subtle.importKey(
@@ -635,7 +639,9 @@ describe("JWK key_ops duplicate values", () => {
         ),
       ),
       okp: await outcome(
-        crypto.subtle.importKey("jwk", { ...edPub, key_ops: ["verify", "verify"] }, { name: "Ed25519" }, true, ["verify"]),
+        crypto.subtle.importKey("jwk", { ...edPub, key_ops: ["verify", "verify"] }, { name: "Ed25519" }, true, [
+          "verify",
+        ]),
       ),
       rsa: await outcome(
         crypto.subtle.importKey(
@@ -653,9 +659,13 @@ describe("JWK key_ops duplicate values", () => {
         ]),
       ),
       ecNoDup: await outcome(
-        crypto.subtle.importKey("jwk", { ...ecPub, key_ops: ["verify"] }, { name: "ECDSA", namedCurve: "P-256" }, true, [
-          "verify",
-        ]),
+        crypto.subtle.importKey(
+          "jwk",
+          { ...ecPub, key_ops: ["verify"] },
+          { name: "ECDSA", namedCurve: "P-256" },
+          true,
+          ["verify"],
+        ),
       ),
       // The usages argument itself is allowed to contain duplicates; only JWK key_ops is constrained.
       usagesDup: await outcome(

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -584,3 +584,127 @@ describe("X25519 JWK import", () => {
     }).toEqual({ extFalse: "DataError", extTrue: "imported" });
   });
 });
+
+// RFC 7517 §4.3: "Duplicate key operation values MUST NOT be present in the array."
+// WebCrypto importKey step: if key_ops "is invalid according to the requirements of
+// JSON Web Key ... then throw a DataError."
+describe("JWK key_ops duplicate values", () => {
+  const b64u = (b: Uint8Array) => Buffer.from(b).toString("base64url");
+  const outcome = (p: Promise<CryptoKey>) =>
+    p.then(
+      key => (key instanceof CryptoKey ? "imported" : "other"),
+      e => e.name,
+    );
+
+  it("importKey rejects a JWK with duplicate key_ops entries across all key types", async () => {
+    const ec = await crypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, ["sign", "verify"]);
+    const ecPub = await crypto.subtle.exportKey("jwk", ec.publicKey);
+    const ed = await crypto.subtle.generateKey({ name: "Ed25519" }, true, ["sign", "verify"]);
+    const edPub = await crypto.subtle.exportKey("jwk", (ed as CryptoKeyPair).publicKey);
+    const rsa = await crypto.subtle.generateKey(
+      { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]) },
+      true,
+      ["sign", "verify"],
+    );
+    const rsaPub = await crypto.subtle.exportKey("jwk", rsa.publicKey);
+    const octAes: JsonWebKey = { kty: "oct", k: b64u(new Uint8Array(16).fill(9)), ext: true };
+    const octHmac: JsonWebKey = { kty: "oct", k: b64u(new Uint8Array(32).fill(9)), ext: true };
+
+    expect({
+      aes: await outcome(
+        crypto.subtle.importKey(
+          "jwk",
+          { ...octAes, key_ops: ["encrypt", "encrypt", "decrypt"] },
+          { name: "AES-GCM" },
+          true,
+          ["encrypt"],
+        ),
+      ),
+      hmac: await outcome(
+        crypto.subtle.importKey("jwk", { ...octHmac, key_ops: ["sign", "sign"] }, { name: "HMAC", hash: "SHA-256" }, true, [
+          "sign",
+        ]),
+      ),
+      ec: await outcome(
+        crypto.subtle.importKey(
+          "jwk",
+          { ...ecPub, key_ops: ["verify", "verify"] },
+          { name: "ECDSA", namedCurve: "P-256" },
+          true,
+          ["verify"],
+        ),
+      ),
+      okp: await outcome(
+        crypto.subtle.importKey("jwk", { ...edPub, key_ops: ["verify", "verify"] }, { name: "Ed25519" }, true, ["verify"]),
+      ),
+      rsa: await outcome(
+        crypto.subtle.importKey(
+          "jwk",
+          { ...rsaPub, key_ops: ["verify", "verify"] },
+          { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+          true,
+          ["verify"],
+        ),
+      ),
+      // Same JWKs without duplicates still import (prove the rejection is about duplicates, not shape).
+      aesNoDup: await outcome(
+        crypto.subtle.importKey("jwk", { ...octAes, key_ops: ["encrypt", "decrypt"] }, { name: "AES-GCM" }, true, [
+          "encrypt",
+        ]),
+      ),
+      ecNoDup: await outcome(
+        crypto.subtle.importKey("jwk", { ...ecPub, key_ops: ["verify"] }, { name: "ECDSA", namedCurve: "P-256" }, true, [
+          "verify",
+        ]),
+      ),
+      // The usages argument itself is allowed to contain duplicates; only JWK key_ops is constrained.
+      usagesDup: await outcome(
+        crypto.subtle.importKey("raw", new Uint8Array(16).fill(9), { name: "AES-GCM" }, true, [
+          "encrypt",
+          "encrypt",
+          "decrypt",
+        ]),
+      ),
+    }).toEqual({
+      aes: "DataError",
+      hmac: "DataError",
+      ec: "DataError",
+      okp: "DataError",
+      rsa: "DataError",
+      aesNoDup: "imported",
+      ecNoDup: "imported",
+      usagesDup: "imported",
+    });
+  });
+
+  it("unwrapKey rejects a wrapped JWK with duplicate key_ops entries", async () => {
+    const keyData = new Uint8Array(32).fill(1);
+    const iv = new Uint8Array(12).fill(2);
+    const wrapper = await crypto.subtle.importKey("raw", keyData, { name: "AES-GCM" }, false, [
+      "encrypt",
+      "decrypt",
+      "wrapKey",
+      "unwrapKey",
+    ]);
+    const wrap = async (jwk: JsonWebKey) =>
+      crypto.subtle.encrypt({ name: "AES-GCM", iv }, wrapper, new TextEncoder().encode(JSON.stringify(jwk)));
+    const unwrap = (wrapped: ArrayBuffer) =>
+      crypto.subtle.unwrapKey("jwk", wrapped, wrapper, { name: "AES-GCM", iv }, { name: "AES-GCM" }, true, ["encrypt"]);
+
+    const dup: JsonWebKey = {
+      kty: "oct",
+      k: b64u(new Uint8Array(16).fill(9)),
+      ext: true,
+      key_ops: ["encrypt", "encrypt", "decrypt"],
+    };
+    const noDup: JsonWebKey = { ...dup, key_ops: ["encrypt", "decrypt"] };
+
+    expect({
+      dup: await outcome(unwrap(await wrap(dup))),
+      noDup: await outcome(unwrap(await wrap(noDup))),
+    }).toEqual({
+      dup: "DataError",
+      noDup: "imported",
+    });
+  });
+});


### PR DESCRIPTION
## What

`crypto.subtle.importKey("jwk", ...)` and `crypto.subtle.unwrapKey(..., "jwk", ...)` accepted JWKs whose `key_ops` array contains duplicate entries. RFC 7517 section 4.3 states "Duplicate key operation values MUST NOT be present in the array", and the WebCrypto spec requires a `DataError` when `key_ops` is invalid per RFC 7517. Node.js and Chrome both reject these.

## Reproduction

```js
const k = Buffer.from(new Uint8Array(16).fill(9)).toString("base64url");
await crypto.subtle.importKey(
  "jwk",
  { kty: "oct", k, ext: true, key_ops: ["encrypt", "encrypt", "decrypt"] },
  { name: "AES-GCM" },
  true,
  ["encrypt"],
);
// Bun before: resolves with a CryptoKey
// Node 26 / Chrome: DataError "Duplicate key operation"
```

The same gap held for every key class (oct/AES, oct/HMAC, EC, OKP, RSA) and for the `unwrapKey` JWK path.

## Cause

`normalizeJsonWebKey` in `SubtleCrypto.cpp` collapsed `key_ops` directly into a usage bitmap via `toCryptoKeyUsageBitmap`, so by the time the per-class importers (`CryptoKeyAES`, `CryptoKeyEC`, `CryptoKeyHMAC`, `CryptoKeyOKP`, `CryptoKeyRSA`) ran their `(keyData.usages & usages) != usages` check, duplicates were already merged into a single bit and structurally undetectable. The source carried a "Maybe we shouldn't silently bypass duplicated usages?" note at exactly this spot.

## Fix

`normalizeJsonWebKey` now builds the bitmap itself and returns `false` the first time a bit repeats. Both call sites (the `toKeyData` JWK branch used by `importKey`, and the JWK branch inside the `unwrapKey` decrypt callback) reject the promise with `DataError` on that result, matching the surrounding error handling for the adjacent JWK parse failures.

The `usages` argument to `importKey`/`unwrapKey` itself is untouched and still permits duplicates, which matches the spec and Node.

## Verification

New tests in `test/js/web/crypto/web-crypto.test.ts` cover `importKey` across all five key classes, the `unwrapKey` path, the non-duplicate control cases, and that the `usages` argument still accepts duplicates.

```
USE_SYSTEM_BUN=1 bun test test/js/web/crypto/web-crypto.test.ts -t "key_ops duplicate"
  2 fail (aes/hmac/ec/okp/rsa all "imported"; unwrap dup "imported")

bun bd test test/js/web/crypto/web-crypto.test.ts
  25 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/crypto/web-crypto.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (e9e7fbfac)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [5.26ms]
(pass) Web Crypto > keeps event loop alive [555.29ms]
(pass) Web Crypto > has globals [3.22ms]
(pass) Web Crypto > should encrypt and decrypt [14.19ms]
(pass) Web Crypto > should verify and sign [44.96ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [17.19ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [11.61ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [2582.48ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of abort
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (9c0814d55)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [0.07ms]
(pass) Web Crypto > keeps event loop alive [13.19ms]
(pass) Web Crypto > has globals [0.06ms]
(pass) Web Crypto > should encrypt and decrypt [0.41ms]
(pass) Web Crypto > should verify and sign [0.77ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [0.31ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [0.46ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [29.82ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [12.73ms]
(pass) Ed25519 > generateKey > should return CryptoKeys without namedCurve in algorithm field [0.17ms]
(pass) AES-KW wrapKey/unwrapKey with jwk format > round-trips an HMAC SHA-256 key [0.21ms]
(pass) AES-KW wrapKey/unwrapKey with jwk format > round-trips an HMAC SHA-384 key [0.05ms]
(pass) AES-KW wrapKey/unwrapKey with jwk format > round-trips an HMAC SHA-512 key [0.04ms]
(pass) AES-KW wrapKey/unwrapKey with 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/crypto/web-crypto.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (e9e7fbfac)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [4.95ms]
(pass) Web Crypto > keeps event loop alive [470.79ms]
(pass) Web Crypto > has globals [3.15ms]
(pass) Web Crypto > should encrypt and decrypt [13.99ms]
(pass) Web Crypto > should verify and sign [45.27ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [23.46ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [20.03ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [2488.79ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of abort
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 663ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] cxx obj/src/jsc/bindings/webcrypto/SubtleCrypto.cpp.o
[2/8] gen generated_host_exports.rs
generated_host_exports.rs: 90 exports (host=3, lazy=10, generic=77, rust=0); 248 extern-C blocks audited
[3/8] gen cpp.rs (cppbind)
[3/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/sr
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcrypto/SubtleCrypto.cpp |  33 +++++--
 test/js/web/crypto/web-crypto.test.ts       | 134 ++++++++++++++++++++++++++++
 2 files changed, 161 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/jsc/bindings/webcrypto/SubtleCrypto.cpp      4      3      0
test/js/web/crypto/web-crypto.test.ts            1      1      0
```

</details>

<!-- robobun:evidence:end -->