### PR TITLE
test(node-http-connect): sequence partial-writes test on conditions, not fixed delays

### DIFF
--- a/test/js/node/http/node-http-connect.node.mts
+++ b/test/js/node/http/node-http-connect.node.mts
@@ -308,11 +308,13 @@ describe("HTTP server CONNECT", () => {
     let bufferReceived = "";
 
     proxyServer.on("connect", (req, socket, head) => {
+      let sentTestData = false;
       socket.on("data", chunk => {
         bufferReceived += chunk.toString();
         // End only once the client's tunneled bytes have arrived so the
         // assertion on bufferReceived is not racing the server's FIN.
-        if (bufferReceived.includes("Client data")) {
+        if (!sentTestData && bufferReceived.includes("Client data")) {
+          sentTestData = true;
           socket.write("Test data");
           socket.end();
         }

--- a/test/js/node/http/node-http-connect.node.mts
+++ b/test/js/node/http/node-http-connect.node.mts
@@ -310,6 +310,12 @@ describe("HTTP server CONNECT", () => {
     proxyServer.on("connect", (req, socket, head) => {
       socket.on("data", chunk => {
         bufferReceived += chunk.toString();
+        // End only once the client's tunneled bytes have arrived so the
+        // assertion on bufferReceived is not racing the server's FIN.
+        if (bufferReceived.includes("Client data")) {
+          socket.write("Test data");
+          socket.end();
+        }
       });
 
       // Send response in small chunks
@@ -317,10 +323,6 @@ describe("HTTP server CONNECT", () => {
       setTimeout(() => socket.write("200 "), 10);
       setTimeout(() => socket.write("Connection "), 20);
       setTimeout(() => socket.write("established\r\n\r\n"), 30);
-      setTimeout(() => {
-        socket.write("Test data");
-        socket.end();
-      }, 40);
     });
 
     await once(proxyServer.listen(0, "127.0.0.1"), "listening");
@@ -331,14 +333,19 @@ describe("HTTP server CONNECT", () => {
       client.write("CONNECT example.com:80 ");
       setTimeout(() => client.write("HTTP/1.1\r\n"), 5);
       setTimeout(() => client.write("Host: example.com\r\n\r\n"), 10);
-      setTimeout(() => client.write("Client data"), 35);
     });
 
     const { promise, resolve } = Promise.withResolvers<string>();
     const received: string[] = [];
+    let sentClientData = false;
 
     client.on("data", data => {
       received.push(data.toString());
+      // Send the client bytes once the tunnel is up, not at a fixed delay.
+      if (!sentClientData && received.join("").includes("Connection established\r\n\r\n")) {
+        sentClientData = true;
+        client.write("Client data");
+      }
     });
 
     client.on("end", () => {

--- a/test/js/node/http/node-http-connect.node.mts
+++ b/test/js/node/http/node-http-connect.node.mts
@@ -305,45 +305,47 @@ describe("HTTP server CONNECT", () => {
 
   test("should handle partial writes and buffering", async () => {
     await using proxyServer = http.createServer();
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
     let bufferReceived = "";
 
     proxyServer.on("connect", (req, socket, head) => {
       let sentTestData = false;
+      socket.on("error", reject);
       socket.on("data", chunk => {
         bufferReceived += chunk.toString();
         // End only once the client's tunneled bytes have arrived so the
         // assertion on bufferReceived is not racing the server's FIN.
         if (!sentTestData && bufferReceived.includes("Client data")) {
           sentTestData = true;
-          socket.write("Test data");
-          socket.end();
+          socket.write("Test data", () => socket.end());
         }
       });
 
-      // Send response in small chunks
-      socket.write("HTTP/1.1 ");
-      setTimeout(() => socket.write("200 "), 10);
-      setTimeout(() => socket.write("Connection "), 20);
-      setTimeout(() => socket.write("established\r\n\r\n"), 30);
+      // Send response in small chunks, each after the previous is flushed.
+      socket.write("HTTP/1.1 ", () =>
+        socket.write("200 ", () =>
+          socket.write("Connection ", () => socket.write("established\r\n\r\n")),
+        ),
+      );
     });
 
     await once(proxyServer.listen(0, "127.0.0.1"), "listening");
     const proxyAddress = proxyServer.address() as AddressInfo;
 
     const client = net.connect(proxyAddress.port, proxyAddress.address, () => {
-      // Send request in chunks
-      client.write("CONNECT example.com:80 ");
-      setTimeout(() => client.write("HTTP/1.1\r\n"), 5);
-      setTimeout(() => client.write("Host: example.com\r\n\r\n"), 10);
+      // Send request in chunks, each after the previous is flushed.
+      client.write("CONNECT example.com:80 ", () =>
+        client.write("HTTP/1.1\r\n", () => client.write("Host: example.com\r\n\r\n")),
+      );
     });
 
-    const { promise, resolve } = Promise.withResolvers<string>();
     const received: string[] = [];
     let sentClientData = false;
 
+    client.on("error", reject);
     client.on("data", data => {
       received.push(data.toString());
-      // Send the client bytes once the tunnel is up, not at a fixed delay.
+      // Send the client bytes once the tunnel is up.
       if (!sentClientData && received.join("").includes("Connection established\r\n\r\n")) {
         sentClientData = true;
         client.write("Client data");

--- a/test/js/node/http/node-http-connect.node.mts
+++ b/test/js/node/http/node-http-connect.node.mts
@@ -304,6 +304,15 @@ describe("HTTP server CONNECT", () => {
   });
 
   test("should handle partial writes and buffering", async () => {
+    // Write each chunk, wait for its write callback, then yield one I/O poll so
+    // the peer sees a fragmented stream without any fixed-delay timers.
+    async function writeChunked(sock: net.Socket, chunks: string[]) {
+      for (const chunk of chunks) {
+        await new Promise<void>((res, rej) => sock.write(chunk, e => (e ? rej(e) : res())));
+        await new Promise<void>(res => setImmediate(res));
+      }
+    }
+
     await using proxyServer = http.createServer();
     const { promise, resolve, reject } = Promise.withResolvers<string>();
     let bufferReceived = "";
@@ -321,22 +330,14 @@ describe("HTTP server CONNECT", () => {
         }
       });
 
-      // Send response in small chunks, each after the previous is flushed.
-      socket.write("HTTP/1.1 ", () =>
-        socket.write("200 ", () =>
-          socket.write("Connection ", () => socket.write("established\r\n\r\n")),
-        ),
-      );
+      writeChunked(socket, ["HTTP/1.1 ", "200 ", "Connection ", "established\r\n\r\n"]).catch(reject);
     });
 
     await once(proxyServer.listen(0, "127.0.0.1"), "listening");
     const proxyAddress = proxyServer.address() as AddressInfo;
 
     const client = net.connect(proxyAddress.port, proxyAddress.address, () => {
-      // Send request in chunks, each after the previous is flushed.
-      client.write("CONNECT example.com:80 ", () =>
-        client.write("HTTP/1.1\r\n", () => client.write("Host: example.com\r\n\r\n")),
-      );
+      writeChunked(client, ["CONNECT example.com:80 ", "HTTP/1.1\r\n", "Host: example.com\r\n\r\n"]).catch(reject);
     });
 
     const received: string[] = [];


### PR DESCRIPTION
"should handle partial writes and buffering" in `node-http-connect.node.mts` wrote `"Client data"` from the client at a fixed `t=35ms` while the server wrote `"Test data"`+`end()` at `t=40ms` relative to its own `'connect'` event. Under CPU load on Windows the client's 35ms timer fires late enough that the server's FIN reaches the client first, the awaited promise resolves on the client's `'end'`, and the assertion on `bufferReceived` runs before the server's data handler has seen the bytes.

Seen red on Windows 2019 x64-baseline in two unrelated PR builds: [71915](https://buildkite.com/bun/bun/builds/71915) (#33974, epoll-only change) and [71800](https://buildkite.com/bun/bun/builds/71800) (#33183, a types-only change), both with:

```
AssertionError: false == true
      at toContain (...\node-http-connect.node.mts:18:14)
      at ...\node-http-connect.node.mts:351:28
(fail) HTTP server CONNECT > should handle partial writes and buffering
```

Reproduced locally on Windows with 16 background spinners: 8/50 runs fail. After this change, 0/100 under the same load.

The test no longer uses `setTimeout`. A `writeChunked` helper writes each chunk, awaits its write callback, then yields one `setImmediate` so the peer still sees a fragmented stream (verified: 1 `'data'` event with a bare write-callback chain vs 3 with this helper, both Node and Bun). The client sends `"Client data"` once it has seen the full `"Connection established"` response, the server ends only once it has received it (from the `"Test data"` write callback so the FIN cannot outrun it), and both sockets have `'error'` wired to reject the awaited promise. Passes under Node and Bun on Linux and Windows.

The test landed in #22756 and has had this race since then.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->