### PR TITLE
Bun.redis: reject invalid database segment in connection URL

### DIFF
--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -668,10 +668,25 @@ impl JSValkeyClient {
         }
 
         // Parse database number from pathname (e.g., "/1" -> database 1)
-        let database: u32 = if pathname_utf8.slice().len() > 1 {
-            bun_core::fmt::parse_int::<u32>(&pathname_utf8.slice()[1..], 10).unwrap_or(0)
-        } else {
-            0
+        let database: u32 = match uri {
+            // For unix sockets the pathname is the socket path, not a db index.
+            valkey::Protocol::StandaloneUnix | valkey::Protocol::StandaloneTlsUnix => 0,
+            _ => {
+                let path = pathname_utf8.slice();
+                if path.len() > 1 {
+                    match bun_core::fmt::parse_int::<u32>(&path[1..], 10) {
+                        Ok(n) => n,
+                        Err(_) => {
+                            return Err(global_object.throw_invalid_arguments(format_args!(
+                                "Invalid database number in Redis URL: {}",
+                                bun_core::fmt::quote(&path[1..]),
+                            )));
+                        }
+                    }
+                } else {
+                    0
+                }
+            }
         };
 
         bun_core::analytics::Features::VALKEY.fetch_add(1, core::sync::atomic::Ordering::Relaxed);

--- a/test/js/valkey/valkey.test.ts
+++ b/test/js/valkey/valkey.test.ts
@@ -6906,7 +6906,7 @@ for (const connectionType of [ConnectionType.TLS, ConnectionType.TCP]) {
 }
 
 describe("RedisClient URL parsing", () => {
-  test.each(["/notadb", "/5abc", "/-2", "/5/6", "/99999999999999999999"])(
+  test.each(["/notadb", "/5abc", "/-2", "/5/6", "/4294967296", "/99999999999999999999"])(
     "rejects invalid database segment %j at construction time",
     path => {
       expect(() => new RedisClient(`redis://127.0.0.1:6399${path}`)).toThrow(
@@ -6915,15 +6915,21 @@ describe("RedisClient URL parsing", () => {
     },
   );
 
-  test.each(["", "/", "/0", "/5", "/15"])("accepts valid database segment %j", path => {
+  test.each(["", "/", "/0", "/5", "/15", "/4294967295"])("accepts valid database segment %j", path => {
     const client = new RedisClient(`redis://127.0.0.1:6399${path}`);
-    expect(client.connected).toBe(false);
-    client.close?.();
+    try {
+      expect(client.connected).toBe(false);
+    } finally {
+      client.close();
+    }
   });
 
   test("unix socket path is not treated as a database number", () => {
     const client = new RedisClient("redis+unix:///tmp/not-a-real-redis.sock");
-    expect(client.connected).toBe(false);
-    client.close?.();
+    try {
+      expect(client.connected).toBe(false);
+    } finally {
+      client.close();
+    }
   });
 });

--- a/test/js/valkey/valkey.test.ts
+++ b/test/js/valkey/valkey.test.ts
@@ -6904,3 +6904,26 @@ for (const connectionType of [ConnectionType.TLS, ConnectionType.TCP]) {
     });
   });
 }
+
+describe("RedisClient URL parsing", () => {
+  test.each(["/notadb", "/5abc", "/-2", "/5/6", "/99999999999999999999"])(
+    "rejects invalid database segment %j at construction time",
+    path => {
+      expect(() => new RedisClient(`redis://127.0.0.1:6399${path}`)).toThrow(
+        `Invalid database number in Redis URL: "${path.slice(1)}"`,
+      );
+    },
+  );
+
+  test.each(["", "/", "/0", "/5", "/15"])("accepts valid database segment %j", path => {
+    const client = new RedisClient(`redis://127.0.0.1:6399${path}`);
+    expect(client.connected).toBe(false);
+    client.close?.();
+  });
+
+  test("unix socket path is not treated as a database number", () => {
+    const client = new RedisClient("redis+unix:///tmp/not-a-real-redis.sock");
+    expect(client.connected).toBe(false);
+    client.close?.();
+  });
+});


### PR DESCRIPTION
## What

`new Bun.RedisClient("redis://host/notadb")` now throws instead of silently connecting to database 0.

## Why

The URL path parse in `js_valkey.rs` fell back to `0` on any parse failure via `.unwrap_or(0)`, and `authenticate()` only sends `SELECT` when `database > 0`. So an unparsable path segment was indistinguishable from an absent one: the client connected "successfully" to db 0 with no `SELECT` on the wire and no error.

```
/5      -> connected, SELECT 5       (control)
/notadb -> connected, SELECT=none    <- silently db 0
/5abc   -> connected, SELECT=none    <- silently db 0
/-2     -> connected, SELECT=none    <- silently db 0
/5/6    -> connected, SELECT=none    <- silently db 0
```

A typo in the database index (the exact mistake this validation exists to catch) would read and write the wrong database with no signal. node-redis and ioredis both reject an unparsable db segment with an error.

## Fix

Throw `Invalid database number in Redis URL: "<segment>"` at construction time when the path segment is present but not a valid `u32`. Unix socket URLs are unaffected since their pathname is the socket path, not a db index.

## Verification

```
$ bun -e 'new Bun.RedisClient("redis://127.0.0.1/notadb")'
error: Invalid database number in Redis URL: "notadb"
```

New tests in `test/js/valkey/valkey.test.ts` cover the invalid cases (`/notadb`, `/5abc`, `/-2`, `/5/6`, overflow), the valid cases (`""`, `/`, `/0`, `/5`, `/15`), and that `redis+unix://` paths are not affected. The invalid-segment tests fail on main and pass with this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 failed, 910 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (bf1a4c276)

test/js/valkey/valkey.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Redis is not enabled, skipping tests
(skip) Valkey Redis Client (tls) > (unnamed)
(skip) Valkey Redis Client (tls) > Basic Operations > should keep process alive when connecting
(skip) Valkey Redis Client (tls) > Basic Operations > should set and get strings
(skip) Valkey Redis Client (tls) > Basic Operations > should test key existence
(skip) Valkey Redis Client (tls) > Basic Operations > should increment and decrement counters
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by sp
... (truncated)

release without fix: 910 skipped
bun test v1.4.0-canary.1 (10b900193)

test/js/valkey/valkey.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Redis is not enabled, skipping tests
(skip) Valkey Redis Client (tls) > (unnamed)
(skip) Valkey Redis Client (tls) > Basic Operations > should keep process alive when connecting
(skip) Valkey Redis Client (tls) > Basic Operations > should set and get strings
(skip) Valkey Redis Client (tls) > Basic Operations > should test key existence
(skip) Valkey Redis Client (tls) > Basic Operations > should increment and decrement counters
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by specified amount with INCRBY
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by float amount with INCRBYFLOAT
(skip) Valkey Redis Client (tls) > Basic Operations > should decrement by specified amount with DECRBY
(skip) Valkey Redis Client (tls) > Basic Operations > should rename a key with RENAME
(skip) Valkey Redis Client (tls) > Basic Operations > should rename a key with RENAME overwr
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 910 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (bf1a4c276)

test/js/valkey/valkey.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Redis is not enabled, skipping tests
(skip) Valkey Redis Client (tls) > (unnamed)
(skip) Valkey Redis Client (tls) > Basic Operations > should keep process alive when connecting
(skip) Valkey Redis Client (tls) > Basic Operations > should set and get strings
(skip) Valkey Redis Client (tls) > Basic Operations > should test key existence
(skip) Valkey Redis Client (tls) > Basic Operations > should increment and decrement counters
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by sp
... (truncated)

release with fix: 910 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 819ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/valkey_jsc/js_valkey.rs | 23 +++++++++++++++++++----
 test/js/valkey/valkey.test.ts       | 29 +++++++++++++++++++++++++++++
 2 files changed, 48 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/runtime/valkey_jsc/js_valkey.rs      2      1      0
test/js/valkey/valkey.test.ts            1      2      0
```

</details>

<!-- robobun:evidence:end -->