### PR TITLE
webcore: reject interior NUL in Blob structured-clone path field

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4257,6 +4257,12 @@ fn _on_structured_clone_deserialize<B: AsRef<[u8]>>(
                 PathOrFileDescriptorSerializeTag::Path => {
                     let path_len = reader.read_int_le::<u32>()?;
                     let path = read_slice(reader, path_len as usize)?;
+                    // Same constraint the JS entry (`Valid::path_null_bytes`)
+                    // enforces: a NUL-embedded path cannot be handed to the
+                    // syscall layer (`ZStr::as_cstr` would truncate / panic).
+                    if strings::index_of_char(&path, 0).is_some() {
+                        return Err(bun_core::err!("InvalidValue"));
+                    }
                     // The owned `CowSlice`
                     // adopts the `Box<[u8]>` so the store frees it in
                     // `PathLike::drop`; borrowing here would drop `path` at scope

--- a/test/js/web/structured-clone-blob-file.test.ts
+++ b/test/js/web/structured-clone-blob-file.test.ts
@@ -459,6 +459,69 @@ describe("structuredClone with Blob and File", () => {
       expect(exitCode).toBe(0);
     });
 
+    test("file-backed Blob path with interior NUL is rejected at deserialize", async () => {
+      // A crafted Blob wire image whose File store path contains an interior
+      // NUL must be rejected as a JS error at deserialize time; it must never
+      // reach the syscall layer where the C-string view would truncate (and
+      // debug builds abort in ZStr::as_cstr). Build the image by round-tripping
+      // a real file-backed blob and overwriting the path bytes, so the outer
+      // serializer framing and the Blob record layout stay whatever the current
+      // build emits.
+      const probe = Buffer.alloc(16, 0x5a);
+      const good = Buffer.from(serialize(Bun.file(probe.toString("latin1"))));
+      const at = good.indexOf(probe);
+      expect(at).toBeGreaterThan(0);
+      // Sanity: both entry points accept the unmodified image.
+      expect(deserialize(good)).toBeInstanceOf(Blob);
+      expect(v8.deserialize(good)).toBeInstanceOf(Blob);
+
+      const bad = Buffer.from(good);
+      bad.set(Buffer.from("/e\0tc/host\0s____", "latin1"), at);
+
+      // Run in a child so that if the reader ever aborts on these bytes the
+      // test runner survives. The assertion is on the deserialize step: it
+      // must throw, so no Blob carrying a NUL-embedded path ever exists.
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const { deserialize } = require("bun:jsc");
+            const v8 = require("node:v8");
+            const bad = Buffer.from(process.argv[1], "base64");
+            for (const [name, de] of [["bun:jsc", deserialize], ["node:v8", b => v8.deserialize(b)]]) {
+              let threw = null;
+              try {
+                de(bad);
+              } catch (e) {
+                threw = { name: e?.constructor?.name, message: String(e?.message ?? e) };
+              }
+              process.stdout.write(JSON.stringify({ entry: name, threw }) + "\\n");
+            }
+          `,
+          bad.toString("base64"),
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      const lines = stdout
+        .split("\n")
+        .filter(Boolean)
+        .map(l => JSON.parse(l));
+      expect({ lines, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+        lines: [
+          { entry: "bun:jsc", threw: { name: "TypeError", message: "Unable to deserialize data." } },
+          { entry: "node:v8", threw: { name: "TypeError", message: "Unable to deserialize data." } },
+        ],
+        stderr: "",
+        exitCode: 0,
+        signalCode: null,
+      });
+    });
+
     test("in-process: offset at store boundary yields empty view", async () => {
       // offset == store length stays within the allocation on any build, so
       // this is safe to assert in-process and covers the boundary directly.


### PR DESCRIPTION
## Repro

```js
import * as v8 from "node:v8";
import { serialize } from "bun:jsc";

// round-trip a real file-backed Blob, then overwrite the path bytes with NULs
const probe = Buffer.alloc(16, 0x5a);
const img = Buffer.from(serialize(Bun.file(probe.toString("latin1"))));
img.set(Buffer.from("/e\0tc/host\0s____", "latin1"), img.indexOf(probe));

const blob = v8.deserialize(img);
console.log(blob.size);   // panic: ZStr::as_cstr: interior NUL would truncate the C view
```

On a debug build of `main` this aborts:

```
panic: ZStr::as_cstr: interior NUL would truncate the C view
  ZStr::as_cstr (src/bun_core/util.rs:212)
  bun_sys::linux_syscall::stat
  bun_runtime::webcore::blob::resolve_file_stat
  Blob::resolve_size
  Blob::get_size
```

## Cause

`_on_structured_clone_deserialize` reads the `Path` variant's bytes off the wire and hands them straight to `find_or_create_file_from_path` with no validation. `Bun.file()` from JS already rejects interior NULs via `Valid::path_null_bytes`, but the wire reader bypasses that entry point, so a crafted image constructs a `Store::File` whose path has embedded NULs. The first operation that reaches the syscall layer (`stat` via `.size`) trips the `ZStr::as_cstr` interior-NUL check.

## Fix

Apply the same NUL check in the structured-clone reader's `Path` arm and return `InvalidValue`, which surfaces to JS as `TypeError: Unable to deserialize data.` (the same error the reader already throws for an unknown store tag or truncated trailer).

## Verification

New test in `test/js/web/structured-clone-blob-file.test.ts` crafts a file-backed Blob image with NUL bytes in the path and asserts both `bun:jsc` `deserialize` and `v8.deserialize` throw `TypeError: Unable to deserialize data.` Run in a child so any abort surfaces as a test failure rather than killing the runner.

```
bun bd test test/js/web/structured-clone-blob-file.test.ts
  37 pass, 0 fail
```

Without the `src/` change the new test fails with `threw: null` for both entry points.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/structured-clone-blob-file.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (1abd5d544)

test/js/web/structured-clone-blob-file.test.ts:
(pass) structuredClone with Blob and File > Blob structured clone > slices and re-slices serialize only their own byte windows [25.09ms]
(pass) structuredClone with Blob and File > Blob structured clone > empty Blob [3.11ms]
(pass) structuredClone with Blob and File > Blob structured clone > Blob with text content [6.50ms]
(pass) structuredClone with Blob and File > Blob structured clone > Blob with binary content [7.56ms]
(pass) structuredClone with Blob and File > Blob structured clone > nested Blob in object [4.03ms]
(pass) structuredClone with Blob and File > Blob structured clone > nested Blob in array [4.15ms]
(pass) structuredClone with Blob and File > B
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (1abd5d544)

test/js/web/structured-clone-blob-file.test.ts:
(pass) structuredClone with Blob and File > Blob structured clone > slices and re-slices serialize only their own byte windows [0.44ms]
(pass) structuredClone with Blob and File > Blob structured clone > empty Blob [0.04ms]
(pass) structuredClone with Blob and File > Blob structured clone > Blob with text content [0.11ms]
(pass) structuredClone with Blob and File > Blob structured clone > Blob with binary content [0.13ms]
(pass) structuredClone with Blob and File > Blob structured clone > nested Blob in object [0.05ms]
(pass) structuredClone with Blob and File > Blob structured clone > nested Blob in array [0.04ms]
(pass) structuredClone with Blob and File > Blob structured clone > multiple Blobs in object [0.05ms]
(pass) structuredClone with Blob and File > Blob structured clone > deeply nested Blob [0.04ms]
(pass) structuredClone with Blob and File > Blob structured clone > sliced Blob transmits only the sliced bytes [0.14ms]
(pass) structuredClone with Blob and File > File structured clone > File with basic properties [0.05ms]
(pass) structuredClone with Blob and File > File str
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/structured-clone-blob-file.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (1abd5d544)

test/js/web/structured-clone-blob-file.test.ts:
(pass) structuredClone with Blob and File > Blob structured clone > slices and re-slices serialize only their own byte windows [24.38ms]
(pass) structuredClone with Blob and File > Blob structured clone > empty Blob [2.99ms]
(pass) structuredClone with Blob and File > Blob structured clone > Blob with text content [6.30ms]
(pass) structuredClone with Blob and File > Blob structured clone > Blob with binary content [7.41ms]
(pass) structuredClone with Blob and File > Blob structured clone > nested Blob in object [3.99ms]
(pass) structuredClone with Blob and File > Blob structured clone > nested Blob in array [3.72ms]
(pass) structuredClone with Blob and File > B
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 683ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 90 exports (host=3, lazy=10, generic=77, rust=0); 248 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/Blob.rs                    |  6 +++
 test/js/web/structured-clone-blob-file.test.ts | 63 ++++++++++++++++++++++++++
 2 files changed, 69 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/runtime/webcore/Blob.rs                         5      1      0
test/js/web/structured-clone-blob-file.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->