### PR TITLE
Bun.gzipSync/deflateSync: throw invalid-argument for out-of-range libdeflate level

### DIFF
--- a/src/libdeflate_sys/libdeflate.rs
+++ b/src/libdeflate_sys/libdeflate.rs
@@ -20,8 +20,15 @@ impl Default for Options {
     }
 }
 
+/// Valid `compression_level` range for `libdeflate_alloc_compressor`. Values
+/// outside this range make the allocator return NULL (indistinguishable from OOM),
+/// so callers must range-check first.
+pub const MIN_COMPRESSION_LEVEL: c_int = 0;
+pub const MAX_COMPRESSION_LEVEL: c_int = 12;
+
 unsafe extern "C" {
-    // Allocation: scalar arg, no preconditions; returns null on OOM.
+    // Allocation: scalar arg, no preconditions; returns null on OOM or
+    // compression_level outside MIN..=MAX_COMPRESSION_LEVEL.
     pub(crate) safe fn libdeflate_alloc_compressor(compression_level: c_int) -> *mut Compressor;
     // NOT safe: `Options` carries caller-supplied `malloc_func`/`free_func`
     // callbacks that libdeflate will invoke and write through. A bogus callback
@@ -254,7 +261,8 @@ impl Compressor {
 pub struct OwnedCompressor(NonNull<Compressor>);
 
 impl OwnedCompressor {
-    /// Allocate a compressor at `level` (0..=12). Returns `None` on OOM.
+    /// Allocate a compressor at `level` ([`MIN_COMPRESSION_LEVEL`]..=[`MAX_COMPRESSION_LEVEL`]).
+    /// Returns `None` on OOM or if `level` is out of range.
     #[inline]
     pub fn new(level: c_int) -> Option<Self> {
         NonNull::new(Compressor::alloc(level)).map(Self)

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2708,8 +2708,17 @@ pub mod JSZlib {
                 leak_list_into_uint8array(global_this, list)
             }
             Library::Libdeflate => {
-                let Some(mut compressor) = bun_libdeflate::OwnedCompressor::new(level.unwrap_or(6))
-                else {
+                let level = level.unwrap_or(6);
+                if !(bun_libdeflate::MIN_COMPRESSION_LEVEL..=bun_libdeflate::MAX_COMPRESSION_LEVEL)
+                    .contains(&level)
+                {
+                    return Err(global_this.throw_invalid_arguments(format_args!(
+                        "Compression level must be between {} and {} for libdeflate",
+                        bun_libdeflate::MIN_COMPRESSION_LEVEL,
+                        bun_libdeflate::MAX_COMPRESSION_LEVEL,
+                    )));
+                }
+                let Some(mut compressor) = bun_libdeflate::OwnedCompressor::new(level) else {
                     return Err(global_this.throw_out_of_memory());
                 };
                 let encoding = if is_gzip {

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -105,6 +105,36 @@ describe("zlib", () => {
     const data = new TextEncoder().encode("Hello World!".repeat(1));
     expect(() => gunzipSync(data, { library: "zlib" })).toThrow(new Error("incorrect header check"));
   });
+
+  describe("libdeflate level validation", () => {
+    const data = Buffer.alloc(64, "a");
+    // libdeflate_alloc_compressor returns NULL for level outside [0, 12]; that NULL must
+    // surface as an invalid-argument error, not "Out of memory".
+    for (const fn of [gzipSync, deflateSync]) {
+      it(`${fn.name}: out-of-range level throws an argument error, not OOM`, () => {
+        for (const level of [-2, -1, 13, 100]) {
+          let err;
+          try {
+            fn(data, { library: "libdeflate", level });
+          } catch (e) {
+            err = e;
+          }
+          expect(err).toBeDefined();
+          expect(err.message).not.toContain("memory");
+          expect(err.message).toContain("Compression level must be between 0 and 12");
+        }
+      });
+
+      it(`${fn.name}: in-range levels 0..12 succeed and round-trip`, () => {
+        const decompress = fn === gzipSync ? gunzipSync : inflateSync;
+        for (const level of [0, 1, 6, 9, 12]) {
+          const out = fn(data, { library: "libdeflate", level });
+          expect(out.length).toBeGreaterThan(0);
+          expect(Buffer.from(decompress(out, { library: "libdeflate" }))).toEqual(data);
+        }
+      });
+    }
+  });
 });
 
 function* window(buffer, size, advance = size) {


### PR DESCRIPTION
### What does this PR do?

`Bun.gzipSync` / `Bun.deflateSync` with `{ library: "libdeflate" }` threw `"Out of memory"` when given a compression level outside libdeflate's `[0, 12]` range, including `level: -1` (zlib's `Z_DEFAULT_COMPRESSION`, accepted by the same call without the `library` option).

```js
Bun.gzipSync(buf, { library: "libdeflate", level: -1 });
// before: RangeError: Out of memory
// after:  TypeError: Compression level must be between 0 and 12 for libdeflate
```

#### Cause

`libdeflate_alloc_compressor` returns `NULL` both for real allocation failure and for an out-of-range level (documented in `vendor/libdeflate/libdeflate.h`). `gzip_or_deflate_sync` mapped every `None` from `OwnedCompressor::new` to `throw_out_of_memory()`, so an argument error surfaced as a fake OOM.

#### Fix

Range-check the level against new `MIN_COMPRESSION_LEVEL` / `MAX_COMPRESSION_LEVEL` constants in `bun_libdeflate_sys` before calling the allocator, and throw an invalid-argument error that names the valid range. The remaining `None` from the allocator is now only reachable on real OOM.

### How did you verify your code works?

New tests in `test/js/node/zlib/zlib.test.js` cover both `gzipSync` and `deflateSync`:
- levels `-2, -1, 13, 100` throw with a message containing `"Compression level must be between 0 and 12"` and not `"memory"`
- levels `0, 1, 6, 9, 12` compress and round-trip through the matching decompressor

Fails on released bun with `"Out of memory"`, passes on this branch.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/zlib/zlib.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (3306df161)

test/js/node/zlib/zlib.test.js:
(pass) prototype and name and constructor > Gzip > Gzip.prototype should be instanceof Gzip.__proto__ [1.78ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.constructor should be Gzip [1.52ms]
(pass) prototype and name and constructor > Gzip > Gzip.name should be Gzip [1.12ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.__proto__.constructor.name should be Zlib [1.83ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype should be instanceof Gunzip.__proto__ [0.50ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.constructor should be Gunzip [0.34ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.n
... (truncated)

release without fix: 2 failed, 2 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/zlib/zlib.test.js:
(pass) prototype and name and constructor > Gzip > Gzip.prototype should be instanceof Gzip.__proto__ [0.03ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.constructor should be Gzip [0.01ms]
(pass) prototype and name and constructor > Gzip > Gzip.name should be Gzip [0.02ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.__proto__.constructor.name should be Zlib [0.02ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype should be instanceof Gunzip.__proto__
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.constructor should be Gunzip
(pass) prototype and name and constructor > Gunzip > Gunzip.name should be Gunzip
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.__proto__.constructor.name should be Zlib
(pass) prototype and name and constructor > Deflate > Deflate.prototype should be instanceof Deflate.__proto__
(pass) prototype and name and constructor > Deflate > Deflate.prototype.constructor should be Deflate
(pass) prototype and name and constructor > Deflate > Deflate.name should be Deflate

... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/zlib/zlib.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (3306df161)

test/js/node/zlib/zlib.test.js:
(pass) prototype and name and constructor > Gzip > Gzip.prototype should be instanceof Gzip.__proto__ [2.78ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.constructor should be Gzip [1.54ms]
(pass) prototype and name and constructor > Gzip > Gzip.name should be Gzip [1.10ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.__proto__.constructor.name should be Zlib [1.82ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype should be instanceof Gunzip.__proto__ [0.52ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.constructor should be Gunzip [0.31ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.n
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 781ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_libdeflate_sys v0.0.0 (/workspace/bun/src/libdefla
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/libdeflate_sys/libdeflate.rs | 12 ++++++++++--
 src/runtime/api/BunObject.rs     | 13 +++++++++++--
 test/js/node/zlib/zlib.test.js   | 30 ++++++++++++++++++++++++++++++
 3 files changed, 51 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
src/libdeflate_sys/libdeflate.rs      1      2      0
src/runtime/api/BunObject.rs          1      1      0
test/js/node/zlib/zlib.test.js        1      1      0
```

</details>

<!-- robobun:evidence:end -->