### PR TITLE
napi: apply ToObject coercion to element/property-name/prototype APIs

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -126,10 +126,16 @@ using namespace Zig;
 
 // Node's CHECK_TO_OBJECT: ToObject coerces primitives and throws on
 // null/undefined; on failure the TypeError is left pending and the call
-// returns napi_object_expected. Declares `_result` in the enclosing scope.
-#define NAPI_CHECK_TO_OBJECT(_env, _globalObject, _result, _src) \
-    JSObject* _result = (_src).toObject((_globalObject));        \
-    RETURN_IF_EXCEPTION(napi_preamble_throw_scope__,             \
+// returns napi_object_expected. Node's own NAPI_PREAMBLE has already returned
+// napi_pending_exception for an env-stashed exception (from napi_throw) by this
+// point; bun's preamble only checks the VM scope, so re-check here so callers
+// keep bailing before any observable side effect (matching the
+// NAPI_RETURN_IF_EXCEPTION they previously used). Declares `_result` in the
+// enclosing scope.
+#define NAPI_CHECK_TO_OBJECT(_env, _globalObject, _result, _src)                                \
+    NAPI_RETURN_EARLY_IF_FALSE((_env), !(_env)->hasPendingException(), napi_pending_exception); \
+    JSObject* _result = (_src).toObject((_globalObject));                                       \
+    RETURN_IF_EXCEPTION(napi_preamble_throw_scope__,                                            \
         napi_set_last_error((_env), napi_object_expected))
 
 // Return an error code if an exception was thrown after NAPI_PREAMBLE

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -124,6 +124,14 @@ using namespace Zig;
         }                                                 \
     } while (0)
 
+// Node's CHECK_TO_OBJECT: ToObject coerces primitives and throws on
+// null/undefined; on failure the TypeError is left pending and the call
+// returns napi_object_expected. Declares `_result` in the enclosing scope.
+#define NAPI_CHECK_TO_OBJECT(_env, _globalObject, _result, _src)      \
+    JSObject* _result = (_src).toObject((_globalObject));             \
+    RETURN_IF_EXCEPTION(napi_preamble_throw_scope__,                  \
+        napi_set_last_error((_env), napi_object_expected))
+
 // Return an error code if an exception was thrown after NAPI_PREAMBLE
 #define NAPI_RETURN_IF_VM_EXCEPTION(_env) RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error((_env), napi_pending_exception))
 
@@ -434,8 +442,7 @@ extern "C" napi_status napi_set_element(napi_env env, napi_value object_,
     NAPI_RETURN_EARLY_IF_FALSE(env, !object.isEmpty() && !value.isEmpty(), napi_invalid_arg);
 
     auto globalObject = toJS(env);
-    JSObject* jsObject = object.getObject();
-    NAPI_RETURN_EARLY_IF_FALSE(env, jsObject, napi_array_expected);
+    NAPI_CHECK_TO_OBJECT(env, globalObject, jsObject, object);
 
     (void)jsObject->putByIndexInline(globalObject, index, value, false);
     NAPI_RETURN_SUCCESS_UNLESS_EXCEPTION(env);
@@ -451,10 +458,10 @@ extern "C" napi_status napi_has_element(napi_env env, napi_value object_,
     JSValue object = toJS(object_);
     NAPI_RETURN_EARLY_IF_FALSE(env, !object.isEmpty(), napi_invalid_arg);
 
-    JSObject* jsObject = object.getObject();
-    NAPI_RETURN_EARLY_IF_FALSE(env, jsObject, napi_array_expected);
+    auto globalObject = toJS(env);
+    NAPI_CHECK_TO_OBJECT(env, globalObject, jsObject, object);
 
-    bool has_property = jsObject->hasProperty(toJS(env), index);
+    bool has_property = jsObject->hasProperty(globalObject, index);
     NAPI_RETURN_IF_EXCEPTION(env);
     *result = has_property;
     NAPI_RETURN_SUCCESS(env);
@@ -1850,9 +1857,16 @@ extern "C" napi_status napi_get_all_property_names(
     NAPI_PREAMBLE(env);
     NAPI_CHECK_ARG(env, result);
     NAPI_CHECK_ARG(env, objectNapi);
+    NAPI_RETURN_EARLY_IF_FALSE(env,
+        key_mode == napi_key_include_prototypes || key_mode == napi_key_own_only,
+        napi_invalid_arg);
+    NAPI_RETURN_EARLY_IF_FALSE(env,
+        key_conversion == napi_key_keep_numbers || key_conversion == napi_key_numbers_to_strings,
+        napi_invalid_arg);
+
+    auto globalObject = toJS(env);
     auto objectValue = toJS(objectNapi);
-    auto* object = objectValue.getObject();
-    NAPI_RETURN_EARLY_IF_FALSE(env, object, napi_object_expected);
+    NAPI_CHECK_TO_OBJECT(env, globalObject, object, objectValue);
 
     // Always request non-enumerable properties from JSC; whether to exclude them is decided by
     // key_filter (napi_key_enumerable) in the filter loop below. JSC only supports Exclude when
@@ -1864,8 +1878,6 @@ extern "C" napi_status napi_get_all_property_names(
     } else if (key_filter & napi_key_skip_strings) {
         jsc_property_mode = PropertyNameMode::Symbols;
     }
-
-    auto globalObject = toJS(env);
 
     JSArray* exportKeys = nullptr;
     if (key_mode == napi_key_include_prototypes) {
@@ -1914,6 +1926,24 @@ extern "C" napi_status napi_get_all_property_names(
             }
         }
         exportKeys = filteredKeys;
+    }
+
+    // JSC property enumeration always yields string keys for array indices;
+    // convert canonical index strings back to numbers for napi_key_keep_numbers.
+    if (key_conversion == napi_key_keep_numbers) {
+        unsigned length = exportKeys->getArrayLength();
+        for (unsigned i = 0; i < length; i++) {
+            JSValue key = exportKeys->getDirectIndex(globalObject, i);
+            if (!key.isString())
+                continue;
+            auto keyStr = asString(key)->value(globalObject);
+            NAPI_RETURN_IF_EXCEPTION(env);
+            if (auto* impl = keyStr->impl()) {
+                if (auto index = parseIndex(*impl)) {
+                    exportKeys->putDirectIndex(globalObject, i, jsNumber(*index));
+                }
+            }
+        }
     }
 
     *result = toNapi(JSValue(exportKeys), globalObject);
@@ -2032,12 +2062,10 @@ extern "C" napi_status napi_get_property_names(napi_env env, napi_value object,
     NAPI_CHECK_ARG(env, object);
     NAPI_CHECK_ARG(env, result);
     JSValue jsValue = toJS(object);
-    JSObject* jsObject = jsValue.getObject();
-    NAPI_RETURN_EARLY_IF_FALSE(env, jsObject, napi_object_expected);
-
     Zig::GlobalObject* globalObject = toJS(env);
+    NAPI_CHECK_TO_OBJECT(env, globalObject, jsObject, jsValue);
 
-    JSC::EnsureStillAliveScope ensureStillAlive(jsValue);
+    JSC::EnsureStillAliveScope ensureStillAlive(jsObject);
     JSValue value = collectInheritedPropertyKeys(globalObject, jsObject, PropertyNameMode::Strings, DontEnumPropertiesMode::Exclude);
     NAPI_RETURN_IF_EXCEPTION(env);
     JSC::EnsureStillAliveScope ensureStillAlive1(value);
@@ -2437,13 +2465,13 @@ extern "C" napi_status napi_get_element(napi_env env, napi_value objectValue,
     NAPI_CHECK_ARG(env, result);
     NAPI_CHECK_ARG(env, objectValue);
     JSValue jsValue = toJS(objectValue);
-    JSObject* jsObject = jsValue.getObject();
-    NAPI_RETURN_EARLY_IF_FALSE(env, jsObject, napi_object_expected);
+    auto globalObject = toJS(env);
+    NAPI_CHECK_TO_OBJECT(env, globalObject, jsObject, jsValue);
 
-    JSValue element = jsObject->getIndex(toJS(env), index);
+    JSValue element = jsObject->getIndex(globalObject, index);
     NAPI_RETURN_IF_EXCEPTION(env);
 
-    *result = toNapi(element, toJS(env));
+    *result = toNapi(element, globalObject);
     NAPI_RETURN_SUCCESS(env);
 }
 
@@ -2453,13 +2481,15 @@ extern "C" napi_status napi_delete_element(napi_env env, napi_value objectValue,
     NAPI_PREAMBLE(env);
     NAPI_CHECK_ARG(env, objectValue);
     JSValue jsValue = toJS(objectValue);
-    JSObject* jsObject = jsValue.getObject();
-    NAPI_RETURN_EARLY_IF_FALSE(env, jsObject, napi_object_expected);
+    auto globalObject = toJS(env);
+    NAPI_CHECK_TO_OBJECT(env, globalObject, jsObject, jsValue);
 
+    bool deleteResult = jsObject->methodTable()->deletePropertyByIndex(jsObject, globalObject, index);
+    NAPI_RETURN_IF_EXCEPTION(env);
     if (result) [[likely]] {
-        *result = jsObject->methodTable()->deletePropertyByIndex(jsObject, toJS(env), index);
+        *result = deleteResult;
     }
-    NAPI_RETURN_SUCCESS_UNLESS_EXCEPTION(env);
+    NAPI_RETURN_SUCCESS(env);
 }
 
 extern "C" napi_status napi_create_object(napi_env env, napi_value* result)

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -414,8 +414,7 @@ extern "C" napi_status napi_set_property(napi_env env, napi_value target,
     JSValue targetValue = toJS(target);
 
     auto globalObject = toJS(env);
-    auto* object = targetValue.toObject(globalObject);
-    NAPI_RETURN_IF_EXCEPTION(env);
+    NAPI_CHECK_TO_OBJECT(env, globalObject, object, targetValue);
 
     auto keyProp = toJS(key);
 
@@ -476,8 +475,7 @@ extern "C" napi_status napi_has_property(napi_env env, napi_value object,
     NAPI_CHECK_ARG(env, key);
 
     auto globalObject = toJS(env);
-    auto* target = toJS(object).toObject(globalObject);
-    NAPI_RETURN_IF_EXCEPTION(env);
+    NAPI_CHECK_TO_OBJECT(env, globalObject, target, toJS(object));
 
     auto keyProp = toJS(key);
     JSC::PropertyName name = keyProp.toPropertyKey(globalObject);
@@ -514,8 +512,7 @@ extern "C" napi_status napi_get_property(napi_env env, napi_value object,
 
     auto globalObject = toJS(env);
 
-    auto* target = toJS(object).toObject(globalObject);
-    NAPI_RETURN_IF_EXCEPTION(env);
+    NAPI_CHECK_TO_OBJECT(env, globalObject, target, toJS(object));
     JSC::EnsureStillAliveScope ensureAlive(target);
 
     auto keyProp = toJS(key);
@@ -551,8 +548,7 @@ extern "C" napi_status napi_delete_property(napi_env env, napi_value object,
 
     auto globalObject = toJS(env);
 
-    auto* target = toJS(object).toObject(globalObject);
-    NAPI_RETURN_IF_EXCEPTION(env);
+    NAPI_CHECK_TO_OBJECT(env, globalObject, target, toJS(object));
 
     auto keyProp = toJS(key);
     auto name = JSC::PropertyName(keyProp.toPropertyKey(globalObject));
@@ -579,8 +575,7 @@ extern "C" napi_status napi_has_own_property(napi_env env, napi_value object,
 
     auto globalObject = toJS(env);
 
-    auto* target = toJS(object).toObject(globalObject);
-    NAPI_RETURN_IF_EXCEPTION(env);
+    NAPI_CHECK_TO_OBJECT(env, globalObject, target, toJS(object));
 
     JSValue keyProp = toJS(key);
     NAPI_RETURN_EARLY_IF_FALSE(env, keyProp.isString() || keyProp.isSymbol(), napi_name_expected);
@@ -622,8 +617,7 @@ extern "C" napi_status napi_set_named_property(napi_env env, napi_value object,
 
     auto globalObject = toJS(env);
     auto& vm = JSC::getVM(globalObject);
-    auto target = toJS(object).toObject(globalObject);
-    NAPI_RETURN_IF_EXCEPTION(env);
+    NAPI_CHECK_TO_OBJECT(env, globalObject, target, toJS(object));
 
     JSValue jsValue = toJS(value);
     JSC::EnsureStillAliveScope ensureAlive(jsValue);
@@ -699,8 +693,7 @@ extern "C" napi_status napi_has_named_property(napi_env env, napi_value object,
     auto globalObject = toJS(env);
     auto& vm = JSC::getVM(globalObject);
 
-    JSObject* target = toJS(object).toObject(globalObject);
-    NAPI_RETURN_IF_EXCEPTION(env);
+    NAPI_CHECK_TO_OBJECT(env, globalObject, target, toJS(object));
 
     JSC::Identifier propertyName = identifierFromUtf8(vm, utf8Name);
 
@@ -720,8 +713,7 @@ extern "C" napi_status napi_get_named_property(napi_env env, napi_value object,
     auto globalObject = toJS(env);
     auto& vm = JSC::getVM(globalObject);
 
-    JSObject* target = toJS(object).toObject(globalObject);
-    NAPI_RETURN_IF_EXCEPTION(env);
+    NAPI_CHECK_TO_OBJECT(env, globalObject, target, toJS(object));
 
     JSC::Identifier propertyName = identifierFromUtf8(vm, utf8Name);
 

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1941,6 +1941,7 @@ extern "C" napi_status napi_get_all_property_names(
             if (auto* impl = keyStr->impl()) {
                 if (auto index = parseIndex(*impl)) {
                     exportKeys->putDirectIndex(globalObject, i, jsNumber(*index));
+                    NAPI_RETURN_IF_EXCEPTION(env);
                 }
             }
         }

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -127,9 +127,9 @@ using namespace Zig;
 // Node's CHECK_TO_OBJECT: ToObject coerces primitives and throws on
 // null/undefined; on failure the TypeError is left pending and the call
 // returns napi_object_expected. Declares `_result` in the enclosing scope.
-#define NAPI_CHECK_TO_OBJECT(_env, _globalObject, _result, _src)      \
-    JSObject* _result = (_src).toObject((_globalObject));             \
-    RETURN_IF_EXCEPTION(napi_preamble_throw_scope__,                  \
+#define NAPI_CHECK_TO_OBJECT(_env, _globalObject, _result, _src) \
+    JSObject* _result = (_src).toObject((_globalObject));        \
+    RETURN_IF_EXCEPTION(napi_preamble_throw_scope__,             \
         napi_set_last_error((_env), napi_object_expected))
 
 // Return an error code if an exception was thrown after NAPI_PREAMBLE

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1855,16 +1855,17 @@ extern "C" napi_status napi_get_all_property_names(
     NAPI_PREAMBLE(env);
     NAPI_CHECK_ARG(env, result);
     NAPI_CHECK_ARG(env, objectNapi);
+
+    auto globalObject = toJS(env);
+    auto objectValue = toJS(objectNapi);
+    NAPI_CHECK_TO_OBJECT(env, globalObject, object, objectValue);
+
     NAPI_RETURN_EARLY_IF_FALSE(env,
         key_mode == napi_key_include_prototypes || key_mode == napi_key_own_only,
         napi_invalid_arg);
     NAPI_RETURN_EARLY_IF_FALSE(env,
         key_conversion == napi_key_keep_numbers || key_conversion == napi_key_numbers_to_strings,
         napi_invalid_arg);
-
-    auto globalObject = toJS(env);
-    auto objectValue = toJS(objectNapi);
-    NAPI_CHECK_TO_OBJECT(env, globalObject, object, objectValue);
 
     // Always request non-enumerable properties from JSC; whether to exclude them is decided by
     // key_filter (napi_key_enumerable) in the filter loop below. JSC only supports Exclude when
@@ -3134,6 +3135,11 @@ extern "C" bool NapiEnv__getAndClearPendingException(napi_env env, JSC::EncodedJ
     }
 
     return false;
+}
+
+extern "C" bool NapiEnv__hasPendingException(napi_env env)
+{
+    return env->hasPendingException();
 }
 
 extern "C" void NapiEnv__ref(napi_env env)

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -70,6 +70,7 @@ bun_opaque::opaque_ffi! {
 unsafe extern "C" {
     fn NapiEnv__globalObject(env: *mut NapiEnv) -> *mut JSGlobalObject;
     fn NapiEnv__getAndClearPendingException(env: *mut NapiEnv, out: *mut JSValue) -> bool;
+    fn NapiEnv__hasPendingException(env: *mut NapiEnv) -> bool;
     fn napi_internal_get_version(env: *mut NapiEnv) -> u32;
     fn NapiEnv__deref(env: *mut NapiEnv);
     fn NapiEnv__ref(env: *mut NapiEnv);
@@ -119,6 +120,11 @@ impl NapiEnv {
     pub fn get_version(&self) -> u32 {
         // SAFETY: env is non-null; C++ side is read-only here.
         unsafe { napi_internal_get_version(self.as_mut_ptr()) }
+    }
+
+    pub fn has_pending_exception(&self) -> bool {
+        // SAFETY: interior mutability via `as_mut_ptr`; the C++ side is read-only.
+        unsafe { NapiEnv__hasPendingException(self.as_mut_ptr()) }
     }
 
     pub fn get_and_clear_pending_exception(&self) -> Option<JSValue> {
@@ -872,6 +878,13 @@ pub(super) extern "C" fn napi_get_prototype(
     let object = object_.get();
     if object.is_empty() {
         return env.invalid_arg();
+    }
+    // Node's NAPI_PREAMBLE bails with napi_pending_exception before
+    // CHECK_TO_OBJECT when an exception from napi_throw is already stashed on
+    // the env. Mirror that so ToObject on null/undefined below does not push a
+    // fresh VM TypeError that would shadow the addon's original exception.
+    if env.has_pending_exception() {
+        return NapiEnv::set_last_error(Some(env), NapiStatus::pending_exception);
     }
     // Node's CHECK_TO_OBJECT: ToObject throws on null/undefined; leave the
     // TypeError pending and return napi_object_expected. Other primitives are

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -873,7 +873,12 @@ pub(super) extern "C" fn napi_get_prototype(
     if object.is_empty() {
         return env.invalid_arg();
     }
-    if !object.is_object() {
+    // Node's CHECK_TO_OBJECT: ToObject throws on null/undefined; leave the
+    // TypeError pending and return napi_object_expected. Other primitives are
+    // coerced, so `get_prototype` (which synthesizes the prototype for
+    // non-object values) handles them without an allocation.
+    if object.is_undefined_or_null() {
+        let _ = object.to_object(env.to_js());
         return NapiEnv::set_last_error(Some(env), NapiStatus::object_expected);
     }
 

--- a/test/napi/napi-app/js_test_helpers.cpp
+++ b/test/napi/napi-app/js_test_helpers.cpp
@@ -303,22 +303,6 @@ static napi_value get_property_names(const Napi::CallbackInfo &info) {
   return result;
 }
 
-// get_all_property_names(object, key_mode, key_filter, key_conversion) -> array
-static napi_value get_all_property_names(const Napi::CallbackInfo &info) {
-  napi_env env = info.Env();
-  uint32_t key_mode, key_filter, key_conversion;
-  NODE_API_CALL(env, napi_get_value_uint32(env, info[1], &key_mode));
-  NODE_API_CALL(env, napi_get_value_uint32(env, info[2], &key_filter));
-  NODE_API_CALL(env, napi_get_value_uint32(env, info[3], &key_conversion));
-  napi_value result;
-  NODE_API_CALL(env,
-                napi_get_all_property_names(
-                    env, info[0], (napi_key_collection_mode)key_mode,
-                    (napi_key_filter)key_filter,
-                    (napi_key_conversion)key_conversion, &result));
-  return result;
-}
-
 // add_tag(object, lower, upper)
 static napi_value add_tag(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
@@ -512,7 +496,6 @@ void register_js_test_helpers(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, make_empty_array);
   REGISTER_FUNCTION(env, exports, make_empty_object);
   REGISTER_FUNCTION(env, exports, get_property_names);
-  REGISTER_FUNCTION(env, exports, get_all_property_names);
   REGISTER_FUNCTION(env, exports, add_tag);
   REGISTER_FUNCTION(env, exports, try_add_tag);
   REGISTER_FUNCTION(env, exports, check_tag);

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -266,7 +266,7 @@ nativeTests.test_property_names_cache_poisoning = () => {
   console.log("Reflect.ownKeys after get_all_property_names(own_only):", Reflect.ownKeys(mkD()).join(","));
 
   // The napi result itself should still include inherited keys.
-  const apnResult = nativeTests.get_all_property_names(mkA(), 0, 0, 0);
+  const apnResult = nativeTests.get_all_property_names(mkA(), 0, 0, 0).keys;
   console.log("napi include_prototypes result has own a,b:", apnResult.includes("a") && apnResult.includes("b"));
   console.log("napi include_prototypes result has inherited toString:", apnResult.includes("toString"));
   const gpnResult = nativeTests.get_property_names(mkB());

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -1836,6 +1836,164 @@ test_napi_freeze_seal_indexed(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+// Prints "<label>: status=<n> pending=<0|1>" and clears any pending exception
+// so the next call starts clean.
+static void report_status(napi_env env, const char *label, napi_status status) {
+  bool pending = false;
+  napi_is_exception_pending(env, &pending);
+  printf("%s: status=%d pending=%d\n", label, (int)status, pending ? 1 : 0);
+  if (pending) {
+    napi_value exc;
+    napi_get_and_clear_last_exception(env, &exc);
+  }
+}
+
+// Verifies that the element / property-name / prototype N-API family follows
+// Node's CHECK_TO_OBJECT semantics: primitives are coerced via ToObject and
+// succeed, null/undefined fail with napi_object_expected and a pending
+// TypeError, napi_get_all_property_names validates its enum arguments, and
+// napi_key_keep_numbers yields numeric (not string) index keys.
+static napi_value test_napi_object_coercion(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+#ifndef _WIN32
+  BlockingStdoutScope blocking_stdout;
+#endif
+
+  napi_value v_null, v_undef, v_num, v_str, v_true, v_one, out;
+  bool bresult;
+  NODE_API_CALL(env, napi_get_null(env, &v_null));
+  NODE_API_CALL(env, napi_get_undefined(env, &v_undef));
+  NODE_API_CALL(env, napi_create_double(env, 42.5, &v_num));
+  NODE_API_CALL(env,
+                napi_create_string_utf8(env, "abc", NAPI_AUTO_LENGTH, &v_str));
+  NODE_API_CALL(env, napi_get_boolean(env, true, &v_true));
+  NODE_API_CALL(env, napi_create_int32(env, 1, &v_one));
+
+  // napi_set_element
+  report_status(env, "set_element(number)",
+                napi_set_element(env, v_num, 0, v_one));
+  report_status(env, "set_element(string)",
+                napi_set_element(env, v_str, 0, v_one));
+  report_status(env, "set_element(null)",
+                napi_set_element(env, v_null, 0, v_one));
+  report_status(env, "set_element(undefined)",
+                napi_set_element(env, v_undef, 0, v_one));
+
+  // napi_has_element
+  report_status(env, "has_element(string)",
+                napi_has_element(env, v_str, 1, &bresult));
+  report_status(env, "has_element(null)",
+                napi_has_element(env, v_null, 0, &bresult));
+
+  // napi_get_element
+  {
+    napi_value r = nullptr;
+    napi_status s = napi_get_element(env, v_str, 1, &r);
+    report_status(env, "get_element(string,1)", s);
+    if (s == napi_ok) {
+      char buf[8] = {0};
+      size_t len = 0;
+      if (napi_get_value_string_utf8(env, r, buf, sizeof(buf), &len) ==
+          napi_ok) {
+        printf("get_element(string,1) value=%s\n", buf);
+      }
+    }
+  }
+  report_status(env, "get_element(number)",
+                napi_get_element(env, v_num, 0, &out));
+  report_status(env, "get_element(null)",
+                napi_get_element(env, v_null, 0, &out));
+  report_status(env, "get_element(undefined)",
+                napi_get_element(env, v_undef, 0, &out));
+
+  // napi_delete_element
+  report_status(env, "delete_element(number)",
+                napi_delete_element(env, v_num, 0, &bresult));
+  report_status(env, "delete_element(null)",
+                napi_delete_element(env, v_null, 0, &bresult));
+
+  // napi_get_property_names
+  report_status(env, "get_property_names(string)",
+                napi_get_property_names(env, v_str, &out));
+  report_status(env, "get_property_names(number)",
+                napi_get_property_names(env, v_num, &out));
+  report_status(env, "get_property_names(null)",
+                napi_get_property_names(env, v_null, &out));
+
+  // napi_get_prototype
+  {
+    napi_value r = nullptr;
+    napi_status s = napi_get_prototype(env, v_num, &r);
+    report_status(env, "get_prototype(number)", s);
+    if (s == napi_ok) {
+      napi_value number_ctor, number_proto;
+      NODE_API_CALL(env, napi_get_global(env, &out));
+      NODE_API_CALL(env,
+                    napi_get_named_property(env, out, "Number", &number_ctor));
+      NODE_API_CALL(env, napi_get_named_property(env, number_ctor, "prototype",
+                                                 &number_proto));
+      bool eq = false;
+      NODE_API_CALL(env, napi_strict_equals(env, r, number_proto, &eq));
+      printf("get_prototype(number) is Number.prototype=%d\n", eq ? 1 : 0);
+    }
+  }
+  report_status(env, "get_prototype(string)",
+                napi_get_prototype(env, v_str, &out));
+  report_status(env, "get_prototype(bool)",
+                napi_get_prototype(env, v_true, &out));
+  report_status(env, "get_prototype(null)",
+                napi_get_prototype(env, v_null, &out));
+  report_status(env, "get_prototype(undefined)",
+                napi_get_prototype(env, v_undef, &out));
+
+  // napi_get_all_property_names enum validation
+  napi_value obj;
+  NODE_API_CALL(env, napi_create_object(env, &obj));
+  report_status(env, "get_all_property_names(key_mode=99)",
+                napi_get_all_property_names(
+                    env, obj, static_cast<napi_key_collection_mode>(99),
+                    napi_key_all_properties, napi_key_numbers_to_strings,
+                    &out));
+  report_status(
+      env, "get_all_property_names(key_conversion=99)",
+      napi_get_all_property_names(env, obj, napi_key_own_only,
+                                  napi_key_all_properties,
+                                  static_cast<napi_key_conversion>(99), &out));
+  report_status(env, "get_all_property_names(string)",
+                napi_get_all_property_names(
+                    env, v_str, napi_key_own_only, napi_key_all_properties,
+                    napi_key_numbers_to_strings, &out));
+  report_status(env, "get_all_property_names(null)",
+                napi_get_all_property_names(
+                    env, v_null, napi_key_own_only, napi_key_all_properties,
+                    napi_key_numbers_to_strings, &out));
+
+  // napi_key_keep_numbers vs napi_key_numbers_to_strings
+  {
+    napi_value arr;
+    NODE_API_CALL(env, napi_create_array_with_length(env, 1, &arr));
+    NODE_API_CALL(env, napi_set_element(env, arr, 0, v_one));
+
+    napi_value keys;
+    NODE_API_CALL(env, napi_get_all_property_names(
+                           env, arr, napi_key_own_only, napi_key_skip_symbols,
+                           napi_key_keep_numbers, &keys));
+    napi_value key0;
+    NODE_API_CALL(env, napi_get_element(env, keys, 0, &key0));
+    printf("keep_numbers key0 typeof=%s\n",
+           napi_valuetype_to_string(get_typeof(env, key0)));
+
+    NODE_API_CALL(env, napi_get_all_property_names(
+                           env, arr, napi_key_own_only, napi_key_skip_symbols,
+                           napi_key_numbers_to_strings, &keys));
+    NODE_API_CALL(env, napi_get_element(env, keys, 0, &key0));
+    printf("numbers_to_strings key0 typeof=%s\n",
+           napi_valuetype_to_string(get_typeof(env, key0)));
+  }
+
+  return ok(env);
+}
+
 // Test for napi_create_external_buffer with empty/null data
 static void empty_buffer_finalizer(napi_env env, void *data, void *hint) {
   // No-op finalizer for empty buffers
@@ -2716,6 +2874,7 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_napi_dataview_bounds_errors);
   REGISTER_FUNCTION(env, exports, test_napi_typeof_empty_value);
   REGISTER_FUNCTION(env, exports, test_napi_freeze_seal_indexed);
+  REGISTER_FUNCTION(env, exports, test_napi_object_coercion);
   REGISTER_FUNCTION(env, exports, test_napi_create_external_buffer_empty);
   REGISTER_FUNCTION(env, exports, test_napi_empty_buffer_info);
   REGISTER_FUNCTION(env, exports, napi_get_typeof);

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -1990,6 +1990,11 @@ static napi_value test_napi_object_coercion(const Napi::CallbackInfo &info) {
                 napi_get_all_property_names(
                     env, v_null, napi_key_own_only, napi_key_all_properties,
                     napi_key_numbers_to_strings, &out));
+  report_status(env, "get_all_property_names(null,key_mode=99)",
+                napi_get_all_property_names(
+                    env, v_null, static_cast<napi_key_collection_mode>(99),
+                    napi_key_all_properties, napi_key_numbers_to_strings,
+                    &out));
 
   // napi_key_keep_numbers vs napi_key_numbers_to_strings
   {

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -1911,6 +1911,17 @@ static napi_value test_napi_object_coercion(const Napi::CallbackInfo &info) {
                 napi_delete_element(env, v_num, 0, &bresult));
   report_status(env, "delete_element(null)",
                 napi_delete_element(env, v_null, 0, &bresult));
+  {
+    // result may be NULL; the delete must still happen.
+    napi_value arr;
+    NODE_API_CALL(env, napi_create_array_with_length(env, 1, &arr));
+    NODE_API_CALL(env, napi_set_element(env, arr, 0, v_one));
+    report_status(env, "delete_element(array,result=NULL)",
+                  napi_delete_element(env, arr, 0, nullptr));
+    bool has = true;
+    NODE_API_CALL(env, napi_has_element(env, arr, 0, &has));
+    printf("delete_element(array,result=NULL) has[0]=%d\n", has ? 1 : 0);
+  }
 
   // napi_get_property_names
   report_status(env, "get_property_names(string)",

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -1946,6 +1946,29 @@ static napi_value test_napi_object_coercion(const Napi::CallbackInfo &info) {
   report_status(env, "get_prototype(undefined)",
                 napi_get_prototype(env, v_undef, &out));
 
+  // by-key property siblings: also route through CHECK_TO_OBJECT in Node
+  {
+    napi_value key;
+    NODE_API_CALL(env,
+                  napi_create_string_utf8(env, "k", NAPI_AUTO_LENGTH, &key));
+    report_status(env, "set_property(null)",
+                  napi_set_property(env, v_null, key, v_one));
+    report_status(env, "get_property(null)",
+                  napi_get_property(env, v_null, key, &out));
+    report_status(env, "has_property(null)",
+                  napi_has_property(env, v_null, key, &bresult));
+    report_status(env, "delete_property(null)",
+                  napi_delete_property(env, v_null, key, &bresult));
+    report_status(env, "has_own_property(null)",
+                  napi_has_own_property(env, v_null, key, &bresult));
+    report_status(env, "set_named_property(null)",
+                  napi_set_named_property(env, v_null, "k", v_one));
+    report_status(env, "get_named_property(null)",
+                  napi_get_named_property(env, v_null, "k", &out));
+    report_status(env, "has_named_property(null)",
+                  napi_has_named_property(env, v_null, "k", &bresult));
+  }
+
   // napi_get_all_property_names enum validation
   napi_value obj;
   NODE_API_CALL(env, napi_create_object(env, &obj));

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -1293,6 +1293,30 @@ describe.skipIf(!canBuildNodeAddons())("cleanup hooks", () => {
     });
   });
 
+  describe("object API ToObject coercion", () => {
+    // The element/property-name/prototype family must coerce primitive targets
+    // via ToObject (succeeding for strings/numbers/booleans) and return
+    // napi_object_expected with a pending TypeError for null/undefined.
+    // napi_get_all_property_names must reject out-of-range enum arguments and
+    // honor napi_key_keep_numbers so index keys come back as numbers.
+    it("matches Node's CHECK_TO_OBJECT semantics and validates enums", async () => {
+      const output = await checkSameOutput("test_napi_object_coercion", []);
+      // Spot-check the lines that carry the most signal; checkSameOutput has
+      // already asserted full byte-for-byte parity with Node.
+      expect(output).toContain("set_element(number): status=0 pending=0");
+      expect(output).toContain("set_element(null): status=2 pending=1");
+      expect(output).toContain("get_element(string,1): status=0 pending=0");
+      expect(output).toContain("get_element(string,1) value=b");
+      expect(output).toContain("get_prototype(number): status=0 pending=0");
+      expect(output).toContain("get_prototype(number) is Number.prototype=1");
+      expect(output).toContain("get_prototype(null): status=2 pending=1");
+      expect(output).toContain("get_all_property_names(key_mode=99): status=1 pending=0");
+      expect(output).toContain("get_all_property_names(key_conversion=99): status=1 pending=0");
+      expect(output).toContain("keep_numbers key0 typeof=number");
+      expect(output).toContain("numbers_to_strings key0 typeof=string");
+    });
+  });
+
   describe("napi_object_freeze and napi_object_seal", () => {
     it("should handle arrays with indexed properties", async () => {
       const output = await checkSameOutput("test_napi_freeze_seal_indexed", []);


### PR DESCRIPTION
## What does this PR do?

The N-API object-operating family diverged from Node's `CHECK_TO_OBJECT` contract across two groups of entry points.

**Group 1 (element / property-name / prototype):** `napi_set_element`, `napi_has_element`, `napi_get_element`, `napi_delete_element`, `napi_get_property_names`, `napi_get_all_property_names`, `napi_get_prototype`. These called `getObject()` / `is_object()` and rejected every primitive with `napi_array_expected` or `napi_object_expected` and **no** pending exception.

**Group 2 (by-key property siblings):** `napi_set_property`, `napi_get_property`, `napi_has_property`, `napi_delete_property`, `napi_has_own_property`, `napi_set_named_property`, `napi_get_named_property`, `napi_has_named_property`. These already coerced primitives via `toObject` but returned `napi_pending_exception` (10) instead of Node's `napi_object_expected` (2) on `null`/`undefined`.

```c
// per call: bun status vs node status
napi_set_element(env, num42_5, 0, v);        // bun 8, no exc  | node 0 (coerced no-op)
napi_set_element(env, jsnull, 0, v);         // bun 8, NO exc  | node 2 + pending TypeError
napi_get_element(env, str_abc, 1, &r);       // bun 2          | node 0, r = "b"
napi_get_property_names(env, str_abc, &r);   // bun 2          | node 0 (index keys)
napi_get_prototype(env, num42_5, &r);        // bun 2          | node 0 (Number.prototype)
napi_get_property(env, jsnull, key, &r);     // bun 10         | node 2 + pending TypeError
napi_get_all_property_names(env, o, /*key_mode*/99, f, c, &r);       // bun 0 | node 1
napi_get_all_property_names(env, o, m, f, /*key_conversion*/99, &r); // bun 0 | node 1
// napi_key_keep_numbers on ["x"]-style index keys:
//   key0 typeof -> bun string | node number
```

Portable addons feature-detect against these status codes, and `napi_array_expected` is a status Node uses only for `napi_get_array_length`.

### Cause

Node runs `ToObject(context)` (its `CHECK_TO_OBJECT` macro, [js_native_api_v8.cc](https://github.com/nodejs/node/blob/main/src/js_native_api_v8.cc)) on the target in every one of these entry points, which coerces strings/numbers/booleans/symbols to their wrapper object and only throws on `null`/`undefined`; when it throws, the status is `napi_object_expected` and the `TypeError` is left pending.

`napi_get_all_property_names` additionally never validated its `key_mode` / `key_conversion` enum arguments (Node rejects out-of-range values with `napi_invalid_arg`) and never read `key_conversion` at all, so `napi_key_keep_numbers` still returned array-index keys as `JSString`s.

### Fix

- Add a `NAPI_CHECK_TO_OBJECT(env, globalObject, result, src)` macro that mirrors Node's semantics: `JSValue::toObject()` to coerce primitives, and on exception return `napi_object_expected` with the `TypeError` still pending. Apply it at all fourteen C++ sites above.
- `napi_get_prototype` (Rust): replace the `is_object()` gate with an `is_undefined_or_null()` gate that throws the `TypeError` via `to_object()` and returns `napi_object_expected`; other primitives fall through to `JSValue::getPrototype()`, which already synthesizes the correct prototype ([`synthesizePrototype`](https://github.com/oven-sh/bun/blob/main/vendor/WebKit/Source/JavaScriptCore/runtime/JSCJSValue.cpp#L188)) without allocating a wrapper.
- `napi_get_all_property_names`: validate `key_mode` and `key_conversion`; when `key_conversion == napi_key_keep_numbers`, walk the result array and replace canonical array-index strings with `jsNumber` values (JSC's `ownPropertyKeys`/`allPropertyKeys` always emit string keys).
- `napi_delete_element` now performs the delete even when `result == NULL`, matching Node (previously the delete itself was skipped).

### Verification

`test/napi/napi-app/standalone_tests.cpp` gains `test_napi_object_coercion`, which prints `status` / `pending` for every call above plus the `key_conversion` typeof check. The `napi.test.ts` case runs it through `checkSameOutput`, so Bun's output is asserted byte-for-byte against Node's, and additionally spot-checks the high-signal lines so the assertion fails under `USE_SYSTEM_BUN=1` even if the Node comparison happened to produce matching (wrong) output.

<details>
<summary>Before / after</summary>

```
# system bun (before)               # this PR == node v26.3.0
set_element(number): status=8       set_element(number): status=0 pending=0
set_element(null): status=8         set_element(null): status=2 pending=1
get_element(string,1): status=2     get_element(string,1): status=0 pending=0
                                    get_element(string,1) value=b
get_prototype(number): status=2     get_prototype(number): status=0 pending=0
                                    get_prototype(number) is Number.prototype=1
get_prototype(null): status=2       get_prototype(null): status=2 pending=1
get_property(null): status=10       get_property(null): status=2 pending=1
get_all_property_names(key_mode=99): status=0    ... status=1 pending=0
keep_numbers key0 typeof=string     keep_numbers key0 typeof=number
```
</details>

Node's upstream `js-native-api/test_object`, `test_array`, and `test_properties` suites continue to pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->