### PR TITLE
Report require.resolve() edges in Bun.Transpiler.scanImports()

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -848,18 +848,39 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let expr = Expr::init(t, loc);
         if SCAN_ONLY {
             if let js_ast::ExprData::ECall(call) = expr.data {
-                if let js_ast::ExprData::EIdentifier(ident) = call.target.data {
-                    // is this a require("something")
-                    if self.load_name_from_ref(ident.ref_) == b"require" && call.args.len_u32() == 1
-                    {
-                        if let js_ast::ExprData::EString(s) = call.args.at(0).data {
-                            let _ = self.add_import_record(
-                                ImportKind::Require,
-                                loc,
-                                s.string(self.arena).expect("unreachable"),
-                            );
+                match call.target.data {
+                    js_ast::ExprData::EIdentifier(ident) => {
+                        // is this a require("something")
+                        if self.load_name_from_ref(ident.ref_) == b"require"
+                            && call.args.len_u32() == 1
+                        {
+                            if let js_ast::ExprData::EString(s) = call.args.at(0).data {
+                                let _ = self.add_import_record(
+                                    ImportKind::Require,
+                                    loc,
+                                    s.string(self.arena).expect("unreachable"),
+                                );
+                            }
                         }
                     }
+                    js_ast::ExprData::EDot(dot) => {
+                        // is this a require.resolve("something")
+                        if let js_ast::ExprData::EIdentifier(ident) = dot.target.data {
+                            if dot.name == b"resolve"
+                                && self.load_name_from_ref(ident.ref_) == b"require"
+                                && call.args.len_u32() == 1
+                            {
+                                if let js_ast::ExprData::EString(s) = call.args.at(0).data {
+                                    let _ = self.add_import_record(
+                                        ImportKind::RequireResolve,
+                                        loc,
+                                        s.string(self.arena).expect("unreachable"),
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
                 }
             }
         }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -848,39 +848,34 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let expr = Expr::init(t, loc);
         if SCAN_ONLY {
             if let js_ast::ExprData::ECall(call) = expr.data {
-                match call.target.data {
-                    js_ast::ExprData::EIdentifier(ident) => {
-                        // is this a require("something")
-                        if self.load_name_from_ref(ident.ref_) == b"require"
-                            && call.args.len_u32() == 1
-                        {
-                            if let js_ast::ExprData::EString(s) = call.args.at(0).data {
-                                let _ = self.add_import_record(
-                                    ImportKind::Require,
-                                    loc,
-                                    s.string(self.arena).expect("unreachable"),
-                                );
-                            }
-                        }
+                // is this a require("something") / require.resolve("something")
+                let kind = match call.target.data {
+                    js_ast::ExprData::EIdentifier(ident)
+                        if self.load_name_from_ref(ident.ref_) == b"require" =>
+                    {
+                        Some(ImportKind::Require)
                     }
-                    js_ast::ExprData::EDot(dot) => {
-                        // is this a require.resolve("something")
-                        if let js_ast::ExprData::EIdentifier(ident) = dot.target.data {
+                    js_ast::ExprData::EDot(dot) => match dot.target.data {
+                        js_ast::ExprData::EIdentifier(ident)
                             if dot.name == b"resolve"
-                                && self.load_name_from_ref(ident.ref_) == b"require"
-                                && call.args.len_u32() == 1
-                            {
-                                if let js_ast::ExprData::EString(s) = call.args.at(0).data {
-                                    let _ = self.add_import_record(
-                                        ImportKind::RequireResolve,
-                                        loc,
-                                        s.string(self.arena).expect("unreachable"),
-                                    );
-                                }
-                            }
+                                && self.load_name_from_ref(ident.ref_) == b"require" =>
+                        {
+                            Some(ImportKind::RequireResolve)
+                        }
+                        _ => None,
+                    },
+                    _ => None,
+                };
+                if let Some(kind) = kind {
+                    if call.args.len_u32() == 1 {
+                        if let js_ast::ExprData::EString(s) = call.args.at(0).data {
+                            let _ = self.add_import_record(
+                                kind,
+                                loc,
+                                s.string(self.arena).expect("unreachable"),
+                            );
                         }
                     }
-                    _ => {}
                 }
             }
         }

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2074,6 +2074,36 @@ console.log(<div {...obj} key="after" />);`),
       expect(imports.filter(({ path }) => path === "react")).toHaveLength(1);
       expect(imports).toHaveLength(2);
     });
+
+    it("reports require() and require.resolve() edges", () => {
+      const src = `
+        const p = require.resolve("./native-addon.node");
+        const q = require("./cjs-dep");
+        const r = require.resolve("side-a");
+        export { p, q, r };
+      `;
+      for (const loader of ["js", "ts", "jsx", "tsx"]) {
+        const imports = new Bun.Transpiler({ loader }).scanImports(src);
+        expect({ loader, imports }).toEqual({
+          loader,
+          imports: [
+            { kind: "require-resolve", path: "./native-addon.node" },
+            { kind: "require-call", path: "./cjs-dep" },
+            { kind: "require-resolve", path: "side-a" },
+          ],
+        });
+      }
+    });
+
+    it("does not report non-require .resolve() calls", () => {
+      const src = `
+        const a = foo.resolve("not-a-dep");
+        const b = require.other("also-not-a-dep");
+        const c = require.resolve(dynamic);
+        const d = require.resolve("two", { paths: [] });
+      `;
+      expect(new Bun.Transpiler({ loader: "js" }).scanImports(src)).toEqual([]);
+    });
   });
 
   const parsed = (code, trim = true, autoExport = false, transpiler_ = transpiler) => {


### PR DESCRIPTION
## What

`Bun.Transpiler.scanImports()` now reports `require.resolve("...")` edges with kind `"require-resolve"`, matching `scan()` and the documented import kinds.

## Repro

```js
const src = 'const p = require.resolve("./native-addon.node"); const q = require("./cjs-dep"); export { p, q };';
new Bun.Transpiler({ loader: "ts" }).scanImports(src);
// before: [{ kind: "require-call", path: "./cjs-dep" }]
// after:  [{ kind: "require-resolve", path: "./native-addon.node" },
//          { kind: "require-call",    path: "./cjs-dep" }]
```

## Cause

`scanImports` runs the parser with `SCAN_ONLY = true` and never runs the visit pass. The SCAN_ONLY hook in `P::new_expr` (src/js_parser/p.rs) matched `ECall { target: EIdentifier("require") }` and emitted an `ImportKind::Require` record, but for `require.resolve("x")` the call target is an `EDot`, so it fell through. The `ImportKind::RequireResolve` record is normally created by `transpose_require_resolve_known_string` during the visit pass, which `scanImports` skips, so the edge was never recorded.

## Fix

Add an `EDot` arm to the SCAN_ONLY hook that mirrors the existing `require(...)` match: when the call target is `require.resolve` with a single string-literal argument, emit an `ImportKind::RequireResolve` record. Non-`require` `.resolve()` calls, non-string arguments, and the two-argument `require.resolve("x", { paths })` form are left alone, matching the visit-pass behavior.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/bundler/transpiler/transpiler.test.js -t scanImports  # fails
bun bd test test/bundler/transpiler/transpiler.test.js -t scanImports                # passes
bun bd test test/bundler/transpiler/transpiler.test.js                               # 173 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (6e71e8168)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.32ms]
(pass) Bun.Transpiler > normalizes \r\n [6.76ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.07ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [6.98ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.54ms]
(pass) Bun.Transpiler > property access inlining > works [2.40ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.08ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [2.73ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [2.29ms]
(pass) B
... (truncated)

release without fix: 22 skipped
bun test v1.4.0-canary.1 (6e71e8168)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.08ms]
(pass) Bun.Transpiler > normalizes \r\n [0.16ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.07ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.12ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.04ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.03ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.07ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [0.06ms]
(pass) Bun.Transpiler > TypeScript > contextual keywords used as plain identifiers keep their statements [0.30ms]
(pass) Bun.Transpiler > TypeScript > does not crash when export default abstract is an expression followed by a class [0.25ms]
(pass) Bun.Transpiler > TypeScript > scope tracking stays balanced when a contextual keyword starts a larger expression [0.23ms]
(pass) Bun.Transpiler > TypeScript > scope tracking stays balan
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (6e71e8168)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.68ms]
(pass) Bun.Transpiler > normalizes \r\n [7.11ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.63ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [7.22ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.94ms]
(pass) Bun.Transpiler > property access inlining > works [2.69ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.57ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [3.10ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [2.62ms]
(pass) B
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 670ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[2/21] gen JS modules (bundle-modules)
Preprocess modules (6617ms)
Bundle modules (39ms)
Postprocesss modules (22ms)
Bundle Functions (722ms)
Generate Code (72ms)

[7.49s] Bundled "src/js" for production
  1913 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                         | 24 ++++++++++++++++++++----
 test/bundler/transpiler/transpiler.test.js | 30 ++++++++++++++++++++++++++++++
 2 files changed, 50 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser/p.rs                              3      2      0
test/bundler/transpiler/transpiler.test.js      1      1      0
```

</details>

<!-- robobun:evidence:end -->