### PR TITLE
test(sql): share one mock server per file in postgres fault-injection tests

### DIFF
--- a/test/js/sql/postgres-binary-array-bounds.test.ts
+++ b/test/js/sql/postgres-binary-array-bounds.test.ts
@@ -9,7 +9,7 @@
 // The binary array parser must validate `len` against the column's byte length
 // before iterating; otherwise slice() reads and writes past the read buffer.
 import { SQL } from "bun";
-import { expect, test } from "bun:test";
+import { afterAll, expect, test } from "bun:test";
 import {
   listeningServer,
   pgAuthenticationOk,
@@ -40,32 +40,44 @@ function binaryArrayHeader(opts: {
   return Buffer.concat([i32(opts.ndim), i32(opts.flags), i32(opts.elemtype), i32(opts.len), i32(opts.lbound)]);
 }
 
-async function runMockQuery(columnBytes: Buffer, typeOid: number): Promise<unknown> {
-  const { port, server } = await listeningServer(socket => {
-    let startup = true;
-    socket.on("data", data => {
-      if (startup) {
-        startup = false;
-        socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
-        return;
-      }
-      if (data[0] !== 0x51 /* 'Q' */) return;
-      // Column name length is chosen so the column payload lands on a
-      // 4-byte boundary within the response buffer; this lets the
-      // unpatched parser reach slice() (the actual overflow) instead of
-      // tripping the debug-only @alignCast in init() first.
-      socket.write(
-        Buffer.concat([
-          pgRowDescription([{ name: "arr", typeOid, format: 1 /* binary */ }]),
-          pgDataRow([columnBytes]),
-          pgCommandComplete("SELECT 1"),
-          pgReadyForQuery(),
-        ]),
-      );
-    });
-    socket.on("error", () => {});
+// One mock server for the whole file. The DataRow payload is read from
+// `current` at the moment each connection is accepted; every test sets it
+// immediately before connecting. A per-test server here used to flake on
+// Windows CI with ERR_POSTGRES_CONNECTION_REFUSED: bun disables SYN
+// retransmission for loopback connects (packages/bun-usockets/src/bsd.c,
+// SIO_TCP_INITIAL_RTO), so a listen()+connect() churn after a port-heavy test
+// in the same shard can lose the single SYN. A single long-lived listener
+// keeps the port stable across all cases.
+let current!: { col: Buffer; oid: number };
+const { port, server } = await listeningServer(socket => {
+  const { col, oid } = current;
+  let startup = true;
+  socket.on("data", data => {
+    if (startup) {
+      startup = false;
+      socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+      return;
+    }
+    if (data[0] !== 0x51 /* 'Q' */) return;
+    // Column name length is chosen so the column payload lands on a
+    // 4-byte boundary within the response buffer; this lets the
+    // unpatched parser reach slice() (the actual overflow) instead of
+    // tripping the debug-only @alignCast in init() first.
+    socket.write(
+      Buffer.concat([
+        pgRowDescription([{ name: "arr", typeOid: oid, format: 1 /* binary */ }]),
+        pgDataRow([col]),
+        pgCommandComplete("SELECT 1"),
+        pgReadyForQuery(),
+      ]),
+    );
   });
+  socket.on("error", () => {});
+});
+afterAll(() => new Promise<void>(r => server.close(() => r())));
 
+async function runMockQuery(columnBytes: Buffer, typeOid: number): Promise<unknown> {
+  current = { col: columnBytes, oid: typeOid };
   const sql = new SQL({
     url: `postgres://u@127.0.0.1:${port}/db`,
     max: 1,
@@ -77,7 +89,6 @@ async function runMockQuery(columnBytes: Buffer, typeOid: number): Promise<unkno
     return await sql`select x`.simple();
   } finally {
     await sql.close().catch(() => {});
-    await new Promise<void>(r => server.close(() => r()));
   }
 }
 

--- a/test/js/sql/postgres-binary-array-bounds.test.ts
+++ b/test/js/sql/postgres-binary-array-bounds.test.ts
@@ -40,14 +40,9 @@ function binaryArrayHeader(opts: {
   return Buffer.concat([i32(opts.ndim), i32(opts.flags), i32(opts.elemtype), i32(opts.len), i32(opts.lbound)]);
 }
 
-// One mock server for the whole file. The DataRow payload is read from
-// `current` at the moment each connection is accepted; every test sets it
-// immediately before connecting. A per-test server here used to flake on
-// Windows CI with ERR_POSTGRES_CONNECTION_REFUSED: bun disables SYN
-// retransmission for loopback connects (packages/bun-usockets/src/bsd.c,
-// SIO_TCP_INITIAL_RTO), so a listen()+connect() churn after a port-heavy test
-// in the same shard can lose the single SYN. A single long-lived listener
-// keeps the port stable across all cases.
+// One mock server for the file; each test sets `current` before connecting and
+// the accept handler latches it per connection. A per-test server flaked on
+// Windows CI with ERR_POSTGRES_CONNECTION_REFUSED (loopback SYN not retransmitted).
 let current!: { col: Buffer; oid: number };
 const { port, server } = await listeningServer(socket => {
   const { col, oid } = current;

--- a/test/js/sql/postgres-invalid-message-length.test.ts
+++ b/test/js/sql/postgres-invalid-message-length.test.ts
@@ -12,11 +12,34 @@
 // the connection path. It must surface as ERR_POSTGRES_INVALID_MESSAGE_LENGTH
 // on that connection rather than being trusted.
 import { SQL } from "bun";
-import { expect, test } from "bun:test";
+import { afterAll, expect, test } from "bun:test";
 import { listeningServer, pgAuthenticationOk, pgCString, pgRaw, pgReadyForQuery } from "./wire-frames";
 
 // connectionTimeout (seconds) bounds the connect-retry budget; keep it short
 // in tests that expect the failure to surface.
+
+// One mock server for the whole file. Each test sets `current` immediately
+// before connecting, and the server latches it per connection. A per-test
+// server here used to flake on Windows CI with ERR_POSTGRES_CONNECTION_REFUSED:
+// bun disables SYN retransmission for loopback connects
+// (packages/bun-usockets/src/bsd.c, SIO_TCP_INITIAL_RTO), so a
+// listen()+connect() churn after a port-heavy test in the same shard can lose
+// the single SYN. A single long-lived listener keeps the port stable.
+let current!: { atStartup: Buffer[]; atQuery?: Buffer[] };
+const { port, server } = await listeningServer(socket => {
+  const { atStartup, atQuery } = current;
+  let startup = true;
+  socket.on("data", data => {
+    if (startup) {
+      startup = false;
+      socket.write(Buffer.concat([pgAuthenticationOk(), ...atStartup]));
+      return;
+    }
+    if (atQuery && data[0] === 0x51 /* 'Q' */) socket.write(Buffer.concat(atQuery));
+  });
+  socket.on("error", () => {});
+});
+afterAll(() => new Promise<void>(r => server.close(() => r())));
 
 /**
  * Reply to the startup packet with AuthenticationOk followed by `frames`, so
@@ -24,10 +47,7 @@ import { listeningServer, pgAuthenticationOk, pgCString, pgRaw, pgReadyForQuery 
  * connect()'s rejection.
  */
 async function connectError(frames: Buffer[]): Promise<any> {
-  const { port, server } = await listeningServer(socket => {
-    socket.once("data", () => socket.write(Buffer.concat([pgAuthenticationOk(), ...frames])));
-    socket.on("error", () => {});
-  });
+  current = { atStartup: frames };
   const db = new SQL({ url: `postgres://postgres@127.0.0.1:${port}/postgres`, max: 1, connectionTimeout: 1 });
   try {
     await db.connect();
@@ -36,7 +56,6 @@ async function connectError(frames: Buffer[]): Promise<any> {
     return err;
   } finally {
     await db.close({ timeout: 0 });
-    await new Promise<void>(r => server.close(() => r()));
   }
 }
 
@@ -46,19 +65,7 @@ async function connectError(frames: Buffer[]): Promise<any> {
  * rejection.
  */
 async function queryError(frames: Buffer[]): Promise<any> {
-  const { port, server } = await listeningServer(socket => {
-    let startup = true;
-    socket.on("data", data => {
-      if (startup) {
-        startup = false;
-        socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
-        return;
-      }
-      if (data[0] !== 0x51 /* 'Q' */) return;
-      socket.write(Buffer.concat(frames));
-    });
-    socket.on("error", () => {});
-  });
+  current = { atStartup: [pgReadyForQuery()], atQuery: frames };
   const db = new SQL({ url: `postgres://postgres@127.0.0.1:${port}/postgres`, max: 1, connectionTimeout: 1 });
   try {
     await db`select x`.simple();
@@ -67,7 +74,6 @@ async function queryError(frames: Buffer[]): Promise<any> {
     return err;
   } finally {
     await db.close({ timeout: 0 });
-    await new Promise<void>(r => server.close(() => r()));
   }
 }
 
@@ -111,17 +117,11 @@ test("postgres: CommandComplete declaring length 3 fails the in-flight query", a
 // Boundary: a length of exactly 4 (an empty NoticeResponse) is the smallest
 // valid value and must still be accepted.
 test("postgres: an empty NoticeResponse (length exactly 4) is accepted", async () => {
-  const { port, server } = await listeningServer(socket => {
-    socket.once("data", () =>
-      socket.write(Buffer.concat([pgAuthenticationOk(), pgRaw("N", Buffer.alloc(0)), pgReadyForQuery()])),
-    );
-    socket.on("error", () => {});
-  });
+  current = { atStartup: [pgRaw("N", Buffer.alloc(0)), pgReadyForQuery()] };
   const db = new SQL({ url: `postgres://postgres@127.0.0.1:${port}/postgres`, max: 1 });
   try {
     await expect(db.connect()).resolves.toBeDefined();
   } finally {
     await db.close({ timeout: 0 });
-    await new Promise<void>(r => server.close(() => r()));
   }
 });

--- a/test/js/sql/postgres-invalid-message-length.test.ts
+++ b/test/js/sql/postgres-invalid-message-length.test.ts
@@ -18,13 +18,9 @@ import { listeningServer, pgAuthenticationOk, pgCString, pgRaw, pgReadyForQuery 
 // connectionTimeout (seconds) bounds the connect-retry budget; keep it short
 // in tests that expect the failure to surface.
 
-// One mock server for the whole file. Each test sets `current` immediately
-// before connecting, and the server latches it per connection. A per-test
-// server here used to flake on Windows CI with ERR_POSTGRES_CONNECTION_REFUSED:
-// bun disables SYN retransmission for loopback connects
-// (packages/bun-usockets/src/bsd.c, SIO_TCP_INITIAL_RTO), so a
-// listen()+connect() churn after a port-heavy test in the same shard can lose
-// the single SYN. A single long-lived listener keeps the port stable.
+// One mock server for the file; each test sets `current` before connecting and
+// the accept handler latches it per connection. A per-test server flaked on
+// Windows CI with ERR_POSTGRES_CONNECTION_REFUSED (loopback SYN not retransmitted).
 let current!: { atStartup: Buffer[]; atQuery?: Buffer[] };
 const { port, server } = await listeningServer(socket => {
   const { atStartup, atQuery } = current;


### PR DESCRIPTION
## Problem

`postgres-binary-array-bounds.test.ts` and `postgres-invalid-message-length.test.ts` have been flaking on Windows CI lanes (2019 x64, 2019 x64-baseline, 11 aarch64) with `ERR_POSTGRES_CONNECTION_REFUSED`. The first 1-2 cases in the file pass, then every remaining case fails, and the failure persists across every retry of the test process for ~30-50s before recovering. Seen in builds 70081 onward (e.g. 71781, 71702, 71632, 71614, 71607, 71604, 71587, 71582, 71563).

```
error: expect(received).toMatch(expected)
Expected substring or pattern: /ERR_POSTGRES_INVALID_BINARY_DATA|InvalidBinaryData/
Received: "ERR_POSTGRES_CONNECTION_REFUSED"
```

## Cause

Both files create a fresh `net.Server` per test case (7 and 10 respectively) and close it in `finally`. Since #33622 switched the runner to LPT sharding, on Windows both files land in the same shard a few positions after `node-http-uaf.test.ts`, whose fixture issues ~22000 localhost connections and leaves tens of thousands of TIME_WAIT sockets (44k measured locally).

Bun disables SYN retransmission for loopback connects on Windows (`SIO_TCP_INITIAL_RTO` with `TCP_INITIAL_RTO_NO_SYN_RETRANSMISSIONS` in `packages/bun-usockets/src/bsd.c`), so a lost SYN under that load becomes an immediate connect failure, and the SQL client surfaces it as `ERR_POSTGRES_CONNECTION_REFUSED` without retry (by design: "nothing is listening" fails fast).

I could not reproduce the dropped SYN locally on an idle Windows Server 2019 box even with 44k TIME_WAIT sockets in place, but the CI pattern (Windows-only, first-N-then-all-fail, cross-process, ~30-50s recovery, exclusively in the shard that runs after the 22k-connection fixture) is consistent with this mechanism and nothing else in the process carries state across a fresh `bun test` invocation.

## Fix

Start one long-lived mock listener per file at module scope and latch the per-test payload into a module-level variable that the connection handler reads at accept time. Each file now needs one listen port and a handful of client ports for the whole run, removing the per-test `listen()`+`close()` churn. Assertions are unchanged; the combined run also drops from ~395ms to ~150ms on Windows release.

## Verification

```
bun bd test test/js/sql/postgres-binary-array-bounds.test.ts test/js/sql/postgres-invalid-message-length.test.ts
  17 pass  0 fail
```

On Windows, 7 consecutive runs immediately after `node-http-uaf.test.ts` (with thousands of TIME_WAIT sockets in place) all pass.

Refs #33622.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/sql/postgres-binary-array-bounds.test.ts' 'test/js/sql/postgres-invalid-message-length.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/sql/postgres-binary-array-bounds.test.ts test/js/sql/postgres-invalid-message-length.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (8c1de5de2)

test/js/sql/postgres-binary-array-bounds.test.ts:
(pass) binary int4[] with len exceeding column bytes is rejected [454.64ms]
(pass) binary int4[] with len exceeding column bytes (partial data) is rejected [133.45ms]
(pass) binary int4[] with negative len is rejected [63.86ms]
(pass) binary int4[] with ndim=1 but truncated header is rejected [67.45ms]
(pass) binary int4[] with len = INT32_MAX is rejected [111.00ms]
(pass) binary float4[] with len exceeding column bytes is rejected [95.72ms]
(pass) well-formed binary int4[] still parses [66.09ms]

test/js/sql/postgres-invalid-message-length.test.ts:
(pass) postgres: ReadyForQuery declaring length 3 is a protocol error [70.61ms]
(pass) postgres: ReadyForQuery declaring length 0 is a protocol error [31.84ms]
(pass) postgres: ReadyForQuery declaring length -1 is a protocol error [33.82ms]
(pass) postgres: ParameterStatus declaring length 3 is a protocol error [38.84ms]
(pass) postgres: NotificationResponse declaring length 3 is a protocol error [42.64ms]
(pass) postgres: NoticeResponse declaring length 3 is a protocol error [51.42ms]
(pass) postgres: ErrorResponse declaring length 3 is a protocol error [53.33ms]
(pass) postgres: unknown message type declaring length 3 is a protocol error [53.54ms]
(pass) postgres: CommandComplete declaring length 3 fails the in-flight query [82.24ms]
(pass) postgres: an empty NoticeResponse (length exactly 4) is accepted [58.24ms]

 17 pass
 0 fail
 23 expect() calls
Ran 17 tests across 2 files. [4.22s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/sql/postgres-binary-array-bounds.test.ts   | 58 ++++++++++++----------
 .../js/sql/postgres-invalid-message-length.test.ts | 50 +++++++++----------
 2 files changed, 55 insertions(+), 53 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
test/js/sql/postgres-binary-array-bounds.test.ts         2      2      0
test/js/sql/postgres-invalid-message-length.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->