### PR TITLE
test(proxy-stress): cap memory-probe iterations on macOS to avoid ephemeral-port exhaustion

### DIFF
--- a/test/js/bun/http/proxy-stress-concurrent.test.ts
+++ b/test/js/bun/http/proxy-stress-concurrent.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isCI, isWindows } from "harness";
+import { bunEnv, bunExe, isASAN, isCI, isMacOS, isWindows } from "harness";
 import { once } from "node:events";
 import net from "node:net";
 import { join } from "node:path";
@@ -390,14 +390,17 @@ describe("memory probe (subprocess)", () => {
     mode: MODES,
   })) {
     // ASAN inflates RSS and slows everything down; use fewer iterations
-    // there but still enough to surface a UAF. Windows is capped for a
-    // different reason: 12 concurrent subprocesses x 1200 iterations leave
-    // ~11k loopback TIME_WAIT entries (120s drain), close to the 16384-port
-    // ephemeral range, so later tests in the shard see listen(0) and
-    // connect() hand out the same few ports and hit 4-tuple collisions
-    // with those TIME_WAITs (observed as ERR_POSTGRES_CONNECTION_REFUSED /
-    // WSAENOTCONN in test/js/sql/postgres-binary-array-bounds.test.ts).
-    const iterations = isASAN || isWindows ? 300 : isCI ? 1200 : 600;
+    // there but still enough to surface a UAF. Windows and macOS are capped
+    // for a different reason: both use a 16,384-port ephemeral range
+    // (49152-65535), and 12 concurrent subprocesses x 1200 iterations x 2
+    // loopback connections each leave ~15k entries in TIME_WAIT (120s drain
+    // on Windows, 30s on macOS). On Windows that poisons later tests in the
+    // shard (listen(0)/connect() recycling into stale TIME_WAIT 4-tuples,
+    // observed as ERR_POSTGRES_CONNECTION_REFUSED / WSAENOTCONN in
+    // test/js/sql/postgres-binary-array-bounds.test.ts); on macOS the
+    // https-proxy fixtures themselves see a single ConnectionRefused at
+    // ~i=550 once TIME_WAIT passes ~15k.
+    const iterations = isASAN || isWindows || isMacOS ? 300 : isCI ? 1200 : 600;
 
     test.concurrent(
       `${proxyTls ? "https" : "http"}-proxy → https-origin mode=${mode} ×${iterations}`,
@@ -426,7 +429,14 @@ describe("memory probe (subprocess)", () => {
         // Surface the child's final stats line before asserting.
         const lines = stdout.trim().split("\n");
         const lastLine = lines[lines.length - 1];
-        let result: { completed: number; failed: number; rssStart: number; rssEnd: number; rssMax: number };
+        let result: {
+          completed: number;
+          failed: number;
+          firstError?: string;
+          rssStart: number;
+          rssEnd: number;
+          rssMax: number;
+        };
         try {
           result = JSON.parse(lastLine);
         } catch {
@@ -441,7 +451,12 @@ describe("memory probe (subprocess)", () => {
         if (mode.includes("abort")) {
           expect(result.failed).toBeGreaterThan(0);
         } else {
-          expect(result.failed).toBe(0);
+          // Carry `firstError` in the diff so a CI failure shows the
+          // actual fetch error, not just the count.
+          expect({ failed: result.failed, firstError: result.firstError }).toEqual({
+            failed: 0,
+            firstError: undefined,
+          });
           expect(result.completed).toBe(iterations);
         }
 

--- a/test/js/bun/http/proxy-stress-memory-fixture.ts
+++ b/test/js/bun/http/proxy-stress-memory-fixture.ts
@@ -96,8 +96,17 @@ const originUrl = (p: string) => `https://localhost:${origin.port}${p}`;
 
 let completed = 0;
 let failed = 0;
+let firstError: string | undefined;
 let rssStart = 0;
 let rssMax = 0;
+
+function recordError(i: number, e: unknown) {
+  failed++;
+  if (firstError === undefined) {
+    const any = e as { code?: unknown; name?: unknown; message?: unknown };
+    firstError = `[i=${i}] ${any?.code ?? any?.name ?? "Error"}: ${any?.message ?? e}`;
+  }
+}
 
 const rss = () => process.memoryUsage.rss();
 
@@ -120,8 +129,8 @@ async function one(i: number): Promise<void> {
     });
     await res.arrayBuffer();
     completed++;
-  } catch {
-    failed++;
+  } catch (e) {
+    recordError(i, e);
   }
 }
 
@@ -149,8 +158,8 @@ async function run() {
               await r.arrayBuffer();
               completed++;
             })
-            .catch(() => {
-              failed++;
+            .catch(e => {
+              recordError(idx, e);
             });
           queueMicrotask(() => ac.abort());
           tasks.push(p);
@@ -179,7 +188,7 @@ async function run() {
 
   Bun.gc(true);
   const rssEnd = rss();
-  console.log(JSON.stringify({ completed, failed, rssStart, rssEnd, rssMax }));
+  console.log(JSON.stringify({ completed, failed, firstError, rssStart, rssEnd, rssMax }));
 }
 
 await run();


### PR DESCRIPTION
## Problem

`test/js/bun/http/proxy-stress-concurrent.test.ts` fails on macOS 14 x64 (`darwin-x64-mini-2`, e.g. [build 71656](https://buildkite.com/bun/bun/builds/71656#019f4e30-18d0-448b-995d-72c7fc092eff)) with:

```
memory probe (subprocess) > https-proxy → https-origin mode=complete ×1200
memory probe (subprocess) > https-proxy → https-origin mode=redirect ×1200
error: expect(received).toBe(expected)
Expected: 0
Received: 1
```

4/4 retries, always exactly `failed: 1`. The fixture's `catch {}` swallowed the error, so the CI log gave no hint beyond the count.

## Root cause

Same ephemeral-port exhaustion #33898 fixed for Windows, which also has a 16,384-port ephemeral range (49152-65535). The `memory probe (subprocess)` block spawns 12 concurrent fixtures, each doing 1200 iterations × 2 loopback connections (client→proxy, proxy→origin) with `keepalive: false`.

Reproduced on `darwin-test-x64-5` (macOS 14.4) by running 6 http-proxy + 6 https-proxy fixtures concurrently:

```
[i=564] FAILED code=ConnectionRefused | netprobe=connect-ok | TIME_WAIT=15257 | tcpAccepted=564
[i=567] FAILED code=ConnectionRefused | netprobe=connect-ok | TIME_WAIT=15257 | tcpAccepted=567
[i=573] FAILED code=ConnectionRefused | netprobe=connect-ok | TIME_WAIT=15262 | tcpAccepted=573
```

The proxy never sees the refused connection at TCP level (`tcpAccepted` does not tick). The http-proxy fixtures finish first (no outer TLS handshake, ~2× faster) and never hit the window; the slower https-proxy fixtures are still running when TIME_WAIT crosses ~15k and each sees a single `ConnectionRefused` on the outer connect. Pushing further (12 × http × 3000) drives TIME_WAIT to ~19,800 and everything fails with `FailedToOpenSocket` / `EADDRNOTAVAIL`.

With 12 concurrent fixtures × 300 iterations, all pass cleanly.

## Fix

- Extend the Windows cap from #33898 to macOS: `isASAN || isWindows || isMacOS ? 300`. 300 is still enough iterations for the RSS/UAF assertion the block exists for; Linux keeps 1200 (ephemeral range is ~28k ports there).
- Make the fixture record and emit `firstError` in its JSON summary, and have the test include it in the assertion diff. A future failure now shows the actual `code: message` and iteration number in the CI log instead of just `Received: 1`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->