### PR TITLE
error: never return an empty JSValue from computeErrorInfoWrapperToJSValue

### DIFF
--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -6,7 +6,6 @@
 
 #include "JavaScriptCore/ArgList.h"
 #include "JavaScriptCore/CallData.h"
-#include "JavaScriptCore/DeferTermination.h"
 #include "JavaScriptCore/TopExceptionScope.h"
 #include "JavaScriptCore/Error.h"
 #include "JavaScriptCore/ErrorInstance.h"
@@ -640,11 +639,6 @@ void computeLineColumnWithSourcemap(JSC::VM& vm, JSC::SourceProvider* _Nonnull s
 
 JSC::JSValue computeErrorInfoWrapperToJSValue(JSC::VM& vm, Vector<StackFrame>& stackTrace, unsigned int& line_in, unsigned int& column_in, String& sourceURL, JSObject* errorInstance, void* bunErrorData)
 {
-    // ErrorInstance::getOwnPropertySlot doesn't check for exceptions after materializeErrorInfoIfNeeded,
-    // so a TerminationException raised in here trips getOwnPropertyDescriptor's EXCEPTION_ASSERT.
-    // https://github.com/oven-sh/bun/issues/34095
-    JSC::DeferTerminationForAWhile deferTermination(vm);
-
     OrdinalNumber line = OrdinalNumber::fromOneBasedInt(line_in);
     OrdinalNumber column = OrdinalNumber::fromOneBasedInt(column_in);
 
@@ -654,7 +648,7 @@ JSC::JSValue computeErrorInfoWrapperToJSValue(JSC::VM& vm, Vector<StackFrame>& s
     column_in = column.oneBasedInt();
 
     // materializeErrorInfoIfNeeded putDirect()s this unconditionally; an empty JSValue
-    // in property storage crashes the next read.
+    // in property storage crashes the next read. https://github.com/oven-sh/bun/issues/34095
     if (!result) [[unlikely]]
         return jsUndefined();
     return result;

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -6,6 +6,7 @@
 
 #include "JavaScriptCore/ArgList.h"
 #include "JavaScriptCore/CallData.h"
+#include "JavaScriptCore/DeferTermination.h"
 #include "JavaScriptCore/TopExceptionScope.h"
 #include "JavaScriptCore/Error.h"
 #include "JavaScriptCore/ErrorInstance.h"
@@ -639,6 +640,11 @@ void computeLineColumnWithSourcemap(JSC::VM& vm, JSC::SourceProvider* _Nonnull s
 
 JSC::JSValue computeErrorInfoWrapperToJSValue(JSC::VM& vm, Vector<StackFrame>& stackTrace, unsigned int& line_in, unsigned int& column_in, String& sourceURL, JSObject* errorInstance, void* bunErrorData)
 {
+    // ErrorInstance::getOwnPropertySlot doesn't check for exceptions after materializeErrorInfoIfNeeded,
+    // so a TerminationException raised in here trips getOwnPropertyDescriptor's EXCEPTION_ASSERT.
+    // https://github.com/oven-sh/bun/issues/34095
+    JSC::DeferTerminationForAWhile deferTermination(vm);
+
     OrdinalNumber line = OrdinalNumber::fromOneBasedInt(line_in);
     OrdinalNumber column = OrdinalNumber::fromOneBasedInt(column_in);
 
@@ -647,6 +653,10 @@ JSC::JSValue computeErrorInfoWrapperToJSValue(JSC::VM& vm, Vector<StackFrame>& s
     line_in = line.oneBasedInt();
     column_in = column.oneBasedInt();
 
+    // materializeErrorInfoIfNeeded putDirect()s this unconditionally; an empty JSValue
+    // in property storage crashes the next read.
+    if (!result) [[unlikely]]
+        return jsUndefined();
     return result;
 }
 

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1003,3 +1003,27 @@ test("printing an error whose message getter calls Error.captureStackTrace on it
 
   expect({ lastLine: stdout.trimEnd().split("\n").pop(), exitCode }).toEqual({ lastLine: "after", exitCode: 0 });
 });
+
+// https://github.com/oven-sh/bun/issues/34095
+test("lazy error-info materialization does not store an empty stack value when the compute hook throws", async () => {
+  const src = `
+    Error.prepareStackTrace = (e, s) => "custom-stack";
+    const e = new Error("x");
+    Object.defineProperty(e, "message", { get() { throw new TypeError("msg-boom"); } });
+    let first = "no-throw";
+    try { void e.stack; } catch (err) { first = err.message; }
+    console.log(JSON.stringify({ first, secondType: typeof e.stack }));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), signalCode: proc.signalCode }).toEqual({
+    stdout: JSON.stringify({ first: "msg-boom", secondType: "undefined" }),
+    signalCode: null,
+  });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
`computeErrorInfoWrapperToJSValue` is Bun's `vm.onComputeErrorInfoJSValue` hook, called from `ErrorInstance::materializeErrorInfoIfNeeded` when a lazy error property (`stack`/`line`/`column`/`sourceURL`) is first read. When the hook throws before the default stack string has been computed (e.g. a throwing `.message` getter while `Error.prepareStackTrace` is set), `computeErrorInfoToJSValue` returns `{}`. `materializeErrorInfoIfNeeded` then `putDirect`s that empty value into the error's `stack` slot, and the next read segfaults:

```js
Error.prepareStackTrace = (e, s) => "custom";
const e = new Error("x");
Object.defineProperty(e, "message", { get() { throw new TypeError("boom"); } });
e.stack;   // Segmentation fault at address 0x5 (release), UBSan null deref (debug)
```

Fall back to `jsUndefined()` so the stored value is always valid. The `.message` throw still propagates to the caller.

### About the `getOwnPropertyDescriptor` assertion in #34095

`ErrorInstance::getOwnPropertySlot` in WebKit does not check for an exception after `materializeErrorInfoIfNeeded` (unlike its siblings `defineOwnProperty`/`put`, which do). When the hook leaves one pending, `JSObject::getOwnPropertyDescriptor` trips:

```
ASSERTION FAILED: !scope.exception() || !result
vendor/WebKit/Source/JavaScriptCore/runtime/JSObject.cpp(3936)
```

An earlier revision of this PR wrapped the hook in `DeferTerminationForAWhile` to keep a `TerminationException` from reaching that assertion, but that scope would have covered the `profiledCall` into user `Error.prepareStackTrace`, making an infinite loop there uninterruptible by `worker.terminate()`. Dropped in 3dd57f6. A proper fix for the termination case is a `RETURN_IF_EXCEPTION` in `ErrorInstance::getOwnPropertySlot` on the WebKit side.

### Related

- #33966 applies `DeferTerminationForAWhile` to the `process.*` lazy property builders (bounded C++ initializers, no unbounded user JS), which is the path `test-worker-message-port-transfer-terminate.js` actually hits during worker bootstrap.
- #30823 takes the alternative approach of clearing every exception in this hook via `tryClearException`, which covers a throwing `Error.prepareStackTrace` reaching `getOwnPropertyDescriptor` on debug/ASAN, at the cost of `e.stack` no longer propagating the throw.

### Verification

New test in `test/js/node/v8/capture-stack-trace.test.js` spawns the `.message`-throws repro and asserts the first `.stack` read throws `msg-boom` and a subsequent read returns `undefined` instead of crashing. Segfaults on the unfixed build, passes with this change. The full test file (41 tests, including the existing `e.stack`-throws and `prepareStackTrace`-propagation tests) passes.

Refs #34095

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/v8/capture-stack-trace.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (3dd57f69d)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [12.67ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [6.81ms]
(pass) capture stack trace [6.22ms]
(pass) capture stack trace with message [6.94ms]
(pass) capture stack trace with constructor [4.93ms]
(pass) capture stack trace limit [21.63ms]
(pass) prepare stack trace [10.24ms]
(pass) capture stack trace second argument [17.05ms]
(pass) capture stack trace edge cases [11.07ms]
(pass) prepare stack trace call sites [12.77ms]
(pass) sanity check [13.28ms]
(pass) CallFrame isEval works as expected [6.69ms]
(pass) CallFrame isTopLevel returns false for Function constructor [7.85ms]
(pass) CallFrame.p.getThisgetFunction: strict/slopp
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (3dd57f69d)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [0.39ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [0.11ms]
(pass) capture stack trace [0.07ms]
(pass) capture stack trace with message [0.09ms]
(pass) capture stack trace with constructor [0.06ms]
(pass) capture stack trace limit [0.22ms]
(pass) prepare stack trace [0.12ms]
(pass) capture stack trace second argument [0.18ms]
(pass) capture stack trace edge cases [0.10ms]
(pass) prepare stack trace call sites [0.11ms]
(pass) sanity check [0.11ms]
(pass) CallFrame isEval works as expected [0.14ms]
(pass) CallFrame isTopLevel returns false for Function constructor [0.12ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [0.11ms]
(pass) CallFrame.p.isConstructor [0.04ms]
(pass) CallFrame.p.isNative [0.04ms]
(pass) return non-strings from Error.prepareStackTrace [0.03ms]
(pass) CallFrame.p.toString [0.03ms]
(pass) err.stack should invoke prepareStackTrace [0.30ms]
(pass) Error.prepareStackTrace inside a node:vm works [4.77ms]
(pass) Error.captureStackTrace inside error constructor works [0.10ms]
(pass) Error.prepareStackTrace has 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/v8/capture-stack-trace.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (3dd57f69d)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [12.34ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [6.56ms]
(pass) capture stack trace [6.06ms]
(pass) capture stack trace with message [6.90ms]
(pass) capture stack trace with constructor [4.93ms]
(pass) capture stack trace limit [21.98ms]
(pass) prepare stack trace [10.25ms]
(pass) capture stack trace second argument [17.39ms]
(pass) capture stack trace edge cases [11.23ms]
(pass) prepare stack trace call sites [12.74ms]
(pass) sanity check [12.78ms]
(pass) CallFrame isEval works as expected [6.62ms]
(pass) CallFrame isTopLevel returns false for Function constructor [7.84ms]
(pass) CallFrame.p.getThisgetFunction: strict/slopp
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 643ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/26] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[2/26] gen cpp.rs (cppbind)
[3/26] gen JS modules (bundle-modules)
Preprocess modules (6586ms)
Bundle modules (26ms)
Postprocesss modules (26ms)
Bundle Functions (664ms)
Generate Code (74ms)

[7.39s] Bundled "src/js" for production
  1912 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[3/17] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/FormatStackTraceForJS.cpp  |  4 ++++
 test/js/node/v8/capture-stack-trace.test.js | 24 ++++++++++++++++++++++++
 2 files changed, 28 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/jsc/bindings/FormatStackTraceForJS.cpp       9      9      0
test/js/node/v8/capture-stack-trace.test.js      2      3      0
```

</details>

<!-- robobun:evidence:end -->