### PR TITLE
test(install-proxy): run iterations sequentially to avoid squid saturation

### DIFF
--- a/test/cli/install/bun-install-proxy.test.ts
+++ b/test/cli/install/bun-install-proxy.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, it } from "bun:test";
+import { beforeAll, expect, it } from "bun:test";
 import { exec } from "child_process";
 import { rm } from "fs/promises";
 import { bunEnv, bunExe, dockerExe, isDockerEnabled, tempDirWithFiles } from "harness";
@@ -62,36 +62,35 @@ if (isDockerEnabled()) {
         },
       }),
     };
-    const promises = new Array(5);
-    // this repro a hang when using a proxy, we run multiple times to make sure it's not a flaky test
+    // Regression test for the proxy hang (#19771). Run sequentially so all five
+    // installs don't push ~240 concurrent CONNECT tunnels through a single squid
+    // instance at once; a real hang is caught by the test-level timeout.
     for (let i = 0; i < 5; i++) {
       const package_dir = tempDirWithFiles("codex-" + i, files);
-
-      const { exited } = Bun.spawn([bunExe(), "install", "--ignore-scripts"], {
-        cwd: package_dir,
-        // @ts-ignore
-        env: {
-          ...bunEnv,
-          BUN_INSTALL_CACHE_DIR: join(package_dir, ".bun-install-cache"),
-          TMPDIR: join(package_dir, ".tmp"),
-          BUN_TMPDIR: join(package_dir, ".tmp"),
-          HTTPS_PROXY: SQUID_URL,
-          HTTP_PROXY: SQUID_URL,
-        },
-        stdio: ["inherit", "inherit", "inherit"],
-        timeout: 20_000,
-      });
-      promises[i] = exited
-        .then(r => {
-          if (r !== 0) {
-            throw new Error("failed to install with exit code " + r);
-          }
-        })
-        .finally(() => {
-          return rm(package_dir, { recursive: true, force: true });
+      try {
+        await using proc = Bun.spawn([bunExe(), "install", "--ignore-scripts"], {
+          cwd: package_dir,
+          // @ts-ignore
+          env: {
+            ...bunEnv,
+            BUN_INSTALL_CACHE_DIR: join(package_dir, ".bun-install-cache"),
+            TMPDIR: join(package_dir, ".tmp"),
+            BUN_TMPDIR: join(package_dir, ".tmp"),
+            HTTPS_PROXY: SQUID_URL,
+            HTTP_PROXY: SQUID_URL,
+          },
+          stdout: "pipe",
+          stderr: "pipe",
         });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        if (exitCode !== 0) {
+          console.error(`iteration ${i} stdout:\n${stdout}`);
+          console.error(`iteration ${i} stderr:\n${stderr}`);
+        }
+        expect(exitCode).toBe(0);
+      } finally {
+        await rm(package_dir, { recursive: true, force: true });
+      }
     }
-
-    await Promise.all(promises);
-  }, 60_000);
+  }, 120_000);
 }


### PR DESCRIPTION
## What

`test/cli/install/bun-install-proxy.test.ts` has been going red on first attempt in roughly 30% of PR builds since 2026-07-11 (and briefly on 2026-07-06), always with the same shape:

```
error: failed to install with exit code 143
      at bun-install-proxy.test.ts:87
✗ bun install with proxy with big packages [20020.05ms]
```

Four of the five concurrent `bun install` processes finish in ~1s; one stalls at "Resolving dependencies" until the 20s `Bun.spawn` `timeout` SIGTERMs it (143 = 128 + SIGTERM). Seen in build [72962](https://buildkite.com/bun/bun/builds/72962) and many others (72954, 72935, 72927, 72916, 72912, 72910, 72906, 72903, 72900, ...).

## Not a code regression

I checked merge bases for every failed build on 2026-07-11: builds based on the *same* main commit (`55ba6e453c`, `ab84aa22d2`, `9657f37896`) are both clean and red within the same hour. The flake correlates with wall-clock time, not with what was merged. Before 2026-07-06 the rate was 0/60 across several sampled days.

## Cause

The test spawns five `bun install` processes in parallel, each with the default `--network-concurrency` of 48. All traffic goes through a single squid container to `registry.npmjs.org`, so up to ~240 CONNECT tunnels compete for the one proxy. Under current npm/network conditions one of the five occasionally gets starved past 20s.

## Fix

Run the five iterations sequentially instead of concurrently, drop the 20s per-spawn timeout, and rely on the 120s test-level timeout for hang detection. A genuine proxy hang (what #19771 fixed and this test guards) still fails the test; transient npm slowness no longer does. Also pipe stdout/stderr and print them on non-zero exit so a real failure is diagnosable.

The test still hits the live npm registry; making it hermetic is a larger change that #33115 is already moving toward.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/install/bun-install-proxy.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/install/bun-install-proxy.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (158e3f19f)

test/cli/install/bun-install-proxy.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory

 0 pass
 0 fail
Ran 0 tests across 1 file. [2.31s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/cli/install/bun-install-proxy.test.ts | 57 +++++++++++++++---------------
 1 file changed, 28 insertions(+), 29 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
test/cli/install/bun-install-proxy.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->