### PR TITLE
process: make availableMemory() cgroup-aware on Linux

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3253,10 +3253,10 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionAssert, (JSGlobalObject * globalObject,
     return Bun::ERR::ASSERTION(throwScope, globalObject, "assertion error"_s);
 }
 
-extern "C" uint64_t Bun__Os__getFreeMemory(void);
+extern "C" uint64_t Bun__Os__getAvailableMemory(void);
 JSC_DEFINE_HOST_FUNCTION(Process_availableMemory, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
-    return JSValue::encode(jsNumber(Bun__Os__getFreeMemory()));
+    return JSValue::encode(jsNumber(Bun__Os__getAvailableMemory()));
 }
 
 #define PROCESS_BINDING_NOT_IMPLEMENTED_ISSUE(str, issue)                                                                                                                                                                                \

--- a/src/jsc/bindings/OsBinding.cpp
+++ b/src/jsc/bindings/OsBinding.cpp
@@ -19,6 +19,13 @@ extern "C" uint64_t Bun__Os__getFreeMemory(void)
     }
     return (uint64_t)info.free_count * sysconf(_SC_PAGESIZE);
 }
+
+// Darwin has no per-process memory cgroup equivalent that libuv consults, so
+// uv_get_available_memory() == uv_get_free_memory() there.
+extern "C" uint64_t Bun__Os__getAvailableMemory(void)
+{
+    return Bun__Os__getFreeMemory();
+}
 #endif
 
 #if OS(LINUX)
@@ -29,6 +36,7 @@ extern "C" uint64_t Bun__Os__getFreeMemory(void)
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
+#include <climits>
 
 // Read a numeric field (in kB) from /proc/meminfo, matching libuv's
 // uv__read_proc_meminfo. Returns the value in bytes, or 0 on failure.
@@ -98,12 +106,219 @@ extern "C" uint64_t Bun__Os__getFreeMemory(void)
     }
     return 0;
 }
+
+// Read a short file (cgroup control file, /proc/self/cgroup) into buf and
+// NUL-terminate. Returns 0 on success, -1 on any failure. Matches libuv's
+// uv__slurp.
+static int bunSlurp(const char* filename, char* buf, size_t len)
+{
+    int fd;
+    ssize_t n;
+
+    do {
+        fd = open(filename, O_RDONLY | O_CLOEXEC);
+    } while (fd == -1 && errno == EINTR);
+    if (fd == -1) {
+        return -1;
+    }
+
+    do {
+        n = read(fd, buf, len - 1);
+    } while (n == -1 && errno == EINTR);
+    close(fd);
+
+    if (n < 0) {
+        return -1;
+    }
+    buf[n] = '\0';
+    return 0;
+}
+
+// Read a single decimal uint64 from a cgroup control file. cgroup v2's literal
+// "max\n" maps to UINT64_MAX; 0 means "could not read".
+static uint64_t bunReadCgroupUint64(const char* filename)
+{
+    char buf[32];
+    if (bunSlurp(filename, buf, sizeof(buf)) != 0) {
+        return 0;
+    }
+    uint64_t rc = 0;
+    if (sscanf(buf, "%" SCNu64, &rc) == 1) {
+        return rc;
+    }
+    if (strcmp(buf, "max\n") == 0) {
+        return UINT64_MAX;
+    }
+    return 0;
+}
+
+// Locate the :memory: controller's mount path in a cgroup v1 /proc/self/cgroup
+// buffer. Returns a pointer to the path (past its leading '/') and its length
+// via *n, or NULL if the memory controller line wasn't found.
+static char* bunCgroup1FindMemoryController(char* buf, int* n)
+{
+    char* p = strchr(buf, ':');
+    while (p != nullptr && strncmp(p, ":memory:", 8) != 0) {
+        p = strchr(p, '\n');
+        if (p != nullptr) {
+            p = strchr(p, ':');
+        }
+    }
+    if (p != nullptr) {
+        p += strlen(":memory:/");
+        *n = static_cast<int>(strcspn(p, "\n"));
+    }
+    return p;
+}
+
+static void bunGetCgroup1MemoryLimits(char* buf, uint64_t* high, uint64_t* max)
+{
+    char filename[4097];
+    int n;
+
+    *high = 0;
+    *max = 0;
+
+    char* p = bunCgroup1FindMemoryController(buf, &n);
+    if (p != nullptr) {
+        snprintf(filename, sizeof(filename), "/sys/fs/cgroup/memory/%.*s/memory.soft_limit_in_bytes", n, p);
+        *high = bunReadCgroupUint64(filename);
+        snprintf(filename, sizeof(filename), "/sys/fs/cgroup/memory/%.*s/memory.limit_in_bytes", n, p);
+        *max = bunReadCgroupUint64(filename);
+    }
+    if (*high == 0 || *max == 0) {
+        *high = bunReadCgroupUint64("/sys/fs/cgroup/memory/memory.soft_limit_in_bytes");
+        *max = bunReadCgroupUint64("/sys/fs/cgroup/memory/memory.limit_in_bytes");
+    }
+
+    // cgroup v1 reports "unlimited" as LONG_MAX rounded down to a page.
+    uint64_t cgroup1Max = static_cast<uint64_t>(LONG_MAX) & ~static_cast<uint64_t>(sysconf(_SC_PAGESIZE) - 1);
+    if (*high == cgroup1Max) {
+        *high = UINT64_MAX;
+    }
+    if (*max == cgroup1Max) {
+        *max = UINT64_MAX;
+    }
+}
+
+static void bunGetCgroup2MemoryLimits(char* buf, uint64_t* high, uint64_t* max)
+{
+    char path[4097];
+    char filename[4097];
+    char* p = buf + strlen("0::/");
+    int n = static_cast<int>(strcspn(p, "\n"));
+    snprintf(path, sizeof(path), "/sys/fs/cgroup/%.*s", n, p);
+
+    *high = UINT64_MAX;
+    *max = UINT64_MAX;
+
+    // cgroup v2 limits are hierarchical: walk from the leaf to the root and
+    // keep the tightest limit seen at any level.
+    while (strncmp(path, "/sys/fs/cgroup", sizeof("/sys/fs/cgroup") - 1) == 0) {
+        uint64_t v;
+        snprintf(filename, sizeof(filename), "%s/memory.max", path);
+        v = bunReadCgroupUint64(filename);
+        if (v > 0 && v < *max) {
+            *max = v;
+        }
+        snprintf(filename, sizeof(filename), "%s/memory.high", path);
+        v = bunReadCgroupUint64(filename);
+        if (v > 0 && v < *high) {
+            *high = v;
+        }
+        if (strcmp(path, "/sys/fs/cgroup") == 0) {
+            break;
+        }
+        char* lastSlash = strrchr(path, '/');
+        if (lastSlash == nullptr) {
+            break;
+        }
+        *lastSlash = '\0';
+    }
+}
+
+static uint64_t bunGetCgroupConstrainedMemory(char* buf)
+{
+    uint64_t high;
+    uint64_t max;
+    if (strncmp(buf, "0::/", 4) != 0) {
+        bunGetCgroup1MemoryLimits(buf, &high, &max);
+    } else {
+        bunGetCgroup2MemoryLimits(buf, &high, &max);
+    }
+    if (high == 0 || max == 0) {
+        return 0;
+    }
+    uint64_t result = high < max ? high : max;
+    if (result == UINT64_MAX) {
+        return 0;
+    }
+    return result;
+}
+
+static uint64_t bunGetCgroupCurrentMemory(char* buf)
+{
+    char filename[4097];
+    if (strncmp(buf, "0::/", 4) == 0) {
+        char* p = buf + strlen("0::/");
+        int n = static_cast<int>(strcspn(p, "\n"));
+        snprintf(filename, sizeof(filename), "/sys/fs/cgroup/%.*s/memory.current", n, p);
+        return bunReadCgroupUint64(filename);
+    }
+    int n;
+    char* p = bunCgroup1FindMemoryController(buf, &n);
+    if (p != nullptr) {
+        snprintf(filename, sizeof(filename), "/sys/fs/cgroup/memory/%.*s/memory.usage_in_bytes", n, p);
+        uint64_t current = bunReadCgroupUint64(filename);
+        if (current != 0) {
+            return current;
+        }
+    }
+    return bunReadCgroupUint64("/sys/fs/cgroup/memory/memory.usage_in_bytes");
+}
+
+// Matches libuv's uv_get_available_memory (vendor/libuv/src/unix/linux.c):
+// when the process runs under a cgroup memory limit, return the remaining
+// budget (limit - current usage). When there is no limit, or the limit is
+// larger than physical RAM, fall back to host MemAvailable. This is the
+// value Node.js documents for process.availableMemory().
+extern "C" uint64_t Bun__Os__getAvailableMemory(void)
+{
+    char buf[1024];
+    if (bunSlurp("/proc/self/cgroup", buf, sizeof(buf)) != 0) {
+        return Bun__Os__getFreeMemory();
+    }
+
+    uint64_t constrained = bunGetCgroupConstrainedMemory(buf);
+    if (constrained == 0) {
+        return Bun__Os__getFreeMemory();
+    }
+
+    struct sysinfo info;
+    if (sysinfo(&info) == 0) {
+        uint64_t total = static_cast<uint64_t>(info.totalram) * info.mem_unit;
+        if (constrained > total) {
+            return Bun__Os__getFreeMemory();
+        }
+    }
+
+    uint64_t current = bunGetCgroupCurrentMemory(buf);
+    if (constrained < current) {
+        return 0;
+    }
+    return constrained - current;
+}
 #endif
 
 #if OS(WINDOWS)
 extern "C" uint64_t uv_get_available_memory(void);
 
 extern "C" uint64_t Bun__Os__getFreeMemory(void)
+{
+    return uv_get_available_memory();
+}
+
+extern "C" uint64_t Bun__Os__getAvailableMemory(void)
 {
     return uv_get_available_memory();
 }
@@ -123,5 +338,10 @@ extern "C" uint64_t Bun__Os__getFreeMemory(void)
         return 0;
     }
     return static_cast<uint64_t>(free_pages) * sysconf(_SC_PAGESIZE);
+}
+
+extern "C" uint64_t Bun__Os__getAvailableMemory(void)
+{
+    return Bun__Os__getFreeMemory();
 }
 #endif

--- a/src/jsc/bindings/OsBinding.cpp
+++ b/src/jsc/bindings/OsBinding.cpp
@@ -29,6 +29,7 @@ extern "C" uint64_t Bun__Os__getAvailableMemory(void)
 #endif
 
 #if OS(LINUX)
+#include <wtf/RAMSize.h>
 #include <sys/sysinfo.h>
 #include <inttypes.h>
 #include <stdio.h>
@@ -36,7 +37,6 @@ extern "C" uint64_t Bun__Os__getAvailableMemory(void)
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
-#include <climits>
 
 // Read a numeric field (in kB) from /proc/meminfo, matching libuv's
 // uv__read_proc_meminfo. Returns the value in bytes, or 0 on failure.
@@ -134,29 +134,38 @@ static int bunSlurp(const char* filename, char* buf, size_t len)
     return 0;
 }
 
-// Read a single decimal uint64 from a cgroup control file. cgroup v2's literal
-// "max\n" maps to UINT64_MAX; 0 means "could not read".
+// Read a single decimal uint64 from a cgroup control file. 0 = couldn't read.
 static uint64_t bunReadCgroupUint64(const char* filename)
 {
     char buf[32];
-    if (bunSlurp(filename, buf, sizeof(buf)) != 0) {
-        return 0;
-    }
     uint64_t rc = 0;
-    if (sscanf(buf, "%" SCNu64, &rc) == 1) {
-        return rc;
+    if (bunSlurp(filename, buf, sizeof(buf)) == 0) {
+        sscanf(buf, "%" SCNu64, &rc);
     }
-    if (strcmp(buf, "max\n") == 0) {
-        return UINT64_MAX;
-    }
-    return 0;
+    return rc;
 }
 
-// Locate the :memory: controller's mount path in a cgroup v1 /proc/self/cgroup
-// buffer. Returns a pointer to the path (past its leading '/') and its length
-// via *n, or NULL if the memory controller line wasn't found.
-static char* bunCgroup1FindMemoryController(char* buf, int* n)
+// Current cgroup memory usage for this process. Matches libuv's
+// uv__get_cgroup_current_memory: cgroup v2 reads memory.current under the
+// path from /proc/self/cgroup's "0::/<path>" line; cgroup v1 reads
+// memory.usage_in_bytes under the :memory: controller's mount path.
+static uint64_t bunGetCgroupCurrentMemory(void)
 {
+    char buf[1024];
+    char filename[4097];
+
+    if (bunSlurp("/proc/self/cgroup", buf, sizeof(buf)) != 0) {
+        return 0;
+    }
+
+    if (strncmp(buf, "0::/", 4) == 0) {
+        char* p = buf + strlen("0::/");
+        int n = static_cast<int>(strcspn(p, "\n"));
+        snprintf(filename, sizeof(filename), "/sys/fs/cgroup/%.*s/memory.current", n, p);
+        return bunReadCgroupUint64(filename);
+    }
+
+    // cgroup v1: locate the :memory: controller line.
     char* p = strchr(buf, ':');
     while (p != nullptr && strncmp(p, ":memory:", 8) != 0) {
         p = strchr(p, '\n');
@@ -166,108 +175,7 @@ static char* bunCgroup1FindMemoryController(char* buf, int* n)
     }
     if (p != nullptr) {
         p += strlen(":memory:/");
-        *n = static_cast<int>(strcspn(p, "\n"));
-    }
-    return p;
-}
-
-static void bunGetCgroup1MemoryLimits(char* buf, uint64_t* high, uint64_t* max)
-{
-    char filename[4097];
-    int n;
-
-    *high = 0;
-    *max = 0;
-
-    char* p = bunCgroup1FindMemoryController(buf, &n);
-    if (p != nullptr) {
-        snprintf(filename, sizeof(filename), "/sys/fs/cgroup/memory/%.*s/memory.soft_limit_in_bytes", n, p);
-        *high = bunReadCgroupUint64(filename);
-        snprintf(filename, sizeof(filename), "/sys/fs/cgroup/memory/%.*s/memory.limit_in_bytes", n, p);
-        *max = bunReadCgroupUint64(filename);
-    }
-    if (*high == 0 || *max == 0) {
-        *high = bunReadCgroupUint64("/sys/fs/cgroup/memory/memory.soft_limit_in_bytes");
-        *max = bunReadCgroupUint64("/sys/fs/cgroup/memory/memory.limit_in_bytes");
-    }
-
-    // cgroup v1 reports "unlimited" as LONG_MAX rounded down to a page.
-    uint64_t cgroup1Max = static_cast<uint64_t>(LONG_MAX) & ~static_cast<uint64_t>(sysconf(_SC_PAGESIZE) - 1);
-    if (*high == cgroup1Max) {
-        *high = UINT64_MAX;
-    }
-    if (*max == cgroup1Max) {
-        *max = UINT64_MAX;
-    }
-}
-
-static void bunGetCgroup2MemoryLimits(char* buf, uint64_t* high, uint64_t* max)
-{
-    char path[4097];
-    char filename[4097];
-    char* p = buf + strlen("0::/");
-    int n = static_cast<int>(strcspn(p, "\n"));
-    snprintf(path, sizeof(path), "/sys/fs/cgroup/%.*s", n, p);
-
-    *high = UINT64_MAX;
-    *max = UINT64_MAX;
-
-    // cgroup v2 limits are hierarchical: walk from the leaf to the root and
-    // keep the tightest limit seen at any level.
-    while (strncmp(path, "/sys/fs/cgroup", sizeof("/sys/fs/cgroup") - 1) == 0) {
-        uint64_t v;
-        snprintf(filename, sizeof(filename), "%s/memory.max", path);
-        v = bunReadCgroupUint64(filename);
-        if (v > 0 && v < *max) {
-            *max = v;
-        }
-        snprintf(filename, sizeof(filename), "%s/memory.high", path);
-        v = bunReadCgroupUint64(filename);
-        if (v > 0 && v < *high) {
-            *high = v;
-        }
-        if (strcmp(path, "/sys/fs/cgroup") == 0) {
-            break;
-        }
-        char* lastSlash = strrchr(path, '/');
-        if (lastSlash == nullptr) {
-            break;
-        }
-        *lastSlash = '\0';
-    }
-}
-
-static uint64_t bunGetCgroupConstrainedMemory(char* buf)
-{
-    uint64_t high;
-    uint64_t max;
-    if (strncmp(buf, "0::/", 4) != 0) {
-        bunGetCgroup1MemoryLimits(buf, &high, &max);
-    } else {
-        bunGetCgroup2MemoryLimits(buf, &high, &max);
-    }
-    if (high == 0 || max == 0) {
-        return 0;
-    }
-    uint64_t result = high < max ? high : max;
-    if (result == UINT64_MAX) {
-        return 0;
-    }
-    return result;
-}
-
-static uint64_t bunGetCgroupCurrentMemory(char* buf)
-{
-    char filename[4097];
-    if (strncmp(buf, "0::/", 4) == 0) {
-        char* p = buf + strlen("0::/");
         int n = static_cast<int>(strcspn(p, "\n"));
-        snprintf(filename, sizeof(filename), "/sys/fs/cgroup/%.*s/memory.current", n, p);
-        return bunReadCgroupUint64(filename);
-    }
-    int n;
-    char* p = bunCgroup1FindMemoryController(buf, &n);
-    if (p != nullptr) {
         snprintf(filename, sizeof(filename), "/sys/fs/cgroup/memory/%.*s/memory.usage_in_bytes", n, p);
         uint64_t current = bunReadCgroupUint64(filename);
         if (current != 0) {
@@ -277,32 +185,25 @@ static uint64_t bunGetCgroupCurrentMemory(char* buf)
     return bunReadCgroupUint64("/sys/fs/cgroup/memory/memory.usage_in_bytes");
 }
 
-// Matches libuv's uv_get_available_memory (vendor/libuv/src/unix/linux.c):
-// when the process runs under a cgroup memory limit, return the remaining
-// budget (limit - current usage). When there is no limit, or the limit is
-// larger than physical RAM, fall back to host MemAvailable. This is the
-// value Node.js documents for process.availableMemory().
+// Matches libuv's uv_get_available_memory: when the process runs under a
+// cgroup memory limit, return the remaining budget (limit - current usage);
+// otherwise fall back to host MemAvailable. The limit is WTF::ramSize(),
+// the same cgroup-aware value process.constrainedMemory() returns, so
+// availableMemory() <= constrainedMemory() holds by construction.
 extern "C" uint64_t Bun__Os__getAvailableMemory(void)
 {
-    char buf[1024];
-    if (bunSlurp("/proc/self/cgroup", buf, sizeof(buf)) != 0) {
-        return Bun__Os__getFreeMemory();
-    }
-
-    uint64_t constrained = bunGetCgroupConstrainedMemory(buf);
-    if (constrained == 0) {
-        return Bun__Os__getFreeMemory();
-    }
+    uint64_t constrained = static_cast<uint64_t>(WTF::ramSize());
 
     struct sysinfo info;
-    if (sysinfo(&info) == 0) {
-        uint64_t total = static_cast<uint64_t>(info.totalram) * info.mem_unit;
-        if (constrained > total) {
-            return Bun__Os__getFreeMemory();
-        }
+    if (constrained == 0 || sysinfo(&info) != 0) {
+        return Bun__Os__getFreeMemory();
+    }
+    uint64_t total = static_cast<uint64_t>(info.totalram) * info.mem_unit;
+    if (constrained >= total) {
+        return Bun__Os__getFreeMemory();
     }
 
-    uint64_t current = bunGetCgroupCurrentMemory(buf);
+    uint64_t current = bunGetCgroupCurrentMemory();
     if (constrained < current) {
         return 0;
     }

--- a/test/js/node/process/process-availableMemory.test.ts
+++ b/test/js/node/process/process-availableMemory.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "bun:test";
+import { isLinux } from "harness";
+import { existsSync, readFileSync } from "node:fs";
+import { totalmem } from "node:os";
+
+// On Linux, process.availableMemory() must honour the cgroup memory limit the
+// process is running under, returning (limit - current usage) like libuv's
+// uv_get_available_memory() and therefore Node.js. Previously bun returned the
+// host's /proc/meminfo MemAvailable, which inside a container reports the host
+// machine's free memory and can exceed the process's own constrainedMemory()
+// by orders of magnitude.
+
+// Detect whether this process is running under a real cgroup memory limit
+// (i.e. constrainedMemory() reports something smaller than host totalmem).
+function hasCgroupMemoryLimit(): boolean {
+  if (!isLinux) return false;
+  const constrained = process.constrainedMemory();
+  const total = totalmem();
+  return constrained > 0 && total > 0 && constrained < total;
+}
+
+// Read the cgroup's current memory usage directly so the test can compute the
+// expected available value independently of the implementation under test.
+function readCgroupCurrentMemory(): number | null {
+  try {
+    const entry = readFileSync("/proc/self/cgroup", "utf8");
+    // cgroup v2: single "0::/<path>" line.
+    if (entry.startsWith("0::/")) {
+      const path = entry.slice("0::/".length).split("\n", 1)[0];
+      const leaf = "/sys/fs/cgroup/" + path + (path.length && !path.endsWith("/") ? "/" : "") + "memory.current";
+      for (const candidate of [leaf, "/sys/fs/cgroup/memory.current"]) {
+        if (existsSync(candidate)) {
+          const n = Number(readFileSync(candidate, "utf8"));
+          if (Number.isFinite(n)) return n;
+        }
+      }
+      return null;
+    }
+    // cgroup v1: find the :memory: controller.
+    for (const line of entry.split("\n")) {
+      const match = line.match(/^\d+:memory:\/(.*)$/);
+      if (match) {
+        const p = "/sys/fs/cgroup/memory/" + match[1] + (match[1].length ? "/" : "") + "memory.usage_in_bytes";
+        for (const candidate of [p, "/sys/fs/cgroup/memory/memory.usage_in_bytes"]) {
+          if (existsSync(candidate)) {
+            const n = Number(readFileSync(candidate, "utf8"));
+            if (Number.isFinite(n)) return n;
+          }
+        }
+      }
+    }
+  } catch {}
+  return null;
+}
+
+test("process.availableMemory() returns a positive number", () => {
+  const available = process.availableMemory();
+  expect(typeof available).toBe("number");
+  expect(Number.isFinite(available)).toBe(true);
+  expect(available).toBeGreaterThanOrEqual(0);
+});
+
+test.skipIf(!hasCgroupMemoryLimit())(
+  "process.availableMemory() respects cgroup memory limits on Linux",
+  () => {
+    const constrained = process.constrainedMemory();
+    const available = process.availableMemory();
+    const total = totalmem();
+
+    // The invariant the bug violates: a process can never have more memory
+    // available to it than its own cgroup limit. Before the fix, available
+    // was the host's MemAvailable (often hundreds of GB) while constrained
+    // was the container limit (often hundreds of MB).
+    expect(available).toBeLessThanOrEqual(constrained);
+
+    // Sanity: it should also never exceed host total memory.
+    expect(available).toBeLessThanOrEqual(total);
+
+    // Compare against an independent computation of the expected value:
+    // libuv's uv_get_available_memory() on Linux is (limit - current usage).
+    // Memory usage moves between the two reads, so allow generous slack.
+    const current = readCgroupCurrentMemory();
+    if (current !== null) {
+      const expected = Math.max(0, constrained - current);
+      const tolerance = 256 * 1024 * 1024;
+      expect(Math.abs(available - expected)).toBeLessThanOrEqual(tolerance);
+    }
+  },
+);

--- a/test/js/node/process/process-availableMemory.test.ts
+++ b/test/js/node/process/process-availableMemory.test.ts
@@ -60,30 +60,27 @@ test("process.availableMemory() returns a positive number", () => {
   expect(available).toBeGreaterThanOrEqual(0);
 });
 
-test.skipIf(!hasCgroupMemoryLimit())(
-  "process.availableMemory() respects cgroup memory limits on Linux",
-  () => {
-    const constrained = process.constrainedMemory();
-    const available = process.availableMemory();
-    const total = totalmem();
+test.skipIf(!hasCgroupMemoryLimit())("process.availableMemory() respects cgroup memory limits on Linux", () => {
+  const constrained = process.constrainedMemory();
+  const available = process.availableMemory();
+  const total = totalmem();
 
-    // The invariant the bug violates: a process can never have more memory
-    // available to it than its own cgroup limit. Before the fix, available
-    // was the host's MemAvailable (often hundreds of GB) while constrained
-    // was the container limit (often hundreds of MB).
-    expect(available).toBeLessThanOrEqual(constrained);
+  // The invariant the bug violates: a process can never have more memory
+  // available to it than its own cgroup limit. Before the fix, available
+  // was the host's MemAvailable (often hundreds of GB) while constrained
+  // was the container limit (often hundreds of MB).
+  expect(available).toBeLessThanOrEqual(constrained);
 
-    // Sanity: it should also never exceed host total memory.
-    expect(available).toBeLessThanOrEqual(total);
+  // Sanity: it should also never exceed host total memory.
+  expect(available).toBeLessThanOrEqual(total);
 
-    // Compare against an independent computation of the expected value:
-    // libuv's uv_get_available_memory() on Linux is (limit - current usage).
-    // Memory usage moves between the two reads, so allow generous slack.
-    const current = readCgroupCurrentMemory();
-    if (current !== null) {
-      const expected = Math.max(0, constrained - current);
-      const tolerance = 256 * 1024 * 1024;
-      expect(Math.abs(available - expected)).toBeLessThanOrEqual(tolerance);
-    }
-  },
-);
+  // Compare against an independent computation of the expected value:
+  // libuv's uv_get_available_memory() on Linux is (limit - current usage).
+  // Memory usage moves between the two reads, so allow generous slack.
+  const current = readCgroupCurrentMemory();
+  if (current !== null) {
+    const expected = Math.max(0, constrained - current);
+    const tolerance = 256 * 1024 * 1024;
+    expect(Math.abs(available - expected)).toBeLessThanOrEqual(tolerance);
+  }
+});


### PR DESCRIPTION
## What does this PR do?

`process.availableMemory()` on Linux returned the host's `/proc/meminfo` `MemAvailable` (the `os.freemem()` primitive) instead of the process's own remaining cgroup budget. Inside any memory-limited container this reports the host machine's free memory and can exceed the process's own `constrainedMemory()` by orders of magnitude:

```js
// Under a 128 MiB cgroup memory limit (any container / K8s pod):
console.log("constrainedMemory =", process.constrainedMemory());
console.log("availableMemory   =", process.availableMemory());
// node:   constrainedMemory = 134217728
//         availableMemory   = 123056128    (limit - current usage)
// bun:    constrainedMemory = 134217728    <- bun already sees the limit here
//         availableMemory   = 153305661440 <- host MemAvailable, ~1200x the budget
```

Memory-aware code in containers sees the host's free memory and allocates past its limit into an OOM kill; memory-pressure heuristics keyed on this value never fire.

## Cause

`Process_availableMemory` called `Bun__Os__getFreeMemory()`, which is the `os.freemem()` primitive (host `MemAvailable` on Linux). Node.js documents `availableMemory()` as `uv_get_available_memory()`: when running under a cgroup memory limit, return `limit - current usage`; otherwise fall back to host free memory. Bun's Windows arm already routed through `uv_get_available_memory()`; only the POSIX arms used the `os.freemem()` value.

## Fix

Add `Bun__Os__getAvailableMemory()` in `OsBinding.cpp` with per-platform semantics matching libuv:

- **Linux**: use `WTF::ramSize()` (the same cgroup-aware value `process.constrainedMemory()` already returns) as the limit, read the cgroup's `memory.current` / `memory.usage_in_bytes`, and return `limit - current`. Falls back to `MemAvailable` when no limit is in effect or the limit is not below physical RAM. Reusing `WTF::ramSize()` guarantees `availableMemory() <= constrainedMemory()` by construction.
- **Darwin / FreeBSD / Windows**: equivalent to the free-memory value (libuv has no per-process constraint on these platforms either).

`Process_availableMemory` now calls this instead of `Bun__Os__getFreeMemory()`. `os.freemem()` is unchanged and continues to return host `MemAvailable`, matching `uv_get_free_memory()`.

## How did you verify your code works?

New test `test/js/node/process/process-availableMemory.test.ts`:
- asserts `process.availableMemory() <= process.constrainedMemory()` whenever a cgroup limit is in effect (the invariant the bug violated)
- independently computes `limit - memory.current` from the cgroup filesystem and checks `availableMemory()` is within tolerance

Fails on the released bun (`251 GB > 32 GB` in the gate environment), passes with this change.