### PR TITLE
console: honor customInspect option in Bun.inspect and console.dir

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4194,6 +4194,11 @@ declare module "bun" {
      * Whether to compact the output
      */
     compact?: boolean;
+    /**
+     * Whether to call `[util.inspect.custom]` on the object if it exists.
+     * @default true
+     */
+    customInspect?: boolean;
   }
 
   type WebSocketOptionsProtocolsOrProtocol =

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -558,21 +558,28 @@ fn message_with_type_and_level_(
         }
     }
 
-    if message_type == MessageType::Dir && len >= 2 {
-        print_length = 1;
-        let opts = vals_slice[1];
-        if opts.is_object() {
-            if let Some(depth_prop) = opts.get(global, b"depth")? {
-                if depth_prop.is_int32() || depth_prop.is_number() || depth_prop.is_big_int() {
-                    // Clamp negatives to 0, then truncate (not saturate) to u16.
-                    print_options.max_depth = depth_prop.to_int32().max(0) as u32 as u16;
-                } else if depth_prop.is_null() {
-                    print_options.max_depth = u16::MAX;
+    if message_type == MessageType::Dir {
+        // Node's `console.dir` defaults `customInspect` to `false`.
+        print_options.disable_inspect_custom = true;
+        if len >= 2 {
+            print_length = 1;
+            let opts = vals_slice[1];
+            if opts.is_object() {
+                if let Some(depth_prop) = opts.get(global, b"depth")? {
+                    if depth_prop.is_int32() || depth_prop.is_number() || depth_prop.is_big_int() {
+                        // Clamp negatives to 0, then truncate (not saturate) to u16.
+                        print_options.max_depth = depth_prop.to_int32().max(0) as u32 as u16;
+                    } else if depth_prop.is_null() {
+                        print_options.max_depth = u16::MAX;
+                    }
                 }
-            }
-            if let Some(colors_prop) = opts.get(global, b"colors")? {
-                if colors_prop.is_boolean() {
-                    print_options.enable_colors = colors_prop.to_boolean();
+                if let Some(colors_prop) = opts.get(global, b"colors")? {
+                    if colors_prop.is_boolean() {
+                        print_options.enable_colors = colors_prop.to_boolean();
+                    }
+                }
+                if let Some(ci_prop) = opts.get_boolean_loose(global, "customInspect")? {
+                    print_options.disable_inspect_custom = !ci_prop;
                 }
             }
         }
@@ -1257,6 +1264,7 @@ pub struct FormatOptions {
     pub single_line: bool,
     pub default_indent: u16,
     pub error_display_level: ErrorDisplayLevel,
+    pub disable_inspect_custom: bool,
 }
 
 impl Default for FormatOptions {
@@ -1271,6 +1279,7 @@ impl Default for FormatOptions {
             single_line: false,
             default_indent: 0,
             error_display_level: ErrorDisplayLevel::Full,
+            disable_inspect_custom: false,
         }
     }
 }
@@ -1379,6 +1388,9 @@ impl FormatOptions {
             if let Some(opt) = arg1.get_boolean_loose(global_this, "compact")? {
                 self.single_line = opt;
             }
+            if let Some(opt) = arg1.get_boolean_loose(global_this, "customInspect")? {
+                self.disable_inspect_custom = !opt;
+            }
         } else {
             // formatOptions.show_hidden = arg1.toBoolean();
             if !arguments.is_empty() {
@@ -1439,7 +1451,8 @@ pub fn format2(
         fmt.stack_check = StackCheck::init();
         fmt.can_throw_stack_overflow = true;
         fmt.error_display_level = options.error_display_level;
-        let tag = formatter::Tag::get(vals[0], global)?;
+        fmt.disable_inspect_custom = options.disable_inspect_custom;
+        let tag = formatter::Tag::get_advanced(vals[0], global, fmt.top_level_tag_opts())?;
         if fmt.write_indent(writer).is_err() {
             return Ok(());
         }
@@ -1502,6 +1515,8 @@ pub fn format2(
     fmt.stack_check = StackCheck::init();
     fmt.can_throw_stack_overflow = true;
     fmt.error_display_level = options.error_display_level;
+    fmt.disable_inspect_custom = options.disable_inspect_custom;
+    let top_level_tag_opts = fmt.top_level_tag_opts();
     let mut tag: formatter::TagResult;
 
     if fmt.write_indent(writer).is_err() {
@@ -1519,7 +1534,7 @@ pub fn format2(
             }
             any = true;
 
-            tag = formatter::Tag::get(this_value, global)?;
+            tag = formatter::Tag::get_advanced(this_value, global, top_level_tag_opts)?;
             if matches!(tag.tag, TagPayload::String) && !fmt.remaining().is_empty() {
                 tag.tag = TagPayload::StringPossiblyFormatted;
             }
@@ -1541,7 +1556,7 @@ pub fn format2(
                 let _ = writer.write_all(b" ");
             }
             any = true;
-            tag = formatter::Tag::get(this_value, global)?;
+            tag = formatter::Tag::get_advanced(this_value, global, top_level_tag_opts)?;
             if matches!(tag.tag, TagPayload::String) && !fmt.remaining().is_empty() {
                 tag.tag = TagPayload::StringPossiblyFormatted;
             }
@@ -1870,8 +1885,12 @@ pub mod formatter {
             formatter.remaining_values = bun_ptr::RawSlice::new(&one);
 
             let result = (|| {
-                let tag =
-                    Tag::get(self.value, formatter.global_this).map_err(|_| core::fmt::Error)?;
+                let tag = Tag::get_advanced(
+                    self.value,
+                    formatter.global_this,
+                    formatter.top_level_tag_opts(),
+                )
+                .map_err(|_| core::fmt::Error)?;
                 let mut sink = bun_io::FmtAdapter::new(f);
                 let global = formatter.global_this;
                 formatter
@@ -3536,6 +3555,14 @@ pub mod formatter {
                 opts |= TagOptions::DISABLE_INSPECT_CUSTOM;
             }
             opts
+        }
+
+        pub(super) fn top_level_tag_opts(&self) -> TagOptions {
+            if self.disable_inspect_custom {
+                TagOptions::DISABLE_INSPECT_CUSTOM
+            } else {
+                TagOptions::empty()
+            }
         }
 
         #[inline(never)]

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -749,7 +749,11 @@ impl<'a> TablePrinter<'a> {
     ) -> JsResult<CellRef> {
         let offset = cell_text.len();
         let mut value_formatter = self.value_formatter.shallow_clone();
-        let tag = formatter::Tag::get(value, self.global_object)?;
+        let tag = formatter::Tag::get_advanced(
+            value,
+            self.global_object,
+            value_formatter.top_level_tag_opts(),
+        )?;
         value_formatter.quote_strings = !(matches!(
             tag.tag,
             TagPayload::String | TagPayload::StringPossiblyFormatted

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2322,7 +2322,7 @@ pub mod formatter {
 
             if js_type == jsc::JSType::GlobalProxy {
                 if !opts.contains(TagOptions::HIDE_GLOBAL) {
-                    return Tag::get(value.get_proxy_target(), global_this);
+                    return Tag::get_advanced(value.get_proxy_target(), global_this, opts);
                 }
                 return Ok(TagResult {
                     tag: TagPayload::GlobalObject,
@@ -3686,7 +3686,7 @@ pub mod formatter {
             // `Proxy { target: ..., handlers: ... }` — this is default off so
             // it is not used.
             self.format::<C>(
-                Tag::get(target, self.global_this)?,
+                Tag::get_advanced(target, self.global_this, self.top_level_tag_opts())?,
                 writer_,
                 target,
                 self.global_this,

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -701,6 +701,7 @@ pub(crate) fn inspect_table(
     table_printer.value_formatter.depth = format_options.max_depth;
     table_printer.value_formatter.ordered_properties = format_options.ordered_properties;
     table_printer.value_formatter.single_line = format_options.single_line;
+    table_printer.value_formatter.disable_inspect_custom = format_options.disable_inspect_custom;
 
     let print_result = if format_options.enable_colors {
         table_printer.print_table::<true>(&mut array)

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -518,6 +518,15 @@ describe("customInspect option", () => {
     const nested = Bun.inspect({ inner: o }, { customInspect: false });
     expect(calls).toBe(0);
     expect(nested).not.toContain("HOOK-OUTPUT");
+
+    // Proxy wrapper must not bypass the flag (top-level and nested)
+    calls = 0;
+    const proxied = Bun.inspect(new Proxy(o, {}), { customInspect: false });
+    expect({ calls, proxied }).toEqual({ calls: 0, proxied: out });
+
+    calls = 0;
+    Bun.inspect({ inner: new Proxy(o, {}) }, { customInspect: false });
+    expect(calls).toBe(0);
   });
 
   it("Bun.inspect runs the custom inspect hook by default and when customInspect is true", () => {
@@ -555,6 +564,9 @@ describe("customInspect option", () => {
 
       calls = 0; console.dir({ inner: o }, { customInspect: false });
       process.stdout.write("calls-nested=" + calls + "\\n");
+
+      calls = 0; console.dir(new Proxy(o, {}));
+      process.stdout.write("calls-proxy=" + calls + "\\n");
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", src],
@@ -566,7 +578,7 @@ describe("customInspect option", () => {
     const lines = stdout.split("\n").filter(l => l.startsWith("calls-"));
     expect({ stderr, lines }).toEqual({
       stderr: "",
-      lines: ["calls-default=0", "calls-false=0", "calls-true=1", "calls-nested=0"],
+      lines: ["calls-default=0", "calls-false=0", "calls-true=1", "calls-nested=0", "calls-proxy=0"],
     });
     expect(stdout.match(/HOOK-OUTPUT/g)?.length).toBe(1);
     expect(exitCode).toBe(0);

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -494,6 +494,85 @@ it("Bun.inspect.custom exists", () => {
   expect(Bun.inspect.custom).toBe(util.inspect.custom);
 });
 
+describe("customInspect option", () => {
+  const CUSTOM = Symbol.for("nodejs.util.inspect.custom");
+
+  it("Bun.inspect skips the custom inspect hook when customInspect is false", () => {
+    let calls = 0;
+    const o = {
+      plain: 1,
+      [CUSTOM]() {
+        calls++;
+        return "HOOK-OUTPUT";
+      },
+    };
+
+    const out = Bun.inspect(o, { customInspect: false });
+    expect({ calls, out }).toEqual({
+      calls: 0,
+      out: "{\n  plain: 1,\n  [Symbol(nodejs.util.inspect.custom)]: [Function],\n}",
+    });
+
+    // nested hook is also skipped
+    calls = 0;
+    const nested = Bun.inspect({ inner: o }, { customInspect: false });
+    expect(calls).toBe(0);
+    expect(nested).not.toContain("HOOK-OUTPUT");
+  });
+
+  it("Bun.inspect runs the custom inspect hook by default and when customInspect is true", () => {
+    let calls = 0;
+    const o = {
+      plain: 1,
+      [CUSTOM]() {
+        calls++;
+        return "HOOK-OUTPUT";
+      },
+    };
+
+    expect(Bun.inspect(o)).toBe("HOOK-OUTPUT");
+    expect(calls).toBe(1);
+
+    calls = 0;
+    expect(Bun.inspect(o, { customInspect: true })).toBe("HOOK-OUTPUT");
+    expect(calls).toBe(1);
+  });
+
+  it("console.dir defaults customInspect to false and honors the option", async () => {
+    const src = `
+      const CUSTOM = Symbol.for("nodejs.util.inspect.custom");
+      let calls = 0;
+      const o = { plain: 1, [CUSTOM]() { calls++; return "HOOK-OUTPUT"; } };
+
+      calls = 0; console.dir(o);
+      process.stdout.write("calls-default=" + calls + "\\n");
+
+      calls = 0; console.dir(o, { customInspect: false });
+      process.stdout.write("calls-false=" + calls + "\\n");
+
+      calls = 0; console.dir(o, { customInspect: true });
+      process.stdout.write("calls-true=" + calls + "\\n");
+
+      calls = 0; console.dir({ inner: o }, { customInspect: false });
+      process.stdout.write("calls-nested=" + calls + "\\n");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const lines = stdout.split("\n").filter(l => l.startsWith("calls-"));
+    expect({ stderr, lines }).toEqual({
+      stderr: "",
+      lines: ["calls-default=0", "calls-false=0", "calls-true=1", "calls-nested=0"],
+    });
+    expect(stdout.match(/HOOK-OUTPUT/g)?.length).toBe(1);
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe("Functions with names", () => {
   const closures = [
     () => function f() {},

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -529,6 +529,24 @@ describe("customInspect option", () => {
     expect(calls).toBe(0);
   });
 
+  it("Bun.inspect.table skips the custom inspect hook on cell values when customInspect is false", () => {
+    let calls = 0;
+    const cell = {
+      [CUSTOM]() {
+        calls++;
+        return "HOOK-OUTPUT";
+      },
+    };
+    const out = Bun.inspect.table([{ col: cell }], { customInspect: false });
+    expect(calls).toBe(0);
+    expect(out).not.toContain("HOOK-OUTPUT");
+
+    calls = 0;
+    const on = Bun.inspect.table([{ col: cell }], { customInspect: true });
+    expect(calls).toBe(1);
+    expect(on).toContain("HOOK-OUTPUT");
+  });
+
   it("Bun.inspect runs the custom inspect hook by default and when customInspect is true", () => {
     let calls = 0;
     const o = {


### PR DESCRIPTION
## Repro

```js
const CUSTOM = Symbol.for("nodejs.util.inspect.custom");
let calls = 0;
const o = { plain: 1, [CUSTOM]() { calls++; return "HOOK-OUTPUT"; } };

calls = 0; console.dir(o, { customInspect: false });
console.log(calls); // node: 0   bun: 1
calls = 0; console.dir(o);
console.log(calls); // node: 0   bun: 1 (dir defaults customInspect to false in Node)
calls = 0; Bun.inspect(o, { customInspect: false });
console.log(calls); // bun: 1, output is "HOOK-OUTPUT"
```

`customInspect: false` exists so that callers can inspect untrusted values without running their code. Bun's JS-ported `util.inspect` and `new Console(stream).dir` already honor it; only the native formatter (global `console.dir`, `Bun.inspect`) was affected.

## Cause

`FormatOptions` in `src/jsc/ConsoleObject.rs` reads `depth`, `colors`, `sorted`, and `compact` from the options object but never reads `customInspect`. The `Formatter` struct already has a `disable_inspect_custom` flag (used internally to break recursion when a hook returns its own receiver), but nothing wires the user-facing option into it. The top-level `Tag::get` calls in `format2` also run with `TagOptions::empty()`, so the hook lookup always fires regardless of the flag.

The native `console.dir` handler reads `depth`/`colors` from its second argument but not `customInspect`, and does not default it to `false`.

## Fix

- Add `disable_inspect_custom` to `FormatOptions` and parse `customInspect` in `FormatOptions::from_js` (used by `Bun.inspect` / `Bun.inspect.table`).
- Thread it into the `Formatter` in `format2` and pass `TagOptions::DISABLE_INSPECT_CUSTOM` to the top-level `Tag::get_advanced` calls when set. Nested values already consult `formatter.disable_inspect_custom` via `tag_opts()`.
- Make the native `console.dir` default `customInspect` to `false` and read the option from its second argument, matching Node.
- Add `customInspect?: boolean` to `BunInspectOptions`.

## Verification

New `describe("customInspect option")` in `test/js/bun/util/inspect.test.js`:

- `Bun.inspect(o, {customInspect:false})`: hook not called, object rendered normally (top-level and nested).
- `Bun.inspect(o)` / `Bun.inspect(o, {customInspect:true})`: hook called (unchanged default).
- Spawned `console.dir`: default → 0 calls, `{customInspect:false}` → 0 calls, `{customInspect:true}` → 1 call, nested with `false` → 0 calls.

```
USE_SYSTEM_BUN=1 bun test test/js/bun/util/inspect.test.js -t "customInspect option"  → 2 fail, 1 pass
bun bd test test/js/bun/util/inspect.test.js                                          → 76 pass
bun bd test test/js/web/console/console-log.test.ts                                   → 4 pass
bun bd test test/js/node/console/console.test.ts                                      → 7 pass
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (14022e95f)

test/js/bun/util/inspect.test.js:
(pass) prototype [307.81ms]
(pass) getters [4.96ms]
(pass) setters [3.91ms]
(pass) getter/setters [2.12ms]
(pass) Timeout [4.71ms]
(pass) when prototype defines the same property, don't print the same property twice [2.11ms]
(pass) Blob inspect [8.52ms]
(pass) utf16 property name [59.74ms]
(pass) latin1 [4.28ms]
(pass) Request object [2.48ms]
(pass) MessageEvent [1.83ms]
(pass) MessageEvent with no data set [1.83ms]
(pass) MessageEvent with deleted data [2.48ms]
(pass) TypedArray prints [99.39ms]
(pass) BigIntArray [34.54ms]
(pass) Float32Array 42.68000030517578 [4.12ms]
(pass) Float32Array 42.68 [3.96ms]
(pass) Float64Array 42.68000030517578 [1.46ms]
(pass) Float64Array 42.68 [1.37ms]
(p
... (truncated)

release without fix: 4 FAILED
bun test v1.3.14 (0d9b296a)

test/js/bun/util/inspect.test.js:
(pass) prototype [5.51ms]
(pass) getters [0.09ms]
(pass) setters [0.04ms]
(pass) getter/setters [0.03ms]
(pass) Timeout [0.88ms]
(pass) when prototype defines the same property, don't print the same property twice [0.05ms]
(pass) Blob inspect [0.26ms]
(pass) utf16 property name [19.74ms]
(pass) latin1 [0.06ms]
(pass) Request object [1.11ms]
(pass) MessageEvent [0.07ms]
(pass) MessageEvent with no data set [0.02ms]
(pass) MessageEvent with deleted data [0.03ms]
(pass) TypedArray prints [5.37ms]
(pass) BigIntArray [0.36ms]
(pass) Float32Array 42.68000030517578 [0.07ms]
(pass) Float32Array 42.68 [0.05ms]
(pass) Float64Array 42.68000030517578
(pass) Float64Array 42.68
(pass) jsx with two elements [0.54ms]
(pass) jsx with anon component [0.04ms]
(pass) jsx with fragment [0.09ms]
(pass) inspect [0.75ms]
(pass) latin1 supplemental > latin1 (input) "äbc" [ "äbc" ] [0.03ms]
(pass) latin1 supplemental > latin1 (input) "cbä" [ "cbä" ]
(pass) latin1 supplemental > latin1 (input) "cäb" [ "cäb" ]
(pass) latin1 supplemental > latin1 (input) "äbc äbc" [ "äbc äbc" ]
(pass) latin1 supplemental > latin1 (input) "
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (14022e95f)

test/js/bun/util/inspect.test.js:
(pass) prototype [298.88ms]
(pass) getters [5.45ms]
(pass) setters [3.65ms]
(pass) getter/setters [2.13ms]
(pass) Timeout [4.88ms]
(pass) when prototype defines the same property, don't print the same property twice [2.14ms]
(pass) Blob inspect [9.07ms]
(pass) utf16 property name [59.99ms]
(pass) latin1 [4.30ms]
(pass) Request object [2.59ms]
(pass) MessageEvent [1.94ms]
(pass) MessageEvent with no data set [1.90ms]
(pass) MessageEvent with deleted data [2.91ms]
(pass) TypedArray prints [96.77ms]
(pass) BigIntArray [35.98ms]
(pass) Float32Array 42.68000030517578 [4.06ms]
(pass) Float32Array 42.68 [3.97ms]
(pass) Float64Array 42.68000030517578 [1.87ms]
(pass) Float64Array 42.68 [1.37ms]
(p
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     14022e95fa
  features     (none)

22 deps, 106 codegen, 1168 objects in 597ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1230] install /workspace/bun
bun install v1.3.14 (0d9b296a)

Checked 124 installs across 170 packages (no changes) [4.00ms]
[2/1230] install /workspace/bun/packages/bun-error
bun install v1.3.14 (0d9b296a)

Checked 1 install across 2 packages (no changes) [3.00ms]
[3/1230] install /workspace/bun/src/node-fallbacks
bun install v1.3.14 (0d9b296a)

Checked 129 installs across 147 packages (no changes) [4.00ms]
[4/1230] gen ErrorCode+*.h
[5/1230] gen bindgenv2
[6/1230] fetch picohttpparser
[picohttpparser] up to date
[7/1230] fetch zlib
[zlib] up to date
[8/1230] gen .bind.ts → GeneratedBindings.cpp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/bun.d.ts      |   5 ++
 src/jsc/ConsoleObject.rs         |  75 +++++++++++++++++++--------
 src/runtime/api/BunObject.rs     |   1 +
 test/js/bun/util/inspect.test.js | 109 +++++++++++++++++++++++++++++++++++++++
 4 files changed, 168 insertions(+), 22 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
packages/bun-types/bun.d.ts           1      1      0
src/jsc/ConsoleObject.rs             11     13      0
src/runtime/api/BunObject.rs          2      1      0
test/js/bun/util/inspect.test.js      3      8      0
```

</details>

<!-- robobun:evidence:end -->