### PR TITLE
fix(completions): pipe history array into grep instead of executing it

### DIFF
--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -991,7 +991,7 @@ _set_remove() {
 _bun_add_param_package_completion() {
 
     IFS=$'\n' inexact=($(history -n bun | grep -E "^bun add " | cut -c 9- | uniq))
-    IFS=$'\n' exact=($($inexact | grep -E "^$words[$CURRENT]"))
+    IFS=$'\n' exact=($(print -l -- $inexact | grep -E "^$words[$CURRENT]"))
     IFS=$'\n' packages=($(SHELL=zsh bun getcompletes a $words[$CURRENT]))
 
     to_print=$inexact


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in `_bun_add_param_package_completion` (zsh completions)
where the `$inexact` array was expanded unquoted in command position,
causing zsh to try to *execute* past `bun add` history entries instead
of filtering them with grep. This throws a spurious error like:

 ` _bun_add_param_package_completion:3: no such file or directory: -g @fsouza/prettierd`

any time your `bun add` history contains a line with flags after the
command (e.g. `bun add -g @fsouza/prettierd`) and you tab-complete
`bun add `.

Replaces `$($inexact | grep ...)` with `$(print -l -- $inexact | grep ...)`:
- `print -l` prints each array element on its own line, so the array's
  contents are piped into grep as originally intended, instead of
  being run as a command.
- The `--` stops `print` from parsing its own arguments as options,
  which matters because entries can themselves start with a dash
  (e.g. `-g @fsouza/prettierd`, `--global foo`) — without `--`, those
  entries would be silently swallowed as flags to `print` rather than
  printed as data.

### How did you verify your code works?

https://github.com/user-attachments/assets/2a39ff74-c7ab-446c-a030-8d745cd75750

