### PR TITLE
test(bun:jsc): bound profile() workload by wall-clock so the sampler always fires

### DIFF
--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -196,11 +196,22 @@ describe("bun:jsc", () => {
     // sampled regardless of how fast the optimized code runs.
     const sampleInterval = 50;
 
-    // fib(26) keeps each call long enough (~400k recursive calls) to collect
-    // samples at a 50us interval while staying within the per-test timeout on
-    // slow debug builds; fib(30) takes >4s per call there.
+    // Keep the JS thread busy for a fixed wall-clock window so the sampler
+    // thread is guaranteed time to fire regardless of how fast the JIT makes
+    // fib() or how slowly the sampler thread wakes after start()/pause(). A
+    // single fib(n) call has no such lower bound: once JIT-compiled, fib(26)
+    // can complete inside one 50us sample interval on fast release hardware.
+    const work = () => {
+      const start = performance.now();
+      let acc = 0;
+      do {
+        acc += fib(18);
+      } while (performance.now() - start < 10);
+      return acc;
+    };
+
     // First profile call
-    const result1 = profile(() => fib(26), sampleInterval);
+    const result1 = profile(work, sampleInterval);
     expect(result1).toBeDefined();
     expect(result1.functions).toBeDefined();
     expect(result1.stackTraces).toBeDefined();
@@ -208,14 +219,14 @@ describe("bun:jsc", () => {
 
     // Second profile call - should work after first one completed
     // This verifies that shutdown() -> pause() fix works
-    const result2 = profile(() => fib(26), sampleInterval);
+    const result2 = profile(work, sampleInterval);
     expect(result2).toBeDefined();
     expect(result2.functions).toBeDefined();
     expect(result2.stackTraces).toBeDefined();
     expect(result2.stackTraces.traces.length).toBeGreaterThan(0);
 
     // Third profile call - verify profiler can be reused multiple times
-    const result3 = profile(() => fib(26), sampleInterval);
+    const result3 = profile(work, sampleInterval);
     expect(result3).toBeDefined();
     expect(result3.functions).toBeDefined();
     expect(result3.stackTraces).toBeDefined();


### PR DESCRIPTION
Fixes `test/js/bun/jsc/bun-jsc.test.ts` going red on the debian 13 x64 lane in [build 72010](https://buildkite.com/bun/bun/builds/72010#019f546c-0875-422c-8f22-fa88eac52a1b):

```
215 |     expect(result2.stackTraces.traces.length).toBeGreaterThan(0);
error: expect(received).toBeGreaterThan(expected)
Expected: > 0
Received: 0
✗ bun:jsc > profile can be called multiple times [4.71ms]
```

### Cause

The test profiles `fib(26)` three times at a 50µs sample interval and asserts each run collected at least one trace. #33072 shrank the workload from `fib(30)` to `fib(26)` so three runs fit inside the per-test timeout on slow debug builds. On fast release hardware a JIT-compiled `fib(26)` can finish inside one 50µs interval (the whole 3-call test completed in 4.71ms there), so the sampler thread simply never fires during the second call.

This is the same race #28873 addressed by lowering the sample interval; lowering the instruction count in #33072 reopened it.

### Fix

Loop `fib(18)` for a fixed 10ms of wall-clock per `profile()` call instead of relying on a single `fib(n)` being slow enough. 10ms is ~200 sample intervals, so the sampler thread is guaranteed time to fire regardless of JIT tier or how slowly it wakes after `pause()`/`start()`. On debug builds the loop still exits after ~12ms of JS work (one `fib(18)` of overshoot), so the test is no slower there than before.

The test still catches the original regression from #25939 (using `shutdown()` instead of `pause()`): a shut-down sampler returns zero traces no matter how long the workload runs.

### Verification

- `USE_SYSTEM_BUN=1 bun test test/js/bun/jsc/bun-jsc.test.ts -t 'profile can be called multiple times'`: 30/30 pass, ~80 traces per call
- `bun bd test test/js/bun/jsc/bun-jsc.test.ts`: 36 pass / 0 fail, profile test ~1.6s (dominated by the profiler's JSON reporting, same as before)

This is a timing flake that does not reproduce on the dev container (`fib(26)` takes ~800µs there after JIT warmup, well above 50µs), so there is no deterministic fail-before to show; the CI failure above is the reproduction.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->