### PR TITLE
clippy: fix the remaining lints on aarch64-linux and macOS

### DIFF
--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -1685,8 +1685,8 @@ pub unsafe fn free_sensitive_cstr(p: *const core::ffi::c_char) {
     // size-agnostic).
     unsafe {
         let len = libc::strlen(p);
-        secure_zero(p as *mut u8, len);
-        crate::default_alloc::free(p as *mut core::ffi::c_void);
+        secure_zero(p.cast::<u8>().cast_mut(), len);
+        crate::default_alloc::free(p.cast::<core::ffi::c_void>().cast_mut());
     }
 }
 

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -3927,7 +3927,7 @@ pub fn dupe_z(bytes: &[u8]) -> *const core::ffi::c_char {
         core::ptr::copy_nonoverlapping(bytes.as_ptr(), p, bytes.len());
         *p.add(bytes.len()) = 0;
     }
-    p as *const core::ffi::c_char
+    p.cast_const().cast::<core::ffi::c_char>()
 }
 
 /// Port of `bun.freeSensitive(bun.default_allocator, slice)` for the C-string

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -68,6 +68,11 @@ struct Sendfile {
     has_set_on_writable: bool,
 }
 
+#[allow(
+    clippy::derivable_impls,
+    reason = "only derivable where the linux/android-gated fields are absent; `Fd` has no \
+              `Default` impl, so `#[derive(Default)]` would not compile on linux/android"
+)]
 impl Default for Sendfile {
     fn default() -> Self {
         Self {


### PR DESCRIPTION
Follow-up to #33951, which unbroke `cargo clippy` on the Clippy workflow's runner (`x86_64-unknown-linux-gnu`). The workspace is still not clean on the other hosts, so `bun run rust:clippy` fails for anyone developing on an Apple Silicon Mac, and for the aarch64 Linux target.

Measured on `main` (`55ba6e453c`) vs this branch, `cargo clippy --workspace --no-deps --keep-going`:

| | macOS arm64 (host) | aarch64-unknown-linux-gnu | x86_64-unknown-linux-gnu |
| --- | --- | --- | --- |
| `main` | ❌ 2 errors | ❌ 2 errors | ✅ |
| this PR | ✅ | ✅ | ✅ |

## `ptr_cast_constness` — aarch64 only

`c_char` is `u8` on aarch64 and `i8` on x86_64, so these casts change *only* constness on aarch64 and the lint fires there but not on the runner:

- `bun_core::util::dupe_z` — `p as *const c_char`
- `bun_alloc::free_sensitive_cstr` — `p as *mut u8`, `p as *mut c_void`

Rewritten with `.cast()` / `.cast_const()` / `.cast_mut()`. These are not "smarter" than `as`: in `core` they are literally `#[inline(always)] pub const fn cast_const(self) -> *const T { self as _ }`, so each rewrite is the same single `PtrToPtr` cast with the same address and the same provenance.

The `*const` → `*mut` laundering in `free_sensitive_cstr` is pre-existing and unchanged by this PR. The pointer's root is a `default_alloc::malloc` allocation that `dupe_z` already wrote through, so writing through it here was sound before and is sound now — Rust does not track mutability in raw-pointer provenance.

## `derivable_impls` — macOS only

`Sendfile`'s `Default` impl is only derivable where the `#[cfg(any(target_os = "linux", target_os = "android"))]` fields are absent. On linux/android the impl carries `socket_fd: Fd::INVALID`, and `Fd` has no `Default` impl at all — `#[derive(Default)]` would not compile there. Suppressed with the reason recorded.

`#[allow]` rather than `#[expect]` in both suppression sites, because an expectation would go *unfulfilled* on the platform where the lint doesn't fire, and `warnings = "deny"` would turn that into an error.

## Verification

`cargo clippy --workspace --no-deps --keep-going` exits 0 on all three targets above (and `cargo fmt --check` is clean). Built `bun-debug` and exercised the touched crates through the CLI — `path.resolve`/`path.win32.normalize`, `process.env`, `Bun.spawnSync` — plus `bun bd test test/js/node/path/` → 122 pass, 0 fail.

Reverting just this commit reproduces both failures on macOS and aarch64, so the changes are load-bearing.
