### PR TITLE
Use C++17 `inline constexpr` for header constants

### DIFF
--- a/packages/bun-uws/src/HttpError.h
+++ b/packages/bun-uws/src/HttpError.h
@@ -31,7 +31,7 @@ enum HttpError {
 #ifndef UWS_HTTPRESPONSE_NO_WRITEMARK
 
 /* Returned parser errors match this LUT. */
-static const std::string_view httpErrorResponses[] = {
+inline constexpr std::string_view httpErrorResponses[] = {
     "", /* Zeroth place is no error so don't use it */
     "HTTP/1.1 505 HTTP Version Not Supported\r\nConnection: close\r\n\r\n<h1>HTTP Version Not Supported</h1><p>This server does not support HTTP/1.0.</p><hr><i>uWebSockets/20 Server</i>",
     "HTTP/1.1 431 Request Header Fields Too Large\r\nConnection: close\r\n\r\n<h1>Request Header Fields Too Large</h1><hr><i>uWebSockets/20 Server</i>",
@@ -40,7 +40,7 @@ static const std::string_view httpErrorResponses[] = {
 
 #else
 /* Anonymized pages */
-static const std::string_view httpErrorResponses[] = {
+inline constexpr std::string_view httpErrorResponses[] = {
     "", /* Zeroth place is no error so don't use it */
     "HTTP/1.1 505 HTTP Version Not Supported\r\nConnection: close\r\n\r\n",
     "HTTP/1.1 431 Request Header Fields Too Large\r\nConnection: close\r\n\r\n",

--- a/packages/bun-uws/src/HttpErrors.h
+++ b/packages/bun-uws/src/HttpErrors.h
@@ -29,7 +29,7 @@ enum HttpError {
 
 
 /* Anonymized pages */
-static const std::string_view httpErrorResponses[] = {
+inline constexpr std::string_view httpErrorResponses[] = {
     "", /* Zeroth place is no error so don't use it */
     "HTTP/1.1 505 HTTP Version Not Supported\r\nConnection: close\r\n\r\n",
     "HTTP/1.1 431 Request Header Fields Too Large\r\nConnection: close\r\n\r\n",

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -51,7 +51,7 @@ namespace uWS
 {
 
     /* We require at least this much post padding */
-    static const unsigned int MINIMUM_HTTP_POST_PADDING = 32;
+    inline constexpr unsigned int MINIMUM_HTTP_POST_PADDING = 32;
 
     enum HttpParserError: uint8_t {
         HTTP_PARSER_ERROR_NONE = 0,

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -40,7 +40,7 @@ namespace uWS {
 template <bool, bool, typename> struct WebSocketContext;
 
 /* Some pre-defined status constants to use with writeStatus */
-static const char *HTTP_200_OK = "200 OK";
+inline constexpr const char* HTTP_200_OK = "200 OK";
 
 template <bool SSL>
 struct HttpResponse : public AsyncSocket<SSL> {

--- a/packages/bun-uws/src/HttpRouter.h
+++ b/packages/bun-uws/src/HttpRouter.h
@@ -40,10 +40,10 @@ struct HttpRouter {
 
 private:
     UserDataType userData;
-    static const unsigned int MAX_URL_SEGMENTS = 100;
+    static constexpr unsigned int MAX_URL_SEGMENTS = 100;
 
     /* Handler ids are 32-bit */
-    static const uint32_t HANDLER_MASK = 0x0fffffff;
+    static constexpr uint32_t HANDLER_MASK = 0x0fffffff;
 
     /* List of handlers */
     std::vector<MoveOnlyFunction<bool(HttpRouter *)>> handlers;

--- a/packages/bun-uws/src/LoopData.h
+++ b/packages/bun-uws/src/LoopData.h
@@ -198,7 +198,7 @@ public:
     bool noMark = false;
 
     /* Good 16k for SSL perf. */
-    static const unsigned int CORK_BUFFER_SIZE = 16 * 1024;
+    static constexpr unsigned int CORK_BUFFER_SIZE = 16 * 1024;
 
     /* Per message deflate data */
     ZlibContext *zlibContext = nullptr;

--- a/packages/bun-uws/src/WebSocketProtocol.h
+++ b/packages/bun-uws/src/WebSocketProtocol.h
@@ -31,13 +31,13 @@
 namespace uWS {
 
 /* We should not overcomplicate these */
-const std::string_view ERR_TOO_BIG_MESSAGE("Received too big message");
-const std::string_view ERR_WEBSOCKET_TIMEOUT("WebSocket timed out from inactivity");
-const std::string_view ERR_INVALID_TEXT("Received invalid UTF-8");
-const std::string_view ERR_TOO_BIG_MESSAGE_INFLATION("Received too big message, or other inflation error");
-const std::string_view ERR_INVALID_CLOSE_PAYLOAD("Received invalid close payload");
-const std::string_view ERR_INVALID_MASKING("Received an incorrectly masked frame");
-const std::string_view ERR_INVALID_RSV1("Received unexpected RSV1 bit");
+inline constexpr std::string_view ERR_TOO_BIG_MESSAGE("Received too big message");
+inline constexpr std::string_view ERR_WEBSOCKET_TIMEOUT("WebSocket timed out from inactivity");
+inline constexpr std::string_view ERR_INVALID_TEXT("Received invalid UTF-8");
+inline constexpr std::string_view ERR_TOO_BIG_MESSAGE_INFLATION("Received too big message, or other inflation error");
+inline constexpr std::string_view ERR_INVALID_CLOSE_PAYLOAD("Received invalid close payload");
+inline constexpr std::string_view ERR_INVALID_MASKING("Received an incorrectly masked frame");
+inline constexpr std::string_view ERR_INVALID_RSV1("Received unexpected RSV1 bit");
 
 enum OpCode : unsigned char {
     CONTINUATION = 0,
@@ -57,9 +57,9 @@ enum {
 template <bool isServer>
 struct WebSocketState {
 public:
-    static const unsigned int SHORT_MESSAGE_HEADER = isServer ? 6 : 2;
-    static const unsigned int MEDIUM_MESSAGE_HEADER = isServer ? 8 : 4;
-    static const unsigned int LONG_MESSAGE_HEADER = isServer ? 14 : 10;
+    static constexpr unsigned int SHORT_MESSAGE_HEADER = isServer ? 6 : 2;
+    static constexpr unsigned int MEDIUM_MESSAGE_HEADER = isServer ? 8 : 4;
+    static constexpr unsigned int LONG_MESSAGE_HEADER = isServer ? 14 : 10;
 
     // 16 bytes
     struct State {
@@ -230,9 +230,9 @@ static inline size_t formatMessage(char *dst, const char *src, size_t length, Op
 template <const bool isServer, typename Impl>
 struct WebSocketProtocol {
 public:
-    static const unsigned int SHORT_MESSAGE_HEADER = isServer ? 6 : 2;
-    static const unsigned int MEDIUM_MESSAGE_HEADER = isServer ? 8 : 4;
-    static const unsigned int LONG_MESSAGE_HEADER = isServer ? 14 : 10;
+    static constexpr unsigned int SHORT_MESSAGE_HEADER = isServer ? 6 : 2;
+    static constexpr unsigned int MEDIUM_MESSAGE_HEADER = isServer ? 8 : 4;
+    static constexpr unsigned int LONG_MESSAGE_HEADER = isServer ? 14 : 10;
 
 protected:
     static inline bool isFin(char *frame) {return *((unsigned char *) frame) & 128;}
@@ -462,8 +462,8 @@ public:
         }
     }
 
-    static const int CONSUME_POST_PADDING = 4;
-    static const int CONSUME_PRE_PADDING = LONG_MESSAGE_HEADER - 1;
+    static constexpr int CONSUME_POST_PADDING = 4;
+    static constexpr int CONSUME_PRE_PADDING = LONG_MESSAGE_HEADER - 1;
 };
 
 }

--- a/src/jsc/bindings/JSDOMWrapper.h
+++ b/src/jsc/bindings/JSDOMWrapper.h
@@ -45,20 +45,20 @@ class ScriptExecutionContext;
 // offset | 7 | 6 | 5 | 4 | 3   2   1   0  |
 // value  | 1 | 1 | 1 | 1 |    NodeType    |
 
-static const uint8_t JSDOMWrapperType = 0b11101110;
-static const uint8_t JSEventType = 0b11101111;
-static const uint8_t JSNodeType = 0b11110000;
-static const uint8_t JSNodeTypeMask = 0b00001111;
-static const uint8_t JSTextNodeType = JSNodeType | NodeConstants::TEXT_NODE;
-static const uint8_t JSProcessingInstructionNodeType = JSNodeType | NodeConstants::PROCESSING_INSTRUCTION_NODE;
-static const uint8_t JSDocumentTypeNodeType = JSNodeType | NodeConstants::DOCUMENT_TYPE_NODE;
-static const uint8_t JSDocumentFragmentNodeType = JSNodeType | NodeConstants::DOCUMENT_FRAGMENT_NODE;
-static const uint8_t JSDocumentWrapperType = JSNodeType | NodeConstants::DOCUMENT_NODE;
-static const uint8_t JSCommentNodeType = JSNodeType | NodeConstants::COMMENT_NODE;
-static const uint8_t JSCDATASectionNodeType = JSNodeType | NodeConstants::CDATA_SECTION_NODE;
-static const uint8_t JSAttrNodeType = JSNodeType | NodeConstants::ATTRIBUTE_NODE;
-static const uint8_t JSElementType = 0b11110000 | NodeConstants::ELEMENT_NODE;
-static const uint8_t JSAsJSONType = JSElementType;
+inline constexpr uint8_t JSDOMWrapperType = 0b11101110;
+inline constexpr uint8_t JSEventType = 0b11101111;
+inline constexpr uint8_t JSNodeType = 0b11110000;
+inline constexpr uint8_t JSNodeTypeMask = 0b00001111;
+inline constexpr uint8_t JSTextNodeType = JSNodeType | NodeConstants::TEXT_NODE;
+inline constexpr uint8_t JSProcessingInstructionNodeType = JSNodeType | NodeConstants::PROCESSING_INSTRUCTION_NODE;
+inline constexpr uint8_t JSDocumentTypeNodeType = JSNodeType | NodeConstants::DOCUMENT_TYPE_NODE;
+inline constexpr uint8_t JSDocumentFragmentNodeType = JSNodeType | NodeConstants::DOCUMENT_FRAGMENT_NODE;
+inline constexpr uint8_t JSDocumentWrapperType = JSNodeType | NodeConstants::DOCUMENT_NODE;
+inline constexpr uint8_t JSCommentNodeType = JSNodeType | NodeConstants::COMMENT_NODE;
+inline constexpr uint8_t JSCDATASectionNodeType = JSNodeType | NodeConstants::CDATA_SECTION_NODE;
+inline constexpr uint8_t JSAttrNodeType = JSNodeType | NodeConstants::ATTRIBUTE_NODE;
+inline constexpr uint8_t JSElementType = 0b11110000 | NodeConstants::ELEMENT_NODE;
+inline constexpr uint8_t JSAsJSONType = JSElementType;
 
 static_assert(JSDOMWrapperType > JSC::LastJSCObjectType, "JSC::JSType offers the highest bit.");
 static_assert(NodeConstants::LastNodeType <= JSNodeTypeMask, "NodeType should be represented in 4bit.");

--- a/src/jsc/bindings/NodeConstants.h
+++ b/src/jsc/bindings/NodeConstants.h
@@ -46,7 +46,7 @@ struct NodeConstants {
         NOTATION_NODE = 12,
     };
 
-    static const uint8_t LastNodeType = NOTATION_NODE;
+    static constexpr uint8_t LastNodeType = NOTATION_NODE;
 };
 
 } // namespace WebCore::NodeType

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -135,7 +135,7 @@ typedef struct ResolvedSource {
     // Converted to file:// URL. If empty, origin is derived from source_url.
     BunString bytecode_origin_path;
 } ResolvedSource;
-static const uint32_t ResolvedSourceTagPackageJSONTypeModule = 1;
+inline constexpr uint32_t ResolvedSourceTagPackageJSONTypeModule = 1;
 typedef union ErrorableResolvedSourceResult {
     ResolvedSource value;
     ZigErrorType err;
@@ -160,19 +160,19 @@ typedef struct SystemError {
 typedef void* ArrayBufferSink;
 
 typedef uint8_t BunPluginTarget;
-const BunPluginTarget BunPluginTargetBun = 0;
-const BunPluginTarget BunPluginTargetBrowser = 1;
-const BunPluginTarget BunPluginTargetNode = 2;
-const BunPluginTarget BunPluginTargetMax = BunPluginTargetNode;
+inline constexpr BunPluginTarget BunPluginTargetBun = 0;
+inline constexpr BunPluginTarget BunPluginTargetBrowser = 1;
+inline constexpr BunPluginTarget BunPluginTargetNode = 2;
+inline constexpr BunPluginTarget BunPluginTargetMax = BunPluginTargetNode;
 
 typedef uint8_t ZigStackFrameCode;
-const ZigStackFrameCode ZigStackFrameCodeNone = 0;
-const ZigStackFrameCode ZigStackFrameCodeEval = 1;
-const ZigStackFrameCode ZigStackFrameCodeModule = 2;
-const ZigStackFrameCode ZigStackFrameCodeFunction = 3;
-const ZigStackFrameCode ZigStackFrameCodeGlobal = 4;
-const ZigStackFrameCode ZigStackFrameCodeWasm = 5;
-const ZigStackFrameCode ZigStackFrameCodeConstructor = 6;
+inline constexpr ZigStackFrameCode ZigStackFrameCodeNone = 0;
+inline constexpr ZigStackFrameCode ZigStackFrameCodeEval = 1;
+inline constexpr ZigStackFrameCode ZigStackFrameCodeModule = 2;
+inline constexpr ZigStackFrameCode ZigStackFrameCodeFunction = 3;
+inline constexpr ZigStackFrameCode ZigStackFrameCodeGlobal = 4;
+inline constexpr ZigStackFrameCode ZigStackFrameCodeWasm = 5;
+inline constexpr ZigStackFrameCode ZigStackFrameCodeConstructor = 6;
 
 extern "C" void __attribute((__noreturn__)) Bun__panic(const char* message, size_t length);
 #define BUN_PANIC(message) Bun__panic(message, sizeof(message) - 1)

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -240,69 +240,69 @@ typedef struct ZigException {
 } ZigException;
 
 typedef uint8_t JSErrorCode;
-const JSErrorCode JSErrorCodeError = 0;
-const JSErrorCode JSErrorCodeEvalError = 1;
-const JSErrorCode JSErrorCodeRangeError = 2;
-const JSErrorCode JSErrorCodeReferenceError = 3;
-const JSErrorCode JSErrorCodeSyntaxError = 4;
-const JSErrorCode JSErrorCodeTypeError = 5;
-const JSErrorCode JSErrorCodeURIError = 6;
-const JSErrorCode JSErrorCodeAggregateError = 7;
-const JSErrorCode JSErrorCodeOutOfMemoryError = 8;
-const JSErrorCode JSErrorCodeStackOverflow = 253;
-const JSErrorCode JSErrorCodeUserErrorCode = 254;
+inline constexpr JSErrorCode JSErrorCodeError = 0;
+inline constexpr JSErrorCode JSErrorCodeEvalError = 1;
+inline constexpr JSErrorCode JSErrorCodeRangeError = 2;
+inline constexpr JSErrorCode JSErrorCodeReferenceError = 3;
+inline constexpr JSErrorCode JSErrorCodeSyntaxError = 4;
+inline constexpr JSErrorCode JSErrorCodeTypeError = 5;
+inline constexpr JSErrorCode JSErrorCodeURIError = 6;
+inline constexpr JSErrorCode JSErrorCodeAggregateError = 7;
+inline constexpr JSErrorCode JSErrorCodeOutOfMemoryError = 8;
+inline constexpr JSErrorCode JSErrorCodeStackOverflow = 253;
+inline constexpr JSErrorCode JSErrorCodeUserErrorCode = 254;
 
 // Must be kept in sync with Loader in src/options_types/schema.rs
 typedef uint8_t BunLoaderType;
-const BunLoaderType BunLoaderTypeNone = 254;
-const BunLoaderType BunLoaderTypeJSX = 1;
-const BunLoaderType BunLoaderTypeJS = 2;
-const BunLoaderType BunLoaderTypeTS = 3;
-const BunLoaderType BunLoaderTypeTSX = 4;
-const BunLoaderType BunLoaderTypeCSS = 5;
-const BunLoaderType BunLoaderTypeFILE = 6;
-const BunLoaderType BunLoaderTypeJSON = 7;
-const BunLoaderType BunLoaderTypeJSONC = 8;
-const BunLoaderType BunLoaderTypeTOML = 9;
-const BunLoaderType BunLoaderTypeWASM = 10;
-const BunLoaderType BunLoaderTypeNAPI = 11;
-const BunLoaderType BunLoaderTypeYAML = 19;
-const BunLoaderType BunLoaderTypeMD = 20;
+inline constexpr BunLoaderType BunLoaderTypeNone = 254;
+inline constexpr BunLoaderType BunLoaderTypeJSX = 1;
+inline constexpr BunLoaderType BunLoaderTypeJS = 2;
+inline constexpr BunLoaderType BunLoaderTypeTS = 3;
+inline constexpr BunLoaderType BunLoaderTypeTSX = 4;
+inline constexpr BunLoaderType BunLoaderTypeCSS = 5;
+inline constexpr BunLoaderType BunLoaderTypeFILE = 6;
+inline constexpr BunLoaderType BunLoaderTypeJSON = 7;
+inline constexpr BunLoaderType BunLoaderTypeJSONC = 8;
+inline constexpr BunLoaderType BunLoaderTypeTOML = 9;
+inline constexpr BunLoaderType BunLoaderTypeWASM = 10;
+inline constexpr BunLoaderType BunLoaderTypeNAPI = 11;
+inline constexpr BunLoaderType BunLoaderTypeYAML = 19;
+inline constexpr BunLoaderType BunLoaderTypeMD = 20;
 
 #pragma mark - Stream
 
 typedef uint8_t Encoding;
-const Encoding Encoding__utf8 = 0;
-const Encoding Encoding__ucs2 = 1;
-const Encoding Encoding__utf16le = 2;
-const Encoding Encoding__latin1 = 3;
-const Encoding Encoding__ascii = 4;
-const Encoding Encoding__base64 = 5;
-const Encoding Encoding__base64url = 6;
-const Encoding Encoding__hex = 7;
-const Encoding Encoding__buffer = 8;
+inline constexpr Encoding Encoding__utf8 = 0;
+inline constexpr Encoding Encoding__ucs2 = 1;
+inline constexpr Encoding Encoding__utf16le = 2;
+inline constexpr Encoding Encoding__latin1 = 3;
+inline constexpr Encoding Encoding__ascii = 4;
+inline constexpr Encoding Encoding__base64 = 5;
+inline constexpr Encoding Encoding__base64url = 6;
+inline constexpr Encoding Encoding__hex = 7;
+inline constexpr Encoding Encoding__buffer = 8;
 
 typedef uint8_t WritableEvent;
-const WritableEvent WritableEvent__Close = 0;
-const WritableEvent WritableEvent__Drain = 1;
-const WritableEvent WritableEvent__Error = 2;
-const WritableEvent WritableEvent__Finish = 3;
-const WritableEvent WritableEvent__Pipe = 4;
-const WritableEvent WritableEvent__Unpipe = 5;
-const WritableEvent WritableEvent__Open = 6;
-const WritableEvent WritableEventUser = 254;
+inline constexpr WritableEvent WritableEvent__Close = 0;
+inline constexpr WritableEvent WritableEvent__Drain = 1;
+inline constexpr WritableEvent WritableEvent__Error = 2;
+inline constexpr WritableEvent WritableEvent__Finish = 3;
+inline constexpr WritableEvent WritableEvent__Pipe = 4;
+inline constexpr WritableEvent WritableEvent__Unpipe = 5;
+inline constexpr WritableEvent WritableEvent__Open = 6;
+inline constexpr WritableEvent WritableEventUser = 254;
 
 typedef uint8_t ReadableEvent;
 
-const ReadableEvent ReadableEvent__Close = 0;
-const ReadableEvent ReadableEvent__Data = 1;
-const ReadableEvent ReadableEvent__End = 2;
-const ReadableEvent ReadableEvent__Error = 3;
-const ReadableEvent ReadableEvent__Pause = 4;
-const ReadableEvent ReadableEvent__Readable = 5;
-const ReadableEvent ReadableEvent__Resume = 6;
-const ReadableEvent ReadableEvent__Open = 7;
-const ReadableEvent ReadableEventUser = 254;
+inline constexpr ReadableEvent ReadableEvent__Close = 0;
+inline constexpr ReadableEvent ReadableEvent__Data = 1;
+inline constexpr ReadableEvent ReadableEvent__End = 2;
+inline constexpr ReadableEvent ReadableEvent__Error = 3;
+inline constexpr ReadableEvent ReadableEvent__Pause = 4;
+inline constexpr ReadableEvent ReadableEvent__Readable = 5;
+inline constexpr ReadableEvent ReadableEvent__Resume = 6;
+inline constexpr ReadableEvent ReadableEvent__Open = 7;
+inline constexpr ReadableEvent ReadableEventUser = 254;
 
 #ifndef STRING_POINTER
 #define STRING_POINTER

--- a/src/jsc/bindings/node/crypto/CryptoSignJob.h
+++ b/src/jsc/bindings/node/crypto/CryptoSignJob.h
@@ -8,7 +8,7 @@ namespace Bun {
 JSC_DECLARE_HOST_FUNCTION(jsSignOneShot);
 JSC_DECLARE_HOST_FUNCTION(jsVerifyOneShot);
 
-static const unsigned int NoDsaSignature = static_cast<unsigned int>(-1);
+inline constexpr unsigned int NoDsaSignature = static_cast<unsigned int>(-1);
 
 struct SignJobCtx {
     WTF_MAKE_TZONE_ALLOCATED(SignJobCtx);

--- a/src/jsc/bindings/webcore/DOMJITIDLTypeFilter.h
+++ b/src/jsc/bindings/webcore/DOMJITIDLTypeFilter.h
@@ -35,108 +35,108 @@ template<typename IDLType>
 struct IDLArgumentTypeFilter;
 
 template<> struct IDLArgumentTypeFilter<IDLBoolean> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecBoolean;
+    static constexpr JSC::SpeculatedType value = JSC::SpecBoolean;
 };
 template<> struct IDLArgumentTypeFilter<IDLByte> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecInt32Only;
+    static constexpr JSC::SpeculatedType value = JSC::SpecInt32Only;
 };
 template<> struct IDLArgumentTypeFilter<IDLOctet> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecInt32Only;
+    static constexpr JSC::SpeculatedType value = JSC::SpecInt32Only;
 };
 template<> struct IDLArgumentTypeFilter<IDLShort> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecInt32Only;
+    static constexpr JSC::SpeculatedType value = JSC::SpecInt32Only;
 };
 template<> struct IDLArgumentTypeFilter<IDLUnsignedShort> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecInt32Only;
+    static constexpr JSC::SpeculatedType value = JSC::SpecInt32Only;
 };
 template<> struct IDLArgumentTypeFilter<IDLLong> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecInt32Only;
+    static constexpr JSC::SpeculatedType value = JSC::SpecInt32Only;
 };
 template<> struct IDLArgumentTypeFilter<IDLDOMString> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecString;
+    static constexpr JSC::SpeculatedType value = JSC::SpecString;
 };
 template<> struct IDLArgumentTypeFilter<IDLAtomStringAdaptor<IDLDOMString>> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecString;
+    static constexpr JSC::SpeculatedType value = JSC::SpecString;
 };
 template<> struct IDLArgumentTypeFilter<IDLRequiresExistingAtomStringAdaptor<IDLDOMString>> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecString;
+    static constexpr JSC::SpeculatedType value = JSC::SpecString;
 };
 template<> struct IDLArgumentTypeFilter<IDLUint8Array> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecUint8Array;
+    static constexpr JSC::SpeculatedType value = JSC::SpecUint8Array;
 };
 
 template<typename IDLType>
 struct IDLResultTypeFilter {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecFullTop;
+    static constexpr JSC::SpeculatedType value = JSC::SpecFullTop;
 };
 
 template<> struct IDLResultTypeFilter<IDLAny> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecHeapTop;
+    static constexpr JSC::SpeculatedType value = JSC::SpecHeapTop;
 };
 template<> struct IDLResultTypeFilter<IDLBoolean> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecBoolean;
+    static constexpr JSC::SpeculatedType value = JSC::SpecBoolean;
 };
 template<> struct IDLResultTypeFilter<IDLByte> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecInt32Only;
+    static constexpr JSC::SpeculatedType value = JSC::SpecInt32Only;
 };
 template<> struct IDLResultTypeFilter<IDLOctet> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecInt32Only;
+    static constexpr JSC::SpeculatedType value = JSC::SpecInt32Only;
 };
 template<> struct IDLResultTypeFilter<IDLShort> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecInt32Only;
+    static constexpr JSC::SpeculatedType value = JSC::SpecInt32Only;
 };
 template<> struct IDLResultTypeFilter<IDLUnsignedShort> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecInt32Only;
+    static constexpr JSC::SpeculatedType value = JSC::SpecInt32Only;
 };
 template<> struct IDLResultTypeFilter<IDLLong> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecInt32Only;
+    static constexpr JSC::SpeculatedType value = JSC::SpecInt32Only;
 };
 template<> struct IDLResultTypeFilter<IDLUnsignedLong> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecBytecodeNumber;
+    static constexpr JSC::SpeculatedType value = JSC::SpecBytecodeNumber;
 };
 template<> struct IDLResultTypeFilter<IDLLongLong> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecBytecodeNumber;
+    static constexpr JSC::SpeculatedType value = JSC::SpecBytecodeNumber;
 };
 template<> struct IDLResultTypeFilter<IDLUnsignedLongLong> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecBytecodeNumber;
+    static constexpr JSC::SpeculatedType value = JSC::SpecBytecodeNumber;
 };
 template<> struct IDLResultTypeFilter<IDLFloat> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecBytecodeNumber;
+    static constexpr JSC::SpeculatedType value = JSC::SpecBytecodeNumber;
 };
 template<> struct IDLResultTypeFilter<IDLUnrestrictedFloat> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecBytecodeNumber;
+    static constexpr JSC::SpeculatedType value = JSC::SpecBytecodeNumber;
 };
 template<> struct IDLResultTypeFilter<IDLDouble> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecBytecodeNumber;
+    static constexpr JSC::SpeculatedType value = JSC::SpecBytecodeNumber;
 };
 template<> struct IDLResultTypeFilter<IDLUnrestrictedDouble> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecBytecodeNumber;
+    static constexpr JSC::SpeculatedType value = JSC::SpecBytecodeNumber;
 };
 template<> struct IDLResultTypeFilter<IDLDOMString> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecString;
+    static constexpr JSC::SpeculatedType value = JSC::SpecString;
 };
 template<> struct IDLResultTypeFilter<IDLByteString> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecString;
+    static constexpr JSC::SpeculatedType value = JSC::SpecString;
 };
 template<> struct IDLResultTypeFilter<IDLUSVString> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecString;
+    static constexpr JSC::SpeculatedType value = JSC::SpecString;
 };
 template<> struct IDLResultTypeFilter<IDLAtomStringAdaptor<IDLDOMString>> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecString;
+    static constexpr JSC::SpeculatedType value = JSC::SpecString;
 };
 template<> struct IDLResultTypeFilter<IDLRequiresExistingAtomStringAdaptor<IDLDOMString>> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecString;
+    static constexpr JSC::SpeculatedType value = JSC::SpecString;
 };
 template<> struct IDLResultTypeFilter<IDLUint8Array> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecUint8Array;
+    static constexpr JSC::SpeculatedType value = JSC::SpecUint8Array;
 };
 template<> struct IDLResultTypeFilter<IDLObject> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecBytecodeTop;
+    static constexpr JSC::SpeculatedType value = JSC::SpecBytecodeTop;
 };
 
 template<typename T>
 struct IDLResultTypeFilter<IDLNullable<T>> {
-    static const constexpr JSC::SpeculatedType value = JSC::SpecOther | IDLResultTypeFilter<T>::value;
+    static constexpr JSC::SpeculatedType value = JSC::SpecOther | IDLResultTypeFilter<T>::value;
 };
 
 }

--- a/src/jsc/bindings/webcrypto/CommonCryptoDERUtilities.h
+++ b/src/jsc/bindings/webcrypto/CommonCryptoDERUtilities.h
@@ -36,15 +36,15 @@
 namespace WebCore {
 
 // Per X.690 08/2015: https://www.itu.int/rec/T-REC-X.680-X.693/en
-static const unsigned char BitStringMark = 0x03;
-static const unsigned char IntegerMark = 0x02;
-static const unsigned char OctetStringMark = 0x04;
-static const unsigned char SequenceMark = 0x30;
+inline constexpr unsigned char BitStringMark = 0x03;
+inline constexpr unsigned char IntegerMark = 0x02;
+inline constexpr unsigned char OctetStringMark = 0x04;
+inline constexpr unsigned char SequenceMark = 0x30;
 // Version 0. Per https://tools.ietf.org/html/rfc5208#section-5
-static const unsigned char Version[] = { 0x02, 0x01, 0x00 };
+inline constexpr unsigned char Version[] = { 0x02, 0x01, 0x00 };
 
-static const unsigned char InitialOctet = 0x00;
-static const size_t MaxLengthInOneByte = 128;
+inline constexpr unsigned char InitialOctet = 0x00;
+inline constexpr size_t MaxLengthInOneByte = 128;
 
 size_t bytesUsedToEncodedLength(uint8_t);
 size_t extraBytesNeededForEncodedLength(size_t);

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmSHA256.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmSHA256.h
@@ -36,7 +36,7 @@ public:
     static constexpr ASCIILiteral s_name = "SHA-256"_s;
     static constexpr ASCIILiteral s_alternative_name = "SHA256"_s;
 
-    static const CryptoAlgorithmIdentifier s_identifier = CryptoAlgorithmIdentifier::SHA_256;
+    static constexpr CryptoAlgorithmIdentifier s_identifier = CryptoAlgorithmIdentifier::SHA_256;
     static Ref<CryptoAlgorithm> create();
 
 private:

--- a/src/jsc/bindings/webcrypto/CryptoKeyAES.h
+++ b/src/jsc/bindings/webcrypto/CryptoKeyAES.h
@@ -41,9 +41,9 @@ struct JsonWebKey;
 
 class CryptoKeyAES final : public CryptoKey {
 public:
-    static const int s_length128 = 128;
-    static const int s_length192 = 192;
-    static const int s_length256 = 256;
+    static constexpr int s_length128 = 128;
+    static constexpr int s_length192 = 192;
+    static constexpr int s_length256 = 256;
 
     static Ref<CryptoKeyAES> create(CryptoAlgorithmIdentifier algorithm, const Vector<uint8_t>& key, bool extractable, CryptoKeyUsageBitmap usage)
     {


### PR DESCRIPTION
Applies the same pattern as https://bugs.webkit.org/show_bug.cgi?id=319329 to Bun's C++ code.

Bun had no `extern const` declarations (the exact pattern from that change), but did have `static const` / bare `const` constants at namespace scope in headers, which create one copy per translation unit with internal linkage. Converting those to `inline constexpr` gives a single ODR-merged definition with external linkage and guarantees compile-time evaluation.

### Changes

**Namespace scope `static const` / `const` → `inline constexpr`:**
- `src/jsc/bindings/headers-handwritten.h`: `ResolvedSourceTagPackageJSONTypeModule`, `BunPluginTarget*`, `ZigStackFrameCode*`
- `src/jsc/bindings/JSDOMWrapper.h`: `JSDOMWrapperType` and 13 related type constants
- `src/jsc/bindings/webcrypto/CommonCryptoDERUtilities.h`: DER tag constants
- `src/jsc/bindings/node/crypto/CryptoSignJob.h`: `NoDsaSignature`
- `packages/bun-uws/src/WebSocketProtocol.h`: `ERR_*` `std::string_view` constants
- `packages/bun-uws/src/HttpError.h`, `HttpErrors.h`: `httpErrorResponses[]`
- `packages/bun-uws/src/HttpParser.h`: `MINIMUM_HTTP_POST_PADDING`
- `packages/bun-uws/src/HttpResponse.h`: `HTTP_200_OK`

**Class scope `static const` → `static constexpr`:**
- `src/jsc/bindings/NodeConstants.h`: `LastNodeType`
- `src/jsc/bindings/webcrypto/CryptoAlgorithmSHA256.h`: `s_identifier` (all siblings were already `constexpr`)
- `src/jsc/bindings/webcrypto/CryptoKeyAES.h`: `s_length128/192/256`
- `packages/bun-uws/src/WebSocketProtocol.h`: header-size constants, `CONSUME_*_PADDING`
- `packages/bun-uws/src/LoopData.h`: `CORK_BUFFER_SIZE`
- `packages/bun-uws/src/HttpRouter.h`: `MAX_URL_SEGMENTS`, `HANDLER_MASK`

**Cleanup:**
- `src/jsc/bindings/webcore/DOMJITIDLTypeFilter.h`: dropped redundant `const` from `static const constexpr` (33 sites)

### Left unchanged

- `src/jsc/bindings/helpers.h` `ZigStringEmpty` / `BunString*`: initializers use `reinterpret_cast`, not constexpr-eligible
- `src/jsc/bindings/sqlite/lazy_sqlite3.h` `sqlite3_lib_path`: mutated at runtime by `setCustomSQLite`
- `src/jsc/bindings/ZigLazyStaticFunctions-inlines.h`: generated file, runtime-dependent initializer
- `packages/bun-usockets/src/internal/eventing/epoll_kqueue.h`: compiled as C