### PR TITLE
test(spawn-pipe-leak): compare per-batch peak RSS instead of a single post-GC sample

### DIFF
--- a/test/js/bun/spawn/spawn-pipe-leak.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-leak.test.ts
@@ -75,11 +75,13 @@ describe.todoIf(
     /**
      * @param batchSize # of processes to spawn in parallel in each batch
      * @param totalBatches # of batches to run
+     * @returns peak RSS observed across the batches
      */
     async function testSpawnMemoryLeak(batchSize: number, totalBatches: number) {
       log("Starting memory leak test...");
       log(`Initial memory usage: ${Math.round(process.memoryUsage.rss() / MB)} MB`);
 
+      let peak = 0;
       for (let batch = 0; batch < totalBatches; batch++) {
         const batchPromises: Promise<void>[] = [];
 
@@ -92,34 +94,42 @@ describe.todoIf(
         // Wait for all processes in this batch to complete
         await Promise.all(batchPromises);
 
+        // Collect between batches so the next batch reuses the same pages instead of
+        // growing the heap; otherwise uncollected Blob garbage makes RSS climb across
+        // batches and the peak comparison sees a false positive.
+        Bun.gc(true);
+
+        const rss = process.memoryUsage.rss();
+        peak = Math.max(peak, rss);
+
         // Log progress after each batch
         log(`Batch ${batch + 1}/${totalBatches} completed (${(batch + 1) * batchSize} processes)`);
-        log(`Current memory usage: ${Math.round(process.memoryUsage.rss() / MB)} MB`);
+        log(`Current memory usage: ${Math.round(rss / MB)} MB`);
       }
 
-      // Force garbage collection after all batches have completed
-      Bun.gc(true);
+      return peak;
     }
 
     const batchSize = process.platform === "win32" ? 10 : 50;
 
     // Warmup
-    await testSpawnMemoryLeak(batchSize, 5);
-    const memBefore = process.memoryUsage();
+    const warmupPeak = await testSpawnMemoryLeak(batchSize, 5);
 
     // Run the test
-    await testSpawnMemoryLeak(batchSize, 10);
-    const memAfter = process.memoryUsage();
+    const mainPeak = await testSpawnMemoryLeak(batchSize, 10);
 
     log("Memory leak test completed");
     log(`Final memory usage: ${Math.round(process.memoryUsage.rss() / MB)} MB`);
-    log(`Memory difference: ${Math.round((process.memoryUsage.rss() - memBefore.rss) / MB)} MB`);
 
-    // should not have grown more than 80%
-    const delta = memAfter.rss - memBefore.rss;
-    const pct = delta / memBefore.rss;
-    console.log(`RSS delta: ${delta / MB}MB (${Math.round(100 * pct)}%)`);
-    // In Bun v1.2.0 this was 1.87 on macOS & Linux
+    // Compare the max RSS seen across batches rather than a single post-run sample.
+    // mimalloc returns pages on its own schedule, so one sample can land anywhere;
+    // the max over N batches is stable and still grows per batch under #18316/#20095.
+    const delta = mainPeak - warmupPeak;
+    const pct = delta / warmupPeak;
+    console.log(
+      `Peak RSS: warmup ${Math.round(warmupPeak / MB)} MB -> main ${Math.round(mainPeak / MB)} MB, ` +
+        `delta ${Math.round(delta / MB)} MB (${Math.round(100 * pct)}%)`,
+    );
     expect(pct).toBeLessThan(0.8);
   }
 


### PR DESCRIPTION
The first `Bun.spawn` leak test in `test/js/bun/spawn/spawn-pipe-leak.test.ts` has been flaking on roughly one lane every six or seven builds across Windows, Linux and macOS (e.g. [build 72075](https://buildkite.com/bun/bun/builds/72075), 72073, 72071, 72067, 72060, 72053, 72042, 72035, 72030, 72013, 72010, 72006, 72004, 72002), always on the `toBeLessThan(0.8)` assertion with received values between 0.84 and 2.37.

### Cause

The test sampled RSS once after `Bun.gc(true)` at the end of each phase and compared the two samples. `Bun.gc` frees the JS heap, but mimalloc hands pages back to the OS on its own schedule, so that single sample is nondeterministic. From the build 72075 log:

```
Warmup: 134 -> 158 -> 158 -> 160 -> 85   (Bun.gc)  memBefore = 85 MB
Main:   153 -> 165 -> ... -> 185 -> 185  (Bun.gc)  memAfter  = 185 MB
(185 - 85) / 85 = 1.19  =>  fails 0.8 threshold
```

The very next test in the same process then drops to 54 MB and stays there, so nothing was actually leaking; the 85 MB baseline just happened to land after mimalloc had returned pages and the 185 MB sample happened to land before it had.

### Fix

Collect after every batch (so uncollected `Blob` garbage does not accumulate across batches and drive RSS up on its own) and take the max RSS observed over the batches as the phase result. The max over N samples is stable across the occasional low reading that follows a page return, and a real leak (#18316 / #20095) still shows up: leaked native buffers survive GC, so the per-batch RSS climbs every iteration and the 10-batch run peaks well past the 5-batch warmup.

Replaying the build 72075 trace through the new metric gives `(185 - 160) / 160 = 0.16` and the build 72004 Windows trace gives `(162 - 155) / 155 = 0.05`.

### Verification

<details><summary>40 back-to-back runs on Windows x64</summary>

```
t1 deltas (%): 3 0 0 0 3 0 0 3 1 0 0 1 0 3 3 3 0 0 0 0 0 3 3 0 3 0 3 0 2 0 1 0 0 0 0 0 3 0 3 3
max 3%, 0 fails
```
</details>

<details><summary>10 back-to-back runs on Linux x64 (all three tests)</summary>

```
readPipeAfterExit : 7 4 -2 -5 3 3 0 4 14 0    (max 14%)
dontRead          : 0 0 0 0 0 0 0 0 0 0
readPipeBeforeExit: -7 3 0 23 2 2 2 27 7 3    (max 27%)
0 fails
```
</details>

This is a long-standing flake (it shows up at a similar rate back to at least build 70300), so there is no single culprit PR; the test introduced in #20095 has always had this sensitivity to the post-GC RSS sample point and 0a92d64f0f already bumped the threshold from 0.5 to 0.8 once.

Test-only change; no `src/` diff.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->