### PR TITLE
gitignore heap snapshots, profiler output, and core dumps in all variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,7 +193,21 @@ test/integration/bun-types/fixture/bun.lock
 .claude/worktrees
 src/runtime/bake/generated.ts
 /target/
+# Heap snapshots, profiler output, and core dumps can contain secrets from
+# process memory (env vars, tokens). Never commit them, compressed or not.
 *.heapsnapshot
+*.heapsnapshot.*
+*.heapprofile
+*.heapprofile.*
+*.heaptimeline
+*.heaptimeline.*
+*.cpuprofile
+*.cpuprofile.*
+Heap-*.json
+Heap-*.json.*
+isolate-*.log
+core
+core.[0-9]*
 # Legacy codegen outputs (no longer written, but old build trees still have
 # them on disk; keep ignored so they don't show as untracked).
 src/jsc/bindings/GeneratedJS2Native.zig


### PR DESCRIPTION
The existing `*.heapsnapshot` rule missed compressed variants (`.heapsnapshot.gz`), `.heapprofile`, `.heaptimeline`, `.cpuprofile`, v8 isolate logs, and core dumps — all of which capture process memory (including environment variables) and must never be committed.

Verified each new pattern with `git check-ignore -v` and confirmed no tracked files collide with the new rules.