### PR TITLE
node:dns: clamp high-bit wire TTLs to 0 per RFC 2181 section 8

### DIFF
--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -507,7 +507,9 @@ impl hostent_with_ttls {
             .iter()
             .enumerate()
         {
-            with_ttls.ttls[i] = ttl.ttl;
+            // RFC 2181 §8: a wire TTL with the high bit set MUST be treated as 0.
+            // c-ares stores the u32 wire value in a signed int, so it arrives negative.
+            with_ttls.ttls[i] = ttl.ttl.max(0);
         }
         Ok(with_ttls)
     }
@@ -536,7 +538,9 @@ impl hostent_with_ttls {
             .iter()
             .enumerate()
         {
-            with_ttls.ttls[i] = ttl.ttl;
+            // RFC 2181 §8: a wire TTL with the high bit set MUST be treated as 0.
+            // c-ares stores the u32 wire value in a signed int, so it arrives negative.
+            with_ttls.ttls[i] = ttl.ttl.max(0);
         }
         Ok(with_ttls)
     }

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -204,7 +204,8 @@ pub(crate) fn addr_info_to_js_array(
                 result_to_js(
                     &bun_dns::GetAddrInfoResult {
                         address,
-                        ttl: this_node.ttl,
+                        // RFC 2181 §8: high-bit wire TTLs arrive negative via c-ares's signed int.
+                        ttl: this_node.ttl.max(0),
                     },
                     global_this,
                 )?,

--- a/test/js/node/dns/dns-resolve-ttl-high-bit.test.ts
+++ b/test/js/node/dns/dns-resolve-ttl-high-bit.test.ts
@@ -1,0 +1,80 @@
+// RFC 2181 §8: a DNS TTL is transmitted as a 32-bit unsigned integer but
+// "Implementations should treat TTL values received with the most significant
+// bit set as if the entire value received was zero." c-ares's legacy API
+// exposes TTL as a signed int, so a wire TTL of 0xFFFFFFFF / 0x80000000
+// arrives as -1 / INT32_MIN. Bun previously surfaced those negative values
+// verbatim to JS.
+//
+// The fixture runs a hermetic UDP DNS server that answers A/AAAA queries with
+// a chosen wire TTL, then asserts on the {ttl} reported by node:dns.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+const fixture = /* js */ `
+import dgram from "node:dgram";
+import { once } from "node:events";
+import { promises as dns } from "node:dns";
+
+const TTLS = { "hi.tt.test": 0xffffffff, "mid.tt.test": 0x80000000, "max31.tt.test": 0x7fffffff, "one.tt.test": 1 };
+const u16 = n => [(n >>> 8) & 0xff, n & 0xff];
+const u32 = n => [(n >>> 24) & 0xff, (n >>> 16) & 0xff, (n >>> 8) & 0xff, n & 0xff];
+
+const srv = dgram.createSocket("udp4");
+srv.on("message", (msg, rinfo) => {
+  // parse question name + qtype
+  let off = 12;
+  const labels = [];
+  while (msg[off] !== 0) {
+    labels.push(msg.subarray(off + 1, off + 1 + msg[off]).toString());
+    off += 1 + msg[off];
+  }
+  off++;
+  const qtype = msg.readUInt16BE(off);
+  const question = msg.subarray(12, off + 4);
+  const name = labels.join(".").toLowerCase();
+  const ttl = TTLS[name];
+
+  // one A (type 1) or AAAA (type 28) RR at 0xc00c, TTL = wire TTL
+  const rdata = qtype === 28 ? [...u16(16), 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5] : [...u16(4), 192, 0, 2, 5];
+  const answer = Buffer.from([0xc0, 0x0c, ...u16(qtype), 0x00, 0x01, ...u32(ttl), ...rdata]);
+  const header = Buffer.from([...u16(msg.readUInt16BE(0)), 0x85, 0x80, ...u16(1), ...u16(1), ...u16(0), ...u16(0)]);
+  srv.send(Buffer.concat([header, question, answer]), rinfo.port, rinfo.address);
+});
+srv.bind(0, "127.0.0.1");
+await once(srv, "listening");
+
+const r = new dns.Resolver({ timeout: 2000, tries: 1 });
+r.setServers(["127.0.0.1:" + srv.address().port]);
+
+const out = {};
+for (const name of Object.keys(TTLS)) {
+  const [a] = await r.resolve4(name, { ttl: true });
+  const [aaaa] = await r.resolve6(name, { ttl: true });
+  out[name] = { a: a.ttl, aaaa: aaaa.ttl, addr4: a.address, addr6: aaaa.address };
+}
+console.log(JSON.stringify(out));
+srv.close();
+`;
+
+test("dns.resolve4/resolve6 {ttl:true} clamps high-bit wire TTLs to 0 (RFC 2181 §8)", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr.trim()).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    // High bit set: RFC 2181 §8 says treat as zero. Before the fix bun
+    // reported -1 / -2147483648 here.
+    "hi.tt.test": { a: 0, aaaa: 0, addr4: "192.0.2.5", addr6: "2001:db8::5" },
+    "mid.tt.test": { a: 0, aaaa: 0, addr4: "192.0.2.5", addr6: "2001:db8::5" },
+    // High bit clear: reported exactly.
+    "max31.tt.test": { a: 0x7fffffff, aaaa: 0x7fffffff, addr4: "192.0.2.5", addr6: "2001:db8::5" },
+    "one.tt.test": { a: 1, aaaa: 1, addr4: "192.0.2.5", addr6: "2001:db8::5" },
+  });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

`dns.resolve4(name, {ttl:true})` and `dns.resolve6(name, {ttl:true})` reported **negative** TTLs when the 32-bit wire TTL had its high bit set:

| wire TTL     | bun (before) | node v26 | RFC 2181 |
|--------------|-------------:|---------:|---------:|
| `0xFFFFFFFF` |         `-1` | `4294967295` | `0` |
| `0x80000000` | `-2147483648` | `2147483648` | `0` |
| `0x7FFFFFFF` | `2147483647` | `2147483647` | `2147483647` |

Any consumer scheduling re-resolves as `Date.now() + ttl*1000` gets a time in the past from a single hostile or broken authority packet.

## Reproduction

<details>
<summary>hermetic in-process DNS server, A 192.0.2.5 with a chosen wire TTL</summary>

```js
import dgram from "node:dgram";
import { promises as dnsp } from "node:dns";
const zone = new Map();
const u16=n=>[n>>8&255,n&255], u32=n=>[n>>>24&255,n>>>16&255,n>>>8&255,n&255];
const srv = dgram.createSocket("udp4");
srv.on("message",(m,ri)=>{ let i=12,l=[]; while(m[i]){l.push(m.slice(i+1,i+1+m[i]).toString());i+=1+m[i];} i++;
  const q=l.join(".").toLowerCase(); const ttl=zone.get(q);
  const an=[[0xc0,12,...u16(1),0,1,...u32(ttl),0,4,192,0,2,5]];
  srv.send(Buffer.concat([Buffer.from([...u16(m.readUInt16BE(0)),0x85,0x80,0,1,...u16(1),0,0,0,0]),m.slice(12,i+4),Buffer.from(an.flat())]),ri.port,ri.address);});
await new Promise(r=>srv.bind(0,"127.0.0.1",r));
const R=new dnsp.Resolver(); R.setServers([`127.0.0.1:${srv.address().port}`]);
for (const [name,ttl] of [["hi.tt.test",0xFFFFFFFF],["mid.tt.test",0x80000000],["max31.tt.test",0x7FFFFFFF]]) {
  zone.set(name,ttl);
  const v = await R.resolve4(name,{ttl:true});
  console.log(`wire TTL 0x${ttl.toString(16)}: reported ttl=${v[0].ttl}`);
}
srv.close();
```
</details>

## Cause

c-ares parses the wire TTL as `unsigned int` internally but the legacy `struct ares_addrttl.ttl` / `struct ares_addr6ttl.ttl` / `struct ares_addrinfo_node.ai_ttl` fields are `int`, so the value is reinterpreted as signed before it reaches Bun. `hostent_with_ttls::parse_a` / `parse_aaaa` and the `AddrInfo_node` walker copied that `c_int` through to JS unchanged.

## Fix

[RFC 2181 section 8](https://www.rfc-editor.org/rfc/rfc2181#section-8):

> Implementations should treat TTL values received with the most significant bit set as if the entire value received was zero.

Clamp to `0` via `.max(0)` at the two c-ares boundaries where Bun first receives the signed value: `hostent_with_ttls::parse_a` / `parse_aaaa` (covers `resolve4`/`resolve6` `{ttl:true}` and the A/AAAA legs of `resolveAny`) and the `ares_addrinfo_node` walker.

Node.js surfaces the raw unsigned value instead; this PR follows the RFC's mandated interpretation, which is the safer behavior for re-resolve scheduling.

The "record is cached anyway" half of the report (wire-counted as 1 query for every TTL, not just high-bit ones) is c-ares's in-process query cache being enabled by default since c-ares 1.31.0; that is addressed separately in #34183.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/node/dns/dns-resolve-ttl-high-bit.test.ts
(fail)  ...  "a": -1, "aaaa": -1  /  "a": -2147483648, "aaaa": -2147483648

$ bun bd test test/js/node/dns/dns-resolve-ttl-high-bit.test.ts
(pass) dns.resolve4/resolve6 {ttl:true} clamps high-bit wire TTLs to 0 (RFC 2181 §8)
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/dns/dns-resolve-ttl-high-bit.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b42a2defb)

test/js/node/dns/dns-resolve-ttl-high-bit.test.ts:
65 |   });
66 | 
67 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
68 | 
69 |   expect(stderr.trim()).toBe("");
70 |   expect(JSON.parse(stdout)).toEqual({
                                  ^
error: expect(received).toEqual(expected)

  {
    "hi.tt.test": {
-     "a": 0,
-     "aaaa": 0,
+     "a": -1,
+     "aaaa": -1,
      "addr4": "192.0.2.5",
      "addr6": "2001:db8::5",
    },
    "max31.tt.test": {
      "a": 2147483647,
      "aaaa": 2147483647,
      "addr4": "192.0.2.5",
      "addr6": "2001:db8::5",
    },
    "mid.tt.test": {
-     "a": 0,
-     "aaaa": 0,
+     "a": -21474836
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (b42a2defb)

test/js/node/dns/dns-resolve-ttl-high-bit.test.ts:
(pass) dns.resolve4/resolve6 {ttl:true} clamps high-bit wire TTLs to 0 (RFC 2181 §8) [54.31ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [307.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/dns/dns-resolve-ttl-high-bit.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b42a2defb)

test/js/node/dns/dns-resolve-ttl-high-bit.test.ts:
(pass) dns.resolve4/resolve6 {ttl:true} clamps high-bit wire TTLs to 0 (RFC 2181 §8) [1090.56ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [3.07s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 858ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/119] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[2/119] gen cpp.rs (cppbind)
[2/119] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_libdef
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/cares_sys/c_ares.rs                           |  8 ++-
 src/runtime/dns_jsc/cares_jsc.rs                  |  3 +-
 test/js/node/dns/dns-resolve-ttl-high-bit.test.ts | 80 +++++++++++++++++++++++
 3 files changed, 88 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/cares_sys/c_ares.rs                                5      2      0
src/runtime/dns_jsc/cares_jsc.rs                       4      1      0
test/js/node/dns/dns-resolve-ttl-high-bit.test.ts      0      1      0
```

</details>

<!-- robobun:evidence:end -->