### PR TITLE
node:fs: reject paths of exactly MAX_PATH_BYTES with ENAMETOOLONG

### DIFF
--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -1362,7 +1362,9 @@ pub struct Valid;
 impl Valid {
     pub fn path_slice(zig_str: &ZigStringSlice, ctx: &JSGlobalObject) -> JsResult<()> {
         match zig_str.slice().len() {
-            0..=MAX_PATH_BYTES => Ok(()),
+            // Exclusive: `PathBuffer` is `[u8; MAX_PATH_BYTES]` and
+            // `slice_z_with_force_copy` needs `len + NUL ≤ MAX_PATH_BYTES`.
+            0..MAX_PATH_BYTES => Ok(()),
             _ => {
                 let mut system_error =
                     bun_sys::Error::from_code(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::open)
@@ -1376,7 +1378,9 @@ impl Valid {
 
     pub fn path_string_length(len: usize, ctx: &JSGlobalObject) -> JsResult<()> {
         match len {
-            0..=MAX_PATH_BYTES => Ok(()),
+            // Exclusive: `PathBuffer` is `[u8; MAX_PATH_BYTES]` and
+            // `slice_z_with_force_copy` needs `len + NUL ≤ MAX_PATH_BYTES`.
+            0..MAX_PATH_BYTES => Ok(()),
             _ => {
                 let mut system_error =
                     bun_sys::Error::from_code(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::open)
@@ -1398,7 +1402,9 @@ impl Valid {
                 Err(ctx
                     .throw_invalid_arguments(format_args!("Invalid path buffer: can't be empty")))
             }
-            1..=MAX_PATH_BYTES => Ok(()),
+            // Exclusive: `PathBuffer` is `[u8; MAX_PATH_BYTES]` and
+            // `slice_z_with_force_copy` needs `len + NUL ≤ MAX_PATH_BYTES`.
+            1..MAX_PATH_BYTES => Ok(()),
             _ => {
                 let mut system_error =
                     bun_sys::Error::from_code(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::open)

--- a/test/js/node/fs/fs-path-length.test.ts
+++ b/test/js/node/fs/fs-path-length.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { isPosix, isWindows } from "harness";
+import { isLinux, isMacOS, isPosix, isWindows } from "harness";
 import fs from "node:fs";
 
 // On POSIX systems, MAX_PATH_BYTES is 4096.
@@ -41,6 +41,31 @@ describe.if(isPosix)("path length validation with multi-byte characters", () => 
     // U+00E9 (é) is 2 bytes in UTF-8. 3000 chars = 6000 bytes > 4096
     const accentPath = "\u00e9".repeat(3000);
     expect(() => fs.statSync(accentPath)).toThrow("ENAMETOOLONG");
+  });
+
+  // PATH_MAX (Linux 4096, macOS 1024) includes the NUL terminator, so the
+  // longest usable path string is PATH_MAX-1 bytes. A path of exactly
+  // PATH_MAX bytes used to pass the `0..=MAX_PATH_BYTES` length guard, then
+  // `slice_z_with_force_copy` had no room for the NUL and returned "" — the
+  // syscall ran on the empty path and came back ENOENT instead of
+  // ENAMETOOLONG. PATH_MAX-1 (kernel rejects) and PATH_MAX+1 (guard rejects)
+  // were already correct; only this one length was wrong.
+  describe.each([
+    ["Linux", isLinux, 4096],
+    ["macOS", isMacOS, 1024],
+  ])("PATH_MAX boundary on %s", (_, isHost, PATH_MAX) => {
+    const mk = (n: number) => "/tmp/" + Buffer.alloc(n - 5, "A").toString();
+    it.if(isHost).each([PATH_MAX - 1, PATH_MAX, PATH_MAX + 1])(
+      "returns ENAMETOOLONG for a %i-byte path (sync/promises/Buffer)",
+      async n => {
+        const p = mk(n);
+        expect(() => fs.statSync(p)).toThrow(expect.objectContaining({ code: "ENAMETOOLONG" }));
+        expect(() => fs.openSync(p, "r")).toThrow(expect.objectContaining({ code: "ENAMETOOLONG" }));
+        expect(() => fs.mkdirSync(p)).toThrow(expect.objectContaining({ code: "ENAMETOOLONG" }));
+        expect(() => fs.statSync(Buffer.from(p))).toThrow(expect.objectContaining({ code: "ENAMETOOLONG" }));
+        await expect(fs.promises.stat(p)).rejects.toMatchObject({ code: "ENAMETOOLONG" });
+      },
+    );
   });
 
   // Verify that the process does not crash - the key property is that these


### PR DESCRIPTION
## What

A path of **exactly** `MAX_PATH_BYTES` bytes (4096 on Linux, 1024 on macOS) was silently swapped for the empty path before the syscall, so every `node:fs` op (sync / promises / callback, string and `Buffer` paths) plus `Bun.file()` / `Bun.write()` answered `ENOENT` where Node says `ENAMETOOLONG`. `strace` shows `statx(AT_FDCWD, "")` at that length. Lengths of `MAX_PATH_BYTES - 1` and `MAX_PATH_BYTES + 1` were already correct; only this one-length window was wrong.

## Repro

```js
import * as fs from "node:fs";
const code = fn => { try { fn(); return "ok"; } catch (e) { return e.code; } };
const mk = n => "/tmp/" + "A".repeat(n - 5);
for (const n of [4095, 4096, 4097])
  console.log(n, code(() => fs.statSync(mk(n))));
// node:        4095 ENAMETOOLONG, 4096 ENAMETOOLONG, 4097 ENAMETOOLONG
// bun before:  4095 ENAMETOOLONG, 4096 ENOENT,       4097 ENAMETOOLONG
```

## Cause

`Valid::path_slice` / `path_string_length` / `path_buffer` in `src/runtime/node/types.rs` accepted `0..=MAX_PATH_BYTES` (inclusive), but `PathBuffer` is `[u8; MAX_PATH_BYTES]` and `slice_z_with_force_copy` needs `len + NUL <= MAX_PATH_BYTES`; at `sliced.len() >= buf.len()` it returns `ZStr::EMPTY`. So `len == MAX_PATH_BYTES` passed the guard, the copy declined, and the syscall ran on `""` (kernel `ENOENT` for the empty path).

## Fix

Make the three length guards exclusive (`0..MAX_PATH_BYTES`). `PATH_MAX` includes the NUL terminator, so a `PATH_MAX`-byte string cannot be passed as a C path anyway; rejecting it up front matches Node.

## Verification

`test/js/node/fs/fs-path-length.test.ts` now asserts `ENAMETOOLONG` (not `ENOENT`) for `statSync` / `openSync` / `mkdirSync` / `statSync(Buffer)` / `promises.stat` at `PATH_MAX - 1`, `PATH_MAX`, `PATH_MAX + 1` on both Linux (4096) and macOS (1024). The `PATH_MAX` case fails with `ENOENT` on the unfixed build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/fs-path-length.test.ts

<!-- robobun:evidence:end -->