### PR TITLE
process.stdin: route throwing 'data'/'readable' listeners to uncaughtException instead of destroying stdin

### DIFF
--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -250,9 +250,6 @@ export function getStdinStream(
       return;
     }
 
-    // push() runs user 'data'/'readable'/'end' listeners synchronously. A throw from
-    // one of them is a programming error, not a read failure: it must surface as an
-    // uncaughtException and must NOT destroy stdin (node keeps delivering input).
     try {
       if (value) {
         stream.push(value);
@@ -268,8 +265,6 @@ export function getStdinStream(
         stream.push(null);
       }
     } catch (err) {
-      // The throw short-circuited addChunk() before maybeReadMore(), so re-arm
-      // the read loop ourselves to keep stdin flowing (libuv does this for node).
       if (value) triggerRead.$call(stream, undefined);
       process.nextTick(rethrowUncaught, err);
     }

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -224,16 +224,36 @@ export function getStdinStream(
     return ret;
   };
 
+  function rethrowUncaught(err) {
+    throw err;
+  }
+
   async function internalRead(stream) {
     $debug("internalRead();");
     // The reader this read belongs to. releaseLock() rejects the in-flight read(); by the
     // time that rejection lands, own() may already have acquired a NEW reader, so the catch
     // must key on this acquisition rather than on the current `reader`.
     const readerForThisRead = reader;
+    let value;
     try {
       $assert(readerForThisRead);
-      const { value } = await readerForThisRead.read();
+      ({ value } = await readerForThisRead.read());
+    } catch (err) {
+      if (readerForThisRead !== reader) {
+        // disown() released this read's reader while it was in flight (stdin may have been
+        // re-owned since), so the read rejected because the stream was unref()ed, not
+        // because it failed. triggerRead() re-arms if/when it is ref()ed again.
+        triggerRead.$call(stream, undefined);
+        return;
+      }
+      stream.destroy(err);
+      return;
+    }
 
+    // push() runs user 'data'/'readable'/'end' listeners synchronously. A throw from
+    // one of them is a programming error, not a read failure: it must surface as an
+    // uncaughtException and must NOT destroy stdin (node keeps delivering input).
+    try {
       if (value) {
         stream.push(value);
       } else {
@@ -248,14 +268,10 @@ export function getStdinStream(
         stream.push(null);
       }
     } catch (err) {
-      if (readerForThisRead !== reader) {
-        // disown() released this read's reader while it was in flight (stdin may have been
-        // re-owned since), so the read rejected because the stream was unref()ed, not
-        // because it failed. triggerRead() re-arms if/when it is ref()ed again.
-        triggerRead.$call(stream, undefined);
-        return;
-      }
-      stream.destroy(err);
+      // The throw short-circuited addChunk() before maybeReadMore(), so re-arm
+      // the read loop ourselves to keep stdin flowing (libuv does this for node).
+      if (value) triggerRead.$call(stream, undefined);
+      process.nextTick(rethrowUncaught, err);
     }
   }
 

--- a/test/js/node/process/process-stdin.test.ts
+++ b/test/js/node/process/process-stdin.test.ts
@@ -304,6 +304,93 @@ test.concurrent("stdin should not allow process to exit when not paused", async 
   expect(await proc.stderr.text()).toMatchInlineSnapshot(`""`);
 });
 
+test.concurrent("a throw from a 'data' listener is an uncaughtException, and stdin keeps reading", async () => {
+  // A user 'data' handler throwing is a programming error and must reach
+  // process.on('uncaughtException'); it is not a read failure, so stdin stays
+  // alive and the next chunk is delivered (node compat).
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const seen = [];
+      process.on("uncaughtException", (e, origin) => seen.push("uncaughtException:" + e.message + ":" + origin));
+      process.stdin.on("error", e => seen.push("stream-error:" + e.message));
+      let n = 0;
+      process.stdin.on("data", d => {
+        seen.push("data:" + d.toString());
+        if (++n === 1) { console.log("GOT1"); throw new Error("handler-throw"); }
+      });
+      process.stdin.on("end", () => {
+        console.log(JSON.stringify({ seen, destroyed: process.stdin.destroyed }));
+      });`,
+    ],
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  proc.stdin.write("one");
+  await proc.stdin.flush();
+  // The second chunk is sent strictly after the handler threw on the first, so
+  // it can only arrive if stdin survived the throw.
+  const reader = proc.stdout.getReader();
+  const decoder = new TextDecoder();
+  let stdout = "";
+  for (let r; !(r = await reader.read()).done; ) {
+    stdout += decoder.decode(r.value, { stream: true });
+    if (stdout.includes("GOT1")) break;
+  }
+  proc.stdin.write("two");
+  await proc.stdin.end();
+  for (let r; !(r = await reader.read()).done; ) stdout += decoder.decode(r.value, { stream: true });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect({ stdout, exitCode, ...(exitCode === 0 ? {} : { stderr }) }).toEqual({
+    stdout:
+      "GOT1\n" +
+      JSON.stringify({
+        seen: ["data:one", "uncaughtException:handler-throw:uncaughtException", "data:two"],
+        destroyed: false,
+      }) +
+      "\n",
+    exitCode: 0,
+  });
+});
+
+test.concurrent("a throw from a 'readable' listener is an uncaughtException and does not destroy stdin", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const seen = [];
+      process.on("uncaughtException", e => seen.push("uncaughtException:" + e.message));
+      process.stdin.on("error", e => seen.push("stream-error:" + e.message));
+      process.stdin.on("readable", () => {
+        let chunk;
+        while ((chunk = process.stdin.read()) !== null) seen.push("readable:" + chunk.toString());
+        throw new Error("readable-throw");
+      });
+      process.stdin.on("end", () => {
+        console.log(JSON.stringify({ seen, destroyed: process.stdin.destroyed }));
+      });`,
+    ],
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  proc.stdin.write("hello");
+  await proc.stdin.end();
+
+  const result = await stdioResult(proc);
+  const report = JSON.parse(result.stdout!);
+  expect(report.seen).toContain("readable:hello");
+  expect(report.seen).toContain("uncaughtException:readable-throw");
+  expect(report.seen).not.toContain("stream-error:readable-throw");
+  expect(report.destroyed).toBe(false);
+  expect(result.exitCode).toBe(0);
+});
+
 test.concurrent("pause() and resume() churn while data is in flight never destroys stdin", async () => {
   await using proc = Bun.spawn({
     cmd: [

--- a/test/js/node/process/process-stdin.test.ts
+++ b/test/js/node/process/process-stdin.test.ts
@@ -305,9 +305,6 @@ test.concurrent("stdin should not allow process to exit when not paused", async 
 });
 
 test.concurrent("a throw from a 'data' listener is an uncaughtException, and stdin keeps reading", async () => {
-  // A user 'data' handler throwing is a programming error and must reach
-  // process.on('uncaughtException'); it is not a read failure, so stdin stays
-  // alive and the next chunk is delivered (node compat).
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -331,8 +328,6 @@ test.concurrent("a throw from a 'data' listener is an uncaughtException, and std
   });
   proc.stdin.write("one");
   await proc.stdin.flush();
-  // The second chunk is sent strictly after the handler threw on the first, so
-  // it can only arrive if stdin survived the throw.
   const reader = proc.stdout.getReader();
   const decoder = new TextDecoder();
   let stdout = "";
@@ -358,10 +353,6 @@ test.concurrent("a throw from a 'data' listener is an uncaughtException, and std
 });
 
 test.concurrent("a throw from a 'readable' listener is an uncaughtException, including the EOF emission", async () => {
-  // 'readable' fires twice: once for the buffered chunk (via nextTick; already
-  // routed to uncaughtException) and once synchronously from push(null) at EOF.
-  // The EOF-path throw must reach uncaughtException too (node compat); before
-  // this fix internalRead() silently swallowed it.
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),

--- a/test/js/node/process/process-stdin.test.ts
+++ b/test/js/node/process/process-stdin.test.ts
@@ -357,7 +357,11 @@ test.concurrent("a throw from a 'data' listener is an uncaughtException, and std
   });
 });
 
-test.concurrent("a throw from a 'readable' listener is an uncaughtException and does not destroy stdin", async () => {
+test.concurrent("a throw from a 'readable' listener is an uncaughtException, including the EOF emission", async () => {
+  // 'readable' fires twice: once for the buffered chunk (via nextTick; already
+  // routed to uncaughtException) and once synchronously from push(null) at EOF.
+  // The EOF-path throw must reach uncaughtException too (node compat); before
+  // this fix internalRead() silently swallowed it.
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -365,14 +369,15 @@ test.concurrent("a throw from a 'readable' listener is an uncaughtException and 
       `const seen = [];
       process.on("uncaughtException", e => seen.push("uncaughtException:" + e.message));
       process.stdin.on("error", e => seen.push("stream-error:" + e.message));
+      let n = 0;
       process.stdin.on("readable", () => {
+        n++;
         let chunk;
         while ((chunk = process.stdin.read()) !== null) seen.push("readable:" + chunk.toString());
-        throw new Error("readable-throw");
+        throw new Error("readable-throw-" + n);
       });
-      process.stdin.on("end", () => {
-        console.log(JSON.stringify({ seen, destroyed: process.stdin.destroyed }));
-      });`,
+      process.stdin.on("end", () => seen.push("end"));
+      process.on("exit", () => console.log(JSON.stringify(seen)));`,
     ],
     stdin: "pipe",
     stdout: "pipe",
@@ -382,13 +387,16 @@ test.concurrent("a throw from a 'readable' listener is an uncaughtException and 
   proc.stdin.write("hello");
   await proc.stdin.end();
 
-  const result = await stdioResult(proc);
-  const report = JSON.parse(result.stdout!);
-  expect(report.seen).toContain("readable:hello");
-  expect(report.seen).toContain("uncaughtException:readable-throw");
-  expect(report.seen).not.toContain("stream-error:readable-throw");
-  expect(report.destroyed).toBe(false);
-  expect(result.exitCode).toBe(0);
+  expect(await stdioResult(proc)).toEqual({
+    stdout:
+      JSON.stringify([
+        "readable:hello",
+        "uncaughtException:readable-throw-1",
+        "end",
+        "uncaughtException:readable-throw-2",
+      ]) + "\n",
+    exitCode: 0,
+  });
 });
 
 test.concurrent("pause() and resume() churn while data is in flight never destroys stdin", async () => {


### PR DESCRIPTION
## What does this PR do?

A throw from a `process.stdin` `'data'` handler (or a `'readable'` handler, a `'keypress'` handler via `emitKeypressEvents`, or a sync-throwing readline completer) was being caught by the stdin read loop, mislabeled as a stream `'error'`, and fed to `stream.destroy(err)`. The throw never reached `process.on('uncaughtException')`, and stdin was permanently destroyed so all later input was silently dropped.

### Reproduction

```js
import { spawn } from "node:child_process";

if (process.argv[2] === "child") {
  const seen = [];
  process.on("uncaughtException", e => seen.push("uncaughtException:" + e.message));
  process.stdin.on("error", e => seen.push("stream-error:" + e.message));
  let n = 0;
  process.stdin.on("data", d => {
    seen.push("data:" + d.toString().trim());
    if (++n === 1) { console.log("GOT1"); throw new Error("handler-throw"); }
  });
  setTimeout(() => {
    console.log("REPORT " + JSON.stringify({ seen, destroyed: process.stdin.destroyed }));
    process.exit(0);
  }, 900);
} else {
  const c = spawn(process.execPath, [process.argv[1], "child"], { stdio: ["pipe", "pipe", "inherit"] });
  let out = "", sent2 = false;
  c.stdout.on("data", d => {
    out += d;
    if (!sent2 && out.includes("GOT1")) { sent2 = true; setTimeout(() => c.stdin.write("two\n"), 150); }
  });
  c.stdin.write("one\n");
  c.on("exit", () => console.log(out.match(/REPORT .*/)[0]));
}
```

Before (bun 1.4.0 and origin/main):
```
REPORT {"seen":["data:one","stream-error:handler-throw"],"destroyed":true}
```
uncaughtException never fires; the user's exception is re-surfaced as a stdin `'error'` event; stdin is destroyed and `"two"` is silently lost.

After / Node.js v26.3.0:
```
REPORT {"seen":["data:one","uncaughtException:handler-throw","data:two"],"destroyed":false}
```
throw routed to uncaughtException; stdin stays alive and the second chunk is delivered.

### Cause

In `src/js/builtins/ProcessObjectInternals.ts` `internalRead()`, `stream.push(value)` sat inside the `try/catch` meant to classify `reader.read()` failures. `push()` synchronously emits `'data'` (and at EOF emits `'readable'` synchronously via `onEofChunk`), so a user handler's throw was booked as a failed read and fed to `stream.destroy(err)`.

### Fix

Narrow the first `try` to cover only `reader.read()`. Move `stream.push()` to its own `try` whose `catch`:
- re-throws via `process.nextTick` so the error reaches `process.on('uncaughtException')` with `origin === 'uncaughtException'` (matching Node, where the libuv read callback's throw is reported as an uncaught exception), and
- re-arms the read loop when a data chunk was pushed, since the throw short-circuited `addChunk()` before it could call `maybeReadMore()` (Node doesn't need this because libuv keeps pushing regardless).

### How did you verify your code works?

New tests in `test/js/node/process/process-stdin.test.ts` covering both the `'data'` and `'readable'` listener paths. Both fail on main and pass with this change; the `'data'` test's expected output was taken verbatim from Node.js v26.3.0.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/process/process-stdin.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b209d84ef)

test/js/node/process/process-stdin.test.ts:
(pass) file does the right thing [1297.04ms]
(pass) pipe does the right thing [1362.96ms]
(pass) paused mode read(n) returns the buffered remainder at EOF [1596.32ms]
(pass) stdin with 'readable' event handler should receive data when paused [2271.90ms]
(pass) stdin with 'data' event handler should NOT receive data when paused [2355.45ms]
(pass) a read() that throws does not keep the process alive [1307.69ms]
(pass) explicit read(n) with no 'readable' listener still pulls from stdin [1556.87ms]
(pass) touching stdin again after 'end' does not keep the process alive [1528.79ms]
(pass) stdin should not allow process to exit when not paused [1030.50ms]
(pass) stdin should
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/process/process-stdin.test.ts:
(pass) file does the right thing [53.62ms]
(pass) pipe does the right thing [56.68ms]
(pass) explicit read(n) with no 'readable' listener still pulls from stdin [64.54ms]
(pass) paused mode read(n) returns the buffered remainder at EOF [65.53ms]
(pass) a read() that throws does not keep the process alive [64.89ms]
(pass) 'end' is not emitted when the buffer is never drained, and the process still exits [62.12ms]
338 |   proc.stdin.write("two");
339 |   await proc.stdin.end();
340 |   for (let r; !(r = await reader.read()).done; ) stdout += decoder.decode(r.value, { stream: true });
341 | 
342 |   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
343 |   expect({ stdout, exitCode, ...(exitCode === 0 ? {} : { stderr }) }).toEqual({
                                                                            ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "stdout": 
  "GOT1
- {"seen":["data:one","uncaughtException:handler-throw:uncaughtException","data:two"],"destroyed":false}
  "
  ,
  }

- Expected  - 1
+ Received  + 0

      at <ano
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/process/process-stdin.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b209d84ef)

test/js/node/process/process-stdin.test.ts:
(pass) pipe does the right thing [1296.83ms]
(pass) file does the right thing [1298.65ms]
(pass) paused mode read(n) returns the buffered remainder at EOF [1523.29ms]
(pass) stdin with 'readable' event handler should receive data when paused [2265.37ms]
(pass) stdin with 'data' event handler should NOT receive data when paused [2299.93ms]
(pass) a read() that throws does not keep the process alive [1369.78ms]
(pass) explicit read(n) with no 'readable' listener still pulls from stdin [1532.85ms]
(pass) touching stdin again after 'end' does not keep the process alive [1535.61ms]
(pass) stdin should allow process to exit when paused [1329.58ms]
(pass) stdin should not all
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 726ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen cpp.rs (cppbind)
[2/21] gen JS modules (bundle-modules)
Preprocess modules (6677ms)
Bundle modules (31ms)
Postprocesss modules (127ms)
Bundle Functions (744ms)
Generate Code (80ms)

[7.67s] Bundled "src/js" for production
  1911 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/builtins/ProcessObjectInternals.ts  | 29 ++++++----
 test/js/node/process/process-stdin.test.ts | 86 ++++++++++++++++++++++++++++++
 2 files changed, 106 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js/builtins/ProcessObjectInternals.ts       2      2      0
test/js/node/process/process-stdin.test.ts      3      8      0
```

</details>

<!-- robobun:evidence:end -->