### PR TITLE
fix(completions): don't execute history array in zsh add completion

### DIFF
--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -991,7 +991,7 @@ _set_remove() {
 _bun_add_param_package_completion() {
 
     IFS=$'\n' inexact=($(history -n bun | grep -E "^bun add " | cut -c 9- | uniq))
-    IFS=$'\n' exact=($($inexact | grep -E "^$words[$CURRENT]"))
+    IFS=$'\n' exact=($(print -l $inexact | grep -E "^$words[$CURRENT]"))
     IFS=$'\n' packages=($(SHELL=zsh bun getcompletes a $words[$CURRENT]))
 
     to_print=$inexact


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in `_bun_add_param_package_completion` (zsh completions)
where the `$inexact` array was expanded unquoted in command position,
causing zsh to try to *execute* past `bun add` history entries instead
of filtering them with grep. This throws a spurious error like:

  _bun_add_param_package_completion:3: no such file or directory: -g @fsouza/prettierd

any time your `bun add` history contains a line with flags after the
command (e.g. `bun add -g @fsouza/prettierd`) and you tab-complete
`bun add `.

Replaces `$($inexact | grep ...)` with `$(print -l $inexact | grep ...)`
so the array's contents are printed and piped into grep as originally
intended, instead of being run as a command.

### How did you verify your code works?

1. Ran `bun add -g @fsouza/prettierd` so it lands in zsh history.
2. Opened a new zsh session and typed `bun add ` + Tab.
3. Before fix: completion prints
   `_bun_add_param_package_completion:3: no such file or directory: -g @fsouza/prettierd`
   before showing suggestions.
4. After fix: no error; suggestions from history/registry still show,
   and typing a partial package name still filters them correctly
   (confirms `$words[$CURRENT]` filtering logic is unaffected).