### PR TITLE
test(init): pass --bun to the react template build step so it runs the bun under test

### DIFF
--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -358,10 +358,13 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
       expect({ tscStdout, tscStderr, tscExited }).toMatchObject({ tscExited: 0 });
 
       // The blank template has no `build` script; the react templates do.
+      // bun-plugin-tailwind's `bun` peer dep links a node_modules/.bin/bun that
+      // would otherwise shadow bunExe() in the nested `bun run build.ts`, so
+      // pass --bun.
       const pkg = JSON.parse(fs.readFileSync(path.join(temp, "package.json"), "utf8"));
       if (pkg.scripts?.build) {
         await using build = Bun.spawn({
-          cmd: [bunExe(), "run", "build"],
+          cmd: [bunExe(), "--bun", "run", "build"],
           cwd: temp,
           stdio: ["ignore", "pipe", "pipe"],
           env: bunEnv,

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -171,3 +171,6 @@ test/js/third_party/@azure/service-bus/azure-service-bus.test.ts
 # real addons. Under validateExceptionChecks every scope simulates a throw, so
 # the second call trips the assertion at the napi boundary.
 test/bundler/native-plugin.test.ts
+# `bun run build` in the react templates loads bun-plugin-tailwind's napi
+# addon, same Init() pattern.
+test/cli/init/init.test.ts


### PR DESCRIPTION
Fixes `test/cli/init/init.test.ts` going red on darwin-x64 CI (build [72304](https://buildkite.com/bun/bun/builds/72304), agent `darwin-x64-mini-2`):

```
✗ bun init > bun init --react=shadcn installs TypeScript 6, typechecks, and builds
  buildExited: 1
  buildStderr: $ bun run build.ts
    Error: Bun's postinstall script was not run.
```

### Cause

`bun-plugin-tailwind@0.1.x` declares `peerDependencies: { bun: ">=1.0.0" }`, so the `bun install` that `bun init --react=tailwind|shadcn` runs links `node_modules/.bin/bun` into the new project. `bun run <script>` prepends `node_modules/.bin` to PATH (and does not prepend the self-shim dir when `node` is on PATH and no `--bun` / `run.bun` is set), so the bare `bun` in the template's `"build": "bun run build.ts"` script resolved to that stub rather than the bun under test:

- When the npm `bun` package's postinstall had run, the stub was a working copy of bun 1.3.14. The build step succeeded but was exercising a stale release, not the build under test.
- When the postinstall had not completed (one darwin-x64 CI run), the stub was the npm placeholder that prints "Bun's postinstall script was not run" and exits 1, and the test failed as above. I could not reproduce that state on the same box post-reboot (0/60 placeholders across five 12-way concurrent rounds with a fresh cache), so whatever left the placeholder on Jul 12 was transient.

Either outcome is a test running the wrong binary. The test was added in #33265.

### Fix

Pass `--bun` on the test's `bun run build` spawn so the nested `bun` resolves to `bunExe()` regardless of what `node_modules/.bin/bun` contains. Now that the build actually runs the bun under test and loads `bun-plugin-tailwind`'s NAPI addon, add the test to `test/no-validate-exceptions.txt` under the existing `napi_create_function` / `napi_set_named_property` block (same reason as `test/bundler/native-plugin.test.ts`).

Culprit PR: #33265.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->