### PR TITLE
crypto: cap GCM IV length at 128 bytes in createCipheriv

### DIFF
--- a/src/jsc/bindings/node/crypto/JSCipherConstructor.cpp
+++ b/src/jsc/bindings/node/crypto/JSCipherConstructor.cpp
@@ -189,6 +189,16 @@ JSC_DEFINE_HOST_FUNCTION(constructCipher, (JSC::JSGlobalObject * globalObject, J
         }
     }
 
+    // OpenSSL 3 caps GCM IVs at 1024 bits (GCM_IV_MAX_SIZE). BoringSSL has no
+    // such cap, so enforce it here to match Node.js and avoid unbounded GHASH work.
+    if (cipher.isGcmMode()) {
+        ASSERT(ivView);
+
+        if (ivView->byteLength() > 128) {
+            return ERR::CRYPTO_INVALID_IV(scope, globalObject);
+        }
+    }
+
     CipherCtxPointer ctx = CipherCtxPointer::New();
 
     if (cipher.isWrapMode()) {

--- a/test/js/bun/crypto/cipheriv-decipheriv.test.ts
+++ b/test/js/bun/crypto/cipheriv-decipheriv.test.ts
@@ -117,6 +117,19 @@ it("only zero-sized iv or null should be accepted in ECB mode", () => {
 it("should allow only valid iv lengths in GCM mode", () => {
   expect(sampleEncryptDecryptGCM("aes-256-gcm", randomBytes(32), randomBytes(1))).toBe(true);
   expect(sampleEncryptDecryptGCM("aes-256-gcm", randomBytes(32), randomBytes(96))).toBe(true);
+  expect(sampleEncryptDecryptGCM("aes-256-gcm", randomBytes(32), randomBytes(128))).toBe(true);
+});
+
+it("should reject GCM IVs longer than 128 bytes", () => {
+  // Node.js (OpenSSL 3) caps GCM IV length at 1024 bits / 128 bytes.
+  const invalidIV = { code: "ERR_CRYPTO_INVALID_IV" };
+  for (const algo of ["aes-128-gcm", "aes-192-gcm", "aes-256-gcm"] as const) {
+    const key = randomBytes(algo === "aes-128-gcm" ? 16 : algo === "aes-192-gcm" ? 24 : 32);
+    expect(() => createCipheriv(algo, key, Buffer.alloc(128))).not.toThrow();
+    expect(() => createCipheriv(algo, key, Buffer.alloc(129))).toThrow(expect.objectContaining(invalidIV));
+    expect(() => createCipheriv(algo, key, Buffer.alloc(4096))).toThrow(expect.objectContaining(invalidIV));
+    expect(() => createDecipheriv(algo, key, Buffer.alloc(129))).toThrow(expect.objectContaining(invalidIV));
+  }
 });
 
 const referencePlaintext = "Out of the mountain of despair, a stone of hope.";

--- a/test/js/node/test/parallel/test-crypto-cipheriv-decipheriv.js
+++ b/test/js/node/test/parallel/test-crypto-cipheriv-decipheriv.js
@@ -208,7 +208,9 @@ assert.throws(
 
 // But all other IV lengths should be accepted.
 const minIvLength = hasOpenSSL3 ? 8 : 1;
-const maxIvLength = hasOpenSSL3 ? 64 : 256;
+// Bun: BoringSSL has no upper bound, but Bun enforces the OpenSSL 3 cap of
+// 128 bytes (1024 bits) for Node.js compatibility.
+const maxIvLength = hasOpenSSL3 ? 64 : 129;
 for (let n = minIvLength; n < maxIvLength; n += 1) {
   if (isFipsEnabled && n < 12) continue;
   crypto.createCipheriv('aes-128-gcm', Buffer.alloc(16), Buffer.alloc(n));


### PR DESCRIPTION
## What does this PR do?

`crypto.createCipheriv` and `createDecipheriv` accepted GCM IVs of any length (tested up to 64 MiB). Node.js rejects GCM IVs longer than 128 bytes with `ERR_CRYPTO_INVALID_IV` because OpenSSL 3's GCM provider enforces `GCM_IV_MAX_SIZE = 1024 / 8`. BoringSSL has no such cap, so `EVP_CTRL_AEAD_SET_IVLEN` silently accepted the oversized IV.

Two consequences:
- An attacker-controlled IV length is absorbed as GHASH work inside a single constructor call (a 64 MiB IV is ~4M block multiplications) instead of being rejected at the API boundary.
- Ciphertext produced with an IV >128 bytes cannot be deciphered by Node.js (`createDecipheriv` throws).

## Reproduction

```js
import crypto from "node:crypto";
const key = Buffer.alloc(16);
for (const n of [12, 128, 129, 4096, 1 << 20]) {
  try {
    crypto.createCipheriv("aes-128-gcm", key, Buffer.alloc(n, 7)).final();
    console.log(`iv len=${n} ACCEPTED`);
  } catch (e) {
    console.log(`iv len=${n} rejected: ${e.code}`);
  }
}
```

| iv length | Node v26.3.0 | Bun before | Bun after |
| --- | --- | --- | --- |
| 12 | accepted | accepted | accepted |
| 128 | accepted | accepted | accepted |
| 129 | `ERR_CRYPTO_INVALID_IV` | accepted | `ERR_CRYPTO_INVALID_IV` |
| 4096 | `ERR_CRYPTO_INVALID_IV` | accepted | `ERR_CRYPTO_INVALID_IV` |
| 1048576 | `ERR_CRYPTO_INVALID_IV` | accepted | `ERR_CRYPTO_INVALID_IV` |

Auth tags for the 12- and 128-byte rows are byte-identical across Node and Bun, isolating the divergence to the missing upper bound.

## How did you verify your code works?

- `bun bd test test/js/bun/crypto/cipheriv-decipheriv.test.ts` (new test fails on main, passes with fix)
- `bun bd test/js/node/test/parallel/test-crypto-cipheriv-decipheriv.js`
- `bun bd test/js/node/test/parallel/test-crypto-authenticated.js`
- `bun bd test/js/node/test/parallel/test-crypto-authenticated-stream.js`

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/crypto/cipheriv-decipheriv.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (944509692)

test/js/bun/crypto/cipheriv-decipheriv.test.ts:
(pass) should encrypt & decrypt using update & final interface [31.54ms]
(pass) should encrypt & decrypt using streaming interface [321.97ms]
(pass) should fail when cipher is not defined [6.95ms]
(pass) should fail when key is not defined [5.32ms]
(pass) should fail when iv is not defined [4.73ms]
(pass) should fail when key length is invalid [12.31ms]
(pass) should fail when iv length is invalid [12.61ms]
(pass) only zero-sized iv or null should be accepted in ECB mode [16.14ms]
(pass) should allow only valid iv lengths in GCM mode [20.83ms]
124 |   // Node.js (OpenSSL 3) caps GCM IV length at 1024 bits / 128 bytes.
125 |   const invalidIV = { code: "ERR_CRYP
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/crypto/cipheriv-decipheriv.test.ts:
(pass) should encrypt & decrypt using update & final interface [0.62ms]
(pass) should encrypt & decrypt using streaming interface [4.72ms]
(pass) should fail when cipher is not defined [0.12ms]
(pass) should fail when key is not defined [0.05ms]
(pass) should fail when iv is not defined [0.05ms]
(pass) should fail when key length is invalid [0.12ms]
(pass) should fail when iv length is invalid [0.10ms]
(pass) only zero-sized iv or null should be accepted in ECB mode [0.18ms]
(pass) should allow only valid iv lengths in GCM mode [0.25ms]
124 |   // Node.js (OpenSSL 3) caps GCM IV length at 1024 bits / 128 bytes.
125 |   const invalidIV = { code: "ERR_CRYPTO_INVALID_IV" };
126 |   for (const algo of ["aes-128-gcm", "aes-192-gcm", "aes-256-gcm"] as const) {
127 |     const key = randomBytes(algo === "aes-128-gcm" ? 16 : algo === "aes-192-gcm" ? 24 : 32);
128 |     expect(() => createCipheriv(algo, key, Buffer.alloc(128))).not.toThrow();
129 |     expect(() => createCipheriv(algo, key, Buffer.alloc(129))).toThrow(expect.objectContaining(invalidIV));
                                    
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/crypto/cipheriv-decipheriv.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (944509692)

test/js/bun/crypto/cipheriv-decipheriv.test.ts:
(pass) should encrypt & decrypt using update & final interface [31.36ms]
(pass) should encrypt & decrypt using streaming interface [308.79ms]
(pass) should fail when cipher is not defined [6.76ms]
(pass) should fail when key is not defined [5.28ms]
(pass) should fail when iv is not defined [4.72ms]
(pass) should fail when key length is invalid [12.30ms]
(pass) should fail when iv length is invalid [11.37ms]
(pass) only zero-sized iv or null should be accepted in ECB mode [15.79ms]
(pass) should allow only valid iv lengths in GCM mode [21.75ms]
(pass) should reject GCM IVs longer than 128 bytes [29.28ms]
(pass) should encrypt & decrypt well-known values [37.73ms
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 854ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_crypto-1.cpp.o
[2/7] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_crypto-0.cpp.o
[3/7] gen cpp.rs (cppbind)
[3/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Finished[0m `release` profile [opt
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/node/crypto/JSCipherConstructor.cpp        | 10 ++++++++++
 test/js/bun/crypto/cipheriv-decipheriv.test.ts              | 13 +++++++++++++
 .../node/test/parallel/test-crypto-cipheriv-decipheriv.js   |  4 +++-
 3 files changed, 26 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/bindings/node/crypto/JSCipherConstructor.cpp          1      1      0
test/js/bun/crypto/cipheriv-decipheriv.test.ts                1      1      0
…s/node/test/parallel/test-crypto-cipheriv-decipheriv.js      1      1      0
```

</details>

<!-- robobun:evidence:end -->