### PR TITLE
timers: Timeout.hasRef() reports the sticky ref flag after clearTimeout

### DIFF
--- a/src/runtime/timer/timer_object_internals.rs
+++ b/src/runtime/timer/timer_object_internals.rs
@@ -958,9 +958,14 @@ impl TimerObjectInternals {
     }
 
     pub fn has_ref(&self) -> JsResult<JSValue> {
-        Ok(JSValue::from(
-            self.flags.get().is_keeping_event_loop_alive(),
-        ))
+        let flags = self.flags.get();
+        // Node's Timeout.prototype.hasRef reports the sticky [kRefed] slot,
+        // which clearTimeout/fire leave untouched. Node's Immediate nulls
+        // [kRefed] on clear/fire; `is_keeping_event_loop_alive` mirrors that.
+        Ok(JSValue::from(match flags.kind() {
+            Kind::SetTimeout | Kind::SetInterval => flags.has_js_ref(),
+            Kind::SetImmediate => flags.is_keeping_event_loop_alive(),
+        }))
     }
 
     /// First access mints an

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -223,11 +223,11 @@ describe("hasRef", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    expect({ stdout: stdout.trim(), exitCode }).toEqual({
       stdout: `{"hasRef":true,"destroyed":true}`,
-      stderr: "",
       exitCode: 0,
     });
+    expect(stderr).not.toContain("fired");
   });
 });
 

--- a/test/js/node/timers/node-timers.test.ts
+++ b/test/js/node/timers/node-timers.test.ts
@@ -155,6 +155,82 @@ describe("_destroyed", () => {
   });
 });
 
+describe("hasRef", () => {
+  it("stays true after clearTimeout/clearInterval", () => {
+    const t = setTimeout(() => {}, 1_000_000);
+    clearTimeout(t);
+    const i = setInterval(() => {}, 1_000_000);
+    clearInterval(i);
+    expect({ timeout: t.hasRef(), interval: i.hasRef() }).toEqual({ timeout: true, interval: true });
+    expect({ timeout: t.ref().hasRef(), interval: i.ref().hasRef() }).toEqual({ timeout: true, interval: true });
+  });
+
+  it("stays false for an unref'd timer after clearing", () => {
+    const t = setTimeout(() => {}, 1_000_000);
+    t.unref();
+    clearTimeout(t);
+    const i = setInterval(() => {}, 1_000_000);
+    i.unref();
+    clearInterval(i);
+    expect({ timeout: t.hasRef(), interval: i.hasRef() }).toEqual({ timeout: false, interval: false });
+  });
+
+  it("reflects ref()/unref() after clearTimeout", () => {
+    const t = setTimeout(() => {}, 1_000_000);
+    clearTimeout(t);
+    t.unref();
+    expect(t.hasRef()).toBe(false);
+    t.ref();
+    expect(t.hasRef()).toBe(true);
+  });
+
+  it("stays true after a setTimeout fires", async () => {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const t = setTimeout(() => resolve(), 0);
+    await promise;
+    expect(t.hasRef()).toBe(true);
+    t.unref();
+    expect(t.hasRef()).toBe(false);
+    t.ref();
+    expect(t.hasRef()).toBe(true);
+  });
+
+  it("is false for setImmediate after clearing or firing", async () => {
+    const cleared = setImmediate(() => {});
+    clearImmediate(cleared);
+    expect(cleared.hasRef()).toBe(false);
+    expect(cleared.ref().hasRef()).toBe(false);
+
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const fired = setImmediate(() => resolve());
+    await promise;
+    expect(fired.hasRef()).toBe(false);
+    expect(fired.ref().hasRef()).toBe(false);
+  });
+
+  it("ref() on a cleared timer does not keep the process alive", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const t = setTimeout(() => { throw new Error("fired"); }, 24 * 3600 * 1000);
+         clearTimeout(t);
+         t.ref();
+         console.log(JSON.stringify({ hasRef: t.hasRef(), destroyed: t._destroyed }));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: `{"hasRef":true,"destroyed":true}`,
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});
+
 describe("clear", () => {
   it("can clear the other kind of timer", async () => {
     const timeout1 = setTimeout(() => {


### PR DESCRIPTION
## Repro

```js
const t = setTimeout(() => {}, 1000);
clearTimeout(t);
console.log(t.hasRef());        // node: true   bun: false
console.log(t.ref().hasRef());  // node: true   bun: false
```

Same for `setInterval`/`clearInterval`, and for a `setTimeout` that has already fired. An `unref()`'d-then-cleared timer agrees (both `false`).

## Cause

`TimerObjectInternals::has_ref()` returned `flags.is_keeping_event_loop_alive()`, the loop-liveness contribution. `cancel()` (and the fire path) drop that contribution, so `hasRef()` flipped to `false` for any destroyed Timeout regardless of whether the user had called `unref()`.

Node's `Timeout.prototype.hasRef` returns `this[kRefed]`, a sticky slot that `clearTimeout` and the timer list never write. Bun already tracks the same thing as `flags.has_js_ref()` (defaulted to `true`, toggled only by `ref()`/`unref()`), so `do_ref()` on a destroyed timer was already correctly leaving the event loop alone; only the getter was reading the wrong bit.

## Fix

`has_ref()` now returns `has_js_ref()` for `setTimeout`/`setInterval`. `setImmediate` keeps reporting `is_keeping_event_loop_alive`: Node's `clearImmediate` and `processImmediate` null `[kRefed]` before returning, which that flag already mirrors (and `ref()` on a destroyed Immediate remains a no-op via the `!get_destroyed()` guard in `do_ref`).

This is introspection only; `ref()`/`unref()`/exit timing are unchanged.

## Verification

New `describe("hasRef")` block in `test/js/node/timers/node-timers.test.ts` covering cleared timeout/interval, cleared-then-`ref()`/`unref()`, fired timeout, cleared/fired immediate, and a spawned check that `ref()` after `clearTimeout` reports `true` without keeping the process alive.

```
# fail-before (released bun)
$ USE_SYSTEM_BUN=1 bun test test/js/node/timers/node-timers.test.ts -t hasRef
 2 pass, 4 fail

# with fix
$ bun bd test test/js/node/timers/node-timers.test.ts
 26 pass, 0 fail
```

`test/js/node/test/parallel/test-timers-{unref,refresh,immediate-unref}.js` pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/timers/node-timers.test.ts

<!-- robobun:evidence:end -->