### PR TITLE
test: stop deliberate crash tests from uploading to CI's crash-report server

### DIFF
--- a/test/bundler/native-plugin.test.ts
+++ b/test/bundler/native-plugin.test.ts
@@ -456,10 +456,9 @@ const many_foo = ["foo","foo","foo","foo","foo","foo","foo"]
     // BUN_CRASH_REPORT_URL="": this segfault is deliberate; uploading it to
     // CI's remap server pins a spurious "crash reported" error on the next
     // unrelated failing test (runner only drains /traces on non-zero exit).
-    const { stdout, stderr } =
-      await Bun.$`BUN_CRASH_REPORT_URL="" BUN_ENABLE_CRASH_REPORTING=0 BUN_TEST_TEMP_DIR=${tempdir} ${bunExe()} run build.ts`.throws(
-        false,
-      );
+    const { stdout, stderr } = await Bun.$`${bunExe()} run build.ts`
+      .env({ ...bunEnv, BUN_TEST_TEMP_DIR: tempdir, BUN_CRASH_REPORT_URL: "", BUN_ENABLE_CRASH_REPORTING: "0" })
+      .throws(false);
     const errorString = stderr.toString();
     expect(errorString).toContain('\x1b[31m\x1b[2m"native_plugin_test"\x1b[0m');
   });

--- a/test/bundler/native-plugin.test.ts
+++ b/test/bundler/native-plugin.test.ts
@@ -453,7 +453,13 @@ const many_foo = ["foo","foo","foo","foo","foo","foo","foo"]
     `;
 
     await Bun.$`echo ${build_code} > build.ts`;
-    const { stdout, stderr } = await Bun.$`BUN_TEST_TEMP_DIR=${tempdir} ${bunExe()} run build.ts`.throws(false);
+    // BUN_CRASH_REPORT_URL="": this segfault is deliberate; uploading it to
+    // CI's remap server pins a spurious "crash reported" error on the next
+    // unrelated failing test (runner only drains /traces on non-zero exit).
+    const { stdout, stderr } =
+      await Bun.$`BUN_CRASH_REPORT_URL="" BUN_ENABLE_CRASH_REPORTING=0 BUN_TEST_TEMP_DIR=${tempdir} ${bunExe()} run build.ts`.throws(
+        false,
+      );
     const errorString = stderr.toString();
     expect(errorString).toContain('\x1b[31m\x1b[2m"native_plugin_test"\x1b[0m');
   });

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -4,6 +4,11 @@ import { bunEnv, bunExe, isDebug, isLinux, isPosix, mergeWindowEnvs } from "harn
 import path from "path";
 const { getMachOImageZeroOffset } = crash_handler;
 
+// CI sets BUN_CRASH_REPORT_URL so unexpected crashes are captured; these
+// deliberate crashes must not upload there or the runner pins them on the
+// next unrelated failing test as "crash reported" and blocks its retries.
+const noReportEnv = { ...bunEnv, BUN_CRASH_REPORT_URL: "", BUN_ENABLE_CRASH_REPORTING: "0" };
+
 // On Linux, debug builds symbolize crash traces by spawning llvm-symbolizer;
 // without it the fallback printer has no Rust symbol names to assert on.
 const hasSymbolizer = !!(Bun.which("llvm-symbolizer") || Bun.which("llvm-symbolizer-21"));
@@ -13,7 +18,7 @@ test.if(isDebug && isLinux && hasSymbolizer)(
   async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), path.join(import.meta.dir, "fixture-crash.js"), "panic"],
-      env: bunEnv,
+      env: noReportEnv,
       stdio: ["ignore", "pipe", "pipe"],
     });
     // The panic header goes to stderr; the symbolized frames are printed by
@@ -58,7 +63,7 @@ test.if(isPosix)(
         // spawning llvm-symbolizer, which can take tens of seconds.
         "--debug-crash-handler-use-trace-string",
       ],
-      env: bunEnv,
+      env: noReportEnv,
       stdio: ["ignore", "pipe", "pipe"],
     });
 
@@ -101,7 +106,7 @@ describe.if(isPosix)("terminal signal reflects the crash cause", () => {
         approach,
         "--debug-crash-handler-use-trace-string",
       ],
-      env: bunEnv,
+      env: noReportEnv,
       stdio: ["ignore", "pipe", "pipe"],
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);

--- a/test/js/node/tls/tls-syscall-fault.test.ts
+++ b/test/js/node/tls/tls-syscall-fault.test.ts
@@ -27,13 +27,15 @@ test.skipIf(!fault.available())(
       cmd: [bunExe(), join(import.meta.dir, "tls-loop-buffer-oom-fixture.ts")],
       // BUN_CRASH_REPORT_URL="": this OOM is deliberate; uploading it to CI's
       // remap server would pin a spurious "crash reported" error on the next
-      // unrelated failing test. With reporting off the phrasing is stable.
+      // unrelated failing test.
       env: { ...bunEnv, BUN_CRASH_REPORT_URL: "", BUN_ENABLE_CRASH_REPORTING: "0" },
       stdout: "pipe",
       stderr: "pipe",
     });
     const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    const outOfMemory = stderr.includes("Bun ran out of memory");
+    // `CrashReason::OutOfMemory` phrasing varies with SHOW_CRASH_TRACE, so
+    // match the shared substring (see run-crash-handler.test.ts).
+    const outOfMemory = stderr.toLowerCase().includes("out of memory");
     expect({
       markers: stdout
         .split("\n")

--- a/test/js/node/tls/tls-syscall-fault.test.ts
+++ b/test/js/node/tls/tls-syscall-fault.test.ts
@@ -20,21 +20,20 @@ afterEach(() => fault.clear());
 // stream; anything past "ARMED" means a TLS socket survived the failed
 // allocation and reached its read loop.
 const OOM_FIXTURE_MARKERS = ["ARMED", "READ DATA", "CLOSED", "CLIENT ERROR"];
-// How `CrashReason::OutOfMemory` is phrased depends on whether a crash report is
-// being generated, and CI configures that per job (BUN_CRASH_REPORT_URL is only
-// set when its remap server came up). Match either phrasing.
-const OOM_CRASH_MESSAGES = ["Bun ran out of memory", "Bun has run out of memory"];
 test.skipIf(!fault.available())(
   "a failed per-loop TLS buffer allocation reports out of memory instead of faulting inside SSL_read",
   async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), join(import.meta.dir, "tls-loop-buffer-oom-fixture.ts")],
-      env: bunEnv,
+      // BUN_CRASH_REPORT_URL="": this OOM is deliberate; uploading it to CI's
+      // remap server would pin a spurious "crash reported" error on the next
+      // unrelated failing test. With reporting off the phrasing is stable.
+      env: { ...bunEnv, BUN_CRASH_REPORT_URL: "", BUN_ENABLE_CRASH_REPORTING: "0" },
       stdout: "pipe",
       stderr: "pipe",
     });
     const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    const outOfMemory = OOM_CRASH_MESSAGES.some(message => stderr.includes(message));
+    const outOfMemory = stderr.includes("Bun ran out of memory");
     expect({
       markers: stdout
         .split("\n")


### PR DESCRIPTION
`test/integration/next-pages/test/dev-server-ssr-100.test.ts` was reported RED in build [72106](https://buildkite.com/bun/bun/builds/72106) on `:darwin: 26 aarch64` with `5 crashes reported during this test`. The test itself is fine on main (last four completed main builds 72110/72020/71943/71860 have no mention of it). The RED was manufactured by CI's crash-report attribution.

## Cause

`scripts/runner.node.mjs` exports `BUN_CRASH_REPORT_URL=http://localhost:<remapPort>` to every test so real crashes are captured. It only drains `/traces` when a test exits non-zero (the known caveat is documented in the runner at the drain site).

`run-crash-handler.test.ts` spawns processes that crash on purpose with `env: bunEnv`, which inherits that URL, and `native-plugin.test.ts`'s "prints name when plugin crashes" does the same via `Bun.$`. Both files pass (exit 0), so their five crash reports stay on the remap server:

```
Segmentation fault at address 0x00000000        # native-plugin
panic: invoked crashByPanic() handler           # run-crash-handler (x2)
Bun ran out of memory                           # run-crash-handler
Segmentation fault at address 0xDEADBEEF        # run-crash-handler
```

In build 72106 a transient npm-registry hang on one tart agent (`66790-tart-26`) made `dev-server-ssr-100`'s `bun i` block for 100 s and time out. That non-zero exit drained `/traces`, inherited the five deliberate crashes, and became `error = "crash reported"`; `isAlwaysFailure("crash reported")` blocks retries, so one transient timeout became a hard RED. `next-auth.test.ts` hit the same npm hang on the same agent minutes later, got normal retries, and passed on attempt #4.

Same five reports pinned on unrelated tests in other recent PR builds:

- build [72095](https://buildkite.com/bun/bun/builds/72095): `test/js/node/http/node-http-backpressure-max.test.ts` ("5 crashes reported", identical list)
- build [72085](https://buildkite.com/bun/bun/builds/72085): `test/js/web/fetch/fetch-leak.test.ts` (segfault at `0x0` from `native-plugin`)

## Fix

Set `BUN_CRASH_REPORT_URL=""` (and `BUN_ENABLE_CRASH_REPORTING=0` for the fall-through branch in `is_reporting_enabled()`) on every spawn that crashes on purpose but is not asserting on upload behaviour:

- `run-crash-handler.test.ts`: the three `env: bunEnv` spawns now use a shared `noReportEnv`.
- `native-plugin.test.ts`: the "prints name when plugin crashes" `Bun.$` command sets the two vars inline.

The "automatic crash reporter" and "raise ignoring panic handler" tests already point `BUN_CRASH_REPORT_URL` at their own local server and are unchanged.

## Verification

Simulated CI's remap server and ran the test file against it:

```
before: CI-server hits: 5  (the /ack uploads listed above)
after:  CI-server hits: 0, 9 pass / 1 skip / 0 fail
```

`bun bd test test/cli/run/run-crash-handler.test.ts` passes. `native-plugin.test.ts` "prints name when plugin crashes" is `skipIf(isASAN)` so it is skipped under the debug build; a neighbouring case in the same file still loads, and the inline-env override was verified separately (`Bun.$\`VAR="" ...\`` reaches the child as an empty string, which `is_reporting_enabled()` treats as disabled).

Test-only change; no `src/` diff because the behaviour being fixed lives in the CI runner and the child's env, not in bun itself.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->