### PR TITLE
napi: add the missing safety comment on free_orphaned's unsafe block

### DIFF
--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2808,6 +2808,7 @@ impl ThreadSafeFunction {
     /// SAFETY: `this` is a live allocation from `new`, the caller holds no
     /// lock on it, and no other thread holds a reference.
     unsafe fn free_orphaned(this: *mut ThreadSafeFunction) {
+        // SAFETY: `this` was allocated by heap::alloc in `new`.
         drop(unsafe { bun_core::heap::take(this) });
     }
 


### PR DESCRIPTION
`cargo clippy` is failing on `main` again, and therefore on **every open pull request that touches a `.rs` file**:

```
error: unsafe block missing a safety comment
  --> src/runtime/napi/napi_body.rs:2811:14
   = note: requested on the command line with `-D clippy::undocumented-unsafe-blocks`
error: could not compile `bun_runtime` (lib) due to 1 previous error
```

`undocumented_unsafe_blocks = "deny"` is set workspace-wide. #34067 added `ThreadSafeFunction::free_orphaned`, whose *doc comment* carries a `SAFETY:` paragraph describing the function's own contract — but the lint wants a comment attached to the unsafe **block**. Its sibling `free`, ten lines above, already has exactly the comment this one needs:

```rust
    // SAFETY: `this` was allocated by heap::alloc in `new`.
    drop(unsafe { bun_core::heap::take(this) });
```

## Why it keeps happening

`.github/workflows/clippy.yml` triggers on `workflow_call`, `workflow_dispatch`, `pull_request` and `merge_group` — there is **no `push:` trigger**, so main never lints itself. Since `pull_request` lints the PR *merged into* main, breaks introduced on main surface on contributors' PRs and look like their fault.

This is the third such breakage in a few days (#33951 fixed `let_and_return` in `bun_paths` and `large_stack_frames` in `bun_runtime`; #33958 fixed the aarch64/macOS-only lints). Adding a `push:` trigger — or a scheduled run on main — would catch these at the source. Happy to send that separately if wanted.

## Verification

- Reproduced on a clean `main` tip (`16c557635b`) before changing anything; `cargo clippy -p bun_runtime --no-deps` reports the error, and reverting the one-line fix reproduces it again (2 errors → 0).
- After the fix, `cargo clippy --workspace --no-deps --keep-going` exits **0** on all three: macOS arm64 (host), `x86_64-unknown-linux-gnu` (what the Clippy workflow runs), and `aarch64-unknown-linux-gnu`.
- `cargo fmt --check -p bun_runtime` clean.

Comment-only; no runtime surface.
