### PR TITLE
css: print raw @supports condition slices with write_bytes

### DIFF
--- a/src/css/rules/supports.rs
+++ b/src/css/rules/supports.rs
@@ -194,11 +194,14 @@ impl SupportsCondition {
             }
             SupportsCondition::Selector(sel) => {
                 dest.write_str(b"selector(")?;
-                dest.write_str(sel)?;
+                // Raw parser-input slice: may span newlines. `write_bytes`
+                // tracks line/col across them; `write_str` would assert.
+                dest.write_bytes(sel)?;
                 dest.write_char(b')')?;
             }
             SupportsCondition::Unknown(unk) => {
-                dest.write_str(unk)?;
+                // Raw parser-input slice (see above).
+                dest.write_bytes(unk)?;
             }
         }
         Ok(())
@@ -230,7 +233,8 @@ impl SupportsCondition {
             |d, _flag| {
                 d.serialize_name(name)?;
                 d.delim(b':', false)?;
-                d.write_str(value)
+                // Raw parser-input slice: may span newlines.
+                d.write_bytes(value)
             },
         )?;
 

--- a/test/js/bun/css/supports-condition-newline.test.ts
+++ b/test/js/bun/css/supports-condition-newline.test.ts
@@ -1,0 +1,62 @@
+import { cssInternals } from "bun:internal-for-testing";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+const { minifyTest } = cssInternals;
+
+// `SupportsCondition::{Unknown,Selector,Declaration}` hold raw slices of the
+// parser input. Printing them via `write_str` debug-asserted on embedded
+// newlines (found by fuzzing `@supports (color: lab(0%\n 0 \r\n0))`). In
+// release builds the same path silently desynced the printer's line/col
+// tracking instead of panicking.
+
+test("`@supports` condition containing a literal newline prints without panicking", () => {
+  // Unknown variant: a parenthesised condition the parser stores verbatim.
+  const unknown = "@supports (color: lab(0%\n 0 \r\n0)) {.x{color:red}}";
+  const unknownMin = "@supports (color: lab(0%\n 0 \r\n0)){.x{color:red}}";
+  expect(minifyTest(unknown, "")).toBe(unknownMin);
+  expect(minifyTest(unknownMin, "")).toBe(unknownMin);
+
+  // Selector variant: `selector(...)` body is a raw input slice.
+  expect(minifyTest("@supports selector(a\n b) {.x{color:red}}", "")).toBe(
+    "@supports selector(a\n b){.x{color:red}}",
+  );
+
+  // Declaration variant via `@import ... supports(...)`: the value is a raw input slice.
+  expect(minifyTest("@import url(x.css) supports(color: lab(0%\n 0 0));", "")).toBe(
+    '@import "x.css" supports(color:lab(0%\n 0 0));',
+  );
+});
+
+test("fuzzer-minimized input: `@supports` condition with `\\n` and `\\r\\n`", async () => {
+  // Run in a child process so a panic doesn't take down the test runner.
+  const input =
+    "LmZvbyB7CiAgICAgICAgLS1jdXN0b206ICNiMzIzMjMgIWltcG9ydGFudDsKICAgICAgfQoKICAgICAgQHN1cHBvcnRzIChjb2xvcjogbGFiKDAlCiAwIA0KMCkpIHsKICAgICAgICAuZm9vIHsKICAgICAgICAgIC0tY3VzdG9tOiBsYWIoNDAlIDU2LjYgMzkpICFpbXBvcnRhbnQ7CiAgICAgICAgfQogICAgICB9";
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const c = require("bun:internal-for-testing").cssInternals;
+       const i = atob(${JSON.stringify(input)});
+       const m = c.minifyTest(i, "");
+       c._test(i, "", { chrome: 80 << 16 });
+       c.prefixTest(i, "", { chrome: 80 << 16 });
+       // Round-trip the minified output through the minifier again.
+       if (c.minifyTest(m, "") !== m) throw new Error("round-trip mismatch");
+       console.log(JSON.stringify(m));`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout: stdout.trim(), exitCode }).toEqual({
+    stdout: JSON.stringify(
+      ".foo{--custom:#b32323!important}@supports (color: lab(0%\n 0 \r\n0)){.foo{--custom:lab(40% 56.6 39)!important}}",
+    ),
+    exitCode: 0,
+  });
+  void stderr;
+});

--- a/test/js/bun/css/supports-condition-newline.test.ts
+++ b/test/js/bun/css/supports-condition-newline.test.ts
@@ -18,9 +18,7 @@ test("`@supports` condition containing a literal newline prints without panickin
   expect(minifyTest(unknownMin, "")).toBe(unknownMin);
 
   // Selector variant: `selector(...)` body is a raw input slice.
-  expect(minifyTest("@supports selector(a\n b) {.x{color:red}}", "")).toBe(
-    "@supports selector(a\n b){.x{color:red}}",
-  );
+  expect(minifyTest("@supports selector(a\n b) {.x{color:red}}", "")).toBe("@supports selector(a\n b){.x{color:red}}");
 
   // Declaration variant via `@import ... supports(...)`: the value is a raw input slice.
   expect(minifyTest("@import url(x.css) supports(color: lab(0%\n 0 0));", "")).toBe(


### PR DESCRIPTION
Found by fuzzing.

## Repro

```sh
BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1 bun-debug -e 'require("bun:internal-for-testing").cssInternals.minifyTest("@supports (color: lab(0%\n 0 \r\n0)) {.x{color:red}}", "")'
```

```
panic: assertion failed: !s.contains(&b'\n')
  <bun_css::printer::Printer>::write_str (src/css/printer.rs:533)
  <bun_css::rules::supports::SupportsCondition>::to_css (src/css/rules/supports.rs:201)
```

## Cause

`SupportsCondition::{Unknown,Selector,Declaration}` each hold a raw slice of the parser input captured via `slice_from_cloned()`. CSS permits whitespace (including newlines) inside the parenthesised condition, so a condition like `@supports (color: lab(0%\n 0 \r\n0))` produces a slice containing literal `\n`/`\r\n`. `SupportsCondition::to_css` printed these slices with `Printer::write_str`, which debug-asserts the input has no newlines. In release builds the assertion compiles out and the printer's line/col counters go stale instead, which corrupts source maps.

## Fix

Print all three raw-slice payloads with `Printer::write_bytes`, the newline-aware path already used for whitespace tokens and comments.

Swept `src/css/` for other raw-slice `write_str` call sites: the `@property` `initial-value` slice is re-parsed into a `ParsedComponent` before printing, and the `unicode-range` slice is parsed into a `UnicodeRange` struct, so neither reaches `write_str`. These three were the only multi-token spans printed raw.

## Verification

- `bun bd test test/js/bun/css/supports-condition-newline.test.ts` panics at `supports.rs:201` without the fix, passes with it.
- `bun bd test test/js/bun/css/css.test.ts`: 1129 pass / 0 fail.