### PR TITLE
test(proxy-stress-headers): share proxy pair across concurrent tests

### DIFF
--- a/test/js/bun/http/proxy-stress-headers.test.ts
+++ b/test/js/bun/http/proxy-stress-headers.test.ts
@@ -6,13 +6,9 @@
  * Also: Content-Range (206), long URLs, and the decompress:false path
  * that surfaces the raw encoded body.
  *
- * Concurrency note: 76 tests share one {http, https} proxy pair created in
- * beforeAll. The proxy is a pure forwarder, so one long-lived pair serves
- * every test that does not inspect `proxy.connections`. A fresh proxy per
- * test churned ~150 `listen(0)` ports under `test.concurrent`'s rolling
- * window and CI saw a single ConnectionRefused (https-origin) or wrong
- * Content-Type (http-origin) roughly once per ~100 runs; pinning the proxy
- * ports for the file's lifetime removes the port-reuse surface.
+ * Concurrency note: 76 tests share one {http, https} proxy pair from beforeAll
+ * to avoid ephemeral-port reuse under test.concurrent's rolling listen(0)
+ * churn. Tests that inspect proxy.connections create a dedicated proxy.
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";

--- a/test/js/bun/http/proxy-stress-headers.test.ts
+++ b/test/js/bun/http/proxy-stress-headers.test.ts
@@ -5,6 +5,14 @@
  *
  * Also: Content-Range (206), long URLs, and the decompress:false path
  * that surfaces the raw encoded body.
+ *
+ * Concurrency note: 76 tests share one {http, https} proxy pair created in
+ * beforeAll. The proxy is a pure forwarder, so one long-lived pair serves
+ * every test that does not inspect `proxy.connections`. A fresh proxy per
+ * test churned ~150 `listen(0)` ports under `test.concurrent`'s rolling
+ * window and CI saw a single ConnectionRefused (https-origin) or wrong
+ * Content-Type (http-origin) roughly once per ~100 runs; pinning the proxy
+ * ports for the file's lifetime removes the port-reuse surface.
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
@@ -13,6 +21,7 @@ import net from "node:net";
 import tls from "node:tls";
 import zlib from "node:zlib";
 import {
+  AdversarialProxy,
   cartesian,
   clearProxyEnv,
   createAdversarialOrigin,
@@ -23,10 +32,18 @@ import {
 } from "./proxy-stress-helpers";
 
 let savedEnv: Record<string, string | undefined>;
-beforeAll(() => {
+let sharedHttpProxy: AdversarialProxy;
+let sharedHttpsProxy: AdversarialProxy;
+const sharedProxy = (tls: boolean) => (tls ? sharedHttpsProxy : sharedHttpProxy);
+
+beforeAll(async () => {
   savedEnv = clearProxyEnv();
+  sharedHttpProxy = await createAdversarialProxy({ tls: false });
+  sharedHttpsProxy = await createAdversarialProxy({ tls: true });
 });
-afterAll(() => {
+afterAll(async () => {
+  await sharedHttpProxy?.close();
+  await sharedHttpsProxy?.close();
   restoreProxyEnv(savedEnv);
 });
 
@@ -46,7 +63,7 @@ describe("many response headers", () => {
         const headers: Record<string, string> = {};
         for (let i = 0; i < count; i++) headers[`X-Resp-${i}`] = `val-${i}`;
         await using origin = await createAdversarialOrigin({ tls: originTls, body: "ok", headers });
-        await using proxy = await createAdversarialProxy({ tls: proxyTls });
+        const proxy = sharedProxy(proxyTls);
         const res = await fetch(origin.url, { proxy: proxy.url, keepalive: false, tls: laxTls });
         expect(res.status).toBe(200);
         expect(await res.text()).toBe("ok");
@@ -92,7 +109,7 @@ describe("duplicate Set-Cookie through tunnel", () => {
         server.listen(0, "127.0.0.1");
         await once(server, "listening");
         const originUrl = `${originTls ? "https" : "http"}://localhost:${(server.address() as net.AddressInfo).port}`;
-        await using proxy = await createAdversarialProxy({ tls: proxyTls });
+        const proxy = sharedProxy(proxyTls);
         try {
           const res = await fetch(originUrl, { proxy: proxy.url, keepalive: false, tls: laxTls });
           expect(res.status).toBe(200);
@@ -132,7 +149,7 @@ describe("Content-Type through tunnel", () => {
           body: "ct",
           headers: { "Content-Type": ct },
         });
-        await using proxy = await createAdversarialProxy({ tls: proxyTls });
+        const proxy = sharedProxy(proxyTls);
         const res = await fetch(origin.url, { proxy: proxy.url, keepalive: false, tls: laxTls });
         expect(res.status).toBe(200);
         expect(res.headers.get("content-type")).toBe(ct);
@@ -159,7 +176,7 @@ describe("206 Content-Range through tunnel", () => {
           body: "partial",
           headers: { "Content-Range": "bytes 0-6/100", "Accept-Ranges": "bytes" },
         });
-        await using proxy = await createAdversarialProxy({ tls: proxyTls });
+        const proxy = sharedProxy(proxyTls);
         const res = await fetch(origin.url, {
           proxy: proxy.url,
           keepalive: false,
@@ -195,7 +212,7 @@ describe("decompress:false through tunnel", () => {
           body: payload,
           encoding,
         });
-        await using proxy = await createAdversarialProxy({ tls: proxyTls });
+        const proxy = sharedProxy(proxyTls);
         const res = await fetch(origin.url, {
           proxy: proxy.url,
           keepalive: false,
@@ -223,6 +240,7 @@ describe("CONNECT envelope shape", () => {
   for (const proxyTls of [false, true] as const) {
     test.concurrent(`${proxyTls ? "https" : "http"}-proxy CONNECT carries Host and Proxy-Connection`, async () => {
       await using origin = await createAdversarialOrigin({ tls: true, body: "ok" });
+      // This test inspects proxy.connections, so it needs a dedicated proxy.
       await using proxy = await createAdversarialProxy({ tls: proxyTls });
       const res = await fetch(origin.url, { proxy: proxy.url, keepalive: false, tls: laxTls });
       expect(res.status).toBe(200);
@@ -248,7 +266,7 @@ describe("long URL through proxy", () => {
       async () => {
         const path = "/" + Buffer.alloc(len - 1, "p").toString("latin1");
         await using origin = await createAdversarialOrigin({ tls: originTls, body: "ok" });
-        await using proxy = await createAdversarialProxy({ tls: proxyTls });
+        const proxy = sharedProxy(proxyTls);
         const res = await fetch(origin.url + path, { proxy: proxy.url, keepalive: false, tls: laxTls });
         expect(res.status).toBe(200);
         expect(origin.requests[0].path).toBe(path);
@@ -266,6 +284,7 @@ describe("switching proxy", () => {
   for (const originTls of [false, true] as const) {
     test.concurrent(`two different proxies, same ${originTls ? "https" : "http"}-origin`, async () => {
       await using origin = await createAdversarialOrigin({ tls: originTls, body: "ok" });
+      // This test counts connections per proxy, so each needs its own.
       await using proxyA = await createAdversarialProxy({});
       await using proxyB = await createAdversarialProxy({});
       let res = await fetch(origin.url, { proxy: proxyA.url, keepalive: true, tls: laxTls });
@@ -295,7 +314,7 @@ describe("Content-Encoding header after decompress", () => {
       async () => {
         const payload = Buffer.alloc(2048, "D").toString("latin1");
         await using origin = await createAdversarialOrigin({ tls: originTls, body: payload, encoding: "gzip" });
-        await using proxy = await createAdversarialProxy({ tls: proxyTls });
+        const proxy = sharedProxy(proxyTls);
         const res = await fetch(origin.url, { proxy: proxy.url, keepalive: false, tls: laxTls });
         expect(res.status).toBe(200);
         // Bun keeps Content-Encoding after transparent decompression


### PR DESCRIPTION
## Problem

`test/js/bun/http/proxy-stress-headers.test.ts` has been flaking in CI since it was added in #32635, roughly once every ~100 runs across darwin (14/26, aarch64/x64), alpine x64-baseline, and debian x64-baseline lanes. Always exactly 1 of 76 tests, in two shapes:

**`ConnectionRefused` on an https-origin test** (e.g. [build 71878](https://buildkite.com/bun/bun/builds/71878), [71453](https://buildkite.com/bun/bun/builds/71453), [71343](https://buildkite.com/bun/bun/builds/71343), [71279](https://buildkite.com/bun/bun/builds/71279), [70843](https://buildkite.com/bun/bun/builds/70843), [70725](https://buildkite.com/bun/bun/builds/70725), [70679](https://buildkite.com/bun/bun/builds/70679)):
```
error: Unable to connect. Is the computer able to access the url?
  path: "https://localhost:58938/",
 errno: 0,
  code: "ConnectionRefused"
✗ Content-Type through tunnel > http-proxy → https-origin Content-Type="application/octet-stream"
```

**Wrong Content-Type received on an http-origin test** (e.g. [build 71888](https://buildkite.com/bun/bun/builds/71888), [70668](https://buildkite.com/bun/bun/builds/70668), [70454](https://buildkite.com/bun/bun/builds/70454)), always receiving `text/html; charset=utf-8` (the second entry in the Content-Type matrix):
```
Expected: "application/x-www-form-urlencoded"
Received: "text/html; charset=utf-8"
✗ Content-Type through tunnel > http-proxy → http-origin Content-Type="application/x-www-form-urlencoded"
```

Both fail on the single CI retry too.

## Cause

76 `test.concurrent` cases each created a fresh adversarial proxy + origin, for ~150 `listen(0, "127.0.0.1")` calls per file under the test runner's rolling `max_concurrency` window (20 in release, 5 under ASAN). As early tests finish and dispose their servers, later tests' `listen(0)` can be handed a just-freed port while a sibling test is still mid-dial (the proxy's `net.connect(port, "localhost")` goes through autoSelectFamily, adding async hops between port capture and connect).

I could not reproduce the single-failure shape in isolation (150 runs linux, 105 serial runs on a macOS 26 CI box all clean; running this file past ~100 back-to-back iterations on macOS hits full ephemeral-port exhaustion instead, which is mass EADDRNOTAVAIL/502, not the single-test failure CI sees). Ruled out as causes: the HTTP client's keep-alive pool (lookup and release are both gated on `!disable_keepalive`, so `keepalive: false` never touches the pool), the HTTP-thread scratch buffers (`SHARED_REQUEST_HEADERS_BUF` etc. are filled and consumed within one callback with no yield), and node:net cross-connection state (`lookupAndConnectMultiple` builds a fresh per-call context).

## Fix

Share one `{http, https}` proxy pair across the file, created in `beforeAll` and torn down in `afterAll`. The adversarial proxy is a stateless forwarder, so one long-lived pair serves every test that does not inspect `proxy.connections`; the two tests that do ("CONNECT envelope shape" and "switching proxy") keep per-test proxies. Proxy ports are now fixed for the file's lifetime, and per-file `listen(0)` churn drops from ~152 to ~84.

Coverage is unchanged: 76 tests, 1206 expect() calls. All existing assertions preserved.

## Verification

```
bun bd test test/js/bun/http/proxy-stress-headers.test.ts   # 76 pass, 0 fail (ASAN)
```
150 consecutive runs on linux and 100 on a macOS 26 CI box, all clean.

The sibling `proxy-stress-matrix.test.ts` has the same per-test proxy pattern (480 tests) but its payload is a constant `makeBody(n, "R")`, so if the same port-reuse race bites there the assertion cannot distinguish one origin's response from another's. Left alone for now since it is not red in CI.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/http/proxy-stress-headers.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/http/proxy-stress-headers.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (9033b14a8)

test/js/bun/http/proxy-stress-headers.test.ts:
(pass) many response headers > http-proxy → http-origin, 5 response headers [1401.23ms]
(pass) many response headers > http-proxy → http-origin, 50 response headers [1391.27ms]
(pass) many response headers > http-proxy → http-origin, 200 response headers [1386.46ms]
(pass) many response headers > http-proxy → https-origin, 5 response headers [1650.19ms]
(pass) many response headers > http-proxy → https-origin, 50 response headers [1662.04ms]
(pass) many response headers > https-proxy → http-origin, 5 response headers [501.52ms]
(pass) many response headers > https-proxy → http-origin, 50 response headers [551.86ms]
(pass) many response headers > http-proxy → https-origin, 200 response headers [1214.01ms]
(pass) many response headers > https-proxy → http-origin, 200 response headers [1412.05ms]
(pass) many response headers > https-proxy → https-origin, 5 response headers [1597.69ms]
(pass) duplicate Set-Cookie through tunnel > http-proxy → http-origin, 3 Set-Cookie headers [750.87ms]
(pass) many response headers > https-proxy → https-origin, 50 response headers [2082.60ms]
(pass) many response headers > https-proxy → https-origin, 200 response headers [2041.62ms]
(pass) duplicate Set-Cookie through tunnel > http-proxy → https-origin, 3 Set-Cookie headers [994.17ms]
(pass) duplicate Set-Cookie through tunnel > https-proxy → http-origin, 3 Set-Cookie headers [844.36ms]
(pass) Content-Type through tunnel > http-proxy → http-origin Content-Type="text/plain" [251.09ms]
(pass) Co
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/http/proxy-stress-headers.test.ts | 33 +++++++++++++++++++--------
 1 file changed, 24 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
test/js/bun/http/proxy-stress-headers.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->