### PR TITLE
shell: throw instead of panic on ReadableStream redirect

### DIFF
--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -1,7 +1,7 @@
 export function createBunShellTemplateFunction(createShellInterpreter_, createParsedShellScript_) {
   const createShellInterpreter = createShellInterpreter_ as (
     resolve: (code: number, stdout: Buffer, stderr: Buffer) => void,
-    reject: (code: number, stdout: Buffer, stderr: Buffer) => void,
+    reject: (err: unknown) => void,
     args: $ZigGeneratedClasses.ParsedShellScript,
   ) => $ZigGeneratedClasses.ShellInterpreter;
   const createParsedShellScript = createParsedShellScript_ as (
@@ -108,7 +108,7 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
     #hasRun: boolean = false;
     #throws: boolean = true;
     #resolve: (code: number, stdout: Buffer, stderr: Buffer) => void;
-    #reject: (code: number, stdout: Buffer, stderr: Buffer) => void;
+    #reject: (err: unknown) => void;
 
     constructor(args: $ZigGeneratedClasses.ParsedShellScript, throws: boolean) {
       // Create the error immediately so it captures the stacktrace at the point
@@ -131,10 +131,7 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
             res(out);
           }
         };
-        reject = (code, stdout, stderr) => {
-          potentialError!.initialize(new ShellOutput(stdout, stderr, code), code);
-          rej(potentialError);
-        };
+        reject = err => rej(err);
       });
 
       this.#throws = throws;

--- a/src/runtime/shell/Yield.rs
+++ b/src/runtime/shell/Yield.rs
@@ -140,12 +140,11 @@ impl Yield {
                     err,
                 } => crate::shell::io_writer::on_io_writer_chunk(interp, child, written, err),
                 Yield::Failed => {
+                    // Reject the ShellPromise and stop: do not drain pipelines,
+                    // or downstream commands would spawn after the promise is
+                    // already settled (hang/UAF) or throw into a cleared reject.
                     interp.reject_pending_exception();
-                    if let Some(y) = Self::drain_pipelines(interp, &mut pipeline_stack) {
-                        y
-                    } else {
-                        return;
-                    }
+                    return;
                 }
                 Yield::Suspended | Yield::Done => {
                     if let Some(y) = Self::drain_pipelines(interp, &mut pipeline_stack) {

--- a/src/runtime/shell/Yield.rs
+++ b/src/runtime/shell/Yield.rs
@@ -139,7 +139,15 @@ impl Yield {
                     written,
                     err,
                 } => crate::shell::io_writer::on_io_writer_chunk(interp, child, written, err),
-                Yield::Suspended | Yield::Failed | Yield::Done => {
+                Yield::Failed => {
+                    interp.reject_pending_exception();
+                    if let Some(y) = Self::drain_pipelines(interp, &mut pipeline_stack) {
+                        y
+                    } else {
+                        return;
+                    }
+                }
+                Yield::Suspended | Yield::Done => {
                     if let Some(y) = Self::drain_pipelines(interp, &mut pipeline_stack) {
                         y
                     } else {

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -360,6 +360,12 @@ impl InterpreterFlags {
     pub fn set_quiet(&mut self, v: bool) {
         if v { self.0 |= 0b10 } else { self.0 &= !0b10 }
     }
+    pub const fn rejected(self) -> bool {
+        self.0 & 0b100 != 0
+    }
+    pub fn set_rejected(&mut self, v: bool) {
+        if v { self.0 |= 0b100 } else { self.0 &= !0b100 }
+    }
 }
 
 #[repr(u8)]
@@ -1266,9 +1272,14 @@ impl Interpreter {
         let Some(global) = self.global_this_ref() else {
             return;
         };
+        if self.flags.get().rejected() {
+            let _ = global.try_take_exception();
+            return;
+        }
         let Some(exc) = global.try_take_exception() else {
             return;
         };
+        self.update_flags(|f| f.set_rejected(true));
         let err = exc.to_error().unwrap_or(exc);
         self.keep_alive.with_mut(|k| k.disable());
         let this_jsvalue = self.this_jsvalue.get();
@@ -1388,8 +1399,6 @@ impl Interpreter {
         let root = Script::init(self, shell, ast, NodeId::INTERPRETER, io);
         self.started.store(true, Ordering::SeqCst);
         Script::start(self, root).run(self);
-        // `Yield::run` rejects the promise and releases keepalive on
-        // `Yield::Failed`, so no post-run exception check is needed here.
 
         Ok(crate::jsc::JSValue::UNDEFINED)
     }

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -1356,9 +1356,9 @@ impl Interpreter {
         self.started.store(true, Ordering::SeqCst);
         Script::start(self, root).run(self);
         if global_this.has_exception() {
-            // A state node threw synchronously (`Yield::failed()`); undo the
-            // pending-activity increment and release the event-loop keepalive.
-            Self::decr_pending_activity_flag(&self.has_pending_activity);
+            // A state node threw (`Yield::failed()`); release the event-loop
+            // keepalive. `has_pending_activity` stays non-zero so GC cannot
+            // collect us while a PipeReader still holds our pointer.
             self.keep_alive.with_mut(|k| k.disable());
             return Err(crate::jsc::JsError::Thrown);
         }

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -1257,11 +1257,12 @@ impl Interpreter {
     }
 
     /// `Yield::Failed`: reject the ShellPromise with the pending exception and
-    /// release the keepalive. `has_pending_activity` stays non-zero so GC
-    /// cannot collect us while a PipeReader still holds our pointer.
+    /// release the keepalive. `has_pending_activity` is decremented only when
+    /// no spawned subprocess still holds a raw backref into us.
     pub fn reject_pending_exception(&self) {
         use crate::jsc::JSValue;
         use crate::jsc::generated::JSShellInterpreter;
+        use crate::shell::states::cmd::Exec;
 
         let Some(global) = self.global_this_ref() else {
             return;
@@ -1271,6 +1272,12 @@ impl Interpreter {
         };
         let err = exc.to_error().unwrap_or(exc);
         self.keep_alive.with_mut(|k| k.disable());
+        let has_live_subproc = self.nodes.get().iter().any(|n| {
+            matches!(n, Node::Cmd(c) if matches!(&c.exec, Exec::Subproc(s) if !s.child.is_null()))
+        });
+        if !has_live_subproc {
+            Self::decr_pending_activity_flag(&self.has_pending_activity);
+        }
         let this_jsvalue = self.this_jsvalue.get();
         let reject = (this_jsvalue != JSValue::ZERO)
             .then(|| JSShellInterpreter::reject_get_cached(this_jsvalue))

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -1257,12 +1257,11 @@ impl Interpreter {
     }
 
     /// `Yield::Failed`: reject the ShellPromise with the pending exception and
-    /// release the keepalive. `has_pending_activity` is decremented only when
-    /// no spawned subprocess still holds a raw backref into us.
+    /// release the keepalive. `has_pending_activity` is left pinned because a
+    /// sibling subprocess / glob / builtin task may still hold a raw backref.
     pub fn reject_pending_exception(&self) {
         use crate::jsc::JSValue;
         use crate::jsc::generated::JSShellInterpreter;
-        use crate::shell::states::cmd::Exec;
 
         let Some(global) = self.global_this_ref() else {
             return;
@@ -1272,12 +1271,6 @@ impl Interpreter {
         };
         let err = exc.to_error().unwrap_or(exc);
         self.keep_alive.with_mut(|k| k.disable());
-        let has_live_subproc = self.nodes.get().iter().any(|n| {
-            matches!(n, Node::Cmd(c) if matches!(&c.exec, Exec::Subproc(s) if !s.child.is_null()))
-        });
-        if !has_live_subproc {
-            Self::decr_pending_activity_flag(&self.has_pending_activity);
-        }
         let this_jsvalue = self.this_jsvalue.get();
         let reject = (this_jsvalue != JSValue::ZERO)
             .then(|| JSShellInterpreter::reject_get_cached(this_jsvalue))

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -1338,6 +1338,7 @@ impl Interpreter {
         );
 
         if let Err(e) = self.setup_io_before_run() {
+            self.keep_alive.with_mut(|k| k.disable());
             self.deref_root_shell_and_io_if_needed(true);
             let shellerr = ShellErr::new_sys(&e);
             return Err(throw_shell_err(
@@ -1355,6 +1356,10 @@ impl Interpreter {
         self.started.store(true, Ordering::SeqCst);
         Script::start(self, root).run(self);
         if global_this.has_exception() {
+            // A state node threw synchronously (`Yield::failed()`); undo the
+            // pending-activity increment and release the event-loop keepalive.
+            Self::decr_pending_activity_flag(&self.has_pending_activity);
+            self.keep_alive.with_mut(|k| k.disable());
             return Err(crate::jsc::JsError::Thrown);
         }
 

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -1256,6 +1256,39 @@ impl Interpreter {
         Ok(())
     }
 
+    /// `Yield::Failed`: reject the ShellPromise with the pending exception and
+    /// release the keepalive. `has_pending_activity` stays non-zero so GC
+    /// cannot collect us while a PipeReader still holds our pointer.
+    pub fn reject_pending_exception(&self) {
+        use crate::jsc::JSValue;
+        use crate::jsc::generated::JSShellInterpreter;
+
+        let Some(global) = self.global_this_ref() else {
+            return;
+        };
+        let Some(exc) = global.try_take_exception() else {
+            return;
+        };
+        let err = exc.to_error().unwrap_or(exc);
+        self.keep_alive.with_mut(|k| k.disable());
+        let this_jsvalue = self.this_jsvalue.get();
+        let reject = (this_jsvalue != JSValue::ZERO)
+            .then(|| JSShellInterpreter::reject_get_cached(this_jsvalue))
+            .flatten()
+            .filter(|r| r.is_callable());
+        let Some(reject) = reject else {
+            global.report_active_exception_as_unhandled(global.throw_value(err));
+            return;
+        };
+        JSShellInterpreter::resolve_set_cached(this_jsvalue, global, JSValue::UNDEFINED);
+        JSShellInterpreter::reject_set_cached(this_jsvalue, global, JSValue::UNDEFINED);
+        let loop_ = self.event_loop;
+        let _entered = loop_.entered();
+        if let Err(e) = reject.call(global, JSValue::UNDEFINED, &[err]) {
+            global.report_active_exception_as_unhandled(e);
+        }
+    }
+
     pub fn finish(&self, exit_code: ExitCode) -> Yield {
         use crate::jsc::JSValue;
         use crate::jsc::generated::JSShellInterpreter;
@@ -1355,13 +1388,8 @@ impl Interpreter {
         let root = Script::init(self, shell, ast, NodeId::INTERPRETER, io);
         self.started.store(true, Ordering::SeqCst);
         Script::start(self, root).run(self);
-        if global_this.has_exception() {
-            // A state node threw (`Yield::failed()`); release the event-loop
-            // keepalive. `has_pending_activity` stays non-zero so GC cannot
-            // collect us while a PipeReader still holds our pointer.
-            self.keep_alive.with_mut(|k| k.disable());
-            return Err(crate::jsc::JsError::Thrown);
-        }
+        // `Yield::run` rejects the promise and releases keepalive on
+        // `Yield::Failed`, so no post-run exception check is needed here.
 
         Ok(crate::jsc::JSValue::UNDEFINED)
     }

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -776,8 +776,6 @@ impl Cmd {
                             STDERR_NO as i32,
                         )?;
                     }
-                } else if crate::webcore::ReadableStream::from_js(jsval, global)?.is_some() {
-                    panic!("TODO SHELL READABLE STREAM");
                 } else if let Some(req) = jsval.as_::<crate::webcore::Response>() {
                     // SAFETY: `as_` returns a live JSC-owned `*mut Response`.
                     let req = unsafe { &mut *req };

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1561,7 +1561,10 @@ describe("deno_task", () => {
         ["stderr from subprocess", `$\`\${process.execPath} -e 0 2> \${stream}\``],
         ["in pipeline", `$\`\${process.execPath} -e 0 | \${process.execPath} -e 0 < \${stream}\``],
         ["first in pipeline", `$\`\${process.execPath} -e 0 < \${stream} | \${process.execPath} -e 0\``],
-        ["both sides of pipeline", `$\`\${process.execPath} -e 0 < \${stream} | \${process.execPath} -e 0 < \${stream}\``],
+        [
+          "both sides of pipeline",
+          `$\`\${process.execPath} -e 0 < \${stream} | \${process.execPath} -e 0 < \${stream}\``,
+        ],
         ["after && (async re-entry)", `$\`\${process.execPath} -e 0 && \${process.execPath} -e 0 < \${stream}\``],
       ])("%s", async (_, shellExpr) => {
         const script = /* ts */ `

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1560,6 +1560,8 @@ describe("deno_task", () => {
         ["stdout from subprocess", `$\`\${process.execPath} -e 0 > \${stream}\``],
         ["stderr from subprocess", `$\`\${process.execPath} -e 0 2> \${stream}\``],
         ["in pipeline", `$\`\${process.execPath} -e 0 | \${process.execPath} -e 0 < \${stream}\``],
+        ["first in pipeline", `$\`\${process.execPath} -e 0 < \${stream} | \${process.execPath} -e 0\``],
+        ["both sides of pipeline", `$\`\${process.execPath} -e 0 < \${stream} | \${process.execPath} -e 0 < \${stream}\``],
         ["after && (async re-entry)", `$\`\${process.execPath} -e 0 && \${process.execPath} -e 0 < \${stream}\``],
       ])("%s", async (_, shellExpr) => {
         const script = /* ts */ `

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1560,6 +1560,7 @@ describe("deno_task", () => {
         ["stdout from subprocess", `$\`\${process.execPath} -e 0 > \${stream}\``],
         ["stderr from subprocess", `$\`\${process.execPath} -e 0 2> \${stream}\``],
         ["in pipeline", `$\`\${process.execPath} -e 0 | \${process.execPath} -e 0 < \${stream}\``],
+        ["after && (async re-entry)", `$\`\${process.execPath} -e 0 && \${process.execPath} -e 0 < \${stream}\``],
       ])("%s", async (_, shellExpr) => {
         const script = /* ts */ `
           import { $ } from "bun";
@@ -1578,13 +1579,12 @@ describe("deno_task", () => {
           stdout: "pipe",
           stderr: "pipe",
         });
-        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
         expect({ stdout: stdout.trim(), exitCode, signalCode: proc.signalCode }).toEqual({
           stdout: "caught: Unknown JS value used in shell: [object ReadableStream]",
           exitCode: 0,
           signalCode: null,
         });
-        expect(stderr).not.toContain("panic");
       });
     });
   });

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1554,11 +1554,12 @@ describe("deno_task", () => {
       .runAsTest("bunception redirect /dev/null");
 
     describe("ReadableStream as redirect target throws instead of panicking", () => {
-      test.each([
+      test.concurrent.each([
         ["stdin to subprocess", `$\`\${process.execPath} -e 0 < \${stream}\``],
         ["stdin to subprocess (Response.body)", `$\`\${process.execPath} -e 0 < \${new Response("x").body}\``],
         ["stdout from subprocess", `$\`\${process.execPath} -e 0 > \${stream}\``],
         ["stderr from subprocess", `$\`\${process.execPath} -e 0 2> \${stream}\``],
+        ["in pipeline", `$\`\${process.execPath} -e 0 | \${process.execPath} -e 0 < \${stream}\``],
       ])("%s", async (_, shellExpr) => {
         const script = /* ts */ `
           import { $ } from "bun";
@@ -1569,6 +1570,7 @@ describe("deno_task", () => {
           } catch (e) {
             console.log("caught:", e.message);
           }
+          Bun.gc(true);
         `;
         await using proc = Bun.spawn({
           cmd: [bunExe(), "-e", script],

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1552,6 +1552,39 @@ describe("deno_task", () => {
     TestBuilder.command`BUN_DEBUG_QUIET_LOGS=1 ${BUN} -e ${code} > /dev/null`
       .quiet()
       .runAsTest("bunception redirect /dev/null");
+
+    describe("ReadableStream as redirect target throws instead of panicking", () => {
+      test.each([
+        ["stdin to subprocess", `$\`\${process.execPath} -e 0 < \${stream}\``],
+        ["stdin to subprocess (Response.body)", `$\`\${process.execPath} -e 0 < \${new Response("x").body}\``],
+        ["stdout from subprocess", `$\`\${process.execPath} -e 0 > \${stream}\``],
+        ["stderr from subprocess", `$\`\${process.execPath} -e 0 2> \${stream}\``],
+      ])("%s", async (_, shellExpr) => {
+        const script = /* ts */ `
+          import { $ } from "bun";
+          const stream = new ReadableStream({ start(c) { c.close(); } });
+          try {
+            await ${shellExpr}.quiet();
+            console.log("no throw");
+          } catch (e) {
+            console.log("caught:", e.message);
+          }
+        `;
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "-e", script],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ stdout: stdout.trim(), exitCode, signalCode: proc.signalCode }).toEqual({
+          stdout: "caught: Unknown JS value used in shell: [object ReadableStream]",
+          exitCode: 0,
+          signalCode: null,
+        });
+        expect(stderr).not.toContain("panic");
+      });
+    });
   });
 
   describe("pwd", async () => {


### PR DESCRIPTION
Passing a `ReadableStream` as a redirect target in Bun Shell aborts the whole process when the command resolves to a spawned subprocess:

```js
import { $ } from "bun";
await $`cat < ${new Response("hello").body}`;
// panic: TODO SHELL READABLE STREAM
```

The builtin path (`echo hi > ${stream}`) already threw `Unknown JS value used in shell: [object ReadableStream]`. The subprocess path in `Cmd::init_subproc_redirections` instead had a literal `panic!("TODO SHELL READABLE STREAM")` that ran before any direction check, so every direction (`<`, `>`, `2>`) aborted. On POSIX `cat` and `cp` are `posix_disabled` builtins, so they always take the subprocess path; any spawned command hits it too.

### Fix

- `src/runtime/shell/states/Cmd.rs`: drop the `ReadableStream` placeholder branch so the value falls through to the existing `Unknown JS value used in shell` throw, matching `Builtin::init_redirections`.
- `src/runtime/shell/Yield.rs`, `src/runtime/shell/interpreter.rs`: on `Yield::Failed` the trampoline now calls `Interpreter::reject_pending_exception` and returns immediately instead of draining pipelines. That method takes the pending exception, rejects the ShellPromise with it, and releases the event-loop keepalive. It is guarded by a `rejected` flag on `InterpreterFlags` so a second `Yield::Failed` reached from a separate `.run()` invocation (e.g. an `IOWriter` error loop) swallows the follow-up exception instead of reporting it as unhandled. `has_pending_activity` is left pinned because a pipeline sibling's subprocess / glob task / builtin threadpool task may still hold a raw `*mut Interpreter`.
- `src/js/builtins/shell.ts`: the cached `reject` callback was never invoked from native; repurpose it to forward the error value straight to the promise reject so the caller's `catch` receives the thrown error.

### Known limitation

`spawned-cmd | throwing-cmd` (a pipeline sibling that already spawned before the throw) leaves the interpreter GC-pinned and the sibling's pipe read-end held open. If the sibling writes more than the socketpair buffer (~64KB) it blocks in `write(2)` and the process hangs after the `catch` fires. The builtin variant of this already hung on `main` pre-PR. Resolving it soundly needs a detach-then-release walk (close unwrapped pipe ends, kill/detach live subprocesses, cancel in-flight shell tasks, then release the pin), which belongs in a follow-up alongside #30550.

### Verification

8 cases added to `bunshell.test.ts` (stdin / stdout / stderr to subprocess, `Response.body`, pipeline with `Bun.gc(true)`, first-in-pipeline, both-sides-of-pipeline, `&&` async re-entry). Each spawns a child that catches the error and asserts a clean exit.

```
USE_SYSTEM_BUN=1 bun test bunshell.test.ts -t "ReadableStream as redirect"  # 8 fail (SIGABRT / exit 134)
bun bd test bunshell.test.ts -t "ReadableStream as redirect"                # 8 pass
```

Full `bunshell.test.ts` is green (394 pass, 0 fail).

Related: #18262. #30550 is the full implementation of `ReadableStream` as shell stdin; this change is the minimal safety fix so the placeholder no longer crashes the process in the meantime.
