### PR TITLE
napi: mark threadsafe functions closing on env teardown

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -3039,6 +3039,19 @@ extern "C" void napi_internal_cleanup_env_cpp(napi_env env)
     env->cleanup();
 }
 
+// No-preamble entry points for the per-TSF cleanup hook: NAPI_PREAMBLE early-returns
+// on a pending VM exception, which would silently skip registration (leaving the
+// UAF this hook guards against) or skip removal (leaving a dangling hook).
+extern "C" void napi_internal_add_env_cleanup_hook(napi_env env, void (*function)(void*), void* data)
+{
+    env->addCleanupHook(function, data);
+}
+
+extern "C" void napi_internal_remove_env_cleanup_hook(napi_env env, void (*function)(void*), void* data)
+{
+    env->removeCleanupHook(function, data);
+}
+
 extern "C" void napi_internal_remove_finalizer(napi_env env, napi_finalize callback, void* hint, void* data)
 {
     env->removeFinalizer(callback, hint, data);

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2225,6 +2225,16 @@ unsafe extern "C" {
     ) -> napi_status;
 
     fn napi_internal_cleanup_env_cpp(env: napi_env);
+    fn napi_internal_add_env_cleanup_hook(
+        env: napi_env,
+        function: extern "C" fn(*mut c_void),
+        data: *mut c_void,
+    );
+    fn napi_internal_remove_env_cleanup_hook(
+        env: napi_env,
+        function: extern "C" fn(*mut c_void),
+        data: *mut c_void,
+    );
     fn napi_internal_check_gc(env: napi_env);
 }
 
@@ -2618,12 +2628,15 @@ impl ThreadSafeFunction {
 
     pub fn enqueue(&mut self, ctx: *mut c_void, block: bool) -> napi_status {
         let _g = self.lock.lock_guard();
+        // Node's Push() gates the wait on `state == kOpen`: once env teardown has
+        // set closing, a full bounded queue must fall through to the napi_closing
+        // return below instead of reporting queue_full or re-parking forever.
         if block {
             while self.queue.is_blocked() && !self.is_closing() {
                 self.blocking_condvar.wait(&self.lock);
             }
         } else {
-            if self.queue.is_blocked() {
+            if self.queue.is_blocked() && !self.is_closing() {
                 // don't set the error on the env as this is run from another thread
                 return NapiStatus::queue_full as napi_status;
             }
@@ -2669,12 +2682,14 @@ impl ThreadSafeFunction {
         // SAFETY: caller contract — `this` is a live heap allocation; we consume it here.
         let self_ = unsafe { &mut *this };
         // Drop the env-cleanup hook registered at creation so that a later env
-        // teardown does not call `env_cleanup` on freed storage.
+        // teardown does not call `env_cleanup` on freed storage. The internal
+        // no-preamble entry point is used so a pending VM exception cannot
+        // silently skip removal and leave a dangling hook.
         // SAFETY: env is refcounted (alive while `self_.env` holds it).
         unsafe {
-            napi_remove_env_cleanup_hook(
+            napi_internal_remove_env_cleanup_hook(
                 self_.env.as_ptr(),
-                Some(ThreadSafeFunction::env_cleanup),
+                ThreadSafeFunction::env_cleanup,
                 this.cast::<c_void>(),
             )
         };
@@ -2739,6 +2754,11 @@ impl ThreadSafeFunction {
                 .closing
                 .store(ClosingState::Closing as u8, Ordering::SeqCst);
             self_.aborted.store(true, Ordering::SeqCst);
+            // Zero the public count so is_blocked() goes false; together with the
+            // `&& !is_closing()` guard on enqueue()'s wait loop this guarantees a
+            // producer parked on a full bounded queue wakes into the napi_closing
+            // return instead of re-sleeping.
+            self_.queue.count.store(0, Ordering::SeqCst);
             if self_.queue.max_queue_size > 0 {
                 self_.blocking_condvar.broadcast();
             }
@@ -2758,6 +2778,16 @@ impl ThreadSafeFunction {
             TsfnCallback::Js(_) => None,
         };
         self_.poll_ref.disable();
+        // Drain queued items so the addon can free per-call data (Node calls
+        // `call_js_cb(null, null, ctx, data)` for each). No new items can be
+        // enqueued once `closing` is set under the lock. Runs before the user
+        // finalizer (Node v24+ `Finalize`: `EmptyQueue` then `CallFinalizer`,
+        // nodejs/node#61956) so `ctx` is still valid for each drained item.
+        if let Some(call_js_cb) = call_js_cb {
+            while let Some(item) = self_.queue.data.read_item() {
+                call_js_cb(core::ptr::null_mut(), napi_value(0), self_.ctx, item);
+            }
+        }
         // Call the user finalizer now (the normal finalize path goes through
         // `event_loop.enqueue_task`, which we can no longer touch).
         if let Some(fun) = self_.finalizer_fun.take() {
@@ -2766,14 +2796,6 @@ impl ThreadSafeFunction {
             let env_ref = unsafe { &*env_ptr };
             let _hs = NapiHandleScope::open_scoped(env_ref);
             fun(env_ptr, self_.finalizer_data, self_.ctx);
-        }
-        // Drain queued items so the addon can free per-call data (Node calls
-        // `call_js_cb(null, null, ctx, data)` for each). No new items can be
-        // enqueued once `closing` is set under the lock.
-        if let Some(call_js_cb) = call_js_cb {
-            while let Some(item) = self_.queue.data.read_item() {
-                call_js_cb(core::ptr::null_mut(), napi_value(0), self_.ctx, item);
-            }
         }
     }
 
@@ -2891,12 +2913,13 @@ pub(super) extern "C" fn napi_create_threadsafe_function(
     // Node registers an env-cleanup hook per TSF so that teardown (worker
     // termination / process exit) marks it closing before the loop is freed;
     // without this a native thread's later `napi_release_threadsafe_function`
-    // would wake a dealloc'd event loop.
+    // would wake a dealloc'd event loop. The internal no-preamble entry point
+    // is used so a pending VM exception cannot silently skip registration.
     // SAFETY: `env_` is the non-null napi_env we validated via get_env! above.
     unsafe {
-        napi_add_env_cleanup_hook(
+        napi_internal_add_env_cleanup_hook(
             env_,
-            Some(ThreadSafeFunction::env_cleanup),
+            ThreadSafeFunction::env_cleanup,
             function.cast::<c_void>(),
         )
     };

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2668,6 +2668,16 @@ impl ThreadSafeFunction {
     pub unsafe fn destroy(this: *mut ThreadSafeFunction) {
         // SAFETY: caller contract — `this` is a live heap allocation; we consume it here.
         let self_ = unsafe { &mut *this };
+        // Drop the env-cleanup hook registered at creation so that a later env
+        // teardown does not call `env_cleanup` on freed storage.
+        // SAFETY: env is refcounted (alive while `self_.env` holds it).
+        unsafe {
+            napi_remove_env_cleanup_hook(
+                self_.env.as_ptr(),
+                Some(ThreadSafeFunction::env_cleanup),
+                this.cast::<c_void>(),
+            )
+        };
         self_.unref();
 
         if let Some(fun) = self_.finalizer_fun {
@@ -2708,6 +2718,63 @@ impl ThreadSafeFunction {
         }
         let _ = self.thread_count.fetch_add(1, Ordering::SeqCst);
         NapiStatus::ok as napi_status
+    }
+
+    /// Env-cleanup hook (registered in `napi_create_threadsafe_function`, removed
+    /// in `destroy`). Runs on the owning JS thread during `NapiEnv::cleanup()` /
+    /// `vm.on_exit()`, i.e. before the worker's `VirtualMachine` box is dealloc'd.
+    /// Marks the TSF closing so a later `napi_release_threadsafe_function` /
+    /// `napi_call_threadsafe_function` from a native thread takes the
+    /// `is_closing()` early-return instead of `schedule_dispatch()` (which would
+    /// touch `event_loop` after it is freed). Mirrors Node's
+    /// `ThreadSafeFunction::Cleanup` in node_api.cc.
+    extern "C" fn env_cleanup(data: *mut c_void) {
+        let this = data.cast::<ThreadSafeFunction>();
+        // SAFETY: `this` is the live heap allocation we registered at creation; the
+        // hook is removed in `destroy()` before the allocation is freed.
+        let self_ = unsafe { &mut *this };
+        {
+            let _g = self_.lock.lock_guard();
+            self_
+                .closing
+                .store(ClosingState::Closing as u8, Ordering::SeqCst);
+            self_.aborted.store(true, Ordering::SeqCst);
+            if self_.queue.max_queue_size > 0 {
+                self_.blocking_condvar.broadcast();
+            }
+        }
+        // Drop the Strong JS handle while JSC is still live; keep the C call_js_cb
+        // pointer so we can drain queued items. Anything left in the struct is plain
+        // heap state that the (leaked) allocation keeps valid for any late
+        // `release()`/`acquire()` from native threads.
+        let call_js_cb = match core::mem::replace(
+            &mut self_.callback,
+            TsfnCallback::Js(StrongOptional::empty()),
+        ) {
+            TsfnCallback::C {
+                napi_threadsafe_function_call_js,
+                ..
+            } => Some(napi_threadsafe_function_call_js),
+            TsfnCallback::Js(_) => None,
+        };
+        self_.poll_ref.disable();
+        // Call the user finalizer now (the normal finalize path goes through
+        // `event_loop.enqueue_task`, which we can no longer touch).
+        if let Some(fun) = self_.finalizer_fun.take() {
+            let env_ptr = self_.env.as_ptr();
+            // SAFETY: env is refcounted and still live during cleanup.
+            let env_ref = unsafe { &*env_ptr };
+            let _hs = NapiHandleScope::open_scoped(env_ref);
+            fun(env_ptr, self_.finalizer_data, self_.ctx);
+        }
+        // Drain queued items so the addon can free per-call data (Node calls
+        // `call_js_cb(null, null, ctx, data)` for each). No new items can be
+        // enqueued once `closing` is set under the lock.
+        if let Some(call_js_cb) = call_js_cb {
+            while let Some(item) = self_.queue.data.read_item() {
+                call_js_cb(core::ptr::null_mut(), napi_value(0), self_.ctx, item);
+            }
+        }
     }
 
     pub fn release(
@@ -2820,6 +2887,19 @@ pub(super) extern "C" fn napi_create_threadsafe_function(
     // nodejs by default keeps the event loop alive until the thread-safe function is unref'd
     function_ref.ref_();
     function_ref.tracker.did_schedule(vm.global());
+
+    // Node registers an env-cleanup hook per TSF so that teardown (worker
+    // termination / process exit) marks it closing before the loop is freed;
+    // without this a native thread's later `napi_release_threadsafe_function`
+    // would wake a dealloc'd event loop.
+    // SAFETY: `env_` is the non-null napi_env we validated via get_env! above.
+    unsafe {
+        napi_add_env_cleanup_hook(
+            env_,
+            Some(ThreadSafeFunction::env_cleanup),
+            function.cast::<c_void>(),
+        )
+    };
 
     *result = function;
     env.ok()

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2750,9 +2750,13 @@ impl ThreadSafeFunction {
         let self_ = unsafe { &mut *this };
         {
             let _g = self_.lock.lock_guard();
+            // `Closed` (not `Closing`): the finalizer runs below, so release()'s
+            // last-ref-after-abort dispatch (which targets `Closing`) must not
+            // fire here — `event_loop` is about to be freed.
             self_
                 .closing
-                .store(ClosingState::Closing as u8, Ordering::SeqCst);
+                .store(ClosingState::Closed as u8, Ordering::SeqCst);
+            self_.has_queued_finalizer = true;
             self_.aborted.store(true, Ordering::SeqCst);
             // Zero the public count so is_blocked() goes false; together with the
             // `&& !is_closing()` guard on enqueue()'s wait loop this guarantees a
@@ -2825,10 +2829,14 @@ impl ThreadSafeFunction {
                     }
                 }
                 self.schedule_dispatch();
-            } else if prev_remaining == 1 {
+            } else if prev_remaining == 1
+                && self.closing.load(Ordering::SeqCst) == ClosingState::Closing as u8
+            {
                 // Already closing from an earlier abort. The last release must
                 // still reach dispatch_one's thread_count==0 path so the
                 // finalizer runs and the event-loop keepalive is dropped.
+                // `Closing` only: `Closed` means env_cleanup already ran the
+                // finalizer and `event_loop` may be freed.
                 self.schedule_dispatch();
             }
         }

--- a/test/napi/napi-app/async_tests.cpp
+++ b/test/napi/napi-app/async_tests.cpp
@@ -1,6 +1,7 @@
 #include "async_tests.h"
 
 #include "utils.h"
+#include <atomic>
 #include <cassert>
 #include <chrono>
 #include <thread>
@@ -186,6 +187,53 @@ create_promise_with_threadsafe_function(const Napi::CallbackInfo &info) {
   return promise;
 }
 
+// Shared between a worker thread's env and the main thread's env (dlopen loads
+// the .node once per process so static storage is process-global).
+static std::atomic<napi_threadsafe_function> g_late_release_tsfn{nullptr};
+static std::atomic<int> g_late_release_finalized{0};
+
+static void late_release_noop_call_js(napi_env, napi_value, void *, void *) {}
+
+static void late_release_finalize(napi_env, void *, void *) {
+  g_late_release_finalized.fetch_add(1);
+}
+
+// Called inside a worker_thread: create a TSF and unref it so the worker's
+// event loop is free to drain. The main thread releases it after the worker has
+// exited (see release_tsfn_from_other_thread).
+napi_value create_tsfn_for_late_release(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  napi_value resource_name =
+      Napi::String::New(env, "napitests::create_tsfn_for_late_release");
+  napi_threadsafe_function tsfn;
+  NODE_API_CALL(env, napi_create_threadsafe_function(
+                         env, nullptr, nullptr, resource_name,
+                         /* max_queue_size */ 0, /* initial_thread_count */ 1,
+                         /* finalize_data */ nullptr, late_release_finalize,
+                         /* context */ nullptr, late_release_noop_call_js,
+                         &tsfn));
+  NODE_API_CALL(env, napi_unref_threadsafe_function(env, tsfn));
+  g_late_release_tsfn.store(tsfn);
+  return info.Env().Undefined();
+}
+
+// Called on the main thread after the worker's 'exit' event: release the TSF
+// created above. Without env-teardown handling this would schedule a dispatch
+// on the worker's freed event loop (heap-use-after-free under ASAN); with it
+// the TSF is already marked closing during worker env cleanup so release()
+// is a no-op and the finalizer has already run.
+napi_value release_tsfn_from_other_thread(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  napi_threadsafe_function tsfn = g_late_release_tsfn.exchange(nullptr);
+  NODE_API_ASSERT(env, tsfn != nullptr);
+  napi_status status = napi_release_threadsafe_function(tsfn, napi_tsfn_release);
+  NODE_API_ASSERT(env, status == napi_ok);
+  napi_value result;
+  NODE_API_CALL(env,
+                napi_create_int32(env, g_late_release_finalized.load(), &result));
+  return result;
+}
+
 napi_value create_async_work_with_null_execute(const Napi::CallbackInfo &info) {
   napi_env env = info.Env();
 
@@ -326,6 +374,8 @@ void register_async_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, create_promise);
   REGISTER_FUNCTION(env, exports, create_promise_with_napi_cpp);
   REGISTER_FUNCTION(env, exports, create_promise_with_threadsafe_function);
+  REGISTER_FUNCTION(env, exports, create_tsfn_for_late_release);
+  REGISTER_FUNCTION(env, exports, release_tsfn_from_other_thread);
   REGISTER_FUNCTION(env, exports, create_async_work_with_null_execute);
   REGISTER_FUNCTION(env, exports, create_async_work_with_null_complete);
   REGISTER_FUNCTION(env, exports, test_cancel_async_work);

--- a/test/napi/napi-app/async_tests.cpp
+++ b/test/napi/napi-app/async_tests.cpp
@@ -226,6 +226,11 @@ napi_value release_tsfn_from_other_thread(const Napi::CallbackInfo &info) {
   napi_env env = info.Env();
   napi_threadsafe_function tsfn = g_late_release_tsfn.exchange(nullptr);
   NODE_API_ASSERT(env, tsfn != nullptr);
+  // A call after env teardown must return napi_closing (Node's Push() contract)
+  // rather than napi_queue_full or touching the freed event loop.
+  napi_status call_status =
+      napi_call_threadsafe_function(tsfn, nullptr, napi_tsfn_nonblocking);
+  NODE_API_ASSERT(env, call_status == napi_closing);
   napi_status status = napi_release_threadsafe_function(tsfn, napi_tsfn_release);
   NODE_API_ASSERT(env, status == napi_ok);
   napi_value result;

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -429,6 +429,39 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       const result = await checkSameOutput("test_threadsafe_function_abort_blocked_producers", []);
       expect(result).toContain("finalized: true");
     });
+
+    it("is marked closing when its worker_threads owner exits so a later release does not touch the freed loop", async () => {
+      // Reproduces the next-swc crash from next build: a Worker creates an
+      // unref'd TSF and exits; a foreign thread then releases it. Before the
+      // fix release() scheduled a dispatch on the worker's dealloc'd event
+      // loop (SIGSEGV in us_wakeup_loop on release builds, heap-use-after-free
+      // under ASAN). After the fix env teardown marks the TSF closing and runs
+      // its finalizer, so release() takes the is_closing early-return.
+      const addon = JSON.stringify(join(__dirname, "napi-app/build/Debug/napitests.node"));
+      const code = `
+        const { Worker } = require("node:worker_threads");
+        const main = require(${addon});
+        const w = new Worker(
+          "require(" + ${JSON.stringify(addon)} + ").create_tsfn_for_late_release()",
+          { eval: true },
+        );
+        w.on("error", e => { console.error(e); process.exit(1); });
+        w.on("exit", code => {
+          if (code !== 0) { console.error("worker exit " + code); process.exit(1); }
+          const finalized = main.release_tsfn_from_other_thread();
+          console.log("finalized=" + finalized);
+        });
+      `;
+      await using proc = spawn({
+        cmd: [bunExe(), "-e", code],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "finalized=1", stderr: "", exitCode: 0 });
+      expect(proc.signalCode).toBeNull();
+    });
   });
 
   describe("exception handling", () => {


### PR DESCRIPTION
Fixes `test/integration/next-pages/test/next-build.test.ts` which has been red on the musl lanes since #31216 landed (builds 71706, 71726, 71800).

## Reproduction

`next build` under `bun --bun` segfaults in a tokio worker thread:

```
panic: Segmentation fault at address 0x0
#7  us_wakeup_loop at packages/bun-usockets/src/loop.c:164
#8  wakeup() at src/uws_sys/Loop.rs:239
#9  wakeup() at src/jsc/event_loop.rs:975
#10 enqueue_task_concurrent() at src/jsc/event_loop.rs:990
#11 schedule_dispatch() at src/runtime/napi/napi_body.rs:2653
#12 release() at src/runtime/napi/napi_body.rs:2735
#13 napi_release_threadsafe_function() at src/runtime/napi/napi_body.rs:2858
#14 ... next-swc.linux-x64-musl.node (tokio-runtime-w thread)
```

Minimal repro (added as a test): a `worker_threads` Worker creates an unref'd TSF and exits; the main thread then calls `napi_release_threadsafe_function` on it. Under ASAN this is a deterministic heap-use-after-free at `EventLoop::vm_ref`, with the freed region being the worker's `VirtualMachine` box (dealloc'd in `web_worker.rs::shutdown`).

## Cause

A `ThreadSafeFunction` holds a raw `BackRef<EventLoop>` into its owning VM. Bun has no mechanism to abort TSFs when their env tears down (Node registers a per-TSF env-cleanup hook; Bun did not), so after the worker's VM box is dealloc'd any `napi_release_threadsafe_function` / `napi_call_threadsafe_function` from a native thread calls `schedule_dispatch()` on freed memory.

This was latent until #31216: that PR made `MessagePort.unref()` release the event-loop ref taken by a `'message'` listener (correct, matches Node). Before, next's worker-side port with `.on('message', fn); .unref()` left one `refEventLoop()` outstanding and the worker never drained. Now it drains, its VM is freed, and next-swc's tokio threads (which hold unref'd TSFs) hit the UAF when they release.

## Fix

Register an env-cleanup hook per TSF in `napi_create_threadsafe_function` and remove it in `ThreadSafeFunction::destroy`. The hook runs on the owning JS thread during `vm.on_exit()`, i.e. before the VM box is freed, and:
- under the TSF's lock, sets `closing = Closing` and broadcasts to wake blocked producers;
- drops the Strong JS callback handle and disables the poll ref (JSC and the loop are still live here);
- runs the user finalizer synchronously;
- drains queued items via `call_js_cb(null, null, ctx, item)`.

This mirrors Node's `ThreadSafeFunction::Cleanup` / `CloseHandlesAndMaybeDelete(true)` / `EmptyQueueAndDelete` in node_api.cc. Once `closing` is set, `release()`, `enqueue()` and `acquire()` take their existing `is_closing()` early-return and never touch `event_loop`. The TSF struct itself is left allocated so a late `release()` from a native thread can still take the lock and read the atomic.

## Verification

```
# fail-before (src/ stashed), 3/3 runs:
==20003==ERROR: AddressSanitizer: heap-use-after-free on address 0x73f068150628
    #0 <bun_jsc::event_loop::EventLoop>::vm_ref src/jsc/event_loop.rs:1029
    #1 <bun_jsc::event_loop::EventLoop>::enqueue_task_concurrent src/jsc/event_loop.rs:985
    #2 <ThreadSafeFunction>::schedule_dispatch src/runtime/napi/napi_body.rs:2653
    #3 <ThreadSafeFunction>::release src/runtime/napi/napi_body.rs:2735
    #4 napi_release_threadsafe_function src/runtime/napi/napi_body.rs:2858
freed by thread T10 (Worker) in <WebWorker>::shutdown src/jsc/web_worker.rs:1346

# pass-after, 3/3 runs:
(pass) napi > napi_threadsafe_function > is marked closing when its worker_threads owner exits ... [3134.01ms]
```

The existing `napi_threadsafe_function` and `cleanup hooks` test groups (31 tests) still pass, and `rust:check-all` is green across all 10 targets.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->