### PR TITLE
fix(transpiler): scanImports drops dynamic import() with non-ASCII specifier

### DIFF
--- a/src/js_parser/parse/parse_import_export.rs
+++ b/src/js_parser/parse/parse_import_export.rs
@@ -72,7 +72,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // Reshaped for borrowck — EString::slice takes &mut self (rope flatten),
             // so capture the slice (arena-lifetime) before re-using `value` by-value below.
             let slice_opt: Option<&'a [u8]> = if let ExprData::EString(e_string) = &mut value.data {
-                if e_string.is_utf8() && e_string.is_present() {
+                if e_string.is_present() {
                     Some(e_string.slice(p.arena))
                 } else {
                     None

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2074,6 +2074,26 @@ console.log(<div {...obj} key="after" />);`),
       expect(imports.filter(({ path }) => path === "react")).toHaveLength(1);
       expect(imports).toHaveLength(2);
     });
+
+    it("reports dynamic import() with non-ASCII specifiers", () => {
+      const t = new Bun.Transpiler({ loader: "ts" });
+      for (const src of [
+        `import("./café");`,
+        `import("./caf\\u00e9");`,
+        `import("./caf\\u{e9}");`,
+        `import("./中文");`,
+        `import("./🍣");`,
+        `import("./plain");`,
+      ]) {
+        const fast = t.scanImports(src);
+        const full = t.scan(src).imports;
+        expect({ src, fast }).toEqual({
+          src,
+          fast: [{ kind: "dynamic-import", path: expect.any(String) }],
+        });
+        expect({ src, fast }).toEqual({ src, fast: full });
+      }
+    });
   });
 
   const parsed = (code, trim = true, autoExport = false, transpiler_ = transpiler) => {


### PR DESCRIPTION
## What

`Bun.Transpiler.scanImports()` silently dropped every dynamic `import()` whose specifier contains a non-ASCII character, while `scan()` and static imports with the same specifier were reported.

```js
const t = new Bun.Transpiler({ loader: "ts" });
t.scanImports(`import("./café");`)        // []   <- dropped
t.scanImports(`import("./caf\u00e9");`)   // []   <- dropped even with pure-ASCII source
t.scan(`import("./café");`).imports       // [{ kind: "dynamic-import", ... }]
t.scanImports(`import a from "./café";a`) // [{ kind: "import-statement", ... }]
```

## Why

The `SCAN_ONLY` branch of `parse_import_expr` only called `add_import_record` when `e_string.is_utf8()` was true. Any non-ASCII code point makes the lexer store the literal as UTF-16, so the guard failed and the branch fell through without recording the import.

The full parse records the same import via `transpose_import`, which calls `EString::slice()` without the guard. `slice()` already handles both encodings (it transcodes UTF-16 to UTF-8 via `string()`).

## Fix

Drop the `is_utf8()` guard; `slice()` handles both encodings.

The test asserts `scanImports()` matches `scan().imports` for non-ASCII dynamic imports rather than hardcoding path bytes, since the path text is currently Latin-1-decoded in `named_imports_to_js` (pre-existing, affects static imports and `scan()` too, tracked separately).

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b4f409584)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.70ms]
(pass) Bun.Transpiler > normalizes \r\n [6.57ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.25ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [6.77ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.71ms]
(pass) Bun.Transpiler > property access inlining > works [2.43ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.33ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [2.87ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [2.31ms]
(pass) B
... (truncated)

release without fix: 1 failed, 22 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.16ms]
(pass) Bun.Transpiler > normalizes \r\n [0.20ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.13ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.13ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.03ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.03ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.05ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [0.06ms]
(pass) Bun.Transpiler > TypeScript > contextual keywords used as plain identifiers keep their statements [0.27ms]
(pass) Bun.Transpiler > TypeScript > does not crash when export default abstract is an expression followed by a class [0.24ms]
(pass) Bun.Transpiler > TypeScript > scope tracking stays balanced when a contextual keyword starts a larger expression [0.24ms]
(pass) Bun.Transpiler > TypeScript > scope tracking stays balan
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b4f409584)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.40ms]
(pass) Bun.Transpiler > normalizes \r\n [6.72ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.48ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [6.80ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.68ms]
(pass) Bun.Transpiler > property access inlining > works [2.43ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.26ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [2.84ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [2.59ms]
(pass) B
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 818ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[2/21] gen JS modules (bundle-modules)
Preprocess modules (6758ms)
Bundle modules (36ms)
Postprocesss modules (31ms)
Bundle Functions (744ms)
Generate Code (86ms)

[7.67s] Bundled "src/js" for production
  1913 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/parse/parse_import_export.rs |  2 +-
 test/bundler/transpiler/transpiler.test.js | 20 ++++++++++++++++++++
 2 files changed, 21 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser/parse/parse_import_export.rs      1      1      0
test/bundler/transpiler/transpiler.test.js      1      2      0
```

</details>

<!-- robobun:evidence:end -->