### PR TITLE
node:vm: don't let a non-extensible sandbox block guest-side global creation

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1107,14 +1107,23 @@ bool NodeVMGlobalObject::put(JSCell* cell, JSGlobalObject* globalObject, Propert
         RELEASE_AND_RETURN(scope, specialSandbox->putInline(globalObject, propertyName, value, slot));
     }
 
-    slot.setThisValue(sandbox);
-
-    bool result = sandbox->methodTable()->put(sandbox, globalObject, propertyName, value, slot);
-    RETURN_IF_EXCEPTION(scope, false);
-    if (!result) return false;
+    // Node's PropertySetterCallback does a sloppy sandbox->Set() then returns
+    // Intercepted::kNo so V8 also stores on the inner global; a non-extensible
+    // sandbox therefore never blocks guest-side global creation.
+    bool result;
+    {
+        PutPropertySlot sandboxSlot(sandbox, false);
+        result = sandbox->methodTable()->put(sandbox, globalObject, propertyName, value, sandboxSlot);
+        RETURN_IF_EXCEPTION(scope, false);
+    }
 
     if (isDeclaredOnSandbox && getter.isAccessor() and (getter.attributes() & PropertyAttribute::DontEnum) == 0) {
         return true;
+    }
+
+    if (!result && isDeclaredOnSandbox) {
+        // Existing read-only property rejected the write; keep the strict-mode throw.
+        return typeError(globalObject, scope, slot.isStrictMode(), ReadonlyPropertyWriteError);
     }
 
     slot.setThisValue(thisValue);
@@ -1315,23 +1324,28 @@ bool NodeVMGlobalObject::defineOwnProperty(JSObject* cell, JSGlobalObject* globa
         RELEASE_AND_RETURN(scope, Base::defineOwnProperty(cell, globalObject, propertyName, descriptor, shouldThrow));
     }
 
-    // Dispatch through the method table so exotic sandboxes (e.g. Proxy objects)
-    // observe the [[DefineOwnProperty]] exactly once, like V8's contextify
-    // PropertyDefinerCallback.
+    // Node's PropertyDefinerCallback calls V8's Object::DefineProperty (kDontThrow)
+    // and returns Intercepted::kNo on failure, so the inner global still gets the
+    // define; mirror that with shouldThrow=false and a fall-through on refusal.
     if (descriptor.isAccessorDescriptor()) {
-        RELEASE_AND_RETURN(scope, contextifiedObject->methodTable()->defineOwnProperty(contextifiedObject, contextifiedObject->globalObject(), propertyName, descriptor, shouldThrow));
+        bool did = contextifiedObject->methodTable()->defineOwnProperty(contextifiedObject, contextifiedObject->globalObject(), propertyName, descriptor, false);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (did) return true;
+        RELEASE_AND_RETURN(scope, Base::defineOwnProperty(cell, globalObject, propertyName, descriptor, shouldThrow));
     }
 
     bool isDeclaredOnSandbox = contextifiedObject->getPropertySlot(globalObject, propertyName, slot);
     RETURN_IF_EXCEPTION(scope, false);
 
     if (isDeclaredOnSandbox && !isDeclaredOnGlobalProxy) {
-        RELEASE_AND_RETURN(scope, contextifiedObject->methodTable()->defineOwnProperty(contextifiedObject, contextifiedObject->globalObject(), propertyName, descriptor, shouldThrow));
+        bool did = contextifiedObject->methodTable()->defineOwnProperty(contextifiedObject, contextifiedObject->globalObject(), propertyName, descriptor, false);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (did) return true;
+        RELEASE_AND_RETURN(scope, Base::defineOwnProperty(cell, globalObject, propertyName, descriptor, shouldThrow));
     }
 
-    auto did = contextifiedObject->methodTable()->defineOwnProperty(contextifiedObject, contextifiedObject->globalObject(), propertyName, descriptor, shouldThrow);
+    contextifiedObject->methodTable()->defineOwnProperty(contextifiedObject, contextifiedObject->globalObject(), propertyName, descriptor, false);
     RETURN_IF_EXCEPTION(scope, false);
-    if (!did) return false;
 
     RELEASE_AND_RETURN(scope, Base::defineOwnProperty(cell, globalObject, propertyName, descriptor, shouldThrow));
 }

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1121,8 +1121,8 @@ bool NodeVMGlobalObject::put(JSCell* cell, JSGlobalObject* globalObject, Propert
         return true;
     }
 
-    if (!result && isDeclaredOnSandbox) {
-        // Existing read-only property rejected the write; keep the strict-mode throw.
+    if (!result && isDeclaredOnSandbox && (getter.attributes() & PropertyAttribute::ReadOnly)) {
+        // Existing read-only own property rejected the write; keep the strict-mode throw.
         return typeError(globalObject, scope, slot.isStrictMode(), ReadonlyPropertyWriteError);
     }
 

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1126,7 +1126,6 @@ bool NodeVMGlobalObject::put(JSCell* cell, JSGlobalObject* globalObject, Propert
         return typeError(globalObject, scope, slot.isStrictMode(), ReadonlyPropertyWriteError);
     }
 
-    slot.setThisValue(thisValue);
     RELEASE_AND_RETURN(scope, Base::put(cell, globalObject, propertyName, value, slot));
 }
 

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1121,7 +1121,7 @@ bool NodeVMGlobalObject::put(JSCell* cell, JSGlobalObject* globalObject, Propert
         return true;
     }
 
-    if (!result && isDeclaredOnSandbox && (getter.attributes() & PropertyAttribute::ReadOnly)) {
+    if (!result && isDeclaredOnSandbox && getter.slotBase() == sandbox && (getter.attributes() & PropertyAttribute::ReadOnly)) {
         // Existing read-only own property rejected the write; keep the strict-mode throw.
         return typeError(globalObject, scope, slot.isStrictMode(), ReadonlyPropertyWriteError);
     }

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1170,6 +1170,13 @@ describe("createContext with a non-extensible sandbox", () => {
     expect(runInContext("f0 = 99; f0", sandbox)).toBe(99);
     expect(sandbox.f0).toBe(99);
   });
+
+  test("frozen: writing a name inherited from Object.prototype does not throw in strict mode", () => {
+    const sandbox = Object.freeze({});
+    createContext(sandbox);
+    expect(runInContext("'use strict'; globalThis.toString = 5; typeof toString", sandbox)).toBe("function");
+    expect(runInContext("globalThis.hasOwnProperty = 1; typeof hasOwnProperty", sandbox)).toBe("function");
+  });
 });
 
 describe("node:vm SourceTextModule cyclic graph linking", () => {

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1121,38 +1121,36 @@ describe("createContext with a non-extensible sandbox", () => {
   // Node's contextify stores globals on a separate inner global and only
   // copies out to the sandbox via interceptors, so a frozen/sealed/non-extensible
   // sandbox never blocks guest-side var/function/property creation.
-  for (const [label, make] of [
+  test.each([
     ["frozen", () => Object.freeze({ f0: 1 })],
     ["sealed", () => Object.seal({ f0: 1 })],
     ["non-extensible", () => Object.preventExtensions({ f0: 1 })],
-  ] as const) {
-    test(`${label}: global creation inside the context works`, () => {
-      const sandbox = make();
-      createContext(sandbox);
+  ] as const)("%s: global creation inside the context works", (_label, make) => {
+    const sandbox = make();
+    createContext(sandbox);
 
-      expect(runInContext("globalThis.a1 = 2; typeof a1", sandbox)).toBe("number");
-      expect(runInContext("a1", sandbox)).toBe(2);
-      expect(runInContext("var v1 = 3; typeof v1", sandbox)).toBe("number");
-      expect(runInContext("v1", sandbox)).toBe(3);
-      expect(runInContext("function f1(){ return 7 }; typeof f1", sandbox)).toBe("function");
-      expect(runInContext("f1()", sandbox)).toBe(7);
-      expect(
-        runInContext("Object.defineProperty(globalThis,'d1',{value:4,configurable:true}); typeof d1", sandbox),
-      ).toBe("number");
-      expect(
-        runInContext("Object.defineProperty(globalThis,'ac1',{get(){return 42},configurable:true}); ac1", sandbox),
-      ).toBe(42);
-      expect(runInContext("'use strict'; globalThis.s1 = 5; typeof s1", sandbox)).toBe("number");
-      expect(runInContext("[Object.isFrozen(globalThis), Object.isExtensible(globalThis)]", sandbox)).toEqual([
-        false,
-        true,
-      ]);
+    expect(runInContext("globalThis.a1 = 2; typeof a1", sandbox)).toBe("number");
+    expect(runInContext("a1", sandbox)).toBe(2);
+    expect(runInContext("var v1 = 3; typeof v1", sandbox)).toBe("number");
+    expect(runInContext("v1", sandbox)).toBe(3);
+    expect(runInContext("function f1(){ return 7 }; typeof f1", sandbox)).toBe("function");
+    expect(runInContext("f1()", sandbox)).toBe(7);
+    expect(
+      runInContext("Object.defineProperty(globalThis,'d1',{value:4,configurable:true}); typeof d1", sandbox),
+    ).toBe("number");
+    expect(
+      runInContext("Object.defineProperty(globalThis,'ac1',{get(){return 42},configurable:true}); ac1", sandbox),
+    ).toBe(42);
+    expect(runInContext("'use strict'; globalThis.s1 = 5; typeof s1", sandbox)).toBe("number");
+    expect(runInContext("[Object.isFrozen(globalThis), Object.isExtensible(globalThis)]", sandbox)).toEqual([
+      false,
+      true,
+    ]);
 
-      // The sandbox is non-extensible, so nothing is copied out.
-      expect(Object.getOwnPropertyDescriptor(sandbox, "a1")).toBeUndefined();
-      expect(Object.getOwnPropertyDescriptor(sandbox, "v1")).toBeUndefined();
-    });
-  }
+    // The sandbox is non-extensible, so nothing is copied out.
+    expect(Object.getOwnPropertyDescriptor(sandbox, "a1")).toBeUndefined();
+    expect(Object.getOwnPropertyDescriptor(sandbox, "v1")).toBeUndefined();
+  });
 
   test("frozen: writing an existing read-only property is still rejected", () => {
     const sandbox = Object.freeze({ f0: 1 });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1175,7 +1175,17 @@ describe("createContext with a non-extensible sandbox", () => {
     const sandbox = Object.freeze({});
     createContext(sandbox);
     expect(runInContext("'use strict'; globalThis.toString = 5; typeof toString", sandbox)).toBe("function");
-    expect(runInContext("globalThis.hasOwnProperty = 1; typeof hasOwnProperty", sandbox)).toBe("function");
+    expect(runInContext("'use strict'; globalThis.hasOwnProperty = 1; typeof hasOwnProperty", sandbox)).toBe(
+      "function",
+    );
+  });
+
+  test("writing a read-only property inherited from the sandbox's prototype does not throw in strict mode", () => {
+    const proto = Object.defineProperty({}, "foo", { value: 1, writable: false, enumerable: true, configurable: true });
+    const sandbox = Object.create(proto);
+    createContext(sandbox);
+    expect(runInContext("'use strict'; globalThis.foo = 2; foo", sandbox)).toBe(1);
+    expect(Object.getOwnPropertyDescriptor(sandbox, "foo")).toBeUndefined();
   });
 });
 

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1117,6 +1117,71 @@ test("node:vm SourceTextModule.link() rejects holey and mismatched argument arra
   expect(exitCode).toBe(0);
 });
 
+describe("createContext with a non-extensible sandbox", () => {
+  // Node's contextify stores globals on a separate inner global and only
+  // copies out to the sandbox via interceptors, so a frozen/sealed/non-extensible
+  // sandbox never blocks guest-side var/function/property creation.
+  for (const [label, make] of [
+    ["frozen", () => Object.freeze({ f0: 1 })],
+    ["sealed", () => Object.seal({ f0: 1 })],
+    ["non-extensible", () => Object.preventExtensions({ f0: 1 })],
+  ] as const) {
+    test(`${label}: global creation inside the context works`, () => {
+      const sandbox = make();
+      createContext(sandbox);
+
+      expect(runInContext("globalThis.a1 = 2; typeof a1", sandbox)).toBe("number");
+      expect(runInContext("a1", sandbox)).toBe(2);
+      expect(runInContext("var v1 = 3; typeof v1", sandbox)).toBe("number");
+      expect(runInContext("v1", sandbox)).toBe(3);
+      expect(runInContext("function f1(){ return 7 }; typeof f1", sandbox)).toBe("function");
+      expect(runInContext("f1()", sandbox)).toBe(7);
+      expect(
+        runInContext(
+          "Object.defineProperty(globalThis,'d1',{value:4,configurable:true}); typeof d1",
+          sandbox,
+        ),
+      ).toBe("number");
+      expect(
+        runInContext(
+          "Object.defineProperty(globalThis,'ac1',{get(){return 42},configurable:true}); ac1",
+          sandbox,
+        ),
+      ).toBe(42);
+      expect(runInContext("'use strict'; globalThis.s1 = 5; typeof s1", sandbox)).toBe("number");
+      expect(
+        runInContext("[Object.isFrozen(globalThis), Object.isExtensible(globalThis)]", sandbox),
+      ).toEqual([false, true]);
+
+      // The sandbox is non-extensible, so nothing is copied out.
+      expect(Object.getOwnPropertyDescriptor(sandbox, "a1")).toBeUndefined();
+      expect(Object.getOwnPropertyDescriptor(sandbox, "v1")).toBeUndefined();
+    });
+  }
+
+  test("frozen: writing an existing read-only property is still rejected", () => {
+    const sandbox = Object.freeze({ f0: 1 });
+    createContext(sandbox);
+    expect(runInContext("f0 = 99; f0", sandbox)).toBe(1);
+    expect(
+      runInContext("'use strict'; try{f0 = 99; 'ok'}catch(e){e.constructor.name}", sandbox),
+    ).toBe("TypeError");
+    expect(
+      runInContext(
+        "try{Object.defineProperty(globalThis,'f0',{value:99}); 'ok'}catch(e){e.constructor.name}",
+        sandbox,
+      ),
+    ).toBe("TypeError");
+  });
+
+  test("sealed: writing an existing writable property still copies out to the sandbox", () => {
+    const sandbox = Object.seal({ f0: 1 });
+    createContext(sandbox);
+    expect(runInContext("f0 = 99; f0", sandbox)).toBe(99);
+    expect(sandbox.f0).toBe(99);
+  });
+});
+
 describe("node:vm SourceTextModule cyclic graph linking", () => {
   // Building a cyclic SourceTextModule graph and linking + evaluating each
   // module from inside the linker callback (instead of linking the whole graph

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1137,21 +1137,16 @@ describe("createContext with a non-extensible sandbox", () => {
       expect(runInContext("function f1(){ return 7 }; typeof f1", sandbox)).toBe("function");
       expect(runInContext("f1()", sandbox)).toBe(7);
       expect(
-        runInContext(
-          "Object.defineProperty(globalThis,'d1',{value:4,configurable:true}); typeof d1",
-          sandbox,
-        ),
+        runInContext("Object.defineProperty(globalThis,'d1',{value:4,configurable:true}); typeof d1", sandbox),
       ).toBe("number");
       expect(
-        runInContext(
-          "Object.defineProperty(globalThis,'ac1',{get(){return 42},configurable:true}); ac1",
-          sandbox,
-        ),
+        runInContext("Object.defineProperty(globalThis,'ac1',{get(){return 42},configurable:true}); ac1", sandbox),
       ).toBe(42);
       expect(runInContext("'use strict'; globalThis.s1 = 5; typeof s1", sandbox)).toBe("number");
-      expect(
-        runInContext("[Object.isFrozen(globalThis), Object.isExtensible(globalThis)]", sandbox),
-      ).toEqual([false, true]);
+      expect(runInContext("[Object.isFrozen(globalThis), Object.isExtensible(globalThis)]", sandbox)).toEqual([
+        false,
+        true,
+      ]);
 
       // The sandbox is non-extensible, so nothing is copied out.
       expect(Object.getOwnPropertyDescriptor(sandbox, "a1")).toBeUndefined();
@@ -1163,14 +1158,9 @@ describe("createContext with a non-extensible sandbox", () => {
     const sandbox = Object.freeze({ f0: 1 });
     createContext(sandbox);
     expect(runInContext("f0 = 99; f0", sandbox)).toBe(1);
+    expect(runInContext("'use strict'; try{f0 = 99; 'ok'}catch(e){e.constructor.name}", sandbox)).toBe("TypeError");
     expect(
-      runInContext("'use strict'; try{f0 = 99; 'ok'}catch(e){e.constructor.name}", sandbox),
-    ).toBe("TypeError");
-    expect(
-      runInContext(
-        "try{Object.defineProperty(globalThis,'f0',{value:99}); 'ok'}catch(e){e.constructor.name}",
-        sandbox,
-      ),
+      runInContext("try{Object.defineProperty(globalThis,'f0',{value:99}); 'ok'}catch(e){e.constructor.name}", sandbox),
     ).toBe("TypeError");
   });
 

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1141,6 +1141,18 @@ describe("createContext with a non-extensible sandbox", () => {
     expect(
       runInContext("Object.defineProperty(globalThis,'ac1',{get(){return 42},configurable:true}); ac1", sandbox),
     ).toBe(42);
+    expect(
+      runInContext(
+        "(d => [d.value, d.writable, d.enumerable, d.configurable])(Object.getOwnPropertyDescriptor(globalThis,'d1'))",
+        sandbox,
+      ),
+    ).toEqual([4, false, false, true]);
+    expect(
+      runInContext(
+        "(d => [typeof d.get, d.set, d.enumerable, d.configurable])(Object.getOwnPropertyDescriptor(globalThis,'ac1'))",
+        sandbox,
+      ),
+    ).toEqual(["function", undefined, false, true]);
     expect(runInContext("'use strict'; globalThis.s1 = 5; typeof s1", sandbox)).toBe("number");
     expect(runInContext("[Object.isFrozen(globalThis), Object.isExtensible(globalThis)]", sandbox)).toEqual([
       false,

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1135,9 +1135,9 @@ describe("createContext with a non-extensible sandbox", () => {
     expect(runInContext("v1", sandbox)).toBe(3);
     expect(runInContext("function f1(){ return 7 }; typeof f1", sandbox)).toBe("function");
     expect(runInContext("f1()", sandbox)).toBe(7);
-    expect(
-      runInContext("Object.defineProperty(globalThis,'d1',{value:4,configurable:true}); typeof d1", sandbox),
-    ).toBe("number");
+    expect(runInContext("Object.defineProperty(globalThis,'d1',{value:4,configurable:true}); typeof d1", sandbox)).toBe(
+      "number",
+    );
     expect(
       runInContext("Object.defineProperty(globalThis,'ac1',{get(){return 42},configurable:true}); ac1", sandbox),
     ).toBe(42);


### PR DESCRIPTION
## What

A frozen/sealed/non-extensible sandbox passed to `vm.createContext()` turned the context's inner global effectively non-extensible: sloppy assignments, `var`, and `function` declarations were silent no-ops, strict-mode assignments threw, and `Object.defineProperty(globalThis, ...)` threw `TypeError`. Meanwhile `Object.isExtensible(globalThis)` still reported `true`.

```js
import * as vm from "node:vm";
const box = Object.freeze({ f0: 1 });
vm.createContext(box);
vm.runInContext("globalThis.a = 2; typeof a", box);       // bun: "undefined"   node: "number"
vm.runInContext("var v = 3; typeof v", box);              // bun: "undefined"   node: "number"
vm.runInContext("function f(){}; typeof f", box);         // bun: "undefined"   node: "function"
vm.runInContext("Object.defineProperty(globalThis,'d',{value:1}); typeof d", box);
                                                          // bun: TypeError     node: "number"
```

This is a common hardening idiom: freeze the sandbox so the guest can't add host-visible globals. On Node the guest keeps working and the freeze only stops new globals being copied out.

## Cause

`NodeVMGlobalObject::put` forwarded the store to the sandbox with the caller's `PutPropertySlot` and returned `false` when that store failed, so the property was never created on the inner global. `defineOwnProperty` forwarded with `shouldThrow=true` and returned `false` on failure.

Node's contextify `PropertySetterCallback` / `PropertyDefinerCallback` call the sandbox with V8's `kDontThrow` and return `Intercepted::kNo` when the sandbox refuses, so V8 stores on the inner global regardless; the sandbox's `[[Extensible]]` is never part of the guest's global-creation policy.

## Fix

In `put`, call the sandbox with a fresh sloppy `PutPropertySlot` and, when it refuses a property that isn't already on the sandbox, fall through to `Base::put`. When the sandbox already owns the property (read-only data), keep surfacing the rejection so strict-mode writes still throw.

In `defineOwnProperty`, call the sandbox with `shouldThrow=false` and fall through to `Base::defineOwnProperty` when it refuses. `Base::defineOwnProperty` reads the current descriptor through the overridden `getOwnPropertySlot`, so redefining an existing frozen property still throws `TypeError`.

## Verification

New `describe("createContext with a non-extensible sandbox", ...)` in `test/js/node/vm/vm.test.ts` covers assignment / `var` / `function` / `defineProperty` (data and accessor) / strict-mode for frozen, sealed, and `preventExtensions` sandboxes, plus guards that existing read-only properties still reject and sealed-but-writable properties still copy out. All 97 `test/js/node/test/parallel/test-vm-*.js` compat tests continue to pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 6 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 failed, 68 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (4f0146691)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [21.44ms]
(pass) vm > runInContext() > can return a value [15.56ms]
(pass) vm > runInContext() > can return a complex value [15.98ms]
(pass) vm > runInContext() > can return the last value [15.70ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [16.71ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [13.94ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [15.78ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [15.65ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.99ms]
(pass) vm > runInContext() > new Int16
... (truncated)

release without fix: 68 skipped
bun test v1.4.0-canary.1 (7e1fdd177)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [4.01ms]
(pass) vm > runInContext() > can return a value [0.80ms]
(pass) vm > runInContext() > can return a complex value [0.24ms]
(pass) vm > runInContext() > can return the last value [0.17ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [0.20ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [0.14ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [0.17ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [0.20ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [0.17ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [0.14ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Float32Array() in VM context doesn't crash [0.13ms]
(pass) vm > runInContext() > new Float64Array() in VM context doesn't crash [0.18ms]
(pass) vm > runInContext() > new Big
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 68 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (4f0146691)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [22.78ms]
(pass) vm > runInContext() > can return a value [15.81ms]
(pass) vm > runInContext() > can return a complex value [15.84ms]
(pass) vm > runInContext() > can return the last value [15.68ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [16.84ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [13.76ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [15.95ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [16.09ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [17.63ms]
(pass) vm > runInContext() > new Int16
... (truncated)

release with fix: 68 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 784ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen cpp.rs (cppbind)
[1/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeVM.cpp | 39 ++++++++++++++-------
 test/js/node/vm/vm.test.ts  | 82 +++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 108 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 6 passed · 0 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                         reads  edits  tests
src/jsc/bindings/NodeVM.cpp      6      8      0
test/js/node/vm/vm.test.ts       6      8      0
```

</details>

<!-- robobun:evidence:end -->