### PR TITLE
test(autobahn): skip when the Docker daemon is arm64

### DIFF
--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1058,6 +1058,24 @@ export function isDockerEnabled(): boolean {
     return false;
   }
 }
+
+let cachedDockerDaemonArch: string | undefined;
+// Go-style arch of the Docker *daemon* (e.g. "amd64", "arm64"), not this
+// process. Darwin CI runners talk to a remote Linux sidecar daemon via
+// DOCKER_HOST, so `process.arch` says nothing about which images can run.
+export function dockerDaemonArch(): string {
+  if (cachedDockerDaemonArch !== undefined) return cachedDockerDaemonArch;
+  const dockerCLI = dockerExe();
+  if (!dockerCLI) return (cachedDockerDaemonArch = "");
+  try {
+    const out = execSync(`"${dockerCLI}" version --format "{{.Server.Arch}}"`, {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return (cachedDockerDaemonArch = out.toString().trim());
+  } catch {
+    return (cachedDockerDaemonArch = "");
+  }
+}
 export async function waitForPort(port: number, timeout: number = 60_000): Promise<void> {
   let deadline = Date.now() + Math.max(1, timeout);
   let error: unknown;

--- a/test/js/web/websocket/autobahn.test.ts
+++ b/test/js/web/websocket/autobahn.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { isDockerEnabled } from "harness";
+import { dockerDaemonArch, isDockerEnabled } from "harness";
 import * as dockerCompose from "../../../docker/index.ts";
 
 let url: string = "";
@@ -28,7 +28,10 @@ async function load() {
   return true;
 }
 
-describe.skipIf(!isDockerEnabled())("autobahn", () => {
+// crossbario/autobahn-testsuite only publishes linux/amd64; on an arm64 daemon
+// without qemu binfmt the container dies with `exec format error`. The x64
+// lanes still exercise every case, so skip rather than depend on emulation.
+describe.skipIf(!isDockerEnabled() || dockerDaemonArch() === "arm64")("autobahn", () => {
   let wsOptions: any;
 
   beforeAll(async () => {

--- a/test/js/web/websocket/autobahn.test.ts
+++ b/test/js/web/websocket/autobahn.test.ts
@@ -28,11 +28,9 @@ async function load() {
   return true;
 }
 
-// crossbario/autobahn-testsuite only publishes linux/amd64; on an arm64 daemon
-// without qemu binfmt the container dies with `exec format error`. The x64
-// lanes still exercise every case, so skip rather than depend on emulation.
-// The env overrides short-circuit the docker checks so an external server
-// (BUN_AUTOBAHN_URL / BUN_TEST_SERVICE_autobahn) still forces the suite.
+// crossbario/autobahn-testsuite is linux/amd64-only; arm64 daemons without qemu
+// binfmt hit `exec format error`, so skip there (x64 lanes still cover every
+// case). BUN_AUTOBAHN_URL / BUN_TEST_SERVICE_autobahn bypass the docker checks.
 const hasAutobahnOverride = !!(process.env.BUN_AUTOBAHN_URL || process.env.BUN_TEST_SERVICE_autobahn);
 describe.skipIf(!hasAutobahnOverride && (!isDockerEnabled() || dockerDaemonArch() === "arm64"))("autobahn", () => {
   let wsOptions: any;

--- a/test/js/web/websocket/autobahn.test.ts
+++ b/test/js/web/websocket/autobahn.test.ts
@@ -31,7 +31,10 @@ async function load() {
 // crossbario/autobahn-testsuite only publishes linux/amd64; on an arm64 daemon
 // without qemu binfmt the container dies with `exec format error`. The x64
 // lanes still exercise every case, so skip rather than depend on emulation.
-describe.skipIf(!isDockerEnabled() || dockerDaemonArch() === "arm64")("autobahn", () => {
+// The env overrides short-circuit the docker checks so an external server
+// (BUN_AUTOBAHN_URL / BUN_TEST_SERVICE_autobahn) still forces the suite.
+const hasAutobahnOverride = !!(process.env.BUN_AUTOBAHN_URL || process.env.BUN_TEST_SERVICE_autobahn);
+describe.skipIf(!hasAutobahnOverride && (!isDockerEnabled() || dockerDaemonArch() === "arm64"))("autobahn", () => {
   let wsOptions: any;
 
   beforeAll(async () => {


### PR DESCRIPTION
## What

`test/js/web/websocket/autobahn.test.ts` goes red on the `:darwin: 14 aarch64 - test-bun` lane whenever shard 0 lands on a tart host whose sidecar image lacks qemu binfmt. Seen in [build 71789, agent `fond-mighty-corgi-tart`](https://buildkite.com/bun/bun/builds/71789#019f4f90-e668-4e75-84ef-f25a15140bb0):

```
autobahn The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
...
autobahn-1  | exec /opt/pypy/bin/wstest: exec format error
```

## Why

`crossbario/autobahn-testsuite:25.10.1` is published for `linux/amd64` only (upstream `docker/Makefile` does a plain `docker build`/`docker push`, no buildx multi-arch). The darwin aarch64 CI runners drive a Linux arm64 sidecar daemon over `DOCKER_HOST`; whether an amd64 image runs there depends on the sidecar base image having qemu-user-static binfmt registered, which varies by host. In the same build, `79509-tart` ran the identical container under emulation and the test passed (`Running 56 of 517 test cases`), while `fond-mighty-corgi-tart` had no binfmt and every retry exited 255.

This is not a code regression on main; no commit changed the autobahn service or the WebSocket client around this failure. It is per-host infra variance surfacing as a red test that blocks unrelated PRs.

## Fix

Add `dockerDaemonArch()` to `test/harness.ts` (Go-style arch of the daemon via `docker version --format '{{.Server.Arch}}'`, cached) and gate the autobahn describe on `dockerDaemonArch() !== "arm64"`. Multi-arch services (postgres, mysql, redis, minio) keep running on those shards; only the one amd64-only image is skipped. Every Autobahn case still runs on the x64 test lanes.

## Verification

- `test/js/web/websocket/autobahn.test.ts` still loads cleanly and skips when no daemon is reachable (current behavior preserved).
- `dockerDaemonArch()` returns `""` on failure (short-circuits to existing `isDockerEnabled()` gate) and the Go arch name otherwise.

Related infra: #31732 introduced the `Dockerfile.autobahn` built image as part of the sidecar-Docker migration.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/websocket/autobahn.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/websocket/autobahn.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (1eb0ee2c7)

test/js/web/websocket/autobahn.test.ts:
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
(skip) autobahn > (unnamed)
(skip) autobahn > should run Autobahn test cases
(skip) autobahn > (unnamed)

 0 pass
 3 skip
 0 fail
Ran 3 tests across 1 file. [2.52s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/harness.ts                        | 18 ++++++++++++++++++
 test/js/web/websocket/autobahn.test.ts |  8 ++++++--
 2 files changed, 24 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
test/harness.ts                             1      1      0
test/js/web/websocket/autobahn.test.ts      2      4      0
```

</details>

<!-- robobun:evidence:end -->