### PR TITLE
ResolveMessage: tag .message/.specifier/.referrer as UTF-8

### DIFF
--- a/src/jsc/BuildMessage.rs
+++ b/src/jsc/BuildMessage.rs
@@ -145,12 +145,12 @@ impl BuildMessage {
         object.put(
             global,
             b"lineText",
-            ZigString::init(location.line_text.as_deref().unwrap_or(b"")).to_js(global),
+            ZigString::init_utf8(location.line_text.as_deref().unwrap_or(b"")).to_js(global),
         );
         object.put(
             global,
             b"file",
-            ZigString::init(&location.file).to_js(global),
+            ZigString::init_utf8(&location.file).to_js(global),
         );
         object.put(
             global,
@@ -191,7 +191,7 @@ impl BuildMessage {
 
     #[crate::host_fn(getter)]
     pub fn get_message(&self, global: &JSGlobalObject) -> JsResult<JSValue> {
-        Ok(ZigString::init(&self.msg.data.text).to_js(global))
+        Ok(ZigString::init_utf8(&self.msg.data.text).to_js(global))
     }
 
     #[crate::host_fn(getter)]

--- a/src/jsc/BuildMessage.rs
+++ b/src/jsc/BuildMessage.rs
@@ -155,7 +155,7 @@ impl BuildMessage {
         object.put(
             global,
             b"namespace",
-            ZigString::init(location.namespace).to_js(global),
+            ZigString::init_utf8(location.namespace).to_js(global),
         );
         object.put(global, b"line", JSValue::from(location.line));
         object.put(global, b"column", JSValue::from(location.column));

--- a/src/jsc/ResolveMessage.rs
+++ b/src/jsc/ResolveMessage.rs
@@ -327,7 +327,7 @@ impl ResolveMessage {
 
     #[crate::host_fn(getter)]
     pub fn get_message(this: &Self, global: &JSGlobalObject) -> JsResult<JSValue> {
-        Ok(ZigString::init(&this.msg.data.text).to_js(global))
+        Ok(ZigString::init_utf8(&this.msg.data.text).to_js(global))
     }
 
     #[crate::host_fn(getter)]
@@ -339,7 +339,7 @@ impl ResolveMessage {
     pub fn get_specifier(this: &Self, global: &JSGlobalObject) -> JsResult<JSValue> {
         Ok(match &this.msg.metadata {
             bun_ast::Metadata::Resolve(resolve) => {
-                ZigString::init(resolve.specifier.slice(&this.msg.data.text)).to_js(global)
+                ZigString::init_utf8(resolve.specifier.slice(&this.msg.data.text)).to_js(global)
             }
             // Unreachable in practice (ResolveMessage is only constructed for
             // `.resolve` metadata).
@@ -360,7 +360,7 @@ impl ResolveMessage {
     #[crate::host_fn(getter)]
     pub fn get_referrer(this: &Self, global: &JSGlobalObject) -> JsResult<JSValue> {
         Ok(if let Some(referrer) = &this.referrer {
-            ZigString::init(referrer).to_js(global)
+            ZigString::init_utf8(referrer).to_js(global)
         } else {
             JSValue::NULL
         })

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import path from "node:path";
 
 describe("ResolveMessage", () => {
   it("position object does not segfault", async () => {
@@ -88,6 +89,21 @@ describe("ResolveMessage", () => {
     }
     expect(err.referrer).toBe(referrer);
     expect(err.message).toContain(referrer);
+  });
+
+  it("preserves non-ASCII in position.lineText and position.file", async () => {
+    const lineText = `const caf\u00e9 = 1; import "./na\u00efve-missing.js"; // \u{1F389}`;
+    const fileName = "entry-caf\u00e9-\u{1F389}.js";
+    using dir = tempDir("resolve-position-utf8", {
+      [fileName]: lineText + "\n",
+    });
+    const result = await Bun.build({ entrypoints: [path.join(String(dir), fileName)], throw: false });
+    expect(result.success).toBe(false);
+    const log: any = result.logs.find(l => l.name === "ResolveMessage");
+    expect(log).toBeDefined();
+    expect(log.position.lineText).toBe(lineText);
+    expect(path.basename(log.position.file)).toBe(fileName);
+    expect(log.specifier).toBe("./na\u00efve-missing.js");
   });
 
   it("invalid data URL import", async () => {

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -47,6 +47,49 @@ describe("ResolveMessage", () => {
     }
   });
 
+  it("preserves non-ASCII specifier in .message and .specifier (import)", async () => {
+    const spec = "./caf\u00e9-missing-\u{1F389}";
+    let err: any;
+    try {
+      await import(spec);
+      expect.unreachable();
+    } catch (e) {
+      err = e;
+    }
+    expect(err.name).toBe("ResolveMessage");
+    expect(err.specifier).toBe(spec);
+    expect(err.message).toContain(spec);
+    expect(String(err)).toContain(spec);
+    expect(JSON.parse(JSON.stringify(err))).toMatchObject({ specifier: spec });
+  });
+
+  it("preserves non-ASCII specifier in .message and .specifier (require node:)", () => {
+    const spec = "node:sql\u0131te"; // dotless i U+0131
+    let err: any;
+    try {
+      require(spec);
+      expect.unreachable();
+    } catch (e) {
+      err = e;
+    }
+    expect(err.code).toBe("ERR_UNKNOWN_BUILTIN_MODULE");
+    expect(err.specifier).toBe(spec);
+    expect(err.message).toBe(`No such built-in module: ${spec}`);
+  });
+
+  it("preserves non-ASCII referrer in .referrer and .message", () => {
+    const referrer = "/tmp/caf\u00e9-tr\u00e8s-\u{1F389}/file.js";
+    let err: any;
+    try {
+      Bun.resolveSync("./does-not-exist", referrer);
+      expect.unreachable();
+    } catch (e) {
+      err = e;
+    }
+    expect(err.referrer).toBe(referrer);
+    expect(err.message).toContain(referrer);
+  });
+
   it("invalid data URL import", async () => {
     expect(async () => {
       // @ts-ignore


### PR DESCRIPTION
## What

`ResolveMessage.message`, `.specifier`, and `.referrer` returned Latin-1-widened UTF-8 mojibake for non-ASCII module specifiers. A failed `import("./café")` or `require("node:sqlıte")` produced an error whose `.message` rendered `./cafÃ©` / `node:sqlÄ±te`, and `.specifier` was the raw UTF-8 byte sequence widened one-char-per-byte:

```
e.specifier codepoints: 6e 6f 64 65 3a 73 71 6c c4 b1 74 65
                                                ^^^^^ U+0131 as UTF-8 bytes, not U+0131
```

So `e.message.includes(spec)` was always false and `e.specifier === spec` could never hold, which is the whole purpose of that property.

## Cause

`ResolveMessage::fmt` writes the message text as UTF-8 bytes (`write!` over `bstr::BStr`), and the stored specifier/referrer are the original UTF-8 request bytes. The JS-facing getters `get_message` / `get_specifier` / `get_referrer` converted with untagged `ZigString::init(...)`, which per `ZigString`'s contract is decoded as Latin-1 by the C++ side.

## Fix

Use `ZigString::init_utf8` in the three `ResolveMessage` getters. Apply the same fix to the sibling sites in `BuildMessage` (`get_message`, and `position.lineText` / `position.file` in `generate_position_object`) that share the identical shape.

`get_level` / `get_import_kind` are left on `init` since they only ever emit ASCII literals. `to_string_fn` already calls `set_output_encoding()` so it was correct.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/resolve/resolve-error.test.ts -t "non-ASCII"
(fail) preserves non-ASCII specifier ... Expected: "node:sqlıte"  Received: "node:sqlÄ±te"
(fail) preserves non-ASCII referrer  ... Expected: "/tmp/café-..." Received: "/tmp/cafÃ©-..."
3 fail

$ bun bd test test/js/bun/resolve/resolve-error.test.ts
18 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/resolve/resolve-error.test.ts

<!-- robobun:evidence:end -->