### PR TITLE
bunx: honor the project-local bunfig.toml [install] registry

### DIFF
--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1665,6 +1665,19 @@ fn run_security_scanner(manager: &mut PackageManager, ctx: Command::Context, ori
         return;
     }
 
+    // bunx forwards the project's bunfig.toml to this `bun add`, but runs it
+    // with cwd set to the bunx cache dir. A `[install.security] scanner`
+    // named there is not installed in (or a dependency of) the cache dir's
+    // `{}` package.json, so resolving it would always fail and abort the
+    // bunx invocation. The scanner gates what enters the project's
+    // dependency tree, not one-off tool executions.
+    if bun_core::env_var::feature_flag::BUN_INTERNAL_BUNX_INSTALL
+        .get()
+        .unwrap_or(false)
+    {
+        return;
+    }
+
     match security_scanner::perform_security_scan_after_resolution(manager, ctx, original_cwd) {
         Err(err) => {
             match err {

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -585,16 +585,29 @@ impl BunxCommand {
     }
 
     /// Refuse to forward a `bunfig.toml` discovered by walking up from the
-    /// invoking cwd unless it is a regular file owned by the current user.
-    /// The walk may cross into world-writable ancestors (e.g. `/tmp`), where
-    /// another local user could plant a `bunfig.toml` redirecting `[install]
-    /// registry` to a host they control; bunx would then fetch and execute
-    /// their package. Same threat model as `is_trusted_cached_binary`.
+    /// invoking cwd unless it is (or resolves to) a regular file owned by
+    /// the current user. The walk may cross into world-writable ancestors
+    /// (e.g. `/tmp`), where another local user could plant a `bunfig.toml`
+    /// redirecting `[install] registry` to a host they control; bunx would
+    /// then fetch and execute their package. Symlinks are followed once so a
+    /// dotfile-managed config is accepted when both link and target are
+    /// uid-owned, mirroring `is_trusted_cached_binary`.
     #[cfg(unix)]
     fn is_trusted_local_bunfig(path: &ZStr, uid: libc::uid_t) -> bool {
+        let reg_ok =
+            |st: &bun_sys::Stat| st.st_uid == uid && (st.st_mode & libc::S_IFMT) == libc::S_IFREG;
         match bun_sys::lstat(path) {
-            Ok(st) => st.st_uid == uid && (st.st_mode & libc::S_IFMT) == libc::S_IFREG,
-            Err(_) => false,
+            Ok(st) if st.st_uid == uid => {
+                let kind = st.st_mode & libc::S_IFMT;
+                if kind == libc::S_IFREG {
+                    true
+                } else if kind == libc::S_IFLNK {
+                    matches!(bun_sys::stat(path), Ok(target) if reg_ok(&target))
+                } else {
+                    false
+                }
+            }
+            _ => false,
         }
     }
 
@@ -747,6 +760,76 @@ impl BunxCommand {
             };
         // Cloned to avoid borrowck overlap when PATH is reassigned below.
 
+        #[cfg(unix)]
+        // SAFETY: getuid() is always safe to call (no preconditions, never fails)
+        let uid = unsafe { libc::getuid() };
+        #[cfg(windows)]
+        let uid = bun_sys::windows::user_unique_id();
+
+        // The spawned `bun add` runs with cwd = `bunx_cache_dir`, so it cannot
+        // discover a project-local bunfig.toml on its own. Resolve it here from
+        // the invoking directory and forward it via `--config=<path>` so
+        // `[install]` settings such as `registry` are honored. `--config`'s
+        // value is optional in the install arg parser, so the `=` form is
+        // required for the path to be consumed. Discovery runs before
+        // `package_fmt` so the cache directory can be namespaced per bunfig
+        // (the registry may differ per project; without this a warm cache from
+        // one project would serve another).
+        //
+        // `bun add` run directly from a workspace member chdirs to the
+        // workspace root before loading bunfig.toml; replicating that walk
+        // would require parsing each ancestor package.json's `workspaces`, so
+        // instead walk up from the invoking cwd and take the first
+        // bunfig.toml found. On Unix the candidate is rejected unless it is
+        // (or resolves to) a regular file owned by the current user (see
+        // `is_trusted_local_bunfig`), so a bunfig.toml planted by another
+        // local user in a world-writable ancestor cannot redirect the
+        // install.
+        // SAFETY: `Transpiler::init` always sets `fs` to the process singleton.
+        let top_level_dir: &[u8] = unsafe { (*this_transpiler.fs).top_level_dir };
+        let local_bunfig_arg: Option<Vec<u8>> = 'find_bunfig: {
+            const PREFIX: &[u8] = b"--config=";
+            let mut buf = bun_paths::path_buffer_pool::get();
+            let total = buf.len();
+            let mut dir: &[u8] = strings::without_trailing_slash(top_level_dir);
+            loop {
+                let Ok(len) = (|| {
+                    let mut cursor: &mut [u8] = &mut buf[..total - 1];
+                    write!(
+                        cursor,
+                        "--config={dir}{sep}bunfig.toml",
+                        dir = BStr::new(dir),
+                        sep = bun_paths::SEP as char,
+                    )?;
+                    Ok::<_, std::io::Error>((total - 1) - cursor.len())
+                })() else {
+                    break 'find_bunfig None;
+                };
+                buf[len] = 0;
+                let path_z = ZStr::from_buf(&buf[PREFIX.len()..], len - PREFIX.len());
+                if bun_sys::exists_z(path_z) {
+                    if !Self::is_trusted_local_bunfig(path_z, uid) {
+                        bun_core::warn!(
+                            "ignoring <b>{}<r> because it is not a regular file owned by the current user",
+                            BStr::new(path_z.as_bytes()),
+                        );
+                        break 'find_bunfig None;
+                    }
+                    break 'find_bunfig Some(buf[..len].to_vec());
+                }
+                match bun_paths::dirname(dir) {
+                    Some(parent) => {
+                        let parent = strings::without_trailing_slash(parent);
+                        if parent.len() >= dir.len() {
+                            break 'find_bunfig None;
+                        }
+                        dir = parent;
+                    }
+                    None => break 'find_bunfig None,
+                }
+            }
+        };
+
         let display_version: &[u8] = if update_request.version.literal.is_empty() {
             b"latest"
         } else {
@@ -791,6 +874,12 @@ impl BunxCommand {
                     BStr::new(display_version),
                 )
                 .map_err(|_| crate::Error::Alloc(bun_alloc::AllocError))?;
+            }
+            if let Some(arg) = &local_bunfig_arg {
+                // Namespace the cache dir by bunfig path so projects pinning
+                // different registries do not share a cache entry.
+                write!(&mut v, "@{:x}", hash(&arg[b"--config=".len()..]))
+                    .map_err(|_| crate::Error::Alloc(bun_alloc::AllocError))?;
             }
             break 'brk v;
         };
@@ -880,12 +969,6 @@ impl BunxCommand {
         //     where a user can replace the directory with malicious code.
         //
         // If this format changes, please update cache clearing code in package_manager_command.rs
-        #[cfg(unix)]
-        // SAFETY: getuid() is always safe to call (no preconditions, never fails)
-        let uid = unsafe { libc::getuid() };
-        #[cfg(windows)]
-        let uid = bun_sys::windows::user_unique_id();
-
         path = {
             let mut v = Vec::new();
             let path_is_nonzero = !path.is_empty();
@@ -917,7 +1000,6 @@ impl BunxCommand {
         // `path_buf` is a stack local so
         // `bun_which::which`'s returned slice can borrow it for the rest of exec().
         let mut path_buf = PathBuffer::uninit();
-        let top_level_dir: &[u8] = fs.top_level_dir;
 
         let mut absolute_in_cache_dir_buf = PathBuffer::uninit();
         let buf_total = absolute_in_cache_dir_buf.len();
@@ -1239,66 +1321,6 @@ impl BunxCommand {
             );
             Global::exit(1);
         }
-
-        // The spawned `bun add` runs with cwd = `bunx_cache_dir`, so it cannot
-        // discover a project-local bunfig.toml on its own. Resolve it here from
-        // the invoking directory and forward it via `--config=<path>` so
-        // `[install]` settings such as `registry` are honored. `--config`'s
-        // value is optional in the install arg parser, so the `=` form is
-        // required for the path to be consumed.
-        //
-        // `bun add` run directly from a workspace member chdirs to the
-        // workspace root before loading bunfig.toml; replicating that walk
-        // would require parsing each ancestor package.json's `workspaces`, so
-        // instead walk up from the invoking cwd and take the first
-        // bunfig.toml found. On Unix the candidate is rejected unless it is a
-        // regular file owned by the current user (see
-        // `is_trusted_local_bunfig`), so a bunfig.toml planted by another
-        // local user in a world-writable ancestor cannot redirect the
-        // install.
-        let mut local_bunfig_buf = PathBuffer::uninit();
-        let local_bunfig_arg: Option<&[u8]> = 'find_bunfig: {
-            const PREFIX: &[u8] = b"--config=";
-            let mut dir: &[u8] = strings::without_trailing_slash(top_level_dir);
-            loop {
-                let len = {
-                    let total = local_bunfig_buf.len();
-                    let mut cursor: &mut [u8] = &mut local_bunfig_buf[..];
-                    write!(
-                        cursor,
-                        "--config={dir}{sep}bunfig.toml",
-                        dir = BStr::new(dir),
-                        sep = bun_paths::SEP as char,
-                    )
-                    .map_err(|_| crate::Error::PathTooLong)?;
-                    total - cursor.len()
-                };
-                local_bunfig_buf[len] = 0;
-                let path_z = ZStr::from_buf(&local_bunfig_buf[PREFIX.len()..], len - PREFIX.len());
-                if bun_sys::exists_z(path_z) {
-                    if !Self::is_trusted_local_bunfig(path_z, uid) {
-                        bun_output::scoped_log!(
-                            bunx,
-                            "ignoring untrusted bunfig.toml: {}",
-                            BStr::new(path_z.as_bytes())
-                        );
-                        break 'find_bunfig None;
-                    }
-                    break 'find_bunfig Some(&local_bunfig_buf[..len]);
-                }
-                match bun_paths::dirname(dir) {
-                    Some(parent) => {
-                        let parent = strings::without_trailing_slash(parent);
-                        if parent.len() >= dir.len() {
-                            break 'find_bunfig None;
-                        }
-                        dir = parent;
-                    }
-                    None => break 'find_bunfig None,
-                }
-            }
-        };
-
         let bunx_install_dir = Fd::cwd().make_open_path(bunx_cache_dir)?;
 
         'create_package_json: {
@@ -1323,7 +1345,7 @@ impl BunxCommand {
         let mut args: BoundedArray<&[u8], 9> =
             BoundedArray::from_slice(&install_args).expect("unreachable"); // upper bound is known
 
-        if let Some(config_arg) = local_bunfig_arg {
+        if let Some(config_arg) = local_bunfig_arg.as_deref() {
             args.append(config_arg).expect("unreachable"); // upper bound is known
         }
 

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -1220,6 +1220,40 @@ impl BunxCommand {
             Global::exit(1);
         }
 
+        // The spawned `bun add` runs with cwd = `bunx_cache_dir`, so it cannot
+        // discover a project-local bunfig.toml on its own. Resolve it here from
+        // the invoking directory (nearest enclosing package.json dir, else cwd)
+        // and forward it via `--config=<path>` so `[install]` settings such as
+        // `registry` are honored. `--config`'s value is optional in the install
+        // arg parser, so the `=` form is required for the path to be consumed.
+        let bunfig_dir: &[u8] = match root_dir_info.enclosing_package_json {
+            Some(pkg) => bun_paths::dirname(pkg.source.path.text).unwrap_or(top_level_dir),
+            None => top_level_dir,
+        };
+        let mut local_bunfig_buf = PathBuffer::uninit();
+        let local_bunfig_arg: Option<&[u8]> = {
+            const PREFIX: &[u8] = b"--config=";
+            let len = {
+                let total = local_bunfig_buf.len();
+                let mut cursor: &mut [u8] = &mut local_bunfig_buf[..];
+                write!(
+                    cursor,
+                    "--config={dir}{sep}bunfig.toml",
+                    dir = BStr::new(strings::without_trailing_slash(bunfig_dir)),
+                    sep = bun_paths::SEP as char,
+                )
+                .map_err(|_| crate::Error::PathTooLong)?;
+                total - cursor.len()
+            };
+            local_bunfig_buf[len] = 0;
+            let path_z = ZStr::from_buf(&local_bunfig_buf[PREFIX.len()..], len - PREFIX.len());
+            if bun_sys::exists_z(path_z) {
+                Some(&local_bunfig_buf[..len])
+            } else {
+                None
+            }
+        };
+
         let bunx_install_dir = Fd::cwd().make_open_path(bunx_cache_dir)?;
 
         'create_package_json: {
@@ -1241,8 +1275,12 @@ impl BunxCommand {
             install_param.as_slice(),
             b"--no-summary",
         ];
-        let mut args: BoundedArray<&[u8], 8> =
+        let mut args: BoundedArray<&[u8], 9> =
             BoundedArray::from_slice(&install_args).expect("unreachable"); // upper bound is known
+
+        if let Some(config_arg) = local_bunfig_arg {
+            args.append(config_arg).expect("unreachable"); // upper bound is known
+        }
 
         if do_cache_bust {
             // disable the manifest cache when a tag is specified

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -1222,35 +1222,49 @@ impl BunxCommand {
 
         // The spawned `bun add` runs with cwd = `bunx_cache_dir`, so it cannot
         // discover a project-local bunfig.toml on its own. Resolve it here from
-        // the invoking directory (nearest enclosing package.json dir, else cwd)
-        // and forward it via `--config=<path>` so `[install]` settings such as
-        // `registry` are honored. `--config`'s value is optional in the install
-        // arg parser, so the `=` form is required for the path to be consumed.
-        let bunfig_dir: &[u8] = match root_dir_info.enclosing_package_json {
-            Some(pkg) => bun_paths::dirname(pkg.source.path.text).unwrap_or(top_level_dir),
-            None => top_level_dir,
-        };
+        // the invoking directory and forward it via `--config=<path>` so
+        // `[install]` settings such as `registry` are honored. `--config`'s
+        // value is optional in the install arg parser, so the `=` form is
+        // required for the path to be consumed.
+        //
+        // `bun add` run directly from a workspace member chdirs to the
+        // workspace root before loading bunfig.toml; replicating that walk
+        // would require parsing each ancestor package.json's `workspaces`, so
+        // instead walk up from the invoking cwd and take the first
+        // bunfig.toml found. This is a superset of what `bun add` would find,
+        // which is the safe direction for registry pinning.
         let mut local_bunfig_buf = PathBuffer::uninit();
-        let local_bunfig_arg: Option<&[u8]> = {
+        let local_bunfig_arg: Option<&[u8]> = 'find_bunfig: {
             const PREFIX: &[u8] = b"--config=";
-            let len = {
-                let total = local_bunfig_buf.len();
-                let mut cursor: &mut [u8] = &mut local_bunfig_buf[..];
-                write!(
-                    cursor,
-                    "--config={dir}{sep}bunfig.toml",
-                    dir = BStr::new(strings::without_trailing_slash(bunfig_dir)),
-                    sep = bun_paths::SEP as char,
-                )
-                .map_err(|_| crate::Error::PathTooLong)?;
-                total - cursor.len()
-            };
-            local_bunfig_buf[len] = 0;
-            let path_z = ZStr::from_buf(&local_bunfig_buf[PREFIX.len()..], len - PREFIX.len());
-            if bun_sys::exists_z(path_z) {
-                Some(&local_bunfig_buf[..len])
-            } else {
-                None
+            let mut dir: &[u8] = strings::without_trailing_slash(top_level_dir);
+            loop {
+                let len = {
+                    let total = local_bunfig_buf.len();
+                    let mut cursor: &mut [u8] = &mut local_bunfig_buf[..];
+                    write!(
+                        cursor,
+                        "--config={dir}{sep}bunfig.toml",
+                        dir = BStr::new(dir),
+                        sep = bun_paths::SEP as char,
+                    )
+                    .map_err(|_| crate::Error::PathTooLong)?;
+                    total - cursor.len()
+                };
+                local_bunfig_buf[len] = 0;
+                let path_z = ZStr::from_buf(&local_bunfig_buf[PREFIX.len()..], len - PREFIX.len());
+                if bun_sys::exists_z(path_z) {
+                    break 'find_bunfig Some(&local_bunfig_buf[..len]);
+                }
+                match bun_paths::dirname(dir) {
+                    Some(parent) => {
+                        let parent = strings::without_trailing_slash(parent);
+                        if parent.len() >= dir.len() {
+                            break 'find_bunfig None;
+                        }
+                        dir = parent;
+                    }
+                    None => break 'find_bunfig None,
+                }
             }
         };
 

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -813,6 +813,7 @@ impl BunxCommand {
                             "ignoring <b>{}<r> because it is not a regular file owned by the current user",
                             BStr::new(path_z.as_bytes()),
                         );
+                        Output::flush();
                         break 'find_bunfig None;
                     }
                     break 'find_bunfig Some(buf[..len].to_vec());

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -1431,6 +1431,12 @@ impl BunxCommand {
             },
         };
 
+        // `Run::run_binary` below execs the installed tool with this same
+        // `env_loader`; the tool (e.g. a scaffolder that runs `bun install`)
+        // must not inherit the internal marker, or that grandchild install
+        // would skip the configured security scanner.
+        env_loader.map.remove(b"BUN_INTERNAL_BUNX_INSTALL");
+
         match &spawn_result.status {
             SpawnStatus::Exited(exited) => {
                 // Any non-zero byte (incl. RT signals >31) is a valid signal.

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -584,6 +584,26 @@ impl BunxCommand {
         true
     }
 
+    /// Refuse to forward a `bunfig.toml` discovered by walking up from the
+    /// invoking cwd unless it is a regular file owned by the current user.
+    /// The walk may cross into world-writable ancestors (e.g. `/tmp`), where
+    /// another local user could plant a `bunfig.toml` redirecting `[install]
+    /// registry` to a host they control; bunx would then fetch and execute
+    /// their package. Same threat model as `is_trusted_cached_binary`.
+    #[cfg(unix)]
+    fn is_trusted_local_bunfig(path: &ZStr, uid: libc::uid_t) -> bool {
+        match bun_sys::lstat(path) {
+            Ok(st) => st.st_uid == uid && (st.st_mode & libc::S_IFMT) == libc::S_IFREG,
+            Err(_) => false,
+        }
+    }
+
+    #[cfg(not(unix))]
+    #[inline(always)]
+    fn is_trusted_local_bunfig(_path: &ZStr, _uid: u32) -> bool {
+        true
+    }
+
     fn exit_with_usage() -> ! {
         crate::cli::command::tag_print_help(Command::Tag::BunxCommand, false);
         Global::exit(1);
@@ -1231,8 +1251,11 @@ impl BunxCommand {
         // workspace root before loading bunfig.toml; replicating that walk
         // would require parsing each ancestor package.json's `workspaces`, so
         // instead walk up from the invoking cwd and take the first
-        // bunfig.toml found. This is a superset of what `bun add` would find,
-        // which is the safe direction for registry pinning.
+        // bunfig.toml found. On Unix the candidate is rejected unless it is a
+        // regular file owned by the current user (see
+        // `is_trusted_local_bunfig`), so a bunfig.toml planted by another
+        // local user in a world-writable ancestor cannot redirect the
+        // install.
         let mut local_bunfig_buf = PathBuffer::uninit();
         let local_bunfig_arg: Option<&[u8]> = 'find_bunfig: {
             const PREFIX: &[u8] = b"--config=";
@@ -1253,6 +1276,14 @@ impl BunxCommand {
                 local_bunfig_buf[len] = 0;
                 let path_z = ZStr::from_buf(&local_bunfig_buf[PREFIX.len()..], len - PREFIX.len());
                 if bun_sys::exists_z(path_z) {
+                    if !Self::is_trusted_local_bunfig(path_z, uid) {
+                        bun_output::scoped_log!(
+                            bunx,
+                            "ignoring untrusted bunfig.toml: {}",
+                            BStr::new(path_z.as_bytes())
+                        );
+                        break 'find_bunfig None;
+                    }
                     break 'find_bunfig Some(&local_bunfig_buf[..len]);
                 }
                 match bun_paths::dirname(dir) {

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -1341,40 +1341,43 @@ describe("bunx honors the project-local bunfig.toml [install] registry", () => {
   // discovered bunfig.toml is refused unless it is a regular file owned by
   // the current user. chown to another uid needs root, so exercise the
   // regular-file check via a symlink instead.
-  it.skipIf(isWindows)("ignores a bunfig.toml in an ancestor directory that is not a trusted regular file", async () => {
-    const hitsA: string[] = [];
-    const hitsB: string[] = [];
-    await using srvA = registry(await makePkgTarball("ANCESTOR"), hitsA);
-    await using srvB = registry(await makePkgTarball("GLOBAL"), hitsB);
+  it.skipIf(isWindows)(
+    "ignores a bunfig.toml in an ancestor directory that is not a trusted regular file",
+    async () => {
+      const hitsA: string[] = [];
+      const hitsB: string[] = [];
+      await using srvA = registry(await makePkgTarball("ANCESTOR"), hitsA);
+      await using srvB = registry(await makePkgTarball("GLOBAL"), hitsB);
 
-    const { x_dir, env } = setup();
-    const home = tmpdirSync();
-    const cwd = join(x_dir, "work");
-    await mkdir(cwd, { recursive: true });
-    // Ancestor bunfig.toml is a symlink: fails the regular-file trust check.
-    const target = join(x_dir, "planted.toml");
-    await writeFile(target, `[install]\nregistry = "http://127.0.0.1:${srvA.port}/"\n`);
-    symlinkSync(target, join(x_dir, "bunfig.toml"));
-    await writeFile(join(home, ".bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:${srvB.port}/"\n`);
+      const { x_dir, env } = setup();
+      const home = tmpdirSync();
+      const cwd = join(x_dir, "work");
+      await mkdir(cwd, { recursive: true });
+      // Ancestor bunfig.toml is a symlink: fails the regular-file trust check.
+      const target = join(x_dir, "planted.toml");
+      await writeFile(target, `[install]\nregistry = "http://127.0.0.1:${srvA.port}/"\n`);
+      symlinkSync(target, join(x_dir, "bunfig.toml"));
+      await writeFile(join(home, ".bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:${srvB.port}/"\n`);
 
-    await using proc = spawn({
-      cmd: [bunExe(), "x", "px-probe"],
-      cwd,
-      stdout: "pipe",
-      stdin: "ignore",
-      stderr: "pipe",
-      env: bunxEnv(env, home),
-    });
-    const [err, out, exited] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      await using proc = spawn({
+        cmd: [bunExe(), "x", "px-probe"],
+        cwd,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env: bunxEnv(env, home),
+      });
+      const [err, out, exited] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
 
-    expect({ out: out.trim(), hitsA, hitsB }).toEqual({
-      out: "SERVED-BY-GLOBAL",
-      hitsA: [],
-      hitsB: ["/px-probe", "/px-probe-1.0.0.tgz"],
-    });
-    expect(err).not.toContain("error:");
-    expect(exited).toBe(0);
-  });
+      expect({ out: out.trim(), hitsA, hitsB }).toEqual({
+        out: "SERVED-BY-GLOBAL",
+        hitsA: [],
+        hitsB: ["/px-probe", "/px-probe-1.0.0.tgz"],
+      });
+      expect(err).not.toContain("error:");
+      expect(exited).toBe(0);
+    },
+  );
 });
 
 // Regression test: bunx should not crash on corrupted .bunx files (Windows only)

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -1342,37 +1342,34 @@ describe("bunx honors the project-local bunfig.toml [install] registry", () => {
   // regular file owned by the current user, and a warning is printed so the
   // fallback is not silent. chown to another uid needs root, so exercise the
   // regular-file check via a directory named bunfig.toml.
-  it.skipIf(isWindows)(
-    "warns and ignores an ancestor bunfig.toml that is not a trusted regular file",
-    async () => {
-      const hits: string[] = [];
-      await using srv = registry(await makePkgTarball("GLOBAL"), hits);
+  it.skipIf(isWindows)("warns and ignores an ancestor bunfig.toml that is not a trusted regular file", async () => {
+    const hits: string[] = [];
+    await using srv = registry(await makePkgTarball("GLOBAL"), hits);
 
-      const { x_dir, env } = setup();
-      const home = tmpdirSync();
-      const cwd = join(x_dir, "work");
-      await mkdir(cwd, { recursive: true });
-      await mkdir(join(x_dir, "bunfig.toml"), { recursive: true });
-      await writeFile(join(home, ".bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:${srv.port}/"\n`);
+    const { x_dir, env } = setup();
+    const home = tmpdirSync();
+    const cwd = join(x_dir, "work");
+    await mkdir(cwd, { recursive: true });
+    await mkdir(join(x_dir, "bunfig.toml"), { recursive: true });
+    await writeFile(join(home, ".bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:${srv.port}/"\n`);
 
-      await using proc = spawn({
-        cmd: [bunExe(), "x", "px-probe"],
-        cwd,
-        stdout: "pipe",
-        stdin: "ignore",
-        stderr: "pipe",
-        env: bunxEnv(env, home),
-      });
-      const [err, out, exited] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+    await using proc = spawn({
+      cmd: [bunExe(), "x", "px-probe"],
+      cwd,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: bunxEnv(env, home),
+    });
+    const [err, out, exited] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
 
-      expect(err).toContain("ignoring");
-      expect(err).toContain(join(x_dir, "bunfig.toml"));
-      expect(err).toContain("not a regular file owned by the current user");
-      expect(out.trim()).toBe("SERVED-BY-GLOBAL");
-      expect(hits).toEqual(["/px-probe", "/px-probe-1.0.0.tgz"]);
-      expect(exited).toBe(0);
-    },
-  );
+    expect(err).toContain("ignoring");
+    expect(err).toContain(join(x_dir, "bunfig.toml"));
+    expect(err).toContain("not a regular file owned by the current user");
+    expect(out.trim()).toBe("SERVED-BY-GLOBAL");
+    expect(hits).toEqual(["/px-probe", "/px-probe-1.0.0.tgz"]);
+    expect(exited).toBe(0);
+  });
 
   // A uid-owned symlink to a uid-owned regular file is accepted (dotfile
   // managers commonly symlink config files).

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -1363,11 +1363,10 @@ describe("bunx honors the project-local bunfig.toml [install] registry", () => {
     });
     const [err, out, exited] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
 
-    expect(err).toContain("ignoring");
-    expect(err).toContain(join(x_dir, "bunfig.toml"));
-    expect(err).toContain("not a regular file owned by the current user");
     expect(out.trim()).toBe("SERVED-BY-GLOBAL");
     expect(hits).toEqual(["/px-probe", "/px-probe-1.0.0.tgz"]);
+    expect(err).toContain("not a regular file owned by the current user");
+    expect(err).toContain(join(x_dir, "bunfig.toml"));
     expect(exited).toBe(0);
   });
 

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -1338,26 +1338,22 @@ describe("bunx honors the project-local bunfig.toml [install] registry", () => {
   });
 
   // The walk-up may cross into world-writable ancestors, so on Unix a
-  // discovered bunfig.toml is refused unless it is a regular file owned by
-  // the current user. chown to another uid needs root, so exercise the
-  // regular-file check via a symlink instead.
+  // discovered bunfig.toml is refused unless it is (or resolves to) a
+  // regular file owned by the current user, and a warning is printed so the
+  // fallback is not silent. chown to another uid needs root, so exercise the
+  // regular-file check via a directory named bunfig.toml.
   it.skipIf(isWindows)(
-    "ignores a bunfig.toml in an ancestor directory that is not a trusted regular file",
+    "warns and ignores an ancestor bunfig.toml that is not a trusted regular file",
     async () => {
-      const hitsA: string[] = [];
-      const hitsB: string[] = [];
-      await using srvA = registry(await makePkgTarball("ANCESTOR"), hitsA);
-      await using srvB = registry(await makePkgTarball("GLOBAL"), hitsB);
+      const hits: string[] = [];
+      await using srv = registry(await makePkgTarball("GLOBAL"), hits);
 
       const { x_dir, env } = setup();
       const home = tmpdirSync();
       const cwd = join(x_dir, "work");
       await mkdir(cwd, { recursive: true });
-      // Ancestor bunfig.toml is a symlink: fails the regular-file trust check.
-      const target = join(x_dir, "planted.toml");
-      await writeFile(target, `[install]\nregistry = "http://127.0.0.1:${srvA.port}/"\n`);
-      symlinkSync(target, join(x_dir, "bunfig.toml"));
-      await writeFile(join(home, ".bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:${srvB.port}/"\n`);
+      await mkdir(join(x_dir, "bunfig.toml"), { recursive: true });
+      await writeFile(join(home, ".bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:${srv.port}/"\n`);
 
       await using proc = spawn({
         cmd: [bunExe(), "x", "px-probe"],
@@ -1369,15 +1365,99 @@ describe("bunx honors the project-local bunfig.toml [install] registry", () => {
       });
       const [err, out, exited] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
 
-      expect({ out: out.trim(), hitsA, hitsB }).toEqual({
-        out: "SERVED-BY-GLOBAL",
-        hitsA: [],
-        hitsB: ["/px-probe", "/px-probe-1.0.0.tgz"],
-      });
-      expect(err).not.toContain("error:");
+      expect(err).toContain("ignoring");
+      expect(err).toContain(join(x_dir, "bunfig.toml"));
+      expect(err).toContain("not a regular file owned by the current user");
+      expect(out.trim()).toBe("SERVED-BY-GLOBAL");
+      expect(hits).toEqual(["/px-probe", "/px-probe-1.0.0.tgz"]);
       expect(exited).toBe(0);
     },
   );
+
+  // A uid-owned symlink to a uid-owned regular file is accepted (dotfile
+  // managers commonly symlink config files).
+  it.skipIf(isWindows)("accepts a uid-owned symlinked bunfig.toml", async () => {
+    const hits: string[] = [];
+    await using srv = registry(await makePkgTarball("PROJECT"), hits);
+
+    const { x_dir, env } = setup();
+    const home = tmpdirSync();
+    const target = join(x_dir, "real-bunfig.toml");
+    await writeFile(target, `[install]\nregistry = "http://127.0.0.1:${srv.port}/"\n`);
+    symlinkSync(target, join(x_dir, "bunfig.toml"));
+    await writeFile(join(home, ".bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:1/"\n`);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "x", "px-probe"],
+      cwd: x_dir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: bunxEnv(env, home),
+    });
+    const [err, out, exited] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+
+    expect(out.trim()).toBe("SERVED-BY-PROJECT");
+    expect(hits).toEqual(["/px-probe", "/px-probe-1.0.0.tgz"]);
+    expect(err).not.toContain("ignoring");
+    expect(exited).toBe(0);
+  });
+
+  // When a local bunfig.toml is forwarded, the bunx cache dir is namespaced
+  // by its path so two projects pinning different registries do not share a
+  // cache entry for the same package name.
+  it("does not serve a warm cache entry installed from a different project's registry", async () => {
+    const hitsA: string[] = [];
+    const hitsB: string[] = [];
+    await using srvA = registry(await makePkgTarball("A"), hitsA);
+    await using srvB = registry(await makePkgTarball("B"), hitsB);
+
+    // Shared TMPDIR so both invocations see the same bunx cache namespace.
+    // The install tarball cache is per-project; this test isolates the bunx
+    // layer, not `bun add`'s own tarball cache.
+    const tmp = tmpdirSync();
+    const home = tmpdirSync();
+    await writeFile(join(home, ".bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:1/"\n`);
+
+    async function runIn(srv: ReturnType<typeof registry>) {
+      const dir = tmpdirSync();
+      await writeFile(join(dir, "package.json"), JSON.stringify({ name: "p", version: "1.0.0" }));
+      await writeFile(join(dir, "bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:${srv.port}/"\n`);
+      await using proc = spawn({
+        cmd: [bunExe(), "x", "px-probe"],
+        cwd: dir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env: {
+          ...bunEnv,
+          TEMP: tmp,
+          BUN_TMPDIR: tmp,
+          TMPDIR: tmp,
+          BUN_INSTALL_CACHE_DIR: join(dir, ".install-cache"),
+          HOME: home,
+          USERPROFILE: home,
+          XDG_CONFIG_HOME: home,
+          PATH: pathWithout("px-probe", bunEnv.PATH),
+          npm_config_registry: undefined as any,
+          NPM_CONFIG_REGISTRY: undefined as any,
+          BUN_CONFIG_REGISTRY: undefined as any,
+        },
+      });
+      const [, out, exited] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      return { out: out.trim(), exited };
+    }
+
+    const a = await runIn(srvA);
+    const b = await runIn(srvB);
+
+    expect({ a, b, hitsA, hitsB }).toEqual({
+      a: { out: "SERVED-BY-A", exited: 0 },
+      b: { out: "SERVED-BY-B", exited: 0 },
+      hitsA: ["/px-probe", "/px-probe-1.0.0.tgz"],
+      hitsB: ["/px-probe", "/px-probe-1.0.0.tgz"],
+    });
+  });
 });
 
 // Regression test: bunx should not crash on corrupted .bunx files (Windows only)

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -1336,6 +1336,45 @@ describe("bunx honors the project-local bunfig.toml [install] registry", () => {
     expect(err).not.toContain("error:");
     expect(exited).toBe(0);
   });
+
+  // The walk-up may cross into world-writable ancestors, so on Unix a
+  // discovered bunfig.toml is refused unless it is a regular file owned by
+  // the current user. chown to another uid needs root, so exercise the
+  // regular-file check via a symlink instead.
+  it.skipIf(isWindows)("ignores a bunfig.toml in an ancestor directory that is not a trusted regular file", async () => {
+    const hitsA: string[] = [];
+    const hitsB: string[] = [];
+    await using srvA = registry(await makePkgTarball("ANCESTOR"), hitsA);
+    await using srvB = registry(await makePkgTarball("GLOBAL"), hitsB);
+
+    const { x_dir, env } = setup();
+    const home = tmpdirSync();
+    const cwd = join(x_dir, "work");
+    await mkdir(cwd, { recursive: true });
+    // Ancestor bunfig.toml is a symlink: fails the regular-file trust check.
+    const target = join(x_dir, "planted.toml");
+    await writeFile(target, `[install]\nregistry = "http://127.0.0.1:${srvA.port}/"\n`);
+    symlinkSync(target, join(x_dir, "bunfig.toml"));
+    await writeFile(join(home, ".bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:${srvB.port}/"\n`);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "x", "px-probe"],
+      cwd,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: bunxEnv(env, home),
+    });
+    const [err, out, exited] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+
+    expect({ out: out.trim(), hitsA, hitsB }).toEqual({
+      out: "SERVED-BY-GLOBAL",
+      hitsA: [],
+      hitsB: ["/px-probe", "/px-probe-1.0.0.tgz"],
+    });
+    expect(err).not.toContain("error:");
+    expect(exited).toBe(0);
+  });
 });
 
 // Regression test: bunx should not crash on corrupted .bunx files (Windows only)

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -1204,7 +1204,7 @@ describe("bunx honors the project-local bunfig.toml [install] registry", () => {
     return new Uint8Array(await Bun.file(tgz).arrayBuffer());
   }
 
-  function registry(tag: string, tgz: Uint8Array, hits: string[]) {
+  function registry(tgz: Uint8Array, hits: string[]) {
     const server = Bun.serve({
       port: 0,
       fetch(req) {
@@ -1228,13 +1228,24 @@ describe("bunx honors the project-local bunfig.toml [install] registry", () => {
     return server;
   }
 
+  function bunxEnv(env: Record<string, string>, home: string) {
+    return {
+      ...env,
+      HOME: home,
+      USERPROFILE: home,
+      XDG_CONFIG_HOME: home,
+      PATH: pathWithout("px-probe", env.PATH),
+      npm_config_registry: undefined as any,
+      NPM_CONFIG_REGISTRY: undefined as any,
+      BUN_CONFIG_REGISTRY: undefined as any,
+    };
+  }
+
   it("prefers the project bunfig registry over the global one", async () => {
-    const tgzA = await makePkgTarball("PROJECT");
-    const tgzB = await makePkgTarball("GLOBAL");
     const hitsA: string[] = [];
     const hitsB: string[] = [];
-    await using srvA = registry("PROJECT", tgzA, hitsA);
-    await using srvB = registry("GLOBAL", tgzB, hitsB);
+    await using srvA = registry(await makePkgTarball("PROJECT"), hitsA);
+    await using srvB = registry(await makePkgTarball("GLOBAL"), hitsB);
 
     const { x_dir, env } = setup();
     const home = tmpdirSync();
@@ -1248,16 +1259,7 @@ describe("bunx honors the project-local bunfig.toml [install] registry", () => {
       stdout: "pipe",
       stdin: "ignore",
       stderr: "pipe",
-      env: {
-        ...env,
-        HOME: home,
-        USERPROFILE: home,
-        XDG_CONFIG_HOME: home,
-        PATH: pathWithout("px-probe", env.PATH),
-        npm_config_registry: undefined as any,
-        NPM_CONFIG_REGISTRY: undefined as any,
-        BUN_CONFIG_REGISTRY: undefined as any,
-      },
+      env: bunxEnv(env, home),
     });
     const [err, out, exited] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
 
@@ -1271,9 +1273,8 @@ describe("bunx honors the project-local bunfig.toml [install] registry", () => {
   });
 
   it("honors the cwd bunfig.toml even without a package.json in the project", async () => {
-    const tgz = await makePkgTarball("PROJECT");
     const hits: string[] = [];
-    await using srv = registry("PROJECT", tgz, hits);
+    await using srv = registry(await makePkgTarball("PROJECT"), hits);
 
     const { x_dir, env } = setup();
     const home = tmpdirSync();
@@ -1289,21 +1290,49 @@ describe("bunx honors the project-local bunfig.toml [install] registry", () => {
       stdout: "pipe",
       stdin: "ignore",
       stderr: "pipe",
-      env: {
-        ...env,
-        HOME: home,
-        USERPROFILE: home,
-        XDG_CONFIG_HOME: home,
-        PATH: pathWithout("px-probe", env.PATH),
-        npm_config_registry: undefined as any,
-        NPM_CONFIG_REGISTRY: undefined as any,
-        BUN_CONFIG_REGISTRY: undefined as any,
-      },
+      env: bunxEnv(env, home),
     });
     const [err, out, exited] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
 
     expect(out.trim()).toBe("SERVED-BY-PROJECT");
     expect(hits).toEqual(["/px-probe", "/px-probe-1.0.0.tgz"]);
+    expect(err).not.toContain("error:");
+    expect(exited).toBe(0);
+  });
+
+  it("finds the workspace-root bunfig.toml when run from a workspace member", async () => {
+    const hitsA: string[] = [];
+    const hitsB: string[] = [];
+    await using srvA = registry(await makePkgTarball("PROJECT"), hitsA);
+    await using srvB = registry(await makePkgTarball("GLOBAL"), hitsB);
+
+    const { x_dir, env } = setup();
+    const home = tmpdirSync();
+    const appDir = join(x_dir, "packages", "app");
+    await mkdir(appDir, { recursive: true });
+    await writeFile(
+      join(x_dir, "package.json"),
+      JSON.stringify({ name: "root", version: "1.0.0", workspaces: ["packages/*"] }),
+    );
+    await writeFile(join(x_dir, "bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:${srvA.port}/"\n`);
+    await writeFile(join(appDir, "package.json"), JSON.stringify({ name: "app", version: "1.0.0" }));
+    await writeFile(join(home, ".bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:${srvB.port}/"\n`);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "x", "px-probe"],
+      cwd: appDir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: bunxEnv(env, home),
+    });
+    const [err, out, exited] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+
+    expect({ out: out.trim(), hitsA, hitsB }).toEqual({
+      out: "SERVED-BY-PROJECT",
+      hitsA: ["/px-probe", "/px-probe-1.0.0.tgz"],
+      hitsB: [],
+    });
     expect(err).not.toContain("error:");
     expect(exited).toBe(0);
   });

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -1183,6 +1183,132 @@ describe("package name aliases", () => {
   });
 });
 
+// bunx spawns its internal `bun add` with cwd set to the bunx cache dir under
+// $TMPDIR, so the project-local bunfig.toml was never discovered; only the
+// global ~/.bunfig.toml (or env) was honored. In a project that pins a private
+// registry via its bunfig.toml, `bunx <tool>` silently resolved and executed
+// the package from the wrong registry.
+describe("bunx honors the project-local bunfig.toml [install] registry", () => {
+  async function makePkgTarball(tag: string) {
+    const root = tmpdirSync();
+    const pkgDir = join(root, "package");
+    await mkdir(pkgDir, { recursive: true });
+    await writeFile(
+      join(pkgDir, "package.json"),
+      JSON.stringify({ name: "px-probe", version: "1.0.0", bin: { "px-probe": "cli.js" } }),
+    );
+    await writeFile(join(pkgDir, "cli.js"), `#!/usr/bin/env node\nconsole.log("SERVED-BY-${tag}");\n`);
+    const tgzDir = tmpdirSync();
+    const tgz = join(tgzDir, "px-probe-1.0.0.tgz");
+    await Bun.$`tar -czf ${tgz} -C ${root} package`;
+    return new Uint8Array(await Bun.file(tgz).arrayBuffer());
+  }
+
+  function registry(tag: string, tgz: Uint8Array, hits: string[]) {
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const path = new URL(req.url).pathname;
+        hits.push(path);
+        if (path.endsWith(".tgz")) return new Response(tgz);
+        return Response.json({
+          name: "px-probe",
+          "dist-tags": { latest: "1.0.0" },
+          versions: {
+            "1.0.0": {
+              name: "px-probe",
+              version: "1.0.0",
+              bin: { "px-probe": "cli.js" },
+              dist: { tarball: `http://127.0.0.1:${server.port}/px-probe-1.0.0.tgz` },
+            },
+          },
+        });
+      },
+    });
+    return server;
+  }
+
+  it("prefers the project bunfig registry over the global one", async () => {
+    const tgzA = await makePkgTarball("PROJECT");
+    const tgzB = await makePkgTarball("GLOBAL");
+    const hitsA: string[] = [];
+    const hitsB: string[] = [];
+    await using srvA = registry("PROJECT", tgzA, hitsA);
+    await using srvB = registry("GLOBAL", tgzB, hitsB);
+
+    const { x_dir, env } = setup();
+    const home = tmpdirSync();
+    await writeFile(join(x_dir, "package.json"), JSON.stringify({ name: "proj", version: "1.0.0" }));
+    await writeFile(join(x_dir, "bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:${srvA.port}/"\n`);
+    await writeFile(join(home, ".bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:${srvB.port}/"\n`);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "x", "px-probe"],
+      cwd: x_dir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: {
+        ...env,
+        HOME: home,
+        USERPROFILE: home,
+        XDG_CONFIG_HOME: home,
+        PATH: pathWithout("px-probe", env.PATH),
+        npm_config_registry: undefined as any,
+        NPM_CONFIG_REGISTRY: undefined as any,
+        BUN_CONFIG_REGISTRY: undefined as any,
+      },
+    });
+    const [err, out, exited] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+
+    expect({ out: out.trim(), hitsA, hitsB }).toEqual({
+      out: "SERVED-BY-PROJECT",
+      hitsA: ["/px-probe", "/px-probe-1.0.0.tgz"],
+      hitsB: [],
+    });
+    expect(err).not.toContain("error:");
+    expect(exited).toBe(0);
+  });
+
+  it("honors the cwd bunfig.toml even without a package.json in the project", async () => {
+    const tgz = await makePkgTarball("PROJECT");
+    const hits: string[] = [];
+    await using srv = registry("PROJECT", tgz, hits);
+
+    const { x_dir, env } = setup();
+    const home = tmpdirSync();
+    // No package.json in x_dir; only bunfig.toml.
+    await writeFile(join(x_dir, "bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:${srv.port}/"\n`);
+    // Global bunfig points at an unroutable address so the test never
+    // touches the public npm registry on failure.
+    await writeFile(join(home, ".bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:1/"\n`);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "x", "px-probe"],
+      cwd: x_dir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: {
+        ...env,
+        HOME: home,
+        USERPROFILE: home,
+        XDG_CONFIG_HOME: home,
+        PATH: pathWithout("px-probe", env.PATH),
+        npm_config_registry: undefined as any,
+        NPM_CONFIG_REGISTRY: undefined as any,
+        BUN_CONFIG_REGISTRY: undefined as any,
+      },
+    });
+    const [err, out, exited] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+
+    expect(out.trim()).toBe("SERVED-BY-PROJECT");
+    expect(hits).toEqual(["/px-probe", "/px-probe-1.0.0.tgz"]);
+    expect(err).not.toContain("error:");
+    expect(exited).toBe(0);
+  });
+});
+
 // Regression test: bunx should not crash on corrupted .bunx files (Windows only)
 // When the .bunx metadata file is corrupted (e.g., missing quote terminator in bin_path),
 // bunx should gracefully fall back to the slow path instead of panicking.

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -1189,7 +1189,7 @@ describe("package name aliases", () => {
 // registry via its bunfig.toml, `bunx <tool>` silently resolved and executed
 // the package from the wrong registry.
 describe("bunx honors the project-local bunfig.toml [install] registry", () => {
-  async function makePkgTarball(tag: string) {
+  async function makePkgTarball(tag: string, cli = `console.log("SERVED-BY-${tag}");`) {
     const root = tmpdirSync();
     const pkgDir = join(root, "package");
     await mkdir(pkgDir, { recursive: true });
@@ -1197,7 +1197,7 @@ describe("bunx honors the project-local bunfig.toml [install] registry", () => {
       join(pkgDir, "package.json"),
       JSON.stringify({ name: "px-probe", version: "1.0.0", bin: { "px-probe": "cli.js" } }),
     );
-    await writeFile(join(pkgDir, "cli.js"), `#!/usr/bin/env node\nconsole.log("SERVED-BY-${tag}");\n`);
+    await writeFile(join(pkgDir, "cli.js"), `#!/usr/bin/env node\n${cli}\n`);
     const tgzDir = tmpdirSync();
     const tgz = join(tgzDir, "px-probe-1.0.0.tgz");
     await Bun.$`tar -czf ${tgz} -C ${root} package`;
@@ -1454,6 +1454,38 @@ describe("bunx honors the project-local bunfig.toml [install] registry", () => {
       hitsA: ["/px-probe", "/px-probe-1.0.0.tgz"],
       hitsB: ["/px-probe", "/px-probe-1.0.0.tgz"],
     });
+  });
+
+  // BUN_INTERNAL_BUNX_INSTALL is set for the internal `bun add` (so it can,
+  // among other things, skip the [install.security] scanner) but must not
+  // leak into the environment of the tool bunx executes: a scaffolder that
+  // spawns `bun install` in the new project would otherwise inherit it and
+  // bypass the configured scanner for the real dependency tree.
+  it("does not leak BUN_INTERNAL_BUNX_INSTALL into the executed tool's environment", async () => {
+    const hits: string[] = [];
+    await using srv = registry(
+      await makePkgTarball("ENV", `console.log("marker=" + (process.env.BUN_INTERNAL_BUNX_INSTALL ?? "<unset>"));`),
+      hits,
+    );
+
+    const { x_dir, env } = setup();
+    const home = tmpdirSync();
+    await writeFile(join(x_dir, "bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:${srv.port}/"\n`);
+    await writeFile(join(home, ".bunfig.toml"), `[install]\nregistry = "http://127.0.0.1:1/"\n`);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "x", "px-probe"],
+      cwd: x_dir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: bunxEnv(env, home),
+    });
+    const [err, out, exited] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+
+    expect(out.trim()).toBe("marker=<unset>");
+    expect(err).not.toContain("error:");
+    expect(exited).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Problem

`bunx` installs into a per-package cache directory under `$TMPDIR` and spawns `bun add` with that directory as its cwd. The child's bunfig discovery only ever saw the global `~/.bunfig.toml` (or `$XDG_CONFIG_HOME/.bunfig.toml` / env vars); the project's local `bunfig.toml` was never read.

In a project that pins a private registry via `[install] registry`, `bunx <tool>` silently resolved, downloaded and **executed** the package from the default npm registry instead (dependency-confusion shape). `bun add` / `bun install` in the same directory correctly honor the local file.

## Reproduction

Two in-process registries, project `bunfig.toml` points at A, global `~/.bunfig.toml` points at B:

```text
bunx px-probe
# before: hits B, prints "SERVED-BY-GLOBAL"
# after:  hits A, prints "SERVED-BY-PROJECT"
```

## Cause

`src/runtime/cli/bunx_command.rs` spawns `bun add <pkg>@<ver> --no-summary [...]` with `cwd = <tmp>/bunx-<uid>-<pkg>@<ver>`. `PackageManager::init` walks up from that cwd, finds only the `{}` `package.json` bunx just wrote there, and loads `bunfig.toml` relative to that temp dir (which doesn't exist), falling back to the global config.

## Fix

Before building the cache key, walk up from the invoking cwd and take the first `bunfig.toml` found, then:

- forward it as `--config=<abs-path>` to the spawned `bun add` (the `=` form is required because `--config`'s value is optional in the install arg parser; a space-separated path would be consumed as a positional package name);
- fold a hash of its absolute path into the bunx cache directory name so two projects pinning different registries don't share a cache entry for the same `<name>@<version>`;
- on Unix, refuse the candidate unless it is (or resolves via one symlink hop to) a regular file owned by the current user, and print a user-visible warning on refusal, so a `bunfig.toml` planted by another local user in a world-writable ancestor (e.g. `/tmp`) cannot redirect the install. This mirrors the existing `is_trusted_cache_root` / `is_trusted_cached_binary` hardening in the same file;
- on path-buffer overflow (cwd near `PATH_MAX` on macOS), degrade to "no config forwarded" rather than aborting bunx.

Additionally, `run_security_scanner` now returns early when `BUN_INTERNAL_BUNX_INSTALL` is set: forwarding the whole bunfig also forwards `[install.security] scanner`, which the bunx-spawned `bun add` cannot resolve from the cache dir's `{}` package.json.

When no local `bunfig.toml` exists, nothing is forwarded and behavior is unchanged (global config / env vars still apply, cache key is unchanged).

## Verification

```
$ bun bd test test/cli/install/bunx.test.ts -t "bunx honors the project-local bunfig"
(pass) ... > prefers the project bunfig registry over the global one
(pass) ... > honors the cwd bunfig.toml even without a package.json in the project
(pass) ... > finds the workspace-root bunfig.toml when run from a workspace member
(pass) ... > warns and ignores an ancestor bunfig.toml that is not a trusted regular file
(pass) ... > accepts a uid-owned symlinked bunfig.toml
(pass) ... > does not serve a warm cache entry installed from a different project's registry
```

All six fail on `main`.

Fixes #5361

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bunx.test.ts

<!-- robobun:evidence:end -->