### PR TITLE
node:crypto: Hash/Sign/Verify .update() treat detached ArrayBufferView as empty input

### DIFF
--- a/src/jsc/bindings/node/crypto/JSHash.cpp
+++ b/src/jsc/bindings/node/crypto/JSHash.cpp
@@ -212,9 +212,6 @@ JSC_DEFINE_HOST_FUNCTION(jsHashProtoFuncUpdate, (JSC::JSGlobalObject * globalObj
 
         return JSValue::encode(hashWrapper);
     } else if (auto* view = dynamicDowncast<JSArrayBufferView>(inputValue)) {
-        if (view->isDetached()) [[unlikely]] {
-            return Bun::ERR::INVALID_STATE(scope, globalObject, "Cannot hash a detached buffer"_s);
-        }
         if (!hash->update(view->span())) {
             return Bun::ERR::CRYPTO_HASH_UPDATE_FAILED(scope, globalObject);
         }

--- a/src/jsc/bindings/node/crypto/JSSign.cpp
+++ b/src/jsc/bindings/node/crypto/JSSign.cpp
@@ -220,11 +220,6 @@ void updateWithBufferView(JSGlobalObject* globalObject, JSSign* sign, JSC::JSArr
 {
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
 
-    if (bufferView->isDetached()) {
-        throwTypeError(globalObject, scope, "Buffer is detached"_s);
-        return;
-    }
-
     size_t byteLength = bufferView->byteLength();
     if (byteLength > INT_MAX) {
         throwRangeError(globalObject, scope, "data is too long"_s);

--- a/src/jsc/bindings/node/crypto/JSVerify.cpp
+++ b/src/jsc/bindings/node/crypto/JSVerify.cpp
@@ -265,12 +265,6 @@ JSC_DEFINE_HOST_FUNCTION(jsVerifyProtoFuncUpdate, (JSGlobalObject * globalObject
 
         auto* view = dynamicDowncast<JSC::JSArrayBufferView>(buf);
 
-        // Update the digest context with the buffer data
-        if (view->isDetached()) {
-            throwTypeError(globalObject, scope, "Buffer is detached"_s);
-            return {};
-        }
-
         size_t byteLength = view->byteLength();
         if (byteLength > INT_MAX) {
             throwRangeError(globalObject, scope, "data is too long"_s);
@@ -296,11 +290,6 @@ JSC_DEFINE_HOST_FUNCTION(jsVerifyProtoFuncUpdate, (JSGlobalObject * globalObject
 
     // Handle ArrayBufferView input
     if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(data)) {
-        if (view->isDetached()) {
-            throwTypeError(globalObject, scope, "Buffer is detached"_s);
-            return {};
-        }
-
         size_t byteLength = view->byteLength();
         if (byteLength > INT_MAX) {
             throwRangeError(globalObject, scope, "data is too long"_s);

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -534,6 +534,14 @@ describe("createHash", () => {
 
     const emptyKeyHmac = crypto.createHmac("sha256", Buffer.alloc(0)).update("m").digest("hex");
     expect(crypto.createHmac("sha256", detachedView()).update("m").digest("hex")).toBe(emptyKeyHmac);
+
+    const { privateKey, publicKey } = crypto.generateKeyPairSync("ec", { namedCurve: "P-256" });
+
+    const sig = crypto.createSign("sha256").update(detachedView()).sign(privateKey);
+    expect(crypto.createVerify("sha256").verify(publicKey, sig)).toBe(true);
+
+    const emptySig = crypto.createSign("sha256").sign(privateKey);
+    expect(crypto.createVerify("sha256").update(detachedView()).verify(publicKey, emptySig)).toBe(true);
   });
 
   it("uses the Transform options object", () => {

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -518,6 +518,24 @@ describe("createHash", () => {
     expect(copy.digest("hex")).toBe(hash.digest("hex"));
   });
 
+  it("treats a view over a detached ArrayBuffer as empty input", () => {
+    const detachedView = () => {
+      const ab = new ArrayBuffer(8);
+      const v = new Uint8Array(ab);
+      ab.transfer();
+      return v;
+    };
+
+    const emptyHash = crypto.createHash("sha256").digest("hex");
+    expect(crypto.createHash("sha256").update(detachedView()).digest("hex")).toBe(emptyHash);
+
+    const emptyDataHmac = crypto.createHmac("sha256", "k").digest("hex");
+    expect(crypto.createHmac("sha256", "k").update(detachedView()).digest("hex")).toBe(emptyDataHmac);
+
+    const emptyKeyHmac = crypto.createHmac("sha256", Buffer.alloc(0)).update("m").digest("hex");
+    expect(crypto.createHmac("sha256", detachedView()).update("m").digest("hex")).toBe(emptyKeyHmac);
+  });
+
   it("uses the Transform options object", () => {
     const hasher = crypto.createHash("sha256", { defaultEncoding: "binary" });
     hasher.on("readable", () => {

--- a/test/regression/issue/28024.test.ts
+++ b/test/regression/issue/28024.test.ts
@@ -27,11 +27,12 @@ test("Hash native digest() throws ERR_INVALID_THIS instead of segfaulting on bad
   expect(() => nativeDigest.call(null)).toThrow(expect.objectContaining({ code: "ERR_INVALID_THIS" }));
 });
 
-test("Hash.update() throws ERR_INVALID_STATE on detached ArrayBufferView", () => {
+test("Hash.update() does not crash on a detached ArrayBufferView", () => {
   const hash = createHash("sha256");
   const view = new Uint8Array(16);
   // @ts-ignore - transfer() detaches the underlying buffer
   view.buffer.transfer();
 
-  expect(() => hash.update(view)).toThrow(expect.objectContaining({ code: "ERR_INVALID_STATE" }));
+  // Node.js treats a detached view as 0 bytes; the digest matches sha256("").
+  expect(hash.update(view).digest("hex")).toBe(createHash("sha256").digest("hex"));
 });


### PR DESCRIPTION
## What does this PR do?

`crypto.createHash(...).update(view)` threw `ERR_INVALID_STATE: Cannot hash a detached buffer` when `view` was a typed array over a detached `ArrayBuffer`. `createSign(...).update(view)` and `createVerify(...).update(view)` threw `TypeError: Buffer is detached` on the same input. Node.js hashes the view's 0 bytes for all four streaming-digest classes (a detached view reports `byteLength === 0`), and Bun's own `createHmac(...).update(view)` already did the same, so Hash/Sign/Verify were inconsistent with both Node.js and Hmac.

```js
import crypto from "node:crypto";
const ab = new ArrayBuffer(8);
const v = new Uint8Array(ab);
ab.transfer(); // v.byteLength is now 0

// before: throws ERR_INVALID_STATE
// after (and in Node.js): e3b0c442... == sha256("")
crypto.createHash("sha256").update(v).digest("hex");

// before: throws TypeError
// after (and in Node.js): signs/verifies 0 bytes
crypto.createSign("sha256").update(v).sign(privateKey);
crypto.createVerify("sha256").update(v).verify(publicKey, sig);

// already worked in Bun, matching Node.js:
crypto.createHmac("sha256", "k").update(v).digest("hex");
crypto.createHmac("sha256", v).update("m").digest("hex");
```

Code that transfers buffers (postMessage transfer lists, `ArrayBuffer.transfer()`, worker handoff) and then hashes a possibly-leftover view works on Node.js and on Bun's Hmac path but threw on the other three.

## How did you verify your code works?

New test in `test/js/node/crypto/node-crypto.test.js` asserts Hash, Hmac-as-data, Hmac-as-key, Sign and Verify all treat a detached view as the empty-input equivalent. Fails on current release with `ERR_INVALID_STATE` (Hash) / `TypeError` (Sign/Verify), passes with this change.

Also updated `test/regression/issue/28024.test.ts`, whose original purpose was to guard against a segfault; it now asserts the Node.js-compatible behavior instead of the throw.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/crypto/node-crypto.test.js "test/regression/issue/28024.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (d0741a9a1)

test/regression/issue/28024.test.ts:
(pass) Hash native update() throws ERR_INVALID_THIS instead of segfaulting on bad this [27.54ms]
(pass) Hash native digest() throws ERR_INVALID_THIS instead of segfaulting on bad this [6.07ms]
32 |   const view = new Uint8Array(16);
33 |   // @ts-ignore - transfer() detaches the underlying buffer
34 |   view.buffer.transfer();
35 | 
36 |   // Node.js treats a detached view as 0 bytes; the digest matches sha256("").
37 |   expect(hash.update(view).digest("hex")).toBe(createHash("sha256").digest("hex"));
                   ^
error: Invalid state: Cannot hash a detached buffer
      at <anonymous> (/workspace/bun/test/regression/issue/28024.tes
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (4c14fd565)

test/regression/issue/28024.test.ts:
(pass) Hash native update() throws ERR_INVALID_THIS instead of segfaulting on bad this [1.06ms]
(pass) Hash native digest() throws ERR_INVALID_THIS instead of segfaulting on bad this [0.11ms]
(pass) Hash.update() does not crash on a detached ArrayBufferView [0.19ms]

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [0.09ms]
(pass) crypto.randomInt should return a number [0.03ms]
(pass) crypto.randomInt with no arguments [0.05ms]
(pass) crypto.randomInt with one argument [0.03ms]
(pass) crypto.randomInt with a callback [0.75ms]
(pass) createHash > rsa-md5 - "Hello World" [0.11ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [0.06ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [0.01ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary
(pass) createHash > rsa-sha1 - "Hello World" [0.08ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [0.03ms]
(pass) createHash > rsa-sha1-2 - "Hello World"
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary
(pass) createHash > rsa-sha224 - "Hello World" [0.02ms]
(pass) createHash > rs
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/crypto/node-crypto.test.js "test/regression/issue/28024.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (d0741a9a1)

test/regression/issue/28024.test.ts:
(pass) Hash native update() throws ERR_INVALID_THIS instead of segfaulting on bad this [29.85ms]
(pass) Hash native digest() throws ERR_INVALID_THIS instead of segfaulting on bad this [6.32ms]
(pass) Hash.update() does not crash on a detached ArrayBufferView [5.03ms]

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [4.35ms]
(pass) crypto.randomInt should return a number [2.34ms]
(pass) crypto.randomInt with no arguments [2.77ms]
(pass) crypto.randomInt with one argument [2.41ms]
(pass) crypto.randomInt with a callback [43.32ms]
(pass) createHash > rsa-md5 - "Hello World" [5.97ms]
(pass) createHash > 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 784ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_crypto-0.cpp.o
[2/8] gen cpp.rs (cppbind)
[2/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/wor
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/node/crypto/JSHash.cpp   |  3 ---
 src/jsc/bindings/node/crypto/JSSign.cpp   |  5 -----
 src/jsc/bindings/node/crypto/JSVerify.cpp | 11 -----------
 test/js/node/crypto/node-crypto.test.js   | 26 ++++++++++++++++++++++++++
 test/regression/issue/28024.test.ts       |  5 +++--
 5 files changed, 29 insertions(+), 21 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/jsc/bindings/node/crypto/JSHash.cpp        1      1      0
src/jsc/bindings/node/crypto/JSSign.cpp        1      1      0
src/jsc/bindings/node/crypto/JSVerify.cpp      1      1      0
test/js/node/crypto/node-crypto.test.js        3      2      0
test/regression/issue/28024.test.ts            1      1      0
```

</details>

<!-- robobun:evidence:end -->