### PR TITLE
test(install): mark "peer *" hoisting case todoIf(isFlaky)

### DIFF
--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -3663,7 +3663,10 @@ describe("hoisting", async () => {
       },
     ];
     for (const { dependencies, expected, situation } of peerTests) {
-      test.todoIf(isFlaky && isMacOS && situation === "peer ^1.0.2")(
+      // `peer *` matches every a-dep version already in the tree, so the hoisted
+      // choice depends on manifest-fetch completion order; observed flaking to
+      // "1.0.9" on Windows (11 aarch64, 2019 x64) and debian aarch64.
+      test.todoIf(isFlaky && (situation === "peer *" || (isMacOS && situation === "peer ^1.0.2")))(
         `it should hoist ${expected} when ${situation}`,
         async () => {
           await writeFile(


### PR DESCRIPTION
`test/cli/install/bun-install-registry.test.ts` has been going red on unrelated PRs with:

```
✗ hoisting > peers > it should hoist 1.0.1 when peer *
Expected to contain: "1.0.1"
Received: "{\n    \"name\": \"a-dep\",\n    \"version\": \"1.0.9\"\n}"
```

Seen in builds 71894, 71892, 71889, 71887, 71881, 71872, 71867, 71857, 71851 and going back at least to build 67000. Mostly `:windows: 11 aarch64` and `:windows: 2019 x64`; once on `:debian: 13 aarch64`.

The sibling `peer ^1.0.2` case has been under `test.todoIf(isFlaky && isMacOS && ...)` since #16118 for the same underlying reason: when a ranged peer is satisfied by more than one `a-dep` version already in the tree, which one gets hoisted depends on manifest-fetch completion order. `peer *` is the only case whose expected hoist is the *lowest* version (1.0.1), so any reordering flips it; the other ranged cases expect 1.0.10 and almost always land there.

This extends the existing `todoIf` to cover `peer *` on CI (all platforms, since it has been observed on Windows and Linux). The other four peer cases and the non-peer hoisting cases keep running on every lane.

Reported from #33726 (build 71891). That build's own `bun-install-registry.test.ts` failure was a different, one-off snapshot hash mismatch on a single darwin-26 agent alongside a segfault crash report; the recurring red on main is this one.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->