### PR TITLE
HTMLRewriter: empty ^= $= ~= attribute selectors match nothing

### DIFF
--- a/patches/lolhtml/empty-attr-operand.patch
+++ b/patches/lolhtml/empty-attr-operand.patch
@@ -1,0 +1,52 @@
+--- a/src/selectors_vm/attribute_matcher.rs
++++ b/src/selectors_vm/attribute_matcher.rs
+@@ -123,6 +123,10 @@
+ 
+     #[inline]
+     pub fn matches_splitted_by_whitespace(&self, operand: &AttrExprOperands) -> bool {
++        if operand.value.is_empty() {
++            return false;
++        }
++
+         self.value_matches(&operand.name, |actual_value| {
+             let case_sensitivity = to_unconditional(operand.case_sensitivity, self.is_html_element);
+ 
+@@ -134,13 +138,16 @@
+ 
+     #[inline]
+     pub fn has_attr_with_prefix(&self, operand: &AttrExprOperands) -> bool {
++        if operand.value.is_empty() {
++            return false;
++        }
++
+         self.value_matches(&operand.name, |actual_value| {
+             let case_sensitivity = to_unconditional(operand.case_sensitivity, self.is_html_element);
+ 
+             let prefix_len = operand.value.len();
+ 
+-            !actual_value.is_empty()
+-                && actual_value.len() >= prefix_len
++            actual_value.len() >= prefix_len
+                 && actual_value
+                     .get(..prefix_len)
+                     .is_some_and(|prefix| case_sensitivity.eq(prefix, &operand.value))
+@@ -167,14 +174,17 @@
+ 
+     #[inline]
+     pub fn has_attr_with_suffix(&self, operand: &AttrExprOperands) -> bool {
++        if operand.value.is_empty() {
++            return false;
++        }
++
+         self.value_matches(&operand.name, |actual_value| {
+             let case_sensitivity = to_unconditional(operand.case_sensitivity, self.is_html_element);
+ 
+             let suffix_len = operand.value.len();
+             let value_len = actual_value.len();
+ 
+-            !actual_value.is_empty()
+-                && value_len >= suffix_len
++            value_len >= suffix_len
+                 && actual_value
+                     .get(value_len - suffix_len..)
+                     .is_some_and(|prefix| case_sensitivity.eq(prefix, &operand.value))

--- a/scripts/build/deps/lolhtml.ts
+++ b/scripts/build/deps/lolhtml.ts
@@ -33,6 +33,10 @@ export const lolhtml: Dependency = {
     commit: LOLHTML_COMMIT,
   }),
 
+  // CSS Selectors spec: [x^=""], [x$=""], [x~=""] represent nothing and
+  // must never match. Upstream as https://github.com/cloudflare/lol-html.
+  patches: ["patches/lolhtml/empty-attr-operand.patch"],
+
   // No separate build — compiled as part of the workspace cargo build via
   // `bun_runtime`/`bun_bundler`'s path dep on `vendor/lolhtml`.
   build: () => ({ kind: "none" }),

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -683,6 +683,41 @@ describe("HTMLRewriter", () => {
     );
   });
 
+  it("attribute selectors with an empty value match nothing (css3-modsel-184)", () => {
+    // CSS Selectors: [x^=""], [x$=""], [x~=""], [x*=""] represent nothing and never match.
+    const doc = '<a i="0" x=""></a><a i="1" x="v"></a><a i="2" x="a  b"></a><a i="3"></a>';
+    const hits = selector => {
+      const matched = [];
+      new HTMLRewriter()
+        .on(selector, {
+          element(e) {
+            matched.push(e.getAttribute("i"));
+          },
+        })
+        .transform(doc);
+      return matched;
+    };
+
+    expect(hits('[x^=""]')).toEqual([]);
+    expect(hits('[x$=""]')).toEqual([]);
+    expect(hits('[x~=""]')).toEqual([]);
+    expect(hits('[x*=""]')).toEqual([]);
+    // case-insensitive variants take the same guard path
+    expect(hits('[x^="" i]')).toEqual([]);
+    expect(hits('[x$="" i]')).toEqual([]);
+    expect(hits('[x~="" i]')).toEqual([]);
+    // :not() over a selector that matches nothing matches everything
+    expect(hits('a:not([x^=""])')).toEqual(["0", "1", "2", "3"]);
+    expect(hits('a:not([x$=""])')).toEqual(["0", "1", "2", "3"]);
+    expect(hits('a:not([x~=""])')).toEqual(["0", "1", "2", "3"]);
+    // [x=""] is exact-match and must still match the empty attribute
+    expect(hits('[x=""]')).toEqual(["0"]);
+    // non-empty operands are unaffected
+    expect(hits('[x^="v"]')).toEqual(["1"]);
+    expect(hits('[x$="b"]')).toEqual(["2"]);
+    expect(hits('[x~="a"]')).toEqual(["2"]);
+  });
+
   it("supports deleting innerContent", async () => {
     expect(
       await new HTMLRewriter()


### PR DESCRIPTION
Per CSS Selectors, `[x^=""]`, `[x$=""]`, and `[x~=""]` represent nothing and must never match (css3-modsel-184a/b/c, which are already in `vendor/lolhtml/tests/data/selector_matching/`). Bun matched plenty.

## Reproduction

```js
const doc = `<a i="0" x=""></a><a i="1" x="v"></a><a i="2" x="a  b"></a><a i="3"></a>`;
const hits = sel => {
  const h = [];
  new HTMLRewriter().on(sel, { element(e) { h.push(e.getAttribute("i")); } }).transform(doc);
  return `[${h.join(",")}]`;
};
for (const [sel, want] of [
  [`[x^=""]`,        "[]"],          // bun: [1,2]
  [`[x$=""]`,        "[]"],          // bun: [1,2]
  [`[x~=""]`,        "[]"],          // bun: [0,2]
  [`[x*=""]`,        "[]"],          // ok
  [`[x=""]`,         "[0]"],         // ok
  [`a:not([x^=""])`, "[0,1,2,3]"],   // bun: [0,3]
]) console.log(hits(sel) === want ? "ok " : "BUG", sel, "got", hits(sel), "want", want);
```

Empty operands arrive naturally from templated selectors like `` `[data-x^="${prefix}"]` ``, where an empty `prefix` flips from "match nothing" to "match every element carrying the attribute", and `:not()` guards that should be vacuous start excluding real elements.

## Cause

In `lol_html`'s `selectors_vm/attribute_matcher.rs`:

- `has_attr_with_prefix` / `has_attr_with_suffix` guard only `!actual_value.is_empty()`, then compare a zero-length slice of the actual value against the empty operand, which always succeeds. So `[x^=""]` / `[x$=""]` match every element with a non-empty `x`.
- `matches_splitted_by_whitespace` (`~=`) has no empty-operand guard. Splitting `x=""` or `x="a  b"` by whitespace yields an empty part that compares equal to the empty operand.
- `has_attr_with_substring` (`*=`) already rejects an empty operand via `split_first()`.

## Fix

Add an `operand.value.is_empty() -> false` early return to `matches_splitted_by_whitespace`, `has_attr_with_prefix`, and `has_attr_with_suffix`, mirroring the `*=` guard. Shipped as `patches/lolhtml/empty-attr-operand.patch` since `vendor/lolhtml` is fetched from upstream at build time.

`[x=""]` (exact match) remains unchanged and still matches an empty attribute value.

## Verification

New test in `test/js/workerd/html-rewriter.test.js` covers `^=` `$=` `~=` `*=` with empty operands (both case-sensitive and `i`), their `:not()` forms, exact `=""` match, and non-empty operands as a non-regression check. Fails on 1.4.0 / current main, passes with the patch.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/workerd/html-rewriter.test.js'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/workerd/html-rewriter.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f793acb02)

test/js/workerd/html-rewriter.test.js:
(pass) HTMLRewriter > error handling [4.34ms]
(pass) HTMLRewriter > error inside element handler [6.03ms]
(pass) HTMLRewriter > error inside element handler (string) [4.49ms]
(pass) HTMLRewriter > fast async error inside element handler [21.49ms]
(pass) HTMLRewriter > slow async error inside element handler [17.49ms]
(pass) HTMLRewriter > HTMLRewriter: async replacement [112.38ms]
(pass) HTMLRewriter > HTMLRewriter handles Symbol invalid type error [12.78ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > control: .text() on the untransformed response rejects [325.63ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .text() on the transformed response rejects [54.99ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .arrayBuffer() on the transformed response rejects [42.60ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .body on the transformed response is an errored stream [46.40ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > a read already pending on .body when the upstream fails rejects [44.03ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .clone() of a failed transformed body is also failed [34.02ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > does not invoke onDocument end for a document that never completed [53.41ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > transform() of a body that already failed throws the u
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
patches/lolhtml/empty-attr-operand.patch | 52 ++++++++++++++++++++++++++++++++
 scripts/build/deps/lolhtml.ts            |  4 +++
 test/js/workerd/html-rewriter.test.js    | 35 +++++++++++++++++++++
 3 files changed, 91 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
patches/lolhtml/empty-attr-operand.patch      1      1      0
scripts/build/deps/lolhtml.ts                 1      1      0
test/js/workerd/html-rewriter.test.js         2      1      0
```

</details>

<!-- robobun:evidence:end -->