### PR TITLE
node:module: make Module.wrap() consistent with Module.wrapper

### DIFF
--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -429,8 +429,8 @@ export function createRequireCache() {
 }
 
 type WrapperMutate = (start: string, end: string) => void;
-export function getWrapperArrayProxy(onMutate: WrapperMutate) {
-  const wrapper = ["(function(exports,require,module,__filename,__dirname){", "})"];
+export function getWrapperArrayProxy(onMutate: WrapperMutate, start: string, end: string) {
+  const wrapper = [start, end];
   return new Proxy(wrapper, {
     set(_target, prop, value, receiver) {
       Reflect.set(wrapper, prop, value, receiver);

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -213,6 +213,9 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionIsBuiltinModule,
     return JSValue::encode(jsBoolean(Bun::isBuiltinModule(moduleStr)));
 }
 
+static constexpr ASCIILiteral nodeDefaultWrapperStart = "(function (exports, require, module, __filename, __dirname) { "_s;
+static constexpr ASCIILiteral nodeDefaultWrapperEnd = "\n});"_s;
+
 JSC_DEFINE_HOST_FUNCTION(jsFunctionWrap, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
@@ -223,13 +226,18 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionWrap, (JSC::JSGlobalObject * globalObject, JS
         return JSC::JSValue::encode(JSC::jsUndefined());
     }
 
-    JSString* prefix = jsString(
-        vm,
-        String(
-            "(function (exports, require, module, __filename, __dirname) { "_s));
-    JSString* suffix = jsString(vm, String("\n});"_s));
+    auto* zigGlobalObject = defaultGlobalObject(globalObject);
+    JSString* prefix;
+    JSString* suffix;
+    if (zigGlobalObject->hasOverriddenModuleWrapper) [[unlikely]] {
+        prefix = jsString(vm, zigGlobalObject->m_moduleWrapperStart);
+        suffix = jsString(vm, zigGlobalObject->m_moduleWrapperEnd);
+    } else {
+        prefix = jsString(vm, String(nodeDefaultWrapperStart));
+        suffix = jsString(vm, String(nodeDefaultWrapperEnd));
+    }
 
-    return JSValue::encode(jsString(globalObject, prefix, code, suffix));
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsString(globalObject, prefix, code, suffix)));
 }
 extern "C" void Bun__Node__Path_joinWTF(BunString* lhs, const char* rhs,
     size_t len, BunString* result);
@@ -719,6 +727,7 @@ JSC_DEFINE_CUSTOM_GETTER(nodeModuleWrapper,
 {
     // This does not cache anything because it is assumed nobody reads it more than once.
     VM& vm = global->vm();
+    auto* zigGlobalObject = defaultGlobalObject(global);
     JSC::JSFunction* cb = JSC::JSFunction::create(vm, global, WebCore::commonJSGetWrapperArrayProxyCodeGenerator(vm), global);
     JSC::CallData callData = JSC::getCallData(cb);
 
@@ -727,6 +736,13 @@ JSC_DEFINE_CUSTOM_GETTER(nodeModuleWrapper,
         vm, global, 1, "onMutate"_s,
         jsFunctionSetCJSWrapperItem, JSC::ImplementationVisibility::Public,
         JSC::NoIntrinsic));
+    if (zigGlobalObject->hasOverriddenModuleWrapper) [[unlikely]] {
+        args.append(jsString(vm, zigGlobalObject->m_moduleWrapperStart));
+        args.append(jsString(vm, zigGlobalObject->m_moduleWrapperEnd));
+    } else {
+        args.append(jsString(vm, String(nodeDefaultWrapperStart)));
+        args.append(jsString(vm, String(nodeDefaultWrapperEnd)));
+    }
 
     NakedPtr<JSC::Exception> returnedException = nullptr;
     auto result = JSC::profiledCall(global, JSC::ProfilingReason::API, cb, callData, JSC::jsUndefined(), args, returnedException);

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -130,6 +130,34 @@ describe.concurrent("node-module-module", () => {
     expect(wrap()).toBe("(function (exports, require, module, __filename, __dirname) { undefined\n});");
   });
 
+  test("Module.wrap is consistent with Module.wrapper", async () => {
+    const script = `
+      const assert = require("node:assert");
+      const { Module } = require("node:module");
+
+      assert.strictEqual(Module.wrapper[0], "(function (exports, require, module, __filename, __dirname) { ");
+      assert.strictEqual(Module.wrapper[1], "\\n});");
+      assert.strictEqual(Module.wrap("X"), Module.wrapper[0] + "X" + Module.wrapper[1]);
+
+      Module.wrapper[0] = "(function (exports, require, module, __filename, __dirname) { module.__viaWrapper = true; ";
+      assert.strictEqual(Module.wrap("Y").includes("__viaWrapper"), true);
+      assert.strictEqual(Module.wrap("Y"), Module.wrapper[0] + "Y" + Module.wrapper[1]);
+
+      Module.wrapper = ["PREFIX{", "}SUFFIX"];
+      assert.strictEqual(Module.wrapper[0], "PREFIX{");
+      assert.strictEqual(Module.wrapper[1], "}SUFFIX");
+      assert.strictEqual(Module.wrap("Z"), "PREFIX{Z}SUFFIX");
+      console.log("PASS");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "PASS\n", stderr: "", exitCode: 0 });
+  });
+
   test("Overwriting _resolveFilename", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "run", path.join(import.meta.dir, "resolveFilenameOverwrite.cjs")],


### PR DESCRIPTION
## Repro

```js
const { Module } = require("node:module");
console.log(JSON.stringify(Module.wrapper[0]));
// node: "(function (exports, require, module, __filename, __dirname) { "
// bun:  "(function(exports,require,module,__filename,__dirname){"
console.log(Module.wrap("X") === Module.wrapper[0] + "X" + Module.wrapper[1]);
// node: true, bun: false

Module.wrapper[0] = "(function (exports, require, module, __filename, __dirname) { module.__via = true; ";
console.log(Module.wrap("Y").includes("__via"));
// node: true, bun: false (wrap() ignores the override that compilation honors)
```

Node's contract is `wrap(code) === wrapper[0] + code + wrapper[1]` always. Coverage and source-transform tools (istanbul and similar) rely on this to compute the CJS header column offset; when the two surfaces disagree, offsets are wrong from the first read, and after an override `wrap()` misreports how the next module will actually be compiled.

## Cause

`jsFunctionWrap` in `src/jsc/modules/NodeModuleModule.cpp` concatenated two hardcoded literals and never consulted `m_moduleWrapperStart`/`m_moduleWrapperEnd`, the state that `setNodeModuleWrapper` and CJS compilation already use. Separately, the `Module.wrapper` getter seeded each new proxy with a compact default (`"(function(exports,require,module,__filename,__dirname){"`, `"})"`), so even at defaults `wrap()` and `wrapper[]` disagreed, and reading `Module.wrapper` after an override returned the defaults again.

## Fix

Both `jsFunctionWrap` and the `Module.wrapper` getter now read from the same source: `m_moduleWrapperStart`/`End` when `hasOverriddenModuleWrapper` is set, otherwise Node's exact default pair (`"(function (exports, require, module, __filename, __dirname) { "`, `"\n});"`). The getter passes the current pair into `getWrapperArrayProxy`, which seeds the proxy from its arguments instead of a hardcoded array.

## Verification

New test in `test/js/node/module/node-module-module.test.js` asserts `wrap(x) === wrapper[0]+x+wrapper[1]` at defaults, after an index mutation, and after whole-array reassignment. Fails on the released build (`wrapper[0]` is the compact form) and passes with the fix. The existing `Module.wrap`, `test-module-wrap.js`, and `test-module-wrapper.js` tests continue to pass.