### PR TITLE
s3: reject CompleteMultipartUpload 200 responses without a result element

### DIFF
--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -420,11 +420,8 @@ impl S3HttpSimpleTask {
                 let status = response.status_code;
                 if !this.fail_if_contains_error(status)? {
                     let committed = this.result.body.as_ref().is_some_and(|b| {
-                        strings::index_of(
-                            b.list.as_slice(),
-                            b"</CompleteMultipartUploadResult>",
-                        )
-                        .is_some()
+                        strings::index_of(b.list.as_slice(), b"</CompleteMultipartUploadResult>")
+                            .is_some()
                     });
                     if committed {
                         callback(S3CommitResult::Success, this.callback_context)?;

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -414,10 +414,27 @@ impl S3HttpSimpleTask {
                 }
             },
             Callback::Commit(callback) => {
-                // commit multipart upload can fail with status 200
+                // CompleteMultipartUpload can return 200 with an <Error> body, and AWS
+                // documents that a 200 without a well-formed CompleteMultipartUploadResult
+                // (truncated/proxy body) must also be treated as a failure.
                 let status = response.status_code;
                 if !this.fail_if_contains_error(status)? {
-                    callback(S3CommitResult::Success, this.callback_context)?;
+                    let committed = this.result.body.as_ref().is_some_and(|b| {
+                        strings::index_of(
+                            b.list.as_slice(),
+                            b"</CompleteMultipartUploadResult>",
+                        )
+                        .is_some()
+                    });
+                    if committed {
+                        callback(S3CommitResult::Success, this.callback_context)?;
+                    } else {
+                        this.callback.fail(
+                            b"InternalError",
+                            b"CompleteMultipartUpload returned 200 without a CompleteMultipartUploadResult body; the upload was not committed",
+                            this.callback_context,
+                        )?;
+                    }
                 }
             }
             Callback::Part(callback) => {

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -419,16 +419,20 @@ impl S3HttpSimpleTask {
                 // (truncated/proxy body) must also be treated as a failure.
                 let status = response.status_code;
                 if !this.fail_if_contains_error(status)? {
-                    let committed = this.result.body.as_ref().is_some_and(|b| {
-                        strings::index_of(b.list.as_slice(), b"</CompleteMultipartUploadResult>")
+                    let committed = status == 200
+                        && this.result.body.as_ref().is_some_and(|b| {
+                            strings::index_of(
+                                b.list.as_slice(),
+                                b"</CompleteMultipartUploadResult>",
+                            )
                             .is_some()
-                    });
+                        });
                     if committed {
                         callback(S3CommitResult::Success, this.callback_context)?;
                     } else {
                         this.callback.fail(
                             b"InternalError",
-                            b"CompleteMultipartUpload returned 200 without a CompleteMultipartUploadResult body; the upload was not committed",
+                            b"CompleteMultipartUpload response did not contain a CompleteMultipartUploadResult element; the upload was not committed",
                             this.callback_context,
                         )?;
                     }

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1786,7 +1786,15 @@ describe("s3 multipart upload id validation", () => {
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
+      // The S3 client does not honor NO_PROXY, so an inherited proxy would
+      // hijack the request to the stub server.
+      env: {
+        ...bunEnv,
+        HTTP_PROXY: undefined,
+        HTTPS_PROXY: undefined,
+        http_proxy: undefined,
+        https_proxy: undefined,
+      },
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1801,3 +1801,87 @@ describe("s3 multipart upload id validation", () => {
     expect(exitCode).toBe(0);
   }, 60_000);
 });
+
+describe("s3 multipart CompleteMultipartUpload body validation", () => {
+  // AWS documents that CompleteMultipartUpload can return 200 and still have failed; the
+  // response body must contain a CompleteMultipartUploadResult element. A 200 with a
+  // truncated, empty, HTML, or otherwise unparsable body (proxy/gateway hiccup) must reject.
+  it("rejects a 200 CompleteMultipartUpload response whose body lacks a CompleteMultipartUploadResult element", async () => {
+    const fixture = `
+        const completeBodies = {
+          ok: '<CompleteMultipartUploadResult><Bucket>b</Bucket><Key>k</Key><ETag>"e"</ETag></CompleteMultipartUploadResult>',
+          truncated: "<CompleteMultipartUploadResult><Buck",
+          empty: "",
+          html: "<html><body>502 Bad Gateway</body></html>",
+          binary: new Uint8Array([0, 1, 254, 255]),
+          error: '<Error><Code>InternalError</Code><Message>We encountered an internal error.</Message></Error>',
+        };
+
+        const results = {};
+        for (const [mode, completeBody] of Object.entries(completeBodies)) {
+          const server = Bun.serve({
+            port: 0,
+            async fetch(req) {
+              const url = new URL(req.url);
+              if (req.method === "POST" && url.search.includes("uploads=")) {
+                return new Response(
+                  "<InitiateMultipartUploadResult><Bucket>b</Bucket><Key>k</Key><UploadId>UP1</UploadId></InitiateMultipartUploadResult>",
+                  { status: 200, headers: { "Content-Type": "text/xml" } },
+                );
+              }
+              if (req.method === "POST" && url.search.includes("uploadId=")) {
+                return new Response(completeBody, { status: 200, headers: { "Content-Type": "text/xml" } });
+              }
+              return new Response(undefined, { status: 200, headers: { ETag: '"abc"' } });
+            },
+          });
+
+          const client = new Bun.S3Client({
+            endpoint: server.url.href,
+            bucket: "b",
+            region: "us-east-1",
+            accessKeyId: "AK",
+            secretAccessKey: "SK",
+          });
+
+          const writer = client.file("k-" + mode).writer({ partSize: 5 * 1024 * 1024, retry: 0 });
+          writer.write(Buffer.alloc(6 * 1024 * 1024, "a"));
+          try {
+            await writer.end();
+            results[mode] = "resolved";
+          } catch (e) {
+            results[mode] = "rejected:" + (e?.code ?? e?.name);
+          }
+          server.stop(true);
+        }
+        console.log(JSON.stringify(results));
+      `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      // The S3 client does not honor NO_PROXY, so an inherited proxy would
+      // hijack the request to the stub server.
+      env: {
+        ...bunEnv,
+        HTTP_PROXY: undefined,
+        HTTPS_PROXY: undefined,
+        http_proxy: undefined,
+        https_proxy: undefined,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(JSON.parse(stdout.trim())).toEqual({
+      ok: "resolved",
+      truncated: "rejected:InternalError",
+      empty: "rejected:InternalError",
+      html: "rejected:InternalError",
+      binary: "rejected:InternalError",
+      error: "rejected:InternalError",
+    });
+    expect(exitCode).toBe(0);
+  }, 60_000);
+});

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1883,5 +1883,5 @@ describe("s3 multipart CompleteMultipartUpload body validation", () => {
       error: "rejected:InternalError",
     });
     expect(exitCode).toBe(0);
-  }, 60_000);
+  });
 });


### PR DESCRIPTION
## What

`Bun.S3Client` multipart uploads now reject when `CompleteMultipartUpload` returns HTTP 200 with a body that does not contain a `</CompleteMultipartUploadResult>` element. Previously the only body validation was a substring search for `<Error>`, so a truncated XML body, an empty body, an HTML 502 page, or binary garbage all resolved the write as success even though the object was never committed.

## Reproduction

Local S3 stub: `CreateMultipartUpload` and `UploadPart` succeed, `CompleteMultipartUpload` returns 200 with a garbage body.

```ts
const writer = client.file("k").writer({ partSize: 5 * 1024 * 1024 });
writer.write(Buffer.alloc(6 * 1024 * 1024, "a"));
await writer.end(); // resolves on main, should reject
```

| Complete body (200) | main | this PR |
|---|---|---|
| `<CompleteMultipartUploadResult>...</CompleteMultipartUploadResult>` | resolves | resolves |
| `<CompleteMultipartUploadResult><Buck` (truncated) | **resolves** | rejects `InternalError` |
| `` (empty) | **resolves** | rejects `InternalError` |
| `<html><body>502 Bad Gateway</body></html>` | **resolves** | rejects `InternalError` |
| `\x00\x01\xfe\xff` (binary) | **resolves** | rejects `InternalError` |
| `<Error><Code>InternalError</Code>...</Error>` | rejects | rejects |

AWS documents that a 200 from `CompleteMultipartUpload` can still mean failure and that clients must parse the body. A truncated or garbage body is exactly what a dying proxy or gateway timeout produces; every AWS SDK treats an unparsable completion as a failed upload.

## Cause

`src/runtime/webcore/s3/simple_request.rs` `Callback::Commit` arm called `fail_if_contains_error`, which only greps for the literal substring `<Error>`. If that substring is absent and the status is 200, it returned success with no positive check that the body is a well-formed result.

## Fix

After `fail_if_contains_error` reports no `<Error>` element, require `</CompleteMultipartUploadResult>` in the body before reporting success. Checking the closing tag catches mid-body truncation. Anything else is surfaced as `S3CommitResult::Failure` with code `InternalError`, which the existing commit path already retries up to `options.retry` times.

## Verification

New `s3 multipart CompleteMultipartUpload body validation` test in `test/js/bun/s3/s3.test.ts` runs a local S3 stub that scripts six Complete bodies (one valid, four garbage, one well-formed `<Error>`). Fails on main (four garbage bodies resolve), passes with this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 286 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f18016eb0)

test/js/bun/s3/s3.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(skip) R2 > s3 > fetch > bucket in path > should download file via fetch GET
(skip) R2 > s3 > fetch > bucket in path > should download range
(skip) R2 > s3 > fetch > bucket in path > should check if a key exists or content-length
(skip) R2 > s3 > fetch > bucket in path > should check if a key does not exist
(skip) R2 > s3 > fetch > bucket in path > should be able to set content-type
(skip) R2 > s3 > fetch > bucket in path > should be able to upload large files
(skip) R2 > s3 > Bun.S3Client > bucket in path > s
... (truncated)

release without fix: 286 skipped
bun test v1.4.0-canary.1 (724a4dafb)

test/js/bun/s3/s3.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(skip) R2 > s3 > fetch > bucket in path > should download file via fetch GET
(skip) R2 > s3 > fetch > bucket in path > should download range
(skip) R2 > s3 > fetch > bucket in path > should check if a key exists or content-length
(skip) R2 > s3 > fetch > bucket in path > should check if a key does not exist
(skip) R2 > s3 > fetch > bucket in path > should be able to set content-type
(skip) R2 > s3 > fetch > bucket in path > should be able to upload large files
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download file via Bun.s3().text()
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download range
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download range with 0 offset
(skip) R2 > s3 > Bun.S3Client > bucket in path > should check if a key exists or content-length
(skip) R2 > s3 > Bun.S3Client > bucket in path > should check if a key does not exist
(skip) R2 > s3 > Bun.S3Client > 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 286 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f18016eb0)

test/js/bun/s3/s3.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(skip) R2 > s3 > fetch > bucket in path > should download file via fetch GET
(skip) R2 > s3 > fetch > bucket in path > should download range
(skip) R2 > s3 > fetch > bucket in path > should check if a key exists or content-length
(skip) R2 > s3 > fetch > bucket in path > should check if a key does not exist
(skip) R2 > s3 > fetch > bucket in path > should be able to set content-type
(skip) R2 > s3 > fetch > bucket in path > should be able to upload large files
(skip) R2 > s3 > Bun.S3Client > bucket in path > s
... (truncated)

release with fix: 286 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 659ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/s3/simple_request.rs | 22 +++++++-
 test/js/bun/s3/s3.test.ts                | 94 +++++++++++++++++++++++++++++++-
 2 files changed, 113 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/runtime/webcore/s3/simple_request.rs      3      5      0
test/js/bun/s3/s3.test.ts                     3      4      0
```

</details>

<!-- robobun:evidence:end -->