### PR TITLE
usockets: defer eof for a paused socket that already sent FIN; stop backpressure pauses from holding the loop

### DIFF
--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -693,30 +693,31 @@ void us_poll_start(struct us_poll_t *p, struct us_loop_t *loop, int events) {
     us_poll_start_rc(p, loop, events);
 }
 
-void us_poll_change(struct us_poll_t *p, struct us_loop_t *loop, int events) {
+int us_poll_change(struct us_poll_t *p, struct us_loop_t *loop, int events) {
     int old_events = us_poll_events(p);
+    int rc = 0;
     if (old_events != events) {
 
         p->state.poll_type = us_internal_poll_type(p) | ((events & LIBUS_SOCKET_READABLE) ? POLL_TYPE_POLLING_IN : 0) | ((events & LIBUS_SOCKET_WRITABLE) ? POLL_TYPE_POLLING_OUT : 0);
 
 #ifdef LIBUS_USE_EPOLL
         struct epoll_event event;
+        event.events = events;
         if(!(events & LIBUS_SOCKET_READABLE) && !(events & LIBUS_SOCKET_WRITABLE)) {
             /* See us_poll_start_rc: EPOLLHUP/EPOLLERR are implicit; never add
              * EPOLLRDHUP for an already-half-closed socket or the loop spins. */
-            events |= EPOLLHUP | EPOLLERR;
+            event.events |= EPOLLHUP | EPOLLERR;
         }
-        event.events = events;
         event.data.ptr = p;
-        int rc;
         do {
             rc = epoll_ctl(loop->fd, EPOLL_CTL_MOD, p->state.fd, &event);
         } while (IS_EINTR(rc));
-        /* A paused socket that hung up was taken out of epoll by the dispatcher; put it back. */
+        /* A paused socket that hung up was taken out of epoll by the dispatcher
+         * (loop.c); this is the resume putting it back. Registering anew can
+         * fail like any first registration, so it goes through the same path
+         * and the caller gets the verdict (us_socket_resume closes on it). */
         if (rc == -1 && errno == ENOENT) {
-            do {
-                rc = epoll_ctl(loop->fd, EPOLL_CTL_ADD, p->state.fd, &event);
-            } while (IS_EINTR(rc));
+            rc = us_poll_start_rc(p, loop, events);
         }
 #else
         kqueue_change(loop->fd, p->state.fd, old_events, events, p);
@@ -724,6 +725,7 @@ void us_poll_change(struct us_poll_t *p, struct us_loop_t *loop, int events) {
         /* Set all removed events to null-polls in pending ready poll list */
         us_internal_loop_update_pending_ready_polls(loop, p, p, old_events, events);
     }
+    return rc;
 }
 
 void us_poll_stop(struct us_poll_t *p, struct us_loop_t *loop) {

--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -284,15 +284,19 @@ void us_poll_start(struct us_poll_t *p, struct us_loop_t *loop, int events) {
   us_poll_start_rc(p, loop, events);
 }
 
-void us_poll_change(struct us_poll_t *p, struct us_loop_t *loop, int events) {
-  if(!p->uv_p) return;
+int us_poll_change(struct us_poll_t *p, struct us_loop_t *loop, int events) {
+  if(!p->uv_p) return 0;
   if (us_poll_events(p) != events) {
     p->poll_type =
         us_internal_poll_type(p) |
         ((events & LIBUS_SOCKET_READABLE) ? POLL_TYPE_POLLING_IN : 0) |
         ((events & LIBUS_SOCKET_WRITABLE) ? POLL_TYPE_POLLING_OUT : 0);
+    /* The poll stays initialized across changes here (the dispatcher never
+     * parks a libuv poll), so this cannot hit the registration failure the
+     * epoll re-add can; uv_poll_start on a live poll only rejects bad args. */
     uv_poll_start(p->uv_p, events | UV_DISCONNECT, poll_cb);
   }
+  return 0;
 }
 
 void us_poll_stop(struct us_poll_t *p, struct us_loop_t *loop) {

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -618,7 +618,9 @@ void us_poll_init(us_poll_r p, LIBUS_SOCKET_DESCRIPTOR fd, int poll_type);
 void us_poll_start(us_poll_r p, us_loop_r loop, int events) nonnull_fn_decl;
 /* Returns 0 if successful */
 int us_poll_start_rc(us_poll_r p, us_loop_r loop, int events) nonnull_fn_decl;
-void us_poll_change(us_poll_r p, us_loop_r loop, int events) nonnull_fn_decl;
+/* Returns 0 unless the fd had to be registered anew (a poll parked by the
+ * dispatcher while paused) and that registration failed; errno is set then. */
+int us_poll_change(us_poll_r p, us_loop_r loop, int events) nonnull_fn_decl;
 void us_poll_stop(us_poll_r p, struct us_loop_t *loop) nonnull_fn_decl;
 
 /* Return what events we are polling for */

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -852,16 +852,18 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                 } while (s);
             }
 
-            /* kqueue reports EV_EOF on the same readable event as a connection's
-             * final data. If the data callback paused the socket mid-burst (stream
-             * backpressure), the read loop above stopped with bytes still queued in
-             * the kernel, and acting on the hint now would end+close the socket and
-             * discard them. Defer it: resuming re-arms the poll and the EOF is
-             * re-reported once the rest has been read. Sockets we already shut down
-             * are exempt (their peer's FIN must still close them promptly below),
-             * as are error-flagged events. */
-            if (eof && s && !error && s->flags.is_paused && !us_socket_is_shut_down(s) &&
-                !us_socket_is_closed(s) && !(hangup && s->read_eof)) {
+            /* The EOF hint (kqueue EV_EOF riding the final data's readable event,
+             * epoll's EPOLLHUP once both directions are down, AFD DISCONNECT on a
+             * shut-down socket) can arrive with the tail of the peer's stream still
+             * queued in the kernel. Acting on it while the socket is paused would
+             * end+close and discard that tail, so defer: resume() re-arms reads and
+             * the read loop drains to recv()==0, which re-derives eof with nothing
+             * left behind it. This includes sockets we already shut down (a client
+             * that end()ed before reading the reply), the case that truncated; once
+             * read_eof is set there is nothing left to drain and deferring would only
+             * lose the close. Error-flagged events keep the error path. */
+            const int eof_deferrable = eof && s && !error && !us_socket_is_closed(s) && !s->read_eof;
+            if (eof_deferrable && s->flags.is_paused) {
 #ifdef LIBUS_USE_EPOLL
                 /* EPOLLHUP is unmaskable: leave epoll while paused so it cannot re-fire; the unread tail stays in
                  * the kernel until resume() re-adds the fd via us_poll_change (end() while paused keeps it parked). */
@@ -871,6 +873,13 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                     s->p.state.poll_type = us_internal_poll_type(&s->p);
                 }
 #endif
+                eof = 0;
+            } else if (eof_deferrable && !(events & LIBUS_SOCKET_READABLE) &&
+                       (us_poll_events(&s->p) & LIBUS_SOCKET_READABLE)) {
+                /* Collected while the socket was paused, but an earlier dispatch in
+                 * this batch resumed it: reads are armed again and nothing was read
+                 * here, so let the next poll re-report it together with READABLE and
+                 * the read loop drain it, instead of closing over the unread tail. */
                 eof = 0;
             }
             if(eof && s) {

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -894,12 +894,16 @@ void us_socket_resume(struct us_socket_t *s) {
     // closed cannot be resumed
     if (us_socket_is_closed(s)) return;
 
-    int readable = s->read_eof ? 0 : LIBUS_SOCKET_READABLE;
-    if (us_socket_is_shut_down(s)) {
-        // we already sent FIN so we resume only readable side we are read-only
-        us_poll_change(&s->p, s->group->loop, readable);
-        return;
+    int events = s->read_eof ? 0 : LIBUS_SOCKET_READABLE;
+    if (!us_socket_is_shut_down(s)) {
+        // still writable: a FIN of ours would have left the socket read-only
+        events |= LIBUS_SOCKET_WRITABLE;
     }
-    // we are readable and writable so we resume everything
-    us_poll_change(&s->p, s->group->loop, readable | LIBUS_SOCKET_WRITABLE);
+    if (us_poll_change(&s->p, s->group->loop, events) != 0) {
+        /* The dispatcher parked this socket while it was paused (loop.c) and the
+         * kernel refused to take it back: nothing would ever deliver its tail,
+         * end or close again, so fail it now like a failed first registration. */
+        int err = errno;
+        us_internal_socket_close_raw(s, err > 2 ? err : ECONNRESET, NULL);
+    }
 }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -413,7 +413,7 @@ const SocketHandlers: SocketHandler = {
     self._unrefTimer();
     self.bytesRead += buffer.length;
     if (!self.push(buffer)) {
-      socket.pause();
+      pauseForBackpressure(self, socket);
     }
   },
   drain(socket) {
@@ -429,6 +429,7 @@ const SocketHandlers: SocketHandler = {
         failWrite(self, res, callback);
       } else if (res) {
         self._pendingData = self[kwriteCallback] = null;
+        unrefAfterDrain(self, socket);
         callback(null);
       } else {
         self._pendingData = null;
@@ -560,6 +561,30 @@ const SocketHandlers: SocketHandler = {
   },
   binaryType: "buffer",
 } as const;
+
+// push() (or an onread callback) said stop. Like node's readStop, a socket that
+// is not reading does not hold the loop (see Socket.prototype.pause); a write
+// awaiting drain still does, and unrefAfterDrain drops the hold once it completes.
+function pauseForBackpressure(self, handle) {
+  handle?.pause?.();
+  if (self[kupgraded] && !(self[kupgraded] instanceof Socket)) return;
+  self[kPausedUnref] = true;
+  if (!self[kwriteCallback]) handle?.unref?.();
+}
+
+// Reads are flowing again: give back the hold a pause dropped. Cleared even when
+// the user unref'd, so a later ref() is not undone by unrefAfterDrain.
+function restorePausedHold(self, handle) {
+  if (!self[kPausedUnref]) return;
+  self[kPausedUnref] = false;
+  if (!self[kUserUnrefed]) handle?.ref?.();
+}
+
+// The write that was holding the loop (_write) just drained; a socket whose
+// reads are over (peer FIN) or stopped is back at rest and lets go again.
+function unrefAfterDrain(self, handle) {
+  if ((self[kended] || self[kPausedUnref]) && !self[kUserUnrefed] && handle === self._handle) handle.unref?.();
+}
 
 function finishSocketEnd(self) {
   if (self[kended]) return;
@@ -730,7 +755,7 @@ const ServerHandlers: SocketHandler<NetSocket> = {
     self._unrefTimer();
     self.bytesRead += buffer.length;
     if (!self.push(buffer)) {
-      socket.pause();
+      pauseForBackpressure(self, socket);
     }
   },
   keylog(socket, line) {
@@ -1251,7 +1276,7 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     const { self } = socket.data;
     self._unrefTimer();
     self.bytesRead += buffer.length;
-    if (!self.push(buffer)) socket.pause();
+    if (!self.push(buffer)) pauseForBackpressure(self, socket);
   },
   drain(socket) {
     $debug("Bun.Socket drain");
@@ -1268,9 +1293,7 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
       } else if (res) {
         self[kBytesWritten] = socket.bytesWritten;
         self._pendingData = self[kwriteCallback] = null;
-        // The buffered write drained: if end() already unref'd (peer FIN) and _write
-        // re-ref'd for this pending flush, drop the ref again now nothing is in flight.
-        if (self[kended] && !self[kUserUnrefed] && socket === self._handle) socket.unref?.();
+        unrefAfterDrain(self, socket);
         callback(null);
       } else {
         self[kBytesWritten] = socket.bytesWritten;
@@ -1696,7 +1719,7 @@ function Socket(options?) {
           if (self.destroyed) return;
           if (ret === false || self.isPaused()) {
             self[kOnreadTail] = kOnreadEmptyTail;
-            self._handle?.pause?.();
+            pauseForBackpressure(self, self._handle);
           }
           return;
         }
@@ -1727,7 +1750,7 @@ function Socket(options?) {
         if (ret === false || self.isPaused()) {
           const rest = buffer.subarray(offset);
           self[kOnreadTail] = rest.length !== 0 ? rest : kOnreadEmptyTail;
-          self._handle?.pause?.();
+          pauseForBackpressure(self, self._handle);
           return;
         }
       }
@@ -2305,6 +2328,7 @@ function drainOnreadTailNT(socket) {
     finishSocketEnd(socket);
   } else if (fromRead || !socket.isPaused()) {
     socket._handle?.resume?.();
+    restorePausedHold(socket, socket._handle);
   }
 }
 
@@ -2316,14 +2340,8 @@ Socket.prototype.resume = function resume() {
   if (!this.connecting && !drainOnreadTail(this)) {
     this._handle?.resume?.();
   }
-  // Restore the hold pause() removed - even while still connecting, so the
-  // pause-then-resume sequence is symmetric. Gated on the pause flag so a
-  // socket that was never paused (e.g. a wrapped duplex with no fd) is not
-  // newly pinned to the loop.
-  if (this[kPausedUnref] && !this[kUserUnrefed]) {
-    this._handle?.ref?.();
-    this[kPausedUnref] = false;
-  }
+  // Even while still connecting, so pause-then-resume stays symmetric.
+  restorePausedHold(this, this._handle);
   return ret;
 };
 
@@ -2428,13 +2446,7 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
 Socket.prototype.read = function read(size) {
   if (!this.connecting && !drainOnreadTail(this, true)) {
     this._handle?.resume?.();
-    // Restarting kernel reads makes the handle hold the loop open again;
-    // mirror resume()'s re-ref or a paused-then-read() socket waits for
-    // data without keeping the process alive.
-    if (this[kPausedUnref] && !this[kUserUnrefed]) {
-      this._handle?.ref?.();
-      this[kPausedUnref] = false;
-    }
+    restorePausedHold(this, this._handle);
   }
   return Duplex.prototype.read.$call(this, size);
 };
@@ -2445,12 +2457,7 @@ Socket.prototype._read = function _read(size) {
     this.once("connect", () => this._read(size));
   } else if (!drainOnreadTail(this, true)) {
     socket?.resume?.();
-    // See read() above - the Readable machinery's pull path must also
-    // restore the handle's hold on the loop.
-    if (this[kPausedUnref] && !this[kUserUnrefed]) {
-      socket?.ref?.();
-      this[kPausedUnref] = false;
-    }
+    restorePausedHold(this, socket);
   }
 };
 
@@ -2502,6 +2509,9 @@ Object.defineProperty(Socket.prototype, "readyState", {
 
 Socket.prototype.ref = function ref() {
   this[kUserUnrefed] = false;
+  // An explicit ref() supersedes the hold a pause dropped on the user's behalf;
+  // unrefAfterDrain must not give it up again.
+  this[kPausedUnref] = false;
   const socket = this._handle;
   if (!socket) {
     this.once("connect", this.ref);
@@ -2822,10 +2832,9 @@ Socket.prototype._write = function _write(chunk, encoding, callback) {
     callback(new Error("overlapping _write()"));
   } else {
     this[kwriteCallback] = callback;
-    // libuv holds the loop for a pending uv_write_t regardless of the handle's ref
-    // state; end() dropped ours on the peer's FIN. Re-ref while this buffered write
-    // waits for drain so the process does not exit with data unflushed.
-    if (this[kended] && !this[kUserUnrefed]) socket.ref?.();
+    // A pending write holds the loop even on a handle whose FIN/pause dropped
+    // its hold (libuv: the uv_write_t is active); unrefAfterDrain lets go again.
+    if ((this[kended] || this[kPausedUnref]) && !this[kUserUnrefed]) socket.ref?.();
   }
 };
 

--- a/test/js/bun/net/socket-syscall-fault.test.ts
+++ b/test/js/bun/net/socket-syscall-fault.test.ts
@@ -1,6 +1,6 @@
 import { socketFaultInjection as fault } from "bun:internal-for-testing";
 import { afterEach, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows } from "harness";
 import { once } from "node:events";
 import http2 from "node:http2";
 import net from "node:net";
@@ -95,6 +95,66 @@ describe.skipIf(!fault.available())("poll_start failure is reported, not a crash
     `),
   );
 });
+
+// A paused socket whose peer hung up is taken out of epoll by the dispatcher
+// (EPOLLHUP is level-triggered and cannot be masked) and registered again by
+// resume(), which is a fresh EPOLL_CTL_ADD and can fail the way the first one
+// can. epoll only: kqueue and libuv never park the fd, so their resume is a
+// plain filter/poll change with nothing for the hook to fail.
+test.skipIf(!fault.available() || !isLinux)(
+  "resume() of a parked socket that cannot be registered again fails the socket instead of leaving it deaf",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+        const net = require("net");
+        const { once } = require("events");
+        let resolveClosed;
+        const serverClosed = new Promise(r => (resolveClosed = r));
+        const server = net.createServer({ allowHalfOpen: true }, s => {
+          s.resume();
+          s.on("end", () => s.write(Buffer.alloc(64 * 1024, 0x61), () => s.end()));
+          s.on("close", resolveClosed);
+        });
+        server.listen(0, async () => {
+          const conn = net.connect({ port: server.address().port, allowHalfOpen: true });
+          await once(conn, "connect");
+          conn.end();
+          conn.pause();
+          await serverClosed;
+          server.close();
+          // The peer's FIN reached our fd before its close event reached us, so
+          // the next poll phase reports the hangup and parks the socket; an
+          // immediate runs after that phase.
+          await new Promise(r => setImmediate(r));
+          conn.on("data", () => console.log("data"));
+          conn.on("error", e => console.log("error", e.code, e.syscall));
+          conn.on("end", () => console.log("end"));
+          conn.on("close", hadError => console.log("close", hadError));
+          fault.set({ syscall: "poll_start", action: "errno", errno: "ENOMEM", repeat: 1 });
+          try {
+            conn.resume();
+          } finally {
+            fault.clear();
+          }
+        });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim().split("\n"), stderr: stderr.trim(), exitCode }).toEqual({
+      stdout: ["error ENOMEM read", "close true"],
+      stderr: "",
+      exitCode: 0,
+    });
+  },
+);
 
 // uSockets' TLS low-priority handshake queue (loop->data.low_prio_head)
 // shares its prev/next links with group->head_sockets. A socket already

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1,7 +1,7 @@
 import { Socket as _BunSocket, TCPSocketListener } from "bun";
 import { heapStats } from "bun:jsc";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, expectMaxObjectTypeCount, isASAN, isDebug, isWindows, tmpdirSync } from "harness";
+import { bunEnv, bunExe, expectMaxObjectTypeCount, gc, isASAN, isDebug, isWindows, tmpdirSync } from "harness";
 import { randomUUID } from "node:crypto";
 import { once } from "node:events";
 import fs from "node:fs";
@@ -973,8 +973,13 @@ it.if(isWindows)(
       }
     }
 
+    // The pipe transport keeps one wrapper reachable regardless of how many
+    // connections were made (1 after one exchange, still 1 after hundreds), so
+    // take the baseline after a warm-up exchange: the 700 below must not add to it.
+    await test(`\\\\.\\pipe\\test\\${randomUUID()}`);
+    gc(true);
+    const before = heapStats().objectTypeCounts.TCPSocket || 0;
     const batch = [];
-    const before = heapStats().objectTypeCounts.TLSSocket || 0;
     for (let i = 0; i < 100; i++) {
       batch.push(test(`\\\\.\\pipe\\test\\${randomUUID()}`));
       batch.push(test(`\\\\?\\pipe\\test\\${randomUUID()}`));
@@ -989,7 +994,9 @@ it.if(isWindows)(
       }
     }
     await Promise.all(batch);
-    expectMaxObjectTypeCount(expect, "TCPSocket", before);
+    // Awaited: left dangling, the assertion landed inside whichever later test
+    // was running and counted that test's live sockets.
+    await expectMaxObjectTypeCount(expect, "TCPSocket", before);
   },
   20_000,
 );
@@ -1102,6 +1109,264 @@ describe("Socket fd adoption", () => {
     // No explicit writable: true -> no adoption, no fstat. child_process
     // extra stdio relies on this path (connect({ fd }) attaches natively).
     expect(() => new Socket({ fd: 0x7ffff })).not.toThrow();
+  });
+});
+
+describe.concurrent("socket that already sent FIN and is paused with unread data", () => {
+  async function runFixture(source: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { lines: stdout.trim().split("\n").sort(), stderr: stderr.trim(), exitCode };
+  }
+
+  it("delivers every buffered byte before 'end' when the data handler pauses", async () => {
+    const SIZE = 1024 * 1024;
+    const result = await runFixture(`
+      const net = require("net");
+      const SIZE = ${SIZE};
+      let received = 0;
+      const server = net.createServer({ allowHalfOpen: true }, socket => {
+        socket.resume();
+        socket.on("end", () => socket.write(Buffer.alloc(SIZE, 0x61), () => socket.end()));
+      }).listen(0, () => {
+        const conn = net.connect({ port: server.address().port, allowHalfOpen: true });
+        conn.on("connect", () => conn.end());
+        conn.on("data", buf => {
+          received += buf.length;
+          conn.pause();
+          // Let the loop poll again with the peer's FIN in place, so the EOF hint
+          // is reported while bytes are still queued in the kernel.
+          setTimeout(() => conn.resume(), 5);
+        });
+        conn.on("error", err => console.log("error", err.code || err.message));
+        conn.on("end", () => console.log("end", received));
+        conn.on("close", () => { server.close(); console.log("close", received); });
+      });
+    `);
+    expect(result).toEqual({ lines: [`close ${SIZE}`, `end ${SIZE}`], stderr: "", exitCode: 0 });
+  });
+
+  it("stays parked without spinning the loop, then delivers the tail on resume", async () => {
+    const result = await runFixture(`
+      const net = require("net");
+      const { once } = require("events");
+      let resolveClosed;
+      const serverClosed = new Promise(r => (resolveClosed = r));
+      const server = net.createServer({ allowHalfOpen: true }, socket => {
+        socket.resume();
+        socket.on("end", () => socket.write(Buffer.alloc(64 * 1024, 0x61), () => socket.end()));
+        socket.on("close", resolveClosed);
+      }).listen(0, async () => {
+        const conn = net.connect({ port: server.address().port, allowHalfOpen: true });
+        await once(conn, "connect");
+        conn.end();
+        conn.pause();
+        await serverClosed;
+        // Both FINs have been exchanged and 64 KiB sits unread in the kernel.
+        let received = 0;
+        conn.on("data", b => { received += b.length; });
+        conn.on("close", () => { server.close(); console.log("close", received); });
+        const before = process.cpuUsage();
+        setTimeout(() => {
+          const d = process.cpuUsage(before);
+          console.log("cpu", d.user + d.system);
+          conn.resume();
+        }, 1000);
+      });
+    `);
+    // A level-triggered hangup left registered would have burned the whole 1s of
+    // wall time as CPU; 500ms leaves room over the debug+ASAN idle baseline.
+    const cpuMicros = Number((result.lines.find(l => l.startsWith("cpu ")) ?? "cpu -1").slice(4));
+    expect({ ...result, cpuIdle: cpuMicros >= 0 && cpuMicros < 500_000 }).toEqual({
+      lines: ["close 65536", `cpu ${cpuMicros}`],
+      stderr: "",
+      exitCode: 0,
+      cpuIdle: true,
+    });
+  });
+});
+
+// A socket whose reads are stopped for backpressure must not hold the process
+// open: in node a handle that is not reading is inactive, so a program that
+// never consumes a reply (or a request) still exits. Each fixture leaves such a
+// socket behind with its tail unread and nothing else alive; the only way to
+// print "exit 0" is for the loop to run down on its own.
+describe.concurrent("backpressure-paused socket does not keep the process alive", () => {
+  async function expectExits(source: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `${source}\nprocess.on("exit", code => console.log("exit", code));`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr: stderr.trim(), exitCode }).toEqual({
+      stdout: "exit 0",
+      stderr: "",
+      exitCode: 0,
+    });
+  }
+
+  it("client that end()s and never reads the reply", () =>
+    expectExits(`
+      const net = require("net");
+      const server = net.createServer(s => {
+        s.resume();
+        s.end(Buffer.alloc(128 * 1024, 0x61));
+        s.on("close", () => server.close());
+      }).listen(0, () => {
+        net.connect(server.address().port, function () { this.end(); });
+      });
+    `));
+
+  it("client that never reads the reply and whose peer goes away", () =>
+    expectExits(`
+      const net = require("net");
+      const server = net.createServer(s => {
+        s.end(Buffer.alloc(128 * 1024, 0x61), () => { s.destroy(); server.close(); });
+      }).listen(0, () => {
+        net.connect(server.address().port);
+      });
+    `));
+
+  it("server that end()s a connection without reading the request", () =>
+    expectExits(`
+      const net = require("net");
+      const server = net.createServer(s => s.end("go away")).listen(0, () => {
+        const c = net.connect(server.address().port, () => c.end(Buffer.alloc(128 * 1024, 0x61)));
+        c.resume();
+        c.on("close", () => server.close());
+      });
+    `));
+
+  // onread mode stops reads from the callback's return value instead of push().
+  it("onread client whose callback returns false after it end()ed", () =>
+    expectExits(`
+      const net = require("net");
+      const server = net.createServer(s => {
+        s.resume();
+        s.end(Buffer.alloc(128 * 1024, 0x61));
+        s.on("close", () => server.close());
+      }).listen(0, () => {
+        net.connect(
+          { port: server.address().port, onread: { buffer: Buffer.alloc(4096), callback: () => false } },
+          function () { this.end(); },
+        );
+      });
+    `));
+
+  it("onread client whose callback returns false and whose peer goes away", () =>
+    expectExits(`
+      const net = require("net");
+      const server = net.createServer(s => {
+        s.end(Buffer.alloc(128 * 1024, 0x61), () => { s.destroy(); server.close(); });
+      }).listen(0, () => {
+        net.connect({ port: server.address().port, onread: { buffer: Buffer.alloc(4096), callback: () => false } });
+      });
+    `));
+
+  it("but a write still waiting for drain does keep it alive until it completes", async () => {
+    // Everything on the server side is unref'd, so only the client's pending
+    // write can hold the loop open long enough for the server's timer to drain
+    // it; the stream-level pause for the unread reply must not drop that hold.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const net = require("net");
+        let drained = false;
+        const server = net.createServer(s => {
+          s.unref();
+          s.pause();
+          s.write(Buffer.alloc(256 * 1024, 0x61));
+          setTimeout(() => { s.on("data", () => {}); s.resume(); }, 100).unref();
+        });
+        server.unref();
+        server.listen(0, () => {
+          const c = net.connect(server.address().port, () => {
+            c.write(Buffer.alloc(8 * 1024 * 1024, 0x62), () => { drained = true; c.destroy(); });
+          });
+        });
+        process.on("exit", code => console.log("exit", code, "drained", drained));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr: stderr.trim(), exitCode }).toEqual({
+      stdout: "exit 0 drained true",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("a drain does not give up a hold the user re-took with ref() after the pause was over", async () => {
+    // unref() -> the reply stops reads for backpressure -> resume() re-arms them
+    // while still user-unref'd -> ref() -> a big write goes pending and drains.
+    // The socket is reading and explicitly ref'd at that point, so the process
+    // has to still be around to receive "final"; the listener and the server
+    // side are unref'd before the write so nothing else can keep it alive.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const net = require("net");
+        const { once } = require("events");
+        const REPLY = 256 * 1024, REQ = 8 * 1024 * 1024;
+        const server = net.createServer(s => {
+          s.unref();
+          let got = 0;
+          s.on("data", d => {
+            got += d.length;
+            if (got === REQ) setTimeout(() => s.write("final"), 50).unref();
+          });
+          s.write(Buffer.alloc(REPLY, 0x61));
+        });
+        server.listen(0, async () => {
+          const c = net.connect(server.address().port);
+          await once(c, "connect");
+          c.unref();
+          await once(c, "readable");
+          const { promise: replyDone, resolve } = Promise.withResolvers();
+          let total = 0;
+          c.on("data", d => {
+            if (d.includes("final")) {
+              console.log("got final");
+              c.destroy();
+              server.close();
+              return;
+            }
+            total += d.length;
+            if (total === REPLY) resolve();
+          });
+          c.resume();
+          await replyDone;
+          c.ref();
+          server.unref();
+          c.write(Buffer.alloc(REQ, 0x62), () => console.log("drained"));
+        });
+        process.on("exit", code => console.log("exit", code));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim().split("\n"), stderr: stderr.trim(), exitCode }).toEqual({
+      stdout: ["drained", "got final", "exit 0"],
+      stderr: "",
+      exitCode: 0,
+    });
   });
 });
 


### PR DESCRIPTION
### Problem

- A `net.Socket` that has already sent its FIN (`end()`) and then pauses under backpressure loses the tail of the peer's stream. The eof-while-paused deferral on main (#32488) exempts shut-down sockets, so the `is_shut_down` arm in `us_internal_dispatch_ready_poll` (`packages/bun-usockets/src/loop.c`) closes the socket while bytes are still queued in the kernel: kqueue reports `EV_EOF` on the readable event carrying the final data, epoll latches `EPOLLHUP` once both directions are down. Deterministic on Linux with a 1 MiB reply (`end 586752` of 1048576 on main); about a third of runs on macOS.
- The exemption's original reason was uws HTTP, but every uws HTTP socket is `allow_half_open` and pairs `shutdown()` with `close()`, so it never reaches this arm; what the exemption (and the earlier `allow_half_open` version of this PR) actually left truncating were `Bun.connect`/`Bun.listen` without `allowHalfOpen` and `us_socket_from_fd` sockets.
- Deferring the FIN exposes a loop-hold bug in `src/js/node/net.ts`: the three `push()`-returned-false pause sites and the two onread-mode ones (callback returned `false`) pause the native handle but, unlike `Socket.prototype.pause`, keep the process alive. With a deferred FIN, a program that never reads a reply or a request sits forever; node (whose `readStop`'d handles are inactive) exits. The not-shut-down deferral already on main has this hang today (`net.connect()` to a server that writes and goes away, never read: hangs on main, exits in node).

### Fix

- `loop.c`: defer the eof hint whenever the socket is paused and `read_eof` is not set (a delivered FIN means nothing is left to drain, so the close stays prompt); shut-down sockets included. The existing epoll `us_poll_stop` applies to every deferral, so an AF_UNIX peer close (`EPOLLHUP` on a socket we did not shut down) cannot spin either. A second arm covers the batch race on epoll: an entry carrying `EPOLLHUP` collected while paused still dispatches after an earlier entry in the same batch resumed the socket, with no `READABLE` bit; it is left for the next poll, which re-reports it with `READABLE` and lets the read loop drain to `recv()==0`.
- `us_poll_change` returns the result of re-registering a parked fd (it goes through `us_poll_start_rc`, so `EPOLL_CTL_ADD` failure is handled and fault-injectable); `us_socket_resume` closes the socket with that errno instead of leaving it registered nowhere.
- `net.ts`: all five stop-reading sites drop the hold the way `Socket.prototype.pause` does (`kPausedUnref`; `read()`/`_read()`/`resume()` and the onread tail drain restore it), except while a write is waiting for drain, which re-refs in `_write` and is released by the drain handlers. `kPausedUnref` is cleared on every resume path and on `ref()`, so a drain never gives up a hold the user re-took.
- Why this is right: a paused socket not observing the peer's FIN until it resumes, and not keeping the process alive while it is not reading, are both node's behavior (readStop); every fixture below was checked against node v26 and matches it.
- Windows is affected too: `libuv.c` maps AFD `DISCONNECT` on a shut-down socket to the same eof hint, so it takes the new arm; the truncation tests now run there (they pass on current main there only because AFD's single forced `recv()` happens to cover the remainder at these sizes, and they exercise the resume re-report path on the branch).

### Tests

`test/js/node/net/node-net.test.ts` (red on main, green with the change, unless noted):
- delivers every buffered byte before `'end'` when the data handler pauses (main: truncated)
- stays parked without spinning the loop, then delivers the tail on resume (main: `close 0`; also bounds the CPU of the parked second)
- client that never reads the reply and whose peer goes away exits (main: hangs)
- onread client whose callback returns `false`, with and without `end()` (both hang on main here: the bare onread pause held the loop whether or not the FIN made it through the buffers)
- client that `end()`s and never reads / server that `end()`s without reading the request exit (pass on main because main closes them; hang with the `loop.c` change alone, which is the regression the `net.ts` part prevents)
- a write still waiting for drain keeps the process alive until it completes; a drain does not give up a hold re-taken with `ref()` (both fail with the naive versions of the `net.ts` change)
- its named-pipe leak check is now awaited with a warmed baseline: left dangling, its assertion landed inside whichever test was running ~1s later and counted that test's sockets (this is what an earlier CI run hit once these tests shifted the timing); the pipe transport keeps exactly one wrapper reachable regardless of connection count, on main as well, which is what the warm-up absorbs.

`test/js/bun/net/socket-syscall-fault.test.ts`: resume of a parked socket whose re-registration fails surfaces `read ENOMEM` + `close`, instead of a deaf socket (epoll only; main closes the socket before the resume, so it is red there too).

Verified: full `node-net.test.ts`, `socket.test.ts`, `tcp-server.test.ts`, `socket-syscall-fault.test.ts`, `fetch-backpressure.test.ts`, `node-http.test.ts`, `node-tls-server.test.ts`, `child_process.test.ts` have failure sets identical to main in this environment (the shared failures are no-network / `localhost` dual-stack ones); the 327 `test-net-*`/`test-tls-*` node tests show the same two pre-existing failures as main. On Windows x64 (debug build): `node-net.test.ts` 77 pass / 0 fail, `node-http.test.ts`, `fetch-backpressure.test.ts`, `socket-syscall-fault.test.ts` clean, the pause-related `test-net-*`/`test-http-pause*` node tests pass. (`net.Socket write > should allow reconnecting after end()` is flaky on Windows debug builds on main as well: 1/12 there vs 4/24 here, a pre-existing 3ms race in that test, unrelated to this change.)

### Background

- eof hint: the `eof` argument to the dispatcher. Where it comes from differs per backend (kqueue `EV_EOF`, epoll `EPOLLHUP`, AFD `DISCONNECT`, or `recv()` returning 0 inside the read loop); only the last one proves the buffer is empty.
- parked socket: on epoll `EPOLLHUP` is level-triggered and cannot be masked, so a paused socket that hung up is removed from the epoll set (`us_poll_stop`) and added back on resume; that re-add is a fresh registration.
- `read_eof`: set once the peer's FIN has been delivered as `on_end` on a half-open socket.
- onread mode: the `onread` connect option delivers reads into a caller-supplied buffer through a callback instead of the stream's `push()`; returning `false` from the callback is that mode's way of stopping reads.
- `kPausedUnref` / `kUserUnrefed`: `net.ts` bookkeeping for the handle's hold on the event loop. `kUserUnrefed` records an explicit `socket.unref()`; `kPausedUnref` records that a pause dropped the hold on the user's behalf and the next resume should restore it.

Related: #35939 fixes a different problem in the same block (`on_end` re-dispatch after a partial write); the two are independent.
