### PR TITLE
fix: correct typo 'docker built' to 'docker build' in shell docs

### DIFF
--- a/docs/runtime/shell.mdx
+++ b/docs/runtime/shell.mdx
@@ -264,7 +264,7 @@ import { $ } from "bun";
 
 await $`
   REV=$(git rev-parse HEAD)
-  docker built -t myapp:$REV
+  docker build -t myapp:$REV
   echo Done building docker image "myapp:$REV"
 `;
 ```


### PR DESCRIPTION
## Summary

Fixes a typo in `docs/runtime/shell.mdx` where `docker built` should be `docker build`.

This is a one-character fix correcting the Docker CLI command name in the documentation example.