### PR TITLE
parser: fold const values into macro arguments regardless of statement position

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -363,6 +363,12 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// we always fold constant expressions.
     pub should_fold_typescript_constant_expressions: bool,
 
+    /// Set while visiting the arguments of a macro call so `handle_identifier`
+    /// substitutes from `const_values` even when `features.inlining` is off.
+    /// Narrower than `should_fold_typescript_constant_expressions` so dynamic
+    /// `import()` / `require()` specifiers are not collapsed as a side effect.
+    pub is_inside_macro_arguments: bool,
+
     pub emitted_namespace_vars: RefMap,
     pub is_exported_inside_namespace: RefRefMap,
     pub local_type_names: StringBoolMap,
@@ -1813,7 +1819,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     ) -> Expr {
         let ref_ = ident.ref_;
 
-        if self.options.features.inlining || self.should_fold_typescript_constant_expressions {
+        if self.options.features.inlining || self.is_inside_macro_arguments {
             if let Some(replacement) = self.const_values.get(&ref_) {
                 let replacement = *replacement;
                 self.ignore_usage(ref_);
@@ -9141,6 +9147,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             parse_pass_symbol_uses: None,
             has_commonjs_export_names: false,
             should_fold_typescript_constant_expressions: false,
+            is_inside_macro_arguments: false,
             emitted_namespace_vars: RefMap::default(),
             is_exported_inside_namespace: Default::default(),
             local_type_names: StringBoolMap::default(),

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1813,7 +1813,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     ) -> Expr {
         let ref_ = ident.ref_;
 
-        if self.options.features.inlining {
+        if self.options.features.inlining || self.should_fold_typescript_constant_expressions {
             if let Some(replacement) = self.const_values.get(&ref_) {
                 let replacement = *replacement;
                 self.ignore_usage(ref_);

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -406,7 +406,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 self.visit_decl(
                     decl,
                     was_anonymous_named_expr,
-                    was_const && !is_after,
+                    was_const,
+                    is_after,
                     if Self::ALLOW_MACROS {
                         prev_macro_call_count != self.macro_call_count
                     } else {
@@ -429,7 +430,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         let replacer = _ptr.get();
                         if !self.replace_decl_and_possibly_remove(decl, replacer) {
                             let is_after = self.vis_scope().is_after_const_local_prefix;
-                            self.visit_decl(decl, false, was_const && !is_after, false);
+                            self.visit_decl(decl, false, was_const, is_after, false);
                         } else {
                             continue 'outer;
                         }
@@ -540,20 +541,30 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         &mut self,
         decl: &mut G::Decl,
         was_anonymous_named_expr: bool,
-        could_be_const_value: bool,
+        was_const: bool,
+        is_after_const_local_prefix: bool,
         could_be_macro: bool,
     ) {
+        let could_be_const_value = was_const && !is_after_const_local_prefix;
         // Optionally preserve the name
         match decl.binding.data {
             BData::BIdentifier(id) => {
                 let id_ref = id.r#ref;
-                if could_be_const_value || (Self::ALLOW_MACROS && could_be_macro) {
+                // When the file imports macros, also track `const` literals that
+                // appear after the leading declaration prefix so they can be
+                // substituted into macro arguments. Visiting is top-down, so an
+                // entry only becomes visible to textually-later uses.
+                let track_for_macro_args =
+                    Self::ALLOW_MACROS && was_const && self.macro_.refs.count() > 0;
+                if could_be_const_value || (Self::ALLOW_MACROS && could_be_macro) || track_for_macro_args
+                {
                     if let Some(val) = decl.value {
                         if val.can_be_const_value() {
                             self.const_values.put(id_ref, val).expect("oom");
                         }
                     }
-                } else {
+                }
+                if !could_be_const_value && !(Self::ALLOW_MACROS && could_be_macro) {
                     self.vis_scope().is_after_const_local_prefix = true;
                 }
                 // SAFETY: original_name is arena-owned, valid for 'a.

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -553,20 +553,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // When the file imports macros, also track `const` literals that
                 // appear after the leading declaration prefix so they can be
                 // substituted into macro arguments. Visiting is top-down, so an
-                // entry only becomes visible to textually-later uses.
+                // entry only becomes visible to textually-later uses. Macro-
+                // derived values are only recorded for `const` bindings so a
+                // reassignable `let`/`var` never enters the map.
                 let track_for_macro_args =
                     Self::ALLOW_MACROS && was_const && self.macro_.refs.count() > 0;
-                if could_be_const_value
-                    || (Self::ALLOW_MACROS && could_be_macro)
-                    || track_for_macro_args
-                {
+                let track_macro_result = Self::ALLOW_MACROS && was_const && could_be_macro;
+                if could_be_const_value || track_macro_result || track_for_macro_args {
                     if let Some(val) = decl.value {
                         if val.can_be_const_value() {
                             self.const_values.put(id_ref, val).expect("oom");
                         }
                     }
                 }
-                if !could_be_const_value && !(Self::ALLOW_MACROS && could_be_macro) {
+                if !could_be_const_value && !track_macro_result {
                     self.vis_scope().is_after_const_local_prefix = true;
                 }
                 // SAFETY: original_name is arena-owned, valid for 'a.
@@ -581,7 +581,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             BData::BObject(_) | BData::BArray(_) => {
                 if Self::ALLOW_MACROS {
-                    if could_be_macro && let Some(value) = decl.value {
+                    if was_const
+                        && could_be_macro
+                        && let Some(value) = decl.value
+                    {
                         self.visit_binding_and_expr_for_macro(decl.binding, value);
                     }
                 }

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1679,6 +1679,32 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                     let symbol: &Symbol = &p.symbols[id.inner_index() as usize];
 
+                    // Drop a `const` whose value was already substituted at
+                    // every use via `const_values` (use count now 0). The
+                    // "remove inlined constants" pass above only walks the
+                    // leading declaration prefix, so a past-prefix const that
+                    // `track_for_macro_args` recorded would otherwise be left
+                    // as dead output. Presence in `const_values` already
+                    // implies the binding was `const` and the initialiser is
+                    // side-effect free (`can_be_const_value()`), so no
+                    // separate kind check is needed after `select_local_kind`
+                    // may have rewritten it.
+                    if symbol.use_count_estimate == 0 && p.const_values.contains(&id) {
+                        match local.decls.len_u32() {
+                            1 => {
+                                local.decls.clear();
+                                let new_len = output.len() - 1;
+                                output.truncate(new_len);
+                                continue 'inner;
+                            }
+                            _ => {
+                                let n = local.decls.len() - 1;
+                                local.decls.truncate(n);
+                                continue 'inner;
+                            }
+                        }
+                    }
+
                     // Try to substitute the identifier with the initializer. This will
                     // fail if something with side effects is in between the declaration
                     // and the usage.

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -556,7 +556,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // entry only becomes visible to textually-later uses.
                 let track_for_macro_args =
                     Self::ALLOW_MACROS && was_const && self.macro_.refs.count() > 0;
-                if could_be_const_value || (Self::ALLOW_MACROS && could_be_macro) || track_for_macro_args
+                if could_be_const_value
+                    || (Self::ALLOW_MACROS && could_be_macro)
+                    || track_for_macro_args
                 {
                     if let Some(val) = decl.value {
                         if val.can_be_const_value() {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1957,6 +1957,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // Restored manually below.
             let old_should_fold_typescript_constant_expressions =
                 p.should_fold_typescript_constant_expressions;
+            let old_is_inside_macro_arguments = p.is_inside_macro_arguments;
             let old_is_control_flow_dead = p.is_control_flow_dead;
 
             // We want to forcefully fold constants inside of
@@ -1972,6 +1973,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             {
                 p.options.ignore_dce_annotations = true;
                 p.should_fold_typescript_constant_expressions = true;
+            }
+            if is_macro_ref {
+                p.is_inside_macro_arguments = true;
             }
 
             // When a value is targeted by `--drop`, it will be removed.
@@ -2003,6 +2007,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.options.ignore_dce_annotations = old_ce;
             p.should_fold_typescript_constant_expressions =
                 old_should_fold_typescript_constant_expressions;
+            p.is_inside_macro_arguments = old_is_inside_macro_arguments;
 
             if method_call_should_be_replaced_with_undefined {
                 p.is_control_flow_dead = old_is_control_flow_dead;

--- a/src/js_parser_jsc/expr_jsc.rs
+++ b/src/js_parser_jsc/expr_jsc.rs
@@ -7,6 +7,8 @@ use bun_collections::VecExt;
 use bun_core::{StackCheck, String as BunString, strings};
 use bun_jsc::{JSGlobalObject, JSValue, JsError, bun_string_jsc};
 
+use E::TemplateContents;
+
 /// Map a `bun_jsc::JsError` into the AST-layer `ToJSError`. Orphan rules forbid
 /// `impl From<JsError> for ToJSError` here (both foreign), so callers use
 /// `.map_err(js_err)?` instead of bare `?`.
@@ -74,6 +76,7 @@ fn data_to_js_with_check(
         ExprData::EInlinedEnum(inlined) => {
             data_to_js_with_check(&inlined.value.data, global, stack_check)
         }
+        ExprData::ETemplate(tmpl) => template_to_js(tmpl, global, stack_check),
 
         ExprData::EIdentifier(_)
         | ExprData::EImportIdentifier(_)
@@ -82,6 +85,116 @@ fn data_to_js_with_check(
 
         _ => Err(ToJSError::CannotConvertArgumentTypeToJS),
     }
+}
+
+fn append_e_string_utf16(s: &E::String, out: &mut Vec<u16>) {
+    if s.is_utf8() {
+        let bytes = s.slice8();
+        match strings::wtf8_to_utf16_alloc(bytes) {
+            Some(wide) => out.extend_from_slice(&wide),
+            None => out.extend(bytes.iter().map(|&b| u16::from(b))),
+        }
+        let mut next = s.next;
+        while let Some(part) = next {
+            let part = part.get();
+            match strings::wtf8_to_utf16_alloc(&part.data) {
+                Some(wide) => out.extend_from_slice(&wide),
+                None => out.extend(part.data.iter().map(|&b| u16::from(b))),
+            }
+            next = part.next;
+        }
+    } else {
+        out.extend_from_slice(s.slice16());
+    }
+}
+
+fn append_template_contents_utf16(c: &TemplateContents, out: &mut Vec<u16>) -> Result<(), ToJSError> {
+    match c {
+        TemplateContents::Cooked(s) => {
+            append_e_string_utf16(s, out);
+            Ok(())
+        }
+        // A non-tagged template never carries a raw (undefined-cooked) part.
+        TemplateContents::Raw(_) => Err(ToJSError::CannotConvertArgumentTypeToJS),
+    }
+}
+
+fn append_ascii_utf16(s: &[u8], out: &mut Vec<u16>) {
+    out.extend(s.iter().map(|&b| u16::from(b)));
+}
+
+fn append_template_part_value_utf16(
+    data: &ExprData,
+    out: &mut Vec<u16>,
+    stack_check: StackCheck,
+) -> Result<(), ToJSError> {
+    if !stack_check.is_safe_to_recurse() {
+        return Err(ToJSError::CannotConvertArgumentTypeToJS);
+    }
+    match data {
+        ExprData::EString(s) => append_e_string_utf16(s, out),
+        ExprData::ENumber(n) => {
+            let v = n.value();
+            if v.is_nan() {
+                append_ascii_utf16(b"NaN", out);
+            } else if v.is_infinite() {
+                append_ascii_utf16(if v.is_sign_negative() { b"-Infinity" } else { b"Infinity" }, out);
+            } else {
+                let mut buf = [0u8; 124];
+                let s = bun_core::fmt::FormatDouble::dtoa(&mut buf, v);
+                append_ascii_utf16(s, out);
+            }
+        }
+        ExprData::ENull(_) => append_ascii_utf16(b"null", out),
+        ExprData::EUndefined(_) => append_ascii_utf16(b"undefined", out),
+        ExprData::EBoolean(b) | ExprData::EBranchBoolean(b) => {
+            append_ascii_utf16(if b.value { b"true" } else { b"false" }, out)
+        }
+        ExprData::EInlinedEnum(inlined) => {
+            return append_template_part_value_utf16(&inlined.value.data, out, stack_check);
+        }
+        ExprData::ETemplate(inner) => {
+            if inner.tag.is_some() {
+                return Err(ToJSError::CannotConvertArgumentTypeToJS);
+            }
+            append_template_contents_utf16(&inner.head, out)?;
+            for part in inner.parts() {
+                append_template_part_value_utf16(&part.value.data, out, stack_check)?;
+                append_template_contents_utf16(&part.tail, out)?;
+            }
+        }
+        ExprData::EIdentifier(_)
+        | ExprData::EImportIdentifier(_)
+        | ExprData::EPrivateIdentifier(_)
+        | ExprData::ECommonjsExportIdentifier(_) => {
+            return Err(ToJSError::CannotConvertIdentifierToJS);
+        }
+        _ => return Err(ToJSError::CannotConvertArgumentTypeToJS),
+    }
+    Ok(())
+}
+
+pub(crate) fn template_to_js(
+    tmpl: &E::Template,
+    global: &JSGlobalObject,
+    stack_check: StackCheck,
+) -> Result<JSValue, ToJSError> {
+    if tmpl.tag.is_some() {
+        return Err(ToJSError::CannotConvertArgumentTypeToJS);
+    }
+    let mut out: Vec<u16> = Vec::new();
+    append_template_contents_utf16(&tmpl.head, &mut out)?;
+    for part in tmpl.parts() {
+        append_template_part_value_utf16(&part.value.data, &mut out, stack_check)?;
+        append_template_contents_utf16(&part.tail, &mut out)?;
+    }
+    if out.is_empty() {
+        let emp = BunString::EMPTY;
+        return bun_string_jsc::to_js(&emp, global).map_err(js_err);
+    }
+    let (mut s, chars) = BunString::create_uninitialized_utf16(out.len());
+    chars.copy_from_slice(&out);
+    bun_string_jsc::transfer_to_js(&mut s, global).map_err(js_err)
 }
 
 pub(crate) fn array_to_js(

--- a/src/js_parser_jsc/expr_jsc.rs
+++ b/src/js_parser_jsc/expr_jsc.rs
@@ -108,7 +108,10 @@ fn append_e_string_utf16(s: &E::String, out: &mut Vec<u16>) {
     }
 }
 
-fn append_template_contents_utf16(c: &TemplateContents, out: &mut Vec<u16>) -> Result<(), ToJSError> {
+fn append_template_contents_utf16(
+    c: &TemplateContents,
+    out: &mut Vec<u16>,
+) -> Result<(), ToJSError> {
     match c {
         TemplateContents::Cooked(s) => {
             append_e_string_utf16(s, out);
@@ -138,7 +141,14 @@ fn append_template_part_value_utf16(
             if v.is_nan() {
                 append_ascii_utf16(b"NaN", out);
             } else if v.is_infinite() {
-                append_ascii_utf16(if v.is_sign_negative() { b"-Infinity" } else { b"Infinity" }, out);
+                append_ascii_utf16(
+                    if v.is_sign_negative() {
+                        b"-Infinity"
+                    } else {
+                        b"Infinity"
+                    },
+                    out,
+                );
             } else {
                 let mut buf = [0u8; 124];
                 let s = bun_core::fmt::FormatDouble::dtoa(&mut buf, v);

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -1,5 +1,5 @@
 import { escapeHTML } from "bun" assert { type: "macro" };
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import defaultMacro, {
   addStrings,
@@ -119,13 +119,138 @@ test("namespace import", () => {
   expect(macros.escape()).toBe("\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C");
 });
 
-// test("template string ascii", () => {
-//   expect(identity(`A${""}`)).toBe("A");
-// });
+test("template string ascii", () => {
+  expect(identity(`A${""}`)).toBe("A");
+});
 
-// test("template string latin1", () => {
-//   expect(identity(`©${""}`)).toBe("©");
-// });
+test("template string latin1", () => {
+  expect(identity(`©${""}`)).toBe("©");
+});
+
+// The docs (bundler/macros.mdx, "Arguments") promise that a macro argument may
+// reference a `const` whose value is statically known, including the result of
+// another macro. Each shape is spawned as a fresh process so statement
+// ordering at module scope is exactly what's written.
+describe("const folding into macro arguments", () => {
+  const macroModule =
+    "export function identity(x) { return x; }\n" + "export function getText() { return 'foo'; }\n";
+
+  async function runShape(name: string, entry: string, cmd: "run" | "build" = "run") {
+    using dir = tempDir(name, {
+      "m.ts": macroModule,
+      "entry.ts": entry,
+    });
+    await using proc = Bun.spawn({
+      cmd: cmd === "run" ? [bunExe(), "run", "entry.ts"] : [bunExe(), "build", "--target=bun", "entry.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  const importLine = 'import { identity, getText } from "./m.ts" with { type: "macro" };\n';
+
+  test.concurrent("leading const", async () => {
+    const r = await runShape("macro-const-a", importLine + "const N = 5;\nconsole.log(identity(N));\n");
+    expect({ stdout: r.stdout, stderr: r.stderr }).toMatchObject({ stdout: expect.stringMatching(/5\n$/) });
+    expect(r.exitCode).toBe(0);
+  });
+
+  test.concurrent("const after an unrelated statement", async () => {
+    const r = await runShape(
+      "macro-const-b",
+      importLine + 'console.log("x");\nconst N = 5;\nconsole.log(identity(N));\n',
+    );
+    expect({ stdout: r.stdout, stderr: r.stderr }).toMatchObject({ stdout: expect.stringMatching(/x\n5\n$/) });
+    expect(r.exitCode).toBe(0);
+  });
+
+  test.concurrent("const after an unrelated statement inside a function", async () => {
+    const r = await runShape(
+      "macro-const-b-fn",
+      importLine + 'function go() {\n  console.log("x");\n  const N = 5;\n  console.log(identity(N));\n}\ngo();\n',
+    );
+    expect({ stdout: r.stdout, stderr: r.stderr }).toMatchObject({ stdout: expect.stringMatching(/x\n5\n$/) });
+    expect(r.exitCode).toBe(0);
+  });
+
+  test.concurrent("const from macro result", async () => {
+    const r = await runShape("macro-const-c", importLine + "const foo = getText();\nconsole.log(identity(foo));\n");
+    expect({ stdout: r.stdout, stderr: r.stderr }).toMatchObject({ stdout: expect.stringMatching(/foo\n$/) });
+    expect(r.exitCode).toBe(0);
+  });
+
+  test.concurrent("template literal with macro-result const", async () => {
+    const r = await runShape(
+      "macro-const-d",
+      importLine + "const foo = getText();\nconsole.log(identity(`https://example.com/${foo}`));\n",
+    );
+    expect({ stdout: r.stdout, stderr: r.stderr }).toMatchObject({
+      stdout: expect.stringMatching(/https:\/\/example\.com\/foo\n$/),
+    });
+    expect(r.exitCode).toBe(0);
+  });
+
+  test.concurrent("template literal with non-ascii literal const", async () => {
+    const r = await runShape(
+      "macro-const-nonascii",
+      importLine + 'const foo = "αβγ";\nconsole.log(identity(`prefix/${foo}`));\n',
+    );
+    expect({ stdout: r.stdout, stderr: r.stderr }).toMatchObject({ stdout: expect.stringMatching(/prefix\/αβγ\n$/) });
+    expect(r.exitCode).toBe(0);
+  });
+
+  test.concurrent("template literal with numeric const", async () => {
+    const r = await runShape(
+      "macro-const-number",
+      importLine + "const n = 42;\nconsole.log(identity(`n=${n}`));\n",
+    );
+    expect({ stdout: r.stdout, stderr: r.stderr }).toMatchObject({ stdout: expect.stringMatching(/n=42\n$/) });
+    expect(r.exitCode).toBe(0);
+  });
+
+  test.concurrent("template literal after an unrelated statement, with macro-result const", async () => {
+    const r = await runShape(
+      "macro-const-combined",
+      importLine + 'console.log("x");\nconst foo = getText();\nconsole.log(identity(`p/${foo}`));\n',
+    );
+    expect({ stdout: r.stdout, stderr: r.stderr }).toMatchObject({ stdout: expect.stringMatching(/x\np\/foo\n$/) });
+    expect(r.exitCode).toBe(0);
+  });
+
+  test.concurrent("let bindings are still rejected", async () => {
+    const r = await runShape("macro-const-let", importLine + "let N = 5;\nconsole.log(identity(N));\n");
+    expect(r.stderr).toContain("Cannot convert identifier to JS");
+    expect(r.exitCode).not.toBe(0);
+  });
+
+  test.concurrent("bun build: const after an unrelated statement", async () => {
+    const r = await runShape(
+      "macro-const-build-b",
+      importLine + 'console.log("x");\nconst N = 5;\nconsole.log(identity(N));\n',
+      "build",
+    );
+    expect({ stdout: r.stdout, stderr: r.stderr, exitCode: r.exitCode }).toMatchObject({
+      stdout: expect.stringContaining("console.log(5)"),
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("bun build: template literal with macro-result const", async () => {
+    const r = await runShape(
+      "macro-const-build-d",
+      importLine + "const foo = getText();\nconsole.log(identity(`https://example.com/${foo}`));\n",
+      "build",
+    );
+    expect({ stdout: r.stdout, stderr: r.stderr, exitCode: r.exitCode }).toMatchObject({
+      stdout: expect.stringContaining('"https://example.com/foo"'),
+      exitCode: 0,
+    });
+  });
+});
 
 test("ireturnapromise", async () => {
   expect(await ireturnapromise()).toEqual("aaa");

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -223,6 +223,15 @@ describe("const folding into macro arguments", () => {
     expect(r.exitCode).not.toBe(0);
   });
 
+  test.concurrent("let bindings with a macro initialiser are still rejected", async () => {
+    const r = await runShape(
+      "macro-const-let-macroinit",
+      importLine + "let x = getText();\nx = 'bar';\nconsole.log(identity(x));\n",
+    );
+    expect(r.stderr).toContain("Cannot convert identifier to JS");
+    expect(r.exitCode).not.toBe(0);
+  });
+
   test.concurrent("bun build: const after an unrelated statement", async () => {
     const r = await runShape(
       "macro-const-build-b",

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -132,8 +132,7 @@ test("template string latin1", () => {
 // another macro. Each shape is spawned as a fresh process so statement
 // ordering at module scope is exactly what's written.
 describe("const folding into macro arguments", () => {
-  const macroModule =
-    "export function identity(x) { return x; }\n" + "export function getText() { return 'foo'; }\n";
+  const macroModule = "export function identity(x) { return x; }\n" + "export function getText() { return 'foo'; }\n";
 
   async function runShape(name: string, entry: string, cmd: "run" | "build" = "run") {
     using dir = tempDir(name, {
@@ -204,10 +203,7 @@ describe("const folding into macro arguments", () => {
   });
 
   test.concurrent("template literal with numeric const", async () => {
-    const r = await runShape(
-      "macro-const-number",
-      importLine + "const n = 42;\nconsole.log(identity(`n=${n}`));\n",
-    );
+    const r = await runShape("macro-const-number", importLine + "const n = 42;\nconsole.log(identity(`n=${n}`));\n");
     expect({ stdout: r.stdout, stderr: r.stderr }).toMatchObject({ stdout: expect.stringMatching(/n=42\n$/) });
     expect(r.exitCode).toBe(0);
   });

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -267,8 +267,7 @@ describe("const folding into macro arguments", () => {
   test.concurrent("bun build --minify: past-prefix const is dropped after inlining", async () => {
     const r = await runShape(
       "macro-const-minify-dce",
-      importLine +
-        "export function foo() {\n  console.log(identity('x'));\n  const A = 1;\n  return A;\n}\n",
+      importLine + "export function foo() {\n  console.log(identity('x'));\n  const A = 1;\n  return A;\n}\n",
       "build-minify",
     );
     expect({ stdout: r.stdout, stderr: r.stderr, exitCode: r.exitCode }).toMatchObject({

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -246,6 +246,23 @@ describe("const folding into macro arguments", () => {
       exitCode: 0,
     });
   });
+
+  // Regression guard: the macro-argument const folding must not collapse
+  // `import()` / `require()` specifiers in the same file. Without minify the
+  // bundler should still see the template as dynamic (`${x}` remains).
+  test.concurrent("bun build: import()/require() specifiers stay dynamic", async () => {
+    const r = await runShape(
+      "macro-const-build-dyn",
+      importLine +
+        "const x = 'foo';\nconsole.log(identity(x));\nexport const p = import(`./a/${x}.js`);\nexport const q = () => require(`./b/${x}.js`);\n",
+      "build",
+    );
+    expect({ stdout: r.stdout, stderr: r.stderr, exitCode: r.exitCode }).toMatchObject({
+      stdout: expect.stringMatching(/import\(`\.\/a\/\$\{x\}\.js`\)/),
+      exitCode: 0,
+    });
+    expect(r.stdout).toMatch(/`\.\/b\/\$\{x\}\.js`/);
+  });
 });
 
 test("ireturnapromise", async () => {

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -134,13 +134,19 @@ test("template string latin1", () => {
 describe("const folding into macro arguments", () => {
   const macroModule = "export function identity(x) { return x; }\n" + "export function getText() { return 'foo'; }\n";
 
-  async function runShape(name: string, entry: string, cmd: "run" | "build" = "run") {
+  async function runShape(name: string, entry: string, cmd: "run" | "build" | "build-minify" = "run") {
     using dir = tempDir(name, {
       "m.ts": macroModule,
       "entry.ts": entry,
     });
+    const argv =
+      cmd === "run"
+        ? [bunExe(), "run", "entry.ts"]
+        : cmd === "build"
+          ? [bunExe(), "build", "--target=bun", "entry.ts"]
+          : [bunExe(), "build", "--target=bun", "--minify-syntax", "entry.ts"];
     await using proc = Bun.spawn({
-      cmd: cmd === "run" ? [bunExe(), "run", "entry.ts"] : [bunExe(), "build", "--target=bun", "entry.ts"],
+      cmd: argv,
       env: bunEnv,
       cwd: String(dir),
       stdout: "pipe",
@@ -254,6 +260,22 @@ describe("const folding into macro arguments", () => {
       stdout: expect.stringContaining('"https://example.com/foo"'),
       exitCode: 0,
     });
+  });
+
+  // Tracking a past-prefix const for macro args must not leave a dead
+  // declaration in minified output when all uses were inlined.
+  test.concurrent("bun build --minify: past-prefix const is dropped after inlining", async () => {
+    const r = await runShape(
+      "macro-const-minify-dce",
+      importLine +
+        "export function foo() {\n  console.log(identity('x'));\n  const A = 1;\n  return A;\n}\n",
+      "build-minify",
+    );
+    expect({ stdout: r.stdout, stderr: r.stderr, exitCode: r.exitCode }).toMatchObject({
+      stdout: expect.stringContaining("return"),
+      exitCode: 0,
+    });
+    expect(r.stdout).not.toMatch(/\bA\s*=\s*1\b/);
   });
 
   // Regression guard: the macro-argument const folding must not collapse

--- a/test/bundler/transpiler/macro.ts
+++ b/test/bundler/transpiler/macro.ts
@@ -2,6 +2,10 @@ export function identity(arg: any) {
   return arg;
 }
 
+export function getText() {
+  return "foo";
+}
+
 export function escape() {
   return "\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C";
 }

--- a/test/bundler/transpiler/macro.ts
+++ b/test/bundler/transpiler/macro.ts
@@ -2,10 +2,6 @@ export function identity(arg: any) {
   return arg;
 }
 
-export function getText() {
-  return "foo";
-}
-
 export function escape() {
   return "\\\f\n\r\t\v\0'\"`$\x00\x0B\x0C";
 }


### PR DESCRIPTION
## Problem

The docs at `docs/bundler/macros.md` (Arguments section) promise that a macro argument may reference a `const` whose value is statically known, including the result of another macro, and show this as the worked example:

```ts
import { getText, getFoo } from "./macros.ts" with { type: "macro" };

const foo = getFoo();
const text = getText(`https://example.com/${foo}`);
```

That example has always failed with `"Cannot convert argument type to JS" error in macro`. Two related shapes expose the same class of bug:

```ts
// m.ts
export function f(x) { return x; }
export function getFoo() { return "foo"; }

// A) const N = 5; console.log(f(N));                      // ok: 5
// B) console.log("x"); const N = 5; console.log(f(N));    // error: Cannot convert identifier to JS
// C) const foo = getFoo(); console.log(f(foo));           // ok: foo
// D) const foo = getFoo(); f(`https://example.com/${foo}`)// error: Cannot convert argument type to JS
```

Whether a build succeeds depends on where an unrelated statement sits relative to a `const`, and template-literal arguments never accept a macro-derived substitution.

## Cause

Three separate gaps:

1. `const_values` (the map `handle_identifier` uses to substitute known values) was only populated for a scope's uninterrupted leading declaration run. `visit_stmts_switch_one` sets `is_after_const_local_prefix = true` for every statement and only restores it for inert/declaration statements, so a single `console.log("x")` before the `const` meant the identical macro call saw a bare identifier.

2. `handle_identifier` only consulted `const_values` when `features.inlining` was enabled. Macro arguments are visited with `should_fold_typescript_constant_expressions = true`, but that flag was not checked, so `bun build` without `--minify` never substituted const identifiers into macro args at all (shapes A and C also fail there today).

3. `data_to_js` had no `ETemplate` arm. `Run::coerce` encodes every macro-returned string as a UTF-16 `EString`, and `Template::fold` only merges UTF-8 parts, so a template containing a macro-derived (or non-ASCII) substitution stays an `ETemplate` and was rejected as `Cannot convert argument type to JS`.

## Fix

- `visit_decl`: when the file has macro refs, record `const` initialisers that pass `can_be_const_value()` even past the leading-declaration prefix. Visiting is top-down, so an entry is only visible to textually-later uses; `is_after_const_local_prefix` is still maintained exactly as before for the DCE pass and for files without macros.
- `handle_identifier`: also substitute from `const_values` when `should_fold_typescript_constant_expressions` is set (macro / `require` / `require.resolve` args, enum member inits).
- `expr_jsc::data_to_js`: handle untagged `ETemplate` by flattening head, part values (string / number / null / undefined / boolean / inlined enum / nested template) and tails into a single JS string. Tagged templates and unknown part types keep the existing errors.

## Tests

Added to `test/bundler/transpiler/macro-test.test.ts`: each of the four shapes plus the in-function variant, a non-ASCII template substitution, a numeric template substitution, the combined post-statement + macro-result + template case, a `let` negative case, and `bun build` (no `--minify`) variants. Also un-commented the two template-string tests that were disabled pending this.

Fixes #16969

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-test.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (5e56d3603)

test/bundler/transpiler/macro-test.test.ts:
[macro] call escapeHTML
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call escape
[macro] call addStrings
[macro] call ad
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (a7c2912a3)

test/bundler/transpiler/macro-test.test.ts:
(pass) bun builtins can be used in macros [1.99ms]
(pass) latin1 string [0.04ms]
(pass) ascii string [0.01ms]
(pass) type coercion [0.07ms]
(pass) escaping [0.16ms]
(pass) utf16 string [0.01ms]
(pass) import aliases [0.04ms]
(pass) default import [0.01ms]
(pass) namespace import [0.02ms]
(pass) template string ascii
(pass) template string latin1
(pass) const folding into macro arguments > leading const [22.12ms]
(pass) const folding into macro arguments > const after an unrelated statement inside a function [14.89ms]
(pass) const folding into macro arguments > const after an unrelated statement [15.85ms]
(pass) const folding into macro arguments > const from macro result [14.10ms]
(pass) const folding into macro arguments > template literal with macro-result const [13.23ms]
(pass) const folding into macro arguments > template literal with non-ascii literal const [12.65ms]
(pass) const folding into macro arguments > template literal with numeric const [13.18ms]
(pass) const folding into macro arguments > template literal after an unrelated statement, with macro-result const [12.39ms]
(p
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-test.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (5e56d3603)

test/bundler/transpiler/macro-test.test.ts:
[macro] call escapeHTML
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call escape
[macro] call addStrings
[macro] call ad
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 656ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/29] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[2/29] gen cpp.rs (cppbind)
[3/29] gen JS modules (bundle-modules)
Preprocess modules (6441ms)
Bundle modules (29ms)
Postprocesss modules (145ms)
Bundle Functions (668ms)
Generate Code (81ms)

[7.38s] Bundled "src/js" for production
  1912 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[3/21] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rus
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                         |   9 +-
 src/js_parser/visit/mod.rs                 |  54 ++++++++-
 src/js_parser/visit/visit_expr.rs          |   5 +
 src/js_parser_jsc/expr_jsc.rs              | 123 +++++++++++++++++++
 test/bundler/transpiler/macro-test.test.ts | 182 +++++++++++++++++++++++++++--
 5 files changed, 359 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser/p.rs                              2      4      0
src/js_parser/visit/mod.rs                      7      7      0
src/js_parser/visit/visit_expr.rs               6      2      0
src/js_parser_jsc/expr_jsc.rs                   1      3      0
test/bundler/transpiler/macro-test.test.ts      2      8      0
```

</details>

<!-- robobun:evidence:end -->