### PR TITLE
test(proxy-stress-matrix): share proxy pair across concurrent tests

### DIFF
--- a/test/js/bun/http/proxy-stress-matrix.test.ts
+++ b/test/js/bun/http/proxy-stress-matrix.test.ts
@@ -24,13 +24,9 @@ import {
   restoreProxyEnv,
 } from "./proxy-stress-helpers";
 
-// Concurrency note: ~335 test.concurrent cases share one {http, https} proxy
-// pair from beforeAll. With a fresh proxy per test this file issued ~335
-// listen(0) calls for proxies alone; under the runner's rolling concurrency
-// window on darwin that churn lets a just-freed ephemeral port be handed to a
-// sibling test while this one is still mid-dial, surfacing as a one-off
-// ConnectionRefused. Tests that pass non-default proxy options or inspect
-// proxy.connections still create a dedicated proxy.
+// Concurrent stateless cases share one {http, https} proxy pair to avoid
+// ephemeral-port churn under test.concurrent; cases that pass non-default
+// proxy options or inspect proxy.connections still create a dedicated proxy.
 let savedEnv: Record<string, string | undefined>;
 let sharedHttpProxy: AdversarialProxy;
 let sharedHttpsProxy: AdversarialProxy;
@@ -42,13 +38,15 @@ beforeAll(async () => {
   sharedHttpsProxy = await createAdversarialProxy({ tls: true });
 });
 afterAll(async () => {
-  // Smoke check: the shared proxies actually carried traffic (i.e. the
-  // `proxy:` option was honored, not silently bypassed).
-  expect(sharedHttpProxy.connections.length).toBeGreaterThan(0);
-  expect(sharedHttpsProxy.connections.length).toBeGreaterThan(0);
-  await sharedHttpProxy?.close();
-  await sharedHttpsProxy?.close();
-  restoreProxyEnv(savedEnv);
+  try {
+    // Smoke check: the shared proxies actually carried traffic.
+    expect(sharedHttpProxy?.connections.length).toBeGreaterThan(0);
+    expect(sharedHttpsProxy?.connections.length).toBeGreaterThan(0);
+  } finally {
+    await sharedHttpProxy?.close();
+    await sharedHttpsProxy?.close();
+    restoreProxyEnv(savedEnv);
+  }
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/test/js/bun/http/proxy-stress-matrix.test.ts
+++ b/test/js/bun/http/proxy-stress-matrix.test.ts
@@ -12,6 +12,7 @@
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
+  AdversarialProxy,
   BodyEncoding,
   BodyFraming,
   cartesian,
@@ -23,11 +24,30 @@ import {
   restoreProxyEnv,
 } from "./proxy-stress-helpers";
 
+// Concurrency note: ~335 test.concurrent cases share one {http, https} proxy
+// pair from beforeAll. With a fresh proxy per test this file issued ~335
+// listen(0) calls for proxies alone; under the runner's rolling concurrency
+// window on darwin that churn lets a just-freed ephemeral port be handed to a
+// sibling test while this one is still mid-dial, surfacing as a one-off
+// ConnectionRefused. Tests that pass non-default proxy options or inspect
+// proxy.connections still create a dedicated proxy.
 let savedEnv: Record<string, string | undefined>;
-beforeAll(() => {
+let sharedHttpProxy: AdversarialProxy;
+let sharedHttpsProxy: AdversarialProxy;
+const sharedProxy = (tls: boolean) => (tls ? sharedHttpsProxy : sharedHttpProxy);
+
+beforeAll(async () => {
   savedEnv = clearProxyEnv();
+  sharedHttpProxy = await createAdversarialProxy({ tls: false });
+  sharedHttpsProxy = await createAdversarialProxy({ tls: true });
 });
-afterAll(() => {
+afterAll(async () => {
+  // Smoke check: the shared proxies actually carried traffic (i.e. the
+  // `proxy:` option was honored, not silently bypassed).
+  expect(sharedHttpProxy.connections.length).toBeGreaterThan(0);
+  expect(sharedHttpsProxy.connections.length).toBeGreaterThan(0);
+  await sharedHttpProxy?.close();
+  await sharedHttpsProxy?.close();
   restoreProxyEnv(savedEnv);
 });
 
@@ -62,7 +82,7 @@ describe("response matrix", () => {
         framing,
         encoding,
       });
-      await using proxy = await createAdversarialProxy({ tls: proxyTls });
+      const proxy = sharedProxy(proxyTls);
 
       const res = await fetch(origin.url, {
         proxy: proxy.url,
@@ -76,15 +96,8 @@ describe("response matrix", () => {
         head: payload.slice(0, 8),
         tail: payload.slice(-8),
       });
-
-      // The request actually went through the proxy.
-      expect(proxy.connections.length).toBe(1);
-      if (originTls) {
-        expect(proxy.connections[0].method).toBe("CONNECT");
-      } else {
-        expect(proxy.connections[0].method).toBe("GET");
-        expect(proxy.connections[0].target).toStartWith("http://");
-      }
+      // CONNECT vs absolute-form selection is asserted per-connection in the
+      // "redirect through proxy" block below, which uses a dedicated proxy.
     });
   }
 });
@@ -173,7 +186,7 @@ describe("upload matrix", () => {
     test.concurrent(label, async () => {
       const payload = makeBody(bodySize, "U");
       await using origin = await createAdversarialOrigin({ tls: originTls, echo: true });
-      await using proxy = await createAdversarialProxy({ tls: proxyTls });
+      const proxy = sharedProxy(proxyTls);
 
       const { body, duplex, verify } = makeUploadBody(shape, payload);
       const res = await fetch(origin.url, {
@@ -212,7 +225,7 @@ describe("streamed response via reader", () => {
       async () => {
         const payload = makeBody(128 * 1024, "S");
         await using origin = await createAdversarialOrigin({ tls: originTls, body: payload, framing });
-        await using proxy = await createAdversarialProxy({ tls: proxyTls });
+        const proxy = sharedProxy(proxyTls);
 
         const res = await fetch(origin.url, { proxy: proxy.url, keepalive: false, tls: laxTls });
         expect(res.status).toBe(200);
@@ -348,7 +361,7 @@ describe("method matrix", () => {
         `${method} via ${proxyTls ? "https" : "http"}-proxy → ${originTls ? "https" : "http"}-origin`,
         async () => {
           await using origin = await createAdversarialOrigin({ tls: originTls, body: "m" });
-          await using proxy = await createAdversarialProxy({ tls: proxyTls });
+          const proxy = sharedProxy(proxyTls);
 
           const res = await fetch(origin.url, {
             method,

--- a/test/js/bun/http/proxy-stress-matrix.test.ts
+++ b/test/js/bun/http/proxy-stress-matrix.test.ts
@@ -38,15 +38,9 @@ beforeAll(async () => {
   sharedHttpsProxy = await createAdversarialProxy({ tls: true });
 });
 afterAll(async () => {
-  try {
-    // Smoke check: the shared proxies actually carried traffic.
-    expect(sharedHttpProxy?.connections.length).toBeGreaterThan(0);
-    expect(sharedHttpsProxy?.connections.length).toBeGreaterThan(0);
-  } finally {
-    await sharedHttpProxy?.close();
-    await sharedHttpsProxy?.close();
-    restoreProxyEnv(savedEnv);
-  }
+  await sharedHttpProxy?.close();
+  await sharedHttpsProxy?.close();
+  restoreProxyEnv(savedEnv);
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/test/js/bun/http/proxy-stress-matrix.test.ts
+++ b/test/js/bun/http/proxy-stress-matrix.test.ts
@@ -43,6 +43,14 @@ afterAll(async () => {
   restoreProxyEnv(savedEnv);
 });
 
+// Find this test's entry in the shared proxy log: the origin port is unique
+// while its `await using` scope holds it, so the single record in
+// `connections.slice(before)` whose target is that exact port is ours.
+function ownConnections(proxy: AdversarialProxy, before: number, originPort: number) {
+  const p = `:${originPort}`;
+  return proxy.connections.slice(before).filter(c => c.target.endsWith(p) || c.target.includes(p + "/"));
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Response-side matrix: every way the origin can frame/encode a body, through
 // every proxy/origin TLS combination.
@@ -75,6 +83,7 @@ describe("response matrix", () => {
         encoding,
       });
       const proxy = sharedProxy(proxyTls);
+      const before = proxy.connections.length;
 
       const res = await fetch(origin.url, {
         proxy: proxy.url,
@@ -88,8 +97,16 @@ describe("response matrix", () => {
         head: payload.slice(0, 8),
         tail: payload.slice(-8),
       });
-      // CONNECT vs absolute-form selection is asserted per-connection in the
-      // "redirect through proxy" block below, which uses a dedicated proxy.
+
+      // The request actually went through the proxy, with the right envelope.
+      const mine = ownConnections(proxy, before, origin.port);
+      expect(mine.length).toBe(1);
+      if (originTls) {
+        expect(mine[0].method).toBe("CONNECT");
+      } else {
+        expect(mine[0].method).toBe("GET");
+        expect(mine[0].target).toStartWith("http://");
+      }
     });
   }
 });


### PR DESCRIPTION
## Problem

`test/js/bun/http/proxy-stress-matrix.test.ts` went red on darwin 14 aarch64 in [build 71934](https://buildkite.com/bun/bun/builds/71934):

```
error: Unable to connect. Is the computer able to access the url?
  path: "https://localhost:60036/",
 errno: 0,
  code: "ConnectionRefused"
✗ response matrix > https-proxy → https-origin chunked/deflate 65536B keepalive=true
334 pass / 1 fail
```

The runner additionally labelled it "5 crashes reported", which skipped the automatic retry; those crashes are the intentional ones from `run-crash-handler.test.ts` and `native_plugin_test` earlier in the same shard that the crash-report collector misattributed (the traces carry `0xDEADBEEF` / `invoked crashByPanic() handler`). The single ConnectionRefused is the actual failure.

## Cause

Same mechanism #33975 diagnosed for the sibling `proxy-stress-headers.test.ts`: 335 `test.concurrent` cases each create a fresh adversarial proxy + origin, so the file issues ~676 `listen(0, "127.0.0.1")` calls in <1s under the runner's rolling concurrency window. As early tests dispose their servers, a later test's `listen(0)` can be handed a just-freed port while a sibling is still mid-dial (the proxy's `net.connect(port, "localhost")` goes through autoSelectFamily, adding async hops between port capture and connect). #33975 left this file alone because it was not yet red in CI; now it is.

## Fix

Share one `{http, https}` proxy pair from `beforeAll` across the 316 tests that use a default stateless proxy (response / upload / stream / method matrices). Tests that pass non-default proxy options or assert on the full `proxy.connections` array (trickled, split-CONNECT, CONNECT-headers, hop-by-hop, redirect) keep dedicated proxies. This drops per-file `listen(0)` churn from ~676 to ~362.

The response matrix's per-test `proxy.connections` assertions are preserved: each test owns a unique origin port for the duration of its `await using` scope, so `ownConnections()` filters the shared proxy's append-only log by that port (sliced from the index captured before the fetch) to unambiguously recover this test's record under `test.concurrent`, and asserts exactly-one-connection / CONNECT-vs-GET / `http://` target on it as before.

335 tests, 1126 `expect()` calls: identical to main. Introduced by #32635; related sibling fix is #33975.

## Verification

```
bun bd test test/js/bun/http/proxy-stress-matrix.test.ts                # 335 pass, 1126 expect() (debug+ASAN)
bun bd test test/js/bun/http/proxy-stress-matrix.test.ts -t "trickled"  # 2 pass, 333 filtered, 0 fail
```
10 consecutive release runs on linux, all clean (1126 expect() each). [Build 71938](https://buildkite.com/bun/bun/builds/71938) ran this file clean on every darwin lane (14 aarch64 × 2 shards, 14 x64, 26 aarch64 × 2).

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/http/proxy-stress-matrix.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/http/proxy-stress-matrix.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (fb9f9efdb)

test/js/bun/http/proxy-stress-matrix.test.ts:
(pass) response matrix > http-proxy → http-origin content-length/identity 128B keepalive=false [832.21ms]
(pass) response matrix > http-proxy → http-origin content-length/identity 128B keepalive=true [790.98ms]
(pass) response matrix > http-proxy → http-origin content-length/identity 65536B keepalive=false [790.77ms]
(pass) response matrix > http-proxy → http-origin content-length/identity 65536B keepalive=true [792.29ms]
(pass) response matrix > http-proxy → http-origin content-length/gzip 128B keepalive=false [889.55ms]
(pass) response matrix > http-proxy → http-origin content-length/gzip 128B keepalive=true [390.04ms]
(pass) response matrix > http-proxy → http-origin content-length/gzip 65536B keepalive=false [389.42ms]
(pass) response matrix > http-proxy → http-origin content-length/gzip 65536B keepalive=true [389.57ms]
(pass) response matrix > http-proxy → http-origin content-length/deflate 128B keepalive=false [387.09ms]
(pass) response matrix > http-proxy → http-origin content-length/deflate 128B keepalive=true [335.56ms]
(pass) response matrix > http-proxy → http-origin content-length/deflate 65536B keepalive=false [327.15ms]
(pass) response matrix > http-proxy → http-origin content-length/deflate 65536B keepalive=true [326.00ms]
(pass) response matrix > http-proxy → http-origin content-length/br 128B keepalive=false [325.91ms]
(pass) response matrix > http-proxy → http-origin content-length/br 128B keepalive=true [326.40ms]
(pass) response matrix > http-proxy → http-o
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/http/proxy-stress-matrix.test.ts | 44 +++++++++++++++++++++-------
 1 file changed, 33 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
test/js/bun/http/proxy-stress-matrix.test.ts      4      9      0
```

</details>

<!-- robobun:evidence:end -->