### PR TITLE
install: skip --no-orphans subreaper path for internal git spawns

### DIFF
--- a/src/spawn/lib.rs
+++ b/src/spawn/lib.rs
@@ -399,6 +399,11 @@ pub fn run(opts: RunOptions<'_>) -> crate::Result<RunResult> {
         stdout: process::sync::SyncStdio::Buffer,
         stderr: process::sync::SyncStdio::Buffer,
         argv0: argv0_ptr,
+        // `run()` is a capture-output helper (sole caller: `repository::exec`),
+        // not the `bun run` script path. `bun install` calls it on the main
+        // thread (`find_commit`) while its threadpool has live `git clone`
+        // children, which the `--no-orphans` subreaper cleanup would SIGKILL.
+        no_orphans_reap: false,
         // `process::sync::spawn` → `spawn_process_windows`
         // reads `options.windows.loop_` to get the `uv_loop_t*`.
         // `WindowsOptions::default()` leaves `loop_` zeroed,

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -2271,6 +2271,12 @@ mod spawn_process_body {
             pub use_execve_on_macos: bool,
             pub argv0: Option<*const c_char>,
 
+            /// Opt out of the `--no-orphans` subreaper/`wait4(-1)`/adoptee-kill
+            /// path in `spawn_posix` even on the watchdog-arming thread. Set by
+            /// callers that run alongside other managed subprocesses (notably
+            /// `bun install`'s `repository::exec` via `bun_spawn::run`).
+            pub no_orphans_reap: bool,
+
             #[cfg(windows)]
             pub windows: WindowsOptions,
             #[cfg(not(windows))]
@@ -2338,6 +2344,7 @@ mod spawn_process_body {
                     envp: None,
                     use_execve_on_macos: false,
                     argv0: None,
+                    no_orphans_reap: true,
                     #[cfg(windows)]
                     windows: Default::default(),
                     #[cfg(not(windows))]
@@ -3031,7 +3038,14 @@ mod spawn_process_body {
             // exit statuses. Those callers fall through to the plain
             // `reap_child(pid)` path below; the inherited PDEATHSIG on the main
             // thread still tears the whole process down if our parent dies.
-            let no_orphans = ParentDeathWatchdog::is_enabled()
+            //
+            // Also disabled when the caller opts out via `no_orphans_reap`:
+            // `repository::exec` reaches this on the main thread for
+            // `find_commit`'s `git log` while other git clones are live on the
+            // install threadpool; arming here SIGKILLs them in
+            // `kill_subreaper_adoptees` or steals their status in `wait4(-1)`.
+            let no_orphans = options.no_orphans_reap
+                && ParentDeathWatchdog::is_enabled()
                 && bun_spawn_sys::pdeathsig::is_arming_thread()
                 && !(cfg!(target_os = "macos") && options.use_execve_on_macos);
 

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -2271,10 +2271,11 @@ mod spawn_process_body {
             pub use_execve_on_macos: bool,
             pub argv0: Option<*const c_char>,
 
-            /// Opt out of the `--no-orphans` subreaper/`wait4(-1)`/adoptee-kill
-            /// path in `spawn_posix` even on the watchdog-arming thread. Set by
-            /// callers that run alongside other managed subprocesses (notably
-            /// `bun install`'s `repository::exec` via `bun_spawn::run`).
+            /// When `true` (default), participate in the `--no-orphans`
+            /// subreaper/`wait4(-1)`/adoptee-kill path in `spawn_posix` on the
+            /// watchdog-arming thread. Set to `false` by callers that run
+            /// alongside other managed subprocesses (notably `bun install`'s
+            /// `repository::exec` via `bun_spawn::run`).
             pub no_orphans_reap: bool,
 
             #[cfg(windows)]

--- a/test/cli/run/no-orphans.test.ts
+++ b/test/cli/run/no-orphans.test.ts
@@ -971,3 +971,89 @@ test.concurrent.skipIf(!isSupported || !hasPerl)(
     }
   },
 );
+
+// `bun install` resolves git dependencies by shelling out to `git` via
+// `bun_spawn::run` -> `process::sync::spawn`. `find_commit` (`git log`) runs on
+// the main thread while git clones / checkouts run on the install threadpool.
+// The `--no-orphans` spawnSync path arms PR_SET_CHILD_SUBREAPER + a `wait4(-1)`
+// reap loop and finishes with `kill_subreaper_adoptees`, which SIGKILLs any
+// direct child that was not in the pre-spawn snapshot; a threadpool `git clone`
+// forked during that window dies with "git failed with signal 9" (observed as
+// repeated flakes of test/cli/install/migration/complex-workspace.test.ts on the
+// x64-asan CI lane, which sets BUN_FEATURE_FLAG_NO_ORPHANS for every test).
+//
+// `bun_spawn::run` now opts out of that path. This test observes the mechanism
+// deterministically rather than the race: when the subreaper path is armed the
+// git child is placed in its own process group (`new_process_group = no_orphans`
+// in `sync::spawn_posix`), so a fake `git` on PATH records whether `git log`'s
+// pgid equals its pid. With the opt-out applied it must not.
+test.concurrent.skipIf(!isLinux)(
+  "BUN_FEATURE_FLAG_NO_ORPHANS=1: bun install's internal git calls do not arm the subreaper reap path",
+  async () => {
+    const fakeGit =
+      `#!/bin/sh\n` +
+      `last=""\n` +
+      `for a in "$@"; do last="$a"; done\n` +
+      // pgid from /proc/self/stat (field 3 after the comm close-paren). The awk
+      // child inherits the shell's process group, so this reads the pgid bun
+      // assigned to the spawned `git`.
+      `pgid=$(awk -F'\\\\) ' '{split($2,a," "); print a[3]}' /proc/self/stat)\n` +
+      `if [ "$pgid" = "$$" ]; then grp=own; else grp=parent; fi\n` +
+      `case "$*" in\n` +
+      `  *" log "*)\n` +
+      `    echo "log $grp" >> "$FAKE_GIT_MARKER"\n` +
+      `    echo abcdef0123456789abcdef0123456789abcdef01\n` +
+      `    ;;\n` +
+      `  *"--bare"*)\n` +
+      `    echo "clone-bare $grp" >> "$FAKE_GIT_MARKER"\n` +
+      `    mkdir -p "$last"\n` +
+      `    ;;\n` +
+      `  *"--no-checkout"*)\n` +
+      `    echo "clone-no-checkout $grp" >> "$FAKE_GIT_MARKER"\n` +
+      `    mkdir -p "$last"\n` +
+      `    printf '{"name":"fake-dep","version":"1.0.0"}' > "$last/package.json"\n` +
+      `    ;;\n` +
+      `  *) ;;\n` +
+      `esac\n`;
+
+    using dir = tempDir("no-orphans-install-git", {
+      "bin/git": fakeGit,
+      "package.json": JSON.stringify({
+        name: "no-orphans-install-git",
+        dependencies: { "dep-a": "git+file:///fake/repo-a" },
+      }),
+    });
+    chmodSync(`${dir}/bin/git`, 0o755);
+
+    const env: Record<string, string> = {
+      ...bunEnv,
+      BUN_FEATURE_FLAG_NO_ORPHANS: "1",
+      BUN_INSTALL_CACHE_DIR: `${dir}/cache`,
+      FAKE_GIT_MARKER: `${dir}/marker.txt`,
+      PATH: `${dir}/bin:${process.env.PATH ?? ""}`,
+    };
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      env,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const marker = readFileSync(`${dir}/marker.txt`, "utf8").trim();
+    // `git log` is the `find_commit` call on the main thread. "own" means
+    // `sync::spawn_posix` put it in its own process group, i.e. the
+    // `--no-orphans` subreaper/`kill_subreaper_adoptees` path was armed and
+    // would SIGKILL any concurrent threadpool `git` child. The threadpool
+    // checkout step is always "parent" (not the watchdog-arming thread) and
+    // acts as a control that the pgid probe itself works.
+    expect({ stdout, stderr, exitCode, marker }).toEqual({
+      stdout: expect.stringContaining("1 package installed"),
+      stderr: expect.any(String),
+      exitCode: 0,
+      marker: ["log parent", "clone-no-checkout parent"].join("\n"),
+    });
+  },
+);

--- a/test/cli/run/no-orphans.test.ts
+++ b/test/cli/run/no-orphans.test.ts
@@ -1004,10 +1004,6 @@ test.concurrent.skipIf(!isLinux)(
       `    echo "log $grp" >> "$FAKE_GIT_MARKER"\n` +
       `    echo abcdef0123456789abcdef0123456789abcdef01\n` +
       `    ;;\n` +
-      `  *"--bare"*)\n` +
-      `    echo "clone-bare $grp" >> "$FAKE_GIT_MARKER"\n` +
-      `    mkdir -p "$last"\n` +
-      `    ;;\n` +
       `  *"--no-checkout"*)\n` +
       `    echo "clone-no-checkout $grp" >> "$FAKE_GIT_MARKER"\n` +
       `    mkdir -p "$last"\n` +
@@ -1016,6 +1012,10 @@ test.concurrent.skipIf(!isLinux)(
       `  *) ;;\n` +
       `esac\n`;
 
+    // `git+file://` matches neither `try_https` nor `try_ssh`, so the
+    // threadpool GitClone task never runs `git clone --bare` (Repository::
+    // download). `find_commit`'s `git log` on the main thread is the first git
+    // invocation, followed by the threadpool checkout step.
     using dir = tempDir("no-orphans-install-git", {
       "bin/git": fakeGit,
       "package.json": JSON.stringify({


### PR DESCRIPTION
`test/cli/install/migration/complex-workspace.test.ts` has been flaking near-constantly on the `:debian: 13 x64-asan` lane (dozens of builds since ~71375, one hard red in [71888](https://buildkite.com/bun/bun/builds/71888)) with:

```
error: git failed with signal 9
error: git failed with signal 9
error: "git clone" for "install-test1" failed
error: InstallFailed cloning repository for install-test1
```

### Cause

`scripts/runner.node.mjs` sets `BUN_FEATURE_FLAG_NO_ORPHANS=1` for every test on ASAN lanes (since #30875), which `bunEnv` propagates into the `bun install` the test spawns.

Inside that `bun install`:

- `Repository::find_commit` runs `git log` via `bun_spawn::run` -> `process::sync::spawn_posix` **on the main thread** (reached from `runTasks.rs:1375` and `PackageManagerEnqueue.rs:1237`).
- The `git clone` / `git checkout` tasks run via the same helper **on threadpool workers**.

`sync::spawn_posix` on the watchdog-arming (main) thread with no-orphans enabled:

1. snapshots the current direct children,
2. arms `PR_SET_CHILD_SUBREAPER`,
3. runs a `wait4(-1, WNOHANG)` reap loop while waiting on the child,
4. on return calls `kill_subreaper_adoptees(snapshot)`, which SIGKILLs every direct child not in the snapshot.

That machinery is intended for `bun run`/`bunx`, where the script is the only interesting subprocess. When `find_commit` reaches it, any threadpool `git clone` forked between steps 1 and 4 is SIGKILLed, and any that exits during step 3 has its status stolen. ASAN slows the threadpool worker's path from "task picked" to "fork" enough to hit this window regularly.

The existing `is_arming_thread()` guard only covers calls issued *from* worker threads; it does not cover a main-thread caller running alongside worker-thread children.

### Fix

Add `sync::Options::no_orphans_reap` (default `true`) and gate the subreaper/pgroup/adoptee-kill path on it in `spawn_posix`. `bun_spawn::run` sets it to `false`: its sole caller is `repository::exec`, which is a capture-output utility, not the user-script path. `bun run`/`bunx`/`create`/etc. keep the default.

### Verification

New test in `test/cli/run/no-orphans.test.ts` observes the mechanism deterministically rather than the race: it puts a fake `git` on `PATH` that records whether each invocation was placed in its own process group (`new_process_group = no_orphans` in `spawn_posix`). With `BUN_FEATURE_FLAG_NO_ORPHANS=1`:

- before: `find_commit`'s `git log` reports `own` (subreaper path armed),
- after: it reports `parent`, same as the threadpool steps.

```
$ USE_SYSTEM_BUN=1 bun test test/cli/run/no-orphans.test.ts -t "internal git"
  marker: "log own\nclone-no-checkout parent"   # fail
$ bun bd test test/cli/run/no-orphans.test.ts -t "internal git"
  marker: "log parent\nclone-no-checkout parent" # pass
```

Introduced by #30875.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/migration/complex-workspace.test.ts test/cli/run/no-orphans.test.ts

<!-- robobun:evidence:end -->