### PR TITLE
macro: inline RegExp return values as regex literals, not display strings

### DIFF
--- a/docs/bundler/macros.mdx
+++ b/docs/bundler/macros.mdx
@@ -160,6 +160,7 @@ export async function getText() {
 
 The transpiler implements special logic for serializing common data formats like `Response` and `Blob`.
 
+- **RegExp**: Inlined as a regular expression literal.
 - **Response**: Bun reads the `Content-Type` and serializes accordingly; for example, a Response with type `application/json` is parsed into an object and `text/plain` is inlined as a string. Responses with an unrecognized or undefined type are base64-encoded.
 - **Blob**: As with Response, the serialization depends on the `type` property.
 

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -619,7 +619,7 @@ impl<'a> Run<'a> {
             let bytes: &[u8] = self.bump.alloc_slice_copy(&bun_str.to_owned_slice());
             let flags_offset = strings::last_index_of_char(bytes, b'/')
                 .filter(|&i| i + 1 < bytes.len())
-                .map(|i| (i + 1) as u16);
+                .and_then(|i| u16::try_from(i + 1).ok());
             return Ok(Expr::init(
                 E::RegExp {
                     value: E::Str::new(bytes),

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -606,9 +606,29 @@ impl<'a> Run<'a> {
 
     pub fn run(&mut self, value: JSValue) -> Result<Expr, MacroError> {
         use ConsoleObject::formatter::Tag as T;
-        // `Tag::get` returns `TagResult { tag: TagPayload, .. }`;
+        // `Tag::get` returns `TagResult { tag: TagPayload, cell: JSType }`;
         // collapse the payload to its discriminant via `.tag()`.
-        match T::get(value, self.global)?.tag.tag() {
+        let tag_result = T::get(value, self.global)?;
+        // The console formatter classifies RegExpObject as `String` (display text).
+        // That is wrong for AST serialization: emit a regex literal instead so the
+        // inlined value keeps its type at the call site.
+        if tag_result.cell == jsc::JSType::RegExpObject {
+            // RegExp.prototype.toString() yields a valid literal: `/source/flags`
+            // (interior `/` in `source` is escaped per EscapeRegExpPattern).
+            let bun_str = bun_core::OwnedString::new(value.to_bun_string(self.global)?);
+            let bytes: &[u8] = self.bump.alloc_slice_copy(&bun_str.to_owned_slice());
+            let flags_offset = strings::last_index_of_char(bytes, b'/')
+                .filter(|&i| i + 1 < bytes.len())
+                .map(|i| (i + 1) as u16);
+            return Ok(Expr::init(
+                E::RegExp {
+                    value: E::Str::new(bytes),
+                    flags_offset,
+                },
+                self.caller.loc,
+            ));
+        }
+        match tag_result.tag.tag() {
             T::Error => self.coerce(T::Error, value),
             T::Undefined => self.coerce(T::Undefined, value),
             T::Null => self.coerce(T::Null, value),

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -1,5 +1,5 @@
 import { escapeHTML } from "bun" assert { type: "macro" };
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import defaultMacro, {
   addStrings,
@@ -129,6 +129,87 @@ test("namespace import", () => {
 
 test("ireturnapromise", async () => {
   expect(await ireturnapromise()).toEqual("aaa");
+});
+
+// A macro returning a RegExp must be inlined as a regex literal, not its display
+// string. Run in a subprocess so the transpiler sees the macro result at parse
+// time rather than this test file's own parse.
+describe("RegExp return values", () => {
+  test.concurrent("top-level and nested", async () => {
+    using dir = tempDir("macro-regexp", {
+      "m.ts": await Bun.file(require.resolve("./macro.ts")).text(),
+      "c.ts": `
+        import { reWithFlags, reNoFlags, reEmpty, reUnicode, reNested } from "./m.ts" with { type: "macro" };
+        const a = reWithFlags();
+        const b = reNoFlags();
+        const c = reEmpty();
+        const d = reUnicode();
+        const n = reNested();
+        console.log(JSON.stringify({
+          a: { source: a.source, flags: a.flags, isRegExp: a instanceof RegExp, test: a.test("ABBC") },
+          b: { source: b.source, flags: b.flags, isRegExp: b instanceof RegExp, test: b.test("a/b") },
+          c: { source: c.source, flags: c.flags, isRegExp: c instanceof RegExp },
+          d: { flags: d.flags, isRegExp: d instanceof RegExp, test: d.test("日本語"), testNeg: d.test("xyz") },
+          n: {
+            patternIsRegExp: n.pattern instanceof RegExp,
+            patternSource: n.pattern.source,
+            listIsRegExp: n.list.every(r => r instanceof RegExp),
+            listFlags: n.list.map(r => r.flags),
+          },
+        }));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "c.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const last = stdout.trim().split("\n").at(-1) || "";
+    let out: unknown;
+    try {
+      out = JSON.parse(last);
+    } catch {
+      out = { raw: stdout };
+    }
+    expect({ out, stderr, exitCode }).toEqual({
+      out: {
+        a: { source: "ab+c", flags: "gi", isRegExp: true, test: true },
+        b: { source: "a\\/b", flags: "", isRegExp: true, test: true },
+        c: { source: "(?:)", flags: "", isRegExp: true },
+        d: { flags: "u", isRegExp: true, test: true, testNeg: false },
+        n: {
+          patternIsRegExp: true,
+          patternSource: "x[0-9]+",
+          listIsRegExp: true,
+          listFlags: ["", "i"],
+        },
+      },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("Bun.build inlines a regex literal", async () => {
+    using dir = tempDir("macro-regexp-build", {
+      "m.ts": `export function re() { return /ab+c/gi; }`,
+      "c.ts": `import { re } from "./m.ts" with { type: "macro" };\nexport const v = re();\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "c.ts", "--target=bun"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toMatchObject({
+      stdout: expect.stringMatching(/var v = \/ab\+c\/gi;/),
+      exitCode: 0,
+    });
+  });
 });
 
 // A numeric key >= 100000 (JSC's MIN_SPARSE_ARRAY_INDEX) makes the property put inside

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -174,7 +174,7 @@ describe("RegExp return values", () => {
     } catch {
       out = { raw: stdout };
     }
-    expect({ out, stderr, exitCode }).toEqual({
+    expect({ out, stderr, exitCode }).toMatchObject({
       out: {
         a: { source: "ab+c", flags: "gi", isRegExp: true, test: true },
         b: { source: "a\\/b", flags: "", isRegExp: true, test: true },
@@ -187,7 +187,6 @@ describe("RegExp return values", () => {
           listFlags: ["", "i"],
         },
       },
-      stderr: "",
       exitCode: 0,
     });
   });

--- a/test/bundler/transpiler/macro.ts
+++ b/test/bundler/transpiler/macro.ts
@@ -23,3 +23,23 @@ export async function ireturnapromise() {
   setTimeout(() => resolve("aaa"), 100);
   return promise;
 }
+
+export function reWithFlags() {
+  return /ab+c/gi;
+}
+
+export function reNoFlags() {
+  return /a\/b/;
+}
+
+export function reEmpty() {
+  return new RegExp("");
+}
+
+export function reUnicode() {
+  return /日本語/u;
+}
+
+export function reNested() {
+  return { pattern: /x[0-9]+/g, list: [/y/, /z/i] };
+}


### PR DESCRIPTION
## What

A macro returning a `RegExp` was silently inlined as its `toString()` text (a plain string), so `macroRe().test(x)` became a runtime `TypeError` and `typeof` / `instanceof` checks flipped. Sibling class instances (`Date`, `Map`, `Set`) correctly fail the build; `RegExp` alone slipped through.

## Repro

```ts
// m.ts
export function re() { return /ab+c/gi; }

// c.ts
import { re } from "./m.ts" with { type: "macro" };
const v = re();
console.log(typeof v, v instanceof RegExp);  // "string" false
v.test("abc");  // TypeError: "/ab+c/gi".test is not a function
```

`bun build c.ts` emitted `var v = "/ab+c/gi";`.

## Cause

`Run::run` in `src/js_parser_jsc/Macro.rs` classifies macro return values with the console formatter's `Tag::get`, and `src/jsc/ConsoleObject.rs` maps `JSType::RegExpObject` to `TagPayload::String` (correct for `console.log` display, wrong as an AST-serializability verdict). The RegExp then took the `T::String` arm of `coerce`, which calls `to_bun_string()` and emits an `E::EString`.

## Fix

`Tag::get` already returns the underlying `JSType` in `TagResult.cell`. Check it for `RegExpObject` before the tag dispatch and emit an `E::RegExp` node instead. `RegExp.prototype.toString()` produces a valid literal (`/source/flags`, interior `/` escaped per the spec's EscapeRegExpPattern), so the display text is the literal text.

Because the check lives in `run()` (which the `Array`, `Object`, and `Promise` arms recurse through), nested RegExps in arrays/objects and `Promise<RegExp>` are covered.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/bundler/transpiler/macro-test.test.ts -t RegExp
(fail) RegExp return values > top-level and nested
  TypeError: "/ab+c/gi".test is not a function
(fail) RegExp return values > Bun.build inlines a regex literal
  stdout: var v = "/ab+c/gi";

$ bun bd test test/bundler/transpiler/macro-test.test.ts
13 pass, 0 fail
```

Docs updated to list `RegExp` under serializable macro return types.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-test.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (571c343e1)

test/bundler/transpiler/macro-test.test.ts:
[macro] call escapeHTML
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call escape
[macro] call addStrings
[macro] call ad
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/transpiler/macro-test.test.ts:
(pass) bun builtins can be used in macros [0.04ms]
(pass) latin1 string [0.01ms]
(pass) ascii string [0.01ms]
(pass) type coercion [0.07ms]
(pass) escaping [0.15ms]
(pass) utf16 string [0.01ms]
(pass) import aliases [0.04ms]
(pass) default import [0.01ms]
(pass) namespace import [0.02ms]
(pass) ireturnapromise [0.07ms]
202 |       cwd: String(dir),
203 |       stdout: "pipe",
204 |       stderr: "pipe",
205 |     });
206 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
207 |     expect({ stdout, stderr, exitCode }).toMatchObject({
                                               ^
error: expect(received).toMatchObject(expected)

  {
    "exitCode": 0,
-   "stdout": StringMatching /var v = \/ab\+c\/gi;/,
+   "stderr": "",
+   "stdout": 
+ "// @bun
+ // c.ts
+ var v = "/ab+c/gi";
+ export {
+   v
+ };
+ "
+ ,
  }

- Expected  - 1
+ Received  + 10

      at <anonymous> (/workspace/bun/test/bundler/transpiler/macro-test.test.ts:207:42)
(fail) RegExp return values > Bun.build inlines a regex literal [19.22ms]
172 |     try {
17
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-test.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (571c343e1)

test/bundler/transpiler/macro-test.test.ts:
[macro] call escapeHTML
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call escape
[macro] call addStrings
[macro] call ad
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     571c343e1d
  features     (none)

22 deps, 106 codegen, 1168 objects in 795ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [10.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1231] gen bindgenv2
[4/1231] gen ErrorCode+*.h
[5/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [13.00ms]
[6/1231] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/bundler/macros.mdx                    |  1 +
 src/js_parser_jsc/Macro.rs                 | 24 ++++++++-
 test/bundler/transpiler/macro-test.test.ts | 82 +++++++++++++++++++++++++++++-
 test/bundler/transpiler/macro.ts           | 20 ++++++++
 4 files changed, 124 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
docs/bundler/macros.mdx                         1      1      0
src/js_parser_jsc/Macro.rs                      5      3      0
test/bundler/transpiler/macro-test.test.ts      1      6      0
test/bundler/transpiler/macro.ts                1      1      0
```

</details>

<!-- robobun:evidence:end -->