### PR TITLE
webcrypto: validate OKP pkcs8/spki DER via BoringSSL

### DIFF
--- a/src/jsc/bindings/webcrypto/CryptoKeyOKPOpenSSL.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyOKPOpenSSL.cpp
@@ -32,9 +32,23 @@
 // #include "Logging.h"
 #include <wtf/text/Base64.h>
 #include <openssl/curve25519.h>
+#include <openssl/evp.h>
 #include "CommonCryptoDERUtilities.h"
+#include "OpenSSLCryptoUniquePtr.h"
 
 namespace WebCore {
+
+static int namedCurveToNID(CryptoKeyOKP::NamedCurve namedCurve)
+{
+    switch (namedCurve) {
+    case CryptoKeyOKP::NamedCurve::X25519:
+        return EVP_PKEY_X25519;
+    case CryptoKeyOKP::NamedCurve::Ed25519:
+        return EVP_PKEY_ED25519;
+    }
+    ASSERT_NOT_REACHED();
+    return EVP_PKEY_NONE;
+}
 
 bool CryptoKeyOKP::isPlatformSupportedCurve(NamedCurve namedCurve)
 {
@@ -74,60 +88,26 @@ std::optional<CryptoKeyPair> CryptoKeyOKP::platformGeneratePair(CryptoAlgorithmI
 // For all of the OIDs, the parameters MUST be absent.
 RefPtr<CryptoKeyOKP> CryptoKeyOKP::importSpki(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
-    // FIXME: We should use the underlying crypto library to import PKCS8 OKP keys.
+    const uint8_t* ptr = keyData.begin();
 
-    // Read SEQUENCE
-    size_t index = 1;
-    if (keyData.size() < index + 1)
+    auto pkey = EvpPKeyPtr(d2i_PUBKEY(nullptr, &ptr, keyData.size()));
+    if (!pkey)
+        return nullptr;
+    if (ptr - keyData.begin() != (ptrdiff_t)keyData.size())
+        return nullptr;
+    if (EVP_PKEY_id(pkey.get()) != namedCurveToNID(namedCurve))
         return nullptr;
 
-    // Read length and SEQUENCE
-    // FIXME: Check length is 5 + 1 + 1 + 1 + keyByteSize.
-    index += bytesUsedToEncodedLength(keyData[index]) + 1;
-    if (keyData.size() < index + 1)
+    size_t rawLen = 0;
+    if (EVP_PKEY_get_raw_public_key(pkey.get(), nullptr, &rawLen) != 1)
         return nullptr;
 
-    // Read length
-    // FIXME: Check length is 5.
-    index += bytesUsedToEncodedLength(keyData[index]);
-    if (keyData.size() < index + 5)
+    Vector<uint8_t> raw(rawLen);
+    if (EVP_PKEY_get_raw_public_key(pkey.get(), raw.begin(), &rawLen) != 1)
         return nullptr;
+    raw.shrink(rawLen);
 
-    // Read OID
-    // FIXME: spec says this is 1 3 101 11X but WPT tests expect 6 3 43 101 11X.
-    if (keyData[index++] != 6 || keyData[index++] != 3 || keyData[index++] != 43 || keyData[index++] != 101)
-        return nullptr;
-
-    switch (namedCurve) {
-    case NamedCurve::X25519:
-        if (keyData[index++] != 110)
-            return nullptr;
-        break;
-    case NamedCurve::Ed25519:
-        if (keyData[index++] != 112)
-            return nullptr;
-        break;
-    };
-
-    // Read BIT STRING
-    if (keyData.size() < index + 2)
-        return nullptr;
-    if (keyData[index++] != 3)
-        return nullptr;
-
-    // Read length
-    // FIXME: Check length is keyByteSize + 1.
-    index += bytesUsedToEncodedLength(keyData[index]);
-
-    if (keyData.size() < index + 1)
-        return nullptr;
-
-    // Initial octet
-    if (!!keyData[index])
-        return nullptr;
-    ++index;
-
-    return create(identifier, namedCurve, CryptoKeyType::Public, std::span<const uint8_t> { keyData.begin() + index, keyData.size() - index }, extractable, usages);
+    return create(identifier, namedCurve, CryptoKeyType::Public, WTF::move(raw), extractable, usages);
 }
 
 constexpr uint8_t OKPOIDFirstByte = 6;
@@ -193,68 +173,28 @@ ExceptionOr<Vector<uint8_t>> CryptoKeyOKP::exportSpki() const
 // For all of the OIDs, the parameters MUST be absent.
 RefPtr<CryptoKeyOKP> CryptoKeyOKP::importPkcs8(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
-    // FIXME: We should use the underlying crypto library to import PKCS8 OKP keys.
+    const uint8_t* ptr = keyData.begin();
 
-    // Read SEQUENCE
-    size_t index = 1;
-    if (keyData.size() < index + 1)
+    auto p8inf = PKCS8PrivKeyInfoPtr(d2i_PKCS8_PRIV_KEY_INFO(nullptr, &ptr, keyData.size()));
+    if (!p8inf)
+        return nullptr;
+    if (ptr - keyData.begin() != (ptrdiff_t)keyData.size())
         return nullptr;
 
-    // Read length
-    index += bytesUsedToEncodedLength(keyData[index]);
-    if (keyData.size() < index + 1)
+    auto pkey = EvpPKeyPtr(EVP_PKCS82PKEY(p8inf.get()));
+    if (!pkey || EVP_PKEY_id(pkey.get()) != namedCurveToNID(namedCurve))
         return nullptr;
 
-    // Read version
-    index += 3;
-    if (keyData.size() < index + 1)
+    size_t rawLen = 0;
+    if (EVP_PKEY_get_raw_private_key(pkey.get(), nullptr, &rawLen) != 1)
         return nullptr;
 
-    // Read SEQUENCE
-    index += bytesUsedToEncodedLength(keyData[index]);
-    if (keyData.size() < index + 1)
+    Vector<uint8_t> raw(rawLen);
+    if (EVP_PKEY_get_raw_private_key(pkey.get(), raw.begin(), &rawLen) != 1)
         return nullptr;
+    raw.shrink(rawLen);
 
-    // Read length
-    index += bytesUsedToEncodedLength(keyData[index]);
-    if (keyData.size() < index + 5)
-        return nullptr;
-
-    // Read OID
-    if (keyData[index++] != OKPOIDFirstByte || keyData[index++] != OKPOIDSecondByte || keyData[index++] != OKPOIDThirdByte || keyData[index++] != OKPOIDFourthByte)
-        return nullptr;
-
-    switch (namedCurve) {
-    case NamedCurve::X25519:
-        if (keyData[index++] != OKPOIDX25519Byte)
-            return nullptr;
-        break;
-    case NamedCurve::Ed25519:
-        if (keyData[index++] != OKPOIDEd25519Byte)
-            return nullptr;
-        break;
-    };
-
-    // Read OCTET STRING
-    if (keyData.size() < index + 2)
-        return nullptr;
-
-    if (keyData[index++] != 4)
-        return nullptr;
-
-    index += bytesUsedToEncodedLength(keyData[index]);
-    if (keyData.size() < index + 2)
-        return nullptr;
-
-    // Read OCTET STRING
-    if (keyData[index++] != 4)
-        return nullptr;
-
-    index += bytesUsedToEncodedLength(keyData[index]);
-    if (keyData.size() < index + 1)
-        return nullptr;
-
-    return create(identifier, namedCurve, CryptoKeyType::Private, std::span<const uint8_t> { keyData.begin() + index, keyData.size() - index }, extractable, usages);
+    return create(identifier, namedCurve, CryptoKeyType::Private, WTF::move(raw), extractable, usages);
 }
 
 ExceptionOr<Vector<uint8_t>> CryptoKeyOKP::exportPkcs8() const

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -545,6 +545,103 @@ describe("SubtleCrypto.deriveBits length", () => {
   });
 });
 
+// The W3C Web Crypto importKey algorithm for Ed25519/X25519 requires running
+// the "parse a PrivateKeyInfo/SubjectPublicKeyInfo" step and throwing DataError
+// on any structural error. Bun's hand-rolled offset walker skipped tag and
+// length validation entirely, accepting structurally invalid ASN.1.
+describe.each(["Ed25519", "X25519"] as const)("%s pkcs8/spki DER import", alg => {
+  const isEd = alg === "Ed25519";
+  const pkcs8 = Buffer.from(
+    isEd
+      ? "302e020100300506032b657004220420133c1261257a68b5209403da57a229cbea6d7ca891d5666229d6089b880fb974"
+      : "302e020100300506032b656e04220420285a9b6fe4de7886429ee2ad9aaba765dc60938119dc41b04fa22de8014c9d52",
+    "hex",
+  );
+  const spki = Buffer.from(
+    isEd
+      ? "302a300506032b65700321008f0654c04944427e905bcc7e0b7ea660e0e3004d495ebbdfe6d61d8fbb6ac950"
+      : "302a300506032b656e032100fdf82ab3e8778354c50c6bf9fe7c98ffaca0fc5bf5c614ba58f40c1c5e7fd176",
+    "hex",
+  );
+  const set = (b: Buffer, i: number, v: number) => {
+    const x = Buffer.from(b);
+    x[i] = v;
+    return x;
+  };
+  const privUsages: KeyUsage[] = isEd ? ["sign"] : ["deriveBits"];
+  const pubUsages: KeyUsage[] = isEd ? ["verify"] : [];
+  const outcome = (fmt: "pkcs8" | "spki", der: Buffer) =>
+    crypto.subtle.importKey(fmt, der, alg, true, fmt === "pkcs8" ? privUsages : pubUsages).then(
+      k => (k instanceof CryptoKey ? "imported" : "other"),
+      e => e.name,
+    );
+
+  it("imports well-formed pkcs8 and round-trips exactly", async () => {
+    const key = await crypto.subtle.importKey("pkcs8", pkcs8, alg, true, privUsages);
+    const exported = Buffer.from(await crypto.subtle.exportKey("pkcs8", key));
+    expect(exported.toString("hex")).toBe(pkcs8.toString("hex"));
+  });
+
+  it("imports well-formed spki and round-trips exactly", async () => {
+    const key = await crypto.subtle.importKey("spki", spki, alg, true, pubUsages);
+    const exported = Buffer.from(await crypto.subtle.exportKey("spki", key));
+    expect(exported.toString("hex")).toBe(spki.toString("hex"));
+  });
+
+  it("rejects structurally invalid pkcs8 DER with DataError", async () => {
+    expect({
+      "outer SEQUENCE len + 1": await outcome("pkcs8", set(pkcs8, 1, pkcs8[1] + 1)),
+      "outer SEQUENCE len - 1": await outcome("pkcs8", set(pkcs8, 1, pkcs8[1] - 1)),
+      "outer SEQUENCE len = 127": await outcome("pkcs8", set(pkcs8, 1, 127)),
+      "version = 255": await outcome("pkcs8", set(pkcs8, 4, 255)),
+      "version tag = SEQUENCE": await outcome("pkcs8", set(pkcs8, 2, 0x30)),
+      "trailing garbage": await outcome("pkcs8", Buffer.concat([pkcs8, Buffer.of(0)])),
+      "well-formed": await outcome("pkcs8", pkcs8),
+    }).toEqual({
+      "outer SEQUENCE len + 1": "DataError",
+      "outer SEQUENCE len - 1": "DataError",
+      "outer SEQUENCE len = 127": "DataError",
+      "version = 255": "DataError",
+      "version tag = SEQUENCE": "DataError",
+      "trailing garbage": "DataError",
+      "well-formed": "imported",
+    });
+  });
+
+  it("rejects structurally invalid spki DER with DataError", async () => {
+    expect({
+      "outer SEQUENCE len + 1": await outcome("spki", set(spki, 1, spki[1] + 1)),
+      "outer SEQUENCE len - 1": await outcome("spki", set(spki, 1, spki[1] - 1)),
+      "trailing garbage": await outcome("spki", Buffer.concat([spki, Buffer.of(0)])),
+      "well-formed": await outcome("spki", spki),
+    }).toEqual({
+      "outer SEQUENCE len + 1": "DataError",
+      "outer SEQUENCE len - 1": "DataError",
+      "trailing garbage": "DataError",
+      "well-formed": "imported",
+    });
+  });
+
+  it("rejects pkcs8/spki carrying the wrong OID", async () => {
+    const other = isEd ? "X25519" : "Ed25519";
+    expect({
+      "pkcs8 wrong OID": await crypto.subtle
+        .importKey("pkcs8", pkcs8, other, true, isEd ? ["deriveBits"] : ["sign"])
+        .then(
+          () => "imported",
+          e => e.name,
+        ),
+      "spki wrong OID": await crypto.subtle.importKey("spki", spki, other, true, isEd ? [] : ["verify"]).then(
+        () => "imported",
+        e => e.name,
+      ),
+    }).toEqual({
+      "pkcs8 wrong OID": "DataError",
+      "spki wrong OID": "DataError",
+    });
+  });
+});
+
 describe("X25519 JWK import", () => {
   const x25519Public: JsonWebKey = {
     kty: "OKP",


### PR DESCRIPTION
## Problem

`crypto.subtle.importKey("pkcs8"/"spki", ...)` for Ed25519 and X25519 accepts structurally invalid DER. The hand-rolled offset walker in `CryptoKeyOKP::importSpki` / `importPkcs8` never checks the outer `SEQUENCE` tag or length octet, and skips the PKCS#8 version field (`index += 3`) without examining its tag or value. Only the OID bytes and inner OCTET STRING/BIT STRING tags are compared; every length field is stepped over unread.

```js
const P8 = Buffer.from("302e020100300506032b657004220420133c1261257a68b5209403da57a229cbea6d7ca891d5666229d6089b880fb974", "hex");
const set = (b, i, v) => { const x = Buffer.from(b); x[i] = v; return x; };
await crypto.subtle.importKey("pkcs8", set(P8, 1, 127), "Ed25519", true, ["sign"]);  // outer SEQUENCE length = 127
await crypto.subtle.importKey("pkcs8", set(P8, 4, 255), "Ed25519", true, ["sign"]);  // version = 255
await crypto.subtle.importKey("pkcs8", set(P8, 2, 0x30), "Ed25519", true, ["sign"]); // version field is a SEQUENCE
// Bun before: all resolve with a signing CryptoKey
// Node v26 / Chrome / Firefox: DataError
```

The [W3C Web Crypto Ed25519/X25519 importKey algorithm](https://www.w3.org/TR/webcrypto-2/) specifies "run the *parse a PrivateKeyInfo / SubjectPublicKeyInfo* algorithm ... if an error occurred, throw a DataError". `crypto.createPrivateKey({format: "der", type: "pkcs8"})` in the same process rejects every one of these blobs, so Bun ships two PKCS#8 DER parsers that disagree with each other. The extracted key material is correct and bounds-checked, so this is parser leniency and spec/interop conformance rather than key confusion or memory unsafety, but these inputs are attacker-suppliable on any `spki`/`pkcs8` verification path.

## Fix

Route OKP `spki`/`pkcs8` import through BoringSSL's strict `d2i_PUBKEY` / `d2i_PKCS8_PRIV_KEY_INFO` (including the "whole buffer consumed" check) and extract the raw 32-byte key with `EVP_PKEY_get_raw_public_key` / `EVP_PKEY_get_raw_private_key`, matching how `CryptoKeyRSA` and `CryptoKeyEC` already import the same formats. This resolves the `// FIXME: We should use the underlying crypto library to import PKCS8 OKP keys.` left in the source. The key-type check moves from byte-level OID matching to comparing `EVP_PKEY_id` against `EVP_PKEY_ED25519` / `EVP_PKEY_X25519`. The export path is unchanged.

## Verification

New `describe.each(["Ed25519", "X25519"])` block in `test/js/web/crypto/web-crypto.test.ts`:

- Well-formed pkcs8 and spki still import and round-trip byte-identically through `exportKey`.
- Five structurally-invalid pkcs8 mutants (outer length +1/-1/127, version 255, version tag wrong) and two spki mutants reject with `DataError`, plus a trailing-garbage case for each.
- A pkcs8/spki carrying the other curve's OID still rejects with `DataError` (negative control for the OID check move).

```
USE_SYSTEM_BUN=1 bun test test/js/web/crypto/web-crypto.test.ts -t "pkcs8/spki DER import"
  4 fail (malformed DER reports "imported")
bun bd test test/js/web/crypto/web-crypto.test.ts
  33 pass, 0 fail
```

No regressions across `test/js/bun/crypto/x25519-derive-bits.test.ts`, `test/js/deno/crypto/webcrypto.test.ts`, `test/js/node/crypto/crypto.key-objects.test.ts`, `wpt-webcrypto.generateKey.test.ts`, `crypto-oneshot.test.ts`, `sign-jwk-ieee-p1363.test.ts`, `11029-crypto-verify-null-algorithm.test.ts`, `web-crypto-sha3.test.ts` (10,286 tests), and Node's `test-webcrypto-sign-verify.js`, `test-webcrypto-wrap-unwrap.js`, `test-webcrypto-derivebits-cfrg.js`, `test-webcrypto-derivekey-cfrg.js`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/crypto/web-crypto.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (8d1974b2e)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [4.58ms]
(pass) Web Crypto > keeps event loop alive [479.11ms]
(pass) Web Crypto > has globals [3.17ms]
(pass) Web Crypto > should encrypt and decrypt [14.15ms]
(pass) Web Crypto > should verify and sign [50.49ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [23.55ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [12.24ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [2715.31ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of abort
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (108149b6f)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [0.07ms]
(pass) Web Crypto > keeps event loop alive [13.95ms]
(pass) Web Crypto > has globals [0.10ms]
(pass) Web Crypto > should encrypt and decrypt [0.64ms]
(pass) Web Crypto > should verify and sign [1.70ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [0.80ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [0.38ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [30.73ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [13.61ms]
(pass) Ed25519 > generateKey > should return CryptoKeys without namedCurve in algorithm field [0.21ms]
(pass) AES-KW wrapKey/unwrapKey with jwk format > round-trips an HMAC SHA-256 key [0.24ms]
(pass) AES-KW wrapKey/unwrapKey with jwk format > round-trips an HMAC SHA-384 key [0.07ms]
(pass) AES-KW wrapKey/unwrapKey with jwk format > round-trips an HMAC SHA-512 key [0.04ms]
(pass) AES-KW wrapKey/unwrapKey with 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/crypto/web-crypto.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (8d1974b2e)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [4.52ms]
(pass) Web Crypto > keeps event loop alive [470.15ms]
(pass) Web Crypto > has globals [3.12ms]
(pass) Web Crypto > should encrypt and decrypt [13.98ms]
(pass) Web Crypto > should verify and sign [44.74ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [16.88ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [11.12ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [2551.90ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of abort
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 666ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcrypto-1.cpp.o
[2/7] gen cpp.rs (cppbind)
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_paths v0.0.0 (/workspace/bun/src/paths)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/works
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcrypto/CryptoKeyOKPOpenSSL.cpp | 134 ++++++---------------
 test/js/web/crypto/web-crypto.test.ts              |  97 +++++++++++++++
 2 files changed, 134 insertions(+), 97 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/webcrypto/CryptoKeyOKPOpenSSL.cpp      2      3      0
test/js/web/crypto/web-crypto.test.ts                   1      1      0
```

</details>

<!-- robobun:evidence:end -->