### PR TITLE
WebSocket client: reset inflater after Z_STREAM_END with context takeover

### DIFF
--- a/src/http_jsc/websocket_client/WebSocketDeflate.rs
+++ b/src/http_jsc/websocket_client/WebSocketDeflate.rs
@@ -164,6 +164,7 @@ impl PerMessageDeflate {
         in_with_trailer.extend_from_slice(&DEFLATE_TRAILER);
 
         let mut remaining = in_with_trailer.as_slice();
+        let mut saw_stream_end = false;
         loop {
             let (consumed, rc) = self.decompress_stream.step(
                 remaining,
@@ -179,6 +180,7 @@ impl PerMessageDeflate {
             }
 
             if rc == zlib::ReturnCode::StreamEnd {
+                saw_stream_end = true;
                 break;
             }
             if rc != zlib::ReturnCode::Ok {
@@ -194,7 +196,11 @@ impl PerMessageDeflate {
             }
         }
 
-        if self.params.server_no_context_takeover == 1 {
+        // RFC 7692 §7.2.3: a sender may end a DEFLATE stream with BFINAL=1 and
+        // begin a fresh one for the next message. Without a reset here the
+        // finished inflater returns Z_STREAM_END with 0 bytes on every later
+        // message, silently delivering empty payloads.
+        if saw_stream_end || self.params.server_no_context_takeover == 1 {
             self.decompress_stream.reset();
         }
 

--- a/test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts
+++ b/test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts
@@ -1,6 +1,8 @@
 import { serve } from "bun";
 import { expect, setDefaultTimeout, test } from "bun:test";
-import { deflateRawSync } from "node:zlib";
+import crypto from "node:crypto";
+import net from "node:net";
+import { constants as zc, deflateRawSync } from "node:zlib";
 
 // The decompression bomb test needs extra time to compress 150MB of test data
 setDefaultTimeout(30_000);
@@ -463,3 +465,105 @@ test("WebSocket client accepts RSV1 on the first frame of a fragmented compresse
 
   expect(outcome).toEqual({ code: 0, reason: "<still open>", messages: ["Hello, World!"] });
 });
+
+// RFC 7692 §7.2.3: a sender may end a DEFLATE stream with BFINAL=1 and begin
+// a fresh one for the next message. The client's inflater must be reset on
+// Z_STREAM_END even with context takeover, otherwise every later compressed
+// message is silently delivered as 0 bytes.
+test.each([false, true])(
+  "WebSocket client resets inflater after BFINAL (server_no_context_takeover=%p)",
+  async serverNoContextTakeover => {
+    // Deterministic incompressible bytes so msg1 bypasses the libdeflate fast
+    // path (200KiB decompressed exceeds the 128KiB output buffer) and reaches
+    // the persistent zlib stream.
+    const msg1 = Buffer.alloc(200 * 1024);
+    let x = 12345;
+    for (let i = 0; i < msg1.length; i++) {
+      x = (Math.imul(x, 1103515245) + 12345) | 0;
+      msg1[i] = (x >>> 16) & 255;
+    }
+    const msg2 = Buffer.alloc(30 * 19, "hello after bfinal ");
+    const msg3 = Buffer.alloc(30 * 6, "third ");
+
+    // msg1: Z_FINISH -> ends with BFINAL=1 (Z_STREAM_END on the receiver).
+    // msg2/msg3: Z_SYNC_FLUSH with the 4-byte trailer stripped (RFC 7692 §7.2.1).
+    const syncFlush = (p: Buffer) => {
+      const o = deflateRawSync(p, { flush: zc.Z_SYNC_FLUSH, finishFlush: zc.Z_SYNC_FLUSH });
+      return o.subarray(0, o.length - 4);
+    };
+    const wire = [deflateRawSync(msg1), syncFlush(msg2), syncFlush(msg3)];
+
+    const compressedBinaryFrame = (p: Buffer) => {
+      const h = [0xc2]; // FIN=1, RSV1=1, opcode=2 (binary)
+      if (p.length < 126) h.push(p.length);
+      else if (p.length < 65536) h.push(126, (p.length >> 8) & 0xff, p.length & 0xff);
+      else
+        h.push(
+          127,
+          0,
+          0,
+          0,
+          0,
+          Math.floor(p.length / 2 ** 24) & 0xff,
+          (p.length >>> 16) & 0xff,
+          (p.length >>> 8) & 0xff,
+          p.length & 0xff,
+        );
+      return Buffer.concat([Buffer.from(h), p]);
+    };
+
+    const ext = "permessage-deflate" + (serverNoContextTakeover ? "; server_no_context_takeover" : "");
+    const server = net.createServer(sock => {
+      sock.on("error", () => {});
+      let pre = Buffer.alloc(0);
+      const onData = (d: Buffer) => {
+        pre = Buffer.concat([pre, d]);
+        if (pre.indexOf("\r\n\r\n") < 0) return;
+        sock.off("data", onData);
+        const key = pre.toString("latin1").match(/^sec-websocket-key:\s*(.*)$/im)![1].trim();
+        const acc = crypto
+          .createHash("sha1")
+          .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+          .digest("base64");
+        sock.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" +
+            "Upgrade: websocket\r\n" +
+            "Connection: Upgrade\r\n" +
+            `Sec-WebSocket-Accept: ${acc}\r\n` +
+            `Sec-WebSocket-Extensions: ${ext}\r\n` +
+            "\r\n",
+        );
+        for (const w of wire) sock.write(compressedBinaryFrame(w));
+      };
+      sock.on("data", onData);
+    });
+    await new Promise<void>(r => server.listen(0, "127.0.0.1", r));
+
+    const got: Buffer[] = [];
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    const ws = new WebSocket(`ws://127.0.0.1:${(server.address() as net.AddressInfo).port}/`);
+    ws.binaryType = "arraybuffer";
+    ws.onmessage = e => {
+      got.push(Buffer.from(e.data as ArrayBuffer));
+      if (got.length === 3) resolve();
+    };
+    ws.onerror = ev => reject(new Error(`WebSocket error: ${String(ev)}`));
+    ws.onclose = ev => reject(new Error(`closed before 3 messages: code=${ev.code} reason=${ev.reason}`));
+
+    try {
+      await promise;
+      expect({
+        msg1: { len: got[0].length, ok: got[0].equals(msg1) },
+        msg2: { len: got[1].length, ok: got[1].equals(msg2) },
+        msg3: { len: got[2].length, ok: got[2].equals(msg3) },
+      }).toEqual({
+        msg1: { len: 200 * 1024, ok: true },
+        msg2: { len: 570, ok: true },
+        msg3: { len: 180, ok: true },
+      });
+    } finally {
+      ws.close();
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  },
+);

--- a/test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts
+++ b/test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts
@@ -526,7 +526,7 @@ test.each([false, true])(
           .trim();
         const acc = crypto
           .createHash("sha1")
-          .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+          .update(key + WEBSOCKET_GUID)
           .digest("base64");
         sock.write(
           "HTTP/1.1 101 Switching Protocols\r\n" +

--- a/test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts
+++ b/test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts
@@ -2,7 +2,7 @@ import { serve } from "bun";
 import { expect, setDefaultTimeout, test } from "bun:test";
 import crypto from "node:crypto";
 import net from "node:net";
-import { constants as zc, deflateRawSync } from "node:zlib";
+import { deflateRawSync, constants as zc } from "node:zlib";
 
 // The decompression bomb test needs extra time to compress 150MB of test data
 setDefaultTimeout(30_000);
@@ -520,7 +520,10 @@ test.each([false, true])(
         pre = Buffer.concat([pre, d]);
         if (pre.indexOf("\r\n\r\n") < 0) return;
         sock.off("data", onData);
-        const key = pre.toString("latin1").match(/^sec-websocket-key:\s*(.*)$/im)![1].trim();
+        const key = pre
+          .toString("latin1")
+          .match(/^sec-websocket-key:\s*(.*)$/im)![1]
+          .trim();
         const acc = crypto
           .createHash("sha1")
           .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")


### PR DESCRIPTION
### What does this PR do?

RFC 7692 §7.2.3 allows a permessage-deflate sender to end a DEFLATE stream with `BFINAL=1` and begin a fresh stream for the next message. `PerMessageDeflate::decompress` broke out of its zlib loop on `Z_STREAM_END` but only reset the inflater when `server_no_context_takeover` was negotiated. With plain context takeover the persistent inflater stayed in the finished state, so every subsequent compressed message that reached the zlib path was silently delivered to `onmessage` as an **empty payload**, with no error and no close. The connection stayed open; the data was simply lost.

The zlib path is reached when a message's decompressed output exceeds the 128 KiB libdeflate fast-path buffer, or when a sync-flushed message (no BFINAL) makes libdeflate fall through. So one large BFINAL-terminated message poisons the connection for the rest of its lifetime.

### Repro

```js
import net from "node:net"; import crypto from "node:crypto"; import zlib from "node:zlib";
const msg1 = crypto.randomBytes(200 * 1024);
const msg2 = Buffer.from("hello after bfinal ".repeat(30));
const sync = p => zlib.deflateRawSync(p, { flush: 2, finishFlush: 2 }).subarray(0, -4);
const wire = [zlib.deflateRawSync(msg1) /* BFINAL=1 */, sync(msg2), sync(Buffer.from("third ".repeat(30)))];
const frame = p => { const h = [0xc2]; if (p.length < 126) h.push(p.length); else if (p.length < 65536) h.push(126, p.length>>8, p.length&255); else h.push(127,0,0,0,0,(p.length/2**24)&255,(p.length>>>16)&255,(p.length>>>8)&255,p.length&255); return Buffer.concat([Buffer.from(h), p]); };
const srv = net.createServer(s => { let b = Buffer.alloc(0); s.on("data", d => { b = Buffer.concat([b, d]); if (b.indexOf("\r\n\r\n") < 0) return;
  const key = b.toString("latin1").match(/^sec-websocket-key:\s*(.*)$/im)[1].trim();
  const acc = crypto.createHash("sha1").update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").digest("base64");
  s.write("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: " + acc + "\r\nSec-WebSocket-Extensions: permessage-deflate\r\n\r\n");
  for (const w of wire) s.write(frame(w)); }); });
await new Promise(r => srv.listen(0, "127.0.0.1", r));
const ws = new WebSocket("ws://127.0.0.1:" + srv.address().port + "/"); ws.binaryType = "arraybuffer";
ws.onmessage = e => console.log("got", e.data.byteLength, "bytes");
```

Before: `got 204800 bytes`, `got 0 bytes`, `got 0 bytes`
After: `got 204800 bytes`, `got 570 bytes`, `got 180 bytes`
npm `ws` under Node: identical to "after".

### Fix

`decompress` now resets the inflater whenever `Z_STREAM_END` is observed, in addition to the existing `server_no_context_takeover` reset. This matches what npm `ws` does (it closes and recreates its `InflateRaw` on stream end).

### How did you verify your code works?

New `test.each` in `test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts` covering both values of `server_no_context_takeover`. The context-takeover case fails on main with `msg2.len=0, msg3.len=0` and passes with the fix. All existing permessage-deflate tests continue to pass.

Server-side sibling: #33592 handles the analogous case in `Bun.serve`'s uWS decompressor.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (47fe4b612)

test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts:
(pass) WebSocket client handles compressed continuation frames correctly [103.66ms]
(pass) WebSocket client doesn't compress small messages [65.96ms]
(pass) WebSocket client rejects messages exceeding size limit [69.02ms]
(pass) WebSocket client handles compression errors gracefully [56.75ms]
(pass) WebSocket client rejects decompression bombs [4207.44ms]
(pass) WebSocket client fails the connection on RSV1 set on a continuation frame [87.21ms]
(pass) WebSocket client fails the connection on RSV1 set on a continuation frame without deflate [21.07ms]
(pass) WebSocket client fails the connection on RSV1 set on a contr
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (14915540c)

test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts:
(pass) WebSocket client handles compressed continuation frames correctly [3.29ms]
(pass) WebSocket client doesn't compress small messages [0.99ms]
(pass) WebSocket client rejects messages exceeding size limit [4.52ms]
(pass) WebSocket client handles compression errors gracefully [0.82ms]
(pass) WebSocket client rejects decompression bombs [505.71ms]
(pass) WebSocket client fails the connection on RSV1 set on a continuation frame [1.26ms]
(pass) WebSocket client fails the connection on RSV1 set on a continuation frame without deflate [0.38ms]
(pass) WebSocket client fails the connection on RSV1 set on a control frame [0.28ms]
(pass) WebSocket client accepts RSV1 on the first frame of a fragmented compressed message [0.48ms]
(pass) WebSocket client resets inflater after BFINAL (server_no_context_takeover=false) [10.63ms]
(pass) WebSocket client resets inflater after BFINAL (server_no_context_takeover=true) [9.97ms]

 11 pass
 0 fail
 13 expect() calls
Ran 11 tests across 1 file. [702.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (47fe4b612)

test/js/web/websocket/websocket-permessage-deflate-edge-cases.test.ts:
(pass) WebSocket client handles compressed continuation frames correctly [47.65ms]
(pass) WebSocket client doesn't compress small messages [32.88ms]
(pass) WebSocket client rejects messages exceeding size limit [58.89ms]
(pass) WebSocket client handles compression errors gracefully [33.07ms]
(pass) WebSocket client rejects decompression bombs [3161.03ms]
(pass) WebSocket client fails the connection on RSV1 set on a continuation frame [51.17ms]
(pass) WebSocket client fails the connection on RSV1 set on a continuation frame without deflate [24.06ms]
(pass) WebSocket client fails the connection on RSV1 set on a contro
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 691ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[2/21] gen JS modules (bundle-modules)
Preprocess modules (6794ms)
Bundle modules (34ms)
Postprocesss modules (129ms)
Bundle Functions (684ms)
Generate Code (102ms)

[7.76s] Bundled "src/js" for production
  1912 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  night
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http_jsc/websocket_client/WebSocketDeflate.rs  |   8 +-
 ...websocket-permessage-deflate-edge-cases.test.ts | 109 ++++++++++++++++++++-
 2 files changed, 115 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/http_jsc/websocket_client/WebSocketDeflate.rs             1      2      0
…bsocket/websocket-permessage-deflate-edge-cases.test.ts      2      6      0
```

</details>

<!-- robobun:evidence:end -->