### PR TITLE
s3: replace Callback fn-pointer erasure with static tag dispatch

### DIFF
--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -1281,13 +1281,11 @@ impl<'a> BlobReadChain<'a> {
             outer: jsc::JSPromiseStrong::init(global),
         });
         let promise = chain.outer.value();
-        // `read_bytes_to_handler` stores the handler pointer and calls
-        // `on_read_bytes` on the JS thread (sync for in-memory, async for
-        // file/S3). Ownership of the chain transfers there; the trait impl
-        // below reconstructs the Box and frees it.
-        // `read_bytes_to_handler` stores the pointer across an async hop; the
-        // `'a` borrow of `global` is a JSC_BORROW (process-lifetime) so the
-        // `'static` erasure is sound.
+        // `read_bytes_to_handler` stores the pointer and calls `on_read_bytes`
+        // on the JS thread (sync for in-memory, async for file/S3). Ownership
+        // of the chain transfers there; `on_read_bytes` below reconstructs the
+        // Box and frees it. The `'a` borrow of `global` is a JSC_BORROW
+        // (process-lifetime) so the `'static` erasure is sound.
         let raw = bun_core::heap::into_raw(chain).cast::<BlobReadChain<'static>>();
         // SAFETY: `raw` is freshly leaked and uniquely owned by the read
         // dispatch; reclaimed in `BlobReadChain::on_read_bytes`.

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -14,8 +14,8 @@ use core::mem;
 use crate::generated_classes::PropertyName;
 use crate::webcore::Blob;
 use crate::webcore::BlobExt as _;
+use crate::webcore::blob::ReadBytesResult;
 use crate::webcore::blob::store as blob_store;
-use crate::webcore::blob::{ReadBytesHandler, ReadBytesResult};
 use crate::webcore::node_types::PathOrFileDescriptor;
 use bun_core::ZBox;
 use bun_core::base64;
@@ -1234,7 +1234,7 @@ impl Image {
 /// Promise-of-promise flattens, so the caller sees one `await` for
 /// read+decode+ops+encode. After the first read, subsequent terminals on the
 /// same instance reuse the `.owned` bytes without re-reading.
-struct BlobReadChain<'a> {
+pub struct BlobReadChain<'a> {
     image: *const Image,
     global: &'a JSGlobalObject,
     kind: Kind,
@@ -1285,10 +1285,13 @@ impl<'a> BlobReadChain<'a> {
         // `on_read_bytes` on the JS thread (sync for in-memory, async for
         // file/S3). Ownership of the chain transfers there; the trait impl
         // below reconstructs the Box and frees it.
-        let raw = bun_core::heap::into_raw(chain);
+        // `read_bytes_to_handler` stores the pointer across an async hop; the
+        // `'a` borrow of `global` is a JSC_BORROW (process-lifetime) so the
+        // `'static` erasure is sound.
+        let raw = bun_core::heap::into_raw(chain).cast::<BlobReadChain<'static>>();
         // SAFETY: `raw` is freshly leaked and uniquely owned by the read
-        // dispatch; reclaimed in `<BlobReadChain as ReadBytesHandler>::on_read_bytes`.
-        unsafe { blob.read_bytes_to_handler(&raw mut *raw, global) }.map_err(jsc::JsError::from)?;
+        // dispatch; reclaimed in `BlobReadChain::on_read_bytes`.
+        unsafe { blob.read_bytes_to_handler(raw, global) }.map_err(jsc::JsError::from)?;
         Ok(promise)
     }
 
@@ -1360,8 +1363,8 @@ impl<'a> BlobReadChain<'a> {
     }
 }
 
-impl<'a> ReadBytesHandler for BlobReadChain<'a> {
-    fn on_read_bytes(&mut self, result: ReadBytesResult) {
+impl<'a> BlobReadChain<'a> {
+    pub(crate) fn on_read_bytes(&mut self, result: ReadBytesResult) {
         // SAFETY: `self` is the `&mut *heap::alloc(chain)` handed to
         // `read_bytes_to_handler` in `start()`; we are the sole consumer on
         // the JS thread. Reconstruct the Box so the body can move fields out

--- a/src/runtime/image/mod.rs
+++ b/src/runtime/image/mod.rs
@@ -57,6 +57,7 @@ pub mod thumbhash;
 
 #[path = "Image.rs"]
 pub mod image_body;
+pub use image_body::BlobReadChain;
 pub use image_body::{
     AsyncImageTask, Deliver, Fit, Image, Input, Kind, Modulate, Pipeline, PipelineTask, Resize,
     Source, TaskResult,

--- a/src/runtime/server/AnyRequestContext.rs
+++ b/src/runtime/server/AnyRequestContext.rs
@@ -236,4 +236,11 @@ impl AnyRequestContext {
     pub fn deref(self) {
         dispatch!(self, (), |_T, ctx| ctx.deref())
     }
+
+    pub(crate) fn on_s3_stat_resolved(
+        self,
+        result: crate::webcore::s3::simple_request::S3StatResult<'_>,
+    ) {
+        dispatch!(self, (), |T, ctx| T::on_s3_size_resolved(result, ctx))
+    }
 }

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2446,16 +2446,6 @@ where
         // (`on_s3_size_resolved`) releases the ref taken for the S3 stat.
     }
 
-    /// `S3::client::stat` callback shape: `fn(S3StatResult, *mut c_void) -> JsTerminatedResult<()>`.
-    fn on_s3_size_resolved_thunk(
-        result: S3::simple_request::S3StatResult<'_>,
-        this: *mut c_void,
-    ) -> Result<(), jsc::JsTerminated> {
-        // SAFETY: this is the *mut Self registered with stat().
-        Self::on_s3_size_resolved(result, unsafe { bun_ptr::callback_ctx::<Self>(this) });
-        Ok(())
-    }
-
     pub fn on_s3_size_resolved(result: S3::simple_request::S3StatResult<'_>, this: &mut Self) {
         if let Some(resp) = this.resp {
             let size = match result {
@@ -2605,8 +2595,9 @@ where
                     let _ = S3::client::stat(
                         credentials,
                         path,
-                        Self::on_s3_size_resolved_thunk,
-                        std::ptr::from_mut::<Self>(this).cast::<c_void>(),
+                        S3::client::Callback::HeadResponseSize(AnyRequestContext::init(
+                            std::ptr::from_mut::<Self>(this),
+                        )),
                         proxy_url,
                         s3.request_payer,
                     ); // TODO: properly propagate exception upwards

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4586,10 +4586,11 @@ fn write_file_with_empty_source_to_destination(
             let promise_value = promise.value();
             let proxy_owned = http_proxy_href(ctx);
             let proxy_url = proxy_owned.as_deref();
-            let wrapper = bun_core::heap::into_raw(Box::new(S3BlobUploadEmptyTask {
+            let wrapper = bun_core::heap::into_raw(Box::new(S3BlobUploadTask {
                 promise,
                 store: destination_store.clone(),
                 global: bun_ptr::BackRef::new(ctx),
+                resolved_size: 0.0,
             }));
             s3_client::upload(
                 &aws_options.credentials,
@@ -4604,7 +4605,7 @@ fn write_file_with_empty_source_to_destination(
                 proxy_url,
                 aws_options.storage_class,
                 aws_options.request_payer,
-                s3_client::Callback::BlobUploadEmpty(wrapper),
+                s3_client::Callback::BlobUpload(wrapper),
             )?;
             return Ok(promise_value);
         }
@@ -4831,10 +4832,11 @@ pub fn write_file_with_source_destination(
                 } else {
                     let promise = jsc::JSPromiseStrong::init(ctx);
                     let promise_value = promise.value();
-                    let wrapper = bun_core::heap::into_raw(Box::new(S3BlobUploadBytesTask {
+                    let wrapper = bun_core::heap::into_raw(Box::new(S3BlobUploadTask {
                         store: source_store.clone(),
                         promise,
                         global: bun_ptr::BackRef::new(ctx),
+                        resolved_size: bytes.len() as f64,
                     }));
                     s3_client::upload(
                         &aws_options.credentials,
@@ -4849,7 +4851,7 @@ pub fn write_file_with_source_destination(
                         proxy_url,
                         aws_options.storage_class,
                         aws_options.request_payer,
-                        s3_client::Callback::BlobUploadBytes(wrapper),
+                        s3_client::Callback::BlobUpload(wrapper),
                     )?;
                     return Ok(promise_value);
                 }
@@ -5700,34 +5702,19 @@ pub struct S3ReadBytesTask {
 }
 
 impl S3ReadBytesTask {
-    fn done(mut self: Box<Self>, r: ReadBytesResult) {
-        self.poll.unref(bun_io::js_vm_ctx());
-        self.blob.deinit();
-        // SAFETY: caller-owned ctx, kept alive by contract.
-        let c = unsafe { &mut *self.ctx };
-        drop(self);
-        c.on_read_bytes(r);
-    }
-
     pub(crate) fn on_download(
         result: crate::webcore::__s3_client::S3DownloadResult,
         this: *mut Self,
     ) -> JsTerminatedResult<()> {
         // SAFETY: `this` was heap-allocated in `read_bytes_to_handler`.
-        let t = unsafe { bun_core::heap::take(this) };
-        match result {
-            // `body` is owned by us (simple_request.rs); take the Vec's items as-is.
+        let mut t = unsafe { bun_core::heap::take(this) };
+        let r = match result {
             crate::webcore::__s3_client::S3DownloadResult::Success(response) => {
-                t.done(ReadBytesResult::Ok(response.body.list));
+                ReadBytesResult::Ok(response.body.list)
             }
-            // S3Error has its own JS-error builder; flatten to a
-            // SystemError so the callback has one shape to handle.
             crate::webcore::__s3_client::S3DownloadResult::NotFound(e)
             | crate::webcore::__s3_client::S3DownloadResult::Failure(e) => {
-                // reshaped for borrowck — `t.done` moves
-                // `t`, so build the SystemError (cloning the path
-                // out of `t.blob.store`) before the call.
-                let err = bun_jsc::SystemError {
+                ReadBytesResult::Err(Box::new(bun_jsc::SystemError {
                     code: BunString::clone_utf8(e.code),
                     message: BunString::clone_utf8(e.message),
                     path: BunString::clone_utf8(
@@ -5735,62 +5722,36 @@ impl S3ReadBytesTask {
                     ),
                     syscall: BunString::static_("fetch"),
                     ..Default::default()
-                };
-                t.done(ReadBytesResult::Err(Box::new(err)));
+                }))
             }
-        }
+        };
+        t.poll.unref(bun_io::js_vm_ctx());
+        t.blob.deinit();
+        // SAFETY: caller-owned ctx, kept alive by contract.
+        let c = unsafe { &mut *t.ctx };
+        drop(t);
+        c.on_read_bytes(r);
         Ok(())
     }
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// S3BlobUpload{Empty,Bytes}Task — Bun.write(s3file, …) single-PUT paths.
-// ──────────────────────────────────────────────────────────────────────────
-
-pub struct S3BlobUploadEmptyTask {
+/// Bun.write(s3file, …) single-PUT paths (empty and bytes sources).
+pub struct S3BlobUploadTask {
     promise: jsc::JSPromiseStrong,
     store: StoreRef,
     global: bun_ptr::BackRef<JSGlobalObject>,
+    resolved_size: f64,
 }
 
-impl S3BlobUploadEmptyTask {
+impl S3BlobUploadTask {
     pub(crate) fn resolve(result: S3UploadResult, this: *mut Self) -> jsc::JsTerminatedResult<()> {
-        // SAFETY: `this` was heap-allocated in `write_file_with_empty_source_to_destination`.
-        let mut this = unsafe { bun_core::heap::take(this) };
-        let global = this.global.get();
-        match result {
-            S3UploadResult::Success => this.promise.resolve(global, JSValue::js_number(0.0))?,
-            S3UploadResult::Failure(err) => {
-                let err_js = s3_client::error_jsc::s3_error_to_js_with_async_stack(
-                    &err,
-                    global,
-                    this.store.get_path(),
-                    this.promise.get(),
-                );
-                this.promise.reject(global, Ok(err_js))?;
-            }
-        }
-        Ok(())
-    }
-}
-
-pub struct S3BlobUploadBytesTask {
-    store: StoreRef,
-    promise: jsc::JSPromiseStrong,
-    global: bun_ptr::BackRef<JSGlobalObject>,
-}
-
-impl S3BlobUploadBytesTask {
-    pub(crate) fn resolve(result: S3UploadResult, this: *mut Self) -> jsc::JsTerminatedResult<()> {
-        // SAFETY: `this` was heap-allocated in `write_file_with_source_destination`.
+        // SAFETY: `this` was heap-allocated at the `s3_client::upload` call site.
         let mut this = unsafe { bun_core::heap::take(this) };
         let global = this.global.get();
         match result {
             S3UploadResult::Success => {
-                this.promise.resolve(
-                    global,
-                    JSValue::js_number(this.store.data.as_bytes().len() as f64),
-                )?;
+                this.promise
+                    .resolve(global, JSValue::js_number(this.resolved_size))?;
             }
             S3UploadResult::Failure(err) => {
                 let err_js = s3_client::error_jsc::s3_error_to_js_with_async_stack(

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -579,7 +579,7 @@ impl BlobExt for Blob {
                 payer = s3.request_payer;
             }
             // SAFETY: `path` borrows the store held by `t.blob` (a fresh +1 ref);
-            // it stays valid until `S3ReadBytesTask::done` deinits the blob in the callback.
+            // it stays valid until `S3ReadBytesTask::on_download` deinits the blob.
             let path = unsafe { &*path };
             let t_ptr = bun_core::heap::into_raw(t);
             if self.offset.get() > 0 || self.size.get() != MAX_SIZE {

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -86,17 +86,11 @@ pub(crate) fn is_valid_blob_type(slice: &[u8]) -> bool {
     slice.iter().all(|&c| matches!(c, 0x20..=0x7E))
 }
 
-/// Result delivered to `ReadBytesHandler::on_read_bytes`.
+/// Result delivered to `BlobReadChain::on_read_bytes`.
 pub enum ReadBytesResult {
     /// global-allocator-owned by the callback.
     Ok(Vec<u8>),
     Err(Box<bun_jsc::SystemError>),
-}
-
-/// Handler trait for `read_bytes_to_handler` — the body only requires
-/// `on_read_bytes`.
-pub trait ReadBytesHandler {
-    fn on_read_bytes(&mut self, result: ReadBytesResult);
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -146,11 +140,11 @@ pub trait BlobExt {
     ) -> JsTerminatedResult<JSValue>;
     fn do_read_file<F: read_file::ReadFileToJs>(&self, global: &JSGlobalObject) -> JSValue;
     /// # Safety
-    /// `ctx` must be a valid, exclusively-accessible `*mut H` that stays alive
-    /// until `H::on_read_bytes` is invoked (synchronously or via the async task).
-    unsafe fn read_bytes_to_handler<H: ReadBytesHandler>(
+    /// `ctx` must be a valid, exclusively-accessible heap pointer that stays alive
+    /// until `BlobReadChain::on_read_bytes` is invoked (synchronously or via the async task).
+    unsafe fn read_bytes_to_handler(
         &self,
-        ctx: *mut H,
+        ctx: *mut crate::image::BlobReadChain<'static>,
         global: &JSGlobalObject,
     ) -> JsTerminatedResult<()>;
     fn do_image(_this: &Self, global: &JSGlobalObject, cf: &CallFrame) -> JsResult<JSValue>
@@ -532,87 +526,36 @@ impl BlobExt for Blob {
     /// only call this when it's empty.
     ///
     /// # Safety
-    /// `ctx` must be a valid, exclusively-accessible `*mut H` that stays alive
-    /// until `H::on_read_bytes` is invoked.
-    unsafe fn read_bytes_to_handler<H: ReadBytesHandler>(
+    /// `ctx` must be a valid, exclusively-accessible heap pointer that stays alive
+    /// until `BlobReadChain::on_read_bytes` is invoked.
+    unsafe fn read_bytes_to_handler(
         &self,
-        ctx: *mut H,
+        ctx: *mut crate::image::BlobReadChain<'static>,
         global: &JSGlobalObject,
     ) -> JsTerminatedResult<()> {
+        use crate::image::BlobReadChain;
         if self.needs_to_read_file() {
-            struct Adapter<H>(core::marker::PhantomData<H>);
-            impl<H: ReadBytesHandler> InternalReadFileFn<H> for Adapter<H> {
-                fn call(c: *mut H, r: read_file::ReadFileResultType) {
-                    // SAFETY: `c` is the `*mut H` passed by the caller and kept
+            struct Adapter;
+            impl InternalReadFileFn<BlobReadChain<'static>> for Adapter {
+                fn call(c: *mut BlobReadChain<'static>, r: read_file::ReadFileResultType) {
+                    // SAFETY: `c` is the pointer passed by the caller and kept
                     // alive across the async read by contract.
                     let c = unsafe { &mut *c };
-                    H::on_read_bytes(
-                        c,
-                        match r {
+                    c.on_read_bytes(match r {
+                        read_file::ReadFileResultType::Result(b) => {
                             // SAFETY: `buf` is `Box::<[u8]>::into_raw` from the
                             // ReadFile finisher; reclaim ownership here.
-                            read_file::ReadFileResultType::Result(b) => ReadBytesResult::Ok(
-                                unsafe { bun_core::heap::take(b.buf) }.into_vec(),
-                            ),
-                            read_file::ReadFileResultType::Err(e) => {
-                                ReadBytesResult::Err(Box::new(e))
-                            }
-                        },
-                    );
+                            ReadBytesResult::Ok(unsafe { bun_core::heap::take(b.buf) }.into_vec())
+                        }
+                        read_file::ReadFileResultType::Err(e) => ReadBytesResult::Err(Box::new(e)),
+                    });
                 }
             }
-            self.do_read_file_internal::<H, Adapter<H>>(ctx, global);
+            self.do_read_file_internal::<BlobReadChain<'static>, Adapter>(ctx, global);
             return Ok(());
         }
         if self.is_s3() {
-            struct Task<H> {
-                ctx: *mut H,
-                blob: Blob, // dupe for store ref + offset/size
-                poll: bun_io::KeepAlive,
-            }
-            impl<H: ReadBytesHandler> Task<H> {
-                fn done(mut self: Box<Self>, r: ReadBytesResult) {
-                    self.poll.unref(bun_io::js_vm_ctx());
-                    self.blob.deinit();
-                    // SAFETY: caller-owned ctx, kept alive by contract.
-                    let c = unsafe { &mut *self.ctx };
-                    drop(self);
-                    H::on_read_bytes(c, r);
-                }
-                fn cb(
-                    result: crate::webcore::__s3_client::S3DownloadResult,
-                    opaque_self: *mut c_void,
-                ) -> JsTerminatedResult<()> {
-                    // SAFETY: `opaque_self` was heap-allocated below.
-                    let t = unsafe { bun_core::heap::take(opaque_self.cast::<Task<H>>()) };
-                    match result {
-                        // `body` is owned by us (simple_request.rs); take the Vec's items as-is.
-                        crate::webcore::__s3_client::S3DownloadResult::Success(response) => {
-                            t.done(ReadBytesResult::Ok(response.body.list));
-                        }
-                        // S3Error has its own JS-error builder; flatten to a
-                        // SystemError so the callback has one shape to handle.
-                        crate::webcore::__s3_client::S3DownloadResult::NotFound(e)
-                        | crate::webcore::__s3_client::S3DownloadResult::Failure(e) => {
-                            // reshaped for borrowck — `t.done` moves
-                            // `t`, so build the SystemError (cloning the path
-                            // out of `t.blob.store`) before the call.
-                            let err = bun_jsc::SystemError {
-                                code: BunString::clone_utf8(e.code),
-                                message: BunString::clone_utf8(e.message),
-                                path: BunString::clone_utf8(
-                                    t.blob.store().and_then(|s| s.get_path()).unwrap_or(b""),
-                                ),
-                                syscall: BunString::static_("fetch"),
-                                ..Default::default()
-                            };
-                            t.done(ReadBytesResult::Err(Box::new(err)));
-                        }
-                    }
-                    Ok(())
-                }
-            }
-            let mut t = Box::new(Task::<H> {
+            let mut t = Box::new(S3ReadBytesTask {
                 ctx,
                 blob: self.dupe(),
                 poll: bun_io::KeepAlive::default(),
@@ -636,9 +579,9 @@ impl BlobExt for Blob {
                 payer = s3.request_payer;
             }
             // SAFETY: `path` borrows the store held by `t.blob` (a fresh +1 ref);
-            // it stays valid until `Task::done` deinits the blob in the callback.
+            // it stays valid until `S3ReadBytesTask::done` deinits the blob in the callback.
             let path = unsafe { &*path };
-            let t_ptr = bun_core::heap::into_raw(t).cast::<c_void>();
+            let t_ptr = bun_core::heap::into_raw(t);
             if self.offset.get() > 0 || self.size.get() != MAX_SIZE {
                 let len: Option<usize> = if self.size.get() != MAX_SIZE {
                     Some(self.size.get() as usize)
@@ -650,8 +593,7 @@ impl BlobExt for Blob {
                     path,
                     self.offset.get() as usize,
                     len,
-                    Task::<H>::cb,
-                    t_ptr,
+                    crate::webcore::__s3_client::Callback::BlobReadBytes(t_ptr),
                     proxy.as_deref(),
                     payer,
                 )?;
@@ -659,8 +601,7 @@ impl BlobExt for Blob {
                 crate::webcore::__s3_client::download(
                     &cred,
                     path,
-                    Task::<H>::cb,
-                    t_ptr,
+                    crate::webcore::__s3_client::Callback::BlobReadBytes(t_ptr),
                     proxy.as_deref(),
                     payer,
                 )?;
@@ -671,7 +612,7 @@ impl BlobExt for Blob {
         let view = self.shared_view();
         let owned = view.to_vec();
         // SAFETY: caller-owned ctx.
-        H::on_read_bytes(unsafe { &mut *ctx }, ReadBytesResult::Ok(owned));
+        unsafe { &mut *ctx }.on_read_bytes(ReadBytesResult::Ok(owned));
         Ok(())
     }
 
@@ -4641,41 +4582,15 @@ fn write_file_with_empty_source_to_destination(
                 }
             };
 
-            struct Wrapper {
-                promise: jsc::JSPromiseStrong,
-                store: StoreRef,
-                global: bun_ptr::BackRef<JSGlobalObject>,
-            }
-            impl Wrapper {
-                fn resolve(
-                    result: S3UploadResult,
-                    opaque_this: *mut c_void,
-                ) -> jsc::JsTerminatedResult<()> {
-                    // SAFETY: opaque_this was heap-allocated in the caller below.
-                    let mut this = unsafe { bun_core::heap::take(opaque_this.cast::<Wrapper>()) };
-                    let global = this.global.get();
-                    match result {
-                        S3UploadResult::Success => {
-                            this.promise.resolve(global, JSValue::js_number(0.0))?
-                        }
-                        S3UploadResult::Failure(err) => {
-                            let err_js = s3_client::error_jsc::s3_error_to_js_with_async_stack(
-                                &err,
-                                global,
-                                this.store.get_path(),
-                                this.promise.get(),
-                            );
-                            this.promise.reject(global, Ok(err_js))?;
-                        }
-                    }
-                    Ok(())
-                }
-            }
-
             let promise = jsc::JSPromiseStrong::init(ctx);
             let promise_value = promise.value();
             let proxy_owned = http_proxy_href(ctx);
             let proxy_url = proxy_owned.as_deref();
+            let wrapper = bun_core::heap::into_raw(Box::new(S3BlobUploadEmptyTask {
+                promise,
+                store: destination_store.clone(),
+                global: bun_ptr::BackRef::new(ctx),
+            }));
             s3_client::upload(
                 &aws_options.credentials,
                 s3.path(),
@@ -4689,13 +4604,7 @@ fn write_file_with_empty_source_to_destination(
                 proxy_url,
                 aws_options.storage_class,
                 aws_options.request_payer,
-                Wrapper::resolve,
-                bun_core::heap::into_raw(Box::new(Wrapper {
-                    promise,
-                    store: destination_store.clone(),
-                    global: bun_ptr::BackRef::new(ctx),
-                }))
-                .cast::<c_void>(),
+                s3_client::Callback::BlobUploadEmpty(wrapper),
             )?;
             return Ok(promise_value);
         }
@@ -4920,43 +4829,13 @@ pub fn write_file_with_source_destination(
                         ));
                     }
                 } else {
-                    struct Wrapper {
-                        store: StoreRef,
-                        promise: jsc::JSPromiseStrong,
-                        global: bun_ptr::BackRef<JSGlobalObject>,
-                    }
-                    impl Wrapper {
-                        fn resolve(
-                            result: S3UploadResult,
-                            opaque_self: *mut c_void,
-                        ) -> jsc::JsTerminatedResult<()> {
-                            // SAFETY: opaque_self is the heap::alloc(Wrapper) we passed to S3::upload below.
-                            let mut this =
-                                unsafe { bun_core::heap::take(opaque_self.cast::<Wrapper>()) };
-                            let global = this.global.get();
-                            match result {
-                                S3UploadResult::Success => {
-                                    this.promise.resolve(
-                                        global,
-                                        JSValue::js_number(this.store.data.as_bytes().len() as f64),
-                                    )?;
-                                }
-                                S3UploadResult::Failure(err) => {
-                                    let err_js =
-                                        s3_client::error_jsc::s3_error_to_js_with_async_stack(
-                                            &err,
-                                            global,
-                                            this.store.get_path(),
-                                            this.promise.get(),
-                                        );
-                                    this.promise.reject(global, Ok(err_js))?;
-                                }
-                            }
-                            Ok(())
-                        }
-                    }
                     let promise = jsc::JSPromiseStrong::init(ctx);
                     let promise_value = promise.value();
+                    let wrapper = bun_core::heap::into_raw(Box::new(S3BlobUploadBytesTask {
+                        store: source_store.clone(),
+                        promise,
+                        global: bun_ptr::BackRef::new(ctx),
+                    }));
                     s3_client::upload(
                         &aws_options.credentials,
                         s3.path(),
@@ -4970,13 +4849,7 @@ pub fn write_file_with_source_destination(
                         proxy_url,
                         aws_options.storage_class,
                         aws_options.request_payer,
-                        Wrapper::resolve,
-                        bun_core::heap::into_raw(Box::new(Wrapper {
-                            store: source_store.clone(),
-                            promise,
-                            global: bun_ptr::BackRef::new(ctx),
-                        }))
-                        .cast::<c_void>(),
+                        s3_client::Callback::BlobUploadBytes(wrapper),
                     )?;
                     return Ok(promise_value);
                 }
@@ -5817,6 +5690,123 @@ pub fn to_stream_with_offset(
 // no dedicated wrap helper is needed at each call site.
 
 // ──────────────────────────────────────────────────────────────────────────
+// S3ReadBytesTask — S3 arm of `read_bytes_to_handler`.
+// ──────────────────────────────────────────────────────────────────────────
+
+pub struct S3ReadBytesTask {
+    ctx: *mut crate::image::BlobReadChain<'static>,
+    blob: Blob, // dupe for store ref + offset/size
+    poll: bun_io::KeepAlive,
+}
+
+impl S3ReadBytesTask {
+    fn done(mut self: Box<Self>, r: ReadBytesResult) {
+        self.poll.unref(bun_io::js_vm_ctx());
+        self.blob.deinit();
+        // SAFETY: caller-owned ctx, kept alive by contract.
+        let c = unsafe { &mut *self.ctx };
+        drop(self);
+        c.on_read_bytes(r);
+    }
+
+    pub(crate) fn on_download(
+        result: crate::webcore::__s3_client::S3DownloadResult,
+        this: *mut Self,
+    ) -> JsTerminatedResult<()> {
+        // SAFETY: `this` was heap-allocated in `read_bytes_to_handler`.
+        let t = unsafe { bun_core::heap::take(this) };
+        match result {
+            // `body` is owned by us (simple_request.rs); take the Vec's items as-is.
+            crate::webcore::__s3_client::S3DownloadResult::Success(response) => {
+                t.done(ReadBytesResult::Ok(response.body.list));
+            }
+            // S3Error has its own JS-error builder; flatten to a
+            // SystemError so the callback has one shape to handle.
+            crate::webcore::__s3_client::S3DownloadResult::NotFound(e)
+            | crate::webcore::__s3_client::S3DownloadResult::Failure(e) => {
+                // reshaped for borrowck — `t.done` moves
+                // `t`, so build the SystemError (cloning the path
+                // out of `t.blob.store`) before the call.
+                let err = bun_jsc::SystemError {
+                    code: BunString::clone_utf8(e.code),
+                    message: BunString::clone_utf8(e.message),
+                    path: BunString::clone_utf8(
+                        t.blob.store().and_then(|s| s.get_path()).unwrap_or(b""),
+                    ),
+                    syscall: BunString::static_("fetch"),
+                    ..Default::default()
+                };
+                t.done(ReadBytesResult::Err(Box::new(err)));
+            }
+        }
+        Ok(())
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// S3BlobUpload{Empty,Bytes}Task — Bun.write(s3file, …) single-PUT paths.
+// ──────────────────────────────────────────────────────────────────────────
+
+pub struct S3BlobUploadEmptyTask {
+    promise: jsc::JSPromiseStrong,
+    store: StoreRef,
+    global: bun_ptr::BackRef<JSGlobalObject>,
+}
+
+impl S3BlobUploadEmptyTask {
+    pub(crate) fn resolve(result: S3UploadResult, this: *mut Self) -> jsc::JsTerminatedResult<()> {
+        // SAFETY: `this` was heap-allocated in `write_file_with_empty_source_to_destination`.
+        let mut this = unsafe { bun_core::heap::take(this) };
+        let global = this.global.get();
+        match result {
+            S3UploadResult::Success => this.promise.resolve(global, JSValue::js_number(0.0))?,
+            S3UploadResult::Failure(err) => {
+                let err_js = s3_client::error_jsc::s3_error_to_js_with_async_stack(
+                    &err,
+                    global,
+                    this.store.get_path(),
+                    this.promise.get(),
+                );
+                this.promise.reject(global, Ok(err_js))?;
+            }
+        }
+        Ok(())
+    }
+}
+
+pub struct S3BlobUploadBytesTask {
+    store: StoreRef,
+    promise: jsc::JSPromiseStrong,
+    global: bun_ptr::BackRef<JSGlobalObject>,
+}
+
+impl S3BlobUploadBytesTask {
+    pub(crate) fn resolve(result: S3UploadResult, this: *mut Self) -> jsc::JsTerminatedResult<()> {
+        // SAFETY: `this` was heap-allocated in `write_file_with_source_destination`.
+        let mut this = unsafe { bun_core::heap::take(this) };
+        let global = this.global.get();
+        match result {
+            S3UploadResult::Success => {
+                this.promise.resolve(
+                    global,
+                    JSValue::js_number(this.store.data.as_bytes().len() as f64),
+                )?;
+            }
+            S3UploadResult::Failure(err) => {
+                let err_js = s3_client::error_jsc::s3_error_to_js_with_async_stack(
+                    &err,
+                    global,
+                    this.store.get_path(),
+                    this.promise.get(),
+                );
+                this.promise.reject(global, Ok(err_js))?;
+            }
+        }
+        Ok(())
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
 // S3BlobDownloadTask
 // ──────────────────────────────────────────────────────────────────────────
 
@@ -5840,10 +5830,7 @@ impl S3BlobDownloadTask {
     /// # Safety
     /// `this` must be the heap-allocated task produced by [`S3BlobDownloadTask::init`];
     /// ownership is consumed (the box is reclaimed and dropped) by this call.
-    // S3 callback ABI hands us a raw `*mut Self`; ownership is reclaimed below via
-    // `heap::take`, so the param stays a raw pointer rather than `&mut`.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub fn on_s3_download_resolved(
+    pub(crate) fn on_s3_download_resolved(
         result: crate::webcore::__s3_client::S3DownloadResult,
         this: *mut S3BlobDownloadTask,
     ) -> Result<(), jsc::JsTerminated> {
@@ -5922,15 +5909,6 @@ impl S3BlobDownloadTask {
         let proxy_owned = http_proxy_href(global_this);
         let proxy = proxy_owned.as_deref();
 
-        // Adapter: S3 download callback ABI takes `*mut c_void` context — cast
-        // back to the boxed task.
-        fn s3_cb(
-            result: crate::webcore::__s3_client::S3DownloadResult<'_>,
-            ctx: *mut c_void,
-        ) -> Result<(), jsc::JsTerminated> {
-            S3BlobDownloadTask::on_s3_download_resolved(result, ctx.cast::<S3BlobDownloadTask>())
-        }
-
         if blob.offset.get() > 0 {
             let len: Option<usize> = if blob.size.get() != MAX_SIZE {
                 Some(usize::try_from(blob.size.get()).expect("int cast"))
@@ -5943,8 +5921,7 @@ impl S3BlobDownloadTask {
                 path,
                 offset,
                 len,
-                s3_cb,
-                this.cast::<c_void>(),
+                crate::webcore::__s3_client::Callback::BlobDownload(this),
                 proxy,
                 s3_store.request_payer,
             )?;
@@ -5952,8 +5929,7 @@ impl S3BlobDownloadTask {
             crate::webcore::__s3_client::download(
                 credentials,
                 path,
-                s3_cb,
-                this.cast::<c_void>(),
+                crate::webcore::__s3_client::Callback::BlobDownload(this),
                 proxy,
                 s3_store.request_payer,
             )?;
@@ -5965,8 +5941,7 @@ impl S3BlobDownloadTask {
                 path,
                 offset,
                 Some(len),
-                s3_cb,
-                this.cast::<c_void>(),
+                crate::webcore::__s3_client::Callback::BlobDownload(this),
                 proxy,
                 s3_store.request_payer,
             )?;

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -468,7 +468,7 @@ fn construct_s3_file_internal(
     )?))
 }
 
-pub(crate) struct S3BlobStatTask {
+pub struct S3BlobStatTask {
     promise: bun_jsc::JSPromiseStrong,
     // LIFETIMES.tsv: JSC_BORROW (&JSGlobalObject). `BackRef` so the heap task
     // can outlive the constructing frame while reads stay safe.
@@ -483,10 +483,10 @@ impl S3BlobStatTask {
 
     pub(crate) fn on_s3_exists_resolved(
         result: s3::S3StatResult,
-        this: *mut core::ffi::c_void,
+        this: *mut S3BlobStatTask,
     ) -> Result<(), bun_jsc::JsTerminated> {
         // SAFETY: `this` was allocated via heap::alloc in `exists`; reconstructing here replaces `defer this.deinit()`
-        let mut this = unsafe { bun_core::heap::take(this.cast::<S3BlobStatTask>()) };
+        let mut this = unsafe { bun_core::heap::take(this) };
         // Copy the BackRef out so `this` is not borrowed across `&mut this.promise`.
         let global_ref = this.global;
         let global = global_ref.get();
@@ -517,10 +517,10 @@ impl S3BlobStatTask {
 
     pub(crate) fn on_s3_size_resolved(
         result: s3::S3StatResult,
-        this: *mut core::ffi::c_void,
+        this: *mut S3BlobStatTask,
     ) -> Result<(), bun_jsc::JsTerminated> {
         // SAFETY: `this` was allocated via heap::alloc in `size`; reconstructing here replaces `defer this.deinit()`
-        let mut this = unsafe { bun_core::heap::take(this.cast::<S3BlobStatTask>()) };
+        let mut this = unsafe { bun_core::heap::take(this) };
         // Copy the BackRef out so `this` is not borrowed across `&mut this.promise`.
         let global_ref = this.global;
         let global = global_ref.get();
@@ -545,10 +545,10 @@ impl S3BlobStatTask {
 
     pub(crate) fn on_s3_stat_resolved(
         result: s3::S3StatResult,
-        this: *mut core::ffi::c_void,
+        this: *mut S3BlobStatTask,
     ) -> Result<(), bun_jsc::JsTerminated> {
         // SAFETY: `this` was allocated via heap::alloc in `stat`; reconstructing here replaces `defer this.deinit()`
-        let mut this = unsafe { bun_core::heap::take(this.cast::<S3BlobStatTask>()) };
+        let mut this = unsafe { bun_core::heap::take(this) };
         // Copy the BackRef out so `this` is not borrowed across `&mut this.promise`.
         let global_ref = this.global;
         let global = global_ref.get();
@@ -600,8 +600,7 @@ impl S3BlobStatTask {
         s3::stat(
             credentials,
             path,
-            S3BlobStatTask::on_s3_exists_resolved,
-            this.cast::<core::ffi::c_void>(),
+            s3::Callback::BlobExists(this),
             env.get_http_proxy(true, None, None).map(|proxy| proxy.href),
             s3_store.request_payer,
         )?;
@@ -627,8 +626,7 @@ impl S3BlobStatTask {
         s3::stat(
             credentials,
             path,
-            S3BlobStatTask::on_s3_stat_resolved,
-            this.cast::<core::ffi::c_void>(),
+            s3::Callback::BlobStat(this),
             env.get_http_proxy(true, None, None).map(|proxy| proxy.href),
             s3_store.request_payer,
         )?;
@@ -654,8 +652,7 @@ impl S3BlobStatTask {
         s3::stat(
             credentials,
             path,
-            S3BlobStatTask::on_s3_size_resolved,
-            this.cast::<core::ffi::c_void>(),
+            s3::Callback::BlobSize(this),
             env.get_http_proxy(true, None, None).map(|proxy| proxy.href),
             s3_store.request_payer,
         )?;

--- a/src/runtime/webcore/blob/Store.rs
+++ b/src/runtime/webcore/blob/Store.rs
@@ -5,7 +5,6 @@
 //! this module re-exports them and layers the `bun_runtime`-tier behaviour
 //! (S3 I/O, async file ops, structured-clone serialize) via extension traits.
 
-use core::ffi::c_void;
 use core::ptr::NonNull;
 use std::rc::Rc;
 
@@ -303,6 +302,78 @@ impl FileExt for File {
     }
 }
 
+pub struct S3BlobDeleteTask {
+    promise: bun_jsc::JSPromiseStrong,
+    store: StoreRef,
+    // LIFETIMES.tsv: JSC_BORROW → &JSGlobalObject. `BackRef` so the heap
+    // wrapper can outlive the constructing frame while reads stay safe.
+    global: bun_ptr::BackRef<JSGlobalObject>,
+}
+
+impl S3BlobDeleteTask {
+    pub(crate) fn resolve(
+        result: S3DeleteResult<'_>,
+        this: *mut Self,
+    ) -> Result<(), bun_jsc::JsTerminated> {
+        // SAFETY: `this` was created via heap::into_raw in `S3::unlink`.
+        let mut self_ = unsafe { bun_core::heap::take(this) };
+        let global_object = self_.global.get();
+        match result {
+            S3DeleteResult::Success => {
+                self_.promise.resolve(global_object, JSValue::TRUE)?;
+            }
+            S3DeleteResult::NotFound(err) | S3DeleteResult::Failure(err) => {
+                let err_val = err.to_js_with_async_stack(
+                    global_object,
+                    self_.store.get_path(),
+                    self_.promise.get(),
+                );
+                self_.promise.reject(global_object, err_val)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+pub struct S3BlobListObjectsTask {
+    promise: bun_jsc::JSPromiseStrong,
+    store: StoreRef,
+    resolved_list_options: S3ListObjectsOptions,
+    // LIFETIMES.tsv: JSC_BORROW. `BackRef` for safe deref across the async callback.
+    global: bun_ptr::BackRef<JSGlobalObject>,
+}
+
+impl S3BlobListObjectsTask {
+    pub(crate) fn resolve(
+        result: S3ListObjectsResult<'_>,
+        this: *mut Self,
+    ) -> Result<(), bun_jsc::JsTerminated> {
+        // SAFETY: `this` was created via heap::into_raw in `S3::list_objects`.
+        let mut self_ = unsafe { bun_core::heap::take(this) };
+        let global_object = self_.global.get();
+        match result {
+            S3ListObjectsResult::Success(list_result) => {
+                let list_result_js = match list_result.to_js(global_object) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return self_.promise.reject(global_object, Err(e));
+                    }
+                };
+                self_.promise.resolve(global_object, list_result_js)?;
+            }
+            S3ListObjectsResult::NotFound(err) | S3ListObjectsResult::Failure(err) => {
+                let err_val = err.to_js_with_async_stack(
+                    global_object,
+                    self_.store.get_path(),
+                    self_.promise.get(),
+                );
+                self_.promise.reject(global_object, err_val)?;
+            }
+        }
+        Ok(())
+    }
+}
+
 impl S3Ext for S3 {
     fn get_credentials_with_options(
         &self,
@@ -331,51 +402,6 @@ impl S3Ext for S3 {
         global_this: &JSGlobalObject,
         extra_options: Option<JSValue>,
     ) -> JsResult<JSValue> {
-        struct Wrapper {
-            promise: bun_jsc::JSPromiseStrong,
-            store: StoreRef,
-            // LIFETIMES.tsv: JSC_BORROW → &JSGlobalObject. `BackRef` so the heap
-            // wrapper can outlive the constructing frame while reads stay safe.
-            global: bun_ptr::BackRef<JSGlobalObject>,
-        }
-
-        impl Wrapper {
-            #[inline]
-            fn new(init: Wrapper) -> Box<Wrapper> {
-                Box::new(init)
-            }
-
-            fn resolve(
-                result: S3DeleteResult<'_>,
-                opaque_self: *mut c_void,
-            ) -> Result<(), bun_jsc::JsTerminated> {
-                // SAFETY: opaque_self was created via heap::alloc(Wrapper::new(..)) below.
-                let mut self_ = unsafe { bun_core::heap::take(opaque_self.cast::<Wrapper>()) };
-                // `defer self.deinit()` → Box drops at scope exit.
-                let global_object = self_.global.get();
-                match result {
-                    S3DeleteResult::Success => {
-                        self_.promise.resolve(global_object, JSValue::TRUE)?;
-                    }
-                    S3DeleteResult::NotFound(err) | S3DeleteResult::Failure(err) => {
-                        // Split borrows: `reject` takes `&mut promise`, so
-                        // compute the error (which reads `promise.get()`) first.
-                        let err_val = err.to_js_with_async_stack(
-                            global_object,
-                            self_.store.get_path(),
-                            self_.promise.get(),
-                        );
-                        self_.promise.reject(global_object, err_val)?;
-                    }
-                }
-                Ok(())
-            }
-        }
-
-        // Wrapper.deinit body deleted — store.deref() handled by StoreRef::drop,
-        // promise.deinit() handled by JSPromiseStrong::drop, bun.destroy(wrap) handled by
-        // heap::take + drop in resolve().
-
         let promise = bun_jsc::JSPromiseStrong::init(global_this);
         let value = promise.value();
         // `Transpiler::env_mut` is the safe accessor for the process-singleton
@@ -390,18 +416,17 @@ impl S3Ext for S3 {
         let aws_options = self.get_credentials_with_options(extra_options, global_this)?;
         // `defer aws_options.deinit()` → Drop handles it.
 
+        let wrapper = bun_core::heap::into_raw(Box::new(S3BlobDeleteTask {
+            promise,
+            // SAFETY: `store` is a live heap `Store`; `retained` bumps the
+            // intrusive refcount.
+            store: unsafe { StoreRef::retained(NonNull::from(store)) },
+            global: bun_ptr::BackRef::new(global_this),
+        }));
         s3_client::delete(
             &aws_options.credentials,
             self.path(),
-            Wrapper::resolve,
-            bun_core::heap::into_raw(Wrapper::new(Wrapper {
-                promise,
-                // SAFETY: `store` is a live heap `Store`; `retained` bumps the
-                // intrusive refcount.
-                store: unsafe { StoreRef::retained(NonNull::from(store)) },
-                global: bun_ptr::BackRef::new(global_this),
-            }))
-            .cast::<c_void>(),
+            s3_client::Callback::BlobDelete(wrapper),
             proxy,
             aws_options.request_payer,
         )?;
@@ -421,55 +446,6 @@ impl S3Ext for S3 {
                 "S3Client.listObjects() needs a S3ListObjectsOption as it's first argument"
             )));
         }
-
-        struct Wrapper {
-            promise: bun_jsc::JSPromiseStrong,
-            store: StoreRef,
-            resolved_list_options: S3ListObjectsOptions,
-            // LIFETIMES.tsv: JSC_BORROW. `BackRef` for safe deref across the async callback.
-            global: bun_ptr::BackRef<JSGlobalObject>,
-        }
-
-        impl Wrapper {
-            fn resolve(
-                result: S3ListObjectsResult<'_>,
-                opaque_self: *mut c_void,
-            ) -> Result<(), bun_jsc::JsTerminated> {
-                // SAFETY: opaque_self was created via heap::alloc below.
-                let mut self_ = unsafe { bun_core::heap::take(opaque_self.cast::<Wrapper>()) };
-                // `defer self.deinit()` → Box drops at scope exit.
-                let global_object = self_.global.get();
-
-                match result {
-                    S3ListObjectsResult::Success(list_result) => {
-                        // `defer list_result.deinit()` → Drop handles it.
-                        let list_result_js = match list_result.to_js(global_object) {
-                            Ok(v) => v,
-                            Err(e) => {
-                                return self_.promise.reject(global_object, Err(e));
-                            }
-                        };
-                        self_.promise.resolve(global_object, list_result_js)?;
-                    }
-
-                    S3ListObjectsResult::NotFound(err) | S3ListObjectsResult::Failure(err) => {
-                        // Split borrows: `reject` takes `&mut promise`, so
-                        // compute the error (which reads `promise.get()`) first.
-                        let err_val = err.to_js_with_async_stack(
-                            global_object,
-                            self_.store.get_path(),
-                            self_.promise.get(),
-                        );
-                        self_.promise.reject(global_object, err_val)?;
-                    }
-                }
-                Ok(())
-            }
-        }
-
-        // Wrapper.deinit/destroy bodies deleted — store.deref() via StoreRef::drop,
-        // promise.deinit() via JSPromiseStrong::drop, resolvedlistOptions.deinit() via
-        // S3ListObjectsOptions::drop, bun.destroy(self) via heap::take + drop.
 
         let promise = bun_jsc::JSPromiseStrong::init(global_this);
         let value = promise.value();
@@ -492,7 +468,7 @@ impl S3Ext for S3 {
         // borrow to `list_objects` (which only reads them synchronously to
         // build the search-params string). The wrapper retains ownership for
         // `Drop` after the async callback.
-        let wrapper = bun_core::heap::into_raw(Box::new(Wrapper {
+        let wrapper = bun_core::heap::into_raw(Box::new(S3BlobListObjectsTask {
             promise,
             // SAFETY: `store` is a live heap `Store`; `retained` bumps the
             // intrusive refcount.
@@ -506,8 +482,7 @@ impl S3Ext for S3 {
             // SAFETY: `wrapper` is freshly leaked and untouched until the
             // callback; this borrow ends before any other access.
             unsafe { &(*wrapper).resolved_list_options },
-            Wrapper::resolve,
-            wrapper.cast::<c_void>(),
+            s3_client::Callback::BlobListObjects(wrapper),
             proxy,
         )?;
 

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -176,7 +176,7 @@ pub(crate) fn list_objects(
     // The struct owns `Utf8Slice`s and is not
     // `Clone`, but this fn only reads fields synchronously to build the
     // search-params string — borrow so the caller (Store::S3::
-    // list_objects) can retain ownership in its async Wrapper for `Drop`.
+    // list_objects) can retain ownership in its async task for `Drop`.
     list_options: &S3ListObjectsOptions,
     callback: Callback,
     proxy_url: Option<&[u8]>,

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -33,6 +33,7 @@ use bun_s3_signing::credentials::encode_uri_component;
 
 pub use crate::webcore::s3::list_objects::S3ListObjectsOptions;
 pub use crate::webcore::s3::list_objects::get_list_objects_options_from_js;
+pub use crate::webcore::s3::simple_request::Callback;
 pub use crate::webcore::s3::simple_request::S3DeleteResult;
 pub use crate::webcore::s3::simple_request::S3DownloadResult;
 pub use crate::webcore::s3::simple_request::S3HttpSimpleTask;
@@ -64,11 +65,11 @@ type JsTerminatedResult<T> = Result<T, bun_jsc::JsTerminated>;
 pub(crate) fn stat(
     this: &S3Credentials,
     path: &[u8],
-    callback: fn(S3StatResult, *mut c_void) -> JsTerminatedResult<()>,
-    callback_context: *mut c_void,
+    callback: Callback,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
 ) -> JsTerminatedResult<()> {
+    debug_assert!(matches!(callback.kind(), s3_simple_request::Kind::Stat));
     s3_simple_request::execute_simple_s3_request(
         this,
         s3_simple_request::Options {
@@ -79,19 +80,18 @@ pub(crate) fn stat(
             request_payer,
             ..Default::default()
         },
-        s3_simple_request::Callback::Stat(callback),
-        callback_context,
+        callback,
     )
 }
 
 pub(crate) fn download(
     this: &S3Credentials,
     path: &[u8],
-    callback: fn(S3DownloadResult, *mut c_void) -> JsTerminatedResult<()>,
-    callback_context: *mut c_void,
+    callback: Callback,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
 ) -> JsTerminatedResult<()> {
+    debug_assert!(matches!(callback.kind(), s3_simple_request::Kind::Download));
     s3_simple_request::execute_simple_s3_request(
         this,
         s3_simple_request::Options {
@@ -102,8 +102,7 @@ pub(crate) fn download(
             request_payer,
             ..Default::default()
         },
-        s3_simple_request::Callback::Download(callback),
-        callback_context,
+        callback,
     )
 }
 
@@ -112,11 +111,11 @@ pub(crate) fn download_slice(
     path: &[u8],
     offset: usize,
     size: Option<usize>,
-    callback: fn(S3DownloadResult, *mut c_void) -> JsTerminatedResult<()>,
-    callback_context: *mut c_void,
+    callback: Callback,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
 ) -> JsTerminatedResult<()> {
+    debug_assert!(matches!(callback.kind(), s3_simple_request::Kind::Download));
     let range: Option<Vec<u8>> = 'brk: {
         if let Some(size_) = size {
             let mut end = offset + size_;
@@ -146,19 +145,18 @@ pub(crate) fn download_slice(
             request_payer,
             ..Default::default()
         },
-        s3_simple_request::Callback::Download(callback),
-        callback_context,
+        callback,
     )
 }
 
 pub(crate) fn delete(
     this: &S3Credentials,
     path: &[u8],
-    callback: fn(S3DeleteResult, *mut c_void) -> JsTerminatedResult<()>,
-    callback_context: *mut c_void,
+    callback: Callback,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
 ) -> JsTerminatedResult<()> {
+    debug_assert!(matches!(callback.kind(), s3_simple_request::Kind::Delete));
     s3_simple_request::execute_simple_s3_request(
         this,
         s3_simple_request::Options {
@@ -169,8 +167,7 @@ pub(crate) fn delete(
             request_payer,
             ..Default::default()
         },
-        s3_simple_request::Callback::Delete(callback),
-        callback_context,
+        callback,
     )
 }
 
@@ -181,10 +178,13 @@ pub(crate) fn list_objects(
     // search-params string — borrow so the caller (Store::S3::
     // list_objects) can retain ownership in its async Wrapper for `Drop`.
     list_options: &S3ListObjectsOptions,
-    callback: fn(S3ListObjectsResult, *mut c_void) -> JsTerminatedResult<()>,
-    callback_context: *mut c_void,
+    callback: Callback,
     proxy_url: Option<&[u8]>,
 ) -> JsTerminatedResult<()> {
+    debug_assert!(matches!(
+        callback.kind(),
+        s3_simple_request::Kind::ListObjects
+    ));
     let mut search_params: Vec<u8> = Vec::<u8>::default();
 
     let _ = search_params.append_slice(b"?"); // OOM/capacity: fire-and-forget
@@ -279,13 +279,7 @@ pub(crate) fn list_objects(
             drop(search_params);
 
             let error_code_and_message = Error::get_sign_error_code_and_message(sign_err.into());
-            callback(
-                S3ListObjectsResult::Failure(Error::S3Error {
-                    code: error_code_and_message.code,
-                    message: error_code_and_message.message,
-                }),
-                callback_context,
-            )?;
+            callback.fail(error_code_and_message.code, error_code_and_message.message)?;
 
             return Ok(());
         }
@@ -300,8 +294,7 @@ pub(crate) fn list_objects(
         http: core::mem::MaybeUninit::uninit(),
         range: None,
         sign_result: result,
-        callback_context,
-        callback: s3_simple_request::Callback::ListObjects(callback),
+        callback,
         headers,
         vm: Some(bun_ptr::BackRef::new(VirtualMachine::get())),
         response_buffer: MutableString::default(),
@@ -390,9 +383,9 @@ pub fn upload(
     proxy_url: Option<&[u8]>,
     storage_class: Option<StorageClass>,
     request_payer: bool,
-    callback: fn(S3UploadResult, *mut c_void) -> JsTerminatedResult<()>,
-    callback_context: *mut c_void,
+    callback: Callback,
 ) -> JsTerminatedResult<()> {
+    debug_assert!(matches!(callback.kind(), s3_simple_request::Kind::Upload));
     s3_simple_request::execute_simple_s3_request(
         this,
         s3_simple_request::Options {
@@ -408,8 +401,7 @@ pub fn upload(
             request_payer,
             ..Default::default()
         },
-        s3_simple_request::Callback::Upload(callback),
-        callback_context,
+        callback,
     )
 }
 

--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -250,9 +250,8 @@ impl UploadPart {
 
     pub(crate) fn on_part_response(
         result: S3PartResult,
-        this: *mut c_void,
+        this: *mut Self,
     ) -> JsTerminatedResult<()> {
-        let this = this.cast::<Self>();
         // SAFETY: callback context — `this` is the `*mut UploadPart` passed in `perform()`
         let this = unsafe { &mut *this };
         // Copy the BackRef out so the `&mut MultiPartUpload` borrow is detached
@@ -351,7 +350,8 @@ impl UploadPart {
             2048 - w.len()
         };
         let search_params = &params_buffer[..written];
-        let callback_context: *mut c_void = std::ptr::from_mut::<Self>(self).cast::<c_void>();
+        let callback =
+            s3_simple_request::S3Callback::MultipartPart(std::ptr::from_mut::<Self>(self));
         execute_simple_s3_request(
             &*ctx.credentials,
             s3_simple_request::S3RequestOptions {
@@ -363,8 +363,7 @@ impl UploadPart {
                 request_payer: ctx.request_payer,
                 ..Default::default()
             },
-            s3_simple_request::S3Callback::Part(Self::on_part_response),
-            callback_context,
+            callback,
         )
     }
 
@@ -414,11 +413,10 @@ impl Drop for MultiPartUpload {
 }
 
 impl MultiPartUpload {
-    pub fn single_send_upload_response(
+    pub(crate) fn single_send_upload_response(
         result: S3UploadResult,
-        this: *mut c_void,
+        this: *mut Self,
     ) -> JsTerminatedResult<()> {
-        let this = this.cast::<Self>();
         // SAFETY: callback context — `this` was passed as opaque ctx and is live (holds final ref)
         let this = unsafe { &mut *this };
         if this.state == State::Finished {
@@ -433,8 +431,12 @@ impl MultiPartUpload {
                         this.options.retry
                     );
                     this.options.retry -= 1;
-                    let callback_context: *mut c_void =
-                        std::ptr::from_mut::<Self>(this).cast::<c_void>();
+                    let callback =
+                        s3_simple_request::S3Callback::MultipartSingleSend(std::ptr::from_mut::<
+                            Self,
+                        >(
+                            this
+                        ));
                     execute_simple_s3_request(
                         &*this.credentials,
                         s3_simple_request::S3RequestOptions {
@@ -450,8 +452,7 @@ impl MultiPartUpload {
                             request_payer: this.request_payer,
                             ..Default::default()
                         },
-                        s3_simple_request::S3Callback::Upload(Self::single_send_upload_response),
-                        callback_context,
+                        callback,
                     )?;
 
                     Ok(())
@@ -658,11 +659,10 @@ impl MultiPartUpload {
     }
 
     /// Result of the Multipart request, after this we can start draining the parts
-    pub fn start_multi_part_request_result(
+    pub(crate) fn start_multi_part_request_result(
         result: S3DownloadResult,
-        this: *mut c_void,
+        this: *mut Self,
     ) -> JsTerminatedResult<()> {
-        let this = this.cast::<Self>();
         // `adopt` consumes the prior +1 on Drop.
         // SAFETY: callback context — a ref was taken before the request was queued.
         let _deref_guard = unsafe { bun_ptr::ScopedRef::<Self>::adopt(this) };
@@ -733,11 +733,10 @@ impl MultiPartUpload {
     }
 
     /// We do a best effort to commit the multipart upload, if it fails we will retry, if it still fails we will fail the upload
-    pub fn on_commit_multi_part_request(
+    pub(crate) fn on_commit_multi_part_request(
         result: S3CommitResult,
-        this: *mut c_void,
+        this: *mut Self,
     ) -> JsTerminatedResult<()> {
-        let this = this.cast::<Self>();
         // SAFETY: callback context — `this` is live (final-step ref)
         let this_ref = unsafe { &mut *this };
         scoped_log!(
@@ -774,11 +773,10 @@ impl MultiPartUpload {
     }
 
     /// We do a best effort to rollback the multipart upload, if it fails we will retry, if it still we just deinit the upload
-    pub fn on_rollback_multi_part_request(
+    pub(crate) fn on_rollback_multi_part_request(
         result: S3UploadResult,
-        this: *mut c_void,
+        this: *mut Self,
     ) -> JsTerminatedResult<()> {
-        let this = this.cast::<Self>();
         // SAFETY: callback context — `this` is live (final-step ref)
         let this_ref = unsafe { &mut *this };
         scoped_log!(
@@ -820,7 +818,8 @@ impl MultiPartUpload {
         };
         let search_params = &params_buffer[..written];
 
-        let callback_context: *mut c_void = std::ptr::from_mut::<Self>(self).cast::<c_void>();
+        let callback =
+            s3_simple_request::S3Callback::MultipartCommit(std::ptr::from_mut::<Self>(self));
         execute_simple_s3_request(
             &*self.credentials,
             s3_simple_request::S3RequestOptions {
@@ -832,8 +831,7 @@ impl MultiPartUpload {
                 request_payer: self.request_payer,
                 ..Default::default()
             },
-            s3_simple_request::S3Callback::Commit(Self::on_commit_multi_part_request),
-            callback_context,
+            callback,
         )
     }
 
@@ -851,7 +849,8 @@ impl MultiPartUpload {
         };
         let search_params = &params_buffer[..written];
 
-        let callback_context: *mut c_void = std::ptr::from_mut::<Self>(self).cast::<c_void>();
+        let callback =
+            s3_simple_request::S3Callback::MultipartRollback(std::ptr::from_mut::<Self>(self));
         execute_simple_s3_request(
             &*self.credentials,
             s3_simple_request::S3RequestOptions {
@@ -863,8 +862,7 @@ impl MultiPartUpload {
                 request_payer: self.request_payer,
                 ..Default::default()
             },
-            s3_simple_request::S3Callback::Upload(Self::on_rollback_multi_part_request),
-            callback_context,
+            callback,
         )
     }
 
@@ -882,7 +880,8 @@ impl MultiPartUpload {
             // will auto start later
             self.state = State::MultipartStarted;
             self.ref_();
-            let callback_context: *mut c_void = std::ptr::from_mut::<Self>(self).cast::<c_void>();
+            let callback =
+                s3_simple_request::S3Callback::MultipartStart(std::ptr::from_mut::<Self>(self));
             execute_simple_s3_request(
                 &*self.credentials,
                 s3_simple_request::S3RequestOptions {
@@ -899,8 +898,7 @@ impl MultiPartUpload {
                     request_payer: self.request_payer,
                     ..Default::default()
                 },
-                s3_simple_request::S3Callback::Download(Self::start_multi_part_request_result),
-                callback_context,
+                callback,
             )?;
         } else if self.state == State::MultipartCompleted {
             // SAFETY: part points into self.queue which is live; reborrow disjoint from self fields used above
@@ -1025,7 +1023,9 @@ impl MultiPartUpload {
             );
             self.state = State::SinglefileStarted;
             // we can do only 1 request
-            let callback_context: *mut c_void = std::ptr::from_mut::<Self>(self).cast::<c_void>();
+            let callback = s3_simple_request::S3Callback::MultipartSingleSend(
+                std::ptr::from_mut::<Self>(self),
+            );
             let _ = execute_simple_s3_request(
                 &*self.credentials,
                 s3_simple_request::S3RequestOptions {
@@ -1041,8 +1041,7 @@ impl MultiPartUpload {
                     request_payer: self.request_payer,
                     ..Default::default()
                 },
-                s3_simple_request::S3Callback::Upload(Self::single_send_upload_response),
-                callback_context,
+                callback,
             ); // TODO: properly propagate exception upwards
         } else {
             // we need to split

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -1,5 +1,3 @@
-use core::ffi::c_void;
-
 use bun_core::MutableString;
 use bun_core::strings;
 use bun_event_loop::ConcurrentTask::{AutoDeinit, ConcurrentTask};
@@ -19,7 +17,14 @@ use bun_s3_signing::storage_class::StorageClass;
 use bun_threading::thread_pool;
 use bun_url::URL;
 
+use crate::server::AnyRequestContext;
+use crate::webcore::blob::store::{S3BlobDeleteTask, S3BlobListObjectsTask};
+use crate::webcore::blob::{
+    S3BlobDownloadTask, S3BlobUploadBytesTask, S3BlobUploadEmptyTask, S3ReadBytesTask,
+};
 use crate::webcore::s3::list_objects;
+use crate::webcore::s3::multipart::{MultiPartUpload, UploadPart};
+use crate::webcore::s3_file::S3BlobStatTask;
 
 // The result/options structs below carry borrowed slices that are valid only for the
 // duration of the callback invocation (not owned; they must be copied if used
@@ -122,7 +127,6 @@ pub struct S3HttpSimpleTask {
     pub vm: Option<bun_ptr::BackRef<VirtualMachine>>,
     pub sign_result: SignResult,
     pub headers: Headers,
-    pub callback_context: *mut c_void,
     pub callback: Callback,
     pub response_buffer: MutableString,
     // `'static` here because `result.body` (when set) points at our own
@@ -150,16 +154,12 @@ impl Taskable for S3HttpSimpleTask {
 // inert placeholders that callers always overwrite (see client.rs / execute_simple_s3_request).
 impl Default for S3HttpSimpleTask {
     fn default() -> Self {
-        fn unset_callback(_: S3UploadResult<'_>, _: *mut c_void) -> JsTerminatedResult<()> {
-            unreachable!("S3HttpSimpleTask.callback used before being set")
-        }
         Self {
             http: core::mem::MaybeUninit::uninit(),
             vm: None,
             sign_result: SignResult::default(),
             headers: Headers::default(),
-            callback_context: core::ptr::null_mut(),
-            callback: Callback::Upload(unset_callback),
+            callback: Callback::Unset,
             response_buffer: MutableString::default(),
             result: HTTPClientResult::default(),
             concurrent_task: ConcurrentTask::default(),
@@ -174,55 +174,169 @@ impl Default for S3HttpSimpleTask {
 // Re-export the canonical alias so sibling modules that imported it from here keep compiling.
 pub use bun_jsc::JsTerminatedResult;
 
+/// Response-handling kind: selects which `S3*Result` payload `on_response`
+/// builds and which HTTP status codes count as success.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Kind {
+    Stat,
+    Download,
+    Upload,
+    Delete,
+    ListObjects,
+    Commit,
+    Part,
+}
+
+/// Static dispatch: each variant names the concrete context type and the
+/// handler is called directly from the `match` below, so backtraces show the
+/// callee frame instead of dead-ending at an indirect call.
+#[derive(Clone, Copy)]
 pub enum Callback {
-    Stat(fn(S3StatResult<'_>, *mut c_void) -> JsTerminatedResult<()>),
-    Download(fn(S3DownloadResult<'_>, *mut c_void) -> JsTerminatedResult<()>),
-    Upload(fn(S3UploadResult<'_>, *mut c_void) -> JsTerminatedResult<()>),
-    Delete(fn(S3DeleteResult<'_>, *mut c_void) -> JsTerminatedResult<()>),
-    ListObjects(fn(S3ListObjectsResult<'_>, *mut c_void) -> JsTerminatedResult<()>),
-    Commit(fn(S3CommitResult<'_>, *mut c_void) -> JsTerminatedResult<()>),
-    Part(fn(S3PartResult<'_>, *mut c_void) -> JsTerminatedResult<()>),
+    /// Placeholder for `Default`; never dispatched.
+    Unset,
+
+    // Kind::Stat
+    BlobExists(*mut S3BlobStatTask),
+    BlobStat(*mut S3BlobStatTask),
+    BlobSize(*mut S3BlobStatTask),
+    HeadResponseSize(AnyRequestContext),
+
+    // Kind::Download
+    BlobDownload(*mut S3BlobDownloadTask),
+    BlobReadBytes(*mut S3ReadBytesTask),
+    MultipartStart(*mut MultiPartUpload),
+
+    // Kind::Upload
+    BlobUploadEmpty(*mut S3BlobUploadEmptyTask),
+    BlobUploadBytes(*mut S3BlobUploadBytesTask),
+    MultipartSingleSend(*mut MultiPartUpload),
+    MultipartRollback(*mut MultiPartUpload),
+
+    // Kind::Delete
+    BlobDelete(*mut S3BlobDeleteTask),
+
+    // Kind::ListObjects
+    BlobListObjects(*mut S3BlobListObjectsTask),
+
+    // Kind::Commit
+    MultipartCommit(*mut MultiPartUpload),
+
+    // Kind::Part
+    MultipartPart(*mut UploadPart),
 }
 
 impl Callback {
-    pub(crate) fn fail(
-        &self,
-        code: &[u8],
-        message: &[u8],
-        context: *mut c_void,
-    ) -> JsTerminatedResult<()> {
-        let err = S3Error { code, message };
+    pub(crate) fn kind(&self) -> Kind {
         match self {
-            Callback::Upload(callback) => callback(S3UploadResult::Failure(err), context)?,
-            Callback::Download(callback) => callback(S3DownloadResult::Failure(err), context)?,
-            Callback::Stat(callback) => callback(S3StatResult::Failure(err), context)?,
-            Callback::Delete(callback) => callback(S3DeleteResult::Failure(err), context)?,
-            Callback::ListObjects(callback) => {
-                callback(S3ListObjectsResult::Failure(err), context)?
-            }
-            Callback::Commit(callback) => callback(S3CommitResult::Failure(err), context)?,
-            Callback::Part(callback) => callback(S3PartResult::Failure(err), context)?,
+            Callback::Unset => unreachable!("S3HttpSimpleTask.callback used before being set"),
+            Callback::BlobExists(_)
+            | Callback::BlobStat(_)
+            | Callback::BlobSize(_)
+            | Callback::HeadResponseSize(_) => Kind::Stat,
+            Callback::BlobDownload(_)
+            | Callback::BlobReadBytes(_)
+            | Callback::MultipartStart(_) => Kind::Download,
+            Callback::BlobUploadEmpty(_)
+            | Callback::BlobUploadBytes(_)
+            | Callback::MultipartSingleSend(_)
+            | Callback::MultipartRollback(_) => Kind::Upload,
+            Callback::BlobDelete(_) => Kind::Delete,
+            Callback::BlobListObjects(_) => Kind::ListObjects,
+            Callback::MultipartCommit(_) => Kind::Commit,
+            Callback::MultipartPart(_) => Kind::Part,
         }
-        Ok(())
     }
 
-    pub(crate) fn not_found(
-        &self,
-        code: &[u8],
-        message: &[u8],
-        context: *mut c_void,
-    ) -> JsTerminatedResult<()> {
-        let err = S3Error { code, message };
-        match self {
-            Callback::Download(callback) => callback(S3DownloadResult::NotFound(err), context)?,
-            Callback::Stat(callback) => callback(S3StatResult::NotFound(err), context)?,
-            Callback::Delete(callback) => callback(S3DeleteResult::NotFound(err), context)?,
-            Callback::ListObjects(callback) => {
-                callback(S3ListObjectsResult::NotFound(err), context)?
+    fn dispatch_stat(&self, result: S3StatResult<'_>) -> JsTerminatedResult<()> {
+        match *self {
+            Callback::BlobExists(ctx) => S3BlobStatTask::on_s3_exists_resolved(result, ctx),
+            Callback::BlobStat(ctx) => S3BlobStatTask::on_s3_stat_resolved(result, ctx),
+            Callback::BlobSize(ctx) => S3BlobStatTask::on_s3_size_resolved(result, ctx),
+            Callback::HeadResponseSize(ctx) => {
+                ctx.on_s3_stat_resolved(result);
+                Ok(())
             }
-            _ => self.fail(code, message, context)?,
+            _ => unreachable!(),
         }
-        Ok(())
+    }
+
+    fn dispatch_download(&self, result: S3DownloadResult<'_>) -> JsTerminatedResult<()> {
+        match *self {
+            Callback::BlobDownload(ctx) => S3BlobDownloadTask::on_s3_download_resolved(result, ctx),
+            Callback::BlobReadBytes(ctx) => S3ReadBytesTask::on_download(result, ctx),
+            Callback::MultipartStart(ctx) => {
+                MultiPartUpload::start_multi_part_request_result(result, ctx)
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn dispatch_upload(&self, result: S3UploadResult<'_>) -> JsTerminatedResult<()> {
+        match *self {
+            Callback::BlobUploadEmpty(ctx) => S3BlobUploadEmptyTask::resolve(result, ctx),
+            Callback::BlobUploadBytes(ctx) => S3BlobUploadBytesTask::resolve(result, ctx),
+            Callback::MultipartSingleSend(ctx) => {
+                MultiPartUpload::single_send_upload_response(result, ctx)
+            }
+            Callback::MultipartRollback(ctx) => {
+                MultiPartUpload::on_rollback_multi_part_request(result, ctx)
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn dispatch_delete(&self, result: S3DeleteResult<'_>) -> JsTerminatedResult<()> {
+        match *self {
+            Callback::BlobDelete(ctx) => S3BlobDeleteTask::resolve(result, ctx),
+            _ => unreachable!(),
+        }
+    }
+
+    fn dispatch_list_objects(&self, result: S3ListObjectsResult<'_>) -> JsTerminatedResult<()> {
+        match *self {
+            Callback::BlobListObjects(ctx) => S3BlobListObjectsTask::resolve(result, ctx),
+            _ => unreachable!(),
+        }
+    }
+
+    fn dispatch_commit(&self, result: S3CommitResult<'_>) -> JsTerminatedResult<()> {
+        match *self {
+            Callback::MultipartCommit(ctx) => {
+                MultiPartUpload::on_commit_multi_part_request(result, ctx)
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn dispatch_part(&self, result: S3PartResult<'_>) -> JsTerminatedResult<()> {
+        match *self {
+            Callback::MultipartPart(ctx) => UploadPart::on_part_response(result, ctx),
+            _ => unreachable!(),
+        }
+    }
+
+    pub(crate) fn fail(&self, code: &[u8], message: &[u8]) -> JsTerminatedResult<()> {
+        let err = S3Error { code, message };
+        match self.kind() {
+            Kind::Stat => self.dispatch_stat(S3StatResult::Failure(err)),
+            Kind::Download => self.dispatch_download(S3DownloadResult::Failure(err)),
+            Kind::Upload => self.dispatch_upload(S3UploadResult::Failure(err)),
+            Kind::Delete => self.dispatch_delete(S3DeleteResult::Failure(err)),
+            Kind::ListObjects => self.dispatch_list_objects(S3ListObjectsResult::Failure(err)),
+            Kind::Commit => self.dispatch_commit(S3CommitResult::Failure(err)),
+            Kind::Part => self.dispatch_part(S3PartResult::Failure(err)),
+        }
+    }
+
+    pub(crate) fn not_found(&self, code: &[u8], message: &[u8]) -> JsTerminatedResult<()> {
+        let err = S3Error { code, message };
+        match self.kind() {
+            Kind::Stat => self.dispatch_stat(S3StatResult::NotFound(err)),
+            Kind::Download => self.dispatch_download(S3DownloadResult::NotFound(err)),
+            Kind::Delete => self.dispatch_delete(S3DeleteResult::NotFound(err)),
+            Kind::ListObjects => self.dispatch_list_objects(S3ListObjectsResult::NotFound(err)),
+            Kind::Upload | Kind::Commit | Kind::Part => self.fail(code, message),
+        }
     }
 }
 
@@ -276,10 +390,9 @@ impl S3HttpSimpleTask {
                 code = b"NoSuchKey";
                 message = b"The specified key does not exist.";
             }
-            self.callback
-                .not_found(code, message, self.callback_context)?;
+            self.callback.not_found(code, message)?;
         } else {
-            self.callback.fail(code, message, self.callback_context)?;
+            self.callback.fail(code, message)?;
         }
         Ok(())
     }
@@ -321,7 +434,7 @@ impl S3HttpSimpleTask {
         } else if status == 200 || status == 206 {
             return Ok(false);
         }
-        self.callback.fail(code, message, self.callback_context)?;
+        self.callback.fail(code, message)?;
         Ok(true)
     }
 
@@ -347,42 +460,39 @@ impl S3HttpSimpleTask {
         debug_assert!(this.result.metadata.is_some());
         // reshaped for borrowck — borrow response once, dispatch on a copy of `callback`.
         let response = &this.result.metadata.as_ref().unwrap().response;
-        match this.callback {
-            Callback::Stat(callback) => match response.status_code {
+        let callback = this.callback;
+        match callback.kind() {
+            Kind::Stat => match response.status_code {
                 200 => {
-                    callback(
-                        S3StatResult::Success(S3StatSuccess {
-                            etag: response.headers.get(b"etag").unwrap_or(b""),
-                            last_modified: response.headers.get(b"last-modified").unwrap_or(b""),
-                            content_type: response.headers.get(b"content-type").unwrap_or(b""),
-                            size: response
-                                .headers
-                                .get(b"content-length")
-                                .map(bun_http_types::parse_content_length)
-                                .unwrap_or(0),
-                        }),
-                        this.callback_context,
-                    )?;
+                    callback.dispatch_stat(S3StatResult::Success(S3StatSuccess {
+                        etag: response.headers.get(b"etag").unwrap_or(b""),
+                        last_modified: response.headers.get(b"last-modified").unwrap_or(b""),
+                        content_type: response.headers.get(b"content-type").unwrap_or(b""),
+                        size: response
+                            .headers
+                            .get(b"content-length")
+                            .map(bun_http_types::parse_content_length)
+                            .unwrap_or(0),
+                    }))?;
                 }
                 404 => this.error_with_body(ErrorType::NotFound)?,
                 _ => this.error_with_body(ErrorType::Failure)?,
             },
-            Callback::Delete(callback) => match response.status_code {
-                200 | 204 => callback(S3DeleteResult::Success, this.callback_context)?,
+            Kind::Delete => match response.status_code {
+                200 | 204 => callback.dispatch_delete(S3DeleteResult::Success)?,
                 404 => this.error_with_body(ErrorType::NotFound)?,
                 _ => this.error_with_body(ErrorType::Failure)?,
             },
-            Callback::ListObjects(callback) => match response.status_code {
+            Kind::ListObjects => match response.status_code {
                 200 => {
                     if let Some(body) = &this.result.body {
                         // parse_s3_list_objects_result is infallible (alloc-only
                         // failure modes abort).
                         let success =
                             list_objects::parse_s3_list_objects_result(body.list.as_slice());
-                        callback(
-                            S3ListObjectsResult::Success(Box::new(success)),
-                            this.callback_context,
-                        )?;
+                        callback.dispatch_list_objects(S3ListObjectsResult::Success(Box::new(
+                            success,
+                        )))?;
                     } else {
                         this.error_with_body(ErrorType::Failure)?;
                     }
@@ -390,22 +500,19 @@ impl S3HttpSimpleTask {
                 404 => this.error_with_body(ErrorType::NotFound)?,
                 _ => this.error_with_body(ErrorType::Failure)?,
             },
-            Callback::Upload(callback) => match response.status_code {
-                200 => callback(S3UploadResult::Success, this.callback_context)?,
+            Kind::Upload => match response.status_code {
+                200 => callback.dispatch_upload(S3UploadResult::Success)?,
                 _ => this.error_with_body(ErrorType::Failure)?,
             },
-            Callback::Download(callback) => match response.status_code {
+            Kind::Download => match response.status_code {
                 200 | 204 | 206 => {
                     let body = core::mem::take(&mut this.response_buffer);
                     // re-borrow response after &mut access to response_buffer
                     let response = &this.result.metadata.as_ref().unwrap().response;
-                    callback(
-                        S3DownloadResult::Success(S3DownloadSuccess {
-                            etag: response.headers.get(b"etag").unwrap_or(b""),
-                            body,
-                        }),
-                        this.callback_context,
-                    )?;
+                    callback.dispatch_download(S3DownloadResult::Success(S3DownloadSuccess {
+                        etag: response.headers.get(b"etag").unwrap_or(b""),
+                        body,
+                    }))?;
                 }
                 404 => this.error_with_body(ErrorType::NotFound)?,
                 _ => {
@@ -413,19 +520,19 @@ impl S3HttpSimpleTask {
                     this.error_with_body(ErrorType::Failure)?;
                 }
             },
-            Callback::Commit(callback) => {
+            Kind::Commit => {
                 // commit multipart upload can fail with status 200
                 let status = response.status_code;
                 if !this.fail_if_contains_error(status)? {
-                    callback(S3CommitResult::Success, this.callback_context)?;
+                    callback.dispatch_commit(S3CommitResult::Success)?;
                 }
             }
-            Callback::Part(callback) => {
+            Kind::Part => {
                 let status = response.status_code;
                 if !this.fail_if_contains_error(status)? {
                     let response = &this.result.metadata.as_ref().unwrap().response;
                     if let Some(etag) = response.headers.get(b"etag") {
-                        callback(S3PartResult::Etag(etag), this.callback_context)?;
+                        callback.dispatch_part(S3PartResult::Etag(etag))?;
                     } else {
                         this.error_with_body(ErrorType::Failure)?;
                     }
@@ -567,7 +674,6 @@ pub(crate) fn execute_simple_s3_request(
     this: &S3Credentials,
     options: S3SimpleRequestOptions<'_>,
     callback: Callback,
-    callback_context: *mut c_void,
 ) -> JsTerminatedResult<()> {
     let result = match this.sign_request::<false>(
         &SignOptions {
@@ -590,11 +696,7 @@ pub(crate) fn execute_simple_s3_request(
             // options.range drops here automatically
             drop(options.range);
             let error_code_and_message = get_sign_error_code_and_message(sign_err.into());
-            callback.fail(
-                error_code_and_message.code,
-                error_code_and_message.message,
-                callback_context,
-            )?;
+            callback.fail(error_code_and_message.code, error_code_and_message.message)?;
             return Ok(());
         }
     };
@@ -623,7 +725,6 @@ pub(crate) fn execute_simple_s3_request(
         // written below via `MaybeUninit::write` before any read.
         http: core::mem::MaybeUninit::uninit(),
         sign_result: result,
-        callback_context,
         callback,
         range: options.range,
         headers,

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -19,9 +19,7 @@ use bun_url::URL;
 
 use crate::server::AnyRequestContext;
 use crate::webcore::blob::store::{S3BlobDeleteTask, S3BlobListObjectsTask};
-use crate::webcore::blob::{
-    S3BlobDownloadTask, S3BlobUploadBytesTask, S3BlobUploadEmptyTask, S3ReadBytesTask,
-};
+use crate::webcore::blob::{S3BlobDownloadTask, S3BlobUploadTask, S3ReadBytesTask};
 use crate::webcore::s3::list_objects;
 use crate::webcore::s3::multipart::{MultiPartUpload, UploadPart};
 use crate::webcore::s3_file::S3BlobStatTask;
@@ -187,158 +185,71 @@ pub enum Kind {
     Part,
 }
 
-/// Static dispatch: each variant names the concrete context type and the
-/// handler is called directly from the `match` below, so backtraces show the
-/// callee frame instead of dead-ending at an indirect call.
-#[derive(Clone, Copy)]
-pub enum Callback {
-    /// Placeholder for `Default`; never dispatched.
-    Unset,
-
-    // Kind::Stat
-    BlobExists(*mut S3BlobStatTask),
-    BlobStat(*mut S3BlobStatTask),
-    BlobSize(*mut S3BlobStatTask),
-    HeadResponseSize(AnyRequestContext),
-
-    // Kind::Download
-    BlobDownload(*mut S3BlobDownloadTask),
-    BlobReadBytes(*mut S3ReadBytesTask),
-    MultipartStart(*mut MultiPartUpload),
-
-    // Kind::Upload
-    BlobUploadEmpty(*mut S3BlobUploadEmptyTask),
-    BlobUploadBytes(*mut S3BlobUploadBytesTask),
-    MultipartSingleSend(*mut MultiPartUpload),
-    MultipartRollback(*mut MultiPartUpload),
-
-    // Kind::Delete
-    BlobDelete(*mut S3BlobDeleteTask),
-
-    // Kind::ListObjects
-    BlobListObjects(*mut S3BlobListObjectsTask),
-
-    // Kind::Commit
-    MultipartCommit(*mut MultiPartUpload),
-
-    // Kind::Part
-    MultipartPart(*mut UploadPart),
+fn head_response_size(r: S3StatResult<'_>, ctx: AnyRequestContext) -> JsTerminatedResult<()> {
+    ctx.on_s3_stat_resolved(r);
+    Ok(())
 }
 
-impl Callback {
-    pub(crate) fn kind(&self) -> Kind {
-        match self {
-            Callback::Unset => unreachable!("S3HttpSimpleTask.callback used before being set"),
-            Callback::BlobExists(_)
-            | Callback::BlobStat(_)
-            | Callback::BlobSize(_)
-            | Callback::HeadResponseSize(_) => Kind::Stat,
-            Callback::BlobDownload(_)
-            | Callback::BlobReadBytes(_)
-            | Callback::MultipartStart(_) => Kind::Download,
-            Callback::BlobUploadEmpty(_)
-            | Callback::BlobUploadBytes(_)
-            | Callback::MultipartSingleSend(_)
-            | Callback::MultipartRollback(_) => Kind::Upload,
-            Callback::BlobDelete(_) => Kind::Delete,
-            Callback::BlobListObjects(_) => Kind::ListObjects,
-            Callback::MultipartCommit(_) => Kind::Commit,
-            Callback::MultipartPart(_) => Kind::Part,
-        }
-    }
-
-    fn dispatch_stat(&self, result: S3StatResult<'_>) -> JsTerminatedResult<()> {
-        match *self {
-            Callback::BlobExists(ctx) => S3BlobStatTask::on_s3_exists_resolved(result, ctx),
-            Callback::BlobStat(ctx) => S3BlobStatTask::on_s3_stat_resolved(result, ctx),
-            Callback::BlobSize(ctx) => S3BlobStatTask::on_s3_size_resolved(result, ctx),
-            Callback::HeadResponseSize(ctx) => {
-                ctx.on_s3_stat_resolved(result);
-                Ok(())
-            }
-            _ => unreachable!(),
-        }
-    }
-
-    fn dispatch_download(&self, result: S3DownloadResult<'_>) -> JsTerminatedResult<()> {
-        match *self {
-            Callback::BlobDownload(ctx) => S3BlobDownloadTask::on_s3_download_resolved(result, ctx),
-            Callback::BlobReadBytes(ctx) => S3ReadBytesTask::on_download(result, ctx),
-            Callback::MultipartStart(ctx) => {
-                MultiPartUpload::start_multi_part_request_result(result, ctx)
-            }
-            _ => unreachable!(),
-        }
-    }
-
-    fn dispatch_upload(&self, result: S3UploadResult<'_>) -> JsTerminatedResult<()> {
-        match *self {
-            Callback::BlobUploadEmpty(ctx) => S3BlobUploadEmptyTask::resolve(result, ctx),
-            Callback::BlobUploadBytes(ctx) => S3BlobUploadBytesTask::resolve(result, ctx),
-            Callback::MultipartSingleSend(ctx) => {
-                MultiPartUpload::single_send_upload_response(result, ctx)
-            }
-            Callback::MultipartRollback(ctx) => {
-                MultiPartUpload::on_rollback_multi_part_request(result, ctx)
-            }
-            _ => unreachable!(),
-        }
-    }
-
-    fn dispatch_delete(&self, result: S3DeleteResult<'_>) -> JsTerminatedResult<()> {
-        match *self {
-            Callback::BlobDelete(ctx) => S3BlobDeleteTask::resolve(result, ctx),
-            _ => unreachable!(),
-        }
-    }
-
-    fn dispatch_list_objects(&self, result: S3ListObjectsResult<'_>) -> JsTerminatedResult<()> {
-        match *self {
-            Callback::BlobListObjects(ctx) => S3BlobListObjectsTask::resolve(result, ctx),
-            _ => unreachable!(),
-        }
-    }
-
-    fn dispatch_commit(&self, result: S3CommitResult<'_>) -> JsTerminatedResult<()> {
-        match *self {
-            Callback::MultipartCommit(ctx) => {
-                MultiPartUpload::on_commit_multi_part_request(result, ctx)
-            }
-            _ => unreachable!(),
-        }
-    }
-
-    fn dispatch_part(&self, result: S3PartResult<'_>) -> JsTerminatedResult<()> {
-        match *self {
-            Callback::MultipartPart(ctx) => UploadPart::on_part_response(result, ctx),
-            _ => unreachable!(),
-        }
-    }
-
-    pub(crate) fn fail(&self, code: &[u8], message: &[u8]) -> JsTerminatedResult<()> {
-        let err = S3Error { code, message };
-        match self.kind() {
-            Kind::Stat => self.dispatch_stat(S3StatResult::Failure(err)),
-            Kind::Download => self.dispatch_download(S3DownloadResult::Failure(err)),
-            Kind::Upload => self.dispatch_upload(S3UploadResult::Failure(err)),
-            Kind::Delete => self.dispatch_delete(S3DeleteResult::Failure(err)),
-            Kind::ListObjects => self.dispatch_list_objects(S3ListObjectsResult::Failure(err)),
-            Kind::Commit => self.dispatch_commit(S3CommitResult::Failure(err)),
-            Kind::Part => self.dispatch_part(S3PartResult::Failure(err)),
-        }
-    }
-
-    pub(crate) fn not_found(&self, code: &[u8], message: &[u8]) -> JsTerminatedResult<()> {
-        let err = S3Error { code, message };
-        match self.kind() {
-            Kind::Stat => self.dispatch_stat(S3StatResult::NotFound(err)),
-            Kind::Download => self.dispatch_download(S3DownloadResult::NotFound(err)),
-            Kind::Delete => self.dispatch_delete(S3DeleteResult::NotFound(err)),
-            Kind::ListObjects => self.dispatch_list_objects(S3ListObjectsResult::NotFound(err)),
-            Kind::Upload | Kind::Commit | Kind::Part => self.fail(code, message),
-        }
-    }
+/// X-macro: the closed set of S3 simple-request handlers. Row shape:
+/// `Variant(CtxType) Kind ResultType NotFoundVariant handler_path;`
+/// where `NotFoundVariant` is the `ResultType` variant to use on 404
+/// (kinds without a `NotFound` variant reuse `Failure`).
+macro_rules! s3_callbacks {
+    ($m:ident) => { $m! {
+        BlobExists(*mut S3BlobStatTask)              Stat        S3StatResult        NotFound S3BlobStatTask::on_s3_exists_resolved;
+        BlobStat(*mut S3BlobStatTask)                Stat        S3StatResult        NotFound S3BlobStatTask::on_s3_stat_resolved;
+        BlobSize(*mut S3BlobStatTask)                Stat        S3StatResult        NotFound S3BlobStatTask::on_s3_size_resolved;
+        HeadResponseSize(AnyRequestContext)          Stat        S3StatResult        NotFound head_response_size;
+        BlobDownload(*mut S3BlobDownloadTask)        Download    S3DownloadResult    NotFound S3BlobDownloadTask::on_s3_download_resolved;
+        BlobReadBytes(*mut S3ReadBytesTask)          Download    S3DownloadResult    NotFound S3ReadBytesTask::on_download;
+        MultipartStart(*mut MultiPartUpload)         Download    S3DownloadResult    NotFound MultiPartUpload::start_multi_part_request_result;
+        BlobUpload(*mut S3BlobUploadTask)            Upload      S3UploadResult      Failure  S3BlobUploadTask::resolve;
+        MultipartSingleSend(*mut MultiPartUpload)    Upload      S3UploadResult      Failure  MultiPartUpload::single_send_upload_response;
+        MultipartRollback(*mut MultiPartUpload)      Upload      S3UploadResult      Failure  MultiPartUpload::on_rollback_multi_part_request;
+        BlobDelete(*mut S3BlobDeleteTask)            Delete      S3DeleteResult      NotFound S3BlobDeleteTask::resolve;
+        BlobListObjects(*mut S3BlobListObjectsTask)  ListObjects S3ListObjectsResult NotFound S3BlobListObjectsTask::resolve;
+        MultipartCommit(*mut MultiPartUpload)        Commit      S3CommitResult      Failure  MultiPartUpload::on_commit_multi_part_request;
+        MultipartPart(*mut UploadPart)               Part        S3PartResult        Failure  UploadPart::on_part_response;
+    }};
 }
+
+macro_rules! __cb_items {
+    ($($V:ident($Ctx:ty) $K:ident $R:ident $nf:ident $h:path;)*) => {
+        /// Static dispatch: each variant names the concrete context type and the
+        /// handler is called directly from the match arms expanded below, so
+        /// backtraces show the callee frame instead of dead-ending at an indirect call.
+        #[derive(Clone, Copy)]
+        pub enum Callback {
+            /// Placeholder for `Default`; never dispatched.
+            Unset,
+            $($V($Ctx),)*
+        }
+
+        impl Callback {
+            pub(crate) fn kind(&self) -> Kind {
+                match self {
+                    Callback::Unset => unreachable!("S3HttpSimpleTask.callback used before being set"),
+                    $(Callback::$V(_) => Kind::$K,)*
+                }
+            }
+            pub(crate) fn fail(&self, code: &[u8], message: &[u8]) -> JsTerminatedResult<()> {
+                let err = S3Error { code, message };
+                match *self {
+                    Callback::Unset => unreachable!(),
+                    $(Callback::$V(ctx) => $h($R::Failure(err), ctx),)*
+                }
+            }
+            pub(crate) fn not_found(&self, code: &[u8], message: &[u8]) -> JsTerminatedResult<()> {
+                let err = S3Error { code, message };
+                match *self {
+                    Callback::Unset => unreachable!(),
+                    $(Callback::$V(ctx) => $h($R::$nf(err), ctx),)*
+                }
+            }
+        }
+    };
+}
+s3_callbacks!(__cb_items);
 
 // `error_type` is a runtime parameter — the
 // branch is on an error path, no perf concern.
@@ -460,11 +371,15 @@ impl S3HttpSimpleTask {
         debug_assert!(this.result.metadata.is_some());
         // reshaped for borrowck — borrow response once, dispatch on a copy of `callback`.
         let response = &this.result.metadata.as_ref().unwrap().response;
-        let callback = this.callback;
-        match callback.kind() {
-            Kind::Stat => match response.status_code {
+        let status = response.status_code;
+        match this.callback {
+            Callback::Unset => unreachable!(),
+            cb @ (Callback::BlobExists(_)
+            | Callback::BlobStat(_)
+            | Callback::BlobSize(_)
+            | Callback::HeadResponseSize(_)) => match status {
                 200 => {
-                    callback.dispatch_stat(S3StatResult::Success(S3StatSuccess {
+                    let r = S3StatResult::Success(S3StatSuccess {
                         etag: response.headers.get(b"etag").unwrap_or(b""),
                         last_modified: response.headers.get(b"last-modified").unwrap_or(b""),
                         content_type: response.headers.get(b"content-type").unwrap_or(b""),
@@ -473,68 +388,90 @@ impl S3HttpSimpleTask {
                             .get(b"content-length")
                             .map(bun_http_types::parse_content_length)
                             .unwrap_or(0),
-                    }))?;
-                }
-                404 => this.error_with_body(ErrorType::NotFound)?,
-                _ => this.error_with_body(ErrorType::Failure)?,
-            },
-            Kind::Delete => match response.status_code {
-                200 | 204 => callback.dispatch_delete(S3DeleteResult::Success)?,
-                404 => this.error_with_body(ErrorType::NotFound)?,
-                _ => this.error_with_body(ErrorType::Failure)?,
-            },
-            Kind::ListObjects => match response.status_code {
-                200 => {
-                    if let Some(body) = &this.result.body {
-                        // parse_s3_list_objects_result is infallible (alloc-only
-                        // failure modes abort).
-                        let success =
-                            list_objects::parse_s3_list_objects_result(body.list.as_slice());
-                        callback.dispatch_list_objects(S3ListObjectsResult::Success(Box::new(
-                            success,
-                        )))?;
-                    } else {
-                        this.error_with_body(ErrorType::Failure)?;
+                    });
+                    match cb {
+                        Callback::BlobExists(c) => S3BlobStatTask::on_s3_exists_resolved(r, c)?,
+                        Callback::BlobStat(c) => S3BlobStatTask::on_s3_stat_resolved(r, c)?,
+                        Callback::BlobSize(c) => S3BlobStatTask::on_s3_size_resolved(r, c)?,
+                        Callback::HeadResponseSize(c) => head_response_size(r, c)?,
+                        _ => unreachable!(),
                     }
                 }
                 404 => this.error_with_body(ErrorType::NotFound)?,
                 _ => this.error_with_body(ErrorType::Failure)?,
             },
-            Kind::Upload => match response.status_code {
-                200 => callback.dispatch_upload(S3UploadResult::Success)?,
+            Callback::BlobDelete(ctx) => match status {
+                200 | 204 => S3BlobDeleteTask::resolve(S3DeleteResult::Success, ctx)?,
+                404 => this.error_with_body(ErrorType::NotFound)?,
                 _ => this.error_with_body(ErrorType::Failure)?,
             },
-            Kind::Download => match response.status_code {
+            Callback::BlobListObjects(ctx) => match status {
+                200 => match &this.result.body {
+                    Some(body) => S3BlobListObjectsTask::resolve(
+                        S3ListObjectsResult::Success(Box::new(
+                            list_objects::parse_s3_list_objects_result(body.list.as_slice()),
+                        )),
+                        ctx,
+                    )?,
+                    None => this.error_with_body(ErrorType::Failure)?,
+                },
+                404 => this.error_with_body(ErrorType::NotFound)?,
+                _ => this.error_with_body(ErrorType::Failure)?,
+            },
+            cb @ (Callback::BlobUpload(_)
+            | Callback::MultipartSingleSend(_)
+            | Callback::MultipartRollback(_)) => match status {
+                200 => match cb {
+                    Callback::BlobUpload(c) => {
+                        S3BlobUploadTask::resolve(S3UploadResult::Success, c)?
+                    }
+                    Callback::MultipartSingleSend(c) => {
+                        MultiPartUpload::single_send_upload_response(S3UploadResult::Success, c)?
+                    }
+                    Callback::MultipartRollback(c) => {
+                        MultiPartUpload::on_rollback_multi_part_request(S3UploadResult::Success, c)?
+                    }
+                    _ => unreachable!(),
+                },
+                _ => this.error_with_body(ErrorType::Failure)?,
+            },
+            cb @ (Callback::BlobDownload(_)
+            | Callback::BlobReadBytes(_)
+            | Callback::MultipartStart(_)) => match status {
                 200 | 204 | 206 => {
                     let body = core::mem::take(&mut this.response_buffer);
                     // re-borrow response after &mut access to response_buffer
                     let response = &this.result.metadata.as_ref().unwrap().response;
-                    callback.dispatch_download(S3DownloadResult::Success(S3DownloadSuccess {
+                    let r = S3DownloadResult::Success(S3DownloadSuccess {
                         etag: response.headers.get(b"etag").unwrap_or(b""),
                         body,
-                    }))?;
+                    });
+                    match cb {
+                        Callback::BlobDownload(c) => {
+                            S3BlobDownloadTask::on_s3_download_resolved(r, c)?
+                        }
+                        Callback::BlobReadBytes(c) => S3ReadBytesTask::on_download(r, c)?,
+                        Callback::MultipartStart(c) => {
+                            MultiPartUpload::start_multi_part_request_result(r, c)?
+                        }
+                        _ => unreachable!(),
+                    }
                 }
                 404 => this.error_with_body(ErrorType::NotFound)?,
-                _ => {
-                    // error
-                    this.error_with_body(ErrorType::Failure)?;
-                }
+                _ => this.error_with_body(ErrorType::Failure)?,
             },
-            Kind::Commit => {
+            Callback::MultipartCommit(ctx) => {
                 // commit multipart upload can fail with status 200
-                let status = response.status_code;
                 if !this.fail_if_contains_error(status)? {
-                    callback.dispatch_commit(S3CommitResult::Success)?;
+                    MultiPartUpload::on_commit_multi_part_request(S3CommitResult::Success, ctx)?;
                 }
             }
-            Kind::Part => {
-                let status = response.status_code;
+            Callback::MultipartPart(ctx) => {
                 if !this.fail_if_contains_error(status)? {
                     let response = &this.result.metadata.as_ref().unwrap().response;
-                    if let Some(etag) = response.headers.get(b"etag") {
-                        callback.dispatch_part(S3PartResult::Etag(etag))?;
-                    } else {
-                        this.error_with_body(ErrorType::Failure)?;
+                    match response.headers.get(b"etag") {
+                        Some(etag) => UploadPart::on_part_response(S3PartResult::Etag(etag), ctx)?,
+                        None => this.error_with_body(ErrorType::Failure)?,
                     }
                 }
             }


### PR DESCRIPTION
## Problem

`Callback` in `src/runtime/webcore/s3/simple_request.rs` carried both a variant tag and a function pointer, with the actual context erased to `*mut c_void`:

```rust
pub enum Callback {
    Stat(fn(S3StatResult<'_>, *mut c_void) -> JsTerminatedResult<()>),
    Download(fn(S3DownloadResult<'_>, *mut c_void) -> JsTerminatedResult<()>),
    // ...
}
```

The variant already selects which `S3*Result` to build. The fn pointer selects the handler, and every value stored there is a named path known at compile time. `Callback::fail()` matches on the tag and then makes an indirect call through `*mut c_void`, so backtraces through the `on_response -> error_with_body -> Callback::fail` path dead-end at `fail()` with no callee frame.

## Change

`Callback` is now an enum of typed context pointers (one variant per concrete handler, 15 total across the 7 result kinds). `fail()` / `not_found()` / `on_response()` dispatch by direct call, so the handler shows up in crash stacks and LLVM can inline the per-arm calls.

The one apparent blocker was `RequestContext<ThisServer, SSL, DBG, H3>` (generic over server config). `AnyRequestContext` already exists to tag-dispatch the six monomorphisations, so the `HeadResponseSize` variant carries an `AnyRequestContext` and a new `on_s3_stat_resolved` accessor routes through the existing `dispatch!` macro.

`ReadBytesHandler` had exactly one implementor (`BlobReadChain`); the trait is dropped and `read_bytes_to_handler` names the concrete type directly.

## Deleted

- `S3HttpSimpleTask.callback_context` field and the `*mut c_void` parameter on `execute_simple_s3_request`
- `fn(..)` + `*mut c_void` parameters on the six `client.rs` simple-request wrappers (`stat` / `download` / `download_slice` / `delete` / `list_objects` / `upload`)
- the `ReadBytesHandler` trait and the generic `Task<H>` S3 adapter
- `on_s3_size_resolved_thunk` in `RequestContext`
- the `unset_callback` placeholder and the `s3_cb` adapter in `S3BlobDownloadTask::init`
- four local `Wrapper` structs (hoisted to named `S3BlobDeleteTask` / `S3BlobListObjectsTask` / `S3BlobUploadEmptyTask` / `S3BlobUploadBytesTask`)
- one `#[allow(clippy::not_unsafe_ptr_arg_deref)]`

## Out of scope

`MultiPartUpload.callback` / `on_writable`, `S3UploadStreamWrapper.callback`, and `S3HttpDownloadStreamingTask.callback` are separate erasure sites not routed through this enum; left for a follow-up.

## Verification

```
bun run rust:clippy                                      # clean
cargo clippy --workspace --no-deps --keep-going \
  --target x86_64-unknown-linux-gnu                      # clean
bun run rust:check-all                                   # 10 ok, 0 failed
bun bd test test/js/bun/s3/                              # identical to main (37 pass / 294 skip;
                                                         # the 50 local failures are egress-proxy
                                                         # rejections of in-process servers,
                                                         # present on main too, diff is empty)
```