### PR TITLE
test(update-interactive): isolate install cache per test to fix Windows flake

### DIFF
--- a/test/cli/update_interactive_install.test.ts
+++ b/test/cli/update_interactive_install.test.ts
@@ -16,17 +16,27 @@ describe.concurrent("bun update --interactive actually installs packages", () =>
       }),
     });
 
+    // Isolate the install cache per test so the concurrent tests in this file
+    // don't race on the shared global cache (flaky ENOENT on Windows).
+    const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache") };
+
     // First, run bun install to create initial node_modules
     await using installProc = Bun.spawn({
       cmd: [bunExe(), "install"],
       cwd: String(dir),
-      env: bunEnv,
+      env,
       stdout: "pipe",
       stderr: "pipe",
     });
 
-    const installExitCode = await installProc.exited;
-    expect(installExitCode).toBe(0);
+    const [installStdout, installStderr, installExitCode] = await Promise.all([
+      installProc.stdout.text(),
+      installProc.stderr.text(),
+      installProc.exited,
+    ]);
+    expect({ stdout: installStdout, stderr: installStderr, exitCode: installExitCode }).toMatchObject({
+      exitCode: 0,
+    });
 
     // Verify initial installation
     const initialPackageJson = JSON.parse(readFileSync(join(String(dir), "package.json"), "utf8"));
@@ -47,7 +57,7 @@ describe.concurrent("bun update --interactive actually installs packages", () =>
     await using updateProc = Bun.spawn({
       cmd: [bunExe(), "update", "--interactive"],
       cwd: String(dir),
-      env: bunEnv,
+      env,
       stdin: "pipe",
       stdout: "pipe",
       stderr: "pipe",
@@ -118,16 +128,27 @@ describe.concurrent("bun update --interactive actually installs packages", () =>
       }),
     });
 
+    // Isolate the install cache per test so the concurrent tests in this file
+    // don't race on the shared global cache (flaky ENOENT on Windows).
+    const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache") };
+
     // Initial install
     await using installProc = Bun.spawn({
       cmd: [bunExe(), "install"],
       cwd: String(dir),
-      env: bunEnv,
+      env,
       stdout: "pipe",
       stderr: "pipe",
     });
 
-    await installProc.exited;
+    const [installStdout, installStderr, installExitCode] = await Promise.all([
+      installProc.stdout.text(),
+      installProc.stderr.text(),
+      installProc.exited,
+    ]);
+    expect({ stdout: installStdout, stderr: installStderr, exitCode: installExitCode }).toMatchObject({
+      exitCode: 0,
+    });
 
     // Verify initial version
     const initialPkgJson = JSON.parse(
@@ -139,7 +160,7 @@ describe.concurrent("bun update --interactive actually installs packages", () =>
     await using updateProc = Bun.spawn({
       cmd: [bunExe(), "update", "--interactive"],
       cwd: String(dir),
-      env: bunEnv,
+      env,
       stdin: "pipe",
       stdout: "pipe",
       stderr: "pipe",


### PR DESCRIPTION
`test/cli/update_interactive_install.test.ts` has been flaking on Windows lanes (2019 x64, 2019 x64-baseline, 11 aarch64) since it was introduced in #24280. In the 71700-71800 build range alone it shows up in ~35 builds, usually passing on retry but occasionally going fully red (e.g. build 71752, build 71675).

## Repro

On Windows with a cold cache, the unfixed file fails ~30% of the time:

```
Original test failures: 9 / 30
```

The captured stderr is:

```
ENOENT: failed opening cache/package/version dir for package is-number
```

## Cause

The two tests in the describe block run concurrently (`describe.concurrent`) and both transitively depend on `is-number` (via `is-even` -> `is-odd` -> `is-number` and `is-odd` -> `is-number`). Both spawned `bun install` processes share the default global install cache, and on Windows one of them hits ENOENT when the other is mid-write to the same cache entry.

The original test also asserted the install exit code without draining stdout/stderr, so CI only ever showed `Expected: 0 / Received: 1` with no diagnostic.

## Fix

Give each test its own `BUN_INSTALL_CACHE_DIR` inside its temp dir. This is the same pattern used across `test/cli/install/` (e.g. `bun-run-dir.test.ts`, `GHSA-pfwx-36v6-832x.test.ts`, `isolated-install.test.ts`). Also drain and surface stdout/stderr on the initial install so a future failure reports the actual error.

## Verification

On Windows, 50 cold-cache iterations with the fix:

```
Fixed test failures: 0 / 50
```

`bun bd test test/cli/update_interactive_install.test.ts` passes on Linux.

This is a test-only change; no `src/` behaviour is modified.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/update_interactive_install.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/update_interactive_install.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (c10a6210e)

test/cli/update_interactive_install.test.ts:
(pass) bun update --interactive actually installs packages > should work with --latest flag [700.77ms]
(pass) bun update --interactive actually installs packages > should update package.json AND install packages [791.58ms]

 2 pass
 0 fail
 15 expect() calls
Ran 2 tests across 1 file. [2.86s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/cli/update_interactive_install.test.ts | 35 +++++++++++++++++++++++------
 1 file changed, 28 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
test/cli/update_interactive_install.test.ts      2      1      0
```

</details>

<!-- robobun:evidence:end -->