### PR TITLE
fetch: reject non-HTTP(S) schemes before touching the network

### DIFF
--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1593,19 +1593,17 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         ));
     }
 
-    if !url.protocol.is_empty() {
-        if !(url.is_http() || url.is_https() || url.is_s3()) {
-            let err = global_this.to_type_error(
-                jsc::ErrorCode::INVALID_ARG_VALUE,
-                format_args!("protocol must be http:, https: or s3:"),
-            );
-            return Ok(
-                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    global_this,
-                    err,
-                ),
-            );
-        }
+    if !(url.is_http() || url.is_https() || url.is_s3()) {
+        let err = global_this.to_type_error(
+            jsc::ErrorCode::INVALID_ARG_VALUE,
+            format_args!("protocol must be http:, https: or s3:"),
+        );
+        return Ok(
+            JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                global_this,
+                err,
+            ),
+        );
     }
 
     if !ALLOW_GET_BODY && !method.has_request_body() && body.has_body() && !upgraded_connection {

--- a/test/js/web/fetch/fetch-args.test.ts
+++ b/test/js/web/fetch/fetch-args.test.ts
@@ -16,6 +16,51 @@ afterAll(() => {
   server!.stop(true);
 });
 
+describe("non-HTTP(S) URL scheme rejection", () => {
+  // WHATWG URL parses `localhost:3000/x` as scheme "localhost:" with an empty
+  // host. fetch() must reject these without any network activity rather than
+  // treating the scheme name as a hostname.
+  test.each(["about:blank", "javascript:alert(1)", "chrome:flags", "foo:bar"])(
+    "fetch(%j) rejects with TypeError",
+    async input => {
+      const prevCount = requestCount;
+      const err = await fetch(input).then(
+        () => null,
+        e => e,
+      );
+      expect(err).toBeInstanceOf(TypeError);
+      expect(requestCount).toBe(prevCount);
+    },
+  );
+
+  test("fetch('localhost:<port>/path') does not reach the network", async () => {
+    const prevCount = requestCount;
+    const input = `localhost:${server!.port}/api/x?q=1`;
+    expect(new URL(input).host).toBe("");
+    const err = await fetch(input).then(
+      () => null,
+      e => e,
+    );
+    expect(err).toBeInstanceOf(TypeError);
+    expect(requestCount).toBe(prevCount);
+  });
+
+  test("fetch(new Request('about:blank')) rejects with TypeError", async () => {
+    const err = await fetch(new Request("about:blank")).then(
+      () => null,
+      e => e,
+    );
+    expect(err).toBeInstanceOf(TypeError);
+  });
+
+  test("http:// and data: still work", async () => {
+    const res = await fetch(server!.url);
+    expect(res.status).toBe(200);
+    const dataRes = await fetch("data:text/plain,hello");
+    expect(await dataRes.text()).toBe("hello");
+  });
+});
+
 test("fetch(request subclass with headers)", async () => {
   class MyRequest extends Request {
     constructor(input: RequestInfo, init?: RequestInit) {


### PR DESCRIPTION
## Reproduction

```js
import * as http from "node:http";
const seen = [];
const s = http.createServer((rq, rs) => { seen.push(rq.url); rs.end("ok"); });
await new Promise(r => s.listen(0, "127.0.0.1", r));
const u = `localhost:${s.address().port}/api/x?q=1`; // scheme "localhost:", host ""
console.log(await fetch(u).then(r => r.status, e => e.name));
// bun: 200, server receives the request
// node: TypeError, no network activity
console.log(await fetch("about:blank").then(r => r.status, e => `${e.name} ${e.syscall ?? ""} ${e.hostname ?? ""}`));
// bun: issues getaddrinfo("about")
// node: TypeError
```

`fetch()` of a URL whose WHATWG scheme is not http/https leaks a DNS query for the scheme name and, if the resolver answers, opens a real connection. Node/undici and the fetch spec reject these with `TypeError` and zero network activity.

## Cause

`fetch_impl` re-parses the WHATWG-normalized href with the simple `bun_url::URL` parser and gates on scheme:

```rust
if !url.protocol.is_empty() {
    if !(url.is_http() || url.is_https() || url.is_s3()) { /* reject */ }
}
```

`URL::parse_protocol` (src/url/lib.rs) only assigns `self.protocol` when the colon is followed by `//`. Non-special schemes keep their opaque `scheme:rest` form through WHATWG normalization, so `protocol` stays empty, the outer guard skips the check, and the rest of `parse()` treats `scheme:rest` as `host:port`.

`ftp:example.com/` was already rejected only because ftp is a WHATWG special scheme and normalizes to `ftp://example.com/`.

## Fix

Drop the `!url.protocol.is_empty()` guard. The input has already been WHATWG-validated by this point; http/https are special schemes that always normalize to `scheme://host`, so `is_http()`/`is_https()` are reliable without the guard. `data:`, `file:`, and registered `blob:` URLs are handled earlier and are unaffected.

This matches the existing unconditional check in `fetch.preconnect()` in the same file.

## Verification

New tests in `test/js/web/fetch/fetch-args.test.ts` cover `about:blank`, `javascript:alert(1)`, `chrome:flags`, `foo:bar`, `localhost:<port>/path` (asserting the local server is not hit), and `new Request("about:blank")`. A positive test confirms `http://` and `data:` still succeed.

Fails on main with `Received value: null` (fetch resolved via network) or a DNS error; passes with this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-args.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (a3619b52d)

test/js/web/fetch/fetch-args.test.ts:
26 |       const prevCount = requestCount;
27 |       const err = await fetch(input).then(
28 |         () => null,
29 |         e => e,
30 |       );
31 |       expect(err).toBeInstanceOf(TypeError);
                       ^
error: expect(received).toBeInstanceOf(expected)

Expected constructor: [class TypeError extends Error]
Received value: null

      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-args.test.ts:31:19)
(fail) non-HTTP(S) URL scheme rejection > fetch("about:blank") rejects with TypeError [23.13ms]
26 |       const prevCount = requestCount;
27 |       const err = await fetch(input).then(
28 |         () => null,
29 |         e => e,
30 |       );
31 |     
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (2985d11b0)

test/js/web/fetch/fetch-args.test.ts:
(pass) non-HTTP(S) URL scheme rejection > fetch("about:blank") rejects with TypeError [0.27ms]
(pass) non-HTTP(S) URL scheme rejection > fetch("javascript:alert(1)") rejects with TypeError [0.03ms]
(pass) non-HTTP(S) URL scheme rejection > fetch("chrome:flags") rejects with TypeError [0.01ms]
(pass) non-HTTP(S) URL scheme rejection > fetch("foo:bar") rejects with TypeError [0.01ms]
(pass) non-HTTP(S) URL scheme rejection > fetch('localhost:<port>/path') does not reach the network [0.22ms]
(pass) non-HTTP(S) URL scheme rejection > fetch(new Request('about:blank')) rejects with TypeError [0.15ms]
(pass) non-HTTP(S) URL scheme rejection > http:// and data: still work [1.02ms]
(pass) fetch(request subclass with headers) [0.58ms]
(pass) fetch(RequestInit, headers) [0.19ms]
(pass) fetch(url, RequestSubclass) [0.21ms]
(pass) fetch({toString throwing}, {headers} isn't accessed) [0.48ms]
(pass) fetch() rejects instead of throwing synchronously when option conversion throws > url toString() throws [0.13ms]
(pass) fetch() rejects instead of throwing synchronously when option conversion throws > init.he
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-args.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (a3619b52d)

test/js/web/fetch/fetch-args.test.ts:
(pass) non-HTTP(S) URL scheme rejection > fetch("about:blank") rejects with TypeError [7.93ms]
(pass) non-HTTP(S) URL scheme rejection > fetch("javascript:alert(1)") rejects with TypeError [1.34ms]
(pass) non-HTTP(S) URL scheme rejection > fetch("chrome:flags") rejects with TypeError [1.02ms]
(pass) non-HTTP(S) URL scheme rejection > fetch("foo:bar") rejects with TypeError [0.95ms]
(pass) non-HTTP(S) URL scheme rejection > fetch('localhost:<port>/path') does not reach the network [8.46ms]
(pass) non-HTTP(S) URL scheme rejection > fetch(new Request('about:blank')) rejects with TypeError [5.85ms]
(pass) non-HTTP(S) URL scheme rejection > http:// and data: still work [12.35ms]
(pass)
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 715ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/74] gen ErrorCode+*.h
[2/23] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[3/23] gen cpp.rs (cppbind)
[4/23] gen JS modules (bundle-modules)
Preprocess modules (6775ms)
Bundle modules (43ms)
Postprocesss modules (26ms)
Bundle Functions (675ms)
Generate Code (79ms)

[7.61s] Bundled "src/js" for production
  1913 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[4/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to d
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/fetch.rs         | 24 +++++++++----------
 test/js/web/fetch/fetch-args.test.ts | 45 ++++++++++++++++++++++++++++++++++++
 2 files changed, 56 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/runtime/webcore/fetch.rs              4      1      0
test/js/web/fetch/fetch-args.test.ts      2      1      0
```

</details>

<!-- robobun:evidence:end -->