### PR TITLE
File: normalize lastModified option (NaN->0, null is present)

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5690,10 +5690,13 @@ pub fn jsdom_file_construct_(
                 }
             }
 
-            if let Some(last_modified) = options.get_truthy(global_this, "lastModified")? {
+            // WebIDL dictionary member: only `undefined` / not-present falls
+            // through to the Date.now() default. Any present value (including
+            // `null`) goes through ToNumber, with NaN normalized to 0.
+            if let Some(last_modified) = options.get(global_this, "lastModified")? {
                 set_last_modified = true;
-                blob.last_modified
-                    .set(last_modified.to_number(global_this)?);
+                let n = last_modified.to_number(global_this)?;
+                blob.last_modified.set(if n.is_nan() { 0.0 } else { n });
             }
         }
     }
@@ -5776,9 +5779,9 @@ pub fn construct_bun_file(
                     }
                 }
             }
-            if let Some(last_modified) = opts.get_truthy(global_object, "lastModified")? {
-                blob.last_modified
-                    .set(last_modified.to_number(global_object)?);
+            if let Some(last_modified) = opts.get(global_object, "lastModified")? {
+                let n = last_modified.to_number(global_object)?;
+                blob.last_modified.set(if n.is_nan() { 0.0 } else { n });
             }
         }
     }

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -222,20 +222,13 @@ describe("new File() lastModified option", () => {
     expect(lm({ lastModified: input })).toBe(expected);
   });
 
-  test("lastModified: undefined defaults to Date.now()", () => {
-    const before = Date.now();
-    const value = lm({ lastModified: undefined });
-    const after = Date.now();
-    expect(value).toBeGreaterThanOrEqual(before);
-    expect(value).toBeLessThanOrEqual(after);
-  });
-
-  test("missing lastModified defaults to Date.now()", () => {
-    const before = Date.now();
-    const value = lm({});
-    const after = Date.now();
-    expect(value).toBeGreaterThanOrEqual(before);
-    expect(value).toBeLessThanOrEqual(after);
+  // The default comes from a native wall-clock read that may differ from JS
+  // Date.now() by a few ms on Windows; assert "current time" within a wide
+  // tolerance rather than an exact bracket.
+  test.each([[{ lastModified: undefined }], [{}]])("%p defaults to the current time", opts => {
+    const value = lm(opts);
+    expect(Number.isFinite(value)).toBe(true);
+    expect(Math.abs(value - Date.now())).toBeLessThan(60_000);
   });
 
   test("valueOf throwing propagates", () => {

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -202,6 +202,55 @@ test("new File('123', '123') is NOT supported", async () => {
   expect(() => new File("123", "123")).toThrow();
 });
 
+describe("new File() lastModified option", () => {
+  const lm = (o: any) => new File([], "n", o).lastModified;
+
+  test.each([
+    // [input, expected] — present member goes through ToNumber; NaN → 0
+    [NaN, 0],
+    ["not a number", 0],
+    [{}, 0],
+    [{ valueOf: () => NaN }, 0],
+    [null, 0],
+    ["", 0],
+    [false, 0],
+    [true, 1],
+    ["123", 123],
+    [1234, 1234],
+    [-1, -1],
+  ] as const)("lastModified: %p -> %p", (input, expected) => {
+    expect(lm({ lastModified: input })).toBe(expected);
+  });
+
+  test("lastModified: undefined defaults to Date.now()", () => {
+    const before = Date.now();
+    const value = lm({ lastModified: undefined });
+    const after = Date.now();
+    expect(value).toBeGreaterThanOrEqual(before);
+    expect(value).toBeLessThanOrEqual(after);
+  });
+
+  test("missing lastModified defaults to Date.now()", () => {
+    const before = Date.now();
+    const value = lm({});
+    const after = Date.now();
+    expect(value).toBeGreaterThanOrEqual(before);
+    expect(value).toBeLessThanOrEqual(after);
+  });
+
+  test("valueOf throwing propagates", () => {
+    expect(() =>
+      lm({
+        lastModified: {
+          valueOf() {
+            throw new Error("boom");
+          },
+        },
+      }),
+    ).toThrow("boom");
+  });
+});
+
 test("new Blob('123') is NOT supported", async () => {
   expect(() => new Blob("123")).toThrow();
 });


### PR DESCRIPTION
## Problem

`new File(bits, name, {lastModified})` skips the WebIDL dictionary-member conversion for `lastModified`:

```js
new File([], "n", { lastModified: NaN }).lastModified   // NaN   (should be 0)
new File([], "n", { lastModified: "zz" }).lastModified  // NaN   (should be 0)
new File([], "n", { lastModified: null }).lastModified  // Date.now()  (should be 0)
new File([], "n", { lastModified: "" }).lastModified    // Date.now()  (should be 0)
```

Node.js and browsers return `0` for all of these.

## Cause

`jsdom_file_construct_` reads the option with `get_truthy`, which filters `null` and `""` as if the member were absent (falling through to the `Date.now()` default), and stores the raw `to_number` result, which passes `NaN` through unchanged. The `lastModified` getter then returns the stored `NaN` verbatim.

## Fix

Read the option with `get` (only `undefined` / not-present maps to `None`), run the value through `ToNumber`, and normalize `NaN` to `0`. This matches Node.js exactly: `undefined` defaults to `Date.now()`, everything else is `+value` with `NaN -> 0`.

The same normalization is applied to the sibling option-read in `construct_bun_file` so the two sites stay textually consistent; note that for `Bun.file()` the `.lastModified` getter reads the stat-derived mtime and does not consult this field, so that hunk has no effect on the getter.

## Verification

```
# before (USE_SYSTEM_BUN=1): 6 fail / 14
# after  (bun bd):           14 pass / 14
bun bd test test/js/web/fetch/blob.test.ts -t lastModified
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/blob.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (3f02b7591)

test/js/web/fetch/blob.test.ts:
(pass) blob: imports have sourcemapped stacktraces [20.55ms]
(pass) Blob.slice [45.44ms]
(pass) Bun.file().slice [40.69ms]
(pass) new Blob [4.08ms]
(pass) new Blob stringifies non-Blob object parts in order [11.43ms]
(pass) blob: can be fetched [13.54ms]
(pass) blob: URL has Content-Type [11.10ms]
(pass) blob: can be imported [15.73ms]
(pass) blob: can reliable get type from fetch #10072 [257.44ms]
(pass) new Blob(new Uint8Array()) is supported [5.00ms]
(pass) new File(new Uint8Array()) is supported [4.75ms]
(pass) new File('123', '123') is NOT supported [3.04ms]
217 |     [true, 1],
218 |     ["123", 123],
219 |     [1234, 1234],
220 |     [-1, -1],
221 |   ] as const)("lastModified: %p -> %
... (truncated)

release without fix: 2 skipped
bun test v1.4.0-canary.1 (3f02b7591)

test/js/web/fetch/blob.test.ts:
(pass) blob: imports have sourcemapped stacktraces [0.69ms]
(pass) Blob.slice [0.49ms]
(pass) Bun.file().slice [0.95ms]
(pass) new Blob [0.06ms]
(pass) new Blob stringifies non-Blob object parts in order [0.17ms]
(pass) blob: can be fetched [0.22ms]
(pass) blob: URL has Content-Type [0.17ms]
(pass) blob: can be imported [0.28ms]
(pass) blob: can reliable get type from fetch #10072 [202.80ms]
(pass) new Blob(new Uint8Array()) is supported [0.22ms]
(pass) new File(new Uint8Array()) is supported [0.09ms]
(pass) new File('123', '123') is NOT supported [0.06ms]
(pass) new File() lastModified option > lastModified: NaN -> 0 [0.05ms]
(pass) new File() lastModified option > lastModified: "not a number" -> 0
(pass) new File() lastModified option > lastModified: {} -> 0
(pass) new File() lastModified option > lastModified: {
  valueOf: [Function: valueOf],
} -> 0 [0.02ms]
(pass) new File() lastModified option > lastModified: null -> 0
(pass) new File() lastModified option > lastModified: "" -> 0
(pass) new File() lastModified option > lastModified: false -> 0
(pass) new File() lastModified option > lastModi
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/blob.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (3f02b7591)

test/js/web/fetch/blob.test.ts:
(pass) blob: imports have sourcemapped stacktraces [19.82ms]
(pass) Blob.slice [44.66ms]
(pass) Bun.file().slice [47.63ms]
(pass) new Blob [4.20ms]
(pass) new Blob stringifies non-Blob object parts in order [11.14ms]
(pass) blob: can be fetched [12.97ms]
(pass) blob: URL has Content-Type [10.69ms]
(pass) blob: can be imported [15.69ms]
(pass) blob: can reliable get type from fetch #10072 [250.79ms]
(pass) new Blob(new Uint8Array()) is supported [4.99ms]
(pass) new File(new Uint8Array()) is supported [4.54ms]
(pass) new File('123', '123') is NOT supported [2.94ms]
(pass) new File() lastModified option > lastModified: NaN -> 0 [3.07ms]
(pass) new File() lastModified option > lastModified: "not 
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 678ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 90 exports (host=3, lazy=10, generic=77, rust=0); 248 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/Blob.rs    | 15 +++++++++------
 test/js/web/fetch/blob.test.ts | 42 ++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 51 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
src/runtime/webcore/Blob.rs         2      2      0
test/js/web/fetch/blob.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->