### PR TITLE
jsc: fix O(n^3) YARR JIT backtracking for greedy /u character classes

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -7,7 +7,7 @@
 // -lto variants built with ThinLTO (per-module summaries for cross-language
 // importing), and the Windows ICU data table filtered + per-item zstd
 // compressed (lazily decompressed via bun_icu_decompress.cpp).
-export const WEBKIT_VERSION = "autobuild-preview-pr-289-e25e53b0";
+export const WEBKIT_VERSION = "autobuild-preview-pr-289-1e7b9193";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -7,7 +7,7 @@
 // -lto variants built with ThinLTO (per-module summaries for cross-language
 // importing), and the Windows ICU data table filtered + per-item zstd
 // compressed (lazily decompressed via bun_icu_decompress.cpp).
-export const WEBKIT_VERSION = "4895f45dfbd0d1226c4d41799887bc0ecb9f341b";
+export const WEBKIT_VERSION = "autobuild-preview-pr-289-e25e53b0";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/yarr-unicode-greedy-charclass.test.ts
+++ b/test/js/bun/jsc/yarr-unicode-greedy-charclass.test.ts
@@ -105,11 +105,9 @@ test("greedy /u character class backtracking is not O(n^3)", async () => {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
   const { r, dt } = JSON.parse(stdout);
-  expect(r).toBe(false);
+  expect({ r, stderr, exitCode }).toEqual({ r: false, stderr: "", exitCode: 0 });
   // Prior to the fix this ran ~2300ms in a release build; the fixed JIT and the YARR
   // interpreter both finish this in well under 50ms. 1000ms leaves >20x headroom.
   expect(dt).toBeLessThan(1000);
-  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/jsc/yarr-unicode-greedy-charclass.test.ts
+++ b/test/js/bun/jsc/yarr-unicode-greedy-charclass.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Greedy variable-width Unicode character-class backtracking in the YARR JIT used to
+// rematch from the beginning of the quantifier on every single backtrack step, turning a
+// quadratic scan into a cubic one for patterns like /[^"]*X/u on 16-bit input. The
+// correctness tests below guard the O(1) backward step that replaced that rematch loop;
+// the performance test asserts the cubic blowup is gone.
+
+describe("backtracking greedy /u character class", () => {
+  // Patterns crafted so the greedy class consumes the whole string and must backtrack
+  // across a mix of BMP code units, valid surrogate pairs, and lone surrogates.
+  test.each([
+    // [pattern, input, expectedMatch]
+    [/([^"]*)Z/u, "abcZ", "abcZ"],
+    [/([^"]*)Z/u, "\u{1F600}abZ", "\u{1F600}abZ"],
+    [/([^"]*)Z/u, "ab\u{1F600}Z", "ab\u{1F600}Z"],
+    [/([^"]*)Z/u, "ab\u{1F600}cdZ", "ab\u{1F600}cdZ"],
+    [/([^"]*)Z/u, "\u{1F600}\u{1F600}Z", "\u{1F600}\u{1F600}Z"],
+    [/([^"]*)Z/u, "\u2014abcZdef", "\u2014abcZ"],
+    // greedy consumes everything, backtracks past trailing pairs to find Z
+    [/([^"]*)Z/u, "Z\u{1F600}\u{1F600}", "Z"],
+    [/([^"]*)Z/u, "aZ\u{1F600}b\u{1F600}", "aZ"],
+    // lone surrogates treated as width-1
+    [/([^"]*)Z/u, "\uDC00Z", "\uDC00Z"],
+    [/([^"]*)Z/u, "\uD800Z", "\uD800Z"],
+    [/([^"]*)Z/u, "\uD800\uD800Z", "\uD800\uD800Z"],
+    [/([^"]*)Z/u, "\uDC00\uDC00Z", "\uDC00\uDC00Z"],
+    // pair followed by lone trail
+    [/([^"]*)Z/u, "\u{1F600}\uDC00Z", "\u{1F600}\uDC00Z"],
+    // lone lead followed by pair
+    [/([^"]*)Z/u, "\uD800\u{1F600}Z", "\uD800\u{1F600}Z"],
+    // no match: must fully unwind
+    [/([^"]*)Z/u, "\u{1F600}abc\u{1F601}", null],
+    [/([^"]*)Z/u, "\u2014" + Buffer.alloc(50, "a").toString(), null],
+    // match mid-string after surrogate pair boundary
+    [/([^"]*?)\u{1F600}/u, "ab\u{1F600}cd", "ab\u{1F600}"],
+    // greedy '+' variant
+    [/([^"]+)Z/u, "\u{1F600}Z", "\u{1F600}Z"],
+    [/([^"]+)Z/u, "Z", null],
+    // real-world shape from @typescript-eslint JSX detection
+    [/(?:^[^"'`]*<\/)|(?:^[^/]{2}.*\/>)/mu, "abc</", "abc</"],
+    [/(?:^[^"'`]*<\/)|(?:^[^/]{2}.*\/>)/mu, "\u2014\nabc", null],
+  ] as const)("matches %p on %p", (re, input, expected) => {
+    const m = re.exec(input);
+    if (expected === null) {
+      expect(m).toBeNull();
+    } else {
+      expect(m?.[0]).toBe(expected);
+    }
+  });
+
+  test("capture positions across surrogate-pair backtracking", () => {
+    // Greedy class swallows the whole string then backs off 3 code points (one pair + two
+    // BMP) to expose "Zq". Index must land exactly at the Z, not inside the pair.
+    const m = /([^"]*)Z(.)/u.exec("a\u{1F600}bZq\u{1F601}c");
+    expect(m).not.toBeNull();
+    expect([m![0], m![1], m![2], m!.index]).toEqual(["a\u{1F600}bZq", "a\u{1F600}b", "q", 0]);
+  });
+
+  test("backtracking across many mixed-width code points", () => {
+    // "a😀" repeated: alternating 1-unit and 2-unit code points. Z sits at the very
+    // start so the greedy class must unwind every step, alternating -1 and -2.
+    let body = "";
+    for (let i = 0; i < 40; i++) body += "a\u{1F600}";
+    const input = "Z" + body;
+    const m = /([^"]*)Z/u.exec(input);
+    expect(m?.[0]).toBe("Z");
+    expect(m?.[1]).toBe("");
+    expect(m?.index).toBe(0);
+  });
+
+  test("greedy range begins at a lone trail surrogate", () => {
+    // 'q' is outside the negated class so the quantifier begins at the trail; backtracking
+    // to count 0 must restore index to exactly that boundary without peeking at 'q'.
+    const m = /q([^"q]*)Z/u.exec("q\uDC00aZb");
+    expect([m?.[0], m?.[1], m?.index]).toEqual(["q\uDC00aZ", "\uDC00a", 0]);
+    // And fully unwinding to empty:
+    const m2 = /q([^"q]*)q/u.exec("q\uDC00aaq");
+    expect([m2?.[0], m2?.[1]]).toEqual(["q\uDC00aaq", "\uDC00aa"]);
+    expect(/q([^"q]*)Z/u.exec("q\uDC00aa")).toBeNull();
+  });
+});
+
+// Uses a subprocess so debug-build overhead in this process doesn't affect the timed
+// region; the JIT-generated regex code itself runs at native speed either way.
+test("greedy /u character class backtracking is not O(n^3)", async () => {
+  const script = `
+    const s = "\\u2014" + Buffer.alloc(2000, "a").toString();
+    const re = /[^"]*X/u;
+    re.test("\\u2014warmup"); // compile
+    const t0 = performance.now();
+    const r = re.test(s);
+    const dt = performance.now() - t0;
+    process.stdout.write(JSON.stringify({ r, dt }));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const { r, dt } = JSON.parse(stdout);
+  expect(r).toBe(false);
+  // Prior to the fix this ran ~2300ms in a release build; the fixed JIT and the YARR
+  // interpreter both finish this in well under 50ms. 1000ms leaves >20x headroom.
+  expect(dt).toBeLessThan(1000);
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/jsc/yarr-unicode-greedy-charclass.test.ts
+++ b/test/js/bun/jsc/yarr-unicode-greedy-charclass.test.ts
@@ -38,6 +38,10 @@ describe("backtracking greedy /u character class", () => {
     // greedy '+' variant
     [/([^"]+)Z/u, "\u{1F600}Z", "\u{1F600}Z"],
     [/([^"]+)Z/u, "Z", null],
+    // U+F800/U+FC00 are not surrogates; backward step must agree with forward read on width
+    [/([^"]*)Z/u, "Z\uF800\uFC00\uF800\uFC00", "Z"],
+    [/([^"]*)Z/u, "aZ\uF800\uFC00", "aZ"],
+    [/([^"]*)Z/u, "\uF800\uFC00Z", "\uF800\uFC00Z"],
     // real-world shape from @typescript-eslint JSX detection
     [/(?:^[^"'`]*<\/)|(?:^[^/]{2}.*\/>)/mu, "abc</", "abc</"],
     [/(?:^[^"'`]*<\/)|(?:^[^/]{2}.*\/>)/mu, "\u2014\nabc", null],


### PR DESCRIPTION
Depends on oven-sh/WebKit#289. `WEBKIT_VERSION` currently points at that PR's preview build; it will be updated to the merged main sha before this merges.

## Problem

`prettier` with `parser: "typescript"` stalls for many seconds on any TypeScript file that contains a non-ASCII character:

```sh
echo '{"dependencies":{"prettier":"3.3.3"}}' > package.json && bun install
node -e 'let m=["  /**\n   * text \u2014 text\n   */\n  f0: string;"];for(let i=1;i<200;i++)m.push("  /**\n   * d\n   */\n  f"+i+": string;");process.stdout.write("export interface B {\n"+m.join("\n")+"\n}\n")' > input.ts
time node -e 'require("prettier").format(require("fs").readFileSync("input.ts","utf8"),{parser:"typescript"}).then(()=>0)'   # ~0.17s
time bun  -e 'require("prettier").format(require("fs").readFileSync("input.ts","utf8"),{parser:"typescript"}).then(()=>0)'   # ~9.7s
```

Minimal repro (one regex, scales cubically):

```js
/[^"]*X/u.test("\u2014" + "a".repeat(4000))   // 18.6 s in 1.4.0, 30 ms after
```

## Cause

`@typescript-eslint`'s JSX-detection regex ``/(?:^[^"'`]*<\/)|(?:^[^/]{2}.*\/>)/mu`` is run once against the whole source. In the YARR JIT, backtracking a greedy variable-width `/u` character class (any negated class like `[^"]`) rematched forward from `beginIndex` on every single backtrack step, so each attempt was O(n^2) and the unanchored match O(n^3). With `BUN_JSC_useRegExpJIT=0` the interpreter steps backward one code point in O(1) and the stall disappears. Latin1 input (no non-ASCII chars) never enters the surrogate-decoding path and stayed O(n^2).

## Fix

WebKit change (oven-sh/WebKit#289): replace the rematch loop with an O(1) backward step that subtracts one code unit and, if that unit is a trail surrogate whose preceding unit inside the quantified range is a lead surrogate, subtracts one more. Same invariant the existing non-unicode `sub32(TrustedImm32(1), index)` path already relies on.

| n    | before (JIT) | interpreter | after (JIT) |
|------|-------------:|------------:|------------:|
| 1000 | 294 ms       | 7.4 ms      | 2.9 ms      |
| 2000 | 2340 ms      | 29.8 ms     | 7.8 ms      |
| 4000 | 18637 ms     | 119 ms      | 30 ms       |

## Verification

`test/js/bun/jsc/yarr-unicode-greedy-charclass.test.ts` covers correctness across BMP, non-BMP, and lone-surrogate inputs plus a timing guard for the cubic regression. Fails with the previous prebuilt WebKit (`dt` ~2300ms vs 1000ms bound), passes with the bumped one (`dt` ~8ms). JSC's own `JSTests/stress/regexp-unicode-*` and `regexp-*greedy*/backtrack*/charclass*/surrogate*` suites pass unchanged.

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 4 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc/yarr-unicode-greedy-charclass.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/jsc/yarr-unicode-greedy-charclass.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (52c1e4e01)

test/js/bun/jsc/yarr-unicode-greedy-charclass.test.ts:
(pass) backtracking greedy /u character class > matches /([^"]*)Z/u on "abcZ" [2.79ms]
(pass) backtracking greedy /u character class > matches /([^"]*)Z/u on "😀abZ" [1.08ms]
(pass) backtracking greedy /u character class > matches /([^"]*)Z/u on "ab😀Z" [0.28ms]
(pass) backtracking greedy /u character class > matches /([^"]*)Z/u on "ab😀cdZ" [0.29ms]
(pass) backtracking greedy /u character class > matches /([^"]*)Z/u on "😀😀Z" [0.27ms]
(pass) backtracking greedy /u character class > matches /([^"]*)Z/u on "—abcZdef" [0.30ms]
(pass) backtracking greedy /u character class > matches /([^"]*)Z/u on "Z😀😀" [0.29ms]
(pass) backtracking greedy /u character class > matches /([^"]*)Z/u on "aZ😀b😀" [0.29ms]
(pass) backtracking greedy /u character class > matches /([^"]*)Z/u on "\udc00Z" [0.45ms]
(pass) backtracking greedy /u character class > matches /([^"]*)Z/u on "\ud800Z" [0.29ms]
(pass) backtracking greedy /u character class > matches /([^"]*)Z/u on "\ud800\ud800Z" [0.26ms]
(pass) backtracking greedy /u character class > matches /([^"]*)Z/u on "\udc00\udc00Z" [0.25ms]
(pass) backtracking greedy /u character class > matches /([^"]*)Z/u on "😀\udc00Z" [0.27ms]
(pass) backtracking greedy /u character class > matches /([^"]*)Z/u on "\ud800😀Z" [0.25ms]
(pass) backtracking greedy /u character class > matches /([^"]*)Z/u on "😀abc😁" [0.27ms]
(pass) backtracking greedy /u character class > matches /([^"]*)Z/u on "—aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" [0
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                       |   2 +-
 .../bun/jsc/yarr-unicode-greedy-charclass.test.ts  | 113 +++++++++++++++++++++
 2 files changed, 114 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
scripts/build/deps/webkit.ts                               3      2      0
test/js/bun/jsc/yarr-unicode-greedy-charclass.test.ts      2      5      0
```

</details>

<!-- robobun:evidence:end -->