### PR TITLE
macro: report the user's error when a macro throws synchronously

### DIFF
--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -585,10 +585,7 @@ impl<'a> Run<'a> {
         let result = match result {
             Ok(v) => v,
             Err(e) => {
-                let exception = global.take_exception(e);
-                if !exception.is_termination_exception() {
-                    let _ = vm.as_mut().uncaught_exception(global, exception, false);
-                }
+                global.report_active_exception_as_unhandled(e);
                 return Err(MacroError::MacroFailed);
             }
         };

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -580,11 +580,18 @@ impl<'a> Run<'a> {
         };
 
         let global = vm.global();
-        let result = vm.run_with_api_lock(|| {
-            macro_callback
-                .call(global, JSValue::ZERO, args)
-                .unwrap_or_else(|_| global.try_take_exception().unwrap_or(JSValue::ZERO))
-        });
+        let result = vm.run_with_api_lock(|| macro_callback.call(global, JSValue::ZERO, args));
+
+        let result = match result {
+            Ok(v) => v,
+            Err(e) => {
+                let exception = global.take_exception(e);
+                if !exception.is_termination_exception() {
+                    let _ = vm.as_mut().uncaught_exception(global, exception, false);
+                }
+                return Err(MacroError::MacroFailed);
+            }
+        };
 
         let mut runner = Run {
             caller,

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -1,5 +1,5 @@
 import { escapeHTML } from "bun" assert { type: "macro" };
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import defaultMacro, {
   addStrings,
@@ -129,6 +129,45 @@ test("namespace import", () => {
 
 test("ireturnapromise", async () => {
   expect(await ireturnapromise()).toEqual("aaa");
+});
+
+// A macro that throws synchronously must surface the user's error message, not
+// "cannot coerce Exception (JSType(0)) to Bun's AST". Async rejections already did; sync throws
+// should report identically.
+describe("macro that throws reports the user's error message", () => {
+  const throwMacros = `
+export function syncThrow() { throw new Error("this is the real reason the build broke"); }
+export async function asyncThrow() { throw new Error("this is the real reason the build broke"); }
+export function syncThrowString() { throw "this is the real reason the build broke"; }
+`;
+
+  test.concurrent.each([
+    ["sync throw via bun build", "build", "syncThrow"],
+    ["async throw via bun build", "build", "asyncThrow"],
+    ["sync throw of non-Error via bun build", "build", "syncThrowString"],
+    ["sync throw via bun run", "run", "syncThrow"],
+  ])("%s", async (_, cmd, fn) => {
+    using dir = tempDir("macro-throw", {
+      "throw.ts": throwMacros,
+      "index.ts": `import { ${fn} } from "./throw.ts" with { type: "macro" };\nconsole.log(${fn}());\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), cmd, "index.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // Debug builds emit a "[macro] call <fn>" line to stdout; ignore stdout here and assert on
+    // stderr, which carries the printed exception and the bundler log entries.
+    expect({ stdout, stderr, exitCode }).toMatchObject({
+      stderr: expect.stringContaining("this is the real reason the build broke"),
+      exitCode: 1,
+    });
+    expect(stderr).not.toContain("cannot coerce");
+    expect(stderr).toContain("macro threw exception");
+  });
 });
 
 // A numeric key >= 100000 (JSC's MIN_SPARSE_ARRAY_INDEX) makes the property put inside

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -160,9 +160,7 @@ export function syncThrowString() { throw "this is the real reason the build bro
         // never tears down on the failure-exit path; LSan would abort with 134 on the ASAN
         // lane. `bun run` uses the main-thread VM and keeps leak detection.
         ASAN_OPTIONS:
-          cmd === "build"
-            ? [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":")
-            : bunEnv.ASAN_OPTIONS,
+          cmd === "build" ? [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":") : bunEnv.ASAN_OPTIONS,
       },
       cwd: String(dir),
       stdout: "pipe",

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -155,10 +155,14 @@ export function syncThrowString() { throw "this is the real reason the build bro
       cmd: [bunExe(), cmd, "index.ts"],
       env: {
         ...bunEnv,
-        // detect_leaks=0 (last wins): printing the macro's stack trace caches an
-        // Arc<ParsedSourceMap> on the bundler-worker macro VM, which `bun build` never tears
-        // down on the failure-exit path; LSan would abort with 134 on the ASAN lane.
-        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+        // detect_leaks=0 (last wins) for `bun build` only: printing the macro's stack trace
+        // caches an Arc<ParsedSourceMap> on the bundler-worker macro VM, which `bun build`
+        // never tears down on the failure-exit path; LSan would abort with 134 on the ASAN
+        // lane. `bun run` uses the main-thread VM and keeps leak detection.
+        ASAN_OPTIONS:
+          cmd === "build"
+            ? [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":")
+            : bunEnv.ASAN_OPTIONS,
       },
       cwd: String(dir),
       stdout: "pipe",

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -153,7 +153,13 @@ export function syncThrowString() { throw "this is the real reason the build bro
     });
     await using proc = Bun.spawn({
       cmd: [bunExe(), cmd, "index.ts"],
-      env: bunEnv,
+      env: {
+        ...bunEnv,
+        // detect_leaks=0 (last wins): printing the macro's stack trace caches an
+        // Arc<ParsedSourceMap> on the bundler-worker macro VM, which `bun build` never tears
+        // down on the failure-exit path; LSan would abort with 134 on the ASAN lane.
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+      },
       cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",


### PR DESCRIPTION
## Reproduction

```ts
// m.ts
export function syncThrow() { throw new Error("this is the real reason the build broke"); }
export async function asyncThrow() { throw new Error("this is the real reason the build broke"); }
```

```ts
// c.ts
import { syncThrow } from "./m.ts" with { type: "macro" };
console.log(syncThrow());
```

Before this change, `bun build c.ts` reports:

```
error: cannot coerce Exception (JSType(0)) to Bun's AST. Please return a simpler type
    at c.ts:2:13
```

The user's error message and location are completely lost. The byte-equivalent async function (`asyncThrow`) already reports correctly:

```
error: this is the real reason the build broke
      at asyncThrow (m.ts:2:48)
error: macro threw exception
    at c2.ts:2:13
```

## Cause

In `Run::run_async` (`src/js_parser_jsc/Macro.rs`), when `macro_callback.call()` returns `Err`, the exception is taken off the VM and fed directly into the result-coercion switch as if it were the macro's return value. The JSC `Exception` cell matches none of the known tags and falls through to the "cannot coerce" fallback. The promise-rejection path (`T::Promise` in `coerce`) already reports the rejection via `unhandled_rejection` and returns `MacroFailed`.

## Fix

When the sync call fails, take the exception, report it through `uncaught_exception` (matching the existing `T::Error` arm) and return `MacroError::MacroFailed` (matching the `T::Promise` rejection arm). A sync throw and an async throw now produce identical output.

After this change, `bun build c.ts` reports:

```
error: this is the real reason the build broke
      at syncThrow (m.ts:1:88)
error: macro threw exception
    at c.ts:2:13
```

## Verification

`test/bundler/transpiler/macro-test.test.ts` gains four cases covering sync throw, async throw (regression guard), sync throw of a non-Error value, and sync throw under `bun run`. The three sync cases fail on 1.4.0 with "cannot coerce Exception (JSType(0))" and pass with this change; the whole file and `test/regression/issue/03830.test.ts` pass with `bun bd test`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-test.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (147fac1ff)

test/bundler/transpiler/macro-test.test.ts:
[macro] call escapeHTML
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call escape
[macro] call addStrings
[macro] call ad
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (90d7a72f5)

test/bundler/transpiler/macro-test.test.ts:
(pass) bun builtins can be used in macros [0.03ms]
(pass) latin1 string [0.01ms]
(pass) ascii string
(pass) type coercion [0.06ms]
(pass) escaping [0.15ms]
(pass) utf16 string [0.01ms]
(pass) import aliases [0.03ms]
(pass) default import [0.01ms]
(pass) namespace import [0.02ms]
(pass) ireturnapromise [0.06ms]
(pass) macro that throws reports the user's error message > sync throw via bun build [14.44ms]
(pass) macro that throws reports the user's error message > sync throw via bun run [11.16ms]
(pass) macro that throws reports the user's error message > async throw via bun build [12.95ms]
(pass) macro that throws reports the user's error message > sync throw of non-Error via bun build [13.44ms]
(pass) object argument with a sparse numeric key [11.59ms]

 15 pass
 0 fail
 85 expect() calls
Ran 15 tests across 1 file. [245.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-test.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (147fac1ff)

test/bundler/transpiler/macro-test.test.ts:
[macro] call escapeHTML
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call escape
[macro] call addStrings
[macro] call ad
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 669ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_install_jsc v0.0.0 (/workspace/bun/src/install_jsc)
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/worksp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser_jsc/Macro.rs                 | 14 ++++++---
 test/bundler/transpiler/macro-test.test.ts | 49 +++++++++++++++++++++++++++++-
 2 files changed, 57 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser_jsc/Macro.rs                      3      4      0
test/bundler/transpiler/macro-test.test.ts      2      4      0
```

</details>

<!-- robobun:evidence:end -->