### PR TITLE
shell(rm): close the DirTask parent/child hand-off lost-wakeup

### DIFF
--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -1509,8 +1509,7 @@ impl DirTask {
                 .store(true, Ordering::SeqCst);
             (*this).need_to_wait.store(false, Ordering::SeqCst);
             // The caller just took `subtask_count` to 0; restore the slot
-            // that `post_run`'s own decrement (and any enqueue from
-            // `remove_entry_dir_after_children`) expects.
+            // `post_run`'s own decrement expects.
             (*this).subtask_count.store(1, Ordering::SeqCst);
             let tm = &*(*this).task_manager;
             let mut do_post_run = true;

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -901,14 +901,14 @@ impl ShellRmTask {
         }
         // SAFETY: a DirTask's non-atomic fields are single-owner-at-a-time.
         // Ownership starts on the worker that runs `remove_entry*` and is
-        // handed to the last child via `need_to_wait`: the parent
-        // release-stores `true` (SeqCst, `remove_entry_dir`) after its final
-        // append here, and the child acquire-loads it (SeqCst, `post_run`)
-        // before re-entering via `delete_after_waiting_for_children`. That
-        // release/acquire pair makes prior `deleted_entries` writes visible to
-        // the new owner, so this `&mut` is exclusive and race-free. The
-        // reborrow is also disjoint from every other live borrow (`&self`,
-        // `path`).
+        // handed off via `subtask_count`: the parent's final append here is
+        // sequenced-before its `subtask_count.fetch_sub(SeqCst)` in
+        // `remove_entry_dir`, and the child taking the counter to 0 in
+        // `post_run` acquire-reads from that release sequence before
+        // re-entering via `delete_after_waiting_for_children`. That pair
+        // makes prior `deleted_entries` writes visible to the new owner, so
+        // this `&mut` is exclusive and race-free. The reborrow is also
+        // disjoint from every other live borrow (`&self`, `path`).
         let entries = unsafe { &mut (*dir_task).deleted_entries };
         if entries.is_empty() {
             // `output_count` is a `BackRef` into the boxed `Rm` ExecState.
@@ -966,9 +966,9 @@ impl ShellRmTask {
         e.with_path(path)
     }
 
-    /// Returns `Ok(true)` when [`remove_entry_dir`] published
-    /// `need_to_wait = true` on `dir_task`. Once that store is visible, a
-    /// child finishing on another thread may run
+    /// Returns `Ok(true)` when [`remove_entry_dir`] handed `dir_task` off to
+    /// a child (its `subtask_count` slot was released without reaching 0).
+    /// Once that happens, a child finishing on another thread may run
     /// [`DirTask::delete_after_waiting_for_children`] → `post_run` → `deinit`
     /// (or, for the root, the main thread may free the whole
     /// [`ShellRmTask`]). Callers must therefore treat `dir_task` as
@@ -997,9 +997,9 @@ impl ShellRmTask {
         Ok(waiting)
     }
 
-    /// `need_to_wait_out` is set to `true` immediately before the
-    /// `need_to_wait` atomic store that hands `dir_task` off to its children;
-    /// see [`remove_entry`] for why the caller needs this on its own stack
+    /// `need_to_wait_out` is left `true` only when the hand-off in this
+    /// function gave ownership of `dir_task` to a child; see
+    /// [`remove_entry`] for why the caller needs this on its own stack
     /// rather than reading it back from `dir_task`.
     fn remove_entry_dir(
         &self,
@@ -1143,31 +1143,42 @@ impl ShellRmTask {
 
         // Stash any loop error before the hand-off — once `need_to_wait`
         // is published `self` may be freed, and `handle_err` takes a
-        // mutex so it must not sit between the `subtask_count` load and
-        // the `need_to_wait` store. The `error_signal` check below covers
-        // the no-children early-out.
+        // mutex so it must not sit inside the hand-off below. The
+        // `error_signal` check afterwards covers the no-children early-out.
         if let Err(e) = loop_result {
             self.handle_err(e);
         }
 
-        // Need to wait for children to finish.
-        // SAFETY: `dir_task` is live; only this thread reads `subtask_count`
-        // here (children atomically modify it). Atomics through a short-lived
-        // `&DirTask` — interior mutability.
+        // Hand off to children. Publish `need_to_wait` first, then release
+        // this task's own slot on `subtask_count` with the same `fetch_sub`
+        // the children use: whoever takes the counter to 0 owns the rmdir.
+        // A load-then-store here had a lost-wakeup window where the last
+        // child could decrement and read `need_to_wait == false` between
+        // the two operations, stranding `dir_task` forever.
+        //
+        // SAFETY: `dir_task` is live until `subtask_count` drains to 0, and
+        // we still hold one count. Atomics through a short-lived `&DirTask`
+        // — interior mutability.
         unsafe {
             let dt = &*dir_task;
-            if dt.subtask_count.load(Ordering::SeqCst) > 1 {
-                // Record locally first: once `need_to_wait` is published a
-                // child may immediately drive `delete_after_waiting_for_children`
-                // → `post_run` → `deinit` on `dir_task` (or free the owning
-                // ShellRmTask via the main thread for the root), so nothing
-                // after this store may dereference `dir_task`. The directory
-                // fd is closed by the `close_fd` scopeguard on return — that
-                // touches only a stack local, not `dir_task`.
-                *need_to_wait_out = true;
-                dt.need_to_wait.store(true, Ordering::SeqCst);
+            *need_to_wait_out = true;
+            dt.need_to_wait.store(true, Ordering::SeqCst);
+            if dt.subtask_count.fetch_sub(1, Ordering::SeqCst) != 1 {
+                // A child still holds a count. It (or a later child) will
+                // take the counter to 0 and drive
+                // `delete_after_waiting_for_children`; nothing after this
+                // may dereference `dir_task`. The directory fd is closed by
+                // the `close_fd` scopeguard on return — that touches only a
+                // stack local, not `dir_task`.
                 return Ok(());
             }
+            // Every child already released its count (each saw the counter
+            // > 1 and so did not take ownership). `dir_task` is exclusively
+            // ours again: restore the invariants `post_run` expects and
+            // fall through to delete inline.
+            dt.subtask_count.store(1, Ordering::SeqCst);
+            dt.need_to_wait.store(false, Ordering::SeqCst);
+            *need_to_wait_out = false;
         }
 
         if self.error_signal().load(Ordering::SeqCst) {
@@ -1448,25 +1459,16 @@ impl DirTask {
 
                 // If we have a parent and we are the last child, now we can delete the parent.
                 if !me.parent_task.is_null() {
-                    // It's possible that we queued this subdir task and it
-                    // finished, while the parent was still in `remove_entry_dir`.
                     let p = &*me.parent_task;
-                    let tasks_left = p.subtask_count.fetch_sub(1, Ordering::SeqCst);
-                    // Relaxed ordering here would be a
-                    // formal data race on the parent's non-atomic
-                    // `deleted_entries`: the parent thread may have appended
-                    // verbose paths for plain-file children *after* scheduling
-                    // this subtask and *before* its `need_to_wait.store(true,
-                    // SeqCst)` (the only release that covers those writes). A
-                    // Relaxed load reading `true` does not synchronize-with
-                    // that store, so the `Vec<u8>` writes would not
-                    // happen-before our `delete_after_waiting_for_children` →
-                    // `verbose_deleted(parent)` access below. Use SeqCst
-                    // (Acquire suffices) so observing `true` establishes the
-                    // ownership hand-off and makes the parent's
-                    // `deleted_entries` writes visible.
-                    let parent_still_in_remove_entry_dir = !p.need_to_wait.load(Ordering::SeqCst);
-                    if !parent_still_in_remove_entry_dir && tasks_left == 2 {
+                    // The parent releases its own slot on this counter in
+                    // `remove_entry_dir`; whoever takes it to 0 owns the
+                    // parent's rmdir. The parent's `fetch_sub` is sequenced
+                    // after its final `deleted_entries` write and its
+                    // `need_to_wait.store(true)`, and every decrement is a
+                    // SeqCst RMW, so reading 1 here synchronizes-with the
+                    // parent's release and makes those writes visible to
+                    // `delete_after_waiting_for_children`.
+                    if p.subtask_count.fetch_sub(1, Ordering::SeqCst) == 1 {
                         Self::delete_after_waiting_for_children(me.parent_task);
                     }
                     if will_queue_verbose {
@@ -1506,6 +1508,10 @@ impl DirTask {
                 .deleting_after_waiting_for_children
                 .store(true, Ordering::SeqCst);
             (*this).need_to_wait.store(false, Ordering::SeqCst);
+            // The caller just took `subtask_count` to 0; restore the slot
+            // that `post_run`'s own decrement (and any enqueue from
+            // `remove_entry_dir_after_children`) expects.
+            (*this).subtask_count.store(1, Ordering::SeqCst);
             let tm = &*(*this).task_manager;
             let mut do_post_run = true;
             if !tm.error_signal().load(Ordering::SeqCst) {

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -200,11 +200,7 @@ foo/
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout: stdout.trim(), stderr: stderr.trim() }).toEqual({
       stdout: "ok 800",
       stderr: "",

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -6,7 +6,7 @@
  */
 import { $ } from "bun";
 import { beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 import { existsSync, mkdirSync, renameSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "path";
 import { createTestBuilder, sortedShellOutput } from "../util";
@@ -144,6 +144,73 @@ foo/
       expect(await fileExists(`${tempdir}/sub_dir_files`)).toBeTrue();
     }
   });
+
+  // The DirTask parent/child hand-off had a lost-wakeup window between
+  // `subtask_count.load() > 1` and `need_to_wait.store(true)`: the last
+  // child could decrement and read `need_to_wait == false` in between,
+  // stranding the parent DirTask forever. A directory with exactly one
+  // subdirectory is the minimal trigger; the window is a few instructions
+  // so this is a stress probe rather than a deterministic repro.
+  test("recursive rm never hangs on the DirTask hand-off", async () => {
+    const fixture = /* ts */ `
+      import { $ } from "bun";
+      import { mkdirSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+      import { join } from "node:path";
+      import { tmpdir } from "node:os";
+
+      const base = mkdtempSync(join(tmpdir(), "rm-handoff-"));
+      process.on("beforeExit", () => rmSync(base, { recursive: true, force: true }));
+
+      function tree(n: number): string {
+        const d = join(base, "t" + n);
+        mkdirSync(join(d, "foo", "bar"), { recursive: true });
+        writeFileSync(join(d, "foo", "a"), "");
+        writeFileSync(join(d, "foo", "bar", "b"), "");
+        return d;
+      }
+
+      const ITERS = 100;
+      const PAR = 8;
+      for (let it = 0; it < ITERS; it++) {
+        const dirs = Array.from({ length: PAR }, (_, i) => tree(it * PAR + i));
+        const results = await Promise.all(
+          dirs.map(d =>
+            Promise.race([
+              $\`rm -rfv \${d}/foo\`.quiet().then(r => r.exitCode),
+              Bun.sleep(10_000).then(() => "hang" as const),
+            ]),
+          ),
+        );
+        for (const r of results) {
+          if (r === "hang") {
+            console.error("rm -rfv hung at iteration", it);
+            process.exit(1);
+          }
+          if (r !== 0) {
+            console.error("rm -rfv exited", r, "at iteration", it);
+            process.exit(1);
+          }
+        }
+      }
+      console.log("ok", ITERS * PAR);
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect({ stdout: stdout.trim(), stderr: stderr.trim() }).toEqual({
+      stdout: "ok 800",
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  }, 120_000);
 });
 
 function packagejson() {

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -172,14 +172,17 @@ foo/
       const PAR = 8;
       for (let it = 0; it < ITERS; it++) {
         const dirs = Array.from({ length: PAR }, (_, i) => tree(it * PAR + i));
+        let watchdogTimer!: ReturnType<typeof setTimeout>;
+        const watchdog = new Promise<"hang">(r => (watchdogTimer = setTimeout(() => r("hang"), 10_000)));
         const results = await Promise.all(
           dirs.map(d =>
             Promise.race([
-              $\`rm -rfv \${d}/foo\`.quiet().then(r => r.exitCode),
-              Bun.sleep(10_000).then(() => "hang" as const),
+              $\`rm -rfv \${d}/foo\`.quiet().nothrow().then(r => r.exitCode),
+              watchdog,
             ]),
           ),
         );
+        clearTimeout(watchdogTimer);
         for (const r of results) {
           if (r === "hang") {
             console.error("rm -rfv hung at iteration", it);
@@ -192,6 +195,7 @@ foo/
         }
       }
       console.log("ok", ITERS * PAR);
+      process.exit(0);
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -159,7 +159,7 @@ foo/
       import { tmpdir } from "node:os";
 
       const base = mkdtempSync(join(tmpdir(), "rm-handoff-"));
-      process.on("beforeExit", () => rmSync(base, { recursive: true, force: true }));
+      process.on("exit", () => rmSync(base, { recursive: true, force: true }));
 
       function tree(n: number): string {
         const d = join(base, "t" + n);

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -6,7 +6,7 @@
  */
 import { $ } from "bun";
 import { beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
 import { existsSync, mkdirSync, renameSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "path";
 import { createTestBuilder, sortedShellOutput } from "../util";
@@ -152,14 +152,13 @@ foo/
   // subdirectory is the minimal trigger; the window is a few instructions
   // so this is a stress probe rather than a deterministic repro.
   test("recursive rm never hangs on the DirTask hand-off", async () => {
+    using base = tempDir("rm-handoff", {});
     const fixture = /* ts */ `
       import { $ } from "bun";
-      import { mkdirSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+      import { mkdirSync, writeFileSync } from "node:fs";
       import { join } from "node:path";
-      import { tmpdir } from "node:os";
 
-      const base = mkdtempSync(join(tmpdir(), "rm-handoff-"));
-      process.on("exit", () => rmSync(base, { recursive: true, force: true }));
+      const base = ${JSON.stringify(String(base))};
 
       function tree(n: number): string {
         const d = join(base, "t" + n);


### PR DESCRIPTION
## What does this PR do?

Closes the lost-wakeup race in the shell `rm -rf` DirTask parent/child join that was explicitly called out as out of scope in #32617 (85ef0c5612):

> There is a separate, pre-existing few-instruction window between `subtask_count.load(SeqCst) > 1` and `need_to_wait.store(true, SeqCst)` where the last child can decrement and read `need_to_wait == false`. That race predates this change ... closing it cleanly requires reworking the `post_run` join (e.g. parent participates in the same `fetch_sub` instead of check-then-publish).

### Mechanism

`remove_entry_dir` ended with

```rust
if dt.subtask_count.load(SeqCst) > 1 {
    *need_to_wait_out = true;
    dt.need_to_wait.store(true, SeqCst);
    return Ok(());
}
```

while a finishing child in `post_run` did

```rust
let tasks_left = p.subtask_count.fetch_sub(1, SeqCst);
let parent_still = !p.need_to_wait.load(SeqCst);
if !parent_still && tasks_left == 2 {
    Self::delete_after_waiting_for_children(me.parent_task);
}
```

When the last child slipped between the parent's `load` and `store`: the child decremented (`tasks_left == 2`), read `need_to_wait == false`, and skipped `delete_after_waiting_for_children`; the parent then stored `true` and returned `waiting == true`, so `run_from_thread_pool_impl` skipped `post_run` too. The parent DirTask was stranded with `subtask_count == 1, need_to_wait == true`, `finish_concurrently` never fired, and the shell promise never resolved.

A directory containing exactly one subdirectory (e.g. the `foo/bar` tree in `test/js/bun/shell/leak.test.ts`'s `fdleak_rm`) is the minimal trigger.

### Fix

The parent now publishes `need_to_wait = true` first, then releases its own slot on `subtask_count` with the same `fetch_sub` the children use: **whoever takes the counter to 0 owns the rmdir**. If the parent's `fetch_sub` returns 1, every child has already released (and each saw the counter > 1, so none took ownership); the parent restores `subtask_count = 1` / `need_to_wait = false` and falls through to the inline delete so `post_run` runs as before. Otherwise a child still holds a count and the child taking it to 0 drives `delete_after_waiting_for_children`, which now also restores `subtask_count = 1` so `post_run`'s own decrement (and any re-enqueue from `remove_entry_dir_after_children`) starts from the expected value.

The child side drops the separate `need_to_wait` load: the SeqCst RMW chain on `subtask_count` already provides the release/acquire that makes the parent's `deleted_entries` writes visible to the winner.

### Why this surfaced as a `leak.test.ts` red

`fd leak > fdleak_rm` runs 100 iterations of `mkdir foo; touch ...; mkdir foo/bar; touch ...; rm -rfv foo/` in a subprocess with no per-iteration timeout; when one `rm` hit this race the subprocess hung, and the outer test timed out at 100 s. Recent hits on PR builds off current main:

| build | lane | result |
| --- | --- | --- |
| [72115](https://buildkite.com/bun/bun/builds/72115) | darwin 14 aarch64 | `fdleak_rm` 100 s timeout (went red because earlier fixtures' crash reports were attributed here and `isAlwaysFailure` blocked the per-file retry) |
| [72143](https://buildkite.com/bun/bun/builds/72143) | windows 11 aarch64 | `fdleak_rm` 100 s timeout |
| [71942](https://buildkite.com/bun/bun/builds/71942) | windows 2019 x64 | `memleak_*` iteration timed out at 5 s mid-run |
| [71939](https://buildkite.com/bun/bun/builds/71939) | windows 11 aarch64 | `memleak_*` iteration timed out |
| [71915](https://buildkite.com/bun/bun/builds/71915) | windows 11 aarch64 | `fdleak_rm` 100 s timeout |

## How did you verify your code works?

- `bun bd test test/js/bun/shell/commands/rm.test.ts` (6 pass), `bunshell.test.ts` (399 pass), `leak.test.ts` rm/ls cases pass.
- `bun run rust:check-all` clean across all targets.
- Added a stress probe in `rm.test.ts` that runs 800 concurrent `rm -rfv` of the minimal one-subdir tree with a 10 s per-call watchdog.

### Fail-before

This race is a few-instruction interleaving and I could not trigger it on the linux-x64 gate host: a 64 000-iteration probe (`rm -rf` of the minimal tree, 32-wide) against the unfixed release binary ran to completion without a hang. The CI hits above are the fail-before evidence; the new test is a probe that should catch any future regression on the arm64 lanes where scheduling makes the window observable.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/leak.test.ts test/js/bun/shell/commands/rm.test.ts

<!-- robobun:evidence:end -->