### PR TITLE
toml: parse nested array literals with adjacent brackets

### DIFF
--- a/src/parsers/toml.rs
+++ b/src/parsers/toml.rs
@@ -268,6 +268,7 @@ impl<'a> TOML<'a> {
     }
 
     pub fn parse_assignment(&mut self, obj: &mut E::Object, bump: &'a Bump) -> crate::Result<()> {
+        let outer_allow_double_bracket = self.lexer.allow_double_bracket;
         self.lexer.allow_double_bracket = false;
         let rope = self.parse_key(bump)?;
         let rope_end = self.lexer.start;
@@ -278,6 +279,7 @@ impl<'a> TOML<'a> {
         }
 
         self.lexer.expect_assignment()?;
+        self.lexer.allow_double_bracket = outer_allow_double_bracket;
         if !is_array {
             let value = self.parse_value()?;
             match obj.set_rope(rope, self.bump, value) {
@@ -306,7 +308,7 @@ impl<'a> TOML<'a> {
                 }
             }
         }
-        self.lexer.allow_double_bracket = true;
+        self.lexer.allow_double_bracket = outer_allow_double_bracket;
         Ok(())
     }
 
@@ -324,7 +326,10 @@ impl<'a> TOML<'a> {
     fn parse_value_inner(&mut self) -> crate::Result<Expr> {
         let loc = self.lexer.loc();
 
-        self.lexer.allow_double_bracket = true;
+        // `[[`/`]]` merge into header tokens only at top level. Inside a value
+        // the flag is held false; the caller's value is restored before lexing
+        // the token after this value so a following `[[header]]` is recognised.
+        let outer_allow_double_bracket = self.lexer.allow_double_bracket;
 
         match self.lexer.token {
             T::t_false => {
@@ -367,6 +372,7 @@ impl<'a> TOML<'a> {
                 Ok(self.e(E::Number::new(value), loc))
             }
             T::t_open_brace => {
+                self.lexer.allow_double_bracket = false;
                 self.lexer.next()?;
                 let mut is_single_line = !self.lexer.has_newline_before;
                 let key_allocator = self.bump;
@@ -396,23 +402,22 @@ impl<'a> TOML<'a> {
                     unsafe {
                         self.parse_assignment(&mut *obj, key_allocator)?;
                     }
-                    self.lexer.allow_double_bracket = false;
                 }
 
                 if self.lexer.has_newline_before {
                     is_single_line = false;
                 }
                 let _ = is_single_line;
-                self.lexer.allow_double_bracket = true;
+                self.lexer.allow_double_bracket = outer_allow_double_bracket;
                 self.lexer.expect(T::t_close_brace)?;
                 Ok(expr)
             }
             T::t_empty_array => {
                 self.lexer.next()?;
-                self.lexer.allow_double_bracket = true;
                 Ok(self.e(E::Array::default(), loc))
             }
             T::t_open_bracket => {
+                self.lexer.allow_double_bracket = false;
                 self.lexer.next()?;
                 let mut is_single_line = !self.lexer.has_newline_before;
                 let array_ = self.e(E::Array::default(), loc);
@@ -424,7 +429,6 @@ impl<'a> TOML<'a> {
                 // SAFETY: `array` aliases into `array_.data`; the raw pointer
                 // sidesteps overlapping &mut on `array_`.
                 let bump = self.bump;
-                self.lexer.allow_double_bracket = false;
 
                 while self.lexer.token != T::t_close_bracket {
                     // SAFETY: `array` points into the AST store and is live here.
@@ -453,7 +457,7 @@ impl<'a> TOML<'a> {
                     is_single_line = false;
                 }
                 let _ = is_single_line;
-                self.lexer.allow_double_bracket = true;
+                self.lexer.allow_double_bracket = outer_allow_double_bracket;
                 self.lexer.expect(T::t_close_bracket)?;
                 Ok(array_)
             }

--- a/test/js/bun/resolve/toml/toml-parse.test.ts
+++ b/test/js/bun/resolve/toml/toml-parse.test.ts
@@ -132,7 +132,12 @@ test("Bun.TOML.parse accepts nested array literals with adjacent brackets", () =
   expect(Bun.TOML.parse("a = [[1], [2]]")).toEqual({ a: [[1], [2]] });
   expect(Bun.TOML.parse('a = [["x"], ["y"]]')).toEqual({ a: [["x"], ["y"]] });
   expect(Bun.TOML.parse("a = [[[1]]]")).toEqual({ a: [[[1]]] });
-  expect(Bun.TOML.parse("a = [[1, 2], [3, 4]]")).toEqual({ a: [[1, 2], [3, 4]] });
+  expect(Bun.TOML.parse("a = [[1, 2], [3, 4]]")).toEqual({
+    a: [
+      [1, 2],
+      [3, 4],
+    ],
+  });
   expect(Bun.TOML.parse("a = [[]]")).toEqual({ a: [[]] });
   expect(Bun.TOML.parse("a = [[], []]")).toEqual({ a: [[], []] });
   expect(Bun.TOML.parse("a = [[[1], [2]], [[3]]]")).toEqual({ a: [[[1], [2]], [[3]]] });

--- a/test/js/bun/resolve/toml/toml-parse.test.ts
+++ b/test/js/bun/resolve/toml/toml-parse.test.ts
@@ -117,3 +117,41 @@ test("Bun.TOML.parse rejects array values without comma separators (#31252)", ()
   // Trailing comma is legal TOML.
   expect(Bun.TOML.parse("a = [1, 2,]")).toEqual({ a: [1, 2] });
 });
+
+// The TOML lexer has an `allow_double_bracket` mode flag so `[[` / `]]` are
+// merged into a single array-of-tables header token. `parse_value_inner` set
+// the flag to `true` unconditionally on entry and again after every compound
+// value closed, so inside `a = [[1]]` the adjacent `]]` (and at depth >=3 the
+// adjacent `[[`) were merged into header tokens and the parse failed. The same
+// document with spaces between the brackets (`a = [ [1] ]`) parsed fine. The
+// fix saves the caller's flag on entry, keeps it `false` while inside an
+// array or inline table, and restores the saved value only for the token
+// lexed after the outermost closing delimiter.
+test("Bun.TOML.parse accepts nested array literals with adjacent brackets", () => {
+  expect(Bun.TOML.parse("a = [[1]]")).toEqual({ a: [[1]] });
+  expect(Bun.TOML.parse("a = [[1], [2]]")).toEqual({ a: [[1], [2]] });
+  expect(Bun.TOML.parse('a = [["x"], ["y"]]')).toEqual({ a: [["x"], ["y"]] });
+  expect(Bun.TOML.parse("a = [[[1]]]")).toEqual({ a: [[[1]]] });
+  expect(Bun.TOML.parse("a = [[1, 2], [3, 4]]")).toEqual({ a: [[1, 2], [3, 4]] });
+  expect(Bun.TOML.parse("a = [[]]")).toEqual({ a: [[]] });
+  expect(Bun.TOML.parse("a = [[], []]")).toEqual({ a: [[], []] });
+  expect(Bun.TOML.parse("a = [[[1], [2]], [[3]]]")).toEqual({ a: [[[1], [2]], [[3]]] });
+  expect(Bun.TOML.parse("t = {a = [[1]]}")).toEqual({ t: { a: [[1]] } });
+  expect(Bun.TOML.parse("a = [{b = [[1]]}]")).toEqual({ a: [{ b: [[1]] }] });
+  // Whitespace-separated forms already parsed; they must keep working.
+  expect(Bun.TOML.parse("a = [ [1] ]")).toEqual({ a: [[1]] });
+  expect(Bun.TOML.parse("a = [1, [2], 3]")).toEqual({ a: [1, [2], 3] });
+});
+
+test("Bun.TOML.parse still merges [[ / ]] as array-of-tables headers after a value", () => {
+  // The flag restore must re-enable header merging once the top-level value is
+  // consumed; otherwise `[[t]]` on the next line would be lexed as two `[` and
+  // misparsed as a `[table]` header. Every value shape exercises a different
+  // restore point.
+  expect(Bun.TOML.parse("a = 1\n[[t]]\nb = 2\n")).toEqual({ a: 1, t: [{ b: 2 }] });
+  expect(Bun.TOML.parse("a = [1]\n[[t]]\nb = 2\n")).toEqual({ a: [1], t: [{ b: 2 }] });
+  expect(Bun.TOML.parse("a = []\n[[t]]\nb = 2\n")).toEqual({ a: [], t: [{ b: 2 }] });
+  expect(Bun.TOML.parse("a = {b = 1}\n[[t]]\nc = 2\n")).toEqual({ a: { b: 1 }, t: [{ c: 2 }] });
+  expect(Bun.TOML.parse("a = [[1]]\n[[t]]\nb = 2\n")).toEqual({ a: [[1]], t: [{ b: 2 }] });
+  expect(Bun.TOML.parse("[[t]]\na = [[1]]\n[[t]]\nb = 2\n")).toEqual({ t: [{ a: [[1]] }, { b: 2 }] });
+});


### PR DESCRIPTION
## Reproduction

```js
Bun.TOML.parse("a = [[1]]")    // AggregateError: Failed to parse toml
Bun.TOML.parse("a = [[[1]]]")  // Unexpected [[
Bun.TOML.parse("a = [ [1] ]")  // OK: { a: [[1]] }
```

Any TOML nested array literal with adjacent `[` or `]` brackets was rejected, while the same document with whitespace between brackets parsed. All of these are valid TOML 1.0.

## Cause

The lexer has an `allow_double_bracket` flag that merges adjacent `[[` / `]]` into single `t_open_bracket_double` / `t_close_bracket_double` tokens, used to distinguish `[[array.of.tables]]` headers from `[table]` headers. `parse_value_inner` forced this flag to `true` at the top of every call and again after each compound value's closing delimiter, so inside `a = [[1]]` the `]]` was merged into a header-close token (and at depth 3+, the `[[` was merged into a header-open token) and the array parse failed on the unexpected token.

## Fix

`parse_assignment` and `parse_value_inner` now save the caller's flag value on entry, hold it `false` while lexing tokens inside an array or inline table, and restore the saved value before lexing the token that follows the value. At top level the saved value is `true`, so a `[[header]]` on the line after a value is still recognised; at any nested depth the saved value is `false`, so adjacent brackets stay two tokens.

## Verification

- `bun bd test test/js/bun/resolve/toml/` passes (22 tests).
- New tests fail on the system bun and pass on the debug build.
- Cross-checked against `smol-toml` for 12 nested-array and header-after-value cases; all match.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/toml/toml-parse.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (7f24b5e42)

test/js/bun/resolve/toml/toml-parse.test.ts:
(pass) Bun.TOML.parse with non-string input throws [13.39ms]
(pass) Bun.TOML.parse accepts \u{XX} at start of a basic string (#30893) [2.61ms]
(pass) Bun.TOML.parse rejects \x escape in quoted key at file start without panicking (#30893) [3.73ms]
(pass) Bun.TOML.parse rejects \u escape in quoted key at file start without panicking (#30893) [3.73ms]
(pass) Bun.TOML.parse handles trailing backslash-CR in multiline basic string (#30893) [1.87ms]
(pass) Bun.TOML.parse produces correct codepoints for \t and \f escapes [3.90ms]
(pass) Bun.TOML.parse normalizes literal CRLF to LF in multiline basic strings [2.17ms]
(pass) Bun.TOML.parse rejects out-of-range \u{...} escapes 
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (693ae6bde)

test/js/bun/resolve/toml/toml-parse.test.ts:
(pass) Bun.TOML.parse with non-string input throws [0.50ms]
(pass) Bun.TOML.parse accepts \u{XX} at start of a basic string (#30893) [0.10ms]
(pass) Bun.TOML.parse rejects \x escape in quoted key at file start without panicking (#30893) [0.10ms]
(pass) Bun.TOML.parse rejects \u escape in quoted key at file start without panicking (#30893) [0.06ms]
(pass) Bun.TOML.parse handles trailing backslash-CR in multiline basic string (#30893) [0.05ms]
(pass) Bun.TOML.parse produces correct codepoints for \t and \f escapes [0.07ms]
(pass) Bun.TOML.parse normalizes literal CRLF to LF in multiline basic strings [0.04ms]
(pass) Bun.TOML.parse rejects out-of-range \u{...} escapes without overflowing (#30825) [0.18ms]
(pass) Bun.TOML.parse rejects \u{...} escapes with no closing brace (#30825) [0.14ms]
(pass) Bun.TOML.parse still accepts in-range \u{...} escapes (#30825) [0.10ms]
(pass) Bun.TOML.parse rejects array values without comma separators (#31252) [0.25ms]
(pass) Bun.TOML.parse accepts nested array literals with adjacent brackets [0.32ms]
(pass) Bun.TOML.parse still merges [[ / ]] as array-of
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/toml/toml-parse.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (7f24b5e42)

test/js/bun/resolve/toml/toml-parse.test.ts:
(pass) Bun.TOML.parse with non-string input throws [16.27ms]
(pass) Bun.TOML.parse accepts \u{XX} at start of a basic string (#30893) [2.44ms]
(pass) Bun.TOML.parse rejects \x escape in quoted key at file start without panicking (#30893) [4.13ms]
(pass) Bun.TOML.parse rejects \u escape in quoted key at file start without panicking (#30893) [3.40ms]
(pass) Bun.TOML.parse handles trailing backslash-CR in multiline basic string (#30893) [2.21ms]
(pass) Bun.TOML.parse produces correct codepoints for \t and \f escapes [3.89ms]
(pass) Bun.TOML.parse normalizes literal CRLF to LF in multiline basic strings [1.87ms]
(pass) Bun.TOML.parse rejects out-of-range \u{...} escapes 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 759ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/parsers/toml.rs                         | 18 +++++++-----
 test/js/bun/resolve/toml/toml-parse.test.ts | 43 +++++++++++++++++++++++++++++
 2 files changed, 54 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/parsers/toml.rs                              1      8      0
test/js/bun/resolve/toml/toml-parse.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->