### PR TITLE
test(fetch): widen fetch-leak RSS thresholds for macOS/Windows arm64

### DIFF
--- a/test/js/web/fetch/fetch-leak.test.ts
+++ b/test/js/web/fetch/fetch-leak.test.ts
@@ -293,8 +293,10 @@ test("fetch() compress option does not leak bodies or compressor state", async (
     const deltaMB = (final - baseline) / 1024 / 1024;
     console.log(JSON.stringify({ baselineMB: (baseline / 1024 / 1024) | 0, finalMB: (final / 1024 / 1024) | 0, deltaMB: Math.round(deltaMB) }));
     // 80 rounds × 5 encodings × ~700 KiB bodies → a per-request leak of the
-    // body or compressor state would grow RSS by hundreds of MB.
-    if (deltaMB > ${isASAN ? 256 : 32}) {
+    // body or compressor state would grow RSS by hundreds of MB. macOS arm64
+    // Tart runners settle at ~25-40 MB (vs 2-4 on Linux); 64 still catches a
+    // real leak by ~4x.
+    if (deltaMB > ${isASAN ? 256 : 64}) {
       throw new Error("fetch({compress}) leaked " + Math.round(deltaMB) + " MB over 80 rounds");
     }
   `;
@@ -403,7 +405,9 @@ test("fetch() does not leak streaming decompressor state across fragmented compr
     // 60 rounds × 3 encodings = 180 streaming Decompressor handles + 180
     // ~700 KiB compressed request bodies. A leaked boxed zlib/brotli/zstd
     // reader or an un-freed compressed body Vec would grow RSS by >100 MB.
-    if (deltaMB > ${isASAN ? 256 : 32}) {
+    // macOS arm64 Tart runners settle at ~32-43 MB where Linux measures ~9;
+    // 64 still catches a real leak with headroom.
+    if (deltaMB > ${isASAN ? 256 : 64}) {
       throw new Error("fragmented compressed fetch leaked " + Math.round(deltaMB) + " MB over 60 rounds");
     }
   `;
@@ -726,7 +730,10 @@ test("should not leak using readable stream", async () => {
       SERVER_URL: server.url.href,
       // ASAN's quarantine retains freed allocations so RSS stays elevated
       // under bun-asan; the fixture only allows MAX_MEMORY_INCREASE MiB.
-      MAX_MEMORY_INCREASE: isASAN ? "64" : "5", // in MB
+      // Windows/macOS arm64 release lanes routinely measure 6-14 MiB here
+      // (allocator page retention, not a leak — a body leak over the
+      // 250 iterations between sample and end would be >32 MiB).
+      MAX_MEMORY_INCREASE: isASAN ? "64" : "20", // in MB
     },
     stdout: "pipe",
     stderr: "pipe",


### PR DESCRIPTION
### What does this PR do?

`test/js/web/fetch/fetch-leak.test.ts` went red on `:darwin: 14 aarch64` in [build 71937](https://buildkite.com/bun/bun/builds/71937#019f5225-9965-4a25-9e44-38cbffe07ac7) with three RSS-threshold failures:

```
error: fetch({compress}) leaked 35 MB over 80 rounds
error: fragmented compressed fetch leaked 43 MB over 60 rounds
error: expect(received).toBeGreaterThanOrEqual(expected)  Expected: = 43.359375  Received: 43.078125
```

Scanning Buildkite annotations for builds 68000-71940 shows this file has been flaking in dozens of PR runs for weeks:

- the two `compress` tests (added in #32416) flake on the macOS 14 arm64 Tart runners with observed `deltaMB` of 25-43 against a 32 MB threshold (builds 69943, 69985, 70001, 70065, 70076, 70150, 70300, 71200, 71766, 71774, 71776, 71937)
- `should not leak using readable stream` (fixture-6, threshold set in #30875) flakes on Windows 11 arm64 and Windows 2019 x64 with growth of 6-14 MB against a 5 MB threshold (builds 68050, 69125, 69225, 69675, 69735, 69755, 69840, 69885, 69901, 69918, 69925, 69941, 70068, 70085, 70096, 70108, 70114, 70160, 70200, 70800, 71712, 71725, 71731, 71778, 71782, 71792, 71794, 71904, 71937)

These are not leaks. Running the identical compress workloads five times on Linux x64 settles at 2-4 MB and 9-10 MB; the macOS Tart VMs (16 KiB pages, three co-tenant Buildkite agents on one M2 Ultra host) settle at 25-43 MB for the same allocation pattern, and Windows does not return allocator pages to the OS as aggressively between the iteration-250 sample and the final GC. A real per-request leak of the body/compressor state would produce hundreds of MB for the compress tests (80 rounds x 5 encodings x ~700 KiB) and >32 MB for fixture-6 (250 iterations x 128 KiB), as the existing comments already note.

### Fix

Raise the non-ASAN thresholds:

- compress-option and fragmented-decompressor tests: 32 -> 64 MB (matches the existing `file://` response-url leak test in the same file; ~50% headroom over the worst observed 43 MB, still ~4x below a real leak)
- fixture-6 `MAX_MEMORY_INCREASE`: 5 -> 20 MB (~40% headroom over the worst observed 14 MB, still below the 32 MB a body leak would produce)

ASAN thresholds are unchanged.

### How did you verify your code works?

`USE_SYSTEM_BUN=1 bun test test/js/web/fetch/fetch-leak.test.ts` passes all 24 tests locally. Linux deltaMB values (2-4, 8-10, <5) are unchanged by this PR, so Linux would still catch a real leak well below the new thresholds.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->