### PR TITLE
test(install): cover nested aliases across linkers

### DIFF
--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -3221,82 +3221,100 @@ describe.concurrent("bun-install", () => {
   });
 
   // https://github.com/oven-sh/bun/issues/33834
-  it("should resolve nested npm: alias to its registry target, not a same-named alias", async () => {
-    await withContext(defaultOpts, async ctx => {
-      // root aliases "baz" -> bar@0.0.2, and bar depends on "baz-old": "npm:baz@>=0.0.1".
-      // The nested alias must resolve to the real registry package baz, not back to bar.
-      const urls: string[] = [];
-      const manifests: Record<string, Record<string, object>> = {
-        bar: { "0.0.2": { dependencies: { "baz-old": "npm:baz@>=0.0.1" } } },
-        baz: { "0.0.3": { bin: { "baz-run": "index.js" } } },
-      };
-      setContextHandler(ctx, async request => {
-        urls.push(request.url);
-        const path = new URL(request.url).pathname.replace(`/${ctx.id}/`, "").replaceAll("%2f", "/");
-        if (path.endsWith(".tgz")) {
-          return new Response(file(join(import.meta.dir, path)));
-        }
-        const versions: Record<string, object> = {};
-        let latest = "";
-        for (const [version, fields] of Object.entries(manifests[path] ?? {})) {
-          versions[version] = {
-            name: path,
-            version,
-            dist: { tarball: `${ctx.registry_url}${path}-${version}.tgz` },
-            ...fields,
-          };
-          latest = version;
-        }
-        return new Response(JSON.stringify({ name: path, versions, "dist-tags": { latest } }));
-      });
-      await writeFile(
-        join(ctx.package_dir, "package.json"),
-        JSON.stringify({
-          name: "foo",
-          version: "0.0.1",
-          dependencies: {
-            baz: "npm:bar@0.0.2",
+  describe.each(["hoisted", "isolated"] as const)("with %s linker", linker => {
+    it("should resolve nested npm: alias to its registry target, not a same-named alias", async () => {
+      await withContext({ linker }, async ctx => {
+        // root aliases "baz" -> bar@0.0.2, and bar depends on "baz-old": "npm:baz@>=0.0.1".
+        // The nested alias must resolve to the real registry package baz, not back to bar.
+        const urls: string[] = [];
+        const manifests: Record<string, Record<string, object>> = {
+          bar: { "0.0.2": { dependencies: { "baz-old": "npm:baz@>=0.0.1" } } },
+          baz: { "0.0.3": { bin: { "baz-run": "index.js" } } },
+        };
+        setContextHandler(ctx, async request => {
+          urls.push(request.url);
+          const path = new URL(request.url).pathname.replace(`/${ctx.id}/`, "").replaceAll("%2f", "/");
+          if (path.endsWith(".tgz")) {
+            return new Response(file(join(import.meta.dir, path)));
+          }
+          const versions: Record<string, object> = {};
+          let latest = "";
+          for (const [version, fields] of Object.entries(manifests[path] ?? {})) {
+            versions[version] = {
+              name: path,
+              version,
+              dist: { tarball: `${ctx.registry_url}${path}-${version}.tgz` },
+              ...fields,
+            };
+            latest = version;
+          }
+          return new Response(JSON.stringify({ name: path, versions, "dist-tags": { latest } }));
+        });
+        await writeFile(
+          join(ctx.package_dir, "package.json"),
+          JSON.stringify({
+            name: "foo",
+            version: "0.0.1",
+            dependencies: {
+              baz: "npm:bar@0.0.2",
+            },
+          }),
+        );
+        const install = async (args: string[]) => {
+          const { stdout, stderr, exited } = spawn({
+            cmd: [bunExe(), "install", ...args],
+            cwd: ctx.package_dir,
+            stdout: "pipe",
+            stdin: "pipe",
+            stderr: "pipe",
+            env,
+          });
+          const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+          expect(exitCode).toBe(0);
+          expect(out).toContain(`${linker === "hoisted" ? 2 : 4} packages installed`);
+          return err;
+        };
+
+        expect(await install([])).toContain("Saved lockfile");
+        expect(urls.sort()).toEqual([
+          `${ctx.registry_url}bar`,
+          `${ctx.registry_url}bar-0.0.2.tgz`,
+          `${ctx.registry_url}baz`,
+          `${ctx.registry_url}baz-0.0.3.tgz`,
+        ]);
+        const bazOldDir =
+          linker === "hoisted"
+            ? join(ctx.package_dir, "node_modules", "baz-old")
+            : join(ctx.package_dir, "node_modules", ".bun", "baz@0.0.3", "node_modules", "baz");
+        expect(await file(join(ctx.package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
+          name: "bar",
+          version: "0.0.2",
+        });
+        expect(await file(join(bazOldDir, "package.json")).json()).toEqual({
+          name: "baz",
+          version: "0.0.3",
+          bin: {
+            "baz-run": "index.js",
           },
-        }),
-      );
-      const { stdout, stderr, exited } = spawn({
-        cmd: [bunExe(), "install"],
-        cwd: ctx.package_dir,
-        stdout: "pipe",
-        stdin: "pipe",
-        stderr: "pipe",
-        env,
+        });
+        const lockfile = join(ctx.package_dir, "bun.lockb");
+        const lockfileBefore = await file(lockfile).bytes();
+        await rm(join(ctx.package_dir, "node_modules"), { force: true, recursive: true });
+        expect(await install(["--frozen-lockfile"])).not.toContain("Saved lockfile");
+        expect(await file(lockfile).bytes()).toEqual(lockfileBefore);
+        expect(await file(join(ctx.package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
+          name: "bar",
+          version: "0.0.2",
+        });
+        expect(await file(join(bazOldDir, "package.json")).json()).toEqual({
+          name: "baz",
+          version: "0.0.3",
+          bin: {
+            "baz-run": "index.js",
+          },
+        });
+        await access(lockfile);
       });
-      const err = await stderr.text();
-      expect(err).toContain("Saved lockfile");
-      const out = await stdout.text();
-      expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
-        expect.stringContaining("bun install v1."),
-        "",
-        expect.stringContaining("+ baz@0.0.2"),
-        "",
-        "2 packages installed",
-      ]);
-      expect(await exited).toBe(0);
-      expect(urls.sort()).toEqual([
-        `${ctx.registry_url}bar`,
-        `${ctx.registry_url}bar-0.0.2.tgz`,
-        `${ctx.registry_url}baz`,
-        `${ctx.registry_url}baz-0.0.3.tgz`,
-      ]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".bin", ".cache", "baz", "baz-old"]);
-      expect(await file(join(ctx.package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
-        name: "bar",
-        version: "0.0.2",
-      });
-      expect(await file(join(ctx.package_dir, "node_modules", "baz-old", "package.json")).json()).toEqual({
-        name: "baz",
-        version: "0.0.3",
-        bin: {
-          "baz-run": "index.js",
-        },
-      });
-      await access(join(ctx.package_dir, "bun.lockb"));
     });
   });
 


### PR DESCRIPTION
## Summary

Extends the regression coverage added in #33835 without changing production code.

- runs the nested `npm:` alias case with both hoisted and isolated linkers
- removes `node_modules` and reinstalls with `--frozen-lockfile`
- verifies the lockfile bytes remain unchanged and both aliases still resolve to the intended packages

## Verification

- Bun 1.3.14: both linker cases fail before the fix (expected regression proof)
- PR artifact `7ca9abf00`: both linker cases pass
- focused matrix repeated 5 times: 10/10 passed
- complete `test/cli/install/bun-install.test.ts`: 192 passed, 1 skipped, 2 todo
- Prettier check and `git diff --check`: passed

This PR targets the existing #33835 head branch so it can be incorporated without creating a competing fix against `main`.