### PR TITLE
napi: wait for napi_remove_async_cleanup_hook before tearing down the env

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -3352,6 +3352,13 @@ extern "C" JS_EXPORT napi_status napi_remove_async_cleanup_hook(napi_async_clean
     }
 
     napi_env env = handle->env;
+
+    if (handle->started.load(std::memory_order_acquire)) {
+        // Completion signal, possibly from another thread: no NAPI_PREAMBLE.
+        env->asyncCleanupHookCompleted(handle);
+        return napi_ok;
+    }
+
     NAPI_PREAMBLE_NO_PENDING_CHECK(env);
 
     // Always attempt removal like Node.js (no VM terminating check)

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -20,12 +20,15 @@
 #include <wtf/HashSet.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/Lock.h>
+#include <wtf/Threading.h>
 
+#include <atomic>
 #include <optional>
 #include <unordered_set>
 #include <variant>
 
 extern "C" void napi_internal_register_cleanup_zig(napi_env env);
+extern "C" void napi_internal_tick_platform_loop(napi_env env);
 extern "C" void napi_internal_threadsafe_function_env_teardown(void* tsfn);
 extern "C" void napi_internal_suppress_crash_on_abort_if_desired();
 extern "C" void Bun__crashHandler(const char* message, size_t message_len);
@@ -124,6 +127,8 @@ napi_status defineProperty(napi_env env, JSC::JSObject* to, const napi_property_
 // itself has already run (that call is how it signals completion).
 struct napi_async_cleanup_hook_handle__ {
     napi_env env;
+    // Set by drain(); afterwards napi_remove_async_cleanup_hook (any thread) is the completion signal.
+    std::atomic<bool> started { false };
 
     explicit napi_async_cleanup_hook_handle__(napi_env env)
         : env(env)
@@ -216,6 +221,7 @@ public:
         while (!m_cleanupHooks.empty()) {
             drain();
         }
+        waitForAsyncCleanupHooks();
         // erase() above leaves the bucket array allocated; release it here
         // since ~NapiEnv may not run before process exit (late finalizers can
         // hold the last Ref past GlobalObject teardown).
@@ -385,6 +391,14 @@ public:
         // Freed unconditionally, matching Node: for an already-drained hook
         // this call is the addon's completion signal.
         delete handle;
+    }
+
+    // Any thread. `this` is alive: the JS thread is parked in waitForAsyncCleanupHooks() until the counter hits zero.
+    void asyncCleanupHookCompleted(napi_async_cleanup_hook_handle handle)
+    {
+        delete handle;
+        size_t prev = m_pendingAsyncCleanupHooks.fetch_sub(1, std::memory_order_acq_rel);
+        ASSERT_UNUSED(prev, prev > 0);
     }
 
     bool inGC() const
@@ -592,6 +606,7 @@ private:
     Napi::HookSet m_cleanupHooks;
     JSC::Strong<JSC::Unknown> m_pendingException;
     size_t m_cleanupHookCounter = 0;
+    std::atomic<size_t> m_pendingAsyncCleanupHooks { 0 };
 
     WTF::Lock m_threadSafeFunctionsLock;
     WTF::HashSet<void*> m_threadSafeFunctions WTF_GUARDED_BY_LOCK(m_threadSafeFunctionsLock);
@@ -632,13 +647,23 @@ private:
             } else {
                 auto& async = std::get<Napi::AsyncCleanupHook>(hook);
                 ASSERT(async.function != nullptr);
-                // The addon owns the handle and frees it via
-                // napi_remove_async_cleanup_hook, possibly after this returns (#37201).
+                // Node's RunAsyncCleanupHook; the addon frees the handle via napi_remove_async_cleanup_hook (#37201).
+                m_pendingAsyncCleanupHooks.fetch_add(1, std::memory_order_acq_rel);
+                async.handle->started.store(true, std::memory_order_release);
                 async.function(async.handle, async.data);
             }
             // Same invariant as the finalizer loop in cleanup(): a hook
             // that leaked an exception must not poison the next hook.
             clearExceptionsBetweenFinalizers();
+        }
+    }
+
+    // Node's CleanupHandles. Must run after abortThreadSafeFunctions(): a tsfn finalizer may be the completer (#37201).
+    void waitForAsyncCleanupHooks()
+    {
+        while (m_pendingAsyncCleanupHooks.load(std::memory_order_acquire) > 0) {
+            napi_internal_tick_platform_loop(this);
+            WTF::Thread::yield();
         }
     }
 };

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2361,6 +2361,19 @@ extern "C" fn napi_internal_register_cleanup_zig(env_: napi_env) {
     );
 }
 
+/// One non-blocking poll of the platform loop, for `NapiEnv::waitForAsyncCleanupHooks`.
+#[unsafe(no_mangle)]
+extern "C" fn napi_internal_tick_platform_loop(env_: napi_env) {
+    // SAFETY: caller (NapiEnv::waitForAsyncCleanupHooks) guarantees env_ is
+    // non-null and we are on the env's JS thread.
+    let env = unsafe { &*env_ };
+    let loop_ = env.to_js().bun_vm().event_loop_ref().usockets_loop();
+    // SAFETY: `usockets_loop` returns the live per-VM loop (it panics rather
+    // than returning null); JS thread only, and no other `&mut` to the loop is
+    // live because the caller is parked in env teardown, outside any tick.
+    unsafe { (*loop_).tick_without_idle() };
+}
+
 #[unsafe(no_mangle)]
 extern "C" fn napi_internal_suppress_crash_on_abort_if_desired() {
     if bun_core::env_var::feature_flag::BUN_INTERNAL_SUPPRESS_CRASH_ON_NAPI_ABORT

--- a/test/napi/napi-app/binding.gyp
+++ b/test/napi/napi-app/binding.gyp
@@ -176,6 +176,17 @@
             ],
         },
         {
+            "target_name": "test_async_cleanup_hook_deferred",
+            "sources": ["test_async_cleanup_hook_deferred.c"],
+            "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],
+            "libraries": [],
+            "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
+            "defines": [
+                "NAPI_DISABLE_CPP_EXCEPTIONS",
+                "NODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT=1",
+            ],
+        },
+        {
             "target_name": "test_cleanup_hook_duplicates",
             "sources": ["test_cleanup_hook_duplicates.c"],
             "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -1431,6 +1431,11 @@ nativeTests.test_async_cleanup_hook_tsfn_release = () => {
   addon.start();
 };
 
+nativeTests.test_async_cleanup_hook_deferred = (_gc, mode) => {
+  const addon = require("./build/Debug/test_async_cleanup_hook_deferred.node");
+  addon.arm(Number(mode));
+};
+
 nativeTests.test_cleanup_hook_duplicates = () => {
   const addon = require("./build/Debug/test_cleanup_hook_duplicates.node");
   addon.test();

--- a/test/napi/napi-app/test_async_cleanup_hook_deferred.c
+++ b/test/napi/napi-app/test_async_cleanup_hook_deferred.c
@@ -1,0 +1,112 @@
+#include <node_api.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <pthread.h>
+#include <unistd.h>
+#endif
+
+// Two modes driven by the `data` argument to arm():
+//   mode 0: hook synchronously calls napi_remove_async_cleanup_hook
+//   mode 1: hook spawns a thread that sleeps, then calls remove
+// arm() also installs an instance-data finalizer, which env teardown runs
+// after the cleanup hooks. A runtime that waits for the removal prints:
+//   hook-invoked, hook-completed, instance-data-finalized
+// One that does not prints instance-data-finalized right after hook-invoked
+// (and, at process exit, never prints hook-completed at all).
+
+struct ctx {
+    napi_async_cleanup_hook_handle handle;
+};
+
+static struct ctx g_ctx;
+
+static void complete(napi_async_cleanup_hook_handle handle) {
+    printf("hook-completed\n");
+    fflush(stdout);
+    napi_status status = napi_remove_async_cleanup_hook(handle);
+    if (status != napi_ok) {
+        printf("remove-failed:%d\n", (int)status);
+        fflush(stdout);
+    }
+}
+
+#ifdef _WIN32
+static DWORD WINAPI completer_thread(LPVOID p) {
+    Sleep(50);
+    complete(((struct ctx*)p)->handle);
+    return 0;
+}
+#else
+static void* completer_thread(void* p) {
+    usleep(50000);
+    complete(((struct ctx*)p)->handle);
+    return NULL;
+}
+#endif
+
+static void async_hook_sync(napi_async_cleanup_hook_handle handle, void* data) {
+    (void)data;
+    printf("hook-invoked\n");
+    fflush(stdout);
+    complete(handle);
+}
+
+static void async_hook_deferred(napi_async_cleanup_hook_handle handle, void* data) {
+    (void)data;
+    printf("hook-invoked\n");
+    fflush(stdout);
+    g_ctx.handle = handle;
+#ifdef _WIN32
+    HANDLE th = CreateThread(NULL, 0, completer_thread, &g_ctx, 0, NULL);
+    if (th) CloseHandle(th);
+#else
+    pthread_t th;
+    pthread_create(&th, NULL, completer_thread, &g_ctx);
+    pthread_detach(th);
+#endif
+}
+
+static void instance_data_finalizer(napi_env env, void* data, void* hint) {
+    (void)env;
+    (void)data;
+    (void)hint;
+    printf("instance-data-finalized\n");
+    fflush(stdout);
+}
+
+static napi_value arm(napi_env env, napi_callback_info info) {
+    size_t argc = 1;
+    napi_value argv[1];
+    napi_get_cb_info(env, info, &argc, argv, NULL, NULL);
+
+    int32_t mode = 0;
+    if (argc >= 1) {
+        napi_get_value_int32(env, argv[0], &mode);
+    }
+
+    napi_set_instance_data(env, &g_ctx, instance_data_finalizer, NULL);
+
+    napi_async_cleanup_hook_handle h = NULL;
+    napi_status status = napi_add_async_cleanup_hook(
+        env,
+        mode == 0 ? async_hook_sync : async_hook_deferred,
+        NULL,
+        &h);
+    printf("armed:%d status=%d\n", mode, (int)status);
+    fflush(stdout);
+    return NULL;
+}
+
+static napi_value Init(napi_env env, napi_value exports) {
+    napi_value fn;
+    napi_create_function(env, "arm", NAPI_AUTO_LENGTH, arm, NULL, &fn);
+    napi_set_named_property(env, exports, "arm", fn);
+    return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/napi/napi-app/test_cleanup_hook_mixed_order.c
+++ b/test/napi/napi-app/test_cleanup_hook_mixed_order.c
@@ -24,13 +24,13 @@ static void regular_hook2(void* arg) {
 static void async_hook1(napi_async_cleanup_hook_handle handle, void* arg) {
     async1_executed = execution_order++;
     printf("async_hook1 executed at position %d\n", async1_executed);
-    // Signal completion (this is required for async hooks)
+    napi_remove_async_cleanup_hook(handle);
 }
 
 static void async_hook2(napi_async_cleanup_hook_handle handle, void* arg) {
     async2_executed = execution_order++;
     printf("async_hook2 executed at position %d\n", async2_executed);
-    // Signal completion (this is required for async hooks)
+    napi_remove_async_cleanup_hook(handle);
 }
 
 napi_value test_function(napi_env env, napi_callback_info info) {

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -1912,6 +1912,67 @@ describe.skipIf(!canBuildNodeAddons())("cleanup hooks", () => {
     });
   });
 
+  describe("async cleanup hooks", () => {
+    const addonPath = join(__dirname, "napi-app/build/Debug/test_async_cleanup_hook_deferred.node");
+
+    // The addon's instance-data finalizer runs as part of env teardown, after
+    // the cleanup hooks, so "instance-data-finalized" marks the point where
+    // teardown moved past the hooks. With the wait it orders after
+    // "hook-completed"; without it, it prints straight after "hook-invoked".
+    it("waits for a hook that completes synchronously inside the callback", async () => {
+      const out = await checkSameOutput("test_async_cleanup_hook_deferred", [0]);
+      expect(out.split(/\r?\n/)).toEqual([
+        "armed:0 status=0",
+        "hook-invoked",
+        "hook-completed",
+        "instance-data-finalized",
+      ]);
+    });
+
+    it("blocks env teardown until a background thread calls napi_remove_async_cleanup_hook", async () => {
+      // The hook spawns a detached thread that sleeps, then calls
+      // napi_remove_async_cleanup_hook. Env teardown (and process exit) must
+      // not proceed until that call (Node.js: RunCleanup spins uv_run while
+      // request_waiting_ > 0). Not compared against Node: it also blocks, but
+      // releases its env ref from the foreign thread via a non-threadsafe
+      // SetImmediate and so drops the instance-data finalizer in this shape.
+      const out = (await runOn(bunExe(), "test_async_cleanup_hook_deferred", [1]))
+        .replaceAll(/^\[\w+\].+$/gm, "")
+        .trim();
+      expect(out.split(/\r?\n/)).toEqual([
+        "armed:1 status=0",
+        "hook-invoked",
+        "hook-completed",
+        "instance-data-finalized",
+      ]);
+    });
+
+    it("blocks a Worker's env teardown until a background thread calls napi_remove_async_cleanup_hook", async () => {
+      const code = `
+        const { Worker } = require("worker_threads");
+        const w = new Worker(
+          "require(" + JSON.stringify(${JSON.stringify(addonPath)}) + ").arm(1);",
+          { eval: true },
+        );
+        w.on("exit", () => { console.log("worker-exited"); });
+        w.on("error", err => { console.error("worker-error", err); process.exitCode = 1; });
+      `;
+      await using proc = spawn({
+        cmd: [bunExe(), "-e", code],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.split(/\r?\n/).filter(Boolean), stderr, exitCode }).toEqual({
+        stdout: ["armed:1 status=0", "hook-invoked", "hook-completed", "instance-data-finalized", "worker-exited"],
+        stderr: "",
+        exitCode: 0,
+      });
+      expect(proc.signalCode).toBeNull();
+    });
+  });
+
   describe("duplicate prevention", () => {
     it("should crash on duplicate hooks", async () => {
       await checkBothFail("test_cleanup_hook_duplicates", []);


### PR DESCRIPTION
### Problem
- `NapiEnv::cleanup()` (`src/jsc/bindings/napi.h`) invokes an async cleanup hook and moves on. It never waits for the addon to call `napi_remove_async_cleanup_hook`, which is the addon's completion signal. Work the hook hands to a background thread is lost at process exit. Node blocks until the call arrives.
- When the completer outlives a Worker env, it calls `napi_remove_async_cleanup_hook` into a dead env. Before #37204 this was also a `heap-use-after-free` on the handle in `NapiEnv::vm` (`napi_remove_async_cleanup_hook`, `napi.cpp`). #37204 fixed the handle lifetime. The wait was still missing.

### Fix
- `drain()` sets `handle->started` and increments `m_pendingAsyncCleanupHooks` before it calls each async hook. Once a hook has started, `napi_remove_async_cleanup_hook` takes a thread-safe path: it frees the handle and decrements the counter. It does not enter `NAPI_PREAMBLE`, which is not thread-safe.
- `cleanup()` waits for the counter to reach zero after `abortThreadSafeFunctions()` and the second `drain()` pass. The wait polls the platform loop (`tick_without_idle`) and yields. The wait must come after the tsfn pass: the #37201 addon completes its hook from a tsfn finalizer, and a wait placed before that pass would never return.
- Correct because the env, the handle, and the JS thread all stay alive until the addon signals completion, and finalizers (including instance data) run after that signal, which is the order Node produces.
- Verified: `test/napi/napi.test.ts` "async cleanup hooks" (3 tests, 2 fail on main) and the #37201 test. Also all of `-t "cleanup hook"` (29 pass).

### Background
- An async cleanup hook is the N-API hook an addon registers to flush state at env teardown. Unlike a sync hook, it may finish later. The addon reports "done" by calling `napi_remove_async_cleanup_hook` on the handle it received, from any thread.
- Node (`src/api/hooks.cc`, `src/env.cc`) bumps `request_waiting_` when it fires the hook and spins `uv_run` in `CleanupHandles` until the remove call brings it back to zero. This PR is the Bun equivalent of that counter and spin.
- `NapiEnv::cleanup()` runs on the env's JS thread at process exit or Worker exit. Its phases are: cleanup hooks, threadsafe function teardown, a second hook pass, finalizers, instance data finalizer.
- The test fixture installs an instance-data finalizer. Its line in stdout marks where teardown passed the hooks, so the order of `hook-completed` and `instance-data-finalized` proves the wait without any timing assumption.

<details><summary>Notes</summary>

Rebase on #37204: that PR removed `delete async.handle` from `drain()` and made `removeAsyncCleanupHook` free the handle unconditionally. This PR keeps that and adds the wait. The first version of this PR waited at the end of `drain()`. On the rebased tree that hangs the #37201 fixture, because its completion comes from a tsfn finalizer that `abortThreadSafeFunctions()` runs after `drain()` returns. The wait now sits after that pass.

The platform-loop poll goes through `EventLoop::usockets_loop()`, which is the uws loop on both platforms (it wraps libuv on Windows), so no change to `libuv_sys` is needed any more.

Poll and yield rather than a blocking wait: a completer that never touches the loop (this PR's fixture) would leave a blocking tick parked unless the remove path also carried a cross-thread loop wakeup, and a completer that signals via a uv handle still needs the loop pumped on this thread. Node's `CleanupHandles` has the same shape.

Node and the threaded fixture: Node also blocks for the threaded completer. It then releases its env ref from the foreign thread through a non-threadsafe `SetImmediate` and does not run the instance-data finalizer in that shape. Bun runs it on the JS thread after the wait. The threaded process-exit test therefore asserts Bun's output directly instead of through `checkSameOutput`. The sync test still compares against Node and matches line for line.

Fail-before on main (debug build), threaded and Worker tests: stdout is `hook-invoked`, `instance-data-finalized`, then `hook-completed` 50 ms later (or never, at process exit). The gap between `drain()` returning and the instance-data finalizer is a few calls on the same thread, so the order is stable.

`test_cleanup_hook_mixed_order.c` now calls `napi_remove_async_cleanup_hook` from its async hooks. Before, it never did, which violates the API contract and hangs under Node too. It is not wired to a test today.

Suites run: `test/napi/napi.test.ts -t "cleanup hook"` (29 pass), `test/napi/node-napi-tests/test/node-api/test_async_cleanup_hook/` (build passes, `test.js` is a pre-existing todo), `bun run rust:check-all` on the earlier revision, `cargo check -p bun_runtime` on this one.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->