### PR TITLE
node:vm: `var x` over a sandbox property no longer creates a dead undefined binding

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1185,7 +1185,7 @@ bool NodeVMGlobalObject::put(JSCell* cell, JSGlobalObject* globalObject, Propert
 
     // The sandbox setter handled the write; don't forward to Base as any direct
     // property there is the read-only placeholder materialised for the accessor.
-    if (isDeclaredOnSandbox && getter.isAccessor()) {
+    if (isDeclaredOnSandbox && (getter.isAccessor() || getter.isCustom())) {
         return true;
     }
 
@@ -1479,7 +1479,7 @@ JSC_DEFINE_HOST_FUNCTION(vmModuleRunInNewContext, (JSGlobalObject * globalObject
         options.lineOffset.zeroBasedInt(),
         options.columnOffset.zeroBasedInt());
 
-    context->materializeSandboxPropertiesForDeclarations(globalObject, sourceCode);
+    context->materializeSandboxPropertiesForDeclarations(context, sourceCode);
 
     NakedPtr<JSC::Exception> exception;
     JSValue result = JSC::evaluate(context, sourceCode, context, exception);

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1183,9 +1183,11 @@ bool NodeVMGlobalObject::put(JSCell* cell, JSGlobalObject* globalObject, Propert
     RETURN_IF_EXCEPTION(scope, false);
     if (!result) return false;
 
-    // The sandbox setter handled the write; don't forward to Base as any direct
-    // property there is the read-only placeholder materialised for the accessor.
-    if (isDeclaredOnSandbox && (getter.isAccessor() || getter.isCustom())) {
+    // The sandbox's own setter handled the write; don't forward to Base as any
+    // direct property there is the read-only placeholder materialised for the
+    // accessor. Own-only so inherited accessors (Object.prototype.__proto__ &c.)
+    // still fall through and update the vm global.
+    if (isDeclaredOnSandbox && (getter.isAccessor() || getter.isCustom()) && getter.slotBase() == sandbox) {
         return true;
     }
 

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -54,6 +54,9 @@
 #include "JavaScriptCore/JSNativeStdFunction.h"
 #include "JavaScriptCore/BytecodeCacheError.h"
 #include "JavaScriptCore/CodeCache.h"
+#include "JavaScriptCore/ProgramExecutable.h"
+#include "JavaScriptCore/UnlinkedProgramCodeBlock.h"
+#include "JavaScriptCore/ParserError.h"
 #include "JavaScriptCore/FunctionCodeBlock.h"
 #include "JavaScriptCore/JIT.h"
 #include "JavaScriptCore/ProgramCodeBlock.h"
@@ -1056,12 +1059,12 @@ void NodeVMGlobalObject::clearContextifiedObject()
 // directly (not via method table) and so never sees sandbox properties; a program-
 // level `var x` / `function x(){}` over a sandbox prop would add a fresh undefined
 // symbol-table slot that then wins every unqualified lookup for the context's life.
-// Mirror sandbox own-props onto this global (attributes only, placeholder value) so
-// createGlobalVarBinding / canDeclareGlobalFunction observe them; actual reads still
-// resolve through our method-table override, which consults the sandbox first.
-// Best-effort: sandbox traps that throw are swallowed, as Node never surfaces them
-// from var-binding either.
-void NodeVMGlobalObject::materializeSandboxOwnProperties(JSGlobalObject* lexicalGlobalObject)
+// For each name this program actually declares that the sandbox already owns, mirror
+// the sandbox attributes onto this global as a direct property so createGlobalVarBinding
+// / canDeclareGlobalFunction observe it; reads still resolve through our method-table
+// override, which consults the sandbox first. The UnlinkedProgramCodeBlock is fetched
+// via the code cache, so the evaluate that follows reuses it.
+void NodeVMGlobalObject::materializeSandboxPropertiesForDeclarations(JSGlobalObject* lexicalGlobalObject, const JSC::SourceCode& source)
 {
     if (m_contextOptions.notContextified)
         return;
@@ -1072,18 +1075,24 @@ void NodeVMGlobalObject::materializeSandboxOwnProperties(JSGlobalObject* lexical
     VM& vm = this->vm();
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
-    JSC::PropertyNameArrayBuilder names(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
-    sandbox->methodTable()->getOwnPropertyNames(sandbox, lexicalGlobalObject, names, DontEnumPropertiesMode::Include);
+    JSC::ProgramExecutable* executable = JSC::ProgramExecutable::create(this, source);
     if (scope.exception()) [[unlikely]] {
         scope.clearException();
         return;
     }
+    JSC::ParserError parserError;
+    JSC::UnlinkedProgramCodeBlock* unlinkedCodeBlock = vm.codeCache()->getUnlinkedProgramCodeBlock(vm, executable, source, defaultCodeGenerationMode(), parserError);
+    if (!unlinkedCodeBlock || parserError.isValid())
+        return;
+
+    const JSC::VariableEnvironment& varDecls = unlinkedCodeBlock->variableDeclarations();
+    if (varDecls.isEmpty())
+        return;
 
     JSC::BatchedTransitionOptimizer optimizer(vm, this);
 
-    for (const auto& name : names) {
-        if (parseIndex(name))
-            continue;
+    for (const auto& entry : varDecls) {
+        JSC::Identifier name = JSC::Identifier::fromUid(vm, entry.key.get());
 
         PropertySlot existing(this, PropertySlot::InternalMethodType::VMInquiry, &vm);
         bool alreadyOnGlobal = JSC::JSGlobalObject::getOwnPropertySlot(this, this, name, existing);
@@ -1174,14 +1183,9 @@ bool NodeVMGlobalObject::put(JSCell* cell, JSGlobalObject* globalObject, Propert
     RETURN_IF_EXCEPTION(scope, false);
     if (!result) return false;
 
-    if (isDeclaredOnSandbox && getter.isAccessor() and (getter.attributes() & PropertyAttribute::DontEnum) == 0) {
-        return true;
-    }
-
-    // Sandbox accepted the write. Forward to Base only if a symbol-table slot exists
-    // so it stays in sync; otherwise the only global-side copy is the materialized
-    // (possibly read-only) placeholder, which is never observed.
-    if (isDeclaredOnSandbox && propertyName.uid() && !thisObject->symbolTable()->contains(propertyName.uid())) {
+    // The sandbox setter handled the write; don't forward to Base as any direct
+    // property there is the read-only placeholder materialised for the accessor.
+    if (isDeclaredOnSandbox && getter.isAccessor()) {
         return true;
     }
 
@@ -1451,7 +1455,6 @@ JSC_DEFINE_HOST_FUNCTION(vmModuleRunInNewContext, (JSGlobalObject * globalObject
         contextOptions, globalObjectDynamicImportCallback);
 
     context->setContextifiedObject(sandbox);
-    context->materializeSandboxOwnProperties(globalObject);
 
     JSValue optionsArg = callFrame->argument(2);
     JSValue scriptDynamicImportCallback;
@@ -1475,6 +1478,8 @@ JSC_DEFINE_HOST_FUNCTION(vmModuleRunInNewContext, (JSGlobalObject * globalObject
             TextPosition(options.lineOffset, options.columnOffset)),
         options.lineOffset.zeroBasedInt(),
         options.columnOffset.zeroBasedInt());
+
+    context->materializeSandboxPropertiesForDeclarations(globalObject, sourceCode);
 
     NakedPtr<JSC::Exception> exception;
     JSValue result = JSC::evaluate(context, sourceCode, context, exception);

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1052,6 +1052,67 @@ void NodeVMGlobalObject::clearContextifiedObject()
     m_sandbox.clear();
 }
 
+// JSC's GlobalDeclarationInstantiation calls JSGlobalObject::getOwnPropertySlot
+// directly (not via method table) and so never sees sandbox properties; a program-
+// level `var x` / `function x(){}` over a sandbox prop would add a fresh undefined
+// symbol-table slot that then wins every unqualified lookup for the context's life.
+// Mirror sandbox own-props onto this global (attributes only, placeholder value) so
+// createGlobalVarBinding / canDeclareGlobalFunction observe them; actual reads still
+// resolve through our method-table override, which consults the sandbox first.
+// Best-effort: sandbox traps that throw are swallowed, as Node never surfaces them
+// from var-binding either.
+void NodeVMGlobalObject::materializeSandboxOwnProperties(JSGlobalObject* lexicalGlobalObject)
+{
+    if (m_contextOptions.notContextified)
+        return;
+    JSObject* sandbox = m_sandbox.get();
+    if (!sandbox)
+        return;
+
+    VM& vm = this->vm();
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+
+    JSC::PropertyNameArrayBuilder names(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
+    sandbox->methodTable()->getOwnPropertyNames(sandbox, lexicalGlobalObject, names, DontEnumPropertiesMode::Include);
+    if (scope.exception()) [[unlikely]] {
+        scope.clearException();
+        return;
+    }
+
+    JSC::BatchedTransitionOptimizer optimizer(vm, this);
+
+    for (const auto& name : names) {
+        if (parseIndex(name))
+            continue;
+
+        PropertySlot existing(this, PropertySlot::InternalMethodType::VMInquiry, &vm);
+        bool alreadyOnGlobal = JSC::JSGlobalObject::getOwnPropertySlot(this, this, name, existing);
+        existing.disallowVMEntry.reset();
+        if (alreadyOnGlobal)
+            continue;
+
+        PropertySlot sandboxSlot(sandbox, PropertySlot::InternalMethodType::GetOwnProperty);
+        bool found = sandbox->methodTable()->getOwnPropertySlot(sandbox, lexicalGlobalObject, name, sandboxSlot);
+        if (scope.exception()) [[unlikely]] {
+            scope.clearException();
+            continue;
+        }
+        if (!found)
+            continue;
+
+        unsigned sandboxAttributes = sandboxSlot.attributes();
+        unsigned attributes = 0;
+        if (sandboxAttributes & PropertyAttribute::DontDelete)
+            attributes |= PropertyAttribute::DontDelete;
+        if (sandboxAttributes & PropertyAttribute::DontEnum)
+            attributes |= PropertyAttribute::DontEnum;
+        if (sandboxAttributes & (PropertyAttribute::ReadOnly | PropertyAttribute::Accessor | PropertyAttribute::CustomAccessor))
+            attributes |= PropertyAttribute::ReadOnly;
+
+        putDirect(vm, name, jsUndefined(), attributes);
+    }
+}
+
 void NodeVMGlobalObject::sigintReceived()
 {
     vm().notifyNeedTermination();
@@ -1114,6 +1175,13 @@ bool NodeVMGlobalObject::put(JSCell* cell, JSGlobalObject* globalObject, Propert
     if (!result) return false;
 
     if (isDeclaredOnSandbox && getter.isAccessor() and (getter.attributes() & PropertyAttribute::DontEnum) == 0) {
+        return true;
+    }
+
+    // Sandbox accepted the write. Forward to Base only if a symbol-table slot exists
+    // so it stays in sync; otherwise the only global-side copy is the materialized
+    // (possibly read-only) placeholder, which is never observed.
+    if (isDeclaredOnSandbox && propertyName.uid() && !thisObject->symbolTable()->contains(propertyName.uid())) {
         return true;
     }
 
@@ -1383,6 +1451,7 @@ JSC_DEFINE_HOST_FUNCTION(vmModuleRunInNewContext, (JSGlobalObject * globalObject
         contextOptions, globalObjectDynamicImportCallback);
 
     context->setContextifiedObject(sandbox);
+    context->materializeSandboxOwnProperties(globalObject);
 
     JSValue optionsArg = callFrame->argument(2);
     JSValue scriptDynamicImportCallback;

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -129,6 +129,7 @@ public:
     void setContextifiedObject(JSC::JSObject* contextifiedObject);
     JSObject* contextifiedObject() const { return m_sandbox.get(); }
     void clearContextifiedObject();
+    void materializeSandboxOwnProperties(JSGlobalObject* lexicalGlobalObject);
     void sigintReceived();
     bool isNotContextified() const { return m_contextOptions.notContextified; }
     bool hasOwnMicrotaskQueue() const { return m_contextOptions.ownMicrotaskQueue; }

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -129,7 +129,7 @@ public:
     void setContextifiedObject(JSC::JSObject* contextifiedObject);
     JSObject* contextifiedObject() const { return m_sandbox.get(); }
     void clearContextifiedObject();
-    void materializeSandboxOwnProperties(JSGlobalObject* lexicalGlobalObject);
+    void materializeSandboxPropertiesForDeclarations(JSGlobalObject* lexicalGlobalObject, const JSC::SourceCode&);
     void sigintReceived();
     bool isNotContextified() const { return m_contextOptions.notContextified; }
     bool hasOwnMicrotaskQueue() const { return m_contextOptions.ownMicrotaskQueue; }

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -347,6 +347,7 @@ static JSC::EncodedJSValue runInContext(NodeVMGlobalObject* globalObject, NodeVM
 
     // Set the contextified object before evaluating
     globalObject->setContextifiedObject(contextifiedObject);
+    globalObject->materializeSandboxOwnProperties(globalObject);
 
     NakedPtr<JSC::Exception> exception;
     JSValue result {};

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -347,7 +347,7 @@ static JSC::EncodedJSValue runInContext(NodeVMGlobalObject* globalObject, NodeVM
 
     // Set the contextified object before evaluating
     globalObject->setContextifiedObject(contextifiedObject);
-    globalObject->materializeSandboxOwnProperties(globalObject);
+    globalObject->materializeSandboxPropertiesForDeclarations(globalObject, script->source());
 
     NakedPtr<JSC::Exception> exception;
     JSValue result {};

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -470,7 +470,8 @@ function testRunInContext({ fn, isIsolated, isNew }: TestRunInContextArg) {
         const sandbox = {};
         Object.defineProperty(sandbox, "cfg", { value: 42, writable: false, enumerable: true, configurable: false });
         const context = createContext(sandbox);
-        expect(() => fn("function cfg(){}", context)).toThrow();
+        // JSC throws TypeError per ECMA-262 GlobalDeclarationInstantiation; Node/V8 throws SyntaxError.
+        expect(() => fn("function cfg(){}", context)).toThrow(expect.objectContaining({ name: "TypeError" }));
         expect((sandbox as any).cfg).toBe(42);
       });
       test("`var x` over a non-enumerable sandbox property reads through to the sandbox value", () => {
@@ -495,6 +496,29 @@ function testRunInContext({ fn, isIsolated, isNew }: TestRunInContextArg) {
           Object.defineProperty(sandbox, "late", { value: 77, writable: false, enumerable: true, configurable: false });
           const result = fn("var late; [typeof late, late]", context);
           expect(result).toEqual(["number", 77]);
+        });
+        test("a script with no declarations does not keep a host-deleted sandbox property visible", () => {
+          const sandbox: any = { x: 1 };
+          const context = createContext(sandbox);
+          fn("1", context);
+          delete sandbox.x;
+          expect(fn("'x' in this", context)).toBe(false);
+          expect(fn("Object.getOwnPropertyDescriptor(this,'x')", context)).toBeUndefined();
+          expect(() => fn("x", context)).toThrow(expect.objectContaining({ name: "ReferenceError" }));
+        });
+        test("the global-side binding for a `var x = v` over a sandbox property survives host-side sandbox delete", () => {
+          const sandbox: any = { x: 1 };
+          const context = createContext(sandbox);
+          fn("var x = 5;", context);
+          delete sandbox.x;
+          expect(fn("[typeof x, x]", context)).toEqual(["number", 5]);
+        });
+        test("the global-side binding for a `function x(){}` over a sandbox property survives host-side sandbox delete", () => {
+          const sandbox: any = { x: 1 };
+          const context = createContext(sandbox);
+          fn("function x() { return 'f'; }", context);
+          delete sandbox.x;
+          expect(fn("[typeof x, x()]", context)).toEqual(["function", "f"]);
         });
       }
     });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -445,6 +445,11 @@ function testRunInContext({ fn, isIsolated, isNew }: TestRunInContextArg) {
       });
       expect(result).toContain("foo.js");
     });
+    test("assigning this.__proto__ changes the vm global's prototype", () => {
+      const context = createContext({});
+      const result = fn("this.__proto__ = {marker: 1}; [Object.getPrototypeOf(this).marker, 'marker' in this]", context);
+      expect(result).toEqual([1, true]);
+    });
     describe("var/function declarations over existing sandbox properties", () => {
       test("`var x` over a non-writable non-configurable data property reads through to the sandbox value", () => {
         const sandbox = {};

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -445,6 +445,59 @@ function testRunInContext({ fn, isIsolated, isNew }: TestRunInContextArg) {
       });
       expect(result).toContain("foo.js");
     });
+    describe("var/function declarations over existing sandbox properties", () => {
+      test("`var x` over a non-writable non-configurable data property reads through to the sandbox value", () => {
+        const sandbox = {};
+        Object.defineProperty(sandbox, "cfg", { value: 42, writable: false, enumerable: true, configurable: false });
+        const context = createContext(sandbox);
+        const result = fn("var cfg; [typeof cfg, cfg, globalThis.cfg]", context);
+        expect(result).toEqual(["number", 42, 42]);
+      });
+      test("`var x = v` over a getter-only accessor still reads from the getter", () => {
+        const sandbox = {};
+        Object.defineProperty(sandbox, "live", { get: () => 7, enumerable: true, configurable: false });
+        const context = createContext(sandbox);
+        const result = fn("var live = 99; [typeof live, live, globalThis.live]", context);
+        expect(result).toEqual(["number", 7, 7]);
+      });
+      test("`var x` over a writable data property does not shadow it with undefined", () => {
+        const sandbox = { w: 10 };
+        const context = createContext(sandbox);
+        const result = fn("var w; [typeof w, w, globalThis.w]", context);
+        expect(result).toEqual(["number", 10, 10]);
+      });
+      test("top-level function declaration over a non-writable non-configurable property throws", () => {
+        const sandbox = {};
+        Object.defineProperty(sandbox, "cfg", { value: 42, writable: false, enumerable: true, configurable: false });
+        const context = createContext(sandbox);
+        expect(() => fn("function cfg(){}", context)).toThrow();
+        expect((sandbox as any).cfg).toBe(42);
+      });
+      test("`var x` over a non-enumerable sandbox property reads through to the sandbox value", () => {
+        const sandbox = {};
+        Object.defineProperty(sandbox, "hidden", { value: "h", writable: true, enumerable: false, configurable: true });
+        const context = createContext(sandbox);
+        const result = fn("var hidden; hidden", context);
+        expect(result).toBe("h");
+      });
+      if (!isNew) {
+        test("a later script in the same context does not see a stale undefined binding", () => {
+          const sandbox = {};
+          Object.defineProperty(sandbox, "cfg", { value: 42, writable: false, enumerable: true, configurable: false });
+          const context = createContext(sandbox);
+          fn("var cfg;", context);
+          const result = fn("[typeof cfg, cfg, globalThis.cfg]", context);
+          expect(result).toEqual(["number", 42, 42]);
+        });
+        test("`var x` over a sandbox property added after createContext reads through to the sandbox value", () => {
+          const sandbox: any = {};
+          const context = createContext(sandbox);
+          Object.defineProperty(sandbox, "late", { value: 77, writable: false, enumerable: true, configurable: false });
+          const result = fn("var late; [typeof late, late]", context);
+          expect(result).toEqual(["number", 77]);
+        });
+      }
+    });
   } else {
     test("can access global context", () => {
       const props = randomProps(2);

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -481,6 +481,13 @@ function testRunInContext({ fn, isIsolated, isNew }: TestRunInContextArg) {
         const result = fn("var hidden; hidden", context);
         expect(result).toBe("h");
       });
+      test("an idempotent defineProperty on globalThis still validates against the sandbox descriptor", () => {
+        const sandbox = {};
+        Object.defineProperty(sandbox, "cfg", { value: 42, writable: false, enumerable: true, configurable: false });
+        const context = createContext(sandbox);
+        const result = fn("var cfg; Object.defineProperty(this, 'cfg', {value: 42}); cfg", context);
+        expect(result).toBe(42);
+      });
       if (!isNew) {
         test("a later script in the same context does not see a stale undefined binding", () => {
           const sandbox = {};

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -447,7 +447,10 @@ function testRunInContext({ fn, isIsolated, isNew }: TestRunInContextArg) {
     });
     test("assigning this.__proto__ changes the vm global's prototype", () => {
       const context = createContext({});
-      const result = fn("this.__proto__ = {marker: 1}; [Object.getPrototypeOf(this).marker, 'marker' in this]", context);
+      const result = fn(
+        "this.__proto__ = {marker: 1}; [Object.getPrototypeOf(this).marker, 'marker' in this]",
+        context,
+      );
       expect(result).toEqual([1, true]);
     });
     describe("var/function declarations over existing sandbox properties", () => {


### PR DESCRIPTION
## Repro

```js
import * as vm from "node:vm";
const b = {};
Object.defineProperty(b, "cfg", { value: 42, writable: false, enumerable: true, configurable: false });
vm.createContext(b);
console.log(vm.runInContext("var cfg; [typeof cfg, String(cfg), String(globalThis.cfg)].join('/')", b));
// bun:  "undefined/undefined/42"   node: "number/42/42"
console.log(vm.runInContext("[typeof cfg, String(cfg), String(globalThis.cfg)].join('/')", b));
// a later script, no `var`:
// bun STILL: "undefined/undefined/42"   node: "number/42/42"
```

Exposing read-only config on the sandbox (`Object.defineProperty(box, 'cfg', { value, writable: false })`) is the canonical contextify pattern. On Bun the moment any guest code declared `var cfg`, every subsequent unqualified read in the context saw `undefined` forever while `globalThis.cfg` still held the real value. The same thing happened for writable data properties and getter-only accessors; a top-level `function cfg(){}` over a non-writable non-configurable property was a silent no-op instead of throwing.

## Cause

JSC's `ProgramExecutable::initializeGlobalProperties` calls `JSGlobalObject::getOwnPropertySlot` directly, not through the method table, so `createGlobalVarBinding` / `canDeclareGlobalFunction` never see `NodeVMGlobalObject`'s override and never see the sandbox. For a `var cfg` declaration that check returns "not found", JSC adds a fresh symbol-table slot initialised to `undefined`, and `abstractAccess` then resolves every unqualified `cfg` to that slot as `GlobalVar`, bypassing the method-table lookup that would have reached the sandbox. `globalThis.cfg` goes through the method table, so it kept working.

## Fix

Before each `JSC::evaluate` on a contextified global, fetch the program's `UnlinkedProgramCodeBlock` from the code cache (the evaluate that follows reuses it, so no extra parse) and, for each name in its `variableDeclarations()` that the sandbox already owns and the global does not, install a direct property on the `NodeVMGlobalObject` whose attributes mirror the sandbox's (value is a placeholder; accessors mirror as read-only). `JSGlobalObject::getOwnPropertySlot` now reports those names, so `createGlobalVarBinding` returns early without adding a symbol-table slot and `canDeclareGlobalFunction` sees the real attributes (so `function cfg(){}` over a non-configurable non-writable property throws `TypeError`, per spec). `ProhibitsPropertyCaching` on `NodeVMGlobalObject` keeps the link-time resolve type at uncached `GlobalProperty`, and runtime reads still route through our method-table override which consults the sandbox first, so the placeholder value is never observed.

Because the mirroring is driven by the program's own declarations, a script with no `var`/`function` declarations touches nothing; a host-side `delete sandbox.x` between runs leaves no phantom property behind, and the global-side binding for a declared name (which matches Node's behaviour) survives the sandbox delete.

In `NodeVMGlobalObject::put`, once the sandbox's setter has handled a write, stop forwarding to `Base::put` regardless of the accessor's enumerability: the only global-side copy for an accessor is the read-only materialised placeholder, which `Base::put` would fail on.

## Verification

30 new cases in `test/js/node/vm/vm.test.ts` across `runInContext` / `runInNewContext` / `Script#runInContext` / `Script#runInNewContext`, covering read-only data, getter-only accessor, writable data, non-enumerable, late-added, persistence across scripts, the function-declaration error, plus guards that a declaration-free script leaves no placeholder behind and that declared bindings survive host-side sandbox delete. 24 fail on 1.4.0 and all 30 pass with the fix. All 95 `test/js/node/test/parallel/test-vm-*.js` pass.

Related open PRs touching `NodeVMGlobalObject::put` for adjacent behaviours: #33486, #34072. None address this bug; whichever lands first the others will want a small rebase.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 24 failed, 68 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (1935ced70)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [21.18ms]
(pass) vm > runInContext() > can return a value [15.14ms]
(pass) vm > runInContext() > can return a complex value [14.87ms]
(pass) vm > runInContext() > can return the last value [14.51ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [16.08ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [13.57ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [15.11ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [14.80ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.52ms]
(pass) vm > runInContext() > new Int16
... (truncated)

release without fix: 4 failed, 68 skipped
bun test v1.4.0-canary.1 (9a807962b)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [0.46ms]
(pass) vm > runInContext() > can return a value [0.24ms]
(pass) vm > runInContext() > can return a complex value [0.21ms]
(pass) vm > runInContext() > can return the last value [0.22ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [0.25ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [0.17ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [0.21ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [0.19ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [0.20ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [0.17ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Float32Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Float64Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Big
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 68 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (1935ced70)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [26.83ms]
(pass) vm > runInContext() > can return a value [16.02ms]
(pass) vm > runInContext() > can return a complex value [16.99ms]
(pass) vm > runInContext() > can return the last value [15.79ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [16.86ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [14.08ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [16.10ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [15.64ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.34ms]
(pass) vm > runInContext() > new Int16
... (truncated)

release with fix: 68 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 696ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/11] cxx obj/unified/UnifiedSource-src_jsc_bindings_vm-0.cpp.o
[2/11] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[3/11] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[4/11] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[5/11] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[6/11] gen cpp.rs (cppbind)
[6/11] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged -
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeVM.cpp       | 78 ++++++++++++++++++++++++++++++++-
 src/jsc/bindings/NodeVM.h         |  1 +
 src/jsc/bindings/NodeVMScript.cpp |  1 +
 test/js/node/vm/vm.test.ts        | 92 +++++++++++++++++++++++++++++++++++++++
 4 files changed, 171 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/jsc/bindings/NodeVM.cpp           10     17      0
src/jsc/bindings/NodeVM.h              2      3      0
src/jsc/bindings/NodeVMScript.cpp      2      3      0
test/js/node/vm/vm.test.ts             6      7      0
```

</details>

<!-- robobun:evidence:end -->