### PR TITLE
css: reject out-of-range percentages in color-mix()

### DIFF
--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -2459,6 +2459,13 @@ pub fn parse_color_mix(input: &mut css::Parser) -> CssResult<CssColor> {
     };
 
     // https://drafts.csswg.org/css-color-5/#color-mix-percent-norm
+    // The grammar is <percentage [0,100]>; values outside that range are invalid.
+    if first_percent.is_some_and(|p| !(0.0..=1.0).contains(&p))
+        || second_percent.is_some_and(|p| !(0.0..=1.0).contains(&p))
+    {
+        return Err(input.new_custom_error(css::ParserError::invalid_value));
+    }
+
     let (p1, p2): (f32, f32) = if first_percent.is_none() && second_percent.is_none() {
         (0.5, 0.5)
     } else {

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -553,7 +553,7 @@ describe("color-mix() percentage range", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "null", stderr: "", exitCode: 0 });
+    expect({ stdout, exitCode, stderr: exitCode === 0 ? undefined : stderr }).toEqual({ stdout: "null", exitCode: 0 });
   });
 
   test.each([

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -536,3 +536,49 @@ describe("input forms", () => {
     expect(color("#f00", "[rgb]")).toEqual([255, 0, 0]);
   });
 });
+
+// https://drafts.csswg.org/css-color-5/#color-mix — the grammar is
+// <percentage [0,100]>, so a value outside that range is a parse error.
+describe("color-mix() percentage range", () => {
+  // fuzz repro: -9% drove HSL saturation negative and tripped a debug assertion
+  // in hsl_to_rgb; release builds produced out-of-gamut garbage.
+  test("does not crash on a negative mix percentage", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.stdout.write(String(Bun.color("color-mix(in hsl,red -9%,color(display-p3 0 0 0)", "lab")))`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "null", stderr: "", exitCode: 0 });
+  });
+
+  test.each([
+    "color-mix(in hsl, red -9%, blue)",
+    "color-mix(in hsl, red 150%, blue)",
+    "color-mix(in hsl, -10% red, blue)",
+    "color-mix(in hsl, red, blue -9%)",
+    "color-mix(in hsl, red, blue 150%)",
+    "color-mix(in hsl, red, 150% blue)",
+    "color-mix(in srgb, red -1%, blue)",
+    "color-mix(in srgb, red 100.001%, blue)",
+    "color-mix(in lab, red -9%, blue)",
+    "color-mix(in hwb, red -9%, blue)",
+    "color-mix(in oklch, red 150%, blue)",
+  ])("rejects %s", input => {
+    expect(color(input, "css")).toBeNull();
+  });
+
+  test.each([
+    ["color-mix(in hsl, red 0%, blue)", "#00f"],
+    ["color-mix(in hsl, red 100%, blue)", "red"],
+    ["color-mix(in hsl, red 50%, blue 50%)", "#f0f"],
+    ["color-mix(in hsl, red, blue 0%)", "red"],
+    ["color-mix(in hsl, red, blue 100%)", "#00f"],
+  ])("accepts %s", (input, expected) => {
+    expect(color(input, "css")).toBe(expected);
+  });
+});


### PR DESCRIPTION
## What

`parse_color_mix` accepted mix percentages outside `[0%, 100%]`. With a negative percentage the interpolated HSL saturation goes negative and trips a `debug_assert!(saturation >= 0.0 && saturation <= 1.0)` in `hsl_to_rgb`. Release builds skip the assert and emit garbage colors.

## Repro

```sh
bun -e 'Bun.color("color-mix(in hsl,red -9%,color(display-p3 0 0 0)", "lab")'
```

Debug build panics:
```
panic: assertion failed: saturation >= 0.0 && saturation <= 1.0
```

Release build returns a bogus value instead of `null`:
```js
Bun.color("color-mix(in srgb, red -9%, blue)", "css")  // "#0043e8" (should be null)
Bun.color("color-mix(in hsl, red 150%, blue)", "css")  // "#ff0"    (should be null)
```

## Fix

Per [css-color-5 §3](https://drafts.csswg.org/css-color-5/#color-mix) the grammar is `[ <color> && <percentage [0,100]>? ]`; values outside that range are parse errors. WPT `color-invalid-color-mix-function.html` tests exactly this ("Percentages less than 0 are not valid", "Percentages greater than 100 are not valid") and WebKit enforces it via `CSS::Percentage<Range{0, 100}>`.

Added a range check on each parsed percentage in `parse_color_mix` before normalization.

## Tests

Added to `test/js/bun/css/color.test.ts`:
- subprocess test for the fuzz repro (asserts `null` output)
- out-of-range percentages (negative, >100%, before/after the color, both operands, across color spaces) return `null`
- boundary values `0%` / `100%` still parse

Found by fuzzing `Bun.color()`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/color.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (5acf29404)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [3.75ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [1.51ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [1.26ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [2.17ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [17.03ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [2.00ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [2.01ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit")) [0.42ms]
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (64edcaf68)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [0.08ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [0.02ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [0.01ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [0.03ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [0.55ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [0.03ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [0.01ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit"))
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-256"))
[92m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-16"))
(pass) color({"r":0,"g":255,"b":0}, "{rgb}") = {"r":0,"g":255,"b":0}
(pass) color({"r":0,"g":255,"b":0}, "ansi-24bit")
(pass) color({"r":0,"g":255,"b":0}, "ansi-16")
(pass) color({"r":0,"g":255,"b":0}, "ansi256")
[38;2;0;0;255m[object Object]
(pass) console.log(color({"r":0,"g":0,"b":255}, "ansi-24bit"))
[38;5;
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/color.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (5acf29404)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [4.00ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [1.74ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [1.29ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [2.20ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [16.69ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [2.26ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [2.02ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit")) [0.33ms]
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 733ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standal
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/values/color.rs       |  7 +++++++
 test/js/bun/css/color.test.ts | 46 +++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 53 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/css/values/color.rs            4      1      0
test/js/bun/css/color.test.ts      5      2      0
```

</details>

<!-- robobun:evidence:end -->