### PR TITLE
test(require-cache): gate the long-export-names import() leak fixture on mimalloc page growth

### DIFF
--- a/test/cli/run/require-cache.test.ts
+++ b/test/cli/run/require-cache.test.ts
@@ -171,11 +171,19 @@ describe.concurrent("require.cache", () => {
       await using dir = tempDir("require-cache-bug-leak-4", {
         "index.js": text,
         "require-cache-bug-leak-fixture.js": `
+          import { heapStats } from "bun:jsc";
           const path = require.resolve("./index.js");
           const gc = global.gc || globalThis?.Bun?.gc || (() => {});
           const rss = process.platform === "darwin" && typeof Bun !== "undefined" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
           function bust() {
             delete require.cache[path];
+          }
+          // Live page count from the heap walk (not the aggregate counter,
+          // which can under-count across threads).
+          function livePages() {
+            let n = 0;
+            for (const h of heapStats({ dump: true }).mimallocDump.heaps) n += h.pages.length;
+            return n;
           }
 
           for (let i = 0; i < 50; i++) {
@@ -183,19 +191,19 @@ describe.concurrent("require.cache", () => {
             bust();
           }
           gc(true);
-          const baseline = rss();
+          const baselinePages = livePages();
+          const baselineRss = rss();
           for (let i = 0; i < 250; i++) {
             await import(path);
             bust(path);
           }
           gc(true);
-          const after = rss();
-          const diff = after - baseline;
-          console.log("RSS diff", (diff / 1024 / 1024) | 0, "MB");
-          console.log("RSS", (diff / 1024 / 1024) | 0, "MB");
-          if (diff > ${isASAN ? 320 : 64} * 1024 * 1024) {
-            // Bun v1.1.21 reported 423 MB here on macoS arm64.
-            // Bun v1.1.22 reported 4 MB here on macoS arm64.
+          const pageDiff = livePages() - baselinePages;
+          const rssDiff = rss() - baselineRss;
+          console.log("mimalloc page diff", pageDiff, "RSS diff", (rssDiff / 1024 / 1024) | 0, "MB");
+          // ASAN routes SourceProvider storage through system malloc, so fall
+          // back to RSS there. Retaining the source is ~+290 MB / +2666 pages.
+          if (${isASAN} ? rssDiff > 320 * 1024 * 1024 : pageDiff > 100) {
             throw new Error("Memory leak detected");
           }
 


### PR DESCRIPTION
Follow-up to #34009. Originally opened for `test/cli/run/require-cache.test.ts` going red on `:darwin: 26 aarch64` (builds 72796, 72798, 72816, 72819, 72827, 72828, 72836); rebased onto main after #36429.

### Status after #36429

#36429 switched the leak fixtures to `Bun.unsafe.memoryFootprint()` on darwin, which fixed the darwin 26 failure this PR was opened for: in the 60 most recent completed main builds (Aug 9-16) this fixture has not failed on darwin. It did fail once on `:ubuntu: 25.04 aarch64` (build 92941, diff exactly 64 MB against the 64 MB bound), so the RSS-based check is still sitting at the boundary on non-darwin lanes.

This PR now does one thing: switch the `via import() with a lot of long export names` fixture from an RSS/footprint diff to mimalloc's live page count, which is what the review asked for and is independent of OS page accounting on every platform.

### Original failure

```
RSS diff 70 MB
error: Memory leak detected
✗ require.cache > files transpiled and loaded don't leak the output source code
  > via import() with a lot of long export names
```

### Cause

After #34009 moved JSC onto mimalloc, steady-state memory for this loop is reached after ~200-250 iterations; the 50-iteration warmup captures baseline below the plateau, so an RSS diff measures the climb to steady state rather than per-iteration growth. `heapStats().heapSize` (0.62 MB) and `objectCount` (~2132) are identical before and after #34009 at every checkpoint out to 2000 iterations, so no JS objects leak; the delta is allocator page retention plus OS page accounting.

### Fix

- Measure `heapStats({ dump: true }).mimallocDump` live page count before and after the measured 250 iterations; bound is 100 pages.
- Under `isASAN` the mimalloc heap walk does not see `SourceProvider` storage (it goes through system malloc), so keep the original 320 MB bound on the #36429 `rss()` metric there.
- No sleep; no change to the other fixtures.

Observed page-diff for the measured 250 iterations:

| environment | page-diff |
|---|---|
| macOS 26 arm64, post-#34009 release, 25 runs (10 solo + 15 at 3x concurrent) | -10 to +26 |
| macOS 26 arm64, pre-#34009 release | 0 |
| Linux x64 release, idle host | -1 |
| Linux x64 release, host load avg ~450, 5 runs | 37 to 55 |
| Simulated leak (retain the namespace objects), macOS | +2666 |

### Not in this PR

The sibling `via require() with a lot of function calls` fixture is the one still flaking on main post-#36429 (`:windows: 11 aarch64`, 4 of the same 60 builds, diffs 99-152 MB against 64). Same root cause; it is `todo` on macOS and musl-arm64 but live on Windows. Happy to apply the same page-count change to the other three fixtures in this PR if that is preferred, or leave it for a follow-up.

Side note: `heapStats().mimalloc.pages.current` (the aggregate counter, not the heap walk) goes negative after a few hundred iterations on post-#34009 builds; that is tracked separately and is why the fixture walks the heaps.