### PR TITLE
node:vm: block sloppy [[Set]] on read-only contextified globals

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1086,6 +1086,19 @@ bool NodeVMGlobalObject::put(JSCell* cell, JSGlobalObject* globalObject, Propert
     }
     bool isDeclaredOnGlobalObject = slot.type() == JSC::PutPropertySlot::NewProperty;
     auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // If the property already exists on the global object as read-only, do not
+    // forward the store to the sandbox. Matches Node's contextify
+    // PropertySetterCallback, which intercepts and returns early on ReadOnly.
+    {
+        PropertySlot existingSlot(thisObject, PropertySlot::InternalMethodType::GetOwnProperty, nullptr);
+        bool existsOnGlobal = thisObject->JSC::JSGlobalObject::getOwnPropertySlot(thisObject, globalObject, propertyName, existingSlot);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (existsOnGlobal && (existingSlot.attributes() & PropertyAttribute::ReadOnly) != 0) {
+            RELEASE_AND_RETURN(scope, Base::put(cell, globalObject, propertyName, value, slot));
+        }
+    }
+
     PropertySlot getter(sandbox, PropertySlot::InternalMethodType::Get, nullptr);
     bool isDeclaredOnSandbox = sandbox->getPropertySlot(globalObject, propertyName, getter);
     RETURN_IF_EXCEPTION(scope, false);

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -420,6 +420,31 @@ function testRunInContext({ fn, isIsolated, isNew }: TestRunInContextArg) {
       expect(context.baz).toEqual([undefined, "b", "c"]);
       expect(result).toBe(true);
     });
+    test("sloppy assignment to read-only globals is a no-op", () => {
+      const context = createContext({});
+      for (const name of ["NaN", "undefined", "Infinity"]) {
+        const result = fn(
+          `(function () {` +
+            `globalThis[${JSON.stringify(name)}] = 123;` +
+            `var d = Object.getOwnPropertyDescriptor(globalThis, ${JSON.stringify(name)});` +
+            `return { value: String(globalThis[${JSON.stringify(name)}]), writable: d.writable, configurable: d.configurable };` +
+            `})()`,
+          context,
+        );
+        expect({ name, ...result }).toEqual({ name, value: name, writable: false, configurable: false });
+      }
+      expect(Object.keys(context)).toEqual([]);
+    });
+    test("strict assignment to read-only globals throws and does not mutate the sandbox", () => {
+      const context = createContext({});
+      const result = fn(
+        "(function(){'use strict'; try { globalThis.NaN = 5; return 'set'; } catch (e) { return e.constructor.name; } })()",
+        context,
+      );
+      expect(result).toBe("TypeError");
+      expect(fn("String(globalThis.NaN)", context)).toBe("NaN");
+      expect(Object.keys(context)).toEqual([]);
+    });
     test("cannot access `process`", () => {
       const context = createContext({});
       const result = fn("typeof process;", context);

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -432,8 +432,9 @@ function testRunInContext({ fn, isIsolated, isNew }: TestRunInContextArg) {
           context,
         );
         expect({ name, ...result }).toEqual({ name, value: name, writable: false, configurable: false });
+        expect(Object.prototype.hasOwnProperty.call(context, name)).toBe(false);
       }
-      expect(Object.keys(context)).toEqual([]);
+      expect(Object.getOwnPropertyNames(context)).toEqual([]);
     });
     test("strict assignment to read-only globals throws and does not mutate the sandbox", () => {
       const context = createContext({});
@@ -443,7 +444,8 @@ function testRunInContext({ fn, isIsolated, isNew }: TestRunInContextArg) {
       );
       expect(result).toBe("TypeError");
       expect(fn("String(globalThis.NaN)", context)).toBe("NaN");
-      expect(Object.keys(context)).toEqual([]);
+      expect(Object.prototype.hasOwnProperty.call(context, "NaN")).toBe(false);
+      expect(Object.getOwnPropertyNames(context)).toEqual([]);
     });
     test("cannot access `process`", () => {
       const context = createContext({});


### PR DESCRIPTION
## What

Inside a `node:vm` context, a plain sloppy-mode assignment could overwrite non-writable globals:

```js
import * as vm from "node:vm";
const ctx = vm.createContext({});
vm.runInContext("globalThis.NaN = 123; String(globalThis.NaN)", ctx);
// Bun before: "123"  (descriptor still reports writable:false)
// Node:       "NaN"  (silent sloppy-mode no-op)
```

The strict-mode path threw the expected `TypeError`, but only after the sandbox had already been mutated, so a subsequent read still saw the overwritten value.

## Why

`NodeVMGlobalObject::put` forwarded every store to the sandbox via `sandbox->methodTable()->put(...)` without first checking whether the property already exists on the global object as `ReadOnly`. The extensible sandbox happily acquired a fresh own `NaN` that then shadowed the non-writable global on the next `getOwnPropertySlot`.

`NodeVMGlobalObject::defineOwnProperty` already carries exactly this guard, and Node's contextify `PropertySetterCallback` intercepts and returns early when the global's own attributes include `ReadOnly`.

## Fix

Before touching the sandbox, look up the property on the global object itself (bypassing the sandbox interception via `JSC::JSGlobalObject::getOwnPropertySlot`). If it exists with `ReadOnly`, delegate to `Base::put`, which applies the ordinary sloppy-mode no-op / strict-mode `TypeError` semantics and leaves the sandbox untouched.

## Tests

Added to the shared `testRunInContext` harness so they run against `runInContext`, `runInNewContext`, `Script#runInContext`, and `Script#runInNewContext`:

- sloppy `globalThis.{NaN,undefined,Infinity} = 123` is a no-op; the descriptor stays `{writable:false, configurable:false}` and the sandbox gains no keys
- strict `globalThis.NaN = 5` throws `TypeError` and leaves both the global value and the sandbox unmodified

All 97 `test/js/node/test/parallel/test-vm-*.js` Node compat tests continue to pass.

Note: this overlaps textually with #33486, which also adds a `JSGlobalObject::getOwnPropertySlot` call in `put` for a different purpose (sandbox as store for guest-created globals). Whichever lands second will need a small rebase; the two guards are independent.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 failed, 68 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (20b8ba12b)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [21.54ms]
(pass) vm > runInContext() > can return a value [16.30ms]
(pass) vm > runInContext() > can return a complex value [15.47ms]
(pass) vm > runInContext() > can return the last value [16.08ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [16.54ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [14.19ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [15.80ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [15.76ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.49ms]
(pass) vm > runInContext() > new Int16
... (truncated)

release without fix: 68 skipped
bun test v1.4.0-canary.1 (7d0a0ac30)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [0.39ms]
(pass) vm > runInContext() > can return a value [0.23ms]
(pass) vm > runInContext() > can return a complex value [0.21ms]
(pass) vm > runInContext() > can return the last value [0.18ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [0.23ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [0.17ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [0.22ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [0.19ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [0.19ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [0.17ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [0.17ms]
(pass) vm > runInContext() > new Float32Array() in VM context doesn't crash [0.14ms]
(pass) vm > runInContext() > new Float64Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Big
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 68 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (20b8ba12b)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [22.28ms]
(pass) vm > runInContext() > can return a value [15.21ms]
(pass) vm > runInContext() > can return a complex value [15.66ms]
(pass) vm > runInContext() > can return the last value [15.49ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [16.71ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [14.20ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [16.28ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [15.72ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.84ms]
(pass) vm > runInContext() > new Int16
... (truncated)

release with fix: 68 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 712ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[2/6] gen cpp.rs (cppbind)
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 3m 35s
[3/6] link bun-profile
[4/6] bun-profile --re
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeVM.cpp | 13 +++++++++++++
 test/js/node/vm/vm.test.ts  | 27 +++++++++++++++++++++++++++
 2 files changed, 40 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                         reads  edits  tests
src/jsc/bindings/NodeVM.cpp      1      1      0
test/js/node/vm/vm.test.ts       3      4      0
```

</details>

<!-- robobun:evidence:end -->