### PR TITLE
jest: fix null deref in useFakeTimers when setTimeout is a non-object cell

### DIFF
--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -339,7 +339,7 @@ fn set_fake_timer_marker(global: &JSGlobalObject, enabled: bool) {
     let Ok(Some(set_timeout_fn)) = global_this.get(global, "setTimeout") else {
         return;
     };
-    if !set_timeout_fn.is_cell() {
+    if !set_timeout_fn.is_object() {
         return;
     }
     // testing-library/react checks Object.hasOwnProperty.call(setTimeout, 'clock')

--- a/test/js/bun/test/test-timers.test.ts
+++ b/test/js/bun/test/test-timers.test.ts
@@ -77,6 +77,29 @@ test("setSystemTime accepts pre-epoch and epoch times and resets with no argumen
   }
 });
 
+test.each(["'x'", "Symbol()", "1n"])(
+  "useFakeTimers does not crash when globalThis.setTimeout is %s",
+  async value => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `globalThis.setTimeout = ${value};
+         const jest = Bun.jest().jest;
+         jest.useFakeTimers();
+         jest.useRealTimers();
+         console.log("ok");`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok\n", stderr: "", exitCode: 0 });
+    expect(proc.signalCode).toBeNull();
+  },
+);
+
 test("real timer heap is ticked against the real clock under useFakeTimers", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "test", path.join(import.meta.dir, "test-timers-gc-spin-fixture.ts")],

--- a/test/js/bun/test/test-timers.test.ts
+++ b/test/js/bun/test/test-timers.test.ts
@@ -77,28 +77,25 @@ test("setSystemTime accepts pre-epoch and epoch times and resets with no argumen
   }
 });
 
-test.each(["'x'", "Symbol()", "1n"])(
-  "useFakeTimers does not crash when globalThis.setTimeout is %s",
-  async value => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `globalThis.setTimeout = ${value};
+test.each(["'x'", "Symbol()", "1n"])("useFakeTimers does not crash when globalThis.setTimeout is %s", async value => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `globalThis.setTimeout = ${value};
          const jest = Bun.jest().jest;
          jest.useFakeTimers();
          jest.useRealTimers();
          console.log("ok");`,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok\n", stderr: "", exitCode: 0 });
-    expect(proc.signalCode).toBeNull();
-  },
-);
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok\n", stderr: "", exitCode: 0 });
+  expect(proc.signalCode).toBeNull();
+});
 
 test("real timer heap is ticked against the real clock under useFakeTimers", async () => {
   await using proc = Bun.spawn({


### PR DESCRIPTION
## What does this PR do?

Fixes a segfault found by fuzzing. `jest.useFakeTimers()` sets a `clock` marker property on `globalThis.setTimeout` so that testing-library/react can detect fake timers. The guard before the write used `is_cell()`, but strings, symbols and heap bigints are cells that are not objects. `JSC__JSValue__put` does `asCell()->getObject()` which returns `nullptr` for those and then calls `->putDirect()` on it.

Repro:
```js
globalThis.setTimeout = "x";
Bun.jest().jest.useFakeTimers();
// panic(main thread): Segmentation fault at address 0x0
```

Changed the guard to `is_object()` so the marker write is simply skipped when `setTimeout` has been replaced with a primitive. The `useRealTimers` side was already safe since `JSC__JSValue__deleteProperty` checks `isObject()` internally.

## How did you verify your code works?

Added a `test.each` over string, symbol and bigint that spawns a subprocess, overrides `setTimeout`, calls `useFakeTimers()`/`useRealTimers()` and asserts clean exit. Segfaults on `USE_SYSTEM_BUN=1`, passes on this build.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/test-timers.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (a27a303bf)

test/js/bun/test/test-timers.test.ts:
(pass) we can go back in time [38.51ms]
(pass) advanceTimersByTime ticks from the setSystemTime value [5.58ms]
(pass) setSystemTime accepts pre-epoch and epoch times and resets with no argument [4.56ms]
91 |     env: bunEnv,
92 |     stdout: "pipe",
93 |     stderr: "pipe",
94 |   });
95 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
96 |   expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok\n", stderr: "", exitCode: 0 });
                                            ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
-   "stderr": "",
-   "stdout": 
- "ok
+   "exitCode": 1,
+   "stderr": 
+ ".
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (764f47f1d)

test/js/bun/test/test-timers.test.ts:
(pass) we can go back in time [2.73ms]
(pass) advanceTimersByTime ticks from the setSystemTime value [0.10ms]
(pass) setSystemTime accepts pre-epoch and epoch times and resets with no argument [0.06ms]
(pass) useFakeTimers does not crash when globalThis.setTimeout is 'x' [11.80ms]
(pass) useFakeTimers does not crash when globalThis.setTimeout is Symbol() [11.13ms]
(pass) useFakeTimers does not crash when globalThis.setTimeout is 1n [11.85ms]
(pass) real timer heap is ticked against the real clock under useFakeTimers [36.14ms]

 7 pass
 0 fail
 27 expect() calls
Ran 7 tests across 1 file. [231.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/test-timers.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (a27a303bf)

test/js/bun/test/test-timers.test.ts:
(pass) we can go back in time [49.49ms]
(pass) advanceTimersByTime ticks from the setSystemTime value [6.51ms]
(pass) setSystemTime accepts pre-epoch and epoch times and resets with no argument [4.69ms]
(pass) useFakeTimers does not crash when globalThis.setTimeout is 'x' [538.72ms]
(pass) useFakeTimers does not crash when globalThis.setTimeout is Symbol() [444.00ms]
(pass) useFakeTimers does not crash when globalThis.setTimeout is 1n [443.49ms]
(pass) real timer heap is ticked against the real clock under useFakeTimers [1843.89ms]

 7 pass
 0 fail
 27 expect() calls
Ran 7 tests across 1 file. [5.36s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 709ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[2/21] gen JS modules (bundle-modules)
Preprocess modules (6796ms)
Bundle modules (64ms)
Postprocesss modules (156ms)
Bundle Functions (697ms)
Generate Code (79ms)

[7.81s] Bundled "src/js" for production
  1912 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/timers/FakeTimers.rs |  2 +-
 test/js/bun/test/test-timers.test.ts         | 20 ++++++++++++++++++++
 2 files changed, 21 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/runtime/test_runner/timers/FakeTimers.rs      2      1      0
test/js/bun/test/test-timers.test.ts              2      1      0
```

</details>

<!-- robobun:evidence:end -->