### PR TITLE
Bun.color: clamp out-of-range object alpha instead of wrapping mod 256

### DIFF
--- a/src/css_jsc/color_js.rs
+++ b/src/css_jsc/color_js.rs
@@ -300,8 +300,9 @@ pub fn js_function_color(global: &JSGlobalObject, frame: &CallFrame) -> JsResult
             let a: Option<u8> = if let Some(a_value) = args[0].get_truthy(global, b"a")? {
                 'brk2: {
                     if a_value.is_number() {
+                        // CSS spec says to clamp values to their valid range so we'll respect that here
                         break 'brk2 Some(
-                            u8::try_from(((a_value.as_number() * 255.0) as i64).rem_euclid(256))
+                            u8::try_from(((a_value.as_number() * 255.0) as i64).clamp(0, 255))
                                 .unwrap(),
                         );
                     }

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -535,6 +535,30 @@ describe("input forms", () => {
     expect(color("#f00", "{rgb}")).toEqual({ r: 255, g: 0, b: 0 });
     expect(color("#f00", "[rgb]")).toEqual([255, 0, 0]);
   });
+
+  // The r/g/b keys of an object input and the CSS rgba() parser both clamp
+  // out-of-range values; the object's `a` key must too (it used to wrap mod 256,
+  // so a: 1.004 became fully transparent).
+  test("out-of-range object alpha clamps to [0, 1]", () => {
+    expect(color({ r: 10, g: 20, b: 30, a: 1.004 }, "{rgba}")).toEqual({ r: 10, g: 20, b: 30, a: 1 });
+    expect(color({ r: 10, g: 20, b: 30, a: 2 }, "{rgba}")).toEqual({ r: 10, g: 20, b: 30, a: 1 });
+    expect(color({ r: 10, g: 20, b: 30, a: 100 }, "{rgba}")).toEqual({ r: 10, g: 20, b: 30, a: 1 });
+    expect(color({ r: 10, g: 20, b: 30, a: -1 }, "{rgba}")).toEqual({ r: 10, g: 20, b: 30, a: 0 });
+    expect(color({ r: 10, g: 20, b: 30, a: -0.5 }, "{rgba}")).toEqual({ r: 10, g: 20, b: 30, a: 0 });
+    expect(color({ r: 10, g: 20, b: 30, a: Infinity }, "{rgba}")).toEqual({ r: 10, g: 20, b: 30, a: 1 });
+    expect(color({ r: 10, g: 20, b: 30, a: -Infinity }, "{rgba}")).toEqual({ r: 10, g: 20, b: 30, a: 0 });
+  });
+
+  test("object alpha agrees with the CSS parser's clamping", () => {
+    for (const a of [1.5, 2, -0.5, -1, 1.004]) {
+      expect(color({ r: 10, g: 20, b: 30, a }, "{rgba}")).toEqual(color(`rgba(10, 20, 30, ${a})`, "{rgba}"));
+    }
+  });
+
+  test("in-range object alpha is unchanged", () => {
+    expect(color({ r: 10, g: 20, b: 30, a: 1 }, "{rgba}")).toEqual({ r: 10, g: 20, b: 30, a: 1 });
+    expect(color({ r: 10, g: 20, b: 30, a: 0.5 }, "[rgba]")).toEqual([10, 20, 30, 127]);
+  });
 });
 
 // https://drafts.csswg.org/css-color-5/#color-mix — the grammar is


### PR DESCRIPTION
### What

`Bun.color({r, g, b, a})` with `a` outside `[0, 1]` wrapped the alpha byte via `rem_euclid(256)` instead of clamping, so values a hair above opaque became fully transparent:

```js
Bun.color({ r: 10, g: 20, b: 30, a: 1.004 }, "{rgba}").a  // 0      (fully transparent)
Bun.color({ r: 10, g: 20, b: 30, a: 2 },     "{rgba}").a  // 0.996
Bun.color({ r: 10, g: 20, b: 30, a: -1 },    "{rgba}").a  // 0.0039
Bun.color({ r: 10, g: 20, b: 30, a: -0.5 },  "{rgba}").a  // 0.506
```

Any `a` in `[256/255, 257/255)` wraps to 0, which is exactly the shape float compositing math produces for a nearly-opaque result.

The `r`/`g`/`b` keys of the same object input already clamp (with a "CSS spec says to clamp values to their valid range" comment), and the CSS `rgba()` string parser clamps alpha too:

```js
Bun.color({ r: 300, g: 0, b: 0 }, "{rgba}").r        // 255
Bun.color("rgba(10,20,30,1.5)",   "{rgba}").a        // 1
Bun.color("rgba(10,20,30,-0.5)",  "{rgba}").a        // 0
```

### Fix

`src/css_jsc/color_js.rs`: in the object-input arm, replace `.rem_euclid(256)` with `.clamp(0, 255)` to match the neighboring r/g/b path.

### Tests

Added to `test/js/bun/css/color.test.ts` under `input forms`:
- out-of-range `a` (1.004, 2, 100, -1, -0.5, ±Infinity) clamps to the nearest endpoint
- object input agrees with the CSS `rgba()` parser for the same out-of-range alpha values
- in-range alpha (1, 0.5) is unchanged

Fail before: 2 failures with `USE_SYSTEM_BUN=1 bun test`. Pass after: `bun bd test test/js/bun/css/color.test.ts` 992 pass, 0 fail.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/color.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (eb33f7609)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [3.63ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [1.41ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [1.45ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [1.73ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [16.77ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [1.79ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [1.38ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit")) [0.29ms]
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (2a974b452)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [0.07ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [0.02ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [0.01ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [0.03ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [0.50ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [0.05ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [0.01ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit"))
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-256"))
[92m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-16"))
(pass) color({"r":0,"g":255,"b":0}, "{rgb}") = {"r":0,"g":255,"b":0}
(pass) color({"r":0,"g":255,"b":0}, "ansi-24bit")
(pass) color({"r":0,"g":255,"b":0}, "ansi-16")
(pass) color({"r":0,"g":255,"b":0}, "ansi256")
[38;2;0;0;255m[object Object]
(pass) console.log(color({"r":0,"g":0,"b":255}, "ansi-24bit"))
[38;5;
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/color.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (eb33f7609)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [3.59ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [1.43ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [1.44ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [1.71ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [16.43ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [1.39ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [1.70ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit")) [0.28ms]
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 696ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[2/6] gen cpp.rs (cppbind)
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css_jsc/color_js.rs       |  3 ++-
 test/js/bun/css/color.test.ts | 24 ++++++++++++++++++++++++
 2 files changed, 26 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/css_jsc/color_js.rs            1      1      0
test/js/bun/css/color.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->