### PR TITLE
Bun.gunzipSync/inflateSync: lift libdeflate 1 GiB output cap to ArrayBuffer max

### DIFF
--- a/src/libdeflate_sys/libdeflate.rs
+++ b/src/libdeflate_sys/libdeflate.rs
@@ -484,7 +484,7 @@ impl Decompressor {
                 return result;
             }
             let new_cap = out.capacity().max(1).saturating_mul(2).min(max_capacity);
-            out.reserve(new_cap.saturating_sub(out.len()));
+            out.reserve_exact(new_cap.saturating_sub(out.len()));
         }
     }
 }

--- a/src/libdeflate_sys/libdeflate.rs
+++ b/src/libdeflate_sys/libdeflate.rs
@@ -467,9 +467,9 @@ impl Decompressor {
     ///
     /// Clears `out` first (libdeflate restarts decompression from scratch on
     /// each call), then repeatedly doubles `out`'s capacity on
-    /// [`Status::InsufficientSpace`] until success, hard error, or
-    /// `out.capacity() > max_capacity` (returned as the final
-    /// `InsufficientSpace`). On success, `out.len() == result.written`.
+    /// [`Status::InsufficientSpace`] — clamped at `max_capacity` — until
+    /// success, hard error, or `out.capacity() >= max_capacity` (returned as
+    /// the final `InsufficientSpace`). On success, `out.len() == result.written`.
     pub fn decompress_to_vec_grow(
         &mut self,
         input: &[u8],
@@ -480,10 +480,10 @@ impl Decompressor {
         loop {
             out.clear();
             let result = self.decompress_to_vec(input, out, encoding);
-            if result.status != Status::InsufficientSpace || out.capacity() > max_capacity {
+            if result.status != Status::InsufficientSpace || out.capacity() >= max_capacity {
                 return result;
             }
-            let new_cap = out.capacity().max(1) * 2;
+            let new_cap = out.capacity().max(1).saturating_mul(2).min(max_capacity);
             out.reserve(new_cap.saturating_sub(out.len()));
         }
     }

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2579,12 +2579,8 @@ pub mod JSZlib {
                     bun_libdeflate::Encoding::Deflate
                 };
                 let max_output = ArrayBuffer::MAX_SIZE as usize;
-                let result = decompressor.decompress_to_vec_grow(
-                    compressed,
-                    &mut list,
-                    encoding,
-                    max_output,
-                );
+                let result = decompressor
+                    .decompress_to_vec_grow(compressed, &mut list, encoding, max_output);
                 match result.status {
                     bun_libdeflate::Status::Success if list.len() <= max_output => {}
                     bun_libdeflate::Status::Success | bun_libdeflate::Status::InsufficientSpace => {

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2578,17 +2578,25 @@ pub mod JSZlib {
                 } else {
                     bun_libdeflate::Encoding::Deflate
                 };
+                let max_output = ArrayBuffer::MAX_SIZE as usize;
                 let result = decompressor.decompress_to_vec_grow(
                     compressed,
                     &mut list,
                     encoding,
-                    1024 * 1024 * 1024,
+                    max_output,
                 );
                 match result.status {
-                    bun_libdeflate::Status::Success => {}
-                    bun_libdeflate::Status::InsufficientSpace => {
+                    bun_libdeflate::Status::Success if list.len() <= max_output => {}
+                    bun_libdeflate::Status::Success | bun_libdeflate::Status::InsufficientSpace => {
                         drop(list);
-                        return Err(global_this.throw_out_of_memory());
+                        return Err(global_this
+                            .err(
+                                jsc::ErrCode::BUFFER_TOO_LARGE,
+                                format_args!(
+                                    "Cannot create a Buffer larger than {max_output} bytes",
+                                ),
+                            )
+                            .throw());
                     }
                     _ => {
                         drop(list);

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -9,6 +9,7 @@ import {
   zstdDecompressSync,
 } from "bun";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import path from "path";
 
 describe("Zstandard compression", async () => {
@@ -327,6 +328,42 @@ describe("sync compression argument handling", () => {
       Bun.gc(true);
     }
   });
+
+  // libdeflate is one-shot, so Bun retries with a doubling output buffer; the
+  // retry cap must not be tighter than the zlib backend's (ArrayBuffer max).
+  // Spawned so the multi-GB buffer is released with the child.
+  it("gunzipSync({library:'libdeflate'}) decompresses output larger than 1 GiB", async () => {
+    const MiB = 1024 * 1024;
+    const expected = 17 * 64 * MiB; // 1088 MiB
+    const script = `
+      import * as zlib from "node:zlib";
+      const chunk = Buffer.alloc(64 * ${MiB});
+      const bomb = await new Promise((resolve, reject) => {
+        const g = zlib.createGzip({ level: 9 });
+        const out = [];
+        g.on("data", c => out.push(c));
+        g.on("end", () => resolve(Buffer.concat(out)));
+        g.on("error", reject);
+        let left = 17;
+        const w = () => { if (!left--) return g.end(); g.write(chunk) ? w() : g.once("drain", w); };
+        w();
+      });
+      const out = Bun.gunzipSync(bomb, { library: "libdeflate" });
+      console.log(JSON.stringify({ libdeflate: out.length, head: out[0], tail: out[out.length - 1] }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr }).toEqual({
+      stdout: JSON.stringify({ libdeflate: expected, head: 0, tail: 0 }),
+      stderr: expect.not.stringContaining("Out of memory"),
+    });
+    expect(exitCode).toBe(0);
+  }, 60_000);
 });
 
 describe.concurrent("Zstandard HTTP compression", () => {


### PR DESCRIPTION
## Reproduction

```js
import * as zlib from "node:zlib";
// 1.5 GiB of zeros, gzipped (~1.5 MB)
const bomb = await new Promise((resolve, reject) => {
  const g = zlib.createGzip({ level: 9 }), chunks = [];
  g.on("data", c => chunks.push(c));
  g.on("end", () => resolve(Buffer.concat(chunks)));
  g.on("error", reject);
  const chunk = Buffer.alloc(64 * 1024 * 1024);
  let left = 24;
  (function w(){ if (!left--) return g.end(); g.write(chunk) ? w() : g.once("drain", w); })();
});
for (const library of ["libdeflate", "zlib"]) {
  try { console.log(library, "ok len=" + Bun.gunzipSync(bomb, { library }).length); }
  catch (e) { console.log(library, `THROWS "${e.message}"`); }
}
```

Before:
```
libdeflate THROWS "Out of memory"
zlib ok len=1610612736
```

After:
```
libdeflate ok len=1610612736
zlib ok len=1610612736
```

## Cause

libdeflate decompresses in one shot, so `gunzip_or_inflate_sync` retries with a doubling `Vec` via `decompress_to_vec_grow`. The retry loop was hard-capped at `1024 * 1024 * 1024` bytes, and once the doubling ladder passed 1 GiB without fitting the output the final `LIBDEFLATE_INSUFFICIENT_SPACE` was mapped to `throw_out_of_memory()`. The `library: "zlib"` streaming path has no such internal cap, so the two backends of the same function disagreed by 4x on the maximum output they could produce, and the error steered users toward memory debugging instead of the real cause.

## Fix

- `src/runtime/api/BunObject.rs`: pass `ArrayBuffer::MAX_SIZE` (the largest `Uint8Array` the result can occupy) as the retry cap instead of 1 GiB, and surface a genuine cap hit as `ERR_BUFFER_TOO_LARGE` (`RangeError`, code set, byte limit in the message) instead of a fake OOM. Also guard the success path so an allocator-rounded buffer cannot hand an oversized length to `ArrayBuffer::from_bytes`.
- `src/libdeflate_sys/libdeflate.rs`: clamp the doubling step at `max_capacity` (and saturate the multiply) so the loop never reserves past the cap, and stop at `>= max_capacity` so the last attempt is exactly the cap rather than one doubling beyond it.

## Verification

New test in `test/js/bun/util/zstd.test.ts` builds a gzip member that inflates to 1088 MiB (the smallest size at which the doubling ladder lands between 1 GiB and the target) and asserts `Bun.gunzipSync(bomb, { library: "libdeflate" })` returns the full 1140850688 bytes. The test runs in a spawned child so the multi-GB buffer is released with it.

```
USE_SYSTEM_BUN=1 bun test test/js/bun/util/zstd.test.ts -t "larger than 1 GiB"   # fails: RangeError: Out of memory
bun bd test test/js/bun/util/zstd.test.ts -t "larger than 1 GiB"                 # passes
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/zstd.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (1f9af612f)

test/js/bun/util/zstd.test.ts:
(pass) Zstandard compression > throws with invalid level [7.75ms]
(pass) Zstandard compression > throws with invalid input [16.00ms]
(pass) Zstandard compression > does not leak on streaming decompression error (unknown content size + corrupt stream) [7075.83ms]
(pass) Zstandard compression > zstd CLI compatibility > can decompress package.json [7.11ms]
(pass) Zstandard compression > small (13 bytes) > level 1 [15.76ms]
(pass) Zstandard compression > small (13 bytes) > level 2 [10.05ms]
(pass) Zstandard compression > small (13 bytes) > level 3 [10.08ms]
(pass) Zstandard compression > small (13 bytes) > level 4 [10.30ms]
(pass) Zstandard compression > small (13 bytes) > level 5 [10.38ms]
(pass) 
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (7e104915b)

test/js/bun/util/zstd.test.ts:
(pass) Zstandard compression > throws with invalid level [0.11ms]
(pass) Zstandard compression > throws with invalid input [0.13ms]
(pass) Zstandard compression > does not leak on streaming decompression error (unknown content size + corrupt stream) [34.66ms]
(pass) Zstandard compression > zstd CLI compatibility > can decompress package.json [0.85ms]
(pass) Zstandard compression > small (13 bytes) > level 4 [0.27ms]
(pass) Zstandard compression > small (13 bytes) > level 5 [0.28ms]
(pass) Zstandard compression > small (13 bytes) > level 6 [0.28ms]
(pass) Zstandard compression > small (13 bytes) > level 7 [1.72ms]
(pass) Zstandard compression > small (13 bytes) > level 8 [3.53ms]
(pass) Zstandard compression > small (13 bytes) > level 9 [5.81ms]
(pass) Zstandard compression > small (13 bytes) > level 10 [8.31ms]
(pass) Zstandard compression > small (13 bytes) > level 11 [13.51ms]
(pass) Zstandard compression > small (13 bytes) > level 12 [18.54ms]
(pass) Zstandard compression > small (13 bytes) > level 13 [23.91ms]
(pass) Zstandard compression > small (13 bytes) > level 14 [34.08ms]
(pass) Zstandard
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/zstd.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (1f9af612f)

test/js/bun/util/zstd.test.ts:
(pass) Zstandard compression > throws with invalid level [6.74ms]
(pass) Zstandard compression > throws with invalid input [14.91ms]
(pass) Zstandard compression > does not leak on streaming decompression error (unknown content size + corrupt stream) [6870.97ms]
(pass) Zstandard compression > zstd CLI compatibility > can decompress package.json [11.76ms]
(pass) Zstandard compression > small (13 bytes) > level 1 [16.13ms]
(pass) Zstandard compression > small (13 bytes) > level 2 [9.64ms]
(pass) Zstandard compression > small (13 bytes) > level 3 [9.64ms]
(pass) Zstandard compression > small (13 bytes) > level 4 [9.82ms]
(pass) Zstandard compression > small (13 bytes) > level 5 [9.91ms]
(pass) Zst
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 792ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_libdeflate_sys v0.0.0 (/workspace/bun/src/lib
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/libdeflate_sys/libdeflate.rs | 12 ++++++------
 src/runtime/api/BunObject.rs     | 22 +++++++++++++---------
 test/js/bun/util/zstd.test.ts    | 37 +++++++++++++++++++++++++++++++++++++
 3 files changed, 56 insertions(+), 15 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
src/libdeflate_sys/libdeflate.rs      3      2      0
src/runtime/api/BunObject.rs          3      1      0
test/js/bun/util/zstd.test.ts         2      5      0
```

</details>

<!-- robobun:evidence:end -->