### PR TITLE
test: fix fetch-gzip redirect test broken by headers-first redirect follow

### DIFF
--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -498,10 +498,9 @@ describe("corrupt compressed responses", () => {
   }
 
   it("redirect with a malformed chunked body: follow succeeds, manual surfaces the body error", async () => {
-    // Redirects are followed on the response head (WHATWG HTTP-redirect
-    // fetch); the 3xx body is discarded, so a parse failure in it must not
-    // affect redirect:"follow". Under redirect:"manual" the 302 *is* the
-    // caller's Response and reading its body surfaces the error.
+    // Redirects are followed on the response head (WHATWG HTTP-redirect fetch),
+    // so a parse failure in the discarded 3xx body must not affect redirect:
+    // "follow"; under redirect:"manual" the 302 body surfaces the error.
     await using final = Bun.serve({ port: 0, fetch: () => new Response("FINAL") });
     const location = `${final.url.origin}/final`;
     const srv = createNetServer(sock => {

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -497,15 +497,18 @@ describe("corrupt compressed responses", () => {
     }
   }
 
-  it("followed redirect with a malformed chunked body rejects fetch()", async () => {
-    // The intermediate 3xx head is not the caller's Response under
-    // redirect:"follow", so a body parse failure there must reject fetch()
-    // rather than resolving with the 302.
+  it("redirect with a malformed chunked body: follow succeeds, manual surfaces the body error", async () => {
+    // Redirects are followed on the response head (WHATWG HTTP-redirect
+    // fetch); the 3xx body is discarded, so a parse failure in it must not
+    // affect redirect:"follow". Under redirect:"manual" the 302 *is* the
+    // caller's Response and reading its body surfaces the error.
+    await using final = Bun.serve({ port: 0, fetch: () => new Response("FINAL") });
+    const location = `${final.url.origin}/final`;
     const srv = createNetServer(sock => {
       sock.on("error", () => {});
       sock.end(
         "HTTP/1.1 302 Found\r\n" +
-          "Location: http://127.0.0.1:1/unreached\r\n" +
+          `Location: ${location}\r\n` +
           "Transfer-Encoding: chunked\r\n" +
           "Connection: close\r\n\r\n" +
           "ZZ\r\n",
@@ -513,18 +516,19 @@ describe("corrupt compressed responses", () => {
     });
     const port = await listen(srv);
     try {
-      const followErr = await fetch(`http://127.0.0.1:${port}/`, { redirect: "follow" }).then(
-        r => ({ status: r.status }),
-        e => e,
-      );
-      expect(followErr).toBeInstanceOf(Error);
-      expect((followErr as { code?: string }).code).toBe("InvalidHTTPResponse");
+      const res = await fetch(`http://127.0.0.1:${port}/`, { redirect: "follow" });
+      expect({ status: res.status, redirected: res.redirected, url: res.url, body: await res.text() }).toEqual({
+        status: 200,
+        redirected: true,
+        url: location,
+        body: "FINAL",
+      });
 
       // With redirect:"manual" the 302 *is* the final response.
-      const res = await fetch(`http://127.0.0.1:${port}/`, { redirect: "manual" });
-      expect(res.status).toBe(302);
-      expect(res.headers.get("location")).toBe("http://127.0.0.1:1/unreached");
-      const bodyErr = await res.arrayBuffer().then(
+      const manual = await fetch(`http://127.0.0.1:${port}/`, { redirect: "manual" });
+      expect(manual.status).toBe(302);
+      expect(manual.headers.get("location")).toBe(location);
+      const bodyErr = await manual.arrayBuffer().then(
         () => null,
         e => e,
       );


### PR DESCRIPTION
Fixes #33915.

### Problem

`test/js/web/fetch/fetch-gzip.test.ts` > "followed redirect with a malformed chunked body rejects fetch()" fails deterministically on every PR build since #33613 and #33710 landed together:

```
error: expect(received).toBe(expected)
Expected: "InvalidHTTPResponse"
Received: "ConnectionRefused"
      at test/js/web/fetch/fetch-gzip.test.ts:521:53
```

The test, added in #33710, expected `fetch(url, { redirect: "follow" })` to reject with `InvalidHTTPResponse` because the intermediate 302's chunked body is malformed (`ZZ\r\n`). #33613, developed concurrently and merged right after, deliberately changed redirects to follow on the response head per WHATWG HTTP-redirect fetch: the 3xx body is discarded, not awaited or validated, so the follow proceeds to the `Location` target (port 1 in the old test, hence `ConnectionRefused`). Main's own builds are build-only, so this only shows up on PR builds.

### Fix

Test-only change. The `redirect: "follow"` branch now redirects to a real local server and asserts the follow resolves with the final 200 despite the malformed intermediate body, matching the tests #33613 added in `fetch-redirect.test.ts` (and avoiding the non-hermetic port-1 `ConnectionRefused` dependency). The `redirect: "manual"` branch is unchanged: the 302 is the caller's Response there and reading its body still rejects with `InvalidHTTPResponse`.

The property the original test protected, that a malformed intermediate body never resolves fetch() with the 302 itself, is still asserted: the follow branch requires `redirected: true` with the final URL and body.

### Verification

```
bun bd test test/js/web/fetch/fetch-gzip.test.ts   # 42 pass, 0 fail (fails on main)
bun bd test test/js/web/fetch/fetch-redirect.test.ts  # 12 pass, 0 fail
```

Note for review: this is a test-expectation fix for a test broken on main, so there is no `src/` change and the fail-before state is current main itself.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/fetch/fetch-gzip.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/fetch/fetch-gzip.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (81c3d64f6)

test/js/web/fetch/fetch-gzip.test.ts:

      at gcTick (/workspace/bun/test/harness.ts:316:20)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:31:3)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:17:63)
 HTTP/1.1 GET http://localhost:44339/
 Connection: keep-alive
 User-Agent: Bun/1.4.0-debug
 Accept: */*
 Host: localhost:44339
 Accept-Encoding: gzip, deflate, br, zstd

      at gcTick (/workspace/bun/test/harness.ts:316:20)
      at fetch (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:22:7)
< 200 OK
< Content-Encoding: gzip
< Content-Type: text/html; charset=utf-8
< Date: Fri, 10 Jul 2026 12:50:46 GMT
< Content-Length: 16139


      at gcTick (/workspace/bun/test/harness.ts:316:20)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:34:3)

      at gcTick (/workspace/bun/test/harness.ts:316:20)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:37:3)

      at gcTick (/workspace/bun/test/harness.ts:316:20)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:40:5)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:41:43)

      at gcTick (/workspace/bun/test/harness.ts:316:20)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:43:3)
(pass) fetch() with a buffered gzip response works (one chunk) [275.73ms]
 HTTP/1.1 GET http://localhost:35455/hey
 Connection: keep-alive
 User-Agent: Bun/1.4.0-debug
 Accept: */*
 Host: localhost:35455
 Accept-Encoding: gzip, deflate, br, zstd
< 302 Found
< Lo
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/web/fetch/fetch-gzip.test.ts | 33 ++++++++++++++++++---------------
 1 file changed, 18 insertions(+), 15 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
test/js/web/fetch/fetch-gzip.test.ts      1      2      0
```

</details>

**root cause** · written by the author bot

The test was written for the old fetch behavior of reading the full 3xx response body before acting on a redirect, so it expected a malformed chunked body on the intermediate 302 to reject with InvalidHTTPResponse. After #33613, redirects are followed as soon as the response head arrives per the WHATWG HTTP-redirect fetch algorithm, so the malformed body is never parsed and the fetch instead failed against the test's unreachable port 1 target with ConnectionRefused. The fix updates the test to redirect to a real local server and assert the follow succeeds with the final 200 response, while …

<!-- robobun:evidence:end -->