### PR TITLE
fetch: report TLS protocol errors as ERR_TLS_HANDSHAKE_FAILED instead of ConnectionRefused / unknown-cert

### DIFF
--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -1189,10 +1189,15 @@ impl<const SSL: bool> Handler<SSL> {
                 // if we are here is because server rejected us, and the error_no is the cause of this
                 // if we set reject_unauthorized == false this means the server requires custom CA aka NODE_EXTRA_CA_CERTS
                 if client.flags.did_have_handshaking_error {
-                    client.close_and_fail::<SSL>(
-                        get_cert_error_from_no(handshake_error.error_no),
-                        socket,
-                    );
+                    // Negative error_no is the EPROTO/ECONNRESET sentinel
+                    // from the handshake layer (not an X509_V_ERR_* code):
+                    // the peer isn't speaking TLS.
+                    let err = if handshake_error.error_no < 0 {
+                        crate::Error::TLSHandshakeFailed
+                    } else {
+                        get_cert_error_from_no(handshake_error.error_no)
+                    };
+                    client.close_and_fail::<SSL>(err, socket);
                     return;
                 }
                 // if handshake_success it self is false, this means that the connection was rejected

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -1189,10 +1189,12 @@ impl<const SSL: bool> Handler<SSL> {
                 // if we are here is because server rejected us, and the error_no is the cause of this
                 // if we set reject_unauthorized == false this means the server requires custom CA aka NODE_EXTRA_CA_CERTS
                 if client.flags.did_have_handshaking_error {
-                    // Negative error_no is the EPROTO/ECONNRESET sentinel
-                    // from the handshake layer (not an X509_V_ERR_* code):
-                    // the peer isn't speaking TLS.
-                    let err = if handshake_error.error_no < 0 {
+                    // -71 is the EPROTO sentinel from the handshake layer
+                    // (peer sent bytes that are not a TLS record, e.g.
+                    // WRONG_VERSION_NUMBER). Other values, including the
+                    // -46 ECONNRESET sentinel, fall through to the
+                    // cert-error lookup.
+                    let err = if handshake_error.error_no == -71 {
                         crate::Error::TLSHandshakeFailed
                     } else {
                         get_cert_error_from_no(handshake_error.error_no)

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -1189,12 +1189,11 @@ impl<const SSL: bool> Handler<SSL> {
                 // if we are here is because server rejected us, and the error_no is the cause of this
                 // if we set reject_unauthorized == false this means the server requires custom CA aka NODE_EXTRA_CA_CERTS
                 if client.flags.did_have_handshaking_error {
-                    // -71 is the EPROTO sentinel from the handshake layer
-                    // (peer sent bytes that are not a TLS record, e.g.
-                    // WRONG_VERSION_NUMBER). Other values, including the
-                    // -46 ECONNRESET sentinel, fall through to the
-                    // cert-error lookup.
-                    let err = if handshake_error.error_no == -71 {
+                    // The EPROTO sentinel (peer sent bytes that are not a TLS
+                    // record, e.g. WRONG_VERSION_NUMBER) is not an X509_V_ERR_*
+                    // code. Other values, including the ECONNRESET sentinel,
+                    // fall through to the cert-error lookup.
+                    let err = if handshake_error.error_no == uws::HANDSHAKE_EPROTO_SENTINEL {
                         crate::Error::TLSHandshakeFailed
                     } else {
                         get_cert_error_from_no(handshake_error.error_no)

--- a/src/http/ProxyTunnel.rs
+++ b/src/http/ProxyTunnel.rs
@@ -456,10 +456,10 @@ fn on_handshake(
         // if we are here is because server rejected us, and the error_no is the cause of this
         // if we set reject_unauthorized == false this means the server requires custom CA aka NODE_EXTRA_CA_CERTS
         if this.flags.did_have_handshaking_error {
-            // -71 is the EPROTO sentinel from SSLWrapper (peer sent bytes
-            // that are not a TLS record). Other values fall through to the
+            // The EPROTO sentinel (peer sent bytes that are not a TLS record)
+            // is not an X509_V_ERR_* code. Other values fall through to the
             // cert-error lookup.
-            let err = if handshake_error.error_no == -71 {
+            let err = if handshake_error.error_no == uws::HANDSHAKE_EPROTO_SENTINEL {
                 crate::Error::TLSHandshakeFailed
             } else {
                 crate::get_cert_error_from_no(handshake_error.error_no)

--- a/src/http/ProxyTunnel.rs
+++ b/src/http/ProxyTunnel.rs
@@ -378,10 +378,10 @@ fn on_handshake(
     this.state.request_stage = HTTPStage::ProxyHeaders;
     this.state.request_sent_len = 0;
     let handshake_error = HTTPCertError::from_verify_error(ssl_error);
+    // handshake completed but we may have ssl errors
+    this.flags.did_have_handshaking_error = handshake_error.error_no != 0;
     if handshake_success {
         scoped_log!(http_proxy_tunnel, "ProxyTunnel onHandshake success");
-        // handshake completed but we may have ssl errors
-        this.flags.did_have_handshaking_error = handshake_error.error_no != 0;
         if this.flags.reject_unauthorized {
             // only reject the connection if reject_unauthorized == true
             if this.flags.did_have_handshaking_error {
@@ -455,8 +455,16 @@ fn on_handshake(
         scoped_log!(http_proxy_tunnel, "ProxyTunnel onHandshake failed");
         // if we are here is because server rejected us, and the error_no is the cause of this
         // if we set reject_unauthorized == false this means the server requires custom CA aka NODE_EXTRA_CA_CERTS
-        if this.flags.did_have_handshaking_error && handshake_error.error_no != 0 {
-            let err = crate::get_cert_error_from_no(handshake_error.error_no);
+        if this.flags.did_have_handshaking_error {
+            // Negative error_no is the EPROTO/ECONNRESET sentinel from the
+            // handshake layer (not an X509_V_ERR_* code): the peer isn't
+            // speaking TLS, so report a handshake failure rather than a
+            // certificate error or ConnectionRefused.
+            let err = if handshake_error.error_no < 0 {
+                crate::Error::TLSHandshakeFailed
+            } else {
+                crate::get_cert_error_from_no(handshake_error.error_no)
+            };
             // SAFETY: `this` dead (NLL); reenter via raw ptr.
             ProxyTunnel::close_from_callback(proxy_nn, err);
             return;

--- a/src/http/ProxyTunnel.rs
+++ b/src/http/ProxyTunnel.rs
@@ -456,11 +456,10 @@ fn on_handshake(
         // if we are here is because server rejected us, and the error_no is the cause of this
         // if we set reject_unauthorized == false this means the server requires custom CA aka NODE_EXTRA_CA_CERTS
         if this.flags.did_have_handshaking_error {
-            // Negative error_no is the EPROTO/ECONNRESET sentinel from the
-            // handshake layer (not an X509_V_ERR_* code): the peer isn't
-            // speaking TLS, so report a handshake failure rather than a
-            // certificate error or ConnectionRefused.
-            let err = if handshake_error.error_no < 0 {
+            // -71 is the EPROTO sentinel from SSLWrapper (peer sent bytes
+            // that are not a TLS record). Other values fall through to the
+            // cert-error lookup.
+            let err = if handshake_error.error_no == -71 {
                 crate::Error::TLSHandshakeFailed
             } else {
                 crate::get_cert_error_from_no(handshake_error.error_no)

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -45,6 +45,8 @@ pub enum Error {
     DNSResolveFailed,
     #[error("ConnectionRefused")]
     ConnectionRefused,
+    #[error("ERR_TLS_HANDSHAKE_FAILED")]
+    TLSHandshakeFailed,
     #[error("TooManyRedirects")]
     TooManyRedirects,
     #[error("HTTP3Unsupported")]
@@ -282,6 +284,7 @@ impl Error {
             Self::ConnectionClosed => "ConnectionClosed",
             Self::DNSResolveFailed => "DNSResolveFailed",
             Self::ConnectionRefused => "ConnectionRefused",
+            Self::TLSHandshakeFailed => "ERR_TLS_HANDSHAKE_FAILED",
             Self::TooManyRedirects => "TooManyRedirects",
             Self::HTTP3Unsupported => "HTTP3Unsupported",
             Self::ResponseHeadersTooLarge => "ResponseHeadersTooLarge",

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1345,6 +1345,9 @@ impl FetchTasklet {
             http::Error::ConnectionRefused => {
                 BunString::static_("Unable to connect. Is the computer able to access the url?")
             }
+            http::Error::TLSHandshakeFailed => BunString::static_(
+                "TLS handshake failed: the server (or a proxy along the path) did not respond with a valid TLS ServerHello",
+            ),
             http::Error::RedirectURLInvalid => {
                 BunString::static_("Redirect URL in Location header is invalid.")
             }

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1346,7 +1346,7 @@ impl FetchTasklet {
                 BunString::static_("Unable to connect. Is the computer able to access the url?")
             }
             http::Error::TLSHandshakeFailed => BunString::static_(
-                "TLS handshake failed: the server (or a proxy along the path) did not respond with a valid TLS ServerHello",
+                "TLS handshake failed: the server (or a proxy along the path) responded with data that is not valid TLS",
             ),
             http::Error::RedirectURLInvalid => {
                 BunString::static_("Redirect URL in Location header is invalid.")

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -156,7 +156,8 @@ pub mod ssl_wrapper {
     mod boring_sys {
         pub(super) use bun_boringssl::c::{
             BIO_ctrl_pending, BIO_free, BIO_new, BIO_read, BIO_s_mem, BIO_set_mem_eof_return,
-            BIO_write, ERR_clear_error, SSL, SSL_CTX, SSL_CTX_free, SSL_CTX_get_verify_mode,
+            BIO_write, ERR_clear_error, ERR_peek_last_error, ERR_reason_error_string, SSL,
+            SSL_CTX, SSL_CTX_free, SSL_CTX_get_verify_mode,
             SSL_ERROR_SSL, SSL_ERROR_SYSCALL, SSL_ERROR_WANT_READ, SSL_ERROR_WANT_RENEGOTIATE,
             SSL_ERROR_WANT_WRITE, SSL_ERROR_ZERO_RETURN, SSL_RECEIVED_SHUTDOWN, SSL_VERIFY_NONE,
             SSL_VERIFY_PEER, SSL_do_handshake, SSL_free, SSL_get_error, SSL_get_rbio,
@@ -899,6 +900,14 @@ pub mod ssl_wrapper {
             if result <= 0 {
                 // SAFETY: ssl is still valid.
                 let err = unsafe { boring_sys::SSL_get_error(ssl.as_ptr(), result) };
+                // Capture the protocol-level reason (e.g. WRONG_VERSION_NUMBER)
+                // before draining the queue so the handshake callback can report
+                // it. Mirrors `ssl_park_fatal_reason` in openssl.c.
+                let ssl_queue_err = if err == boring_sys::SSL_ERROR_SSL {
+                    boring_sys::ERR_peek_last_error()
+                } else {
+                    0
+                };
                 boring_sys::ERR_clear_error();
                 if err == boring_sys::SSL_ERROR_ZERO_RETURN {
                     // Remotely-Initiated Shutdown
@@ -920,7 +929,19 @@ pub mod ssl_wrapper {
                     Self::r(this)
                         .flags
                         .set_handshake_state(HandshakeState::HandshakeCompleted);
-                    let verify = Self::r(this).get_verify_error();
+                    let verify = if ssl_queue_err != 0 {
+                        // Same shape `ssl_dispatch_parked_reason` (openssl.c)
+                        // dispatches for a fatal handshake error: error_no =
+                        // -71 (EPROTO sentinel), reason from BoringSSL's
+                        // static error-string table.
+                        us_bun_verify_error_t {
+                            error_no: -71,
+                            code: c"EPROTO".as_ptr(),
+                            reason: boring_sys::ERR_reason_error_string(ssl_queue_err),
+                        }
+                    } else {
+                        Self::r(this).get_verify_error()
+                    };
                     Self::r(this).trigger_handshake_callback(false, verify);
 
                     if Self::r(this).flags.fatal_error() {

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -156,15 +156,15 @@ pub mod ssl_wrapper {
     mod boring_sys {
         pub(super) use bun_boringssl::c::{
             BIO_ctrl_pending, BIO_free, BIO_new, BIO_read, BIO_s_mem, BIO_set_mem_eof_return,
-            BIO_write, ERR_clear_error, ERR_peek_last_error, ERR_reason_error_string, SSL,
-            SSL_CTX, SSL_CTX_free, SSL_CTX_get_verify_mode,
-            SSL_ERROR_SSL, SSL_ERROR_SYSCALL, SSL_ERROR_WANT_READ, SSL_ERROR_WANT_RENEGOTIATE,
-            SSL_ERROR_WANT_WRITE, SSL_ERROR_ZERO_RETURN, SSL_RECEIVED_SHUTDOWN, SSL_VERIFY_NONE,
-            SSL_VERIFY_PEER, SSL_do_handshake, SSL_free, SSL_get_error, SSL_get_rbio,
-            SSL_get_shutdown, SSL_get_wbio, SSL_is_init_finished, SSL_new, SSL_pending, SSL_read,
-            SSL_renegotiate, SSL_set_accept_state, SSL_set_bio, SSL_set_connect_state,
-            SSL_set_renegotiate_mode, SSL_set_verify, SSL_set0_verify_cert_store, SSL_shutdown,
-            SSL_write, X509_STORE, X509_STORE_CTX, ssl_renegotiate_explicit, ssl_renegotiate_never,
+            BIO_write, ERR_clear_error, ERR_peek_last_error, ERR_reason_error_string, SSL, SSL_CTX,
+            SSL_CTX_free, SSL_CTX_get_verify_mode, SSL_ERROR_SSL, SSL_ERROR_SYSCALL,
+            SSL_ERROR_WANT_READ, SSL_ERROR_WANT_RENEGOTIATE, SSL_ERROR_WANT_WRITE,
+            SSL_ERROR_ZERO_RETURN, SSL_RECEIVED_SHUTDOWN, SSL_VERIFY_NONE, SSL_VERIFY_PEER,
+            SSL_do_handshake, SSL_free, SSL_get_error, SSL_get_rbio, SSL_get_shutdown,
+            SSL_get_wbio, SSL_is_init_finished, SSL_new, SSL_pending, SSL_read, SSL_renegotiate,
+            SSL_set_accept_state, SSL_set_bio, SSL_set_connect_state, SSL_set_renegotiate_mode,
+            SSL_set_verify, SSL_set0_verify_cert_store, SSL_shutdown, SSL_write, X509_STORE,
+            X509_STORE_CTX, ssl_renegotiate_explicit, ssl_renegotiate_never,
         };
     }
 

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -93,7 +93,10 @@ pub use bun_uws_sys::{
 // Re-export the `_sys` definitions so higher tiers see one type. `to_js`
 // (`createBunSocketErrorToJS` / `verifyErrorToJS`) live as extension traits
 // in the *_jsc crate.
-pub use bun_uws_sys::{Opcode, SendStatus, create_bun_socket_error_t, us_bun_verify_error_t};
+pub use bun_uws_sys::{
+    HANDSHAKE_ECONNRESET_SENTINEL, HANDSHAKE_EPROTO_SENTINEL, Opcode, SendStatus,
+    create_bun_socket_error_t, us_bun_verify_error_t,
+};
 
 /// Owned socket-address shape (boxed IP). Distinct from the sys type by
 /// design — that one stores the IP text inline as returned from
@@ -931,11 +934,10 @@ pub mod ssl_wrapper {
                         .set_handshake_state(HandshakeState::HandshakeCompleted);
                     let verify = if ssl_queue_err != 0 {
                         // Same shape `ssl_dispatch_parked_reason` (openssl.c)
-                        // dispatches for a fatal handshake error: error_no =
-                        // -71 (EPROTO sentinel), reason from BoringSSL's
-                        // static error-string table.
+                        // dispatches for a fatal handshake error; reason is from
+                        // BoringSSL's static error-string table.
                         us_bun_verify_error_t {
-                            error_no: -71,
+                            error_no: crate::HANDSHAKE_EPROTO_SENTINEL,
                             code: c"EPROTO".as_ptr(),
                             reason: boring_sys::ERR_reason_error_string(ssl_queue_err),
                         }

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -34,6 +34,14 @@ pub const LIBUS_LISTEN_DISALLOW_REUSE_PORT_FAILURE: core::ffi::c_int = 32;
 /// BoringSSL `SSL_CTX` (alias so callers don't need a direct boringssl dep).
 pub type SslCtx = bun_boringssl_sys::SSL_CTX;
 
+/// `error_no` sentinel dispatched by `ssl_dispatch_parked_reason` (openssl.c)
+/// and `SSLWrapper::update_handshake_state` for a fatal TLS protocol error
+/// (BoringSSL `SSL_ERROR_SSL`). Negated Linux `EPROTO`; used cross-platform.
+pub const HANDSHAKE_EPROTO_SENTINEL: core::ffi::c_int = -71;
+/// `error_no` sentinel dispatched by `ssl_trigger_handshake_econnreset`
+/// (openssl.c) when the socket closes before the handshake completes.
+pub const HANDSHAKE_ECONNRESET_SENTINEL: core::ffi::c_int = -46;
+
 /// `struct us_bun_verify_error_t` — TLS handshake verification result.
 ///
 /// Field is named `error_no` so the Node-compat

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -708,29 +708,21 @@ describe.concurrent("fetch-tls", () => {
     direct.listen(0, "127.0.0.1");
     await once(direct, "listening");
 
-    // A port we know is refused.
-    const refused = net.createServer();
-    refused.listen(0, "127.0.0.1");
-    await once(refused, "listening");
-    const refusedPort = (refused.address() as net.AddressInfo).port;
-    refused.close();
-    await once(refused, "close");
-
     try {
       const proxyPort = (proxy.address() as net.AddressInfo).port;
       const directPort = (direct.address() as net.AddressInfo).port;
 
       // Spawn a subprocess with proxy-bypass env cleared so the explicit
       // `proxy:` option is honored for loopback targets regardless of the
-      // ambient environment.
+      // ambient environment. Port 1 (tcpmux) is the refused-connection control.
       const fixture = `
         const probe = async (url, proxy) => {
           try { await fetch(url, proxy ? { proxy } : {}); return "RESOLVED"; }
           catch (e) { return e?.code ?? "NO_CODE"; }
         };
         const [tunnelGarbage, proxyRefused, directGarbage] = await Promise.all([
-          probe("https://127.0.0.1:${refusedPort}/x", "http://127.0.0.1:${proxyPort}"),
-          probe("https://127.0.0.1:${refusedPort}/x", "http://127.0.0.1:${refusedPort}"),
+          probe("https://127.0.0.1:1/x", "http://127.0.0.1:${proxyPort}"),
+          probe("https://127.0.0.1:1/x", "http://127.0.0.1:1"),
           probe("https://127.0.0.1:${directPort}/x"),
         ]);
         console.log(JSON.stringify({ tunnelGarbage, proxyRefused, directGarbage }));

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isASAN, tmpdirSync } from "harness";
+import { once } from "node:events";
+import net from "node:net";
 import { join } from "node:path";
 import tls from "node:tls";
-import net from "node:net";
-import { once } from "node:events";
 
 type TLSOptions = {
   cert: string;
@@ -746,11 +746,7 @@ describe.concurrent("fetch-tls", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect({ result: JSON.parse(stdout.trim() || "null"), stderr }).toEqual({
         result: {
           tunnelGarbage: "ERR_TLS_HANDSHAKE_FAILED",

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -526,7 +526,10 @@ describe.concurrent("fetch-tls", () => {
   it("fetch timeout works on tls", async () => {
     using server = Bun.serve({
       tls: validTls,
-      hostname: "localhost",
+      // Bind the IPv4 loopback explicitly: `hostname: "localhost"` binds ::1
+      // only on some hosts while fetch connects to 127.0.0.1, failing with
+      // ConnectionRefused before the timeout under test can ever fire.
+      hostname: "127.0.0.1",
       port: 0,
       rejectUnauthorized: false,
       async fetch() {

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isASAN, tmpdirSync } from "harness";
 import { join } from "node:path";
 import tls from "node:tls";
+import net from "node:net";
+import { once } from "node:events";
 
 type TLSOptions = {
   cert: string;
@@ -668,6 +670,99 @@ describe.concurrent("fetch-tls", () => {
       const stderr = await proc.stderr.text();
       expect(stderr).toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
       expect(stderr).toContain("ignoring extra certs");
+    }
+  });
+
+  // A TLS protocol-level failure (the peer answers the ClientHello with bytes
+  // that are not a TLS record) must surface as a TLS handshake error, not as
+  // ConnectionRefused (which is what a dead/refusing endpoint reports) and not
+  // as a certificate verification error. The three failure classes must be
+  // distinguishable regardless of whether a CONNECT proxy is in the path.
+  it("reports a TLS handshake error (not ConnectionRefused or a certificate error) when the peer speaks non-TLS, with and without a CONNECT proxy", async () => {
+    const garbage = Buffer.alloc(480, "GARBAGE NOT TLS ");
+
+    // CONNECT proxy that answers 200 then feeds garbage into the tunnel.
+    const proxy = net.createServer(cs => {
+      cs.on("error", () => {});
+      let buf = "";
+      cs.on("data", d => {
+        buf += d;
+        if (buf.includes("\r\n\r\n") && buf.startsWith("CONNECT")) {
+          cs.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+          cs.write(garbage);
+          buf = "";
+        }
+      });
+    });
+    proxy.listen(0, "127.0.0.1");
+    await once(proxy, "listening");
+
+    // Direct TCP server that answers any bytes (the ClientHello) with garbage.
+    const direct = net.createServer(s => {
+      s.on("error", () => {});
+      s.on("data", () => s.write(garbage));
+    });
+    direct.listen(0, "127.0.0.1");
+    await once(direct, "listening");
+
+    // A port we know is refused.
+    const refused = net.createServer();
+    refused.listen(0, "127.0.0.1");
+    await once(refused, "listening");
+    const refusedPort = (refused.address() as net.AddressInfo).port;
+    refused.close();
+    await once(refused, "close");
+
+    try {
+      const proxyPort = (proxy.address() as net.AddressInfo).port;
+      const directPort = (direct.address() as net.AddressInfo).port;
+
+      // Spawn a subprocess with proxy-bypass env cleared so the explicit
+      // `proxy:` option is honored for loopback targets regardless of the
+      // ambient environment.
+      const fixture = `
+        const probe = async (url, proxy) => {
+          try { await fetch(url, proxy ? { proxy } : {}); return "RESOLVED"; }
+          catch (e) { return e?.code ?? "NO_CODE"; }
+        };
+        const [tunnelGarbage, proxyRefused, directGarbage] = await Promise.all([
+          probe("https://127.0.0.1:${refusedPort}/x", "http://127.0.0.1:${proxyPort}"),
+          probe("https://127.0.0.1:${refusedPort}/x", "http://127.0.0.1:${refusedPort}"),
+          probe("https://127.0.0.1:${directPort}/x"),
+        ]);
+        console.log(JSON.stringify({ tunnelGarbage, proxyRefused, directGarbage }));
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: {
+          ...bunEnv,
+          NO_PROXY: undefined,
+          no_proxy: undefined,
+          HTTP_PROXY: undefined,
+          http_proxy: undefined,
+          HTTPS_PROXY: undefined,
+          https_proxy: undefined,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect({ result: JSON.parse(stdout.trim() || "null"), stderr }).toEqual({
+        result: {
+          tunnelGarbage: "ERR_TLS_HANDSHAKE_FAILED",
+          proxyRefused: "ConnectionRefused",
+          directGarbage: "ERR_TLS_HANDSHAKE_FAILED",
+        },
+        stderr: expect.any(String),
+      });
+      expect(exitCode).toBe(0);
+    } finally {
+      proxy.close();
+      direct.close();
     }
   });
 });


### PR DESCRIPTION
When a server (or the upstream inside a CONNECT proxy tunnel) answers the ClientHello with bytes that are not a TLS record, the handshake fails at the protocol level (BoringSSL: `WRONG_VERSION_NUMBER`). `fetch()` was misreporting this in two different ways depending on topology:

```
through a CONNECT proxy:  code=ConnectionRefused
direct connection:        code=UNKNOWN_CERTIFICATE_VERIFICATION_ERROR
```

Both identities are wrong. A live-but-mangling proxy (interception-grade middlebox, protocol downgrade) was therefore byte-identical to a dead one, and a non-TLS direct peer was reported as a certificate verification problem. Node reports the same scenario as `ERR_SSL_WRONG_VERSION_NUMBER` (distinguishable from `ECONNREFUSED`).

#### Reproduction

```js
import net from "node:net";
const proxy = net.createServer(cs => {
  cs.on("error", () => {});
  let b = "";
  cs.on("data", d => {
    b += d;
    if (b.includes("\r\n\r\n") && b.startsWith("CONNECT")) {
      cs.write("HTTP/1.1 200 Connection Established\r\n\r\n");
      cs.write("GARBAGE NOT TLS ".repeat(30));
      b = "";
    }
  });
});
await new Promise(r => proxy.listen(0, "127.0.0.1", r));
const direct = net.createServer(s => { s.on("error", () => {}); s.on("data", () => s.write("GARBAGE NOT TLS ".repeat(30))); });
await new Promise(r => direct.listen(0, "127.0.0.1", r));

const probe = async (tag, url, p) => {
  try { await fetch(url, p ? { proxy: p } : {}); }
  catch (e) { console.log(tag, e?.code); }
};
await probe("tunnel-garbage", "https://127.0.0.1:1/x", `http://127.0.0.1:${proxy.address().port}`);
await probe("proxy-refused ", "https://127.0.0.1:1/x", "http://127.0.0.1:9");
await probe("direct-garbage", `https://127.0.0.1:${direct.address().port}/x`);
```

Before:
```
tunnel-garbage ConnectionRefused
proxy-refused  ConnectionRefused
direct-garbage UNKNOWN_CERTIFICATE_VERIFICATION_ERROR
```

After:
```
tunnel-garbage ERR_TLS_HANDSHAKE_FAILED
proxy-refused  ConnectionRefused
direct-garbage ERR_TLS_HANDSHAKE_FAILED
```

#### Cause

Two stacked defects:

1. `SSLWrapper::update_handshake_state()` (the inner-TLS engine used by the proxy tunnel, `UpgradedDuplex`, and `WindowsNamedPipe`) called `ERR_clear_error()` immediately after `SSL_get_error`, discarding the BoringSSL error-queue reason before the handshake callback fired. Only the X509 verify result was passed to `on_handshake`, so the protocol error was lost.

2. `ProxyTunnel::on_handshake` only set `did_have_handshaking_error` inside its success branch. The failure-branch guard `did_have_handshaking_error && error_no != 0` therefore never held on a fresh client, so every failed inner-TLS handshake fell through to the `ConnectionRefused` catch-all regardless of what the SSL layer reported.

For the direct case, usockets' `openssl.c` already surfaces the protocol reason as `{error_no: -71, code: "EPROTO"}`; `HTTPContext::on_handshake` fed that `-71` straight into `get_cert_error_from_no`, which treats its input as an `X509_V_ERR_*` code and maps anything unknown to `UNKNOWN_CERTIFICATE_VERIFICATION_ERROR`.

#### Fix

- `src/uws/lib.rs`: peek `ERR_peek_last_error()` before clearing the queue on `SSL_ERROR_SSL`. When nonzero, dispatch `{error_no: -71, code: "EPROTO", reason: ERR_reason_error_string(..)}` to the handshake callback. This mirrors `ssl_park_fatal_reason` / `ssl_dispatch_parked_reason` in `openssl.c`, so the tunnel's inner TLS now reports the same shape the outer TLS already does.
- `src/http/ProxyTunnel.rs`: set `did_have_handshaking_error` before branching on success, matching `HTTPContext::on_handshake`.
- `src/http/HTTPContext.rs`, `src/http/ProxyTunnel.rs`: in the handshake-failure branch, map a negative `error_no` (the EPROTO/ECONNRESET sentinel from the handshake layer; `X509_V_ERR_*` values are all non-negative) to a new `http::Error::TLSHandshakeFailed` instead of routing it through `get_cert_error_from_no`.
- `src/http/error.rs`, `src/runtime/webcore/fetch/FetchTasklet.rs`: add the `TLSHandshakeFailed` variant with code `ERR_TLS_HANDSHAKE_FAILED` and a user-facing message.

#### Testing

New test in `test/js/web/fetch/fetch.tls.test.ts` stands up a garbage-speaking CONNECT proxy, a garbage-speaking direct TCP server, and a refused port, and asserts `{ tunnelGarbage, proxyRefused, directGarbage }` map to `{ ERR_TLS_HANDSHAKE_FAILED, ConnectionRefused, ERR_TLS_HANDSHAKE_FAILED }`. Fails on the unfixed build with exactly the mislabels above.

Related: #31950 covers the adjacent `-46` ECONNRESET-during-handshake sentinel for the direct path.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch.tls.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (c2b0ae487)

test/js/web/fetch/fetch.tls.test.ts:
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity that throws should reject [1140.44ms]
(pass) fetch-tls > fetch with valid tls should not throw [1745.83ms]
(pass) fetch-tls > can handle multiple requests with non native checkServerIdentity [2079.85ms]
(pass) fetch-tls > fetch with rejectUnauthorized: false should not call checkServerIdentity [351.67ms]
(pass) fetch-tls > re-derives the Host header and TLS verification hostname from the redirect target on a cross-origin redirect [2153.18ms]
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity should work [2078.15ms]
(pass) fetch-tls > fetch with self-sign tls should throw [157.28ms]
(pa
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (49b6d5fcd)

test/js/web/fetch/fetch.tls.test.ts:
(pass) fetch-tls > fetch with valid tls should not throw [1532.63ms]
(pass) fetch-tls > fetch with checkServerIdentity rejects when connection closes before response headers (with AbortSignal) [38.22ms]
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity should work [1550.27ms]
(pass) fetch-tls > checkServerIdentity approval still transmits the request and round-trips the response [39.41ms]
(pass) fetch-tls > fetch should use NODE_EXTRA_CA_CERTS even if the used CA is not first in bundle [37.69ms]
(pass) fetch-tls > checkServerIdentity rejection prevents the request from being transmitted [44.62ms]
(pass) fetch-tls > re-derives the Host header and TLS verification hostname from the redirect target on a cross-origin redirect [1559.01ms]
(pass) fetch-tls > fetch should respect rejectUnauthorized env [43.21ms]
(pass) fetch-tls > fetch should use NODE_EXTRA_CA_CERTS [40.91ms]
(pass) fetch-tls > fetch with invalid tls + rejectUnauthorized: false should not throw [44.06ms]
(pass) fetch-tls > fetch with self-sign certificate tls + rejectUnauthorized: false should not throw [44
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch.tls.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (c2b0ae487)

test/js/web/fetch/fetch.tls.test.ts:
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity that throws should reject [1137.51ms]
(pass) fetch-tls > fetch with valid tls should not throw [1745.48ms]
(pass) fetch-tls > can handle multiple requests with non native checkServerIdentity [2053.65ms]
(pass) fetch-tls > fetch with rejectUnauthorized: false should not call checkServerIdentity [416.94ms]
(pass) fetch-tls > re-derives the Host header and TLS verification hostname from the redirect target on a cross-origin redirect [2220.10ms]
(pass) fetch-tls > fetch with checkServerIdentity rejects when connection closes before response headers [550.72ms]
(pass) fetch-tls > fetch with valid tls and non-native
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 734ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/119] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[2/119] gen cpp.rs (cppbind)
[2/119] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_libdeflate_s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/HTTPContext.rs                   | 14 +++--
 src/http/ProxyTunnel.rs                   | 15 ++++--
 src/http/error.rs                         |  3 ++
 src/runtime/webcore/fetch/FetchTasklet.rs |  3 ++
 src/uws/lib.rs                            | 43 +++++++++++----
 src/uws_sys/lib.rs                        |  8 +++
 test/js/web/fetch/fetch.tls.test.ts       | 88 ++++++++++++++++++++++++++++++-
 7 files changed, 155 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/http/HTTPContext.rs                        4      4      0
src/http/ProxyTunnel.rs                        6      4      0
src/http/error.rs                              2      2      0
src/runtime/webcore/fetch/FetchTasklet.rs      3      2      0
src/uws/lib.rs                                 5      5      0
src/uws_sys/lib.rs                             2      1      0
test/js/web/fetch/fetch.tls.test.ts            5      7      0
```

</details>

<!-- robobun:evidence:end -->