### PR TITLE
test(proxy-stress-protocol): share proxy pair across concurrent tests

### DIFF
--- a/test/js/bun/http/proxy-stress-protocol.test.ts
+++ b/test/js/bun/http/proxy-stress-protocol.test.ts
@@ -12,6 +12,7 @@ import { once } from "node:events";
 import net from "node:net";
 import tls from "node:tls";
 import {
+  AdversarialProxy,
   cartesian,
   clearProxyEnv,
   createAdversarialOrigin,
@@ -22,11 +23,23 @@ import {
   tlsCert,
 } from "./proxy-stress-helpers";
 
+// Concurrency note: 102 tests share one {http, https} proxy pair from
+// beforeAll to avoid ephemeral-port reuse under test.concurrent's rolling
+// listen(0) churn. Tests that inspect proxy.connections keep a dedicated
+// proxy.
 let savedEnv: Record<string, string | undefined>;
-beforeAll(() => {
+let sharedHttpProxy: AdversarialProxy;
+let sharedHttpsProxy: AdversarialProxy;
+const sharedProxy = (tls: boolean) => (tls ? sharedHttpsProxy : sharedHttpProxy);
+
+beforeAll(async () => {
   savedEnv = clearProxyEnv();
+  sharedHttpProxy = await createAdversarialProxy({ tls: false });
+  sharedHttpsProxy = await createAdversarialProxy({ tls: true });
 });
-afterAll(() => {
+afterAll(async () => {
+  await sharedHttpProxy?.close();
+  await sharedHttpsProxy?.close();
   restoreProxyEnv(savedEnv);
 });
 
@@ -75,7 +88,7 @@ describe("early reply during upload", () => {
       `${proxyTls ? "https" : "http"}-proxy → ${originTls ? "https" : "http"}-origin, ${status} after 1KB of a 1MB upload`,
       async () => {
         await using origin = await makeEarlyReplyOrigin(status, 1024, originTls);
-        await using proxy = await createAdversarialProxy({ tls: proxyTls });
+        const proxy = sharedProxy(proxyTls);
         const res = await fetch(origin.url, {
           method: "POST",
           body: Buffer.alloc(1024 * 1024, "u"),
@@ -122,6 +135,7 @@ describe("multi-hop redirect through proxy", () => {
           origins.push({ close: () => o.close(), url: o.url });
           next = o.url;
         }
+        // This test inspects proxy.connections, so it needs a dedicated proxy.
         await using proxy = await createAdversarialProxy({ tls: proxyTls });
         try {
           const res = await fetch(next!, { proxy: proxy.url, keepalive: false, tls: laxTls });
@@ -160,7 +174,7 @@ describe("large response headers through tunnel", () => {
           body: "big",
           headers: { "X-Big": bigValue },
         });
-        await using proxy = await createAdversarialProxy({ tls: proxyTls });
+        const proxy = sharedProxy(proxyTls);
         const res = await fetch(origin.url, { proxy: proxy.url, keepalive: false, tls: laxTls });
         expect(await res.text()).toBe("big");
         expect(res.headers.get("x-big")).toBe(bigValue);
@@ -185,7 +199,7 @@ describe("large request headers through tunnel", () => {
       async () => {
         const bigValue = Buffer.alloc(size, "Q").toString("latin1");
         await using origin = await createAdversarialOrigin({ tls: originTls, body: "ok" });
-        await using proxy = await createAdversarialProxy({ tls: proxyTls });
+        const proxy = sharedProxy(proxyTls);
         const res = await fetch(origin.url, {
           proxy: proxy.url,
           keepalive: false,
@@ -234,7 +248,7 @@ describe("1xx through tunnel", () => {
       `${proxyTls ? "https" : "http"}-proxy → ${originTls ? "https" : "http"}-origin, ${info} then 200`,
       async () => {
         await using origin = await make1xxOrigin(originTls, info);
-        await using proxy = await createAdversarialProxy({ tls: proxyTls });
+        const proxy = sharedProxy(proxyTls);
         const res = await fetch(origin.url, {
           method: "POST",
           body: "x",
@@ -267,6 +281,7 @@ describe.skipIf(!isIPv6())("IPv6 literal origin through proxy", () => {
         tls: originTls ? tlsCert : undefined,
         fetch: () => new Response("v6"),
       });
+      // This test inspects proxy.connections, so it needs a dedicated proxy.
       await using proxy = await createAdversarialProxy({ tls: proxyTls });
       const scheme = originTls ? "https" : "http";
       const res = await fetch(`${scheme}://[::1]:${origin.port}/`, {
@@ -300,6 +315,7 @@ describe("many proxy.headers", () => {
       `${proxyTls ? "https" : "http"}-proxy → ${originTls ? "https" : "http"}-origin, ${count} proxy headers`,
       async () => {
         await using origin = await createAdversarialOrigin({ tls: originTls, body: "ok" });
+        // This test inspects proxy.connections, so it needs a dedicated proxy.
         await using proxy = await createAdversarialProxy({ tls: proxyTls });
         const headers: Record<string, string> = {};
         for (let i = 0; i < count; i++) headers[`X-Proxy-${i}`] = `v${i}`;
@@ -383,7 +399,7 @@ describe("HTTP/1.0 origin through tunnel", () => {
       `${proxyTls ? "https" : "http"}-proxy → ${originTls ? "https" : "http"}-origin HTTP/1.0`,
       async () => {
         await using origin = await makeHttp10Origin(originTls);
-        await using proxy = await createAdversarialProxy({ tls: proxyTls });
+        const proxy = sharedProxy(proxyTls);
         const res = await fetch(origin.url, { proxy: proxy.url, keepalive: false, tls: laxTls });
         expect(await res.text()).toBe("old-school");
         expect(res.status).toBe(200);
@@ -407,6 +423,7 @@ describe('redirect: "manual" through proxy', () => {
       async () => {
         await using target = await createAdversarialOrigin({ tls: originTls, body: "should-not-reach" });
         await using origin = await createAdversarialOrigin({ tls: originTls, redirectTo: target.url });
+        // This test inspects proxy.connections, so it needs a dedicated proxy.
         await using proxy = await createAdversarialProxy({ tls: proxyTls });
         const res = await fetch(origin.url, {
           proxy: proxy.url,
@@ -439,6 +456,7 @@ describe('redirect: "error" through proxy', () => {
           tls: originTls,
           redirectTo: "http://never-reached.invalid/",
         });
+        // This test inspects proxy.connections, so it needs a dedicated proxy.
         await using proxy = await createAdversarialProxy({ tls: proxyTls });
         await expect(
           fetch(origin.url, {
@@ -473,7 +491,7 @@ describe("response body consumers through tunnel", () => {
           body: payload,
           headers: consumer === "json" ? { "Content-Type": "application/json" } : {},
         });
-        await using proxy = await createAdversarialProxy({ tls: proxyTls });
+        const proxy = sharedProxy(proxyTls);
         const res = await fetch(origin.url, { proxy: proxy.url, keepalive: false, tls: laxTls });
         expect(res.status).toBe(200);
         switch (consumer) {


### PR DESCRIPTION
## Problem

`test/js/bun/http/proxy-stress-protocol.test.ts` has been flaking on darwin since it was added in #32635. Always exactly 1 of 102 tests, across darwin 14 x64 and 26 aarch64:

[build 71945](https://buildkite.com/bun/bun/builds/71945) (darwin 14 x64): the proxy's upstream dial reached an unrelated Express server instead of the test origin:
```
- "early"
+ "... Error ... Cannot POST / ..."
✗ early reply during upload > https-proxy → http-origin, 413 after 1KB of a 1MB upload
```

[build 71690](https://buildkite.com/bun/bun/builds/71690) (darwin 14 x64): reached a Verdaccio registry from another job on the same box:
```
- "final-5"
+ "... Verdaccio ... window.__VERDACCIO_BASENAME_UI_OPTIONS={...,\"base\":\"http://localhost:58343/\",...}"
✗ multi-hop redirect through proxy > https-proxy, 5-hop [s→h→s→h→s]
```

[build 71696](https://buildkite.com/bun/bun/builds/71696) (darwin 26 aarch64): 200 response from a server that was not the test origin:
```
TypeError: undefined is not an object (evaluating 'origin.requests[0].headers')
✗ large request headers through tunnel > http-proxy → http-origin, request header 512B
```

[build 71727](https://buildkite.com/bun/bun/builds/71727), [build 71795](https://buildkite.com/bun/bun/builds/71795): `ConnectionRefused` on the origin URL. All failed on the single CI retry.

## Cause

Same mechanism #33975 diagnosed for `proxy-stress-headers.test.ts` and #33984 for `proxy-stress-matrix.test.ts`: 102 `test.concurrent` cases each create a fresh adversarial proxy + origin, issuing ~200 `listen(0, "127.0.0.1")` calls per file under the test runner's rolling concurrency window. As early tests dispose their servers, a later test's `listen(0)` can be handed a just-freed port while a sibling is still mid-dial (the proxy's `net.connect(port, "localhost")` goes through autoSelectFamily, adding async hops between port capture and connect). On the persistent darwin runners the `"localhost"` dial can additionally land on an unrelated IPv6 listener (Verdaccio / Express from another job), which is why builds 71690 and 71945 received recognisable third-party HTML.

## Fix

Share one `{http, https}` proxy pair from `beforeAll` across the 68 tests that do not inspect `proxy.connections` (early-reply, large-headers, 1xx, HTTP/1.0, body-consumer matrices). The 32 tests that assert on the proxy's connection log (multi-hop redirect, IPv6, `many proxy.headers`, redirect manual/error) keep dedicated proxies. Per-file `listen(0)` churn drops from ~200 to ~134.

Coverage is unchanged: 102 tests, 508 `expect()` calls, identical to main. Same approach as the two open sibling PRs.

Introduced by #32635; sibling fixes are #33975 and #33984.

## Verification

```
bun bd test test/js/bun/http/proxy-stress-protocol.test.ts   # 102 pass, 508 expect() (debug+ASAN)
```
15 consecutive debug+ASAN runs and 30 release runs on linux, all clean.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/http/proxy-stress-protocol.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/http/proxy-stress-protocol.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (e926c3577)

test/js/bun/http/proxy-stress-protocol.test.ts:
(pass) early reply during upload > http-proxy → http-origin, 413 after 1KB of a 1MB upload [818.20ms]
(pass) early reply during upload > http-proxy → http-origin, 400 after 1KB of a 1MB upload [787.76ms]
(pass) early reply during upload > http-proxy → http-origin, 500 after 1KB of a 1MB upload [788.48ms]
(pass) early reply during upload > http-proxy → https-origin, 413 after 1KB of a 1MB upload [988.57ms]
(pass) early reply during upload > http-proxy → https-origin, 400 after 1KB of a 1MB upload [1089.31ms]
(pass) early reply during upload > https-proxy → http-origin, 413 after 1KB of a 1MB upload [522.18ms]
(pass) early reply during upload > https-proxy → http-origin, 400 after 1KB of a 1MB upload [526.23ms]
(pass) early reply during upload > https-proxy → http-origin, 500 after 1KB of a 1MB upload [366.37ms]
(pass) early reply during upload > http-proxy → https-origin, 500 after 1KB of a 1MB upload [687.29ms]
(pass) early reply during upload > https-proxy → https-origin, 413 after 1KB of a 1MB upload [545.75ms]
(pass) early reply during upload > https-proxy → https-origin, 400 after 1KB of a 1MB upload [521.02ms]
(pass) early reply during upload > https-proxy → https-origin, 500 after 1KB of a 1MB upload [520.15ms]
(pass) multi-hop redirect through proxy > http-proxy, 3-hop [h→h→h] [915.91ms]
(pass) multi-hop redirect through proxy > http-proxy, 3-hop [s→s→s] [1297.09ms]
(pass) multi-hop redirect through proxy > https-proxy, 3-hop [h→h→h] [932.18ms]
(pass) multi-ho
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/http/proxy-stress-protocol.test.ts | 34 ++++++++++++++++++++------
 1 file changed, 26 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
test/js/bun/http/proxy-stress-protocol.test.ts      1     12      0
```

</details>

<!-- robobun:evidence:end -->