### PR TITLE
process: keep the onEachMicrotaskTick nextTick hook armed across preloads

### DIFF
--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -387,6 +387,7 @@ export function initializeNextTickQueue(
 
         drainMicrotasks();
       } while (!queue.isEmpty());
+      $putInternalField(nextTickQueue, 0, 0);
     }
 
     $putInternalField(nextTickQueue, 0, 0);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3934,6 +3934,10 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionReportUncaughtException, (JSC::JSGlobalObject
 
 JSC_DEFINE_HOST_FUNCTION(jsFunctionDrainMicrotaskQueue, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
+    // processTicksAndRejections calls this between tick batches. The
+    // onEachMicrotaskTick hook must not re-enter drain() from here, so set the
+    // same guard the hook checks.
+    WTF::SetForScope drainingGuard(defaultGlobalObject(globalObject)->m_isDrainingNextTickQueue, true);
     JSC::getVM(globalObject).drainMicrotasks();
     return JSValue::encode(jsUndefined());
 }

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3934,9 +3934,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionReportUncaughtException, (JSC::JSGlobalObject
 
 JSC_DEFINE_HOST_FUNCTION(jsFunctionDrainMicrotaskQueue, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
-    // processTicksAndRejections calls this between tick batches. The
-    // onEachMicrotaskTick hook must not re-enter drain() from here, so set the
-    // same guard the hook checks.
+    // Only caller is processTicksAndRejections; suppress the onEachMicrotaskTick hook while it drains.
     WTF::SetForScope drainingGuard(defaultGlobalObject(globalObject)->m_isDrainingNextTickQueue, true);
     JSC::getVM(globalObject).drainMicrotasks();
     return JSValue::encode(jsUndefined());

--- a/src/jsc/bindings/JSNextTickQueue.cpp
+++ b/src/jsc/bindings/JSNextTickQueue.cpp
@@ -10,11 +10,9 @@
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/Structure.h>
 #include <JavaScriptCore/JSInternalFieldObjectImplInlines.h>
-#include <wtf/SetForScope.h>
 #include "ExtendedDOMClientIsoSubspaces.h"
 #include "ExtendedDOMIsoSubspaces.h"
 #include "BunClientData.h"
-#include "ZigGlobalObject.h"
 
 namespace Bun {
 
@@ -78,7 +76,6 @@ bool JSNextTickQueue::isEmpty()
 
 void JSNextTickQueue::drain(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
 {
-    auto* zigGlobal = defaultGlobalObject(globalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     bool mustResetContext = false;
     if (isEmpty()) {
@@ -89,12 +86,6 @@ void JSNextTickQueue::drain(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
     }
 
     if (!isEmpty()) {
-        // The onEachMicrotaskTick hook calls drain() between microtasks, and
-        // processTicksAndRejections calls vm.drainMicrotasks(); guard so the
-        // hook does not re-enter processTicksAndRejections while it is running.
-        if (zigGlobal->m_isDrainingNextTickQueue)
-            return;
-        SetForScope drainingGuard(zigGlobal->m_isDrainingNextTickQueue, true);
         RETURN_IF_EXCEPTION(throwScope, );
         if (mustResetContext) {
             globalObject->m_asyncContextData.get()->putInternalField(vm, 0, jsUndefined());

--- a/src/jsc/bindings/JSNextTickQueue.cpp
+++ b/src/jsc/bindings/JSNextTickQueue.cpp
@@ -10,9 +10,11 @@
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/Structure.h>
 #include <JavaScriptCore/JSInternalFieldObjectImplInlines.h>
+#include <wtf/SetForScope.h>
 #include "ExtendedDOMClientIsoSubspaces.h"
 #include "ExtendedDOMIsoSubspaces.h"
 #include "BunClientData.h"
+#include "ZigGlobalObject.h"
 
 namespace Bun {
 
@@ -76,6 +78,7 @@ bool JSNextTickQueue::isEmpty()
 
 void JSNextTickQueue::drain(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
 {
+    auto* zigGlobal = defaultGlobalObject(globalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     bool mustResetContext = false;
     if (isEmpty()) {
@@ -86,6 +89,12 @@ void JSNextTickQueue::drain(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
     }
 
     if (!isEmpty()) {
+        // The onEachMicrotaskTick hook calls drain() between microtasks, and
+        // processTicksAndRejections calls vm.drainMicrotasks(); guard so the
+        // hook does not re-enter processTicksAndRejections while it is running.
+        if (zigGlobal->m_isDrainingNextTickQueue)
+            return;
+        SetForScope drainingGuard(zigGlobal->m_isDrainingNextTickQueue, true);
         RETURN_IF_EXCEPTION(throwScope, );
         if (mustResetContext) {
             globalObject->m_asyncContextData.get()->putInternalField(vm, 0, jsUndefined());

--- a/src/jsc/bindings/JSNextTickQueue.cpp
+++ b/src/jsc/bindings/JSNextTickQueue.cpp
@@ -13,7 +13,6 @@
 #include "ExtendedDOMClientIsoSubspaces.h"
 #include "ExtendedDOMIsoSubspaces.h"
 #include "BunClientData.h"
-#include "ZigGlobalObject.h"
 
 namespace Bun {
 
@@ -88,8 +87,7 @@ void JSNextTickQueue::drain(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
 
     if (!isEmpty()) {
         RETURN_IF_EXCEPTION(throwScope, );
-        // m_isDrainingNextTickQueue set => an outer processTicksAndRejections owns the async-context restore.
-        if (mustResetContext && !defaultGlobalObject(globalObject)->m_isDrainingNextTickQueue) {
+        if (mustResetContext) {
             globalObject->m_asyncContextData.get()->putInternalField(vm, 0, jsUndefined());
             RETURN_IF_EXCEPTION(throwScope, );
         }

--- a/src/jsc/bindings/JSNextTickQueue.cpp
+++ b/src/jsc/bindings/JSNextTickQueue.cpp
@@ -88,9 +88,7 @@ void JSNextTickQueue::drain(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
 
     if (!isEmpty()) {
         RETURN_IF_EXCEPTION(throwScope, );
-        // An outer processTicksAndRejections frame owns the async-context save/restore
-        // while m_isDrainingNextTickQueue is set; clearing it here would drop that
-        // frame's AsyncLocalStorage store mid-callback.
+        // m_isDrainingNextTickQueue set => an outer processTicksAndRejections owns the async-context restore.
         if (mustResetContext && !defaultGlobalObject(globalObject)->m_isDrainingNextTickQueue) {
             globalObject->m_asyncContextData.get()->putInternalField(vm, 0, jsUndefined());
             RETURN_IF_EXCEPTION(throwScope, );

--- a/src/jsc/bindings/JSNextTickQueue.cpp
+++ b/src/jsc/bindings/JSNextTickQueue.cpp
@@ -13,6 +13,7 @@
 #include "ExtendedDOMClientIsoSubspaces.h"
 #include "ExtendedDOMIsoSubspaces.h"
 #include "BunClientData.h"
+#include "ZigGlobalObject.h"
 
 namespace Bun {
 
@@ -87,7 +88,10 @@ void JSNextTickQueue::drain(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
 
     if (!isEmpty()) {
         RETURN_IF_EXCEPTION(throwScope, );
-        if (mustResetContext) {
+        // An outer processTicksAndRejections frame owns the async-context save/restore
+        // while m_isDrainingNextTickQueue is set; clearing it here would drop that
+        // frame's AsyncLocalStorage store mid-callback.
+        if (mustResetContext && !defaultGlobalObject(globalObject)->m_isDrainingNextTickQueue) {
             globalObject->m_asyncContextData.get()->putInternalField(vm, 0, jsUndefined());
             RETURN_IF_EXCEPTION(throwScope, );
         }

--- a/src/jsc/bindings/JSNextTickQueue.cpp
+++ b/src/jsc/bindings/JSNextTickQueue.cpp
@@ -77,20 +77,14 @@ bool JSNextTickQueue::isEmpty()
 void JSNextTickQueue::drain(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
 {
     auto throwScope = DECLARE_THROW_SCOPE(vm);
-    bool mustResetContext = false;
     if (isEmpty()) {
         RETURN_IF_EXCEPTION(throwScope, );
         vm.drainMicrotasks();
         RETURN_IF_EXCEPTION(throwScope, );
-        mustResetContext = true;
     }
 
     if (!isEmpty()) {
         RETURN_IF_EXCEPTION(throwScope, );
-        if (mustResetContext) {
-            globalObject->m_asyncContextData.get()->putInternalField(vm, 0, jsUndefined());
-            RETURN_IF_EXCEPTION(throwScope, );
-        }
         auto* drainFn = internalField(2).get().getObject();
         MarkedArgumentBuffer drainArgs;
         JSC::call(globalObject, drainFn, drainArgs, "Failed to drain next tick queue"_s);

--- a/src/jsc/bindings/NodeAsyncHooks.cpp
+++ b/src/jsc/bindings/NodeAsyncHooks.cpp
@@ -17,9 +17,7 @@ using namespace JSC;
 JSC_DEFINE_HOST_FUNCTION(jsCleanupLater, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     ASSERT(callFrame->argumentCount() == 0);
-    auto* global = uncheckedDowncast<Zig::GlobalObject>(globalObject);
-    global->asyncHooksNeedsCleanup = true;
-    global->resetOnEachMicrotaskTick();
+    uncheckedDowncast<Zig::GlobalObject>(globalObject)->resetOnEachMicrotaskTick();
     return JSC::JSValue::encode(JSC::jsUndefined());
 }
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -389,11 +389,16 @@ extern "C" JSC::EncodedJSValue BunObject__createBunStdout(JSC::JSGlobalObject*);
 static void checkIfNextTickWasCalledDuringMicrotask(JSC::VM& vm)
 {
     auto* globalObject = defaultGlobalObject();
+    // Prevent this hook from re-entering drain() through its own
+    // processTicksAndRejections -> drainMicrotasks() path. drain() itself must
+    // stay re-enterable from GlobalObject::drainMicrotasks (a tick callback may
+    // spin wait_for_promise, which needs to drain ticks queued during the spin).
     if (globalObject->m_isDrainingNextTickQueue)
         return;
     auto queue = globalObject->m_nextTickQueue.get();
     if (!queue || queue->isEmpty())
         return;
+    WTF::SetForScope drainingGuard(globalObject->m_isDrainingNextTickQueue, true);
     queue->drain(vm, globalObject);
 }
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -404,7 +404,6 @@ static void cleanupAsyncHooksData(JSC::VM& vm)
 {
     auto* globalObject = defaultGlobalObject();
     globalObject->m_asyncContextData.get()->putInternalField(vm, 0, jsUndefined());
-    globalObject->asyncHooksNeedsCleanup = false;
     vm.setOnEachMicrotaskTick(&checkIfNextTickWasCalledDuringMicrotask);
     checkIfNextTickWasCalledDuringMicrotask(vm);
 }
@@ -446,8 +445,6 @@ JSC::Structure* GlobalObject::createStructure(JSC::VM& vm)
 
 void Zig::GlobalObject::resetOnEachMicrotaskTick()
 {
-    // Sole caller (jsCleanupLater) sets asyncHooksNeedsCleanup = true immediately before.
-    ASSERT(this->asyncHooksNeedsCleanup);
     this->vm().setOnEachMicrotaskTick(&cleanupAsyncHooksData);
 }
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -389,10 +389,12 @@ extern "C" JSC::EncodedJSValue BunObject__createBunStdout(JSC::JSGlobalObject*);
 static void checkIfNextTickWasCalledDuringMicrotask(JSC::VM& vm)
 {
     auto* globalObject = defaultGlobalObject();
-    if (auto queue = globalObject->m_nextTickQueue.get()) {
-        globalObject->resetOnEachMicrotaskTick();
-        queue->drain(vm, globalObject);
-    }
+    if (globalObject->m_isDrainingNextTickQueue)
+        return;
+    auto queue = globalObject->m_nextTickQueue.get();
+    if (!queue || queue->isEmpty())
+        return;
+    queue->drain(vm, globalObject);
 }
 
 static void cleanupAsyncHooksData(JSC::VM& vm)
@@ -400,12 +402,8 @@ static void cleanupAsyncHooksData(JSC::VM& vm)
     auto* globalObject = defaultGlobalObject();
     globalObject->m_asyncContextData.get()->putInternalField(vm, 0, jsUndefined());
     globalObject->asyncHooksNeedsCleanup = false;
-    if (!globalObject->m_nextTickQueue) {
-        vm.setOnEachMicrotaskTick(&checkIfNextTickWasCalledDuringMicrotask);
-        checkIfNextTickWasCalledDuringMicrotask(vm);
-    } else {
-        vm.setOnEachMicrotaskTick(nullptr);
-    }
+    vm.setOnEachMicrotaskTick(&checkIfNextTickWasCalledDuringMicrotask);
+    checkIfNextTickWasCalledDuringMicrotask(vm);
 }
 
 GlobalObject* GlobalObject::create(JSC::VM& vm, JSC::Structure* structure)
@@ -449,11 +447,7 @@ void Zig::GlobalObject::resetOnEachMicrotaskTick()
     if (this->asyncHooksNeedsCleanup) {
         vm.setOnEachMicrotaskTick(&cleanupAsyncHooksData);
     } else {
-        if (this->m_nextTickQueue) {
-            vm.setOnEachMicrotaskTick(nullptr);
-        } else {
-            vm.setOnEachMicrotaskTick(&checkIfNextTickWasCalledDuringMicrotask);
-        }
+        vm.setOnEachMicrotaskTick(&checkIfNextTickWasCalledDuringMicrotask);
     }
 }
 
@@ -555,15 +549,7 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
     vm.setOnComputeErrorInfo(computeErrorInfoWrapperToString);
     vm.setOnComputeErrorInfoJSValue(computeErrorInfoWrapperToJSValue);
     vm.setComputeLineColumnWithSourcemap(computeLineColumnWithSourcemap);
-    vm.setOnEachMicrotaskTick([](JSC::VM& vm) -> void {
-        // if you process.nextTick on a microtask we need this
-        auto* globalObject = defaultGlobalObject();
-        if (auto queue = globalObject->m_nextTickQueue.get()) {
-            globalObject->resetOnEachMicrotaskTick();
-            queue->drain(vm, globalObject);
-            return;
-        }
-    });
+    vm.setOnEachMicrotaskTick(&checkIfNextTickWasCalledDuringMicrotask);
 
     if (executionContextId > -1) {
         const auto initializeWorker = [&](WebCore::Worker& worker) -> void {

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -389,10 +389,8 @@ extern "C" JSC::EncodedJSValue BunObject__createBunStdout(JSC::JSGlobalObject*);
 static void checkIfNextTickWasCalledDuringMicrotask(JSC::VM& vm)
 {
     auto* globalObject = defaultGlobalObject();
-    // Prevent this hook from re-entering drain() through its own
-    // processTicksAndRejections -> drainMicrotasks() path. drain() itself must
-    // stay re-enterable from GlobalObject::drainMicrotasks (a tick callback may
-    // spin wait_for_promise, which needs to drain ticks queued during the spin).
+    // Guard only this hook, not drain(): GlobalObject::drainMicrotasks must still
+    // re-enter drain() when a tick callback spins wait_for_promise.
     if (globalObject->m_isDrainingNextTickQueue)
         return;
     auto queue = globalObject->m_nextTickQueue.get();

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3235,7 +3235,7 @@ uint8_t GlobalObject::drainMicrotasks()
     }
     scope.assertNoExceptionExceptTermination();
 
-    if (auto nextTickQueue = this->m_nextTickQueue.get()) {
+    if (auto nextTickQueue = this->m_nextTickQueue.get(); nextTickQueue && !nextTickQueue->isEmpty()) {
         nextTickQueue->drain(vm, this);
         if (auto* exception = scope.exception()) {
             if (vm.isTerminationException(exception)) {

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -446,12 +446,9 @@ JSC::Structure* GlobalObject::createStructure(JSC::VM& vm)
 
 void Zig::GlobalObject::resetOnEachMicrotaskTick()
 {
-    auto& vm = this->vm();
-    if (this->asyncHooksNeedsCleanup) {
-        vm.setOnEachMicrotaskTick(&cleanupAsyncHooksData);
-    } else {
-        vm.setOnEachMicrotaskTick(&checkIfNextTickWasCalledDuringMicrotask);
-    }
+    // Sole caller (jsCleanupLater) sets asyncHooksNeedsCleanup = true immediately before.
+    ASSERT(this->asyncHooksNeedsCleanup);
+    this->vm().setOnEachMicrotaskTick(&cleanupAsyncHooksData);
 }
 
 extern "C" size_t Bun__reported_memory_size;

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -434,6 +434,7 @@ public:
     }
 
     bool asyncHooksNeedsCleanup = false;
+    bool m_isDrainingNextTickQueue = false;
     double INSPECT_MAX_BYTES = 50;
     bool isInsideErrorPrepareStackTraceCallback = false;
 

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -433,7 +433,6 @@ public:
         return func;
     }
 
-    bool asyncHooksNeedsCleanup = false;
     bool m_isDrainingNextTickQueue = false;
     double INSPECT_MAX_BYTES = 50;
     bool isInsideErrorPrepareStackTraceCallback = false;

--- a/test/regression/issue/34115.test.ts
+++ b/test/regression/issue/34115.test.ts
@@ -1,0 +1,95 @@
+// https://github.com/oven-sh/bun/issues/34115
+// A preload script that touches process.nextTick (directly, or via a module that
+// does) must not change the relative order of process.nextTick vs microtasks
+// scheduled at the top level of the entry module.
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+const orderFixture = `
+process.nextTick(() => console.log("nextTick"));
+queueMicrotask(() => console.log("microtask"));
+Promise.resolve().then(() => console.log("promise"));
+`;
+
+describe("process.nextTick ordering is preserved with --preload", () => {
+  test.each([
+    ["that reads process.nextTick", `process.nextTick;`],
+    ["that calls process.nextTick", `process.nextTick(() => console.log("preload-tick"));`, "preload-tick\n"],
+    ["that requires node:stream", `require("node:stream");`],
+    ["that requires node:zlib", `require("node:zlib");`],
+  ])("preload %s", async (_name, preloadBody, preloadOutput = "") => {
+    using dir = tempDir("issue-34115-order", {
+      "preload.js": preloadBody,
+      "order.js": orderFixture,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--preload", "./preload.js", "order.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(preloadOutput + "nextTick\nmicrotask\npromise\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("preserved with two preload scripts", async () => {
+    using dir = tempDir("issue-34115-two-preloads", {
+      "preload-a.js": `process.nextTick(() => console.log("a"));`,
+      "preload-b.js": `process.nextTick(() => console.log("b"));`,
+      "order.js": orderFixture,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--preload", "./preload-a.js", "--preload", "./preload-b.js", "order.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("a\nb\nnextTick\nmicrotask\npromise\n");
+    expect(exitCode).toBe(0);
+  });
+});
+
+test("Writable.toWeb() close rejects with ABORT_ERR when preload requires node:stream", async () => {
+  using dir = tempDir("issue-34115-writable", {
+    "preload.js": `require("node:stream");`,
+    "repro.js": `
+      const { Writable } = require("stream");
+      const w = new Writable({ write(c, e, cb) { cb(); } });
+      const ws = Writable.toWeb(w);
+      ws.close().then(
+        () => console.log("RESOLVED"),
+        e => console.log("rejected:", e.code),
+      );
+      w.end();
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--preload", "./preload.js", "repro.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("rejected: ABORT_ERR\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/34115.test.ts
+++ b/test/regression/issue/34115.test.ts
@@ -2,7 +2,7 @@
 // A preload script that touches process.nextTick (directly, or via a module that
 // does) must not change the relative order of process.nextTick vs microtasks
 // scheduled at the top level of the entry module.
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 const orderFixture = `
@@ -29,11 +29,7 @@ describe("process.nextTick ordering is preserved with --preload", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(stdout).toBe(preloadOutput + "nextTick\nmicrotask\npromise\n");
     expect(exitCode).toBe(0);
@@ -52,11 +48,7 @@ describe("process.nextTick ordering is preserved with --preload", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(stdout).toBe("a\nb\nnextTick\nmicrotask\npromise\n");
     expect(exitCode).toBe(0);
@@ -84,11 +76,7 @@ test("Writable.toWeb() close rejects with ABORT_ERR when preload requires node:s
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   expect(stdout).toBe("rejected: ABORT_ERR\n");
   expect(exitCode).toBe(0);

--- a/test/regression/issue/34115.test.ts
+++ b/test/regression/issue/34115.test.ts
@@ -123,8 +123,8 @@ test.concurrent("Writable.toWeb() close rejects with ABORT_ERR when preload requ
 });
 
 // A nextTick callback that spins wait_for_promise re-enters GlobalObject::drainMicrotasks
-// while the hook's re-entrancy guard is held; gating that call on !isEmpty() keeps the
-// nested drain from clearing asyncContextData[0] via the mustResetContext branch.
+// under the hook's m_isDrainingNextTickQueue guard; JSNextTickQueue::drain must not clear
+// asyncContextData[0] on that nested path.
 test.concurrent("AsyncLocalStorage frame survives a nextTick callback that spins wait_for_promise", async () => {
   await using proc = Bun.spawn({
     cmd: [

--- a/test/regression/issue/34115.test.ts
+++ b/test/regression/issue/34115.test.ts
@@ -16,7 +16,7 @@ Promise.resolve().then(() => console.log("promise"));
 `;
 
 describe("process.nextTick ordering is preserved with --preload", () => {
-  test.each([
+  test.concurrent.each([
     ["that reads process.nextTick", `process.nextTick;`],
     ["that calls process.nextTick", `process.nextTick(() => console.log("preload-tick"));`, "preload-tick\n"],
     ["that requires node:stream", `require("node:stream");`],
@@ -39,7 +39,7 @@ describe("process.nextTick ordering is preserved with --preload", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("preserved with two preload scripts", async () => {
+  test.concurrent("preserved with two preload scripts", async () => {
     using dir = tempDir("issue-34115-two-preloads", {
       "preload-a.js": `process.nextTick(() => console.log("a"));`,
       "preload-b.js": `process.nextTick(() => console.log("b"));`,
@@ -95,7 +95,7 @@ w.on("error", e => { console.error(String(e)); process.exitCode = 1; });
   });
 });
 
-test("Writable.toWeb() close rejects with ABORT_ERR when preload requires node:stream", async () => {
+test.concurrent("Writable.toWeb() close rejects with ABORT_ERR when preload requires node:stream", async () => {
   using dir = tempDir("issue-34115-writable", {
     "preload.js": `require("node:stream");`,
     "repro.js": `

--- a/test/regression/issue/34115.test.ts
+++ b/test/regression/issue/34115.test.ts
@@ -121,3 +121,42 @@ test.concurrent("Writable.toWeb() close rejects with ABORT_ERR when preload requ
   expect(stdout).toBe("rejected: ABORT_ERR\n");
   expect(exitCode).toBe(0);
 });
+
+// A nextTick callback that spins wait_for_promise re-enters GlobalObject::drainMicrotasks
+// while the hook's re-entrancy guard is held; gating that call on !isEmpty() keeps the
+// nested drain from clearing asyncContextData[0] via the mustResetContext branch.
+test.concurrent("AsyncLocalStorage frame survives a nextTick callback that spins wait_for_promise", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const { AsyncLocalStorage } = require("node:async_hooks");
+const als = new AsyncLocalStorage();
+als.run("outer-frame", () => {
+  process.nextTick(() => {
+    const before = als.getStore();
+    new HTMLRewriter()
+      .on("*", {
+        async element() {
+          await 0;
+          process.nextTick(() => {});
+          await 0;
+        },
+      })
+      .transform(new Response("<div></div><div></div>"))
+      .text();
+    console.log(before, als.getStore());
+  });
+});
+`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("outer-frame outer-frame\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/34115.test.ts
+++ b/test/regression/issue/34115.test.ts
@@ -2,6 +2,10 @@
 // A preload script that touches process.nextTick (directly, or via a module that
 // does) must not change the relative order of process.nextTick vs microtasks
 // scheduled at the top level of the entry module.
+//
+// node:worker_threads workers hit the same path: since #31216 every such worker
+// implicitly preloads node:worker_threads, which pulls in node:stream and
+// touches process.nextTick before the worker's own entry runs.
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
@@ -51,6 +55,42 @@ describe("process.nextTick ordering is preserved with --preload", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(stdout).toBe("a\nb\nnextTick\nmicrotask\npromise\n");
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe("process.nextTick ordering at the top level of a worker_threads CJS entry", () => {
+  const workerOrderBody = `
+const seq = ["sync"];
+Promise.resolve().then(() => seq.push("pt"));
+queueMicrotask(() => seq.push("qm"));
+process.nextTick(() => seq.push("nt"));
+setImmediate(() => require("node:worker_threads").parentPort.postMessage(seq.join(",")));
+`;
+
+  test.concurrent.each([
+    ["file entry", `"./worker.cjs"`],
+    ["eval: true", `${JSON.stringify(workerOrderBody)}, { eval: true }`],
+  ])("matches the main thread (%s)", async (_name, workerArgs) => {
+    using dir = tempDir("issue-34115-worker", {
+      "worker.cjs": workerOrderBody,
+      "main.mjs": `
+import { Worker } from "node:worker_threads";
+const w = new Worker(${workerArgs});
+w.on("message", seq => { console.log(seq); w.terminate(); });
+w.on("error", e => { console.error(String(e)); process.exitCode = 1; });
+`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("sync,nt,pt,qm\n");
     expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem

A `--preload` script (or anything that runs before the entry and touches `process.nextTick`) inverts the relative order of `process.nextTick` vs microtasks scheduled at the top level of the entry module. Since #31216 every `node:worker_threads` worker implicitly preloads `node:worker_threads`, which pulls in `node:stream`, whose `internal/streams/destroy` reads `process.nextTick` at top level, so a CJS worker entry always hits this.

```js
process.nextTick(() => console.log("nextTick"));
queueMicrotask(() => console.log("microtask"));
```

| entry | bun before | bun after |
|---|---|---|
| no preload | `nextTick, microtask` | `nextTick, microtask` |
| `--preload` that touches `process.nextTick` | `microtask, nextTick` | `nextTick, microtask` |
| `worker_threads` CJS entry | `microtask, nextTick` | `nextTick, microtask` |

The #34115 symptom (`Writable.toWeb(w).close()` resolving instead of rejecting with `ABORT_ERR` when a preload required `node:stream`) is one instance.

### Cause

`checkIfNextTickWasCalledDuringMicrotask` is installed as `vm.setOnEachMicrotaskTick` at VM init as a one-shot: on the first microtask where `m_nextTickQueue` exists it calls `resetOnEachMicrotaskTick()`, which nulls the hook. A preload that reads `process.nextTick` (the property is lazy and creates `m_nextTickQueue` on first access) consumes the one-shot during preload's microtask checkpoint, so the entry module runs with no hook and its top-level `nextTick` drains only at the next task boundary.

### Fix

Keep the hook armed instead of nulling it on first fire. A re-entrancy guard (`m_isDrainingNextTickQueue`) in the hook and in `jsFunctionDrainMicrotaskQueue` (the only caller of `vm.drainMicrotasks()` from inside `processTicksAndRejections`) prevents recursion; `GlobalObject::drainMicrotasks` stays unguarded so `drain()` can still re-enter when a tick callback spins `wait_for_promise` (zlib/HTMLRewriter/expect().resolves), and its call is gated on `!isEmpty()` to match the hook. `processTicksAndRejections` now clears `internalField(0)` after its `do...while` so `isEmpty()` reflects the drained state and the hook short-circuits.

With the hook persistently armed, the `mustResetContext` branch in `JSNextTickQueue::drain` (which cleared `asyncContextData[0]`) became unreachable and is removed: any nextTick queued during its `vm.drainMicrotasks()` is drained by a nested hook firing. `cleanupAsyncHooksData` / `resetOnEachMicrotaskTick` reduce to re-arming the hook (the only other user is `AsyncLocalStorage.enterWith`), and the `asyncHooksNeedsCleanup` field they branched on is now write-only and removed.

The per-microtask cost is one bool check plus `isEmpty()` (two field loads) and only applies once `m_nextTickQueue` exists, which is the same predicate the old bootstrap lambda already paid on every microtask before the one-shot fired.

This change also makes `process.nextTick` queued from inside a microtask run between that microtask and its siblings consistently, regardless of whether the queue was accessed earlier. Before, the ordering depended on whether the one-shot had already fired. Node runs it after the whole microtask FIFO; aligning that is a separate concern (#33088 / #33366) and would require moving the drain point, not just keeping the hook armed.

### Verification

`test/regression/issue/34115.test.ts`: four preload variants (reads/calls `process.nextTick`, requires `node:stream`/`node:zlib`), two-preload case, `worker_threads` CJS entry via file and `eval: true`, the original `Writable.toWeb()` repro, plus a wait_for_promise-inside-nextTick case for the ALS frame. 6/9 fail on released bun, all 9 pass with this change.

Fixes #34115

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 18 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/34115.test.ts"
bun test v1.4.0 (1ef0083d3)

test/regression/issue/34115.test.ts:
33 |       stdout: "pipe",
34 |       stderr: "pipe",
35 |     });
36 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
37 |     expect(stderr).toBe("");
38 |     expect(stdout).toBe(preloadOutput + "nextTick\nmicrotask\npromise\n");
                        ^
error: expect(received).toBe(expected)

- "nextTick
- microtask
+ "microtask
  promise
+ nextTick
  "

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/regression/issue/34115.test.ts:38:20)
(fail) process.nextTick ordering is preserved with --preload > preload that reads process.nextTick [472.60ms]
33 |       stdout: "pipe",
34 |       stderr: "pipe",
35 |     });
36 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
37 |     expect(stderr).toBe("");
38 |     expect(stdout).toBe(preloadOutput + "nextTick\nmicrotask\npromise\n"
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (cc50790ce)

test/regression/issue/34115.test.ts:
(pass) process.nextTick ordering is preserved with --preload > preload that reads process.nextTick [13.93ms]
(pass) process.nextTick ordering is preserved with --preload > preload that calls process.nextTick [9.98ms]
(pass) process.nextTick ordering is preserved with --preload > preserved with two preload scripts [12.02ms]
(pass) process.nextTick ordering is preserved with --preload > preload that requires node:stream [17.29ms]
(pass) process.nextTick ordering is preserved with --preload > preload that requires node:zlib [17.57ms]
(pass) AsyncLocalStorage frame survives a nextTick callback that spins wait_for_promise [14.09ms]
(pass) Writable.toWeb() close rejects with ABORT_ERR when preload requires node:stream [17.73ms]
(pass) process.nextTick ordering at the top level of a worker_threads CJS entry > matches the main thread (file entry) [49.18ms]
(pass) process.nextTick ordering at the top level of a worker_threads CJS entry > matches the main thread (eval: true) [49.94ms]

 9 pass
 0 fail
 27 expect() calls
Ran 9 tests across 1 file. [231.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/34115.test.ts"
bun test v1.4.0 (1ef0083d3)

test/regression/issue/34115.test.ts:
(pass) process.nextTick ordering is preserved with --preload > preload that reads process.nextTick [467.25ms]
(pass) process.nextTick ordering is preserved with --preload > preload that calls process.nextTick [442.17ms]
(pass) process.nextTick ordering is preserved with --preload > preserved with two preload scripts [459.11ms]
(pass) process.nextTick ordering is preserved with --preload > preload that requires node:stream [788.12ms]
(pass) process.nextTick ordering is preserved with --preload > preload that requires node:zlib [922.76ms]
(pass) Writable.toWeb() close rejects with ABORT_ERR when preload requires node:stream [979.77ms]
(pass) AsyncLocalStorage frame survives a nextTick callback that spins wait_for_promise [840.47ms]
(pass) process.nextTick ordering at the top level of a worker_threads CJS entry > matches the main thread (file entry) [2557.64ms]
(pass) process.nextTick ordering at the top level of a worker_threads CJS en
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 719ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/123] gen cpp.rs (cppbind)
[2/123] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[3/123] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[4/123] gen JS modules (bundle-modules)
Preprocess modules (9402ms)
Bundle modules (69ms)
Postprocesss modules (258ms)
Bundle Functions (811ms)
Generate Code (35ms)

[10.60s] Bundled "src/js" for production
  2570 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[4/122] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Com
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/builtins/ProcessObjectInternals.ts |   1 +
 src/jsc/bindings/BunProcess.cpp           |   2 +
 src/jsc/bindings/JSNextTickQueue.cpp      |   6 --
 src/jsc/bindings/NodeAsyncHooks.cpp       |   4 +-
 src/jsc/bindings/ZigGlobalObject.cpp      |  45 +++------
 src/jsc/bindings/ZigGlobalObject.h        |   2 +-
 test/regression/issue/34115.test.ts       | 162 ++++++++++++++++++++++++++++++
 7 files changed, 181 insertions(+), 41 deletions(-)
```

</details>

**gate history** · 16 passed · 3 rejected · iteration 18

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/builtins/ProcessObjectInternals.ts      2      1      0
src/jsc/bindings/BunProcess.cpp                6      2      0
src/jsc/bindings/JSNextTickQueue.cpp          10     14      0
src/jsc/bindings/NodeAsyncHooks.cpp            3      1      0
src/jsc/bindings/ZigGlobalObject.cpp           9     19      0
src/jsc/bindings/ZigGlobalObject.h             4      3      0
test/regression/issue/34115.test.ts            8     10      0
```

</details>

<!-- robobun:evidence:end -->