### PR TITLE
napi: enforce the pending-exception gate in NAPI_PREAMBLE

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1477,7 +1477,7 @@ node_api_create_external_string_latin1(napi_env env,
     bool* copied)
 {
     // https://nodejs.org/api/n-api.html#node_api_create_external_string_latin1
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ARG(env, str);
     NAPI_CHECK_ARG(env, result);
 
@@ -1512,7 +1512,7 @@ node_api_create_external_string_utf16(napi_env env,
     bool* copied)
 {
     // https://nodejs.org/api/n-api.html#node_api_create_external_string_utf16
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ARG(env, str);
     NAPI_CHECK_ARG(env, result);
 
@@ -2615,7 +2615,7 @@ extern "C" napi_status napi_get_value_bigint_uint64(napi_env env, napi_value val
     // toBigInt64 can throw if the value is not a bigint. we have already checked, so we shouldn't
     // hit an exception here and it's okay to assert at the end
     *result = jsValue.toBigUInt64(toJS(env));
-    NAPI_RETURN_IF_EXCEPTION(env);
+    NAPI_RETURN_IF_VM_EXCEPTION(env);
 
     // bigint to uint64 conversion is lossless if and only if there aren't multiple digits and the
     // value is positive
@@ -2984,7 +2984,7 @@ extern "C" JS_EXPORT napi_status napi_add_async_cleanup_hook(napi_env env,
     napi_async_cleanup_hook function,
     void* data, napi_async_cleanup_hook_handle* handle_out)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     if (function) {
         napi_async_cleanup_hook_handle handle = env->addAsyncCleanupHook(function, data);
         if (handle_out) {
@@ -3019,7 +3019,7 @@ extern "C" JS_EXPORT napi_status napi_remove_async_cleanup_hook(napi_async_clean
     }
 
     napi_env env = handle->env;
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
 
     // Always attempt removal like Node.js (no VM terminating check)
     // Node.js has no such check in napi_remove_async_cleanup_hook

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -668,7 +668,7 @@ extern "C" napi_status napi_create_arraybuffer(napi_env env,
 
 extern "C" napi_status napi_is_buffer(napi_env env, napi_value value, bool* result)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ARG(env, value);
     NAPI_CHECK_ARG(env, result);
 
@@ -681,7 +681,7 @@ extern "C" napi_status napi_is_buffer(napi_env env, napi_value value, bool* resu
 
 extern "C" napi_status napi_is_typedarray(napi_env env, napi_value value, bool* result)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ARG(env, value);
     NAPI_CHECK_ARG(env, result);
 
@@ -1004,7 +1004,7 @@ extern "C" napi_status napi_get_cb_info(
     napi_value* this_arg, // [out] Receives the JS 'this' arg for the call
     void** data) // [out] Receives the data pointer for the callback
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ARG(env, cbinfo);
 
     auto* callFrame = reinterpret_cast<NAPICallFrame*>(cbinfo);
@@ -1134,7 +1134,7 @@ extern "C" napi_status napi_create_reference(napi_env env, napi_value value,
     uint32_t initial_refcount,
     napi_ref* result)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     NAPI_CHECK_ARG(env, result);
     NAPI_CHECK_ARG(env, value);
@@ -1172,7 +1172,7 @@ extern "C" napi_status napi_add_finalizer(napi_env env, napi_value js_object,
     void* finalize_hint,
     napi_ref* result)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     NAPI_CHECK_ARG(env, js_object);
     NAPI_CHECK_ARG(env, finalize_cb);
@@ -1206,7 +1206,7 @@ extern "C" JS_EXPORT napi_status node_api_post_finalizer(napi_env env,
     void* finalize_data,
     void* finalize_hint)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ARG(env, finalize_cb);
     napi_internal_enqueue_finalizer(env, finalize_cb, finalize_data, finalize_hint);
     NAPI_RETURN_SUCCESS(env);
@@ -1215,7 +1215,7 @@ extern "C" JS_EXPORT napi_status node_api_post_finalizer(napi_env env,
 extern "C" napi_status napi_reference_unref(napi_env env, napi_ref ref,
     uint32_t* result)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     NAPI_CHECK_ARG(env, ref);
 
@@ -1238,7 +1238,7 @@ extern "C" napi_status napi_reference_unref(napi_env env, napi_ref ref,
 extern "C" napi_status napi_get_reference_value(napi_env env, napi_ref ref,
     napi_value* result)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     NAPI_CHECK_ARG(env, ref);
     NAPI_CHECK_ARG(env, result);
@@ -1251,7 +1251,7 @@ extern "C" napi_status napi_get_reference_value(napi_env env, napi_ref ref,
 extern "C" napi_status napi_reference_ref(napi_env env, napi_ref ref,
     uint32_t* result)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     NAPI_CHECK_ARG(env, ref);
     NapiRef* napiRef = toJS(ref);
@@ -1284,7 +1284,7 @@ extern "C" napi_status napi_is_detached_arraybuffer(napi_env env,
     napi_value arraybuffer,
     bool* result)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     NAPI_CHECK_ARG(env, arraybuffer);
     NAPI_CHECK_ARG(env, result);
@@ -1300,7 +1300,7 @@ extern "C" napi_status napi_is_detached_arraybuffer(napi_env env,
 extern "C" napi_status napi_detach_arraybuffer(napi_env env,
     napi_value arraybuffer)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     Zig::GlobalObject* globalObject = toJS(env);
     JSC::VM& vm = JSC::getVM(globalObject);
@@ -1319,7 +1319,7 @@ extern "C" napi_status napi_adjust_external_memory(napi_env env,
     int64_t change_in_bytes,
     int64_t* adjusted_value)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ARG(env, adjusted_value);
 
     JSC::Heap& heap = toJS(env)->vm().heap;
@@ -1412,7 +1412,7 @@ extern "C" napi_status node_api_symbol_for(napi_env env,
     const char* utf8description,
     size_t length, napi_value* result)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     NAPI_CHECK_ARG(env, result);
 
@@ -1598,7 +1598,7 @@ extern "C" JS_EXPORT napi_status node_api_create_buffer_from_arraybuffer(napi_en
 extern "C" JS_EXPORT napi_status node_api_get_module_file_name(napi_env env,
     const char** result)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ARG(env, result);
     *result = env->filename;
     NAPI_RETURN_SUCCESS(env);
@@ -1652,7 +1652,7 @@ extern "C" napi_status napi_object_seal(napi_env env, napi_value object_value)
 
 extern "C" napi_status napi_get_global(napi_env env, napi_value* result)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     NAPI_CHECK_ARG(env, result);
     Zig::GlobalObject* globalObject = toJS(env);
@@ -1674,7 +1674,7 @@ extern "C" napi_status napi_get_new_target(napi_env env,
     napi_callback_info cbinfo,
     napi_value* result)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     // handle:
     // - if they call this function when it was originally a getter/setter call
@@ -2570,7 +2570,7 @@ static_assert(std::is_same_v<JSBigInt::Digit, uint64_t>, "All NAPI bigint functi
 
 extern "C" napi_status napi_get_value_bigint_int64(napi_env env, napi_value value, int64_t* result, bool* lossless)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     NAPI_CHECK_ARG(env, value);
     NAPI_CHECK_ARG(env, result);
@@ -2604,7 +2604,7 @@ extern "C" napi_status napi_get_value_bigint_int64(napi_env env, napi_value valu
 
 extern "C" napi_status napi_get_value_bigint_uint64(napi_env env, napi_value value, uint64_t* result, bool* lossless)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     NAPI_CHECK_ARG(env, value);
     NAPI_CHECK_ARG(env, result);
@@ -2631,7 +2631,7 @@ extern "C" napi_status napi_get_value_bigint_words(napi_env env,
     size_t* word_count,
     uint64_t* words)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     NAPI_CHECK_ARG(env, value);
     NAPI_CHECK_ARG(env, word_count);
@@ -2665,7 +2665,7 @@ extern "C" napi_status napi_get_value_bigint_words(napi_env env,
 extern "C" napi_status napi_get_value_external(napi_env env, napi_value value,
     void** result)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     NAPI_CHECK_ARG(env, result);
     NAPI_CHECK_ARG(env, value);
@@ -2680,7 +2680,7 @@ extern "C" napi_status napi_get_value_external(napi_env env, napi_value value,
 extern "C" napi_status napi_get_instance_data(napi_env env,
     void** data)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ARG(env, data);
 
     *data = env->instanceData;
@@ -2724,7 +2724,7 @@ extern "C" napi_status napi_set_instance_data(napi_env env,
     napi_finalize finalize_cb,
     void* finalize_hint)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
 
     env->instanceData = data;
     env->instanceDataFinalizer = Bun::NapiFinalizer { finalize_cb, finalize_hint };
@@ -2734,11 +2734,11 @@ extern "C" napi_status napi_set_instance_data(napi_env env,
 
 extern "C" napi_status napi_create_bigint_uint64(napi_env env, uint64_t value, napi_value* result)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ARG(env, result);
     auto* globalObject = toJS(env);
     auto* bigint = JSBigInt::createFrom(globalObject, value);
-    NAPI_RETURN_IF_EXCEPTION(env);
+    NAPI_RETURN_IF_VM_EXCEPTION(env);
     *result = toNapi(bigint, globalObject);
     ensureStillAliveHere(bigint);
     NAPI_RETURN_SUCCESS(env);
@@ -2746,11 +2746,11 @@ extern "C" napi_status napi_create_bigint_uint64(napi_env env, uint64_t value, n
 
 extern "C" napi_status napi_create_bigint_int64(napi_env env, int64_t value, napi_value* result)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ARG(env, result);
     auto* globalObject = toJS(env);
     auto* bigint = JSBigInt::createFrom(globalObject, value);
-    NAPI_RETURN_IF_EXCEPTION(env);
+    NAPI_RETURN_IF_VM_EXCEPTION(env);
     *result = toNapi(bigint, globalObject);
     ensureStillAliveHere(bigint);
     NAPI_RETURN_SUCCESS(env);
@@ -2798,7 +2798,7 @@ extern "C" napi_status napi_create_bigint_words(napi_env env,
 extern "C" napi_status napi_create_symbol(napi_env env, napi_value description,
     napi_value* result)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     NAPI_CHECK_ARG(env, result);
 
@@ -2810,7 +2810,7 @@ extern "C" napi_status napi_create_symbol(napi_env env, napi_value description,
         NAPI_RETURN_EARLY_IF_FALSE(env, descriptionValue.isString(), napi_string_expected);
 
         WTF::String descriptionString = descriptionValue.getString(globalObject);
-        NAPI_RETURN_IF_EXCEPTION(env);
+        NAPI_RETURN_IF_VM_EXCEPTION(env);
 
         if (descriptionString.length() > 0) {
             *result = toNapi(JSC::Symbol::createWithDescription(vm, descriptionString),
@@ -2973,7 +2973,7 @@ extern "C" JS_EXPORT napi_status napi_add_env_cleanup_hook(napi_env env,
     void (*function)(void*),
     void* data)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     if (function) {
         env->addCleanupHook(function, data);
     }
@@ -2998,7 +2998,7 @@ extern "C" JS_EXPORT napi_status napi_remove_env_cleanup_hook(napi_env env,
     void (*function)(void*),
     void* data)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
 
     // Always attempt removal like Node.js (no VM terminating check)
     // Node.js has no such check in RemoveEnvironmentCleanupHook

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -91,7 +91,7 @@ using namespace Zig;
     /* You should not use this throw scope directly -- if you need */   \
     /* to throw or clear exceptions, make your own scope */             \
     auto napi_preamble_throw_scope__ = DECLARE_THROW_SCOPE(_env->vm()); \
-    NAPI_RETURN_IF_VM_EXCEPTION(_env)
+    NAPI_RETURN_IF_EXCEPTION(_env)
 
 // Only use this for functions that need their own throw or catch scope. Functions that call into
 // JS code that might throw should use NAPI_RETURN_IF_EXCEPTION.
@@ -100,6 +100,17 @@ using namespace Zig;
         NAPI_LOG_CURRENT_FUNCTION;         \
         NAPI_CHECK_ARG(_env, _env);        \
     } while (0)
+
+// Like NAPI_PREAMBLE but does NOT return napi_pending_exception when the env
+// has a stashed napi_throw* exception. Mirrors Node.js's CHECK_ENV_NOT_IN_GC
+// for pure value constructors/accessors that are safe to call while an
+// exception is pending. Still declares a throw scope so NAPI_RETURN_SUCCESS
+// can assert and VM-level exceptions from JSC internals are caught.
+#define NAPI_PREAMBLE_NO_PENDING_CHECK(_env)                            \
+    NAPI_LOG_CURRENT_FUNCTION;                                          \
+    NAPI_CHECK_ARG(_env, _env);                                         \
+    auto napi_preamble_throw_scope__ = DECLARE_THROW_SCOPE(_env->vm()); \
+    NAPI_RETURN_IF_VM_EXCEPTION(_env)
 
 // Return an error code if arg is null. Only use for input validation.
 #define NAPI_CHECK_ARG(_env, arg)                               \
@@ -965,7 +976,6 @@ extern "C" napi_status napi_create_function(napi_env env, const char* utf8name,
     void* data, napi_value* result)
 {
     NAPI_PREAMBLE(env);
-    NAPI_RETURN_IF_EXCEPTION(env);
     NAPI_CHECK_ARG(env, result);
     NAPI_CHECK_ARG(env, cb);
 
@@ -1390,7 +1400,6 @@ extern "C" napi_status napi_throw(napi_env env, napi_value error)
 {
     NAPI_PREAMBLE(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
-    NAPI_RETURN_IF_EXCEPTION(env);
     if (env->isFinishingFinalizers()) {
         return napi_set_last_error(env, env->napiModule().nm_version >= 10 ? napi_cannot_run_js : napi_pending_exception);
     }
@@ -1560,13 +1569,13 @@ extern "C" JS_EXPORT napi_status node_api_create_buffer_from_arraybuffer(napi_en
 {
     NAPI_LOG_CURRENT_FUNCTION;
     NAPI_PREAMBLE_NO_THROW_SCOPE(env);
+    auto* globalObject = toJS(env);
+    auto scope = DECLARE_THROW_SCOPE(JSC::getVM(globalObject));
+    NAPI_RETURN_IF_EXCEPTION_WITH_SCOPE(env, scope);
     NAPI_CHECK_ARG(env, result);
 
     JSC::JSArrayBuffer* jsArrayBuffer = dynamicDowncast<JSC::JSArrayBuffer>(toJS(arraybuffer));
     NAPI_RETURN_EARLY_IF_FALSE(env, jsArrayBuffer, napi_arraybuffer_expected);
-
-    auto* globalObject = toJS(env);
-    auto scope = DECLARE_THROW_SCOPE(JSC::getVM(globalObject));
 
     auto* impl = jsArrayBuffer->impl();
 
@@ -1687,7 +1696,7 @@ extern "C" napi_status napi_create_dataview(napi_env env, size_t length,
     NAPI_PREAMBLE_NO_THROW_SCOPE(env);
     Zig::GlobalObject* globalObject = toJS(env);
     auto scope = DECLARE_THROW_SCOPE(JSC::getVM(globalObject));
-    RETURN_IF_EXCEPTION(scope, napi_set_last_error(env, napi_pending_exception));
+    NAPI_RETURN_IF_EXCEPTION_WITH_SCOPE(env, scope);
     NAPI_CHECK_ARG(env, arraybuffer);
     NAPI_CHECK_ARG(env, result);
     JSValue arraybufferValue = toJS(arraybuffer);
@@ -1780,7 +1789,6 @@ extern "C" napi_status napi_create_typedarray(
 {
     NAPI_PREAMBLE(env);
     Zig::GlobalObject* globalObject = toJS(env);
-    NAPI_RETURN_IF_EXCEPTION(env);
     NAPI_CHECK_ARG(env, arraybuffer);
     NAPI_CHECK_ARG(env, result);
     JSValue arraybufferValue = toJS(arraybuffer);
@@ -2082,13 +2090,6 @@ extern "C" napi_status napi_create_external_buffer(napi_env env, size_t length,
 {
     NAPI_PREAMBLE(env);
     NAPI_CHECK_ARG(env, result);
-    // Match Node.js: reject while a napi exception is pending before
-    // adopting data. NAPI_RETURN_IF_EXCEPTION below also consults
-    // hasPendingException(), so without this early return a stashed
-    // napi_throw* exception would pass the preamble, let createFromBytes
-    // adopt data, then bail after JSUint8Array::create succeeded but
-    // before arm(), orphaning a GC cell with a disarmed destructor.
-    NAPI_RETURN_EARLY_IF_FALSE(env, !env->hasPendingException(), napi_pending_exception);
 
     Zig::GlobalObject* globalObject = toJS(env);
     JSC::VM& vm = JSC::getVM(globalObject);
@@ -2134,11 +2135,6 @@ extern "C" napi_status napi_create_external_arraybuffer(napi_env env, void* exte
 {
     NAPI_PREAMBLE(env);
     NAPI_CHECK_ARG(env, result);
-    // Match Node.js: reject while a napi exception is pending before
-    // adopting external_data, so the caller cleanly retains ownership.
-    // Checking after JSArrayBuffer::create would orphan a GC cell that
-    // still points at external_data with a disarmed destructor.
-    NAPI_RETURN_EARLY_IF_FALSE(env, !env->hasPendingException(), napi_pending_exception);
 
     Zig::GlobalObject* globalObject = toJS(env);
     JSC::VM& vm = JSC::getVM(globalObject);
@@ -2169,7 +2165,7 @@ extern "C" napi_status napi_create_external_arraybuffer(napi_env env, void* exte
 extern "C" napi_status napi_create_double(napi_env env, double value,
     napi_value* result)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     NAPI_CHECK_ARG(env, result);
     // The addon controls every bit of `value`; an impure NaN must not be
@@ -2181,7 +2177,7 @@ extern "C" napi_status napi_create_double(napi_env env, double value,
 extern "C" napi_status napi_get_value_double(napi_env env, napi_value value,
     double* result)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     NAPI_CHECK_ARG(env, result);
     NAPI_CHECK_ARG(env, value);
@@ -2194,7 +2190,7 @@ extern "C" napi_status napi_get_value_double(napi_env env, napi_value value,
 
 extern "C" napi_status napi_get_value_int32(napi_env env, napi_value value, int32_t* result)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     NAPI_CHECK_ARG(env, result);
     NAPI_CHECK_ARG(env, value);
@@ -2207,7 +2203,7 @@ extern "C" napi_status napi_get_value_int32(napi_env env, napi_value value, int3
 
 extern "C" napi_status napi_get_value_uint32(napi_env env, napi_value value, uint32_t* result)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     NAPI_CHECK_ARG(env, result);
     NAPI_CHECK_ARG(env, value);
@@ -2220,7 +2216,7 @@ extern "C" napi_status napi_get_value_uint32(napi_env env, napi_value value, uin
 
 extern "C" napi_status napi_get_value_int64(napi_env env, napi_value value, int64_t* result)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     NAPI_CHECK_ARG(env, result);
     NAPI_CHECK_ARG(env, value);
@@ -2266,7 +2262,7 @@ struct BufferElement<NapiStringEncoding::utf16> {
 template<NapiStringEncoding EncodeTo>
 napi_status napi_get_value_string_any_encoding(napi_env env, napi_value napiValue, typename BufferElement<EncodeTo>::Type* buf, size_t bufsize, size_t* writtenPtr)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ARG(env, napiValue);
     JSValue jsValue = toJS(napiValue);
     NAPI_RETURN_EARLY_IF_FALSE(env, jsValue.isString(), napi_string_expected);
@@ -2392,7 +2388,7 @@ extern "C" napi_status napi_get_value_string_utf16(napi_env env, napi_value napi
 
 extern "C" napi_status napi_get_value_bool(napi_env env, napi_value value, bool* result)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     NAPI_CHECK_ARG(env, value);
     NAPI_CHECK_ARG(env, result);
@@ -2437,7 +2433,7 @@ extern "C" napi_status napi_delete_element(napi_env env, napi_value objectValue,
 
 extern "C" napi_status napi_create_object(napi_env env, napi_value* result)
 {
-    NAPI_PREAMBLE(env);
+    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     NAPI_CHECK_ARG(env, result);
 
@@ -2695,15 +2691,14 @@ extern "C" napi_status napi_run_script(napi_env env, napi_value script,
     napi_value* result)
 {
     NAPI_PREAMBLE_NO_THROW_SCOPE(env);
+    Zig::GlobalObject* globalObject = toJS(env);
+    auto& vm = JSC::getVM(globalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    NAPI_RETURN_IF_EXCEPTION_WITH_SCOPE(env, throwScope);
     NAPI_CHECK_ARG(env, script);
     NAPI_CHECK_ARG(env, result);
     JSValue scriptValue = toJS(script);
     NAPI_RETURN_EARLY_IF_FALSE(env, scriptValue.isString(), napi_string_expected);
-
-    Zig::GlobalObject* globalObject = toJS(env);
-
-    auto& vm = JSC::getVM(globalObject);
-    auto throwScope = DECLARE_THROW_SCOPE(vm);
 
     WTF::String code = scriptValue.getString(globalObject);
     RETURN_IF_EXCEPTION(throwScope, napi_set_last_error(env, napi_pending_exception));
@@ -2768,14 +2763,14 @@ extern "C" napi_status napi_create_bigint_words(napi_env env,
     napi_value* result)
 {
     NAPI_PREAMBLE_NO_THROW_SCOPE(env);
+    Zig::GlobalObject* globalObject = toJS(env);
+    auto& vm = env->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    NAPI_RETURN_IF_EXCEPTION_WITH_SCOPE(env, scope);
     NAPI_CHECK_ARG(env, result);
     NAPI_CHECK_ARG(env, words);
     // JSBigInt::createWithLength's size argument is unsigned int.
     NAPI_RETURN_EARLY_IF_FALSE(env, word_count <= UINT_MAX, napi_invalid_arg);
-
-    Zig::GlobalObject* globalObject = toJS(env);
-    auto& vm = env->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
 
     // we check INT_MAX here because it won't reject any bigints that should be able to be created
     // (as the true limit is much lower), and one Node.js test expects an exception instead of
@@ -2862,15 +2857,14 @@ extern "C" napi_status napi_new_instance(napi_env env, napi_value constructor,
 extern "C" napi_status napi_instanceof(napi_env env, napi_value object, napi_value constructor, bool* result)
 {
     NAPI_PREAMBLE_NO_THROW_SCOPE(env);
-    NAPI_CHECK_ARG(env, result);
-
     Zig::GlobalObject* globalObject = toJS(env);
+    auto scope = DECLARE_THROW_SCOPE(JSC::getVM(globalObject));
+    NAPI_RETURN_IF_EXCEPTION_WITH_SCOPE(env, scope);
+    NAPI_CHECK_ARG(env, result);
 
     JSValue objectValue = toJS(object);
     JSValue constructorValue = toJS(constructor);
     JSC::JSObject* constructorObject = constructorValue.getObject();
-
-    auto scope = DECLARE_THROW_SCOPE(JSC::getVM(globalObject));
 
     if (!constructorObject || !constructorValue.isConstructor()) {
         throwVMError(globalObject, scope, JSC::createTypeError(globalObject, "Constructor must be a function"_s));
@@ -3057,6 +3051,15 @@ extern "C" void napi_internal_remove_finalizer(napi_env env, napi_finalize callb
 extern "C" void napi_internal_check_gc(napi_env env)
 {
     env->checkGC();
+}
+
+extern "C" bool NapiEnv__hasPendingException(napi_env env)
+{
+    if (env->hasPendingException()) {
+        return true;
+    }
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(env->vm());
+    return scope.exception() != nullptr;
 }
 
 extern "C" uint32_t napi_internal_get_version(napi_env env)

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -70,6 +70,7 @@ bun_opaque::opaque_ffi! {
 unsafe extern "C" {
     fn NapiEnv__globalObject(env: *mut NapiEnv) -> *mut JSGlobalObject;
     fn NapiEnv__getAndClearPendingException(env: *mut NapiEnv, out: *mut JSValue) -> bool;
+    fn NapiEnv__hasPendingException(env: *mut NapiEnv) -> bool;
     fn napi_internal_get_version(env: *mut NapiEnv) -> u32;
     fn NapiEnv__deref(env: *mut NapiEnv);
     fn NapiEnv__ref(env: *mut NapiEnv);
@@ -107,6 +108,17 @@ impl NapiEnv {
             bun_output::scoped_log!(napi, "generic failure");
         }
         Self::set_last_error(Some(self), NapiStatus::generic_failure)
+    }
+
+    pub fn pending_exception(&self) -> napi_status {
+        Self::set_last_error(Some(self), NapiStatus::pending_exception)
+    }
+
+    /// Checks both `env->m_pendingException` (set by `napi_throw*`) and the JSC
+    /// VM exception slot. This is the gate Node.js's `NAPI_PREAMBLE` enforces.
+    pub fn has_pending_exception(&self) -> bool {
+        // SAFETY: env is non-null; C++ side is read-only here.
+        unsafe { NapiEnv__hasPendingException(self.as_mut_ptr()) }
     }
 
     /// Assert that we're not currently performing garbage collection
@@ -419,6 +431,19 @@ macro_rules! get_env {
             None => return env_is_null(),
         }
     };
+}
+
+/// Like `get_env!` but also returns `napi_pending_exception` if a JS exception
+/// is pending on the env (mirrors Node's `NAPI_PREAMBLE`). Use this for napi
+/// entry points that can execute JS or have observable side effects.
+macro_rules! preamble {
+    ($env:expr) => {{
+        let env = get_env!($env);
+        if env.has_pending_exception() {
+            return env.pending_exception();
+        }
+        env
+    }};
 }
 
 macro_rules! get_out {
@@ -867,7 +892,7 @@ pub(super) extern "C" fn napi_get_prototype(
     result_: *mut napi_value,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_get_prototype");
-    let env = get_env!(env_);
+    let env = preamble!(env_);
     let result = get_out!(env, result_);
     let object = object_.get();
     if object.is_empty() {
@@ -945,7 +970,7 @@ pub(super) extern "C" fn napi_get_array_length(
     result_: *mut u32,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_get_array_length");
-    let env = get_env!(env_);
+    let env = preamble!(env_);
     let result = get_out!(env, result_);
     let value = value_.get();
 
@@ -968,7 +993,7 @@ pub(super) extern "C" fn napi_strict_equals(
     result_: *mut bool,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_strict_equals");
-    let env = get_env!(env_);
+    let env = preamble!(env_);
     let result = get_out!(env, result_);
     let (lhs, rhs) = (lhs_.get(), rhs_.get());
     *result = match lhs.is_strict_equal(rhs, env.to_js()) {
@@ -1145,7 +1170,7 @@ pub(super) extern "C" fn napi_make_callback(
     maybe_result: *mut napi_value,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_make_callback");
-    let env = get_env!(env_);
+    let env = preamble!(env_);
     let (recv, func) = (recv_.get(), func_.get());
     if func.is_empty_or_undefined_or_null()
         || (!func.is_callable() && !func.is_async_context_frame())
@@ -1504,7 +1529,7 @@ pub(super) extern "C" fn napi_create_promise(
     promise_: *mut napi_value,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_create_promise");
-    let env = get_env!(env_);
+    let env = preamble!(env_);
     let deferred = get_out!(env, deferred_);
     let promise = get_out!(env, promise_);
     let strong = Box::new(JSPromiseStrong::init(env.to_js()));
@@ -1523,7 +1548,7 @@ pub(super) extern "C" fn napi_resolve_deferred(
     resolution_: napi_value,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_resolve_deferred");
-    let env = get_env!(env_);
+    let env = preamble!(env_);
     // SAFETY: deferred was created by heap::alloc in napi_create_promise.
     let deferred_box = unsafe { bun_core::heap::take(deferred) };
     // `deferred_box` drops at scope exit (deinit + free).
@@ -1542,7 +1567,7 @@ pub(super) extern "C" fn napi_reject_deferred(
     rejection_: napi_value,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_reject_deferred");
-    let env = get_env!(env_);
+    let env = preamble!(env_);
     // SAFETY: deferred was created by heap::alloc in napi_create_promise.
     let deferred_box = unsafe { bun_core::heap::take(deferred) };
     let rejection = rejection_.get();
@@ -1593,7 +1618,7 @@ pub(super) extern "C" fn napi_create_date(
     result_: *mut napi_value,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_create_date");
-    let env = get_env!(env_);
+    let env = preamble!(env_);
     let result = get_out!(env, result_);
     result.set(
         env,
@@ -1985,7 +2010,7 @@ pub(super) extern "C" fn napi_create_buffer_copy(
     result_: *mut napi_value,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_create_buffer_copy: {}", length);
-    let env = get_env!(env_);
+    let env = preamble!(env_);
     let result = get_out!(env, result_);
     let buffer: JSValue = match JSValue::create_buffer_from_length(env.to_js(), length) {
         Ok(b) => b,

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2374,6 +2374,129 @@ static napi_value test_external_buffer_with_pending_exception(
   return ok(env);
 }
 
+// With an exception pending (via napi_throw_error), every napi call that
+// Node.js gates with NAPI_PREAMBLE must return napi_pending_exception and
+// perform NO side effects. Before the fix, NAPI_PREAMBLE only consulted the
+// JSC VM throw scope, but napi_throw* stashes the exception on the env
+// without raising a VM exception, so the gate never fired: napi_run_script
+// ran the script, napi_object_freeze froze the object, etc.
+static int pending_gate_script_ran = 0;
+
+static napi_value pending_gate_mark_script_ran(napi_env env,
+                                               napi_callback_info) {
+  pending_gate_script_ran++;
+  return nullptr;
+}
+
+static napi_value test_pending_exception_gate(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  pending_gate_script_ran = 0;
+
+  // Set up inputs BEFORE arming the exception.
+  napi_value obj, arr, five, script, global, fn_ctor, arraybuffer;
+  napi_value date_in;
+  void *ab_data;
+  NODE_API_CALL(env, napi_create_object(env, &obj));
+  NODE_API_CALL(env, napi_create_array_with_length(env, 3, &arr));
+  NODE_API_CALL(env, napi_create_int32(env, 5, &five));
+  NODE_API_CALL(env, napi_create_string_utf8(
+                         env, "globalThis.__napiGateMark()", NAPI_AUTO_LENGTH,
+                         &script));
+  NODE_API_CALL(env, napi_get_global(env, &global));
+  NODE_API_CALL(env,
+                napi_get_named_property(env, global, "Function", &fn_ctor));
+  NODE_API_CALL(env,
+                napi_create_arraybuffer(env, 16, &ab_data, &arraybuffer));
+  NODE_API_CALL(env, napi_create_date(env, 1234.0, &date_in));
+
+  // Install a global the script would call so we can observe it running.
+  napi_value mark_fn;
+  NODE_API_CALL(env, napi_create_function(env, "mark", NAPI_AUTO_LENGTH,
+                                          pending_gate_mark_script_ran,
+                                          nullptr, &mark_fn));
+  NODE_API_CALL(env,
+                napi_set_named_property(env, global, "__napiGateMark",
+                                        mark_fn));
+
+  // Create a real deferred/promise BEFORE throwing so resolve_deferred has
+  // a valid handle to refuse.
+  napi_deferred deferred_pre;
+  napi_value promise_pre;
+  NODE_API_CALL(env,
+                napi_create_promise(env, &deferred_pre, &promise_pre));
+
+  // Arm: exception now pending on the env (not the VM).
+  NODE_API_CALL(env, napi_throw_error(env, "EGATE", "armed"));
+
+  napi_status st;
+  napi_value out;
+  bool bool_out;
+  uint32_t u32_out;
+  double f64_out;
+  napi_deferred deferred_out = nullptr;
+
+  st = napi_object_freeze(env, obj);
+  printf("napi_object_freeze: status=%d\n", (int)st);
+  st = napi_object_seal(env, obj);
+  printf("napi_object_seal: status=%d\n", (int)st);
+  st = napi_set_element(env, arr, 7, five);
+  printf("napi_set_element: status=%d\n", (int)st);
+  st = napi_run_script(env, script, &out);
+  printf("napi_run_script: status=%d\n", (int)st);
+  st = napi_instanceof(env, obj, fn_ctor, &bool_out);
+  printf("napi_instanceof: status=%d\n", (int)st);
+  st = napi_strict_equals(env, five, five, &bool_out);
+  printf("napi_strict_equals: status=%d\n", (int)st);
+  st = napi_wrap(env, obj, nullptr, nullptr, nullptr, nullptr);
+  printf("napi_wrap: status=%d\n", (int)st);
+  st = napi_get_prototype(env, obj, &out);
+  printf("napi_get_prototype: status=%d\n", (int)st);
+  st = napi_get_date_value(env, date_in, &f64_out);
+  printf("napi_get_date_value: status=%d\n", (int)st);
+  st = napi_get_array_length(env, arr, &u32_out);
+  printf("napi_get_array_length: status=%d\n", (int)st);
+  st = napi_create_date(env, 42.0, &out);
+  printf("napi_create_date: status=%d\n", (int)st);
+  st = napi_create_dataview(env, 8, arraybuffer, 0, &out);
+  printf("napi_create_dataview: status=%d\n", (int)st);
+  st = napi_create_promise(env, &deferred_out, &out);
+  printf("napi_create_promise: status=%d\n", (int)st);
+  napi_status resolve_st = napi_resolve_deferred(env, deferred_pre, five);
+  printf("napi_resolve_deferred: status=%d\n", (int)resolve_st);
+
+  // Clear the pending exception so we can inspect side effects.
+  napi_value exc;
+  NODE_API_CALL(env, napi_get_and_clear_last_exception(env, &exc));
+
+  // Side-effect checks (the part a status-only test can't catch).
+  napi_value frozen_obj, is_frozen;
+  NODE_API_CALL(env,
+                napi_get_named_property(env, global, "Object", &frozen_obj));
+  NODE_API_CALL(env, napi_get_named_property(env, frozen_obj, "isFrozen",
+                                             &frozen_obj));
+  NODE_API_CALL(env, napi_call_function(env, global, frozen_obj, 1, &obj,
+                                        &is_frozen));
+  bool frozen;
+  NODE_API_CALL(env, napi_get_value_bool(env, is_frozen, &frozen));
+  printf("side_effect frozen=%s\n", frozen ? "true" : "false");
+
+  bool has7;
+  NODE_API_CALL(env, napi_has_element(env, arr, 7, &has7));
+  printf("side_effect arr[7]=%s\n", has7 ? "set" : "undefined");
+
+  printf("side_effect script_ran=%s\n",
+         pending_gate_script_ran ? "true" : "false");
+
+  // The pre-created promise must still be pending: resolve_deferred was
+  // refused, so the deferred is still valid. Conclude it now so we don't
+  // leak the handle. Skip if a buggy runtime already consumed it.
+  if (resolve_st != napi_ok) {
+    NODE_API_CALL(env, napi_resolve_deferred(env, deferred_pre, five));
+  }
+
+  return ok(env);
+}
+
 // Regression test: PROPERTY_NAME_FROM_UTF8 must copy string data.
 // Previously it used StringImpl::createWithoutCopying for ASCII strings,
 // which could leave dangling pointers in JSC's atom string table.
@@ -2725,6 +2848,7 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
                     test_external_arraybuffer_with_pending_exception);
   REGISTER_FUNCTION(env, exports,
                     test_external_buffer_with_pending_exception);
+  REGISTER_FUNCTION(env, exports, test_pending_exception_gate);
   REGISTER_FUNCTION(env, exports, test_napi_get_named_property_copied_string);
   REGISTER_FUNCTION(env, exports, test_issue_25933);
   REGISTER_FUNCTION(env, exports, test_napi_make_callback_async_context_frame);

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2477,7 +2477,8 @@ static napi_value test_pending_exception_gate(const Napi::CallbackInfo &info) {
   printf("napi_reference_unref: status=%d\n", (int)st);
   st = napi_get_reference_value(env, ref, &out);
   printf("napi_get_reference_value: status=%d\n", (int)st);
-  st = napi_create_bigint_int64(env, 42, &out);
+  napi_value bigint_val;
+  st = napi_create_bigint_int64(env, 42, &bigint_val);
   printf("napi_create_bigint_int64: status=%d\n", (int)st);
   st = napi_create_symbol(env, nullptr, &out);
   printf("napi_create_symbol: status=%d\n", (int)st);
@@ -2487,6 +2488,17 @@ static napi_value test_pending_exception_gate(const Napi::CallbackInfo &info) {
   printf("napi_is_typedarray: status=%d\n", (int)st);
   st = napi_get_instance_data(env, &inst_data);
   printf("napi_get_instance_data: status=%d\n", (int)st);
+  uint64_t u64_out;
+  st = napi_get_value_bigint_uint64(env, bigint_val, &u64_out, &bool_out);
+  printf("napi_get_value_bigint_uint64: status=%d\n", (int)st);
+  napi_async_cleanup_hook_handle ach = nullptr;
+  st = napi_add_async_cleanup_hook(
+      env, +[](napi_async_cleanup_hook_handle, void *) {}, nullptr, &ach);
+  printf("napi_add_async_cleanup_hook: status=%d\n", (int)st);
+  if (st == napi_ok) {
+    st = napi_remove_async_cleanup_hook(ach);
+    printf("napi_remove_async_cleanup_hook: status=%d\n", (int)st);
+  }
 
   // Clear the pending exception so we can inspect side effects.
   napi_value exc;

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2464,6 +2464,30 @@ static napi_value test_pending_exception_gate(const Napi::CallbackInfo &info) {
   napi_status resolve_st = napi_resolve_deferred(env, deferred_pre, five);
   printf("napi_resolve_deferred: status=%d\n", (int)resolve_st);
 
+  // Functions Node.js does NOT gate (CHECK_ENV): must still succeed with a
+  // pending exception. Pins the NO_PENDING_CHECK set so future preamble
+  // changes don't over-gate them.
+  napi_ref ref = nullptr;
+  void *inst_data;
+  st = napi_get_global(env, &out);
+  printf("napi_get_global: status=%d\n", (int)st);
+  st = napi_create_reference(env, obj, 1, &ref);
+  printf("napi_create_reference: status=%d\n", (int)st);
+  st = napi_reference_unref(env, ref, &u32_out);
+  printf("napi_reference_unref: status=%d\n", (int)st);
+  st = napi_get_reference_value(env, ref, &out);
+  printf("napi_get_reference_value: status=%d\n", (int)st);
+  st = napi_create_bigint_int64(env, 42, &out);
+  printf("napi_create_bigint_int64: status=%d\n", (int)st);
+  st = napi_create_symbol(env, nullptr, &out);
+  printf("napi_create_symbol: status=%d\n", (int)st);
+  st = napi_is_buffer(env, arr, &bool_out);
+  printf("napi_is_buffer: status=%d\n", (int)st);
+  st = napi_is_typedarray(env, arr, &bool_out);
+  printf("napi_is_typedarray: status=%d\n", (int)st);
+  st = napi_get_instance_data(env, &inst_data);
+  printf("napi_get_instance_data: status=%d\n", (int)st);
+
   // Clear the pending exception so we can inspect side effects.
   napi_value exc;
   NODE_API_CALL(env, napi_get_and_clear_last_exception(env, &exc));
@@ -2493,6 +2517,7 @@ static napi_value test_pending_exception_gate(const Napi::CallbackInfo &info) {
   if (resolve_st != napi_ok) {
     NODE_API_CALL(env, napi_resolve_deferred(env, deferred_pre, five));
   }
+  NODE_API_CALL(env, napi_delete_reference(env, ref));
 
   return ok(env);
 }

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -385,6 +385,20 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       ]) {
         expect(result).toContain(`${fn}: status=10`);
       }
+      // functions Node.js does NOT gate (CHECK_ENV) must still succeed
+      for (const fn of [
+        "napi_get_global",
+        "napi_create_reference",
+        "napi_reference_unref",
+        "napi_get_reference_value",
+        "napi_create_bigint_int64",
+        "napi_create_symbol",
+        "napi_is_buffer",
+        "napi_is_typedarray",
+        "napi_get_instance_data",
+      ]) {
+        expect(result).toContain(`${fn}: status=0`);
+      }
       // side effects must NOT have happened
       expect(result).toContain("side_effect frozen=false");
       expect(result).toContain("side_effect arr[7]=undefined");

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -363,6 +363,35 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     });
   });
 
+  describe("pending-exception gate", () => {
+    it("refuses and performs no side effects while a napi exception is pending", async () => {
+      const result = await checkSameOutput("test_pending_exception_gate", []);
+      // every gated call must report napi_pending_exception (10)
+      for (const fn of [
+        "napi_object_freeze",
+        "napi_object_seal",
+        "napi_set_element",
+        "napi_run_script",
+        "napi_instanceof",
+        "napi_strict_equals",
+        "napi_wrap",
+        "napi_get_prototype",
+        "napi_get_date_value",
+        "napi_get_array_length",
+        "napi_create_date",
+        "napi_create_dataview",
+        "napi_create_promise",
+        "napi_resolve_deferred",
+      ]) {
+        expect(result).toContain(`${fn}: status=10`);
+      }
+      // side effects must NOT have happened
+      expect(result).toContain("side_effect frozen=false");
+      expect(result).toContain("side_effect arr[7]=undefined");
+      expect(result).toContain("side_effect script_ran=false");
+    });
+  });
+
   describe("napi_async_work", () => {
     it("null checks execute callbacks", async () => {
       const output = await checkSameOutput("test_napi_async_work_execute_null_check", []);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -396,6 +396,9 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
         "napi_is_buffer",
         "napi_is_typedarray",
         "napi_get_instance_data",
+        "napi_get_value_bigint_uint64",
+        "napi_add_async_cleanup_hook",
+        "napi_remove_async_cleanup_hook",
       ]) {
         expect(result).toContain(`${fn}: status=0`);
       }


### PR DESCRIPTION
## What

With a napi exception pending (via `napi_throw_error`), Bun executed napi calls that Node.js refuses: `napi_run_script` ran the script, `napi_object_freeze`/`napi_set_element` mutated, `napi_resolve_deferred` resolved, and a further 10 entry points returned `napi_ok`. Node returns `napi_pending_exception` and performs zero side effects for every one of them.

The worst face: `napi_object_freeze`/`napi_set_element` returned `napi_pending_exception` *like Node* but only **after** performing the mutation, so a status-checking addon sees a matching code and a silently-diverged world.

## Repro

```c
napi_throw_error(env, "EGATE", "armed");          // exception now pending
napi_object_freeze(env, obj);                     // node: 10, no-op   bun: 10, but FROZEN
napi_set_element(env, arr, 7, five);              // node: 10, no-op   bun: 10, but arr[7]=5
napi_run_script(env, script, &r);                 // node: 10, not run bun: 0,  script RAN
napi_create_promise(env, &d, &p);                 // node: 10          bun: 0
napi_resolve_deferred(env, d, v);                 // node: 10          bun: 0, RESOLVED
// + instanceof, strict_equals, wrap, get_prototype, get_date_value,
//   get_array_length, create_date, create_dataview
```

## Cause

`napi_throw*` stores the exception via `env->scheduleException()` into `m_pendingException` (a `Strong<>`) without throwing to the JSC VM. `NAPI_PREAMBLE` (napi.cpp:88) declared a throw scope and checked only the VM exception slot, so the stashed exception never tripped the gate. The tail `NAPI_RETURN_SUCCESS_UNLESS_EXCEPTION` *did* consult `hasPendingException()`, producing the "correct status, mutation already done" rows. Node's `NAPI_PREAMBLE` checks `env->last_exception.IsEmpty()` (the env slot) up front.

The Rust-implemented entry points (`napi_get_prototype`, `napi_strict_equals`, `napi_create_promise`, ...) had no preamble gate at all.

## Fix

- `NAPI_PREAMBLE` now calls `NAPI_RETURN_IF_EXCEPTION`, which checks both the VM scope and `env->hasPendingException()`. Covers every C++ entry point Node.js gates with its own `NAPI_PREAMBLE` (`object_freeze`/`seal`, `set/get/has/delete_element`, property access, `wrap`/`unwrap`, `get_date_value`, `coerce_to_*`, `define_class`, `new_instance`, `create_external`, ...).
- `napi_run_script`, `napi_instanceof`, `napi_create_dataview`, `napi_create_bigint_words`, `node_api_create_buffer_from_arraybuffer` (which open their own throw scope via `NAPI_PREAMBLE_NO_THROW_SCOPE`) now check `hasPendingException()` at the top of that scope.
- New `NAPI_PREAMBLE_NO_PENDING_CHECK` for the entry points Node.js does **not** gate (`CHECK_ENV`/`CHECK_ENV_NOT_IN_GC`), so they keep succeeding with a pending exception: `get_cb_info`, `get_global`, `get_new_target`, `create_reference`, `reference_ref/unref`, `get_reference_value`, `add_finalizer`, `node_api_post_finalizer`, `is_buffer`, `is_typedarray`, `is/detach_detached_arraybuffer`, `adjust_external_memory`, `node_api_symbol_for`, `node_api_get_module_file_name`, `get_value_bigint_*`, `get_value_external`, `get/set_instance_data`, `create_bigint_int64/uint64`, `create_symbol`, `add/remove_env_cleanup_hook`, `create_object`, `create_double`, `get_value_int32/uint32/int64/double/bool/string_*`. Before this PR these happened to match Node only because the old preamble never saw the env slot.
- Removed the two per-site `hasPendingException()` workarounds in `napi_create_external_buffer`/`arraybuffer` that the preamble now covers.
- Rust side (`napi_body.rs`): added `NapiEnv::has_pending_exception()` (via new `NapiEnv__hasPendingException` FFI) and a `preamble!` macro, applied to every Rust entry point Node.js gates with `NAPI_PREAMBLE`: `get_prototype`, `get_array_length`, `strict_equals`, `make_callback`, `create_promise`, `resolve_deferred`, `reject_deferred`, `create_date`, `create_buffer_copy`.

## Verification

`test_pending_exception_gate` in the napi addon arms `napi_throw_error`, then:
- calls 14 gated entry points and records every status;
- calls 9 non-gated entry points (`get_global`, `create_reference`, `reference_unref`, `get_reference_value`, `create_bigint_int64`, `create_symbol`, `is_buffer`, `is_typedarray`, `get_instance_data`);
- clears the exception and inspects side effects (`Object.isFrozen`, `arr[7]`, a global the script would touch).

Run via `checkSameOutput`, so Bun's output is diffed byte-for-byte against Node.

<details>
<summary>Before / after</summary>

```
# node v26 == this PR               # bun 1.4.0 / main
napi_object_freeze: status=10       napi_object_freeze: status=10
napi_set_element: status=10         napi_set_element: status=10
napi_run_script: status=10          napi_run_script: status=10
napi_instanceof: status=10          napi_instanceof: status=0
napi_strict_equals: status=10       napi_strict_equals: status=0
napi_wrap: status=10                napi_wrap: status=0
napi_get_prototype: status=10       napi_get_prototype: status=0
napi_get_date_value: status=10      napi_get_date_value: status=0
napi_get_array_length: status=10    napi_get_array_length: status=0
napi_create_date: status=10         napi_create_date: status=0
napi_create_dataview: status=10     napi_create_dataview: status=0
napi_create_promise: status=10      napi_create_promise: status=0
napi_resolve_deferred: status=10    napi_resolve_deferred: status=0
napi_get_global: status=0           napi_get_global: status=0
napi_create_reference: status=0     napi_create_reference: status=0
napi_reference_unref: status=0      napi_reference_unref: status=0
...                                 ...
side_effect frozen=false            side_effect frozen=true
side_effect arr[7]=undefined        side_effect arr[7]=set
side_effect script_ran=false        side_effect script_ran=true
```
</details>

```
$ USE_SYSTEM_BUN=1 bun test test/napi/napi.test.ts -t 'pending-exception gate'
(fail) ... 13 lines differ

$ bun bd test test/napi/napi.test.ts -t 'pending-exception gate'
(pass) napi > pending-exception gate > refuses and performs no side effects while a napi exception is pending
```

The pre-existing `test_deferred_exceptions` and `test_external_*_with_pending_exception` tests continue to pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->