### PR TITLE
ci(verify-baseline): pin qemu 9.1.0 for Linux; fail the step on any emulated-run failure

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -704,13 +704,20 @@ function needsBaselineVerification(platform) {
   return false;
 }
 
-// Ubuntu 20.04's qemu 4.2 mis-handles concurrent `lock cmpxchg` in x86_64-on-x86_64 user mode;
-// after #34009 (mimalloc per-thread heaps) the SIMD baseline test segfaults/deadlocks in
-// `_mi_theap_init` ~10-20% of the time. qemu 7.2 is 40/40 green. aarch64 is unaffected.
-const PINNED_QEMU_X64 = {
-  url: "https://github.com/multiarch/qemu-user-static/releases/download/v7.2.0-1/qemu-x86_64-static",
-  sha256: "7132ffd39aef71c26d3344cc0c7dffc530e10e3e720c58c8279a97ef6fdd7784",
-  path: "./qemu-x86_64-static",
+// Ubuntu 20.04's qemu 4.2 mis-emulates concurrent atomics in same-arch user mode; after #34009
+// (mimalloc per-thread heaps) the SIMD baseline test segfaults/deadlocks in `_mi_theap_init`
+// ~10-20% of x64 runs and ~5% of aarch64 runs. qemu 9.1 is 40/40 green. Static-pie binaries.
+const PINNED_QEMU = {
+  x64: {
+    url: "https://github.com/ziglang/qemu-static/releases/download/9.1.0/qemu-linux-x86_64-9.1.0.tar.xz",
+    sha256: "1ac92f632417d981810fda891e4a1b20f2d71f50f9ec705532afa8162b449c70",
+    binary: "qemu-linux-x86_64-9.1.0/bin/qemu-x86_64",
+  },
+  aarch64: {
+    url: "https://github.com/ziglang/qemu-static/releases/download/9.1.0/qemu-linux-aarch64-9.1.0.tar.xz",
+    sha256: "5a82a96ac74932a802fb5753673beff27359faea8736286477b0bf2c268fd06d",
+    binary: "qemu-linux-aarch64-9.1.0/bin/qemu-aarch64",
+  },
 };
 
 /**
@@ -725,9 +732,8 @@ function getEmulatorBinary(platform) {
   // (Install-IntelSde): downloadmirror.intel.com sits behind a bot challenge
   // that blocks non-browser clients, so it cannot be downloaded at job time.
   if (os === "windows") return "C:\\intel-sde\\sde.exe";
-  if (arch === "aarch64") return "qemu-aarch64-static";
-  // Fetched into the checkout root by the setup command below (see PINNED_QEMU_X64).
-  return PINNED_QEMU_X64.path;
+  // Fetched into the checkout root by the setup command below (see PINNED_QEMU).
+  return `./${PINNED_QEMU[arch].binary}`;
 }
 
 /**
@@ -777,15 +783,15 @@ function getVerifyBaselineStep(platform, options) {
           `buildkite-agent artifact download '${profileDir}.zip' . --step ${targetKey}-build-bun`,
           `unzip -o '${profileDir}.zip'`,
           `chmod +x ${profileDir}/${profileExe}`,
-          // x64 lanes pin a known-good qemu (see PINNED_QEMU_X64); aarch64 uses the system one.
-          // sha256 check makes a truncated/hijacked download a hard failure before anything runs under it.
-          ...(emulator === PINNED_QEMU_X64.path
-            ? [
-                `curl -fsSL --retry 5 --connect-timeout 15 --max-time 60 -o ${PINNED_QEMU_X64.path} '${PINNED_QEMU_X64.url}'`,
-                `echo '${PINNED_QEMU_X64.sha256}  ${PINNED_QEMU_X64.path}' | sha256sum -c -`,
-                `chmod +x ${PINNED_QEMU_X64.path}`,
-              ]
-            : []),
+          // Linux lanes pin a known-good qemu (see PINNED_QEMU). sha256 check makes a
+          // truncated/hijacked download a hard failure before anything runs under it.
+          ...(abi === "android"
+            ? [] // --skip-emulation: no emulator needed
+            : [
+                `curl -fsSL --retry 5 --connect-timeout 15 --max-time 120 -o ./qemu.tar.xz '${PINNED_QEMU[platform.arch].url}'`,
+                `echo '${PINNED_QEMU[platform.arch].sha256}  ./qemu.tar.xz' | sha256sum -c -`,
+                `tar -xJf ./qemu.tar.xz '${PINNED_QEMU[platform.arch].binary}'`,
+              ]),
         ];
 
   // Windows: the emulator phase runs bun-profile.exe under Intel SDE, so the

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -778,7 +778,7 @@ function getVerifyBaselineStep(platform, options) {
           // sha256 check makes a truncated/hijacked download a hard failure before anything runs under it.
           ...(emulator === PINNED_QEMU_X64.path
             ? [
-                `curl -fsSL --retry 5 -o ${PINNED_QEMU_X64.path} '${PINNED_QEMU_X64.url}'`,
+                `curl -fsSL --retry 5 --connect-timeout 15 --max-time 60 -o ${PINNED_QEMU_X64.path} '${PINNED_QEMU_X64.url}'`,
                 `echo '${PINNED_QEMU_X64.sha256}  ${PINNED_QEMU_X64.path}' | sha256sum -c -`,
                 `chmod +x ${PINNED_QEMU_X64.path}`,
               ]

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -704,6 +704,15 @@ function needsBaselineVerification(platform) {
   return false;
 }
 
+// Ubuntu 20.04's qemu 4.2 mis-handles concurrent `lock cmpxchg` in x86_64-on-x86_64 user mode;
+// after #34009 (mimalloc per-thread heaps) the SIMD baseline test segfaults/deadlocks in
+// `_mi_theap_init` ~10-20% of the time. qemu 7.2 is 40/40 green. aarch64 is unaffected.
+const PINNED_QEMU_X64 = {
+  url: "https://github.com/multiarch/qemu-user-static/releases/download/v7.2.0-1/qemu-x86_64-static",
+  sha256: "7132ffd39aef71c26d3344cc0c7dffc530e10e3e720c58c8279a97ef6fdd7784",
+  path: "./qemu-x86_64-static",
+};
+
 /**
  * Returns the emulator binary name for the given platform.
  * Linux uses QEMU user-mode; Windows uses Intel SDE.
@@ -717,7 +726,8 @@ function getEmulatorBinary(platform) {
   // that blocks non-browser clients, so it cannot be downloaded at job time.
   if (os === "windows") return "C:\\intel-sde\\sde.exe";
   if (arch === "aarch64") return "qemu-aarch64-static";
-  return "qemu-x86_64-static";
+  // Fetched into the checkout root by the setup command below (see PINNED_QEMU_X64).
+  return PINNED_QEMU_X64.path;
 }
 
 /**
@@ -764,6 +774,15 @@ function getVerifyBaselineStep(platform, options) {
           `buildkite-agent artifact download '${profileDir}.zip' . --step ${targetKey}-build-bun`,
           `unzip -o '${profileDir}.zip'`,
           `chmod +x ${profileDir}/${profileExe}`,
+          // x64 lanes pin a known-good qemu (see PINNED_QEMU_X64); aarch64 uses the system one.
+          // sha256 check makes a truncated/hijacked download a hard failure before anything runs under it.
+          ...(emulator === PINNED_QEMU_X64.path
+            ? [
+                `curl -fsSL --retry 5 -o ${PINNED_QEMU_X64.path} '${PINNED_QEMU_X64.url}'`,
+                `echo '${PINNED_QEMU_X64.sha256}  ${PINNED_QEMU_X64.path}' | sha256sum -c -`,
+                `chmod +x ${PINNED_QEMU_X64.path}`,
+              ]
+            : []),
         ];
 
   // Windows: the emulator phase runs bun-profile.exe under Intel SDE, so the

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -746,11 +746,14 @@ function hasWebKitChanges(options) {
  * @returns {Step}
  */
 function getVerifyBaselineStep(platform, options) {
-  const { os } = platform;
+  const { os, abi } = platform;
   const targetKey = getTargetKey(platform);
   const triplet = getTargetTriplet(platform);
   const emulator = getEmulatorBinary(platform);
   const jitStressFlag = hasWebKitChanges(options) ? " --jit-stress" : "";
+  // Android binaries need /system/bin/linker64 + a bionic sysroot, neither of which exist on the
+  // build host, so qemu-user cannot load them; only the static instruction scan is meaningful.
+  const skipEmulationFlag = abi === "android" ? " --skip-emulation" : "";
 
   // Scan bun-profile, not bun. The stripped binary has no .symtab (ELF) and
   // no companion .pdb (PE) — the static scanner would emit <no-symbol@addr>
@@ -806,7 +809,7 @@ function getVerifyBaselineStep(platform, options) {
     command: [
       ...setupCommands,
       `cargo build --release --manifest-path scripts/verify-baseline-static/Cargo.toml${os === "windows" ? " || exit /b 1" : ""}`,
-      `bun scripts/verify-baseline.ts --binary ${profileDir}/${profileExe} --emulator ${emulator}${jitStressFlag}`,
+      `bun scripts/verify-baseline.ts --binary ${profileDir}/${profileExe} --emulator ${emulator}${skipEmulationFlag}${jitStressFlag}`,
     ],
   };
 }

--- a/scripts/verify-baseline.ts
+++ b/scripts/verify-baseline.ts
@@ -117,11 +117,6 @@ async function runTest(label: string, binaryArgs: string[], options?: RunTestOpt
     cwd: config.cwd ?? options?.cwd,
     stdout: "pipe",
     stderr: "pipe",
-    // A crash inside the emulated process can deadlock the emulator itself (qemu-user never delivers
-    // the re-raised signal), which otherwise runs out the step's hard timeout. Normal is ~2s (qemu)
-    // to ~30s (SDE); allow an order of magnitude headroom and force-kill beyond it.
-    timeout: 120_000,
-    killSignal: "SIGKILL",
   });
 
   let stdout: string;
@@ -144,13 +139,6 @@ async function runTest(label: string, binaryArgs: string[], options?: RunTestOpt
   const signalCode = proc.signalCode;
   const elapsed = ((performance.now() - start) / 1000).toFixed(1);
   const output = stdout + "\n" + stderr;
-
-  if (exitCode === null && signalCode === "SIGKILL") {
-    if (!live && output.trim()) console.log(output.trim());
-    console.log(`    WARN: emulated process hung; force-killed after ${elapsed}s (not a CPU instruction issue)`);
-    otherFailures++;
-    return false;
-  }
 
   if (exitCode === 0) {
     if (!live && stdout.trim()) console.log(stdout.trim());

--- a/scripts/verify-baseline.ts
+++ b/scripts/verify-baseline.ts
@@ -163,8 +163,9 @@ async function runTest(label: string, binaryArgs: string[], options?: RunTestOpt
   } else {
     if (!live && output.trim()) console.log(output.trim());
     const how = exitCode === null ? `signal ${signalCode}` : `exit code ${exitCode}`;
-    console.log(`    WARN: ${how} (${elapsed}s, not a CPU instruction issue)`);
+    console.log(`    FAIL: ${how} (${elapsed}s, not a CPU instruction issue)`);
     otherFailures++;
+    failedTests.push(label);
   }
   return false;
 }
@@ -204,8 +205,9 @@ if (await Bun.file(staticChecker).exists()) {
     instructionFailures++;
     failedTests.push("Static instruction scan");
   } else {
-    console.log(`    WARN: checker exited ${code} (${elapsed}s, tool error)`);
+    console.log(`    FAIL: checker exited ${code} (${elapsed}s, tool error)`);
     otherFailures++;
+    failedTests.push("Static instruction scan (tool error)");
   }
   console.log();
 } else {
@@ -253,20 +255,26 @@ console.log();
 console.log("--- Summary");
 console.log(`    Passed: ${passed}`);
 console.log(`    Instruction failures: ${instructionFailures}`);
-console.log(`    Other failures: ${otherFailures} (warnings, not CPU instruction issues)`);
+console.log(`    Other failures: ${otherFailures} (not CPU instruction issues)`);
 console.log();
+
+const platform = isWindows
+  ? isAarch64
+    ? "Windows aarch64"
+    : "Windows x64"
+  : isAarch64
+    ? "Linux aarch64"
+    : "Linux x64";
+
+function annotate(html: string) {
+  Bun.spawnSync(["buildkite-agent", "annotate", "--append", "--style", "error", "--context", "verify-baseline"], {
+    stdin: new Blob([html]),
+  });
+}
 
 if (instructionFailures > 0) {
   console.error("    FAILED: Code uses unsupported CPU instructions.");
 
-  // Report to Buildkite annotations tab
-  const platform = isWindows
-    ? isAarch64
-      ? "Windows aarch64"
-      : "Windows x64"
-    : isAarch64
-      ? "Linux aarch64"
-      : "Linux x64";
   const parts = [
     `<details open>`,
     `<summary>❌ CPU instruction violation on <b>${platform}</b> — ${instructionFailures} check(s) failed</summary>`,
@@ -290,19 +298,26 @@ if (instructionFailures > 0) {
     );
   }
   parts.push(`</details>`);
-  const annotation = parts.join("\n");
-
-  Bun.spawnSync(["buildkite-agent", "annotate", "--append", "--style", "error", "--context", "verify-baseline"], {
-    stdin: new Blob([annotation]),
-  });
+  annotate(parts.join("\n"));
 
   process.exit(1);
 }
 
 if (otherFailures > 0) {
-  console.log(
-    `    Baseline verification passed with ${otherFailures} non-instruction warning(s) on ${config.cpuDesc}.`,
+  console.error(`    FAILED: ${otherFailures} check(s) failed under emulation on ${config.cpuDesc}.`);
+
+  annotate(
+    [
+      `<details open>`,
+      `<summary>❌ Baseline verification failed on <b>${platform}</b> — ${otherFailures} check(s)</summary>`,
+      `<p>The baseline build crashed or failed tests under <code>${config.cpuDesc}</code> emulation ` +
+        `(not an unsupported-instruction fault). See the step log for the crash output.</p>`,
+      `<ul>${failedTests.map(t => `<li><code>${t}</code></li>`).join("")}</ul>`,
+      `</details>`,
+    ].join("\n"),
   );
-} else {
-  console.log(`    All baseline verification passed on ${config.cpuDesc}.`);
+
+  process.exit(1);
 }
+
+console.log(`    All baseline verification passed on ${config.cpuDesc}.`);

--- a/scripts/verify-baseline.ts
+++ b/scripts/verify-baseline.ts
@@ -20,6 +20,7 @@ const { values } = parseArgs({
     binary: { type: "string" },
     emulator: { type: "string" },
     "jit-stress": { type: "boolean", default: false },
+    "skip-emulation": { type: "boolean", default: false },
   },
   strict: true,
 });
@@ -216,12 +217,21 @@ if (await Bun.file(staticChecker).exists()) {
   console.log();
 }
 
-// Phase 1: SIMD code path verification (always runs)
-const simdTestPath = join(repoRoot, "test", "js", "bun", "jsc-stress", "fixtures", "simd-baseline.test.ts");
-await runTest("SIMD baseline tests", ["test", simdTestPath], { live: true });
+// Phase 1/2: emulated runs. --skip-emulation (CI sets this for Android, whose
+// binary needs /system/bin/linker64 and has no sysroot on the build host)
+// leaves only the static scan.
+if (values["skip-emulation"]) {
+  console.log("--- Skipping emulated runs (--skip-emulation)");
+} else {
+  // Phase 1: SIMD code path verification
+  const simdTestPath = join(repoRoot, "test", "js", "bun", "jsc-stress", "fixtures", "simd-baseline.test.ts");
+  await runTest("SIMD baseline tests", ["test", simdTestPath], { live: true });
+}
 
 // Phase 2: JIT stress fixtures (only with --jit-stress, e.g. on WebKit changes)
-if (values["jit-stress"]) {
+if (values["skip-emulation"]) {
+  // already reported the skip above
+} else if (values["jit-stress"]) {
   const jsFixtures = readdirSync(fixturesDir)
     .filter(f => f.endsWith(".js"))
     .sort();

--- a/scripts/verify-baseline.ts
+++ b/scripts/verify-baseline.ts
@@ -74,9 +74,11 @@ const config = isWindows
         cwd: undefined,
       };
 
-function isInstructionViolation(exitCode: number | null, output: string): boolean {
+function isInstructionViolation(signalCode: NodeJS.Signals | null, output: string): boolean {
   if (isWindows) return SDE_VIOLATION_PATTERN.test(output);
-  return exitCode === 132; // SIGILL = 128 + signal 4
+  // qemu-user re-raises the guest's fatal signal on the host, so the process is WIFSIGNALED:
+  // `proc.exitCode` is null and only `proc.signalCode` carries the verdict.
+  return signalCode === "SIGILL";
 }
 
 console.log(`--- Verifying ${basename(binary)} on ${config.cpuDesc}`);
@@ -139,11 +141,11 @@ async function runTest(label: string, binaryArgs: string[], options?: RunTestOpt
   }
 
   const exitCode = proc.exitCode;
-  const killed = exitCode === null && proc.signalCode === "SIGKILL";
+  const signalCode = proc.signalCode;
   const elapsed = ((performance.now() - start) / 1000).toFixed(1);
   const output = stdout + "\n" + stderr;
 
-  if (killed) {
+  if (exitCode === null && signalCode === "SIGKILL") {
     if (!live && output.trim()) console.log(output.trim());
     console.log(`    WARN: emulated process hung; force-killed after ${elapsed}s (not a CPU instruction issue)`);
     otherFailures++;
@@ -157,7 +159,7 @@ async function runTest(label: string, binaryArgs: string[], options?: RunTestOpt
     return true;
   }
 
-  if (isInstructionViolation(exitCode, output)) {
+  if (isInstructionViolation(signalCode, output)) {
     if (!live && output.trim()) console.log(output.trim());
     console.log();
     console.log(`    FAIL: CPU instruction violation detected (${elapsed}s)`);
@@ -172,7 +174,8 @@ async function runTest(label: string, binaryArgs: string[], options?: RunTestOpt
     failedTests.push(label);
   } else {
     if (!live && output.trim()) console.log(output.trim());
-    console.log(`    WARN: exit code ${exitCode} (${elapsed}s, not a CPU instruction issue)`);
+    const how = exitCode === null ? `signal ${signalCode}` : `exit code ${exitCode}`;
+    console.log(`    WARN: ${how} (${elapsed}s, not a CPU instruction issue)`);
     otherFailures++;
   }
   return false;

--- a/scripts/verify-baseline.ts
+++ b/scripts/verify-baseline.ts
@@ -74,7 +74,7 @@ const config = isWindows
         cwd: undefined,
       };
 
-function isInstructionViolation(exitCode: number, output: string): boolean {
+function isInstructionViolation(exitCode: number | null, output: string): boolean {
   if (isWindows) return SDE_VIOLATION_PATTERN.test(output);
   return exitCode === 132; // SIGILL = 128 + signal 4
 }
@@ -115,6 +115,11 @@ async function runTest(label: string, binaryArgs: string[], options?: RunTestOpt
     cwd: config.cwd ?? options?.cwd,
     stdout: "pipe",
     stderr: "pipe",
+    // A crash inside the emulated process can deadlock the emulator itself (qemu-user never delivers
+    // the re-raised signal), which otherwise runs out the step's hard timeout. Normal is ~2s (qemu)
+    // to ~30s (SDE); allow an order of magnitude headroom and force-kill beyond it.
+    timeout: 120_000,
+    killSignal: "SIGKILL",
   });
 
   let stdout: string;
@@ -133,9 +138,17 @@ async function runTest(label: string, binaryArgs: string[], options?: RunTestOpt
     ]);
   }
 
-  const exitCode = proc.exitCode!;
+  const exitCode = proc.exitCode;
+  const killed = exitCode === null && proc.signalCode === "SIGKILL";
   const elapsed = ((performance.now() - start) / 1000).toFixed(1);
   const output = stdout + "\n" + stderr;
+
+  if (killed) {
+    if (!live && output.trim()) console.log(output.trim());
+    console.log(`    WARN: emulated process hung; force-killed after ${elapsed}s (not a CPU instruction issue)`);
+    otherFailures++;
+    return false;
+  }
 
   if (exitCode === 0) {
     if (!live && stdout.trim()) console.log(stdout.trim());


### PR DESCRIPTION
Since #34009 landed, `:linux: x64-baseline - verify-baseline` has been timing out on roughly half of PR builds (e.g. [#72807](https://buildkite.com/bun/bun/builds/72807#019f5f65-75a2-4b3f-bf87-b594e40a3913), [#72854](https://buildkite.com/bun/bun/builds/72854#019f6009-85e6-48d3-8d0c-2636a63cefa9), #72903, #72909, #72910, #72912, #72916, #72921, #72925, #72927), burning 20 minutes of the retry budget each time. `:linux: aarch64 - verify-baseline` hits the same failure at ~5% (#72864, #72906, [#73007](https://buildkite.com/bun/bun/builds/73007#019f6291-b51a-4bd5-97cc-b7afbbdcc7b5)). The other runs either pass cleanly or segfault and get silently recorded as a non-fatal warning, so the step flips between green and red on identical code.

## Cause

The step runs `simd-baseline.test.ts` under `qemu-{x86_64,aarch64} -cpu <baseline>`. The Ubuntu 20.04 link image ships **qemu 4.2** (Dec 2019), whose same-arch user-mode emulation has a known race around concurrent atomics. #34009 moved JSC onto mimalloc, whose per-thread heap (`theap`) and lock-free abandoned-page list now run on the transpiler worker threads during test-file preload. Under qemu 4.2 that corrupts the free list and the worker segfaults; about half the time Bun's crash handler re-raises the signal and qemu never delivers it, so the process deadlocks.

Reproduced locally with a release baseline LTO build at cc0c1e8355:

| qemu | runs | failures |
|---|---|---|
| 4.2.0 (focal's) | 40 | 5 |
| 9.1.0 | 40 | 0 |

Symbolicated top of a local crash (transpiler worker thread):

```
mi_arenas_page_try_find_abandoned  vendor/mimalloc/src/arena.c:723
_mi_arenas_page_alloc              vendor/mimalloc/src/arena.c
_mi_malloc_generic                 vendor/mimalloc/src/page.c:2008
bun_alloc::MimallocArena::alloc_layout
bun_bundler::transpiler::Transpiler::parse_maybe_return_file_only_allow_shared_buffer
bun_jsc::runtime_transpiler_store::TranspilerJob::run_from_worker_thread
bun_threading::thread_pool::ThreadPool::run
```

The same binary passes 28/28 under qemu 9.1 and natively on every `x64-baseline - test-bun` lane, so this is an emulator defect, not a baseline correctness regression. The Alpine (musl) verify lanes already have newer qemu and never hit it.

## Fix

* **`.buildkite/ci.mjs`**: for every Linux verify-baseline step that runs emulation, download the static-pie qemu 9.1.0 tarball from [ziglang/qemu-static](https://github.com/ziglang/qemu-static/releases/tag/9.1.0) (the only release found that publishes both an x86_64-hosted `qemu-x86_64` and an aarch64-hosted `qemu-aarch64`), sha256-verify it, extract the single user-mode binary, and pass that path as `--emulator`. The Windows SDE step is unchanged.
* **`scripts/verify-baseline.ts`**: two pre-existing bugs surfaced while investigating:
  * SIGILL detection checked `exitCode === 132`, but qemu-user re-raises the guest's fatal signal on the host so `proc.exitCode` is always `null` for a signaled process; a real AVX leak fell through to the warning path. Check `signalCode === "SIGILL"` instead.
  * A non-SIGILL emulated-run failure (segfault, test failure, tool error) was counted as `otherFailures` and the script still exited 0, which is exactly how the post-#34009 segfault was being masked whenever qemu happened to exit cleanly after the crash. Promote those to hard failures with their own Buildkite annotation.
  * Add `--skip-emulation` so the Android lane (whose bionic binary cannot be loaded by qemu-user on the glibc host) stops accidentally passing via the removed warning path; only the static instruction scan runs there.

## Verification

* `node .buildkite/ci.mjs` generates the qemu setup commands on the four Linux lanes that run emulation; `linux-aarch64-android-verify-baseline` sets `--skip-emulation` and downloads nothing; the Windows SDE step is byte-identical.
* Exit codes: PASS -> 0; `vzeroupper` under Nehalem -> exit 1 with `Instruction failures: 1`; SIGSEGV under Nehalem -> exit 1 with `Other failures: 1` (previously exit 0).
* 40x under the pinned qemu 9.1.0: 0 failures. 40x under qemu 4.2: 5 failures.
* CI [build #72954](https://buildkite.com/bun/bun/builds/72954#019f6138-55a7-44b2-9315-fc4852a7f34f): all six `verify-baseline` steps passed with the pinned qemu on x64.

This is a CI-script change (`.buildkite/` + `scripts/`); the fail-before cannot be reproduced by `bun bd test <file>` alone because the test file itself is not at fault.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->