### PR TITLE
structured-clone: reject RegExp records with unparseable patterns

### DIFF
--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -5120,6 +5120,10 @@ private:
             }
             VM& vm = m_lexicalGlobalObject->vm();
             RegExp* regExp = RegExp::create(vm, pattern->string(), reFlags.value());
+            if (!regExp->isValid()) [[unlikely]] {
+                fail();
+                return JSValue();
+            }
             RegExpObject* obj = RegExpObject::create(vm, m_globalObject->regExpStructure(), regExp);
             addTerminalToObjectPool(obj);
             return obj;

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -309,6 +309,58 @@ it("deserialize rejects a typed array whose backing store is not an array buffer
   expect(exitCode).toBe(0);
 });
 
+it("deserialize rejects a RegExp record whose pattern does not parse", async () => {
+  // A serialized RegExp whose pattern bytes are rewritten to an unparseable
+  // expression must be rejected at deserialize time instead of producing a
+  // RegExp object that throws SyntaxError on every use.
+  const script = `
+    import { serialize, deserialize } from "bun:jsc";
+    import * as v8 from "node:v8";
+
+    function patch(buf) {
+      const bytes = buf instanceof Buffer ? buf : Buffer.from(buf);
+      const idx = bytes.indexOf("abc");
+      bytes.write("(((", idx, "latin1");
+      return buf;
+    }
+
+    for (const [name, ser, deser] of [
+      ["bun:jsc", serialize, deserialize],
+      ["node:v8", v8.serialize, v8.deserialize],
+    ]) {
+      let outcome;
+      try {
+        const value = deser(patch(ser(/abc/g)));
+        outcome = "accepted " + value.source + " " + value.flags;
+      } catch (error) {
+        outcome = error instanceof Error ? "rejected " + error.constructor.name : "threw non-error";
+      }
+      console.log(name, outcome);
+      // A valid RegExp still round-trips.
+      const roundTripped = deser(ser(/xyz/gi));
+      console.log(name, roundTripped instanceof RegExp, roundTripped.source, roundTripped.flags, roundTripped.test("AXYZB"));
+    }
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe(
+    [
+      "bun:jsc rejected TypeError",
+      "bun:jsc true xyz gi true",
+      "node:v8 rejected TypeError",
+      "node:v8 true xyz gi true",
+      "",
+    ].join("\n"),
+  );
+  expect(exitCode).toBe(0);
+});
+
 it("serialize rejects a CryptoKey created with extractable set to false", async () => {
   // bun:jsc serialize() (and node:v8 serialize(), which wraps it) hands the raw
   // structured-clone buffer to the caller, so a key imported with


### PR DESCRIPTION
## Reproduction

```js
import * as v8 from "node:v8";
const b = Buffer.from(v8.serialize(/abc/g));
b.write("(((", b.indexOf("abc"), "latin1");
const re = v8.deserialize(b);     // bun: accepted; node: throws SyntaxError
re.test("x");                     // throws SyntaxError
new RegExp(re.source, re.flags);  // throws SyntaxError
```

Bun hands back a live `RegExp` whose pattern is `(((` and whose every method throws `SyntaxError`. No JavaScript can construct this object, and it re-serializes cleanly. Node rejects the same image at the deserialize boundary.

## Cause

`CloneDeserializer::readTerminal()`'s `RegExpTag` arm validates the flags via `Yarr::parseFlags` but then calls `RegExp::create(vm, pattern, flags)` without checking `isValid()`, so an unparseable pattern produces a `RegExp` whose `m_constructionErrorCode` is set and which errors on every subsequent use.

## Fix

Check `regExp->isValid()` after `RegExp::create()` and `fail()` if the pattern does not parse, matching how invalid flags are already handled in the same switch arm. The deserializer now rejects the payload with `TypeError: Unable to deserialize data.`, consistent with other malformed-payload handling (invalid flags, out-of-range object references, etc.).

## Verification

```
# before (USE_SYSTEM_BUN=1):
(fail) deserialize rejects a RegExp record whose pattern does not parse
  - "bun:jsc rejected TypeError
  + "bun:jsc accepted ((( g
  - node:v8 rejected TypeError
  + node:v8 accepted ((( g

# after (bun bd):
(pass) deserialize rejects a RegExp record whose pattern does not parse
```

The new test covers both `bun:jsc` `deserialize` and `node:v8` `deserialize` (which wraps it), and confirms valid RegExps still round-trip.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/jsc/bun-jsc.test.ts

<!-- robobun:evidence:end -->