### PR TITLE
webcore/Blob: validate content-type in the structured-clone deserializer

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4339,9 +4339,15 @@ fn _on_structured_clone_deserialize<B: AsRef<[u8]>>(
         blob.offset.set(0);
     }
 
-    if !content_type.is_empty() {
+    // Wire bytes are untrusted: apply the same WHATWG §3.1 validate+lowercase as
+    // `new Blob(parts, {type})` so a crafted record cannot materialize a
+    // `Blob.type` no JS could construct and feed it into HTTP headers.
+    if !content_type.is_empty() && is_valid_blob_type(&content_type) {
         blob.content_type
-            .set(BlobContentType::Owned(std::sync::Arc::from(content_type)));
+            .set(match global_this.bun_vm().as_mut().mime_type(&content_type) {
+                Some(mime) => BlobContentType::from(mime),
+                None => BlobContentType::from_lowercased(&content_type),
+            });
         blob.content_type_was_set.set(content_type_was_set);
     }
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4343,11 +4343,12 @@ fn _on_structured_clone_deserialize<B: AsRef<[u8]>>(
     // `new Blob(parts, {type})` so a crafted record cannot materialize a
     // `Blob.type` no JS could construct and feed it into HTTP headers.
     if !content_type.is_empty() && is_valid_blob_type(&content_type) {
-        blob.content_type
-            .set(match global_this.bun_vm().as_mut().mime_type(&content_type) {
+        blob.content_type.set(
+            match global_this.bun_vm().as_mut().mime_type(&content_type) {
                 Some(mime) => BlobContentType::from(mime),
                 None => BlobContentType::from_lowercased(&content_type),
-            });
+            },
+        );
         blob.content_type_was_set.set(content_type_was_set);
     }
 

--- a/test/js/web/structured-clone-blob-file.test.ts
+++ b/test/js/web/structured-clone-blob-file.test.ts
@@ -609,6 +609,61 @@ describe("structuredClone with Blob and File", () => {
       });
     });
 
+    test("crafted content-type is validated and normalized like the Blob constructor", async () => {
+      // A Blob's `type` is only stored when every byte is in U+0020..U+007E, and
+      // is ASCII-lowercased before storage. The deserializer must enforce the
+      // same rule on the wire record's content-type so a crafted image cannot
+      // materialize a `Blob.type` no `new Blob()` could produce and feed raw
+      // bytes (control chars, CR/LF) into `Response`'s `Content-Type` header.
+      //
+      // Locate the field by serializing a Blob whose type is a distinctive
+      // all-lowercase sentinel, then overwrite it in place; keeps the test
+      // robust against serializer framing changes.
+      const sentinel = "qwerty/probe-ct";
+      const image = Buffer.from(serialize(new Blob(["body"], { type: sentinel })));
+      const at = image.indexOf(Buffer.from(sentinel));
+      expect(at).toBeGreaterThan(0);
+
+      function craftType(bytes: string) {
+        expect(bytes.length).toBe(sentinel.length);
+        const out = Buffer.from(image);
+        out.set(Buffer.from(bytes, "binary"), at);
+        return out;
+      }
+
+      for (const de of [deserialize, (b: Buffer) => v8.deserialize(b)] as const) {
+        // A control byte anywhere in the field makes the whole type the empty
+        // string, and nothing reaches an outgoing Content-Type header.
+        const ctl = de(craftType("TEXT/HTM\x01;A=BCD"));
+        expect(ctl).toBeInstanceOf(Blob);
+        expect(await ctl.text()).toBe("body");
+        expect({
+          type: ctl.type,
+          ctor: new Blob(["x"], { type: "TEXT/HTM\x01;A=BCD" }).type,
+          response: new Response(ctl).headers.get("content-type"),
+        }).toEqual({ type: "", ctor: "", response: null });
+
+        // CR/LF (the header-injection vector) and DEL are rejected the same way.
+        for (const c of ["\r", "\n", "\x7f"]) {
+          expect(de(craftType(`text/plain${c};q=1`)).type).toBe("");
+        }
+
+        // A byte outside ASCII (>= 0x80) is rejected.
+        expect(de(craftType("text/pl\u00e1in;a=bc")).type).toBe("");
+
+        // Valid bytes with uppercase are accepted and lowercased, matching the
+        // constructor's normalization.
+        const upper = "ABCDE/WXYZ;Q=AA";
+        expect({
+          type: de(craftType(upper)).type,
+          ctor: new Blob(["x"], { type: upper }).type,
+        }).toEqual({ type: "abcde/wxyz;q=aa", ctor: "abcde/wxyz;q=aa" });
+
+        // A value the constructor already produces round-trips unchanged.
+        expect(de(image).type).toBe(sentinel);
+      }
+    });
+
     test("truncated payload at every byte boundary throws cleanly", () => {
       // Every truncation point must surface as a thrown error (never a
       // partially-constructed Blob, never a crash). This is the functional


### PR DESCRIPTION
## Problem

The Blob structured-clone deserializer stored the wire record's `content_type` field verbatim, with no validation or lowercasing. A crafted serialized image can therefore produce a Blob whose `.type` holds bytes the `Blob` constructor would reject (control characters, CR/LF, bytes above 0x7E, or simply un-lowercased ASCII), and that string then propagates unchanged into `new Response(blob)`'s `Content-Type` header.

```js
import * as v8 from "node:v8";
const T = "TEXT/HT" + String.fromCharCode(1) + "L";
const img = Buffer.concat([
  Buffer.from([14,0,0,0, 254, 4]), Buffer.alloc(8),
  Buffer.from([T.length,0,0,0]), Buffer.from(T, "binary"),
  Buffer.from([1, 1, 2,0,0,0]), Buffer.from("hi"),
  Buffer.from([0,0,0,0,0]), Buffer.alloc(8),
]);
const blob = v8.deserialize(img);
blob.type                                       // "TEXT/HT\^AL"
new Blob(["hi"], { type: T }).type              // ""  (the constructor rejects it)
new Response(blob).headers.get("content-type")  // "TEXT/HT\^AL"
```

An object state unreachable from JS materialises from bytes and flows into an HTTP header; anything that serves deserialized Blobs is exposed to header-value bytes the application never produced.

## Cause

`_on_structured_clone_deserialize` in `src/runtime/webcore/Blob.rs` reads the length-prefixed `content_type` field and assigns it directly:

```rust
if !content_type.is_empty() {
    blob.content_type
        .set(BlobContentType::Owned(std::sync::Arc::from(content_type)));
    blob.content_type_was_set.set(content_type_was_set);
}
```

Every JS-facing entry point (the `Blob`/`File` constructors, `Blob.prototype.slice`, `Bun.file().write`, the S3 file path) runs the string through `is_valid_blob_type` (WHATWG File API 3.1: every byte in U+0020..U+007E) and then lowercases it. The wire reader skipped both.

## Fix

Apply the same guard and normalization on the deserialize path: reject to the empty string when any byte is outside U+0020..U+007E, otherwise store the lowercased value via the same `mime_type` lookup / `BlobContentType::from_lowercased` step every other entry point uses. Honest payloads Bun itself wrote are already normalized, so only crafted images are affected.

This is the third wire-field validator at this boundary, alongside the existing fd-range and NUL-in-path checks in the same function.

## Verification

New test in `test/js/web/structured-clone-blob-file.test.ts` under `deserialize of crafted payloads`. It serialises a Blob with a sentinel content-type, locates the field in the output, and patches it with control bytes, CR/LF, DEL, a byte above 0x7F, and all-uppercase input, exercising both `bun:jsc` and `node:v8` deserialize entry points. Each case also checks `new Blob(parts, {type})` with the same string so the two paths are asserted to agree.

```
USE_SYSTEM_BUN=1 bun test test/js/web/structured-clone-blob-file.test.ts -t "crafted content-type"
  0 pass, 1 fail  (type: "TEXT/HTM\^A;A=BCD", response: "TEXT/HTM\^A;A=BCD")

bun bd test test/js/web/structured-clone-blob-file.test.ts
  42 pass, 0 fail
```

Also green: `test/js/web/fetch/blob.test.ts` (42 pass) and `test/js/web/workers/structured-clone.test.ts` (226 pass).

Note: #33605 (not yet landed) removes the `vm.mime_type()` lookup at the user-`type` call sites in favour of plain `from_lowercased`. Whichever lands second needs a one-line rebase at this site; the validation and the test here are unaffected.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/structured-clone-blob-file.test.ts

<!-- robobun:evidence:end -->