### PR TITLE
bundler: pair HTML chunk with its actual entry JS chunk under code splitting

### DIFF
--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -284,12 +284,16 @@ impl Chunk {
     }
 
     pub fn get_js_chunk_for_html<'a>(&self, chunks: &'a mut [Chunk]) -> Option<&'a mut Chunk> {
+        // Non-entry chunks created under code splitting carry a default
+        // entry_point_id of 0, so the id alone is ambiguous; require
+        // is_entry_point to find the actual entry chunk.
         let entry_point_id = self.entry_point.entry_point_id();
         for other in chunks.iter_mut() {
-            if matches!(other.content, Content::Javascript(_)) {
-                if other.entry_point.entry_point_id() == entry_point_id {
-                    return Some(other);
-                }
+            if matches!(other.content, Content::Javascript(_))
+                && other.entry_point.is_entry_point()
+                && other.entry_point.entry_point_id() == entry_point_id
+            {
+                return Some(other);
             }
         }
         None
@@ -305,7 +309,9 @@ impl Chunk {
         let css_idx: Option<usize> = 'find: {
             for other in chunks.iter() {
                 if let Content::Javascript(js) = &other.content {
-                    if other.entry_point.entry_point_id() == entry_point_id {
+                    if other.entry_point.is_entry_point()
+                        && other.entry_point.entry_point_id() == entry_point_id
+                    {
                         let css_chunk_indices = &js.css_chunks[..];
                         if !css_chunk_indices.is_empty() {
                             break 'find Some(css_chunk_indices[0] as usize);
@@ -321,10 +327,11 @@ impl Chunk {
         }
         // Fallback: match by entry_point_id for cases without a JS chunk.
         for other in chunks.iter_mut() {
-            if matches!(other.content, Content::Css(_)) {
-                if other.entry_point.entry_point_id() == entry_point_id {
-                    return Some(other);
-                }
+            if matches!(other.content, Content::Css(_))
+                && other.entry_point.is_entry_point()
+                && other.entry_point.entry_point_id() == entry_point_id
+            {
+                return Some(other);
             }
         }
         None

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -377,6 +377,47 @@ export const initNav = () => console.log('Navigation initialized');`,
     },
   });
 
+  // https://github.com/oven-sh/bun/issues/34111
+  // With code splitting, the HTML <script src> must reference the chunk that
+  // actually contains the entry module, not a shared chunk that happens to
+  // sort before it.
+  {
+    const pageCount = 10;
+    const files: Record<string, string> = {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>`,
+      "/main.ts":
+        `console.log("MAIN_ENTRY_EXECUTED");\n` +
+        Array.from({ length: pageCount }, (_, p) => `import("./pages/page${p}");`).join("\n"),
+      "/shared.ts": `export function shared() { return 1000; }`,
+    };
+    for (let p = 0; p < pageCount; p++) {
+      // The last two pages share a module so a non-entry shared chunk exists.
+      files[`/pages/page${p}.ts`] =
+        p >= pageCount - 2
+          ? `import { shared } from "../shared";\nexport default shared() + ${p};`
+          : `export default ${p};`;
+    }
+    itBundled("html/script-src-is-entry-chunk-with-splitting", {
+      outdir: "out/",
+      files,
+      entryPoints: ["/index.html"],
+      splitting: true,
+      onAfterBundle(api) {
+        const html = api.readFile("out/index.html");
+        const src = html.match(/<script[^>]*\bsrc="\.?\/?([^"]+)"/)?.[1];
+        expect(src).toBeDefined();
+        expect(api.readFile("out/" + src!)).toContain("MAIN_ENTRY_EXECUTED");
+      },
+    });
+  }
+
   // Test multiple HTML entries with shared chunks
   itBundled("html/shared-chunks", {
     outdir: "out/",


### PR DESCRIPTION
Fixes #34111
Fixes #24344

### Repro

With `splitting: true` and an HTML entry point, once the build produces enough shared chunks, the generated `index.html` `<script src>` references a shared chunk instead of the entry chunk:

```
result.outputs entry-point : /chunk-cxfkfr9z.js   (contains the entry module)
index.html <script src>    : /chunk-kd6swde3.js   (a shared chunk)
```

In a browser the entry module graph never executes, so the page stays blank with no errors. A dependency-free trigger is an HTML entry whose script dynamically imports 10 modules where the last two share a common import.

### Cause

`Chunk::get_js_chunk_for_html` (and the two scans in `get_css_chunk_for_html`) pair the HTML chunk with the first JS chunk whose `entry_point_id` matches. Non-entry chunks created under code splitting (`computeChunks.rs`) carry a default `entry_point_id` of 0, the same id as the first entry point, and chunk sorting groups all id-0 chunks first ordered by their entry-bits key. With enough entry points (10+, so the key grows past one byte), a shared chunk's key sorts before the entry chunk's key and wins the scan.

### Fix

Require `entry_point.is_entry_point()` in addition to the id match in all three scan sites in `src/bundler/Chunk.rs`.

### Verification

New test `html/script-src-is-entry-chunk-with-splitting` in `test/bundler/bundler_html.test.ts` fails before the fix (the referenced chunk contains only the shared module) and passes after. The reporter's 20-page React repro from the issue also produces matching entry-point and `<script src>` outputs after the fix. Existing HTML, splitting, and compile-splitting bundler suites pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_html.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (5a82870e2)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [601.88ms]
(pass) bundler > html/implicit-relative-paths [131.43ms]
(pass) bundler > html/multiple-assets [116.18ms]
(pass) bundler > html/image-hashing [117.33ms]
(pass) bundler > html/external-assets [106.40ms]
(pass) bundler > html/mixed-assets [149.17ms]
(pass) bundler > html/js-imports [148.10ms]
(pass) bundler > html/css-imports [116.81ms]
(pass) bundler > html/multiple-entries [154.56ms]
411 |       splitting: true,
412 |       onAfterBundle(api) {
413 |         const html = api.readFile("out/index.html");
414 |         const src = html.match(/<script[^>]*\bsrc="\.?\/?([^"]+)"/)?.[1];
415 |         expect(src).toBeDefined();
416 |         expect(api.re
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (cfc6190ca)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [15.81ms]
(pass) bundler > html/implicit-relative-paths [5.69ms]
(pass) bundler > html/multiple-assets [6.76ms]
(pass) bundler > html/image-hashing [5.41ms]
(pass) bundler > html/external-assets [5.72ms]
(pass) bundler > html/mixed-assets [3.55ms]
(pass) bundler > html/js-imports [5.65ms]
(pass) bundler > html/css-imports [3.07ms]
(pass) bundler > html/multiple-entries [4.77ms]
(pass) bundler > html/script-src-is-entry-chunk-with-splitting [5.33ms]
(pass) bundler > html/shared-chunks [5.02ms]
(pass) bundler > html/js-importing-html [3.30ms]
// in/2nd.js
console.log("2nd");
// in/entry.js
console.log("Loaded HTML!");

(pass) bundler > html/js-importing-html-and-entry-point-side-effect-import [5.32ms]
(pass) bundler > html/js-importing-html-and-entry-point-default-import-fails [6.13ms]
(pass) bundler > html/circular-js-html [10.62ms]
(pass) bundler > html/css-only [12.02ms]
(pass) bundler > html/absolute-paths [4.10ms]
(pass) bundler > html/no-sourcemap-comments [3.88ms]
(pass) bundler > html/no-sourcemap-comments-inline [6.46ms]
(pass) bundler > html/SharedCSSProducti
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_html.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (5a82870e2)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [821.06ms]
(pass) bundler > html/implicit-relative-paths [136.00ms]
(pass) bundler > html/multiple-assets [154.74ms]
(pass) bundler > html/image-hashing [135.08ms]
(pass) bundler > html/external-assets [139.38ms]
(pass) bundler > html/mixed-assets [158.79ms]
(pass) bundler > html/js-imports [166.87ms]
(pass) bundler > html/css-imports [148.11ms]
(pass) bundler > html/multiple-entries [174.93ms]
(pass) bundler > html/script-src-is-entry-chunk-with-splitting [179.35ms]
(pass) bundler > html/shared-chunks [192.34ms]
(pass) bundler > html/js-importing-html [116.57ms]
// in/2nd.js
console.log("2nd");
// in/entry.js
console.log("Loaded HTML!");

(pass) bundler > ht
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 779ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/Chunk.rs              | 25 +++++++++++++++---------
 test/bundler/bundler_html.test.ts | 41 +++++++++++++++++++++++++++++++++++++++
 2 files changed, 57 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/bundler/Chunk.rs                   2      1      0
test/bundler/bundler_html.test.ts      2      1      0
```

</details>

<!-- robobun:evidence:end -->