### PR TITLE
websocket: fire error event before close for post-establishment failures

### DIFF
--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -1535,6 +1535,7 @@ void WebSocket::didReceiveClose(CleanStatus wasClean, unsigned short code, WTF::
     // queueTaskKeepingObjectAlive(*this, TaskSource::WebSocket, [this, reason = WTF::move(reason)] {
     if (m_state == CLOSED)
         return;
+    const bool wasClosing = m_state == CLOSING;
     m_state = CLOSED;
 
     // Native callback: state transitioned, hand off the close code.
@@ -1554,8 +1555,10 @@ void WebSocket::didReceiveClose(CleanStatus wasClean, unsigned short code, WTF::
         // connection ... fire an event named error". Every NotClean caller
         // here is a fail-the-connection path (handshake reject, transport
         // reset, protocol violation), so fire error before close for all
-        // of them, matching Node/undici and browsers.
-        if (wasClean == CleanStatus::NotClean) {
+        // of them, matching Node/undici and browsers. CLOSING means the
+        // user already called close()/terminate(); that is not a
+        // fail-the-connection case, so skip error for it (matches npm ws).
+        if (wasClean == CleanStatus::NotClean && !wasClosing) {
             auto eventInit = createErrorEventInit(*this, reason, context->jsGlobalObject());
             dispatchEvent(ErrorEvent::create(eventNames().errorEvent, WTF::move(eventInit), EventIsTrusted::Yes));
         }

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -1737,7 +1737,7 @@ void WebSocket::didFailWithErrorCode(Bun::WebSocketErrorCode code)
         break;
     }
     case Bun::WebSocketErrorCode::timeout: {
-        didReceiveClose(CleanStatus::Clean, 1013, "Timeout"_s);
+        didReceiveClose(CleanStatus::NotClean, 1006, "Timeout"_s);
         break;
     }
     case Bun::WebSocketErrorCode::closed: {

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -1529,13 +1529,12 @@ void WebSocket::didReceiveBinaryData(const AtomString& eventName, const std::spa
     // });
 }
 
-void WebSocket::didReceiveClose(CleanStatus wasClean, unsigned short code, WTF::String reason, bool isConnectionError)
+void WebSocket::didReceiveClose(CleanStatus wasClean, unsigned short code, WTF::String reason)
 {
     // LOG(Network, "WebSocket %p didReceiveErrorMessage()", this);
     // queueTaskKeepingObjectAlive(*this, TaskSource::WebSocket, [this, reason = WTF::move(reason)] {
     if (m_state == CLOSED)
         return;
-    const bool wasConnecting = m_state == CONNECTING;
     m_state = CLOSED;
 
     // Native callback: state transitioned, hand off the close code.
@@ -1551,7 +1550,12 @@ void WebSocket::didReceiveClose(CleanStatus wasClean, unsigned short code, WTF::
 
     if (auto* context = scriptExecutionContext()) {
         this->incPendingActivityCount();
-        if (wasConnecting && isConnectionError) {
+        // WHATWG §4: "If the user agent was required to fail the WebSocket
+        // connection ... fire an event named error". Every NotClean caller
+        // here is a fail-the-connection path (handshake reject, transport
+        // reset, protocol violation), so fire error before close for all
+        // of them, matching Node/undici and browsers.
+        if (wasClean == CleanStatus::NotClean) {
             auto eventInit = createErrorEventInit(*this, reason, context->jsGlobalObject());
             dispatchEvent(ErrorEvent::create(eventNames().errorEvent, WTF::move(eventInit), EventIsTrusted::Yes));
         }
@@ -1686,39 +1690,39 @@ void WebSocket::didFailWithErrorCode(Bun::WebSocketErrorCode code)
         break;
     }
     case Bun::WebSocketErrorCode::invalid_response: {
-        didReceiveClose(CleanStatus::NotClean, 1002, "Invalid response"_s, true);
+        didReceiveClose(CleanStatus::NotClean, 1002, "Invalid response"_s);
         break;
     }
     case Bun::WebSocketErrorCode::expected_101_status_code: {
-        didReceiveClose(CleanStatus::NotClean, 1002, "Expected 101 status code"_s, true);
+        didReceiveClose(CleanStatus::NotClean, 1002, "Expected 101 status code"_s);
         break;
     }
     case Bun::WebSocketErrorCode::missing_upgrade_header: {
-        didReceiveClose(CleanStatus::NotClean, 1002, "Missing upgrade header"_s, true);
+        didReceiveClose(CleanStatus::NotClean, 1002, "Missing upgrade header"_s);
         break;
     }
     case Bun::WebSocketErrorCode::missing_connection_header: {
-        didReceiveClose(CleanStatus::NotClean, 1002, "Missing connection header"_s, true);
+        didReceiveClose(CleanStatus::NotClean, 1002, "Missing connection header"_s);
         break;
     }
     case Bun::WebSocketErrorCode::missing_websocket_accept_header: {
-        didReceiveClose(CleanStatus::NotClean, 1002, "Missing websocket accept header"_s, true);
+        didReceiveClose(CleanStatus::NotClean, 1002, "Missing websocket accept header"_s);
         break;
     }
     case Bun::WebSocketErrorCode::invalid_upgrade_header: {
-        didReceiveClose(CleanStatus::NotClean, 1002, "Invalid upgrade header"_s, true);
+        didReceiveClose(CleanStatus::NotClean, 1002, "Invalid upgrade header"_s);
         break;
     }
     case Bun::WebSocketErrorCode::invalid_connection_header: {
-        didReceiveClose(CleanStatus::NotClean, 1002, "Invalid connection header"_s, true);
+        didReceiveClose(CleanStatus::NotClean, 1002, "Invalid connection header"_s);
         break;
     }
     case Bun::WebSocketErrorCode::invalid_websocket_version: {
-        didReceiveClose(CleanStatus::NotClean, 1002, "Invalid websocket version"_s, true);
+        didReceiveClose(CleanStatus::NotClean, 1002, "Invalid websocket version"_s);
         break;
     }
     case Bun::WebSocketErrorCode::mismatch_websocket_accept_header: {
-        didReceiveClose(CleanStatus::NotClean, 1002, "Mismatch websocket accept header"_s, true);
+        didReceiveClose(CleanStatus::NotClean, 1002, "Mismatch websocket accept header"_s);
         break;
     }
     case Bun::WebSocketErrorCode::missing_client_protocol: {
@@ -1742,15 +1746,15 @@ void WebSocket::didFailWithErrorCode(Bun::WebSocketErrorCode code)
         break;
     }
     case Bun::WebSocketErrorCode::failed_to_connect: {
-        didReceiveClose(CleanStatus::NotClean, 1006, "Failed to connect"_s, true);
+        didReceiveClose(CleanStatus::NotClean, 1006, "Failed to connect"_s);
         break;
     }
     case Bun::WebSocketErrorCode::headers_too_large: {
-        didReceiveClose(CleanStatus::NotClean, 1007, "Headers too large"_s, true);
+        didReceiveClose(CleanStatus::NotClean, 1007, "Headers too large"_s);
         break;
     }
     case Bun::WebSocketErrorCode::ended: {
-        didReceiveClose(CleanStatus::NotClean, 1006, "Connection ended"_s, true);
+        didReceiveClose(CleanStatus::NotClean, 1006, "Connection ended"_s);
         break;
     }
 
@@ -1767,7 +1771,7 @@ void WebSocket::didFailWithErrorCode(Bun::WebSocketErrorCode code)
         break;
     }
     case Bun::WebSocketErrorCode::compression_unsupported: {
-        didReceiveClose(CleanStatus::Clean, 1011, "Compression not implemented yet"_s);
+        didReceiveClose(CleanStatus::NotClean, 1002, "Protocol error - RSV1 set but compression not negotiated"_s);
         break;
     }
     case Bun::WebSocketErrorCode::unexpected_mask_from_server: {
@@ -1797,7 +1801,7 @@ void WebSocket::didFailWithErrorCode(Bun::WebSocketErrorCode code)
         break;
     }
     case Bun::WebSocketErrorCode::tls_handshake_failed: {
-        didReceiveClose(CleanStatus::NotClean, 1015, "TLS handshake failed"_s, true);
+        didReceiveClose(CleanStatus::NotClean, 1015, "TLS handshake failed"_s);
         break;
     }
     case Bun::WebSocketErrorCode::message_too_big: {
@@ -1817,19 +1821,19 @@ void WebSocket::didFailWithErrorCode(Bun::WebSocketErrorCode code)
         break;
     }
     case Bun::WebSocketErrorCode::proxy_connect_failed: {
-        didReceiveClose(CleanStatus::NotClean, 1006, "Proxy connection failed"_s, true);
+        didReceiveClose(CleanStatus::NotClean, 1006, "Proxy connection failed"_s);
         break;
     }
     case Bun::WebSocketErrorCode::proxy_authentication_required: {
-        didReceiveClose(CleanStatus::NotClean, 1006, "Proxy authentication required"_s, true);
+        didReceiveClose(CleanStatus::NotClean, 1006, "Proxy authentication required"_s);
         break;
     }
     case Bun::WebSocketErrorCode::proxy_connection_refused: {
-        didReceiveClose(CleanStatus::NotClean, 1006, "Proxy connection refused"_s, true);
+        didReceiveClose(CleanStatus::NotClean, 1006, "Proxy connection refused"_s);
         break;
     }
     case Bun::WebSocketErrorCode::proxy_tunnel_failed: {
-        didReceiveClose(CleanStatus::NotClean, 1006, "Proxy tunnel failed"_s, true);
+        didReceiveClose(CleanStatus::NotClean, 1006, "Proxy tunnel failed"_s);
         break;
     }
     }

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -1726,11 +1726,11 @@ void WebSocket::didFailWithErrorCode(Bun::WebSocketErrorCode code)
         break;
     }
     case Bun::WebSocketErrorCode::missing_client_protocol: {
-        didReceiveClose(CleanStatus::Clean, 1002, "Missing client protocol"_s);
+        didReceiveClose(CleanStatus::NotClean, 1002, "Missing client protocol"_s);
         break;
     }
     case Bun::WebSocketErrorCode::mismatch_client_protocol: {
-        didReceiveClose(CleanStatus::Clean, 1002, "Mismatch client protocol"_s);
+        didReceiveClose(CleanStatus::NotClean, 1002, "Mismatch client protocol"_s);
         break;
     }
     case Bun::WebSocketErrorCode::timeout: {

--- a/src/jsc/bindings/webcore/WebSocket.h
+++ b/src/jsc/bindings/webcore/WebSocket.h
@@ -309,7 +309,7 @@ private:
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 
-    void didReceiveClose(CleanStatus wasClean, unsigned short code, WTF::String reason, bool isConnectionError = false);
+    void didReceiveClose(CleanStatus wasClean, unsigned short code, WTF::String reason);
     void didUpdateBufferedAmount(unsigned bufferedAmount);
     void failConnectingWebSocket();
 

--- a/test/js/web/websocket/autobahn.test.ts
+++ b/test/js/web/websocket/autobahn.test.ts
@@ -92,7 +92,7 @@ describe.skipIf(!isDockerEnabled())("autobahn", () => {
   }
 
   function runTestCase(testID: number) {
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       const socket = new WebSocket(`${url}/runCase?case=${testID}&agent=${agent}`, wsOptions);
       socket.binaryType = "arraybuffer";
 
@@ -102,9 +102,9 @@ describe.skipIf(!isDockerEnabled())("autobahn", () => {
       socket.addEventListener("close", () => {
         resolve(undefined);
       });
-      socket.addEventListener("error", event => {
-        reject(event);
-      });
+      // Autobahn cases deliberately trigger protocol errors, which fire error
+      // before close; the result is read via getCaseStatus after close.
+      socket.addEventListener("error", () => {});
     });
   }
 

--- a/test/js/web/websocket/error-event.test.ts
+++ b/test/js/web/websocket/error-event.test.ts
@@ -48,7 +48,7 @@ describe("fires error before close on post-establishment failure", () => {
   const MAGIC = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
   async function rawWsServer(afterUpgrade: (sock: net.Socket) => void) {
-    const { promise, resolve } = Promise.withResolvers<net.Server>();
+    const { promise, resolve, reject } = Promise.withResolvers<net.Server>();
     const server = net.createServer(sock => {
       let buf = "";
       let upgraded = false;
@@ -74,6 +74,7 @@ describe("fires error before close on post-establishment failure", () => {
       });
       sock.on("error", () => {});
     });
+    server.once("error", reject);
     server.listen(0, "127.0.0.1", () => resolve(server));
     return promise;
   }
@@ -138,6 +139,51 @@ describe("fires error before close on post-establishment failure", () => {
     expect(events).toEqual(["open", "error", "close{1002,wasClean:false}"]);
   });
 
+  test.concurrent("subprotocol mismatch (server responds with unrequested protocol)", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<net.Server>();
+    const server = net.createServer(sock => {
+      let buf = "";
+      let upgraded = false;
+      sock.on("data", d => {
+        if (upgraded) return;
+        buf += d;
+        if (!buf.includes("\r\n\r\n")) return;
+        upgraded = true;
+        const key = /Sec-WebSocket-Key: (.+)\r\n/i.exec(buf)![1];
+        const accept = crypto
+          .createHash("sha1")
+          .update(key + MAGIC)
+          .digest("base64");
+        sock.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" +
+            "Upgrade: websocket\r\n" +
+            "Connection: Upgrade\r\n" +
+            "Sec-WebSocket-Accept: " +
+            accept +
+            "\r\n" +
+            "Sec-WebSocket-Protocol: not-what-you-asked\r\n\r\n",
+        );
+      });
+      sock.on("error", () => {});
+    });
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve(server));
+    await promise;
+    const address = server.address() as net.AddressInfo;
+    const ws = new WebSocket(`ws://127.0.0.1:${address.port}/`, ["chat"]);
+    const events: string[] = [];
+    const done = Promise.withResolvers<void>();
+    ws.onopen = () => events.push("open");
+    ws.onerror = () => events.push("error");
+    ws.onclose = e => {
+      events.push(`close{${e.code},wasClean:${e.wasClean}}`);
+      done.resolve();
+    };
+    await done.promise;
+    await new Promise<void>(r => server.close(() => r()));
+    expect(events).toEqual(["error", "close{1002,wasClean:false}"]);
+  });
+
   test.concurrent("clean close does NOT fire error", async () => {
     // FIN=1, opcode=close, len=2, code=1000
     const server = await rawWsServer(sock => sock.write(Buffer.from([0x88, 0x02, 0x03, 0xe8])));
@@ -146,7 +192,7 @@ describe("fires error before close on post-establishment failure", () => {
   });
 
   test.concurrent("handshake failure fires error then close (control, pre-establishment)", async () => {
-    const { promise, resolve } = Promise.withResolvers<net.Server>();
+    const { promise, resolve, reject } = Promise.withResolvers<net.Server>();
     const server = net.createServer(sock => {
       sock.on("data", () => {
         sock.write("HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n");
@@ -154,6 +200,7 @@ describe("fires error before close on post-establishment failure", () => {
       });
       sock.on("error", () => {});
     });
+    server.once("error", reject);
     server.listen(0, "127.0.0.1", () => resolve(server));
     await promise;
     const address = server.address() as net.AddressInfo;

--- a/test/js/web/websocket/error-event.test.ts
+++ b/test/js/web/websocket/error-event.test.ts
@@ -47,7 +47,7 @@ test("ErrorEvent with no message", async () => {
 describe("fires error before close on post-establishment failure", () => {
   const MAGIC = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
-  async function rawWsServer(afterUpgrade: (sock: net.Socket) => void) {
+  async function rawWsServer(afterUpgrade: (sock: net.Socket) => void, extraHeaders = "") {
     const { promise, resolve, reject } = Promise.withResolvers<net.Server>();
     const server = net.createServer(sock => {
       let buf = "";
@@ -68,7 +68,9 @@ describe("fires error before close on post-establishment failure", () => {
             "Connection: Upgrade\r\n" +
             "Sec-WebSocket-Accept: " +
             accept +
-            "\r\n\r\n",
+            "\r\n" +
+            extraHeaders +
+            "\r\n",
         );
         afterUpgrade(sock);
       });
@@ -79,15 +81,18 @@ describe("fires error before close on post-establishment failure", () => {
     return promise;
   }
 
-  async function connectAndTrace(server: net.Server, onOpen?: (ws: WebSocket) => void) {
+  async function connectAndTrace(
+    server: net.Server,
+    opts: { onOpen?: (ws: WebSocket) => void; protocols?: string[] } = {},
+  ) {
     const address = server.address() as net.AddressInfo;
-    const ws = new WebSocket(`ws://127.0.0.1:${address.port}/`);
+    const ws = new WebSocket(`ws://127.0.0.1:${address.port}/`, opts.protocols);
     const events: string[] = [];
     let errorMessage: string | undefined;
     const { promise, resolve } = Promise.withResolvers<void>();
     ws.onopen = () => {
       events.push("open");
-      onOpen?.(ws);
+      opts.onOpen?.(ws);
     };
     ws.onerror = e => {
       events.push("error");
@@ -105,7 +110,7 @@ describe("fires error before close on post-establishment failure", () => {
   test.concurrent("socket destroyed with no close frame", async () => {
     // Destroy once we see the client's first frame (proves open fired).
     const server = await rawWsServer(sock => sock.once("data", () => sock.destroy()));
-    const { events, errorMessage } = await connectAndTrace(server, ws => ws.send("x"));
+    const { events, errorMessage } = await connectAndTrace(server, { onOpen: ws => ws.send("x") });
     expect(events).toEqual(["open", "error", "close{1006,wasClean:false}"]);
     expect(errorMessage).toContain("Connection ended");
   });
@@ -140,47 +145,8 @@ describe("fires error before close on post-establishment failure", () => {
   });
 
   test.concurrent("subprotocol mismatch (server responds with unrequested protocol)", async () => {
-    const { promise, resolve, reject } = Promise.withResolvers<net.Server>();
-    const server = net.createServer(sock => {
-      let buf = "";
-      let upgraded = false;
-      sock.on("data", d => {
-        if (upgraded) return;
-        buf += d;
-        if (!buf.includes("\r\n\r\n")) return;
-        upgraded = true;
-        const key = /Sec-WebSocket-Key: (.+)\r\n/i.exec(buf)![1];
-        const accept = crypto
-          .createHash("sha1")
-          .update(key + MAGIC)
-          .digest("base64");
-        sock.write(
-          "HTTP/1.1 101 Switching Protocols\r\n" +
-            "Upgrade: websocket\r\n" +
-            "Connection: Upgrade\r\n" +
-            "Sec-WebSocket-Accept: " +
-            accept +
-            "\r\n" +
-            "Sec-WebSocket-Protocol: not-what-you-asked\r\n\r\n",
-        );
-      });
-      sock.on("error", () => {});
-    });
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => resolve(server));
-    await promise;
-    const address = server.address() as net.AddressInfo;
-    const ws = new WebSocket(`ws://127.0.0.1:${address.port}/`, ["chat"]);
-    const events: string[] = [];
-    const done = Promise.withResolvers<void>();
-    ws.onopen = () => events.push("open");
-    ws.onerror = () => events.push("error");
-    ws.onclose = e => {
-      events.push(`close{${e.code},wasClean:${e.wasClean}}`);
-      done.resolve();
-    };
-    await done.promise;
-    await new Promise<void>(r => server.close(() => r()));
+    const server = await rawWsServer(() => {}, "Sec-WebSocket-Protocol: not-what-you-asked\r\n");
+    const { events } = await connectAndTrace(server, { protocols: ["chat"] });
     expect(events).toEqual(["error", "close{1002,wasClean:false}"]);
   });
 

--- a/test/js/web/websocket/error-event.test.ts
+++ b/test/js/web/websocket/error-event.test.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "bun:test";
+import { expect, test, describe } from "bun:test";
+import net from "node:net";
+import crypto from "node:crypto";
 
 test("WebSocket error event snapshot", async () => {
   const ws = new WebSocket("ws://127.0.0.1:8080");
@@ -37,4 +39,132 @@ test("ErrorEvent with no message", async () => {
   message: "", 
   error: null
 }`);
+});
+
+// WHATWG §4 requires an error event before the close event whenever the user
+// agent is required to "fail the WebSocket connection" (RFC 6455 §7.1.7).
+// Node/undici and browsers all fire error for these post-open failure shapes.
+describe("fires error before close on post-establishment failure", () => {
+  const MAGIC = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+  async function rawWsServer(afterUpgrade: (sock: net.Socket) => void) {
+    const { promise, resolve } = Promise.withResolvers<net.Server>();
+    const server = net.createServer(sock => {
+      let buf = "";
+      let upgraded = false;
+      sock.on("data", d => {
+        if (upgraded) return;
+        buf += d;
+        if (!buf.includes("\r\n\r\n")) return;
+        upgraded = true;
+        const key = /Sec-WebSocket-Key: (.+)\r\n/i.exec(buf)![1];
+        const accept = crypto.createHash("sha1").update(key + MAGIC).digest("base64");
+        sock.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" +
+            "Upgrade: websocket\r\n" +
+            "Connection: Upgrade\r\n" +
+            "Sec-WebSocket-Accept: " +
+            accept +
+            "\r\n\r\n",
+        );
+        afterUpgrade(sock);
+      });
+      sock.on("error", () => {});
+    });
+    server.listen(0, "127.0.0.1", () => resolve(server));
+    return promise;
+  }
+
+  async function connectAndTrace(server: net.Server, onOpen?: (ws: WebSocket) => void) {
+    const address = server.address() as net.AddressInfo;
+    const ws = new WebSocket(`ws://127.0.0.1:${address.port}/`);
+    const events: string[] = [];
+    let errorMessage: string | undefined;
+    const { promise, resolve } = Promise.withResolvers<void>();
+    ws.onopen = () => {
+      events.push("open");
+      onOpen?.(ws);
+    };
+    ws.onerror = e => {
+      events.push("error");
+      errorMessage = (e as ErrorEvent).message;
+    };
+    ws.onclose = e => {
+      events.push(`close{${e.code},wasClean:${e.wasClean}}`);
+      resolve();
+    };
+    await promise;
+    await new Promise<void>(r => server.close(() => r()));
+    return { events, errorMessage };
+  }
+
+  test.concurrent("socket destroyed with no close frame", async () => {
+    // Destroy once we see the client's first frame (proves open fired).
+    const server = await rawWsServer(sock => sock.once("data", () => sock.destroy()));
+    const { events, errorMessage } = await connectAndTrace(server, ws => ws.send("x"));
+    expect(events).toEqual(["open", "error", "close{1006,wasClean:false}"]);
+    expect(errorMessage).toContain("Connection ended");
+  });
+
+  test.concurrent("RSV bit set without permessage-deflate negotiated", async () => {
+    // FIN=1, RSV1=1, opcode=text, len=1, payload 'x'
+    const server = await rawWsServer(sock => sock.write(Buffer.from([0xc1, 0x01, 0x78])));
+    const { events } = await connectAndTrace(server);
+    expect(events).toEqual(["open", "error", "close{1002,wasClean:false}"]);
+  });
+
+  test.concurrent("RSV2/RSV3 set", async () => {
+    // FIN=1, RSV2=1, opcode=text, len=1, payload 'x'
+    const server = await rawWsServer(sock => sock.write(Buffer.from([0xa1, 0x01, 0x78])));
+    const { events } = await connectAndTrace(server);
+    expect(events).toEqual(["open", "error", "close{1002,wasClean:false}"]);
+  });
+
+  test.concurrent("text frame with invalid UTF-8", async () => {
+    // FIN=1, opcode=text, len=2, payload 0xc3 0x28 (invalid UTF-8 sequence)
+    const server = await rawWsServer(sock => sock.write(Buffer.from([0x81, 0x02, 0xc3, 0x28])));
+    const { events, errorMessage } = await connectAndTrace(server);
+    expect(events).toEqual(["open", "error", "close{1007,wasClean:false}"]);
+    expect(errorMessage).toContain("invalid UTF8");
+  });
+
+  test.concurrent("masked frame from server", async () => {
+    // FIN=1, opcode=text, MASK=1, len=1, mask=00000000, payload 'x'
+    const server = await rawWsServer(sock => sock.write(Buffer.from([0x81, 0x81, 0, 0, 0, 0, 0x78])));
+    const { events } = await connectAndTrace(server);
+    expect(events).toEqual(["open", "error", "close{1002,wasClean:false}"]);
+  });
+
+  test.concurrent("clean close does NOT fire error", async () => {
+    // FIN=1, opcode=close, len=2, code=1000
+    const server = await rawWsServer(sock => sock.write(Buffer.from([0x88, 0x02, 0x03, 0xe8])));
+    const { events } = await connectAndTrace(server);
+    expect(events).toEqual(["open", "close{1000,wasClean:true}"]);
+  });
+
+  test.concurrent("handshake failure fires error then close (control, pre-establishment)", async () => {
+    const { promise, resolve } = Promise.withResolvers<net.Server>();
+    const server = net.createServer(sock => {
+      sock.on("data", () => {
+        sock.write("HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n");
+        sock.end();
+      });
+      sock.on("error", () => {});
+    });
+    server.listen(0, "127.0.0.1", () => resolve(server));
+    await promise;
+    const address = server.address() as net.AddressInfo;
+    const ws = new WebSocket(`ws://127.0.0.1:${address.port}/`);
+    const events: string[] = [];
+    const done = Promise.withResolvers<void>();
+    ws.onopen = () => events.push("open");
+    ws.onerror = () => events.push("error");
+    ws.onclose = e => {
+      events.push(`close{${e.code},wasClean:${e.wasClean}}`);
+      done.resolve();
+    };
+    await done.promise;
+    await new Promise<void>(r => server.close(() => r()));
+    expect(events).toEqual(["error", "close{1002,wasClean:false}"]);
+  });
 });

--- a/test/js/web/websocket/error-event.test.ts
+++ b/test/js/web/websocket/error-event.test.ts
@@ -1,6 +1,6 @@
-import { expect, test, describe } from "bun:test";
-import net from "node:net";
+import { describe, expect, test } from "bun:test";
 import crypto from "node:crypto";
+import net from "node:net";
 
 test("WebSocket error event snapshot", async () => {
   const ws = new WebSocket("ws://127.0.0.1:8080");
@@ -58,7 +58,10 @@ describe("fires error before close on post-establishment failure", () => {
         if (!buf.includes("\r\n\r\n")) return;
         upgraded = true;
         const key = /Sec-WebSocket-Key: (.+)\r\n/i.exec(buf)![1];
-        const accept = crypto.createHash("sha1").update(key + MAGIC).digest("base64");
+        const accept = crypto
+          .createHash("sha1")
+          .update(key + MAGIC)
+          .digest("base64");
         sock.write(
           "HTTP/1.1 101 Switching Protocols\r\n" +
             "Upgrade: websocket\r\n" +

--- a/test/js/web/websocket/error-event.test.ts
+++ b/test/js/web/websocket/error-event.test.ts
@@ -157,6 +157,12 @@ describe("fires error before close on post-establishment failure", () => {
     expect(events).toEqual(["open", "close{1000,wasClean:true}"]);
   });
 
+  test.concurrent("ws.terminate() after open does NOT fire error (user-initiated, matches npm ws)", async () => {
+    const server = await rawWsServer(() => {});
+    const { events } = await connectAndTrace(server, { onOpen: ws => ws.terminate() });
+    expect(events).toEqual(["open", "close{1006,wasClean:false}"]);
+  });
+
   test.concurrent("handshake failure fires error then close (control, pre-establishment)", async () => {
     const { promise, resolve, reject } = Promise.withResolvers<net.Server>();
     const server = net.createServer(sock => {

--- a/test/js/web/websocket/websocket-syscall-fault.test.ts
+++ b/test/js/web/websocket/websocket-syscall-fault.test.ts
@@ -128,9 +128,9 @@ describe.concurrent.skipIf(skip)("WebSocket client (ws://) under injected syscal
     expect(r.signal).toBeNull();
     expect(r.ok).toBe(true);
     expect(r.code).toBe(1006);
-    // Per WHATWG, onerror during the data-exchange phase is optional; Bun
-    // currently does not fire it for a transport reset after open.
-    expect(r.errored).toBe(false);
+    // A transport reset after open is a fail-the-connection case; Bun fires
+    // error before close to match Node/undici and browsers.
+    expect(r.errored).toBe(true);
   });
 
   test("recv → 0 (peer closed) fires onclose", async () => {


### PR DESCRIPTION
## What does this PR do?

The WebSocket client only fired an `error` event for handshake-phase failures. `didReceiveClose` gated the error dispatch on `m_state == CONNECTING`, so any failure after `open` (transport reset, protocol violation) surfaced only as a bare `CloseEvent{wasClean:false}`. The `error` event never fired, so `onerror` handlers and the reconnect/telemetry libraries built on them silently never engaged.

### Repro

```js
import net from "node:net"; import crypto from "node:crypto";
const MAGIC = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
const srv = net.createServer(s => { let h = "", done = false;
  s.on("data", d => { if (done) return; h += d; if (!h.includes("\r\n\r\n")) return; done = true;
    const key = /Sec-WebSocket-Key: (.+)\r\n/i.exec(h)[1];
    s.write("HTTP/1.1 101 x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: "
      + crypto.createHash("sha1").update(key + MAGIC).digest("base64") + "\r\n\r\n");
    s.once("data", () => s.destroy());
  }); });
await new Promise(r => srv.listen(0, "127.0.0.1", r));
const ws = new WebSocket(`ws://127.0.0.1:${srv.address().port}/`);
const ev = [];
ws.onopen = () => { ev.push("open"); ws.send("x"); };
ws.onerror = () => ev.push("error");
ws.onclose = e => { ev.push(`close{${e.code},wasClean:${e.wasClean}}`); console.log(ev.join(" -> ")); };
```

Before: `open -> close{1006,wasClean:false}`
After (and in Node): `open -> error -> close{1006,wasClean:false}`

The same applies to RSV bits set without deflate negotiated, invalid UTF-8 in a text frame, and a masked frame from the server.

### Fix

[WHATWG §4](https://websockets.spec.whatwg.org/#feedback-from-the-protocol) requires an `error` event whenever the user agent is required to _fail the WebSocket connection_ (RFC 6455 §7.1.7), which covers handshake rejection, transport reset, and every framing protocol violation. Every `CleanStatus::NotClean` caller of `didReceiveClose` is one of these paths, so the condition is now `wasClean == NotClean`. The `isConnectionError` parameter it replaced is removed.

`compression_unsupported` (RSV1 set without permessage-deflate negotiated) was also reporting `Clean`/1011; it now reports `NotClean`/1002 since it is a protocol error.

### Not in this PR

A received close frame carrying a reserved/invalid code is currently echoed as 1002 and reported to JS as `{code: 1002, wasClean: true}` via `dispatch_close`. Routing that through the fail-the-connection path would change the wire behavior Autobahn 7.9.* observes and is left for a follow-up.

## How did you verify your code works?

New tests in `test/js/web/websocket/error-event.test.ts` cover socket-destroyed-with-no-close-frame, RSV1 without deflate, RSV2/RSV3, invalid UTF-8, and a masked server frame, plus a clean-close control (no error) and a handshake-failure control (already worked). All five failure tests fail on `USE_SYSTEM_BUN=1` and pass on this build.

`websocket-syscall-fault.test.ts` previously asserted `errored === false` for ECONNRESET after open and is updated to expect `true`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/websocket/websocket-syscall-fault.test.ts

<!-- robobun:evidence:end -->