### PR TITLE
node:crypto: validate RSA private key material on JWK import

### DIFF
--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -4373,10 +4373,9 @@ bool Rsa::checkPrivateKey() const
     if (rsa_ == nullptr) return false;
     if (RSA_check_key(rsa_) == 1) return true;
 
-    // BoringSSL hard-fails sign/decrypt on inconsistent CRT parameters where
-    // OpenSSL would fall back to m^d mod n. Recompute dp, dq, qi from d, p, q
-    // so JWK imports with permuted or corrupt CRT hints still produce a working
-    // key when the core (n, e, d, p, q) material is valid.
+    // BoringSSL hard-fails on inconsistent CRT params where OpenSSL falls back
+    // to m^d mod n. Recompute dp/dq/qi from d,p,q so JWK imports with bad CRT
+    // hints still yield a working key when the core (n,e,d,p,q) is valid.
     ERR_clear_error();
 
     const BIGNUM* d;

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -4407,7 +4407,8 @@ bool Rsa::checkPrivateKey() const
     }
 
     if (RSA_set0_crt_params(
-            const_cast<RSA*>(rsa_), dp.get(), dq.get(), qi.get()) != 1) {
+            const_cast<RSA*>(rsa_), dp.get(), dq.get(), qi.get())
+        != 1) {
         return false;
     }
     dp.release();

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -4368,7 +4368,7 @@ bool Rsa::setPrivateKey(BignumPointer&& d,
     return true;
 }
 
-bool Rsa::checkPrivateKey() const
+bool Rsa::validateOrRepairPrivateKey()
 {
     if (rsa_ == nullptr) return false;
     if (RSA_check_key(rsa_) == 1) return true;

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -4368,6 +4368,57 @@ bool Rsa::setPrivateKey(BignumPointer&& d,
     return true;
 }
 
+bool Rsa::checkPrivateKey() const
+{
+    if (rsa_ == nullptr) return false;
+    if (RSA_check_key(rsa_) == 1) return true;
+
+    // BoringSSL hard-fails sign/decrypt on inconsistent CRT parameters where
+    // OpenSSL would fall back to m^d mod n. Recompute dp, dq, qi from d, p, q
+    // so JWK imports with permuted or corrupt CRT hints still produce a working
+    // key when the core (n, e, d, p, q) material is valid.
+    ERR_clear_error();
+
+    const BIGNUM* d;
+    const BIGNUM* p;
+    const BIGNUM* q;
+    RSA_get0_key(rsa_, nullptr, nullptr, &d);
+    RSA_get0_factors(rsa_, &p, &q);
+    if (!d || !p || !q) return false;
+
+    BignumCtxPointer ctx(BN_CTX_new());
+    BignumPointer pm1(BN_dup(p));
+    BignumPointer qm1(BN_dup(q));
+    BignumPointer dp = BignumPointer::New();
+    BignumPointer dq = BignumPointer::New();
+    if (!ctx || !pm1 || !qm1 || !dp || !dq
+        || BN_sub_word(pm1.get(), 1) != 1
+        || BN_sub_word(qm1.get(), 1) != 1
+        || BN_mod(dp.get(), d, pm1.get(), ctx.get()) != 1
+        || BN_mod(dq.get(), d, qm1.get(), ctx.get()) != 1) {
+        ERR_clear_error();
+        return false;
+    }
+
+    BignumPointer qi(BN_mod_inverse(nullptr, q, p, ctx.get()));
+    if (!qi) {
+        ERR_clear_error();
+        return false;
+    }
+
+    if (RSA_set0_crt_params(
+            const_cast<RSA*>(rsa_), dp.get(), dq.get(), qi.get()) != 1) {
+        return false;
+    }
+    dp.release();
+    dq.release();
+    qi.release();
+
+    if (RSA_check_key(rsa_) == 1) return true;
+    ERR_clear_error();
+    return false;
+}
+
 DataPointer Rsa::encrypt(const EVPKeyPointer& key,
     const Rsa::CipherParams& params,
     const Buffer<const void> in)

--- a/src/jsc/bindings/ncrypto.h
+++ b/src/jsc/bindings/ncrypto.h
@@ -455,6 +455,7 @@ public:
         BignumPointer&& dp,
         BignumPointer&& dq,
         BignumPointer&& qi);
+    bool checkPrivateKey() const;
 
     using CipherParams = Cipher::CipherParams;
 

--- a/src/jsc/bindings/ncrypto.h
+++ b/src/jsc/bindings/ncrypto.h
@@ -455,7 +455,7 @@ public:
         BignumPointer&& dp,
         BignumPointer&& dq,
         BignumPointer&& qi);
-    bool checkPrivateKey() const;
+    bool validateOrRepairPrivateKey();
 
     using CipherParams = Cipher::CipherParams;
 

--- a/src/jsc/bindings/node/crypto/KeyObject.cpp
+++ b/src/jsc/bindings/node/crypto/KeyObject.cpp
@@ -988,7 +988,7 @@ KeyObject KeyObject::getKeyObjectHandleFromJwk(JSGlobalObject* globalObject, Thr
                 return {};
             }
 
-            if (!rsaView.checkPrivateKey()) {
+            if (!rsaView.validateOrRepairPrivateKey()) {
                 ERR::CRYPTO_INVALID_JWK(scope, globalObject, "Invalid JWK RSA key"_s);
                 return {};
             }

--- a/src/jsc/bindings/node/crypto/KeyObject.cpp
+++ b/src/jsc/bindings/node/crypto/KeyObject.cpp
@@ -987,6 +987,11 @@ KeyObject KeyObject::getKeyObjectHandleFromJwk(JSGlobalObject* globalObject, Thr
                 ERR::CRYPTO_INVALID_JWK(scope, globalObject, "Invalid JWK RSA key"_s);
                 return {};
             }
+
+            if (!rsaView.checkPrivateKey()) {
+                ERR::CRYPTO_INVALID_JWK(scope, globalObject, "Invalid JWK RSA key"_s);
+                return {};
+            }
         }
 
         auto key = EVPKeyPointer::NewRSA(WTF::move(rsa));

--- a/test/js/node/crypto/crypto.key-objects.test.ts
+++ b/test/js/node/crypto/crypto.key-objects.test.ts
@@ -1801,12 +1801,9 @@ function randomProp() {
   return "prop" + crypto.randomUUID().replace(/-/g, "");
 }
 
-// Previously createPrivateKey({ format: "jwk" }) did no RSA key-material
-// validation, so inconsistent components produced a poisoned KeyObject whose
-// first sign()/privateDecrypt() threw an OpenSSL internal error instead of a
-// recoverable ERR_CRYPTO_INVALID_JWK at import time. Node.js (OpenSSL) rejects
-// n != p*q at import and otherwise falls back to m^d mod n, so it signs
-// correctly even when the supplied CRT hints are wrong.
+// Node.js (OpenSSL) rejects n != p*q at JWK import and otherwise falls back to
+// m^d mod n for bad CRT hints; BoringSSL hard-fails at sign() instead, so an
+// unvalidated import yielded a poisoned KeyObject.
 describe("createPrivateKey RSA JWK key-material validation", () => {
   const msg = Buffer.from("hello");
   const { privateKey, publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });

--- a/test/js/node/crypto/crypto.key-objects.test.ts
+++ b/test/js/node/crypto/crypto.key-objects.test.ts
@@ -1800,3 +1800,77 @@ test("ECDSA should work", async () => {
 function randomProp() {
   return "prop" + crypto.randomUUID().replace(/-/g, "");
 }
+
+// Previously createPrivateKey({ format: "jwk" }) did no RSA key-material
+// validation, so inconsistent components produced a poisoned KeyObject whose
+// first sign()/privateDecrypt() threw an OpenSSL internal error instead of a
+// recoverable ERR_CRYPTO_INVALID_JWK at import time. Node.js (OpenSSL) rejects
+// n != p*q at import and otherwise falls back to m^d mod n, so it signs
+// correctly even when the supplied CRT hints are wrong.
+describe("createPrivateKey RSA JWK key-material validation", () => {
+  const msg = Buffer.from("hello");
+  const { privateKey, publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const jwk = privateKey.export({ format: "jwk" }) as Required<JsonWebKey>;
+  const flipByte = (b64u: string, i: number) => {
+    const buf = Buffer.from(b64u, "base64url");
+    buf[i] ^= 1;
+    return buf.toString("base64url");
+  };
+
+  type Outcome =
+    | { imported: false; code: string }
+    | { imported: true; signVerified: boolean; decryptRoundTrip: boolean };
+
+  const tryImport = (mutated: JsonWebKey): Outcome => {
+    let key: KeyObject;
+    try {
+      key = createPrivateKey({ key: mutated, format: "jwk" });
+    } catch (e: any) {
+      return { imported: false, code: e.code };
+    }
+    const sig = sign("sha256", msg, key);
+    const signVerified = verify("sha256", msg, publicKey, sig);
+    const enc = publicEncrypt(publicKey, msg);
+    const decryptRoundTrip = privateDecrypt(key, enc).equals(msg);
+    return { imported: true, signVerified, decryptRoundTrip };
+  };
+
+  it("round-trips an unmodified JWK", () => {
+    expect(tryImport(jwk)).toEqual({ imported: true, signVerified: true, decryptRoundTrip: true });
+  });
+
+  // OpenSSL tolerates inconsistent CRT hints by falling back to a raw modular
+  // exponentiation; BoringSSL does not, so we recompute dp/dq/qi at import.
+  const usable: Outcome = { imported: true, signVerified: true, decryptRoundTrip: true };
+  it.each([
+    ["p and q swapped", { ...jwk, p: jwk.q, q: jwk.p }],
+    ["dp corrupt", { ...jwk, dp: flipByte(jwk.dp, 3) }],
+    ["dq corrupt", { ...jwk, dq: flipByte(jwk.dq, 3) }],
+    ["qi corrupt", { ...jwk, qi: flipByte(jwk.qi, 3) }],
+    ["dp and dq swapped", { ...jwk, dp: jwk.dq, dq: jwk.dp }],
+  ])("accepts and signs correctly when CRT hints are inconsistent: %s", (_name, mutated) => {
+    expect(tryImport(mutated)).toEqual(usable);
+  });
+
+  const rejected: Outcome = { imported: false, code: "ERR_CRYPTO_INVALID_JWK" };
+  it.each([
+    ["n != p*q (p corrupt)", { ...jwk, p: flipByte(jwk.p, 3) }],
+    ["n != p*q (q corrupt)", { ...jwk, q: flipByte(jwk.q, 3) }],
+    ["n corrupt", { ...jwk, n: flipByte(jwk.n, 3) }],
+    ["d corrupt", { ...jwk, d: flipByte(jwk.d, 10) }],
+    ["e = 1", { ...jwk, e: "AQ" }],
+    ["e mismatched with d", { ...jwk, e: "Aw" }],
+  ])("rejects at import when the core key material is invalid: %s", (_name, mutated) => {
+    expect(tryImport(mutated)).toEqual(rejected);
+  });
+
+  it("exports recomputed CRT hints after importing with corrupt ones", () => {
+    const key = createPrivateKey({ key: { ...jwk, qi: flipByte(jwk.qi, 3) }, format: "jwk" });
+    const reexported = key.export({ format: "jwk" }) as Required<JsonWebKey>;
+    expect({ dp: reexported.dp, dq: reexported.dq, qi: reexported.qi }).toEqual({
+      dp: jwk.dp,
+      dq: jwk.dq,
+      qi: jwk.qi,
+    });
+  });
+});


### PR DESCRIPTION
## What

`createPrivateKey({ key, format: "jwk" })` now validates the assembled RSA private key with `RSA_check_key` and, when the CRT hints (`dp`/`dq`/`qi`) are inconsistent with `d`/`p`/`q`, recomputes them instead of returning a poisoned `KeyObject`.

## Repro

```js
import crypto from "node:crypto";
const { privateKey } = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
const J = privateKey.export({ format: "jwk" });
const flip = (s, i) => { const b = Buffer.from(s, "base64url"); b[i] ^= 1; return b.toString("base64url"); };
for (const [name, jwk] of Object.entries({
  "pq-swapped": { ...J, p: J.q, q: J.p },
  "qi-corrupt": { ...J, qi: flip(J.qi, 3) },
  "n-ne-p*q":   { ...J, p: flip(J.p, 3) },
})) {
  try {
    const k = crypto.createPrivateKey({ key: jwk, format: "jwk" });
    try { crypto.sign("sha256", Buffer.from("m"), k); console.log(name, "ACCEPTED, sign()=ok"); }
    catch (e) { console.log(name, "ACCEPTED, sign() THREW", e.code); }
  } catch (e) { console.log(name, "rejected at import", e.code); }
}
```

Before: every case imports successfully and `sign()` later throws `error:04000044:RSA routines:OPENSSL_internal:internal error` (`ERR_OSSL_INTERNAL ERROR`).
After: matches Node: `pq-swapped` / `qi-corrupt` import and sign correctly, `n-ne-p*q` is rejected at import with `ERR_CRYPTO_INVALID_JWK`.

## Cause

`KeyObject::getKeyObjectHandleFromJwk` decodes `n/e/d/p/q/dp/dq/qi` and calls `Rsa::setPrivateKey`, which is just `RSA_set0_key` + `RSA_set0_factors` + `RSA_set0_crt_params`. No consistency check runs, so inconsistent components are accepted.

Node.js links OpenSSL, whose `rsa_ossl_mod_exp` cross-checks the CRT result against `m^d mod n` and silently falls back to the non-CRT path when they differ, so bad CRT hints still sign correctly. BoringSSL's `rsa_default_private_transform` runs the same cross-check but fails the operation with `ERR_R_INTERNAL_ERROR` instead of falling back. Node additionally checks `n == p*q` at import (nodejs/node `src/crypto/crypto_rsa.cc::ImportJWKRsaKey`).

## Fix

Add `Rsa::checkPrivateKey()` to `ncrypto`: run `RSA_check_key`; on failure recompute `dp = d mod (p-1)`, `dq = d mod (q-1)`, `qi = q^(-1) mod p` and re-check. Call it from the JWK private-key import path; throw `ERR_CRYPTO_INVALID_JWK` if the key is still invalid.

This matches Node for every case where Node either rejects at import or produces a verifiable signature. Bun is intentionally stricter where Node would accept the key and produce garbage (`e = 1`, `d` not inverse of `e`): those now reject at import rather than returning a key BoringSSL will refuse to use.

The WebCrypto `subtle.importKey("jwk")` face of this bug is addressed separately in #33903; the helper added here is available should that path want the same CRT-recomputation behaviour.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/js/node/crypto/crypto.key-objects.test.ts -t "RSA JWK key-material validation"
# 12/13 fail with OPENSSL_internal:internal error
bun bd test test/js/node/crypto/crypto.key-objects.test.ts -t "RSA JWK key-material validation"
# 13/13 pass
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/crypto/crypto.key-objects.test.ts

<!-- robobun:evidence:end -->