### PR TITLE
test(napi): remove duplicate get_all_property_names helper

### DIFF
--- a/test/napi/napi-app/js_test_helpers.cpp
+++ b/test/napi/napi-app/js_test_helpers.cpp
@@ -303,22 +303,6 @@ static napi_value get_property_names(const Napi::CallbackInfo &info) {
   return result;
 }
 
-// get_all_property_names(object, key_mode, key_filter, key_conversion) -> array
-static napi_value get_all_property_names(const Napi::CallbackInfo &info) {
-  napi_env env = info.Env();
-  uint32_t key_mode, key_filter, key_conversion;
-  NODE_API_CALL(env, napi_get_value_uint32(env, info[1], &key_mode));
-  NODE_API_CALL(env, napi_get_value_uint32(env, info[2], &key_filter));
-  NODE_API_CALL(env, napi_get_value_uint32(env, info[3], &key_conversion));
-  napi_value result;
-  NODE_API_CALL(env,
-                napi_get_all_property_names(
-                    env, info[0], (napi_key_collection_mode)key_mode,
-                    (napi_key_filter)key_filter,
-                    (napi_key_conversion)key_conversion, &result));
-  return result;
-}
-
 // add_tag(object, lower, upper)
 static napi_value add_tag(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
@@ -512,7 +496,6 @@ void register_js_test_helpers(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, make_empty_array);
   REGISTER_FUNCTION(env, exports, make_empty_object);
   REGISTER_FUNCTION(env, exports, get_property_names);
-  REGISTER_FUNCTION(env, exports, get_all_property_names);
   REGISTER_FUNCTION(env, exports, add_tag);
   REGISTER_FUNCTION(env, exports, try_add_tag);
   REGISTER_FUNCTION(env, exports, check_tag);

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -266,7 +266,7 @@ nativeTests.test_property_names_cache_poisoning = () => {
   console.log("Reflect.ownKeys after get_all_property_names(own_only):", Reflect.ownKeys(mkD()).join(","));
 
   // The napi result itself should still include inherited keys.
-  const apnResult = nativeTests.get_all_property_names(mkA(), 0, 0, 0);
+  const { keys: apnResult } = nativeTests.get_all_property_names(mkA(), 0, 0, 0);
   console.log("napi include_prototypes result has own a,b:", apnResult.includes("a") && apnResult.includes("b"));
   console.log("napi include_prototypes result has inherited toString:", apnResult.includes("toString"));
   const gpnResult = nativeTests.get_property_names(mkB());


### PR DESCRIPTION
## Problem

`test/napi/napi-value-ffi.test.ts` and `test/napi/napi.test.ts` are red on main because the `napi-app` test addon fails to compile:

```
js_test_helpers.cpp:307:19: error: redefinition of 'napi_value__* napitests::get_all_property_names(const Napi::CallbackInfo&)'
js_test_helpers.cpp:255:19: note: previously defined here
```

First seen in build [72808](https://buildkite.com/bun/bun/builds/72808) on debian x64-asan and both Windows x64 lanes.

## Cause

#34126 and #34130 each added a static `get_all_property_names()` helper to `test/napi/napi-app/js_test_helpers.cpp` (plus a `REGISTER_FUNCTION` line). Both merged on the same day, and git cleanly stacked the hunks since they were at different offsets, so the file ended up with two definitions of the same function name.

## Fix

Keep the `{status, keys}` variant from #34126 (it returns a superset of what the bare-array variant from #34130 returned), drop the duplicate definition and duplicate registration, and adjust the single call site from #34130's test that read the result as a bare array.

## Verification

```
$ rm -rf test/napi/napi-app/build && bun bd test test/napi/napi-value-ffi.test.ts
 1 pass / 3 todo / 0 fail

$ bun bd test test/napi/napi.test.ts -t napi_get_all_property_names
(pass) napi > napi_get_all_property_names > own_only with skip_strings/skip_symbols includes non-enumerable own keys
(pass) napi > napi_get_property_names / napi_get_all_property_names > does not poison JSC's per-Structure own-keys cache
 2 pass / 0 fail
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->