### PR TITLE
node:util: make inspect's getOwnNonIndexProperties native

### DIFF
--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -84,9 +84,7 @@ const NumberPrototypeToString = uncurryThis(Number.prototype.toString);
 const NumberPrototypeValueOf = uncurryThis(Number.prototype.valueOf);
 const ObjectAssign = Object.assign;
 const ObjectDefineProperty = Object.defineProperty;
-const ObjectEntries = Object.entries;
 const ObjectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
-const ObjectGetOwnPropertyDescriptors = Object.getOwnPropertyDescriptors;
 const ObjectGetOwnPropertyNames = Object.getOwnPropertyNames;
 const ObjectGetOwnPropertySymbols = Object.getOwnPropertySymbols;
 const ObjectGetPrototypeOf = Object.getPrototypeOf;
@@ -2682,23 +2680,7 @@ function stripVTControlCharacters(str) {
 }
 
 // utils
-function getOwnNonIndexProperties(a, filter = ONLY_ENUMERABLE) {
-  const desc = ObjectGetOwnPropertyDescriptors(a);
-  const ret = [];
-  for (const [k, v] of ObjectEntries(desc)) {
-    if (!RegExpPrototypeTest(/^(0|[1-9][0-9]*)$/, k) || NumberParseInt(k, 10) >= 2 ** 32 - 1) {
-      // Arrays are limited in size
-      if (filter === ONLY_ENUMERABLE && !v.enumerable) continue;
-      else ArrayPrototypePush.$call(ret, k);
-    }
-  }
-  for (const s of ObjectGetOwnPropertySymbols(a)) {
-    const v = ObjectGetOwnPropertyDescriptor(a, s);
-    if (filter === ONLY_ENUMERABLE && !v.enumerable) continue;
-    ArrayPrototypePush.$call(ret, s);
-  }
-  return ret;
-}
+const getOwnNonIndexProperties = $newCppFunction("UtilInspect.cpp", "jsFunctionGetOwnNonIndexProperties", 2);
 function getPromiseDetails(promise) {
   const state = $peekPromiseStatus(promise);
   if (state !== 0) {

--- a/src/jsc/bindings/UtilInspect.cpp
+++ b/src/jsc/bindings/UtilInspect.cpp
@@ -7,10 +7,51 @@
 #include "JavaScriptCore/JSGlobalObject.h"
 #include "ZigGlobalObject.h"
 #include "JavaScriptCore/ObjectConstructor.h"
+#include "JavaScriptCore/PropertyNameArray.h"
+#include "JavaScriptCore/IdentifierInlines.h"
 
 namespace Bun {
 
 using namespace JSC;
+
+// Mirrors Node's internal getOwnNonIndexProperties(): own string keys (excluding array
+// indices) in insertion order followed by own symbols, optionally filtered to enumerable.
+JSC_DEFINE_HOST_FUNCTION(jsFunctionGetOwnNonIndexProperties, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue value = callFrame->argument(0);
+    if (!value.isObject()) [[unlikely]]
+        RELEASE_AND_RETURN(scope, JSValue::encode(constructEmptyArray(globalObject, nullptr, 0)));
+    JSObject* object = asObject(value);
+
+    // inspect.js passes ALL_PROPERTIES (0) or ONLY_ENUMERABLE (2).
+    int32_t filter = callFrame->argument(1).toInt32(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    DontEnumPropertiesMode mode = (filter & 2) ? DontEnumPropertiesMode::Exclude : DontEnumPropertiesMode::Include;
+
+    PropertyNameArrayBuilder properties(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Exclude);
+    object->getOwnNonIndexPropertyNames(globalObject, properties, mode);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    size_t size = properties.size();
+    JSArray* keys = constructEmptyArray(globalObject, nullptr, size);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    unsigned index = 0;
+    for (const auto& identifier : properties) {
+        if (identifier.isSymbol()) {
+            ASSERT(!identifier.isPrivateName());
+            keys->putDirectIndex(globalObject, index++, Symbol::create(vm, static_cast<SymbolImpl&>(*identifier.impl())));
+        } else {
+            keys->putDirectIndex(globalObject, index++, jsOwnedString(vm, identifier.string()));
+        }
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+
+    return JSValue::encode(keys);
+}
 
 Structure* createUtilInspectOptionsStructure(VM& vm, JSC::JSGlobalObject* globalObject)
 {

--- a/src/jsc/bindings/UtilInspect.h
+++ b/src/jsc/bindings/UtilInspect.h
@@ -4,4 +4,6 @@ namespace Bun {
 
 JSC::Structure* createUtilInspectOptionsStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject);
 
+JSC_DECLARE_HOST_FUNCTION(jsFunctionGetOwnNonIndexProperties);
+
 }

--- a/test/js/node/util/node-inspect-tests/internal-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/internal-inspect.test.js
@@ -12,6 +12,9 @@ describe("util.inspect large arrays with maxArrayLength", () => {
     ["Float64Array", n => new Float64Array(n)],
   ]) {
     test(`${label}: bounded by maxArrayLength, not length`, () => {
+      // Warm up inspect and allocate outside the timed region so the assertion
+      // measures only the inspect call itself.
+      util.inspect(make(8), { maxArrayLength: 4 });
       const big = make(1_000_000);
       const start = performance.now();
       const out = util.inspect(big, { maxArrayLength: 4 });
@@ -30,6 +33,17 @@ describe("util.inspect large arrays with maxArrayLength", () => {
     big[Symbol.for("s")] = "sym";
     const out = util.inspect(big, { maxArrayLength: 2, breakLength: Infinity });
     assert.strictEqual(out, "[ 7, 7, ... 999998 more items, foo: 'bar', Symbol(s): 'sym' ]");
+  });
+
+  test("Array: numeric-string keys at the array-index boundary are non-index", () => {
+    const a = [1, 2, 3];
+    a["4294967295"] = "not-an-index"; // 2**32 - 1 is not a valid array index
+    a["4294967296"] = "also-not-an-index";
+    a.foo = "bar";
+    assert.strictEqual(
+      util.inspect(a, { breakLength: Infinity }),
+      "[ 1, 2, 3, '4294967295': 'not-an-index', '4294967296': 'also-not-an-index', foo: 'bar' ]",
+    );
   });
 
   test("Array: showHidden includes non-enumerable own keys", () => {
@@ -56,6 +70,7 @@ describe("util.inspect large arrays with maxArrayLength", () => {
   });
 
   test("util.format %o on large array is bounded", () => {
+    util.format("%o", [1, 2, 3]);
     const big = new Array(1_000_000).fill(7);
     const start = performance.now();
     const out = util.format("%o", big);

--- a/test/js/node/util/node-inspect-tests/internal-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/internal-inspect.test.js
@@ -1,6 +1,70 @@
 import assert from "assert";
 import util from "util";
 
+describe("util.inspect large arrays with maxArrayLength", () => {
+  // util.inspect used to enumerate every own property descriptor to find
+  // non-index keys, so inspecting a 1e6-element array took seconds even when
+  // maxArrayLength bounded the output to a few items.
+
+  for (const [label, make] of [
+    ["Array", n => new Array(n).fill(7)],
+    ["Uint8Array", n => new Uint8Array(n)],
+    ["Float64Array", n => new Float64Array(n)],
+  ]) {
+    test(`${label}: bounded by maxArrayLength, not length`, () => {
+      const big = make(1_000_000);
+      const start = performance.now();
+      const out = util.inspect(big, { maxArrayLength: 4 });
+      const elapsed = performance.now() - start;
+      assert.ok(out.includes("... 999996 more items"), out);
+      // With the native non-index property scan this is sub-millisecond work.
+      // Leave wide headroom for debug+ASAN builds; the regressed path takes
+      // multiple seconds.
+      assert.ok(elapsed < 500, `inspect(${label}(1e6), {maxArrayLength: 4}) took ${elapsed}ms`);
+    });
+  }
+
+  test("Array: non-index own keys are still shown", () => {
+    const big = new Array(1_000_000).fill(7);
+    big.foo = "bar";
+    big[Symbol.for("s")] = "sym";
+    const out = util.inspect(big, { maxArrayLength: 2, breakLength: Infinity });
+    assert.strictEqual(out, "[ 7, 7, ... 999998 more items, foo: 'bar', Symbol(s): 'sym' ]");
+  });
+
+  test("Array: showHidden includes non-enumerable own keys", () => {
+    const a = new Array(5).fill(7);
+    a.foo = 1;
+    a[Symbol.for("s")] = 2;
+    a.bar = 3;
+    Object.defineProperty(a, "hidden", { value: 4, enumerable: false });
+    assert.strictEqual(
+      util.inspect(a, { breakLength: Infinity, compact: true }),
+      "[ 7, 7, 7, 7, 7, foo: 1, bar: 3, Symbol(s): 2 ]",
+    );
+    assert.strictEqual(
+      util.inspect(a, { showHidden: true, breakLength: Infinity, compact: true }),
+      "[ 7, 7, 7, 7, 7, [length]: 5, foo: 1, bar: 3, [hidden]: 4, Symbol(s): 2 ]",
+    );
+  });
+
+  test("TypedArray: non-index own keys are still shown", () => {
+    const big = new Uint8Array(1_000_000);
+    big.foo = "bar";
+    const out = util.inspect(big, { maxArrayLength: 2, breakLength: Infinity });
+    assert.strictEqual(out, "Uint8Array(1000000) [ 0, 0, ... 999998 more items, foo: 'bar' ]");
+  });
+
+  test("util.format %o on large array is bounded", () => {
+    const big = new Array(1_000_000).fill(7);
+    const start = performance.now();
+    const out = util.format("%o", big);
+    const elapsed = performance.now() - start;
+    assert.ok(out.includes("more items"), out);
+    assert.ok(elapsed < 500, `format("%o", Array(1e6)) took ${elapsed}ms`);
+  });
+});
+
 test("no assertion failures", () => {
   // Errors in accessors are not triggered
   const obj = new Proxy(


### PR DESCRIPTION
### What does this PR do?

`util.inspect` / `util.format("%o", ...)` is O(length) on large dense arrays and typed arrays even when `maxArrayLength` bounds the output to a handful of items, so logging a big array blocks the event loop for seconds.

```js
import { inspect } from "node:util";
inspect(new Array(1_000_000).fill(7), { maxArrayLength: 10 });
// node v26:    0 ms   -> "[ 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, ... 999990 more items ]"
// bun before:  ~2.4 s -> same 61 bytes
// bun after:   0 ms
```

### Cause

`src/js/internal/util/inspect.js` polyfilled Node's internal C++ `getOwnNonIndexProperties()` by calling `Object.getOwnPropertyDescriptors(value)`, iterating `Object.entries` of that, and regex-testing every key against `/^(0|[1-9][0-9]*)$/`. For a 1e6-element dense array that materializes a million-entry descriptor object, a million-pair entries array and a million regex executions just to learn there are no non-index keys. `formatArray` / `formatTypedArray` themselves are already bounded by `maxArrayLength`; only this key scan was hot.

### Fix

Replace the polyfill with a host function in `UtilInspect.cpp` that calls `JSObject::getOwnNonIndexPropertyNames`. That walks the structure's property table (O(named properties)) and never touches indexed storage, which is the same approach Node's native helper takes. Output is unchanged: own non-index string keys in insertion order, then own symbols, optionally filtered to enumerable for the `showHidden: false` path.

### How did you verify your code works?

New tests in `test/js/node/util/node-inspect-tests/internal-inspect.test.js`:

- `inspect(new Array(1e6).fill(7), {maxArrayLength: 4})` (and Uint8Array / Float64Array) complete well under 500 ms on debug+ASAN; before this change they took multiple seconds.
- `util.format("%o", bigArray)` is similarly bounded.
- Non-index string keys, symbol keys, and non-enumerable keys under `showHidden: true` still render in the same order as before (and as Node).

`bun bd test test/js/node/util/` passes; `BUN_JSC_validateExceptionChecks=1` is clean on the new host function.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/node-inspect-tests/internal-inspect.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (7beeb0d2b)

test/js/node/util/node-inspect-tests/internal-inspect.test.js:
27 |       expected: true,
28 |       message,
29 |       operator: "==",
30 |       stackStartFn: fn
31 |     });
32 |     throw err;
                  ^
AssertionError: inspect(Array(1e6), {maxArrayLength: 4}) took 91144.100305ms
      at innerOk (internal:assert/utils:32:14)
      at ok (node:assert:112:10)
      at <anonymous> (/workspace/bun/test/js/node/util/node-inspect-tests/internal-inspect.test.js:26:14)
(fail) util.inspect large arrays with maxArrayLength > Array: bounded by maxArrayLength, not length [91260.46ms]
  ^ this test timed out after 5000ms.
27 |       expected: true,
28 |       message,
29 |       operator: "=
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (7beeb0d2b)

test/js/node/util/node-inspect-tests/internal-inspect.test.js:
(pass) util.inspect large arrays with maxArrayLength > Array: bounded by maxArrayLength, not length [5.54ms]
(pass) util.inspect large arrays with maxArrayLength > Uint8Array: bounded by maxArrayLength, not length [0.29ms]
(pass) util.inspect large arrays with maxArrayLength > Float64Array: bounded by maxArrayLength, not length [0.07ms]
(pass) util.inspect large arrays with maxArrayLength > Array: non-index own keys are still shown [7.84ms]
(pass) util.inspect large arrays with maxArrayLength > Array: numeric-string keys at the array-index boundary are non-index [0.08ms]
(pass) util.inspect large arrays with maxArrayLength > Array: showHidden includes non-enumerable own keys [0.13ms]
(pass) util.inspect large arrays with maxArrayLength > TypedArray: non-index own keys are still shown [0.94ms]
(pass) util.inspect large arrays with maxArrayLength > util.format %o on large array is bounded [1.79ms]
(pass) no assertion failures [0.96ms]
(skip) util.stylizeWithHTML

 9 pass
 1 skip
 0 fail
Ran 10 tests across 1 file. [173.00ms]
__F:0:S:1
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/node-inspect-tests/internal-inspect.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (7beeb0d2b)

test/js/node/util/node-inspect-tests/internal-inspect.test.js:
(pass) util.inspect large arrays with maxArrayLength > Array: bounded by maxArrayLength, not length [98.00ms]
(pass) util.inspect large arrays with maxArrayLength > Uint8Array: bounded by maxArrayLength, not length [12.86ms]
(pass) util.inspect large arrays with maxArrayLength > Float64Array: bounded by maxArrayLength, not length [4.22ms]
(pass) util.inspect large arrays with maxArrayLength > Array: non-index own keys are still shown [111.01ms]
(pass) util.inspect large arrays with maxArrayLength > Array: numeric-string keys at the array-index boundary are non-index [4.79ms]
(pass) util.inspect large arrays with maxArrayLength > Ar
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 683ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen cpp.rs (cppbind)
[2/21] gen JS modules (bundle-modules)
Preprocess modules (6697ms)
Bundle modules (57ms)
Postprocesss modules (21ms)
Bundle Functions (656ms)
Generate Code (72ms)

[7.52s] Bundled "src/js" for production
  1912 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[3/8] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[4/8] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[5/8] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[5/8] link bun-profile
[6/8] bun-profile --revision
1.4.0-canary.1+7beeb0d2b
[8/8] strip bun
[build] done
bun test v1.4.0-canary.1 (7beeb0d2b)

test/js/node/util/node-inspect-tests/internal-inspect.test.js:
(pass) util.inspect large arrays with maxArrayLength > A
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/util/inspect.js                    | 20 +-----
 src/jsc/bindings/UtilInspect.cpp                   | 41 +++++++++++
 src/jsc/bindings/UtilInspect.h                     |  2 +
 .../node-inspect-tests/internal-inspect.test.js    | 79 ++++++++++++++++++++++
 4 files changed, 123 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/internal/util/inspect.js                               4      2      0
src/jsc/bindings/UtilInspect.cpp                              1      1      0
src/jsc/bindings/UtilInspect.h                                1      1      0
…s/node/util/node-inspect-tests/internal-inspect.test.js      2      6      0
```

</details>

<!-- robobun:evidence:end -->