### PR TITLE
bun:sqlite: Database[Symbol.dispose] no longer throws over live prepared statements

### DIFF
--- a/src/js/bun/sqlite.ts
+++ b/src/js/bun/sqlite.ts
@@ -475,7 +475,7 @@ class Database implements SqliteTypes.Database {
 
   [Symbol.dispose]() {
     if (!this.#hasClosed) {
-      this.close(true);
+      this.close();
     }
   }
 

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1401,16 +1401,31 @@ it("close() should NOT throw an error if the database is in use", () => {
   expect(() => db.close()).not.toThrow("database is locked");
 });
 
-it("should dispose AND throw an error if the database is in use", () => {
+it("should dispose without throwing when a prepared statement is still live", () => {
+  let prepared;
   expect(() => {
-    let prepared;
     {
       using db = new Database(":memory:");
       db.exec("CREATE TABLE foo (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)");
       db.exec("INSERT INTO foo (name) VALUES ('foo')");
       prepared = db.prepare("SELECT * FROM foo");
+      prepared.get();
     }
-  }).toThrow("database is locked");
+  }).not.toThrow();
+});
+
+it("should not mask an error thrown from a `using db` block with SuppressedError", () => {
+  let caught;
+  try {
+    using db = new Database(":memory:");
+    const stmt = db.prepare("select 1 as x");
+    throw new Error("REAL-BUG");
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught).toBeInstanceOf(Error);
+  expect(caught).not.toBeInstanceOf(SuppressedError);
+  expect(caught.message).toBe("REAL-BUG");
 });
 
 it("should dispose", () => {

--- a/test/regression/issue/14709.test.ts
+++ b/test/regression/issue/14709.test.ts
@@ -24,7 +24,6 @@ test("db.close(true) works after db.transaction() with actual work", () => {
 test("using declaration works with db.transaction()", () => {
   using db = new Database(":memory:");
   db.transaction(() => {})();
-  // Symbol.dispose calls close(true), should not throw
 });
 
 test("db.close(true) works after multiple transaction types", () => {


### PR DESCRIPTION
## Repro

```js
import { Database } from "bun:sqlite";

{
  using db = new Database(":memory:");
  const stmt = db.prepare("select 1 as x");
  stmt.get();
} // throws: database is locked
```

The more harmful face: when the block body throws, the real error is buried as `SuppressedError.suppressed` behind `"database is locked"`:

```js
try {
  using db = new Database(":memory:");
  const stmt = db.prepare("select 1 as x");
  throw new Error("REAL-BUG");
} catch (e) {
  // e is SuppressedError { error: "database is locked", suppressed: Error("REAL-BUG") }
}
```

## Cause

`Database[Symbol.dispose]()` calls `close(true)`, which routes to `sqlite3_close()`. That returns `SQLITE_BUSY` while any prepared statement is still live, so every `db.prepare()` not explicitly finalized before `}` makes the disposer throw. Only `db.query()` statements were safe, because `close()` finalizes the query cache first.

## Fix

Route `[Symbol.dispose]()` to `close()` (the non-strict path, `sqlite3_close_v2`), matching both `close()`'s default and what GC cleanup already does. `sqlite3_close_v2` never fails over live statements; it defers the actual close until the last statement is finalized. Node's `node:sqlite` `DatabaseSync[Symbol.dispose]()` likewise does not throw on this state.

`close(true)` is unchanged and still throws on outstanding statements, which is its documented contract.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/sqlite/sqlite.test.js -t "should dispose without throwing"
(fail) should dispose without throwing when a prepared statement is still live
  Error message: "database is locked"

$ USE_SYSTEM_BUN=1 bun test test/js/bun/sqlite/sqlite.test.js -t "should not mask"
(fail) should not mask an error thrown from a `using db` block with SuppressedError
  Expected constructor: not [class SuppressedError extends Error]

$ bun bd test test/js/bun/sqlite/sqlite.test.js
 88 pass
 0 fail
```

The previous `should dispose AND throw an error if the database is in use` test asserted the old behavior and is replaced.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/sqlite/sqlite.test.js

<!-- robobun:evidence:end -->