### PR TITLE
napi: map Float16Array in napi_get_typedarray_info/napi_create_typedarray

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1733,6 +1733,8 @@ static JSC::TypedArrayType getTypedArrayTypeFromNAPI(napi_typedarray_type type)
         return JSC::TypedArrayType::TypeBigInt64;
     case napi_biguint64_array:
         return JSC::TypedArrayType::TypeBigUint64;
+    case napi_float16_array:
+        return JSC::TypedArrayType::TypeFloat16;
     default:
         ASSERT_NOT_REACHED_WITH_MESSAGE("Unexpected napi_typedarray_type");
     }
@@ -1769,6 +1771,8 @@ static JSC::JSArrayBufferView* createArrayBufferView(
         return JSC::JSBigInt64Array::create(globalObject, structure, WTF::move(arrayBuffer), byteOffset, length);
     case napi_biguint64_array:
         return JSC::JSBigUint64Array::create(globalObject, structure, WTF::move(arrayBuffer), byteOffset, length);
+    case napi_float16_array:
+        return JSC::JSFloat16Array::create(globalObject, structure, WTF::move(arrayBuffer), byteOffset, length);
     default:
         ASSERT_NOT_REACHED_WITH_MESSAGE("Unexpected napi_typedarray_type");
     }
@@ -1801,7 +1805,8 @@ extern "C" napi_status napi_create_typedarray(
     case napi_float32_array:
     case napi_float64_array:
     case napi_bigint64_array:
-    case napi_biguint64_array: {
+    case napi_biguint64_array:
+    case napi_float16_array: {
         break;
     }
     default: {

--- a/src/runtime/napi/js_native_api_types.h
+++ b/src/runtime/napi/js_native_api_types.h
@@ -66,6 +66,8 @@ typedef enum {
     napi_float64_array,
     napi_bigint64_array,
     napi_biguint64_array,
+#define NODE_API_HAS_FLOAT16_ARRAY
+    napi_float16_array,
 } napi_typedarray_type;
 
 typedef enum {

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -322,6 +322,7 @@ pub(super) enum napi_typedarray_type {
     float64_array = 8,
     bigint64_array = 9,
     biguint64_array = 10,
+    float16_array = 11,
 }
 
 impl napi_typedarray_type {
@@ -340,6 +341,7 @@ impl napi_typedarray_type {
             jsc::JSType::Float64Array => napi_typedarray_type::float64_array,
             jsc::JSType::BigInt64Array => napi_typedarray_type::bigint64_array,
             jsc::JSType::BigUint64Array => napi_typedarray_type::biguint64_array,
+            jsc::JSType::Float16Array => napi_typedarray_type::float16_array,
             _ => return None,
         })
     }

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -266,7 +266,7 @@ nativeTests.test_property_names_cache_poisoning = () => {
   console.log("Reflect.ownKeys after get_all_property_names(own_only):", Reflect.ownKeys(mkD()).join(","));
 
   // The napi result itself should still include inherited keys.
-  const apnResult = nativeTests.get_all_property_names(mkA(), 0, 0, 0).keys;
+  const { keys: apnResult } = nativeTests.get_all_property_names(mkA(), 0, 0, 0);
   console.log("napi include_prototypes result has own a,b:", apnResult.includes("a") && apnResult.includes("b"));
   console.log("napi include_prototypes result has inherited toString:", apnResult.includes("toString"));
   const gpnResult = nativeTests.get_property_names(mkB());

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -266,7 +266,7 @@ nativeTests.test_property_names_cache_poisoning = () => {
   console.log("Reflect.ownKeys after get_all_property_names(own_only):", Reflect.ownKeys(mkD()).join(","));
 
   // The napi result itself should still include inherited keys.
-  const { keys: apnResult } = nativeTests.get_all_property_names(mkA(), 0, 0, 0);
+  const apnResult = nativeTests.get_all_property_names(mkA(), 0, 0, 0).keys;
   console.log("napi include_prototypes result has own a,b:", apnResult.includes("a") && apnResult.includes("b"));
   console.log("napi include_prototypes result has inherited toString:", apnResult.includes("toString"));
   const gpnResult = nativeTests.get_property_names(mkB());

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2873,13 +2873,15 @@ static napi_value test_napi_float16_array(const Napi::CallbackInfo &info) {
          static_cast<int>(sc), created_is ? 1 : 0,
          static_cast<int>(created_type), created_len);
 
-  napi_value global = nullptr;
-  napi_value ctor = nullptr;
   bool is_instance = false;
-  NODE_API_CALL(env, napi_get_global(env, &global));
-  NODE_API_CALL(env,
-                napi_get_named_property(env, global, "Float16Array", &ctor));
-  NODE_API_CALL(env, napi_instanceof(env, created, ctor, &is_instance));
+  if (sc == napi_ok) {
+    napi_value global = nullptr;
+    napi_value ctor = nullptr;
+    NODE_API_CALL(env, napi_get_global(env, &global));
+    NODE_API_CALL(env,
+                  napi_get_named_property(env, global, "Float16Array", &ctor));
+    NODE_API_CALL(env, napi_instanceof(env, created, ctor, &is_instance));
+  }
   printf("created instanceof Float16Array=%d\n", is_instance ? 1 : 0);
 
   return ok(env);

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2821,6 +2821,70 @@ test_dataview_info_byte_offset(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+static napi_value test_napi_float16_array(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  // napi_float16_array == 11; cast so older headers without the member compile.
+  const napi_typedarray_type float16 = static_cast<napi_typedarray_type>(11);
+
+  napi_value view = info[1];
+  bool is = false;
+  NODE_API_CALL(env, napi_is_typedarray(env, view, &is));
+
+  napi_typedarray_type type = static_cast<napi_typedarray_type>(999);
+  size_t length = 0;
+  void *data = nullptr;
+  napi_value arraybuffer = nullptr;
+  size_t byte_offset = SIZE_MAX;
+  napi_status si = napi_get_typedarray_info(env, view, &type, &length, &data,
+                                            &arraybuffer, &byte_offset);
+  uint16_t e0 = (si == napi_ok && data && length > 0)
+                    ? static_cast<uint16_t *>(data)[0]
+                    : 0;
+  printf("is_typedarray=%d info_status=%d type=%d length=%zu byte_offset=%zu "
+         "e0=0x%04X\n",
+         is ? 1 : 0, static_cast<int>(si), static_cast<int>(type), length,
+         byte_offset, e0);
+
+  void *ab_data = nullptr;
+  size_t ab_len = 0;
+  NODE_API_CALL(
+      env, napi_get_arraybuffer_info(env, arraybuffer, &ab_data, &ab_len));
+  printf("arraybuffer_byte_length=%zu data_is_ab_plus_offset=%d\n", ab_len,
+         static_cast<uint8_t *>(ab_data) + byte_offset ==
+                 static_cast<uint8_t *>(data)
+             ? 1
+             : 0);
+
+  napi_value created = nullptr;
+  napi_status sc =
+      napi_create_typedarray(env, float16, 4, arraybuffer, 0, &created);
+  bool created_is = false;
+  napi_typedarray_type created_type = static_cast<napi_typedarray_type>(999);
+  size_t created_len = 0;
+  if (sc == napi_ok) {
+    NODE_API_CALL(env, napi_is_typedarray(env, created, &created_is));
+    NODE_API_CALL(env,
+                  napi_get_typedarray_info(env, created, &created_type,
+                                           &created_len, nullptr, nullptr,
+                                           nullptr));
+  }
+  printf("create_status=%d created_is_typedarray=%d created_type=%d "
+         "created_length=%zu\n",
+         static_cast<int>(sc), created_is ? 1 : 0,
+         static_cast<int>(created_type), created_len);
+
+  napi_value global = nullptr;
+  napi_value ctor = nullptr;
+  bool is_instance = false;
+  NODE_API_CALL(env, napi_get_global(env, &global));
+  NODE_API_CALL(env,
+                napi_get_named_property(env, global, "Float16Array", &ctor));
+  NODE_API_CALL(env, napi_instanceof(env, created, ctor, &is_instance));
+  printf("created instanceof Float16Array=%d\n", is_instance ? 1 : 0);
+
+  return ok(env);
+}
+
 static napi_value
 test_create_arraybuffer_zeroed(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
@@ -2865,6 +2929,7 @@ test_create_arraybuffer_zeroed(const Napi::CallbackInfo &info) {
 void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_typedarray_info_byte_offset);
   REGISTER_FUNCTION(env, exports, test_dataview_info_byte_offset);
+  REGISTER_FUNCTION(env, exports, test_napi_float16_array);
   REGISTER_FUNCTION(env, exports, test_create_arraybuffer_zeroed);
   REGISTER_FUNCTION(env, exports, test_issue_7685);
   REGISTER_FUNCTION(env, exports, test_issue_11949);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -712,6 +712,21 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
         "byte_offset=32 length=4 arraybuffer_byte_length=64 data_is_arraybuffer_data_plus_byte_offset=true",
       );
     });
+
+    it("maps Float16Array to napi_float16_array in both napi_get_typedarray_info and napi_create_typedarray", async () => {
+      const output = await checkSameOutput(
+        "test_napi_float16_array",
+        "[(() => { const f = new Float16Array(new ArrayBuffer(16), 4, 4); f.set([1.5, 2, 3, 4]); return f; })()]",
+      );
+      expect(output).toBe(
+        [
+          "is_typedarray=1 info_status=0 type=11 length=4 byte_offset=4 e0=0x3E00",
+          "arraybuffer_byte_length=16 data_is_ab_plus_offset=1",
+          "create_status=0 created_is_typedarray=1 created_type=11 created_length=4",
+          "created instanceof Float16Array=1",
+        ].join("\n"),
+      );
+    });
   });
 
   describe("napi_get_dataview_info", () => {

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -718,14 +718,13 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
         "test_napi_float16_array",
         "[(() => { const f = new Float16Array(new ArrayBuffer(16), 4, 4); f.set([1.5, 2, 3, 4]); return f; })()]",
       );
-      expect(output).toBe(
-        [
-          "is_typedarray=1 info_status=0 type=11 length=4 byte_offset=4 e0=0x3E00",
-          "arraybuffer_byte_length=16 data_is_ab_plus_offset=1",
-          "create_status=0 created_is_typedarray=1 created_type=11 created_length=4",
-          "created instanceof Float16Array=1",
-        ].join("\n"),
-      );
+      // printf() via the Windows CRT emits \r\n, so split on either ending.
+      expect(output.split(/\r?\n/)).toEqual([
+        "is_typedarray=1 info_status=0 type=11 length=4 byte_offset=4 e0=0x3E00",
+        "arraybuffer_byte_length=16 data_is_ab_plus_offset=1",
+        "create_status=0 created_is_typedarray=1 created_type=11 created_length=4",
+        "created instanceof Float16Array=1",
+      ]);
     });
   });
 


### PR DESCRIPTION
## What

`napi_is_typedarray` reports `true` for a `Float16Array`, but `napi_get_typedarray_info` on that same value returns `napi_invalid_arg` (leaving every out-param untouched), and `napi_create_typedarray(napi_float16_array, ...)` also returns `napi_invalid_arg`. Node.js v26 ships `napi_float16_array` unconditionally (`NODE_API_HAS_FLOAT16_ARRAY`), so any addon that accepts user-supplied typed arrays works on Node and errors on Bun the moment a `Float16Array` crosses the ABI.

```c
// view = new Float16Array([1.5, 2, 3, 4])
napi_is_typedarray(env, view, &is);                 // node: 1   bun: 1
napi_get_typedarray_info(env, view, &t, &len, ...); // node: ok, type=11, len=4
                                                    // bun : napi_invalid_arg
napi_create_typedarray(env, napi_float16_array, 4, ab, 0, &out);
                                                    // node: ok, [object Float16Array]
                                                    // bun : napi_invalid_arg
```

## Why

The `napi_typedarray_type` ⇄ JSC type tables stop at `napi_biguint64_array`:

- `napi_typedarray_type::from_js_type` in `src/runtime/napi/napi_body.rs` has no `Float16Array` arm, so `napi_get_typedarray_info` bails with `invalid_arg` when the caller asks for the type.
- `getTypedArrayTypeFromNAPI`, `createArrayBufferView`, and the enum-range guard in `napi_create_typedarray` (`src/jsc/bindings/napi.cpp`) have no `napi_float16_array` case, so creation is rejected before reaching JSC.
- The vendored `src/runtime/napi/js_native_api_types.h` predates the enum member entirely.

## Fix

Add `napi_float16_array` (= 11) to the vendored header with the `NODE_API_HAS_FLOAT16_ARRAY` marker to match upstream, add the variant to the Rust enum and its `from_js_type` mapping, and add the `napi_float16_array` ⇄ `JSC::TypeFloat16` / `JSC::JSFloat16Array` arms to the three switches in `napi.cpp`.

## Test

`test/napi/napi.test.ts` (`napi_get_typedarray_info > maps Float16Array to napi_float16_array ...`) runs a native addon helper under both Bun and Node and asserts identical output: `is_typedarray=1`, `info_status=0 type=11 length=4 byte_offset=4`, first element bytes `0x3E00` (fp16 for 1.5), `create_status=0`, and `created instanceof Float16Array=1`. Before the fix, Bun reports `info_status=1 type=999` and never gets to the create call.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->