### PR TITLE
dotenv: cap ${} expansion output size to prevent allocation abort

### DIFF
--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -1365,8 +1365,6 @@ impl<'a> Parser<'a> {
     /// Same as [`parse`] but takes the source bytes directly. Exists so
     /// `load_env_file*` can parse a transient `Vec<u8>` without constructing a
     /// `bun_ast::Source` (whose `contents` field is currently `&'static [u8]`).
-    ///
-    /// Returns `true` if any expansion hit a size cap and was stored empty.
     fn parse_bytes<const OVERRIDE: bool, const IS_PROCESS: bool, const EXPAND: bool>(
         src: &[u8],
         map: &mut Map,

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -988,25 +988,18 @@ struct Parser<'a> {
 // there (NBSP is C2 A0), and trimming it byte-wise corrupts multi-byte sequences.
 const WHITESPACE_CHARS: &[u8] = b"\t\x0B\x0C \n\r";
 
-/// Upper bound on a single expanded value. A `.env` file whose `${}` references
-/// transitively exceed this produces an empty value (and a one-time warning)
-/// instead of aborting the process on allocation failure. Sized well above any
-/// legitimate env var but well below where allocation becomes a DoS vector.
+/// Per-value cap on `${}` expansion output; a value over this is stored empty.
 const MAX_EXPANDED_VALUE_LEN: usize = 4 * 1024 * 1024;
 
-/// Upper bound on the sum of expanded-value bytes stored per `parse` call.
-/// Bounds the linear case (many variables each referencing one at-cap value)
-/// that the per-value cap alone does not.
+/// Per-file cap on the sum of stored expansion output.
 const MAX_EXPANDED_TOTAL_LEN: usize = 32 * 1024 * 1024;
 
 struct ExpansionTooLarge;
 
 enum Expansion<'a> {
-    /// No `$` reference in the input; keep the original value.
     Unchanged,
-    /// Expanded result (borrow of `value_buffer`).
+    /// Borrows `value_buffer`.
     Value(&'a [u8]),
-    /// Expansion would exceed [`MAX_EXPANDED_VALUE_LEN`]; caller sets the value empty.
     TooLarge,
 }
 
@@ -1194,10 +1187,6 @@ impl<'a> Parser<'a> {
     /// `${...}` locates its matching `}` by depth (`${` opens, `}` closes,
     /// `\x` skipped); malformed forms fall through as literal text. The `:-`
     /// default clause is expanded recursively.
-    ///
-    /// Literal bytes copied from `value` are bounded by the file size; only
-    /// looked-up substitutions can grow without bound, so those go through
-    /// `push_lookup` and trip [`MAX_EXPANDED_VALUE_LEN`].
     fn expand_into(
         map: &Map,
         value: &[u8],
@@ -1209,6 +1198,7 @@ impl<'a> Parser<'a> {
             matches!(b, b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_')
         }
 
+        // Only looked-up values are size-checked; literal bytes are bounded by the input.
         fn push_lookup(out: &mut Vec<u8>, v: &[u8]) -> Result<(), ExpansionTooLarge> {
             if out.len().saturating_add(v.len()) > MAX_EXPANDED_VALUE_LEN {
                 return Err(ExpansionTooLarge);
@@ -1376,9 +1366,7 @@ impl<'a> Parser<'a> {
     /// `load_env_file*` can parse a transient `Vec<u8>` without constructing a
     /// `bun_ast::Source` (whose `contents` field is currently `&'static [u8]`).
     ///
-    /// Returns `true` when at least one `${}` expansion was capped (per-value at
-    /// [`MAX_EXPANDED_VALUE_LEN`] or per-file aggregate at [`MAX_EXPANDED_TOTAL_LEN`])
-    /// and the affected value was set to empty.
+    /// Returns `true` if any expansion hit a size cap and was stored empty.
     fn parse_bytes<const OVERRIDE: bool, const IS_PROCESS: bool, const EXPAND: bool>(
         src: &[u8],
         map: &mut Map,

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -616,6 +616,7 @@ impl Loader {
         // `node:util.parseEnv` pass JS-owned non-'static buffers).
         let mut value_buffer: Vec<u8> = Vec::new();
         Parser::parse_bytes::<OVERWRITE, false, EXPAND>(str, &mut self.map, &mut value_buffer)
+            .map(drop)
     }
 
     pub fn load<D: DirEntryProbe + ?Sized>(
@@ -871,7 +872,11 @@ impl Loader {
                 }
             }
             ReadEnvFile::Bytes(buf) => {
-                Parser::parse_bytes::<OVERRIDE, false, true>(&buf, &mut self.map, value_buffer)?;
+                if Parser::parse_bytes::<OVERRIDE, false, true>(&buf, &mut self.map, value_buffer)?
+                    && !self.quiet
+                {
+                    Self::warn_expansion_capped(base);
+                }
             }
         }
 
@@ -918,7 +923,11 @@ impl Loader {
                 }
             }
             ReadEnvFile::Bytes(buf) => {
-                Parser::parse_bytes::<OVERRIDE, false, true>(&buf, &mut self.map, value_buffer)?;
+                if Parser::parse_bytes::<OVERRIDE, false, true>(&buf, &mut self.map, value_buffer)?
+                    && !self.quiet
+                {
+                    Self::warn_expansion_capped(file_path);
+                }
             }
         }
 
@@ -927,6 +936,16 @@ impl Loader {
         self.custom_files_loaded
             .put(file_path, bun_ast::Source::default())?;
         Ok(())
+    }
+
+    #[cold]
+    fn warn_expansion_capped(file_path: &[u8]) {
+        bun_core::pretty_errorln!(
+            "<r><yellow>warn<r><d>:<r> {} variable expansion exceeds size limit ({} bytes per value, {} total); oversized values set to empty",
+            bun_core::fmt::quote(file_path),
+            MAX_EXPANDED_VALUE_LEN,
+            MAX_EXPANDED_TOTAL_LEN,
+        );
     }
 }
 
@@ -968,6 +987,28 @@ struct Parser<'a> {
 // Input is UTF-8, so this set must be ASCII-only: 0xA0 is a continuation byte
 // there (NBSP is C2 A0), and trimming it byte-wise corrupts multi-byte sequences.
 const WHITESPACE_CHARS: &[u8] = b"\t\x0B\x0C \n\r";
+
+/// Upper bound on a single expanded value. A `.env` file whose `${}` references
+/// transitively exceed this produces an empty value (and a one-time warning)
+/// instead of aborting the process on allocation failure. Sized well above any
+/// legitimate env var but well below where allocation becomes a DoS vector.
+const MAX_EXPANDED_VALUE_LEN: usize = 4 * 1024 * 1024;
+
+/// Upper bound on the sum of expanded-value bytes stored per `parse` call.
+/// Bounds the linear case (many variables each referencing one at-cap value)
+/// that the per-value cap alone does not.
+const MAX_EXPANDED_TOTAL_LEN: usize = 32 * 1024 * 1024;
+
+struct ExpansionTooLarge;
+
+enum Expansion<'a> {
+    /// No `$` reference in the input; keep the original value.
+    Unchanged,
+    /// Expanded result (borrow of `value_buffer`).
+    Value(&'a [u8]),
+    /// Expansion would exceed [`MAX_EXPANDED_VALUE_LEN`]; caller sets the value empty.
+    TooLarge,
+}
 
 impl<'a> Parser<'a> {
     fn skip_line(&mut self) {
@@ -1134,25 +1175,46 @@ impl<'a> Parser<'a> {
         Ok(strings::trim(&self.src[start..end], WHITESPACE_CHARS))
     }
 
-    fn expand_value(&mut self, map: &Map, value: &[u8]) -> Result<Option<&[u8]>, AllocError> {
+    fn expand_value(&mut self, map: &Map, value: &[u8]) -> Expansion<'_> {
         if value.len() < 2 {
-            return Ok(None);
+            return Expansion::Unchanged;
         }
         self.value_buffer.clear();
-        if !Self::expand_into(map, value, self.value_buffer, 0) {
-            return Ok(None);
+        match Self::expand_into(map, value, self.value_buffer, 0) {
+            Ok(false) => Expansion::Unchanged,
+            Ok(true) => Expansion::Value(self.value_buffer.as_slice()),
+            Err(ExpansionTooLarge) => {
+                self.value_buffer.clear();
+                Expansion::TooLarge
+            }
         }
-        Ok(Some(self.value_buffer.as_slice()))
     }
 
     /// Left-to-right expansion of `$NAME` / `${NAME}` / `${NAME:-default}`.
     /// `${...}` locates its matching `}` by depth (`${` opens, `}` closes,
     /// `\x` skipped); malformed forms fall through as literal text. The `:-`
     /// default clause is expanded recursively.
-    fn expand_into(map: &Map, value: &[u8], out: &mut Vec<u8>, depth: u8) -> bool {
+    ///
+    /// Literal bytes copied from `value` are bounded by the file size; only
+    /// looked-up substitutions can grow without bound, so those go through
+    /// `push_lookup` and trip [`MAX_EXPANDED_VALUE_LEN`].
+    fn expand_into(
+        map: &Map,
+        value: &[u8],
+        out: &mut Vec<u8>,
+        depth: u8,
+    ) -> Result<bool, ExpansionTooLarge> {
         #[inline]
         fn is_ident(b: u8) -> bool {
             matches!(b, b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_')
+        }
+
+        fn push_lookup(out: &mut Vec<u8>, v: &[u8]) -> Result<(), ExpansionTooLarge> {
+            if out.len().saturating_add(v.len()) > MAX_EXPANDED_VALUE_LEN {
+                return Err(ExpansionTooLarge);
+            }
+            out.extend_from_slice(v);
+            Ok(())
         }
 
         let mut pos = 0;
@@ -1212,13 +1274,13 @@ impl<'a> Parser<'a> {
                 let rest = &inner[key_end..];
                 if rest.is_empty() {
                     if let Some(v) = map.get(key) {
-                        out.extend_from_slice(v);
+                        push_lookup(out, v)?;
                     }
                 } else if let Some(default) = rest.strip_prefix(b":-") {
                     if let Some(v) = map.get(key) {
-                        out.extend_from_slice(v);
+                        push_lookup(out, v)?;
                     } else if depth < 200 {
-                        Self::expand_into(map, default, out, depth + 1);
+                        Self::expand_into(map, default, out, depth + 1)?;
                     } else {
                         out.extend_from_slice(default);
                     }
@@ -1236,7 +1298,7 @@ impl<'a> Parser<'a> {
                     k += 1;
                 }
                 if let Some(v) = map.get(&value[key_start..k]) {
-                    out.extend_from_slice(v);
+                    push_lookup(out, v)?;
                 }
                 pos = k;
                 continue;
@@ -1244,14 +1306,15 @@ impl<'a> Parser<'a> {
             out.push(b'$');
             pos += 1;
         }
-        changed
+        Ok(changed)
     }
 
     fn parse<const OVERRIDE: bool, const IS_PROCESS: bool, const EXPAND: bool>(
         &mut self,
         map: &mut Map,
-    ) -> Result<(), AllocError> {
+    ) -> Result<bool, AllocError> {
         let mut count = map.map.count();
+        let mut expansion_capped = false;
         while self.pos < self.src.len() {
             let Some(key) = self.parse_key::<true>() else {
                 self.skip_line();
@@ -1279,30 +1342,48 @@ impl<'a> Parser<'a> {
             // `values_mut()`. Values are dupe'd by `parse` above, so length
             // is bounded by file size.
             let total = map.map.count();
+            let mut expanded_total: usize = 0;
             let mut idx = count;
             while idx < total {
                 let current: Box<[u8]> = Box::from(&*map.map.values()[idx].value);
-                if let Some(expanded) = self.expand_value(map, &current)? {
-                    map.map.values_mut()[idx] = HashTableValue {
-                        value: Box::from(expanded),
-                    };
-                }
+                let value: Box<[u8]> = match self.expand_value(map, &current) {
+                    Expansion::Unchanged => {
+                        idx += 1;
+                        continue;
+                    }
+                    Expansion::Value(expanded)
+                        if expanded_total.saturating_add(expanded.len())
+                            <= MAX_EXPANDED_TOTAL_LEN =>
+                    {
+                        expanded_total += expanded.len();
+                        Box::from(expanded)
+                    }
+                    Expansion::Value(_) | Expansion::TooLarge => {
+                        expansion_capped = true;
+                        Box::default()
+                    }
+                };
+                map.map.values_mut()[idx] = HashTableValue { value };
                 idx += 1;
             }
             count = 0;
         }
         let _ = count;
-        Ok(())
+        Ok(expansion_capped)
     }
 
     /// Same as [`parse`] but takes the source bytes directly. Exists so
     /// `load_env_file*` can parse a transient `Vec<u8>` without constructing a
     /// `bun_ast::Source` (whose `contents` field is currently `&'static [u8]`).
+    ///
+    /// Returns `true` when at least one `${}` expansion was capped (per-value at
+    /// [`MAX_EXPANDED_VALUE_LEN`] or per-file aggregate at [`MAX_EXPANDED_TOTAL_LEN`])
+    /// and the affected value was set to empty.
     fn parse_bytes<const OVERRIDE: bool, const IS_PROCESS: bool, const EXPAND: bool>(
         src: &[u8],
         map: &mut Map,
         value_buffer: &mut Vec<u8>,
-    ) -> Result<(), AllocError> {
+    ) -> Result<bool, AllocError> {
         // Clear the buffer before each parse to ensure no leftover data
         value_buffer.clear();
         let mut parser = Parser {

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -331,6 +331,77 @@ test(".env ${VAR:-default} with nested references (issue #32411)", async () => {
   expect(result.exitCode).toBe(0);
 });
 
+test.concurrent(".env value expansion is bounded", async () => {
+  // Doubling chain: X0="a", Xi=$X{i-1}$X{i-1}. Uncapped, X24 would be 16 MiB and
+  // the geometric series keeps doubling until allocation aborts the process.
+  let env = "X0=a\n";
+  for (let i = 1; i <= 24; i++) env += `X${i}=$X${i - 1}$X${i - 1}\n`;
+  using dir = tempDir("dotenv-expand-cap", {
+    ".env": env,
+    "index.ts": `console.log(JSON.stringify({ X0: process.env.X0, X24: process.env.X24 }));`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    cwd: String(dir),
+    env: { ...bunEnv, NODE_ENV: undefined },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(JSON.parse(stdout.trim())).toEqual({ X0: "a", X24: "" });
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent(".env total expansion is bounded", async () => {
+  // A0..A22 doubles to exactly 4 MiB (at the per-value cap). Then ten B lines
+  // each reference A22; uncapped, all ten would be 4 MiB for ~40 MiB retained.
+  // The per-file aggregate cap stops storing expansions once the sum exceeds
+  // its limit, so the tail of B9 must be empty.
+  let env = "A0=a\n";
+  for (let i = 1; i <= 22; i++) env += `A${i}=$A${i - 1}$A${i - 1}\n`;
+  for (let i = 0; i <= 9; i++) env += `B${i}=$A22\n`;
+  using dir = tempDir("dotenv-expand-aggregate", {
+    ".env": env,
+    "index.ts": `console.log(JSON.stringify({ B0: process.env.B0?.length ?? -1, B9: process.env.B9 }));`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    cwd: String(dir),
+    env: { ...bunEnv, NODE_ENV: undefined },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(JSON.parse(stdout.trim())).toEqual({ B0: 4194304, B9: "" });
+  expect(exitCode).toBe(0);
+});
+
+// ulimit -v is a no-op under ASAN (which reserves ~20 TiB of shadow VM).
+test.concurrent.skipIf(!isLinux || isASAN)(".env value expansion doesn't abort the process", async () => {
+  // A 419-byte .env whose doubling chain requests 2^35 bytes. Under a
+  // virtual-memory limit the unfixed loader hits Rust's alloc-error abort
+  // before any user code runs.
+  let env = "X0=ab\n";
+  for (let i = 1; i <= 34; i++) env += `X${i}=$X${i - 1}$X${i - 1}\n`;
+  using dir = tempDir("dotenv-expand-abort", {
+    ".env": env,
+  });
+  await using proc = Bun.spawn({
+    cmd: ["bash", "-c", `ulimit -v 4000000 && exec "$0" -e 'console.log("alive", process.env.X34)'`, bunExe()],
+    cwd: String(dir),
+    env: { ...bunEnv, NODE_ENV: undefined },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), signalCode: proc.signalCode, exitCode }).toEqual({
+    stdout: "alive",
+    signalCode: null,
+    exitCode: 0,
+  });
+  expect(stderr).not.toContain("memory allocation");
+});
+
 test.concurrent(".env comments", async () => {
   using dir = tempDir("dotenv-comments", {
     ".env": "#FOZ\nFOO = foo#FAIL\nBAR='bar' #BAZ",


### PR DESCRIPTION
## Repro

```js
import { writeFileSync, mkdtempSync } from "node:fs";
import { spawnSync } from "node:child_process";
const d = mkdtempSync("/tmp/envboom-");
let s = "X0=ab\n";
for (let i = 1; i <= 34; i++) s += `X${i}=$X${i-1}$X${i-1}\n`;
writeFileSync(d + "/.env", s);            // 419 bytes on disk
const r = spawnSync("bash", ["-c", `ulimit -v 4000000 && cd ${d} && bun -e 'console.log("alive")'`], { encoding: "utf8" });
console.log(r.status, "|", r.stderr.trim().split("\n").pop());
// 134 | memory allocation of 536870912 bytes failed   (SIGABRT)
```

A 419-byte `.env` of self-doubling `$X$X` references hard-aborts every `bun` command run in that directory. `${}` expansion has no output-size cap, so a 35-line doubling chain requests 2^35 bytes and dies in Rust's alloc-error SIGABRT before user code runs. The `ulimit` only makes the failure point cheap; extend the chain to X63 and it requests 2^64 bytes, unsatisfiable on any machine. Node's `--env-file` on the same file is fine (no expansion).

## Cause

`Parser::expand_into` in `src/dotenv/env_loader.rs` appends each looked-up substitution to the output `Vec<u8>` with no bound. Each `Xi` looks up the already-expanded `X{i-1}` twice, so the buffer doubles per line. `Vec` growth routes allocation failure through the global alloc-error hook, which aborts. The file-read side of the loader already treats `ENOMEM` as a recoverable warn-and-continue (`read_env_file_contents`); the expansion pass had no corresponding guard.

## Fix

Two caps, both recovered by storing the value as empty and emitting one warning per file through the existing `quiet`-gated path:

- Per value (4 MiB): every looked-up substitution in `expand_into` goes through `push_lookup`, which fails with `ExpansionTooLarge` before growing past the cap. Literal bytes copied from the input are bounded by the file size and are not checked. `expand_value` maps this to `Expansion::TooLarge`.
- Per file (32 MiB): `parse` tracks the sum of expanded bytes it stores across the expansion pass, so N lines each referencing one at-cap value cannot retain N x 4 MiB.

```
warn: ".env" variable expansion exceeds size limit (4194304 bytes per value, 33554432 total); oversized values set to empty
```

Storing the oversized value as empty also stops the chain: later references to it resolve to `""`.

## Verification

Three tests in `test/cli/run/env.test.ts`:

- `.env value expansion is bounded`: 24-level doubling chain from `"a"`. Asserts `X24 === ""` and exit 0. Unfixed, `X24` is a 16 MiB string.
- `.env total expansion is bounded`: `A22` is exactly 4 MiB (passes the per-value cap), then ten `Bi=$A22` lines. Asserts `B0.length === 4194304` and `B9 === ""`. Unfixed, all ten are 4 MiB.
- `.env value expansion doesn't abort the process` (Linux, non-ASAN): the repro above under `ulimit -v`. Asserts user code runs and exit 0. Unfixed: `SIGABRT` / `memory allocation of 536870912 bytes failed`.

Existing expansion coverage (including the nested `${A:-${B}}` cases from #36199) still passes.
