### PR TITLE
structured-clone: reject zero-length X509Certificate DER at deserialize

### DIFF
--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -4752,10 +4752,12 @@ private:
             return JSValue();
         }
 
+        // The serializer never writes a zero-length DER (i2d_X509 <= 0 is an encode
+        // failure), so an empty buffer is crafted bytes. Reject it: a JSX509Certificate
+        // without an X509* hands out a KeyObject over a null EVP_PKEY via .publicKey.
         if (buffer.size() == 0) {
-            auto* cert_obj = Bun::JSX509Certificate::create(m_lexicalGlobalObject->vm(), defaultGlobalObject(m_globalObject)->m_JSX509CertificateClassStructure.get(m_globalObject));
-            addTerminalToObjectPool(cert_obj);
-            return cert_obj;
+            fail();
+            return JSValue();
         }
         ncrypto::ClearErrorOnReturn clear_error_on_return;
         X509* ptr = nullptr;

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -730,6 +730,75 @@ for (const structuredCloneFn of [
   });
 }
 
+// X509Certificate wire record = [version u32][tag=253][derLen u32][der…]. The serializer
+// never emits derLen == 0; a crafted zero-length DER used to materialize a cert-less
+// instance whose .publicKey wrapped a null EVP_PKEY and SEGV'd the first use.
+describe("deserialize of crafted X509Certificate payloads", () => {
+  // Derive header + tag from a real serialized cert so version bumps don't break this.
+  // Literal shape as of version 14: Buffer.from([14, 0, 0, 0, 253, 0, 0, 0, 0]).
+  const emptyDer = (() => {
+    const real = Buffer.from(new Uint8Array(serialize(new X509Certificate(tls.cert))));
+    const tagAt = real.indexOf(253, 4);
+    if (tagAt < 4) throw new Error("could not locate X509 tag in serialized output");
+    // Sanity: bytes after the tag are the little-endian DER length.
+    expect(real.readUInt32LE(tagAt + 1)).toBe(real.length - tagAt - 5);
+    const out = Buffer.from(real.subarray(0, tagAt + 5));
+    out.writeUInt32LE(0, tagAt + 1);
+    return out;
+  })();
+
+  test("empty DER is rejected at deserialize and cannot yield a null-EVP_PKEY KeyObject", async () => {
+    // Runs in a subprocess because the pre-fix build SEGFAULTs on key.equals(key),
+    // which would take the test runner down with it.
+    const childScript = `
+      const { deserialize } = require("bun:jsc");
+      const v8 = require("node:v8");
+      const payload = Buffer.from(process.argv[1], "base64");
+      const out = [];
+      for (const [entry, de] of [["bun:jsc", deserialize], ["node:v8", b => v8.deserialize(Buffer.from(b))]]) {
+        try {
+          const cert = de(payload);
+          // Pre-fix: cert is an X509Certificate with m_x509 == null. .publicKey hands out a
+          // KeyObject over a null EVP_PKEY; key.equals(key) dereferences it and SEGFAULTs.
+          const key = cert.publicKey;
+          out.push({ entry, threw: false, keyType: key?.type, equals: key.equals(key) });
+        } catch (e) {
+          out.push({ entry, threw: true, name: e?.name, message: e?.message });
+        }
+      }
+      process.stdout.write(JSON.stringify(out));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", childScript, emptyDer.toString("base64")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const rejection = { threw: true, name: "TypeError", message: "Unable to deserialize data." };
+    expect({ stdout: stdout ? JSON.parse(stdout) : stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: [
+        { entry: "bun:jsc", ...rejection },
+        { entry: "node:v8", ...rejection },
+      ],
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  test("a real X509Certificate still round-trips and its .publicKey is usable", () => {
+    const original = new X509Certificate(tls.cert);
+    const cloned = deserialize(serialize(original));
+    expect(cloned).toBeInstanceOf(X509Certificate);
+    expect(cloned.subject).toBe(original.subject);
+    const key = cloned.publicKey;
+    expect(key).toBeInstanceOf(KeyObject);
+    expect(key.type).toBe("public");
+    expect(key.equals(key)).toBe(true);
+    expect(key.equals(original.publicKey)).toBe(true);
+  });
+});
+
 describe("reference pool survives a process boundary", () => {
   // One cold subprocess hop covering the whole identity matrix, so every platform object
   // type (X509Certificate, KeyObjects, Blob, File, ...) is deserialized in a fresh VM.


### PR DESCRIPTION
## Reproduction

```js
import * as v8 from "node:v8";
const cert = v8.deserialize(Buffer.from([14, 0, 0, 0, 253, 0, 0, 0, 0])); // tag 253, derLen 0
const key = cert.publicKey;   // KeyObject wrapping a null EVP_PKEY
key.equals(key);              // SIGSEGV
```

```
panic(main thread): Segmentation fault at address 0x10
```

Deterministic on 1.4.0 and current main. Reachable via `node:v8` / `bun:jsc` deserialize and `child_process` IPC with `serialization: "advanced"`. Node.js rejects the record at deserialize time.

## Cause

The X509Certificate wire record is `[version u32][tag=253][derLen u32][der…]`. The serializer never writes `derLen == 0` (it returns an encode failure when `i2d_X509 <= 0`), but `readX509Certificate` special-cased `buffer.size() == 0` by constructing a `JSX509Certificate` via the two-argument `create(vm, structure)` helper, leaving `m_x509` null.

`ncrypto::X509View::getPublicKey()` returns a successful-but-empty `EVPKeyPointer` when `cert_ == nullptr`, so `.publicKey` on that instance wraps a null `EVP_PKEY` in a `JSPublicKeyObject`. Any later use of the key (equals, export, inspect) dereferences it and SEGFAULTs. Other accessors on the cert-less instance either throw or return bogus values; `.publicKey` is the one that propagates the poisoned state into a second object.

## Fix

Reject a zero-length DER the same way an undecodable one already is: `fail()` and surface the standard `TypeError: Unable to deserialize data.`. No legitimate serialize path produces this shape, and with it gone no `JSX509Certificate` can exist without a real `X509*`, so no null-`EVP_PKEY` `KeyObject` can be reached from bytes alone.

## Verification

`test/js/web/workers/structured-clone.test.ts` gains a crafted-payload describe. The empty-DER case runs in a subprocess (pre-fix SEGFAULTs the runner) and asserts both `bun:jsc` and `node:v8` entry points throw the deserialize `TypeError` and exit cleanly; a positive control asserts a real certificate still round-trips and its `.publicKey.equals()` works.

```
USE_SYSTEM_BUN=1 bun test test/js/web/workers/structured-clone.test.ts -t "crafted X509Certificate"
  1 fail  (subprocess exits 139 SIGSEGV)
  1 pass  (positive control)

bun bd test test/js/web/workers/structured-clone.test.ts
  228 pass
```