### PR TITLE
install: let bunfig.toml registry take precedence over npm_config_registry

### DIFF
--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -341,7 +341,7 @@ minimumReleaseAgeExcludes = ["@types/node", "typescript"]
 
 ### Configuring with environment variables
 
-Environment variables take priority over `bunfig.toml`.
+These environment variables take priority over `bunfig.toml`.
 
 | Name                               | Description                                               |
 | ---------------------------------- | --------------------------------------------------------- |

--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -352,6 +352,8 @@ Environment variables take priority over `bunfig.toml`.
 | `BUN_CONFIG_SKIP_LOAD_LOCKFILE`    | Don’t load a lockfile                                     |
 | `BUN_CONFIG_SKIP_INSTALL_PACKAGES` | Don’t install any packages                                |
 
+For npm compatibility, Bun also reads `NPM_CONFIG_REGISTRY` (or `npm_config_registry`) as a fallback: it only applies when no registry is explicitly configured in `bunfig.toml` or `.npmrc`, while `BUN_CONFIG_REGISTRY` and `--registry` override both.
+
 Bun uses the fastest installation method available on the target platform: `clonefile` on macOS and `hardlink` on Linux. You can change the installation method with the `--backend` flag. When unavailable or on error, `clonefile` and `hardlink` fall back to a platform-specific implementation of copying files.
 
 Bun stores installed packages from npm in `~/.bun/install/cache/${name}@${version}`. If the semver version has a `build` or a `pre` tag, Bun replaces it with a hash of that value. This reduces the chances of errors from long file paths, but complicates figuring out where a package was installed on disk.

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -1594,9 +1594,13 @@ mod draft {
             // mutating that same field. Copy the two fields we compare against so
             // the borrow ends before the `install.default_registry` mutation.
             let (default_registry_host, default_registry_pathname): (Box<[u8]>, Box<[u8]>) = 'brk: {
+                // An empty url means auth-only config (see below); match
+                // against the default registry URL it will resolve to.
                 if let Some(dr) = &install.default_registry {
-                    let u = URL::parse(&dr.url);
-                    break 'brk (Box::from(u.host), Box::from(u.pathname));
+                    if !dr.url.is_empty() {
+                        let u = URL::parse(&dr.url);
+                        break 'brk (Box::from(u.host), Box::from(u.pathname));
+                    }
                 }
                 let u = URL::parse(
                     bun_install_types::NodeLinker::npm::Registry::DEFAULT_URL.as_bytes(),
@@ -1694,14 +1698,14 @@ mod draft {
                         if let Some(r) = install.default_registry.as_mut() {
                             break 'brk r;
                         }
+                        // Leave the url empty: this carries auth for the
+                        // default registry without explicitly configuring a
+                        // registry URL. Options::load fills in the default.
                         install.default_registry = Some(NpmRegistry {
                             password: Box::default(),
                             token: Box::default(),
                             username: Box::default(),
-                            url: Box::<[u8]>::from(
-                                bun_install_types::NodeLinker::npm::Registry::DEFAULT_URL
-                                    .as_bytes(),
-                            ),
+                            url: Box::default(),
                             email: Box::default(),
                         });
                         install.default_registry.as_mut().unwrap()

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -578,15 +578,25 @@ impl Options {
         // technically, npm_config is case in-sensitive
         // load_registry:
         {
-            const REGISTRY_KEYS: [&[u8]; 3] = [
-                b"BUN_CONFIG_REGISTRY",
-                b"NPM_CONFIG_REGISTRY",
-                b"npm_config_registry",
-            ];
+            // An explicit registry in bunfig.toml / .npmrc wins over the
+            // npm-compat env vars; BUN_CONFIG_REGISTRY and --registry still
+            // override it.
+            let config_has_registry = bun_install_ref
+                .and_then(|config| config.default_registry.as_ref())
+                .is_some_and(|registry| !registry.url.is_empty());
+            let registry_keys: &[&[u8]] = if config_has_registry {
+                &[b"BUN_CONFIG_REGISTRY"]
+            } else {
+                &[
+                    b"BUN_CONFIG_REGISTRY",
+                    b"NPM_CONFIG_REGISTRY",
+                    b"npm_config_registry",
+                ]
+            };
             let mut did_set = false;
 
             // was `inline for`; homogeneous elements → plain for.
-            for registry_key in REGISTRY_KEYS {
+            for &registry_key in registry_keys {
                 if !did_set {
                     if let Some(registry_) = env.get(registry_key) {
                         if !registry_.is_empty()

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -9202,3 +9202,48 @@ test("npm_config_registry env var is used when bunfig.toml has no registry", asy
   expect(received).toEqual(["/no-deps"]);
   expect(await exited).not.toBe(0);
 });
+
+test("npm_config_registry env var is used when .npmrc only has auth for the default registry", async () => {
+  // `npm login` writes an auth-only .npmrc line with no registry= line; that
+  // must not count as an explicitly configured registry.
+  const received: { pathname: string; authorization: string | null }[] = [];
+  using envRegistry = Bun.serve({
+    port: 0,
+    fetch(req) {
+      received.push({ pathname: new URL(req.url).pathname, authorization: req.headers.get("authorization") });
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { npm: true, linker: "hoisted" } });
+  await Promise.all([
+    write(join(packageDir, ".npmrc"), `//registry.npmjs.org/:_authToken=npm_secret_token\n`),
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        version: "1.0.0",
+        dependencies: {
+          "no-deps": "1.0.0",
+        },
+      }),
+    ),
+  ]);
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env: mergeWindowEnvs([env, { npm_config_registry: `http://127.0.0.1:${envRegistry.port}/` }]),
+  });
+
+  await stderr.text();
+  await stdout.text();
+
+  // The env var registry is used, and the token saved for the default
+  // registry host is not sent to it.
+  expect(received).toEqual([{ pathname: "/no-deps", authorization: null }]);
+  expect(await exited).not.toBe(0);
+});

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -9099,3 +9099,106 @@ registry = { url = "https://127.0.0.1:${otherRegistry.port}/", token = "${token}
     expect(await exited).not.toBe(0);
   }
 });
+
+// https://github.com/oven-sh/bun/issues/34168
+test("registry from bunfig.toml takes precedence over npm_config_registry env vars", async () => {
+  const bunfigReceived: string[] = [];
+  using bunfigRegistry = Bun.serve({
+    port: 0,
+    fetch(req) {
+      bunfigReceived.push(new URL(req.url).pathname);
+      return new Response("not found", { status: 404 });
+    },
+  });
+  const envReceived: string[] = [];
+  using envRegistry = Bun.serve({
+    port: 0,
+    fetch(req) {
+      envReceived.push(new URL(req.url).pathname);
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  for (const key of ["npm_config_registry", "NPM_CONFIG_REGISTRY"]) {
+    bunfigReceived.length = 0;
+    envReceived.length = 0;
+    await Promise.all([
+      write(
+        join(packageDir, "bunfig.toml"),
+        `
+[install]
+cache = false
+registry = "http://127.0.0.1:${bunfigRegistry.port}/"
+`,
+      ),
+      write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          version: "1.0.0",
+          dependencies: {
+            "no-deps": "1.0.0",
+          },
+        }),
+      ),
+    ]);
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env: mergeWindowEnvs([env, { [key]: `http://127.0.0.1:${envRegistry.port}/` }]),
+    });
+
+    await stderr.text();
+    await stdout.text();
+
+    // The manifest request must go to the bunfig.toml registry, and no
+    // request may reach the env var registry.
+    expect(bunfigReceived).toEqual(["/no-deps"]);
+    expect(envReceived).toEqual([]);
+    expect(await exited).not.toBe(0);
+  }
+});
+
+test("npm_config_registry env var is used when bunfig.toml has no registry", async () => {
+  const received: string[] = [];
+  using envRegistry = Bun.serve({
+    port: 0,
+    fetch(req) {
+      received.push(new URL(req.url).pathname);
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  // bunfigOpts.npm omits the registry line from the generated bunfig.toml.
+  const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { npm: true, linker: "hoisted" } });
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "foo",
+      version: "1.0.0",
+      dependencies: {
+        "no-deps": "1.0.0",
+      },
+    }),
+  );
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env: mergeWindowEnvs([env, { npm_config_registry: `http://127.0.0.1:${envRegistry.port}/` }]),
+  });
+
+  await stderr.text();
+  await stdout.text();
+
+  // With no explicitly configured registry, the env var still applies.
+  expect(received).toEqual(["/no-deps"]);
+  expect(await exited).not.toBe(0);
+});

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -272,7 +272,9 @@ ${iniInner.join("\n")}
   }
 
   await makeTest([["_authToken", "skibidi"]], result => {
-    expect(result.default_registry_url).toEqual("https://registry.npmjs.org/");
+    // Auth-only config: the url stays empty so env var registries still apply;
+    // Options::load falls back to the default registry URL.
+    expect(result.default_registry_url).toEqual("");
     expect(result.default_registry_token).toEqual("skibidi");
   });
 
@@ -282,7 +284,7 @@ ${iniInner.join("\n")}
       ["_password", "skibidi"],
     ],
     result => {
-      expect(result.default_registry_url).toEqual("https://registry.npmjs.org/");
+      expect(result.default_registry_url).toEqual("");
       expect(result.default_registry_username).toEqual("zorp");
       expect(result.default_registry_password).toEqual("skibidi");
     },
@@ -447,7 +449,7 @@ ${Object.keys(opts)
   );
 
   await makeTest([["email", "user@example.com"]], result => {
-    expect(result.default_registry_url).toEqual("https://registry.npmjs.org/");
+    expect(result.default_registry_url).toEqual("");
     expect(result.default_registry_email).toEqual("user@example.com");
   });
 
@@ -458,7 +460,7 @@ ${Object.keys(opts)
       ["email", "test@example.com"],
     ],
     result => {
-      expect(result.default_registry_url).toEqual("https://registry.npmjs.org/");
+      expect(result.default_registry_url).toEqual("");
       expect(result.default_registry_username).toEqual("testuser");
       expect(result.default_registry_password).toEqual("testpass");
       expect(result.default_registry_email).toEqual("test@example.com");


### PR DESCRIPTION
### What does this PR do?

Fixes #34168

When `npm_config_registry` (or `NPM_CONFIG_REGISTRY`) is set in the environment, an explicit `registry` in `bunfig.toml` or `.npmrc` was silently ignored and the install failed with a confusing `No version matching ... found` error. The lowercase variant is injected into lifecycle-script environments by npm and pnpm and is commonly exported in shell profiles for mirrors, so it often leaks into `bun install` without the user asking for it.

Registry precedence is now:

1. `--registry`
2. `BUN_CONFIG_REGISTRY`
3. `bunfig.toml` / `.npmrc`
4. `NPM_CONFIG_REGISTRY` / `npm_config_registry`
5. default (`https://registry.npmjs.org/`)

The npm-compat env vars become a fallback that only applies when no registry is explicitly configured. Bun's own `BUN_CONFIG_REGISTRY` keeps overriding the config files, so CI setups that force a mirror device-wide still have an env-var escape hatch (as does `--registry`).

The token env vars (`BUN_CONFIG_TOKEN`, `NPM_CONFIG_TOKEN`, `npm_config_token`) are intentionally unchanged: a token overlaid on the configured registry is the common auth-injection pattern and does not redirect traffic.

### Reproduction

```bash
export npm_config_registry="https://registry.npmmirror.com"
cat > bunfig.toml << 'EOF'
[install]
registry = "https://registry.npmjs.org/"
EOF
bun add drizzle-kit@1.0.0-rc.4
# before: error: No version matching "1.0.0-rc.4" found for specifier "drizzle-kit"
# (the bunfig.toml registry was never contacted)
```

### Implementation

`Options::load` in `src/install/PackageManager/PackageManagerOptions.rs` read `BUN_CONFIG_REGISTRY`, `NPM_CONFIG_REGISTRY`, and `npm_config_registry` after applying the bunfig/.npmrc config and unconditionally overwrote the default scope. Now the two npm-compat keys are skipped when the config set a non-empty registry URL.

An auth-only `.npmrc` (what `npm login` writes: `//registry.npmjs.org/:_authToken=...` with no `registry=` line) used to synthesize a `default_registry` with the default URL backfilled, which would have counted as an explicitly configured registry and dropped the env var fallback. The `.npmrc` parser now leaves the URL empty on that path, matching how bunfig represents auth-only registry config, and `Options::load` fills in the default as before.

### Tests

Added to `test/cli/install/bun-install-registry.test.ts`:

- `registry from bunfig.toml takes precedence over npm_config_registry env vars`: two local registries; asserts the manifest request reaches the bunfig registry and nothing reaches the env-var registry, for both spellings. Fails on bun 1.4.0, passes with this change.
- `npm_config_registry env var is used when bunfig.toml has no registry`: pins the fallback behavior.
- `npm_config_registry env var is used when .npmrc only has auth for the default registry`: the `npm login` setup; also asserts the saved token is not sent to the env var registry.

The existing `registry override from a project .env ...` test continues to cover `BUN_CONFIG_REGISTRY` overriding `bunfig.toml` and still passes.

Also documents the fallback in `docs/pm/cli/install.mdx`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-registry.test.ts

<!-- robobun:evidence:end -->