### PR TITLE
fix(types): return jest from setSystemTime

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -92,7 +92,7 @@ declare module "bun:test" {
     function clearAllMocks(): void;
     function resetAllMocks(): void;
     function fn<T extends (...args: any[]) => any>(func?: T): Mock<T>;
-    function setSystemTime(now?: number | Date): void;
+    function setSystemTime(now?: number | Date): typeof jest;
     function setTimeout(milliseconds: number): void;
     function useFakeTimers(options?: { now?: number | Date }): typeof vi;
     function useRealTimers(): typeof vi;

--- a/test/integration/bun-types/fixture/mocks.ts
+++ b/test/integration/bun-types/fixture/mocks.ts
@@ -29,3 +29,5 @@ jest.fn<() => string>().mockResolvedValue("24");
 jest.fn().mockClear();
 jest.fn().mockReset();
 jest.fn().mockRejectedValueOnce(new Error());
+
+expectType(jest.setSystemTime()).is<typeof jest>();


### PR DESCRIPTION
## What changed

- Declare `jest.setSystemTime()` as returning the `jest` object, matching the runtime.
- Add an exact-type regression assertion to the bun-types fixture.

## Why

The native host function returns its receiver, but the declaration reported `void`. This prevented typed fluent usage even though it already works at runtime.

## Verification

- TypeScript 6 compile check without DOM types
- TypeScript 6 compile check with DOM types
- Current-main Bun runtime check: `jest.setSystemTime() === jest`
- Regression assertion fails with the old declaration and passes with this change
