### PR TITLE
install: don't leak package extraction temp directories into $TMPDIR

### DIFF
--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -344,6 +344,7 @@ pub fn do_patch_commit(
                 random_tempdir.as_bytes(),
                 sys::RenameOptions {
                     move_fallback: true,
+                    ..Default::default()
                 },
             )
             .is_err()
@@ -399,6 +400,7 @@ pub fn do_patch_commit(
                 patch_tag_tmpname.as_bytes(),
                 sys::RenameOptions {
                     move_fallback: true,
+                    ..Default::default()
                 },
             ) {
                 bun_core::warn!(
@@ -431,7 +433,7 @@ pub fn do_patch_commit(
                         random_tempdir.as_bytes(),
                         new_folder_handle.fd,
                         b"node_modules",
-                        sys::RenameOptions { move_fallback: true },
+                        sys::RenameOptions { move_fallback: true, ..Default::default() },
                     ) {
                         bun_core::warn!("failed renaming nested node_modules folder, this may cause issues: {}", e);
                     }
@@ -443,7 +445,7 @@ pub fn do_patch_commit(
                         patch_tag_tmpname.as_bytes(),
                         new_folder_handle.fd,
                         patch_tag,
-                        sys::RenameOptions { move_fallback: true },
+                        sys::RenameOptions { move_fallback: true, ..Default::default() },
                     ) {
                         bun_core::warn!("failed renaming the bun patch tag, this may cause issues: {}", e);
                     }
@@ -588,6 +590,7 @@ pub fn do_patch_commit(
         path_in_patches_dir,
         sys::RenameOptions {
             move_fallback: true,
+            ..Default::default()
         },
     ) {
         Output::err(e, "failed renaming patch file to patches dir", ());

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -259,8 +259,6 @@ impl ExtractTarball {
         let mut resolved: &'static [u8] = b"";
         let tmpname =
             FileSystem::tmpname(tmpname_suffix, &mut tmpname_buf.0, bun_core::fast_random())?;
-        // Delete the temp dir if extraction fails before it's renamed into the
-        // cache; defused on success.
         let tmpdir_cleanup = scopeguard::guard((), |()| {
             let _ = Dir::borrow(&self.temp_dir).delete_tree(tmpname.as_bytes());
         });
@@ -535,10 +533,8 @@ impl ExtractTarball {
             }
             let cache_dir = Dir::borrow(&self.cache_dir);
 
-            // An existing npm cache entry without package.json is invalid (the
-            // same check `package_missing_from_cache` uses), so no concurrent
-            // install reads from it. Delete it so the fresh copy below replaces
-            // it instead of being kept as an equivalent existing destination.
+            // An entry without package.json is invalid (see `package_missing_from_cache`);
+            // remove it so the rename below replaces it instead of keeping it.
             if self.resolution.tag == ResolutionTag::Npm {
                 let mut folder_name_z_buf = bun_paths::path_buffer_pool::get();
                 folder_name_z_buf[..folder_name.len()].copy_from_slice(folder_name);
@@ -622,10 +618,8 @@ impl ExtractTarball {
                                     | sys::Errno::EXIST => {
                                         let _ = sys::close(dir_to_move);
 
-                                        // A concurrent install sharing the cache published
-                                        // this entry first. Keep it (it may already have
-                                        // readers) and drop our equivalent copy instead of
-                                        // renaming it out from under them.
+                                        // A concurrent install published this entry first:
+                                        // keep it and drop our copy.
                                         if sys::directory_exists_at_w(
                                             Fd::from_std_dir(cache_dir),
                                             path_to_use,
@@ -673,15 +667,8 @@ impl ExtractTarball {
             }
             #[cfg(not(windows))]
             {
-                // Attempt to gracefully handle duplicate concurrent `bun install` calls
-                //
-                // By:
-                // 1. Rename from temporary directory to cache directory and fail if it already exists
-                // 2. If the rename fails because the destination exists, a concurrent install
-                //    published an equivalent copy first: keep it and delete the temporary
-                //    directory version (`keep_existing_destination`).
-                //
-
+                // Concurrent `bun install` calls publish the same entry:
+                // first writer wins (`keep_existing_destination`).
                 if create_subdir {
                     if let Some(folder) = bun_paths::Dirname::dirname(folder_name) {
                         let _ = bun_sys::make_path::make_path(cache_dir, folder);

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -259,6 +259,11 @@ impl ExtractTarball {
         let mut resolved: &'static [u8] = b"";
         let tmpname =
             FileSystem::tmpname(tmpname_suffix, &mut tmpname_buf.0, bun_core::fast_random())?;
+        // Delete the temp dir if extraction fails before it's renamed into the
+        // cache; defused on success.
+        let tmpdir_cleanup = scopeguard::guard((), |()| {
+            let _ = Dir::borrow(&self.temp_dir).delete_tree(tmpname.as_bytes());
+        });
         {
             let extract_destination = match bun_sys::make_path::make_open_path(
                 tmpdir,
@@ -450,7 +455,11 @@ impl ExtractTarball {
             }
         }
 
-        self.move_to_cache_directory(log, tmpname, name, basename, resolved)
+        let result = self.move_to_cache_directory(log, tmpname, name, basename, resolved);
+        if result.is_ok() {
+            scopeguard::ScopeGuard::into_inner(tmpdir_cleanup);
+        }
+        result
     }
 
     /// Rename the freshly-extracted temp directory into the cache, read
@@ -664,9 +673,9 @@ impl ExtractTarball {
                 //
                 // By:
                 // 1. Rename from temporary directory to cache directory and fail if it already exists
-                // 2a. If the rename fails, swap the cache directory with the temporary directory version
-                // 2b. Delete the temporary directory version ONLY if we're not using a provided temporary directory
-                // 3. If rename still fails, fallback to racily deleting the cache directory version and then renaming the temporary directory version again.
+                // 2. If the rename fails because the destination exists, a concurrent install
+                //    published an equivalent copy first: keep it and delete the temporary
+                //    directory version (`keep_existing_destination`).
                 //
 
                 if create_subdir {
@@ -682,6 +691,7 @@ impl ExtractTarball {
                     folder_name,
                     sys::RenameatConcurrentlyOptions {
                         move_fallback: true,
+                        keep_existing_destination: true,
                     },
                 ) {
                     log.add_error_fmt(

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -540,14 +540,14 @@ impl ExtractTarball {
             // install reads from it. Delete it so the fresh copy below replaces
             // it instead of being kept as an equivalent existing destination.
             if self.resolution.tag == ResolutionTag::Npm {
-                let mut folder_name_z_buf = PathBuffer::uninit();
+                let mut folder_name_z_buf = bun_paths::path_buffer_pool::get();
                 folder_name_z_buf[..folder_name.len()].copy_from_slice(folder_name);
                 folder_name_z_buf[folder_name.len()] = 0;
                 let folder_name_z = ZStr::from_buf(&folder_name_z_buf, folder_name.len());
                 if sys::directory_exists_at(cache_dir.fd(), folder_name_z).unwrap_or(false) {
-                    let mut json_buf = PathBuffer::uninit();
+                    let mut json_buf = bun_paths::path_buffer_pool::get();
                     let json_z = path::resolve_path::join_z_buf::<path::platform::Auto>(
-                        &mut json_buf.0,
+                        &mut json_buf,
                         &[folder_name, b"package.json"],
                     );
                     if !sys::exists_at(cache_dir.fd(), json_z) {

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -599,39 +599,22 @@ impl ExtractTarball {
                                     | sys::Errno::PERM
                                     | sys::Errno::BUSY
                                     | sys::Errno::EXIST => {
-                                        // before we attempt to delete the destination, let's close the source dir.
                                         let _ = sys::close(dir_to_move);
 
-                                        // We tried to move the folder over
-                                        // but it didn't work!
-                                        // so instead of just simply deleting the folder
-                                        // we rename it back into the temp dir
-                                        // and then delete that temp dir
-                                        // The goal is to make it more difficult for an application to reach this folder
-                                        let mut tempdest_buf = bun_paths::path_buffer_pool::get();
-                                        tempdest_buf[0..tmpname.len()]
-                                            .copy_from_slice(tmpname.as_bytes());
-                                        tempdest_buf[tmpname.len()..][0..4]
-                                            .copy_from_slice(&[b't', b'm', b'p', 0]);
-                                        let tempdest =
-                                            ZStr::from_buf(&tempdest_buf, tmpname.len() + 3);
-                                        let mut folder_name_z_buf = bun_paths::path_buffer_pool::get();
-                                        folder_name_z_buf[0..folder_name.len()]
-                                            .copy_from_slice(folder_name);
-                                        folder_name_z_buf[folder_name.len()] = 0;
-                                        let folder_name_z =
-                                            ZStr::from_buf(&folder_name_z_buf, folder_name.len());
-                                        match sys::renameat(
+                                        // A concurrent install sharing the cache published
+                                        // this entry first. Keep it (it may already have
+                                        // readers) and drop our equivalent copy instead of
+                                        // renaming it out from under them.
+                                        if sys::directory_exists_at_w(
                                             Fd::from_std_dir(cache_dir),
-                                            folder_name_z,
-                                            Fd::from_std_dir(tmpdir),
-                                            tempdest,
-                                        ) {
-                                            bun_sys::Result::Err(_) => {}
-                                            bun_sys::Result::Ok(_) => {
-                                                let _ = tmpdir.delete_tree(tempdest.as_bytes());
-                                            }
+                                            path_to_use,
+                                        )
+                                        .unwrap_or(false)
+                                        {
+                                            let _ = tmpdir.delete_tree(tmpname.as_bytes());
+                                            break;
                                         }
+
                                         retries += 1;
                                         // 10ms, 20ms, 40ms, 80ms — long enough
                                         // for a concurrent close to land,

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -535,6 +535,27 @@ impl ExtractTarball {
             }
             let cache_dir = Dir::borrow(&self.cache_dir);
 
+            // An existing npm cache entry without package.json is invalid (the
+            // same check `package_missing_from_cache` uses), so no concurrent
+            // install reads from it. Delete it so the fresh copy below replaces
+            // it instead of being kept as an equivalent existing destination.
+            if self.resolution.tag == ResolutionTag::Npm {
+                let mut folder_name_z_buf = PathBuffer::uninit();
+                folder_name_z_buf[..folder_name.len()].copy_from_slice(folder_name);
+                folder_name_z_buf[folder_name.len()] = 0;
+                let folder_name_z = ZStr::from_buf(&folder_name_z_buf, folder_name.len());
+                if sys::directory_exists_at(cache_dir.fd(), folder_name_z).unwrap_or(false) {
+                    let mut json_buf = PathBuffer::uninit();
+                    let json_z = path::resolve_path::join_z_buf::<path::platform::Auto>(
+                        &mut json_buf.0,
+                        &[folder_name, b"package.json"],
+                    );
+                    if !sys::exists_at(cache_dir.fd(), json_z) {
+                        let _ = cache_dir.delete_tree(folder_name);
+                    }
+                }
+            }
+
             // e.g. @next
             // if it's a namespace package, we need to make sure the @name folder exists
             let create_subdir = basename.len() != name.len() && !self.resolution.tag.is_git();

--- a/src/install/git_runner.rs
+++ b/src/install/git_runner.rs
@@ -311,9 +311,10 @@ impl CacheStaging {
             folder_name,
             bun_sys::RenameatConcurrentlyOptions {
                 move_fallback: false,
+                keep_existing_destination: true,
             },
         );
-        // After an exchange the temporary name holds the folder that was replaced.
+        // On failure the temporary name may still hold our copy.
         self.discard();
         if let Err(err) = renamed {
             log.add_error_fmt(

--- a/src/install/git_runner.rs
+++ b/src/install/git_runner.rs
@@ -559,13 +559,17 @@ impl GitSubprocess {
             return Err(Error::InstallFailed);
         }
 
-        match bun_sys::Dir::borrow(&this.cache_dir).open_at(&checkout_folder_name(&resolved)) {
+        let folder_name = checkout_folder_name(&resolved);
+        match bun_sys::Dir::borrow(&this.cache_dir).open_at(&folder_name) {
             Ok(dir) => {
                 if bun_sys::exists_at(dir.fd(), bun_core::zstr!(".bun-tag")) {
                     Self::finish_on_pool(this, Finalize::CachedCheckout(dir));
                     return Ok(());
                 }
                 dir.close();
+                // Without `.bun-tag` the entry is invalid; remove it so the
+                // fresh checkout replaces it instead of being kept.
+                let _ = bun_sys::Dir::borrow(&this.cache_dir).delete_tree(&folder_name);
             }
             Err(err) if err.get_errno() == bun_sys::E::ENOENT => {}
             Err(err) => return Err(err.into()),

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -431,6 +431,12 @@ impl PatchTask {
 
         let system_tmpdir = self.tempdir;
 
+        // Delete the temp dir on failure; after a successful rename into the
+        // cache this is a no-op.
+        scopeguard::defer! {
+            let _ = sys::Dir::borrow(&system_tmpdir).delete_tree(tempdir_name.as_bytes());
+        }
+
         let pkg_name = patch.pkgname;
 
         let dummy_node_modules = crate::package_installer::NodeModulesFolder {
@@ -584,7 +590,7 @@ impl PatchTask {
             cache_dir_subpath_z,
             sys::RenameOptions {
                 move_fallback: true,
-                ..Default::default()
+                keep_existing_destination: true,
             },
         ) {
             log.add_error_fmt_opts(

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -431,8 +431,7 @@ impl PatchTask {
 
         let system_tmpdir = self.tempdir;
 
-        // Delete the temp dir on failure; after a successful rename into the
-        // cache this is a no-op.
+        // No-op once the temp dir has been renamed into the cache.
         scopeguard::defer! {
             let _ = sys::Dir::borrow(&system_tmpdir).delete_tree(tempdir_name.as_bytes());
         }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -8886,7 +8886,13 @@ pub fn exists(path: &[u8]) -> bool {
 /// retries; on EXDEV falls back to the slow open+copy path. Only opens the
 /// source inside the EXDEV branch.
 pub fn move_file_z(from_dir: Fd, filename: &ZStr, to_dir: Fd, destination: &ZStr) -> Maybe<()> {
-    match renameat_concurrently_without_fallback(from_dir, filename, to_dir, destination) {
+    match renameat_concurrently_without_fallback(
+        from_dir,
+        filename,
+        to_dir,
+        destination,
+        Default::default(),
+    ) {
         Ok(()) => Ok(()),
         // allow over-writing an empty directory
         Err(e) if e.get_errno() == E::EISDIR => {
@@ -8967,6 +8973,12 @@ pub fn renameat_z(from_dir: impl AsFd, from: &ZStr, to_dir: impl AsFd, to: &ZStr
 #[derive(Default, Clone, Copy)]
 pub struct RenameatConcurrentlyOptions {
     pub move_fallback: bool,
+    /// If the destination already exists (a concurrent process published an
+    /// equivalent tree first, e.g. a shared package cache entry), keep it and
+    /// delete the source instead of atomically replacing it. Replacing would
+    /// yank entries out from under processes still reading the existing tree,
+    /// and swapping it into the source leaks the temp directory (#33977).
+    pub keep_existing_destination: bool,
 }
 /// Alias: `bun_install` call sites spell this `RenameOptions`.
 pub type RenameOptions = RenameatConcurrentlyOptions;
@@ -8993,7 +9005,7 @@ pub fn renameat_concurrently(
     to: &ZStr,
     opts: RenameatConcurrentlyOptions,
 ) -> Maybe<()> {
-    match renameat_concurrently_without_fallback(from_dir_fd, from, to_dir_fd, to) {
+    match renameat_concurrently_without_fallback(from_dir_fd, from, to_dir_fd, to, opts) {
         Ok(()) => Ok(()),
         Err(e) => {
             if opts.move_fallback && e.get_errno() == E::EXDEV {
@@ -9013,6 +9025,7 @@ pub(crate) fn renameat_concurrently_without_fallback(
     from: &ZStr,
     to_dir_fd: Fd,
     to: &ZStr,
+    opts: RenameatConcurrentlyOptions,
 ) -> Maybe<()> {
     'attempt: {
         {
@@ -9037,6 +9050,18 @@ pub(crate) fn renameat_concurrently_without_fallback(
                 }
                 Ok(()) => break 'attempt,
             };
+
+            if opts.keep_existing_destination && matches!(err.get_errno(), E::EEXIST | E::ENOTEMPTY)
+            {
+                // Another process won the race; its tree is equivalent to
+                // ours and may already have readers, so drop our copy.
+                if from_dir_fd.is_valid() {
+                    let _ = Dir::borrow(&from_dir_fd).delete_tree(from.as_bytes());
+                } else {
+                    let _ = delete_tree_absolute(from.as_bytes());
+                }
+                break 'attempt;
+            }
 
             // Windows doesn't have any equivalent of renameat with swap
             #[cfg(not(windows))]
@@ -9416,6 +9441,7 @@ mod owned_handle_tests {
             b"sub",
             RenameatConcurrentlyOptions {
                 move_fallback: true,
+                ..Default::default()
             },
         )
         .expect("rename");
@@ -9427,6 +9453,50 @@ mod owned_handle_tests {
         );
 
         // Cleanup.
+        let _ = close(to_dir);
+        let _ = close(root);
+        let _ = Dir::open(&tmp).map(|d| d.delete_tree(b"."));
+    }
+
+    /// With `keep_existing_destination`, losing the publish race keeps the
+    /// destination untouched and deletes the source instead of swapping the
+    /// two (which stranded the swapped-out tree in the temp dir, #33977).
+    #[test]
+    fn renameat_concurrently_keep_existing_destination() {
+        let _g = crate::file::tests::FD_TEST_LOCK.lock();
+        let mut tmp = std::env::temp_dir().as_os_str().as_encoded_bytes().to_vec();
+        tmp.extend_from_slice(b"/bun_sys_renameat_keep_test");
+        let _ = open_dir_at(Fd::cwd(), &tmp).map(close);
+        let _ = mkdir_recursive_at(Fd::cwd(), &tmp);
+        let root = open_dir_at(Fd::cwd(), &tmp).expect("open root");
+        let _ = mkdir_recursive_at(root, b"from/sub");
+        let _ = mkdir_recursive_at(root, b"to/sub");
+        let to_dir = open_dir_at(root, b"to").expect("open to");
+        File::write_file(root, ZStr::from_static(b"to/sub/winner\0"), b"").expect("marker");
+
+        renameat_concurrently_a(
+            root,
+            b"from/sub",
+            to_dir,
+            b"sub",
+            RenameatConcurrentlyOptions {
+                move_fallback: true,
+                keep_existing_destination: true,
+            },
+        )
+        .expect("rename");
+
+        // The existing destination survives with its contents...
+        assert!(
+            exists_at(to_dir, ZStr::from_static(b"sub/winner\0")),
+            "existing destination was replaced"
+        );
+        // ...and the source was cleaned up rather than left (or swapped) behind.
+        assert!(
+            !exists_at(root, ZStr::from_static(b"from/sub\0")),
+            "source left behind"
+        );
+
         let _ = close(to_dir);
         let _ = close(root);
         let _ = Dir::open(&tmp).map(|d| d.delete_tree(b"."));

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -9509,9 +9509,10 @@ mod owned_handle_tests {
             exists_at(to_dir, ZStr::from_static(b"sub/winner\0")),
             "existing destination was replaced"
         );
-        // ...and the source was cleaned up rather than left (or swapped) behind.
+        // ...and the source was cleaned up rather than left (or swapped)
+        // behind. Windows `exists_at` is file-only, so check the directory.
         assert!(
-            !exists_at(root, ZStr::from_static(b"from/sub\0")),
+            !directory_exists_at(root, ZStr::from_static(b"from/sub\0")).unwrap_or(false),
             "source left behind"
         );
 

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -9027,6 +9027,13 @@ pub(crate) fn renameat_concurrently_without_fallback(
     to: &ZStr,
     opts: RenameatConcurrentlyOptions,
 ) -> Maybe<()> {
+    let delete_source = || {
+        if from_dir_fd.is_valid() {
+            let _ = Dir::borrow(&from_dir_fd).delete_tree(from.as_bytes());
+        } else {
+            let _ = delete_tree_absolute(from.as_bytes());
+        }
+    };
     'attempt: {
         {
             // Happy path: the folder doesn't exist in the cache dir, so we can
@@ -9055,11 +9062,7 @@ pub(crate) fn renameat_concurrently_without_fallback(
             {
                 // Another process won the race; its tree is equivalent to
                 // ours and may already have readers, so drop our copy.
-                if from_dir_fd.is_valid() {
-                    let _ = Dir::borrow(&from_dir_fd).delete_tree(from.as_bytes());
-                } else {
-                    let _ = delete_tree_absolute(from.as_bytes());
-                }
+                delete_source();
                 break 'attempt;
             }
 
@@ -9091,6 +9094,20 @@ pub(crate) fn renameat_concurrently_without_fallback(
         }
 
         //  sad path: let's try to delete the folder and then rename it
+        if opts.keep_existing_destination {
+            // The errno didn't tell us whether the destination exists (e.g.
+            // EOPNOTSUPP when the filesystem lacks RENAME_NOREPLACE); check
+            // before deleting a tree another process may be reading.
+            let destination_exists = if to_dir_fd.is_valid() {
+                exists_at(to_dir_fd, to)
+            } else {
+                exists_z(to)
+            };
+            if destination_exists {
+                delete_source();
+                break 'attempt;
+            }
+        }
         if to_dir_fd.is_valid() {
             let _ = Dir::borrow(&to_dir_fd).delete_tree(to.as_bytes());
         } else {

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -9097,13 +9097,14 @@ pub(crate) fn renameat_concurrently_without_fallback(
         if opts.keep_existing_destination {
             // The errno didn't tell us whether the destination exists (e.g.
             // EOPNOTSUPP when the filesystem lacks RENAME_NOREPLACE); check
-            // before deleting a tree another process may be reading.
-            let destination_exists = if to_dir_fd.is_valid() {
-                exists_at(to_dir_fd, to)
+            // before deleting a tree another process may be reading. Windows
+            // `exists_at` is file-only, so ask for the directory explicitly.
+            let dir_fd = if to_dir_fd.is_valid() {
+                to_dir_fd
             } else {
-                exists_z(to)
+                Fd::cwd()
             };
-            if destination_exists {
+            if directory_exists_at(dir_fd, to).unwrap_or(false) {
                 delete_source();
                 break 'attempt;
             }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -8973,11 +8973,8 @@ pub fn renameat_z(from_dir: impl AsFd, from: &ZStr, to_dir: impl AsFd, to: &ZStr
 #[derive(Default, Clone, Copy)]
 pub struct RenameatConcurrentlyOptions {
     pub move_fallback: bool,
-    /// If the destination already exists (a concurrent process published an
-    /// equivalent tree first, e.g. a shared package cache entry), keep it and
-    /// delete the source instead of atomically replacing it. Replacing would
-    /// yank entries out from under processes still reading the existing tree,
-    /// and swapping it into the source leaks the temp directory (#33977).
+    /// If the destination already exists, keep it and delete the source
+    /// instead of replacing it (first writer wins).
     pub keep_existing_destination: bool,
 }
 /// Alias: `bun_install` call sites spell this `RenameOptions`.
@@ -9060,8 +9057,6 @@ pub(crate) fn renameat_concurrently_without_fallback(
 
             if opts.keep_existing_destination && matches!(err.get_errno(), E::EEXIST | E::ENOTEMPTY)
             {
-                // Another process won the race; its tree is equivalent to
-                // ours and may already have readers, so drop our copy.
                 delete_source();
                 break 'attempt;
             }
@@ -9095,10 +9090,7 @@ pub(crate) fn renameat_concurrently_without_fallback(
 
         //  sad path: let's try to delete the folder and then rename it
         if opts.keep_existing_destination {
-            // The errno didn't tell us whether the destination exists (e.g.
-            // EOPNOTSUPP when the filesystem lacks RENAME_NOREPLACE); check
-            // before deleting a tree another process may be reading. Windows
-            // `exists_at` is file-only, so ask for the directory explicitly.
+            // EOPNOTSUPP etc. don't say whether the destination exists; check.
             let dir_fd = if to_dir_fd.is_valid() {
                 to_dir_fd
             } else {
@@ -9476,9 +9468,7 @@ mod owned_handle_tests {
         let _ = Dir::open(&tmp).map(|d| d.delete_tree(b"."));
     }
 
-    /// With `keep_existing_destination`, losing the publish race keeps the
-    /// destination untouched and deletes the source instead of swapping the
-    /// two (which stranded the swapped-out tree in the temp dir, #33977).
+    /// `keep_existing_destination` keeps the destination and deletes the source.
     #[test]
     fn renameat_concurrently_keep_existing_destination() {
         let _g = crate::file::tests::FD_TEST_LOCK.lock();
@@ -9504,13 +9494,11 @@ mod owned_handle_tests {
         )
         .expect("rename");
 
-        // The existing destination survives with its contents...
         assert!(
             exists_at(to_dir, ZStr::from_static(b"sub/winner\0")),
             "existing destination was replaced"
         );
-        // ...and the source was cleaned up rather than left (or swapped)
-        // behind. Windows `exists_at` is file-only, so check the directory.
+        // Windows `exists_at` is file-only, so check the directory.
         assert!(
             !directory_exists_at(root, ZStr::from_static(b"from/sub\0")).unwrap_or(false),
             "source left behind"

--- a/test/cli/install/bun-install-tempdir-cleanup.test.ts
+++ b/test/cli/install/bun-install-tempdir-cleanup.test.ts
@@ -103,9 +103,9 @@ function makeRegistry(packages: Record<string, { tgz: Buffer; integrity: string 
   return server;
 }
 
-async function runInstall(cwd: string, cacheDir: string, tmpDir: string) {
+async function runInstall(cwd: string, cacheDir: string, tmpDir: string, extraArgs: string[] = ["--no-save"]) {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "install", "--no-save", "--linker=hoisted"],
+    cmd: [bunExe(), "install", "--linker=hoisted", ...extraArgs],
     cwd,
     env: {
       ...bunEnv,
@@ -217,4 +217,43 @@ test.concurrent("a patch that fails to apply does not leak its temp directory", 
 
   expect(await readdirSorted(tmpDir)).toEqual([".keep"]);
   expect(exitCode).not.toBe(0);
+});
+
+test.concurrent("re-extracting replaces an invalid cache entry", async () => {
+  using server = makeRegistry({ "heal-pkg": makePackageTarball("heal-pkg", 3) });
+
+  using dir = tempDir("tempdir-leak-heal", {
+    "proj/package.json": JSON.stringify({
+      name: "proj",
+      version: "1.0.0",
+      dependencies: { "heal-pkg": "1.0.0" },
+    }),
+    "proj/bunfig.toml": `[install]\nregistry = "${server.url}"\n`,
+    "tmp/.keep": "",
+    "cache/.keep": "",
+  });
+  const tmpDir = join(String(dir), "tmp");
+  const cacheDir = join(String(dir), "cache");
+  const proj = join(String(dir), "proj");
+
+  // Save a lockfile: with one, the reinstall below skips re-resolution and
+  // relies on the package.json-exists cache check that triggers re-extract.
+  const first = await runInstall(proj, cacheDir, tmpDir, []);
+  expect(first.exitCode).toBe(0);
+
+  const [cacheEntry] = (await readdirSorted(cacheDir)).filter(name => name.startsWith("heal-pkg@"));
+  expect(cacheEntry).toBeDefined();
+
+  // A cache entry without package.json is invalid; a reinstall whose
+  // node_modules copy also fails verification must replace it, not keep it.
+  await Promise.all([
+    rm(join(cacheDir, cacheEntry, "package.json")),
+    rm(join(proj, "node_modules", "heal-pkg", "package.json")),
+  ]);
+
+  const second = await runInstall(proj, cacheDir, tmpDir, []);
+  expect(await readdirSorted(join(cacheDir, cacheEntry))).toContain("package.json");
+  expect(await readdirSorted(join(proj, "node_modules", "heal-pkg"))).toContain("package.json");
+  expect(await readdirSorted(tmpDir)).toEqual([".keep"]);
+  expect(second.exitCode).toBe(0);
 });

--- a/test/cli/install/bun-install-tempdir-cleanup.test.ts
+++ b/test/cli/install/bun-install-tempdir-cleanup.test.ts
@@ -5,11 +5,11 @@
 // strand the loser's copy), nor when extraction or patching fails partway.
 
 import { expect, setDefaultTimeout, test } from "bun:test";
-import { rm } from "node:fs/promises";
 import { bunEnv, bunExe, readdirSorted, tempDir } from "harness";
 import { createHash } from "node:crypto";
-import { gzipSync } from "node:zlib";
+import { rm } from "node:fs/promises";
 import { join } from "node:path";
+import { gzipSync } from "node:zlib";
 
 setDefaultTimeout(1000 * 60 * 5);
 

--- a/test/cli/install/bun-install-tempdir-cleanup.test.ts
+++ b/test/cli/install/bun-install-tempdir-cleanup.test.ts
@@ -1,0 +1,219 @@
+// https://github.com/oven-sh/bun/issues/33977
+// `bun install` must not leave package-extraction temp directories behind in
+// the install temp dir ($BUN_TMPDIR / $TMPDIR): neither when two concurrent
+// installs race the same cache entry (the RENAME_EXCHANGE fallback used to
+// strand the loser's copy), nor when extraction or patching fails partway.
+
+import { expect, setDefaultTimeout, test } from "bun:test";
+import { rm } from "node:fs/promises";
+import { bunEnv, bunExe, readdirSorted, tempDir } from "harness";
+import { createHash } from "node:crypto";
+import { gzipSync } from "node:zlib";
+import { join } from "node:path";
+
+setDefaultTimeout(1000 * 60 * 5);
+
+// ---------------------------------------------------------------------------
+// Minimal in-process tarball + registry helpers (no binary fixtures).
+// ---------------------------------------------------------------------------
+
+function octal(n: number, width: number): string {
+  return n.toString(8).padStart(width - 1, "0") + "\0";
+}
+
+function tarHeader(name: string, size: number, type: "0" | "5"): Buffer {
+  const buf = Buffer.alloc(512, 0);
+  buf.write(name, 0, 100, "utf8");
+  buf.write(octal(0o644, 8), 100); // mode
+  buf.write(octal(0, 8), 108); // uid
+  buf.write(octal(0, 8), 116); // gid
+  buf.write(octal(size, 12), 124); // size
+  buf.write(octal(0, 12), 136); // mtime
+  buf.fill(" ", 148, 156); // checksum placeholder
+  buf.write(type, 156);
+  buf.write("ustar\0", 257);
+  buf.write("00", 263);
+  let sum = 0;
+  for (let i = 0; i < 512; i++) sum += buf[i];
+  buf.write(octal(sum, 8), 148);
+  return buf;
+}
+
+function pad512(len: number): Buffer {
+  return Buffer.alloc((512 - (len % 512)) % 512, 0);
+}
+
+function buildTarball(entries: { path: string; body: Buffer }[]): { tgz: Buffer; integrity: string } {
+  const blocks: Buffer[] = [];
+  for (const { path, body } of entries) {
+    blocks.push(tarHeader(`package/${path}`, body.length, "0"), body, pad512(body.length));
+  }
+  blocks.push(Buffer.alloc(1024, 0)); // end-of-archive
+  const tgz = gzipSync(Buffer.concat(blocks));
+  return { tgz, integrity: "sha512-" + createHash("sha512").update(tgz).digest("base64") };
+}
+
+// A package with enough files that extraction takes long enough for two
+// concurrent installs to reliably race the same cache entry.
+function makePackageTarball(name: string, fileCount: number) {
+  const entries = [{ path: "package.json", body: Buffer.from(JSON.stringify({ name, version: "1.0.0" }) + "\n") }];
+  for (let i = 0; i < fileCount; i++) {
+    // Incompressible content so gzip can't collapse the files away.
+    const body = Buffer.alloc(1024);
+    let seed = createHash("sha256").update(`${name}-${i}`).digest();
+    for (let off = 0; off < body.length; off += 32) {
+      seed.copy(body, off);
+      seed = createHash("sha256").update(seed).digest();
+    }
+    entries.push({ path: `files/f${i}.bin`, body });
+  }
+  return buildTarball(entries);
+}
+
+// Serves packuments at /<name> and tarballs at /<name>/-/<name>-1.0.0.tgz.
+function makeRegistry(packages: Record<string, { tgz: Buffer; integrity: string }>) {
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const { pathname } = new URL(req.url);
+      for (const [name, { tgz, integrity }] of Object.entries(packages)) {
+        if (pathname === `/${name}`) {
+          return Response.json({
+            name,
+            "dist-tags": { latest: "1.0.0" },
+            versions: {
+              "1.0.0": {
+                name,
+                version: "1.0.0",
+                dist: {
+                  integrity,
+                  tarball: `${server.url}${name}/-/${name}-1.0.0.tgz`,
+                },
+              },
+            },
+          });
+        }
+        if (pathname === `/${name}/-/${name}-1.0.0.tgz`) {
+          return new Response(tgz);
+        }
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  return server;
+}
+
+async function runInstall(cwd: string, cacheDir: string, tmpDir: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install", "--no-save", "--linker=hoisted"],
+    cwd,
+    env: {
+      ...bunEnv,
+      BUN_INSTALL_CACHE_DIR: cacheDir,
+      BUN_TMPDIR: tmpDir,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+test("concurrent installs sharing a cache do not leak temp directories", async () => {
+  const packageCount = 8;
+  const packages: Record<string, { tgz: Buffer; integrity: string }> = {};
+  for (let i = 0; i < packageCount; i++) {
+    packages[`leaky-pkg-${i}`] = makePackageTarball(`leaky-pkg-${i}`, 150);
+  }
+  using server = makeRegistry(packages);
+
+  const dependencies = Object.fromEntries(Object.keys(packages).map(name => [name, "1.0.0"]));
+  const files: Record<string, string> = { "tmp/.keep": "", "cache/.keep": "" };
+  for (const proj of ["proj1", "proj2"]) {
+    files[`${proj}/package.json`] = JSON.stringify({ name: proj, version: "1.0.0", dependencies });
+    files[`${proj}/bunfig.toml`] = `[install]\nregistry = "${server.url}"\n`;
+  }
+  using dir = tempDir("tempdir-leak", files);
+  const tmpDir = join(String(dir), "tmp");
+  const cacheDir = join(String(dir), "cache");
+
+  for (let iteration = 0; iteration < 5; iteration++) {
+    // Evict the cache so both installs extract (and race) every package again.
+    await Promise.all([
+      rm(cacheDir, { recursive: true, force: true }),
+      rm(join(String(dir), "proj1", "node_modules"), { recursive: true, force: true }),
+      rm(join(String(dir), "proj2", "node_modules"), { recursive: true, force: true }),
+    ]);
+
+    const [r1, r2] = await Promise.all([
+      runInstall(join(String(dir), "proj1"), cacheDir, tmpDir),
+      runInstall(join(String(dir), "proj2"), cacheDir, tmpDir),
+    ]);
+    expect({ stderr: r1.stderr, exitCode: r1.exitCode }).toMatchObject({ exitCode: 0 });
+    expect({ stderr: r2.stderr, exitCode: r2.exitCode }).toMatchObject({ exitCode: 0 });
+  }
+
+  expect(await readdirSorted(tmpDir)).toEqual([".keep"]);
+});
+
+test("a tarball that fails to extract does not leak its temp directory", async () => {
+  // Valid integrity (computed over the bytes) but not a gzip stream, so the
+  // failure happens during extraction, after the temp dir was created.
+  const tgz = Buffer.from("this is definitely not a gzipped tarball");
+  using server = makeRegistry({
+    "corrupt-pkg": { tgz, integrity: "sha512-" + createHash("sha512").update(tgz).digest("base64") },
+  });
+
+  using dir = tempDir("tempdir-leak-corrupt", {
+    "proj/package.json": JSON.stringify({
+      name: "proj",
+      version: "1.0.0",
+      dependencies: { "corrupt-pkg": "1.0.0" },
+    }),
+    "proj/bunfig.toml": `[install]\nregistry = "${server.url}"\n`,
+    "tmp/.keep": "",
+    "cache/.keep": "",
+  });
+  const tmpDir = join(String(dir), "tmp");
+
+  const { stderr, exitCode } = await runInstall(join(String(dir), "proj"), join(String(dir), "cache"), tmpDir);
+  expect(stderr).toContain("corrupt-pkg");
+  expect(exitCode).not.toBe(0);
+
+  expect(await readdirSorted(tmpDir)).toEqual([".keep"]);
+});
+
+test("a patch that fails to apply does not leak its temp directory", async () => {
+  using server = makeRegistry({ "patched-pkg": makePackageTarball("patched-pkg", 3) });
+
+  // Parses fine, but targets a file the package doesn't contain.
+  const patch = [
+    "diff --git a/missing.txt b/missing.txt",
+    "index 0000000..1111111 100644",
+    "--- a/missing.txt",
+    "+++ b/missing.txt",
+    "@@ -1 +1 @@",
+    "-old",
+    "+new",
+    "",
+  ].join("\n");
+
+  using dir = tempDir("tempdir-leak-patch", {
+    "proj/package.json": JSON.stringify({
+      name: "proj",
+      version: "1.0.0",
+      dependencies: { "patched-pkg": "1.0.0" },
+      patchedDependencies: { "patched-pkg@1.0.0": "patches/patched-pkg.patch" },
+    }),
+    "proj/patches/patched-pkg.patch": patch,
+    "proj/bunfig.toml": `[install]\nregistry = "${server.url}"\n`,
+    "tmp/.keep": "",
+    "cache/.keep": "",
+  });
+  const tmpDir = join(String(dir), "tmp");
+
+  const { stderr } = await runInstall(join(String(dir), "proj"), join(String(dir), "cache"), tmpDir);
+  expect(stderr).toContain("failed applying patch file");
+
+  expect(await readdirSorted(tmpDir)).toEqual([".keep"]);
+});

--- a/test/cli/install/bun-install-tempdir-cleanup.test.ts
+++ b/test/cli/install/bun-install-tempdir-cleanup.test.ts
@@ -119,7 +119,7 @@ async function runInstall(cwd: string, cacheDir: string, tmpDir: string) {
   return { stdout, stderr, exitCode };
 }
 
-test("concurrent installs sharing a cache do not leak temp directories", async () => {
+test.concurrent("concurrent installs sharing a cache do not leak temp directories", async () => {
   const packageCount = 8;
   const packages: Record<string, { tgz: Buffer; integrity: string }> = {};
   for (let i = 0; i < packageCount; i++) {
@@ -156,7 +156,7 @@ test("concurrent installs sharing a cache do not leak temp directories", async (
   expect(await readdirSorted(tmpDir)).toEqual([".keep"]);
 });
 
-test("a tarball that fails to extract does not leak its temp directory", async () => {
+test.concurrent("a tarball that fails to extract does not leak its temp directory", async () => {
   // Valid integrity (computed over the bytes) but not a gzip stream, so the
   // failure happens during extraction, after the temp dir was created.
   const tgz = Buffer.from("this is definitely not a gzipped tarball");
@@ -178,12 +178,12 @@ test("a tarball that fails to extract does not leak its temp directory", async (
 
   const { stderr, exitCode } = await runInstall(join(String(dir), "proj"), join(String(dir), "cache"), tmpDir);
   expect(stderr).toContain("corrupt-pkg");
-  expect(exitCode).not.toBe(0);
 
   expect(await readdirSorted(tmpDir)).toEqual([".keep"]);
+  expect(exitCode).not.toBe(0);
 });
 
-test("a patch that fails to apply does not leak its temp directory", async () => {
+test.concurrent("a patch that fails to apply does not leak its temp directory", async () => {
   using server = makeRegistry({ "patched-pkg": makePackageTarball("patched-pkg", 3) });
 
   // Parses fine, but targets a file the package doesn't contain.
@@ -212,8 +212,9 @@ test("a patch that fails to apply does not leak its temp directory", async () =>
   });
   const tmpDir = join(String(dir), "tmp");
 
-  const { stderr } = await runInstall(join(String(dir), "proj"), join(String(dir), "cache"), tmpDir);
+  const { stderr, exitCode } = await runInstall(join(String(dir), "proj"), join(String(dir), "cache"), tmpDir);
   expect(stderr).toContain("failed applying patch file");
 
   expect(await readdirSorted(tmpDir)).toEqual([".keep"]);
+  expect(exitCode).not.toBe(0);
 });


### PR DESCRIPTION
Fixes #33977
Fixes #28062

### Problem

`bun install` leaks package-extraction temp directories (e.g. `.5dfdff2c5fefbff7-00000006.tmp`, `.79dbbadf3f7fb2bb-7.react-native`) into $TMPDIR. On long-lived CI containers the reporter measured ~25 GB over 40 hours.

Reproduction: run two concurrent `bun install` processes sharing the same `BUN_INSTALL_CACHE_DIR`. Every package whose cache publish they race leaks one fully extracted copy per install, even though both installs exit 0. Error paths (a tarball that fails to extract, a patch that fails to apply) also leak one temp directory per attempt.

### Cause

Extraction writes the package into a temp dir, then publishes it into the cache via `renameat_concurrently` (`renameat2` with `RENAME_NOREPLACE`). When a concurrent install already published the entry, that fails with `EEXIST` and the code fell back to `RENAME_EXCHANGE`, which swaps the temp dir with the existing cache entry and returns success. The swapped-out tree now sits in $TMPDIR under the temp name and nothing ever deletes it. The patched-dependency apply path and the streaming extractor share the same helper and leaked the same way.

Deleting the swapped-out tree after the exchange turns the leak into a correctness bug: the process that won the race can still hold an open directory fd into that tree while hardlinking it into `node_modules`, and deleting the entries under it makes its install fail with `ENOENT: failed copying files from cache to destination` (observed while testing that variant).

The Windows arm of `move_to_cache_directory` already had that stronger form of the bug: on a publish collision it renamed the existing cache entry out of the cache and deleted it before retrying its own move, yanking the entry out from under the concurrent install that published it. That is the mechanism behind #28062 (`ENOENT: failed opening cache/package/version dir` on parallel installs sharing a cache on Windows).

### Fix

Treat the cache publish race as first-writer-wins on every platform. `RenameatConcurrentlyOptions` gains `keep_existing_destination`: when the destination already exists, keep it (it is an equivalent tree extracted from the same tarball, and other processes may be mid-read of it) and delete the caller's private temp copy, which no other process can have open. The tarball extract path (buffered and streaming), the patch apply path, and the git checkout publish in `git_runner.rs` (added on main after this PR was opened, with the same swap-then-delete shape) opt in; the `bun patch` working-directory renames keep the old replace semantics. The Windows arm applies the same rule when the destination directory exists; its rename-out-and-delete fallback block is now dead and deleted.

Keeping an existing entry must not keep an invalid one. Bun already treats an npm entry without `package.json`, or a git checkout without `.bun-tag`, as absent and re-extracts to heal it. Both detection sites now delete the invalid entry before the fresh copy is published, so the heal still lands (existing tests in `bun-install-registry.test.ts` and `bun-install.test.ts` cover both).

Error paths are covered by scope guards: `ExtractTarball::extract` and `PatchTask::apply` now delete their temp directory when they fail before the rename. This also stops the stranded temp directories reported in #11250, though not the underlying `EPERM` there, so that issue is not closed by this PR.

### Verification

New tests in `test/cli/install/bun-install-tempdir-cleanup.test.ts` (all three fail on the unfixed build on Linux, leaking 40/2/1 temp dirs respectively against a local registry; the two error-path tests also fail on unfixed Windows):

- two concurrent installs sharing a cache, 5 iterations with cache eviction: temp dir must be empty afterwards and all installs exit 0
- a tarball with valid integrity that fails to extract: temp dir must be empty
- a patch that parses but fails to apply: temp dir must be empty

Plus a `bun_sys` unit test that `keep_existing_destination` keeps the destination's contents and removes the source. Existing suites `bun-install-patch`, `bun-patch`, `bun-install-streaming-extract`, and `bun-install-tarball-integrity` pass. The full test file was also run against a Windows debug build (3/3 clean runs).

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 5 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/install/bun-install-tempdir-cleanup.test.ts
bun test v1.4.3 (ab25d9042)

test/cli/install/bun-install-tempdir-cleanup.test.ts:
177 |   const tmpDir = join(String(dir), "tmp");
178 | 
179 |   const { stderr, exitCode } = await runInstall(join(String(dir), "proj"), join(String(dir), "cache"), tmpDir);
180 |   expect(stderr).toContain("corrupt-pkg");
181 | 
182 |   expect(await readdirSorted(tmpDir)).toEqual([".keep"]);
                                            ^
error: expect(received).toEqual(expected)

  [
+   ".4cf154b1adb05e39-2.corrupt-pkg",
    ".keep",
  ]

- Expected  - 0
+ Received  + 1

      at <anonymous> (/workspace/bun/test/cli/install/bun-install-tempdir-cleanup.test.ts:182:39)
(fail) a tarball that fails to extract does not leak its temp directory [339.09ms]
213 |   const tmpDir = join(String(dir), "tmp");
214 | 
215 |   const { stderr, exitCode } = await runInstall(join(String(dir), "proj"), join(String(dir), "cache"), tmpDir);
216 |   expect(stderr).toContain("failed applying patch file");
217 | 
218 |   expec
... (truncated)

release without fix: 4 FAILED
bun test v1.4.2 (744846f84)

test/cli/install/bun-install-tempdir-cleanup.test.ts:
213 |   const tmpDir = join(String(dir), "tmp");
214 | 
215 |   const { stderr, exitCode } = await runInstall(join(String(dir), "proj"), join(String(dir), "cache"), tmpDir);
216 |   expect(stderr).toContain("failed applying patch file");
217 | 
218 |   expect(await readdirSorted(tmpDir)).toEqual([".keep"]);
                                            ^
error: expect(received).toEqual(expected)

  [
+   ".44d1a402145d300-3.tmp",
    ".keep",
  ]

- Expected  - 0
+ Received  + 1

      at <anonymous> (/workspace/bun/test/cli/install/bun-install-tempdir-cleanup.test.ts:218:39)
(fail) a patch that fails to apply does not leak its temp directory [19.55ms]
177 |   const tmpDir = join(String(dir), "tmp");
178 | 
179 |   const { stderr, exitCode } = await runInstall(join(String(dir), "proj"), join(String(dir), "cache"), tmpDir);
180 |   expect(stderr).toContain("corrupt-pkg");
181 | 
182 |   expect(await readdirSorted(tmpDir)).toEqual([".keep"]);
                                            ^
error: expect(received).toEqual(expected)

  [
+   ".a16d4f46020179a8-2.corrupt-pkg",
    ".keep",
  ]
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/install/bun-install-tempdir-cleanup.test.ts
bun test v1.4.3 (ab25d9042)

test/cli/install/bun-install-tempdir-cleanup.test.ts:
(pass) a tarball that fails to extract does not leak its temp directory [417.41ms]
(pass) a patch that fails to apply does not leak its temp directory [354.54ms]
(pass) re-extracting replaces an invalid cache entry [484.02ms]
(pass) concurrent installs sharing a cache do not leak temp directories [6962.33ms]

 4 pass
 0 fail
 23 expect() calls
Ran 4 tests across 1 file. [9.22s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     3069264617
  features     baseline

23 deps, 131 codegen, 1172 objects in 654ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1248] mkdir stamps
[2/1248] mkdir codegen
[3/1248] mkdir obj
[4/1248] mkdir pch
[5/1248] install /workspace/bun
bun install v1.4.2 (744846f84)

Checked 22 installs across 61 packages (no changes) [21.00ms]
[6/1248] install /workspace/bun/packages/bun-error
bun install v1.4.2 (744846f84)

Checked 1 install across 2 packages (no changes) [6.00ms]
[7/1248] gen bindgenv2
[8/1248] install /workspace/bun/src/node-fallbacks
bun install v1.4.2 (744846f84)

Checked 111 installs across 104 packages (no changes) [12.00ms]
[9/1248] gen ErrorCode+*.h
[10/1248] gen node-fallbacks/react-refresh.js
Bundled 1 module in 17ms

  react-refresh.js  4.81 KB  (entry point)

[11/1248] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[12/1248] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[13/1248] fetch picohttpparser
[picohttpparser] up
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/PackageManager/patchPackage.rs         |   7 +-
 src/install/extract_tarball.rs                     |  79 +++----
 src/install/git_runner.rs                          |   9 +-
 src/install/patch_install.rs                       |   7 +-
 src/sys/lib.rs                                     |  81 ++++++-
 .../install/bun-install-tempdir-cleanup.test.ts    | 259 +++++++++++++++++++++
 6 files changed, 396 insertions(+), 46 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/install/PackageManager/patchPackage.rs                1      0     32
src/install/extract_tarball.rs                           14     12     32
src/install/git_runner.rs                                 2      3     32
src/install/patch_install.rs                              3      3     32
src/sys/lib.rs                                           11     21     33
test/cli/install/bun-install-tempdir-cleanup.test.ts      4      8     32
```

</details>

**root cause** · written by the author bot

When two installs raced to publish the same package into the global cache, `renameat_concurrently` used a swap-and-replace (`RENAME_EXCHANGE`) strategy that left the loser's extracted tree stranded in `$TMPDIR`, and several error paths in tarball extraction and patch application returned without removing their temp directory at all. The fix changes the cache publish to first-writer-wins via a new `keep_existing_destination` option, which deletes the caller's private temp copy when the destination already exists, and adds scope guards so failed extractions and patch applications clean up the…

<!-- robobun:evidence:end -->
