### PR TITLE
fix(transpiler): skip leading hashbang in scanImports

### DIFF
--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -437,6 +437,11 @@ impl<'a> Parser<'a> {
             p.parse_pass_symbol_uses = Some(&mut scan_pass.used_symbols);
         }
 
+        // Consume a leading hashbang comment
+        if p.lexer.token == js_lexer::T::THashbang {
+            p.lexer.next()?;
+        }
+
         // Parse the file in the first pass, but do not bind symbols
         let mut opts = ParseStatementOptions {
             is_module_scope: true,

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2074,6 +2074,18 @@ console.log(<div {...obj} key="after" />);`),
       expect(imports.filter(({ path }) => path === "react")).toHaveLength(1);
       expect(imports).toHaveLength(2);
     });
+
+    it.each(["ts", "tsx", "js", "jsx"])("accepts a leading hashbang (%s)", loader => {
+      const src = '#!/usr/bin/env bun\nimport { dep } from "./dep";\nconsole.log(dep);\n';
+      const t = new Bun.Transpiler({ loader });
+      expect(t.scanImports(src)).toEqual([{ kind: "import-statement", path: "./dep" }]);
+      expect(t.scan(src).imports).toEqual([{ kind: "import-statement", path: "./dep" }]);
+    });
+
+    it("accepts a hashbang-only file", () => {
+      expect(new Bun.Transpiler().scanImports("#!/usr/bin/env bun\n")).toEqual([]);
+      expect(new Bun.Transpiler().scanImports("#!/usr/bin/env bun")).toEqual([]);
+    });
   });
 
   const parsed = (code, trim = true, autoExport = false, transpiler_ = transpiler) => {


### PR DESCRIPTION
## Reproduction

```js
const src = '#!/usr/bin/env bun\nimport { dep } from "./dep";\nconsole.log(dep);\n';
new Bun.Transpiler({ loader: "ts" }).scanImports(src);
// AggregateError: BuildMessage "Unexpected #!/usr/bin/env bun"
```

`transformSync()`, `scan()`, and `bun run` all accept the identical source; only `scanImports()` rejects it. Since `scanImports()` is the fast path for dependency discovery and CLI entry files routinely start with a shebang, this breaks scanning on exactly the files it most needs to handle.

## Cause

The full-parse entry points in `src/js_parser/parse/parse_entry.rs` consume a leading `THashbang` token before calling `parse_stmts_up_to()`, but the scan-only `_scan_imports` entry went straight to `parse_stmts_up_to()`, so the hashbang token reached the statement parser as an unexpected token.

## Fix

Skip the `THashbang` token in `_scan_imports` the same way the other entry points do.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/bundler/transpiler/transpiler.test.js -t hashbang
(fail) accepts a leading hashbang (ts/tsx/js/jsx)   BuildMessage: Unexpected #!/usr/bin/env bun
(fail) accepts a hashbang-only file                 BuildMessage: Unexpected #!/usr/bin/env bun
5 fail

$ bun bd test test/bundler/transpiler/transpiler.test.js -t hashbang
5 pass, 0 fail
```

Full `transpiler.test.js` run: 176 pass, 0 fail.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (16c6b0662)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [4.81ms]
(pass) Bun.Transpiler > normalizes \r\n [6.32ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.56ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [6.57ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.56ms]
(pass) Bun.Transpiler > property access inlining > works [2.45ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.31ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [2.75ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [2.24ms]
(pass) B
... (truncated)

release without fix: 22 skipped
bun test v1.4.0-canary.1 (0449ed2f7)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.08ms]
(pass) Bun.Transpiler > normalizes \r\n [0.14ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.08ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.11ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.03ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.03ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.05ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [0.04ms]
(pass) Bun.Transpiler > TypeScript > contextual keywords used as plain identifiers keep their statements [0.29ms]
(pass) Bun.Transpiler > TypeScript > does not crash when export default abstract is an expression followed by a class [0.26ms]
(pass) Bun.Transpiler > TypeScript > scope tracking stays balanced when a contextual keyword starts a larger expression [0.22ms]
(pass) Bun.Transpiler > TypeScript > scope tracking stays balan
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (16c6b0662)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [4.79ms]
(pass) Bun.Transpiler > normalizes \r\n [6.24ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.15ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [6.87ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.50ms]
(pass) Bun.Transpiler > property access inlining > works [2.30ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.29ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [2.65ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [2.20ms]
(pass) B
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 719ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[2/21] gen JS modules (bundle-modules)
Preprocess modules (6754ms)
Bundle modules (65ms)
Postprocesss modules (26ms)
Bundle Functions (632ms)
Generate Code (92ms)

[7.58s] Bundled "src/js" for production
  1913 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/parse/parse_entry.rs         |  5 +++++
 test/bundler/transpiler/transpiler.test.js | 12 ++++++++++++
 2 files changed, 17 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser/parse/parse_entry.rs              2      1      0
test/bundler/transpiler/transpiler.test.js      1      1      0
```

</details>

**root cause** · written by the author bot

The scan-only parser entry used by `scanImports` jumped straight into statement parsing without first consuming a leading `THashbang` token, so any source beginning with a shebang hit the statement parser as an unexpected token and failed. The full-parse and other entry points in the same file already skip this token before parsing statements. The fix adds the same token-skipping step to the scan-only entry so it advances past the hashbang before calling `parse_stmts_up_to`.

<!-- robobun:evidence:end -->