### PR TITLE
parser: tree-shake classes with private elements, keep side-effectful computed keys (#20866)

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5750,21 +5750,28 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 continue;
             }
 
-            if !self.expr_can_be_removed_if_unused_without_dce_check(
-                property.key.as_ref().expect("unreachable"),
-            ) {
+            // ToPropertyKey on a computed key can run user code unless it's a primitive literal.
+            if property.flags.contains(Flags::Property::IsComputed)
+                && !property
+                    .key
+                    .map(|key| key.unwrap_inlined().is_primitive_literal())
+                    .unwrap_or(false)
+            {
                 return false;
             }
 
-            if let Some(val) = &property.value {
-                if !self.expr_can_be_removed_if_unused_without_dce_check(val) {
-                    return false;
+            // Non-static values/initializers only run on construction or access, never for an unused class.
+            if property.flags.contains(Flags::Property::IsStatic) {
+                if let Some(val) = &property.value {
+                    if !self.expr_can_be_removed_if_unused_without_dce_check(val) {
+                        return false;
+                    }
                 }
-            }
 
-            if let Some(val) = &property.initializer {
-                if !self.expr_can_be_removed_if_unused_without_dce_check(val) {
-                    return false;
+                if let Some(val) = &property.initializer {
+                    if !self.expr_can_be_removed_if_unused_without_dce_check(val) {
+                        return false;
+                    }
                 }
             }
         }

--- a/test/bundler/esbuild/dce.test.ts
+++ b/test/bundler/esbuild/dce.test.ts
@@ -1509,7 +1509,6 @@ describe("bundler", () => {
     dce: true,
   });
   itBundled("dce/TreeShakingClassProperty", {
-    todo: true,
     files: {
       "/entry.js": /* js */ `
         let remove1 = class { x }
@@ -1536,16 +1535,13 @@ describe("bundler", () => {
         let keep4 = class { set [x](_) {} }
         let keep5 = class { async [x]() {} }
         let keep6 = class { [{ toString() { console.log(1); } }] = 'x' }
-
-        let POSSIBLE_REMOVAL_1 = class { [{ toString() {} }] = 'x' }
+        let keep7 = class { [{ toString() {} }] = 'x' }
       `,
     },
-    bundling: false,
     treeShaking: true,
     dce: true,
   });
   itBundled("dce/TreeShakingClassStaticProperty", {
-    todo: true,
     files: {
       "/entry.js": /* js */ `
         let remove1 = class { static x }
@@ -1572,12 +1568,49 @@ describe("bundler", () => {
         let keep6 = class { static set [x](_) {} }
         let keep7 = class { static async [x]() {} }
         let keep8 = class { static [{ toString() { console.log(1); } }] = 'x' }
-
-        let POSSIBLE_REMOVAL_1 = class { static [{ toString() {} }] = 'x' }
+        let keep9 = class { static [{ toString() {} }] = 'x' }
       `,
     },
-    bundling: false,
     treeShaking: true,
+    dce: true,
+  });
+  // https://github.com/oven-sh/bun/issues/20866
+  itBundled("dce/TreeShakingClassPrivateProperty", {
+    files: {
+      "/entry.js": /* js */ `
+        let remove1 = class { #x }
+        let remove2 = class { #x = x }
+        let remove3 = class { #x() {} }
+        let remove4 = class { get #x() {} }
+        let remove5 = class { set #x(_) {} }
+        let remove6 = class { async #x() {} }
+        let remove7 = class { static #x }
+        let remove8 = class { static #x = 1 }
+        let remove9 = class { static #x() {} }
+        let remove10 = class { static get #x() {} }
+        let remove11 = class { static set #x(_) {} }
+
+        let keep1 = class { static #x = x }
+        let keep2 = class { #x; static { x() } }
+      `,
+    },
+    treeShaking: true,
+    dce: true,
+  });
+  // https://github.com/oven-sh/bun/issues/20866
+  itBundled("dce/TreeShakingClassPrivatePropertyDeclaration", {
+    files: {
+      "/entry.js": /* js */ `
+        class REMOVE1 { #x }
+        class REMOVE2 { #x = x }
+        class REMOVE3 { #x() {} }
+        class REMOVE4 { static #x }
+        class REMOVE5 { static #x = 1 }
+        class REMOVE6 { static #x() {} }
+
+        class KEEP1 { static #x = x }
+      `,
+    },
     dce: true,
   });
   itBundled("dce/TreeShakingUnaryOperators", {


### PR DESCRIPTION
### What does this PR do?

Fixes #20866 — classes with private elements are never tree-shaken.

`class_can_be_removed_if_unused` ran `expr_can_be_removed_if_unused` on every property key, and private names aren't in that allowlist, so any private member kept the class alive. esbuild instead only checks computed keys (primitive literals pass) and only checks value/initializer on static members. This PR matches that, which also fixes the inverse bug: a computed key with a side-effectful `toString` passed the general check, so the class — and its observable side effect — was wrongly removed.

Not ported from esbuild: decorator guards (decorators are lowered before this check runs, so they're dead code here) and `IsSymbolInstance` (not tracked in Bun; omitting it is conservative). Both match the existing `EObject` arm's handling in the same function.

### Tests

Enabled the two `todo` esbuild-ported class DCE tests. They needed bundle mode (transpile-only never tree-shakes unused statements; their passing object-literal sibling already runs bundled) and `POSSIBLE_REMOVAL_1` → `keep7`/`keep9` renames — the harness `/REMOVE/gi` scan rejects that name when the class is correctly kept, and upstream esbuild names this case `keep6`. Added `TreeShakingClassPrivateProperty` and `TreeShakingClassPrivatePropertyDeclaration` covering the issue repros.

All fail with `USE_SYSTEM_BUN=1`, pass with `bun bd test test/bundler/esbuild/dce.test.ts` (77 pass, 0 fail).
