### PR TITLE
uws: fix O(n^2) BackPressure buffer compaction and reallocation on large writes

### DIFF
--- a/packages/bun-uws/src/AsyncSocket.h
+++ b/packages/bun-uws/src/AsyncSocket.h
@@ -183,8 +183,8 @@ public:
 
     /* Returns the user space backpressure. */
     size_t getBufferedAmount() {
-        /* We return the actual amount of bytes in backbuffer, including pendingRemoval */
-        return getAsyncSocketData()->buffer.totalLength();
+        /* Unsent bytes only; already-written bytes waiting for compaction are not backpressure. */
+        return getAsyncSocketData()->buffer.length();
     }
 
     /* Returns the text representation of an IPv4 or IPv6 address */
@@ -253,7 +253,7 @@ public:
             /* Check if we couldn't write the entire buffer */
             if ((unsigned int) written < buffer_len) {
                 /* Remove the successfully written data from the buffer */
-                asyncSocketData->buffer.erase((unsigned int) written);
+                asyncSocketData->buffer.erase((size_t) written);
 
                 /* If we wrote less than we attempted, the socket buffer is likely full
                 * likely is used as an optimization hint to the compiler
@@ -301,7 +301,7 @@ public:
             /* On failure return, otherwise continue down the function */
             if ((unsigned int) written < buffer_len) {
                 /* Update buffering (todo: we can do better here if we keep track of what happens to this guy later on) */
-                asyncSocketData->buffer.erase((unsigned int) written);
+                asyncSocketData->buffer.erase((size_t) written);
 
                 if (optionally) {
                     /* Thankfully we can exit early here */

--- a/packages/bun-uws/src/AsyncSocketData.h
+++ b/packages/bun-uws/src/AsyncSocketData.h
@@ -25,7 +25,7 @@ namespace uWS {
 
 struct BackPressure {
     std::string buffer;
-    unsigned int pendingRemoval = 0;
+    size_t pendingRemoval = 0;
     BackPressure(BackPressure &&other) {
         buffer = std::move(other.buffer);
         pendingRemoval = other.pendingRemoval;
@@ -34,12 +34,12 @@ struct BackPressure {
     void append(const char *data, size_t length) {
         buffer.append(data, length);
     }
-    void erase(unsigned int length) {
+    void erase(size_t length) {
         pendingRemoval += length;
-        /* Always erase a minimum of 1/32th the current backpressure */
-        if (pendingRemoval > (buffer.length() >> 5)) {
+        /* Compact once half the buffer is dead space so draining n bytes moves
+         * O(n) total (geometric series). clear() releases capacity on full drain. */
+        if (pendingRemoval > (buffer.length() >> 1)) {
             buffer.erase(0, pendingRemoval);
-            buffer.shrink_to_fit();
             pendingRemoval = 0;
         }
     }

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -596,6 +596,16 @@ public:
 
         size_t length = data.length();
 
+        /* Large writes are split into several AsyncSocket::write calls below (chunk
+         * framing, INT_MAX slicing). Reserve once so those appends never realloc +
+         * copy a multi-GB backpressure buffer. */
+        {
+            auto &bp = Super::getAsyncSocketData()->buffer;
+            if (bp.length() > 0 || length > 1024 * 1024) {
+                bp.reserve(bp.length() + length + 32);
+            }
+        }
+
         // Special handling for extremely large data (greater than UINT_MAX bytes)
         // most clients expect a max of UINT_MAX, so we need to split the write into multiple writes
         if (length > UINT_MAX) {

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -602,8 +602,10 @@ public:
         if (length > 1024 * 1024) {
             auto &bp = Super::getAsyncSocketData()->buffer;
             size_t need = bp.totalLength() + length + 32;
-            /* libc++ reserve() is exact-fit; keep geometric growth explicit. */
-            bp.buffer.reserve(std::max(bp.buffer.capacity() * 2, need));
+            if (need > bp.buffer.capacity()) {
+                /* libc++ reserve() is exact-fit; keep geometric growth explicit. */
+                bp.buffer.reserve(std::max(bp.buffer.capacity() * 2, need));
+            }
         }
 
         // Special handling for extremely large data (greater than UINT_MAX bytes)

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -596,14 +596,12 @@ public:
 
         size_t length = data.length();
 
-        /* Large writes are split into several AsyncSocket::write calls below (chunk
-         * framing, INT_MAX slicing). Reserve once so those appends never realloc +
-         * copy a multi-GB backpressure buffer. */
-        {
+        /* A write this large is split into several AsyncSocket::write calls below
+         * (chunk framing, INT_MAX slicing). Reserve once so those appends never
+         * realloc + copy a multi-GB backpressure buffer. */
+        if (length > 1024 * 1024) {
             auto &bp = Super::getAsyncSocketData()->buffer;
-            if (bp.length() > 0 || length > 1024 * 1024) {
-                bp.reserve(bp.length() + length + 32);
-            }
+            bp.reserve(bp.length() + length + 32);
         }
 
         // Special handling for extremely large data (greater than UINT_MAX bytes)

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -601,7 +601,9 @@ public:
          * realloc + copy a multi-GB backpressure buffer. */
         if (length > 1024 * 1024) {
             auto &bp = Super::getAsyncSocketData()->buffer;
-            bp.reserve(bp.length() + length + 32);
+            size_t need = bp.totalLength() + length + 32;
+            /* libc++ reserve() is exact-fit; keep geometric growth explicit. */
+            bp.buffer.reserve(std::max(bp.buffer.capacity() * 2, need));
         }
 
         // Special handling for extremely large data (greater than UINT_MAX bytes)

--- a/packages/bun-uws/src/WebSocket.h
+++ b/packages/bun-uws/src/WebSocket.h
@@ -106,7 +106,8 @@ public:
     }
 
     size_t memoryCost() {
-        return getBufferedAmount() + sizeof(WebSocket);
+        /* Allocation footprint for reportExtraMemoryAllocated, not unsent bytes. */
+        return Super::getAsyncSocketData()->buffer.totalLength() + sizeof(WebSocket);
     }
 
     /* Sending fragmented messages puts a bit of effort on the user; you must not interleave regular sends

--- a/test/js/node/http/node-http-backpressure-max.test.ts
+++ b/test/js/node/http/node-http-backpressure-max.test.ts
@@ -11,7 +11,7 @@ import http from "node:http";
 import type { AddressInfo } from "node:net";
 
 describe("backpressure", () => {
-  // Linux CI only have 8GB with is not enought because we will clone all or most of this 4GB into memory
+  // Linux CI only has 8GB which is not enough because we clone all or most of this 4GB into memory.
   it.skipIf(isCI && isLinux)(
     "should handle backpressure with the maximum allowed bytes",
     async () => {
@@ -45,9 +45,6 @@ describe("backpressure", () => {
 
       expect(totalBytes).toBe(payloadSize);
     },
-    // Moving 4 GiB through the server and the fetch reader takes ~60s on the
-    // slowest CI runners (darwin x64), which sat exactly at the old 60s
-    // limit and made the test flaky there.
-    120_000,
+    30_000,
   );
 });


### PR DESCRIPTION
### What does this PR do?

Fixes two compounding costs in the uws `BackPressure` `std::string` that made large `res.write()` calls through `node:http` scale worse than linearly, and lowers the `node-http-backpressure-max.test.ts` timeout from 120s to 30s now that it runs in a fraction of that.

### Why?

[Build 72095](https://buildkite.com/bun/bun/builds/72095#019f5501-cdbc-474a-9656-8a6a41661de3) went red on `:darwin: 14 x64` with:

```
✗ backpressure > should handle backpressure with the maximum allowed bytes [120661.99ms]
  ^ this test timed out after 120000ms.
```

The test had already been bumped 60s -> 120s in #31587 for the same reason and was sitting at the new limit on the slow Intel mac runners. A 4 GiB `res.write()` through `node:http` took ~36s on a linux release build (75-120s on the darwin x64 runners) versus 2.2s in Node.js.

Two problems in `packages/bun-uws`:

1. **`BackPressure::erase()`** compacted the `std::string` (front-erase `memmove` + `shrink_to_fit` realloc+copy) every time `pendingRemoval` exceeded 1/32 of the buffer, so draining n bytes moved ~60n bytes in total.

2. **`HttpResponse::write()`** splits payloads at `INT_MAX` and adds chunk framing as separate `AsyncSocket::write` calls; each append after the first could realloc+copy the whole multi-GB buffer. Instrumenting a 4 GiB write:

   ```
   append 2GB to empty string:   1.4s
   append 2GB to 2GB string:     2.7s  (realloc 2GB -> 4GB, copy both halves)
   append 1 byte to 4GB string:  2.5s  (realloc 4GB -> 8GB, copy 4GB)
   ```

   The 1-byte append is the UINT_MAX split remainder.

### Fix

- `BackPressure::erase()`: compact only once half the buffer is dead space (sum of memmove sizes over a full drain is O(n) as a geometric series), drop the redundant `shrink_to_fit`, and widen `pendingRemoval` to `size_t`.
- `HttpResponse::write()`: reserve the backpressure buffer once up front for writes that will certainly be buffered, so the split appends never realloc.
- `AsyncSocket::getBufferedAmount()`: report unsent bytes (`length()`), not `totalLength()`, so drain progress is observable between compactions. This is what every caller (WebSocket drain handler, `maxBackpressure` check, shutdown gate) actually wants; without it the less-frequent compaction stalled the WebSocket drain loop.

### Results (linux x64 release, raw socket client)

| payload | before | after | Node.js |
| --- | --- | --- | --- |
| 0.25 GiB | 452ms | 329ms | 159ms |
| 1 GiB | 1634ms | 1076ms | 573ms |
| 4 GiB | 9218ms | 5344ms | 2245ms |

and for the full test (4 GiB via the fetch reader, same as CI):

|  | release | debug |
| --- | --- | --- |
| before | 36s | 35s |
| after | 7s | 13.5s |

The remaining ~2.4x vs Node is the one-time memcpy of the payload into the `std::string`; Node keeps a reference to the caller's Buffer and `writev`s slices directly. Closing that gap means `NodeHTTPResponse` holding a `Strong` ref to the JS buffer and slicing on drain instead of handing the bytes to uws's copy buffer.

### How did you verify your code works?

```
# gate: fails on an unfixed build, passes on the fixed one
$ git stash push -- packages/
$ bun bd test test/js/node/http/node-http-backpressure-max.test.ts
(fail) backpressure > should handle backpressure with the maximum allowed bytes [30046.38ms]
  ^ this test timed out after 30000ms.
$ git stash pop
$ bun bd test test/js/node/http/node-http-backpressure-max.test.ts
(pass) backpressure > should handle backpressure with the maximum allowed bytes [13477.68ms]
```

Also ran `node-http-backpressure.test.ts`, `node-http.test.ts`, `serve.test.ts`, `websocket-server.test.ts` and `serve-response-gc-backpressure-abort.test.ts`; failures in those files reproduce on `main` without this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/http/node-http-backpressure-max.test.ts

<!-- robobun:evidence:end -->