### PR TITLE
Bun.redis: treat torn VerbatimString/BlobError body as partial, not fatal

### DIFF
--- a/src/valkey/valkey_protocol.rs
+++ b/src/valkey/valkey_protocol.rs
@@ -309,7 +309,7 @@ impl<'a> ValkeyReader<'a> {
         }
         let len = usize::try_from(len).expect("int cast");
         if self.pos + len > self.buffer.len() {
-            return Err(RedisError::InvalidVerbatimString);
+            return Err(RedisError::InvalidResponse);
         }
 
         let content_with_format = &self.buffer[self.pos..self.pos + len];
@@ -443,7 +443,7 @@ impl<'a> ValkeyReader<'a> {
                 }
                 let len = usize::try_from(len).expect("int cast");
                 if self.pos + len > self.buffer.len() {
-                    return Err(RedisError::InvalidBlobError);
+                    return Err(RedisError::InvalidResponse);
                 }
                 let str = &self.buffer[self.pos..self.pos + len];
                 self.pos += len;

--- a/test/js/valkey/valkey-incremental-scan.test.ts
+++ b/test/js/valkey/valkey-incremental-scan.test.ts
@@ -2,7 +2,7 @@ import { RedisClient, type TCPSocketListener } from "bun";
 import { describe, expect, test } from "bun:test";
 import net from "node:net";
 
-describe("Valkey reply torn across socket reads", () => {
+describe.concurrent("Valkey reply torn across socket reads", () => {
   const CRLF = "\r\n";
   const bulk = (s: string) => `$${Buffer.byteLength(s)}${CRLF}${s}${CRLF}`;
   // Minimal RESP3 HELLO map so the client enters the Connected state.
@@ -87,27 +87,30 @@ describe("Valkey reply torn across socket reads", () => {
     }
   }
 
-  // Split offset 10 lands inside the blob body for all three frames below.
-  const SPLIT = 10;
+  // `$15`/`=15` frames: 5-byte header, 15-byte body at [5,20), trailing CRLF at [20,22).
+  // `!21` frame: 5-byte header, 21-byte body at [5,26), trailing CRLF at [26,28).
+  // Offsets cover: body start, mid-body, last body byte, and mid-CRLF.
+  const SHORT_SPLITS = [5, 10, 19, 21] as const;
+  const LONG_SPLITS = [5, 10, 25, 27] as const;
 
-  test("BulkString ($) with body torn mid-payload decodes (baseline)", async () => {
-    const server = createTornReplyServer(`$15${CRLF}xxx:Some string${CRLF}`, SPLIT);
+  test.each(SHORT_SPLITS)("BulkString ($) torn at byte %i decodes (baseline)", async splitAt => {
+    const server = createTornReplyServer(`$15${CRLF}xxx:Some string${CRLF}`, splitAt);
     await withClient(server, async client => {
       expect(await client.get("k")).toBe("xxx:Some string");
       expect(await client.send("PING", [])).toBe("OK");
     });
   });
 
-  test("VerbatimString (=) with body torn mid-payload decodes instead of failing the connection", async () => {
-    const server = createTornReplyServer(`=15${CRLF}txt:Some string${CRLF}`, SPLIT);
+  test.each(SHORT_SPLITS)("VerbatimString (=) torn at byte %i decodes instead of failing the connection", async splitAt => {
+    const server = createTornReplyServer(`=15${CRLF}txt:Some string${CRLF}`, splitAt);
     await withClient(server, async client => {
       expect(await client.get("k")).toBe("Some string");
       expect(await client.send("PING", [])).toBe("OK");
     });
   });
 
-  test("BlobError (!) with body torn mid-payload decodes instead of failing the connection", async () => {
-    const server = createTornReplyServer(`!21${CRLF}SYNTAX invalid syntax${CRLF}`, SPLIT);
+  test.each(LONG_SPLITS)("BlobError (!) torn at byte %i decodes instead of failing the connection", async splitAt => {
+    const server = createTornReplyServer(`!21${CRLF}SYNTAX invalid syntax${CRLF}`, splitAt);
     await withClient(server, async client => {
       // A parsed BlobError resolves (not rejects) with an Error carrying the
       // server's message. Before the fix this rejected with

--- a/test/js/valkey/valkey-incremental-scan.test.ts
+++ b/test/js/valkey/valkey-incremental-scan.test.ts
@@ -101,13 +101,16 @@ describe.concurrent("Valkey reply torn across socket reads", () => {
     });
   });
 
-  test.each(SHORT_SPLITS)("VerbatimString (=) torn at byte %i decodes instead of failing the connection", async splitAt => {
-    const server = createTornReplyServer(`=15${CRLF}txt:Some string${CRLF}`, splitAt);
-    await withClient(server, async client => {
-      expect(await client.get("k")).toBe("Some string");
-      expect(await client.send("PING", [])).toBe("OK");
-    });
-  });
+  test.each(SHORT_SPLITS)(
+    "VerbatimString (=) torn at byte %i decodes instead of failing the connection",
+    async splitAt => {
+      const server = createTornReplyServer(`=15${CRLF}txt:Some string${CRLF}`, splitAt);
+      await withClient(server, async client => {
+        expect(await client.get("k")).toBe("Some string");
+        expect(await client.send("PING", [])).toBe("OK");
+      });
+    },
+  );
 
   test.each(LONG_SPLITS)("BlobError (!) torn at byte %i decodes instead of failing the connection", async splitAt => {
     const server = createTornReplyServer(`!21${CRLF}SYNTAX invalid syntax${CRLF}`, splitAt);

--- a/test/js/valkey/valkey-incremental-scan.test.ts
+++ b/test/js/valkey/valkey-incremental-scan.test.ts
@@ -1,6 +1,124 @@
-import { RedisClient } from "bun";
+import { RedisClient, type TCPSocketListener } from "bun";
 import { describe, expect, test } from "bun:test";
 import net from "node:net";
+
+describe("Valkey reply torn across socket reads", () => {
+  const CRLF = "\r\n";
+  const bulk = (s: string) => `$${Buffer.byteLength(s)}${CRLF}${s}${CRLF}`;
+  // Minimal RESP3 HELLO map so the client enters the Connected state.
+  const HELLO =
+    `%3${CRLF}` + bulk("server") + bulk("redis") + bulk("proto") + `:3${CRLF}` + bulk("version") + bulk("7.4.0");
+
+  type PerSocket = { buf: Buffer; replied: boolean };
+
+  /**
+   * Mock server: answers HELLO, then answers the first GET with `reply` split at
+   * `splitAt` across two event-loop turns so the client's empty-read-buffer
+   * stack path sees a partial blob body. Subsequent commands get `+OK`.
+   */
+  function createTornReplyServer(reply: string, splitAt: number): TCPSocketListener<PerSocket> {
+    return Bun.listen<PerSocket>({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        open(s) {
+          s.data = { buf: Buffer.alloc(0), replied: false };
+        },
+        error() {},
+        close() {},
+        data(s, raw) {
+          const st = s.data;
+          st.buf = Buffer.concat([st.buf, raw]);
+          // Parse complete client RESP command frames (`*N\r\n($len\r\n...\r\n){N}`).
+          for (;;) {
+            const b = st.buf;
+            if (!b.length || b[0] !== 0x2a) break;
+            const headerEnd = b.indexOf(CRLF);
+            if (headerEnd < 0) break;
+            const argc = parseInt(b.subarray(1, headerEnd).toString("latin1"), 10);
+            let pos = headerEnd + 2;
+            const fields: string[] = [];
+            let complete = true;
+            for (let i = 0; i < argc; i++) {
+              const lenEnd = b.indexOf(CRLF, pos);
+              if (lenEnd < 0 || b[pos] !== 0x24) {
+                complete = false;
+                break;
+              }
+              const len = parseInt(b.subarray(pos + 1, lenEnd).toString("latin1"), 10);
+              const next = lenEnd + 2 + len + 2;
+              if (next > b.length) {
+                complete = false;
+                break;
+              }
+              fields.push(b.subarray(lenEnd + 2, lenEnd + 2 + len).toString("latin1"));
+              pos = next;
+            }
+            if (!complete) break;
+            st.buf = b.subarray(pos);
+            const cmd = fields[0]?.toUpperCase();
+            if (cmd === "HELLO") {
+              s.write(HELLO);
+            } else if (cmd === "GET" && !st.replied) {
+              st.replied = true;
+              s.write(reply.slice(0, splitAt));
+              s.flush();
+              // Yield twice so the first write reaches the client's `on_data`
+              // before the second is sent.
+              setImmediate(() => setImmediate(() => s.write(reply.slice(splitAt))));
+            } else {
+              s.write(`+OK${CRLF}`);
+            }
+          }
+        },
+      },
+    });
+  }
+
+  async function withClient<T>(server: TCPSocketListener<PerSocket>, body: (client: RedisClient) => Promise<T>) {
+    const client = new RedisClient(`redis://127.0.0.1:${server.port}`, { autoReconnect: false });
+    client.onconnect = client.onclose = () => {};
+    try {
+      await client.connect();
+      return await body(client);
+    } finally {
+      client.close();
+      server.stop(true);
+    }
+  }
+
+  // Split offset 10 lands inside the blob body for all three frames below.
+  const SPLIT = 10;
+
+  test("BulkString ($) with body torn mid-payload decodes (baseline)", async () => {
+    const server = createTornReplyServer(`$15${CRLF}xxx:Some string${CRLF}`, SPLIT);
+    await withClient(server, async client => {
+      expect(await client.get("k")).toBe("xxx:Some string");
+      expect(await client.send("PING", [])).toBe("OK");
+    });
+  });
+
+  test("VerbatimString (=) with body torn mid-payload decodes instead of failing the connection", async () => {
+    const server = createTornReplyServer(`=15${CRLF}txt:Some string${CRLF}`, SPLIT);
+    await withClient(server, async client => {
+      expect(await client.get("k")).toBe("Some string");
+      expect(await client.send("PING", [])).toBe("OK");
+    });
+  });
+
+  test("BlobError (!) with body torn mid-payload decodes instead of failing the connection", async () => {
+    const server = createTornReplyServer(`!21${CRLF}SYNTAX invalid syntax${CRLF}`, SPLIT);
+    await withClient(server, async client => {
+      // A parsed BlobError resolves (not rejects) with an Error carrying the
+      // server's message. Before the fix this rejected with
+      // "Failed to read data (stack path)" and killed the connection.
+      const result = await client.get("k");
+      expect(result).toBeInstanceOf(Error);
+      expect((result as unknown as Error).message).toBe("SYNTAX invalid syntax");
+      expect(await client.send("PING", [])).toBe("OK");
+    });
+  });
+});
 
 describe("Valkey incremental reply scanning", () => {
   // Sizes chosen so the reply line stays under the protocol's 512 KiB line


### PR DESCRIPTION
## What

A RESP3 `=` (VerbatimString) or `!` (BlobError) reply whose body arrives split across two TCP reads kills the whole `Bun.RedisClient` connection: every in-flight command rejects with `ERR_REDIS_INVALID_RESPONSE "Failed to read data (stack path)"`. A `$` (BulkString) reply torn at the same offset decodes fine.

## Repro

```js
// Mock server that answers HELLO, then sends the GET reply split mid-body.
// Before:
//   control-$   ok xxx:Some string            conn-survived=true
//   verbatim-=  rej ERR_REDIS_INVALID_RESPONSE conn-survived=false
//   bloberror-! rej ERR_REDIS_INVALID_RESPONSE conn-survived=false
// After:
//   verbatim-=  ok Some string                conn-survived=true
//   bloberror-! ok <Error: SYNTAX ...>        conn-survived=true
```

## Cause

`on_data`'s empty-read-buffer stack path calls `ValkeyReader::read_value()` directly and treats only `RedisError::InvalidResponse` as "partial frame, buffer and wait". The `BulkString` arm returns `InvalidResponse` when `pos + len > buffer.len()`, but the `VerbatimString` and `BlobError` arms return `InvalidVerbatimString` / `InvalidBlobError` for the same not-enough-bytes check, so they fall through to the fatal branch. (The incremental `ReplyScanner` on the non-empty-buffer path already classifies all three blob types correctly.)

## Fix

Return `InvalidResponse` from the `pos + len > buffer.len()` check in `read_verbatim_string()` and the `BlobError` arm of `read_value_with_depth()`, matching the `BulkString` arm. The type-specific error variants are still returned for genuinely malformed input (out-of-range length, missing `xxx:` prefix, bad trailing CRLF).

## Verification

Added three tests in `test/js/valkey/valkey-incremental-scan.test.ts` using a `Bun.listen` mock server that splits the reply body across two socket writes. Before the fix the `=` and `!` tests fail with `ERR_REDIS_INVALID_RESPONSE` and a dead connection; after, all three decode and a follow-up `PING` succeeds.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey-incremental-scan.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (dacff8c69)

test/js/valkey/valkey-incremental-scan.test.ts:
RedisError: Failed to read data (stack path)
 code: "ERR_REDIS_INVALID_RESPONSE"

(fail) Valkey reply torn across socket reads > VerbatimString (=) torn at byte 5 decodes instead of failing the connection [63.69ms]
(pass) Valkey reply torn across socket reads > BulkString ($) torn at byte 5 decodes (baseline) [104.85ms]
(pass) Valkey reply torn across socket reads > BulkString ($) torn at byte 10 decodes (baseline) [92.68ms]
(pass) Valkey reply torn across socket reads > BulkString ($) torn at byte 19 decodes (baseline) [92.53ms]
(pass) Valkey reply torn across socket reads > BulkString ($) torn at byte 21 decodes (baseline) [96.50ms]
RedisError: Failed to read
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (7435f52ee)

test/js/valkey/valkey-incremental-scan.test.ts:
(pass) Valkey reply torn across socket reads > BulkString ($) torn at byte 5 decodes (baseline) [2.90ms]
(pass) Valkey reply torn across socket reads > BulkString ($) torn at byte 10 decodes (baseline) [2.52ms]
(pass) Valkey reply torn across socket reads > BulkString ($) torn at byte 19 decodes (baseline) [2.46ms]
(pass) Valkey reply torn across socket reads > BulkString ($) torn at byte 21 decodes (baseline) [2.41ms]
(pass) Valkey reply torn across socket reads > VerbatimString (=) torn at byte 5 decodes instead of failing the connection [2.37ms]
(pass) Valkey reply torn across socket reads > VerbatimString (=) torn at byte 10 decodes instead of failing the connection [2.23ms]
(pass) Valkey reply torn across socket reads > VerbatimString (=) torn at byte 19 decodes instead of failing the connection [2.19ms]
(pass) Valkey reply torn across socket reads > VerbatimString (=) torn at byte 21 decodes instead of failing the connection [2.15ms]
(pass) Valkey reply torn across socket reads > BlobError (!) torn at byte 5 decodes instead of failing the connection [2.11ms]
(pass) Valkey rep
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey-incremental-scan.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (dacff8c69)

test/js/valkey/valkey-incremental-scan.test.ts:
(pass) Valkey reply torn across socket reads > BulkString ($) torn at byte 5 decodes (baseline) [97.27ms]
(pass) Valkey reply torn across socket reads > BulkString ($) torn at byte 10 decodes (baseline) [85.18ms]
(pass) Valkey reply torn across socket reads > BulkString ($) torn at byte 19 decodes (baseline) [85.10ms]
(pass) Valkey reply torn across socket reads > BulkString ($) torn at byte 21 decodes (baseline) [85.10ms]
(pass) Valkey reply torn across socket reads > VerbatimString (=) torn at byte 5 decodes instead of failing the connection [89.12ms]
(pass) Valkey reply torn across socket reads > VerbatimString (=) torn at byte 10 decodes instead of failing 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 708ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/valkey/valkey_protocol.rs                  |   4 +-
 test/js/valkey/valkey-incremental-scan.test.ts | 126 ++++++++++++++++++++++++-
 2 files changed, 127 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/valkey/valkey_protocol.rs                       1      1      0
test/js/valkey/valkey-incremental-scan.test.ts      3      9      0
```

</details>

<!-- robobun:evidence:end -->