### PR TITLE
dns: reject '/' and '*' in a hostname being looked up

### DIFF
--- a/src/dns/lib.rs
+++ b/src/dns/lib.rs
@@ -464,11 +464,9 @@ impl Order {
     }
 }
 
-/// A numeric address, or a host name within the RFC 1035 limits whose labels are
-/// LDH plus `_` (the set glibc `getaddrinfo` accepts before it builds a query) or
-/// non-ASCII bytes (UTF-8 mDNS names). c-ares's own `ares_is_hostnamech` also takes
-/// `/` and `*` because record data can hold them (RFC 2317 CNAMEs, wildcards); a
-/// name being looked up cannot, so they are rejected here like glibc does.
+/// A numeric address, or a host name within the RFC 1035 limits whose labels are LDH
+/// plus `_` (what glibc `getaddrinfo` accepts in a name to look up; narrower than
+/// c-ares's record-name set, which also has `/` and `*`) or non-ASCII (UTF-8 mDNS).
 pub fn is_valid_hostname(name: &[u8]) -> bool {
     fn is_hostname_byte(b: u8) -> bool {
         b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_') || !b.is_ascii()

--- a/src/dns/lib.rs
+++ b/src/dns/lib.rs
@@ -464,9 +464,8 @@ impl Order {
     }
 }
 
-/// A numeric address, or a host name within the RFC 1035 limits whose labels are LDH
-/// plus `_` (what glibc `getaddrinfo` accepts in a name to look up; narrower than
-/// c-ares's record-name set, which also has `/` and `*`) or non-ASCII (UTF-8 mDNS).
+/// A numeric address, or a host name within the RFC 1035 limits made of LDH, `_`
+/// (the bytes glibc `getaddrinfo` accepts in a query) or non-ASCII bytes (UTF-8 mDNS names).
 pub fn is_valid_hostname(name: &[u8]) -> bool {
     fn is_hostname_byte(b: u8) -> bool {
         b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_') || !b.is_ascii()

--- a/src/dns/lib.rs
+++ b/src/dns/lib.rs
@@ -464,11 +464,14 @@ impl Order {
     }
 }
 
-/// A numeric address, or a host name within the RFC 1035 limits made of the bytes
-/// c-ares allows in one (`ares_is_hostnamech`) or of non-ASCII bytes (UTF-8 mDNS names).
+/// A numeric address, or a host name within the RFC 1035 limits whose labels are
+/// LDH plus `_` (the set glibc `getaddrinfo` accepts before it builds a query) or
+/// non-ASCII bytes (UTF-8 mDNS names). c-ares's own `ares_is_hostnamech` also takes
+/// `/` and `*` because record data can hold them (RFC 2317 CNAMEs, wildcards); a
+/// name being looked up cannot, so they are rejected here like glibc does.
 pub fn is_valid_hostname(name: &[u8]) -> bool {
     fn is_hostname_byte(b: u8) -> bool {
-        b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'/' | b'*') || !b.is_ascii()
+        b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_') || !b.is_ascii()
     }
     if name.is_empty() || bun_core::strings::contains_char(name, 0) {
         return false;

--- a/test/js/bun/dns/lookup-invalid-hostname-fixture.ts
+++ b/test/js/bun/dns/lookup-invalid-hostname-fixture.ts
@@ -1,0 +1,82 @@
+// A local UDP DNS stub records every QNAME it receives and answers 127.0.0.1.
+// dns.setServers() points Bun's c-ares channel at it, so a c-ares lookup that
+// reaches the wire shows up in `qnames`, and one rejected in-process does not.
+import dgram from "node:dgram";
+import dns from "node:dns";
+import { once } from "node:events";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+const qnames: string[] = [];
+const stub = dgram.createSocket("udp4");
+stub.on("message", (msg, rinfo) => {
+  let off = 12;
+  const labels: string[] = [];
+  while (msg[off]) {
+    labels.push(msg.subarray(off + 1, off + 1 + msg[off]).toString("latin1"));
+    off += msg[off] + 1;
+  }
+  qnames.push(labels.join("."));
+  // Header (ID, QR|RD, RA, QDCOUNT=1, ANCOUNT=1), the question, one A RR -> 127.0.0.1.
+  stub.send(
+    Buffer.concat([
+      msg.subarray(0, 2),
+      Buffer.from([0x81, 0x80]),
+      msg.subarray(4, 6),
+      Buffer.from([0, 1, 0, 0, 0, 0]),
+      msg.subarray(12, off + 5),
+      Buffer.from([0xc0, 12, 0, 1, 0, 1, 0, 0, 0, 60, 0, 4, 127, 0, 0, 1]),
+    ]),
+    rinfo.port,
+    rinfo.address,
+  );
+});
+stub.bind(0, "127.0.0.1");
+await once(stub, "listening");
+dns.setServers([`127.0.0.1:${(stub.address() as AddressInfo).port}`]);
+
+let originHits = 0;
+const origin = http.createServer((_req, res) => {
+  originHits++;
+  res.end();
+});
+origin.listen(0, "127.0.0.1");
+await once(origin, "listening");
+const originPort = (origin.address() as AddressInfo).port;
+
+const code = (p: Promise<unknown>) => p.then(() => null, (e: any) => e?.code ?? String(e));
+
+const invalid = ["leak-a.invalid/x", "leak-b*c.invalid", "*.leak-c.invalid"];
+
+// The c-ares backend is the one whose own validation lets `/` and `*` through.
+const cares: Record<string, string | null> = {};
+for (const hostname of invalid) {
+  cares[hostname] = await code(Bun.dns.lookup(hostname, { backend: "c-ares" }));
+}
+
+// node:dns lookup() and the http client on top of it use the system backend;
+// the name is rejected before that backend is asked, whatever it would do.
+const node: Record<string, string | null> = {};
+for (const hostname of invalid) {
+  node[hostname] = await code(dns.promises.lookup(hostname));
+}
+const httpGet = await new Promise<string | null>(resolve => {
+  http
+    .get({ host: "h.invalid/smug", port: originPort, path: "/" }, res => {
+      res.resume();
+      res.on("end", () => resolve(null));
+    })
+    .on("error", (e: NodeJS.ErrnoException) => resolve(e.code ?? e.message));
+});
+
+// Control: `_` is accepted (glibc accepts it too) and must reach the stub, which
+// also proves the stub is wired up. The trailing dot skips search-domain expansion.
+const control = await Bun.dns.lookup("ok_name.invalid.", { backend: "c-ares" }).then(
+  r => r[0]?.address ?? null,
+  (e: any) => e?.code ?? String(e),
+);
+
+console.log(JSON.stringify({ cares, node, httpGet, originHits, control, qnames: [...new Set(qnames)] }));
+
+stub.close();
+origin.close();

--- a/test/js/bun/dns/lookup-invalid-hostname.test.ts
+++ b/test/js/bun/dns/lookup-invalid-hostname.test.ts
@@ -1,0 +1,37 @@
+// `/` and `*` are in c-ares's record-name charset, so without a query-side check a
+// lookup for `evil.tld/path` or `a*b.tld` becomes a real QNAME on the wire (and,
+// if it resolves, a connection with that string as the Host header). glibc
+// getaddrinfo and Node refuse such names locally; Bun must too, on every backend.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+import { join } from "node:path";
+
+// Subprocess because dns.setServers() is process-global.
+test.skipIf(isWindows)("lookup rejects '/' and '*' in a hostname before any packet is sent", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "lookup-invalid-hostname-fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stderr, exitCode }).toMatchObject({ exitCode: 0 });
+  expect(JSON.parse(stdout.trim())).toEqual({
+    cares: {
+      "leak-a.invalid/x": "DNS_ENOTFOUND",
+      "leak-b*c.invalid": "DNS_ENOTFOUND",
+      "*.leak-c.invalid": "DNS_ENOTFOUND",
+    },
+    node: {
+      "leak-a.invalid/x": "ENOTFOUND",
+      "leak-b*c.invalid": "ENOTFOUND",
+      "*.leak-c.invalid": "ENOTFOUND",
+    },
+    httpGet: "ENOTFOUND",
+    originHits: 0,
+    control: "127.0.0.1",
+    // Only the control name reached the stub resolver.
+    qnames: ["ok_name.invalid"],
+  });
+});

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -10,8 +10,20 @@ const invalidHostnames = ["adsfa.asdfasdf.asdf.com"]; // known invalid
 // Not host names at all: rejected before any resolver is asked, so the answer
 // does not depend on what the network's DNS server does with a label that has
 // a space in it (some never answer, and mDNSResponder then waits out its 5s or
-// 30s timeout).
-const malformedHostnames = [" ", ".", " .", "localhost:80", "this is not a hostname", "a..b", "foo bar.example.com"];
+// 30s timeout). `/` and `*` are in c-ares's record-name charset but glibc
+// getaddrinfo refuses them in a name being looked up, and so does Bun.
+const malformedHostnames = [
+  " ",
+  ".",
+  " .",
+  "localhost:80",
+  "this is not a hostname",
+  "a..b",
+  "foo bar.example.com",
+  "example.com/path",
+  "a*b.example.com",
+  "*.example.com",
+];
 
 describe("dns", () => {
   describe.each(backends)("lookup() [backend: %s]", backend => {

--- a/test/js/bun/net/socket-dns-error.test.ts
+++ b/test/js/bun/net/socket-dns-error.test.ts
@@ -120,11 +120,11 @@ test("consecutive Bun.connect calls to the same unresolvable hostname all get th
   expect(errors).toEqual([EXPECTED, EXPECTED, EXPECTED]);
 });
 
-// A name that cannot be a host name (a space, a colon, an empty label) is
-// answered ENOTFOUND in-process, without asking the system resolver. Some DNS
-// servers never answer a query for such a label, and the resolver then waits
-// out its own timeout (30s on macOS) before reporting anything.
-test.each(["this is not a hostname", "localhost:80", "a..b"])(
+// A name that cannot be a host name (a space, a colon, a slash, an asterisk, an
+// empty label) is answered ENOTFOUND in-process, without asking the system
+// resolver. Some DNS servers never answer a query for such a label, and the
+// resolver then waits out its own timeout (30s on macOS) before reporting anything.
+test.each(["this is not a hostname", "localhost:80", "a..b", "example.com/path", "*.example.com"])(
   "Bun.connect to %p, which is not a hostname, fails with ENOTFOUND without asking the resolver",
   async hostname => {
     const error = await Bun.connect({
@@ -142,7 +142,7 @@ test.each(["this is not a hostname", "localhost:80", "a..b"])(
 // The listen side binds through a synchronous getaddrinfo, so a name the
 // resolver would sit on blocks the whole thread. The same names are rejected
 // before the call, with the same error the connect side reports.
-test.each(["this is not a hostname", "localhost:80", "a..b"])(
+test.each(["this is not a hostname", "localhost:80", "a..b", "example.com/path", "*.example.com"])(
   "Bun.listen on %p, which is not a hostname, throws ENOTFOUND without asking the resolver",
   hostname => {
     let error: any;


### PR DESCRIPTION
### Problem
- `Bun.dns.lookup("evil.tld/path")` or `("a*b.tld")` with the c-ares backend sends a real DNS query for the raw string. If a wildcard zone answers, Bun connects and sends the request with `Host: evil.tld/path:PORT`. Node (glibc `getaddrinfo`) refuses such names with `ENOTFOUND` before building a packet.
- The cause is `bun_dns::is_valid_hostname` (`src/dns/lib.rs:469`, added in #40970). It gates every lookup path but uses c-ares's record-name charset `ares_is_hostnamech`, `[A-Za-z0-9-*._/]`, which keeps `/` for RFC 2317 CNAME data and `*` for wildcard records. Neither can appear in a name being queried.

### Fix
- Drop `/` and `*` from the accepted label bytes. The set is now LDH plus `_` plus non-ASCII, the same set glibc accepts before it builds a query. IP literals (including scoped IPv6, via `to_ip_address`) are still accepted ahead of the label check.
- Correct because every caller of `is_valid_hostname` is a query-side check (`Bun.dns.lookup`, `node:dns` `lookup`, `Bun.connect`/`fetch` via the addrinfo cache, `Bun.listen`, `Bun.serve`, udp). None of them validates record data, where `/` and `*` are legal. `dns.resolve*` does not go through it and still accepts both, as Node does.
- Verified: `test/js/bun/dns/lookup-invalid-hostname.test.ts` (new; a UDP stub proves zero packets for the bad names and one for an `_` control). `resolve-dns.test.ts` and `socket-dns-error.test.ts` gain `/` and `*` cases on every backend and on connect/listen. Stock bun 1.4.3 fails all of them. Also ran `test/js/node/dns/`, `dns-prefetch`, and `test/js/bun/udp/`.

### Background
- `dns.lookup` has three backends. `system` and `libc` call the platform `getaddrinfo`, which already rejects these bytes. `c-ares` (the `Bun.dns.lookup` default on Linux) sends whatever passes `ares_is_hostnamech`.
- LDH is the RFC 1123 hostname alphabet: letters, digits, hyphen. glibc's `res_hnok` adds `_` because SRV-style names use it. That is the query-side rule. Record data has a wider alphabet because a CNAME target or a wildcard owner name can hold `/` or `*`.

<details><summary>Notes</summary>

- History: the first revision of this PR added a separate `is_valid_lookup_name` guard in `Resolver::do_lookup`. #40970 then landed `is_valid_hostname` on main, covering the same call site and five more, with the length/label/NUL/IP-literal handling the earlier review rounds here asked for (scoped IPv6 via `%zone` stripping, native IP-literal path). On rebase the separate guard was dropped and the fix reduced to the charset change inside `is_valid_hostname`. The earlier test moved from `test/js/node/dns/` to `test/js/bun/dns/` because `node:dns` `lookup` now always uses the `system` backend, so the stub only observes the c-ares path through `Bun.dns.lookup`.
- The stub test is skipped on Windows only. It no longer depends on which backend `node:dns` picks, so it runs on macOS too.
- `*` as a listen hostname: nothing in bun or uSockets treats `"*"` as a wildcard bind address (`0.0.0.0`/`::` are the spellings), so rejecting it in `Bun.listen`/`Bun.serve` changes no working configuration.
- In this sandbox the `example.com` / `1.1.1.1` cases in `resolve-dns.test.ts` and `node-dns.test.js` fail identically with and without the diff (no external DNS). The failure sets were diffed: zero bd-only failures, nine system-only failures (the new `/` and `*` cases).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/dns/resolve-dns.test.ts, test/js/bun/dns/lookup-invalid-hostname.test.ts

<!-- robobun:evidence:end -->