### PR TITLE
webcrypto: validate RSA private key components on JWK import

### DIFF
--- a/src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp
@@ -136,6 +136,9 @@ RefPtr<CryptoKeyRSA> CryptoKeyRSA::create(CryptoAlgorithmIdentifier identifier, 
         iqmp.release();
     }
 
+    if (!RSA_check_key(rsa.get()))
+        return nullptr;
+
     auto pkey = EvpPKeyPtr(EVP_PKEY_new());
     if (!pkey)
         return nullptr;

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -545,6 +545,77 @@ describe("SubtleCrypto.deriveBits length", () => {
   });
 });
 
+// importKey("jwk", ...) for RSA private keys must validate the key material at import
+// time (DataError), not hand back a poisoned CryptoKey whose first sign()/decrypt()
+// fails with OperationError. https://www.w3.org/TR/WebCryptoAPI/#rsassa-pkcs1-operations
+describe("RSA private JWK import validation", () => {
+  const msg = new TextEncoder().encode("hello");
+  const flip = (b64u: string, i: number) => {
+    const b = Buffer.from(b64u, "base64url");
+    b[i] ^= 0xff;
+    return b.toString("base64url");
+  };
+  const mutations = (jwk: JsonWebKey) => ({
+    "p and q swapped": { ...jwk, p: jwk.q, q: jwk.p },
+    "dp corrupted": { ...jwk, dp: flip(jwk.dp!, 4) },
+    "dq corrupted": { ...jwk, dq: flip(jwk.dq!, 4) },
+    "qi corrupted": { ...jwk, qi: flip(jwk.qi!, 3) },
+    "d corrupted": { ...jwk, d: flip(jwk.d!, 10) },
+    "e mismatched with d": { ...jwk, e: "Aw" },
+    "p corrupted (n != p*q)": { ...jwk, p: flip(jwk.p!, 4) },
+  });
+  const outcome = (jwk: JsonWebKey, alg: RsaHashedImportParams, usages: KeyUsage[]) =>
+    crypto.subtle.importKey("jwk", jwk, alg, true, usages).then(
+      key => (key instanceof CryptoKey ? "imported" : "other"),
+      e => e.name,
+    );
+
+  it.each([["RSASSA-PKCS1-v1_5"], ["RSA-PSS"], ["RSA-OAEP"]])(
+    "%s rejects inconsistent private key components with DataError",
+    async name => {
+      const usages: KeyUsage[] = name === "RSA-OAEP" ? ["encrypt", "decrypt"] : ["sign", "verify"];
+      const privUsage: KeyUsage[] = name === "RSA-OAEP" ? ["decrypt"] : ["sign"];
+      const alg = { name, hash: "SHA-256" } as const;
+      const { privateKey } = await crypto.subtle.generateKey(
+        { ...alg, modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]) },
+        true,
+        usages,
+      );
+      const jwk = await crypto.subtle.exportKey("jwk", privateKey);
+
+      const results: Record<string, string> = {};
+      for (const [label, mutated] of Object.entries(mutations(jwk))) {
+        results[label] = await outcome(mutated, alg, privUsage);
+      }
+      expect(results).toEqual({
+        "p and q swapped": "DataError",
+        "dp corrupted": "DataError",
+        "dq corrupted": "DataError",
+        "qi corrupted": "DataError",
+        "d corrupted": "DataError",
+        "e mismatched with d": "DataError",
+        "p corrupted (n != p*q)": "DataError",
+      });
+    },
+  );
+
+  it("still imports, signs and verifies a consistent round-tripped JWK", async () => {
+    const alg = { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" } as const;
+    const { privateKey, publicKey } = await crypto.subtle.generateKey(
+      { ...alg, modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]) },
+      true,
+      ["sign", "verify"],
+    );
+    const jwk = await crypto.subtle.exportKey("jwk", privateKey);
+    const reimported = await crypto.subtle.importKey("jwk", jwk, alg, true, ["sign"]);
+    const sig = await crypto.subtle.sign(alg, reimported, msg);
+    expect(await crypto.subtle.verify(alg, publicKey, sig, msg)).toBe(true);
+
+    const pubJwk = await crypto.subtle.exportKey("jwk", publicKey);
+    expect(await outcome(pubJwk, alg, ["verify"])).toBe("imported");
+  });
+});
+
 describe("X25519 JWK import", () => {
   const x25519Public: JsonWebKey = {
     kty: "OKP",


### PR DESCRIPTION
## Repro

```js
const s = crypto.subtle;
const alg = { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" };
const { privateKey, publicKey } = await s.generateKey(
  { ...alg, modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]) }, true, ["sign", "verify"]);
const jwk = await s.exportKey("jwk", privateKey);
const flip = (b, i) => { const a = Buffer.from(b, "base64url"); a[i] ^= 0xff; return a.toString("base64url"); };
for (const [name, j] of Object.entries({
  "p/q swapped":     { ...jwk, p: jwk.q, q: jwk.p },
  "dp corrupted":    { ...jwk, dp: flip(jwk.dp, 4) },
  "qi corrupted":    { ...jwk, qi: flip(jwk.qi, 3) },
  "e mismatched":    { ...jwk, e: "Aw" },
  "n != p*q":        { ...jwk, p: flip(jwk.p, 4) },
})) {
  try {
    const k = await s.importKey("jwk", j, alg, true, ["sign"]);
    try { await s.sign(alg, k, new Uint8Array(1)); console.log(name, "signed"); }
    catch (e) { console.log(name, "-> POISONED: import ok, sign threw", e.name); }
  } catch (e) { console.log(name, "-> rejected at import:", e.name); }
}
```

On main, all five cases import successfully and then every `sign()`/`decrypt()` throws `OperationError` (`BoringSSL` lazily freezes the key and rejects at first private operation). `exportKey` on the resulting CryptoKey hands the inconsistent material back out. Node 26 rejects the `n != p*q` case at import with `DataError`.

## Cause

`CryptoKeyRSA::create` in `CryptoKeyRSAOpenSSL.cpp` assembles the private key via `RSA_set0_key` / `RSA_set0_factors` / `RSA_set0_crt_params` and wraps it in an `EVP_PKEY` without running any consistency check. The WebCrypto spec puts RSA key-data validation at import time (`DataError`).

The PKCS8 import path already validates: `d2i_PKCS8_PRIV_KEY_INFO` routes through BoringSSL's `RSA_parse_private_key`, which calls `RSA_check_key`. The EC JWK import path calls `EC_KEY_check_key` on every entry. Only the RSA components-from-JWK (and structured-clone deserialization) path skipped it.

## Fix

Call `RSA_check_key` on the assembled key before wrapping it in the `EVP_PKEY`, matching the EC pattern in the same file. BoringSSL's `RSA_check_key` verifies `n = p*q`, `d*e ≡ 1 mod (p-1)` and `mod (q-1)`, and when CRT parameters are present that `dp`, `dq`, `qi` are consistent with `p`, `q`, `d`. Returning `nullptr` surfaces as `DataError` at the call site.

This is stricter than Node for CRT-inconsistent-but-otherwise-valid keys (Node's OpenSSL tolerates them by cross-checking CRT against plain `m^d mod n` at sign time), but it matches the spec, matches Bun's PKCS8 import for the same material, and ensures `importKey` never hands back a key whose first operation is guaranteed to fail.

## Verification

New tests in `test/js/web/crypto/web-crypto.test.ts` exercise seven mutations across RSASSA-PKCS1-v1_5, RSA-PSS and RSA-OAEP, plus a control that a valid exported JWK still re-imports, signs and verifies.

<details>
<summary>output</summary>

```
$ USE_SYSTEM_BUN=1 bun test test/js/web/crypto/web-crypto.test.ts -t "RSA private JWK"
  { "p and q swapped": "imported", "dp corrupted": "imported", ... }
  3 fail

$ bun bd test test/js/web/crypto/web-crypto.test.ts
  27 pass, 0 fail
```

`test/js/deno/crypto/webcrypto.test.ts`, `test/js/bun/crypto/wpt-webcrypto.generateKey.test.ts`, `test/js/node/crypto/crypto.key-objects.test.ts`, and the `test-webcrypto-*` node parallel tests all still pass.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/crypto/web-crypto.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b54053b41)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [4.74ms]
(pass) Web Crypto > keeps event loop alive [475.15ms]
(pass) Web Crypto > has globals [2.98ms]
(pass) Web Crypto > should encrypt and decrypt [14.39ms]
(pass) Web Crypto > should verify and sign [45.64ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [22.71ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [12.24ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [2563.38ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of abort
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (92ddcfe99)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [0.07ms]
(pass) Web Crypto > keeps event loop alive [13.49ms]
(pass) Web Crypto > has globals [0.06ms]
(pass) Web Crypto > should encrypt and decrypt [0.39ms]
(pass) Web Crypto > should verify and sign [0.76ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [0.31ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [0.77ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [32.67ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [13.05ms]
(pass) Ed25519 > generateKey > should return CryptoKeys without namedCurve in algorithm field [0.17ms]
(pass) AES-KW wrapKey/unwrapKey with jwk format > round-trips an HMAC SHA-256 key [0.20ms]
(pass) AES-KW wrapKey/unwrapKey with jwk format > round-trips an HMAC SHA-384 key [0.08ms]
(pass) AES-KW wrapKey/unwrapKey with jwk format > round-trips an HMAC SHA-512 key [0.05ms]
(pass) AES-KW wrapKey/unwrapKey with 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/crypto/web-crypto.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b54053b41)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [4.57ms]
(pass) Web Crypto > keeps event loop alive [471.29ms]
(pass) Web Crypto > has globals [4.00ms]
(pass) Web Crypto > should encrypt and decrypt [15.26ms]
(pass) Web Crypto > should verify and sign [54.25ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [26.50ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [17.90ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [2665.40ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of abort
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 700ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcrypto-1.cpp.o
[2/8] gen generated_host_exports.rs
generated_host_exports.rs: 90 exports (host=3, lazy=10, generic=77, rust=0); 248 extern-C blocks audited
[3/8] gen cpp.rs (cppbind)
[3/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_core v0.0.0 (/works
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp |  3 +
 test/js/web/crypto/web-crypto.test.ts              | 71 ++++++++++++++++++++++
 2 files changed, 74 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp      1      1      0
test/js/web/crypto/web-crypto.test.ts                   2      1      0
```

</details>

<!-- robobun:evidence:end -->