### PR TITLE
Bun.randomUUIDv7: reject timestamps >= 2^48 and NaN instead of truncating

### DIFF
--- a/src/jsc/uuid.rs
+++ b/src/jsc/uuid.rs
@@ -130,7 +130,7 @@ impl UUID7 {
         };
 
         if count > 0x0FFF {
-            ts = ts.wrapping_add(1);
+            ts = (ts + 1).min((1u64 << 48) - 1);
             count = seed;
         }
 

--- a/src/runtime/webcore/Crypto.rs
+++ b/src/runtime/webcore/Crypto.rs
@@ -207,7 +207,7 @@ pub(crate) fn bun_random_uuid_v7(
     };
 
     let timestamp: u64 = 'brk: {
-        let timestamp_value: JSValue = if !encoding_value.is_undefined() && arguments.len > 1 {
+        let timestamp_value: JSValue = if arguments.len > 1 {
             arguments.ptr[1]
         } else if arguments.len == 1 && encoding_value.is_undefined() {
             arguments.ptr[0]
@@ -216,15 +216,30 @@ pub(crate) fn bun_random_uuid_v7(
         };
 
         if !timestamp_value.is_undefined() {
+            // UUIDv7's unix_ts_ms field is 48 bits (RFC 9562 §5.7).
+            const MAX_TIMESTAMP: i64 = (1i64 << 48) - 1;
+            let range_opts = bun_jsc::RangeErrorOptions {
+                min: 0,
+                max: MAX_TIMESTAMP,
+                field_name: b"timestamp",
+                ..Default::default()
+            };
             if timestamp_value.is_date() {
                 let date = timestamp_value.get_unix_timestamp();
-                break 'brk date.max(0.0) as u64;
+                if !date.is_finite() || date < 0.0 || date > MAX_TIMESTAMP as f64 {
+                    return Err(global.throw_range_error(date, range_opts));
+                }
+                break 'brk date as u64;
+            }
+            if timestamp_value.is_number() && timestamp_value.as_number().is_nan() {
+                return Err(global.throw_range_error(f64::NAN, range_opts));
             }
             break 'brk u64::try_from(global.validate_integer_range::<i64>(
                 timestamp_value,
                 0,
                 bun_jsc::IntegerRange {
                     min: 0,
+                    max: i128::from(MAX_TIMESTAMP),
                     field_name: b"timestamp",
                     ..Default::default()
                 },

--- a/test/js/bun/util/randomUUIDv7.test.ts
+++ b/test/js/bun/util/randomUUIDv7.test.ts
@@ -12,15 +12,6 @@ describe("randomUUIDv7", () => {
     expect(Bun.randomUUIDv7()["0192ce01-8345-".length]).toBe("7");
   });
 
-  test("timestamp", () => {
-    const now = Date.now();
-    const uuid = Bun.randomUUIDv7(undefined, now).replaceAll("-", "");
-    const timestampOriginal = parseInt(uuid.slice(0, 12).toString(), 16);
-
-    // On Windows, timers drift by about 16ms. Let's 2x that.
-    const timestamp = Math.max(timestampOriginal, now) - Math.min(timestampOriginal, now);
-    expect(timestamp).toBeLessThanOrEqual(32);
-  });
 
   test("base64 format", () => {
     const uuid = Bun.randomUUIDv7("base64");
@@ -108,6 +99,32 @@ describe("randomUUIDv7", () => {
       expect(stderr).toBe("");
       const max = 2 ** 48 - 1;
       expect(JSON.parse(stdout)).toEqual([max, max, max]);
+      expect(exitCode).toBe(0);
+    });
+
+    test("counter rollover at 2**48-1 clamps instead of wrapping to epoch 0", async () => {
+      // 5000 calls at the max 48-bit timestamp forces the 12-bit counter to roll
+      // over at least once; the bumped timestamp must clamp at 2**48-1, not wrap.
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const tsOf = u => parseInt(u.replaceAll("-", "").slice(0, 12), 16);
+            const max = 2 ** 48 - 1;
+            let bad = -1;
+            for (let i = 0; i < 5000; i++) {
+              if (tsOf(Bun.randomUUIDv7("hex", max)) !== max) { bad = i; break; }
+            }
+            console.log(bad);
+          `,
+        ],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("-1");
       expect(exitCode).toBe(0);
     });
   });

--- a/test/js/bun/util/randomUUIDv7.test.ts
+++ b/test/js/bun/util/randomUUIDv7.test.ts
@@ -55,6 +55,63 @@ describe("randomUUIDv7", () => {
     expect(firstBreak).toBe(-1);
   });
 
+  describe("timestamp range validation", () => {
+    test.each([
+      ["2**48", 2 ** 48],
+      ["2**53 - 1", 2 ** 53 - 1],
+      ["NaN", NaN],
+      ["Date(-1)", new Date(-1)],
+      ["Date(2**48)", new Date(2 ** 48)],
+      ["Date(8.64e15)", new Date(8.64e15)],
+      ["Invalid Date", new Date(NaN)],
+    ])("rejects %s", (_, ts) => {
+      expect(() => Bun.randomUUIDv7("hex", ts)).toThrow(RangeError);
+      expect(() => Bun.randomUUIDv7(undefined, ts)).toThrow(RangeError);
+      // @ts-expect-error single-arg timestamp overload
+      expect(() => Bun.randomUUIDv7(ts)).toThrow(RangeError);
+    });
+
+    test("RangeError message advertises the 48-bit bound", () => {
+      const err = (() => {
+        try {
+          Bun.randomUUIDv7("hex", 2 ** 48);
+        } catch (e) {
+          return e as RangeError;
+        }
+        throw new Error("did not throw");
+      })();
+      expect(err).toBeInstanceOf(RangeError);
+      expect(err.message).toContain("281474976710655");
+      expect(err.message).not.toContain("9007199254740991");
+    });
+
+    test("accepts 2**48 - 1 (max 48-bit value)", async () => {
+      // Subprocess: 2**48-1 would park the process-global timestamp at year 10889.
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const tsOf = u => parseInt(u.replaceAll("-", "").slice(0, 12), 16);
+            const max = 2 ** 48 - 1;
+            console.log(JSON.stringify([
+              tsOf(Bun.randomUUIDv7("hex", max)),
+              tsOf(Bun.randomUUIDv7(undefined, max)),
+              tsOf(Bun.randomUUIDv7("hex", new Date(max))),
+            ]));
+          `,
+        ],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      const max = 2 ** 48 - 1;
+      expect(JSON.parse(stdout)).toEqual([max, max, max]);
+      expect(exitCode).toBe(0);
+    });
+  });
+
   // The remaining tests pass far-future timestamps. UUID_V7_LAST_TIMESTAMP is a
   // process-global that never moves backward, so run each in a fresh subprocess
   // to avoid leaving the test process parked in the year 2100+.

--- a/test/js/bun/util/randomUUIDv7.test.ts
+++ b/test/js/bun/util/randomUUIDv7.test.ts
@@ -12,7 +12,6 @@ describe("randomUUIDv7", () => {
     expect(Bun.randomUUIDv7()["0192ce01-8345-".length]).toBe("7");
   });
 
-
   test("base64 format", () => {
     const uuid = Bun.randomUUIDv7("base64");
     expect(uuid).toMatch(/^[0-9a-zA-Z+/=]+$/);


### PR DESCRIPTION
## Repro

```js
const tsOf = u => parseInt(u.replaceAll('-', '').slice(0, 12), 16);
console.log(tsOf(Bun.randomUUIDv7('hex', 2 ** 48)));      // 0 (truncated)
console.log(tsOf(Bun.randomUUIDv7('hex', 2 ** 53 - 1)));  // 281474976710655 (truncated)
console.log(tsOf(Bun.randomUUIDv7('hex', NaN)));          // 0
console.log(Bun.randomUUIDv7('hex', 2 ** 48) < Bun.randomUUIDv7('hex')); // true
console.log(tsOf(Bun.randomUUIDv7(undefined, 123456789))); // Date.now(), not 123456789
```

## Cause

The UUIDv7 `unix_ts_ms` field is 48 bits (RFC 9562 section 5.7). `UUID7::init` writes only the low 6 bytes of the timestamp, but the range check in `bun_random_uuid_v7` used the `IntegerRange` default `max` of `Number.MAX_SAFE_INTEGER` (2^53-1). So `[2^48, 2^53-1]` was accepted and then truncated mod 2^48: `2**48` encoded as epoch 0 and sorted before every real UUID. The RangeError message also advertised the unreachable 2^53-1 bound.

`validate_integer_range` maps NaN to the passed default (0), so `NaN` produced a timestamp-0 UUID instead of throwing.

The `Date` argument path (`date.max(0.0) as u64`) bypassed all validation, so `new Date(8.64e15)` truncated and `new Date(NaN)` / pre-epoch dates silently encoded 0.

The `timestamp_value` selector required the first argument to be a string before reading `arguments.ptr[1]`, so `Bun.randomUUIDv7(undefined, ts)` (valid per the `encoding?: ...` type signature) silently ignored `ts` and used the current time.

`UUID7::next` (from #34022) did `ts.wrapping_add(1)` on 12-bit counter rollover with no 48-bit clamp: after <=4096 calls pinned at `2**48-1`, the bumped timestamp reaches `2**48` and encodes as epoch 0 (same symptom via the internal rollover path).

## Fix

- `src/runtime/webcore/Crypto.rs`: set `max: (1 << 48) - 1` on the `IntegerRange`; reject NaN with `ERR_OUT_OF_RANGE` before `validate_integer_range`'s NaN-to-default mapping; validate extracted Date timestamps against `[0, 2^48-1]`; route `arguments.ptr[1]` whenever `arguments.len > 1`.
- `src/jsc/uuid.rs`: clamp the counter-rollover timestamp bump at `(1<<48)-1`.

## Verification

```
bun bd test test/js/bun/util/randomUUIDv7.test.ts   # 18 pass
```

The `timestamp range validation` block covers rejection of `2**48`, `2**53-1`, `NaN`, `new Date(-1)`, `new Date(2**48)`, `new Date(8.64e15)`, and Invalid Date with `RangeError` across all three call shapes (`("hex", ts)`, `(undefined, ts)`, `(ts)`); acceptance and exact encoding of `2**48-1` (subprocess, since it parks the process-global timestamp); a 5000-iteration subprocess asserting counter rollover at `2**48-1` does not wrap to epoch 0; and an assertion that the RangeError message advertises `281474976710655` rather than `9007199254740991`.

The pre-existing `test("timestamp")` was dropped: it compared `(undefined, Date.now())` to `Date.now()` within 32ms, which cannot distinguish a dropped argument from an honored one, and cannot be rewritten in-process post-#34022 since the process-global timestamp never moves backward. Its intended coverage lives in the subprocess accept test and the rejection matrix.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/util/randomUUIDv7.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f54393657)

test/js/bun/util/randomUUIDv7.test.ts:
(pass) randomUUIDv7 > basic [4.28ms]
(pass) randomUUIDv7 > base64 format [2.23ms]
019f5a24bee7755ab60a89259e18b1c4
(pass) randomUUIDv7 > buffer output encoding [2.82ms]
(pass) randomUUIDv7 > monotonic [28.63ms]
(pass) randomUUIDv7 > monotonic across 12-bit counter rollover [390.73ms]
53 |       ["Date(-1)", new Date(-1)],
54 |       ["Date(2**48)", new Date(2 ** 48)],
55 |       ["Date(8.64e15)", new Date(8.64e15)],
56 |       ["Invalid Date", new Date(NaN)],
57 |     ])("rejects %s", (_, ts) => {
58 |       expect(() => Bun.randomUUIDv7("hex", ts)).toThrow(RangeError);
                                                     ^
error: expect(received).toThrow(expected)

Expected c
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (6e2a54c63)

test/js/bun/util/randomUUIDv7.test.ts:
(pass) randomUUIDv7 > basic [0.13ms]
(pass) randomUUIDv7 > base64 format [0.04ms]
019f5a24ce08768f9fb7d2a1f1ae9a8f
(pass) randomUUIDv7 > buffer output encoding [0.09ms]
(pass) randomUUIDv7 > monotonic [0.34ms]
(pass) randomUUIDv7 > monotonic across 12-bit counter rollover [2.22ms]
(pass) randomUUIDv7 > timestamp range validation > rejects 2**48 [0.14ms]
(pass) randomUUIDv7 > timestamp range validation > rejects 2**53 - 1 [0.02ms]
(pass) randomUUIDv7 > timestamp range validation > rejects NaN [0.02ms]
(pass) randomUUIDv7 > timestamp range validation > rejects Date(-1)
(pass) randomUUIDv7 > timestamp range validation > rejects Date(2**48)
(pass) randomUUIDv7 > timestamp range validation > rejects Date(8.64e15)
(pass) randomUUIDv7 > timestamp range validation > rejects Invalid Date
(pass) randomUUIDv7 > timestamp range validation > RangeError message advertises the 48-bit bound [0.08ms]
(pass) randomUUIDv7 > timestamp range validation > accepts 2**48 - 1 (max 48-bit value) [11.74ms]
(pass) randomUUIDv7 > timestamp range validation > counter rollover at 2**48-1 clamps instead of wrapping to epo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/util/randomUUIDv7.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f54393657)

test/js/bun/util/randomUUIDv7.test.ts:
(pass) randomUUIDv7 > basic [3.93ms]
(pass) randomUUIDv7 > base64 format [2.20ms]
019f5a2572c973d6b70714d87bf942d1
(pass) randomUUIDv7 > buffer output encoding [2.81ms]
(pass) randomUUIDv7 > monotonic [28.03ms]
(pass) randomUUIDv7 > monotonic across 12-bit counter rollover [391.95ms]
(pass) randomUUIDv7 > timestamp range validation > rejects 2**48 [8.00ms]
(pass) randomUUIDv7 > timestamp range validation > rejects 2**53 - 1 [1.74ms]
(pass) randomUUIDv7 > timestamp range validation > rejects NaN [1.98ms]
(pass) randomUUIDv7 > timestamp range validation > rejects Date(-1) [1.42ms]
(pass) randomUUIDv7 > timestamp range validation > rejects Date(2**48) [1.31ms]
(pass) randomUUIDv7
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 678ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/uuid.rs                       |  2 +-
 src/runtime/webcore/Crypto.rs         | 19 ++++++-
 test/js/bun/util/randomUUIDv7.test.ts | 93 +++++++++++++++++++++++++++++++----
 3 files changed, 101 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 5 passed · 1 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/jsc/uuid.rs                            2      1      0
src/runtime/webcore/Crypto.rs              5      6      0
test/js/bun/util/randomUUIDv7.test.ts      4      7      0
```

</details>

<!-- robobun:evidence:end -->