### PR TITLE
Add module.registerHooks named export to node:module

### DIFF
--- a/docs/runtime/nodejs-compat.mdx
+++ b/docs/runtime/nodejs-compat.mdx
@@ -121,7 +121,7 @@ This page is updated regularly and reflects the latest version of Bun's compatib
 
 ### [`node:module`](https://nodejs.org/api/module.html)
 
-🟡 Missing `syncBuiltinESMExports`, `Module#load()`. Overriding `require.cache` is supported for ESM & CJS modules. `module._extensions`, `module._pathCache`, `module._cache` are no-ops. `module.register` is not implemented; we recommend [`Bun.plugin`](/runtime/plugins) instead.
+🟡 Missing `syncBuiltinESMExports`, `Module#load()`. Overriding `require.cache` is supported for ESM & CJS modules. `module._extensions`, `module._pathCache`, `module._cache` are no-ops. `module.register` and `module.registerHooks` are no-ops (registered hooks are never invoked); we recommend [`Bun.plugin`](/runtime/plugins) instead.
 
 ### [`node:net`](https://nodejs.org/api/net.html)
 

--- a/src/js/builtins/NodeModuleObject.ts
+++ b/src/js/builtins/NodeModuleObject.ts
@@ -24,3 +24,8 @@ export function _initPaths() {
   const M = require("node:module");
   M.globalPaths = paths;
 }
+
+// Implementation for `require('node:module').registerHooks`.
+export function registerHooks(hooks) {
+  return require("internal/modules/customization_hooks").registerHooks(hooks);
+}

--- a/src/js/internal/modules/customization_hooks.ts
+++ b/src/js/internal/modules/customization_hooks.ts
@@ -1,0 +1,33 @@
+// Mirror of Node's `lib/internal/modules/customization_hooks.js` (`module.registerHooks`,
+// added in Node v22.15.0). Hooks are validated and returned with Node's observable shape,
+// but Bun's module loader does not invoke them yet.
+const { validateFunction } = require("internal/validators");
+
+const ObjectFreeze = Object.freeze;
+
+class ModuleHooks {
+  resolve: Function | undefined = undefined;
+  load: Function | undefined = undefined;
+
+  constructor(resolve, load) {
+    this.resolve = resolve;
+    this.load = load;
+    ObjectFreeze(this);
+  }
+
+  deregister() {}
+}
+
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/modules/customization_hooks.js
+function registerHooks(hooks) {
+  const { resolve, load } = hooks;
+  if (resolve) {
+    validateFunction(resolve, "hooks.resolve");
+  }
+  if (load) {
+    validateFunction(load, "hooks.load");
+  }
+  return new ModuleHooks(resolve, load);
+}
+
+export default { registerHooks };

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -908,6 +908,7 @@ globalPaths             getGlobalPathsObject              PropertyCallback
 isBuiltin               jsFunctionIsBuiltinModule         Function 1
 prototype               getModulePrototypeObject          PropertyCallback
 register                jsFunctionRegister                Function 1
+registerHooks           JSBuiltin                         Function|Builtin 1
 runMain                 moduleRunMain                        CustomAccessor
 SourceMap               getSourceMapFunction              PropertyCallback
 syncBuiltinESMExports   jsFunctionSyncBuiltinESMExports   Function 0

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, ospath } from "harness";
-import Module, { _nodeModulePaths, builtinModules, createRequire, isBuiltin, wrap } from "module";
+import Module, { _nodeModulePaths, builtinModules, createRequire, isBuiltin, registerHooks, wrap } from "module";
 import path from "path";
 
 describe.concurrent("node-module-module", () => {
@@ -299,5 +299,72 @@ describe.concurrent("node-module-module", () => {
    ./j.cjs (seen)
    ./k.cjs (seen)`);
     expect(await proc.exited).toBe(0);
+  });
+
+  // https://github.com/oven-sh/bun/issues/34171
+  describe("registerHooks", () => {
+    test("is a named ESM export of node:module", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `import { builtinModules, createRequire, registerHooks } from "node:module"; console.log(typeof registerHooks);`,
+        ],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toBe("function\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("named export, default export, and CJS require agree", () => {
+      expect(registerHooks).toBeFunction();
+      expect(Module.registerHooks).toBe(registerHooks);
+      expect(require("module").registerHooks).toBe(registerHooks);
+    });
+
+    // Shape assertions below verified against Node v26.3.0.
+    test("returns a frozen ModuleHooks object with a deregister method", () => {
+      const resolve = () => {};
+      const load = () => {};
+      const hooks = registerHooks({ resolve, load });
+      expect(hooks.constructor.name).toBe("ModuleHooks");
+      expect(Object.isFrozen(hooks)).toBe(true);
+      expect(Object.getOwnPropertyNames(hooks)).toEqual(["resolve", "load"]);
+      expect(hooks.resolve).toBe(resolve);
+      expect(hooks.load).toBe(load);
+      expect(hooks.deregister()).toBeUndefined();
+      // deregister is idempotent
+      expect(hooks.deregister()).toBeUndefined();
+    });
+
+    test("accepts missing and nullish hook properties", () => {
+      expect(() => registerHooks({})).not.toThrow();
+      expect(() => registerHooks({ resolve: null, load: null })).not.toThrow();
+      expect(() => registerHooks({ resolve: undefined, load: undefined })).not.toThrow();
+    });
+
+    test("rejects non-function hooks with ERR_INVALID_ARG_TYPE", () => {
+      expect(() => registerHooks({ resolve: 1 })).toThrow(
+        expect.objectContaining({
+          name: "TypeError",
+          code: "ERR_INVALID_ARG_TYPE",
+          message: 'The "hooks.resolve" property must be of type function. Received type number (1)',
+        }),
+      );
+      expect(() => registerHooks({ load: "x" })).toThrow(
+        expect.objectContaining({
+          name: "TypeError",
+          code: "ERR_INVALID_ARG_TYPE",
+          message: `The "hooks.load" property must be of type function. Received type string ('x')`,
+        }),
+      );
+    });
+
+    test("rejects nullish hooks argument with TypeError", () => {
+      expect(() => registerHooks()).toThrow(TypeError);
+      expect(() => registerHooks(null)).toThrow(TypeError);
+    });
   });
 });


### PR DESCRIPTION
Fixes #34171
Fixes #27369

### Repro

```js
import { builtinModules, createRequire, registerHooks } from "node:module";
```

```
SyntaxError: Export named 'registerHooks' not found in module 'node:module'.
```

This is the top line of `@cloudflare/vite-plugin`'s dist bundle, so `bun --bun vite dev` dies at parse time before any plugin code runs.

### Cause

`registerHooks` (Node v22.15.0+) did not exist anywhere in `node:module`: not in the `nodeModuleObjectTable` LUT, so neither the CJS property nor the generated ESM named export existed.

### Fix

Adds `module.registerHooks` with Node's observable shape, implemented in `internal/modules/customization_hooks.ts` (mirroring Node's `lib/internal/modules/customization_hooks.js`) and wired into the LUT as a JSBuiltin, which also produces the ESM named export:

- truthiness-gated `validateFunction` on `hooks.resolve` / `hooks.load`, throwing the same `ERR_INVALID_ARG_TYPE` messages as Node
- returns a frozen `ModuleHooks` object with own `resolve`/`load` properties and an idempotent `deregister()` method
- nullish `hooks` argument throws the destructuring TypeError, `registerHooks({})` succeeds

Deliberate divergence, stated plainly: the registered hooks are never invoked, since Bun's module loader has no sync customization hook support yet. This matches the existing `module.register` no-op stub in the same table, and is documented in `docs/runtime/nodejs-compat.mdx`. For `@cloudflare/vite-plugin` specifically this is sufficient: it only calls `registerHooks` inside `registerConfigHooks()`, which on Bun throws its own "not supported on Bun" error before reaching the call; the fatal problem was purely the parse-time named import.

This also covers #27369, whose repro is exactly the export's existence (`console.log(module.registerHooks)` printing `[Function: registerHooks]`). It deliberately does not close #31472: `import-fresh`'s feature-detect guard now passes, but its resolve/load hooks are load-bearing (custom `import-fresh://` specifiers), so that issue needs real hook invocation support.

Behavior assertions were verified against Node v26.3.0:

```console
$ node -e "const m=require('node:module'); const r=m.registerHooks({load(u,c,n){return n(u,c)}});
console.log(Object.isFrozen(r), r.constructor.name, Object.getOwnPropertyNames(r), r.deregister());
try { m.registerHooks({resolve: 1}) } catch(e) { console.log(e.code, e.message) }"
true ModuleHooks [ 'resolve', 'load' ] undefined
ERR_INVALID_ARG_TYPE The "hooks.resolve" property must be of type function. Received type number (1)
```

### Verification

- `USE_SYSTEM_BUN=1 bun test test/js/node/module/node-module-module.test.js` fails with the SyntaxError above
- `bun bd test test/js/node/module/` passes (95 tests, 8 files)

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/module/node-module-module.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (5cab525aa)

test/js/node/module/node-module-module.test.js:

# Unhandled error between tests
-------------------------------
SyntaxError: Export named 'registerHooks' not found in module 'node:module'.
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [2.00s]
error: script "bd" exited with code 1
__F:-1:S:0

release without fix: all passed
bun test v1.4.0-canary.1 (b50f488f6)

test/js/node/module/node-module-module.test.js:
(pass) node-module-module > builtinModules exists [0.03ms]
(pass) node-module-module > isBuiltin() works [0.05ms]
(pass) node-module-module > module.globalPaths exists [0.03ms]
(pass) node-module-module > native module functions are not constructors [0.14ms]
(pass) node-module-module > createRequire trailing slash [0.12ms]
(pass) node-module-module > createRequire trailing slash file url [0.06ms]
(pass) node-module-module > Module exists [0.01ms]
(pass) node-module-module > module.Module works [0.02ms]
(pass) node-module-module > _nodeModulePaths() works [0.09ms]
(pass) node-module-module > Module.wrap [0.09ms]
(pass) node-module-module > Module.prototype._compile [0.13ms]
(pass) node-module-module > Module.prototype._compile [0.02ms]
(pass) node-module-module > Module.prototype._compile
(pass) node-module-module > Module.prototype._compile
(pass) node-module-module > Module.prototype._compile
(pass) node-module-module > Module.prototype._compile
(pass) node-module-module > Module._extensions [0.03ms]
(pass) node-module-module > Module._resolveLookupPaths [0.05ms]
(pass) node-modul
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/module/node-module-module.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (5cab525aa)

test/js/node/module/node-module-module.test.js:
(pass) node-module-module > builtinModules exists [2.38ms]
(pass) node-module-module > isBuiltin() works [5.17ms]
(pass) node-module-module > module.globalPaths exists [1.72ms]
(pass) node-module-module > native module functions are not constructors [13.77ms]
(pass) node-module-module > createRequire trailing slash [5.07ms]
(pass) node-module-module > createRequire trailing slash file url [3.74ms]
(pass) node-module-module > Module exists [1.37ms]
(pass) node-module-module > module.Module works [1.85ms]
(pass) node-module-module > _nodeModulePaths() works [8.63ms]
(pass) node-module-module > Module.wrap [5.31ms]
(pass) node-module-module > Module.prototype._com
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 689ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[2/22] gen cpp.rs (cppbind)
[3/22] gen JS modules (bundle-modules)
Preprocess modules (6706ms)
Bundle modules (51ms)
Postprocesss modules (21ms)
Bundle Functions (914ms)
Generate Code (105ms)

[7.82s] Bundled "src/js" for production
  1912 kb
  163 internal modules
  12 native modules
  91 internal functions across 19 files
[3/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/nodejs-compat.mdx                 |  2 +-
 src/js/builtins/NodeModuleObject.ts            |  5 ++
 src/js/internal/modules/customization_hooks.ts | 33 ++++++++++++
 src/jsc/modules/NodeModuleModule.cpp           |  1 +
 test/js/node/module/node-module-module.test.js | 69 +++++++++++++++++++++++++-
 5 files changed, 108 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
docs/runtime/nodejs-compat.mdx                      0      0      0
src/js/builtins/NodeModuleObject.ts                 1      1      0
src/js/internal/modules/customization_hooks.ts      0      2      0
src/jsc/modules/NodeModuleModule.cpp                1      2      0
test/js/node/module/node-module-module.test.js      1      2      0
```

</details>

**root cause** · written by the author bot

Bun's node:module did not provide registerHooks as a named ESM export, so packages like @cloudflare/vite-plugin that statically import it failed at load time with a SyntaxError. The fix adds a registerHooks compatibility shim wired into the node:module exports, so the named import resolves and matches Node's observable API shape. The shim validates the resolve and load hook arguments and returns a frozen hooks object with a deregister method, though the hooks are documented no-ops since Bun's loader does not invoke them.

<!-- robobun:evidence:end -->