### PR TITLE
usockets: bound basename copy in Linux long-unix-path workaround

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1274,7 +1274,8 @@ static LIBUS_SOCKET_DESCRIPTOR bsd_create_unix_socket_address(const char *path, 
                 return LIBUS_SOCKET_ERROR;
             }
 
-            int sun_path_len = snprintf(server_address->sun_path, sizeof(server_address->sun_path), "/proc/self/fd/%d/%s", socket_dir_fd, path + dirname_len);
+            // `path` is a ptr+len pair (not NUL-terminated), so bound the basename copy with %.*s.
+            int sun_path_len = snprintf(server_address->sun_path, sizeof(server_address->sun_path), "/proc/self/fd/%d/%.*s", socket_dir_fd, (int)(path_len - dirname_len), path + dirname_len);
             if (sun_path_len >= sizeof(server_address->sun_path) || sun_path_len < 0) {
                 close(socket_dir_fd);
                 errno = ENAMETOOLONG;

--- a/test/js/bun/net/unix-socket-long-path.test.ts
+++ b/test/js/bun/net/unix-socket-long-path.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+
+// Linux sun_path is 108 bytes. Bun works around longer paths by opening the
+// parent directory and binding to "/proc/self/fd/<dirfd>/<basename>". The
+// workaround previously passed the caller's ptr+len path buffer to snprintf
+// via "%s", which reads past the end of a non-NUL-terminated allocation.
+// Under ASan this aborts; on release the bound address is built from
+// out-of-bounds heap bytes.
+
+describe.skipIf(!isLinux)("unix domain socket long-path workaround", () => {
+  function makeSockPath(prefix: string, total: number) {
+    // Pad the directory so tempDir() returns something long enough to leave a
+    // short basename that still fits inside /proc/self/fd/N/.
+    const pad = Buffer.alloc(Math.max(0, total - 60), "d").toString();
+    const dir = tempDir(prefix + pad, {});
+    const basenameLen = total - String(dir).length - 1;
+    const sock = String(dir) + "/" + Buffer.alloc(basenameLen, "l").toString();
+    expect(sock.length).toBe(total);
+    return { dir, sock };
+  }
+
+  async function run(fixture: string, sock: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      // symbolize=0: the regression this covers aborts under ASan, and four
+      // concurrent llvm-symbolizer invocations blow past the default test
+      // timeout. The assertion only needs the ASan header, not the stack.
+      env: { ...bunEnv, SOCK: sock, ASAN_OPTIONS: (bunEnv.ASAN_OPTIONS ?? "") + ":symbolize=0" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    // ASan reports are the failure mode of interest; surface the header while
+    // keeping benign debug/ASan-option chatter out of the assertion.
+    const asan = stderr.includes("AddressSanitizer") ? stderr.split("\n").slice(0, 4).join("\n") : "";
+    return { stdout, asan, exitCode };
+  }
+
+  // 108 is the exact boundary where the workaround engages; 150 exercises a
+  // longer directory prefix with the same short basename.
+  for (const total of [108, 150]) {
+    test.concurrent(`net.createServer + net.connect round-trip over a ${total}-byte path`, async () => {
+      const { dir, sock } = makeSockPath("sun-long-net-", total);
+      using _ = dir;
+
+      const fixture = `
+        const net = require("node:net");
+        const path = process.env.SOCK;
+        const srv = net.createServer(c => c.on("data", d => c.write(d)));
+        srv.on("error", e => { console.log("listen error:", e.code ?? e.message); process.exit(1); });
+        srv.listen(path, () => {
+          const client = net.connect(path);
+          client.on("data", d => {
+            console.log("echo:" + d.toString());
+            client.end();
+            srv.close(() => process.exit(0));
+          });
+          client.on("connect", () => client.write("hello"));
+          client.on("error", e => { console.log("connect error:", e.code ?? e.message); process.exit(1); });
+        });
+      `;
+
+      expect(await run(fixture, sock)).toEqual({
+        stdout: "echo:hello\n",
+        asan: "",
+        exitCode: 0,
+      });
+    });
+
+    test.concurrent(`Bun.listen + Bun.connect round-trip over a ${total}-byte path`, async () => {
+      const { dir, sock } = makeSockPath("sun-long-bun-", total);
+      using _ = dir;
+
+      const fixture = `
+        const path = process.env.SOCK;
+        const listener = Bun.listen({
+          unix: path,
+          socket: {
+            data(s, d) { s.write(d); },
+            open() {},
+          },
+        });
+        const { promise, resolve, reject } = Promise.withResolvers();
+        Bun.connect({
+          unix: path,
+          socket: {
+            open(s) { s.write("hello"); },
+            data(s, d) { console.log("echo:" + d.toString()); s.end(); resolve(); },
+            error(s, e) { reject(e); },
+            connectError(s, e) { reject(e); },
+          },
+        }).catch(reject);
+        await promise;
+        listener.stop();
+      `;
+
+      expect(await run(fixture, sock)).toEqual({
+        stdout: "echo:hello\n",
+        asan: "",
+        exitCode: 0,
+      });
+    });
+  }
+});

--- a/test/js/bun/net/unix-socket-long-path.test.ts
+++ b/test/js/bun/net/unix-socket-long-path.test.ts
@@ -30,11 +30,7 @@ describe.skipIf(!isLinux)("unix domain socket long-path workaround", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     // ASan reports are the failure mode of interest; surface the header while
     // keeping benign debug/ASan-option chatter out of the assertion.
     const asan = stderr.includes("AddressSanitizer") ? stderr.split("\n").slice(0, 4).join("\n") : "";


### PR DESCRIPTION
### What does this PR do?

`bsd_create_unix_socket_address()` takes the caller's path as `(const char *path, size_t path_len)` and, on Linux, works around `sun_path`'s 108-byte limit by opening the parent directory and binding to `/proc/self/fd/<dirfd>/<basename>` instead. The basename was being copied with

```c
snprintf(sun_path, sizeof sun_path, "/proc/self/fd/%d/%s", fd, path + dirname_len);
```

but `path` is a ptr+len pair coming from a Rust `&[u8]` with no NUL terminator. `%s` walks past the end of the allocation. On ASan builds this aborts with `heap-buffer-overflow`; on release builds `sun_path` is assembled from whatever heap bytes follow the path buffer, so the kernel sees an address built from out-of-bounds memory (sometimes the right one, sometimes `EINVAL`, sometimes something else).

The trigger window is any pathname unix socket with `108 <= path_len` whose basename still fits inside `/proc/self/fd/N/`, reachable from `net.createServer().listen(path)`, `net.connect(path)`, `Bun.listen({unix})` and `Bun.connect({unix})`. Node binds a full 108-byte `sun_path` here, so this is also a parity break at exactly length 108.

Fix: use `%.*s` with `(int)(path_len - dirname_len)` so the copy is bounded by the known basename length.

### Repro

```js
import * as net from "node:net";
import * as fs from "node:fs";
const dir = fs.mkdtempSync("/tmp/sun108-");
const path = dir + "/" + "l".repeat(108 - dir.length - 1); // exactly 108 bytes
net.createServer().listen(path, () => { console.log("LISTENING"); process.exit(0); });
```

Before (debug/ASan):
```
==510==ERROR: AddressSanitizer: heap-buffer-overflow ... READ of size 90 at 0x7339f260062c thread T0
    #0 ... in printf_common
    #2 ... in snprintf
    #3 ... in bsd_create_unix_socket_address packages/bun-usockets/src/bsd.c
```

After: `LISTENING`, exit 0.

### How did you verify your code works?

`bun bd test test/js/bun/net/unix-socket-long-path.test.ts` passes (4/4). With the `packages/` change stashed out, all four cases fail with the ASan `heap-buffer-overflow` header in the subprocess stderr.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/net/unix-socket-long-path.test.ts

<!-- robobun:evidence:end -->