### PR TITLE
v8.deserialize: reject X509Certificate records with empty DER

### DIFF
--- a/src/jsc/bindings/JSX509Certificate.h
+++ b/src/jsc/bindings/JSX509Certificate.h
@@ -93,10 +93,6 @@ public:
 
     static JSX509Certificate* create(
         JSC::VM& vm,
-        JSC::Structure* structure);
-
-    static JSX509Certificate* create(
-        JSC::VM& vm,
         JSC::Structure* structure,
         JSC::JSGlobalObject* globalObject,
         std::span<const uint8_t> data);
@@ -151,6 +147,10 @@ public:
     String toPEMString() const;
 
 private:
+    // Every JSX509Certificate exposed to JS must hold a parsed certificate;
+    // the cell-only overload is an implementation detail of the public ones.
+    static JSX509Certificate* create(JSC::VM& vm, JSC::Structure* structure);
+
     uint16_t m_extraMemorySizeForGC = 0;
 };
 

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -4752,10 +4752,12 @@ private:
             return JSValue();
         }
 
+        // The serializer never writes an empty DER (size <= 0 -> DataCloneError),
+        // so an empty record is hostile-only input. Reject it like any other
+        // undecodable DER instead of producing a JSX509Certificate with no cert.
         if (buffer.size() == 0) {
-            auto* cert_obj = Bun::JSX509Certificate::create(m_lexicalGlobalObject->vm(), defaultGlobalObject(m_globalObject)->m_JSX509CertificateClassStructure.get(m_globalObject));
-            addTerminalToObjectPool(cert_obj);
-            return cert_obj;
+            fail();
+            return JSValue();
         }
         ncrypto::ClearErrorOnReturn clear_error_on_return;
         X509* ptr = nullptr;

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -3,6 +3,7 @@ import { openSync } from "fs";
 import { bunEnv, bunExe, tls } from "harness";
 import { createPrivateKey, createPublicKey, createSecretKey, KeyObject, X509Certificate } from "node:crypto";
 import { BlockList } from "node:net";
+import * as v8 from "node:v8";
 import { join } from "path";
 
 // Terminal object types that were never entered into the structured clone object
@@ -976,5 +977,43 @@ describe("truncated Set/Map payloads are rejected without hanging", () => {
   test("valid Set and Map payloads still round-trip", () => {
     expect(deserialize(serialize(new Set([1, 0])))).toEqual(new Set([1, 0]));
     expect(deserialize(serialize(new Map([[1, 1]])))).toEqual(new Map([[1, 1]]));
+  });
+});
+
+// The wire reader must enforce the same validation as the public constructor for
+// Bun's host tags; otherwise crafted bytes can manufacture objects in states no
+// JS constructor can reach. The X509Certificate tag with a zero-length DER used
+// to produce a JSX509Certificate with m_x509 == nullptr, which every accessor
+// then misbehaves on (crypto errors, a keyless KeyObject from .publicKey, ...).
+describe("deserializing crafted host-tag records", () => {
+  // JSC wire header (version 14) + X509Certificate host tag (253) + u32 length.
+  const x509Record = (der: number[]) => Buffer.from([14, 0, 0, 0, 253, ...intLE(der.length), ...der]);
+  function intLE(n: number) {
+    const b = Buffer.alloc(4);
+    b.writeUInt32LE(n);
+    return [...b];
+  }
+
+  test.each([
+    ["bun:jsc deserialize", deserialize],
+    ["v8.deserialize", v8.deserialize],
+  ])("%s: an X509Certificate record with empty DER is rejected", (_, fn) => {
+    // The serializer refuses to emit this shape (size <= 0 -> DataCloneError),
+    // so this is hostile-only input and must fail the same way junk DER does.
+    expect(() => fn(x509Record([]))).toThrow("Unable to deserialize data.");
+  });
+
+  test.each([
+    ["bun:jsc deserialize", deserialize],
+    ["v8.deserialize", v8.deserialize],
+  ])("%s: an X509Certificate record with undecodable DER is rejected", (_, fn) => {
+    expect(() => fn(x509Record([0xde, 0xad, 0xbe, 0xef]))).toThrow("Unable to deserialize data.");
+  });
+
+  test("round-tripping an X509Certificate still works", () => {
+    const cert = new X509Certificate(tls.cert);
+    const clone = v8.deserialize(v8.serialize(cert));
+    expect(clone).toBeInstanceOf(X509Certificate);
+    expect(clone.fingerprint256).toBe(cert.fingerprint256);
   });
 });

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -983,8 +983,8 @@ describe("truncated Set/Map payloads are rejected without hanging", () => {
 // The wire reader must enforce the same validation as the public constructor for
 // Bun's host tags; otherwise crafted bytes can manufacture objects in states no
 // JS constructor can reach. The X509Certificate tag with a zero-length DER used
-// to produce a JSX509Certificate with m_x509 == nullptr, which every accessor
-// then misbehaves on (crypto errors, a keyless KeyObject from .publicKey, ...).
+// to produce a JSX509Certificate with m_x509 == nullptr; .publicKey on that
+// instance wraps a null EVP_PKEY in a KeyObject, and key.equals(key) SEGFAULTs.
 describe("deserializing crafted host-tag records", () => {
   // JSC wire header (version 14) + X509Certificate host tag (253) + u32 length.
   const x509Record = (der: number[]) => Buffer.from([14, 0, 0, 0, 253, ...intLE(der.length), ...der]);
@@ -994,13 +994,43 @@ describe("deserializing crafted host-tag records", () => {
     return [...b];
   }
 
-  test.each([
-    ["bun:jsc deserialize", deserialize],
-    ["v8.deserialize", v8.deserialize],
-  ])("%s: an X509Certificate record with empty DER is rejected", (_, fn) => {
-    // The serializer refuses to emit this shape (size <= 0 -> DataCloneError),
-    // so this is hostile-only input and must fail the same way junk DER does.
-    expect(() => fn(x509Record([]))).toThrow("Unable to deserialize data.");
+  test("an X509Certificate record with empty DER is rejected and cannot yield a null-key KeyObject", async () => {
+    // Runs in a subprocess because the pre-fix build SEGFAULTs on key.equals(key),
+    // which would take the test runner down with it.
+    const childScript = `
+      const { deserialize } = require("bun:jsc");
+      const v8 = require("node:v8");
+      const payload = Buffer.from(process.argv[1], "base64");
+      const out = [];
+      for (const [entry, de] of [["bun:jsc", deserialize], ["node:v8", b => v8.deserialize(Buffer.from(b))]]) {
+        try {
+          const cert = de(payload);
+          // Pre-fix: cert is an X509Certificate with m_x509 == null. .publicKey hands out a
+          // KeyObject over a null EVP_PKEY; key.equals(key) dereferences it and SEGFAULTs.
+          const key = cert.publicKey;
+          out.push({ entry, threw: false, keyType: key?.type, equals: key.equals(key) });
+        } catch (e) {
+          out.push({ entry, threw: true, name: e?.name, message: e?.message });
+        }
+      }
+      process.stdout.write(JSON.stringify(out));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", childScript, x509Record([]).toString("base64")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const rejection = { threw: true, name: "TypeError", message: "Unable to deserialize data." };
+    expect({ stdout: stdout ? JSON.parse(stdout) : stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: [
+        { entry: "bun:jsc", ...rejection },
+        { entry: "node:v8", ...rejection },
+      ],
+      exitCode: 0,
+      signalCode: null,
+    });
   });
 
   test.each([
@@ -1010,10 +1040,14 @@ describe("deserializing crafted host-tag records", () => {
     expect(() => fn(x509Record([0xde, 0xad, 0xbe, 0xef]))).toThrow("Unable to deserialize data.");
   });
 
-  test("round-tripping an X509Certificate still works", () => {
-    const cert = new X509Certificate(tls.cert);
-    const clone = v8.deserialize(v8.serialize(cert));
-    expect(clone).toBeInstanceOf(X509Certificate);
-    expect(clone.fingerprint256).toBe(cert.fingerprint256);
+  test("a real X509Certificate still round-trips and its .publicKey is usable", () => {
+    const original = new X509Certificate(tls.cert);
+    const cloned = v8.deserialize(v8.serialize(original));
+    expect(cloned).toBeInstanceOf(X509Certificate);
+    expect(cloned.fingerprint256).toBe(original.fingerprint256);
+    const key = cloned.publicKey;
+    expect(key).toBeInstanceOf(KeyObject);
+    expect(key.type).toBe("public");
+    expect(key.equals(original.publicKey)).toBe(true);
   });
 });


### PR DESCRIPTION
## Reproduction

```js
import * as v8 from "node:v8";
// JSC wire header (version 14) + X509Certificate host tag (253) + u32 derLength = 0
const cert = v8.deserialize(Buffer.from([14, 0, 0, 0, 253, 0, 0, 0, 0]));
const key = cert.publicKey;   // KeyObject wrapping a null EVP_PKEY
key.equals(key);              // SEGV at 0x10
```

```
panic(main thread): Segmentation fault at address 0x10
```

Deterministic on 1.4.0 and current `main`. Reachable via `v8.deserialize`, `bun:jsc` `deserialize`, and `child_process` IPC with `serialization: "advanced"`.

## Cause

`readX509Certificate()` special-cased a zero-length DER buffer by constructing a `JSX509Certificate` via the two-argument `create(vm, structure)` overload, leaving `m_x509 == nullptr`, a state the JS constructor cannot produce (`new X509Certificate(Buffer.alloc(0))` throws).

`ncrypto::X509View::getPublicKey()` returns a successful-but-empty `EVPKeyPointer` when the view is null, so `.publicKey` on that instance wraps a null `EVP_PKEY` in a `JSPublicKeyObject`; `key.equals(key)` then dereferences it and crashes. Other accessors on the cert-less instance throw spurious crypto errors (`.fingerprint*`, `.raw`, `.validFrom`, `.serialNumber`), return `undefined` (`.toLegacyObject()`), or DataCloneError on re-serialize.

The serializer never emits this shape: it calls `i2d_X509(cert, nullptr)` and returns `false` when `size <= 0`, before writing the tag. So the empty-DER branch in the reader is reachable only from crafted bytes.

## Fix

`readX509Certificate()` now `fail()`s on an empty DER buffer, matching the existing undecodable-DER path, so both `bun:jsc` `deserialize` and `v8.deserialize` throw `TypeError: Unable to deserialize data.` for this payload.

The two-argument `JSX509Certificate::create(vm, structure)` overload is now private; the remaining callers are the class's own public `create` helpers that fill `m_x509` immediately after.

The other Bun host-tag readers were audited: `readKeyObject()` validates the key-type byte via `read(CryptoKeyType&)` and `fail()`s on every parse error; Blob / BlockList / Histogram use sideband transfer and have no inline-bytes branch in `readTerminal()`.

## Verification

`test/js/web/workers/structured-clone.test.ts` gains a crafted-payload describe. The empty-DER case runs in a subprocess (pre-fix SEGFAULTs the runner) and asserts both entry points throw and exit cleanly; junk DER is asserted in-process; a positive control asserts a real certificate still round-trips and its `.publicKey.equals()` works.

```
$ USE_SYSTEM_BUN=1 bun test test/js/web/workers/structured-clone.test.ts -t "crafted host-tag"
 1 fail   # subprocess exits 139 SIGSEGV
 3 pass
$ bun bd test test/js/web/workers/structured-clone.test.ts
 230 pass / 0 fail
```

Overlaps with #33945 (opened two minutes after this one, same `fail()` fix); this PR additionally makes the cert-less `create` overload private and covers the undecodable-DER sibling. The subprocess crash test here is adapted from #33945.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/structured-clone.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (93f24595d)

test/js/web/workers/structured-clone.test.ts:
(pass) structuredClone > primitive undefined [4.11ms]
(pass) structuredClone > primitive null [0.58ms]
(pass) structuredClone > primitive true [0.49ms]
(pass) structuredClone > primitive false [0.42ms]
(pass) structuredClone > primitive string, empty string [0.38ms]
(pass) structuredClone > primitive string, lone high surrogate [0.37ms]
(pass) structuredClone > primitive string, lone low surrogate [0.42ms]
(pass) structuredClone > primitive string, NUL [0.37ms]
(pass) structuredClone > primitive string, astral character [0.56ms]
(pass) structuredClone > primitive number, 0.2 [0.42ms]
(pass) structuredClone > primitive number, 0 [0.71ms]
(pass) structuredClone > pri
... (truncated)

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/workers/structured-clone.test.ts:
(pass) structuredClone > primitive undefined [0.10ms]
(pass) structuredClone > primitive null [0.01ms]
(pass) structuredClone > primitive true
(pass) structuredClone > primitive false
(pass) structuredClone > primitive string, empty string
(pass) structuredClone > primitive string, lone high surrogate
(pass) structuredClone > primitive string, lone low surrogate
(pass) structuredClone > primitive string, NUL
(pass) structuredClone > primitive string, astral character
(pass) structuredClone > primitive number, 0.2
(pass) structuredClone > primitive number, 0
(pass) structuredClone > primitive number, -0
(pass) structuredClone > primitive number, NaN
(pass) structuredClone > primitive number, Infinity
(pass) structuredClone > primitive number, -Infinity
(pass) structuredClone > primitive number, 9007199254740992
(pass) structuredClone > primitive number, -9007199254740992 [0.01ms]
(pass) structuredClone > primitive number, 9007199254740994
(pass) structuredClone > primitive number, -9007199254740994
(pass) structuredClone > primitive BigInt, 0n
(pass) structuredClone > primitive BigInt
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/structured-clone.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (93f24595d)

test/js/web/workers/structured-clone.test.ts:
(pass) structuredClone > primitive undefined [4.30ms]
(pass) structuredClone > primitive null [0.61ms]
(pass) structuredClone > primitive true [0.51ms]
(pass) structuredClone > primitive false [0.43ms]
(pass) structuredClone > primitive string, empty string [0.41ms]
(pass) structuredClone > primitive string, lone high surrogate [0.38ms]
(pass) structuredClone > primitive string, lone low surrogate [0.40ms]
(pass) structuredClone > primitive string, NUL [0.38ms]
(pass) structuredClone > primitive string, astral character [0.90ms]
(pass) structuredClone > primitive number, 0.2 [0.43ms]
(pass) structuredClone > primitive number, 0 [0.40ms]
(pass) structuredClone > pri
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 698ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/10] cxx obj/src/jsc/bindings/BunProcess.cpp.o
[2/10] cxx obj/src/jsc/bindings/webcore/SerializedScriptValue.cpp.o
[3/10] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[4/10] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[5/10] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[6/10] gen cpp.rs (cppbind)
[6/9] link bun-profile
[7/9] bun-profile --revision
1.4.0-canary.1+93f24595d
[9/9] strip bun
[build] done
bun test v1.4.0-canary.1 (93f24595d)

test/js/web/workers/structured-clone.test.ts:
(pass) structuredClone > primitive undefined [0.10ms]
(pass) structuredClone > primitive null
(pass) structuredClone > primitive true
(pass) structuredClone > primitive false
(pass) structuredClone > primitive string, empty string
(pass) structuredCl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSX509Certificate.h               |  8 +--
 src/jsc/bindings/webcore/SerializedScriptValue.cpp |  8 ++-
 test/js/web/workers/structured-clone.test.ts       | 73 ++++++++++++++++++++++
 3 files changed, 82 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/JSX509Certificate.h                    2      2      0
src/jsc/bindings/webcore/SerializedScriptValue.cpp      3      2      0
test/js/web/workers/structured-clone.test.ts            3      6      0
```

</details>

<!-- robobun:evidence:end -->