### PR TITLE
test(junit): report only the final result for a retried test

### DIFF
--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1196,19 +1196,6 @@ impl CommandLineReporter {
                 }
             }
 
-            for attempt in sequence.flaky_attempts() {
-                junit
-                    .write_test_case(
-                        attempt.result,
-                        filename,
-                        display_label,
-                        &concatenated_describe_scopes,
-                        0,
-                        attempt.elapsed_ns,
-                        line_number,
-                    )
-                    .expect("oom");
-            }
             junit
                 .write_test_case(
                     status,

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -152,8 +152,6 @@ pub struct ExecutionSequence {
     pub test_entry: Option<NonNull<ExecutionEntry>>,
     pub remaining_repeat_count: u32,
     pub remaining_retry_count: u32,
-    pub flaky_attempt_count: usize,
-    pub flaky_attempts_buf: [FlakyAttempt; ExecutionSequence::MAX_FLAKY_ATTEMPTS],
     pub result: Result,
     pub executing: bool,
     pub started_at: Timespec,
@@ -164,15 +162,7 @@ pub struct ExecutionSequence {
     pub maybe_skip: bool,
 }
 
-#[derive(Clone, Copy, Default)]
-pub struct FlakyAttempt {
-    pub result: Result,
-    pub elapsed_ns: u64,
-}
-
 impl ExecutionSequence {
-    pub(crate) const MAX_FLAKY_ATTEMPTS: usize = 16;
-
     pub(crate) fn init(
         first_entry: Option<NonNull<ExecutionEntry>>,
         test_entry: Option<NonNull<ExecutionEntry>>,
@@ -186,8 +176,6 @@ impl ExecutionSequence {
             remaining_repeat_count: repeat_count,
             remaining_retry_count: retry_count,
             // defaults:
-            flaky_attempt_count: 0,
-            flaky_attempts_buf: [FlakyAttempt::default(); Self::MAX_FLAKY_ATTEMPTS],
             result: Result::Pending,
             executing: false,
             started_at: Timespec::EPOCH,
@@ -195,10 +183,6 @@ impl ExecutionSequence {
             expect_assertions: ExpectAssertions::NotSet,
             maybe_skip: false,
         }
-    }
-
-    pub(crate) fn flaky_attempts(&self) -> &[FlakyAttempt] {
-        &self.flaky_attempts_buf[0..self.flaky_attempt_count]
     }
 
     fn entry_mode(&self) -> ScopeMode {
@@ -544,18 +528,6 @@ impl Execution {
 
             // Handle retry logic: if test failed and we have retries remaining, retry it
             if test_failed && sequence.remaining_retry_count > 0 {
-                if sequence.flaky_attempt_count < ExecutionSequence::MAX_FLAKY_ATTEMPTS {
-                    let elapsed_ns: u64 = if sequence.started_at.eql(&Timespec::EPOCH) {
-                        0
-                    } else {
-                        sequence.started_at.since_now_force_real_time()
-                    };
-                    sequence.flaky_attempts_buf[sequence.flaky_attempt_count] = FlakyAttempt {
-                        result: sequence.result,
-                        elapsed_ns,
-                    };
-                    sequence.flaky_attempt_count += 1;
-                }
                 sequence.remaining_retry_count -= 1;
                 Execution::reset_sequence(sequence);
                 return;
@@ -744,17 +716,13 @@ impl Execution {
             }
         }
 
-        // Preserve retry/repeat counts and flaky attempt history across reset
-        let saved_flaky_attempt_count = sequence.flaky_attempt_count;
-        let saved_flaky_attempts_buf = sequence.flaky_attempts_buf;
+        // Preserve retry/repeat counts across reset
         *sequence = ExecutionSequence::init(
             sequence.first_entry,
             sequence.test_entry,
             sequence.remaining_retry_count,
             sequence.remaining_repeat_count,
         );
-        sequence.flaky_attempt_count = saved_flaky_attempt_count;
-        sequence.flaky_attempts_buf = saved_flaky_attempts_buf;
 
         // Snapshot counters are keyed by full test name and incremented on every
         // toMatchSnapshot() call. Without this reset, retries / repeats would

--- a/test/cli/test/retry-flag.test.ts
+++ b/test/cli/test/retry-flag.test.ts
@@ -220,13 +220,13 @@ test("--retry with nested describe blocks", async () => {
   expect(exitCode).toBe(0);
 });
 
-test("--retry past MAX_FLAKY_ATTEMPTS (16) still retries correctly", async () => {
+test("--retry with a large retry count still retries correctly", async () => {
   using dir = tempDir("retry-max", {
     "max.test.ts": `
       import { test, expect } from "bun:test";
       let count = 0;
 
-      // Fails 19 times, passes on attempt 20 -- well past the 16-entry buffer
+      // Fails 19 times, passes on attempt 20
       test("fails many times", { retry: 20 }, () => {
         count++;
         if (count < 20) throw new Error("fail attempt " + count);

--- a/test/js/bun/test/test-retry-repeats-basic-fixture.ts
+++ b/test/js/bun/test/test-retry-repeats-basic-fixture.ts
@@ -1,0 +1,163 @@
+// Basic tests to verify retry and repeats functionality works.
+// Run as a subprocess from test-retry-repeats-basic.test.ts so the intentional
+// intermediate retry failures don't pollute the parent run's reporter output.
+import { afterAll, afterEach, beforeEach, describe, expect, onTestFinished, test } from "bun:test";
+
+describe("retry option", () => {
+  let attempts = 0;
+  test(
+    "retries failed test until it passes",
+    () => {
+      attempts++;
+      if (attempts < 3) {
+        throw new Error("fail");
+      }
+    },
+    { retry: 3 },
+  );
+  test("correct number of attempts from previous test", () => {
+    expect(attempts).toBe(3);
+  });
+});
+
+describe("repeats option with hooks", () => {
+  let log: string[] = [];
+  describe("isolated test with repeats", () => {
+    beforeEach(() => {
+      log.push("beforeEach");
+    });
+
+    afterEach(() => {
+      log.push("afterEach");
+    });
+
+    test(
+      "repeats test multiple times",
+      () => {
+        log.push("test");
+      },
+      { repeats: 2 },
+    );
+  });
+
+  test("verify hooks ran for each repeat", () => {
+    // Should have: beforeEach, test, afterEach (first), beforeEach, test, afterEach (second), beforeEach, test, afterEach (third)
+    // repeats: 2 means 1 initial + 2 repeats = 3 total runs
+    expect(log).toEqual([
+      "beforeEach",
+      "test",
+      "afterEach",
+      "beforeEach",
+      "test",
+      "afterEach",
+      "beforeEach",
+      "test",
+      "afterEach",
+    ]);
+  });
+});
+
+describe("retry option with hooks", () => {
+  let attempts = 0;
+  let log: string[] = [];
+  describe("isolated test with retry", () => {
+    beforeEach(() => {
+      log.push("beforeEach");
+    });
+
+    afterEach(() => {
+      log.push("afterEach");
+    });
+
+    test(
+      "retries with hooks",
+      () => {
+        attempts++;
+        log.push(`test-${attempts}`);
+        if (attempts < 2) {
+          throw new Error("fail");
+        }
+      },
+      { retry: 3 },
+    );
+  });
+
+  test("verify hooks ran for each retry", () => {
+    // Should have: beforeEach, test-1, afterEach (fail), beforeEach, test-2, afterEach (pass)
+    expect(log).toEqual(["beforeEach", "test-1", "afterEach", "beforeEach", "test-2", "afterEach"]);
+  });
+});
+describe("repeats with onTestFinished", () => {
+  let log: string[] = [];
+  test(
+    "repeats with onTestFinished",
+    () => {
+      onTestFinished(() => {
+        log.push("onTestFinished");
+      });
+      log.push("test");
+    },
+    { repeats: 3 },
+  );
+  test("verify correct log", () => {
+    // repeats: 3 means 1 initial + 3 repeats = 4 total runs
+    expect(log).toEqual([
+      "test",
+      "onTestFinished",
+      "test",
+      "onTestFinished",
+      "test",
+      "onTestFinished",
+      "test",
+      "onTestFinished",
+    ]);
+  });
+});
+
+describe("retry with onTestFinished", () => {
+  let attempts = 0;
+  let log: string[] = [];
+  test(
+    "retry with onTestFinished",
+    () => {
+      attempts++;
+      onTestFinished(() => {
+        log.push("onTestFinished");
+      });
+      log.push(`test-${attempts}`);
+      if (attempts < 3) {
+        throw new Error("fail");
+      }
+    },
+    { retry: 3 },
+  );
+  test("verify correct log", () => {
+    expect(log).toEqual(["test-1", "onTestFinished", "test-2", "onTestFinished", "test-3", "onTestFinished"]);
+  });
+});
+
+describe("retry with inner afterAll", () => {
+  let attempts = 0;
+  let log: string[] = [];
+  test(
+    "retry with inner afterAll",
+    () => {
+      attempts++;
+      afterAll(() => {
+        log.push("inner afterAll");
+      });
+      log.push(`test-${attempts}`);
+      if (attempts < 3) {
+        throw new Error("fail");
+      }
+    },
+    { retry: 3 },
+  );
+  test("verify correct log", () => {
+    expect(log).toEqual(["test-1", "inner afterAll", "test-2", "inner afterAll", "test-3", "inner afterAll"]);
+  });
+});
+
+expect(() => {
+  test("can't pass both", () => {}, { retry: 5, repeats: 6 });
+}).toThrow(/Cannot set both retry and repeats/);

--- a/test/js/bun/test/test-retry-repeats-basic.test.ts
+++ b/test/js/bun/test/test-retry-repeats-basic.test.ts
@@ -1,161 +1,23 @@
-// Basic tests to verify retry and repeats functionality works
-import { afterAll, afterEach, beforeEach, describe, expect, onTestFinished, test } from "bun:test";
+// Runs the retry/repeats hook-ordering checks in a subprocess so the
+// intentional intermediate retry failures don't leak into this run's
+// reporter output (JUnit, GitHub Actions annotations).
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
 
-describe("retry option", () => {
-  let attempts = 0;
-  test(
-    "retries failed test until it passes",
-    () => {
-      attempts++;
-      if (attempts < 3) {
-        throw new Error("fail");
-      }
-    },
-    { retry: 3 },
-  );
-  test("correct number of attempts from previous test", () => {
-    expect(attempts).toBe(3);
+test("retry and repeats hook ordering", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", join(import.meta.dir, "test-retry-repeats-basic-fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
   });
+
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("12 pass");
+  expect(stderr).toContain("0 fail");
+  expect(stderr).toContain("(attempt 3)");
+  expect(stderr).not.toContain("::error");
+  expect(exitCode).toBe(0);
 });
-
-describe("repeats option with hooks", () => {
-  let log: string[] = [];
-  describe("isolated test with repeats", () => {
-    beforeEach(() => {
-      log.push("beforeEach");
-    });
-
-    afterEach(() => {
-      log.push("afterEach");
-    });
-
-    test(
-      "repeats test multiple times",
-      () => {
-        log.push("test");
-      },
-      { repeats: 2 },
-    );
-  });
-
-  test("verify hooks ran for each repeat", () => {
-    // Should have: beforeEach, test, afterEach (first), beforeEach, test, afterEach (second), beforeEach, test, afterEach (third)
-    // repeats: 2 means 1 initial + 2 repeats = 3 total runs
-    expect(log).toEqual([
-      "beforeEach",
-      "test",
-      "afterEach",
-      "beforeEach",
-      "test",
-      "afterEach",
-      "beforeEach",
-      "test",
-      "afterEach",
-    ]);
-  });
-});
-
-describe("retry option with hooks", () => {
-  let attempts = 0;
-  let log: string[] = [];
-  describe("isolated test with retry", () => {
-    beforeEach(() => {
-      log.push("beforeEach");
-    });
-
-    afterEach(() => {
-      log.push("afterEach");
-    });
-
-    test(
-      "retries with hooks",
-      () => {
-        attempts++;
-        log.push(`test-${attempts}`);
-        if (attempts < 2) {
-          throw new Error("fail");
-        }
-      },
-      { retry: 3 },
-    );
-  });
-
-  test("verify hooks ran for each retry", () => {
-    // Should have: beforeEach, test-1, afterEach (fail), beforeEach, test-2, afterEach (pass)
-    expect(log).toEqual(["beforeEach", "test-1", "afterEach", "beforeEach", "test-2", "afterEach"]);
-  });
-});
-describe("repeats with onTestFinished", () => {
-  let log: string[] = [];
-  test(
-    "repeats with onTestFinished",
-    () => {
-      onTestFinished(() => {
-        log.push("onTestFinished");
-      });
-      log.push("test");
-    },
-    { repeats: 3 },
-  );
-  test("verify correct log", () => {
-    // repeats: 3 means 1 initial + 3 repeats = 4 total runs
-    expect(log).toEqual([
-      "test",
-      "onTestFinished",
-      "test",
-      "onTestFinished",
-      "test",
-      "onTestFinished",
-      "test",
-      "onTestFinished",
-    ]);
-  });
-});
-
-describe("retry with onTestFinished", () => {
-  let attempts = 0;
-  let log: string[] = [];
-  test(
-    "retry with onTestFinished",
-    () => {
-      attempts++;
-      onTestFinished(() => {
-        log.push("onTestFinished");
-      });
-      log.push(`test-${attempts}`);
-      if (attempts < 3) {
-        throw new Error("fail");
-      }
-    },
-    { retry: 3 },
-  );
-  test("verify correct log", () => {
-    expect(log).toEqual(["test-1", "onTestFinished", "test-2", "onTestFinished", "test-3", "onTestFinished"]);
-  });
-});
-
-describe("retry with inner afterAll", () => {
-  let attempts = 0;
-  let log: string[] = [];
-  test(
-    "retry with inner afterAll",
-    () => {
-      attempts++;
-      afterAll(() => {
-        log.push("inner afterAll");
-      });
-      log.push(`test-${attempts}`);
-      if (attempts < 3) {
-        throw new Error("fail");
-      }
-    },
-    { retry: 3 },
-  );
-  test("verify correct log", () => {
-    expect(log).toEqual(["test-1", "inner afterAll", "test-2", "inner afterAll", "test-3", "inner afterAll"]);
-  });
-});
-
-expect(() => {
-  test("can't pass both", () => {}, { retry: 5, repeats: 6 });
-}).toThrow(/Cannot set both retry and repeats/);

--- a/test/js/bun/test/test-retry-repeats-basic.test.ts
+++ b/test/js/bun/test/test-retry-repeats-basic.test.ts
@@ -18,6 +18,5 @@ test("retry and repeats hook ordering", async () => {
   expect(stderr).toContain("12 pass");
   expect(stderr).toContain("0 fail");
   expect(stderr).toContain("(attempt 3)");
-  expect(stderr).not.toContain("::error");
   expect(exitCode).toBe(0);
 });

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -315,7 +315,7 @@ describe("junit reporter", () => {
     expect(xmlContent2).toContain("line=");
   });
 
-  it("should emit separate testcase entries for each retry attempt", async () => {
+  it("should report only the final result for a retried test", async () => {
     const tmpDir = tempDirWithFiles("junit-retry", {
       "package.json": "{}",
       "flaky.test.js": `
@@ -327,6 +327,12 @@ describe("junit reporter", () => {
             throw new Error("flaky failure attempt " + attempt);
           }
           expect(true).toBe(true);
+        });
+
+        let exhausted = 0;
+        test("exhausted test", { retry: 2 }, () => {
+          exhausted++;
+          throw new Error("always fails " + exhausted);
         });
 
         test("stable test", () => {
@@ -345,21 +351,38 @@ describe("junit reporter", () => {
     await proc.exited;
 
     const xmlContent = await file(junitPath).text();
+    const result = await new Promise((resolve, reject) => {
+      xml2js.parseString(xmlContent, (err, result) => {
+        if (err) reject(err);
+        else resolve(result);
+      });
+    });
 
-    // Each retry attempt should be a separate testcase with the same name
-    const flakyTestCases = [...xmlContent.matchAll(/<testcase[^>]*name="flaky test"[^>]*>/g)];
-    expect(flakyTestCases).toHaveLength(3);
-
-    // The first two should have <failure> elements, the last should be self-closing
+    // A test that passes after retries must not leave <failure> entries behind:
+    // CI systems (Buildkite, Jenkins, GitLab) count every <failure> as a real
+    // failure regardless of sibling passing entries for the same name.
     const flakyEntries = [...xmlContent.matchAll(/<testcase[^>]*name="flaky test"[^/]*(?:\/>|>[\s\S]*?<\/testcase>)/g)];
-    expect(flakyEntries).toHaveLength(3);
-    expect(flakyEntries[0][0]).toContain("<failure");
-    expect(flakyEntries[1][0]).toContain("<failure");
-    expect(flakyEntries[2][0]).not.toContain("<failure");
+    expect(flakyEntries).toHaveLength(1);
+    expect(flakyEntries[0][0]).not.toContain("<failure");
+
+    // A test that fails every retry attempt is reported once, as a failure.
+    const exhaustedEntries = [
+      ...xmlContent.matchAll(/<testcase[^>]*name="exhausted test"[^/]*(?:\/>|>[\s\S]*?<\/testcase>)/g),
+    ];
+    expect(exhaustedEntries).toHaveLength(1);
+    expect(exhaustedEntries[0][0]).toContain("<failure");
 
     expect(xmlContent).toContain('name="stable test"');
 
-    expect(proc.exitCode).toBe(0);
+    // Suite/top-level counts must match the final outcomes (1 failure, 3 tests),
+    // not the number of attempts.
+    expect(result.testsuites.$.tests).toBe("3");
+    expect(result.testsuites.$.failures).toBe("1");
+    const suite = result.testsuites.testsuite[0];
+    expect(suite.$.tests).toBe("3");
+    expect(suite.$.failures).toBe("1");
+
+    expect(proc.exitCode).toBe(1);
   });
 });
 


### PR DESCRIPTION
### Problem

`test/js/bun/test/test-retry-repeats-basic.test.ts` is reported red by Buildkite Test Analytics on every run even though it exits 0 with `12 pass, 0 fail`. Seen in build 71776 (reported as broken on main) and noted as a recurring false positive in #31788's CI notes.

### Cause

#26866 made the JUnit reporter write one `<testcase>` per retry attempt: a test that throws twice and passes on the third try emits two `<failure>` entries plus one passing entry, and the suite-level `failures=""` attribute counts them. The intent was to give flaky-test detection per-attempt data.

Every JUnit consumer Bun uploads to (Buildkite Test Analytics) and the common ones users upload to (Jenkins, GitLab, GitHub Actions test reporters) treat each `<failure>` as a real failure regardless of a sibling passing entry for the same name, so a passing file with retries is shown as failed. For the fixture above the top-level element was `<testsuites tests="19" failures="7">` for a file whose runner summary says `0 fail`.

`test-retry-repeats-basic.test.ts` is the only test in the suite that uses `{ retry: N }` in-process with tests that intentionally throw, so it was the one file permanently red in the dashboard.

### Fix

`maybe_print_junit_line` no longer replays `sequence.flaky_attempts()`; it writes exactly one `<testcase>` per test with the final outcome, matching the terminal summary and the exit code. The terminal `(attempt N)` suffix already communicates that retries happened. The `FlakyAttempt` recording buffer has no remaining reader and is removed along with its preservation across `reset_sequence`.

`test-retry-repeats-basic.test.ts` now spawns its retry/repeats hook-ordering checks (unchanged, moved to `test-retry-repeats-basic-fixture.ts`) in a subprocess with `bunEnv`, so the intentional intermediate throws stay out of the parent run's reporter output. This also removes the seven `::error` GitHub-Actions annotations this file emitted into every CI job log.

### Verification

`test/js/junit-reporter/junit.test.js` now asserts that a test passing on attempt 3 of `{ retry: 3 }` produces one passing `<testcase>` and contributes nothing to `failures`, and that a test failing every attempt of `{ retry: 2 }` produces one failing `<testcase>` (`tests="3" failures="1"` for the three-test fixture). Fails on main with `Received length: 3`, passes with this change.

With the change, the fixture's JUnit is `<testsuites tests="12" failures="0">`:

```
$ bun bd test test/js/junit-reporter/junit.test.js test/js/bun/test/test-retry-repeats-basic.test.ts \
              test/cli/test/retry-flag.test.ts test/cli/test/rerun-each.test.ts
19 pass, 0 fail
```

`bun_test.test.ts`, `test-on-test-finished.test.ts`, `failure-skip.test.ts`, and `node-test.test.ts` pass unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/test-retry-repeats-basic.test.ts test/cli/test/retry-flag.test.ts test/js/junit-reporter/junit.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (15eae3d5b)

test/js/junit-reporter/junit.test.js:
(pass) junit reporter > should generate valid junit xml for passing tests %s [780.38ms]
(pass) junit reporter > should generate valid junit xml for passing tests %s [714.22ms]
/tmp/junit-comprehensive_X16Ayr
(pass) junit reporter > more scenarios [1233.11ms]
360 | 
361 |     // A test that passes after retries must not leave <failure> entries behind:
362 |     // CI systems (Buildkite, Jenkins, GitLab) count every <failure> as a real
363 |     // failure regardless of sibling passing entries for the same name.
364 |     const flakyEntries = [...xmlContent.matchAll(/<testcase[^>]*name="flaky test"[^/
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/junit-reporter/junit.test.js:
(pass) junit reporter > should generate valid junit xml for passing tests %s [24.42ms]
(pass) junit reporter > should generate valid junit xml for passing tests %s [16.23ms]
/tmp/junit-comprehensive_6f2o8n
(pass) junit reporter > more scenarios [32.18ms]
360 | 
361 |     // A test that passes after retries must not leave <failure> entries behind:
362 |     // CI systems (Buildkite, Jenkins, GitLab) count every <failure> as a real
363 |     // failure regardless of sibling passing entries for the same name.
364 |     const flakyEntries = [...xmlContent.matchAll(/<testcase[^>]*name="flaky test"[^/]*(?:\/>|>[\s\S]*?<\/testcase>)/g)];
365 |     expect(flakyEntries).toHaveLength(1);
                               ^
error: expect(received).toHaveLength(expected)

Expected length: 1
Received length: 3

      at <anonymous> (/workspace/bun/test/js/junit-reporter/junit.test.js:365:26)
(fail) junit reporter > should report only the final result for a retried test [14.76ms]

test/cli/test/retry-flag.test.ts:
(pass) --retry retries failed tests [13.38ms]
(pass) per-test { retry } overrides --retry [12.5
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/test-retry-repeats-basic.test.ts test/cli/test/retry-flag.test.ts test/js/junit-reporter/junit.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (15eae3d5b)

test/js/junit-reporter/junit.test.js:
(pass) junit reporter > should generate valid junit xml for passing tests %s [826.13ms]
(pass) junit reporter > should generate valid junit xml for passing tests %s [657.63ms]
/tmp/junit-comprehensive_ivLQEo
(pass) junit reporter > more scenarios [1371.99ms]
(pass) junit reporter > should report only the final result for a retried test [620.28ms]

test/cli/test/retry-flag.test.ts:
(pass) --retry retries failed tests [559.21ms]
(pass) per-test { retry } overrides --retry [462.74ms]
(pass) --retry works with describe blocks and beforeEach/afterEach hooks [457.64ms]
(pass) --retry with multiple tests w
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     15eae3d5b9
  features     (none)

22 deps, 106 codegen, 1168 objects in 812ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [13.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [8.00ms]
[3/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [21.00ms]
[4/1231] fetch zlib
[zlib] up to date
[5/1231] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1231] gen bindgenv2
[7/1231] gen ErrorCode+*.h
[8/1231] fetch tinyc
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/test_command.rs                    |  13 --
 src/runtime/test_runner/Execution.rs               |  34 +---
 test/cli/test/retry-flag.test.ts                   |   4 +-
 .../bun/test/test-retry-repeats-basic-fixture.ts   | 163 ++++++++++++++++++
 test/js/bun/test/test-retry-repeats-basic.test.ts  | 182 +++------------------
 test/js/junit-reporter/junit.test.js               |  45 +++--
 6 files changed, 222 insertions(+), 219 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/runtime/cli/test_command.rs                           0      0      0
src/runtime/test_runner/Execution.rs                      3      3      0
test/cli/test/retry-flag.test.ts                          1      1      0
test/js/bun/test/test-retry-repeats-basic-fixture.ts      0      1      0
test/js/bun/test/test-retry-repeats-basic.test.ts         1      2      0
test/js/junit-reporter/junit.test.js                      1      1      0
```

</details>

<!-- robobun:evidence:end -->