### PR TITLE
node:stream: leave Readable.toWeb source non-flowing after EOF

### DIFF
--- a/src/js/internal/streams/readable.ts
+++ b/src/js/internal/streams/readable.ts
@@ -1135,9 +1135,15 @@ function nReadingNextTick(self) {
 // If the user uses them, then switch into old mode.
 Readable.prototype.resume = function () {
   const state = this._readableState;
-  // Deliberate divergence from Node 26 (nodejs/node#62557): no destroyed
-  // early-return here. fd-slicer-style readables set `destroyed` right before
-  // push(null), and the guard strands their buffer when a piped dest drains.
+  // Node 26 (nodejs/node#62557) early-returns on kDestroyed. We narrow it to
+  // kDestroyed && kEndEmitted: fd-slicer-style readables set `destroyed` right
+  // before push(null), and the full guard strands their buffered tail when a
+  // piped dest drains (yauzl/extract-zip). Once 'end' has fired there is
+  // nothing left to flush, so becoming a no-op restores readableFlowing /
+  // isPaused() parity for consumers that resume() past EOF (Readable.toWeb).
+  if ((state[kState] & (kDestroyed | kEndEmitted)) === (kDestroyed | kEndEmitted)) {
+    return this;
+  }
   if ((state[kState] & kFlowing) === 0) {
     $debug("resume");
     // We flow only if there is no one listening

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -788,6 +788,34 @@ describe("webstreams adapters (Node v26 sync)", () => {
     expect(done).toBe(true);
   });
 
+  // The toWeb adapter's pull() calls resume() on the source. After 'end' and
+  // autoDestroy, Node 26's resume() is a no-op on destroyed streams, so the
+  // source is left paused / non-flowing. We narrow that guard (see the
+  // fd-slicer test below) but must still match Node's resting state here.
+  it("Readable.toWeb leaves the source paused / non-flowing after EOF", async () => {
+    const src = Readable.from([Buffer.from("a"), Buffer.from("b")], { objectMode: false });
+    const reader = Readable.toWeb(src).getReader();
+    const chunks = [];
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+    await new Promise(resolve => (src.closed ? resolve() : src.once("close", resolve)));
+    expect(Buffer.concat(chunks).toString()).toBe("ab");
+    expect({
+      readableEnded: src.readableEnded,
+      destroyed: src.destroyed,
+      readableFlowing: src.readableFlowing,
+      isPaused: src.isPaused(),
+    }).toEqual({
+      readableEnded: true,
+      destroyed: true,
+      readableFlowing: false,
+      isPaused: true,
+    });
+  });
+
   // Upstream: v26 adapters use eos(stream, { writable: false }) so a Duplex
   // readable side completes without waiting for the half-open writable side.
   it("Readable.toWeb of a half-open Duplex closes when the readable side ends", async () => {


### PR DESCRIPTION
## Repro

```js
import { Readable } from "node:stream";
const src = Readable.from([Buffer.from("a"), Buffer.from("b")], { objectMode: false });
const rd = Readable.toWeb(src).getReader();
for (;;) { const { done } = await rd.read(); if (done) break; }
await new Promise(r => setTimeout(r, 30));
console.log(`flowing=${src.readableFlowing} isPaused=${src.isPaused()}`);
```

```
node v26.3.0: flowing=false isPaused=true
bun 1.4.0:    flowing=true  isPaused=false
```

`readableEnded` / `destroyed` agree; only `readableFlowing` / `isPaused()` diverge, so code that branches on those after the adapter finishes (pooling, reuse logic, diagnostics) observes the wrong state.

## Cause

The toWeb adapter's `pull()` calls `source.resume()`. After the source emits `'end'` and autoDestroys, Node 26's `resume()` is a no-op on destroyed streams (nodejs/node#62557), so the late `pull()`s leave the source non-flowing.

Bun dropped that guard in 6abf57e204 so that fd-slicer-style readables (yauzl / extract-zip / puppeteer), which assign `this.destroyed = true` right before `push(null)`, can still be resumed by a piped destination's `'drain'` to flush their buffered tail. With no guard at all, the adapter's post-EOF `resume()` flips `readableFlowing` back to `true`.

## Fix

Narrow the `resume()` guard to `kDestroyed && kEndEmitted` instead of removing it entirely. In the fd-slicer case `'end'` has not yet been emitted when drain resumes the source, so the narrowed guard does not fire and the buffered tail still flushes. Once `'end'` has fired there is nothing left to flush, so `resume()` can become a no-op and keep state parity with Node.

`pause()` is left unchanged; #33467 addresses the mirrored post-pipe divergence on the `pause()` side.

## Verification

- New test `Readable.toWeb leaves the source paused / non-flowing after EOF` fails on main (`readableFlowing: true, isPaused: false`) and passes with this change; the same test body passes on Node v26.3.0.
- The existing fd-slicer regression test (`drain still resumes a source that flagged itself destroyed before EOF`) still passes.
- `test/js/node/stream/` and the vendored `test-stream-*.js` parallel suite: no new failures relative to main.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/stream/node-stream.test.js

<!-- robobun:evidence:end -->