### PR TITLE
types: accept binary input in YAML.parse and JSON5.parse

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1100,12 +1100,12 @@ declare module "bun" {
    */
   namespace YAML {
     /**
-     * Parse a YAML string into a JavaScript value. Every alias (`*name`) of an anchored collection yields the
+     * Parse a YAML document into a JavaScript value. Every alias (`*name`) of an anchored collection yields the
      * same object, and an alias may refer to a collection that contains it, so the result can be cyclic.
      *
      * @category Utilities
      *
-     * @param input The YAML string to parse
+     * @param input The YAML document to parse, as a string or UTF-8 bytes
      * @returns A JavaScript value, or an array of them for a multi-document stream
      *
      * @example
@@ -1120,7 +1120,9 @@ declare module "bun" {
      * console.log(YAML.parse("abc: def")) // { "abc": "def" }
      * ```
      */
-    export function parse(input: string): unknown;
+    export function parse(
+      input: string | NodeJS.TypedArray | DataView<ArrayBufferLike> | ArrayBufferLike | Blob,
+    ): unknown;
 
     /**
      * Convert a JavaScript value into a YAML string. Strings are double quoted if they contain keywords, non-printable or
@@ -1667,7 +1669,7 @@ declare module "bun" {
    */
   namespace JSON5 {
     /**
-     * Parse a JSON5 string into a JavaScript value.
+     * Parse a JSON5 document into a JavaScript value.
      *
      * JSON5 is a superset of JSON based on ECMAScript 5.1 that supports
      * comments, trailing commas, unquoted keys, single-quoted strings,
@@ -1675,7 +1677,7 @@ declare module "bun" {
      *
      * @category Utilities
      *
-     * @param input The JSON5 string to parse
+     * @param input The JSON5 document to parse, as a string or UTF-8 bytes
      * @returns A JavaScript value
      *
      * @example
@@ -1692,7 +1694,9 @@ declare module "bun" {
      * }`);
      * ```
      */
-    export function parse(input: string): unknown;
+    export function parse(
+      input: string | NodeJS.TypedArray | DataView<ArrayBufferLike> | ArrayBufferLike | Blob,
+    ): unknown;
 
     /**
      * Convert a JavaScript value into a JSON5 string. Object keys that are

--- a/test/integration/bun-types/fixture/json5.ts
+++ b/test/integration/bun-types/fixture/json5.ts
@@ -1,0 +1,12 @@
+import { expectType } from "./utilities";
+
+expectType(Bun.JSON5.parse("")).is<unknown>();
+expectType(Bun.JSON5.parse(Buffer.from("{ foo: 'bar' }"))).is<unknown>();
+expectType(Bun.JSON5.parse(new Uint8Array())).is<unknown>();
+expectType(Bun.JSON5.parse(new DataView(new ArrayBuffer(0)))).is<unknown>();
+expectType(Bun.JSON5.parse(new DataView(new SharedArrayBuffer(0)))).is<unknown>();
+expectType(Bun.JSON5.parse(new ArrayBuffer(0))).is<unknown>();
+expectType(Bun.JSON5.parse(new SharedArrayBuffer(0))).is<unknown>();
+expectType(Bun.JSON5.parse(new Blob())).is<unknown>();
+// @ts-expect-error
+expectType(Bun.JSON5.parse({})).is<unknown>();

--- a/test/integration/bun-types/fixture/yaml.ts
+++ b/test/integration/bun-types/fixture/yaml.ts
@@ -1,9 +1,16 @@
 import { expectType } from "./utilities";
 
 expectType(Bun.YAML.parse("")).is<unknown>();
+expectType(Bun.YAML.parse(Buffer.from("foo: bar"))).is<unknown>();
+expectType(Bun.YAML.parse(new Uint8Array())).is<unknown>();
+expectType(Bun.YAML.parse(new DataView(new ArrayBuffer(0)))).is<unknown>();
+expectType(Bun.YAML.parse(new DataView(new SharedArrayBuffer(0)))).is<unknown>();
+expectType(Bun.YAML.parse(new ArrayBuffer(0))).is<unknown>();
+expectType(Bun.YAML.parse(new SharedArrayBuffer(0))).is<unknown>();
+expectType(Bun.YAML.parse(new Blob())).is<unknown>();
 // @ts-expect-error
 expectType(Bun.YAML.parse({})).is<unknown>();
-expectType(Bun.YAML.stringify({ abc: "def"})).is<string>();
+expectType(Bun.YAML.stringify({ abc: "def" })).is<string>();
 // @ts-expect-error
 expectType(Bun.YAML.stringify("hi", {})).is<string>();
 // @ts-expect-error


### PR DESCRIPTION
## What does this PR do?

`Bun.YAML.parse` and `Bun.JSON5.parse` already accept strings, typed arrays, `DataView`, `ArrayBuffer`/`SharedArrayBuffer`, and `Blob` values at runtime. Their TypeScript declarations only accepted `string`, so valid runtime calls required unnecessary conversions or type assertions.

This updates both declarations and their JSDoc to match the existing runtime input surface. It also adds bun-types fixtures covering `Buffer`, `Uint8Array`, `DataView` backed by both `ArrayBuffer` and `SharedArrayBuffer`, `ArrayBuffer`, `SharedArrayBuffer`, and `Blob`. Negative fixtures verify that arbitrary objects remain rejected by both parsers.

The runtime behavior is unchanged.

## How did you verify your code works?

After rebasing onto the latest `main`, on macOS arm64 with Bun `1.3.14`:

```sh
bun test test/integration/bun-types/bun-types.test.ts
```

Result: 15 passed, 0 failed. This covers the bun-types fixtures under configurations with and without `lib.dom.d.ts`, plus the TypeScript 7 native preview.

```sh
bun node_modules/prettier/bin/prettier.cjs --check packages/bun-types/bun.d.ts test/integration/bun-types/fixture/yaml.ts test/integration/bun-types/fixture/json5.ts
```

Result: all matched files use Prettier code style.

The runtime input matrix was also verified on Windows x64 with Bun `1.4.0-canary.1+8f1a9540f`:

```sh
bun -e 'const text = "{a: 1}"; const bytes = new TextEncoder().encode(text); const shared = new SharedArrayBuffer(bytes.length); new Uint8Array(shared).set(bytes); const cases = { string: text, buffer: Buffer.from(bytes), uint8Array: bytes, dataView: new DataView(bytes.buffer), sharedDataView: new DataView(shared), arrayBuffer: bytes.buffer, sharedArrayBuffer: shared, blob: new Blob([bytes]) }; for (const input of Object.values(cases)) { if (Bun.YAML.parse(input).a !== 1 || Bun.JSON5.parse(input).a !== 1) throw new Error("unexpected parse result"); }'
```

Result: all eight input variants passed for both parsers. Before updating the declarations, the type fixture failed with `TS2345` for the binary-input calls.

Also ran `git diff --check`. A native debug build was not run because this PR only changes TypeScript declarations and type fixtures; the repository explicitly documents the bun-types integration test as the verification path for `.d.ts`-only changes.
