### PR TITLE
napi: validate typedarray alignment/length before JSC, type-check view info APIs

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1790,22 +1790,22 @@ extern "C" napi_status napi_create_typedarray(
     size_t size_of_element;
     const char* alignment_msg;
     switch (type) {
-#define NAPI_TYPED_ARRAY_CASE(napi_type, js_type, size)                         \
-    case napi_type:                                                             \
-        size_of_element = size;                                                 \
+#define NAPI_TYPED_ARRAY_CASE(napi_type, js_type, size)                                \
+    case napi_type:                                                                    \
+        size_of_element = size;                                                        \
         alignment_msg = "start offset of " #js_type " should be a multiple of " #size; \
         break;
-    NAPI_TYPED_ARRAY_CASE(napi_int8_array, Int8Array, 1)
-    NAPI_TYPED_ARRAY_CASE(napi_uint8_array, Uint8Array, 1)
-    NAPI_TYPED_ARRAY_CASE(napi_uint8_clamped_array, Uint8ClampedArray, 1)
-    NAPI_TYPED_ARRAY_CASE(napi_int16_array, Int16Array, 2)
-    NAPI_TYPED_ARRAY_CASE(napi_uint16_array, Uint16Array, 2)
-    NAPI_TYPED_ARRAY_CASE(napi_int32_array, Int32Array, 4)
-    NAPI_TYPED_ARRAY_CASE(napi_uint32_array, Uint32Array, 4)
-    NAPI_TYPED_ARRAY_CASE(napi_float32_array, Float32Array, 4)
-    NAPI_TYPED_ARRAY_CASE(napi_float64_array, Float64Array, 8)
-    NAPI_TYPED_ARRAY_CASE(napi_bigint64_array, BigInt64Array, 8)
-    NAPI_TYPED_ARRAY_CASE(napi_biguint64_array, BigUint64Array, 8)
+        NAPI_TYPED_ARRAY_CASE(napi_int8_array, Int8Array, 1)
+        NAPI_TYPED_ARRAY_CASE(napi_uint8_array, Uint8Array, 1)
+        NAPI_TYPED_ARRAY_CASE(napi_uint8_clamped_array, Uint8ClampedArray, 1)
+        NAPI_TYPED_ARRAY_CASE(napi_int16_array, Int16Array, 2)
+        NAPI_TYPED_ARRAY_CASE(napi_uint16_array, Uint16Array, 2)
+        NAPI_TYPED_ARRAY_CASE(napi_int32_array, Int32Array, 4)
+        NAPI_TYPED_ARRAY_CASE(napi_uint32_array, Uint32Array, 4)
+        NAPI_TYPED_ARRAY_CASE(napi_float32_array, Float32Array, 4)
+        NAPI_TYPED_ARRAY_CASE(napi_float64_array, Float64Array, 8)
+        NAPI_TYPED_ARRAY_CASE(napi_bigint64_array, BigInt64Array, 8)
+        NAPI_TYPED_ARRAY_CASE(napi_biguint64_array, BigUint64Array, 8)
 #undef NAPI_TYPED_ARRAY_CASE
     default:
         return napi_set_last_error(env, napi_invalid_arg);

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1692,7 +1692,7 @@ extern "C" napi_status napi_create_dataview(napi_env env, size_t length,
     NAPI_CHECK_ARG(env, result);
     JSValue arraybufferValue = toJS(arraybuffer);
     auto arraybufferPtr = dynamicDowncast<JSC::JSArrayBuffer>(arraybufferValue);
-    NAPI_RETURN_EARLY_IF_FALSE(env, arraybufferPtr, napi_arraybuffer_expected);
+    NAPI_RETURN_EARLY_IF_FALSE(env, arraybufferPtr, napi_invalid_arg);
 
     if (byte_offset + length > arraybufferPtr->impl()->byteLength()) {
         napi_throw_range_error(env, "ERR_NAPI_INVALID_DATAVIEW_ARGS", "byte_offset + byte_length should be less than or equal to the size in bytes of the array passed in");
@@ -1785,25 +1785,39 @@ extern "C" napi_status napi_create_typedarray(
     NAPI_CHECK_ARG(env, result);
     JSValue arraybufferValue = toJS(arraybuffer);
     auto arraybufferPtr = dynamicDowncast<JSC::JSArrayBuffer>(arraybufferValue);
-    NAPI_RETURN_EARLY_IF_FALSE(env, arraybufferPtr, napi_arraybuffer_expected);
+    NAPI_RETURN_EARLY_IF_FALSE(env, arraybufferPtr, napi_invalid_arg);
+
+    size_t size_of_element;
+    const char* alignment_msg;
     switch (type) {
-    case napi_int8_array:
-    case napi_uint8_array:
-    case napi_uint8_clamped_array:
-    case napi_int16_array:
-    case napi_uint16_array:
-    case napi_int32_array:
-    case napi_uint32_array:
-    case napi_float32_array:
-    case napi_float64_array:
-    case napi_bigint64_array:
-    case napi_biguint64_array: {
+#define NAPI_TYPED_ARRAY_CASE(napi_type, js_type, size)                         \
+    case napi_type:                                                             \
+        size_of_element = size;                                                 \
+        alignment_msg = "start offset of " #js_type " should be a multiple of " #size; \
         break;
+    NAPI_TYPED_ARRAY_CASE(napi_int8_array, Int8Array, 1)
+    NAPI_TYPED_ARRAY_CASE(napi_uint8_array, Uint8Array, 1)
+    NAPI_TYPED_ARRAY_CASE(napi_uint8_clamped_array, Uint8ClampedArray, 1)
+    NAPI_TYPED_ARRAY_CASE(napi_int16_array, Int16Array, 2)
+    NAPI_TYPED_ARRAY_CASE(napi_uint16_array, Uint16Array, 2)
+    NAPI_TYPED_ARRAY_CASE(napi_int32_array, Int32Array, 4)
+    NAPI_TYPED_ARRAY_CASE(napi_uint32_array, Uint32Array, 4)
+    NAPI_TYPED_ARRAY_CASE(napi_float32_array, Float32Array, 4)
+    NAPI_TYPED_ARRAY_CASE(napi_float64_array, Float64Array, 8)
+    NAPI_TYPED_ARRAY_CASE(napi_bigint64_array, BigInt64Array, 8)
+    NAPI_TYPED_ARRAY_CASE(napi_biguint64_array, BigUint64Array, 8)
+#undef NAPI_TYPED_ARRAY_CASE
+    default:
+        return napi_set_last_error(env, napi_invalid_arg);
     }
-    default: {
-        napi_set_last_error(env, napi_invalid_arg);
-        return napi_invalid_arg;
+
+    if (size_of_element > 1 && byte_offset % size_of_element != 0) {
+        napi_throw_range_error(env, "ERR_NAPI_INVALID_TYPEDARRAY_ALIGNMENT", alignment_msg);
+        return napi_set_last_error(env, napi_generic_failure);
     }
+    if (length * size_of_element + byte_offset > arraybufferPtr->impl()->byteLength()) {
+        napi_throw_range_error(env, "ERR_NAPI_INVALID_TYPEDARRAY_LENGTH", "Invalid typed array length");
+        return napi_set_last_error(env, napi_generic_failure);
     }
 
     JSC::JSArrayBufferView* view = createArrayBufferView(globalObject, type, arraybufferPtr->impl(), byte_offset, length);

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1815,7 +1815,8 @@ extern "C" napi_status napi_create_typedarray(
         napi_throw_range_error(env, "ERR_NAPI_INVALID_TYPEDARRAY_ALIGNMENT", alignment_msg);
         return napi_set_last_error(env, napi_generic_failure);
     }
-    if (length * size_of_element + byte_offset > arraybufferPtr->impl()->byteLength()) {
+    size_t buffer_len = arraybufferPtr->impl()->byteLength();
+    if (byte_offset > buffer_len || length > (buffer_len - byte_offset) / size_of_element) {
         napi_throw_range_error(env, "ERR_NAPI_INVALID_TYPEDARRAY_LENGTH", "Invalid typed array length");
         return napi_set_last_error(env, napi_generic_failure);
     }

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -1405,13 +1405,20 @@ pub(super) extern "C" fn napi_get_typedarray_info(
     let Some(array_buffer) = typedarray.as_array_buffer(env.to_js()) else {
         return env.invalid_arg();
     };
-    // Node.js checks IsTypedArray() and returns napi_invalid_arg for DataView,
-    // ArrayBuffer, Float16Array, or anything else without a napi_typedarray_type.
-    let Some(napi_ty) = napi_typedarray_type::from_js_type(array_buffer.typed_array_type) else {
+    // Node.js gates on IsTypedArray(), which rejects DataView and ArrayBuffer
+    // but accepts Float16Array (even though Bun has no napi_float16_array yet).
+    if matches!(
+        array_buffer.typed_array_type,
+        jsc::JSType::DataView | jsc::JSType::ArrayBuffer
+    ) {
         return env.invalid_arg();
-    };
+    }
     // SAFETY: `maybe_type` is null or a valid exclusive out-param per N-API contract.
     if let Some(ty) = unsafe { maybe_type.as_mut() } {
+        let Some(napi_ty) = napi_typedarray_type::from_js_type(array_buffer.typed_array_type)
+        else {
+            return env.invalid_arg();
+        };
         *ty = napi_ty;
     }
 

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2818,6 +2818,7 @@ impl ThreadSafeFunction {
     /// SAFETY: `this` is a live allocation from `new`, the caller holds no
     /// lock on it, and no other thread holds a reference.
     unsafe fn free_orphaned(this: *mut ThreadSafeFunction) {
+        // SAFETY: see the function's safety contract above.
         drop(unsafe { bun_core::heap::take(this) });
     }
 

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -1405,14 +1405,13 @@ pub(super) extern "C" fn napi_get_typedarray_info(
     let Some(array_buffer) = typedarray.as_array_buffer(env.to_js()) else {
         return env.invalid_arg();
     };
+    // Node.js checks IsTypedArray() and returns napi_invalid_arg for DataView,
+    // ArrayBuffer, Float16Array, or anything else without a napi_typedarray_type.
+    let Some(napi_ty) = napi_typedarray_type::from_js_type(array_buffer.typed_array_type) else {
+        return env.invalid_arg();
+    };
     // SAFETY: `maybe_type` is null or a valid exclusive out-param per N-API contract.
     if let Some(ty) = unsafe { maybe_type.as_mut() } {
-        // The `ArrayBuffer.typed_array_type` field is already a `JSType`, so map it
-        // straight to `napi_typedarray_type`.
-        let Some(napi_ty) = napi_typedarray_type::from_js_type(array_buffer.typed_array_type)
-        else {
-            return env.invalid_arg();
-        };
         *ty = napi_ty;
     }
 
@@ -1470,8 +1469,13 @@ pub(super) extern "C" fn napi_get_dataview_info(
     let env = get_env!(env_);
     env.check_gc();
     let dataview = dataview_.get();
+    if dataview.is_empty_or_undefined_or_null()
+        || dataview.js_type_loose() != jsc::JSType::DataView
+    {
+        return env.invalid_arg();
+    }
     let Some(array_buffer) = dataview.as_array_buffer(env.to_js()) else {
-        return NapiEnv::set_last_error(Some(env), NapiStatus::object_expected);
+        return env.invalid_arg();
     };
     write_out(maybe_bytelength, array_buffer.byte_len);
     write_out(maybe_data, array_buffer.ptr);

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -1469,8 +1469,7 @@ pub(super) extern "C" fn napi_get_dataview_info(
     let env = get_env!(env_);
     env.check_gc();
     let dataview = dataview_.get();
-    if dataview.is_empty_or_undefined_or_null()
-        || dataview.js_type_loose() != jsc::JSType::DataView
+    if dataview.is_empty_or_undefined_or_null() || dataview.js_type_loose() != jsc::JSType::DataView
     {
         return env.invalid_arg();
     }

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2624,6 +2624,123 @@ test_dataview_info_byte_offset(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+static void print_pending_exception_code(napi_env env) {
+  bool is_pending = false;
+  napi_is_exception_pending(env, &is_pending);
+  if (!is_pending) {
+    printf("  no pending exception\n");
+    return;
+  }
+  napi_value exception;
+  napi_get_and_clear_last_exception(env, &exception);
+  napi_value code_val;
+  char code[128] = "(no .code)";
+  if (napi_get_named_property(env, exception, "code", &code_val) == napi_ok) {
+    size_t len;
+    napi_get_value_string_utf8(env, code_val, code, sizeof(code), &len);
+  }
+  bool is_range = false;
+  napi_value global, range_ctor;
+  napi_get_global(env, &global);
+  napi_get_named_property(env, global, "RangeError", &range_ctor);
+  napi_instanceof(env, exception, range_ctor, &is_range);
+  printf("  code=%s instanceof RangeError=%d\n", code, is_range ? 1 : 0);
+}
+
+static napi_value
+test_napi_create_typedarray_errors(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+
+  napi_value arraybuffer;
+  void *data = nullptr;
+  NODE_API_CALL(env, napi_create_arraybuffer(env, 16, &data, &arraybuffer));
+
+  napi_value ta = nullptr;
+  napi_status s =
+      napi_create_typedarray(env, napi_int32_array, 2, arraybuffer, 2, &ta);
+  printf("misaligned int32 offset=2: status=%d\n", s);
+  print_pending_exception_code(env);
+
+  // A subsequent call must succeed; there must be no leftover VM exception.
+  napi_value str = nullptr;
+  napi_status s2 =
+      napi_create_string_utf8(env, "hello", NAPI_AUTO_LENGTH, &str);
+  printf("create_string_utf8 after misalign: status=%d\n", s2);
+
+  s = napi_create_typedarray(env, napi_float64_array, 2, arraybuffer, 4, &ta);
+  printf("misaligned float64 offset=4: status=%d\n", s);
+  print_pending_exception_code(env);
+
+  s = napi_create_typedarray(env, napi_uint8_array, 32, arraybuffer, 0, &ta);
+  printf("uint8 length=32 over 16-byte buffer: status=%d\n", s);
+  print_pending_exception_code(env);
+
+  s = napi_create_typedarray(env, napi_int32_array, 4, arraybuffer, 4, &ta);
+  printf("int32 length=4 offset=4 over 16-byte buffer: status=%d\n", s);
+  print_pending_exception_code(env);
+
+  napi_value not_a_buffer;
+  NODE_API_CALL(env, napi_create_object(env, &not_a_buffer));
+  s = napi_create_typedarray(env, napi_uint8_array, 4, not_a_buffer, 0, &ta);
+  printf("create_typedarray(non-buffer): status=%d\n", s);
+  napi_value dv;
+  s = napi_create_dataview(env, 4, not_a_buffer, 0, &dv);
+  printf("create_dataview(non-buffer): status=%d\n", s);
+
+  s = napi_create_typedarray(env, napi_int32_array, 4, arraybuffer, 0, &ta);
+  printf("int32 length=4 offset=0 exact fit: status=%d\n", s);
+
+  return ok(env);
+}
+
+static napi_value
+test_napi_view_info_type_check(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+
+  napi_value arraybuffer;
+  void *data = nullptr;
+  NODE_API_CALL(env, napi_create_arraybuffer(env, 16, &data, &arraybuffer));
+  napi_value uint8;
+  NODE_API_CALL(env, napi_create_typedarray(env, napi_uint8_array, 8,
+                                            arraybuffer, 0, &uint8));
+  napi_value dataview;
+  NODE_API_CALL(env, napi_create_dataview(env, 8, arraybuffer, 0, &dataview));
+  napi_value plain;
+  NODE_API_CALL(env, napi_create_object(env, &plain));
+
+  size_t len = 12345;
+  void *p = nullptr;
+  napi_value ab = nullptr;
+  size_t off = 12345;
+  napi_status s;
+
+  s = napi_get_dataview_info(env, uint8, &len, &p, &ab, &off);
+  printf("get_dataview_info(Uint8Array): status=%d\n", s);
+  s = napi_get_dataview_info(env, arraybuffer, &len, &p, &ab, &off);
+  printf("get_dataview_info(ArrayBuffer): status=%d\n", s);
+  s = napi_get_dataview_info(env, plain, &len, &p, &ab, &off);
+  printf("get_dataview_info(Object): status=%d\n", s);
+  s = napi_get_dataview_info(env, dataview, &len, &p, &ab, &off);
+  printf("get_dataview_info(DataView): status=%d len=%zu off=%zu\n", s, len,
+         off);
+
+  napi_typedarray_type ty;
+  s = napi_get_typedarray_info(env, dataview, &ty, &len, &p, &ab, &off);
+  printf("get_typedarray_info(DataView): status=%d\n", s);
+  s = napi_get_typedarray_info(env, arraybuffer, &ty, &len, &p, &ab, &off);
+  printf("get_typedarray_info(ArrayBuffer): status=%d\n", s);
+  s = napi_get_typedarray_info(env, dataview, nullptr, nullptr, nullptr,
+                               nullptr, nullptr);
+  printf("get_typedarray_info(DataView, all-null out): status=%d\n", s);
+  s = napi_get_typedarray_info(env, plain, &ty, &len, &p, &ab, &off);
+  printf("get_typedarray_info(Object): status=%d\n", s);
+  s = napi_get_typedarray_info(env, uint8, &ty, &len, &p, &ab, &off);
+  printf("get_typedarray_info(Uint8Array): status=%d type=%d len=%zu\n", s,
+         static_cast<int>(ty), len);
+
+  return ok(env);
+}
+
 static napi_value
 test_create_arraybuffer_zeroed(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
@@ -2668,6 +2785,8 @@ test_create_arraybuffer_zeroed(const Napi::CallbackInfo &info) {
 void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_typedarray_info_byte_offset);
   REGISTER_FUNCTION(env, exports, test_dataview_info_byte_offset);
+  REGISTER_FUNCTION(env, exports, test_napi_create_typedarray_errors);
+  REGISTER_FUNCTION(env, exports, test_napi_view_info_type_check);
   REGISTER_FUNCTION(env, exports, test_create_arraybuffer_zeroed);
   REGISTER_FUNCTION(env, exports, test_issue_7685);
   REGISTER_FUNCTION(env, exports, test_issue_11949);

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2707,6 +2707,7 @@ test_napi_view_info_type_check(const Napi::CallbackInfo &info) {
   NODE_API_CALL(env, napi_create_dataview(env, 8, arraybuffer, 0, &dataview));
   napi_value plain;
   NODE_API_CALL(env, napi_create_object(env, &plain));
+  napi_value float16 = info[1];
 
   size_t len = 12345;
   void *p = nullptr;
@@ -2732,6 +2733,10 @@ test_napi_view_info_type_check(const Napi::CallbackInfo &info) {
   s = napi_get_typedarray_info(env, dataview, nullptr, nullptr, nullptr,
                                nullptr, nullptr);
   printf("get_typedarray_info(DataView, all-null out): status=%d\n", s);
+  s = napi_get_typedarray_info(env, float16, nullptr, &len, nullptr, nullptr,
+                               &off);
+  printf("get_typedarray_info(Float16Array, type=null): status=%d len=%zu\n", s,
+         len);
   s = napi_get_typedarray_info(env, plain, &ty, &len, &p, &ab, &off);
   printf("get_typedarray_info(Object): status=%d\n", s);
   s = napi_get_typedarray_info(env, uint8, &ty, &len, &p, &ab, &off);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -687,13 +687,14 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
 
   describe("napi_get_typedarray_info / napi_get_dataview_info type check", () => {
     it("returns napi_invalid_arg when given the wrong view type", async () => {
-      const output = await checkSameOutput("test_napi_view_info_type_check", []);
+      const output = await checkSameOutput("test_napi_view_info_type_check", "[new Float16Array(4)]");
       expect(output).toContain("get_dataview_info(Uint8Array): status=1");
       expect(output).toContain("get_dataview_info(ArrayBuffer): status=1");
       expect(output).toContain("get_dataview_info(DataView): status=0 len=8 off=0");
       expect(output).toContain("get_typedarray_info(DataView): status=1");
       expect(output).toContain("get_typedarray_info(ArrayBuffer): status=1");
       expect(output).toContain("get_typedarray_info(DataView, all-null out): status=1");
+      expect(output).toContain("get_typedarray_info(Float16Array, type=null): status=0 len=4");
       expect(output).toContain("get_typedarray_info(Uint8Array): status=0 type=1 len=8");
     });
   });

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -672,6 +672,32 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     });
   });
 
+  describe("napi_create_typedarray", () => {
+    it("throws a coded RangeError for misaligned/out-of-range arguments and leaves no VM exception", async () => {
+      const output = await checkSameOutput("test_napi_create_typedarray_errors", []);
+      expect(output).toContain("misaligned int32 offset=2: status=9");
+      expect(output).toContain("code=ERR_NAPI_INVALID_TYPEDARRAY_ALIGNMENT instanceof RangeError=1");
+      expect(output).toContain("create_string_utf8 after misalign: status=0");
+      expect(output).toContain("code=ERR_NAPI_INVALID_TYPEDARRAY_LENGTH instanceof RangeError=1");
+      expect(output).toContain("create_typedarray(non-buffer): status=1");
+      expect(output).toContain("create_dataview(non-buffer): status=1");
+      expect(output).toContain("int32 length=4 offset=0 exact fit: status=0");
+    });
+  });
+
+  describe("napi_get_typedarray_info / napi_get_dataview_info type check", () => {
+    it("returns napi_invalid_arg when given the wrong view type", async () => {
+      const output = await checkSameOutput("test_napi_view_info_type_check", []);
+      expect(output).toContain("get_dataview_info(Uint8Array): status=1");
+      expect(output).toContain("get_dataview_info(ArrayBuffer): status=1");
+      expect(output).toContain("get_dataview_info(DataView): status=0 len=8 off=0");
+      expect(output).toContain("get_typedarray_info(DataView): status=1");
+      expect(output).toContain("get_typedarray_info(ArrayBuffer): status=1");
+      expect(output).toContain("get_typedarray_info(DataView, all-null out): status=1");
+      expect(output).toContain("get_typedarray_info(Uint8Array): status=0 type=1 len=8");
+    });
+  });
+
   // TODO(@190n) test allocating in a finalizer from a napi module with the right version
 
   describe("napi_wrap", () => {


### PR DESCRIPTION
## What

`napi_create_typedarray` now validates alignment and length before calling into JSC and throws a coded `RangeError` via `napi_throw_range_error`, matching Node.js. `napi_get_typedarray_info` / `napi_get_dataview_info` now reject values of the wrong view type instead of returning `napi_ok` with the wrong geometry.

## Why

### `napi_create_typedarray`: raw VM exception, wrong status, no `.code`

```c
napi_status s  = napi_create_typedarray(env, napi_int32_array, 2, ab, /*offset*/2, &ta);
napi_status s2 = napi_create_string_utf8(env, "hello", NAPI_AUTO_LENGTH, &str);
```

| | `s` | thrown error `.code` | `s2` |
|---|---|---|---|
| Node.js | 9 (`napi_generic_failure`) | `ERR_NAPI_INVALID_TYPEDARRAY_ALIGNMENT` | 0 |
| Bun (before) | 10 (`napi_pending_exception`) | `undefined` | 0 (release) / **SIGABRT** (asserts) |
| Bun (after) | 9 | `ERR_NAPI_INVALID_TYPEDARRAY_ALIGNMENT` | 0 |

Previously `napi_create_typedarray` delegated validation to `JSGenericTypedArrayView::create`, which throws directly into the VM. The `RangeError` carried no `.code`, the returned status was `napi_pending_exception` (Node.js returns `napi_generic_failure`), and because the exception sat on the VM rather than in `env->m_pendingException`, a follow-up Rust-side N-API call would trip `assert_exception_presence_matches` in its generated FFI wrapper and abort on the asserts build:

```
ASSERTION FAILED: Unexpected exception observed ... Error Exception: Byte offset is not aligned ... !exception()
```

Now we validate `byte_offset % element_size == 0` and `length * element_size + byte_offset <= byteLength` up front and throw via `napi_throw_range_error` (stashed on the env), returning `napi_generic_failure`. This is the same shape `napi_create_dataview` already used for its `ERR_NAPI_INVALID_DATAVIEW_ARGS` path.

### `napi_get_dataview_info` / `napi_get_typedarray_info`: no type check

| call | Bun (before) | Node.js / Bun (after) |
|---|---|---|
| `napi_get_dataview_info(Uint8Array)` | 0 (with the typed array's geometry) | 1 (`napi_invalid_arg`) |
| `napi_get_dataview_info(ArrayBuffer)` | 0 | 1 |
| `napi_get_typedarray_info(DataView)` | 1 only if `type` out-param was non-null, else 0 | 1 |
| `napi_get_typedarray_info(ArrayBuffer)` | 1 only if `type` out-param was non-null, else 0 | 1 |

Both functions accepted anything `as_array_buffer()` would unwrap. `napi_get_typedarray_info` only rejected when the `type` out-param was non-null. An addon guarding its element-size math with these statuses would read the wrong memory layout under a clean `napi_ok`.

Also: `napi_create_typedarray` and `napi_create_dataview` now return `napi_invalid_arg` (was `napi_arraybuffer_expected`) when the `arraybuffer` argument is not an ArrayBuffer, matching Node.js.

## Verification

New `checkSameOutput` tests in `test/napi/napi.test.ts` compare Bun against Node.js byte-for-byte:

```
$ USE_SYSTEM_BUN=1 bun test test/napi/napi.test.ts -t "coded RangeError|wrong view type"
(fail) napi > napi_create_typedarray > throws a coded RangeError ...
(fail) napi > napi_get_typedarray_info / napi_get_dataview_info type check > returns napi_invalid_arg ...

$ bun bd test test/napi/napi.test.ts -t "coded RangeError|wrong view type"
(pass) napi > napi_create_typedarray > throws a coded RangeError ...
(pass) napi > napi_get_typedarray_info / napi_get_dataview_info type check > returns napi_invalid_arg ...
```

The node-napi `test_typedarray` / `test_dataview` suites and existing `napi_get_typedarray_info` / `napi_get_dataview_info` byte-offset tests still pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 9 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->