### PR TITLE
bake: fix use-after-free in ~DevServerSourceProvider during VM teardown

### DIFF
--- a/src/runtime/bake/DevServerSourceProvider.h
+++ b/src/runtime/bake/DevServerSourceProvider.h
@@ -28,9 +28,9 @@ public:
         auto provider = adoptRef(*new DevServerSourceProvider(source, sourceMapJSONPtr, sourceMapJSONLength, sourceOrigin, WTF::move(sourceURL), startPosition, sourceType));
         auto* zigGlobalObject = uncheckedDowncast<::Zig::GlobalObject>(globalObject);
         auto specifier = Bun::toString(provider->sourceURL());
-        provider->m_globalObject = zigGlobalObject;
+        provider->m_bunVM = zigGlobalObject->bunVM();
         provider->m_specifier = specifier;
-        Bun__addDevServerSourceProvider(zigGlobalObject->bunVM(), provider.ptr(), &specifier);
+        Bun__addDevServerSourceProvider(provider->m_bunVM, provider.ptr(), &specifier);
         return provider;
     }
 
@@ -61,13 +61,16 @@ private:
 
     ~DevServerSourceProvider()
     {
-        if (m_globalObject) {
-            Bun__removeDevServerSourceProvider(m_globalObject->bunVM(), this, &m_specifier);
+        if (m_bunVM) {
+            Bun__removeDevServerSourceProvider(m_bunVM, this, &m_specifier);
         }
     }
 
     MiString m_sourceMapJSON;
-    Zig::GlobalObject* m_globalObject;
+    // The Rust VirtualMachine, captured at creation. Not the GC-allocated
+    // Zig::GlobalObject: this destructor runs from JSC sweep, by which point
+    // the global object cell may already have been swept.
+    void* m_bunVM { nullptr };
     BunString m_specifier;
 };
 

--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -142,6 +142,10 @@ export interface DevServerTest {
    * Only run this test.
    */
   only?: boolean;
+  /**
+   * Extra environment variables for the spawned dev-server process.
+   */
+  env?: Record<string, string>;
 }
 
 let interactive = false;
@@ -1971,6 +1975,7 @@ function testImpl<T extends DevServerTest>(
           // BUN_DEBUG_INCREMENTALGRAPH: isDebugBuild && interactive ? "1" : undefined,
           // BUN_DEBUG_WATCHER: isDebugBuild && interactive ? "1" : undefined,
           BUN_ASSUME_PERFECT_INCREMENTAL: "0",
+          ...options.env,
         },
       ]),
       stdio: ["pipe", "pipe", "pipe"],

--- a/test/bake/dev/server-sourcemap.test.ts
+++ b/test/bake/dev/server-sourcemap.test.ts
@@ -1,4 +1,5 @@
 import { expect } from "bun:test";
+import { isASAN } from "harness";
 import { devTest } from "../bake-harness";
 
 devTest("server-side source maps show correct error lines", {
@@ -200,3 +201,36 @@ devTest("server-side source maps stay correct across repeated reloads", {
   },
   timeoutMultiplier: 2,
 });
+
+// ~DevServerSourceProvider ran after the Zig::GlobalObject cell was swept.
+// BUN_DESTRUCT_VM_ON_EXIT=1 triggers that teardown; Malloc=1 puts JSC cells
+// under system malloc so ASAN poisons the freed cell and the UAF is deterministic.
+if (isASAN) {
+  devTest("DevServerSourceProvider destructor does not touch the swept global object on process exit", {
+    framework: "react",
+    files: {
+      "pages/index.tsx": `
+        export const mode = "ssr";
+        export const streaming = false;
+        export default function IndexPage() {
+          return <div>alive</div>;
+        }
+      `,
+    },
+    env: {
+      Malloc: "1",
+      BUN_DESTRUCT_VM_ON_EXIT: "1",
+      // The test is about the use-after-free, not LSan; keep it hermetic
+      // against whatever ASAN_OPTIONS the outer runner chose.
+      ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=0",
+    },
+    async test(dev) {
+      const response = await dev.fetch("/");
+      const html = await response.text();
+      expect(html).toContain("alive");
+      // The harness calls gracefulExit() after this, which sends the dev
+      // server through server.stop(true) + Bun.gc(true) + process.exit(0).
+      // The teardown that follows is what this test is about.
+    },
+  });
+}


### PR DESCRIPTION
Fixes `test/bake/dev/request-cookies.test.ts` going red on the `debian 13 x64-asan` lane (seen in [build 72183](https://buildkite.com/bun/bun/builds/72183#019f55d5-6839-41cf-b0f5-3c56ada43ef9) and [build 71964](https://buildkite.com/bun/bun/builds/71964)):

```
dev| ==1715==ERROR: AddressSanitizer: SEGV on unknown address 0x000000007490
error: DevServer panicked
      at gracefulExit (test/bake/bake-harness.ts:614:17)
✗  DEV:request-cookies-1: request.cookies.get() basic functionality
```

### Cause

`~DevServerSourceProvider` held a raw `Zig::GlobalObject*` and called `m_globalObject->bunVM()` to reach `Bun__removeDevServerSourceProvider`. Under `BUN_DESTRUCT_VM_ON_EXIT=1` (set by the CI runner for the asan lane), the harness's `process.exit(0)` runs `Zig__GlobalObject__destructOnExit`, which does `gcUnprotect(globalObject)` then `collectNow(Sync, Full)` then two `vm.derefSuppressingSaferCPPChecking()`. The global object cell is swept during `collectNow`, but the provider's last `Ref` is only released later from `~CodeCache` inside `~JSC::VM`, so the destructor read `m_bunVM` out of a freed cell.

With bmalloc the freed cell usually still holds the old value and the read happens to work, which is why this was ~0.5% in CI and never reproduced locally. When the memory is reused with a zero at that offset the Rust side receives a null `VirtualMachine*` and the next access is `(null)->source_mappings.mutex`, which lands at exactly 0x7490.

Deterministic ASAN backtrace with `Malloc=1`:

```
==79839==ERROR: AddressSanitizer: heap-use-after-free ...
    #0  Zig::GlobalObject::bunVM() const  ZigGlobalObject.h:353
    #1  Bake::DevServerSourceProvider::~DevServerSourceProvider()  DevServerSourceProvider.h:65
    ...
    #7  JSC::SourceCodeKey::~SourceCodeKey()
    #12 JSC::CodeCacheMap::~CodeCacheMap()
    #16 JSC::VM::~VM()
    #18 Zig__GlobalObject__destructOnExit  ZigGlobalObject.cpp:4049
    #19 VirtualMachine::global_exit  VirtualMachine.rs:1603
    #20 Bun__Process__exit
```

### Fix

Store the Rust `VirtualMachine*` directly (`void* m_bunVM`), captured in `create()`, so the destructor no longer indirects through a GC cell. This mirrors `Zig::SourceProvider`, which already stores `m_bunVM` for the same reason. The Rust `VirtualMachine` outlives every GC cell (step 10 of `global_exit` is `self.destroy()`, after `destructOnExit` has finished).

### Verification

New ASAN-only case in `test/bake/dev/server-sourcemap.test.ts` runs the dev server with `Malloc=1` + `BUN_DESTRUCT_VM_ON_EXIT=1` so ASAN poisons the swept global-object cell, making the UAF deterministic. Added an `env` option to the `devTest` harness so the test can set those for the spawned dev server.

```
# fail-before (src/ stashed)
SUMMARY: AddressSanitizer: heap-use-after-free ZigGlobalObject.h:353:48 in Zig::GlobalObject::bunVM() const
(fail)  DEV:server-sourcemap-5: DevServerSourceProvider destructor does not touch the swept global object on process exit

# pass-after
(pass)  DEV:server-sourcemap-5: DevServerSourceProvider destructor does not touch the swept global object on process exit
```

`test/bake/dev/server-sourcemap.test.ts` (5 tests) and `test/bake/dev/request-cookies.test.ts` (2 tests) are green. `request-cookies.test.ts` now also passes under the full CI LeakSan config (`BUN_DESTRUCT_VM_ON_EXIT=1` + `detect_leaks=1`).

The bug is from a89e61fcaaa (#22138), which introduced `DevServerSourceProvider` with the raw global-object pointer.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/request-cookies.test.ts test/bake/dev/server-sourcemap.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (722d6f067)

test/bake/dev/server-sourcemap.test.ts:
Dev server testing directory: /tmp/bun-dev-test-tI2Y82
bun add v1.4.0 (722d6f067)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

installed react@0.0.0-experimental-603e6108-20241029
installed react-dom@0.0.0-experimental-603e6108-20241029
installed react-server-dom-bun@0.0.0-experimental-603e6108-20241029
installed react-refresh@0.0.0-experimental-603e6108-20241029

6 packages installed [462.00ms]
bun install v1.4.0 (722d6f067)

Checked 6 installs across 7 packages (no changes) [167.00ms]
[0;30mdev|[0m Started development server: http://localhost:37377
[0;30mdev|[0m [32mBundled page in 2125ms[0m[2m:[0
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (1498d7b77)

test/bake/dev/server-sourcemap.test.ts:
Dev server testing directory: /tmp/bun-dev-test-7LPeWv
bun add v1.4.0-canary.1 (1498d7b77)
Resolving dependencies
Resolved, downloaded and extracted [0]
Saved lockfile

installed react@0.0.0-experimental-603e6108-20241029
installed react-dom@0.0.0-experimental-603e6108-20241029
installed react-server-dom-bun@0.0.0-experimental-603e6108-20241029
installed react-refresh@0.0.0-experimental-603e6108-20241029

6 packages installed [9.00ms]
bun install v1.4.0-canary.1 (1498d7b77)

Checked 6 installs across 7 packages (no changes) [0.00ms]
[0;30mdev|[0m Started development server: http://localhost:43275
[0;30mdev|[0m [32mBundled page in 47ms[0m[2m:[0m pages/[...slug].tsx [2m+ 2 more[0m
[0;30mdev|[0m [0m[1m1 |[0m [0m[35mexport[0m [0m[35mdefault[0m [0m[35masync[0m [0m[35mfunction[0m MyPage(params) {
[0;30mdev|[0m [0m[1m2 |[0m   myFunc()[0m[2m;[0m
[0;30mdev|[0m [0m[1m3 |[0m   [0m[35mreturn[0m [0m<[0mh1>{JSON[0m[3m[1m.stringify[0m(params)}[0m<[0m/h1>[0m[2m;[0m
[0;30mdev|[0m [0m[1m4 |[0m }
[0;30mdev|[0m [0m[1m5 |[0m 
[0;30mdev|[0m [0m
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/request-cookies.test.ts test/bake/dev/server-sourcemap.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (722d6f067)

test/bake/dev/server-sourcemap.test.ts:
Dev server testing directory: /tmp/bun-dev-test-dkR1se
bun add v1.4.0 (722d6f067)
Resolving dependencies
Resolved, downloaded and extracted [0]
Saved lockfile

installed react@0.0.0-experimental-603e6108-20241029
installed react-dom@0.0.0-experimental-603e6108-20241029
installed react-server-dom-bun@0.0.0-experimental-603e6108-20241029
installed react-refresh@0.0.0-experimental-603e6108-20241029

6 packages installed [119.00ms]
bun install v1.4.0 (722d6f067)

Checked 6 installs across 7 packages (no changes) [97.00ms]
[0;30mdev|[0m Started development server: http://localhost:44249
[0;30mdev|[0m [32mBundled page in 2351ms[0m[2m:[0m
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 690ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/bake/DevServerSourceProvider.h | 13 +++++++-----
 test/bake/bake-harness.ts                  |  5 +++++
 test/bake/dev/server-sourcemap.test.ts     | 34 ++++++++++++++++++++++++++++++
 3 files changed, 47 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/runtime/bake/DevServerSourceProvider.h      1      2      0
test/bake/bake-harness.ts                       8      2      0
test/bake/dev/server-sourcemap.test.ts          1      4      0
```

</details>

<!-- robobun:evidence:end -->