### PR TITLE
Bun.plugin: preserve module identity for already-loaded builtins

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -1069,6 +1069,15 @@ impl JSGlobalObject {
         })
     }
 
+    /// Returns `true` if the canonical builtin-module key `canonical` already
+    /// has a cached instance (ESM registry, InternalModuleRegistry slot, or
+    /// `require.cache`). Used by runtime resolution to preserve module
+    /// identity against late-registered `onResolve` plugins.
+    pub fn is_builtin_module_cached(&self, canonical: &[u8]) -> bool {
+        let tag = crate::ResolvedSourceTag::try_from_name(canonical).map_or(0, |t| t.0);
+        Bun__isBuiltinModuleCached(self, canonical.as_ptr(), canonical.len(), tag)
+    }
+
     fn bun_vm_unsafe(&self) -> *mut c_void {
         JSC__JSGlobalObject__bunVM(self)
     }
@@ -1715,6 +1724,12 @@ unsafe extern "C" {
         this: &JSGlobalObject,
         name_: &ZigString,
     );
+    safe fn Bun__isBuiltinModuleCached(
+        this: &JSGlobalObject,
+        key_ptr: *const u8,
+        key_len: usize,
+        tag: u32,
+    ) -> bool;
     safe fn JSGlobalObject__clearException(this: &JSGlobalObject);
     safe fn JSGlobalObject__clearExceptionExceptTermination(this: &JSGlobalObject) -> bool;
     safe fn JSGlobalObject__clearTerminationException(this: &JSGlobalObject);

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -1070,12 +1070,14 @@ impl JSGlobalObject {
     }
 
     /// Returns `true` if the canonical builtin-module key `canonical` already
-    /// has a cached instance (ESM registry, InternalModuleRegistry slot, or
-    /// `require.cache`). Used by runtime resolution to preserve module
-    /// identity against late-registered `onResolve` plugins.
+    /// has a cached instance (ESM registry entry or InternalModuleRegistry
+    /// slot). Used by runtime resolution to preserve module identity against
+    /// late-registered `onResolve` plugins.
     pub fn is_builtin_module_cached(&self, canonical: &[u8]) -> bool {
         let tag = crate::ResolvedSourceTag::try_from_name(canonical).map_or(0, |t| t.0);
-        Bun__isBuiltinModuleCached(self, canonical.as_ptr(), canonical.len(), tag)
+        // SAFETY: (ptr, len) borrow the live `canonical: &[u8]` for the
+        // duration of the call.
+        unsafe { Bun__isBuiltinModuleCached(self, canonical.as_ptr(), canonical.len(), tag) }
     }
 
     fn bun_vm_unsafe(&self) -> *mut c_void {
@@ -1724,7 +1726,7 @@ unsafe extern "C" {
         this: &JSGlobalObject,
         name_: &ZigString,
     );
-    safe fn Bun__isBuiltinModuleCached(
+    fn Bun__isBuiltinModuleCached(
         this: &JSGlobalObject,
         key_ptr: *const u8,
         key_len: usize,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4298,23 +4298,26 @@ impl VirtualMachine {
         if jsc_vm.plugin_runner.is_some() {
             use bun_bundler::transpiler::PluginRunner;
             let spec = specifier_utf8.slice();
-            // A builtin that is already cached keeps its canonical key so a
-            // late-registered onResolve cannot redirect it to a fresh registry
-            // entry and fork module identity. Matches the file-path law where
-            // a cached module is returned regardless of later onLoad plugins.
-            if let Some(hardcoded) = hardcoded_alias {
-                let canonical = hardcoded.path.as_bytes();
-                if global.is_builtin_module_cached(canonical) {
-                    *res =
-                        ErrorableString::ok(if is_user_require_resolve && hardcoded.node_builtin {
-                            specifier.dupe_ref()
-                        } else {
-                            bun_core::String::init(canonical)
-                        });
-                    return Ok(());
-                }
-            }
             if PluginRunner::could_be_plugin(spec) {
+                // A builtin that is already cached keeps its canonical key so
+                // a late-registered onResolve cannot redirect it to a fresh
+                // registry entry and fork module identity. Matches the
+                // file-path law where a cached module is returned regardless
+                // of later onLoad plugins. Bare specifiers (`fs`, `path`)
+                // fail `could_be_plugin` so this probe is skipped for them.
+                if let Some(hardcoded) = hardcoded_alias {
+                    let canonical = hardcoded.path.as_bytes();
+                    if global.is_builtin_module_cached(canonical) {
+                        *res = ErrorableString::ok(
+                            if is_user_require_resolve && hardcoded.node_builtin {
+                                specifier.dupe_ref()
+                            } else {
+                                bun_core::String::init(canonical)
+                            },
+                        );
+                        return Ok(());
+                    }
+                }
                 let namespace = PluginRunner::extract_namespace(spec);
                 let after_namespace = if namespace.is_empty() {
                     spec

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4305,13 +4305,12 @@ impl VirtualMachine {
             if let Some(hardcoded) = hardcoded_alias {
                 let canonical = hardcoded.path.as_bytes();
                 if global.is_builtin_module_cached(canonical) {
-                    *res = ErrorableString::ok(
-                        if is_user_require_resolve && hardcoded.node_builtin {
+                    *res =
+                        ErrorableString::ok(if is_user_require_resolve && hardcoded.node_builtin {
                             specifier.dupe_ref()
                         } else {
                             bun_core::String::init(canonical)
-                        },
-                    );
+                        });
                     return Ok(());
                 }
             }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4289,9 +4289,32 @@ impl VirtualMachine {
         let specifier_utf8 = specifier.to_utf8();
         let source_utf8 = source.to_utf8();
 
+        let hardcoded_alias = ModuleLoader::HardcodedModule::Alias::get(
+            specifier_utf8.slice(),
+            bun_ast::Target::Bun,
+            Default::default(),
+        );
+
         if jsc_vm.plugin_runner.is_some() {
             use bun_bundler::transpiler::PluginRunner;
             let spec = specifier_utf8.slice();
+            // A builtin that is already cached keeps its canonical key so a
+            // late-registered onResolve cannot redirect it to a fresh registry
+            // entry and fork module identity. Matches the file-path law where
+            // a cached module is returned regardless of later onLoad plugins.
+            if let Some(hardcoded) = hardcoded_alias {
+                let canonical = hardcoded.path.as_bytes();
+                if global.is_builtin_module_cached(canonical) {
+                    *res = ErrorableString::ok(
+                        if is_user_require_resolve && hardcoded.node_builtin {
+                            specifier.dupe_ref()
+                        } else {
+                            bun_core::String::init(canonical)
+                        },
+                    );
+                    return Ok(());
+                }
+            }
             if PluginRunner::could_be_plugin(spec) {
                 let namespace = PluginRunner::extract_namespace(spec);
                 let after_namespace = if namespace.is_empty() {
@@ -4312,11 +4335,7 @@ impl VirtualMachine {
             }
         }
 
-        if let Some(hardcoded) = ModuleLoader::HardcodedModule::Alias::get(
-            specifier_utf8.slice(),
-            bun_ast::Target::Bun,
-            Default::default(),
-        ) {
+        if let Some(hardcoded) = hardcoded_alias {
             *res = ErrorableString::ok(if is_user_require_resolve && hardcoded.node_builtin {
                 specifier.dupe_ref()
             } else {

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -525,9 +525,8 @@ extern "C" bool Bun__isBuiltinModuleCached(Zig::GlobalObject* globalObject, cons
 {
     auto& vm = JSC::getVM(globalObject);
     auto keyString = WTF::String::fromUTF8(std::span { reinterpret_cast<const char*>(keyPtr), keyLen });
-    auto keyIdent = JSC::Identifier::fromString(vm, keyString);
 
-    if (auto* entry = globalObject->moduleLoader()->registryEntry(keyIdent)) {
+    if (auto* entry = globalObject->moduleLoader()->registryEntry(JSC::Identifier::fromString(vm, keyString))) {
         if (entry->status() >= JSC::ModuleRegistryEntry::Status::Fetched)
             return true;
     }
@@ -538,9 +537,6 @@ extern "C" bool Bun__isBuiltinModuleCached(Zig::GlobalObject* globalObject, cons
         if (!globalObject->internalModuleRegistry()->internalField(field).get().isUndefined())
             return true;
     }
-
-    if (globalObject->requireMap()->has(globalObject, jsString(vm, keyString)))
-        return true;
 
     return false;
 }

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -516,6 +516,35 @@ extern "C" void Bun__onFulfillAsyncModule(
     }
 }
 
+// Returns true when the canonical builtin-module key already has a live cached
+// instance in any of the module caches. The runtime resolver consults this
+// before running plugin `onResolve` for builtin specifiers so that a plugin
+// registered after the builtin was first loaded cannot redirect the key and
+// fork module identity.
+extern "C" bool Bun__isBuiltinModuleCached(Zig::GlobalObject* globalObject, const uint8_t* keyPtr, size_t keyLen, uint32_t tag)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto keyString = WTF::String::fromUTF8(std::span { reinterpret_cast<const char*>(keyPtr), keyLen });
+    auto keyIdent = JSC::Identifier::fromString(vm, keyString);
+
+    if (auto* entry = globalObject->moduleLoader()->registryEntry(keyIdent)) {
+        if (entry->status() >= JSC::ModuleRegistryEntry::Status::Fetched)
+            return true;
+    }
+
+    if (tag & SyntheticModuleType::InternalModuleRegistryFlag) {
+        constexpr auto mask = SyntheticModuleType::InternalModuleRegistryFlag - 1;
+        auto field = static_cast<InternalModuleRegistry::Field>(tag & mask);
+        if (!globalObject->internalModuleRegistry()->internalField(field).get().isUndefined())
+            return true;
+    }
+
+    if (globalObject->requireMap()->has(globalObject, jsString(vm, keyString)))
+        return true;
+
+    return false;
+}
+
 JSValue fetchBuiltinModuleWithoutResolution(
     Zig::GlobalObject* globalObject,
     BunString* specifier,

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1064,6 +1064,13 @@ pub mod resolved_source_tag {
         /// Signal upwards that the matching value in `require.extensions` should be used.
         pub const CommonJsCustomExtension: Self = Self(10);
 
+        /// Fallible variant of [`Self::from_name`]: returns `None` for
+        /// specifiers without a generated InternalModuleRegistry tag.
+        #[inline]
+        pub fn try_from_name(name: &[u8]) -> Option<Self> {
+            INTERNAL_MODULE_TAG.get(name).copied()
+        }
+
         /// Map a canonical builtin-module specifier (e.g. `b"node:fs"`) to its
         /// InternalModuleRegistry tag (`(1 << 9) | id`).
         ///

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -5048,11 +5048,30 @@ unsafe fn resolve_hook(
     let specifier_utf8 = specifier.to_utf8();
     let source_utf8 = source.to_utf8();
 
+    let hardcoded_alias = Alias::get(specifier_utf8.slice(), Target::Bun, AliasCfg::default());
+
     // `PluginRunner.onResolveJSC`.
     // SAFETY: `vm` is the live per-thread VM.
     if unsafe { &*vm }.plugin_runner.is_some() {
         use bun_bundler_jsc::PluginRunner as plugin_runner;
         if plugin_runner::could_be_plugin(specifier_utf8.slice()) {
+            // A builtin that is already cached keeps its canonical key so a
+            // late-registered onResolve cannot redirect it to a fresh registry
+            // entry and fork module identity (see the matching guard in
+            // `VirtualMachine::resolve_maybe_needs_trailing_slash`).
+            if let Some(hardcoded) = hardcoded_alias {
+                let canonical = hardcoded.path.as_bytes();
+                if global_ref.is_builtin_module_cached(canonical) {
+                    let path = if is_user_require_resolve && hardcoded.node_builtin {
+                        specifier.dupe_ref()
+                    } else {
+                        bun_core::String::init(canonical)
+                    };
+                    // SAFETY: per fn contract.
+                    unsafe { *res = ErrorableString::ok(path) };
+                    return true;
+                }
+            }
             let namespace = plugin_runner::extract_namespace(specifier_utf8.slice());
             let after_namespace = if namespace.is_empty() {
                 specifier_utf8.slice()
@@ -5082,7 +5101,7 @@ unsafe fn resolve_hook(
     // Hardcoded builtin alias fast path. For
     // `require.resolve("fs")` (`is_user_require_resolve && node_builtin`) Node
     // returns the bare specifier as-is, not the canonical `node:fs`.
-    if let Some(hardcoded) = Alias::get(specifier_utf8.slice(), Target::Bun, AliasCfg::default()) {
+    if let Some(hardcoded) = hardcoded_alias {
         let path = if is_user_require_resolve && hardcoded.node_builtin {
             specifier.dupe_ref()
         } else {

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -749,9 +749,11 @@ it.concurrent("onResolve registered after a node builtin was imported does not f
   expect(exitCode).toBe(0);
 });
 
-it.concurrent("onResolve registered after a CJS-only require of a node builtin does not fork module identity", async () => {
-  using dir = tempDir("plugin-onresolve-builtin-cjs-first", {
-    "entry.ts": `
+it.concurrent(
+  "onResolve registered after a CJS-only require of a node builtin does not fork module identity",
+  async () => {
+    using dir = tempDir("plugin-onresolve-builtin-cjs-first", {
+      "entry.ts": `
       const cjsBefore = require("node:querystring");
 
       Bun.plugin({
@@ -780,24 +782,25 @@ it.concurrent("onResolve registered after a CJS-only require of a node builtin d
         }),
       );
     `,
-  });
+    });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "entry.ts"],
-    env: bunEnv,
-    cwd: String(dir),
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stdout.trim() ? JSON.parse(stdout) : { crashed: stderr }).toEqual({
-    cjsIdentity: true,
-    cjsAfterFAKE: null,
-    esmAfterFAKE: null,
-    hasRealStringify: true,
-  });
-  expect(exitCode).toBe(0);
-});
+    expect(stdout.trim() ? JSON.parse(stdout) : { crashed: stderr }).toEqual({
+      cjsIdentity: true,
+      cjsAfterFAKE: null,
+      esmAfterFAKE: null,
+      hasRealStringify: true,
+    });
+    expect(exitCode).toBe(0);
+  },
+);
 
 it.concurrent("onResolve registered before first import of a node builtin still intercepts it", async () => {
   using dir = tempDir("plugin-onresolve-builtin-fresh", {

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -693,11 +693,9 @@ it.concurrent("onResolve can redirect a specifier to a real file in the file nam
   expect(exitCode).toBe(0);
 });
 
-it.concurrent(
-  "onResolve registered after a node builtin was imported does not fork module identity",
-  async () => {
-    using dir = tempDir("plugin-onresolve-builtin-cached", {
-      "entry.ts": `
+it.concurrent("onResolve registered after a node builtin was imported does not fork module identity", async () => {
+  using dir = tempDir("plugin-onresolve-builtin-cached", {
+    "entry.ts": `
       const esmBefore = await import("node:querystring");
       const cjsBefore = require("node:querystring");
 
@@ -730,27 +728,26 @@ it.concurrent(
         }),
       );
     `,
-    });
+  });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "entry.ts"],
-      env: bunEnv,
-      cwd: String(dir),
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stdout.trim() ? JSON.parse(stdout) : { crashed: stderr }).toEqual({
-      esmIdentity: true,
-      esmBareIdentity: true,
-      cjsIdentity: true,
-      esmAfterFAKE: null,
-      cjsAfterFAKE: null,
-      hasRealStringify: true,
-    });
-    expect(exitCode).toBe(0);
-  },
-);
+  expect(stdout.trim() ? JSON.parse(stdout) : { crashed: stderr }).toEqual({
+    esmIdentity: true,
+    esmBareIdentity: true,
+    cjsIdentity: true,
+    esmAfterFAKE: null,
+    cjsAfterFAKE: null,
+    hasRealStringify: true,
+  });
+  expect(exitCode).toBe(0);
+});
 
 it.concurrent("onResolve registered before first import of a node builtin still intercepts it", async () => {
   using dir = tempDir("plugin-onresolve-builtin-fresh", {

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -749,6 +749,56 @@ it.concurrent("onResolve registered after a node builtin was imported does not f
   expect(exitCode).toBe(0);
 });
 
+it.concurrent("onResolve registered after a CJS-only require of a node builtin does not fork module identity", async () => {
+  using dir = tempDir("plugin-onresolve-builtin-cjs-first", {
+    "entry.ts": `
+      const cjsBefore = require("node:querystring");
+
+      Bun.plugin({
+        name: "late-intercept-cjs",
+        setup(build) {
+          build.onResolve({ filter: /^querystring$/, namespace: "node" }, (args) => ({
+            path: args.path,
+            namespace: "fake-qs",
+          }));
+          build.onLoad({ filter: /.*/, namespace: "fake-qs" }, () => ({
+            exports: { FAKE: 1 },
+            loader: "object",
+          }));
+        },
+      });
+
+      const cjsAfter = require("node:querystring");
+      const esmAfter = await import("node:querystring");
+
+      console.log(
+        JSON.stringify({
+          cjsIdentity: cjsAfter === cjsBefore,
+          cjsAfterFAKE: cjsAfter.FAKE ?? null,
+          esmAfterFAKE: esmAfter.FAKE ?? null,
+          hasRealStringify: typeof cjsAfter.stringify === "function",
+        }),
+      );
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim() ? JSON.parse(stdout) : { crashed: stderr }).toEqual({
+    cjsIdentity: true,
+    cjsAfterFAKE: null,
+    esmAfterFAKE: null,
+    hasRealStringify: true,
+  });
+  expect(exitCode).toBe(0);
+});
+
 it.concurrent("onResolve registered before first import of a node builtin still intercepts it", async () => {
   using dir = tempDir("plugin-onresolve-builtin-fresh", {
     "entry.ts": `

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -693,6 +693,112 @@ it.concurrent("onResolve can redirect a specifier to a real file in the file nam
   expect(exitCode).toBe(0);
 });
 
+it.concurrent(
+  "onResolve registered after a node builtin was imported does not fork module identity",
+  async () => {
+    using dir = tempDir("plugin-onresolve-builtin-cached", {
+      "entry.ts": `
+      const esmBefore = await import("node:querystring");
+      const cjsBefore = require("node:querystring");
+
+      Bun.plugin({
+        name: "late-intercept",
+        setup(build) {
+          build.onResolve({ filter: /^querystring$/, namespace: "node" }, (args) => ({
+            path: args.path,
+            namespace: "fake-qs",
+          }));
+          build.onLoad({ filter: /.*/, namespace: "fake-qs" }, () => ({
+            exports: { FAKE: 1 },
+            loader: "object",
+          }));
+        },
+      });
+
+      const esmAfter = await import("node:querystring");
+      const esmBare = await import("querystring");
+      const cjsAfter = require("node:querystring");
+
+      console.log(
+        JSON.stringify({
+          esmIdentity: esmAfter === esmBefore,
+          esmBareIdentity: esmBare === esmBefore,
+          cjsIdentity: cjsAfter === cjsBefore,
+          esmAfterFAKE: esmAfter.FAKE ?? null,
+          cjsAfterFAKE: cjsAfter.FAKE ?? null,
+          hasRealStringify: typeof esmAfter.stringify === "function",
+        }),
+      );
+    `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.trim() ? JSON.parse(stdout) : { crashed: stderr }).toEqual({
+      esmIdentity: true,
+      esmBareIdentity: true,
+      cjsIdentity: true,
+      esmAfterFAKE: null,
+      cjsAfterFAKE: null,
+      hasRealStringify: true,
+    });
+    expect(exitCode).toBe(0);
+  },
+);
+
+it.concurrent("onResolve registered before first import of a node builtin still intercepts it", async () => {
+  using dir = tempDir("plugin-onresolve-builtin-fresh", {
+    "entry.ts": `
+      Bun.plugin({
+        name: "early-intercept",
+        setup(build) {
+          build.onResolve({ filter: /^querystring$/, namespace: "node" }, (args) => ({
+            path: args.path,
+            namespace: "fake-qs",
+          }));
+          build.onLoad({ filter: /.*/, namespace: "fake-qs" }, () => ({
+            exports: { FAKE: 1 },
+            loader: "object",
+          }));
+        },
+      });
+
+      const esm1 = await import("node:querystring");
+      const esm2 = await import("node:querystring");
+      const cjs = require("node:querystring");
+
+      console.log(
+        JSON.stringify({
+          esmIdentity: esm1 === esm2,
+          esmFAKE: esm1.FAKE,
+          cjsFAKE: cjs.FAKE,
+        }),
+      );
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim() ? JSON.parse(stdout) : { crashed: stderr }).toEqual({
+    esmIdentity: true,
+    esmFAKE: 1,
+    cjsFAKE: 1,
+  });
+  expect(exitCode).toBe(0);
+});
+
 it.concurrent("a no-op onResolve that returns args.path unchanged is transparent", async () => {
   using dir = tempDir("plugin-onresolve-no-op", {
     "preload.js": `


### PR DESCRIPTION
## Problem

A `Bun.plugin` `onResolve` registered after a node: builtin has already been imported forks module identity: one specifier, two live module instances. Pre-registration importers silently keep the real builtin while post-registration importers get the plugin's module. File-namespace modules don't have this problem because the resolved path is unchanged and the cached registry entry is returned.

```js
const q1 = await import("node:querystring"); // real builtin cached

Bun.plugin({ name: "iq", setup(b) {
  b.onResolve({ filter: /^querystring$/, namespace: "node" }, a => ({ path: a.path, namespace: "fq" }));
  b.onLoad({ filter: /.*/, namespace: "fq" }, () => ({ exports: { FAKE: 1 }, loader: "object" }));
}});

const q2 = await import("node:querystring");
// before: q2 !== q1, q2.FAKE === 1, require("node:querystring").FAKE === 1
// after:  q2 === q1, q2.FAKE === undefined
```

## Cause

`VirtualMachine::resolve_maybe_needs_trailing_slash` consults plugin `onResolve` before the hardcoded-builtin alias check. The plugin rewrites the registry key (`node:querystring` becomes `fq:querystring`), so the populated `node:querystring` entry is bypassed and a fresh module is created.

## Fix

Before running plugin `onResolve`, if the specifier is a hardcoded builtin whose canonical key already has a cached instance (ESM module registry, or `InternalModuleRegistry` slot), return the canonical key directly. This matches the file-path law where a cached module wins over a late-registered plugin.

A plugin registered before the first load of a builtin still intercepts it (covered by a test).

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/plugin/plugins.test.ts -t "does not fork module identity"
(fail) onResolve registered after a node builtin was imported does not fork module identity
  esmIdentity: false, esmAfterFAKE: 1, cjsAfterFAKE: 1

$ bun bd test test/js/bun/plugin/plugins.test.ts
36 pass, 1 todo, 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (4b635f7bf)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1149.63ms]
(pass) require > beep:boop returns 42 [9.99ms]
(pass) require > object module works [8.61ms]
(pass) module > throws with require() [13.54ms]
(pass) module > async module works with async import [24.76ms]
(pass) module > sync module module works with require() [4.52ms]
(pass) module > sync module module works with require.resolve() [4.30ms]
(pass) module > sync modul
... (truncated)

release without fix: 5 failed, 1 skipped
bun test v1.3.14 (0d9b296a)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [32.94ms]
(pass) require > beep:boop returns 42 [0.18ms]
(pass) require > object module works [0.12ms]
(pass) module > throws with require() [0.26ms]
(pass) module > async module works with async import [2.57ms]
(pass) module > sync module module works with require() [0.08ms]
(pass) module > sync module module works with require.resolve() [0.05ms]
(pass) module > sync module module works with import [0.11ms]
(pass) module > modules are overridable [0.24ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [0.12ms]
(pass) dynamic import > beep:boop returns 42 [0.11ms]
(pass) dynamic import > async:onLoad returns 42 [1.38ms]
(pass) dynamic import > async object loader returns 42 [1.27ms]
(pass) import statement > SSRs `<h1>Hello world!</h1>` with Svelte [2.18ms]
(todo) errors > vali
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (4b635f7bf)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1149.58ms]
(pass) require > beep:boop returns 42 [9.37ms]
(pass) require > object module works [8.91ms]
(pass) module > throws with require() [13.55ms]
(pass) module > async module works with async import [25.68ms]
(pass) module > sync module module works with require() [4.51ms]
(pass) module > sync module module works with require.resolve() [3.36ms]
(pass) module > sync modul
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4b635f7bf7
  features     (none)

22 deps, 106 codegen, 1168 objects in 668ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1230] install /workspace/bun
bun install v1.3.14 (0d9b296a)

Checked 124 installs across 170 packages (no changes) [18.00ms]
[2/1230] install /workspace/bun/packages/bun-error
bun install v1.3.14 (0d9b296a)

Checked 1 install across 2 packages (no changes) [2.00ms]
[3/1230] install /workspace/bun/src/node-fallbacks
bun install v1.3.14 (0d9b296a)

Checked 129 installs across 147 packages (no changes) [7.00ms]
[4/1230] gen ErrorCode+*.h
[5/1230] fetch picohttpparser
[picohttpparser] up to date
[6/1230] gen bindgenv2
[7/1230] fetch zlib
[zlib] up to date
[8/1230] fetch libjpeg-turbo
[libjpeg-turbo] u
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/JSGlobalObject.rs          |  17 ++++
 src/jsc/VirtualMachine.rs          |  31 ++++++--
 src/jsc/bindings/ModuleLoader.cpp  |  25 ++++++
 src/jsc/lib.rs                     |   7 ++
 src/runtime/jsc_hooks.rs           |  21 ++++-
 test/js/bun/plugin/plugins.test.ts | 156 +++++++++++++++++++++++++++++++++++++
 6 files changed, 251 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/jsc/JSGlobalObject.rs               4      6      0
src/jsc/VirtualMachine.rs               4      3      0
src/jsc/bindings/ModuleLoader.cpp       4      3      0
src/jsc/lib.rs                          1      1      0
src/runtime/jsc_hooks.rs                5      1      0
test/js/bun/plugin/plugins.test.ts      4      3      0
```

</details>

<!-- robobun:evidence:end -->
