### PR TITLE
test(fs): assert on path segment instead of "1234" substring in tmpdirTestMkdir

### DIFF
--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -88,7 +88,10 @@ function tmpdirTestMkdir(): string {
   if (!res?.includes(now)) {
     expect(res).toInclude("fs.test.ts");
   }
-  expect(res).not.toInclude("1234");
+  // res is the first directory created (the ${now} segment). Check the last
+  // path segment rather than a "1234" substring, which can occur in Date.now().
+  expect(path.basename(res!)).not.toBe("1234");
+  expect(path.basename(res!)).not.toBe("hi");
   expect(existsSync(tempdir)).toBe(true);
   return tempdir;
 }


### PR DESCRIPTION
## Repro

Build [72286](https://buildkite.com/bun/bun/builds/72286) went red on `test/js/node/fs/fs.test.ts`:

```
error: expect(received).not.toInclude(expected)
Expected to not include: "1234"
Received: "/tmp/buntmp-isTkgw/fs.test.ts/1783876123471b71a01c3"
      at tmpdirTestMkdir (test/js/node/fs/fs.test.ts:91:19)
```

## Cause

`tmpdirTestMkdir()` builds `${tmpdir()}/fs.test.ts/${now}/1234/hi` where `now` is `Date.now().toString() + <8 hex chars>`, then asserts that the path `mkdirSync({recursive: true})` returns (the first directory it created) does not include `"1234"`. That fails whenever the `Date.now()` digits happen to contain `1234` as a substring, as `1783876123471` did at 2026-07-12T17:08:43Z. The random hex suffix can also produce it.

The helper has been in place since #14510; this is a time-dependent flake, not a recent regression.

## Fix

Check `path.basename(res)` against the two leaf segment names (`"1234"`, `"hi"`) instead of a substring of the whole path. Same invariant (the returned path is a parent of the leaf), no dependence on the digits of `now`.

## Verification

With `now` forced to the failing value `"1783876123471b71a01c3"`, `mkdirSync` returns `/tmp/fs.test.ts/1783876123471b71a01c3`; the old assertion fails on the substring while `path.basename` is the `${now}` segment and the new assertion passes.

```
$ bun bd test test/js/node/fs/fs.test.ts
 400 pass
 6 skip
 0 fail
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->