### PR TITLE
webcore: reject negative fd in Blob structured-clone deserialize

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4247,6 +4247,15 @@ fn _on_structured_clone_deserialize<B: AsRef<[u8]>>(
             match pathlike_tag {
                 PathOrFileDescriptorSerializeTag::Fd => {
                     let fd: Fd = reader.read_struct()?;
+                    // Wire bytes are untrusted: enforce the same range as
+                    // `Bun.file(fd)` (`FdJsc::from_js_validated`) so a crafted
+                    // record cannot materialize an fd that no JS could
+                    // construct. On posix fd == -1 reaches
+                    // `Fd::as_borrowed_fd`'s `raw != -1` assert and aborts.
+                    #[cfg(not(windows))]
+                    if fd.0 < 0 {
+                        return Err(bun_core::err!("InvalidValue"));
+                    }
                     let mut path_or_fd = PathOrFileDescriptor::Fd(fd);
                     break 'file Blob::new(Blob::find_or_create_file_from_path(
                         &mut path_or_fd,

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4247,11 +4247,9 @@ fn _on_structured_clone_deserialize<B: AsRef<[u8]>>(
             match pathlike_tag {
                 PathOrFileDescriptorSerializeTag::Fd => {
                     let fd: Fd = reader.read_struct()?;
-                    // Wire bytes are untrusted: enforce the same range as
-                    // `Bun.file(fd)` (`FdJsc::from_js_validated`) so a crafted
-                    // record cannot materialize an fd that no JS could
-                    // construct. On posix fd == -1 reaches
-                    // `Fd::as_borrowed_fd`'s `raw != -1` assert and aborts.
+                    // Wire bytes are untrusted: enforce the same range as `FdJsc::from_js_validated`
+                    // so a crafted record cannot materialize an fd no JS could construct (fd == -1
+                    // hits `Fd::as_borrowed_fd`'s `raw != -1` assert on posix and aborts).
                     #[cfg(not(windows))]
                     if fd.0 < 0 {
                         return Err(bun_core::err!("InvalidValue"));

--- a/test/js/web/structured-clone-blob-file.test.ts
+++ b/test/js/web/structured-clone-blob-file.test.ts
@@ -1,6 +1,6 @@
 import { deserialize, serialize } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows } from "harness";
 import v8 from "node:v8";
 
 describe("structuredClone with Blob and File", () => {
@@ -470,6 +470,80 @@ describe("structuredClone with Blob and File", () => {
 
       const viaV8 = v8.deserialize(Buffer.from(craft(4n)));
       expect((await viaV8.arrayBuffer()).byteLength).toBe(0);
+    });
+
+    // The File-store variant of the Blob record carries a raw fd on the wire.
+    // `Bun.file(fd)` enforces `0 <= fd <= i32::MAX`; the deserializer must
+    // apply the same range so a crafted record cannot materialize a Blob over
+    // an fd that no JS could construct. On posix, fd == -1 reaches the
+    // `raw != -1` assert in `Fd::as_borrowed_fd` and aborts the process at
+    // the first `.size` / body-mixin touch.
+    describe.skipIf(isWindows)("crafted File blob fd (posix)", () => {
+      // Robustness against header/framing changes: serialize a file-backed
+      // blob over a distinctive sentinel fd, locate its 4-byte image in the
+      // output (posix Fd is `#[repr(transparent)] i32`), and patch it.
+      const fdSentinel = 0x7e7d7c7b; // distinct bytes, inside [0, i32::MAX]
+      const fdImage = Buffer.from(new Uint8Array(serialize(Bun.file(fdSentinel))));
+      const fdNeedle = Buffer.alloc(4);
+      fdNeedle.writeInt32LE(fdSentinel);
+      const fdFieldIndex = fdImage.indexOf(fdNeedle);
+      if (fdFieldIndex < 0) throw new Error("could not locate fd field in serialized file blob");
+
+      function craftFd(fd: number) {
+        const out = Buffer.from(fdImage);
+        out.writeInt32LE(fd, fdFieldIndex);
+        return out;
+      }
+
+      // The pre-fix build aborts on `.size`, so run each case in a subprocess
+      // and require a clean exit that reports a deserialize-time throw.
+      const fdChildScript = `
+        const { deserialize } = require("bun:jsc");
+        const v8 = require("node:v8");
+        const payload = Buffer.from(process.argv[1], "base64");
+        for (const de of [deserialize, buf => v8.deserialize(Buffer.from(buf))]) {
+          let outcome;
+          try {
+            const blob = de(payload);
+            void blob.size;
+            outcome = { threw: false };
+          } catch (e) {
+            outcome = { threw: true, message: String(e.message) };
+          }
+          process.stdout.write(JSON.stringify(outcome) + "\\n");
+        }
+      `;
+
+      test.concurrent.each([
+        ["fd = -1", -1],
+        ["fd = -2", -2],
+        ["fd = i32::MIN", -2147483648],
+      ])("%s is rejected at deserialize", async (_name, fd) => {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "-e", fdChildScript, craftFd(fd).toString("base64")],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+        const expected = { threw: true, message: "Unable to deserialize data." };
+        expect({
+          stderr,
+          outcomes: stdout
+            .split("\n")
+            .filter(Boolean)
+            .map(l => JSON.parse(l)),
+        }).toEqual({ stderr: "", outcomes: [expected, expected] });
+        expect(exitCode).toBe(0);
+      });
+
+      test("fd >= 0 still deserializes", () => {
+        for (const fd of [0, 1, fdSentinel]) {
+          expect(deserialize(craftFd(fd))).toBeInstanceOf(Blob);
+          expect(v8.deserialize(craftFd(fd))).toBeInstanceOf(Blob);
+        }
+      });
     });
 
     test("truncated payload at every byte boundary throws cleanly", () => {


### PR DESCRIPTION
## Reproduction

```js
import * as v8 from "node:v8";
const u8 = n => Buffer.from([n & 255]);
const u32 = n => { const b = Buffer.alloc(4); b.writeUInt32LE(n >>> 0); return b; };
const u64 = n => { const b = Buffer.alloc(8); b.writeBigUInt64LE(BigInt(n)); return b; };
const f64 = n => { const b = Buffer.alloc(8); b.writeDoubleLE(n); return b; };
const img = Buffer.concat([
  Buffer.from([14, 0, 0, 0, 254]),              // JSC header + Bun Blob tag
  u8(3), u64(0), u32(0), u8(0),                 // ver, offset, ct, ctWasSet
  u8(0), u8(0), u32(0xffffffff),                // File store, Fd tag, fd = -1
  u8(0), f64(0),                                // isJSDOMFile, lastModified
]);
const blob = v8.deserialize(img);               // returns a Blob over raw fd -1
console.log(blob.size);                         // panic: Fd::as_borrowed_fd on raw fd -1
```

```
panic: Fd::as_borrowed_fd on raw fd -1
```

Exit 134 (SIGABRT). Reachable via `node:v8` / `bun:jsc` deserialize and `child_process` IPC with `serialization: "advanced"`.

## Cause

`Bun.file(fd)` enforces `0 <= fd <= i32::MAX` via `FdJsc::from_js_validated` and throws `ERR_OUT_OF_RANGE` otherwise. `_on_structured_clone_deserialize` reads the wire fd with `reader.read_struct::<Fd>()` and does no validation, so a crafted record can materialize a `PathOrFileDescriptor::Fd(-1)` that no JS could construct. On posix, `-1` is the niche value for `std::os::fd::BorrowedFd`; the first touch that stats the fd hits `Fd::as_borrowed_fd`'s `raw != -1` assert and aborts.

Other negative values (`-2`, `AT_FDCWD`, `i32::MIN`) deserialize into a Blob that returns `EBADF` on use. They do not abort but still bypass the front door's range.

## Fix

Apply the same non-negative check at deserialize on posix and reject with `InvalidValue`, which the existing error path turns into the standard `TypeError: Unable to deserialize data.` (Windows serializes the full packed `Fd` including system-kind stdio handles, so no range is enforced there; the `as_borrowed_fd` assert is `#[cfg(unix)]`.)

## Verification

```
USE_SYSTEM_BUN=1 bun test test/js/web/structured-clone-blob-file.test.ts -t "crafted File blob fd"
  3 fail  (fd=-1 child aborts with the panic; fd=-2/i32::MIN report threw:false)
  1 pass  (fd>=0 positive control)

bun bd test test/js/web/structured-clone-blob-file.test.ts
  40 pass
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/structured-clone-blob-file.test.ts

<!-- robobun:evidence:end -->