### PR TITLE
node:dns: disable c-ares in-process query cache to match Node

### DIFF
--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -778,11 +778,18 @@ impl Channel {
             sock_state_cb_data: std::ptr::from_ref::<C>(this).cast_mut().cast::<c_void>(),
             timeout: options.timeout.unwrap_or(-1),
             tries: options.tries.unwrap_or(4),
+            // c-ares >= 1.31 enables a 1h query cache unless ARES_OPT_QUERY_CACHE
+            // is passed with qcache_max_ttl = 0. Node's dns.Resolver re-queries
+            // on every call; match that so resolve*/lookup never replay stale answers.
+            qcache_max_ttl: 0,
             ..Default::default()
         };
 
-        let optmask: c_int =
-            ARES_OPT_FLAGS | ARES_OPT_TIMEOUTMS | ARES_OPT_SOCK_STATE_CB | ARES_OPT_TRIES;
+        let optmask: c_int = ARES_OPT_FLAGS
+            | ARES_OPT_TIMEOUTMS
+            | ARES_OPT_SOCK_STATE_CB
+            | ARES_OPT_TRIES
+            | ARES_OPT_QUERY_CACHE;
 
         // SAFETY: c-ares FFI; opts/channel are valid stack pointers.
         let rc = unsafe { ares_init_options(&raw mut channel, &raw mut opts, optmask) };
@@ -2052,6 +2059,7 @@ pub const ARES_OPT_EDNSPSZ: c_int = 1 << 15;
 pub const ARES_OPT_NOROTATE: c_int = 1 << 16;
 pub const ARES_OPT_RESOLVCONF: c_int = 1 << 17;
 pub const ARES_OPT_HOSTS_FILE: c_int = 1 << 18;
+pub const ARES_OPT_QUERY_CACHE: c_int = 1 << 21;
 pub const ARES_NI_NOFQDN: c_int = 1 << 0;
 pub const ARES_NI_NUMERICHOST: c_int = 1 << 1;
 pub const ARES_NI_NAMEREQD: c_int = 1 << 2;

--- a/test/js/node/dns/dns-resolver-no-cache-fixture.ts
+++ b/test/js/node/dns/dns-resolver-no-cache-fixture.ts
@@ -1,0 +1,69 @@
+// Hermetic: scripted in-process DNS server on 127.0.0.1; a dns.promises.Resolver
+// pointed at it issues resolve4() twice for the same name. Node re-queries on
+// every call (no resolver-level cache); this fixture asserts Bun does too.
+import dgram from "node:dgram";
+import { promises as dnsp } from "node:dns";
+
+const zone = new Map<string, { ip: string; ttl: number }>();
+const hits = new Map<string, number>();
+
+const u16 = (n: number) => [(n >> 8) & 255, n & 255];
+const u32 = (n: number) => [(n >>> 24) & 255, (n >>> 16) & 255, (n >>> 8) & 255, n & 255];
+
+const srv = dgram.createSocket("udp4");
+srv.on("message", (m, ri) => {
+  // decode QNAME
+  let i = 12;
+  const labels: string[] = [];
+  while (m[i]) {
+    labels.push(m.slice(i + 1, i + 1 + m[i]).toString());
+    i += 1 + m[i];
+  }
+  i++; // skip the root label
+  const q = labels.join(".").toLowerCase();
+  hits.set(q, (hits.get(q) ?? 0) + 1);
+  const z = zone.get(q);
+  const an = z ? [[0xc0, 12, ...u16(1), 0, 1, ...u32(z.ttl), 0, 4, ...z.ip.split(".").map(Number)]] : [];
+  const rcode = z ? 0 : 3; // NOERROR or NXDOMAIN
+  const resp = Buffer.concat([
+    Buffer.from([...u16(m.readUInt16BE(0)), 0x85, 0x80 | rcode, 0, 1, ...u16(an.length), 0, 0, 0, 0]),
+    m.slice(12, i + 4),
+    Buffer.from(an.flat()),
+  ]);
+  srv.send(resp, ri.port, ri.address);
+});
+
+await new Promise<void>((resolve, reject) => {
+  srv.once("error", reject);
+  srv.bind(0, "127.0.0.1", resolve);
+});
+
+try {
+  const port = (srv.address() as import("node:net").AddressInfo).port;
+  const R = new dnsp.Resolver();
+  R.setServers([`127.0.0.1:${port}`]);
+
+  // Case 1: two resolve4() calls for the same name must hit the wire twice.
+  zone.set("rep.qc.test", { ip: "192.0.2.1", ttl: 300 });
+  await R.resolve4("rep.qc.test");
+  await R.resolve4("rep.qc.test");
+  const wire1 = hits.get("rep.qc.test");
+
+  // Case 2: a zone change within TTL must be observed on the next resolve4().
+  zone.set("chg.qc.test", { ip: "192.0.2.10", ttl: 300 });
+  const before = await R.resolve4("chg.qc.test");
+  zone.set("chg.qc.test", { ip: "192.0.2.20", ttl: 300 });
+  const after = await R.resolve4("chg.qc.test");
+  const wire2 = hits.get("chg.qc.test");
+
+  console.log(
+    JSON.stringify({
+      wire1,
+      wire2,
+      before,
+      after,
+    }),
+  );
+} finally {
+  srv.close();
+}

--- a/test/js/node/dns/dns-resolver-no-cache.test.ts
+++ b/test/js/node/dns/dns-resolver-no-cache.test.ts
@@ -1,0 +1,27 @@
+// c-ares 1.31+ enables an in-process query cache by default (qcache_max_ttl=3600)
+// unless the embedder passes ARES_OPT_QUERY_CACHE with qcache_max_ttl=0. Node's
+// dns.Resolver re-queries on every call; Bun must match that: no resolver-level
+// caching, so zone changes and DNS-polling code observe fresh answers.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
+
+test("dns.Resolver does not cache responses in-process (matches Node)", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "dns-resolver-no-cache-fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr.trim()).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    wire1: 2,
+    wire2: 2,
+    before: ["192.0.2.10"],
+    after: ["192.0.2.20"],
+  });
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/dns/dns-resolver-no-cache.test.ts
+++ b/test/js/node/dns/dns-resolver-no-cache.test.ts
@@ -16,12 +16,12 @@ test("dns.Resolver does not cache responses in-process (matches Node)", async ()
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr.trim()).toBe("");
-  expect(JSON.parse(stdout)).toEqual({
+  expect({ ...JSON.parse(stdout), stderr, exitCode }).toEqual({
     wire1: 2,
     wire2: 2,
     before: ["192.0.2.10"],
     after: ["192.0.2.20"],
+    stderr: "",
+    exitCode: 0,
   });
-  expect(exitCode).toBe(0);
 });

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -540,9 +540,10 @@ describe("uses `dns.promises` implementations for `util.promisify` factory", () 
   });
 
   it("util.promisify(dns.lookup) acts like dns.promises.lookup", async () => {
-    // This test previously used example.com, but that domain has multiple A records, which can cause this test to fail.
-    // As of this writing, google.com has only one A record. If that changes, update this test with a domain that has only one A record.
-    expect(await util.promisify(dns.lookup)("google.com")).toEqual(await dns.promises.lookup("google.com"));
+    // Use localhost so both calls resolve deterministically without hitting the
+    // wire; public hosts (example.com, google.com) have multiple A records and
+    // round-robin between consecutive uncached lookups.
+    expect(await util.promisify(dns.lookup)("localhost")).toEqual(await dns.promises.lookup("localhost"));
   });
 });
 


### PR DESCRIPTION
## What

Pass `ARES_OPT_QUERY_CACHE` with `qcache_max_ttl = 0` at c-ares channel init so `node:dns` hits the wire on every call, matching Node's behavior.

## Why

c-ares 1.31+ enables an in-process query cache by default: [`vendor/cares/src/lib/ares_options.c`](../blob/main/vendor/cares/src/lib/ares_options.c) sets `qcache_max_ttl = 3600` unless the embedder passes `ARES_OPT_QUERY_CACHE` with `qcache_max_ttl = 0`. Bun's `Channel::init` in `src/cares_sys/c_ares.rs` never passed that option, so every `node:dns` channel inherited the 1-hour cache.

Observable effect (wire-counted against a scripted in-process DNS server on 127.0.0.1):

```js
const R = new dnsp.Resolver();
R.setServers([`127.0.0.1:${port}`]);
await R.resolve4("rep.qc.test");
await R.resolve4("rep.qc.test");
// wire queries: bun 1 (cached), node 2

zone.set("chg.qc.test", { ip: "192.0.2.10", ttl: 300 });
await R.resolve4("chg.qc.test");
zone.set("chg.qc.test", { ip: "192.0.2.20", ttl: 300 }); // zone flips within TTL
await R.resolve4("chg.qc.test");
// bun: ["192.0.2.10"] STALE, 0 new packets    node: ["192.0.2.20"]
```

This affected `resolve4/6/Txt/Srv/...`, `dns.Resolver`, `dns.lookup` and `Bun.dns.lookup` (all share the same channel init). NXDOMAIN was negative-cached for the SOA minimum, so retry-on-ENOTFOUND spun on a cached error. DNS-polling code ported from Node (failover health checks, ACME dns-01 propagation pollers, service-discovery watchers) silently froze on the first answer for up to an hour.

Node's contract and measured behavior is no resolver-level caching; Bun's documented 30s cache is the separate connect-time cache, not this.

## Verification

New hermetic test `test/js/node/dns/dns-resolver-no-cache.test.ts` runs a scripted UDP DNS server, points a `dns.promises.Resolver` at it, and asserts:
- two `resolve4()` calls for the same name produce two wire packets
- a zone change within TTL is observed on the next call

Fails on `main` (`wire1: 1`, `after: ["192.0.2.10"]`), passes with this change (`wire1: 2`, `after: ["192.0.2.20"]`). Cross-checked against Node v26.3.0 which produces the expected output.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/dns/node-dns.test.js

<!-- robobun:evidence:end -->