### PR TITLE
node:net: throw ERR_SOCKET_BAD_PORT for Server.listen("") instead of binding an ephemeral port

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3237,10 +3237,6 @@ Server.prototype.getConnections = function getConnections(callback) {
 
 Server.prototype.listen = function listen(port, hostname, onListen) {
   const argsLength = arguments.length;
-  if (typeof port === "string") {
-    const numPort = Number(port);
-    if (!Number.isNaN(numPort)) port = numPort;
-  }
   let backlog;
   let path;
   let exclusive = false;
@@ -3249,8 +3245,10 @@ Server.prototype.listen = function listen(port, hostname, onListen) {
   let readableAll = false;
   let writableAll = false;
   let fd;
-  //port is actually path
-  if (typeof port === "string") {
+  // Match Node's normalizeArgs: a positional string argument is a pipe path
+  // only when isPipeName() is true; otherwise (including "" and "  ") it is
+  // treated as a port and flows to validatePort which rejects empty strings.
+  if (isPipeName(port)) {
     if (Number.isSafeInteger(hostname)) {
       if (hostname > 0) {
         //hostname is backlog

--- a/src/jsc/bindings/NodeValidator.cpp
+++ b/src/jsc/bindings/NodeValidator.cpp
@@ -297,6 +297,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_validatePort, (JSC::JSGlobalObject * globalO
             if (c >= 0x2029 && c <= 0x2029) return true;
             if (c >= 0x202F && c <= 0x202F) return true;
             if (c >= 0x205F && c <= 0x205F) return true;
+            if (c >= 0x3000 && c <= 0x3000) return true;
 
             // LineTerminator ::
             if (c == 0x000A) return true; // <LF>

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -471,6 +471,29 @@ describe("net.createServer events", () => {
     );
   });
 
+  it.each(["", " ", "   ", "\t"])(
+    "should throw ERR_SOCKET_BAD_PORT synchronously for listen(%j) instead of binding an ephemeral TCP port",
+    port => {
+      const server = createServer();
+      try {
+        let err: any;
+        try {
+          server.listen(port, () => {});
+        } catch (e) {
+          err = e;
+        }
+        expect(err).toBeDefined();
+        expect({ code: err.code, message: err.message }).toEqual({
+          code: "ERR_SOCKET_BAD_PORT",
+          message: expect.stringContaining("options.port"),
+        });
+        expect(server.listening).toBe(false);
+      } finally {
+        if (server.listening) server.close();
+      }
+    },
+  );
+
   it("should call abort with signal", done => {
     const { mustCall, mustNotCall } = createCallCheckCtx(done);
 

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -471,7 +471,7 @@ describe("net.createServer events", () => {
     );
   });
 
-  it.each(["", " ", "   ", "\t"])(
+  it.each(["", " ", "   ", "\t", "\u3000"])(
     "should throw ERR_SOCKET_BAD_PORT synchronously for listen(%j) instead of binding an ephemeral TCP port",
     port => {
       const server = createServer();


### PR DESCRIPTION
## What does this PR do?

`net.Server#listen("")` (and any whitespace-only string) now throws `ERR_SOCKET_BAD_PORT` synchronously, matching Node.js, instead of silently binding a dual-stack ephemeral TCP listener on `::`.

### Reproduction

```js
import net from "node:net";
const srv = net.createServer(() => {});
srv.listen("", () => {
  console.log("LISTENING:", JSON.stringify(srv.address()));
});
```

Node.js throws synchronously:
```
RangeError [ERR_SOCKET_BAD_PORT]: options.port should be >= 0 and < 65536. Received type string ('').
```

Bun (before this change) binds a world-reachable ephemeral port:
```
LISTENING: {"family":"IPv6","address":"::","port":33235}
```

### Cause

`Server.prototype.listen` had an early coercion that converted a string argument via `Number()` before deciding whether it was a pipe path or a port. Since `Number("")` is `0`, empty and whitespace-only strings were silently treated as port `0`, so the server bound an ephemeral listener and `validatePort` never saw the bad value.

Node's `normalizeArgs` uses `isPipeName()` to make this distinction: a positional string is a pipe path only when `isPipeName()` is true; otherwise it becomes `options.port` and is passed to `validatePort`, which rejects empty and whitespace-only strings.

### Fix

Remove the early `Number()` coercion and use `isPipeName(port)` (already defined in the file and used by `normalizeArgs`) to route the positional string argument. Empty and whitespace-only strings are not pipe names, so they reach `validatePort` which throws `ERR_SOCKET_BAD_PORT`. Numeric strings like `"0"` or `"8080"` continue to work (`validatePort` accepts them and they are coerced via `port | 0`).

### Verification

- New test in `test/js/node/net/node-net-server.test.ts` covers `""`, `" "`, `"   "`, `"\\t"`
- Fails on released bun (`err` is undefined, server is listening), passes with this change
- `listen({port: ""})`, `Socket#connect("")` and `listen("0")` were already correct and remain so
- Node parallel tests `test-net-listen-invalid-port`, `test-net-server-listen-options`, `test-net-server-listen-path` pass

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/net/node-net-server.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (3cb104d60)

test/js/node/net/node-net-server.test.ts:
(pass) net.createServer listen > should throw when no port or path when using options [25.62ms]
(pass) net.createServer listen > should listen on IPv6 by default [150.88ms]
(pass) net.createServer listen > should listen on IPv4 [25.71ms]
(pass) net.createServer listen > should call listening [16.38ms]
(pass) net.createServer listen > should provide listening property [18.32ms]
(pass) net.createServer listen > should listen on localhost [16.94ms]
(pass) net.createServer listen > should listen on localhost [17.18ms]
(pass) net.createServer listen > should listen without port or host [10.45ms]
(pass) net.createServer listen > should listen on unix domain socket [21.21ms]
(pas
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (9337493d0)

test/js/node/net/node-net-server.test.ts:
(pass) net.createServer listen > should throw when no port or path when using options [0.50ms]
(pass) net.createServer listen > should listen on IPv6 by default [3.17ms]
(pass) net.createServer listen > should listen on IPv4 [1.26ms]
(pass) net.createServer listen > should call listening [1.21ms]
(pass) net.createServer listen > should provide listening property [1.24ms]
(pass) net.createServer listen > should listen on localhost [1.26ms]
(pass) net.createServer listen > should listen on localhost [1.27ms]
(pass) net.createServer listen > should listen without port or host [1.27ms]
(pass) net.createServer listen > should listen on unix domain socket [1.43ms]
(pass) net.createServer listen > should bind IPv4 0.0.0.0 when listen on 0.0.0.0, issue#7355 [1.55ms]
(pass) net.createServer events > should receive data [3.99ms]
(pass) net.createServer events > should call end [1.75ms]
(pass) net.createServer events > should call close [0.17ms]
(pass) net.createServer events > should call connection and drop [1.88ms]
(pass) net.createServer events > should error on an invalid port [0.10ms]
(pass) 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/net/node-net-server.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (3cb104d60)

test/js/node/net/node-net-server.test.ts:
(pass) net.createServer listen > should throw when no port or path when using options [25.90ms]
(pass) net.createServer listen > should listen on IPv6 by default [150.80ms]
(pass) net.createServer listen > should listen on IPv4 [33.21ms]
(pass) net.createServer listen > should call listening [17.94ms]
(pass) net.createServer listen > should provide listening property [26.98ms]
(pass) net.createServer listen > should listen on localhost [33.39ms]
(pass) net.createServer listen > should listen on localhost [38.57ms]
(pass) net.createServer listen > should listen without port or host [33.66ms]
(pass) net.createServer listen > should listen on unix domain socket [24.66ms]
(pas
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 823ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen cpp.rs (cppbind)
[2/21] gen JS modules (bundle-modules)
Preprocess modules (9258ms)
Bundle modules (72ms)
Postprocesss modules (27ms)
Bundle Functions (656ms)
Generate Code (85ms)

[10.11s] Bundled "src/js" for production
  1912 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/net.ts                       | 10 ++++------
 src/jsc/bindings/NodeValidator.cpp       |  1 +
 test/js/node/net/node-net-server.test.ts | 23 +++++++++++++++++++++++
 3 files changed, 28 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/js/node/net.ts                            2      1      0
src/jsc/bindings/NodeValidator.cpp            2      1      0
test/js/node/net/node-net-server.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->