### PR TITLE
test(proxy-stress): dial 127.0.0.1 for the test proxy's upstream instead of resolving 'localhost'

### DIFF
--- a/test/js/bun/http/proxy-stress-helpers.ts
+++ b/test/js/bun/http/proxy-stress-helpers.ts
@@ -365,13 +365,9 @@ export async function createAdversarialProxy(opts: AdversarialProxyOptions = {})
       // and getaddrinfo want the bare literal.
       if (host.startsWith("[") && host.endsWith("]")) host = host.slice(1, -1);
 
-      // Every origin in this suite binds 127.0.0.1, but its URL says
-      // `localhost`. net.connect(.., "localhost") goes through
-      // autoSelectFamily, which on darwin tries `::1` first. IPv4 and IPv6
-      // ephemeral-port spaces are independent, so an unrelated process on the
-      // CI host can be answering at `[::1]:port` while our origin holds
-      // `127.0.0.1:port` (observed as a stray 204 in build 72283). Dial the
-      // bound address directly; the IPv6-literal tests pass `[::1]` explicitly.
+      // Origins bind 127.0.0.1 but advertise `localhost`; on darwin that
+      // resolves `::1` first, and v4/v6 ephemeral-port spaces are independent,
+      // so dial the bound address. IPv6-literal tests pass `[::1]` explicitly.
       if (host === "localhost") host = "127.0.0.1";
 
       upstream = net.connect(port, host);

--- a/test/js/bun/http/proxy-stress-helpers.ts
+++ b/test/js/bun/http/proxy-stress-helpers.ts
@@ -365,6 +365,15 @@ export async function createAdversarialProxy(opts: AdversarialProxyOptions = {})
       // and getaddrinfo want the bare literal.
       if (host.startsWith("[") && host.endsWith("]")) host = host.slice(1, -1);
 
+      // Every origin in this suite binds 127.0.0.1, but its URL says
+      // `localhost`. net.connect(.., "localhost") goes through
+      // autoSelectFamily, which on darwin tries `::1` first. IPv4 and IPv6
+      // ephemeral-port spaces are independent, so an unrelated process on the
+      // CI host can be answering at `[::1]:port` while our origin holds
+      // `127.0.0.1:port` (observed as a stray 204 in build 72283). Dial the
+      // bound address directly; the IPv6-literal tests pass `[::1]` explicitly.
+      if (host === "localhost") host = "127.0.0.1";
+
       upstream = net.connect(port, host);
       let clientEnded = false;
       const endClient = () => {


### PR DESCRIPTION
## Problem

`test/js/bun/http/proxy-stress-matrix.test.ts` went red on darwin 26 aarch64 in [build 72283](https://buildkite.com/bun/bun/builds/72283):

```
error: expect(received).toBe(expected)
Expected: 200
Received: 204
✗ method matrix > OPTIONS via https-proxy → http-origin
334 pass / 1 fail
```

The runner tagged it "crash reported" (the intentional crashes from `run-crash-handler.test.ts` earlier in the shard, as diagnosed in #33984), which skipped the automatic retry.

## Cause

Nothing in this test file ever emits 204, and the adversarial origin's `buildResponse` defaults to 200 for every cell of the method matrix. The 204 came from outside the test process.

`createAdversarialOrigin` binds to `127.0.0.1` but hands out a `http(s)://localhost:${port}` URL (so that Host / SNI / `checkServerIdentity` assertions see a hostname). The test proxy parses the absolute-form target, pulls `host = "localhost"`, and dials `net.connect(port, "localhost")`. On the darwin boxes `localhost` resolves to `[::1, 127.0.0.1]` with `::1` first, and autoSelectFamily tries addresses in that order:

```
$ ssh darwin-test-arm64-3 "bun -e '...dns.lookup(\"localhost\",{all:true},...)'"
[{"address":"::1","family":6},{"address":"127.0.0.1","family":4}]
```

IPv4 and IPv6 ephemeral-port spaces are independent, so an unrelated process on the bare-metal CI host (another buildkite agent, a system daemon) can be listening on `[::1]:P` at the exact moment our origin holds `127.0.0.1:P`. Verified directly on darwin-test-arm64-3: when both `[::1]:P` (returns 204) and `127.0.0.1:P` (returns 200) are bound, `net.connect(P, "localhost")` connects to `::1` and reads back 204. On linux the same script reads 200.

This is the second half of the mechanism #33984 ("the proxy's `net.connect(port, 'localhost')` goes through autoSelectFamily, adding async hops") reduced but didn't eliminate: #33984 shared the proxy pair to cut ephemeral-port churn; each test still creates a fresh origin, and each origin dial still resolves `localhost`. Introduced by #32635.

## Fix

Normalize `host = "localhost"` to `"127.0.0.1"` in `createAdversarialProxy`'s upstream dial. Every origin in the suite binds `127.0.0.1`; the IPv6-literal tests in `proxy-stress-protocol.test.ts` pass `[::1]` explicitly and are unaffected. The origin URL (and therefore the client's Host header, CONNECT target, SNI, and the `checkServerIdentity` host argument) remains `localhost`, so none of the hostname-shape assertions in `proxy-stress-adversarial.test.ts` / `proxy-stress-headers.test.ts` change.

## Verification

```
bun bd test test/js/bun/http/proxy-stress-matrix.test.ts        # 335 pass (debug+ASAN)
bun bd test test/js/bun/http/proxy-stress-adversarial.test.ts \
            test/js/bun/http/proxy-stress-headers.test.ts \
            test/js/bun/http/proxy-stress-protocol.test.ts      # 329 pass
bun bd test test/js/bun/http/proxy-stress-errors.test.ts \
            test/js/bun/http/proxy-stress-lifecycle.test.ts \
            test/js/bun/http/proxy-stress-concurrent.test.ts    # 177 pass
```

15 consecutive release runs of `proxy-stress-matrix.test.ts`, all 335/335.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->