### PR TITLE
stream: propagate cancel to web source in Readable.fromWeb

### DIFF
--- a/src/js/internal/webstreams_adapters.ts
+++ b/src/js/internal/webstreams_adapters.ts
@@ -47,9 +47,7 @@ function tryTransferToNativeReadable(stream, options) {
 class ReadableFromWeb extends Readable {
   #reader;
   #closed;
-  #pendingChunks;
   #stream;
-  #reading;
 
   constructor(options, stream) {
     const { objectMode, highWaterMark, encoding, signal } = options;
@@ -59,32 +57,9 @@ class ReadableFromWeb extends Readable {
       encoding,
       signal,
     });
-    this.#pendingChunks = [];
     this.#reader = undefined;
     this.#stream = stream;
     this.#closed = false;
-    this.#reading = false;
-  }
-
-  #drainPending() {
-    var pendingChunks = this.#pendingChunks,
-      pendingChunksI = 0,
-      pendingChunksCount = pendingChunks.length;
-
-    for (; pendingChunksI < pendingChunksCount; pendingChunksI++) {
-      const chunk = pendingChunks[pendingChunksI];
-      pendingChunks[pendingChunksI] = undefined;
-      if (!this.push(chunk, undefined)) {
-        this.#pendingChunks = pendingChunks.slice(pendingChunksI + 1);
-        return true;
-      }
-    }
-
-    if (pendingChunksCount > 0) {
-      this.#pendingChunks = [];
-    }
-
-    return false;
   }
 
   #handleDone(reader) {
@@ -92,7 +67,6 @@ class ReadableFromWeb extends Readable {
     this.#reader = undefined;
     this.#closed = true;
     this.push(null);
-    return;
   }
 
   #handleError(reader, error) {
@@ -106,72 +80,31 @@ class ReadableFromWeb extends Readable {
     this.destroy(error);
   }
 
+  // One reader.read() per _read(). Pulling the whole queue in a single call
+  // (readMany) would flip a start()-enqueued source to "closed" before the
+  // consumer can abort, and a cancel() on a closed stream is a spec no-op, so
+  // the source's cancel hook would never run.
   _read() {
     $debug("ReadableFromWeb _read()", this.__id);
-    // Readable calls _read() again as soon as push() is called, but #pump()
-    // pushes many chunks per call. Two pumps hold two read requests on the same
-    // reader, and readMany() drains the queue into whichever settles first.
-    if (this.#reading) return;
-    this.#reading = true;
-    return this.#pump();
-  }
-
-  async #pump() {
-    // #reading must be cleared as the body exits, not one microtask later: a
-    // paused-mode read() loop calls _read() again without yielding, and
-    // Readable leaves kReading set when _read() neither pushes nor pumps.
-    var reader;
-    try {
-      var stream = this.#stream;
-      reader = this.#reader;
-      if (stream) {
-        reader = this.#reader = stream.getReader();
-        this.#stream = undefined;
-      } else if (this.#drainPending()) {
-        return;
-      }
-
-      do {
-        var done = false,
-          value;
-        const firstResult = reader.readMany();
-
-        if ($isPromise(firstResult)) {
-          ({ done, value } = await firstResult);
-
-          if (this.#closed) {
-            this.#pendingChunks.push(...value);
-            return;
-          }
-        } else {
-          ({ done, value } = firstResult);
-        }
-
-        if (done) {
-          this.#handleDone(reader);
-          return;
-        }
-
-        if (!this.push(value[0])) {
-          this.#pendingChunks = value.slice(1);
-          return;
-        }
-
-        for (let i = 1, count = value.length; i < count; i++) {
-          if (!this.push(value[i])) {
-            this.#pendingChunks = value.slice(i + 1);
-            return;
-          }
-        }
-      } while (!this.#closed);
-    } catch (e) {
-      // An error from the web stream must surface on the Readable as an
-      // 'error' event. Rethrowing would only reject #pump()'s promise, which
-      // nothing awaits, turning it into an unhandled rejection instead.
-      this.#handleError(reader, e);
-    } finally {
-      this.#reading = false;
+    if (this.#closed) return;
+    var reader = this.#reader;
+    var stream = this.#stream;
+    if (stream) {
+      reader = this.#reader = stream.getReader();
+      this.#stream = undefined;
     }
+    PromisePrototypeThen.$call(
+      reader.read(),
+      chunk => {
+        if (this.#closed) return;
+        if (chunk.done) {
+          this.#handleDone(reader);
+        } else {
+          this.push(chunk.value);
+        }
+      },
+      error => this.#handleError(reader, error),
+    );
   }
 
   _destroy(error, callback) {

--- a/src/js/internal/webstreams_adapters.ts
+++ b/src/js/internal/webstreams_adapters.ts
@@ -80,10 +80,9 @@ class ReadableFromWeb extends Readable {
     this.destroy(error);
   }
 
-  // One reader.read() per _read(). Pulling the whole queue in a single call
-  // (readMany) would flip a start()-enqueued source to "closed" before the
-  // consumer can abort, and a cancel() on a closed stream is a spec no-op, so
-  // the source's cancel hook would never run.
+  // One reader.read() per _read(). readMany() would drain a start()-enqueued
+  // source to "closed" before the consumer can abort, and cancel() on a closed
+  // stream is a spec no-op, so the source's cancel hook would never run.
   _read() {
     $debug("ReadableFromWeb _read()", this.__id);
     if (this.#closed) return;

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -512,6 +512,82 @@ it("Readable.fromWeb destroyed before the first read cancels the web stream", as
   expect(r.destroyed).toBe(true);
 });
 
+it("Readable.fromWeb: breaking out of for-await cancels the web source with ABORT_ERR", async () => {
+  let cancelReason;
+  const web = new ReadableStream({
+    start(c) {
+      for (let i = 0; i < 6; i++) c.enqueue(new Uint8Array(64).fill(i));
+      c.close();
+    },
+    cancel(reason) {
+      cancelReason = reason;
+    },
+  });
+  const r = Readable.fromWeb(web);
+  r.on("error", () => {});
+  const closed = new Promise(resolve => r.once("close", resolve));
+  let seen = 0;
+  for await (const chunk of r) {
+    seen++;
+    break;
+    void chunk;
+  }
+  await closed;
+  expect(seen).toBe(1);
+  expect({ code: cancelReason?.code, name: cancelReason?.name }).toEqual({ code: "ABORT_ERR", name: "AbortError" });
+});
+
+it("Readable.fromWeb: destroy(err) after consuming a chunk cancels the web source with that error", async () => {
+  let cancelReason;
+  const web = new ReadableStream({
+    start(c) {
+      for (let i = 0; i < 6; i++) c.enqueue(new Uint8Array(64).fill(i));
+      c.close();
+    },
+    cancel(reason) {
+      cancelReason = reason;
+    },
+  });
+  const r = Readable.fromWeb(web);
+  r.on("error", () => {});
+  const closed = new Promise(resolve => r.once("close", resolve));
+  const gotData = new Promise(resolve => r.once("data", resolve));
+  const first = await gotData;
+  expect(first.length).toBe(64);
+  r.destroy(new RangeError("consumer-gone"));
+  await closed;
+  expect({ name: cancelReason?.name, message: cancelReason?.message }).toEqual({
+    name: "RangeError",
+    message: "consumer-gone",
+  });
+});
+
+it("Readable.toWeb(Readable.fromWeb(rs)).cancel(reason) propagates to the web source", async () => {
+  let cancelReason;
+  const web = new ReadableStream({
+    start(c) {
+      for (let i = 0; i < 6; i++) c.enqueue(new Uint8Array(64).fill(i));
+      c.close();
+    },
+    cancel(reason) {
+      cancelReason = reason;
+    },
+  });
+  const inner = Readable.fromWeb(web);
+  inner.on("error", () => {});
+  const innerClosed = new Promise(resolve => inner.once("close", resolve));
+  const outer = Readable.toWeb(inner);
+  const reader = outer.getReader();
+  const first = await reader.read();
+  expect(first.done).toBe(false);
+  await reader.cancel(new RangeError("consumer-gone")).catch(() => {});
+  await innerClosed;
+  expect({ name: cancelReason?.name, message: cancelReason?.message }).toEqual({
+    name: "RangeError",
+    message: "consumer-gone",
+  });
+});
+
 it("#9242.5 Stream has constructor", () => {
   const s = new Stream({});
   expect(s.constructor).toBe(Stream);
@@ -827,9 +903,6 @@ describe("webstreams adapters (Node v26 sync)", () => {
     duplex.destroy();
   });
 
-  // Readable.fromWeb()'s pump pushes several chunks per _read(), and Readable
-  // calls _read() again as soon as push() is called. Two pumps racing on one
-  // reader used to hand back the chunks out of order.
   it("Readable.fromWeb(Readable.toWeb()) preserves chunk order", async () => {
     const src = Readable.from(["A", "B", "C", "D", "E", "F"]);
     const chunks = [];


### PR DESCRIPTION
## Reproduction

```js
import { Readable } from "node:stream";

let cancelReason = "<not-called>";
const rs = new ReadableStream({
  start(c) { for (let i = 0; i < 6; i++) c.enqueue(new Uint8Array(64)); c.close(); },
  cancel(r) { cancelReason = r?.code ?? r?.name ?? String(r); },
});
const nr = Readable.fromWeb(rs);
nr.on("error", () => {});
for await (const _ of nr) break;
await new Promise(r => setTimeout(r, 50));
console.log(cancelReason);      // node: ABORT_ERR   bun: <not-called>
```

The same root cause breaks `reader.cancel(reason)` back-propagation through `Readable.toWeb(Readable.fromWeb(rs))`: the reason never reaches `rs`'s `cancel()` hook.

## Cause

`ReadableFromWeb._read` called `reader.readMany()`, which drains the entire WHATWG queue in one call. For a source that enqueues its chunks in `start()` and then `close()`s, that single drain empties the queue with close already requested, so the stream transitions to `"closed"` immediately. When the Node side is later torn down (early `break`, `destroy()`, or a `cancel()` routed through `Readable.toWeb`), `_destroy` calls `reader.cancel(reason)`, but per spec `ReadableStreamCancel` on a `"closed"` stream resolves without invoking the source's cancel steps. The source's `cancel()` hook never runs and the reason is lost.

Node's adapter issues one `reader.read()` per `_read()`, so unread chunks stay in the web queue, the stream is still `"readable"` at teardown, and `cancel(reason)` reaches the source.

## Fix

Switch `_read` to a single `reader.read()` per invocation (matching Node's adapter) and remove the `#pendingChunks`/`#drainPending` buffering that only existed to hold `readMany()`'s batched overflow.

## Verification

New tests in `test/js/node/stream/node-stream.test.js` covering early `break` out of `for await`, explicit `destroy(err)` after consuming a chunk, and `toWeb(fromWeb(rs)).cancel(reason)` back-propagation. All three fail on the released binary and pass with this change. The existing adapter suite (chunk ordering across flowing/paused/backpressure modes, error propagation, `undici`/`node-fetch` consumers, Node parallel adapter tests) continues to pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/stream/node-stream.test.js

<!-- robobun:evidence:end -->