### PR TITLE
test(sql): use describeWithContainer in sql-prepare-false so it skips on the darwin agent where docker hangs

### DIFF
--- a/test/js/sql/sql-prepare-false.test.ts
+++ b/test/js/sql/sql-prepare-false.test.ts
@@ -1,45 +1,32 @@
 import { SQL } from "bun";
-import { afterAll, describe, expect, test } from "bun:test";
-import * as dockerCompose from "../../docker/index.ts";
+import { expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
 
 // Tests for `prepare: false` (unnamed prepared statements).
 // These verify that parameterized queries work correctly when using unnamed
 // prepared statements, which is critical for PgBouncer compatibility.
 
-describe("PostgreSQL prepare: false", async () => {
-  let container: { port: number; host: string };
-
-  try {
-    const info = await dockerCompose.ensure("postgres_plain");
-    container = { port: info.ports[5432], host: info.host };
-  } catch (e) {
-    test.skip(`Docker not available: ${e}`);
-    return;
-  }
-
-  const options = {
-    db: "bun_sql_test",
-    username: "bun_sql_test",
-    host: container.host,
-    port: container.port,
-    max: 1,
-    prepare: false,
-  };
-
-  afterAll(async () => {
-    if (!process.env.BUN_KEEP_DOCKER) {
-      await dockerCompose.down();
-    }
-  });
+describeWithContainer("PostgreSQL prepare: false", { image: "postgres_plain" }, container => {
+  const options = () =>
+    ({
+      db: "bun_sql_test",
+      username: "bun_sql_test",
+      host: container.host,
+      port: container.port,
+      max: 1,
+      prepare: false,
+    }) as const;
 
   test("basic parameterized query", async () => {
-    await using db = new SQL(options);
+    await container.ready;
+    await using db = new SQL(options());
     const [{ x }] = await db`SELECT ${42}::int AS x`;
     expect(x).toBe(42);
   });
 
   test("multiple parameterized queries sequentially", async () => {
-    await using db = new SQL(options);
+    await container.ready;
+    await using db = new SQL(options());
 
     const [{ a }] = await db`SELECT ${1}::int AS a`;
     expect(a).toBe(1);
@@ -52,7 +39,8 @@ describe("PostgreSQL prepare: false", async () => {
   });
 
   test("same query repeated with different params", async () => {
-    await using db = new SQL(options);
+    await container.ready;
+    await using db = new SQL(options());
     for (let i = 0; i < 10; i++) {
       const [{ x }] = await db`SELECT ${i}::int AS x`;
       expect(x).toBe(i);
@@ -62,7 +50,8 @@ describe("PostgreSQL prepare: false", async () => {
   test("concurrent queries with different tables return correct results", async () => {
     // This test simulates the scenario where concurrent unnamed prepared
     // statements could interfere with each other via PgBouncer.
-    await using db = new SQL({ ...options, max: 4 });
+    await container.ready;
+    await using db = new SQL({ ...options(), max: 4 });
 
     // Create real tables (not temp, so they're visible across connections)
     await db`CREATE TABLE IF NOT EXISTS prepare_false_test_a (id int, val text)`;
@@ -91,19 +80,22 @@ describe("PostgreSQL prepare: false", async () => {
   });
 
   test("parameterized query with multiple params", async () => {
-    await using db = new SQL(options);
+    await container.ready;
+    await using db = new SQL(options());
     const [{ sum }] = await db`SELECT (${10}::int + ${20}::int) AS sum`;
     expect(sum).toBe(30);
   });
 
   test("query without params still works", async () => {
-    await using db = new SQL(options);
+    await container.ready;
+    await using db = new SQL(options());
     const [{ x }] = await db`SELECT 1 AS x`;
     expect(x).toBe(1);
   });
 
   test("transactions with parameterized queries", async () => {
-    await using db = new SQL(options);
+    await container.ready;
+    await using db = new SQL(options());
 
     await db`CREATE TEMP TABLE IF NOT EXISTS tx_test (id int, val text)`;
 
@@ -119,7 +111,8 @@ describe("PostgreSQL prepare: false", async () => {
   });
 
   test("concurrent parameterized queries with high concurrency", async () => {
-    await using db = new SQL({ ...options, max: 8 });
+    await container.ready;
+    await using db = new SQL({ ...options(), max: 8 });
 
     // Fire many concurrent queries to stress-test unnamed statement handling
     const promises = [];


### PR DESCRIPTION
## What

Fixes `test/js/sql/sql-prepare-false.test.ts` going red on darwin x64 CI with `timeout` (and occasionally `crash reported`) since the `darwin-x64-mini-1` agent joined the `test-darwin` queue around build 70660.

Seen in builds 70820, 70844, 70855, 70866, 70909, 70964, 70976, 71002, 71019, 71040, 71172, 71187, 71234, 71293, 71443, 71453, 71495, 71701, 71806, 71828, 71934 (always on `darwin-x64-mini-1-1`, passes on every other darwin agent).

## Cause

`sql-prepare-false.test.ts` was the only file in `test/js/sql/` that called `dockerCompose.ensure("postgres_plain")` directly from an async `describe` instead of going through the `isDockerEnabled()` / `describeWithContainer` guard that every other container-backed sql test uses.

On `darwin-x64-mini-1` the docker client is on PATH but talking to it blocks: the valkey tests' `Bun.spawnSync([docker, "info"], {timeout: 5_000})` hits its 5s timeout on the same agent, while `isDockerEnabled()` (which goes through node `execSync`) returns `false` in under 100ms. So `ensure()`'s `Bun.spawn(["docker", "version"])` / `compose up` path hung until the runner's 180s per-file timeout killed the process with nothing printed after the `bun test` banner.

From [build 71293's darwin-x64-mini-1 shard](https://buildkite.com/bun/bun/builds/71293#019f4a02-883c-4d23-aee1-565728de91a4):

```
--- [927/1066] test/js/sql/sql-prepare-false.test.ts
bun test v1.4.0-canary.1 (0809bdd14)
--- [927/1066] test/js/sql/sql-prepare-false.test.ts - timeout
... 4 attempts, each exactly 180s ...
```

while on the same shard every neighboring `describeWithContainer`-guarded file skips in under 100ms:

```
--- [913/1066] test/js/sql/postgres-binary-numeric.test.ts
Ran 0 tests across 1 file. [68.00ms]
--- [924/1066] test/js/sql/sql-mysql.test.ts
Ran 0 tests across 1 file. [75.00ms]
```

In [build 71934](https://buildkite.com/bun/bun/builds/71934) the non-zero exit also tripped the runner's crash-report drain, so stale intentional crashes from `run-crash-handler.test.ts` (`crashByPanic`, `0xDEADBEEF`, `outOfMemory`) and a bundler `native-plugin` crash were attributed to this file and it surfaced as `crash reported` instead of `timeout`. That is the known limitation commented at [`scripts/runner.node.mjs:1453`](https://github.com/oven-sh/bun/blob/main/scripts/runner.node.mjs#L1453).

## Fix

Move the file onto `describeWithContainer("...", { image: "postgres_plain" }, container => ...)`, the same pattern used by `postgres-binary-numeric.test.ts`, `postgres-prepared-pipeline-reorder.test.ts`, `postgres-simple-query-pipeline.test.ts` and the other recent postgres tests. That helper already short-circuits on `!isDockerEnabled()` with a `describe.todo`, which is what every other sql test on that agent does today.

Also drops the `afterAll(dockerCompose.down())` which tore down the whole compose project (all services) for later files on the same shard; `describeWithContainer` intentionally leaves the shared containers up.

## Verification

All 8 cases still pass against a real postgres:

```
$ bun bd test test/js/sql/sql-prepare-false.test.ts
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) PostgreSQL prepare: false > basic parameterized query
(pass) PostgreSQL prepare: false > multiple parameterized queries sequentially
(pass) PostgreSQL prepare: false > same query repeated with different params
(pass) PostgreSQL prepare: false > concurrent queries with different tables return correct results
(pass) PostgreSQL prepare: false > parameterized query with multiple params
(pass) PostgreSQL prepare: false > query without params still works
(pass) PostgreSQL prepare: false > transactions with parameterized queries
(pass) PostgreSQL prepare: false > concurrent parameterized queries with high concurrency
 8 pass  0 fail
```

#31671 also touches this file for a different reason (making `isDockerEnabled()` throw on macOS CI when docker is absent); that change stacks cleanly on top of this one since `describeWithContainer` already routes through `isDockerEnabled()`.

The test was added in #27952; the hang was exposed when `darwin-x64-mini-1` joined the fleet.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/sql/sql-prepare-false.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/sql/sql-prepare-false.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (c992b92f1)

test/js/sql/sql-prepare-false.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) PostgreSQL prepare: false > basic parameterized query [243.39ms]
(pass) PostgreSQL prepare: false > multiple parameterized queries sequentially [70.17ms]
(pass) PostgreSQL prepare: false > same query repeated with different params [110.18ms]
(pass) PostgreSQL prepare: false > concurrent queries with different tables return correct results [138.41ms]
(pass) PostgreSQL prepare: false > parameterized query with multiple params [41.32ms]
(pass) PostgreSQL prepare: false > query without params still works [30.85ms]
(pass) PostgreSQL prepare: false > transactions with parameterized queries [122.23ms]
(pass) PostgreSQL prepare: false > concurrent parameterized queries with high concurrency [248.81ms]

 8 pass
 0 fail
 73 expect() calls
Ran 8 tests across 1 file. [3.46s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/sql/sql-prepare-false.test.ts | 63 ++++++++++++++++-------------------
 1 file changed, 28 insertions(+), 35 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
test/js/sql/sql-prepare-false.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->