### PR TITLE
fix(process): NUL-terminate the PSI trigger write so memoryPressure arms on Linux

### DIFF
--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -371,6 +371,12 @@ export const isMemoryPressureWatcherInstalled: () => boolean = $newCppFunction(
   0,
 );
 
+export const memoryPressureWatcherHasOsBackend: () => boolean = $newCppFunction(
+  "InternalForTesting.cpp",
+  "jsFunction_memoryPressureWatcherHasOsBackend",
+  0,
+);
+
 export const getEventLoopStats: () => { activeTasks: number; concurrentRef: number; numPolls: number } =
   $newRustFunction("event_loop.rs", "getActiveTasks", 0);
 

--- a/src/jsc/bindings/InternalForTesting.cpp
+++ b/src/jsc/bindings/InternalForTesting.cpp
@@ -103,6 +103,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_BunString_toThreadSafeRefCountDelta, (JSC::J
 
 extern "C" void Bun__MemoryPressure__emit(JSC::JSGlobalObject* global, int level);
 extern "C" bool Bun__MemoryPressure__isInstalled(JSC::JSGlobalObject* global);
+extern "C" bool Bun__MemoryPressure__hasOsBackend(JSC::JSGlobalObject* global);
 
 // Synthetically fire process.on("memoryPressure") so tests can exercise the
 // emit path without depending on real OS memory pressure.
@@ -122,6 +123,14 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_emitMemoryPressure, (JSC::JSGlobalObject * g
 JSC_DEFINE_HOST_FUNCTION(jsFunction_isMemoryPressureWatcherInstalled, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     return JSValue::encode(jsBoolean(Bun__MemoryPressure__isInstalled(defaultGlobalObject(globalObject))));
+}
+
+// Whether the installed watcher registered a real OS signal source (PSI
+// trigger, kqueue filter, notification thread) rather than the silent
+// no-backend fallback.
+JSC_DEFINE_HOST_FUNCTION(jsFunction_memoryPressureWatcherHasOsBackend, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    return JSValue::encode(jsBoolean(Bun__MemoryPressure__hasOsBackend(defaultGlobalObject(globalObject))));
 }
 
 }

--- a/src/jsc/bindings/InternalForTesting.h
+++ b/src/jsc/bindings/InternalForTesting.h
@@ -13,5 +13,6 @@ JSC_DECLARE_HOST_FUNCTION(jsFunction_BunString_toThreadSafeRefCountDelta);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_lowercaseHeaderNameSIMD);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_emitMemoryPressure);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_isMemoryPressureWatcherInstalled);
+JSC_DECLARE_HOST_FUNCTION(jsFunction_memoryPressureWatcherHasOsBackend);
 
 }

--- a/src/runtime/node/memory_pressure.rs
+++ b/src/runtime/node/memory_pressure.rs
@@ -139,9 +139,10 @@ mod posix {
     fn open_psi_fd() -> Option<Fd> {
         use bun_sys::O;
 
-        /// 150 ms of "some"-stall in any 2 s window. 2 s is the minimum
-        /// window for unprivileged PSI triggers (kernel 6.6+).
-        const TRIGGER: &[u8] = b"some 150000 2000000";
+        /// 150 ms of "some"-stall in any 2 s window (the minimum for
+        /// unprivileged PSI triggers, kernel 6.6+). psi_write NUL-terminates
+        /// in place over the last byte written, so the NUL must be included.
+        const TRIGGER: &[u8] = b"some 150000 2000000\0";
 
         let mut cgroup_buf = [0u8; 320];
         let paths = [
@@ -204,6 +205,16 @@ mod posix {
             poll: register_os_watch(global),
         });
         *slot(global.bun_vm().as_mut()) = NonNull::new(bun_core::heap::into_raw(watcher).cast());
+    }
+
+    pub(super) fn has_os_backend(global: &JSGlobalObject) -> bool {
+        match slot(global.bun_vm().as_mut()) {
+            // SAFETY: slot is populated only by `install` with a `Box<MemoryPressureWatcher>`.
+            Some(raw) => unsafe { raw.cast::<MemoryPressureWatcher>().as_ref() }
+                .poll
+                .is_some(),
+            None => false,
+        }
     }
 
     pub(super) fn uninstall(global: &JSGlobalObject) {
@@ -402,6 +413,21 @@ pub extern "C" fn Bun__MemoryPressure__uninstall(global: &JSGlobalObject) {
 #[unsafe(no_mangle)]
 pub extern "C" fn Bun__MemoryPressure__emit(global: &JSGlobalObject, lvl: i32) {
     emit(global, lvl);
+}
+
+/// Whether the installed watcher actually registered an OS-level signal
+/// source (PSI trigger / kqueue filter / notification thread), as opposed to
+/// the silent no-backend fallback. Windows installs are all-or-nothing.
+#[unsafe(no_mangle)]
+pub extern "C" fn Bun__MemoryPressure__hasOsBackend(global: &JSGlobalObject) -> bool {
+    #[cfg(not(windows))]
+    {
+        posix::has_os_backend(global)
+    }
+    #[cfg(windows)]
+    {
+        Bun__MemoryPressure__isInstalled(global)
+    }
 }
 
 #[unsafe(no_mangle)]

--- a/test/js/node/process/process-memory-pressure.test.ts
+++ b/test/js/node/process/process-memory-pressure.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { closeSync, constants, openSync, writeSync } from "node:fs";
+import { closeSync, constants, openSync, readFileSync, writeSync } from "node:fs";
 import { bunEnv, bunExe } from "harness";
 
 // process.on("memoryPressure") is a Bun extension. These tests drive the
@@ -97,10 +97,9 @@ describe.concurrent("process.on('memoryPressure')", () => {
 
   // PSI trigger writes must include the trailing NUL: the kernel's psi_write()
   // NUL-terminates in place over the last byte of the write before parsing.
-  const canCreatePsiTrigger = (() => {
-    if (process.platform !== "linux") return false;
+  function canCreatePsiTriggerAt(path: string) {
     try {
-      const fd = openSync("/proc/pressure/memory", constants.O_RDWR | constants.O_NONBLOCK);
+      const fd = openSync(path, constants.O_RDWR | constants.O_NONBLOCK);
       try {
         writeSync(fd, Buffer.from("some 150000 2000000\0"));
         return true;
@@ -110,6 +109,24 @@ describe.concurrent("process.on('memoryPressure')", () => {
     } catch {
       return false;
     }
+  }
+
+  // Probe the same fallback order as open_psi_fd(): the system-wide file,
+  // then the current cgroup's memory.pressure.
+  const canCreatePsiTrigger = (() => {
+    if (process.platform !== "linux") return false;
+    if (canCreatePsiTriggerAt("/proc/pressure/memory")) return true;
+    let cgroup: string | undefined;
+    try {
+      cgroup = readFileSync("/proc/self/cgroup", "utf8")
+        .split("\n")
+        .find(line => line.startsWith("0::"));
+    } catch {
+      return false;
+    }
+    if (!cgroup) return false;
+    const rest = cgroup.slice("0::".length).replace(/^\/+/, "");
+    return canCreatePsiTriggerAt(`/sys/fs/cgroup/${rest}${rest ? "/" : ""}memory.pressure`);
   })();
 
   // Skipped where PSI trigger creation is unavailable: non-Linux, CONFIG_PSI=n,

--- a/test/js/node/process/process-memory-pressure.test.ts
+++ b/test/js/node/process/process-memory-pressure.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { closeSync, constants, openSync, writeSync } from "node:fs";
 import { bunEnv, bunExe } from "harness";
 
 // process.on("memoryPressure") is a Bun extension. These tests drive the
@@ -91,6 +92,35 @@ describe.concurrent("process.on('memoryPressure')", () => {
       process.stdout.write("done");
     `);
     expect(stdout).toBe("done");
+    expect(exitCode).toBe(0);
+  });
+
+  // PSI trigger writes must include the trailing NUL: the kernel's psi_write()
+  // NUL-terminates in place over the last byte of the write before parsing.
+  const canCreatePsiTrigger = (() => {
+    if (process.platform !== "linux") return false;
+    try {
+      const fd = openSync("/proc/pressure/memory", constants.O_RDWR | constants.O_NONBLOCK);
+      try {
+        writeSync(fd, Buffer.from("some 150000 2000000\0"));
+        return true;
+      } finally {
+        closeSync(fd);
+      }
+    } catch {
+      return false;
+    }
+  })();
+
+  // Skipped where PSI trigger creation is unavailable: non-Linux, CONFIG_PSI=n,
+  // or unprivileged on kernels before 6.6 (CAP_SYS_RESOURCE required).
+  test.skipIf(!canCreatePsiTrigger)("arms a PSI trigger on Linux", async () => {
+    const { stdout, stderr, exitCode } = await run(/* js */ `
+      const { memoryPressureWatcherHasOsBackend } = require("bun:internal-for-testing");
+      process.on("memoryPressure", () => {});
+      process.stdout.write(JSON.stringify(memoryPressureWatcherHasOsBackend()));
+    `);
+    expect({ stdout, stderr: stderr.trim() }).toEqual({ stdout: "true", stderr: "" });
     expect(exitCode).toBe(0);
   });
 


### PR DESCRIPTION
btw you should delete this feature because claude code abuses it to
[break long running sessions](https://catpranks.tv/posts/andrew-kelley-did-nothing-wrong/)

### What does this PR do?

On Linux, `process.on("memoryPressure")` never arms its OS backend: the PSI
trigger write in `open_psi_fd()` sends `some 150000 2000000` **without a
trailing NUL**, and the kernel's `psi_write()` NUL-terminates the buffer in
place by overwriting the last byte of the write before parsing
([kernel/sched/psi.c](https://github.com/torvalds/linux/blob/master/kernel/sched/psi.c)):

```c
buf_size = min(nbytes, sizeof(buf));
if (copy_from_user(buf, user_buf, buf_size))
    return -EFAULT;
buf[buf_size - 1] = '\0';
```

So the kernel parses `some 150000 200000` — a 200 ms window, which fails trigger
validation (unprivileged triggers must use a multiple of 2 s) — the write fails
with `EINVAL` on both `/proc/pressure/memory` and the cgroup fallback, and the
watcher silently installs with no backend. No `memoryPressure` event is ever
delivered on Linux.

With `CAP_SYS_RESOURCE` (e.g. root in a container), current kernels _accept_ the
truncated string instead: the trigger arms with a 200 ms window — requiring 75%
stall instead of the intended 7.5%, so events that should fire mostly don't —
and takes the privileged RT-polling aggregator path, spawning a kernel RT thread
that polls every 20 ms under stall. Same one-byte cause.

Repro (unprivileged, kernel 6.6+):

```python
>>> fd = os.open("/proc/pressure/memory", os.O_RDWR | os.O_NONBLOCK)
>>> os.write(fd, b"some 150000 2000000")    # OSError: EINVAL  (what Bun writes today)
>>> os.write(fd, b"some 150000 2000000\0")  # 20 — trigger armed
```

The fix is one byte: include the NUL in `TRIGGER`, matching the kernel's own
sample code, which writes `strlen(trig) + 1` bytes
([Documentation/accounting/psi.rst](https://www.kernel.org/doc/html/latest/accounting/psi.html)).

The rest of the diff makes the failure observable: the no-backend fallback is
deliberately silent, so `bun:internal-for-testing` gains
`memoryPressureWatcherHasOsBackend()`, and a new test asserts that arming a
listener registers a real PSI trigger. The test first proves the environment can
create PSI triggers with a direct write, then requires Bun to have done the same
— skipped where PSI trigger creation is unavailable (non-Linux, `CONFIG_PSI=n`,
or unprivileged before kernel 6.6).

### How did you verify your code works?

- `bun bd test test/js/node/process/process-memory-pressure.test.ts` — all tests
  pass, including the new `arms a PSI trigger on Linux` (recent kernel,
  unprivileged, PSI enabled).
- Reverting the one-byte `TRIGGER` fix makes the new test fail while its
  skip-guard still passes, so the assertion is live and fails for the right
  reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
