### PR TITLE
Return freed Bun.build memory to the OS after each in-process build

### DIFF
--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -242,7 +242,12 @@ impl<C: CompletionStruct> BundleThread<C> {
             }
 
             if has_bundled {
-                bun_alloc::mimalloc::mi_collect(false);
+                // `force = true` so mimalloc purges (decommits) the arena
+                // slices freed by the per-bundle heaps right away. A plain
+                // collect only schedules a delayed purge, and with
+                // back-to-back `Bun.build()` calls that deadline is rarely
+                // honored — RSS then grows by one bundle graph per build.
+                bun_alloc::mimalloc::mi_collect(true);
                 has_bundled = false;
             }
 

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -1400,13 +1400,13 @@ impl Event {
                 ) {
                     Ok(_) => return,
                     Err(cur) => {
-                        if return_on_broadcast && cur != Self::NOTIFIED && cur != Self::SHUTDOWN {
-                            // A sibling consumed the token between our reload
-                            // and this CAS — the same "broadcast loser" case as
-                            // the post-futex check below, which this thread
-                            // skipped because it still saw NOTIFIED there.
-                            // Without returning here it would fall back into
-                            // the futex with nothing left to wake it.
+                        // A sibling consuming the token between our reload and
+                        // this CAS is the same "broadcast loser" case as the
+                        // post-futex check below, which this thread skipped
+                        // because it still saw NOTIFIED there. Without
+                        // returning here it would fall back into the futex
+                        // with nothing left to wake it.
+                        if return_on_broadcast && self.broadcast_loser_may_return(cur) {
                             return;
                         }
                         state = cur;
@@ -1453,21 +1453,49 @@ impl Event {
             }
             state = self.state.load(Ordering::Relaxed);
             acquire_with = Self::WAITING;
-            if return_on_broadcast
-                && !timed_out
-                && state != Self::NOTIFIED
-                && state != Self::SHUTDOWN
-            {
-                // Woken, but a sibling consumed the token (broadcast wake).
-                // Return so the caller drains its idle queue and re-enters.
-                // A still-pending NOTIFIED must instead fall through to the
-                // consume branch above: its NOTIFIED -> WAITING hand-off is
-                // what keeps `wake()`'s prev == WAITING futex-wake fast path
-                // armed for the next single notify(), so returning here with
-                // the token unconsumed would strand the other parked threads.
+            // Woken, but a sibling consumed the token (broadcast wake):
+            // return so the caller drains its idle queue and re-enters. A
+            // still-pending NOTIFIED must instead fall through to the consume
+            // branch above — its NOTIFIED -> WAITING hand-off is what keeps
+            // `wake()`'s prev == WAITING futex-wake fast path armed for the
+            // next single notify(), so returning here with the token
+            // unconsumed would strand the other parked threads.
+            if return_on_broadcast && !timed_out && self.broadcast_loser_may_return(state) {
                 return;
             }
         }
+    }
+
+    /// Whether a woken `wait_broadcastable` thread that did not consume the
+    /// token may return to its caller instead of looping. True only when the
+    /// token is gone *and* `state` is WAITING again, so the next
+    /// `wake(NOTIFIED, 1)` still futex-wakes any threads left parked (its
+    /// fast path fires only when the previous state was WAITING).
+    fn broadcast_loser_may_return(&self, observed: u32) -> bool {
+        if observed == Self::WAITING {
+            // The consumer was a previously-parked thread; it already
+            // restored WAITING via its `acquire_with`.
+            return true;
+        }
+        if observed == Self::EMPTY {
+            // The consumer was a fresh entrant (first-iteration
+            // `acquire_with == EMPTY`). Restore WAITING on its behalf — the
+            // pre-return loop iteration used to do this before re-parking —
+            // so the wake chain stays armed for the threads still parked. On
+            // CAS failure the state changed under us; let the main loop
+            // re-dispatch on a fresh reload.
+            return self
+                .state
+                .compare_exchange(
+                    Self::EMPTY,
+                    Self::WAITING,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                )
+                .is_ok();
+        }
+        // NOTIFIED or SHUTDOWN: the main loop consumes / exits.
+        false
     }
 
     /// Post a notification to the event if it doesn't have one already

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -1399,7 +1399,18 @@ impl Event {
                     Ordering::Relaxed,
                 ) {
                     Ok(_) => return,
-                    Err(cur) => state = cur,
+                    Err(cur) => {
+                        if return_on_broadcast && cur != Self::NOTIFIED && cur != Self::SHUTDOWN {
+                            // A sibling consumed the token between our reload
+                            // and this CAS — the same "broadcast loser" case as
+                            // the post-futex check below, which this thread
+                            // skipped because it still saw NOTIFIED there.
+                            // Without returning here it would fall back into
+                            // the futex with nothing left to wake it.
+                            return;
+                        }
+                        state = cur;
+                    }
                 }
                 continue;
             }

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -1358,7 +1358,6 @@ impl Event {
 
     /// Wait for and consume a notification
     /// or wait for the event to be shutdown entirely
-    #[inline(never)]
     fn wait(&self) {
         self.wait_inner(false);
     }
@@ -1435,18 +1434,28 @@ impl Event {
             } else {
                 None
             };
-            if Futex::wait(&self.state, Self::WAITING, timeout_ns).is_err() {
+            let timed_out = Futex::wait(&self.state, Self::WAITING, timeout_ns).is_err();
+            if timed_out {
                 has_shrunk_memory = true;
                 bun_core::Global::mimalloc_cleanup(false);
                 bun_alloc::wtf::release_fast_malloc_free_memory_for_this_thread();
-            } else if return_on_broadcast {
-                // Woken by a wake(); if the notification is still pending the
-                // re-entered wait() consumes it immediately, so returning here
-                // never loses a wakeup.
-                return;
             }
             state = self.state.load(Ordering::Relaxed);
             acquire_with = Self::WAITING;
+            if return_on_broadcast
+                && !timed_out
+                && state != Self::NOTIFIED
+                && state != Self::SHUTDOWN
+            {
+                // Woken, but a sibling consumed the token (broadcast wake).
+                // Return so the caller drains its idle queue and re-enters.
+                // A still-pending NOTIFIED must instead fall through to the
+                // consume branch above: its NOTIFIED -> WAITING hand-off is
+                // what keeps `wake()`'s prev == WAITING futex-wake fast path
+                // armed for the next single notify(), so returning here with
+                // the token unconsumed would strand the other parked threads.
+                return;
+            }
         }
     }
 

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -901,7 +901,7 @@ impl ThreadPool {
                 if stats_enabled() {
                     self.stats.sleeps.fetch_add(1, Ordering::Relaxed);
                 }
-                self.idle_event.wait();
+                self.idle_event.wait_broadcastable();
                 sync = self.sync.load(Ordering::Relaxed);
             }
         }
@@ -1360,6 +1360,24 @@ impl Event {
     /// or wait for the event to be shutdown entirely
     #[inline(never)]
     fn wait(&self) {
+        self.wait_inner(false);
+    }
+
+    /// Like [`Self::wait`], but also returns when this thread is woken while
+    /// another thread consumed the notification — the case for every thread
+    /// but one after a broadcast (`wake(NOTIFIED, u32::MAX)`,
+    /// i.e. `wake_for_idle_events`). Plain `wait()` puts those threads back
+    /// to sleep inside the futex loop without ever returning, so the
+    /// per-thread idle tasks queued before the broadcast (the bundler's
+    /// `Worker::deinit`) would not run until the next real task wakes them.
+    /// A spurious return is safe for the caller: it re-checks its queues,
+    /// drains idle events, and re-enters.
+    fn wait_broadcastable(&self) {
+        self.wait_inner(true);
+    }
+
+    #[inline(never)]
+    fn wait_inner(&self, return_on_broadcast: bool) {
         let mut acquire_with: u32 = Self::EMPTY;
         let mut state = self.state.load(Ordering::Relaxed);
         let mut has_shrunk_memory: bool = false;
@@ -1421,6 +1439,11 @@ impl Event {
                 has_shrunk_memory = true;
                 bun_core::Global::mimalloc_cleanup(false);
                 bun_alloc::wtf::release_fast_malloc_free_memory_for_this_thread();
+            } else if return_on_broadcast {
+                // Woken by a wake(); if the notification is still pending the
+                // re-entered wait() consumes it immediately, so returning here
+                // never loses a wakeup.
+                return;
             }
             state = self.state.load(Ordering::Relaxed);
             acquire_with = Self::WAITING;

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -1481,18 +1481,19 @@ impl Event {
             // The consumer was a fresh entrant (first-iteration
             // `acquire_with == EMPTY`). Restore WAITING on its behalf — the
             // pre-return loop iteration used to do this before re-parking —
-            // so the wake chain stays armed for the threads still parked. On
-            // CAS failure the state changed under us; let the main loop
-            // re-dispatch on a fresh reload.
-            return self
-                .state
-                .compare_exchange(
+            // so the wake chain stays armed for the threads still parked.
+            // Err(WAITING) means a sibling loser restored it first, which
+            // satisfies the same postcondition. Err(NOTIFIED)/Err(SHUTDOWN)
+            // defer to the main loop, which consumes / exits.
+            return matches!(
+                self.state.compare_exchange(
                     Self::EMPTY,
                     Self::WAITING,
                     Ordering::Relaxed,
                     Ordering::Relaxed,
-                )
-                .is_ok();
+                ),
+                Ok(_) | Err(Self::WAITING)
+            );
         }
         // NOTIFIED or SHUTDOWN: the main loop consumes / exits.
         false

--- a/test/bundler/bun-build-memory.test.ts
+++ b/test/bundler/bun-build-memory.test.ts
@@ -67,12 +67,16 @@ test.skipIf(!isDebug && !isASAN)(
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(exitCode).toBe(0);
+    // stderr is not asserted empty (debug/ASAN builds emit benign warnings);
+    // surface it when the fixture did not reach its final print.
+    if (exitCode !== 0 || !stdout.trim()) {
+      throw new Error(`fixture failed (exit ${exitCode}):\n${stderr}`);
+    }
     const { growth } = JSON.parse(stdout.trim());
     // Observed (2 warmup + 8 measured builds, settled, quarantine_size_mb=1):
     // ~8-10MB with the forced purge, ~30-34MB without it.
     expect(growth).toBeLessThan(20 * 1024 * 1024);
+    expect(exitCode).toBe(0);
   },
   120_000,
 );

--- a/test/bundler/bun-build-memory.test.ts
+++ b/test/bundler/bun-build-memory.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isDebug, tempDirWithFiles } from "harness";
+import { join } from "path";
+
+// https://github.com/oven-sh/bun/issues/34053
+// Every in-process Bun.build() stranded the bundle's native memory: the
+// per-build mi_heaps were destroyed, but their freed arena slices were only
+// scheduled for a delayed purge that back-to-back builds never let run, so
+// RSS grew by roughly one module graph per build while heapUsed stayed flat.
+// Gated to debug/ASAN like the sourcemap-leak test in bun-build-api.test.ts
+// because release mimalloc page retention makes RSS too noisy to threshold.
+// In its own file (not bun-build-api.test.ts) so the RSS measurement does not
+// share a process-wide allocator with hundreds of unrelated builds.
+test.skipIf(!isDebug && !isASAN)(
+  "Bun.build does not strand native memory across sequential builds",
+  async () => {
+    const dir = tempDirWithFiles("bun-build-rss-leak", {
+      "run.ts": `
+        import { mkdirSync, writeFileSync } from "fs";
+        import { join } from "path";
+
+        const root = process.argv[2];
+        const src = join(root, "src");
+        mkdirSync(src, { recursive: true });
+        const MODULES = 400;
+        for (let i = 0; i < MODULES; i++) {
+          let body = \`export const v\${i} = (x: number): number => {\\n\`;
+          for (let k = 0; k < 20; k++) body += \`  x = (x + \${k}) * 1.0001;\\n\`;
+          body += \`  return x + \${i};\\n};\\n\`;
+          writeFileSync(join(src, \`m\${i}.ts\`), body);
+        }
+        let entry = "";
+        for (let i = 0; i < MODULES; i++) entry += \`import { v\${i} } from "./m\${i}";\\n\`;
+        entry += \`export const all = [\${Array.from({ length: MODULES }, (_, i) => \`v\${i}\`).join(",")}];\\n\`;
+        writeFileSync(join(src, "entry.ts"), entry);
+
+        async function build() {
+          const res = await Bun.build({
+            entrypoints: [join(src, "entry.ts")],
+            outdir: join(root, "out"),
+            target: "browser",
+          });
+          if (!res.success) throw new AggregateError(res.logs, "build failed");
+        }
+        async function settle() {
+          for (let i = 0; i < 4; i++) { Bun.gc(true); await Bun.sleep(10); }
+        }
+        for (let i = 0; i < 2; i++) await build();
+        await settle();
+        const before = process.memoryUsage.rss();
+        for (let i = 0; i < 8; i++) await build();
+        await settle();
+        const after = process.memoryUsage.rss();
+        console.log(JSON.stringify({ before, after, growth: after - before }));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--smol", join(dir, "run.ts"), join(dir, "work")],
+      env: {
+        ...bunEnv,
+        // ASAN's freed-memory quarantine retains ~4MB per measured build,
+        // which would drown the ~4MB/build mimalloc signal this test guards.
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=1"].filter(Boolean).join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    const { growth } = JSON.parse(stdout.trim());
+    // Observed (2 warmup + 8 measured builds, settled, quarantine_size_mb=1):
+    // ~8-10MB with the forced purge, ~30-34MB without it.
+    expect(growth).toBeLessThan(20 * 1024 * 1024);
+  },
+  120_000,
+);

--- a/test/bundler/bun-build-memory.test.ts
+++ b/test/bundler/bun-build-memory.test.ts
@@ -22,7 +22,7 @@ test.skipIf(!isDebug && !isASAN)(
         const root = process.argv[2];
         const src = join(root, "src");
         mkdirSync(src, { recursive: true });
-        const MODULES = 400;
+        const MODULES = 800;
         for (let i = 0; i < MODULES; i++) {
           let body = \`export const v\${i} = (x: number): number => {\\n\`;
           for (let k = 0; k < 20; k++) body += \`  x = (x + \${k}) * 1.0001;\\n\`;
@@ -74,8 +74,8 @@ test.skipIf(!isDebug && !isASAN)(
     }
     const { growth } = JSON.parse(stdout.trim());
     // Observed (2 warmup + 8 measured builds, settled, quarantine_size_mb=1):
-    // ~8-10MB with the forced purge, ~30-34MB without it.
-    expect(growth).toBeLessThan(20 * 1024 * 1024);
+    // ~11-14MB with the forced purge, ~34-37MB without it.
+    expect(growth).toBeLessThan(22 * 1024 * 1024);
     expect(exitCode).toBe(0);
   },
   120_000,


### PR DESCRIPTION
Fixes #34053

### What does this PR do?

Fixes the per-call native memory growth of in-process `Bun.build()`: RSS grew by roughly one module graph per build while the JS heap stayed flat, killing long-lived watch/dev processes.

Repro from the issue (N generated modules, sequential `Bun.build()` calls, `Bun.gc(true)` + `process.memoryUsage()` after each):

```
bun leak.ts 800 12     # release 1.4.0, linux x64
build  1  rss=   80.1MB  heapUsed=1.1MB  Δrss=   0.0MB
build 12  rss=  161.9MB  heapUsed=1.2MB  Δrss= +81.8MB   (still climbing)
```

`/proc/self/smaps` attribution shows the entire growth is in `[anon:mimalloc]` mappings; LSAN reports only ~5KB of unreachable allocations, so nothing is leaked in the malloc sense: the memory is freed but never returned to the OS.

Two compounding problems on the in-process path (the CLI is unaffected because the process exits):

1. The per-build mi_heaps (graph heap, worker AST heaps) are destroyed after each build, but mimalloc only *schedules* a purge of the freed arena slices (default `purge_delay` 1000ms). With back-to-back builds that deadline is effectively never honored at a moment where purging can run, so freed slices stay committed. The bundle thread's existing `mi_collect(false)` after a batch does not help: a non-forced collect skips purging until the deadline expires. Adding an idle sleep between builds makes RSS plateau, confirming the purge machinery itself works; it is just starved.
2. `ThreadPool::wake_for_idle_events()` posts a single notification token (`Event::wake(NOTIFIED, u32::MAX)`). All sleeping workers wake from the futex, but only the one that wins the CAS returns from `Event::wait` and drains its idle queue; the rest go straight back to sleep. The bundler queues each worker's `deinit_task` (which frees that worker's AST heaps) as an idle task and then calls `wake_for_idle_events()`, so one build's worth of worker heaps was always torn down one build late (observed via the `Worker.deinit()` debug log: a constant deficit of N-1 workers).

The fix:

- `BundleThread`: collect with `force = true` after a bundle batch. A forced collect purges (decommits) all freed arena slices immediately, returning the completed build's memory to the OS before the thread goes back to sleep.
- `ThreadPool`: give the idle-event wait broadcast semantics (`wait_broadcastable`). A woken worker returns when a sibling consumed the broadcast token, re-checks its queues, drains idle events, and re-enters the wait. A still-pending token falls through to the normal consume branch so the NOTIFIED -> WAITING hand-off that re-arms `wake()`'s futex-wake fast path is preserved (keeping the single-notify wake chain intact), and the single-waiter `join_event` paths keep the strict `wait()` semantics.

### How did you verify your code works?

Issue-scale repro (1500 modules, 15 builds, debug build, `quarantine_size_mb=1` to exclude ASAN quarantine noise):

| | Δrss after 15 builds |
|---|---|
| before | +107MB (release), still climbing |
| after | +10.7MB, plateaus by build 10 |

Worker teardown promptness (`BUN_DEBUG_ThreadPool=1`, counting `Worker.create()` vs `Worker.deinit()`): before, deinits lagged a constant one build behind creates; after, they balance within each build.

New test `test/bundler/bun-build-memory.test.ts` (debug/ASAN-gated like the sourcemap-leak test in `bun-build-api.test.ts`): 2 warmup + 8 measured builds of an 800-module graph, asserts settled RSS growth < 22MB. Observed ~34-37MB without the fix and ~11-14MB with it (3 runs each, same fixture on a main build vs this branch). It fails on the unfixed build and passes with the fix, verified locally both ways. It lives in its own file so the measurement does not share a process with the 400-build stress test in `bun-build-api.test.ts`.

The forced purge does not slow builds down: per-build time for a 500-module minify+sourcemap bundle is unchanged with the purge on vs off (within 1%), measured in a debug build.

`bun bd test test/bundler/bun-build-api.test.ts` passes (48/48 plus a pre-existing environment-dependent 180s stress-test timeout on slow runners, unaffected by this diff).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bun-build-memory.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ced511457)

test/bundler/bun-build-memory.test.ts:
73 |       throw new Error(`fixture failed (exit ${exitCode}):\n${stderr}`);
74 |     }
75 |     const { growth } = JSON.parse(stdout.trim());
76 |     // Observed (2 warmup + 8 measured builds, settled, quarantine_size_mb=1):
77 |     // ~11-14MB with the forced purge, ~34-37MB without it.
78 |     expect(growth).toBeLessThan(22 * 1024 * 1024);
                        ^
error: expect(received).toBeLessThan(expected)

Expected: < 23068672
Received: 34766848

      at <anonymous> (/workspace/bun/test/bundler/bun-build-memory.test.ts:78:20)
(fail) Bun.build does not strand native memory across sequential builds [6986.40ms]

 0 pass
 1 fail
 1 expect() calls
Ran 1 test across 1 fil
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (959e697c7)

test/bundler/bun-build-memory.test.ts:
(skip) Bun.build does not strand native memory across sequential builds

 0 pass
 1 skip
 0 fail
Ran 1 test across 1 file. [150.00ms]
__F:0:S:1
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bun-build-memory.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ced511457)

test/bundler/bun-build-memory.test.ts:
(pass) Bun.build does not strand native memory across sequential builds [6714.42ms]

 1 pass
 0 fail
 2 expect() calls
Ran 1 test across 1 file. [8.72s]
__F:0:S:0

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 659ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/BundleThread.rs           |  7 ++-
 src/threading/ThreadPool.rs           | 80 ++++++++++++++++++++++++++++++++--
 test/bundler/bun-build-memory.test.ts | 82 +++++++++++++++++++++++++++++++++++
 3 files changed, 164 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/bundler/BundleThread.rs                2      1      0
src/threading/ThreadPool.rs                8      9      0
test/bundler/bun-build-memory.test.ts      1      4      0
```

</details>

**root cause** · written by the author bot

The bug was that worker threads in the bundler's thread pool could be woken by a broadcast, lose the race to consume the wake token, and then either exit or re-park through paths that left the futex state machine disarmed or skipped draining their idle queues. Because each worker's per-build deinit ran as an idle task, a worker that re-parked without draining kept its per-build AST and bundler allocations alive across builds, so native memory accumulated on every Bun.build() call while the JS heap stayed flat. The fix ensures every broadcast wake exit path restores the WAITING state before …

<!-- robobun:evidence:end -->