### PR TITLE
io: register FileReader's epoll/kqueue poll level-triggered

### DIFF
--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -167,6 +167,17 @@ bitflags::bitflags! {
         const MEMFD                    = 1 << 7;
         const USE_PREAD                = 1 << 8;
         const IS_PAUSED                = 1 << 9;
+        // Register the poll level-triggered (no EPOLLONESHOT / EV_ONESHOT).
+        // A one-shot readable is disarmed by the kernel the instant
+        // `epoll_wait` returns it; if that slot is then dropped before
+        // `on_update` reaches it (a nested `us_loop_run_bun_tick` overwriting
+        // `ready_polls`), the fd is left permanently disarmed with no re-arm
+        // path. `FileReader` sets this: its `on_read_chunk` drains to EAGAIN
+        // on every dispatch and only returns `false` after `close()`, so
+        // level-triggered cannot busy-loop. Parents whose `on_read_chunk` can
+        // return `false` with bytes still queued (the shell reader) keep
+        // one-shot.
+        const LEVEL_TRIGGERED          = 1 << 10;
     }
 }
 
@@ -428,7 +439,9 @@ impl PosixBufferedReader {
             poll.enable_keeping_process_alive(ev);
         }
 
-        match poll.register_with_fd(lp.cast(), FilePollKind::Readable, poll.fd()) {
+        let one_shot = !self.flags.contains(PosixFlags::LEVEL_TRIGGERED);
+        match poll.register_with_fd_one_shot(lp.cast(), FilePollKind::Readable, poll.fd(), one_shot)
+        {
             sys::Result::Err(err) => {
                 self.vtable.on_reader_error(err);
                 false

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -405,6 +405,15 @@ impl PosixBufferedReader {
     }
 
     pub fn on_error(&mut self, err: sys::Error) {
+        // Unregister a level-triggered poll before dispatching: a fd with a
+        // persistent error (PTY master `EIO` after slave close, with
+        // `EPOLLHUP` set) would otherwise re-fire every `epoll_wait`. One-shot
+        // callers are unchanged (the kernel already disarmed the fd).
+        // `on_reader_error` may free the struct embedding `self`, so close
+        // first.
+        if self.flags.contains(PosixFlags::LEVEL_TRIGGERED) {
+            self.close_without_reporting();
+        }
         self.vtable.on_reader_error(err);
     }
 
@@ -704,6 +713,9 @@ impl PosixBufferedReader {
                                     ReadState::Progress
                                 },
                             );
+                            if parent.is_done() {
+                                return;
+                            }
                         } else {
                             parent
                                 ._buffer

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -408,10 +408,14 @@ impl PosixBufferedReader {
         // Unregister a level-triggered poll before dispatching: a fd with a
         // persistent error (PTY master `EIO` after slave close, with
         // `EPOLLHUP` set) would otherwise re-fire every `epoll_wait`. One-shot
-        // callers are unchanged (the kernel already disarmed the fd).
-        // `on_reader_error` may free the struct embedding `self`, so close
-        // first.
-        if self.flags.contains(PosixFlags::LEVEL_TRIGGERED) {
+        // callers are unchanged (the kernel already disarmed the fd). Gated on
+        // POLLABLE so a regular-file pread error on the synchronous on_pull
+        // path isn't swallowed as Done. `on_reader_error` may free the struct
+        // embedding `self`, so close first.
+        if self
+            .flags
+            .contains(PosixFlags::LEVEL_TRIGGERED | PosixFlags::POLLABLE)
+        {
             self.close_without_reporting();
         }
         self.vtable.on_reader_error(err);

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -931,6 +931,14 @@ impl PosixBufferedReader {
                                 {
                                     return;
                                 }
+                                // The callback may synchronously close the
+                                // reader (FileReader does on max_size /
+                                // re-entrant cancel); `fd` was captured at
+                                // the top of `on_poll` and is now racing
+                                // the async `Closer`.
+                                if parent.is_done() {
+                                    return;
+                                }
                                 head_start = 0;
                             }
                         }
@@ -978,6 +986,9 @@ impl PosixBufferedReader {
                         },
                     ) && !received_hup
                     {
+                        return;
+                    }
+                    if parent.is_done() {
                         return;
                     }
                 }

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -1886,6 +1886,16 @@ impl FilePollRef {
         kind: FilePollKind,
         fd: Fd,
     ) -> sys::Result<()> {
+        self.register_with_fd_one_shot(loop_, kind, fd, true)
+    }
+    #[inline]
+    pub fn register_with_fd_one_shot(
+        self,
+        loop_: *mut bun_uws_sys::Loop,
+        kind: FilePollKind,
+        fd: Fd,
+        one_shot: bool,
+    ) -> sys::Result<()> {
         let flag = match kind {
             FilePollKind::Readable => PollFlags::Readable,
             FilePollKind::Writable => PollFlags::Writable,
@@ -1895,13 +1905,17 @@ impl FilePollRef {
             self.inner().register_with_fd(
                 Self::uws_loop_mut(loop_),
                 flag,
-                OneShotFlag::Dispatch,
+                if one_shot {
+                    OneShotFlag::Dispatch
+                } else {
+                    OneShotFlag::None
+                },
                 fd,
             )
         }
         #[cfg(windows)]
         {
-            let _ = (loop_, flag, fd);
+            let _ = (loop_, flag, fd, one_shot);
             unreachable!("FilePoll fd registration is POSIX-only");
         }
     }

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -695,8 +695,14 @@ impl FilePoll {
 
         debug_assert!(fd != INVALID_FD);
 
+        // The kernel one-shot bit is derived from `self.flags`, not from
+        // `one_shot`, so a level-triggered re-register on a poll that was
+        // previously registered one-shot (e.g. a `FilePoll` moved from a
+        // `SubprocessPipeReader` into a `FileReader`) must clear the flag.
         if one_shot != OneShotFlag::None {
             self.flags.insert(Flags::OneShot);
+        } else {
+            self.flags.remove(Flags::OneShot);
         }
 
         #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -419,6 +419,21 @@ impl FileReader {
             ));
         }
 
+        // Register the poll level-triggered. A one-shot readable is disarmed
+        // by the kernel the instant `epoll_wait` returns it; if a nested
+        // `us_loop_run_bun_tick` overwrites `ready_polls` before dispatch
+        // reaches that slot, the fd is left disarmed with no re-arm path and
+        // the pending `reader.read()` never resolves (stdin goes input-deaf
+        // until more bytes arrive). Level-triggered makes a dropped slot
+        // harmless: the next `epoll_wait` reports it again. `on_read_chunk`
+        // drains to EAGAIN on every dispatch and only returns `false` after
+        // `close()`, so it cannot busy-loop. `pause()` unregisters the poll.
+        #[cfg(unix)]
+        {
+            use bun_io::pipe_reader::PosixFlags;
+            self.reader().flags.insert(PosixFlags::LEVEL_TRIGGERED);
+        }
+
         if was_lazy {
             // SAFETY: see `parent()`.
             unsafe { (*self.parent()).increment_count() };

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -428,7 +428,10 @@ impl FileReader {
         // harmless: the next `epoll_wait` reports it again. `on_read_chunk`
         // drains to EAGAIN on every dispatch and only returns `false` after
         // `close()`, so it cannot busy-loop. `pause()` unregisters the poll.
-        #[cfg(unix)]
+        // Linux-only: macOS/FreeBSD keep `EV_DISPATCH` (the re-arm path there
+        // is `EV_ADD|EV_ENABLE`, and a plain level-triggered kqueue read
+        // filter on a regular fd has different readiness semantics).
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             use bun_io::pipe_reader::PosixFlags;
             self.reader().flags.insert(PosixFlags::LEVEL_TRIGGERED);
@@ -623,6 +626,11 @@ impl FileReader {
             if let Some(max_size) = self.max_size {
                 let total_readed = self.total_readed.get();
                 if total_readed >= max_size {
+                    // Close so the level-triggered poll is unregistered; the
+                    // caller's `read_with_fn` returns here without re-arm or
+                    // unregister, and a still-armed fd would re-fire every
+                    // epoll_wait reading bytes the slice boundary discards.
+                    self.reader().close();
                     return false;
                 }
                 let len = (max_size - total_readed).min(buf.len());

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -637,9 +637,10 @@ impl FileReader {
                 if buf.len() > len {
                     buf = &buf[0..len];
                 }
-                self.total_readed.set(total_readed + len);
+                let new_total = total_readed + len;
+                self.total_readed.set(new_total);
 
-                if buf.is_empty() {
+                if new_total >= max_size {
                     close = true;
                     has_more = false;
                 }

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -439,6 +439,17 @@ impl ReadableStream {
             .context
             .reader()
             .from(buffered_reader, ctx_ptr.cast::<c_void>());
+        // See the matching insert in `FileReader::on_start`. `from()` moves a
+        // FilePoll already registered one-shot by `SubprocessPipeReader`; set
+        // the flag before any `register_poll()` so the next `CTL_MOD` flips it
+        // to level-triggered (now that `register_with_fd_impl` clears the
+        // sticky `Flags::OneShot` when asked for `OneShotFlag::None`).
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        source
+            .context
+            .reader()
+            .flags
+            .insert(bun_io::pipe_reader::PosixFlags::LEVEL_TRIGGERED);
 
         let stream = source.to_readable_stream(global_this)?;
 

--- a/test/js/bun/spawn/stdin-readable-nested-tick-fixture.ts
+++ b/test/js/bun/spawn/stdin-readable-nested-tick-fixture.ts
@@ -1,0 +1,45 @@
+import { expect } from "bun:test";
+let nested = false;
+let got = "";
+// Register the pidfd polls and let them become ready BEFORE stdin's poll is
+// registered: Linux epoll appends to the ready list in readiness order, so
+// stdin sits AFTER the pidfd that triggers the nested tick.
+const N = 20;
+for (let i = 0; i < N; i++) {
+  Bun.spawn({
+    cmd: ["/bin/true"],
+    stdin: "ignore",
+    stdout: "ignore",
+    stderr: "ignore",
+    onExit() {
+      if (!nested) {
+        nested = true;
+        // Bun.sleep resolves via the timer queue, which only drains inside
+        // autoTick() after us_loop_run_bun_tick: waitForPromise must re-enter
+        // epoll_wait, overwriting the outer dispatch's ready_polls.
+        expect(Bun.sleep(1)).resolves.toBe(undefined);
+      }
+    },
+  });
+}
+// First spin: give /bin/true time to exit so the pidfds are already on the
+// epoll ready list before stdin is registered.
+{
+  const until = Date.now() + 20;
+  while (Date.now() < until) {}
+}
+process.stdin.on("data", d => {
+  got += d.toString();
+  if (got.includes("X")) {
+    process.stdout.write("GOT:" + got + "\n");
+    process.exit(0);
+  }
+});
+process.stdin.resume();
+process.stdout.write("READY\n");
+// Second spin: give the parent time to write "X" so stdin is appended to the
+// ready list after the pidfds, then drain everything in one epoll_wait.
+{
+  const until = Date.now() + 80;
+  while (Date.now() < until) {}
+}

--- a/test/js/bun/spawn/stdin-readable-nested-tick.test.ts
+++ b/test/js/bun/spawn/stdin-readable-nested-tick.test.ts
@@ -1,0 +1,70 @@
+// process.stdin backed by a FileReader polls its fd with EPOLLONESHOT. The
+// kernel disarms the fd the instant epoll_wait returns it, before user-space
+// has dispatched it. If a poll callback then re-enters us_loop_run_bun_tick
+// (expect().resolves -> waitForPromise -> autoTick), the inner epoll_pwait2
+// overwrites loop->ready_polls / num_ready_polls / current_ready_poll and the
+// outer dispatch silently skips its remaining slots. A one-shot stdin readable
+// sitting in a skipped slot is unrecoverable: the fd is disarmed in the kernel,
+// FileReader::on_pull returns Pending without touching it (has_pending_read()
+// stays true), and the pending reader.read() never resolves. The REPL goes
+// input-deaf until more bytes force a fresh readable edge.
+//
+// Observed in the wild as a PTY REPL that stops responding to typing mid-
+// session, with the event loop alive (timers still render), wchan=ep_poll, and
+// typing more un-wedges it and delivers the stalled bytes too; probabilistic
+// (~1/14k turns standalone, ~20% of 100-turn sessions under real load).
+//
+// Fix: register FileReader's poll level-triggered (no EPOLLONESHOT), same as
+// the pidfd poll in src/spawn/process.rs. A pollable FileReader drains to
+// EAGAIN on every dispatch so level-triggered cannot busy-loop; a dropped slot
+// is harmless because the next epoll_wait just returns it again.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux } from "harness";
+import { join } from "node:path";
+
+// The ready_polls clobber is documented behaviour on epoll+kqueue; this test
+// relies on the Linux pidfd + epoll path specifically to reproduce it.
+test.skipIf(!isLinux)(
+  "stdin FileReader readable survives nested event-loop tick dropping its ready_polls slot",
+  async () => {
+    // The fixture arranges for its stdin readable and a batch of pidfd exits
+    // to be reported by a single epoll_wait, with the pidfds first (it spins
+    // synchronously while /bin/true exits and our byte lands). The first
+    // onExit then forces a nested tick that drops the rest of the outer batch.
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "stdin-readable-nested-tick-fixture.ts")],
+      env: bunEnv,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    let out = "";
+    const reader = proc.stdout.getReader();
+    while (!out.includes("READY")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      out += new TextDecoder().decode(value);
+    }
+    proc.stdin.write("X");
+    proc.stdin.flush();
+
+    // With the one-shot bug: stdin's fd is disarmed before dispatch, the
+    // pending read never resolves, and the fixture hangs until the test
+    // timeout with no other wake source.
+    const rest = (async () => {
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        out += new TextDecoder().decode(value);
+      }
+    })();
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, rest]);
+
+    expect({ out: out.trim(), stderr, exitCode }).toEqual({
+      out: "READY\nGOT:X",
+      stderr: "",
+      exitCode: 0,
+    });
+  },
+);


### PR DESCRIPTION
## What does this PR do?

Registers `FileReader`'s `PosixBufferedReader` poll level-triggered (no `EPOLLONESHOT` / `EV_ONESHOT`), matching the pidfd poll in [`src/spawn/process.rs:69-94`](https://github.com/oven-sh/bun/blob/main/src/spawn/process.rs#L69-L94).

A one-shot readable is disarmed by the kernel the instant `epoll_wait` returns it, before user-space has dispatched it. If that slot is dropped before `on_update` reaches it, the fd is left disarmed with no re-arm path: `FileReader::on_pull` returns `Pending` without touching it (`has_pending_read()` stays true because `PollReadable` is still set in userspace), and the pending `reader.read()` never resolves. `process.stdin` goes input-deaf.

With level-triggered registration, a dropped ready_polls slot is harmless: the next `epoll_wait` re-reports it. This is safe for `FileReader` because `on_read_chunk` drains to EAGAIN on every dispatch and only returns `false` after `close()` (which unregisters the poll), so it cannot busy-loop. `pause()` explicitly unregisters. Other `BufferedReaderParent`s (the shell reader) are unchanged and keep one-shot.

One known way to drop a ready_polls slot is a nested `us_loop_run_bun_tick` overwriting the shared `ready_polls` / `num_ready_polls` / `current_ready_poll` (#33261); the test here reproduces that deterministically. Level-triggered also hardens the poll against any other cause of a lost dispatch.

## Verification

`/proc/self/fdinfo` for the child's epoll shows the stdin tfd registered with `events: 19` (level-triggered) instead of `events: 40000019` (one-shot) after this change.

`test/js/bun/spawn/stdin-readable-nested-tick.test.ts`: the fixture spawns 20 fast-exiting children, spins synchronously so the pidfd readable events queue on epoll's ready list, then registers stdin's poll and lets a byte arrive during a second spin; the first `onExit` forces a synchronous nested tick via `expect(Bun.sleep(1)).resolves`.

```
# main (5/5)
(fail) stdin FileReader readable survives nested event-loop tick dropping its ready_polls slot [5000.33ms]
  ^ this test timed out after 5000ms.

# this PR (5/5)
(pass) stdin FileReader readable survives nested event-loop tick dropping its ready_polls slot [1630.35ms]
```

`terminal.test.ts`, `terminal-spawn.test.ts`, `terminal-platform-gaps.test.ts`, `stdin_fell_asleep.test.ts`, `pidfd-exit-nested-tick.test.ts`, `streams.test.js`, `spawn.test.ts`, `spawn-streaming-*.test.ts` pass; `cargo check` is clean for `x86_64-apple-darwin` and `x86_64-pc-windows-msvc`.

## Context

This was investigated for a PTY REPL going input-deaf mid-session under load (typed bytes buffered, event loop alive, `wchan=ep_poll`, writing more un-wedges it and the stalled bytes process too). That code path does not re-enter the event loop via `waitForPromise`, so the nested-tick reproduction in the test is not the production trigger for that specific regression; the level-triggered change closes the symptom class regardless of which step drops the dispatch, but the regression's exact trigger is still open.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/stdin-readable-nested-tick.test.ts

<!-- robobun:evidence:end -->