### PR TITLE
process: defer termination across lazy PropertyCallback builders

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -16,6 +16,7 @@
 #include "ErrorCode+List.h"
 #include "JavaScriptCore/ArgList.h"
 #include "JavaScriptCore/CallData.h"
+#include "JavaScriptCore/DeferTermination.h"
 #include "JavaScriptCore/TopExceptionScope.h"
 #include "JavaScriptCore/JSCJSValue.h"
 #include "JavaScriptCore/JSCast.h"
@@ -207,26 +208,17 @@ static JSValue constructPlatform(VM& vm, JSObject* processObject)
 }
 
 // LazyPropertyCallback builders run inside getOwnPropertySlot, which performs no
-// exception check; tryClearException() won't clear a TerminationException, so
-// clear unconditionally (the VM trap re-throws it at the next safepoint).
-static void clearLazyPropertyCallbackException(JSC::VM& vm, JSC::TopExceptionScope& scope, JSC::JSGlobalObject* globalObject, JSC::Exception* exception)
-{
-    scope.clearException();
-    if (!vm.isTerminationException(exception)) {
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
-        scope.clearException();
-    }
-}
+// exception check; defer termination (as JSC's own LazyProperty::callFunc does)
+// so a worker.terminate() mid-builder can't leave it pending for the caller.
+#define DEFER_TERMINATION_FOR_LAZY_PROPERTY(vm__) JSC::DeferTerminationForAWhile deferScopeForLazyProperty(vm__)
 
 static JSValue constructVersions(VM& vm, JSObject* processObject)
 {
+    DEFER_TERMINATION_FOR_LAZY_PROPERTY(vm);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     auto* globalObject = processObject->globalObject();
     JSC::JSObject* object = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 24);
-    if (auto* exception = scope.exception()) [[unlikely]] {
-        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
-        return JSC::jsUndefined();
-    }
+    RETURN_IF_EXCEPTION(scope, {});
 
     object->putDirect(vm, JSC::Identifier::fromString(vm, "node"_s), JSC::jsOwnedString(vm, makeAtomString(ASCIILiteral::fromLiteralUnsafe(REPORTED_NODEJS_VERSION))));
     object->putDirect(vm, JSC::Identifier::fromString(vm, "bun"_s), JSC::jsOwnedString(vm, String(ASCIILiteral::fromLiteralUnsafe(Bun__version)).substring(1)));
@@ -283,6 +275,7 @@ static JSValue constructVersions(VM& vm, JSObject* processObject)
 static JSValue constructProcessReleaseObject(VM& vm, JSObject* processObject)
 {
     auto* globalObject = processObject->globalObject();
+    DEFER_TERMINATION_FOR_LAZY_PROPERTY(vm);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     auto* release = JSC::constructEmptyObject(globalObject);
 
@@ -290,8 +283,7 @@ static JSValue constructProcessReleaseObject(VM& vm, JSObject* processObject)
     release->putDirect(vm, Identifier::fromString(vm, "sourceUrl"_s), jsOwnedString(vm, WTF::String(std::span { Bun__githubURL, strlen(Bun__githubURL) })), 0);
     release->putDirect(vm, Identifier::fromString(vm, "headersUrl"_s), jsOwnedString(vm, String("https://nodejs.org/download/release/v" REPORTED_NODEJS_VERSION "/node-v" REPORTED_NODEJS_VERSION "-headers.tar.gz"_s)), 0);
 
-    if (auto* exception = scope.exception()) [[unlikely]]
-        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
+    RETURN_IF_EXCEPTION(scope, {});
     return release;
 }
 
@@ -2517,6 +2509,7 @@ static JSValue constructProcessReportObject(VM& vm, JSObject* processObject)
     auto* globalObject = processObject->globalObject();
     auto process = uncheckedDowncast<Process>(processObject);
 
+    DEFER_TERMINATION_FOR_LAZY_PROPERTY(vm);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     auto* report = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 10);
     report->putDirect(vm, JSC::Identifier::fromString(vm, "compact"_s), JSC::jsBoolean(false), 0);
@@ -2529,8 +2522,7 @@ static JSValue constructProcessReportObject(VM& vm, JSObject* processObject)
     report->putDirect(vm, JSC::Identifier::fromString(vm, "excludeEnv"_s), JSC::jsBoolean(false), 0);
     report->putDirect(vm, JSC::Identifier::fromString(vm, "excludeEnv"_s), JSC::jsString(vm, String("SIGUSR2"_s)), 0);
     report->putDirect(vm, JSC::Identifier::fromString(vm, "writeReport"_s), JSC::JSFunction::create(vm, globalObject, 1, String("writeReport"_s), Process_functionWriteReport, ImplementationVisibility::Public), 0);
-    if (auto* exception = scope.exception()) [[unlikely]]
-        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
+    RETURN_IF_EXCEPTION(scope, {});
     return report;
 }
 
@@ -2562,12 +2554,14 @@ static JSValue constructProcessConfigObject(VM& vm, JSObject* processObject)
     // }
     // Lazy property builder: exceptions must not propagate into
     // reifyStaticProperty, which performs no exception check.
+    DEFER_TERMINATION_FOR_LAZY_PROPERTY(vm);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSC::JSObject* config = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
     JSC::JSObject* variables = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
     JSC::JSArray* shareableBuiltins = JSC::constructEmptyArray(globalObject, nullptr);
     if (auto* exception = scope.exception()) [[unlikely]] {
-        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
+        (void)scope.tryClearException();
+        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
         return JSC::jsUndefined();
     }
     variables->putDirect(vm, JSC::Identifier::fromString(vm, "v8_enable_i8n_support"_s), JSC::jsNumber(1), 0);
@@ -2663,8 +2657,7 @@ static JSValue constructProcessConfigObject(VM& vm, JSObject* processObject)
 #endif
 
     config->freeze(vm);
-    if (auto* exception = scope.exception()) [[unlikely]]
-        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
+    RETURN_IF_EXCEPTION(scope, {});
     return config;
 }
 
@@ -2690,6 +2683,7 @@ extern "C" void Bun__ForceFileSinkToBeSynchronousForProcessObjectStdio(JSC::JSGl
 static JSValue constructStdioWriteStream(JSC::JSGlobalObject* globalObject, JSC::JSObject* processObject, int fd)
 {
     auto& vm = JSC::getVM(globalObject);
+    DEFER_TERMINATION_FOR_LAZY_PROPERTY(vm);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
     JSC::JSFunction* getStdioWriteStream = JSC::JSFunction::create(vm, globalObject, processObjectInternalsGetStdioWriteStreamCodeGenerator(vm), globalObject);
@@ -2704,7 +2698,8 @@ static JSValue constructStdioWriteStream(JSC::JSGlobalObject* globalObject, JSC:
 
     auto result = JSC::profiledCall(globalObject, ProfilingReason::API, getStdioWriteStream, callData, globalObject->globalThis(), args);
     if (auto* exception = scope.exception()) {
-        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
+        (void)scope.tryClearException();
+        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
         return jsUndefined();
     }
 
@@ -2752,6 +2747,7 @@ static JSValue constructStderr(VM& vm, JSObject* processObject)
 static JSValue constructStdin(VM& vm, JSObject* processObject)
 {
     auto* globalObject = processObject->globalObject();
+    DEFER_TERMINATION_FOR_LAZY_PROPERTY(vm);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSC::JSFunction* getStdinStream = JSC::JSFunction::create(vm, globalObject, processObjectInternalsGetStdinStreamCodeGenerator(vm), globalObject);
     JSC::MarkedArgumentBuffer args;
@@ -2764,7 +2760,8 @@ static JSValue constructStdin(VM& vm, JSObject* processObject)
 
     auto result = JSC::profiledCall(globalObject, ProfilingReason::API, getStdinStream, callData, globalObject, args);
     if (auto* exception = scope.exception()) {
-        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
+        (void)scope.tryClearException();
+        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
         return jsUndefined();
     }
     return result;
@@ -2820,6 +2817,7 @@ static JSValue constructProcessChannel(VM& vm, JSObject* processObject)
         auto& vm = JSC::getVM(globalObject);
         // Lazy property builder: exceptions must not propagate into
         // reifyStaticProperty, which performs no exception check.
+        DEFER_TERMINATION_FOR_LAZY_PROPERTY(vm);
         auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
         JSC::JSFunction* getControl = JSC::JSFunction::create(vm, globalObject, processObjectInternalsGetChannelCodeGenerator(vm), globalObject);
@@ -2828,7 +2826,8 @@ static JSValue constructProcessChannel(VM& vm, JSObject* processObject)
 
         auto result = JSC::profiledCall(globalObject, ProfilingReason::API, getControl, callData, globalObject->globalThis(), args);
         if (auto* exception = scope.exception()) [[unlikely]] {
-            clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
+            (void)scope.tryClearException();
+            Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
             return jsUndefined();
         }
         return result;
@@ -3026,10 +3025,12 @@ static JSValue constructEnv(VM& vm, JSObject* processObject)
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(processObject->globalObject());
     // Lazy property builder: exceptions must not propagate into
     // reifyStaticProperty, which performs no exception check.
+    DEFER_TERMINATION_FOR_LAZY_PROPERTY(vm);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSValue env = globalObject->processEnvObject();
     if (auto* exception = scope.exception()) [[unlikely]] {
-        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
+        (void)scope.tryClearException();
+        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
         return JSC::jsUndefined();
     }
     return env;
@@ -3894,10 +3895,12 @@ static JSValue Process_stubEmptyArray(VM& vm, JSObject* processObject)
 {
     // Lazy property builder: exceptions must not propagate into
     // reifyStaticProperty, which performs no exception check.
+    DEFER_TERMINATION_FOR_LAZY_PROPERTY(vm);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSC::JSArray* array = JSC::constructEmptyArray(processObject->globalObject(), nullptr);
     if (auto* exception = scope.exception()) [[unlikely]] {
-        clearLazyPropertyCallbackException(vm, scope, processObject->globalObject(), exception);
+        (void)scope.tryClearException();
+        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(processObject->globalObject(), exception);
         return JSC::jsUndefined();
     }
     return array;
@@ -3906,12 +3909,10 @@ static JSValue Process_stubEmptyArray(VM& vm, JSObject* processObject)
 static JSValue Process_stubEmptySet(VM& vm, JSObject* processObject)
 {
     auto* globalObject = processObject->globalObject();
+    DEFER_TERMINATION_FOR_LAZY_PROPERTY(vm);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSSet* result = JSSet::create(vm, globalObject->setStructure());
-    if (auto* exception = scope.exception()) [[unlikely]] {
-        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
-        return JSC::jsUndefined();
-    }
+    RETURN_IF_EXCEPTION(scope, {});
     return result;
 }
 
@@ -4031,19 +4032,22 @@ static JSValue constructMainModuleProperty(VM& vm, JSObject* processObject)
 {
     // Lazy property builder: exceptions must not propagate into
     // reifyStaticProperty, which performs no exception check.
+    DEFER_TERMINATION_FOR_LAZY_PROPERTY(vm);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(processObject->globalObject());
     auto* bun = globalObject->bunObject();
     auto& builtinNames = Bun::builtinNames(vm);
     JSValue mainValue = bun->get(globalObject, builtinNames.mainPublicName());
     if (auto* exception = scope.exception()) [[unlikely]] {
-        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
+        (void)scope.tryClearException();
+        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
         return JSC::jsUndefined();
     }
     auto* requireMap = globalObject->requireMap();
     JSValue mainModule = requireMap->get(globalObject, mainValue);
     if (auto* exception = scope.exception()) [[unlikely]] {
-        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
+        (void)scope.tryClearException();
+        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
         return JSC::jsUndefined();
     }
     return mainModule;
@@ -4069,10 +4073,12 @@ JSValue Process::constructNextTickFn(JSC::VM& vm, Zig::GlobalObject* globalObjec
 
     // Lazy property builder: exceptions must not propagate into
     // reifyStaticProperty, which performs no exception check.
+    DEFER_TERMINATION_FOR_LAZY_PROPERTY(vm);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSValue nextTickFunction = JSC::profiledCall(globalObject, ProfilingReason::API, initializer, JSC::getCallData(initializer), globalObject->globalThis(), args);
     if (auto* exception = scope.exception()) [[unlikely]] {
-        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
+        (void)scope.tryClearException();
+        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
         return JSC::jsUndefined();
     }
     if (nextTickFunction && nextTickFunction.isObject()) {
@@ -4114,6 +4120,7 @@ static JSValue constructFeatures(VM& vm, JSObject* processObject)
     //     cached_builtins: [Getter]
     // }
     auto* globalObject = processObject->globalObject();
+    DEFER_TERMINATION_FOR_LAZY_PROPERTY(vm);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     auto* object = constructEmptyObject(globalObject);
 
@@ -4136,8 +4143,7 @@ static JSValue constructFeatures(VM& vm, JSObject* processObject)
     object->putDirect(vm, Identifier::fromString(vm, "require_module"_s), jsBoolean(true));
     object->putDirect(vm, Identifier::fromString(vm, "typescript"_s), jsString(vm, String("transform"_s)));
 
-    if (auto* exception = scope.exception()) [[unlikely]]
-        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
+    RETURN_IF_EXCEPTION(scope, {});
     return object;
 }
 

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -206,12 +206,27 @@ static JSValue constructPlatform(VM& vm, JSObject* processObject)
 #endif
 }
 
+// LazyPropertyCallback builders run inside getOwnPropertySlot, which performs no
+// exception check; tryClearException() won't clear a TerminationException, so
+// clear unconditionally (the VM trap re-throws it at the next safepoint).
+static void clearLazyPropertyCallbackException(JSC::VM& vm, JSC::TopExceptionScope& scope, JSC::JSGlobalObject* globalObject, JSC::Exception* exception)
+{
+    scope.clearException();
+    if (!vm.isTerminationException(exception)) {
+        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        scope.clearException();
+    }
+}
+
 static JSValue constructVersions(VM& vm, JSObject* processObject)
 {
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     auto* globalObject = processObject->globalObject();
     JSC::JSObject* object = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 24);
-    RETURN_IF_EXCEPTION(scope, {});
+    if (auto* exception = scope.exception()) [[unlikely]] {
+        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
+        return JSC::jsUndefined();
+    }
 
     object->putDirect(vm, JSC::Identifier::fromString(vm, "node"_s), JSC::jsOwnedString(vm, makeAtomString(ASCIILiteral::fromLiteralUnsafe(REPORTED_NODEJS_VERSION))));
     object->putDirect(vm, JSC::Identifier::fromString(vm, "bun"_s), JSC::jsOwnedString(vm, String(ASCIILiteral::fromLiteralUnsafe(Bun__version)).substring(1)));
@@ -275,7 +290,8 @@ static JSValue constructProcessReleaseObject(VM& vm, JSObject* processObject)
     release->putDirect(vm, Identifier::fromString(vm, "sourceUrl"_s), jsOwnedString(vm, WTF::String(std::span { Bun__githubURL, strlen(Bun__githubURL) })), 0);
     release->putDirect(vm, Identifier::fromString(vm, "headersUrl"_s), jsOwnedString(vm, String("https://nodejs.org/download/release/v" REPORTED_NODEJS_VERSION "/node-v" REPORTED_NODEJS_VERSION "-headers.tar.gz"_s)), 0);
 
-    RETURN_IF_EXCEPTION(scope, {});
+    if (auto* exception = scope.exception()) [[unlikely]]
+        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
     return release;
 }
 
@@ -2513,7 +2529,8 @@ static JSValue constructProcessReportObject(VM& vm, JSObject* processObject)
     report->putDirect(vm, JSC::Identifier::fromString(vm, "excludeEnv"_s), JSC::jsBoolean(false), 0);
     report->putDirect(vm, JSC::Identifier::fromString(vm, "excludeEnv"_s), JSC::jsString(vm, String("SIGUSR2"_s)), 0);
     report->putDirect(vm, JSC::Identifier::fromString(vm, "writeReport"_s), JSC::JSFunction::create(vm, globalObject, 1, String("writeReport"_s), Process_functionWriteReport, ImplementationVisibility::Public), 0);
-    RETURN_IF_EXCEPTION(scope, {});
+    if (auto* exception = scope.exception()) [[unlikely]]
+        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
     return report;
 }
 
@@ -2550,8 +2567,7 @@ static JSValue constructProcessConfigObject(VM& vm, JSObject* processObject)
     JSC::JSObject* variables = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
     JSC::JSArray* shareableBuiltins = JSC::constructEmptyArray(globalObject, nullptr);
     if (auto* exception = scope.exception()) [[unlikely]] {
-        (void)scope.tryClearException();
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
         return JSC::jsUndefined();
     }
     variables->putDirect(vm, JSC::Identifier::fromString(vm, "v8_enable_i8n_support"_s), JSC::jsNumber(1), 0);
@@ -2647,7 +2663,8 @@ static JSValue constructProcessConfigObject(VM& vm, JSObject* processObject)
 #endif
 
     config->freeze(vm);
-    RETURN_IF_EXCEPTION(scope, {});
+    if (auto* exception = scope.exception()) [[unlikely]]
+        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
     return config;
 }
 
@@ -2687,8 +2704,7 @@ static JSValue constructStdioWriteStream(JSC::JSGlobalObject* globalObject, JSC:
 
     auto result = JSC::profiledCall(globalObject, ProfilingReason::API, getStdioWriteStream, callData, globalObject->globalThis(), args);
     if (auto* exception = scope.exception()) {
-        (void)scope.tryClearException();
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
         return jsUndefined();
     }
 
@@ -2748,8 +2764,7 @@ static JSValue constructStdin(VM& vm, JSObject* processObject)
 
     auto result = JSC::profiledCall(globalObject, ProfilingReason::API, getStdinStream, callData, globalObject, args);
     if (auto* exception = scope.exception()) {
-        (void)scope.tryClearException();
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
         return jsUndefined();
     }
     return result;
@@ -2813,8 +2828,7 @@ static JSValue constructProcessChannel(VM& vm, JSObject* processObject)
 
         auto result = JSC::profiledCall(globalObject, ProfilingReason::API, getControl, callData, globalObject->globalThis(), args);
         if (auto* exception = scope.exception()) [[unlikely]] {
-            (void)scope.tryClearException();
-            Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+            clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
             return jsUndefined();
         }
         return result;
@@ -3015,8 +3029,7 @@ static JSValue constructEnv(VM& vm, JSObject* processObject)
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSValue env = globalObject->processEnvObject();
     if (auto* exception = scope.exception()) [[unlikely]] {
-        (void)scope.tryClearException();
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
         return JSC::jsUndefined();
     }
     return env;
@@ -3884,8 +3897,7 @@ static JSValue Process_stubEmptyArray(VM& vm, JSObject* processObject)
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSC::JSArray* array = JSC::constructEmptyArray(processObject->globalObject(), nullptr);
     if (auto* exception = scope.exception()) [[unlikely]] {
-        (void)scope.tryClearException();
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(processObject->globalObject(), exception);
+        clearLazyPropertyCallbackException(vm, scope, processObject->globalObject(), exception);
         return JSC::jsUndefined();
     }
     return array;
@@ -3896,7 +3908,10 @@ static JSValue Process_stubEmptySet(VM& vm, JSObject* processObject)
     auto* globalObject = processObject->globalObject();
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSSet* result = JSSet::create(vm, globalObject->setStructure());
-    RETURN_IF_EXCEPTION(scope, {});
+    if (auto* exception = scope.exception()) [[unlikely]] {
+        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
+        return JSC::jsUndefined();
+    }
     return result;
 }
 
@@ -4022,15 +4037,13 @@ static JSValue constructMainModuleProperty(VM& vm, JSObject* processObject)
     auto& builtinNames = Bun::builtinNames(vm);
     JSValue mainValue = bun->get(globalObject, builtinNames.mainPublicName());
     if (auto* exception = scope.exception()) [[unlikely]] {
-        (void)scope.tryClearException();
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
         return JSC::jsUndefined();
     }
     auto* requireMap = globalObject->requireMap();
     JSValue mainModule = requireMap->get(globalObject, mainValue);
     if (auto* exception = scope.exception()) [[unlikely]] {
-        (void)scope.tryClearException();
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
         return JSC::jsUndefined();
     }
     return mainModule;
@@ -4059,8 +4072,7 @@ JSValue Process::constructNextTickFn(JSC::VM& vm, Zig::GlobalObject* globalObjec
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSValue nextTickFunction = JSC::profiledCall(globalObject, ProfilingReason::API, initializer, JSC::getCallData(initializer), globalObject->globalThis(), args);
     if (auto* exception = scope.exception()) [[unlikely]] {
-        (void)scope.tryClearException();
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
         return JSC::jsUndefined();
     }
     if (nextTickFunction && nextTickFunction.isObject()) {
@@ -4124,7 +4136,8 @@ static JSValue constructFeatures(VM& vm, JSObject* processObject)
     object->putDirect(vm, Identifier::fromString(vm, "require_module"_s), jsBoolean(true));
     object->putDirect(vm, Identifier::fromString(vm, "typescript"_s), jsString(vm, String("transform"_s)));
 
-    RETURN_IF_EXCEPTION(scope, {});
+    if (auto* exception = scope.exception()) [[unlikely]]
+        clearLazyPropertyCallbackException(vm, scope, globalObject, exception);
     return object;
 }
 

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1,4 +1,4 @@
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tmpdirSync } from "harness";
 import { once } from "node:events";
 import fs from "node:fs";
 import { join, relative, resolve } from "node:path";
@@ -1303,6 +1303,40 @@ test("close(cb) interleaves with other close listeners in registration order", a
   p2.on("close", () => order2.push("C"));
   await new Promise(r => setImmediate(() => setImmediate(r)));
   expect(order2).toEqual(["B", "C"]);
+});
+
+// terminate() during the worker's node:worker_threads preload used to trip
+// EXCEPTION_ASSERT in JSValue::get / JSObject::getOwnPropertyDescriptor: the
+// lazy process.stdout/stderr/stdin PropertyCallbacks enter JS inside
+// getOwnPropertySlot, and tryClearException() won't clear a termination
+// exception, so getOwnPropertySlot returned true with it still pending.
+// The assertion is debug-build only; amplified from the upstream Node
+// test-worker-message-port-transfer-terminate.js (10 workers → 60).
+test.skipIf(!isASAN && !isDebug)("terminate() during worker bootstrap doesn't trip getOwnPropertySlot assert", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const { Worker } = require("worker_threads");
+       const N = 60;
+       let done = 0;
+       for (let i = 0; i < N; ++i) {
+         const w = new Worker("require('worker_threads').parentPort.on('message', () => {})", { eval: true });
+         setImmediate(() => {
+           w.terminate().then(() => { if (++done === N) console.log("ok"); });
+         });
+       }`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: "ok",
+    stderr: "",
+    exitCode: 0,
+    signalCode: null,
+  });
 });
 
 test("getHeapStatistics settles when terminated mid-request", async () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1312,12 +1312,14 @@ test("close(cb) interleaves with other close listeners in registration order", a
 // exception, so getOwnPropertySlot returned true with it still pending.
 // The assertion is debug-build only; amplified from the upstream Node
 // test-worker-message-port-transfer-terminate.js (10 workers → 60).
-test.skipIf(!isASAN && !isDebug)("terminate() during worker bootstrap doesn't trip getOwnPropertySlot assert", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `const { Worker } = require("worker_threads");
+test.skipIf(!isASAN && !isDebug)(
+  "terminate() during worker bootstrap doesn't trip getOwnPropertySlot assert",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { Worker } = require("worker_threads");
        const N = 60;
        let done = 0;
        for (let i = 0; i < N; ++i) {
@@ -1326,18 +1328,19 @@ test.skipIf(!isASAN && !isDebug)("terminate() during worker bootstrap doesn't tr
            w.terminate().then(() => { if (++done === N) console.log("ok"); });
          });
        }`,
-    ],
-    env: bunEnv,
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
-    stdout: "ok",
-    stderr: "",
-    exitCode: 0,
-    signalCode: null,
-  });
-});
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "ok",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  },
+);
 
 test("getHeapStatistics settles when terminated mid-request", async () => {
   const w = new Worker("setInterval(() => {}, 1e6)", { eval: true });

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1,4 +1,4 @@
-import { bunEnv, bunExe, isASAN, isDebug, tmpdirSync } from "harness";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
 import { once } from "node:events";
 import fs from "node:fs";
 import { join, relative, resolve } from "node:path";
@@ -1304,45 +1304,6 @@ test("close(cb) interleaves with other close listeners in registration order", a
   await new Promise(r => setImmediate(() => setImmediate(r)));
   expect(order2).toEqual(["B", "C"]);
 });
-
-// terminate() armed while a lazy process.* PropertyCallback builder enters JS
-// used to leave the termination pending inside getOwnPropertySlot and trip its
-// EXCEPTION_ASSERT (debug only); the worker_threads preload hits this via stdout.
-test.skipIf(!isASAN && !isDebug)(
-  "terminate() during a lazy process.* builder doesn't trip getOwnPropertySlot assert",
-  async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `const props = ["stdout", "stderr", "stdin", "nextTick", "mainModule"];
-         Promise.all(props.map(p => new Promise((resolve, reject) => {
-           const w = new Worker("data:text/javascript," + encodeURIComponent(
-             'postMessage("go"); Bun.sleepSync(300); process[' + JSON.stringify(p) + '];'
-           ));
-           w.addEventListener("message", () => w.terminate());
-           w.addEventListener("close", resolve, { once: true });
-           w.addEventListener("error", e => reject(new Error(p + ": " + (e.error?.message || e.message))), { once: true });
-         }))).then(() => console.log("ok"), e => { console.error(e); process.exit(1); });`,
-      ],
-      env: bunEnv,
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // stderr is diagnostic-only (ASAN/debug can emit benign warnings on success).
-    expect({
-      stdout: stdout.trim(),
-      stderr: exitCode === 0 ? "" : stderr,
-      exitCode,
-      signalCode: proc.signalCode,
-    }).toEqual({
-      stdout: "ok",
-      stderr: "",
-      exitCode: 0,
-      signalCode: null,
-    });
-  },
-);
 
 test("getHeapStatistics settles when terminated mid-request", async () => {
   const w = new Worker("setInterval(() => {}, 1e6)", { eval: true });

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1329,7 +1329,8 @@ test.skipIf(!isASAN && !isDebug)(
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    // stderr is diagnostic-only (ASAN/debug can emit benign warnings on success).
+    expect({ stdout: stdout.trim(), stderr: exitCode === 0 ? "" : stderr, exitCode, signalCode: proc.signalCode }).toEqual({
       stdout: "ok",
       stderr: "",
       exitCode: 0,

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1305,13 +1305,9 @@ test("close(cb) interleaves with other close listeners in registration order", a
   expect(order2).toEqual(["B", "C"]);
 });
 
-// terminate() during the worker's node:worker_threads preload used to trip
-// EXCEPTION_ASSERT in JSValue::get / JSObject::getOwnPropertyDescriptor: the
-// lazy process.stdout/stderr/stdin PropertyCallbacks enter JS inside
-// getOwnPropertySlot, and tryClearException() won't clear a termination
-// exception, so getOwnPropertySlot returned true with it still pending.
-// The assertion is debug-build only; amplified from the upstream Node
-// test-worker-message-port-transfer-terminate.js (10 workers → 60).
+// Amplified test-worker-message-port-transfer-terminate.js: terminate() during the
+// worker_threads preload reifies lazy process.stdout/stdin inside getOwnPropertySlot,
+// which asserts (debug only) if the builder returns with a termination pending.
 test.skipIf(!isASAN && !isDebug)(
   "terminate() during worker bootstrap doesn't trip getOwnPropertySlot assert",
   async () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1305,25 +1305,25 @@ test("close(cb) interleaves with other close listeners in registration order", a
   expect(order2).toEqual(["B", "C"]);
 });
 
-// Amplified test-worker-message-port-transfer-terminate.js: terminate() during the
-// worker_threads preload reifies lazy process.stdout/stdin inside getOwnPropertySlot,
-// which asserts (debug only) if the builder returns with a termination pending.
+// terminate() armed while a lazy process.* PropertyCallback builder enters JS
+// used to leave the termination pending inside getOwnPropertySlot and trip its
+// EXCEPTION_ASSERT (debug only); the worker_threads preload hits this via stdout.
 test.skipIf(!isASAN && !isDebug)(
-  "terminate() during worker bootstrap doesn't trip getOwnPropertySlot assert",
+  "terminate() during a lazy process.* builder doesn't trip getOwnPropertySlot assert",
   async () => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
-        `const { Worker } = require("worker_threads");
-       const N = 60;
-       let done = 0;
-       for (let i = 0; i < N; ++i) {
-         const w = new Worker("require('worker_threads').parentPort.on('message', () => {})", { eval: true });
-         setImmediate(() => {
-           w.terminate().then(() => { if (++done === N) console.log("ok"); });
-         });
-       }`,
+        `const props = ["stdout", "stderr", "stdin", "nextTick", "mainModule"];
+         Promise.all(props.map(p => new Promise((resolve, reject) => {
+           const w = new Worker("data:text/javascript," + encodeURIComponent(
+             'postMessage("go"); Bun.sleepSync(300); process[' + JSON.stringify(p) + '];'
+           ));
+           w.addEventListener("message", () => w.terminate());
+           w.addEventListener("close", resolve, { once: true });
+           w.addEventListener("error", e => reject(new Error(p + ": " + (e.error?.message || e.message))), { once: true });
+         }))).then(() => console.log("ok"), e => { console.error(e); process.exit(1); });`,
       ],
       env: bunEnv,
       stderr: "pipe",

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1330,7 +1330,12 @@ test.skipIf(!isASAN && !isDebug)(
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     // stderr is diagnostic-only (ASAN/debug can emit benign warnings on success).
-    expect({ stdout: stdout.trim(), stderr: exitCode === 0 ? "" : stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    expect({
+      stdout: stdout.trim(),
+      stderr: exitCode === 0 ? "" : stderr,
+      exitCode,
+      signalCode: proc.signalCode,
+    }).toEqual({
       stdout: "ok",
       stderr: "",
       exitCode: 0,

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -119,3 +119,38 @@ test(
   },
   timeout,
 );
+
+// terminate() armed while a lazy process.* PropertyCallback builder enters JS
+// used to leave the termination pending inside getOwnPropertySlot and trip its
+// EXCEPTION_ASSERT (debug only); the worker_threads preload hits this via stdout.
+test.skipIf(!slow)(
+  "terminate() during a lazy process.* builder doesn't trip getOwnPropertySlot assert",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const props = ["stdout", "stderr", "stdin", "nextTick", "mainModule"];
+         Promise.all(props.map(p => new Promise((resolve, reject) => {
+           const w = new Worker("data:text/javascript," + encodeURIComponent(
+             'postMessage("go"); Bun.sleepSync(300); process[' + JSON.stringify(p) + '];'
+           ));
+           w.addEventListener("message", () => w.terminate());
+           w.addEventListener("close", resolve, { once: true });
+           w.addEventListener("error", e => reject(new Error(p + ": " + (e.error?.message || e.message))), { once: true });
+         }))).then(() => console.log("ok"), e => { console.error(e); process.exit(1); });`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // stderr is diagnostic-only (ASAN/debug can emit benign warnings on success).
+    expect({ stdout: stdout.trim(), stderr: exitCode === 0 ? "" : stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "ok",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  },
+  timeout,
+);

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -145,7 +145,12 @@ test.skipIf(!slow)(
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     // stderr is diagnostic-only (ASAN/debug can emit benign warnings on success).
-    expect({ stdout: stdout.trim(), stderr: exitCode === 0 ? "" : stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    expect({
+      stdout: stdout.trim(),
+      stderr: exitCode === 0 ? "" : stderr,
+      exitCode,
+      signalCode: proc.signalCode,
+    }).toEqual({
       stdout: "ok",
       stderr: "",
       exitCode: 0,


### PR DESCRIPTION
Fixes `test/js/node/test/parallel/test-worker-message-port-transfer-terminate.js` aborting on the x64-asan lane since #31216 (e.g. builds [71759](https://buildkite.com/bun/bun/builds/71759), [71693](https://buildkite.com/bun/bun/builds/71693)):

```
ASSERTION FAILED: !scope.exception() || !result
vendor/WebKit/Source/JavaScriptCore/runtime/JSObject.cpp(3936) : bool JSC::JSObject::getOwnPropertyDescriptor(JSGlobalObject *, PropertyName, PropertyDescriptor &)
```
```
ASSERTION FAILED: !scope.exception() || !hasSlot
JSCJSValuePropertyInlines.h(51) : JSValue JSC::JSValue::get(JSGlobalObject *, PropertyName, PropertySlot &) const
```

### Repro

Deterministic, one worker per builder:

```js
const w = new Worker("data:text/javascript," + encodeURIComponent(
  'postMessage("go"); Bun.sleepSync(300); process["stdout"];'
));
w.addEventListener("message", () => w.terminate());
```

Aborts on every debug build. The vendored Node test hits the same path via `setupWorkerStdio` racing `setImmediate`-then-`terminate()`.

### Cause

`process.stdout`/`stderr`/`stdin`/`nextTick`/`mainModule`/`channel`/`env` (and the callbacks that only allocate) are `PropertyCallback` entries in the process static hash table. JSC reifies them via `setUpStaticFunctionSlot` → `reifyStaticProperty`, neither of which check for exceptions after calling the builder:

```cpp
JSValue result = value.lazyPropertyCallback()(vm, &thisObj);
thisObj.putDirect(vm, propertyName, result, ...);  // no exception check
...
return true;  // getOwnPropertySlot reports the slot found
```

The builders that enter JS try to clear any exception before returning:

```cpp
auto result = JSC::profiledCall(globalObject, ..., getStdioWriteStream, ...);
if (auto* exception = scope.exception()) {
    (void)scope.tryClearException();   // returns false for TerminationException
    ...
    return jsUndefined();
}
```

but `ExceptionScope::tryClearException()` refuses to clear a `TerminationException`. So when `worker.terminate()` arms the trap while the builder is entering JS, the builder returns with the termination still pending, `getOwnPropertySlot` returns `true`, and `JSValue::get` / `getOwnPropertyDescriptor` assert.

#31216 turned this from a rare flake into a per-run abort by preloading `node:worker_threads` in every `worker_threads` `Worker`, whose `setupWorkerStdio()` does `Object.defineProperty(process, "stdout", ...)` during bootstrap, right in the `setImmediate`-then-`terminate()` window.

### Fix

Wrap every process `PropertyCallback` builder in `JSC::DeferTerminationForAWhile`, matching what JSC's own `LazyProperty::callFunc` does: the builder runs to completion with no exception pending, and the trap re-fires on scope exit so the worker unwinds at the next safepoint.

Related: #33418 applies the same idiom to the `Bun.*` lazy builders.

### Verification

New deterministic test in `test/js/node/worker_threads/worker_threads.test.ts` (one worker per `process.stdout`/`stderr`/`stdin`/`nextTick`/`mainModule`, debug/ASAN-gated).

- `git stash push -- src/ && bun bd test ... -t "lazy process.* builder"` → fails 3/3 with `ASSERTION FAILED: !scope.exception() || !hasSlot` / SIGABRT
- `git stash pop && bun bd test ...` → passes 5/5
- `test-worker-message-port-transfer-terminate.js` × 30 runs → clean

Under a 60-worker × 80-run bootstrap stress, a separate pre-existing `assertNoException()` at `ExceptionScope.h:61` still surfaces at about 1 in 4000 workers (termination landing later in the bootstrap, after the stdio builders have completed). That path is unrelated to the lazy-builder contract and not in scope here; the deterministic test in this PR does not reach it.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/test/parallel/test-worker-message-port-transfer-terminate.js test/js/web/workers/worker-terminate-lifetime.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b36f4ed9d)

test/js/web/workers/worker-terminate-lifetime.test.ts:
(pass) new Worker with { ref: false } does not keep the parent alive [635.78ms]
(pass) terminate/ref/unref after worker exits naturally does not UAF [1607.64ms]
(pass) nested worker whose grandchild outlives the middle worker's JSWorker does not assert [1845.56ms]
148 |     expect({
149 |       stdout: stdout.trim(),
150 |       stderr: exitCode === 0 ? "" : stderr,
151 |       exitCode,
152 |       signalCode: proc.signalCode,
153 |     }).toEqual({
             ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
-   "signalCode": null,
-   "stderr": "",
-  
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (4fc5126c2)

test/js/web/workers/worker-terminate-lifetime.test.ts:
(pass) new Worker with { ref: false } does not keep the parent alive [13.98ms]
(pass) terminate/ref/unref after worker exits naturally does not UAF [113.45ms]
(pass) nested worker whose grandchild outlives the middle worker's JSWorker does not assert [47.57ms]
(skip) terminate() during a lazy process.* builder doesn't trip getOwnPropertySlot assert

 3 pass
 1 skip
 0 fail
 9 expect() calls
Ran 4 tests across 1 file. [343.00ms]
__F:0:S:1
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/test/parallel/test-worker-message-port-transfer-terminate.js test/js/web/workers/worker-terminate-lifetime.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b36f4ed9d)

test/js/web/workers/worker-terminate-lifetime.test.ts:
(pass) new Worker with { ref: false } does not keep the parent alive [572.70ms]
(pass) terminate/ref/unref after worker exits naturally does not UAF [1595.20ms]
(pass) nested worker whose grandchild outlives the middle worker's JSWorker does not assert [1830.03ms]
(pass) terminate() during a lazy process.* builder doesn't trip getOwnPropertySlot assert [2315.75ms]

 4 pass
 0 fail
 10 expect() calls
Ran 4 tests across 1 file. [8.65s]
__F:0:S:0

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 657ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[2/8] gen cpp.rs (cppbind)
[2/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/wor
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/BunProcess.cpp                    | 19 ++++++++++
 .../web/workers/worker-terminate-lifetime.test.ts  | 40 ++++++++++++++++++++++
 2 files changed, 59 insertions(+)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
src/jsc/bindings/BunProcess.cpp                           12     34      0
test/js/web/workers/worker-terminate-lifetime.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->