### PR TITLE
Fix use-after-free when worker.terminate() races in-flight fetch/work-pool completions

### DIFF
--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -65,7 +65,16 @@ pub trait CompletionStruct: Node + Send + 'static {
         transpiler: &mut Transpiler<'a>,
         bump: &'a Arena,
     ) -> Result<(), crate::Error>;
+    /// Enqueues the finished completion to the owning JS thread and releases
+    /// the VM pin taken at creation (worker terminate waits for it, so the
+    /// enqueue lands on a live VM). Plugin builds run unpinned — see
+    /// `begin_run` — and may lose the completion at terminate.
     fn complete_on_bundle_thread(&mut self);
+    /// Called before the run starts. Plugin builds drop their VM pin here:
+    /// they round-trip through the owning JS thread mid-bundle, and holding
+    /// the pin across that would deadlock worker terminate. FIXME: give
+    /// plugin builds a cancel signal instead.
+    fn begin_run(&mut self);
     fn set_result(&mut self, result: BundleV2Result);
     fn set_log(&mut self, log: bun_ast::Log);
     fn set_transpiler(&mut self, this: *mut BundleV2<'_>);
@@ -75,7 +84,7 @@ pub trait CompletionStruct: Node + Send + 'static {
     fn file_map(&mut self) -> Option<NonNull<FileMap>>;
     /// Returns a §Dispatch handle (erased owner + `&'static` vtable) the impl
     /// provides, so the bundler can read `result == .err` /
-    /// `jsc_event_loop.enqueueTaskConcurrent` without naming the concrete
+    /// `vm.enqueue_task_concurrent` without naming the concrete
     /// struct.
     fn as_js_bundle_completion_task(&mut self) -> dispatch::CompletionHandle;
 
@@ -226,6 +235,7 @@ impl<C: CompletionStruct> BundleThread<C> {
                 // `panic = "abort"` → a Rust panic on this thread enters the
                 // crash-handler hook and aborts the whole process.
                 // No `catch_unwind` — there is nothing to catch.
+                completion.begin_run();
                 match Self::generate_in_new_thread(completion, generation) {
                     Ok(()) => {}
                     Err(err) => {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1120,6 +1120,8 @@ pub mod bv2_impl {
                             std::ptr::from_mut::<Self>(self).cast::<core::ffi::c_void>(),
                         ),
                         callback: Self::run_on_js_thread_wrap,
+                        // Owned by the bundler dispatch chain, not the queue.
+                        dispose: None,
                     };
                     let task =
                         bun_event_loop::ConcurrentTask::ConcurrentTask::create(self.js_task.task());
@@ -1250,6 +1252,8 @@ pub mod bv2_impl {
                             std::ptr::from_mut::<Self>(self).cast::<core::ffi::c_void>(),
                         ),
                         callback: Self::run_on_js_thread_wrap,
+                        // Owned by the bundler dispatch chain, not the queue.
+                        dispose: None,
                     };
                     let concurrent_task =
                         bun_event_loop::ConcurrentTask::ConcurrentTask::create(self.js_task.task());
@@ -1501,7 +1505,7 @@ pub mod bv2_impl {
         ) {
             debug_assert!(self.plugins.is_some());
             if let Some(completion) = self.completion {
-                // From Bun.build — `completion.jsc_event_loop.enqueueTaskConcurrent(task)`.
+                // From Bun.build — `completion.vm.enqueue_task_concurrent(task)`.
                 completion.enqueue_task_concurrent(task);
                 return;
             }

--- a/src/event_loop/AnyTask.rs
+++ b/src/event_loop/AnyTask.rs
@@ -18,6 +18,10 @@ pub type JsResult<T> = core::result::Result<T, ErasedJsError>;
 pub struct AnyTask {
     pub ctx: Option<NonNull<c_void>>,
     pub callback: fn(*mut c_void) -> JsResult<()>,
+    /// Releases a queue-owned `ctx` when the task is reclaimed unrun by the
+    /// worker-terminate drain (JS thread, VM alive — plain drop suffices).
+    /// `None` ⇒ the ctx is owned elsewhere and must not be freed here.
+    pub dispose: Option<fn(*mut c_void)>,
 }
 
 impl Default for AnyTask {
@@ -27,6 +31,7 @@ impl Default for AnyTask {
         Self {
             ctx: None,
             callback: |_| unreachable!("AnyTask.callback was undefined"),
+            dispose: None,
         }
     }
 }
@@ -64,6 +69,22 @@ impl AnyTask {
                     callback,
                 )
             },
+            dispose: None,
         }
+    }
+
+    /// [`Self::from_typed`] plus a release for `ctx` if the task is
+    /// reclaimed unrun by the terminate drain (see the `dispose` field).
+    #[inline]
+    pub fn from_typed_with_dispose<T>(
+        ctx: *mut T,
+        callback: fn(*mut T) -> JsResult<()>,
+        dispose: fn(*mut T),
+    ) -> Self {
+        let mut task = Self::from_typed(ctx, callback);
+        // SAFETY: same ABI argument as `from_typed`'s callback cast.
+        task.dispose =
+            Some(unsafe { bun_ptr::cast_fn_ptr::<fn(*mut T), fn(*mut c_void)>(dispose) });
+        task
     }
 }

--- a/src/event_loop/ConcurrentTask.rs
+++ b/src/event_loop/ConcurrentTask.rs
@@ -309,6 +309,20 @@ impl ConcurrentTask {
         Self::create(ManagedTask::ManagedTask::new(ptr, callback))
     }
 
+    /// [`Self::from_callback`] plus a cleanup run if the task is reclaimed
+    /// unrun at VM teardown (`EventLoop::deinit`); the cleanup must release
+    /// whatever the callback would have (drain runs pre-teardown, VM alive).
+    pub fn from_callback_with_cleanup<T>(
+        ptr: *mut T,
+        callback: fn(*mut T) -> crate::JsResult<()>,
+        cleanup: fn(*mut T),
+    ) -> core::ptr::NonNull<ConcurrentTask> {
+        bun_core::mark_binding!();
+        Self::create(ManagedTask::ManagedTask::new_with_cleanup(
+            ptr, callback, cleanup,
+        ))
+    }
+
     pub fn from<T: Taskable>(
         &mut self,
         of: *mut T,

--- a/src/event_loop/ManagedTask.rs
+++ b/src/event_loop/ManagedTask.rs
@@ -58,6 +58,29 @@ impl ManagedTask {
         ManagedTask::task(managed)
     }
 
+    /// [`Self::new`] plus a cleanup run when the task is reclaimed unrun at
+    /// VM teardown (`EventLoop::deinit`); the cleanup must free `ctx`
+    /// (it runs on the JS thread; at worker terminate the VM is still alive
+    /// during the drain, only `deinit` runs post-teardown).
+    pub fn new_with_cleanup<T>(
+        ctx: *mut T,
+        callback: fn(*mut T) -> JsResult<()>,
+        cleanup: fn(*mut T),
+    ) -> Task {
+        let managed = bun_core::heap::into_raw(Box::new(ManagedTask {
+            // SAFETY: same fn-pointer ABI cast as `new`.
+            callback: unsafe {
+                bun_ptr::cast_fn_ptr::<fn(*mut T) -> JsResult<()>, fn(*mut c_void) -> JsResult<()>>(
+                    callback,
+                )
+            },
+            ctx: NonNull::new(ctx.cast::<c_void>()),
+            // SAFETY: same fn-pointer ABI cast as `callback` above.
+            cleanup: Some(unsafe { bun_ptr::cast_fn_ptr::<fn(*mut T), fn(*mut c_void)>(cleanup) }),
+        }));
+        ManagedTask::task(managed)
+    }
+
     pub fn new_owned<T>(ctx: *mut T, callback: fn(*mut T) -> JsResult<()>) -> Task {
         fn drop_ctx<T>(p: *mut c_void) {
             // SAFETY: `p` is the `heap::into_raw(Box<T>)` stored in `ctx` by `new_owned`.

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -686,6 +686,9 @@ impl AsyncModule {
                     Self::on_done(p.cast());
                     Ok(())
                 },
+                // Same-thread enqueue; reclaimed by the shutdown drain while
+                // the VM is alive.
+                dispose: None,
             };
             jsc_vm.enqueue_task(Task::init(&raw mut (*clone).any_task));
         }

--- a/src/jsc/ConcurrentPromiseTask.rs
+++ b/src/jsc/ConcurrentPromiseTask.rs
@@ -32,8 +32,12 @@ pub struct ConcurrentPromiseTask<'a, Context: ConcurrentPromiseTaskContext> {
     pub ctx: Box<Context>,
     pub task: WorkPoolTask,
     /// BACKREF — captured from the JS-thread VM at create time; the VM (and its
-    /// `EventLoop`) outlives every task scheduled on it.
+    /// `EventLoop`) outlives every task scheduled on it (the pin below is
+    /// what enforces that for worker VMs).
     pub event_loop: BackRef<EventLoop>,
+    /// Holds the VM's shutdown gate open until the completion is enqueued
+    /// (dropped on the pool thread in `on_finish`); see `VirtualMachine::pin`.
+    pub vm_pin: Option<bun_threading::GateGuest>,
     pub promise: JSPromiseStrong,
     pub global_this: &'a JSGlobalObject,
     pub concurrent_task: ConcurrentTask,
@@ -59,9 +63,11 @@ impl<'a, Context: ConcurrentPromiseTaskContext> ConcurrentPromiseTask<'a, Contex
     pub fn create_on_js_thread(global_this: &'a JSGlobalObject, value: Box<Context>) -> Box<Self> {
         // `VirtualMachine::get()` returns the JS-thread singleton; the VM and
         // its `EventLoop` outlive every task scheduled on it.
-        let event_loop = BackRef::new(VirtualMachine::get().as_mut().event_loop_shared());
+        let vm = VirtualMachine::get();
+        let event_loop = BackRef::new(vm.as_mut().event_loop_shared());
         let mut this = Box::new(Self {
             event_loop,
+            vm_pin: Some(vm.pin()),
             ctx: value,
             task: WorkPoolTask {
                 node: Default::default(),
@@ -109,6 +115,9 @@ impl<'a, Context: ConcurrentPromiseTaskContext> ConcurrentPromiseTask<'a, Contex
         // the pointer (does not dereference it).
         let this_ref = unsafe { &mut *this };
         let event_loop = this_ref.event_loop;
+        // Take the pin into a local first — the enqueue hands the job to the
+        // JS thread, which may free it before this thread returns.
+        let pin = this_ref.vm_pin.take();
         let task = core::ptr::NonNull::from(
             this_ref
                 .concurrent_task
@@ -117,6 +126,9 @@ impl<'a, Context: ConcurrentPromiseTaskContext> ConcurrentPromiseTask<'a, Contex
         // `task` is the live `concurrent_task` field of the heap-allocated
         // job; the queue takes ownership of its intrusive `next` link.
         event_loop.enqueue_task_concurrent(task);
+        // Completion enqueued: dropping the pin lets terminate proceed to
+        // drain it with the VM still alive.
+        drop(pin);
     }
 
     /// Frees the heap allocation backing this task.

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -321,6 +321,7 @@ impl RuntimeTranspilerStore {
                 global_this: BackRef::new(global_object),
                 non_threadsafe_referrer: OwnedString::new(referrer),
                 vm,
+                vm_pin: None,
                 log: bun_ast::Log::init(),
                 loader,
                 promise: StrongOptional::create(JSValue::from_cell(promise), global_object),
@@ -377,6 +378,10 @@ pub struct TranspilerJob {
     // raw pointers/BackRefs are used (BACKREF — VM owns the
     // store and outlives every job).
     pub vm: *mut VirtualMachine,
+    /// Holds the VM's shutdown gate open from `schedule` until the
+    /// completion is enqueued (dropped on the pool thread) — worker
+    /// terminate waits for in-flight transpiles instead of racing them.
+    pub vm_pin: Option<bun_threading::GateGuest>,
     pub global_this: BackRef<JSGlobalObject>,
     pub fetcher: Fetcher,
     pub poll_ref: KeepAlive,
@@ -486,16 +491,19 @@ impl TranspilerJob {
 
     pub(crate) fn dispatch_to_main_thread(&mut self) {
         let vm = self.vm;
-        // SAFETY: vm outlives the job (BACKREF — VM owns the store).
+        // Take the pin (held since `schedule`) into a local first — another
+        // thread may free `self` the moment the push below publishes it.
+        let pin = self.vm_pin.take();
+        // SAFETY: `vm` is kept alive by `pin` (BACKREF — VM owns the store).
         let transpiler_store: *mut RuntimeTranspilerStore =
             unsafe { ptr::addr_of_mut!((*vm).transpiler_store) };
         let job = NonNull::from(&mut *self);
         // SAFETY: queue is concurrent-safe (UnboundedQueue uses atomics).
         unsafe { (*transpiler_store).queue.push(job) };
-        // Another thread may free `self` at any time after .push, so we cannot use it any more.
-        // SAFETY: vm outlives the job; event_loop() returns the live self-pointer.
+        // SAFETY: vm is kept alive by `pin`; event_loop() returns the live self-pointer.
         unsafe { &*(*vm).event_loop() }
             .enqueue_task_concurrent(ConcurrentTask::create_from(transpiler_store));
+        drop(pin);
     }
 
     pub(crate) fn run_from_js_thread(&mut self) -> JsResult<()> {
@@ -559,6 +567,9 @@ impl TranspilerJob {
         // `EventLoopCtx` vtable; resolve it via the `get_vm_ctx` hook (registered by
         // `bun_runtime::init`).
         self.poll_ref.ref_(get_vm_ctx(AllocatorType::Js));
+        // Terminate blocks until this transpile's completion is enqueued.
+        // SAFETY: `vm` is the live per-thread VM (schedule runs on it).
+        self.vm_pin = Some(unsafe { (*self.vm).pin() });
         WorkPool::schedule(&raw mut self.work_task);
     }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -990,12 +990,9 @@ impl VirtualMachine {
     /// teardown. Call on the JS thread when scheduling async work; drop on
     /// the completing thread right after the completion enqueue.
     pub fn pin(&self) -> bun_threading::GateGuest {
-        bun_threading::GateGuest::enter(
-            self.shutdown_gate.as_ref().expect("pin() after destroy()"),
-        )
-        .expect("pin() on a closed gate: producers are created on the live JS thread")
+        bun_threading::GateGuest::enter(self.shutdown_gate.as_ref().expect("pin() after destroy()"))
+            .expect("pin() on a closed gate: producers are created on the live JS thread")
     }
-
 
     pub fn has_run_cleanup_hooks(&self) -> bool {
         self.has_run_cleanup_hooks

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -274,6 +274,19 @@ pub struct VirtualMachine {
     pub regular_event_loop: EventLoop,
     pub event_loop: *mut EventLoop, // BORROW_FIELD — points at sibling regular_event_loop/macro_event_loop
 
+    /// Counted gate async producers hold open (see [`Self::pin`]) from job
+    /// creation until their completion is enqueued back to this VM. Worker
+    /// terminate closes it — blocking until every producer has finished —
+    /// before draining the queue and freeing the VM box. Lives in an `Arc`
+    /// so a guest may outlive the box; `Option` so [`Self::destroy`] can
+    /// drop the VM's ref explicitly (worker boxes are freed without `Drop`).
+    pub shutdown_gate: Option<std::sync::Arc<bun_threading::ShutdownGate>>,
+
+    /// In-flight abortable transfers; see
+    /// [`crate::terminate_abort::TerminateAbortRegistry`].
+    pub terminate_abort_registry:
+        core::cell::RefCell<crate::terminate_abort::TerminateAbortRegistry>,
+
     pub ref_strings: crate::ref_string::Map,
     pub ref_strings_mutex: bun_threading::Mutex,
 
@@ -971,6 +984,19 @@ impl VirtualMachine {
         self.is_shutting_down
     }
 
+    /// Pin this VM's shutdown gate open: [`Self::destroy`] / worker terminate
+    /// will wait for the returned guest before tearing the VM down, so the
+    /// holder may enqueue completions from other threads without racing
+    /// teardown. Call on the JS thread when scheduling async work; drop on
+    /// the completing thread right after the completion enqueue.
+    pub fn pin(&self) -> bun_threading::GateGuest {
+        bun_threading::GateGuest::enter(
+            self.shutdown_gate.as_ref().expect("pin() after destroy()"),
+        )
+        .expect("pin() on a closed gate: producers are created on the live JS thread")
+    }
+
+
     pub fn has_run_cleanup_hooks(&self) -> bool {
         self.has_run_cleanup_hooks
     }
@@ -1572,6 +1598,14 @@ impl VirtualMachine {
                 (hooks.close_dns_for_terminate)();
             }
 
+            // Abort registered in-flight transfers while JSC is alive so
+            // their producer pins drop and their completions land before the
+            // queue drain below.
+            if let Some(hooks) = runtime_hooks() {
+                // SAFETY: live per-thread VM on the JS thread, pre-teardown.
+                unsafe { (hooks.abort_pending_transfers)(core::ptr::from_mut(self)) };
+            }
+
             // The HTTP daemon thread holds a `Box<ThreadlocalAsyncHTTP>` per
             // in-flight request; with the JS thread exiting those never reach
             // a terminal state. Ask it to reclaim them now (waits up to 1s).
@@ -1809,6 +1843,13 @@ pub struct RuntimeHooks {
     /// never lazily created. Called from `WebWorker::shutdown` / `global_exit`
     /// right after `close_all_socket_groups`.
     pub close_dns_for_terminate: fn(),
+    /// Worker-terminate / process-exit walk over
+    /// `vm.terminate_abort_registry`: aborts each registered transfer while
+    /// the VM is still alive so producer pins drop promptly.
+    ///
+    /// # Safety
+    /// `vm` is the live per-thread VM on its own JS thread, pre-teardown.
+    pub abort_pending_transfers: unsafe fn(vm: *mut VirtualMachine),
 }
 
 /// Canonical `EventLoopCtx` vtable for a `*mut VirtualMachine` owner — the JS
@@ -2114,6 +2155,12 @@ impl VirtualMachine {
             (*regular).virtual_machine = NonNull::new(vm);
             let _ = (*regular).tasks.ensure_unused_capacity(64);
             addr_of_mut!((*vm).event_loop).write(regular);
+
+            addr_of_mut!((*vm).terminate_abort_registry)
+                .write(core::cell::RefCell::new(Default::default()));
+            addr_of_mut!((*vm).shutdown_gate).write(Some(std::sync::Arc::new(
+                bun_threading::ShutdownGate::new(),
+            )));
 
             // `source_mappings.map` is a sibling-field backref onto
             // `saved_source_map_table`.
@@ -4372,6 +4419,21 @@ impl VirtualMachine {
     }
     /// Worker-thread teardown.
     pub fn destroy(&mut self) {
+        // Backstop for non-worker teardown paths (global_exit, bake): refuse
+        // new producer pins. Main-VM exit must NOT wait — a pin stranded by
+        // an un-acked HTTP park would hang the process, and the main VM's
+        // box is never freed anyway. Worker shutdown already did the full
+        // close-and-wait before its drain.
+        if let Some(gate) = &self.shutdown_gate {
+            if self.is_main_thread {
+                gate.close_without_waiting();
+            } else {
+                gate.close_and_wait();
+            }
+        }
+        // Drop the VM's ref explicitly — worker boxes are freed without
+        // running `Drop`, which would leak the `Arc` allocation.
+        drop(self.shutdown_gate.take());
         self.regular_event_loop.deinit();
         self.macro_event_loop.deinit();
 

--- a/src/jsc/WorkTask.rs
+++ b/src/jsc/WorkTask.rs
@@ -35,8 +35,12 @@ pub struct WorkTask<Context: WorkTaskContext> {
     pub ctx: *mut Context,
     pub task: WorkPoolTask,
     /// BACKREF — captured from the JS-thread VM at create time; the VM (and its
-    /// `EventLoop`) outlives every task scheduled on it.
+    /// `EventLoop`) outlives every task scheduled on it (the pin below is
+    /// what enforces that for worker VMs).
     pub event_loop: BackRef<EventLoop>,
+    /// Holds the VM's shutdown gate open until the completion is enqueued
+    /// (dropped on the pool thread in `on_finish`); see `VirtualMachine::pin`.
+    pub vm_pin: Option<bun_threading::GateGuest>,
     // allocator field dropped — global mimalloc (see PORTING.md §Allocators)
     pub global_this: BackRef<JSGlobalObject>,
     pub concurrent_task: ConcurrentTask,
@@ -64,6 +68,7 @@ impl<Context: WorkTaskContext> WorkTask<Context> {
         let event_loop = BackRef::new(vm.event_loop_shared());
         let mut this = Box::new(Self {
             event_loop,
+            vm_pin: Some(vm.pin()),
             ctx: value,
             global_this: BackRef::new(global_this),
             task: WorkPoolTask {
@@ -131,6 +136,9 @@ impl<Context: WorkTaskContext> WorkTask<Context> {
         // stores the pointer (does not dereference it).
         let event_loop = this.event_loop;
         let this_ptr: *mut Self = this;
+        // Take the pin into a local first — the enqueue hands the task to
+        // the JS thread, which may free it before this thread returns.
+        let pin = this.vm_pin.take();
         let task = core::ptr::NonNull::from(
             this.concurrent_task
                 .from(this_ptr, AutoDeinit::ManualDeinit),
@@ -138,5 +146,6 @@ impl<Context: WorkTaskContext> WorkTask<Context> {
         // `task` is the inline `concurrent_task` field of the live
         // heap-allocated `*this`; `event_loop` is the JS-thread loop stored at init.
         event_loop.enqueue_task_concurrent(task);
+        drop(pin);
     }
 }

--- a/src/jsc/any_task_job.rs
+++ b/src/jsc/any_task_job.rs
@@ -7,9 +7,6 @@
 //! `WorkTask`) — those go through the central `TaskTag` dispatch table, not
 //! the type-erased `AnyTask` path, and would need a per-instantiation tag.
 
-use core::ffi::c_void;
-use core::ptr::NonNull;
-
 use bun_event_loop::AnyTask::AnyTask;
 use bun_io::KeepAlive;
 use bun_threading::work_pool::{IntrusiveWorkTask as _, Task as WorkPoolTask, WorkPool};
@@ -49,6 +46,9 @@ pub trait AnyTaskJobCtx: Sized {
 /// e.g. a `JSPromiseStrong` field after scheduling.
 pub struct AnyTaskJob<C> {
     vm: bun_ptr::BackRef<VirtualMachine>,
+    /// Holds the VM's shutdown gate open until the completion is enqueued
+    /// (dropped on the pool thread in `run_task`); see `VirtualMachine::pin`.
+    vm_pin: Option<bun_threading::GateGuest>,
     task: WorkPoolTask,
     any_task: AnyTask,
     poll: KeepAlive,
@@ -74,6 +74,7 @@ impl<C: AnyTaskJobCtx> AnyTaskJob<C> {
     pub fn create(global: &JSGlobalObject, ctx: C) -> JsResult<*mut Self> {
         let vm = bun_ptr::BackRef::new(global.bun_vm());
         let job = bun_core::heap::into_raw(Box::new(Self {
+            vm_pin: Some(vm.pin()),
             vm,
             task: WorkPoolTask {
                 node: Default::default(),
@@ -88,10 +89,11 @@ impl<C: AnyTaskJobCtx> AnyTaskJob<C> {
         // SAFETY: `job` was just allocated and is exclusively owned here.
         // Build the erased AnyTask directly with a non-capturing shim.
         unsafe {
-            (*job).any_task = AnyTask {
-                ctx: NonNull::new(job.cast::<c_void>()),
-                callback: |p: *mut c_void| Self::run_from_js(p.cast::<Self>()).map_err(Into::into),
-            };
+            (*job).any_task = AnyTask::from_typed_with_dispose(
+                job,
+                Self::run_from_js_erased,
+                Self::release_unrun,
+            );
         }
         // `ctx.init` may throw (e.g. CryptoJob<Scrypt>); on error, reclaim the
         // box so `Drop for C` releases any resources `ctx` already owns.
@@ -141,10 +143,25 @@ impl<C: AnyTaskJobCtx> AnyTaskJob<C> {
         let job = unsafe { &mut *Self::from_task_ptr(task) };
         let vm = job.vm;
         job.ctx.run(vm.global);
+        // Take the pin into a local first — the enqueue hands the job to the
+        // JS thread, which may free it before this thread returns.
+        let pin = job.vm_pin.take();
         // `ConcurrentTask::create` heap-allocates a fresh task; the queue takes
         // ownership of it.
         vm.event_loop_shared()
             .enqueue_task_concurrent(ConcurrentTask::create(job.any_task.task()));
+        drop(pin);
+    }
+
+    fn run_from_js_erased(this: *mut Self) -> bun_event_loop::AnyTask::JsResult<()> {
+        Self::run_from_js(this).map_err(Into::into)
+    }
+
+    /// Reclaim a queued-but-unrun completion during the shutdown drain
+    /// (JS thread, VM alive): normal drop glue releases everything.
+    fn release_unrun(this: *mut Self) {
+        // SAFETY: queue-owned heap job popped by the drain; sole owner.
+        drop(unsafe { bun_core::heap::take(this) });
     }
 
     /// `AnyTask` callback — runs ON the JS thread. Reclaims the heap
@@ -155,7 +172,10 @@ impl<C: AnyTaskJobCtx> AnyTaskJob<C> {
         // uniquely owned here (the `AnyTask` fires exactly once).
         let mut this = unsafe { bun_core::heap::take(this) };
         let vm = this.vm;
-        if vm.is_shutting_down() {
+        // Bail while worker shutdown / terminate is pending: `then` resolves
+        // promises, and entering JSC with the termination exception set trips
+        // exception-scope asserts.
+        if vm.script_execution_status() != crate::ScriptExecutionStatus::Running {
             return Ok(());
         }
         this.ctx.then(vm.global())

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -731,29 +731,60 @@ impl EventLoop {
     /// `is_shutting_down()` read is non-atomic and can lag — is forwarded into
     /// `self.tasks` for the per-tag release below.
     ///
-    /// `ManagedTask` entries are deliberately re-queued rather than freed:
+    /// `ManagedTask` / `AnyTask` entries that carry a `cleanup` / `dispose` fn
+    /// are reclaimed here (VM alive, so their JSC-handle drops are sound).
+    /// Plain `ManagedTask`s without a cleanup fn are deliberately re-queued:
     /// owners (e.g. `SendQueue.close_next_tick` / `after_close_task`) keep raw
     /// back-pointers that they `cancel()` from `Drop`, and those `Drop`s fire
-    /// during `destructOnExit` (`Subprocess::finalize` → `SendQueue::drop`).
-    /// Freeing the box here would leave those pointers dangling and make
-    /// `cancel()` a heap-use-after-free. `deinit()` runs after `destructOnExit`
-    /// — every owner has cancelled and cleared its pointer by then — so it is
-    /// the correct teardown point for `ManagedTask`s.
+    /// during `destructOnExit` (`Subprocess::finalize` → `SendQueue::drop`);
+    /// freeing the box here would leave those pointers dangling. `deinit()`
+    /// runs after `destructOnExit` and frees them then.
     ///
     /// Tags `__bun_release_task_at_shutdown` doesn't claim are likewise
-    /// re-queued so they remain reachable from the static-rooted VM box (the
-    /// pre-`532a5411961b` state). Consuming them silently here unhooked that
-    /// root and surfaced the boxes as direct leaks (e.g. `AnyTaskJob<_>`); the
-    /// definer can't safely dispatch every `AnyTask` callback at shutdown.
+    /// re-queued so they remain reachable from the static-rooted VM box.
     pub fn release_queued_tasks_for_shutdown(&mut self) {
         self.drop_concurrent_cpp_tasks();
         let mut requeue: Vec<bun_event_loop::Task> = Vec::new();
         while let Some(task) = self.tasks.read_item() {
-            // SAFETY: tag-specific release (drops JSC handles while the VM is
-            // still live); definer in `bun_runtime::dispatch` matches the same
-            // tag set `tick_queue_with_count` does. `false` ⇒ not handled.
-            let consumed = task.tag != bun_event_loop::task_tag::ManagedTask
-                && unsafe { __bun_release_task_at_shutdown(task) };
+            let consumed = match task.tag {
+                // A cleanup-bearing ManagedTask (fetch deferred deinit /
+                // resume) is releasable now, with the VM alive; the plain
+                // ones are owned elsewhere and freed in `deinit`.
+                bun_event_loop::task_tag::ManagedTask => {
+                    // SAFETY: heap_owned (ManagedTask::new -> heap::into_raw).
+                    let managed = unsafe {
+                        bun_core::heap::take(task.ptr.cast::<ManagedTask::ManagedTask>())
+                    };
+                    if let (Some(cleanup), Some(ctx)) = (managed.cleanup, managed.ctx) {
+                        cleanup(ctx.as_ptr());
+                        true
+                    } else {
+                        // Not consumable here — put the box back (re-queued below).
+                        let _ = core::mem::ManuallyDrop::new(managed);
+                        false
+                    }
+                }
+                // A queue-owned AnyTask completion is released via the fn its
+                // producer registered (plain drop — the VM is alive).
+                bun_event_loop::task_tag::AnyTask => {
+                    // SAFETY: `ptr` is the `*mut AnyTask` registered by
+                    // `AnyTask::task()`; copy fields out — `dispose` may free
+                    // the allocation embedding the AnyTask.
+                    let (dispose, ctx) = unsafe {
+                        let any = &*task.ptr.cast::<bun_event_loop::AnyTask::AnyTask>();
+                        (any.dispose, any.ctx)
+                    };
+                    if let (Some(dispose), Some(ctx)) = (dispose, ctx) {
+                        dispose(ctx.as_ptr());
+                        true
+                    } else {
+                        false
+                    }
+                }
+                // SAFETY: tag-specific release (drops JSC handles while the
+                // VM is still live); definer in `bun_runtime::dispatch`.
+                _ => unsafe { __bun_release_task_at_shutdown(task) },
+            };
             if !consumed {
                 requeue.push(task);
             }
@@ -765,18 +796,11 @@ impl EventLoop {
 
     pub fn deinit(&mut self) {
         // Free (don't run — running could re-enter the dying VM) queued
-        // ManagedTask boxes. Other tags are left in place: they were re-queued
-        // by `release_queued_tasks_for_shutdown` because their callback can't
-        // be no-op-dispatched safely (`AnyTask` callbacks call into JS) and
-        // their box may be aliased by the originator. Keeping them in
-        // `self.tasks` (a field of the static-rooted `VirtualMachine` box that
-        // is never `dealloc`'d) leaves the chain reachable to LSan — the same
-        // visibility they had via `concurrent_tasks` before
-        // `drop_concurrent_cpp_tasks` drained it. CppTasks must NOT be deleted
-        // here: this runs after JSC VM teardown on both worker and main paths,
-        // and a Worker dispatchExit task's `~Ref<Worker>` would walk freed
-        // WeakBlock storage via `~JSEventListener`. They are reclaimed before
-        // teardown by `release_queued_tasks_for_shutdown`'s CppTask arm.
+        // ManagedTask boxes. Everything reclaimable was consumed by
+        // `release_queued_tasks_for_shutdown` while the VM was alive (the
+        // producer pin protocol guarantees completions land pre-drain);
+        // anything else here is owned elsewhere and re-queued so it stays
+        // reachable from the static-rooted VM box.
         let mut requeue: Vec<bun_event_loop::Task> = Vec::new();
         while let Some(task) = self.tasks.read_item() {
             if task.tag == bun_event_loop::task_tag::ManagedTask {
@@ -791,10 +815,15 @@ impl EventLoop {
                 requeue.push(task);
             }
         }
-        // Reassigning a fresh value drops the old buffers in place.
-        self.tasks = Queue::init();
-        for task in requeue {
-            let _ = self.tasks.write_item(task);
+        if requeue.is_empty() {
+            // Reassigning a fresh value drops the old buffers in place.
+            self.tasks = Queue::init();
+        } else {
+            // Keep the queue (and its buffers) so the re-queued boxes stay
+            // reachable from the static-rooted VM allocation.
+            for task in requeue {
+                let _ = self.tasks.write_item(task);
+            }
         }
         let pending = core::mem::take(&mut self.immediate_tasks);
         let next = core::mem::take(&mut self.next_immediate_tasks);

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -80,6 +80,7 @@ pub mod script_execution_status;
 pub mod sizes;
 #[path = "SourceProvider.rs"]
 pub mod source_provider;
+pub mod terminate_abort;
 #[path = "TextCodec.rs"]
 pub mod text_codec;
 #[path = "URLSearchParams.rs"]

--- a/src/jsc/terminate_abort.rs
+++ b/src/jsc/terminate_abort.rs
@@ -1,0 +1,52 @@
+//! Per-VM registry of in-flight abortable transfers (JS-thread only).
+//!
+//! Producers whose completion can take arbitrarily long (network transfers)
+//! register an abort action at creation and unregister when the JS side
+//! consumes the completion. Worker terminate / process exit drains the
+//! registry so the transfer finishes promptly and the producer's shutdown
+//! gate pin drops — bounding how long the gate close waits.
+
+/// See the module docs. Entries are keyed by the producer's allocation
+/// address so normal completion can remove its own entry.
+#[derive(Default)]
+pub struct TerminateAbortRegistry {
+    entries: Vec<Entry>,
+}
+
+struct Entry {
+    key: usize,
+    abort: Box<dyn FnOnce()>,
+}
+
+impl TerminateAbortRegistry {
+    /// Register `abort` under `key` (the producer's allocation). The action
+    /// runs at most once, on the JS thread, with the VM alive; it must not
+    /// free `key`'s allocation (the producer's own lifecycle does that).
+    pub fn register<T>(&mut self, key: *mut T, abort: impl FnOnce() + 'static) {
+        self.entries.push(Entry {
+            key: key as usize,
+            abort: Box::new(abort),
+        });
+    }
+
+    /// Drop the entry registered under `key`, if the shutdown walk has not
+    /// already consumed it. Returns whether an entry was removed.
+    pub fn unregister<T>(&mut self, key: *mut T) -> bool {
+        let key = key as usize;
+        let Some(i) = self.entries.iter().position(|e| e.key == key) else {
+            return false;
+        };
+        self.entries.swap_remove(i);
+        true
+    }
+
+    /// Take every registered abort action, leaving the registry empty.
+    /// Callers loop until a take yields nothing: an abort can run user JS
+    /// that registers new transfers.
+    pub fn take_all(&mut self) -> Vec<Box<dyn FnOnce()>> {
+        core::mem::take(&mut self.entries)
+            .into_iter()
+            .map(|e| e.abort)
+            .collect()
+    }
+}

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1312,10 +1312,24 @@ impl WebWorker {
             // or observes m_isShuttingDown under m_lock and drops. Idempotent;
             // teardownJSCVM sets it again.
             Bun__JSCTaskScheduler__markShuttingDown(vm.global());
+            // Abort registered in-flight transfers (fetch/S3) while JSC is
+            // alive so the HTTP side finishes promptly and its producer pins
+            // drop; must precede the gate close below.
+            if let Some(hooks) = runtime_hooks() {
+                // SAFETY: sole owner (unpublished above); JS thread, pre-teardown.
+                unsafe { (hooks.abort_pending_transfers)(vm_ptr) };
+            }
+            // Wait for every async producer to finish: once the gate closes,
+            // all completions are in the queue and nothing can enqueue again.
+            vm.shutdown_gate
+                .as_ref()
+                .expect("gate live until destroy()")
+                .close_and_wait();
             // Reclaim queued CppTasks (the per-worker stdio/messaging
             // MessagePort drain tasks that can be in self.tasks mid-tick when
             // terminate() lands, and any Worker dispatchExit close task from a
-            // sub-worker) while JSC is still live: ~Ref<Worker> walks
+            // sub-worker) and every producer completion parked by the gate
+            // close, while JSC is still live: ~Ref<Worker> walks
             // ~JSEventListener Weak<> handles, and after teardownJSCVM the
             // worker VM is dealloc'd-without-Drop so anything still in
             // self.tasks leaks. Mirrors the global_exit() ordering.

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -682,7 +682,12 @@ pub trait TaskContext: Send {
 pub struct AsyncTask<C: TaskContext> {
     ctx: C,
     promise: JSPromiseStrong,
+    /// JSC_BORROW: kept alive across the job by `vm_pin` below (worker
+    /// terminate waits for the pin).
     vm: *mut VirtualMachine,
+    /// Holds the worker's shutdown gate open until the completion is
+    /// enqueued (dropped on the pool thread).
+    vm_pin: Option<bun_threading::GateGuest>,
     task: WorkPoolTask,
     concurrent_task: ConcurrentTask,
     keep_alive: KeepAlive,
@@ -694,15 +699,14 @@ impl<C: TaskContext> Taskable for AsyncTask<C> {
 
 impl<C: TaskContext> AsyncTask<C> {
     fn create(global: &JSGlobalObject, ctx: C) -> Result<*mut Self, bun_alloc::AllocError> {
-        // `bun_vm_ptr()` returns `*mut VirtualMachine` with write provenance; valid for
-        // process lifetime. Do NOT launder `bun_vm()` (a `&VirtualMachine`) through
-        // `*const _ as *mut _` — that derives a writeable pointer from a shared
-        // reference and is UB under Stacked Borrows.
         let vm: *mut VirtualMachine = global.bun_vm_ptr();
+        // SAFETY: `bun_vm_ptr` returns the live per-thread VM.
+        let vm_pin = Some(unsafe { (*vm).pin() });
         let this = Box::new(AsyncTask {
             ctx,
             promise: JSPromiseStrong::init(global),
             vm,
+            vm_pin,
             task: WorkPoolTask {
                 callback: Self::run_callback,
                 node: Default::default(),
@@ -746,13 +750,29 @@ impl<C: TaskContext> AsyncTask<C> {
         let this: *mut Self = unsafe { bun_core::from_field_ptr!(Self, task, work_task) };
         // SAFETY: thread-pool has exclusive access to ctx until it enqueues the concurrent task.
         unsafe { (*this).ctx.run() };
-        // SAFETY: vm points to the live owning VM; concurrent_task is intrusive on the same allocation.
+        // SAFETY: `this` is the live heap task; `vm` stays alive because the
+        // pin (held since `create`) blocks terminate until dropped below.
         unsafe {
+            // Take the pin into a local first — the enqueue hands the task
+            // to the JS thread, which may free it before this thread returns.
+            let pin = (*this).vm_pin.take();
             let ct = core::ptr::NonNull::from(
                 (*this).concurrent_task.from(this, AutoDeinit::ManualDeinit),
             );
             (*(*this).vm).enqueue_task_concurrent(ct);
+            drop(pin);
         }
+    }
+
+    /// Reclaim a queued-but-unrun completion during the terminate drain
+    /// (JS thread, VM alive): plain drop releases everything.
+    ///
+    /// # Safety
+    /// `this` is the queue-owned heap task popped by the drain.
+    pub unsafe fn release_unrun(this: *mut Self) {
+        // SAFETY: caller contract.
+        let mut owned = unsafe { bun_core::heap::take(this) };
+        owned.keep_alive.unref(bun_io::js_vm_ctx());
     }
 
     /// # Safety

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1339,8 +1339,6 @@ pub mod js_bundler {
         let mut plugins: Option<*mut Plugin> = None;
         let config = Config::from_js(global_this, arguments[0], &mut plugins)?;
 
-        let event_loop = vm.event_loop();
-
         // `BundleV2.generateFromJavaScript` — the completion-task struct lives in
         // `crate::api::js_bundle_completion_task` (bun_runtime owns it because its
         // fields name `Config`/`Plugin`/`HTMLBundle::Route`; lower-tier crates
@@ -1350,7 +1348,6 @@ pub mod js_bundler {
                 config,
                 plugins.and_then(core::ptr::NonNull::new),
                 global_this,
-                event_loop,
             )
             .map_err(|_| JsError::OutOfMemory)?;
         // SAFETY: `completion` is the freshly-boxed allocation returned above;

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -58,9 +58,15 @@ pub struct JSBundleCompletionTask {
     // `unsafe impl Send` below for the thread-affinity constraint this imposes.
     pub ref_count: RefCount<Self>,
     pub config: JSBundlerConfig,
-    // BACKREF — the JS-thread `EventLoop` outlives every completion task; safe
-    // `Deref` so call sites read `self.jsc_event_loop.enqueue_task_concurrent(..)`.
+    /// The owning VM's event loop; kept alive by `vm_pin` (or re-checked via
+    /// `vm_gate` for unpinned plugin builds).
     pub jsc_event_loop: BackRef<EventLoop>,
+    /// The owning VM's shutdown gate, for the unpinned plugin-build enqueue.
+    pub vm_gate: std::sync::Arc<bun_threading::ShutdownGate>,
+    /// Holds the VM's shutdown gate open from creation until the completion
+    /// is enqueued back (plugin builds drop it in `begin_run` — see
+    /// `CompletionStruct::begin_run`).
+    pub vm_pin: Option<bun_threading::GateGuest>,
     pub task: AnyTask,
     pub global_this: BackRef<JSGlobalObject>,
     pub promise: jsc::JSPromiseStrong,
@@ -82,6 +88,15 @@ pub struct JSBundleCompletionTask {
 }
 
 impl JSBundleCompletionTask {
+    /// Release a queued-but-unrun completion during the terminate drain
+    /// (JS thread, VM alive): drop the queue's ref like `on_complete_anytask`
+    /// would have. An `html_build_task` route ref (released by the normal
+    /// completion path via JS) is left held — bounded, dies with the VM.
+    fn release_unrun(this: *mut Self) {
+        // SAFETY: the queue owned this entry; releasing on the JS thread.
+        unsafe { <Self as bun_ptr::AnyRefCounted>::rc_deref(this) };
+    }
+
     /// `RefCounted` destructor — last ref dropped.
     ///
     /// Safe fn: only reachable via the `#[ref_count(destroy = …)]` derive,
@@ -115,16 +130,21 @@ pub(crate) fn create_and_schedule_completion_task(
     config: JSBundlerConfig,
     plugins: Option<NonNull<Plugin>>,
     global_this: &JSGlobalObject,
-    event_loop: *mut EventLoop,
 ) -> crate::Result<*mut JSBundleCompletionTask> {
     let vm = global_this.bun_vm_ptr();
     let env = global_this.bun_vm().transpiler.env;
     let completion = bun_core::heap::into_raw(Box::new(JSBundleCompletionTask {
         ref_count: RefCount::init(),
         config,
-        // `event_loop` is the live JS-thread loop (caller derives it from
-        // `vm.event_loop()`); never null once `Bun.build` is reachable.
-        jsc_event_loop: BackRef::from(core::ptr::NonNull::new(event_loop).expect("event_loop")),
+        jsc_event_loop: BackRef::new(global_this.bun_vm().as_mut().event_loop_shared()),
+        vm_gate: std::sync::Arc::clone(
+            global_this
+                .bun_vm()
+                .shutdown_gate
+                .as_ref()
+                .expect("gate live on the JS thread"),
+        ),
+        vm_pin: None,
         task: AnyTask::default(),
         global_this: BackRef::new(global_this),
         promise: jsc::JSPromiseStrong::default(),
@@ -141,8 +161,12 @@ pub(crate) fn create_and_schedule_completion_task(
     }));
     // SAFETY: freshly-boxed allocation with ref_count == 1; sole handle.
     unsafe {
-        (*completion).task =
-            AnyTask::from_typed(completion, JSBundleCompletionTask::on_complete_anytask);
+        (*completion).vm_pin = Some((*vm).pin());
+        (*completion).task = AnyTask::from_typed_with_dispose(
+            completion,
+            JSBundleCompletionTask::on_complete_anytask,
+            JSBundleCompletionTask::release_unrun,
+        );
         if let Some(plugin) = (*completion).plugins {
             (*plugin.as_ptr()).set_config(completion.cast());
         }
@@ -761,14 +785,31 @@ fn from_completion_handle<'a>(c: NonNull<Bv2OpaqueCompletion>) -> &'a JSBundleCo
 static COMPLETION_VTABLE: dispatch::CompletionDispatch = dispatch::CompletionDispatch {
     result_is_err: |c| matches!(from_completion_handle(c).result, BundleV2Result::Err(_)),
     enqueue_task_concurrent: |c, task| {
-        // `jsc_event_loop` is a `BackRef<EventLoop>` — safe Deref.
-        // SAFETY: `task` is a fresh heap-allocated non-null `ConcurrentTaskItem`
-        // passed through from the bundler vtable; the queue takes ownership.
-        unsafe {
-            from_completion_handle(c)
-                .jsc_event_loop
-                .enqueue_task_concurrent(core::ptr::NonNull::new_unchecked(task))
-        }
+        // `task` is a fresh heap-allocated non-null `ConcurrentTaskItem`
+        // passed through from the bundler vtable; on success the queue takes
+        // ownership. A pinned build's gate entry always succeeds; an
+        // unpinned plugin build re-enters the gate and, on a lost race with
+        // terminate, drops the item (stranding `pending_items` wedges the
+        // BundleThread and leaks the completion — documented residual, see
+        // `begin_run`'s FIXME).
+        let completion = from_completion_handle(c);
+        let guest = match &completion.vm_pin {
+            Some(_) => None, // pin held: VM guaranteed alive
+            None => match bun_threading::GateGuest::enter(&completion.vm_gate) {
+                Some(g) => Some(g),
+                None => {
+                    // SAFETY: the queue never took the item; sole owner here.
+                    drop(unsafe { bun_core::heap::take(task) });
+                    return;
+                }
+            },
+        };
+        completion.jsc_event_loop.enqueue_task_concurrent(
+            // SAFETY: `task` is non-null per the vtable contract (fresh heap
+            // allocation from the bundler side).
+            unsafe { core::ptr::NonNull::new_unchecked(task) },
+        );
+        drop(guest);
     },
 };
 
@@ -979,13 +1020,31 @@ impl CompletionStruct for JSBundleCompletionTask {
         Ok(())
     }
 
-    fn complete_on_bundle_thread(&mut self) {
-        // `jsc_event_loop` is a `BackRef<EventLoop>` — safe Deref.
-        // `ConcurrentTask::create` heap-allocates a fresh task; the
-        // queue takes ownership of it.
-        self.jsc_event_loop
-            .enqueue_task_concurrent(jsc::ConcurrentTask::create(self.task.task()));
+    fn begin_run(&mut self) {
+        if self.plugins.is_some() {
+            // Plugin builds round-trip through the owning JS thread
+            // mid-bundle; holding the pin would deadlock worker terminate.
+            drop(self.vm_pin.take());
+        }
     }
+
+    fn complete_on_bundle_thread(&mut self) {
+        // Enqueue while the pin (taken at creation) is still held so it
+        // lands on a live VM, then release it. Unpinned plugin builds
+        // re-enter the gate for the enqueue; losing that race to terminate
+        // leaks the completion with the wedged bundle (documented residual).
+        let any_task = self.task.task();
+        let pin = match self.vm_pin.take() {
+            Some(pin) => Some(pin),
+            None => bun_threading::GateGuest::enter(&self.vm_gate),
+        };
+        if pin.is_some() {
+            self.jsc_event_loop
+                .enqueue_task_concurrent(jsc::ConcurrentTask::create(any_task));
+        }
+        drop(pin);
+    }
+
     fn set_result(&mut self, result: BundleV2Result) {
         self.result = result;
     }

--- a/src/runtime/crypto/PasswordObject.rs
+++ b/src/runtime/crypto/PasswordObject.rs
@@ -13,8 +13,8 @@ use bun_jsc::{
 // lives in `bun_jsc::zig_string`); used for ASCII→JS conversions only.
 use bun_jsc::AnyTask::{AnyTask, JsResult as AnyTaskJsResult};
 use bun_jsc::ConcurrentTask::ConcurrentTask;
-use bun_jsc::event_loop::EventLoop;
 use bun_jsc::ZigStringJsc as _;
+use bun_jsc::event_loop::EventLoop;
 use bun_jsc::zig_string::ZigString as JscZigString;
 use bun_jsc::{JSPromise, JSPromiseStrong};
 use bun_threading::work_pool::WorkPool;

--- a/src/runtime/crypto/PasswordObject.rs
+++ b/src/runtime/crypto/PasswordObject.rs
@@ -7,13 +7,13 @@ use bun_io::KeepAlive;
 use bun_jsc::{
     self as jsc, CallFrame, JSFunction, JSGlobalObject, JSValue, JsError, JsResult, WorkPoolTask,
 };
-// `bun_jsc::{AnyTask, ConcurrentTask, EventLoop}` are *modules* (re-exported from
+// `bun_jsc::{AnyTask, ConcurrentTask}` are *modules* (re-exported from
 // `bun_event_loop`); pull the concrete types out by name.
-use bun_jsc::event_loop::EventLoop;
 // JSC-side ZigString carries `to_js` (the `bun_core::ZigString` repr-twin
 // lives in `bun_jsc::zig_string`); used for ASCII→JS conversions only.
 use bun_jsc::AnyTask::{AnyTask, JsResult as AnyTaskJsResult};
 use bun_jsc::ConcurrentTask::ConcurrentTask;
+use bun_jsc::event_loop::EventLoop;
 use bun_jsc::ZigStringJsc as _;
 use bun_jsc::zig_string::ZigString as JscZigString;
 use bun_jsc::{JSPromise, JSPromiseStrong};
@@ -549,7 +549,12 @@ struct PasswordJob<Op: PasswordOp> {
     op: Op,
     password: Box<[u8]>,
     promise: JSPromiseStrong,
+    /// JSC_BORROW: kept alive across the job by `vm_pin` below (worker
+    /// terminate waits for the pin).
     event_loop: *mut EventLoop,
+    /// Holds the worker's shutdown gate open until the completion is
+    /// enqueued (dropped on the pool thread in `run_owned`).
+    vm_pin: Option<bun_threading::GateGuest>,
     global: *const JSGlobalObject,
     r#ref: KeepAlive,
     task: WorkPoolTask,
@@ -583,16 +588,23 @@ impl<Op: PasswordOp> PasswordJob<Op> {
         // SAFETY: `result` was just heap-allocated and is not yet shared
         // (enqueue happens after this write).
         unsafe {
-            (*result).task = AnyTask::from_typed(result, PasswordResult::<Op>::run_from_js_erased);
+            (*result).task = AnyTask::from_typed_with_dispose(
+                result,
+                PasswordResult::<Op>::run_from_js_erased,
+                PasswordResult::<Op>::release_unrun,
+            );
         }
-        // SAFETY: `event_loop` was stored from the JS-thread VM and outlives the
-        // job; ownership of `result` transfers to the event loop here. `task` is
-        // an intrusive field at a stable address.
+        // Ownership of `result` transfers to the event loop. The pin (held
+        // since creation) keeps the VM alive across the enqueue.
+        let pin = self.vm_pin.take();
+        // SAFETY: `event_loop` was stored from the JS-thread VM, kept alive
+        // by `pin`; `result` is the live heap allocation initialised above.
         unsafe {
             (*self.event_loop).enqueue_task_concurrent(ConcurrentTask::create_from(
                 core::ptr::addr_of_mut!((*result).task),
             ));
         }
+        drop(pin);
         // `self: Box<Self>` drops here; Drop runs secure_zero on password (+op).
     }
 }
@@ -606,6 +618,13 @@ struct PasswordResult<Op: PasswordOp> {
 }
 
 impl<Op: PasswordOp> PasswordResult<Op> {
+    /// Release a queued-but-unrun completion during the terminate drain
+    /// (JS thread, VM alive): plain drop releases everything.
+    fn release_unrun(p: *mut Self) {
+        // SAFETY: queue-owned heap result popped by the drain; sole owner.
+        drop(unsafe { bun_core::heap::take(p) });
+    }
+
     fn run_from_js_erased(p: *mut Self) -> AnyTaskJsResult<()> {
         Self::run_from_js(p)
             .map_err(|_: jsc::JsTerminated| bun_event_loop::ErasedJsError::Terminated)
@@ -666,12 +685,13 @@ impl JSPasswordObject {
         let promise = JSPromiseStrong::init(global_object);
         let promise_value = promise.value();
 
+        let vm = global_object.bun_vm();
         let mut job = Box::new(PasswordJob::<Op> {
             op,
             password,
             promise,
-            // SAFETY: bun_vm() is non-null for a Bun-owned global; VM outlives the job.
-            event_loop: global_object.bun_vm().event_loop(),
+            event_loop: vm.event_loop(),
+            vm_pin: Some(vm.pin()),
             global: std::ptr::from_ref(global_object),
             r#ref: KeepAlive::default(),
             task: WorkPoolTask::default(),

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1163,13 +1163,27 @@ pub(crate) fn __bun_release_task_at_shutdown(task: bun_event_loop::Task) -> bool
         // posted this entry, then deref'd its own +1 if final; the JS-side
         // +1 it expected `on_progress_update` to drop is the one we release
         // here. Runs on the JS thread, so the plain `deref` (→ `deinit` on
-        // 1→0) is the right teardown path; the HTTP daemon is already
-        // parked (`shutdown_for_exit` precedes `destroy`), so the
-        // `Box<AsyncHTTP>` and any `metadata` it owns are exclusively ours.
+        // 1→0) is the right teardown path. On the main-exit caller the HTTP
+        // daemon is already parked; on the worker-shutdown caller it is not,
+        // but the HTTP side then still holds its own ref, so the deref here
+        // cannot free the tasklet under it.
         task_tag::FetchTasklet => {
-            // SAFETY: `task.ptr` is the live heap `FetchTasklet`; HTTP daemon is
-            // already parked so we hold the sole reference.
-            FetchTasklet::deref(task.ptr.cast::<FetchTasklet>());
+            let tasklet = task.ptr.cast::<FetchTasklet>();
+            // Worker terminate: no JS-side consumer remains, so abort the
+            // transfer. The flag this entry left set steers later HTTP-thread
+            // callbacks onto the CAS-fail path, whose single `is_done` deref
+            // balances the refs. On the main-exit caller the HTTP daemon has
+            // already been parked and its requests reclaimed — scheduling a
+            // shutdown against reclaimed state is unsound, and the registry
+            // walk already aborted the transfer, so skip the abort there.
+            // SAFETY: `task.ptr` is the live heap `FetchTasklet`; the ref this
+            // queued entry owns is released just below, on this (JS) thread.
+            unsafe {
+                if !(*tasklet).javascript_vm.is_main_thread {
+                    (*tasklet).abort_task();
+                }
+            }
+            FetchTasklet::deref(tasklet);
             true
         }
         // `AsyncFSTask`s are `Box::leak`'d in `create()` and freed by
@@ -1213,6 +1227,136 @@ pub(crate) fn __bun_release_task_at_shutdown(task: bun_event_loop::Task) -> bool
             unsafe { Bun__deleteDeferredWorkTask(task.ptr.cast::<JSCDeferredWorkTask>()) };
             true
         }
+        // Producer pins guarantee these transfers/jobs completed before the
+        // worker drain; the main-exit drain has no such barrier, so a
+        // mid-stream entry (HTTP thread still active) is left alone.
+        task_tag::S3HttpDownloadStreamingTask => {
+            let s3 = task.ptr.cast::<S3HttpDownloadStreamingTask>();
+            // SAFETY: queue-owned entry, live box.
+            unsafe {
+                if crate::webcore::s3::download_stream::State(
+                    (*s3).state.load(core::sync::atomic::Ordering::Acquire),
+                )
+                .has_more()
+                {
+                    return false;
+                }
+                // Barrier: a losing CAS callback may still be inside its
+                // mutex-guarded buffer append.
+                (*s3).mutex.lock();
+                (*s3).mutex.unlock();
+                (*s3).callback_context_release.run((*s3).callback_context.as_ptr().cast());
+                drop(bun_core::heap::take(s3));
+            }
+            true
+        }
+        task_tag::S3HttpSimpleTask => {
+            let s3 = task.ptr.cast::<S3HttpSimpleTask>();
+            // SAFETY: queue-owned entry; `is_done` enqueue means the HTTP
+            // side is finished — sole owner.
+            unsafe {
+                (*s3).callback_context_release.run((*s3).callback_context);
+                drop(bun_core::heap::take(s3));
+            }
+            true
+        }
+        task_tag::NativeZlib => {
+            // SAFETY: releases the in-flight write()'s ref on the JS thread.
+            unsafe {
+                <NativeZlib as node_zlib_binding::CompressionStreamImpl>::deref(task.ptr.cast())
+            };
+            true
+        }
+        task_tag::NativeBrotli => {
+            // SAFETY: as NativeZlib above.
+            unsafe {
+                <NativeBrotli as node_zlib_binding::CompressionStreamImpl>::deref(task.ptr.cast())
+            };
+            true
+        }
+        task_tag::NativeZstd => {
+            // SAFETY: as NativeZlib above.
+            unsafe {
+                <NativeZstd as node_zlib_binding::CompressionStreamImpl>::deref(task.ptr.cast())
+            };
+            true
+        }
+        task_tag::AsyncGlobWalkTask => {
+            // SAFETY: queue-owned completed task; destroy drops the box (and
+            // its ctx) on the JS thread with the VM alive.
+            unsafe { AsyncGlobWalkTask::destroy(task.ptr.cast()) };
+            true
+        }
+        task_tag::AsyncTransformTask => {
+            // SAFETY: as AsyncGlobWalkTask above.
+            unsafe { AsyncTransformTask::destroy(task.ptr.cast()) };
+            true
+        }
+        task_tag::AsyncImageTask => {
+            // SAFETY: as AsyncGlobWalkTask above.
+            unsafe { AsyncImageTask::destroy(task.ptr.cast()) };
+            true
+        }
+        task_tag::CopyFilePromiseTask => {
+            // SAFETY: as AsyncGlobWalkTask above.
+            unsafe { CopyFilePromiseTask::destroy(task.ptr.cast()) };
+            true
+        }
+        // WorkTask shells: destroy frees the shell; the heap ctx is dropped
+        // too (its completion-handler box is a known small leak here).
+        task_tag::ReadFileTask => {
+            // SAFETY: queue-owned completed task; sole owner.
+            unsafe {
+                let ctx = (*task.ptr.cast::<ReadFileTask>()).ctx;
+                ReadFileTask::destroy(task.ptr.cast());
+                bun_core::heap::destroy(ctx);
+            }
+            true
+        }
+        task_tag::WriteFileTask => {
+            // SAFETY: as ReadFileTask above.
+            unsafe {
+                let ctx = (*task.ptr.cast::<WriteFileTask>()).ctx;
+                WriteFileTask::destroy(task.ptr.cast());
+                bun_core::heap::destroy(ctx);
+            }
+            true
+        }
+        #[cfg(not(windows))]
+        task_tag::GetAddrInfoRequestTask => {
+            // SAFETY: queue-owned completed request; `release_unrun` frees
+            // the chained lookup boxes too (VM alive — their Drops are safe).
+            unsafe {
+                let ctx = (*task.ptr.cast::<get_addr_info_request::Task>()).ctx;
+                get_addr_info_request::Task::destroy(task.ptr.cast());
+                crate::dns_jsc::GetAddrInfoRequest::release_unrun(ctx);
+            }
+            true
+        }
+        task_tag::ArchiveExtractTask => {
+            // SAFETY: queue-owned completed task; destroy drops the box on
+            // the JS thread with the VM alive.
+            unsafe { ArchiveAsyncTask::release_unrun(task.ptr.cast::<ArchiveExtractTask>()) };
+            true
+        }
+        task_tag::ArchiveBlobTask => {
+            // SAFETY: as ArchiveExtractTask above.
+            unsafe { ArchiveAsyncTask::release_unrun(task.ptr.cast::<ArchiveBlobTask>()) };
+            true
+        }
+        task_tag::ArchiveWriteTask => {
+            // SAFETY: as ArchiveExtractTask above.
+            unsafe { ArchiveAsyncTask::release_unrun(task.ptr.cast::<ArchiveWriteTask>()) };
+            true
+        }
+        task_tag::ArchiveFilesTask => {
+            // SAFETY: as ArchiveExtractTask above.
+            unsafe { ArchiveAsyncTask::release_unrun(task.ptr.cast::<ArchiveFilesTask>()) };
+            true
+        }
+        // NapiAsyncWork is NOT reclaimed here: the work handle itself is
+        // addon-owned (`napi_delete_async_work`); freeing it would double
+        // free when the addon's destructor runs. Re-queued (leaks bounded).
         // Same reclaim `drop_concurrent_cpp_tasks` performs, but for tasks
         // that were already batch-moved into `self.tasks`. Must run before
         // JSC teardown: a Worker `dispatchExit` lambda's `~Ref<Worker>` walks

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1245,7 +1245,9 @@ pub(crate) fn __bun_release_task_at_shutdown(task: bun_event_loop::Task) -> bool
                 // mutex-guarded buffer append.
                 (*s3).mutex.lock();
                 (*s3).mutex.unlock();
-                (*s3).callback_context_release.run((*s3).callback_context.as_ptr().cast());
+                (*s3)
+                    .callback_context_release
+                    .run((*s3).callback_context.as_ptr().cast());
                 drop(bun_core::heap::take(s3));
             }
             true

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -721,11 +721,17 @@ impl ErrorDeferred {
         let vm = global_this.bun_vm();
         // Worker terminate's `close_dns_for_terminate` fires EDESTRUCTION with
         // `is_shutting_down` already set; the task queue is about to be
-        // drained-without-run and ManagedTask has no cleanup here, so enqueuing
-        // would leak the `Context` and its `JSPromiseStrong` box. Drop now while
-        // JSC is still live so the Strong handle releases cleanly.
+        // drained-without-run, so enqueuing is pointless. Drop now while JSC
+        // is still live so the Strong handle releases cleanly.
         if vm.is_shutting_down() {
             return;
+        }
+
+        // Reclaim for a rejection still queued at worker terminate: the
+        // drain runs this on the JS thread with the VM alive.
+        fn cleanup(p: *mut Context) {
+            // SAFETY: `p` is the queue-owned heap `Context`, sole owner.
+            drop(unsafe { bun_core::heap::take(p) });
         }
 
         let context = bun_core::heap::into_raw(Box::new(Context {
@@ -736,9 +742,10 @@ impl ErrorDeferred {
         // SAFETY: `bun_vm()` returns a non-null VM pointer (VM-owned for the lifetime of
         // the JSGlobalObject).
         vm.as_mut()
-            .enqueue_task(bun_jsc::ManagedTask::ManagedTask::new(
+            .enqueue_task(bun_jsc::ManagedTask::ManagedTask::new_with_cleanup(
                 context,
                 Context::callback,
+                cleanup,
             ));
     }
 }

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -373,11 +373,19 @@ pub(super) mod lib_uv_backend {
     }
 
     impl Holder {
-        fn run(held: *mut c_void) -> jsc::AnyTask::JsResult<()> {
+        fn run(held: *mut Self) -> jsc::AnyTask::JsResult<()> {
             // SAFETY: held was heap-allocated in on_raw_libuv_complete
-            let held = unsafe { bun_core::heap::take(held.cast::<Self>()) };
+            let held = unsafe { bun_core::heap::take(held) };
             GetAddrInfoRequest::on_libuv_complete(held.uv_info);
             Ok(())
+        }
+
+        /// Reclaimed unrun by the terminate drain. The libuv request the
+        /// holder points at is owned by the loop; only the queue-owned box
+        /// itself is freed.
+        fn release_unrun(held: *mut Self) {
+            // SAFETY: queue-owned box popped by the drain; sole owner.
+            drop(unsafe { bun_core::heap::take(held) });
         }
     }
 
@@ -400,10 +408,11 @@ pub(super) mod lib_uv_backend {
         }));
         // SAFETY: holder is a valid heap allocation
         unsafe {
-            (*holder).task = jsc::AnyTask::AnyTask {
-                ctx: NonNull::new(holder.cast()),
-                callback: Holder::run,
-            };
+            (*holder).task = jsc::AnyTask::AnyTask::from_typed_with_dispose(
+                holder,
+                Holder::run,
+                Holder::release_unrun,
+            );
             (*this)
                 .head
                 .global_this()
@@ -939,12 +948,25 @@ impl CAresNameInfo {
     /// SAFETY: see `process_resolve`.
     pub(crate) unsafe fn on_complete(this: *mut Self, result: JSValue) {
         // SAFETY: see fn contract — `this` is a live node.
-        let mut promise = unsafe { core::mem::take(&mut (*this).promise) };
-        // SAFETY: see fn contract — `this` is a live node.
-        let global_this = unsafe { (*this).global_this() };
-        let _ = promise.resolve_task(global_this, result); // TODO: properly propagate exception upwards
-        // SAFETY: see fn contract.
-        unsafe { Self::destroy(this) };
+        unsafe {
+            let global_this = (*this).global_this();
+            if result.is_empty() {
+                // Result conversion threw (e.g. worker.terminate() requested
+                // mid-completion): resolving with an empty JSValue is UB.
+                error_to_deferred(
+                    c_ares::Error::ECANCELLED,
+                    b"getnameinfo",
+                    Some((*this).name.as_ref()),
+                    &mut (*this).promise,
+                )
+                .reject_later(global_this);
+                Self::destroy(this);
+                return;
+            }
+            let mut promise = core::mem::take(&mut (*this).promise);
+            let _ = promise.resolve_task(global_this, result); // TODO: properly propagate exception upwards
+            Self::destroy(this);
+        }
     }
 
     /// Conditionally free a heap-allocated tail node. Head nodes (`allocated == false`)
@@ -1322,6 +1344,29 @@ pub mod get_addr_info_request {
             match self {
                 Backend::Libc(l) => &mut l.uv,
                 _ => unreachable!(),
+            }
+        }
+    }
+}
+
+impl GetAddrInfoRequest {
+    /// Reclaim a queued-but-unrun completion during the terminate drain
+    /// (JS thread, VM alive): frees the request and every chained lookup box
+    /// (their Drops release poll refs and resolver refs normally). The
+    /// resolver's pending-host cache entry is NOT evicted — sound only
+    /// because the per-VM resolver dies with the VM right after the drain.
+    ///
+    /// # Safety
+    /// `this` is the queue-owned heap request popped by the drain.
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    pub unsafe fn release_unrun(this: *mut Self) {
+        // SAFETY: caller contract.
+        unsafe {
+            let mut next = (*this).head.next;
+            drop(bun_core::heap::take(this));
+            while let Some(node) = next {
+                let node = bun_core::heap::take(node.as_ptr());
+                next = node.next;
             }
         }
     }
@@ -1729,8 +1774,24 @@ impl CAresReverse {
     pub(crate) unsafe fn on_complete(this: *mut Self, result: JSValue) {
         // SAFETY: caller contract — `this` is live; JSGlobalObject outlives the request.
         unsafe {
-            let mut promise = core::mem::take(&mut (*this).promise);
             let global_this = (*this).global_this();
+            if result.is_empty() {
+                // Result conversion threw (e.g. worker.terminate() requested
+                // mid-completion): resolving with an empty JSValue is UB.
+                error_to_deferred(
+                    c_ares::Error::ECANCELLED,
+                    b"getHostByAddr",
+                    Some(&(*this).name),
+                    &mut (*this).promise,
+                )
+                .reject_later(global_this);
+                if let Some(resolver) = (*this).resolver.as_ref() {
+                    (*resolver.as_ptr()).request_completed();
+                }
+                Self::destroy(this);
+                return;
+            }
+            let mut promise = core::mem::take(&mut (*this).promise);
             let _ = promise.resolve_task(global_this, result); // TODO: properly propagate exception upwards
             if let Some(resolver) = (*this).resolver.as_ref() {
                 // IntrusiveRc holds a live ref; request_completed mutates pending_requests counter only.
@@ -1879,8 +1940,24 @@ impl<T: CAresRecordType> CAresLookup<T> {
     pub(crate) unsafe fn on_complete(this: *mut Self, result: JSValue) {
         // SAFETY: caller contract — `this` is live; JSGlobalObject outlives the request.
         unsafe {
-            let mut promise = core::mem::take(&mut (*this).promise);
             let global_this = (*this).global_this();
+            if result.is_empty() {
+                // Result conversion threw (e.g. worker.terminate() requested
+                // mid-completion): resolving with an empty JSValue is UB.
+                error_to_deferred(
+                    c_ares::Error::ECANCELLED,
+                    T::SYSCALL.as_bytes(),
+                    Some(&(*this).name),
+                    &mut (*this).promise,
+                )
+                .reject_later(global_this);
+                if let Some(resolver) = (*this).resolver.as_ref() {
+                    (*resolver.as_ptr()).request_completed();
+                }
+                Self::destroy(this);
+                return;
+            }
+            let mut promise = core::mem::take(&mut (*this).promise);
             let _ = promise.resolve_task(global_this, result); // TODO: properly propagate exception upwards
             if let Some(resolver) = (*this).resolver.as_ref() {
                 // IntrusiveRc holds a live ref; request_completed mutates pending_requests counter only.
@@ -2057,6 +2134,23 @@ impl DNSLookup {
         bun_output::scoped_log!(DNSLookup, "onCompleteWithArray");
         // SAFETY: caller contract — `this` is live; JSGlobalObject outlives the request.
         unsafe {
+            if result.is_empty() {
+                // Result conversion threw (e.g. worker.terminate() requested
+                // mid-completion): resolving with an empty JSValue is UB.
+                let global_this = (*this).global_this();
+                error_to_deferred(
+                    c_ares::Error::ECANCELLED,
+                    b"getaddrinfo",
+                    None,
+                    &mut (*this).promise,
+                )
+                .reject_later(global_this);
+                if let Some(resolver) = (*this).resolver.as_ref() {
+                    (*resolver.as_ptr()).request_completed();
+                }
+                Self::destroy(this);
+                return;
+            }
             let mut promise = core::mem::take(&mut (*this).promise);
             let global_this = (*this).global_this();
             let _ = promise.resolve_task(global_this, result); // TODO: properly propagate exception upwards
@@ -4525,9 +4619,11 @@ impl Resolver {
                 let new_global = (*value.as_ptr()).global_this();
                 pending = (*value.as_ptr()).next;
                 if !core::ptr::eq(prev_global, new_global) {
+                    // On conversion failure (termination/OOM) fall through with
+                    // an empty value — `on_complete_with_array` rejects it.
                     array = super::options_jsc::result_any_to_js(result, new_global)
                         .unwrap_or(None)
-                        .unwrap(); // TODO: properly propagate exception upwards
+                        .unwrap_or(JSValue::ZERO);
                     prev_global = new_global;
                 }
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1487,6 +1487,7 @@ pub(crate) static __BUN_RUNTIME_HOOKS: RuntimeHooks = RuntimeHooks {
     retroactively_report_discovered_tests,
     cancel_all_timers,
     close_dns_for_terminate,
+    abort_pending_transfers,
 };
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -1587,6 +1588,32 @@ fn cron_clear_all_reload(vm: &mut VirtualMachine) {
 /// Main-thread only; called from `global_exit` after `is_shutting_down` is set.
 fn terminate_all_workers_and_wait(timeout_ms: u64) {
     bun_jsc::web_worker::terminate_all_and_wait(timeout_ms);
+}
+
+/// `RuntimeHooks::abort_pending_transfers` — walk the VM's
+/// `terminate_abort_registry` so every in-flight transfer is aborted and its
+/// producer pin drops promptly.
+///
+/// # Safety
+/// `vm` is the live per-thread VM on its own JS thread, pre-teardown.
+unsafe fn abort_pending_transfers(vm: *mut VirtualMachine) {
+    // Loop until the registry stays empty: an abort can run user JS (fetch's
+    // sink cancel) that starts new transfers, which must be aborted too or
+    // their pins would stall the gate close on a slow server. Bounded so a
+    // pathological cancel handler that keeps starting transfers cannot spin
+    // terminate forever (leftovers still resolve via their pins).
+    for _ in 0..64 {
+        // SAFETY: `vm` per fn contract (JS thread, pre-teardown).
+        let aborts = unsafe { &(*vm).terminate_abort_registry }
+            .borrow_mut()
+            .take_all();
+        if aborts.is_empty() {
+            return;
+        }
+        for abort in aborts {
+            abort();
+        }
+    }
 }
 
 /// `RuntimeHooks::cancel_all_timers` — cancel every `TimeoutObject` /

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -1752,7 +1752,11 @@ pub struct napi_async_work {
     pub task: WorkPoolTask,
     pub concurrent_task: ConcurrentTask,
     // Note: BackRef — `enqueue_task` needs `&mut EventLoop`; reborrowed at use sites.
+    // Kept alive across the job by `vm_pin` below (terminate waits for it).
     pub event_loop: bun_ptr::BackRef<EventLoop>,
+    /// Holds the worker's shutdown gate open from `schedule` until the
+    /// completion is enqueued (dropped on the pool thread).
+    pub vm_pin: Option<bun_threading::GateGuest>,
     pub global: GlobalRef, // JSC_BORROW (lives for vm lifetime)
     pub env: NapiEnvRef,
     pub execute: napi_async_execute_callback,
@@ -1784,10 +1788,10 @@ impl napi_async_work {
             // SAFETY: env outlives the async work; clone bumps the C++ refcount.
             env: unsafe { NapiEnvRef::clone_from_raw(env.as_mut_ptr()) },
             execute,
-            // SAFETY: bun_vm() never null for a Bun-owned global.
             // SAFETY: `event_loop()` is the live JS-thread loop (non-null,
-            // stable address) and outlives every napi_async_work.
+            // outlives the work while `vm_pin` is held).
             event_loop: unsafe { bun_ptr::BackRef::from_raw(global.bun_vm().event_loop()) },
+            vm_pin: None,
             complete,
             data,
             status: AtomicU32::new(AsyncWorkStatus::Pending as u32),
@@ -1811,6 +1815,8 @@ impl napi_async_work {
         }
         self.scheduled = true;
         self.poll_ref.ref_(bun_io::js_vm_ctx());
+        // Terminate blocks until this work's completion is enqueued.
+        self.vm_pin = Some(VirtualMachine::get().pin());
         WorkPool::schedule(&raw mut self.task);
     }
 
@@ -1829,6 +1835,9 @@ impl napi_async_work {
             Ordering::SeqCst,
         ) {
             if state == AsyncWorkStatus::Cancelled as u32 {
+                // Take the pin into a local first — the enqueue hands the
+                // work to the JS thread, which may free it before we return.
+                let pin = self.vm_pin.take();
                 // `concurrent_task` is the live inline field of this heap work;
                 // the queue takes ownership of its `next` link.
                 self.event_loop
@@ -1836,6 +1845,7 @@ impl napi_async_work {
                         self.concurrent_task
                             .from(self_ptr, AutoDeinit::ManualDeinit),
                     ));
+                drop(pin);
                 return;
             }
         }
@@ -1843,6 +1853,9 @@ impl napi_async_work {
         self.status
             .store(AsyncWorkStatus::Completed as u32, Ordering::SeqCst);
 
+        // Take the pin (held since `schedule`) into a local first — the
+        // enqueue hands the work to the JS thread, which may free it.
+        let pin = self.vm_pin.take();
         // `concurrent_task` is the live inline field of this heap work; the
         // queue takes ownership of its `next` link.
         self.event_loop
@@ -1850,6 +1863,7 @@ impl napi_async_work {
                 self.concurrent_task
                     .from(self_ptr, AutoDeinit::ManualDeinit),
             ));
+        drop(pin);
     }
 
     pub fn cancel(&mut self) -> bool {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1242,6 +1242,9 @@ mod _async_tasks {
         /// Wrapped in [`ThreadSafe`] so the paired `unprotect()` runs on drop.
         pub args: ThreadSafe<A>,
         pub global_object: bun_ptr::BackRef<JSGlobalObject>,
+        /// Holds the VM's shutdown gate open until the completion is
+        /// enqueued (dropped on the pool thread).
+        pub vm_pin: Option<bun_threading::GateGuest>,
         pub task: WorkPoolTask,
         pub result: Maybe<R>,
         pub r#ref: KeepAlive,
@@ -1285,14 +1288,15 @@ mod _async_tasks {
                 // niche-optimised; never construct an all-zero `Result` value.
                 result: Err(sys::Error::default()),
                 global_object: bun_ptr::BackRef::new(global_object),
+                vm_pin: None,
                 task: work_pool_task(Self::work_pool_callback),
                 r#ref: KeepAlive::default(),
                 tracker: AsyncTaskTracker::init(vm),
             });
+            task.vm_pin = Some(vm.pin());
             // KeepAlive::ref_ now takes the type-erased aio EventLoopCtx; the JS
             // event loop is the only one that owns AsyncFSTask/UVFSRequest.
             task.r#ref.ref_(bun_io::js_vm_ctx());
-            let _ = vm;
             task.tracker.did_schedule(global_object);
             let promise = task.promise.value();
             WorkPool::schedule(&raw mut bun_core::heap::release(task).task);
@@ -1312,13 +1316,17 @@ mod _async_tasks {
             // documented accessor for off-thread (work-pool) callers; the
             // event-loop's concurrent queue is MPSC-safe.
             let vm = this.global_object().bun_vm_concurrently();
-            // SAFETY: VirtualMachine and its event loop are process-static
-            // (LIFETIMES.tsv); the concurrent queue is MPSC-safe.
+            // Take the pin (held since `create`) into a local first — the
+            // enqueue hands the task to the JS thread, which may free it.
+            let pin = this.vm_pin.take();
+            // SAFETY: the VM is kept alive by `pin`; the concurrent queue is
+            // MPSC-safe.
             unsafe {
                 (*(*vm).event_loop()).enqueue_task_concurrent(ConcurrentTask::create_from(
                     std::ptr::from_mut::<Self>(this),
                 ));
             }
+            drop(pin);
         }
 
         pub fn run_from_js_thread(&mut self) -> Result<(), bun_jsc::JsTerminated> {
@@ -1326,6 +1334,16 @@ mod _async_tasks {
             let _deinit = scopeguard::guard(std::ptr::from_mut::<Self>(self), |p| unsafe {
                 Self::destroy(p)
             });
+            // Worker terminate can land between the pool-thread enqueue and
+            // this tick; resolving a promise against a terminating VM trips
+            // exception-scope asserts, and an emptied Strong would otherwise
+            // panic below. `_deinit` reclaims the task.
+            if !self.promise.has_value()
+                || self.global_object().bun_vm().script_execution_status()
+                    != bun_jsc::ScriptExecutionStatus::Running
+            {
+                return Ok(());
+            }
             // Move `result` out so the `global_object()` `&self` borrow can coexist
             // with `&mut result` below; the sentinel left behind is dropped in `destroy()`.
             let mut result = core::mem::replace(&mut self.result, Err(sys::Error::default()));
@@ -1408,6 +1426,10 @@ mod _async_tasks {
         /// read), not by `Cell` itself — `Cell` is `repr(transparent)` over
         /// `UnsafeCell` and `set()` is exactly the prior `*ptr = val` open-coded.
         pub result: core::cell::Cell<Maybe<ret::Cp>>,
+        /// Holds the VM's shutdown gate open until the final completion is
+        /// enqueued. Taken by the subtask that drops `subtask_count` to zero
+        /// (exclusive access — same argument as `result` above).
+        pub vm_pin: core::cell::Cell<Option<bun_threading::GateGuest>>,
         /// If this task is called by the shell then we shouldn't call this as
         /// it is not threadsafe and is unnecessary as the process will be kept
         /// alive by the shell instance.
@@ -1584,6 +1606,7 @@ mod _async_tasks {
                 // Sentinel — overwritten by `finish_concurrently` (gated by the
                 // `has_result` CAS) before any read on the JS thread.
                 result: core::cell::Cell::new(Ok(())),
+                vm_pin: core::cell::Cell::new(Some(vm.pin())),
                 // `vm.event_loop` is the live per-thread `jsc::EventLoop` field.
                 evtloop: EventLoopHandle::init(vm.event_loop.cast()),
                 task: work_pool_task(Self::work_pool_callback),
@@ -1618,6 +1641,8 @@ mod _async_tasks {
                 // Sentinel — overwritten by `finish_concurrently` (gated by the
                 // `has_result` CAS) before any read on the JS thread.
                 result: core::cell::Cell::new(Ok(())),
+                // Mini loops have no VM/gate to pin.
+                vm_pin: core::cell::Cell::new(None),
                 evtloop: EventLoopHandle::init_mini(mini),
                 task: work_pool_task(Self::work_pool_callback),
                 r#ref: KeepAlive::default(),
@@ -1693,6 +1718,9 @@ mod _async_tasks {
             // Count reached zero ⇒ exclusive access. `this` carries mutable
             // provenance from `Box::leak`, so the enqueued callback may safely
             // form `&mut *this` on the JS thread.
+            // Take the pin into a local first — the enqueue hands the task
+            // to the JS thread, which may free it before this thread returns.
+            let pin = this_ref.vm_pin.take();
             if matches!(this_ref.evtloop, EventLoopHandle::Js { .. }) {
                 this_ref.evtloop.enqueue_task_concurrent(EventLoopTaskPtr {
                     js: ConcurrentTask::from_callback(this, |p| {
@@ -1702,6 +1730,7 @@ mod _async_tasks {
                     })
                     .as_ptr(),
                 });
+                drop(pin);
             } else {
                 this_ref.evtloop.enqueue_task_concurrent(EventLoopTaskPtr {
                     mini: AnyTaskWithExtraContext::from_callback_auto_deinit(
@@ -2167,6 +2196,9 @@ mod _async_tasks {
         /// Wrapped in [`ThreadSafe`] so the paired `unprotect()` runs on drop.
         pub args: ThreadSafe<args::Readdir>,
         pub global_object: bun_ptr::BackRef<JSGlobalObject>,
+        /// Holds the VM's shutdown gate open until the completion is
+        /// enqueued (dropped on the pool thread).
+        pub vm_pin: Option<bun_threading::GateGuest>,
         pub task: WorkPoolTask,
         pub r#ref: KeepAlive,
         pub tracker: AsyncTaskTracker,
@@ -2362,6 +2394,7 @@ mod _async_tasks {
                 args: FsArgument::into_thread_safe(args),
                 has_result: AtomicBool::new(false),
                 global_object: bun_ptr::BackRef::new(global_object),
+                vm_pin: None,
                 task: work_pool_task(Self::work_pool_callback),
                 r#ref: KeepAlive::default(),
                 tracker: AsyncTaskTracker::init(vm),
@@ -2374,6 +2407,7 @@ mod _async_tasks {
                 pending_err: None,
                 pending_err_mutex: bun_threading::Mutex::default(),
             });
+            task.vm_pin = Some(vm.pin());
             task.r#ref.ref_(bun_io::js_vm_ctx());
             task.tracker.did_schedule(global_object);
             let promise = task.promise.value();
@@ -2539,14 +2573,18 @@ mod _async_tasks {
 
             // `bun_vm_concurrently()` skips the JS-thread debug assert and is the
             // documented accessor for off-thread (work-pool) callers.
-            // SAFETY: `bun_vm_concurrently()` returns the process-singleton VM;
-            // sole `&mut` borrow at this point on the work-pool thread.
+            // SAFETY: the VM is kept alive by the pin taken below; sole
+            // `&mut` borrow at this point on the work-pool thread.
             let vm = unsafe { &mut *self.global_object().bun_vm_concurrently() };
+            // Take the pin (held since creation) into a local first — the
+            // enqueue hands the task to the JS thread, which may free it.
+            let pin = self.vm_pin.take();
             // `ConcurrentTask::create` heap-allocates a fresh task; the
             // queue takes ownership of it.
             vm.enqueue_task_concurrent(ConcurrentTask::create(Task::init(std::ptr::from_mut::<
                 Self,
             >(self))));
+            drop(pin);
         }
 
         fn clear_result_list(&mut self) {

--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -1,5 +1,4 @@
 use core::cell::Cell;
-use core::ffi::c_void;
 use core::ptr::NonNull;
 use core::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::thread::{self, ThreadId};
@@ -60,6 +59,10 @@ pub struct StatWatcherScheduler {
     /// concurrent-task queue at process exit).
     is_shutdown: AtomicBool,
     task: WorkPoolTask,
+    /// Holds the VM's shutdown gate open across the work-pool hop (set on
+    /// the JS thread in `timer_callback`, taken by `work_pool_callback`) so
+    /// terminate waits for in-flight restat enqueues.
+    vm_pin: std::cell::Cell<Option<bun_threading::GateGuest>>,
     main_thread: ThreadId,
     // JSC_BORROW per LIFETIMES.tsv — VM outlives the scheduler. `BackRef` gives
     // safe `&VirtualMachine` projection (Deref) at every read site;
@@ -179,6 +182,7 @@ impl StatWatcherScheduler {
 
     pub fn init(vm: *mut VirtualMachine) -> RefPtr<StatWatcherScheduler> {
         RefPtr::new(StatWatcherScheduler {
+            vm_pin: std::cell::Cell::new(None),
             current_interval: AtomicI32::new(0),
             work_pool_in_flight: AtomicBool::new(false),
             is_shutdown: AtomicBool::new(false),
@@ -300,9 +304,9 @@ impl StatWatcherScheduler {
             task: AnyTask,
         }
 
-        fn update_timer(self_: *mut c_void) -> bun_event_loop::JsResult<()> {
+        fn update_timer(self_: *mut Holder) -> bun_event_loop::JsResult<()> {
             // SAFETY: `self_` was heap-allocated below; reclaim and drop at end of scope.
-            let self_ = unsafe { bun_core::heap::take(self_.cast::<Holder>()) };
+            let self_ = unsafe { bun_core::heap::take(self_) };
             // `scheduler` is the refcounted singleton, kept alive across the
             // hop by the triggering `StatWatcher`'s `RefPtr` (ParentRef
             // invariant).
@@ -326,11 +330,17 @@ impl StatWatcherScheduler {
         // SAFETY: `holder_ptr` was just `heap::alloc`'d and is exclusively owned here
         // until `update_timer` reclaims it; `vm` is the live per-thread VM (JSC_BORROW).
         // `addr_of_mut!` so the field pointer inherits whole-Box provenance.
+        // Reclaimed unrun by the terminate drain: the box owns no refs (the
+        // scheduler is kept alive by the StatWatcher's RefPtr) — plain free.
+        fn release_unrun(holder: *mut Holder) {
+            // SAFETY: queue-owned box popped by the drain; sole owner.
+            drop(unsafe { bun_core::heap::take(holder) });
+        }
+        // SAFETY: `holder_ptr` was just `heap::alloc`'d and is exclusively
+        // owned here until `update_timer` (or the drain) reclaims it.
         unsafe {
-            (*holder_ptr).task = AnyTask {
-                ctx: core::ptr::NonNull::new(holder_ptr.cast()),
-                callback: update_timer,
-            };
+            (*holder_ptr).task =
+                AnyTask::from_typed_with_dispose(holder_ptr, update_timer, release_unrun);
             (*this)
                 .vm
                 .event_loop_shared()
@@ -382,6 +392,9 @@ impl StatWatcherScheduler {
         // of accumulating one leak per `set_interval(0)` / re-arm.
         // SAFETY: `self` is live (`&mut self`).
         Self::ref_(core::ptr::from_mut(self));
+        // Terminate blocks until the pool hop (and every restat completion it
+        // enqueues) has finished; dropped by `work_pool_callback`'s guard.
+        self.vm_pin.set(Some(VirtualMachine::get().pin()));
         WorkPool::schedule(&raw mut self.task);
     }
 
@@ -400,6 +413,10 @@ impl StatWatcherScheduler {
         // BACKREF — `this` is alive (ref'd when the timer was scheduled);
         // `ParentRef` Deref gives safe `&Self` for the queue/interval reads.
         let this_ref = ParentRef::from(NonNull::new(this).expect("work_pool_callback: scheduler"));
+        // Take the pin (set in `timer_callback`) into a local: it keeps the
+        // VM alive for every restat completion enqueued below and drops when
+        // this callback returns.
+        let _vm_pin = this_ref.vm_pin.take();
 
         // Instant.now will not fail on our target platforms.
         let now = Instant::now();
@@ -1187,6 +1204,9 @@ pub(crate) struct InitialStatTask {
     // payload). We hold the strong ref via `ref_()`/`deref()` and keep the
     // raw `*mut`.
     watcher: *mut StatWatcher,
+    /// Holds the VM's shutdown gate open until the completion is enqueued
+    /// (dropped on the pool thread).
+    vm_pin: Option<bun_threading::GateGuest>,
     task: WorkPoolTask,
 }
 
@@ -1202,6 +1222,7 @@ impl InitialStatTask {
         StatWatcher::ref_(watcher);
         WorkPool::schedule_new(InitialStatTask {
             watcher,
+            vm_pin: Some(VirtualMachine::get().pin()),
             task: WorkPoolTask::default(),
         });
     }
@@ -1209,10 +1230,13 @@ impl InitialStatTask {
     // `owned_task!` requires `fn run_owned(self: Box<Self>)`; clippy::boxed_local
     // is a false positive on this macro contract.
     #[allow(clippy::boxed_local)]
-    fn run_owned(self: Box<Self>) {
+    fn run_owned(mut self: Box<Self>) {
         // `watcher` is a raw `*mut` (Copy), so dropping the Box does not touch
         // the refcount.
         let this: *mut StatWatcher = self.watcher;
+        // Keeps the VM alive across the enqueue below; dropped at scope exit
+        // (after the enqueue, or immediately on the `closed` early return).
+        let _vm_pin = self.vm_pin.take();
         // BACKREF — `this` is kept alive by the intrusive ref taken in
         // `create_and_schedule`. We only need shared access here — `closed` is
         // read-only, `path` is borrowed, and `set_last_stat`/

--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -210,6 +210,9 @@ pub(crate) trait CompressionStreamImpl: Sized + Taskable + 'static {
     /// Implementations store a `BackRef<JSGlobalObject>`; the single unsafe
     /// deref lives in `BackRef::get`, so callers and impls are safe.
     fn global_this(&self) -> &JSGlobalObject;
+    /// Per-write shutdown-gate pin: set on the JS thread in `write()`,
+    /// dropped on the pool thread right after the completion enqueue.
+    fn vm_pin(&self) -> &JsCell<Option<bun_threading::GateGuest>>;
     fn stream(&self) -> &JsCell<Self::Stream>;
 
     /// Write `(avail_out, avail_in)` into the JS-owned 2-element `Uint32Array`
@@ -449,6 +452,10 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
             callback: Self::async_job_run_task,
         });
         this.poll_ref().with_mut(|p| p.ref_(vm));
+        // Terminate blocks until this write's completion is enqueued.
+        // SAFETY: `bun_vm()` never returns null for a Bun-owned global.
+        let pin = this.global_this().bun_vm().pin();
+        this.vm_pin().with_mut(|slot| *slot = Some(pin));
         WorkPool::schedule(this.task().as_ptr());
 
         Ok(JSValue::UNDEFINED)
@@ -483,14 +490,19 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
 
         this_ref.stream().with_mut(|s| s.do_work());
 
-        // SAFETY: `event_loop()` is a self-pointer into a live VM; the
-        // `enqueue_task_concurrent` body only touches the lock-free
-        // `concurrent_tasks` queue (thread-safe). `this` is the heap-allocated
-        // `m_ctx` payload — the matching `ref()` in `write()` keeps it alive
-        // until `run_from_js_thread` runs and calls `deref()`.
+        // Take the write's pin into a local first — the enqueue hands the
+        // completion to the JS thread, which may deref `this` before we
+        // return.
+        let pin = this_ref.vm_pin().with_mut(Option::take);
+        // SAFETY: `event_loop()` is a self-pointer into the VM kept alive by
+        // `pin`; the `enqueue_task_concurrent` body only touches the
+        // lock-free `concurrent_tasks` queue (thread-safe). `this` is the
+        // heap-allocated `m_ctx` payload — the matching `ref()` in `write()`
+        // keeps it alive until `run_from_js_thread` runs and calls `deref()`.
         unsafe {
             (*vm.event_loop()).enqueue_task_concurrent(ConcurrentTask::create(Task::init(this)));
         }
+        drop(pin);
     }
 
     /// Dispatched from `dispatch.rs` when the worker-thread `do_work()` posts
@@ -998,6 +1010,7 @@ macro_rules! __impl_compression_stream {
             type Stream = $ctx;
 
             #[inline] fn global_this(&self) -> &::bun_jsc::JSGlobalObject { self.global_this.get() }
+            #[inline] fn vm_pin(&self) -> &JsCell<Option<::bun_threading::GateGuest>> { &self.vm_pin }
             #[inline] fn stream(&self) -> &::bun_jsc::JsCell<Self::Stream> { &self.stream }
             #[inline] fn poll_ref(&self) -> &::bun_jsc::JsCell<$crate::node::node_zlib_binding::CountedKeepAlive> { &self.poll_ref }
             #[inline] fn this_value(&self) -> &::bun_jsc::JsCell<::bun_jsc::StrongOptional> { &self.this_value }

--- a/src/runtime/node/zlib/NativeBrotli.rs
+++ b/src/runtime/node/zlib/NativeBrotli.rs
@@ -85,6 +85,8 @@ mod _impl {
         // JSC_BORROW backref; global outlives this m_ctx payload. `BackRef`
         // centralises the single unsafe deref so the trait impl is safe.
         pub global_this: bun_ptr::BackRef<JSGlobalObject>,
+        /// Per-write shutdown-gate pin (see `CompressionStreamImpl::vm_pin`).
+        pub vm_pin: JsCell<Option<bun_threading::GateGuest>>,
         pub stream: JsCell<Context>,
         pub poll_ref: JsCell<CountedKeepAlive>,
         // TODO: Strong self-ref on the wrapper → JsRef per PORTING.md §JSC (Strong back-ref to own wrapper leaks)
@@ -148,6 +150,7 @@ mod _impl {
                 ref_count: Cell::new(1),
                 // JSC_BORROW backref — the global outlives this m_ctx payload.
                 global_this: bun_ptr::BackRef::new(global_this),
+                vm_pin: JsCell::new(None),
                 stream: JsCell::new(stream),
                 poll_ref: JsCell::new(CountedKeepAlive::default()),
                 this_value: JsCell::new(StrongOptional::empty()),

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -42,6 +42,8 @@ mod _impl {
         // JSC_BORROW backref; global outlives this m_ctx payload. `BackRef`
         // centralises the single unsafe deref so the trait impl is safe.
         pub global_this: bun_ptr::BackRef<JSGlobalObject>,
+        /// Per-write shutdown-gate pin (see `CompressionStreamImpl::vm_pin`).
+        pub vm_pin: JsCell<Option<bun_threading::GateGuest>>,
         pub stream: JsCell<Context>,
         pub poll_ref: JsCell<CountedKeepAlive>,
         pub this_value: JsCell<StrongOptional>, // jsc.Strong.Optional
@@ -93,6 +95,7 @@ mod _impl {
                 ref_count: Cell::new(1),
                 // JSC_BORROW backref — the global outlives this m_ctx payload.
                 global_this: bun_ptr::BackRef::new(global),
+                vm_pin: JsCell::new(None),
                 stream: JsCell::new(stream),
                 poll_ref: JsCell::new(CountedKeepAlive::default()),
                 this_value: JsCell::new(StrongOptional::empty()),

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -41,6 +41,8 @@ mod _impl {
         // LIFETIMES.tsv: JSC_BORROW. The global outlives this m_ctx payload;
         // `BackRef` centralises the single unsafe deref so the trait impl is safe.
         pub global_this: bun_ptr::BackRef<JSGlobalObject>,
+        /// Per-write shutdown-gate pin (see `CompressionStreamImpl::vm_pin`).
+        pub vm_pin: JsCell<Option<bun_threading::GateGuest>>,
         pub stream: JsCell<Context>,
         pub poll_ref: JsCell<CountedKeepAlive>,
         pub this_value: JsCell<StrongOptional>, // jsc.Strong.Optional
@@ -105,6 +107,7 @@ mod _impl {
                 // JSC_BORROW — the JSGlobalObject outlives this payload (the C++
                 // wrapper is owned by that global's heap).
                 global_this: bun_ptr::BackRef::new(global),
+                vm_pin: JsCell::new(None),
                 stream: JsCell::new(stream),
                 poll_ref: JsCell::new(CountedKeepAlive::default()),
                 this_value: JsCell::new(StrongOptional::empty()),

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -498,8 +498,7 @@ impl Route {
         }
         config.source_map = bundler_options::SourceMapOption::Linked;
 
-        let completion_task =
-            create_and_schedule_completion_task(config, plugins, global, vm.event_loop())?;
+        let completion_task = create_and_schedule_completion_task(config, plugins, global)?;
         // SAFETY: `completion_task` is the freshly-boxed allocation (refcount==1); sole owner.
         unsafe {
             (*completion_task).started_at_ns =

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2578,6 +2578,7 @@ where
                         path,
                         Self::on_s3_size_resolved_thunk,
                         std::ptr::from_mut::<Self>(this).cast::<c_void>(),
+                        crate::webcore::s3::simple_request::ContextRelease::NONE,
                         proxy_url,
                         s3.request_payer,
                     ); // TODO: properly propagate exception upwards

--- a/src/runtime/socket/WindowsNamedPipeContext.rs
+++ b/src/runtime/socket/WindowsNamedPipeContext.rs
@@ -369,6 +369,8 @@ impl WindowsNamedPipeContext {
                     Self::run_event(ctx.cast::<WindowsNamedPipeContext>());
                     Ok(())
                 },
+                // Owned by the pipe context, not the queue.
+                dispose: None,
             };
 
             // SAFETY: `this` is freshly allocated uninit storage exclusively owned here; we write

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -4566,6 +4566,8 @@ pub fn js_upgrade_duplex_to_tls(
         // `AnyTask::New` can't take the callback as a type parameter (see the
         // notes in AnyTask.rs), so hand-write the `*mut c_void → run_event` shim.
         ptr::addr_of_mut!((*duplex_context).task).write(AnyTask {
+            // Owned by the duplex context, not the queue.
+            dispose: None,
             ctx: NonNull::new(duplex_context.cast::<c_void>()),
             callback: |p| {
                 // SAFETY: `p` is the `*mut DuplexUpgradeContext` stored in

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1456,20 +1456,37 @@ impl JSValkeyClient {
                 // self_ dropped here (Box freed).
             }
         }
+        impl Holder {
+            fn run_task(this: *mut Holder) -> bun_jsc::AnyTask::JsResult<()> {
+                Holder::run(this);
+                Ok(())
+            }
+
+            /// Reclaimed unrun by the terminate drain: release the ref
+            /// without `close()` (close can run JS handlers, forbidden
+            /// mid-drain; the uws loop closes the socket at teardown).
+            fn release_unrun(this: *mut Holder) {
+                // SAFETY: queue-owned box popped by the drain (sole owner);
+                // the deref releases the intrusive ref taken before the
+                // enqueue.
+                unsafe {
+                    let holder = bun_core::heap::take(this);
+                    JSValkeyClient::deref(holder.ctx.cast_mut());
+                }
+            }
+        }
+
         let holder = bun_core::heap::into_raw(Box::new(Holder {
             ctx: self.as_ctx_ptr(),
             task: jsc::AnyTask::AnyTask::default(), // overwritten below
         }));
-        // SAFETY: holder just allocated; closure captures nothing so it coerces
-        // to `fn(*mut c_void) -> JsResult<()>`.
+        // SAFETY: holder just allocated; exclusively owned until enqueued.
         unsafe {
-            (*holder).task = jsc::AnyTask::AnyTask {
-                ctx: Some(core::ptr::NonNull::new_unchecked(holder.cast::<c_void>())),
-                callback: |p: *mut c_void| {
-                    Holder::run(p.cast::<Holder>());
-                    Ok(())
-                },
-            };
+            (*holder).task = jsc::AnyTask::AnyTask::from_typed_with_dispose(
+                holder,
+                Holder::run_task,
+                Holder::release_unrun,
+            );
         }
 
         // SAFETY: VM-owned event loop pointer; uniquely accessed on the JS thread.

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -596,7 +596,6 @@ impl BlobExt for Blob {
                     }
                     Ok(())
                 }
-
             }
             let mut t = Box::new(Task::<H> {
                 ctx,
@@ -4635,7 +4634,6 @@ fn write_file_with_empty_source_to_destination(
                     }
                     Ok(())
                 }
-
             }
 
             let promise = jsc::JSPromiseStrong::init(ctx);
@@ -4919,7 +4917,6 @@ pub fn write_file_with_source_destination(
                             }
                             Ok(())
                         }
-
                     }
                     let promise = jsc::JSPromiseStrong::init(ctx);
                     let promise_value = promise.value();
@@ -5842,7 +5839,6 @@ impl S3BlobDownloadTask {
         }
         Ok(())
     }
-
 
     pub fn init(
         global_this: &JSGlobalObject,

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -596,6 +596,7 @@ impl BlobExt for Blob {
                     }
                     Ok(())
                 }
+
             }
             let mut t = Box::new(Task::<H> {
                 ctx,
@@ -637,6 +638,7 @@ impl BlobExt for Blob {
                     len,
                     Task::<H>::cb,
                     t_ptr,
+                    crate::webcore::s3::simple_request::ContextRelease::drop_box::<Task<H>>(),
                     proxy.as_deref(),
                     payer,
                 )?;
@@ -646,6 +648,7 @@ impl BlobExt for Blob {
                     path,
                     Task::<H>::cb,
                     t_ptr,
+                    crate::webcore::s3::simple_request::ContextRelease::drop_box::<Task<H>>(),
                     proxy.as_deref(),
                     payer,
                 )?;
@@ -4632,6 +4635,7 @@ fn write_file_with_empty_source_to_destination(
                     }
                     Ok(())
                 }
+
             }
 
             let promise = jsc::JSPromiseStrong::init(ctx);
@@ -4658,6 +4662,7 @@ fn write_file_with_empty_source_to_destination(
                     global: bun_ptr::BackRef::new(ctx),
                 }))
                 .cast::<c_void>(),
+                crate::webcore::s3::simple_request::ContextRelease::drop_box::<Wrapper>(),
             )?;
             return Ok(promise_value);
         }
@@ -4914,6 +4919,7 @@ pub fn write_file_with_source_destination(
                             }
                             Ok(())
                         }
+
                     }
                     let promise = jsc::JSPromiseStrong::init(ctx);
                     let promise_value = promise.value();
@@ -4937,6 +4943,7 @@ pub fn write_file_with_source_destination(
                             global: bun_ptr::BackRef::new(ctx),
                         }))
                         .cast::<c_void>(),
+                        crate::webcore::s3::simple_request::ContextRelease::drop_box::<Wrapper>(),
                     )?;
                     return Ok(promise_value);
                 }
@@ -5836,6 +5843,7 @@ impl S3BlobDownloadTask {
         Ok(())
     }
 
+
     pub fn init(
         global_this: &JSGlobalObject,
         blob: &Blob,
@@ -5892,6 +5900,7 @@ impl S3BlobDownloadTask {
                 len,
                 s3_cb,
                 this.cast::<c_void>(),
+                crate::webcore::s3::simple_request::ContextRelease::drop_box::<Self>(),
                 proxy,
                 s3_store.request_payer,
             )?;
@@ -5901,6 +5910,7 @@ impl S3BlobDownloadTask {
                 path,
                 s3_cb,
                 this.cast::<c_void>(),
+                crate::webcore::s3::simple_request::ContextRelease::drop_box::<Self>(),
                 proxy,
                 s3_store.request_payer,
             )?;
@@ -5914,6 +5924,7 @@ impl S3BlobDownloadTask {
                 Some(len),
                 s3_cb,
                 this.cast::<c_void>(),
+                crate::webcore::s3::simple_request::ContextRelease::drop_box::<Self>(),
                 proxy,
                 s3_store.request_payer,
             )?;

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -581,6 +581,7 @@ impl S3BlobStatTask {
         Ok(())
     }
 
+
     pub(crate) fn exists(global: &JSGlobalObject, blob: &Blob) -> JsResult<JSValue> {
         let this = S3BlobStatTask::new(S3BlobStatTask {
             promise: bun_jsc::JSPromiseStrong::init(global),
@@ -602,6 +603,7 @@ impl S3BlobStatTask {
             path,
             S3BlobStatTask::on_s3_exists_resolved,
             this.cast::<core::ffi::c_void>(),
+            crate::webcore::s3::simple_request::ContextRelease::drop_box::<S3BlobStatTask>(),
             env.get_http_proxy(true, None, None).map(|proxy| proxy.href),
             s3_store.request_payer,
         )?;
@@ -629,6 +631,7 @@ impl S3BlobStatTask {
             path,
             S3BlobStatTask::on_s3_stat_resolved,
             this.cast::<core::ffi::c_void>(),
+            crate::webcore::s3::simple_request::ContextRelease::drop_box::<S3BlobStatTask>(),
             env.get_http_proxy(true, None, None).map(|proxy| proxy.href),
             s3_store.request_payer,
         )?;
@@ -656,6 +659,7 @@ impl S3BlobStatTask {
             path,
             S3BlobStatTask::on_s3_size_resolved,
             this.cast::<core::ffi::c_void>(),
+            crate::webcore::s3::simple_request::ContextRelease::drop_box::<S3BlobStatTask>(),
             env.get_http_proxy(true, None, None).map(|proxy| proxy.href),
             s3_store.request_payer,
         )?;

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -581,7 +581,6 @@ impl S3BlobStatTask {
         Ok(())
     }
 
-
     pub(crate) fn exists(global: &JSGlobalObject, blob: &Blob) -> JsResult<JSValue> {
         let this = S3BlobStatTask::new(S3BlobStatTask {
             promise: bun_jsc::JSPromiseStrong::init(global),

--- a/src/runtime/webcore/blob/Store.rs
+++ b/src/runtime/webcore/blob/Store.rs
@@ -324,6 +324,7 @@ impl S3Ext for S3 {
                 }
                 Ok(())
             }
+
         }
 
         // Wrapper.deinit body deleted — store.deref() handled by StoreRef::drop,
@@ -356,6 +357,7 @@ impl S3Ext for S3 {
                 global: bun_ptr::BackRef::new(global_this),
             }))
             .cast::<c_void>(),
+            crate::webcore::s3::simple_request::ContextRelease::drop_box::<Wrapper>(),
             proxy,
             aws_options.request_payer,
         )?;
@@ -419,6 +421,7 @@ impl S3Ext for S3 {
                 }
                 Ok(())
             }
+
         }
 
         // Wrapper.deinit/destroy bodies deleted — store.deref() via StoreRef::drop,
@@ -462,6 +465,7 @@ impl S3Ext for S3 {
             unsafe { &(*wrapper).resolved_list_options },
             Wrapper::resolve,
             wrapper.cast::<c_void>(),
+            crate::webcore::s3::simple_request::ContextRelease::drop_box::<Wrapper>(),
             proxy,
         )?;
 

--- a/src/runtime/webcore/blob/Store.rs
+++ b/src/runtime/webcore/blob/Store.rs
@@ -324,7 +324,6 @@ impl S3Ext for S3 {
                 }
                 Ok(())
             }
-
         }
 
         // Wrapper.deinit body deleted — store.deref() handled by StoreRef::drop,
@@ -421,7 +420,6 @@ impl S3Ext for S3 {
                 }
                 Ok(())
             }
-
         }
 
         // Wrapper.deinit/destroy bodies deleted — store.deref() via StoreRef::drop,

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -68,6 +68,11 @@ pub struct FetchTasklet {
     pub result: HTTPClientResult<'static>,
     pub metadata: Option<HTTPResponseMetadata>,
     pub javascript_vm: &'static VirtualMachine,
+    /// Holds the VM's shutdown gate open while the HTTP side may still
+    /// enqueue for this transfer (set in `queue()`, dropped at the final
+    /// callback's end / exit reclaim — disjoint single-thread access).
+    /// Terminate waits for every pin before draining the queue.
+    pub vm_pin: Option<bun_threading::GateGuest>,
     pub global_this: GlobalRef,
     pub request_body: HTTPRequestBody,
     // ThreadSafeStreamBuffer is intrusively refcounted (`ref_count: AtomicU32`,
@@ -393,23 +398,39 @@ impl FetchTasklet {
             return;
         }
         let self_ = Self::from_raw_ref(this);
-        if self_.javascript_vm.is_shutting_down() {
-            // SAFETY: last ref; exclusive access. `deinit()` would run
-            // `clear_data()` + `Drop` for the JSC `Strong`/`Weak` fields, which
-            // reach into the VM's HandleSet from this (HTTP) thread — not
-            // thread-safe. Reclaim only the Rust-side boxes; the HandleSet is
-            // freed wholesale by `destructOnExit`.
+        if self_.javascript_vm.is_main_thread && self_.javascript_vm.is_shutting_down() {
+            // Main-VM exit: the loop will never tick again, so park the box
+            // for the exit drain instead of enqueueing.
+            // SAFETY: last ref; exclusive access.
             unsafe { FetchTasklet::dealloc_for_shutdown(this) };
             return;
         }
         // this is really unlikely to happen, but can happen
         // lets make sure that we always call deinit from main thread
-        // `from_callback` heap-allocates a fresh `ConcurrentTaskItem`; the queue
-        // takes ownership of it.
+        // The caller's pin keeps the VM (and its queue) alive across this
+        // enqueue; a terminating worker reclaims the task via its cleanup
+        // during the shutdown drain, with the VM still alive.
         Self::enqueue_concurrent(
             self_.javascript_vm,
-            ConcurrentTask::from_callback(this, FetchTasklet::deinit_callback),
+            ConcurrentTask::from_callback_with_cleanup(
+                this,
+                FetchTasklet::deinit_callback,
+                FetchTasklet::deinit_unrun_cleanup,
+            ),
         );
+    }
+
+    /// `ManagedTask` cleanup for a deinit task reclaimed unrun by the
+    /// terminate drain (JS thread, VM alive): the ref count is already zero.
+    fn deinit_unrun_cleanup(this: *mut FetchTasklet) {
+        // SAFETY: enqueued by `deref_from_thread` with the last ref released.
+        unsafe { FetchTasklet::deinit(this) };
+    }
+
+    /// `ManagedTask` cleanup for a resume task reclaimed unrun by the
+    /// terminate drain: releases the ref its enqueue took.
+    fn deref_unrun_cleanup(this: *mut FetchTasklet) {
+        FetchTasklet::deref(this);
     }
 
     // ConcurrentTask::from_callback takes `fn(*mut T) -> bun_event_loop::JsResult<()>`
@@ -525,6 +546,9 @@ impl FetchTasklet {
     /// been allocated via heap::alloc.
     unsafe fn dealloc_for_shutdown(this: *mut FetchTasklet) {
         bun_output::scoped_log!(FetchTasklet, "deallocForShutdown");
+        // Main-VM exit only (see `deref_from_thread`): park the box for the
+        // exit drain. Worker tasklets never reach here — their pin keeps the
+        // VM alive until the deferred deinit is enqueued.
         // SAFETY: caller contract — `this` is live with ref_count == 0.
         unsafe { (*this).ref_count.assert_no_refs() };
         http::defer_shutdown_reclaim(this.cast(), FetchTasklet::deinit_erased);
@@ -562,6 +586,12 @@ impl FetchTasklet {
     /// `result_callback.ctx` in `get()`; HTTP-thread-only at this point.
     unsafe fn release_at_shutdown(this: *mut ()) {
         let this = this.cast::<FetchTasklet>();
+        // Take the pin into a local so it is not left in the box: the box
+        // may be parked on the main-VM path and must not carry the pin with
+        // it. Dropping it last preserves the enqueue-then-unpin ordering
+        // every other pin-drop site uses.
+        // SAFETY: caller contract — `this` is live and HTTP-thread-exclusive.
+        let pin = unsafe { (*this).vm_pin.take() };
         // Free the body-bytes buffer the same way the `is_shutting_down`
         // branch in `callback` does (no JS-thread drain will reclaim it).
         // SAFETY: caller contract — `this` is live and HTTP-thread-exclusive.
@@ -575,6 +605,7 @@ impl FetchTasklet {
             // SAFETY: caller contract — `this` is live and HTTP-thread-exclusive.
             FetchTasklet::deref_from_thread(this);
         }
+        drop(pin);
     }
 
     fn get_current_response(&self) -> Option<*mut Response> {
@@ -822,6 +853,7 @@ impl FetchTasklet {
             }
             self.mutex.unlock();
             if is_done {
+                self.release_registry_ref();
                 // SAFETY: `self` is the live heap tasklet; we hold a ref.
                 FetchTasklet::deref(std::ptr::from_mut(self));
             }
@@ -853,6 +885,7 @@ impl FetchTasklet {
                 }
                 let mut poll_ref = core::mem::take(&mut this.poll_ref);
                 poll_ref.unref(bun_io::js_vm_ctx());
+                this.release_registry_ref();
                 // SAFETY: `this` is the live heap tasklet; we hold a ref.
                 FetchTasklet::deref(std::ptr::from_mut(this));
             }
@@ -1111,6 +1144,13 @@ impl FetchTasklet {
         fn reject_erased(p: *mut Holder) -> ElJsResult<()> {
             Holder::reject(p).map_err(|_| bun_event_loop::ErasedJsError::Terminated)
         }
+        impl Holder {
+            /// Reclaimed unrun by the terminate drain (JS thread, VM alive).
+            fn release_unrun(p: *mut Holder) {
+                // SAFETY: queue-owned box popped by the drain; sole owner.
+                drop(unsafe { bun_core::heap::take(p) });
+            }
+        }
 
         let holder = bun_core::heap::into_raw(Box::new(Holder {
             held: result,
@@ -1121,13 +1161,14 @@ impl FetchTasklet {
         }));
         // SAFETY: holder is valid until consumed by resolve/reject
         unsafe {
-            (*holder).task = AnyTask::from_typed(
+            (*holder).task = AnyTask::from_typed_with_dispose(
                 holder,
                 if success {
                     resolve_erased
                 } else {
                     reject_erased
                 },
+                Holder::release_unrun,
             );
             (*vm.event_loop()).enqueue_task(Task::init(&raw mut (*holder).task));
         }
@@ -1884,6 +1925,7 @@ impl FetchTasklet {
             result: HTTPClientResult::default(),
             metadata: None,
             javascript_vm: jsc_vm,
+            vm_pin: None,
             global_this: GlobalRef::from(global_this),
             request_body: fetch_options.body,
             request_body_streaming_buffer: None,
@@ -2140,13 +2182,19 @@ impl FetchTasklet {
         if this_ref.javascript_vm.is_shutting_down() {
             return;
         }
-        // ref until the main thread callback is called
+        // ref until the main thread callback is called; released by the
+        // callback or, if the task is reclaimed unrun at teardown, by the
+        // cleanup below.
         this_ref.ref_();
         // `from_callback` heap-allocates a fresh `ConcurrentTaskItem`; the queue
         // takes ownership of it.
         Self::enqueue_concurrent(
             this_ref.javascript_vm,
-            ConcurrentTask::from_callback(this, FetchTasklet::resume_request_data_stream),
+            ConcurrentTask::from_callback_with_cleanup(
+                this,
+                FetchTasklet::resume_request_data_stream,
+                FetchTasklet::deref_unrun_cleanup,
+            ),
         );
     }
 
@@ -2313,9 +2361,62 @@ impl FetchTasklet {
 
         // increment ref so we can keep it alive until the http client is done
         node_ref.ref_();
+        // Registry ref: entered in `vm.terminate_abort_registry` so worker
+        // terminate / process exit can abort the transfer while the VM is
+        // alive; released in `release_registry_ref` (normal completion) or
+        // the shutdown walk (`abort_for_terminate`).
+        node_ref.ref_();
+        // Terminate blocks until the HTTP side finishes with this transfer
+        // (post-abort, bounded) — completions always land on a live VM.
+        node_ref.vm_pin = Some(node_ref.javascript_vm.pin());
+        node_ref
+            .javascript_vm
+            .terminate_abort_registry
+            .borrow_mut()
+            // SAFETY: the registry entry's extra ref keeps `node` live until
+            // the walk or `release_registry_ref` consumes the entry.
+            .register(node, move || unsafe { Self::abort_for_terminate(node) });
         http::HTTPThread::schedule(batch);
 
         Ok(node)
+    }
+
+    /// Drop the registry entry and its ref, if still present (the shutdown
+    /// walk empties the registry first and consumes the refs). JS thread only.
+    fn release_registry_ref(&mut self) {
+        if !self
+            .javascript_vm
+            .terminate_abort_registry
+            .borrow_mut()
+            .unregister(std::ptr::from_mut(self))
+        {
+            return;
+        }
+        // SAFETY: the registry entry held this ref; `self` stays live (the
+        // caller holds at least the JS-side progress ref).
+        FetchTasklet::deref(std::ptr::from_mut(self));
+    }
+
+    /// Worker-terminate / process-exit walk body (see
+    /// `RuntimeHooks::abort_pending_transfers`): abort the transfer so the
+    /// HTTP side finishes promptly — its completions land on the still-alive
+    /// VM and are reclaimed by the queue drain via the normal release paths.
+    ///
+    /// # Safety
+    /// `this` is live (the registry entry's ref pins it), on the VM's JS
+    /// thread, pre-JSC-teardown. Consumes the registry ref.
+    pub(crate) unsafe fn abort_for_terminate(this: *mut FetchTasklet) {
+        // SAFETY: registered in `queue()` with the tasklet pointer.
+        let t = unsafe { &mut *this };
+        t.abort_task();
+        // A streaming request body holds a `start_request_stream` ref that
+        // only `write_end_request` (via the sink's on_end) releases — cancel
+        // the sink like the normal `is_done` path does, while JS is alive.
+        if let Some(sink) = t.sink_mut() {
+            sink.cancel(JSValue::UNDEFINED);
+        }
+        // SAFETY: consumes the registry ref taken in `queue()`.
+        FetchTasklet::deref(this);
     }
 
     /// Called from HTTP thread. Handles HTTP events received from socket.
@@ -2450,8 +2551,13 @@ impl FetchTasklet {
             if has_schedule_callback {
                 task_ref.mutex.unlock();
                 if is_done {
+                    // Take the pin out first — the deref below may free the
+                    // tasklet; the local keeps the VM alive until the very
+                    // end of the HTTP side's involvement.
+                    let pin = task_ref.vm_pin.take();
                     // SAFETY: `task` is the live heap tasklet; HTTP-thread ref held.
                     FetchTasklet::deref_from_thread(task);
+                    drop(pin);
                 }
                 return;
             }
@@ -2478,14 +2584,17 @@ impl FetchTasklet {
                 .store(false, Ordering::Release);
             task_ref.mutex.unlock();
             if is_done {
+                // Take the pin out first — the derefs below may free the
+                // tasklet.
+                let pin = task_ref.vm_pin.take();
                 // No on_progress_update will ever run for this final result, so
                 // release the JS-side ref it would have dropped, then the
-                // HTTP-side ref. The 1→0 transition runs `dealloc_for_shutdown`
-                // (Rust boxes only — JSC handles are leaked to destructOnExit).
+                // HTTP-side ref.
                 // SAFETY: `task` is the live heap tasklet; both refs held.
                 FetchTasklet::deref_from_thread(task);
                 // SAFETY: second ref still held until this 1→0 transition.
                 FetchTasklet::deref_from_thread(task);
+                drop(pin);
             }
             return;
         }
@@ -2502,8 +2611,11 @@ impl FetchTasklet {
         // we are done with the http client so we can deref our side
         // this is a atomic operation and will enqueue a task to deinit on the main thread
         if is_done {
+            // Take the pin out first — the deref below may free the tasklet.
+            let pin = task_ref.vm_pin.take();
             // SAFETY: `task` is the live heap tasklet; HTTP-thread ref held.
             FetchTasklet::deref_from_thread(task);
+            drop(pin);
         }
     }
 }

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -66,6 +66,7 @@ pub(crate) fn stat(
     path: &[u8],
     callback: fn(S3StatResult, *mut c_void) -> JsTerminatedResult<()>,
     callback_context: *mut c_void,
+    context_release: s3_simple_request::ContextRelease,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
 ) -> JsTerminatedResult<()> {
@@ -81,6 +82,7 @@ pub(crate) fn stat(
         },
         s3_simple_request::Callback::Stat(callback),
         callback_context,
+        context_release,
     )
 }
 
@@ -89,6 +91,7 @@ pub(crate) fn download(
     path: &[u8],
     callback: fn(S3DownloadResult, *mut c_void) -> JsTerminatedResult<()>,
     callback_context: *mut c_void,
+    context_release: s3_simple_request::ContextRelease,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
 ) -> JsTerminatedResult<()> {
@@ -104,6 +107,7 @@ pub(crate) fn download(
         },
         s3_simple_request::Callback::Download(callback),
         callback_context,
+        context_release,
     )
 }
 
@@ -114,6 +118,7 @@ pub(crate) fn download_slice(
     size: Option<usize>,
     callback: fn(S3DownloadResult, *mut c_void) -> JsTerminatedResult<()>,
     callback_context: *mut c_void,
+    context_release: s3_simple_request::ContextRelease,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
 ) -> JsTerminatedResult<()> {
@@ -148,6 +153,7 @@ pub(crate) fn download_slice(
         },
         s3_simple_request::Callback::Download(callback),
         callback_context,
+        context_release,
     )
 }
 
@@ -156,6 +162,7 @@ pub(crate) fn delete(
     path: &[u8],
     callback: fn(S3DeleteResult, *mut c_void) -> JsTerminatedResult<()>,
     callback_context: *mut c_void,
+    context_release: s3_simple_request::ContextRelease,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
 ) -> JsTerminatedResult<()> {
@@ -171,6 +178,7 @@ pub(crate) fn delete(
         },
         s3_simple_request::Callback::Delete(callback),
         callback_context,
+        context_release,
     )
 }
 
@@ -183,6 +191,7 @@ pub(crate) fn list_objects(
     list_options: &S3ListObjectsOptions,
     callback: fn(S3ListObjectsResult, *mut c_void) -> JsTerminatedResult<()>,
     callback_context: *mut c_void,
+    context_release: s3_simple_request::ContextRelease,
     proxy_url: Option<&[u8]>,
 ) -> JsTerminatedResult<()> {
     let mut search_params: Vec<u8> = Vec::<u8>::default();
@@ -301,9 +310,11 @@ pub(crate) fn list_objects(
         range: None,
         sign_result: result,
         callback_context,
+        callback_context_release: context_release,
         callback: s3_simple_request::Callback::ListObjects(callback),
         headers,
         vm: Some(bun_ptr::BackRef::new(VirtualMachine::get())),
+        vm_pin: Some(VirtualMachine::get().pin()),
         response_buffer: MutableString::default(),
         result: bun_http::HTTPClientResult::default(),
         concurrent_task: Default::default(),
@@ -341,12 +352,8 @@ pub(crate) fn list_objects(
     } else {
         None
     };
-    let mut vm_ref = task.vm.expect("vm set at task creation");
-    // SAFETY: `task.vm` is the live per-thread VM BackRef from
-    // `VirtualMachine::get()`; `get_mut` exclusivity holds — single-threaded
-    // dispatch on the JS thread, no other `&`/`&mut VirtualMachine` is live for
-    // this call's duration.
-    let vm = unsafe { vm_ref.get_mut() };
+    // JS thread: read the fetch options off the live per-thread VM directly.
+    let vm = VirtualMachine::get().as_mut();
 
     task.http.write(bun_http::AsyncHTTP::init(
         bun_http::Method::GET,
@@ -372,6 +379,18 @@ pub(crate) fn list_objects(
 
     // queue http request
     bun_http::http_thread::init(&Default::default());
+    // Terminate/exit can abort this transfer while the VM is alive: wake
+    // the HTTP side so the final callback fires and the producer pin drops.
+    VirtualMachine::get()
+        .terminate_abort_registry
+        .borrow_mut()
+        .register(task_ptr, move || {
+            // SAFETY: the entry is unregistered at the top of `on_response`,
+            // before any path frees the task, and `http` was initialised
+            // above.
+            let id = unsafe { (*task_ptr).http.assume_init_ref().async_http_id };
+            bun_http::http_thread().schedule_shutdown_by_id(id);
+        });
     let mut batch = bun_threading::thread_pool::Batch::default();
     // SAFETY: `http` was initialised by `task.http.write(...)` immediately above.
     unsafe { task.http.assume_init_mut() }.schedule(&mut batch);
@@ -392,6 +411,7 @@ pub fn upload(
     request_payer: bool,
     callback: fn(S3UploadResult, *mut c_void) -> JsTerminatedResult<()>,
     callback_context: *mut c_void,
+    context_release: s3_simple_request::ContextRelease,
 ) -> JsTerminatedResult<()> {
     s3_simple_request::execute_simple_s3_request(
         this,
@@ -410,6 +430,7 @@ pub fn upload(
         },
         s3_simple_request::Callback::Upload(callback),
         callback_context,
+        context_release,
     )
 }
 
@@ -505,10 +526,6 @@ pub(crate) fn writable_stream(
         request_payer,
         credentials,
         poll_ref: KeepAlive::init(),
-        // SAFETY (JSC_BORROW): VirtualMachine::get() returns the live per-thread VM; it
-        // outlives every MultiPartUpload (the VM owns the heap that owns the JS objects
-        // keeping this task alive). Dereference to `&'static` for storage.
-        vm: VirtualMachine::get(),
         global_this: global_static,
         buffered: StreamBuffer::default(),
         path: Box::<[u8]>::from(path),
@@ -859,9 +876,6 @@ pub fn upload_stream(
         request_payer,
         credentials,
         poll_ref: KeepAlive::init(),
-        // SAFETY (JSC_BORROW): VirtualMachine::get() returns the live per-thread VM; it
-        // outlives every MultiPartUpload. Dereference to `&'static` for storage.
-        vm: VirtualMachine::get(),
         global_this: global_static,
         buffered: StreamBuffer::default(),
         path: Box::<[u8]>::from(path),
@@ -927,6 +941,7 @@ pub(crate) fn download_stream(
         ctx: *mut c_void,
     ),
     callback_context: *mut c_void,
+    context_release: s3_simple_request::ContextRelease,
 ) -> *mut S3HttpDownloadStreamingTask {
     let range: Option<Vec<u8>> = 'brk: {
         if let Some(size_) = size {
@@ -1006,11 +1021,13 @@ pub(crate) fn download_stream(
             proxy_url: owned_proxy,
             callback_context: NonNull::new(callback_context.cast::<()>())
                 .expect("callers always pass a non-null Box-allocated context"),
+            callback_context_release: context_release,
             callback,
             range: range.map(Vec::into_boxed_slice),
             headers,
             // `VirtualMachine::get()` returns the live per-thread VM singleton.
             vm: Some(bun_ptr::BackRef::new(VirtualMachine::get())),
+            vm_pin: Some(VirtualMachine::get().pin()),
             has_schedule_callback: core::sync::atomic::AtomicBool::new(false),
             signal_store: Default::default(),
             signals: Default::default(),
@@ -1085,6 +1102,23 @@ pub(crate) fn download_stream(
     // SAFETY: `http` was initialised by `task.http.write(...)` immediately above.
     let http = unsafe { task.http.assume_init_mut() };
     task.async_http_id = http.async_http_id;
+    // Terminate/exit can abort this transfer while the VM is alive: flag
+    // the abort and wake the HTTP side so the final chunk fires and the
+    // producer pin drops.
+    VirtualMachine::get()
+        .terminate_abort_registry
+        .borrow_mut()
+        .register(task_ptr, move || {
+            // SAFETY: the entry is unregistered in the final `on_response`,
+            // before the task is freed.
+            unsafe {
+                (*task_ptr)
+                    .signal_store
+                    .aborted
+                    .store(true, core::sync::atomic::Ordering::Relaxed);
+                bun_http::http_thread().schedule_shutdown_by_id((*task_ptr).async_http_id);
+            }
+        });
     // enable streaming
     http.enable_response_body_streaming();
     // queue http request
@@ -1221,6 +1255,7 @@ pub fn readable_stream(
             let self_: &mut Self = unsafe { bun_ptr::callback_ctx::<Self>(opaque_self) };
             let _ = Self::callback(chunk, has_more, err, self_); // TODO: properly propagate exception upwards
         }
+
     }
 
     impl Drop for S3DownloadStreamWrapper {
@@ -1276,6 +1311,7 @@ pub fn readable_stream(
         request_payer,
         S3DownloadStreamWrapper::opaque_callback,
         wrapper.cast::<c_void>(),
+        s3_simple_request::ContextRelease::drop_box::<S3DownloadStreamWrapper>(),
     );
     if !task.is_null() {
         // SAFETY: on the success path `download_stream` only schedules work onto the HTTP

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -1255,7 +1255,6 @@ pub fn readable_stream(
             let self_: &mut Self = unsafe { bun_ptr::callback_ctx::<Self>(opaque_self) };
             let _ = Self::callback(chunk, has_more, err, self_); // TODO: properly propagate exception upwards
         }
-
     }
 
     impl Drop for S3DownloadStreamWrapper {

--- a/src/runtime/webcore/s3/download_stream.rs
+++ b/src/runtime/webcore/s3/download_stream.rs
@@ -18,12 +18,18 @@ pub struct S3HttpDownloadStreamingTask {
     // `MaybeUninit` because `AsyncHTTP` contains non-null references, so
     // `mem::zeroed()` can't be used here (mirrors `S3HttpSimpleTask`).
     pub http: core::mem::MaybeUninit<AsyncHTTP<'static>>,
-    /// JSC_BORROW: per-thread VM singleton, outlives every task. `None` only in
-    /// the inert `Default` placeholder (overwritten before the task escapes).
+    /// JSC_BORROW: kept alive across the transfer by `vm_pin` below (worker
+    /// terminate waits for the pin). `None` only in the inert `Default`
+    /// placeholder (overwritten before the task escapes).
     pub vm: Option<bun_ptr::BackRef<VirtualMachine>>,
+    /// Holds the VM's shutdown gate open for the whole transfer (set at
+    /// creation, dropped on the HTTP thread at the final enqueue). Terminate
+    /// aborts the transfer via the abort registry, so the wait is bounded.
+    pub vm_pin: Option<bun_threading::GateGuest>,
     pub sign_result: SignResult,
     pub headers: Headers,
     pub callback_context: NonNull<()>,
+    pub callback_context_release: crate::webcore::s3::simple_request::ContextRelease,
     pub callback: fn(chunk: &MutableString, has_more: bool, err: Option<S3Error>, ctx: *mut c_void),
     pub has_schedule_callback: AtomicBool,
     pub signal_store: bun_http::signals::Store,
@@ -62,9 +68,11 @@ impl Default for S3HttpDownloadStreamingTask {
             // never read — fully overwritten by `AsyncHTTP::init` before first use.
             http: core::mem::MaybeUninit::uninit(),
             vm: None,
+            vm_pin: None,
             sign_result: SignResult::default(),
             headers: Headers::default(),
             callback_context: NonNull::dangling(),
+            callback_context_release: crate::webcore::s3::simple_request::ContextRelease::NONE,
             callback: |_, _, _, _| {},
             range: None,
             proxy_url: Box::default(),
@@ -196,6 +204,12 @@ impl S3HttpDownloadStreamingTask {
         // the state is atomic let's load it once
         let state = self_.get_state();
         let has_more = state.has_more();
+        if !has_more {
+            VirtualMachine::get()
+                .terminate_abort_registry
+                .borrow_mut()
+                .unregister(this);
+        }
         // Use a scopeguard so any future early-exit / unwind through
         // `report_progress` still unlocks + deinits.
         let this_ptr = this;
@@ -339,21 +353,26 @@ impl S3HttpDownloadStreamingTask {
         let self_ = unsafe { &mut *this };
         // SAFETY: `async_http` is the live HTTP-thread copy; non-null for the callback's duration.
         let async_http = unsafe { &mut *async_http };
+        let is_final = !result.has_more;
+        // Take the pin out FIRST on the final chunk: the enqueue publishes
+        // the task and the JS thread may free it before we return.
+        let final_pin = if is_final { self_.vm_pin.take() } else { None };
         if self_.process_http_callback(async_http, result) {
             // we are always unlocked here and its safe to enqueue
+            debug_assert!(
+                final_pin.is_some() || self_.vm_pin.is_some(),
+                "pin held until the final chunk"
+            );
+            let vm = self_.vm.expect("vm set at task creation");
             let task = core::ptr::NonNull::from(
                 self_.concurrent_task.from(this, AutoDeinit::ManualDeinit),
             );
-            // `vm` is the live per-thread VM BackRef captured at task creation; event_loop
-            // is initialized for the request's lifetime and enqueue is thread-safe (`&self`).
-            // `task` is the inline `concurrent_task` field of this heap request;
-            // the queue takes ownership of its `next` link.
-            self_
-                .vm
-                .expect("vm set at task creation")
-                .event_loop_shared()
-                .enqueue_task_concurrent(task);
+            // `vm` is the VM BackRef captured at task creation, kept alive by
+            // the pin (in `final_pin` or still in the task); enqueue is
+            // thread-safe (`&self`).
+            vm.event_loop_shared().enqueue_task_concurrent(task);
         }
+        drop(final_pin);
     }
 }
 

--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -102,7 +102,6 @@ use bun_core::{declare_scope, scoped_log};
 use bun_io::KeepAlive;
 use bun_io::StreamBuffer;
 use bun_jsc::GlobalRef;
-use bun_jsc::virtual_machine::VirtualMachine;
 use bun_s3_signing::acl::ACL;
 use bun_s3_signing::credentials::S3Credentials;
 use bun_s3_signing::error::S3Error;
@@ -137,7 +136,6 @@ pub struct MultiPartUpload {
     pub request_payer: bool,
     pub credentials: bun_ptr::IntrusiveRc<S3Credentials>,
     pub poll_ref: KeepAlive,
-    pub vm: &'static VirtualMachine,
     // JSC_BORROW per LIFETIMES.tsv row 1886 — rust_type `&JSGlobalObject` used verbatim
     pub global_this: GlobalRef,
 
@@ -180,6 +178,16 @@ impl MultiPartUpload {
     // `ref_()`/`deref()` are provided by `#[derive(CellRefCounted)]`.
     // Inherent associated types (`pub type Ref = ...` inside `impl`) are
     // unstable; the alias lives at module scope as `MultiPartUploadRef`.
+    /// Terminate-drain release for a queued-but-unrun response whose ctx is
+    /// the upload itself: drops the request-held ref the JS callback would
+    /// have dropped (JS thread, VM alive).
+    ///
+    /// # Safety
+    /// `ctx` is the live `MultiPartUpload` registered as callback context.
+    pub(crate) unsafe fn release_unrun_ctx(ctx: *mut Self) {
+        Self::deref_(ctx);
+    }
+
     /// # Safety
     /// `this` must be a live heap-allocated `MultiPartUpload` created via
     /// `heap::alloc` with a non-zero intrusive refcount.
@@ -221,6 +229,17 @@ pub struct UploadPartResult {
 }
 
 impl UploadPart {
+    /// Terminate-drain release for a queued-but-unrun part response: drops
+    /// the ctx ref taken in `start()` (JS thread, VM alive). The part itself
+    /// stays owned by the upload's queue.
+    ///
+    /// # Safety
+    /// `part` is the live `UploadPart` registered as callback context.
+    pub(crate) unsafe fn release_unrun_part_ctx(part: *mut Self) {
+        // SAFETY: caller contract; the BackRef target outlives the part.
+        MultiPartUpload::deref_(unsafe { (*part).ctx.as_ptr() });
+    }
+
     fn free_allocated_slice(&mut self) {
         if self.allocated_size > 0 {
             // SAFETY: `data.ptr` was allocated by the global allocator with capacity == allocated_size
@@ -362,6 +381,7 @@ impl UploadPart {
             },
             s3_simple_request::S3Callback::Part(Self::on_part_response),
             callback_context,
+            s3_simple_request::ContextRelease::of(UploadPart::release_unrun_part_ctx),
         )
     }
 
@@ -395,7 +415,6 @@ impl Drop for MultiPartUpload {
         // queue: Box<[UploadPart]> — dropped automatically (parts' raw `data` already freed during lifecycle)
         // KeepAlive::unref takes an `EventLoopCtx` (aio cycle-break vtable),
         // not `&VirtualMachine`. Route through the global hook like simple_request does.
-        let _ = self.vm;
         self.poll_ref.unref(bun_io::posix_event_loop::get_vm_ctx(
             bun_io::AllocatorType::Js,
         ));
@@ -448,6 +467,7 @@ impl MultiPartUpload {
                         },
                         s3_simple_request::S3Callback::Upload(Self::single_send_upload_response),
                         callback_context,
+                        s3_simple_request::ContextRelease::of(MultiPartUpload::release_unrun_ctx),
                     )?;
 
                     Ok(())
@@ -829,6 +849,7 @@ impl MultiPartUpload {
             },
             s3_simple_request::S3Callback::Commit(Self::on_commit_multi_part_request),
             callback_context,
+            s3_simple_request::ContextRelease::of(MultiPartUpload::release_unrun_ctx),
         )
     }
 
@@ -860,6 +881,7 @@ impl MultiPartUpload {
             },
             s3_simple_request::S3Callback::Upload(Self::on_rollback_multi_part_request),
             callback_context,
+            s3_simple_request::ContextRelease::of(MultiPartUpload::release_unrun_ctx),
         )
     }
 
@@ -896,6 +918,7 @@ impl MultiPartUpload {
                 },
                 s3_simple_request::S3Callback::Download(Self::start_multi_part_request_result),
                 callback_context,
+                s3_simple_request::ContextRelease::of(MultiPartUpload::release_unrun_ctx),
             )?;
         } else if self.state == State::MultipartCompleted {
             // SAFETY: part points into self.queue which is live; reborrow disjoint from self fields used above
@@ -1038,6 +1061,7 @@ impl MultiPartUpload {
                 },
                 s3_simple_request::S3Callback::Upload(Self::single_send_upload_response),
                 callback_context,
+                s3_simple_request::ContextRelease::of(MultiPartUpload::release_unrun_ctx),
             ); // TODO: properly propagate exception upwards
         } else {
             // we need to split

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -760,12 +760,14 @@ pub(crate) fn execute_simple_s3_request(
     ));
     // Terminate/exit can abort this transfer while the VM is alive: wake
     // the HTTP side so the final callback fires and the producer pin drops.
-    vm.terminate_abort_registry.borrow_mut().register(task_ptr, move || {
-        // SAFETY: the entry is unregistered at the top of `on_response`,
-        // before any path frees the task, and `http` was initialised above.
-        let id = unsafe { (*task_ptr).http.assume_init_ref().async_http_id };
-        bun_http::http_thread().schedule_shutdown_by_id(id);
-    });
+    vm.terminate_abort_registry
+        .borrow_mut()
+        .register(task_ptr, move || {
+            // SAFETY: the entry is unregistered at the top of `on_response`,
+            // before any path frees the task, and `http` was initialised above.
+            let id = unsafe { (*task_ptr).http.assume_init_ref().async_http_id };
+            bun_http::http_thread().schedule_shutdown_by_id(id);
+        });
     // queue http request
     bun_http::http_thread::init(&Default::default());
     let mut batch = thread_pool::Batch::default();

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -117,12 +117,17 @@ pub struct S3HttpSimpleTask {
     // `execute_simple_s3_request` before the task pointer escapes, so every later access (in
     // `http_callback` / `Drop`) may `assume_init`.
     pub http: core::mem::MaybeUninit<AsyncHTTP<'static>>,
-    /// JSC_BORROW: per-thread VM singleton, outlives every task. `None` only in
-    /// the inert `Default` placeholder (overwritten before the task escapes).
+    /// JSC_BORROW: kept alive across the transfer by `vm_pin` below (worker
+    /// terminate waits for the pin). `None` only in the inert `Default`
+    /// placeholder (overwritten before the task escapes).
     pub vm: Option<bun_ptr::BackRef<VirtualMachine>>,
+    /// Holds the VM's shutdown gate open until the completion is enqueued
+    /// (set at creation, dropped on the HTTP thread).
+    pub vm_pin: Option<bun_threading::GateGuest>,
     pub sign_result: SignResult,
     pub headers: Headers,
     pub callback_context: *mut c_void,
+    pub callback_context_release: ContextRelease,
     pub callback: Callback,
     pub response_buffer: MutableString,
     // `'static` here because `result.body` (when set) points at our own
@@ -156,9 +161,11 @@ impl Default for S3HttpSimpleTask {
         Self {
             http: core::mem::MaybeUninit::uninit(),
             vm: None,
+            vm_pin: None,
             sign_result: SignResult::default(),
             headers: Headers::default(),
             callback_context: core::ptr::null_mut(),
+            callback_context_release: ContextRelease::NONE,
             callback: Callback::Upload(unset_callback),
             response_buffer: MutableString::default(),
             result: HTTPClientResult::default(),
@@ -173,6 +180,48 @@ impl Default for S3HttpSimpleTask {
 
 // Re-export the canonical alias so sibling modules that imported it from here keep compiling.
 pub use bun_jsc::JsTerminatedResult;
+
+/// How to release a task's `callback_context` if the completion is
+/// reclaimed unrun by the terminate drain (JS thread, VM alive). The
+/// constructors are typed; the erasure lives here only.
+#[derive(Clone, Copy)]
+pub struct ContextRelease(unsafe fn(*mut c_void));
+
+impl ContextRelease {
+    /// Ctx owned elsewhere (refcounted / parent-owned): nothing to free.
+    pub const NONE: Self = Self(Self::noop);
+
+    unsafe fn noop(_: *mut c_void) {}
+
+    /// Queue-owned `Box<T>`: the drain drops it.
+    pub fn drop_box<T>() -> Self {
+        unsafe fn drop_it<T>(ptr: *mut c_void) {
+            // SAFETY: `run` caller contract — `ptr` is the queue-owned
+            // `heap::into_raw` `Box<T>` and the drain is its sole owner.
+            drop(unsafe { bun_core::heap::take(ptr.cast::<T>()) });
+        }
+        Self(drop_it::<T>)
+    }
+
+    /// Custom release (e.g. a refcount decrement).
+    pub fn of<T>(release: unsafe fn(*mut T)) -> Self {
+        // SAFETY: `*mut T` and `*mut c_void` are ABI-identical, so the two
+        // fn-pointer types are ABI-compatible; `run` only ever passes back
+        // the ctx pointer stored alongside this value, which originated as
+        // `*mut T`.
+        Self(unsafe { bun_ptr::cast_fn_ptr::<unsafe fn(*mut T), unsafe fn(*mut c_void)>(release) })
+    }
+
+    /// Run the release on the task's ctx pointer.
+    ///
+    /// # Safety
+    /// `ptr` is the same ctx the constructor's `T` described, reclaimed by
+    /// the terminate drain exactly once.
+    pub(crate) unsafe fn run(self, ptr: *mut c_void) {
+        // SAFETY: forwarded caller contract.
+        unsafe { (self.0)(ptr) }
+    }
+}
 
 pub enum Callback {
     Stat(fn(S3StatResult<'_>, *mut c_void) -> JsTerminatedResult<()>),
@@ -335,6 +384,10 @@ impl S3HttpSimpleTask {
     // pointer the queue hands back, non-null by the `ConcurrentTask::from` contract.
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn on_response(this: *mut Self) -> JsTerminatedResult<()> {
+        VirtualMachine::get()
+            .terminate_abort_registry
+            .borrow_mut()
+            .unregister(this);
         // SAFETY: `this` was produced by `S3HttpSimpleTask::new` (heap::alloc) and ownership is
         // reclaimed here exactly once via the ConcurrentTask `.manual_deinit` contract;
         // `this` is dropped at scope exit.
@@ -483,18 +536,20 @@ impl S3HttpSimpleTask {
             // compute the raw self-pointer before borrowing `this.concurrent_task`
             // to avoid a stacked-borrows / aliasing diagnostic on `*this`.
             let this_ptr = std::ptr::from_mut::<Self>(this);
+            // Take the pin into a local first — the enqueue hands the task
+            // to the JS thread, which may free it before this thread returns.
+            let pin = this.vm_pin.take().expect("pin taken at creation");
             let task = core::ptr::NonNull::from(
                 this.concurrent_task
                     .from(this_ptr, AutoDeinit::ManualDeinit),
             );
-            // `vm` is the live per-thread VM BackRef captured at task creation; event_loop
-            // is set during VM init and outlives this task. `enqueue_task_concurrent` is `&self`.
-            // `task` is the inline `concurrent_task` field of this heap request;
-            // the queue takes ownership of its `next` link.
+            // `vm` is the VM BackRef captured at task creation, kept alive by
+            // `pin`; `enqueue_task_concurrent` is `&self` and thread-safe.
             this.vm
                 .expect("vm set at task creation")
                 .event_loop_shared()
                 .enqueue_task_concurrent(task);
+            drop(pin);
         }
     }
 }
@@ -575,6 +630,7 @@ pub(crate) fn execute_simple_s3_request(
     options: S3SimpleRequestOptions<'_>,
     callback: Callback,
     callback_context: *mut c_void,
+    callback_context_release: ContextRelease,
 ) -> JsTerminatedResult<()> {
     let result = match this.sign_request::<false>(
         &SignOptions {
@@ -631,10 +687,12 @@ pub(crate) fn execute_simple_s3_request(
         http: core::mem::MaybeUninit::uninit(),
         sign_result: result,
         callback_context,
+        callback_context_release,
         callback,
         range: options.range,
         headers,
         vm: Some(bun_ptr::BackRef::new(VirtualMachine::get())),
+        vm_pin: Some(VirtualMachine::get().pin()),
         response_buffer: MutableString::default(),
         result: HTTPClientResult::default(),
         concurrent_task: ConcurrentTask::default(),
@@ -700,6 +758,14 @@ pub(crate) fn execute_simple_s3_request(
             ..Default::default()
         },
     ));
+    // Terminate/exit can abort this transfer while the VM is alive: wake
+    // the HTTP side so the final callback fires and the producer pin drops.
+    vm.terminate_abort_registry.borrow_mut().register(task_ptr, move || {
+        // SAFETY: the entry is unregistered at the top of `on_response`,
+        // before any path frees the task, and `http` was initialised above.
+        let id = unsafe { (*task_ptr).http.assume_init_ref().async_http_id };
+        bun_http::http_thread().schedule_shutdown_by_id(id);
+    });
     // queue http request
     bun_http::http_thread::init(&Default::default());
     let mut batch = thread_pool::Batch::default();

--- a/src/threading/ShutdownGate.rs
+++ b/src/threading/ShutdownGate.rs
@@ -1,0 +1,161 @@
+//! A counted guest gate protecting an allocation shared with other threads.
+//!
+//! Guests bracket every access to the protected memory with `enter()`/
+//! `leave()`. The owner calls `close_and_wait()` before freeing the memory:
+//! it refuses new guests, then blocks until every guest inside has left.
+//! The gate itself must live OUTSIDE the protected allocation (e.g. in an
+//! `Arc` cloned by each guest) so that a late `enter()` after the close is a
+//! safe "gate closed" answer instead of a use-after-free.
+
+use core::sync::atomic::{AtomicU32, Ordering};
+
+use crate::futex;
+
+/// Bit 0: closed. Remaining bits: number of guests currently inside ×2.
+const CLOSED: u32 = 1;
+const GUEST: u32 = 2;
+
+#[derive(Default)]
+pub struct ShutdownGate {
+    state: AtomicU32,
+}
+
+impl ShutdownGate {
+    pub const fn new() -> Self {
+        Self {
+            state: AtomicU32::new(0),
+        }
+    }
+
+    /// Try to enter the gate. Returns `false` if the gate is closed — the
+    /// protected memory may already be freed and must not be touched.
+    #[must_use]
+    pub fn enter(&self) -> bool {
+        // Optimistic add, undo on closed: `close_and_wait` tolerates the
+        // transient count because it re-reads state until it settles.
+        let prev = self.state.fetch_add(GUEST, Ordering::Acquire);
+        if prev & CLOSED == 0 {
+            return true;
+        }
+        self.leave();
+        false
+    }
+
+    /// Leave the gate. Must pair with an `enter()` that returned `true` (or
+    /// the internal undo above). After this call the guest must not touch the
+    /// protected memory again.
+    pub fn leave(&self) {
+        let prev = self.state.fetch_sub(GUEST, Ordering::Release);
+        if prev == CLOSED | GUEST {
+            // Last guest out of a closed gate: wake `close_and_wait` (all
+            // waiters — `close_and_wait` is callable from several owners).
+            futex::wake(&self.state, u32::MAX);
+        }
+    }
+
+    /// Set the CLOSED bit without waiting for guests. Only sound when the
+    /// protected memory is never actually freed (the main VM's box lives for
+    /// the process) — new guests are refused, in-flight ones finish on their
+    /// own time.
+    pub fn close_without_waiting(&self) {
+        self.state.fetch_or(CLOSED, Ordering::AcqRel);
+    }
+
+    /// Close the gate and block until every guest has left. After this
+    /// returns, no guest is inside and none can enter; the protected memory
+    /// may be freed. Idempotent; must never be called from a guest section.
+    pub fn close_and_wait(&self) {
+        let mut state = self.state.fetch_or(CLOSED, Ordering::AcqRel) | CLOSED;
+        while state != CLOSED {
+            let _ = futex::wait(&self.state, state, None);
+            state = self.state.load(Ordering::Acquire);
+        }
+    }
+}
+
+/// RAII guest of a [`ShutdownGate`]: holds the gate open (via its own `Arc`,
+/// so it may outlive whatever produced it) until dropped.
+pub struct GateGuest {
+    gate: std::sync::Arc<ShutdownGate>,
+}
+
+impl GateGuest {
+    /// Enter `gate`; `None` if it is already closed.
+    #[must_use]
+    pub fn enter(gate: &std::sync::Arc<ShutdownGate>) -> Option<Self> {
+        gate.enter().then(|| Self {
+            gate: std::sync::Arc::clone(gate),
+        })
+    }
+}
+
+impl Drop for GateGuest {
+    fn drop(&mut self) {
+        self.gate.leave();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+
+    #[test]
+    fn close_and_wait_drains_racing_guests() {
+        for _ in 0..64 {
+            let gate = Arc::new(ShutdownGate::new());
+            let inside = Arc::new(AtomicUsize::new(0));
+            let guests: Vec<_> = (0..8)
+                .map(|_| {
+                    let (gate, inside) = (Arc::clone(&gate), Arc::clone(&inside));
+                    std::thread::spawn(move || {
+                        for _ in 0..500 {
+                            if !gate.enter() {
+                                return;
+                            }
+                            inside.fetch_add(1, Ordering::SeqCst);
+                            std::hint::spin_loop();
+                            inside.fetch_sub(1, Ordering::SeqCst);
+                            gate.leave();
+                        }
+                    })
+                })
+                .collect();
+            // A second concurrent closer: close_and_wait must be callable
+            // from several owners and both must drain.
+            let second_closer = {
+                let gate = Arc::clone(&gate);
+                std::thread::spawn(move || gate.close_and_wait())
+            };
+            gate.close_and_wait();
+            // After close_and_wait returns, no guest is inside and none can enter.
+            assert_eq!(inside.load(Ordering::SeqCst), 0);
+            assert!(!gate.enter());
+            gate.close_and_wait(); // idempotent
+            second_closer.join().unwrap();
+            for g in guests {
+                g.join().unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn enter_is_rejected_while_a_guest_holds_the_gate_closed() {
+        let gate = Arc::new(ShutdownGate::new());
+        assert!(gate.enter());
+        let closer = {
+            let gate = Arc::clone(&gate);
+            std::thread::spawn(move || gate.close_and_wait())
+        };
+        // The closer sets CLOSED immediately; wait until new entries bounce.
+        while gate.enter() {
+            gate.leave();
+            std::hint::spin_loop();
+        }
+        // Release the in-flight guest so the blocked closer drains.
+        gate.leave();
+        closer.join().unwrap();
+        assert!(!gate.enter());
+    }
+}

--- a/src/threading/lib.rs
+++ b/src/threading/lib.rs
@@ -13,6 +13,8 @@ pub mod reset_event;
 pub mod rwlock;
 #[path = "Semaphore.rs"]
 pub mod semaphore;
+#[path = "ShutdownGate.rs"]
+pub mod shutdown_gate;
 #[path = "ThreadPool.rs"]
 pub mod thread_pool;
 pub mod work_pool;
@@ -35,6 +37,7 @@ pub use mutex::{Mutex, MutexGuard};
 pub use reset_event::ResetEvent;
 pub use rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 pub use semaphore::Semaphore;
+pub use shutdown_gate::{GateGuest, ShutdownGate};
 pub use thread_pool::ThreadPool;
 pub use unbounded_queue::{Link, Linked, UnboundedQueue};
 pub use wait_group::WaitGroup;

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir } from "harness";
 import { join } from "path";
 
 // Worker VM startup/teardown is much slower under debug and/or ASAN; these
@@ -82,6 +82,127 @@ test(
   },
   timeout,
 );
+
+// Regression: a fetch() in flight on the shared HTTP thread held a raw
+// pointer to the worker's VirtualMachine; worker.terminate() freed the VM
+// while response callbacks could still read it and push into its embedded
+// concurrent-task queue (heap-use-after-free / segfault at address 0x0 in
+// UnboundedQueue::push_batch on the HTTP Client thread).
+test(
+  "terminating a worker with fetches in flight does not UAF the worker VM",
+  async () => {
+    // The server lives in the test process: the LeakSanitizer-validated child
+    // would otherwise report Bun.serve's intentional exit leaks.
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        // Drip the body forever so responses are always mid-flight when
+        // the worker is terminated.
+        return new Response(
+          new ReadableStream({
+            async pull(controller) {
+              controller.enqueue(new Uint8Array(1024));
+              await Bun.sleep(1);
+            },
+          }),
+        );
+      },
+    });
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const workerSource =
+          "for (let i = 0; i < 16; i++) " +
+          "fetch(" + JSON.stringify(process.env.DRIP_SERVER_URL) + ").then(r => r.text().catch(() => {}), () => {});" +
+          "postMessage('fetching');";
+        const url = "data:text/javascript," + encodeURIComponent(workerSource);
+        for (let i = 0; i < ${perRound}; i++) {
+          const w = new Worker(url);
+          await new Promise(resolve => (w.onmessage = resolve));
+          // Vary the delay to scan the terminate-vs-response race window.
+          await Bun.sleep(i % 4);
+          w.terminate();
+        }
+        console.log("done");
+      `,
+      ],
+      env: { ...bunEnv, DRIP_SERVER_URL: server.url.href },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    // stderr is drained but not asserted: ASAN/debug builds emit benign noise.
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) console.error("child stderr:\n" + stderr);
+    expect(stdout).toBe("done\n");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);
+
+// Same bug class as the fetch test above, for work-pool producers: async fs,
+// Bun.password, zlib, and DNS completions on pool threads enqueued into the
+// worker VM's concurrent-task queue after terminate() freed it. One test per
+// producer, run sequentially: combining job types multiplies pool load and
+// trips a separate, pre-existing JSC worker-churn crash unrelated to this
+// bug class.
+const workPoolJobs: [name: string, source: string][] = [
+  ["Bun.password", "Bun.password.hash('hunter2', { algorithm: 'bcrypt', cost: 8 }).then(swallow, swallow);"],
+  ["node:zlib", "require('node:zlib').gzip(Buffer.alloc(1 << 16, 7), swallow);"],
+  ["node:fs", "require('node:fs/promises').stat(process.execPath).then(swallow, swallow);"],
+  ["node:dns", "require('node:dns').promises.lookup('localhost').then(swallow, swallow);"],
+  ["node:crypto", "require('node:crypto').pbkdf2('pw', 'salt', 25000, 64, 'sha512', swallow);"],
+  [
+    "node:fs readFile/writeFile/copyFile",
+    "const fsp = require('node:fs/promises'); const f = process.env.FS_SCRATCH; " +
+      "fsp.readFile(f + '/big').then(swallow, swallow); " +
+      "fsp.writeFile(f + '/w', Buffer.alloc(1 << 20, 1)).then(swallow, swallow); " +
+      "fsp.copyFile(f + '/big', f + '/c').then(swallow, swallow);",
+  ],
+];
+for (const [name, job] of workPoolJobs) {
+  test(
+    `terminating a worker with ${name} jobs in flight does not UAF the worker VM`,
+    async () => {
+      using scratch = tempDir("worker-terminate-fs", {
+        big: Buffer.alloc(4 << 20, 0x5a).toString("binary"),
+      });
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+          const workerSource =
+            "const swallow = () => {};" +
+            "for (let i = 0; i < 8; i++) { " + ${JSON.stringify(job)} + " }" +
+            "postMessage('working');";
+          const url = "data:text/javascript," + encodeURIComponent(workerSource);
+          for (let i = 0; i < ${perRound}; i++) {
+            const w = new Worker(url);
+            await new Promise(resolve => (w.onmessage = resolve));
+            await Bun.sleep(i % 4);
+            w.terminate();
+          }
+          console.log("done");
+          process.exit(0);
+        `,
+        ],
+        env: { ...bunEnv, FS_SCRATCH: String(scratch) },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      // stderr is drained but not asserted: ASAN/debug builds emit benign noise.
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      if (exitCode !== 0) console.error("child stderr:\n" + stderr);
+      expect(stdout).toBe("done\n");
+      expect(exitCode).toBe(0);
+    },
+    timeout,
+  );
+}
 
 // Regression: WebWorker__dispatchExit deref'd the C++ Worker on the worker
 // thread; if that was the last ref, ~Worker → ~EventTarget ran there and

--- a/test/leaksan.supp
+++ b/test/leaksan.supp
@@ -130,3 +130,8 @@ leak:bun_runtime::cli::multi_run::run
 # NAPI weak finalizers which enqueue Box<NapiFinalizerTask> into the event
 # loop; the loop is already exiting so they never drain.
 leak:napi_internal_enqueue_finalizer
+# test/js/web/workers/worker-terminate-lifetime.test.ts — the per-worker
+# node:fs Binding box is GC-owned; workers terminated mid-tick skip the
+# Heap::lastChanceToFinalize sweep for it. Pre-existing on main; tracked
+# separately.
+leak:bun_runtime::node::node_fs_binding::create_binding


### PR DESCRIPTION
### What

`worker.terminate()` freed the worker's `VirtualMachine` while work-pool and HTTP-thread completions still held raw pointers into it. The late `enqueue_task_concurrent` into the freed event loop corrupted whatever reused the allocation. Three observable faces depending on timing:

```
heap-use-after-free  READ of size 8  thread (Bun Pool)
  #0 event_loop                                  src/jsc/VirtualMachine.rs:716
  #1 AsyncFSTask<CopyFile>::work_pool_callback   src/runtime/node/node_fs.rs:1318
freed by thread (Worker):  WebWorker::shutdown   src/jsc/web_worker.rs:1390
```

plus `Option::unwrap()` panic in `AsyncFSTask::run_from_js_thread` (promise Strong read after the slot emptied), and JSC `StructureID::decode` / `Heap m_collectionScope` asserts when the freed slab is reused.

### Design

1. **Pin.** `VirtualMachine` owns an `Arc<ShutdownGate>`; `vm.pin()` returns an RAII `GateGuest`. Every async producer takes a pin at creation on the JS thread and drops it on the completing thread **after** the completion enqueue. Covered producers: `node:fs` async ops (including recursive `cp`/`readdir`), fetch, S3 (simple/streaming/multipart), dns, zlib/brotli/zstd writes, `Bun.password`, the generic `AnyTaskJob` (pbkdf2, scrypt, `Bun.secrets`, …), napi async work, Archive, `Bun.build`, stat-watcher (periodic + initial), runtime transpiler.
2. **Terminate = abort → wait → drain → tear down.** A per-VM `TerminateAbortRegistry` (fetch + every S3 request type) is walked first so pins drop promptly; `close_and_wait()` blocks until all pins drop; queued completions are reclaimed per-tag with JSC alive; then JSC teardown and box free. Main-VM exit closes without waiting (its box is never freed).
3. **`AsyncFSTask::run_from_js_thread` bails early** when the promise Strong is empty or the VM is stopping, so the drain-race path cleans up instead of panicking the process.

### Known residuals (pre-existing, same race class, not addressed here)

- spawn waiter thread, `Bun.$` shell tasks, and napi `ThreadSafeFunction` still enqueue cross-thread without a pin.
- Plugin builds run unpinned (a pinned build round-tripping through the terminating JS thread would deadlock).
- Drain-time reclaim for `AsyncCpTask` / `TranspilerJob` / `RequestContext` S3 ctx is not wired; these leak a bounded box per in-flight op at terminate.

### Tests

`test/js/web/workers/worker-terminate-lifetime.test.ts`: fetch + 6 work-pool producer families (password, zlib, fs stat, fs readFile/writeFile/copyFile, dns, crypto), each terminating workers mid-op. On an unfixed debug+ASAN build: `Bun.password`, `node:crypto`, and `node:dns` abort with the heap-use-after-free above; with the fix, 11/11 pass.

Raw repro (release build, no ASAN):

```js
const { Worker } = require("node:worker_threads");
const fs = require("node:fs"), os = require("node:os"), path = require("node:path");
const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "wt-"));
const big = path.join(tmp, "big.bin"); fs.writeFileSync(big, Buffer.alloc(48 << 20, 0x5a));
const src = `const { parentPort, workerData } = require("node:worker_threads");
const fsp = require("node:fs/promises");
const lanes = (n, f) => { for (let i = 0; i < n; i++) (async () => { for (;;) { try { await f(i); } catch {} } })(); };
lanes(4, () => fsp.readFile(workerData.big));
lanes(2, (i) => fsp.writeFile(workerData.tmp + "/w" + i, Buffer.alloc(8 << 20, 1)));
lanes(2, (i) => fsp.copyFile(workerData.big, workerData.tmp + "/c" + i));
parentPort.postMessage("up");`;
for (let r = 0; r < 12; r++) {
  const w = new Worker(src, { eval: true, workerData: { big, tmp } });
  await new Promise((res) => w.once("message", res));
  await Bun.sleep(60 + (r * 41) % 220);
  await w.terminate();
}
```

Segfaults at address `0x8` after round 1 on a release build; completes all 12 rounds with the fix.

`rust:check-all`: 10/10 target combos OK.

### Rebase notes (e9c14e1)

Rebased onto 47597ab2c9 as a single commit. Review findings from the previous round addressed: `InitialStatTask` now pinned; `FetchTasklet::release_at_shutdown` pin-drop ordering fixed (pin local, drop last); `any_task_job` uses `script_execution_status()` (the prior `has_termination_request` accessor was removed in #35002); stale doc comments in `event_loop.rs` / `node_fs_stat_watcher.rs` updated; duplicate `#[allow]` in `simple_request.rs` removed. `generate_from_javascript` / `listen_callback` / `SourceType` / `bun_threading::Once` reintroductions dropped (dead on current main). Added a `leaksan.supp` entry for the pre-existing per-worker `node_fs_binding::Binding` leak at terminate (fails on main independent of this diff; tracked separately).

Supersedes #32071.
