### PR TITLE
bundler: propagate no_macros to BundleV2 parse tasks

### DIFF
--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2455,6 +2455,7 @@ pub mod parse_worker {
         opts.features.standard_decorators = !loader.is_typescript()
             || !(task.experimental_decorators || task.emit_decorator_metadata);
         opts.features.unwrap_commonjs_packages = topts.unwrap_commonjs_packages;
+        opts.features.no_macros = topts.no_macros;
         // Modeled as
         // `Option<Box<StringSet>>` on both sides, so we deep-clone (small —
         // CLI-supplied flag set). PERF: retype

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -1,6 +1,8 @@
 import { escapeHTML } from "bun" assert { type: "macro" };
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { existsSync } from "node:fs";
+import path from "node:path";
 import defaultMacro, {
   addStrings,
   addStringsUTF16,
@@ -154,5 +156,90 @@ test("object argument with a sparse numeric key", async () => {
     stdout: expect.stringMatching(/200000\n$/),
     exitCode: 0,
     signalCode: null,
+  });
+});
+
+describe("--no-macros", () => {
+  const files = {
+    "macro.ts": `
+      import { writeFileSync } from "node:fs";
+      export function f() {
+        writeFileSync("MACRO_RAN", "macro executed");
+        return "INLINED_RESULT";
+      }
+    `,
+    "entry.ts": `
+      import { f } from "./macro.ts" with { type: "macro" };
+      console.log(f());
+    `,
+  };
+
+  test("bun build --no-macros refuses to run macros", async () => {
+    using dir = tempDir("bundler-no-macros-cli", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-macros", "./entry.ts", "--outdir", "dist"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toMatchObject({
+      stderr: expect.stringContaining("Macros are disabled"),
+      exitCode: 1,
+    });
+    expect(existsSync(path.join(String(dir), "MACRO_RAN"))).toBe(false);
+    expect(existsSync(path.join(String(dir), "dist", "entry.js"))).toBe(false);
+  });
+
+  test("Bun.build({ macros: false }) refuses to run macros", async () => {
+    using dir = tempDir("bundler-no-macros-api", {
+      ...files,
+      "build.ts": `
+        const result = await Bun.build({
+          entrypoints: ["./entry.ts"],
+          outdir: "./dist",
+          macros: false,
+          throw: false,
+        });
+        console.log(JSON.stringify({
+          success: result.success,
+          logs: result.logs.map(l => l.message),
+        }));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "build.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const parsed = JSON.parse(stdout.trim().split("\n").pop()!);
+    expect({ parsed, stderr, exitCode }).toMatchObject({
+      parsed: {
+        success: false,
+        logs: expect.arrayContaining([expect.stringContaining("Macros are disabled")]),
+      },
+      exitCode: 0,
+    });
+    expect(existsSync(path.join(String(dir), "MACRO_RAN"))).toBe(false);
+  });
+
+  test("bun build without --no-macros still runs macros", async () => {
+    using dir = tempDir("bundler-macros-enabled", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "./entry.ts", "--outdir", "dist"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
+    const out = await Bun.file(path.join(String(dir), "dist", "entry.js")).text();
+    expect(out).toContain("INLINED_RESULT");
+    expect(existsSync(path.join(String(dir), "MACRO_RAN"))).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

`bun build --no-macros` and `Bun.build({ macros: false })` are silently ignored: the macro still **executes at build time** and its return value is inlined into the bundle. Only the runtime path (`bun --no-macros run`) actually refuses.

```ts
// m.ts
import { writeFileSync } from "node:fs";
export function f() { writeFileSync("/tmp/MACRO_RAN.txt", "ran"); return "INLINED"; }

// c.ts
import { f } from "./m.ts" with { type: "macro" };
console.log(f());
```

```
$ bun build --no-macros ./c.ts --outdir dist
  exit 0, no "Macros are disabled" error
  /tmp/MACRO_RAN.txt exists           <- macro code executed during the build
  dist/c.js contains "INLINED"        <- and its result was inlined
```

`docs/bundler/macros.mdx` (Security considerations) advertises `--no-macros` as the kill switch that produces a build-time error. CI pipelines that bundle untrusted monorepo/vendored/direct-path code rely on this as a no-code-execution guarantee.

## Cause

`build_command.rs:468` sets `transpiler.options.no_macros = true`, and the single-file transpiler path copies it into parser features (`transpiler.rs:1602`, which is why `bun --no-macros run` works). But `ParseTask.rs`, which constructs parser options for every BundleV2 parse task, hand-copies ~20 `opts.features.*` flags from the transpiler options and never copies `no_macros`, so every bundle parse runs with the struct default `false`. The same gap affects `Bun.build({ macros: false })`, which also routes through BundleV2.

## Fix

Copy the flag in `ParseTask.rs` alongside the other `topts` feature copies.

## Verification

New tests in `test/bundler/transpiler/macro-test.test.ts` cover both the CLI (`bun build --no-macros`) and the JS API (`Bun.build({ macros: false })`), asserting the build fails with `Macros are disabled`, the macro's side-effect file is never written, and no output bundle is produced. A third test confirms macros still run and inline when the flag is absent.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-test.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (9d7c6b197)

test/bundler/transpiler/macro-test.test.ts:
[macro] call escapeHTML
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call escape
[macro] call addStrings
[macro] call ad
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (9d7c6b197)

test/bundler/transpiler/macro-test.test.ts:
(pass) bun builtins can be used in macros [0.04ms]
(pass) latin1 string [0.01ms]
(pass) ascii string
(pass) type coercion [0.06ms]
(pass) escaping [0.17ms]
(pass) utf16 string [0.01ms]
(pass) import aliases [0.04ms]
(pass) default import [0.01ms]
(pass) namespace import [0.02ms]
(pass) ireturnapromise [0.07ms]
(pass) object argument with a sparse numeric key [13.93ms]
(pass) --no-macros > bun build --no-macros refuses to run macros [4.37ms]
(pass) --no-macros > Bun.build({ macros: false }) refuses to run macros [14.72ms]
(pass) --no-macros > bun build without --no-macros still runs macros [28.79ms]

 14 pass
 0 fail
 81 expect() calls
Ran 14 tests across 1 file. [326.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-test.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (9d7c6b197)

test/bundler/transpiler/macro-test.test.ts:
[macro] call escapeHTML
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call escape
[macro] call addStrings
[macro] call ad
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 692ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/works
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/ParseTask.rs                   |  1 +
 test/bundler/transpiler/macro-test.test.ts | 89 +++++++++++++++++++++++++++++-
 2 files changed, 89 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/bundler/ParseTask.rs                        1      1      0
test/bundler/transpiler/macro-test.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->