### PR TITLE
install: don't re-download a tarball that already failed

### DIFF
--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -127,6 +127,10 @@ pub enum Callback {
 #[derive(Default, Clone, Copy)]
 pub struct DedupeMapEntry {
     pub is_required: bool,
+    /// Set once the download/extract for this task id has terminally failed so a
+    /// later `enqueue_*_for_download` can observe the failure instead of
+    /// re-scheduling the entire network task (and its retry cycle) a second time.
+    pub failed: bool,
 }
 /// `Id` is already a wyhash output, so identity hashing
 /// (hash = value bits) avoids re-hashing.
@@ -709,6 +713,11 @@ pub enum ForTarballError {
     OutOfMemory,
     #[error("InvalidURL")]
     InvalidURL,
+    /// Returned by `enqueue_*_for_download` when the dedupe map already records
+    /// a terminal failure for this task id. Callers handle it silently (the
+    /// original failure was already reported) and advance their own bookkeeping.
+    #[error("TarballFailedToDownload")]
+    AlreadyFailed,
 }
 bun_core::oom_from_alloc!(ForTarballError);
 impl From<ForTarballError> for crate::Error {
@@ -716,6 +725,7 @@ impl From<ForTarballError> for crate::Error {
         match e {
             ForTarballError::OutOfMemory => crate::Error::Alloc(bun_alloc::AllocError),
             ForTarballError::InvalidURL => crate::Error::InvalidURL,
+            ForTarballError::AlreadyFailed => crate::Error::TarballFailedToDownload,
         }
     }
 }

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1550,8 +1550,10 @@ impl<'a> PackageInstaller<'a> {
                         ) {
                             Ok(()) => {}
                             Err(ForTarballError::OutOfMemory) => bun_core::out_of_memory(),
-                            Err(ForTarballError::InvalidURL) => {
-                                self.fail_with_invalid_url::<IS_PENDING_PACKAGE_INSTALL>(log_level)
+                            Err(ForTarballError::InvalidURL | ForTarballError::AlreadyFailed) => {
+                                self.fail_enqueue_for_download::<IS_PENDING_PACKAGE_INSTALL>(
+                                    log_level,
+                                )
                             }
                         }
                     }
@@ -1576,8 +1578,10 @@ impl<'a> PackageInstaller<'a> {
                         ) {
                             Ok(()) => {}
                             Err(ForTarballError::OutOfMemory) => bun_core::out_of_memory(),
-                            Err(ForTarballError::InvalidURL) => {
-                                self.fail_with_invalid_url::<IS_PENDING_PACKAGE_INSTALL>(log_level)
+                            Err(ForTarballError::InvalidURL | ForTarballError::AlreadyFailed) => {
+                                self.fail_enqueue_for_download::<IS_PENDING_PACKAGE_INSTALL>(
+                                    log_level,
+                                )
                             }
                         }
                     }
@@ -1608,8 +1612,10 @@ impl<'a> PackageInstaller<'a> {
                         ) {
                             Ok(()) => {}
                             Err(ForTarballError::OutOfMemory) => bun_core::out_of_memory(),
-                            Err(ForTarballError::InvalidURL) => {
-                                self.fail_with_invalid_url::<IS_PENDING_PACKAGE_INSTALL>(log_level)
+                            Err(ForTarballError::InvalidURL | ForTarballError::AlreadyFailed) => {
+                                self.fail_enqueue_for_download::<IS_PENDING_PACKAGE_INSTALL>(
+                                    log_level,
+                                )
                             }
                         }
                     }
@@ -2236,7 +2242,7 @@ impl<'a> PackageInstaller<'a> {
         }
     }
 
-    fn fail_with_invalid_url<const IS_PENDING_PACKAGE_INSTALL: bool>(
+    fn fail_enqueue_for_download<const IS_PENDING_PACKAGE_INSTALL: bool>(
         &mut self,
         log_level: Options::LogLevel,
     ) {

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1550,11 +1550,15 @@ impl<'a> PackageInstaller<'a> {
                         ) {
                             Ok(()) => {}
                             Err(ForTarballError::OutOfMemory) => bun_core::out_of_memory(),
-                            Err(ForTarballError::InvalidURL | ForTarballError::AlreadyFailed) => {
-                                self.fail_enqueue_for_download::<IS_PENDING_PACKAGE_INSTALL>(
-                                    log_level,
-                                )
+                            Err(ForTarballError::InvalidURL) => {
+                                self.fail_with_invalid_url::<IS_PENDING_PACKAGE_INSTALL>(log_level)
                             }
+                            Err(ForTarballError::AlreadyFailed) => self
+                                .increment_tree_install_count(
+                                    !IS_PENDING_PACKAGE_INSTALL,
+                                    self.current_tree_id,
+                                    log_level,
+                                ),
                         }
                     }
                     resolution::Tag::LocalTarball => {
@@ -1578,11 +1582,15 @@ impl<'a> PackageInstaller<'a> {
                         ) {
                             Ok(()) => {}
                             Err(ForTarballError::OutOfMemory) => bun_core::out_of_memory(),
-                            Err(ForTarballError::InvalidURL | ForTarballError::AlreadyFailed) => {
-                                self.fail_enqueue_for_download::<IS_PENDING_PACKAGE_INSTALL>(
-                                    log_level,
-                                )
+                            Err(ForTarballError::InvalidURL) => {
+                                self.fail_with_invalid_url::<IS_PENDING_PACKAGE_INSTALL>(log_level)
                             }
+                            Err(ForTarballError::AlreadyFailed) => self
+                                .increment_tree_install_count(
+                                    !IS_PENDING_PACKAGE_INSTALL,
+                                    self.current_tree_id,
+                                    log_level,
+                                ),
                         }
                     }
                     resolution::Tag::Npm => {
@@ -1612,11 +1620,15 @@ impl<'a> PackageInstaller<'a> {
                         ) {
                             Ok(()) => {}
                             Err(ForTarballError::OutOfMemory) => bun_core::out_of_memory(),
-                            Err(ForTarballError::InvalidURL | ForTarballError::AlreadyFailed) => {
-                                self.fail_enqueue_for_download::<IS_PENDING_PACKAGE_INSTALL>(
-                                    log_level,
-                                )
+                            Err(ForTarballError::InvalidURL) => {
+                                self.fail_with_invalid_url::<IS_PENDING_PACKAGE_INSTALL>(log_level)
                             }
+                            Err(ForTarballError::AlreadyFailed) => self
+                                .increment_tree_install_count(
+                                    !IS_PENDING_PACKAGE_INSTALL,
+                                    self.current_tree_id,
+                                    log_level,
+                                ),
                         }
                     }
                     _ => {
@@ -2242,7 +2254,7 @@ impl<'a> PackageInstaller<'a> {
         }
     }
 
-    fn fail_enqueue_for_download<const IS_PENDING_PACKAGE_INSTALL: bool>(
+    fn fail_with_invalid_url<const IS_PENDING_PACKAGE_INSTALL: bool>(
         &mut self,
         log_level: Options::LogLevel,
     ) {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -185,6 +185,9 @@ pub fn enqueue_tarball_for_download(
     patch_name_and_version_hash: Option<u64>,
 ) -> Result<(), EnqueueTarballForDownloadError> {
     let task_id = Task::Id::for_tarball(url);
+    if this.network_task_has_failed(task_id) {
+        return Err(EnqueueTarballForDownloadError::AlreadyFailed);
+    }
     let task_queue = this.task_queue.get_or_put(task_id)?;
     if !task_queue.found_existing {
         *task_queue.value_ptr = TaskCallbackList::default();
@@ -390,6 +393,9 @@ pub fn enqueue_package_for_download(
     patch_name_and_version_hash: Option<u64>,
 ) -> Result<(), EnqueuePackageForDownloadError> {
     let task_id = Task::Id::for_npm_package(name, version);
+    if this.network_task_has_failed(task_id) {
+        return Err(EnqueuePackageForDownloadError::AlreadyFailed);
+    }
     let task_queue = this.task_queue.get_or_put(task_id)?;
     if !task_queue.found_existing {
         *task_queue.value_ptr = TaskCallbackList::default();

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -706,20 +706,16 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                         .map(crate::Error::from)
                         .unwrap_or(crate::Error::TarballFailedToDownload);
 
-                    // The download will not be retried for this task_id, so
-                    // drop the dedupe state before dispatching the error.
-                    // Otherwise a later `enqueuePackageForDownload` for the
-                    // same package sees `found_existing`, never schedules a
-                    // network task, and waits forever for a callback that
-                    // will not arrive. `Store.Installer.onPackageDownloadError`
-                    // drains `task_queue` itself but does not touch
-                    // `network_dedupe_map`, so this must run on the callback
-                    // path too. Capture `is_required` first —
-                    // `isNetworkTaskRequired` reads the map and returns `true`
-                    // when the entry is gone, which would upgrade optional-dep
-                    // warnings to errors on the void-callback fallback below.
+                    // The download will not be retried for this task_id. Mark
+                    // the dedupe entry as failed so a later
+                    // `enqueuePackageForDownload` for the same package observes
+                    // the failure and fails fast instead of either waiting
+                    // forever on a callback that never arrives (entry kept) or
+                    // re-running the entire download+retry cycle (entry removed).
+                    // Runs before the callback branch so `Store.Installer`
+                    // (which `continue`s from the callback) is covered too.
                     let is_required = manager.is_network_task_required(task.task_id);
-                    let _ = manager.network_dedupe_map.remove(&task.task_id);
+                    manager.mark_network_task_failed(task.task_id);
 
                     if C::HAS_ON_PACKAGE_DOWNLOAD_ERROR {
                         if C::IS_STORE_INSTALLER {
@@ -792,15 +788,13 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                 let response = &metadata.response;
 
                 if response.status_code > 399 {
-                    // Non-retryable HTTP error: drop dedupe state so a later
-                    // enqueue for this task_id schedules a fresh network task
-                    // instead of waiting on this failed one. Runs before the
-                    // callback branch so `Store.Installer` (which `continue`s
-                    // from the callback) is covered too. Capture
-                    // `is_required` first — `isNetworkTaskRequired` reads the
-                    // map and returns `true` when the entry is gone.
+                    // Non-retryable HTTP error: mark the dedupe entry as failed
+                    // so a later enqueue for this task_id fails fast instead of
+                    // waiting on this failed one or re-downloading it. Runs
+                    // before the callback branch so `Store.Installer` (which
+                    // `continue`s from the callback) is covered too.
                     let is_required = manager.is_network_task_required(task.task_id);
-                    let _ = manager.network_dedupe_map.remove(&task.task_id);
+                    manager.mark_network_task_failed(task.task_id);
 
                     if C::HAS_ON_PACKAGE_DOWNLOAD_ERROR {
                         let err = match response.status_code {
@@ -1080,14 +1074,14 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     let err = task.err.unwrap_or(crate::Error::TarballFailedToExtract);
 
                     // Extract-task failure (integrity check, libarchive error, etc.)
-                    // is symmetric with the HTTP 4xx/5xx branch above: drop the
-                    // dedupe state so a later `enqueuePackageForDownload` for this
-                    // `task_id` schedules a fresh network task instead of waiting
-                    // on this failed one forever. Runs before the callback branch
-                    // so `Store.Installer` (which `continue`s from the callback)
-                    // is covered too. `network_dedupe_map.remove` is a no-op for
+                    // is symmetric with the HTTP 4xx/5xx branch above: mark the
+                    // dedupe entry as failed so a later `enqueuePackageForDownload`
+                    // for this `task_id` fails fast instead of waiting on this
+                    // failed one forever or re-downloading it. Runs before the
+                    // callback branch so `Store.Installer` (which `continue`s from
+                    // the callback) is covered too. The mark is a no-op for
                     // `local_tarball` tasks (they never populate the map).
-                    let _ = manager.network_dedupe_map.remove(&task.id);
+                    manager.mark_network_task_failed(task.id);
 
                     if C::HAS_ON_PACKAGE_DOWNLOAD_ERROR {
                         // SAFETY: `task.tag` selects the active `task.request` union arm.
@@ -1754,6 +1748,18 @@ pub fn is_network_task_required(this: &PackageManager, task_id: Task::Id) -> boo
     }
 }
 
+pub fn mark_network_task_failed(this: &mut PackageManager, task_id: Task::Id) {
+    if let Some(entry) = this.network_dedupe_map.get_mut(&task_id) {
+        entry.failed = true;
+    }
+}
+
+pub fn network_task_has_failed(this: &PackageManager, task_id: Task::Id) -> bool {
+    this.network_dedupe_map
+        .get(&task_id)
+        .is_some_and(|e| e.failed)
+}
+
 pub fn generate_network_task_for_tarball<'a>(
     this: &'a mut PackageManager,
     task_id: Task::Id,
@@ -1929,6 +1935,14 @@ impl PackageManager {
     #[inline]
     pub fn is_network_task_required(&self, task_id: Task::Id) -> bool {
         is_network_task_required(self, task_id)
+    }
+    #[inline]
+    pub fn mark_network_task_failed(&mut self, task_id: Task::Id) {
+        mark_network_task_failed(self, task_id)
+    }
+    #[inline]
+    pub fn network_task_has_failed(&self, task_id: Task::Id) -> bool {
+        network_task_has_failed(self, task_id)
     }
     #[inline]
     pub fn get_network_task(&mut self) -> *mut NetworkTask {

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2419,6 +2419,15 @@ pub(crate) fn install_isolated_packages(
                                 Err(e) if e == crate::Error::Alloc(bun_alloc::AllocError) => {
                                     return Err(AllocError);
                                 }
+                                Err(crate::network_task::ForTarballError::AlreadyFailed) => {
+                                    // .monotonic is okay because an error means the task isn't
+                                    // running on another thread.
+                                    entry_steps[entry_id.get() as usize]
+                                        .store(installer::Step::Done as u32, Ordering::Relaxed);
+                                    installer
+                                        .on_task_complete(entry_id, installer::CompleteState::Fail);
+                                    continue;
+                                }
                                 Err(err) => {
                                     // error.InvalidURL
                                     Output::err(
@@ -2469,6 +2478,15 @@ pub(crate) fn install_isolated_packages(
                                 Err(e) if e == crate::Error::Alloc(bun_alloc::AllocError) => {
                                     bun_core::out_of_memory()
                                 }
+                                Err(crate::network_task::ForTarballError::AlreadyFailed) => {
+                                    // .monotonic is okay because an error means the task isn't
+                                    // running on another thread.
+                                    entry_steps[entry_id.get() as usize]
+                                        .store(installer::Step::Done as u32, Ordering::Relaxed);
+                                    installer
+                                        .on_task_complete(entry_id, installer::CompleteState::Fail);
+                                    continue;
+                                }
                                 Err(err) => {
                                     Output::err(
                                         err,
@@ -2512,6 +2530,15 @@ pub(crate) fn install_isolated_packages(
                                 Ok(()) => {}
                                 Err(e) if e == crate::Error::Alloc(bun_alloc::AllocError) => {
                                     bun_core::out_of_memory()
+                                }
+                                Err(crate::network_task::ForTarballError::AlreadyFailed) => {
+                                    // .monotonic is okay because an error means the task isn't
+                                    // running on another thread.
+                                    entry_steps[entry_id.get() as usize]
+                                        .store(installer::Step::Done as u32, Ordering::Relaxed);
+                                    installer
+                                        .on_task_complete(entry_id, installer::CompleteState::Fail);
+                                    continue;
                                 }
                                 Err(err) => {
                                     Output::err(

--- a/test/cli/install/bun-install-retry.test.ts
+++ b/test/cli/install/bun-install-retry.test.ts
@@ -1,5 +1,5 @@
 import { file, spawn } from "bun";
-import { afterAll, afterEach, beforeAll, beforeEach, expect, it, setDefaultTimeout } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { access, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env, readdirSorted, tmpdirSync, toBeValidBin, toBeWorkspaceLink, toHaveBins } from "harness";
 import { join } from "path";
@@ -295,4 +295,61 @@ it("retries on 500", async () => {
       ))(),
     async () => await access(join(package_dir, "bun.lockb")),
   ]);
+});
+
+// A tarball that fails permanently must run its download (and retry cycle)
+// exactly once and be reported as exactly one error. Previously the resolve
+// phase's failure dropped the dedupe entry so the install phase re-ran the
+// entire download: a 500 endpoint saw 12 GETs instead of 6 and the same
+// `error: GET ...` line was printed twice.
+describe.each(["hoisted", "isolated"])("linker=%s", linker => {
+  it.each([
+    { status: 404, expectedGets: 1 },
+    { status: 500, expectedGets: 6 },
+  ])("does not re-download a tarball that already failed with $status", async ({ status, expectedGets }) => {
+    const urls: string[] = [];
+    setHandler(async request => {
+      const { pathname } = new URL(request.url);
+      urls.push(pathname);
+      if (pathname === "/BaR") {
+        return Response.json({
+          name: "BaR",
+          "dist-tags": { latest: "0.0.2" },
+          versions: {
+            "0.0.2": { name: "BaR", version: "0.0.2", dist: { tarball: `${root_url}/BaR-0.0.2.tgz` } },
+          },
+        });
+      }
+      if (pathname === "/BaR-0.0.2.tgz") {
+        return new Response("no", { status });
+      }
+      return new Response("unexpected", { status: 404 });
+    });
+    await writeFile(
+      join(package_dir, "bunfig.toml"),
+      `[install]\ncache = false\nregistry = "${root_url}/"\nlinker = "${linker}"\n`,
+    );
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { BaR: "0.0.2" } }),
+    );
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--no-progress", "--ignore-scripts"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+
+    const tarballGets = urls.filter(u => u === "/BaR-0.0.2.tgz");
+    const errorLines = err.split("\n").filter(l => l.startsWith("error:"));
+    expect({ tarballGets: tarballGets.length, errorLines }).toEqual({
+      tarballGets: expectedGets,
+      errorLines: [`error: GET ${root_url}/BaR-0.0.2.tgz - ${status}`],
+    });
+    expect(out).not.toContain("installed");
+    expect(exitCode).toBe(1);
+  });
 });

--- a/test/cli/install/bun-install-retry.test.ts
+++ b/test/cli/install/bun-install-retry.test.ts
@@ -352,4 +352,72 @@ describe.each(["hoisted", "isolated"])("linker=%s", linker => {
     expect(out).not.toContain("installed");
     expect(exitCode).toBe(1);
   });
+
+  it("does not re-download an optional dependency's tarball that already failed", async () => {
+    const urls: string[] = [];
+    setHandler(async request => {
+      const { pathname } = new URL(request.url);
+      urls.push(pathname);
+      if (pathname === "/BaR") {
+        return Response.json({
+          name: "BaR",
+          "dist-tags": { latest: "0.0.2" },
+          versions: {
+            "0.0.2": { name: "BaR", version: "0.0.2", dist: { tarball: `${root_url}/BaR-0.0.2.tgz` } },
+          },
+        });
+      }
+      if (pathname === "/BaR-0.0.2.tgz") return new Response("no", { status: 404 });
+      if (pathname === "/baz") {
+        return Response.json({
+          name: "baz",
+          "dist-tags": { latest: "0.0.3" },
+          versions: {
+            "0.0.3": { name: "baz", version: "0.0.3", dist: { tarball: `${root_url}/baz-0.0.3.tgz` } },
+          },
+        });
+      }
+      if (pathname === "/baz-0.0.3.tgz") return new Response(file(join(import.meta.dir, "baz-0.0.3.tgz")));
+      return new Response("unexpected", { status: 404 });
+    });
+    await writeFile(
+      join(package_dir, "bunfig.toml"),
+      `[install]\ncache = false\nregistry = "${root_url}/"\nlinker = "${linker}"\n`,
+    );
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({
+        name: "foo",
+        version: "0.0.1",
+        dependencies: { baz: "0.0.3" },
+        optionalDependencies: { BaR: "0.0.2" },
+      }),
+    );
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "--no-progress", "--ignore-scripts"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+
+    const tarballGets = urls.filter(u => u === "/BaR-0.0.2.tgz");
+    const warnLines = err.split("\n").filter(l => l.startsWith("warn:"));
+    const errorLines = err.split("\n").filter(l => l.startsWith("error:"));
+    expect({ tarballGets: tarballGets.length, warnLines, errorLines }).toEqual({
+      tarballGets: 1,
+      warnLines: [`warn: GET ${root_url}/BaR-0.0.2.tgz - 404`],
+      errorLines: [],
+    });
+    expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toMatchObject({
+      name: "baz",
+      version: "0.0.3",
+    });
+    if (linker === "hoisted") {
+      expect(out).not.toContain("Failed to install");
+      expect(exitCode).toBe(0);
+    }
+  });
 });


### PR DESCRIPTION
## What

`bun install` runs the entire download (including the full retry cycle) for a failing tarball twice: once during the resolve phase, then again during the install phase. A permanently-500 endpoint sees 12 GETs where 6 are intended, and the same `error: GET ... - 404` line prints twice.

## Repro

```js
import * as fs from "node:fs";
const ROOT = fs.mkdtempSync("/tmp/tb-twice-");
let status = 404, reqs = [];
const server = Bun.serve({
  hostname: "127.0.0.1", port: 0,
  fetch(req) {
    const p = new URL(req.url).pathname;
    reqs.push(p);
    if (p === "/tb") return new Response("no", { status });
    if (p === "/pk") return Response.json({ name: "pk", "dist-tags": { latest: "1.0.0" },
      versions: { "1.0.0": { name: "pk", version: "1.0.0",
        dist: { tarball: `http://127.0.0.1:${server.port}/tb` } } } });
    return new Response("nope", { status: 404 });
  },
});
for (const s of [404, 500]) {
  status = s; reqs = [];
  const box = `${ROOT}/${s}`; fs.mkdirSync(box);
  fs.writeFileSync(`${box}/package.json`, '{"name":"s","dependencies":{"pk":"1.0.0"}}');
  fs.writeFileSync(`${box}/bunfig.toml`,
    `[install]\nregistry = "http://127.0.0.1:${server.port}/"\ncache = "${box}/.c"\n`);
  const proc = Bun.spawn([process.execPath, "install", "--no-progress", "--ignore-scripts"],
    { cwd: box, stderr: "pipe", env: { ...process.env, HOME: box, NO_COLOR: "1", CI: "1" } });
  const err = await new Response(proc.stderr).text(); await proc.exited;
  console.log(s, "tarball GETs =", reqs.filter(x => x === "/tb").length,
    "| error lines =", err.split("\n").filter(l => l.startsWith("error:")).length);
}
server.stop(true); fs.rmSync(ROOT, { recursive: true, force: true });
```

Before:
```
404 tarball GETs = 2 | error lines = 2
500 tarball GETs = 12 | error lines = 2
```

After:
```
404 tarball GETs = 1 | error lines = 1
500 tarball GETs = 6 | error lines = 1
```

## Cause

On a fresh install (no lockfile) the resolve phase prefetches the tarball via `generate_network_task_for_tarball`. When that download terminally fails, `runTasks.rs` removed the entry from `network_dedupe_map` (and `task_queue`) so a later enqueue for the same task id would not wait forever on a callback that never arrives. But removing the entry meant the install phase's `enqueue_package_for_download` saw `found_existing == false` for both maps and scheduled a brand-new network task for the same URL, re-running the whole retry cycle and re-reporting the error.

## Fix

Keep the dedupe entry and mark it `failed` instead of removing it. `enqueue_package_for_download` / `enqueue_tarball_for_download` check this flag up front and return a new `ForTarballError::AlreadyFailed`, which each caller handles by advancing its own bookkeeping without scheduling anything:

- hoisted installer: `summary.fail += 1` and `increment_tree_install_count`
- isolated installer: mark the entry step `Done` and `on_task_complete(Fail)` (so the upfront per-entry `pending_tasks` slot is released and the loop does not hang)

Successful downloads are unchanged (still fetched exactly once). Both linkers covered by the new test in `bun-install-retry.test.ts`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-retry.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (299bee1c6)

test/cli/install/bun-install-retry.test.ts:
(pass) retries a manifest whose redirect target 500s once [320.46ms]
(pass) retries an authorized manifest whose cross-origin redirect target 500s once [234.17ms]
(pass) retries a tarball whose redirect target 500s once [205.72ms]
(pass) retries on 500 [318.75ms]
343 |     });
344 |     const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
345 | 
346 |     const tarballGets = urls.filter(u => u === "/BaR-0.0.2.tgz");
347 |     const errorLines = err.split("\n").filter(l => l.startsWith("error:"));
348 |     expect({ tarballGets: tarballGets.length, errorLines }).toEqual({
                                                                
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (cfce8d9a2)

test/cli/install/bun-install-retry.test.ts:
(pass) retries a manifest whose redirect target 500s once [9.19ms]
(pass) retries an authorized manifest whose cross-origin redirect target 500s once [7.50ms]
(pass) retries a tarball whose redirect target 500s once [6.01ms]
(pass) retries on 500 [7.71ms]
(pass) linker=hoisted > does not re-download a tarball that already failed with 404 [4.77ms]
(pass) linker=hoisted > does not re-download a tarball that already failed with 500 [4.71ms]
414 |     expect(await file(join(package_dir, "node_modules", "baz", "package.json")).json()).toMatchObject({
415 |       name: "baz",
416 |       version: "0.0.3",
417 |     });
418 |     if (linker === "hoisted") {
419 |       expect(out).not.toContain("Failed to install");
                            ^
error: expect(received).not.toContain(expected)

Expected to not contain: "Failed to install"
Received: "bun install v1.4.0-canary.1 (cfce8d9a2)\n\n+ baz@0.0.3\n\n1 package installed [3.00ms]\nFailed to install 1 package\n"

      at <anonymous> (/workspace/bun/test/cli/install/bun-install-retry.test.ts:419:23)
(fail) linker=hoisted > does not re-down
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-retry.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (299bee1c6)

test/cli/install/bun-install-retry.test.ts:
(pass) retries a manifest whose redirect target 500s once [332.36ms]
(pass) retries an authorized manifest whose cross-origin redirect target 500s once [257.74ms]
(pass) retries a tarball whose redirect target 500s once [283.89ms]
(pass) retries on 500 [301.93ms]
(pass) linker=hoisted > does not re-download a tarball that already failed with 404 [192.95ms]
(pass) linker=hoisted > does not re-download a tarball that already failed with 500 [201.65ms]
(pass) linker=hoisted > does not re-download an optional dependency's tarball that already failed [291.58ms]
(pass) linker=isolated > does not re-download a tarball that already failed with 404 [240.88ms]
(pass) linker=isol
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 722ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[2/21] gen JS modules (bundle-modules)
Preprocess modules (6866ms)
Bundle modules (31ms)
Postprocesss modules (130ms)
Bundle Functions (812ms)
Generate Code (118ms)

[7.98s] Bundled "src/js" for production
  1912 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  night
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/NetworkTask.rs                         |  10 ++
 src/install/PackageInstaller.rs                    |  18 +++
 .../PackageManager/PackageManagerEnqueue.rs        |   6 +
 src/install/PackageManager/runTasks.rs             |  70 +++++++-----
 src/install/isolated_install.rs                    |  27 +++++
 test/cli/install/bun-install-retry.test.ts         | 127 ++++++++++++++++++++-
 6 files changed, 229 insertions(+), 29 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/install/NetworkTask.rs                               2      2      0
src/install/PackageInstaller.rs                          8      8      0
src/install/PackageManager/PackageManagerEnqueue.rs      7      2      0
src/install/PackageManager/runTasks.rs                   5      5      0
src/install/isolated_install.rs                          2      3      0
test/cli/install/bun-install-retry.test.ts               3      3      0
```

</details>

<!-- robobun:evidence:end -->