### PR TITLE
test(20144): stop racing child startup against the 1s SIGKILL guard

### DIFF
--- a/test/regression/issue/20144/20144.test.ts
+++ b/test/regression/issue/20144/20144.test.ts
@@ -1,25 +1,31 @@
-import { it } from "bun:test";
-import assert from "node:assert";
+import { expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import { spawn } from "node:child_process";
 
-it.skipIf(process.platform === "win32")("should not time out", done => {
-  const child = spawn(process.execPath, ["run", "./20144.fixture.ts"], {
+it.skipIf(process.platform === "win32")("should not time out", async () => {
+  // https://github.com/oven-sh/bun/issues/20144: after cc(), SIGINT must still
+  // break a tight loop. The spawn timeout is only a last-resort kill switch for
+  // a true hang; 20s matches other hang-guard tests and avoids racing startup.
+  const child = spawn(bunExe(), ["run", "./20144.fixture.ts"], {
     cwd: __dirname,
+    env: bunEnv,
     stdio: [null, "inherit", "inherit", "ipc"],
-    timeout: 1000,
+    timeout: 20_000,
     killSignal: "SIGKILL",
   });
 
+  const { promise, resolve, reject } = Promise.withResolvers<{ code: number | null; signal: string | null }>();
+  child.on("error", reject);
+  child.on("exit", (code, signal) => resolve({ code, signal }));
+
+  let gotReady = false;
   child.on("message", message => {
     if (message == "hej") {
-      assert.ok(child.pid);
-      process.kill(child.pid, "SIGINT");
+      gotReady = true;
+      process.kill(child.pid!, "SIGINT");
     }
   });
 
-  child.on("exit", (code, signal) => {
-    assert.strictEqual(signal, "SIGINT");
-    assert.strictEqual(code, null);
-    done();
-  });
+  expect(await promise).toEqual({ code: null, signal: "SIGINT" });
+  expect(gotReady).toBe(true);
 });


### PR DESCRIPTION
`test/regression/issue/20144/20144.test.ts` has been flaking on the macOS aarch64 lanes (102 of the last 500 branch builds carry it in their annotations) and went fully red on darwin 14 aarch64 in build [72915](https://buildkite.com/bun/bun/builds/72915):

```
AssertionError: Expected values to be strictly equal:
+ 'SIGKILL'
- 'SIGINT'
✗ should not time out [1010.48ms]
```

### Cause

The test spawns a child that runs `bun:ffi`'s `cc()` and then sends an IPC `"hej"` before entering `while (true)`. The parent replies with `SIGINT`, and the assertion checks the child exited via `SIGINT`. A `spawn` option of `timeout: 1000, killSignal: "SIGKILL"` is the hang guard.

That 1s budget is spent almost entirely on child startup and the `cc()` compile, not on the property being tested. On an idle macOS box the round-trip is ~30 ms; on a local debug+ASAN build it is ~1.7 s, and under concurrent test-runner load on the macOS tart VM runners it crosses 1 s in release too, so `node:child_process` fires `SIGKILL` before `"hej"` ever arrives.

There is no `src/` culprit in the window where the rate jumped: the first heavily affected build (72519) and the adjacent clean one (72517) share the same merge-base (`7d44148cfa`), and the only main commits between the surrounding bases are test-only (#34043, #34081). This is a latent tight timeout that CI load pushed over the edge.

### Fix

* Raise the kill switch to `20_000` ms to match the other hang-guard tests in the repo (e.g. `test/js/bun/css/angle-serialization-hang.test.ts`). The regression from #20144 was a permanent hang, so the guard still fires on a real regression; it just stops racing startup.
* Spawn with `bunExe()` / `bunEnv` so the child runs with the normalized test environment instead of inheriting the CI runner's full env.
* Replace the `done` callback with `Promise.withResolvers`, wire `child.on("error")` to reject, and assert the exit shape with `expect(...).toEqual({ code: null, signal: "SIGINT" })` plus a check that the ready message was actually received.

### Verification

```
$ bun bd test test/regression/issue/20144/20144.test.ts
(pass) should not time out [1720.56ms]
```

(Three consecutive passes on debug+ASAN; three on release. The debug duration alone shows the old 1 s guard was never safe.)

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->