### PR TITLE
napi: finalize threadsafe function when last ref is released after abort

### DIFF
--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2732,6 +2732,11 @@ impl ThreadSafeFunction {
                     }
                 }
                 self.schedule_dispatch();
+            } else if prev_remaining == 1 {
+                // Already closing from an earlier abort. The last release must
+                // still reach dispatch_one's thread_count==0 path so the
+                // finalizer runs and the event-loop keepalive is dropped.
+                self.schedule_dispatch();
             }
         }
 

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2617,7 +2617,7 @@ impl ThreadSafeFunction {
     pub fn enqueue(&mut self, ctx: *mut c_void, block: bool) -> napi_status {
         let _g = self.lock.lock_guard();
         if block {
-            while self.queue.is_blocked() {
+            while self.queue.is_blocked() && !self.is_closing() {
                 self.blocking_condvar.wait(&self.lock);
             }
         } else {
@@ -2728,7 +2728,9 @@ impl ThreadSafeFunction {
                         .store(ClosingState::Closing as u8, Ordering::SeqCst);
                     self.aborted.store(true, Ordering::SeqCst);
                     if self.queue.max_queue_size > 0 {
-                        self.blocking_condvar.signal();
+                        // Wake all producers blocked in enqueue()'s bounded
+                        // queue wait so they observe is_closing and release.
+                        self.blocking_condvar.broadcast();
                     }
                 }
                 self.schedule_dispatch();

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2523,7 +2523,7 @@ impl ThreadSafeFunction {
 
     pub fn dispatch_one(&mut self, is_first: bool) -> bool {
         let mut queue_finalizer_after_call = false;
-        let (has_more, task) = 'brk: {
+        let task = 'brk: {
             // `MutexGuard` holds the lock by raw pointer, so it does not borrow
             // `*self` across the `&mut self` calls below.
             let _g = self.lock.lock_guard();
@@ -2554,7 +2554,7 @@ impl ThreadSafeFunction {
                 self.blocking_condvar.signal();
             }
 
-            break 'brk (!self.is_closing(), t);
+            break 'brk t;
         };
 
         if self.call(task, !is_first).is_err() {
@@ -2565,7 +2565,9 @@ impl ThreadSafeFunction {
             self.maybe_queue_finalizer();
         }
 
-        has_more
+        // An item was dequeued: keep on_dispatch looping so remaining queued
+        // items drain and the empty-queue thread_count==0 path can finalize.
+        true
     }
 
     /// This function can be called multiple times in one tick of the event loop.

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -77,9 +77,9 @@ nativeTests.test_promise_with_threadsafe_function = async () => {
   return await nativeTests.create_promise_with_threadsafe_function(() => 1234);
 };
 
-nativeTests.test_threadsafe_function_abort_then_last_release = async () => {
-  // create (thread_count=1), acquire (=2), abort (=1, closing)
-  nativeTests.test_napi_threadsafe_function_abort_then_last_release();
+nativeTests.test_threadsafe_function_abort_then_last_release = async (_, queued = 0) => {
+  // create (thread_count=1), acquire (=2), optionally queue items, abort (=1, closing)
+  nativeTests.test_napi_threadsafe_function_abort_then_last_release(queued);
   // let the abort's scheduled dispatch run first
   await new Promise(resolve => setImmediate(resolve));
   // release the last reference of the already-closing tsfn (=0)

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -94,6 +94,17 @@ nativeTests.test_threadsafe_function_abort_then_last_release = async () => {
   // keepalive would hang it forever
 };
 
+nativeTests.test_threadsafe_function_abort_blocked_producers = async () => {
+  // create (max_queue_size=1, thread_count=3), fill the queue, spawn two
+  // producers that block on the condvar, then abort
+  nativeTests.test_napi_threadsafe_function_abort_blocked_producers();
+  for (let i = 0; i < 1000; i++) {
+    if (nativeTests.test_napi_threadsafe_function_abort_blocked_producers_finalized()) break;
+    await new Promise(resolve => setImmediate(resolve));
+  }
+  console.log("finalized:", nativeTests.test_napi_threadsafe_function_abort_blocked_producers_finalized());
+};
+
 nativeTests.test_get_exception = (_, value) => {
   function thrower() {
     throw value;

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -77,6 +77,23 @@ nativeTests.test_promise_with_threadsafe_function = async () => {
   return await nativeTests.create_promise_with_threadsafe_function(() => 1234);
 };
 
+nativeTests.test_threadsafe_function_abort_then_last_release = async () => {
+  // create (thread_count=1), acquire (=2), abort (=1, closing)
+  nativeTests.test_napi_threadsafe_function_abort_then_last_release();
+  // let the abort's scheduled dispatch run first
+  await new Promise(resolve => setImmediate(resolve));
+  // release the last reference of the already-closing tsfn (=0)
+  nativeTests.test_napi_threadsafe_function_abort_then_last_release_drop();
+  // wait for the finalizer (bounded poll, not a timed sleep)
+  for (let i = 0; i < 1000; i++) {
+    if (nativeTests.test_napi_threadsafe_function_abort_then_last_release_finalized()) break;
+    await new Promise(resolve => setImmediate(resolve));
+  }
+  console.log("finalized:", nativeTests.test_napi_threadsafe_function_abort_then_last_release_finalized());
+  // the process must exit on its own after this returns; a leaked event-loop
+  // keepalive would hang it forever
+};
+
 nativeTests.test_get_exception = (_, value) => {
   function thrower() {
     throw value;

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2,11 +2,14 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
+#include <chrono>
 #include <cinttypes>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <string>
+#include <thread>
 
 #include "utils.h"
 
@@ -133,6 +136,61 @@ static napi_value
 test_napi_threadsafe_function_abort_then_last_release_finalized(
     const Napi::CallbackInfo &info) {
   return Napi::Boolean::New(info.Env(), tsfn_abort_release_finalized);
+}
+
+static napi_threadsafe_function tsfn_abort_blocked = nullptr;
+static bool tsfn_abort_blocked_finalized = false;
+static std::atomic<int> tsfn_abort_blocked_about_to_call{0};
+
+static void tsfn_abort_blocked_finalize(napi_env env, void *finalize_data,
+                                        void *finalize_hint) {
+  tsfn_abort_blocked_finalized = true;
+}
+
+static void tsfn_abort_blocked_producer() {
+  tsfn_abort_blocked_about_to_call.fetch_add(1);
+  napi_call_threadsafe_function(tsfn_abort_blocked, nullptr,
+                                napi_tsfn_blocking);
+}
+
+// Create a tsfn with max_queue_size=1 and initial_thread_count=3, fill the
+// queue, spawn two producers that block in napi_call_threadsafe_function
+// (napi_tsfn_blocking), then abort. Both producers must wake, observe
+// napi_closing, and the finalizer must run so the process exits.
+static napi_value test_napi_threadsafe_function_abort_blocked_producers(
+    const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  napi_value resource_name = Napi::String::New(env, "abort_blocked_producers");
+  tsfn_abort_blocked_finalized = false;
+  tsfn_abort_blocked_about_to_call.store(0);
+  NODE_API_CALL(
+      env, napi_create_threadsafe_function(
+               env, /* JavaScript function */ nullptr,
+               /* async resource */ nullptr, resource_name,
+               /* max queue size */ 1,
+               /* initial thread count */ 3, /* finalize data */ nullptr,
+               tsfn_abort_blocked_finalize, /* context */ nullptr,
+               &noop_callback, &tsfn_abort_blocked));
+  // Fill the queue so both producer threads block on the condvar. The JS
+  // thread is parked in this function, so dispatch cannot drain it yet.
+  NODE_API_CALL(env, napi_call_threadsafe_function(tsfn_abort_blocked, nullptr,
+                                                   napi_tsfn_nonblocking));
+  std::thread(tsfn_abort_blocked_producer).detach();
+  std::thread(tsfn_abort_blocked_producer).detach();
+  while (tsfn_abort_blocked_about_to_call.load() < 2) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  NODE_API_CALL(env, napi_release_threadsafe_function(tsfn_abort_blocked,
+                                                      napi_tsfn_abort));
+  tsfn_abort_blocked = nullptr;
+  return env.Undefined();
+}
+
+static napi_value
+test_napi_threadsafe_function_abort_blocked_producers_finalized(
+    const Napi::CallbackInfo &info) {
+  return Napi::Boolean::New(info.Env(), tsfn_abort_blocked_finalized);
 }
 
 static napi_value
@@ -2550,6 +2608,11 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(
       env, exports,
       test_napi_threadsafe_function_abort_then_last_release_finalized);
+  REGISTER_FUNCTION(env, exports,
+                    test_napi_threadsafe_function_abort_blocked_producers);
+  REGISTER_FUNCTION(
+      env, exports,
+      test_napi_threadsafe_function_abort_blocked_producers_finalized);
   REGISTER_FUNCTION(env, exports, test_napi_handle_scope_string);
   REGISTER_FUNCTION(env, exports, test_napi_handle_scope_bigint);
   REGISTER_FUNCTION(env, exports, test_napi_delete_property);

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -100,12 +100,14 @@ static void tsfn_abort_release_finalize(napi_env env, void *finalize_data,
 }
 
 // Create a tsfn (thread_count=1), acquire a second reference (thread_count=2),
-// then abort it (thread_count=1, closing). The abort's dispatch runs on the
-// next event-loop turn, sees thread_count!=0, and returns without finalizing.
+// optionally queue some items, then abort it (thread_count=1, closing). The
+// abort's dispatch runs on the next event-loop turn, sees thread_count!=0, and
+// returns without finalizing.
 static napi_value test_napi_threadsafe_function_abort_then_last_release(
     const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   napi_value resource_name = Napi::String::New(env, "abort_then_last_release");
+  int queued = info[0].IsNumber() ? info[0].As<Napi::Number>().Int32Value() : 0;
   tsfn_abort_release_finalized = false;
   NODE_API_CALL(env,
                 napi_create_threadsafe_function(
@@ -116,6 +118,10 @@ static napi_value test_napi_threadsafe_function_abort_then_last_release(
                     tsfn_abort_release_finalize, /* context */ nullptr,
                     &noop_callback, &tsfn_abort_release));
   NODE_API_CALL(env, napi_acquire_threadsafe_function(tsfn_abort_release));
+  for (int i = 0; i < queued; i++) {
+    NODE_API_CALL(env, napi_call_threadsafe_function(
+                           tsfn_abort_release, nullptr, napi_tsfn_nonblocking));
+  }
   NODE_API_CALL(env, napi_release_threadsafe_function(tsfn_abort_release,
                                                       napi_tsfn_abort));
   return env.Undefined();

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -154,9 +154,9 @@ static void tsfn_abort_blocked_finalize(napi_env env, void *finalize_data,
 }
 
 static void tsfn_abort_blocked_producer() {
+  napi_threadsafe_function tsfn = tsfn_abort_blocked;
   tsfn_abort_blocked_about_to_call.fetch_add(1);
-  napi_call_threadsafe_function(tsfn_abort_blocked, nullptr,
-                                napi_tsfn_blocking);
+  napi_call_threadsafe_function(tsfn, nullptr, napi_tsfn_blocking);
 }
 
 // Create a tsfn with max_queue_size=1 and initial_thread_count=3, fill the
@@ -189,7 +189,6 @@ static napi_value test_napi_threadsafe_function_abort_blocked_producers(
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
   NODE_API_CALL(env, napi_release_threadsafe_function(tsfn_abort_blocked,
                                                       napi_tsfn_abort));
-  tsfn_abort_blocked = nullptr;
   return env.Undefined();
 }
 

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -88,6 +88,53 @@ static napi_value test_napi_threadsafe_function_does_not_hang_after_finalize(
   return env.Undefined();
 }
 
+static napi_threadsafe_function tsfn_abort_release = nullptr;
+static bool tsfn_abort_release_finalized = false;
+
+static void tsfn_abort_release_finalize(napi_env env, void *finalize_data,
+                                        void *finalize_hint) {
+  tsfn_abort_release_finalized = true;
+}
+
+// Create a tsfn (thread_count=1), acquire a second reference (thread_count=2),
+// then abort it (thread_count=1, closing). The abort's dispatch runs on the
+// next event-loop turn, sees thread_count!=0, and returns without finalizing.
+static napi_value test_napi_threadsafe_function_abort_then_last_release(
+    const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  napi_value resource_name = Napi::String::New(env, "abort_then_last_release");
+  tsfn_abort_release_finalized = false;
+  NODE_API_CALL(env,
+                napi_create_threadsafe_function(
+                    env, /* JavaScript function */ nullptr,
+                    /* async resource */ nullptr, resource_name,
+                    /* max queue size (unlimited) */ 0,
+                    /* initial thread count */ 1, /* finalize data */ nullptr,
+                    tsfn_abort_release_finalize, /* context */ nullptr,
+                    &noop_callback, &tsfn_abort_release));
+  NODE_API_CALL(env, napi_acquire_threadsafe_function(tsfn_abort_release));
+  NODE_API_CALL(env, napi_release_threadsafe_function(tsfn_abort_release,
+                                                      napi_tsfn_abort));
+  return env.Undefined();
+}
+
+// Releases the last reference of the already-closing tsfn. The finalizer must
+// run and the event-loop keepalive must drop so the process exits.
+static napi_value test_napi_threadsafe_function_abort_then_last_release_drop(
+    const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  NODE_API_CALL(env, napi_release_threadsafe_function(tsfn_abort_release,
+                                                      napi_tsfn_release));
+  tsfn_abort_release = nullptr;
+  return env.Undefined();
+}
+
+static napi_value
+test_napi_threadsafe_function_abort_then_last_release_finalized(
+    const Napi::CallbackInfo &info) {
+  return Napi::Boolean::New(info.Env(), tsfn_abort_release_finalized);
+}
+
 static napi_value
 test_napi_get_value_string_utf8_with_buffer(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
@@ -2496,6 +2543,13 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_napi_get_value_string_utf8_with_buffer);
   REGISTER_FUNCTION(env, exports,
                     test_napi_threadsafe_function_does_not_hang_after_finalize);
+  REGISTER_FUNCTION(env, exports,
+                    test_napi_threadsafe_function_abort_then_last_release);
+  REGISTER_FUNCTION(env, exports,
+                    test_napi_threadsafe_function_abort_then_last_release_drop);
+  REGISTER_FUNCTION(
+      env, exports,
+      test_napi_threadsafe_function_abort_then_last_release_finalized);
   REGISTER_FUNCTION(env, exports, test_napi_handle_scope_string);
   REGISTER_FUNCTION(env, exports, test_napi_handle_scope_bigint);
   REGISTER_FUNCTION(env, exports, test_napi_delete_property);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -416,6 +416,11 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       const result = await checkSameOutput("test_napi_threadsafe_function_does_not_hang_after_finalize", []);
       expect(result).toBe("success!");
     });
+
+    it("runs the finalizer and exits when the last reference is released after abort", async () => {
+      const result = await checkSameOutput("test_threadsafe_function_abort_then_last_release", []);
+      expect(result).toContain("finalized: true");
+    });
   });
 
   describe("exception handling", () => {

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -417,10 +417,13 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       expect(result).toBe("success!");
     });
 
-    it("runs the finalizer and exits when the last reference is released after abort", async () => {
-      const result = await checkSameOutput("test_threadsafe_function_abort_then_last_release", []);
-      expect(result).toContain("finalized: true");
-    });
+    it.each([0, 3])(
+      "runs the finalizer and exits when the last reference is released after abort (%d queued items)",
+      async queued => {
+        const result = await checkSameOutput("test_threadsafe_function_abort_then_last_release", [queued]);
+        expect(result).toContain("finalized: true");
+      },
+    );
 
     it("wakes blocked producers, runs the finalizer and exits when aborted with a bounded queue", async () => {
       const result = await checkSameOutput("test_threadsafe_function_abort_blocked_producers", []);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -421,6 +421,11 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       const result = await checkSameOutput("test_threadsafe_function_abort_then_last_release", []);
       expect(result).toContain("finalized: true");
     });
+
+    it("wakes blocked producers, runs the finalizer and exits when aborted with a bounded queue", async () => {
+      const result = await checkSameOutput("test_threadsafe_function_abort_blocked_producers", []);
+      expect(result).toContain("finalized: true");
+    });
   });
 
   describe("exception handling", () => {


### PR DESCRIPTION
Three related mechanisms could leave an aborted `napi_threadsafe_function` with its finalizer never invoked and its event-loop keepalive still held, so the process (or Worker) hung at exit. Node v26 finalizes and exits 0 in each case.

## Reproduction

```c
// create + acquire + abort, then on a later tick release the last ref
napi_create_threadsafe_function(env, cb, ..., /*initial_thread_count=*/1, ..., fin, ..., &tsfn);
napi_acquire_threadsafe_function(tsfn);                       // thread_count 2
napi_release_threadsafe_function(tsfn, napi_tsfn_abort);      // thread_count 1, closing
// ... next tick ...
napi_release_threadsafe_function(tsfn, napi_tsfn_release);    // thread_count 0
```

`timeout 5 bun driver.mjs` returns 124; `fin` never runs. The same hang reproduces when items are queued before abort, and when two or more producers are parked in `napi_call_threadsafe_function(..., napi_tsfn_blocking)` on a bounded queue at abort time.

## Cause

- `ThreadSafeFunction::release()` only called `schedule_dispatch()` under `!is_closing()`, so releasing the last reference of an already-aborted tsfn never reached `dispatch_one`'s `thread_count == 0` finalize path.
- `dispatch_one()` returned `has_more = !is_closing()`, so once closing it processed at most one queued item per scheduled dispatch and never drained to the finalize path.
- `enqueue()`'s blocking wait loop only checked queue occupancy (Node's `Push()` also checks `state == kOpen`), and `release(abort)` used `signal()`, so with multiple blocked producers at most one woke.

## Fix

- `release()`: when `prev_remaining == 1` and the tsfn is already closing, schedule a dispatch so `dispatch_one` observes `thread_count == 0` and queues the finalizer. `schedule_dispatch()` is idempotent via the `dispatch_state` swap.
- `dispatch_one()`: keep returning `true` after dequeuing so `on_dispatch` loops until the queue is empty, where the existing `thread_count == 0` branch finalizes.
- `enqueue()`: guard the blocking wait on `!is_closing()` and `broadcast()` on abort so every blocked producer observes closing and releases its reference.

## Verification

```
$ bun bd test test/napi/napi.test.ts -t "napi_threadsafe_function"
(pass) napi > napi_threadsafe_function > does not hang on finalize
(pass) napi > napi_threadsafe_function > keeps the event loop alive without async_work
(pass) napi > napi_threadsafe_function > runs the finalizer and exits when the last reference is released after abort (0 queued items)
(pass) napi > napi_threadsafe_function > runs the finalizer and exits when the last reference is released after abort (3 queued items)
(pass) napi > napi_threadsafe_function > wakes blocked producers, runs the finalizer and exits when aborted with a bounded queue
```

All three new cases time out on the unfixed build and match Node's output (`finalized: true`, exit 0) with the fix. Node's own `test_threadsafe_function` suite continues to pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->