### PR TITLE
node:crypto: reject truncated GCM auth tags without authTagLength (DEP0182 EOL)

### DIFF
--- a/src/jsc/bindings/node/crypto/JSCipherPrototype.cpp
+++ b/src/jsc/bindings/node/crypto/JSCipherPrototype.cpp
@@ -2,13 +2,10 @@
 #include "JSCipher.h"
 #include "ErrorCode.h"
 #include "CryptoUtil.h"
-#include "BunProcess.h"
 #include "NodeValidator.h"
 #include "JSBufferEncodingType.h"
 #include <JavaScriptCore/TypedArrayInlines.h>
 #include <JavaScriptCore/JSCJSValueInlines.h>
-
-extern "C" bool Bun__Node__ProcessNoDeprecation;
 
 using namespace Bun;
 using namespace JSC;
@@ -278,7 +275,7 @@ JSC_DEFINE_HOST_FUNCTION(jsCipherSetAuthTag, (JSC::JSGlobalObject * globalObject
 
     bool isValid;
     if (cipher->m_ctx.isGcmMode()) {
-        isValid = (!cipher->m_authTagLen.has_value() || *cipher->m_authTagLen == tagLen) && Cipher::IsValidGCMTagLength(tagLen);
+        isValid = cipher->m_authTagLen.has_value() ? *cipher->m_authTagLen == tagLen : tagLen == 16;
     } else {
         ASSERT(Cipher::FromCtx(cipher->m_ctx).isSupportedAuthenticatedMode());
         ASSERT(cipher->m_authTagLen.has_value());
@@ -290,11 +287,6 @@ JSC_DEFINE_HOST_FUNCTION(jsCipherSetAuthTag, (JSC::JSGlobalObject * globalObject
         builder.append("Invalid authentication tag length: "_s);
         builder.append(tagLen);
         return ERR::CRYPTO_INVALID_AUTH_TAG(scope, globalObject, builder.toString());
-    }
-
-    if (cipher->m_ctx.isGcmMode() && !cipher->m_authTagLen.has_value() && tagLen != 16 && !Bun__Node__ProcessNoDeprecation) {
-        Bun::Process::emitWarning(globalObject, jsString(vm, makeString("Using AES-GCM authentication tags of less than 128 bits without specifying the authTagLength option when initializing decryption is deprecated."_s)), jsString(vm, makeString("DeprecationWarning"_s)), jsString(vm, makeString("DEP0182"_s)), jsUndefined());
-        CLEAR_IF_EXCEPTION(scope);
     }
 
     cipher->m_authTagLen = tagLen;

--- a/test/js/bun/crypto/cipheriv-decipheriv.test.ts
+++ b/test/js/bun/crypto/cipheriv-decipheriv.test.ts
@@ -1,4 +1,4 @@
-import { expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { BinaryLike, CipherGCM, createCipheriv, createDecipheriv, DecipherGCM, randomBytes } from "crypto";
 
 /**
@@ -247,4 +247,45 @@ it("should ignore authTagLength for non-authenticated cipher modes", () => {
   gcm.update("hi");
   gcm.final();
   expect(gcm.getAuthTag().length).toBe(12);
+});
+
+describe("GCM setAuthTag tag length (DEP0182 end-of-life)", () => {
+  const key = Buffer.alloc(16);
+  const iv = Buffer.alloc(12);
+  const cipher = createCipheriv("aes-128-gcm", key, iv) as CipherGCM;
+  const ct = Buffer.concat([cipher.update("hello world"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+
+  it.each([4, 8, 12, 13, 14, 15])("rejects a %d-byte tag when authTagLength was not specified", len => {
+    const d = createDecipheriv("aes-128-gcm", key, iv) as DecipherGCM;
+    expect(() => d.setAuthTag(tag.subarray(0, len))).toThrow(
+      expect.objectContaining({
+        name: "TypeError",
+        code: "ERR_CRYPTO_INVALID_AUTH_TAG",
+        message: `Invalid authentication tag length: ${len}`,
+      }),
+    );
+  });
+
+  it("accepts a 16-byte tag when authTagLength was not specified", () => {
+    const d = createDecipheriv("aes-128-gcm", key, iv) as DecipherGCM;
+    d.setAuthTag(tag);
+    const pt = Buffer.concat([d.update(ct), d.final()]).toString();
+    expect(pt).toBe("hello world");
+  });
+
+  it.each([4, 8, 12, 13, 14, 15, 16])("accepts a %d-byte tag when authTagLength matches", len => {
+    const d = createDecipheriv("aes-128-gcm", key, iv, { authTagLength: len }) as DecipherGCM;
+    d.setAuthTag(tag.subarray(0, len));
+    const pt = Buffer.concat([d.update(ct), d.final()]).toString();
+    expect(pt).toBe("hello world");
+  });
+
+  it("leaves the decipher usable after a rejected short tag", () => {
+    const d = createDecipheriv("aes-128-gcm", key, iv) as DecipherGCM;
+    expect(() => d.setAuthTag(tag.subarray(0, 12))).toThrow();
+    d.setAuthTag(tag);
+    const pt = Buffer.concat([d.update(ct), d.final()]).toString();
+    expect(pt).toBe("hello world");
+  });
 });

--- a/test/js/node/test/parallel/test-crypto-gcm-implicit-short-tag.js
+++ b/test/js/node/test/parallel/test-crypto-gcm-implicit-short-tag.js
@@ -3,18 +3,16 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
+const assert = require('assert');
 const { createDecipheriv, randomBytes } = require('crypto');
-
-common.expectWarning({
-  DeprecationWarning: [
-    ['Using AES-GCM authentication tags of less than 128 bits without ' +
-     'specifying the authTagLength option when initializing decryption is ' +
-     'deprecated.',
-     'DEP0182'],
-  ]
-});
 
 const key = randomBytes(32);
 const iv = randomBytes(16);
-const tag = randomBytes(12);
-createDecipheriv('aes-256-gcm', key, iv).setAuthTag(tag);
+for (let tagLength = 0; tagLength < 16; tagLength++) {
+  const tag = randomBytes(tagLength);
+  assert.throws(() => {
+    createDecipheriv('aes-256-gcm', key, iv).setAuthTag(tag);
+  }, {
+    message: `Invalid authentication tag length: ${tagLength}`,
+  });
+}


### PR DESCRIPTION
## What does this PR do?

Node.js promoted [DEP0182](https://nodejs.org/api/deprecations.html#dep0182-short-gcm-authentication-tags-without-explicit-authtaglength) to end-of-life: when decrypting AES-GCM, `decipher.setAuthTag()` now throws `ERR_CRYPTO_INVALID_AUTH_TAG` for tags shorter than 16 bytes unless `createDecipheriv()` was called with an explicit `authTagLength` option. Bun was still on the pre-EOL semantics (emit a `DEP0182` `DeprecationWarning` and accept the truncated tag), so code that relies on the runtime to reject short tags would silently authenticate against fewer bytes than expected. Where the tag field is parsed off the wire, an attacker can present a 4-byte tag and drop forgery resistance from 2^-128 to 2^-32.

## Reproduction

```js
import crypto from "node:crypto";

const key = Buffer.alloc(16), iv = Buffer.alloc(12);
const c = crypto.createCipheriv("aes-128-gcm", key, iv);
const ct = Buffer.concat([c.update("hello world"), c.final()]);
const tag = c.getAuthTag(); // 16 bytes

for (const L of [4, 8, 12, 15]) {
  try {
    const d = crypto.createDecipheriv("aes-128-gcm", key, iv); // NO authTagLength option
    d.setAuthTag(tag.subarray(0, L));
    const pt = Buffer.concat([d.update(ct), d.final()]).toString();
    console.log(`tag[0:${L}] ACCEPTED -> ${JSON.stringify(pt)}`);
  } catch (e) {
    console.log(`tag[0:${L}] rejected: ${e.code || e.name}`);
  }
}
// node v26.3.0: all 4 -> rejected: ERR_CRYPTO_INVALID_AUTH_TAG
// bun (before): all 4 -> ACCEPTED -> "hello world"  (plus a DEP0182 DeprecationWarning)
// bun (after):  all 4 -> rejected: ERR_CRYPTO_INVALID_AUTH_TAG
```

## Fix

In `jsCipherSetAuthTag` (`src/jsc/bindings/node/crypto/JSCipherPrototype.cpp`), tighten the GCM `isValid` check: require the supplied tag length to equal `authTagLength` when that option was set at construction, otherwise require exactly 16 bytes. The now-unreachable `DEP0182` warning branch and its supporting include/extern are removed.

`test/js/node/test/parallel/test-crypto-gcm-implicit-short-tag.js` is synced to the upstream Node.js v26 copy, which asserts the throw rather than the warning (the old version of the file no longer passes under Node itself).

## How did you verify your code works?

- New tests in `test/js/bun/crypto/cipheriv-decipheriv.test.ts` cover: every previously-valid short GCM length (4, 8, 12, 13, 14, 15) is rejected without `authTagLength`; 16-byte tags still work without the option; explicit `authTagLength: N` still accepts an N-byte tag and decrypts correctly; and the decipher remains usable after a rejected `setAuthTag`. Fails on the baked bun (7 failures), passes with this change.
- `test-crypto-gcm-implicit-short-tag.js`, `test-crypto-gcm-explicit-short-tag.js`, `test-crypto-authenticated.js`, `test-crypto-authenticated-stream.js`, and `test/js/node/crypto/node-crypto.test.js` all pass with the debug build.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/crypto/cipheriv-decipheriv.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (906789ecd)

test/js/bun/crypto/cipheriv-decipheriv.test.ts:
(pass) should encrypt & decrypt using update & final interface [9.63ms]
(pass) should encrypt & decrypt using streaming interface [182.47ms]
(pass) should fail when cipher is not defined [4.18ms]
(pass) should fail when key is not defined [2.88ms]
(pass) should fail when iv is not defined [2.76ms]
(pass) should fail when key length is invalid [7.18ms]
(pass) should fail when iv length is invalid [7.04ms]
(pass) only zero-sized iv or null should be accepted in ECB mode [9.32ms]
(pass) should allow only valid iv lengths in GCM mode [8.86ms]
(pass) should encrypt & decrypt well-known values [24.51ms]
(pass) should work with authTagLength missing from options [2.57
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (906789ecd)

test/js/bun/crypto/cipheriv-decipheriv.test.ts:
(pass) should encrypt & decrypt using update & final interface [0.18ms]
(pass) should encrypt & decrypt using streaming interface [2.94ms]
(pass) should fail when cipher is not defined [0.07ms]
(pass) should fail when key is not defined [0.04ms]
(pass) should fail when iv is not defined [0.03ms]
(pass) should fail when key length is invalid [0.10ms]
(pass) should fail when iv length is invalid [0.07ms]
(pass) only zero-sized iv or null should be accepted in ECB mode [0.13ms]
(pass) should allow only valid iv lengths in GCM mode [0.11ms]
(pass) should encrypt & decrypt well-known values [0.21ms]
(pass) should work with authTagLength missing from options [0.04ms]
(pass) should not accept negative authTagLength, or other coercable values [0.13ms]
(pass) should ignore authTagLength for non-authenticated cipher modes [0.09ms]
(pass) GCM setAuthTag tag length (DEP0182 end-of-life) > rejects a 4-byte tag when authTagLength was not specified [0.08ms]
(pass) GCM setAuthTag tag length (DEP0182 end-of-life) > rejects a 8-byte tag when authTagLength was not specified [0.01ms]
(pass) GCM setAut
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/crypto/cipheriv-decipheriv.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (906789ecd)

test/js/bun/crypto/cipheriv-decipheriv.test.ts:
(pass) should encrypt & decrypt using update & final interface [10.81ms]
(pass) should encrypt & decrypt using streaming interface [180.35ms]
(pass) should fail when cipher is not defined [4.16ms]
(pass) should fail when key is not defined [2.91ms]
(pass) should fail when iv is not defined [2.77ms]
(pass) should fail when key length is invalid [7.67ms]
(pass) should fail when iv length is invalid [7.01ms]
(pass) only zero-sized iv or null should be accepted in ECB mode [9.71ms]
(pass) should allow only valid iv lengths in GCM mode [8.81ms]
(pass) should encrypt & decrypt well-known values [23.19ms]
(pass) should work with authTagLength missing from options [2.5
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 716ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_crypto-1.cpp.o
[2/7] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_crypto-0.cpp.o
[3/7] gen cpp.rs (cppbind)
[3/6] link bun-profile
[4/6] bun-profile --revision
1.4.0-canary.1+906789ecd
[6/6] strip bun
[build] done
bun test v1.4.0-canary.1 (906789ecd)

test/js/bun/crypto/cipheriv-decipheriv.test.ts:
(pass) should encrypt & decrypt using update & final interface [0.20ms]
(pass) should encrypt & decrypt using streaming interface [2.81ms]
(pass) should fail when cipher is not defined [0.08ms]
(pass) should fail when key is not defined [0.04ms]
(pass) should fail when iv is not defined [0.05ms]
(pass) should fail when key length is invalid [0.08ms]
(pass) should fail when iv length is invalid [
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/node/crypto/JSCipherPrototype.cpp | 10 +----
 test/js/bun/crypto/cipheriv-decipheriv.test.ts     | 43 +++++++++++++++++++++-
 .../parallel/test-crypto-gcm-implicit-short-tag.js | 20 +++++-----
 3 files changed, 52 insertions(+), 21 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/bindings/node/crypto/JSCipherPrototype.cpp            2      2      0
test/js/bun/crypto/cipheriv-decipheriv.test.ts                1      2      0
…ode/test/parallel/test-crypto-gcm-implicit-short-tag.js      1      1      0
```

</details>

<!-- robobun:evidence:end -->