### PR TITLE
fix(transpiler): preserve UTF-8 in scan()/scanImports() import paths

### DIFF
--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -1663,7 +1663,7 @@ fn named_imports_to_js(
         }
 
         array.ensure_still_alive();
-        let path = JscZigString::init(record.path.text).to_js(global);
+        let path = JscZigString::from_utf8(record.path.text).to_js(global);
         let kind = JscZigString::init(record.kind.label()).to_js(global);
         let entry = JSValue::create_object2(global, &path_label, &kind_label, path, kind)?;
         array.put_index(global, i, entry)?;

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2074,6 +2074,21 @@ console.log(<div {...obj} key="after" />);`),
       expect(imports.filter(({ path }) => path === "react")).toHaveLength(1);
       expect(imports).toHaveLength(2);
     });
+
+    it("preserves non-ASCII import specifiers as UTF-8", () => {
+      const spec = "./café-\u{1F600}-中文";
+      const src = `import a from ${JSON.stringify(spec)}; import(${JSON.stringify(spec)}); require(${JSON.stringify(spec)}); a;`;
+
+      expect(transpiler.scanImports(src, "ts")).toEqual([
+        { kind: "import-statement", path: spec },
+        { kind: "require-call", path: spec },
+      ]);
+
+      expect(transpiler.scan(src).imports).toEqual([
+        { kind: "import-statement", path: spec },
+        { kind: "dynamic-import", path: spec },
+      ]);
+    });
   });
 
   const parsed = (code, trim = true, autoExport = false, transpiler_ = transpiler) => {


### PR DESCRIPTION
## Repro

```js
const spec = "./café-\u{1F600}-中文";
const t = new Bun.Transpiler({ loader: "ts" });
const src = `import a from ${JSON.stringify(spec)}; a;`;
const p = t.scan(src).imports[0].path;
console.log(p === spec, JSON.stringify(p), p.length, "want", spec.length);
// false "./cafÃ©-ð-ä¸­æ" 19 want 12
```

Each UTF-8 byte is widened to one UTF-16 code unit (Latin-1 read), so `"./café"` comes back as `"./cafÃ©"` and `Bun.resolveSync(p, dir)` fails against the very directory holding `café.ts`. `scanImports()` has the same problem; `transformSync()` and `scan().exports` are unaffected.

## Cause

`named_imports_to_js` in `src/runtime/api/JSTranspiler.rs` converts `record.path.text` (UTF-8 bytes from the parser) with `ZigString::init(..).to_js(global)`. `ZigString::init` carries no encoding tag, and an untagged `ZigString` is read as Latin-1 by `to_js`.

## Fix

Use `ZigString::from_utf8` so the string is tagged UTF-8 before `to_js`. The `kind` label on the next line is always ASCII and is left as `init`.

## Verification

Added a test to the existing `scanImports` describe block in `test/bundler/transpiler/transpiler.test.js` covering `scan().imports` and `scanImports()` with a specifier containing Latin-1, emoji, and CJK. Fails on main with the mojibake output, passes with this change.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ef4d8c2fa)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [4.78ms]
(pass) Bun.Transpiler > normalizes \r\n [6.31ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.38ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [6.37ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.53ms]
(pass) Bun.Transpiler > property access inlining > works [2.35ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.06ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [2.77ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [2.25ms]
(pass) B
... (truncated)

release without fix: 22 skipped
bun test v1.4.0-canary.1 (b38b29ef5)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.10ms]
(pass) Bun.Transpiler > normalizes \r\n [0.14ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.08ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.11ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.03ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.02ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.05ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [0.04ms]
(pass) Bun.Transpiler > TypeScript > contextual keywords used as plain identifiers keep their statements [0.27ms]
(pass) Bun.Transpiler > TypeScript > does not crash when export default abstract is an expression followed by a class [0.25ms]
(pass) Bun.Transpiler > TypeScript > scope tracking stays balanced when a contextual keyword starts a larger expression [0.21ms]
(pass) Bun.Transpiler > TypeScript > scope tracking stays balan
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ef4d8c2fa)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [4.79ms]
(pass) Bun.Transpiler > normalizes \r\n [6.83ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.23ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [6.54ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.57ms]
(pass) Bun.Transpiler > property access inlining > works [2.42ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.33ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [3.10ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [2.50ms]
(pass) B
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 699ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[2/21] gen JS modules (bundle-modules)
Preprocess modules (6613ms)
Bundle modules (35ms)
Postprocesss modules (19ms)
Bundle Functions (622ms)
Generate Code (75ms)

[7.37s] Bundled "src/js" for production
  1913 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/JSTranspiler.rs            |  2 +-
 test/bundler/transpiler/transpiler.test.js | 15 +++++++++++++++
 2 files changed, 16 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/runtime/api/JSTranspiler.rs                 1      1      0
test/bundler/transpiler/transpiler.test.js      1      2      0
```

</details>

<!-- robobun:evidence:end -->