### PR TITLE
Bun.serve(http3): send CONNECTION_CLOSE on abrupt stop of an idle connection

### DIFF
--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -853,10 +853,20 @@ void us_quic_listen_socket_close(us_quic_listen_socket_t *ls) {
     if (!ls || !ls->udp) return;
     /* Send CONNECTION_CLOSE on every live conn before the fd disappears;
      * cooldown alone only schedules GOAWAY, which leaves peers waiting on
-     * in-flight streams that this abrupt close will never serve. */
+     * in-flight streams that this abrupt close will never serve.
+     *
+     * lsquic_conn_abort (IFC_ABORTED -> immediate_close) is used instead of
+     * lsquic_conn_close: for a *server* connection, ci_close only schedules
+     * SF_SEND_CONN_CLOSE if conn_ok_to_close(), and even then the tick at
+     * lsquic_full_conn_ietf.c's end_write only packs the frame when
+     * IFC_GOAWAY_CLOSE is set, CONNECTION_CLOSE was received, or packets are
+     * already scheduled. An idle server conn satisfies none of those, so
+     * abrupt stop() went silent and pooled clients reused the dead session
+     * until idle-timeout. IFC_ABORTED takes the IFC_IMMEDIATE_CLOSE_FLAGS
+     * path which always packs CONNECTION_CLOSE. */
     if (ls->ctx->engine) {
         for (us_quic_socket_t *qs = ls->ctx->conns; qs; qs = qs->next) {
-            if (qs->conn) lsquic_conn_close(qs->conn);
+            if (qs->conn) lsquic_conn_abort(qs->conn);
         }
         lsquic_engine_cooldown(ls->ctx->engine);
         us_quic_process(ls->ctx);

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -337,6 +337,7 @@ describe("Bun.serve HTTP/3", () => {
       });
       console.error("PORT=" + server.port);
       process.stdin.on("data", () => {});
+      process.stdin.on("end", () => { server.stop(true); setTimeout(() => process.exit(0), 50); });
     `;
     await withCustomServer(script, async port => {
       // 256 KB body via ReadableStream → no Content-Length on the wire.
@@ -395,6 +396,7 @@ describe("Bun.serve HTTP/3", () => {
       });
       console.error("PORT=" + server.port);
       process.stdin.on("data", () => {});
+      process.stdin.on("end", () => { server.stop(true); setTimeout(() => process.exit(0), 50); });
     `;
     await withCustomServer(script, async port => {
       expect(await fetchH3(port, "/anything").then(r => r.text())).toBe("from-route");
@@ -838,7 +840,11 @@ async function withCustomServer(
   try {
     await fn(port, send, waitForStderr);
   } finally {
+    // Give the script a chance to server.stop(true) (CONNECTION_CLOSE) on
+    // stdin end before SIGKILL, so the client's pooled session is released
+    // and can't collide with a later test that reuses the same port.
     proc.stdin?.end();
+    await Promise.race([proc.exited, Bun.sleep(1000)]);
     proc.kill();
     await proc.exited;
     await drain.catch(() => {});
@@ -867,6 +873,7 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
           console.error("RELOADED");
         }
       });
+      process.stdin.on("end", () => { server.stop(true); setTimeout(() => process.exit(0), 50); });
     `;
     await withCustomServer(script, async (port, send, waitForStderr) => {
       expect(await fetchH3(port, "/old").then(r => r.text())).toBe("old-route");
@@ -876,6 +883,75 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
       expect(oldAfter.status).toBe(404);
       expect(await oldAfter.text()).toBe("fallback");
       expect(await fetchH3(port, "/new").then(r => r.text())).toBe("new-route");
+    });
+  });
+
+  // server.stop(true) must send CONNECTION_CLOSE on every live H3 connection
+  // before the UDP fd is closed. Without it the client keeps the pooled
+  // session until the negotiated idle timeout, and if another listener later
+  // binds the same port, a fetch with a ReadableStream body (which can't
+  // retry) is placed on the dead session and fails with HTTP3StreamReset
+  // once the idle alarm fires. This is the root cause of the intermittent
+  // `POST body without Content-Length` failure across the adversarial suite.
+  //
+  // lsquic's ietf_full_conn_ci_close path only packs CONNECTION_CLOSE for a
+  // server conn if there are already-scheduled packets or IFC_GOAWAY_CLOSE;
+  // an idle conn satisfies neither, so abrupt stop used lsquic_conn_abort.
+  test("server.stop(true) sends CONNECTION_CLOSE on an idle H3 connection", async () => {
+    const script = `
+      const tls = ${JSON.stringify(tls)};
+      let server;
+      const start = port => {
+        server = Bun.serve({
+          port, tls, http3: true,
+          async fetch(req) {
+            const body = await req.arrayBuffer();
+            return new Response(body, { headers: { "x-len": String(body.byteLength) } });
+          },
+        });
+        console.error("PORT=" + server.port);
+      };
+      start(0);
+      process.stdin.on("end", () => { server.stop(true); setTimeout(() => process.exit(0), 50); });
+      for await (const line of console) {
+        if (line === "stop") {
+          // Let the delayed-ACK timer fire so send_ctl has nothing scheduled
+          // when listen_socket_close runs; that's the state in which the old
+          // lsquic_conn_close() path went silent.
+          await Bun.sleep(100);
+          const port = server.port;
+          server.stop(true);
+          console.error("STOPPED");
+          start(port);
+        }
+      }
+    `;
+    await withCustomServer(script, async (port, send, waitForStderr) => {
+      // Warm the pooled client session.
+      expect((await fetchH3(port, "/").then(r => r.headers.get("x-len"))) ?? "").toBe("0");
+      send("stop");
+      await waitForStderr(/STOPPED/);
+      // Same process now listens again on the same port. A fresh handshake
+      // should complete because the client dropped the old session on
+      // CONNECTION_CLOSE; if it reused the dead one the POST below stalls
+      // until idle-timeout and then rejects with HTTP3StreamReset.
+      await waitForStderr(/PORT=(\d+)/);
+      const body = Buffer.alloc(40_000, "noCL");
+      const res = await fetchH3(port, "/", {
+        method: "POST",
+        headers: { "content-type": "application/octet-stream" },
+        body: new ReadableStream({
+          start(c) {
+            c.enqueue(body);
+            c.close();
+          },
+        }),
+        // Fail fast instead of waiting out the ~10s idle alarm; the debug
+        // lane's handshake is well under this on a fresh session.
+        signal: AbortSignal.timeout(3000),
+      });
+      expect(res.headers.get("x-len")).toBe(String(body.length));
+      expect((await res.bytes()).length).toBe(body.length);
     });
   });
 
@@ -1016,6 +1092,7 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
       });
       console.error("PORT=" + server.port);
       process.stdin.on("data", () => {});
+      process.stdin.on("end", () => { server.stop(true); setTimeout(() => process.exit(0), 50); });
     `;
     await withCustomServer(script, async port => {
       // Warm the QUIC connection so the /hang stream is actually bound
@@ -1074,6 +1151,7 @@ describe("Bun.serve HTTP/3 production", () => {
       });
       console.error("PORT=" + server.port);
       process.stdin.on("data", () => {});
+      process.stdin.on("end", () => { server.stop(true); setTimeout(() => process.exit(0), 50); });
     `;
     await withCustomServer(script, async port => {
       const res = await fetchH3(port, "/");

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -18,6 +18,15 @@ const fetchH3 = (port: number, path: string, init: RequestInit & { signal?: Abor
 // a live loopback server answers in well under this even on the ASAN lane.
 const DEAD_PORT_ABORT_MS = 1000;
 
+// Every fixture server in this file is torn down on stdin close so the client's
+// pooled session sees CONNECTION_CLOSE and is dropped; otherwise a killed
+// process leaves the client retransmitting until lsquic's idle timeout, and if
+// the OS reuses that ephemeral UDP port a later test's request gets matched
+// onto the dead conn. us_quic_listen_socket_close() flushes CONNECTION_CLOSE
+// synchronously during stop(true); the trailing setTimeout gives the kernel a
+// tick to deliver the loopback datagram before the process exits.
+const STOP_ON_STDIN_END = `process.stdin.on("end", () => { server.stop(true); setTimeout(() => process.exit(0), 100); });`;
+
 const fixture = `
 import { serve } from "bun";
 
@@ -150,12 +159,8 @@ const server = serve({
 });
 
 console.error("PORT=" + server.port);
-// Graceful stop on stdin close so the client receives CONNECTION_CLOSE and
-// drops the session — otherwise a SIGKILLed server leaves the client session
-// retransmitting until lsquic's idle timeout, and if the OS reuses the
-// ephemeral UDP port a later test's request gets matched onto that dead conn.
 process.stdin.on("data", () => {});
-process.stdin.on("end", () => { server.stop(true); setTimeout(() => process.exit(0), 100); });
+${STOP_ON_STDIN_END}
 `;
 
 async function withServer(
@@ -337,7 +342,7 @@ describe("Bun.serve HTTP/3", () => {
       });
       console.error("PORT=" + server.port);
       process.stdin.on("data", () => {});
-      process.stdin.on("end", () => { server.stop(true); setTimeout(() => process.exit(0), 50); });
+      ${STOP_ON_STDIN_END}
     `;
     await withCustomServer(script, async port => {
       // 256 KB body via ReadableStream → no Content-Length on the wire.
@@ -396,7 +401,7 @@ describe("Bun.serve HTTP/3", () => {
       });
       console.error("PORT=" + server.port);
       process.stdin.on("data", () => {});
-      process.stdin.on("end", () => { server.stop(true); setTimeout(() => process.exit(0), 50); });
+      ${STOP_ON_STDIN_END}
     `;
     await withCustomServer(script, async port => {
       expect(await fetchH3(port, "/anything").then(r => r.text())).toBe("from-route");
@@ -873,7 +878,7 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
           console.error("RELOADED");
         }
       });
-      process.stdin.on("end", () => { server.stop(true); setTimeout(() => process.exit(0), 50); });
+      ${STOP_ON_STDIN_END}
     `;
     await withCustomServer(script, async (port, send, waitForStderr) => {
       expect(await fetchH3(port, "/old").then(r => r.text())).toBe("old-route");
@@ -912,30 +917,33 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
         console.error("PORT=" + server.port);
       };
       start(0);
-      process.stdin.on("end", () => { server.stop(true); setTimeout(() => process.exit(0), 50); });
-      for await (const line of console) {
-        if (line === "stop") {
+      process.stdin.setEncoding("utf8");
+      process.stdin.on("data", async line => {
+        if (line.includes("stop")) {
           // Let the delayed-ACK timer fire so send_ctl has nothing scheduled
           // when listen_socket_close runs; that's the state in which the old
           // lsquic_conn_close() path went silent.
           await Bun.sleep(100);
           const port = server.port;
           server.stop(true);
-          console.error("STOPPED");
           start(port);
+          console.error("RESTARTED");
         }
-      }
+      });
+      ${STOP_ON_STDIN_END}
     `;
     await withCustomServer(script, async (port, send, waitForStderr) => {
       // Warm the pooled client session.
       expect((await fetchH3(port, "/").then(r => r.headers.get("x-len"))) ?? "").toBe("0");
       send("stop");
-      await waitForStderr(/STOPPED/);
+      // waitForStderr matches against the accumulated buffer, so a second
+      // /PORT=/ wait would resolve on the startup line; RESTARTED is emitted
+      // only after the new listener is bound.
+      await waitForStderr(/RESTARTED/);
       // Same process now listens again on the same port. A fresh handshake
       // should complete because the client dropped the old session on
       // CONNECTION_CLOSE; if it reused the dead one the POST below stalls
       // until idle-timeout and then rejects with HTTP3StreamReset.
-      await waitForStderr(/PORT=(\d+)/);
       const body = Buffer.alloc(40_000, "noCL");
       const res = await fetchH3(port, "/", {
         method: "POST",
@@ -948,7 +956,7 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
         }),
         // Fail fast instead of waiting out the ~10s idle alarm; the debug
         // lane's handshake is well under this on a fresh session.
-        signal: AbortSignal.timeout(3000),
+        signal: AbortSignal.timeout(2000),
       });
       expect(res.headers.get("x-len")).toBe(String(body.length));
       expect((await res.bytes()).length).toBe(body.length);
@@ -1092,7 +1100,7 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
       });
       console.error("PORT=" + server.port);
       process.stdin.on("data", () => {});
-      process.stdin.on("end", () => { server.stop(true); setTimeout(() => process.exit(0), 50); });
+      ${STOP_ON_STDIN_END}
     `;
     await withCustomServer(script, async port => {
       // Warm the QUIC connection so the /hang stream is actually bound
@@ -1151,7 +1159,7 @@ describe("Bun.serve HTTP/3 production", () => {
       });
       console.error("PORT=" + server.port);
       process.stdin.on("data", () => {});
-      process.stdin.on("end", () => { server.stop(true); setTimeout(() => process.exit(0), 50); });
+      ${STOP_ON_STDIN_END}
     `;
     await withCustomServer(script, async port => {
       const res = await fetchH3(port, "/");


### PR DESCRIPTION
Fixes `test/js/bun/http/serve-http3.test.ts` going intermittently red, most often as `POST body without Content-Length still reaches the handler` failing with `HTTP3StreamReset` after ~8-10s.

## Reproduction

```js
// 1. H3 server A at port P, one fetch to warm the client session
// 2. server.stop(true)               <- conn is idle here
// 3. H3 server B at the SAME port P
// 4. fetch with a ReadableStream body
//    -> HTTP3StreamReset after ~9s
```

On a release build step 2 usually runs while the server still has ACKs scheduled, so the bug is masked; under debug/ASAN or a loaded CI runner the connection is idle and the POST stalls every time.

## Root cause

`server.stop(true)` reaches `us_quic_listen_socket_close()`, which called `lsquic_conn_close()` on each live conn and then closed the UDP fd. For a *server* connection, `ietf_full_conn_ci_close` sets `IFC_CLOSING` and only schedules `SF_SEND_CONN_CLOSE` when `conn_ok_to_close()`; the tick that actually packs the frame (the `end_write` block in `lsquic_full_conn_ietf.c`) additionally requires one of:

- `IFC_GOAWAY_CLOSE`, or
- a received CONNECTION_CLOSE, or
- `lsquic_send_ctl_n_scheduled() > 0`

An idle server conn satisfies none of those, so the UDP fd was closed with nothing on the wire. The client's pooled session stays in `ClientContext.sessions` until the negotiated idle timeout. If a later listener binds the same ephemeral port before that fires, `fetch({protocol:'http3'})` matches the dead session and enqueues on it. Non-stream bodies recover via `retry_or_fail`; a `ReadableStream` body has already been drained into lsquic's send buffer and `retry_or_fail` refuses on `is_streaming_body`, so it surfaces `HTTP3StreamReset` once the idle alarm fires.

The pattern has been present since HTTP/3 support landed (#29768 for the server side, #29795 for the pooled client); it turns into a test failure whenever two ephemeral ports collide inside one idle-timeout window.

## Fix

`us_quic_listen_socket_close()` now calls `lsquic_conn_abort()` instead of `lsquic_conn_close()`. `IFC_ABORTED` is in `IFC_IMMEDIATE_CLOSE_FLAGS`, which takes the `immediate_close` path and unconditionally packs a CONNECTION_CLOSE (transport error `NO_ERROR`, "user aborted connection").

The test file's `withCustomServer` fixtures now `server.stop(true)` on stdin close and `withCustomServer` gives them a moment to do so before `kill()`, so every server process in the file exits through this path.

## Verification

New lifecycle test lets the server conn go idle, stops abruptly, rebinds the same port in-process, then POSTs a `ReadableStream` body:

```
# without packages/ change
(fail) server.stop(true) sends CONNECTION_CLOSE on an idle H3 connection [4766ms]
# with packages/ change
(pass) server.stop(true) sends CONNECTION_CLOSE on an idle H3 connection [1713ms]
```

Across the full file with `BUN_DEBUG_h3_client=1` on a debug build, client-session close breakdown:

| | connects | idle-timeout (status=4) | CONNECTION_CLOSE (status=8) |
|--|--|--|--|
| before | 43 | 29 | 10 |
| after  | 46 | 2  | 42 |

The two remaining timeout closes are the intentional `AbortSignal.timeout` probes against a stopped port; those sessions are still handshaking and recover on retransmission.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/http/serve-http3.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (304079670)

test/js/bun/http/serve-http3.test.ts:
(pass) Bun.serve HTTP/3 > basic GET [1669.34ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [1769.09ms]
(pass) Bun.serve HTTP/3 > 204 with no body [1648.64ms]
(pass) Bun.serve HTTP/3 > query string is preserved [1627.15ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [1726.89ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [1872.41ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [1631.50ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [1631.31ms]
(pass) Bun.serve HTTP/3 > http1: false — url/address/stop see the QUIC listener [2540.7
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (887d0bef6)

test/js/bun/http/serve-http3.test.ts:
(pass) Bun.serve HTTP/3 > basic GET [150.04ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [135.34ms]
(pass) Bun.serve HTTP/3 > 204 with no body [135.24ms]
(pass) Bun.serve HTTP/3 > query string is preserved [135.18ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [136.75ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [134.72ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [134.80ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [137.19ms]
(pass) Bun.serve HTTP/3 > http1: false — url/address/stop see the QUIC listener [1035.49ms]
(pass) Bun.serve HTTP/3 > maxRequestBodySize is enforced for H3 bodies without Content-Length [132.29ms]
(pass) Bun.serve HTTP/3 > unknown route returns 404 [135.57ms]
(pass) Bun.serve HTTP/3 > routes: handler with :params [134.53ms]
(pass) Bun.serve HTTP/3 > routes: per-method handler [135.74ms]
(pass) Bun.serve HTTP/3 > routes: method-specific '/*' falls through to fetch() on other methods [133.48ms]
(pass) Bun.serve H
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/http/serve-http3.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (304079670)

test/js/bun/http/serve-http3.test.ts:
(pass) Bun.serve HTTP/3 > basic GET [1655.54ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [1688.02ms]
(pass) Bun.serve HTTP/3 > 204 with no body [1758.76ms]
(pass) Bun.serve HTTP/3 > query string is preserved [1610.79ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [1732.70ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [1708.12ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [1686.35ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [1675.08ms]
(pass) Bun.serve HTTP/3 > http1: false — url/address/stop see the QUIC listener [2582.9
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 688ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (6473ms)
Bundle modules (27ms)
Postprocesss modules (21ms)
Bundle Functions (706ms)
Generate Code (75ms)

[7.32s] Bundled "src/js" for production
  1912 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[1/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version:
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/quic.c     | 14 +++++-
 test/js/bun/http/serve-http3.test.ts | 96 ++++++++++++++++++++++++++++++++++--
 2 files changed, 103 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
packages/bun-usockets/src/quic.c          6      7      0
test/js/bun/http/serve-http3.test.ts      3     15      0
```

</details>

<!-- robobun:evidence:end -->