### PR TITLE
clippy: unbreak `cargo clippy` on main (let_and_return + large_stack_frames)

### DIFF
--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -1143,9 +1143,7 @@ pub fn normalize_string_generic_tz<
         buf[buf_i] = T::from_u8(0);
     }
 
-    let result = &mut buf[0..buf_i];
-
-    result
+    &mut buf[0..buf_i]
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, core::marker::ConstParamTy)]

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -298,6 +298,12 @@ unsafe fn ssl_ctx_cache_get_or_create(
 /// # Safety
 /// `vm` is the freshly-boxed unique VM on this thread, with `vm.global` /
 /// `vm.jsc_vm` already populated by `bun_jsc::VirtualMachine::init`.
+#[allow(
+    clippy::large_stack_frames,
+    reason = "`Transpiler::init` returns a Transpiler by value (~216 KB: its Resolver embeds \
+              BSSMapInner<DirInfo, 2048>) and it is `ptr::write`n straight into `(*vm).transpiler`. \
+              The copy is elided in optimized builds, and this runs once per VM init."
+)]
 unsafe fn init_runtime_state(
     vm: *mut VirtualMachine,
     opts: &mut InitOptions,


### PR DESCRIPTION
## Problem

`cargo clippy` fails on `main`, and therefore on **every open pull request that touches a `.rs` file**. There are *two* breakages, stacked — the second was hidden because `bun_runtime` depends on `bun_paths`, so it was never checked while `bun_paths` failed to compile.

### 1. `bun_paths` — `clippy::let_and_return`

```
error: returning the result of a `let` binding from a block
    --> src/paths/resolve_path.rs:1148:5
```

#33874 removed the `debug_assert` that used to sit between the binding and the return, leaving `let result = ...;` followed by `result`.

### 2. `bun_runtime` — `clippy::large_stack_frames`

```
error: this function may allocate 221049 bytes on the stack
  --> src/runtime/jsc_hooks.rs:301:11
```

Introduced by #31216. The frame is `bun_bundler::Transpiler::init`'s return value: a `Transpiler` carries a `Resolver` whose `BSSMapInner<DirInfo, 2048>` is ~229 KB, and it is returned by move then `ptr::write`n straight into `(*vm).transpiler`. Optimized builds elide the copy; the function runs once per VM init. Only Linux crosses the 128 KB `stack-size-threshold` from `clippy.toml`, which is why local macOS clippy never flagged it.

## Why neither was caught

`.github/workflows/clippy.yml` triggers on `workflow_call`, `workflow_dispatch`, `pull_request` and `merge_group` — there is **no `push:` trigger**, so **main never lints itself**. Because `pull_request` lints the PR merged into main, both breaks surface on contributors' PRs instead, attributed to their commits.

## Fix

1. Return the slice directly. The binding had no other use.
2. Suppress `large_stack_frames` on `init_runtime_state` with the reason recorded, exactly as `find_context_identifiers::walk_expr` already does. `#[allow]` rather than `#[expect]` because the lint does not fire on macOS, where an expectation would go unfulfilled. Removing the temporary for real needs an in-place `Transpiler::init_in_place(dst, ..)` — a larger change owned by the bundler, and worth doing separately now that every Worker thread runs this init.

## Verification

- Reproduced **both** failures on a clean `main` tip before fixing; `cargo clippy -p bun_paths --no-deps` is clean after (1), and `cargo check -p bun_runtime` + `cargo fmt --check` are clean after (2). CI's ubuntu clippy job is the oracle for (2), since macOS never fires it.
- Built `bun-debug` and drove the surface `normalize_string_generic_tz` actually backs, against a built node v26.3.0 — identical on every case:
  ```
  a/b/../c            => "a/c"
  /a/./b//c/          => "/a/b/c/"
  ../../x             => "../../x"
  resolve             => "/foo/bar/baz"
  resolve-up          => "/foo/baz"
  win32 normalize     => "C:\a\c"
  win32 UNC resolve   => "\\server\share\b"
  normalize("")       => "."
  normalize(".")      => "."
  normalize("/")      => "/"
  ```
- `bun bd test test/js/node/path/` → 122 pass, 2 skip, 0 fail. All 16 vendored `test-path*.js` pass.

## Notes

A workspace-wide `cargo clippy --workspace --no-deps --keep-going` also reports `derivable_impls` for `Sendfile` in `src/runtime/server/FileResponseStream.rs`, but only on macOS: `socket_fd: Fd::INVALID` is a Linux/Android-gated field that is not `Default`, so the impl is genuinely not derivable on the Ubuntu runner. Left alone.

Adding a `push:` trigger to `clippy.yml` would stop this class of breakage from being invisible on main. Happy to do that here or in a follow-up.
