### PR TITLE
Bun.serve: close connection when file body is truncated mid-send

### DIFF
--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -277,17 +277,13 @@ impl FileResponseStream {
         self.resp.timeout(self.idle_timeout);
 
         if state == ReadState::Eof {
-            // EOF with bytes still owed means the file shrank under us. The
-            // advertised Content-Length can no longer be honoured, so close
-            // the connection rather than desync the keep-alive stream.
-            let short = self.max_size.is_some_and(|m| m > 0);
+            if self.max_size.is_some_and(|m| m > 0) {
+                // File shrank; let on_reader_done → finish() force-close.
+                return false;
+            }
             self.state.insert(State::RESPONSE_DONE);
             self.detach_resp();
-            if short {
-                self.resp.force_close();
-            } else {
-                self.resp.end(chunk, self.resp.should_close_connection());
-            }
+            self.resp.end(chunk, self.resp.should_close_connection());
             (self.on_complete)(self.ctx, self.resp);
             return false;
         }
@@ -511,8 +507,14 @@ impl FileResponseStream {
         if !self.state.contains(State::RESPONSE_DONE) {
             self.state.insert(State::RESPONSE_DONE);
             self.detach_resp();
-            self.resp
-                .end_without_body(self.resp.should_close_connection());
+            if self.max_size.is_some_and(|m| m > 0) {
+                // Reader hit EOF with bytes still owed (file shrank); close
+                // rather than end short of the advertised Content-Length.
+                self.resp.force_close();
+            } else {
+                self.resp
+                    .end_without_body(self.resp.should_close_connection());
+            }
             (self.on_complete)(self.ctx, self.resp);
         }
 

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -277,9 +277,17 @@ impl FileResponseStream {
         self.resp.timeout(self.idle_timeout);
 
         if state == ReadState::Eof {
+            // EOF with bytes still owed means the file shrank under us. The
+            // advertised Content-Length can no longer be honoured, so close
+            // the connection rather than desync the keep-alive stream.
+            let short = self.max_size.is_some_and(|m| m > 0);
             self.state.insert(State::RESPONSE_DONE);
             self.detach_resp();
-            self.resp.end(chunk, self.resp.should_close_connection());
+            if short {
+                self.resp.force_close();
+            } else {
+                self.resp.end(chunk, self.resp.should_close_connection());
+            }
             (self.on_complete)(self.ctx, self.resp);
             return false;
         }
@@ -392,7 +400,10 @@ impl FileResponseStream {
             match errno {
                 sys::E::SUCCESS => {
                     if self.sendfile.remain == 0 || sent == 0 {
-                        self.end_sendfile();
+                        // sent == 0 with remain > 0: the file was truncated
+                        // below our offset. Close so the client observes the
+                        // short body instead of desyncing on keep-alive.
+                        self.end_sendfile(self.sendfile.remain != 0);
                         return false;
                     }
                     return self.arm_sendfile_writable();
@@ -431,15 +442,19 @@ impl FileResponseStream {
     }
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    fn end_sendfile(&mut self) {
-        bun_output::scoped_log!(FileResponseStream, "endSendfile");
+    fn end_sendfile(&mut self, short: bool) {
+        bun_output::scoped_log!(FileResponseStream, "endSendfile short={}", short);
         if self.state.contains(State::RESPONSE_DONE) {
             return;
         }
         self.state.insert(State::RESPONSE_DONE);
         self.detach_resp();
-        self.resp
-            .end_send_file(self.sendfile.offset, self.resp.should_close_connection());
+        if short {
+            self.resp.force_close();
+        } else {
+            self.resp
+                .end_send_file(self.sendfile.offset, self.resp.should_close_connection());
+        }
         (self.on_complete)(self.ctx, self.resp);
         self.finish();
     }

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -1,6 +1,16 @@
 import type { Server } from "bun";
 import { afterAll, beforeAll, describe, expect, it, mock, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isLinux, isWindows, rmScope, tempDir, tempDirWithFiles, tls as tlsCert } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  isASAN,
+  isLinux,
+  isWindows,
+  rmScope,
+  tempDir,
+  tempDirWithFiles,
+  tls as tlsCert,
+} from "harness";
 import { mkfifo } from "mkfifo";
 import { once } from "node:events";
 import { truncateSync, unlinkSync } from "node:fs";

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -1,8 +1,10 @@
 import type { Server } from "bun";
 import { afterAll, beforeAll, describe, expect, it, mock, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isWindows, rmScope, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isASAN, isLinux, isWindows, rmScope, tempDir, tempDirWithFiles } from "harness";
 import { mkfifo } from "mkfifo";
-import { unlinkSync } from "node:fs";
+import { once } from "node:events";
+import { truncateSync, unlinkSync } from "node:fs";
+import * as net from "node:net";
 import { join } from "node:path";
 
 const LARGE_SIZE = 1024 * 1024 * 8;
@@ -1138,3 +1140,107 @@ console.log("OK");
   },
   60_000,
 );
+
+// If the backing file shrinks mid-send (log rotation, truncate+rewrite
+// deploy), the server must close the connection rather than treating early
+// EOF as normal completion. Leaving the keep-alive socket open desyncs
+// HTTP/1.1 framing (RFC 9112 §6.2): the next response lands inside the first
+// response's declared Content-Length window. sendfile() is linux-only.
+describe.skipIf(!isLinux)("Bun.serve file body truncated mid-send (sendfile)", () => {
+  const FILE_SIZE = 32 * 1024 * 1024; // well above localhost socket-buffer capacity
+  const MARKER = "SECOND-RESPONSE-MARKER";
+
+  async function probe(route: boolean) {
+    using dir = tempDir("serve-file-truncate", { "big.bin": Buffer.alloc(FILE_SIZE, 0x41) });
+    const file = join(String(dir), "big.bin");
+
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      idleTimeout: 0,
+      ...(route
+        ? {
+            routes: { "/big": Bun.file(file), "/marker": new Response(MARKER) },
+            fetch: () => new Response("x", { status: 404 }),
+          }
+        : {
+            fetch: req => {
+              const p = new URL(req.url).pathname;
+              if (p === "/big") return new Response(Bun.file(file));
+              if (p === "/marker") return new Response(MARKER);
+              return new Response("x", { status: 404 });
+            },
+          }),
+    });
+
+    const sock = net.connect(server.port, "127.0.0.1");
+    await once(sock, "connect");
+    sock.write("GET /big HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n\r\n");
+
+    let head = "";
+    let contentLength = -1;
+    let bodyBytes = 0;
+    let closed = false;
+    let desynced = false;
+    const gotHeaders = Promise.withResolvers<void>();
+    const canTruncate = Promise.withResolvers<void>();
+    const finished = Promise.withResolvers<void>();
+
+    sock.on("data", d => {
+      if (contentLength < 0) {
+        head += d.toString("latin1");
+        const i = head.indexOf("\r\n\r\n");
+        if (i < 0) return;
+        contentLength = Number(head.match(/content-length: ?(\d+)/i)?.[1] ?? -1);
+        bodyBytes = Buffer.byteLength(head.slice(i + 4), "latin1");
+        head = "";
+        gotHeaders.resolve();
+      } else {
+        bodyBytes += d.length;
+      }
+      if (bodyBytes > 64 * 1024) canTruncate.resolve();
+      if (d.includes(MARKER)) {
+        desynced = true;
+        finished.resolve();
+      }
+    });
+    sock.on("error", () => {});
+    sock.on("close", () => {
+      closed = true;
+      gotHeaders.resolve();
+      canTruncate.resolve();
+      finished.resolve();
+    });
+
+    await gotHeaders.promise;
+    await canTruncate.promise;
+    truncateSync(file, 1024);
+
+    // Drain until the server considers the request finished: the sendfile
+    // loop has observed sent==0 (early EOF) and either force-closed the
+    // socket (correct) or marked the response done (desync).
+    while (server.pendingRequests > 0 && !closed) await Bun.sleep(1);
+
+    if (!closed) {
+      // Server believes it is idle on a keep-alive socket; probe for desync.
+      sock.write("GET /marker HTTP/1.1\r\nHost: x\r\n\r\n");
+      await finished.promise;
+    }
+    sock.destroy();
+    return { contentLength, bodyBytes, closed, desynced };
+  }
+
+  for (const [name, route] of [
+    ["static route", true],
+    ["fetch handler", false],
+  ] as const) {
+    test.concurrent(name, async () => {
+      const r = await probe(route);
+      expect(r.contentLength).toBe(FILE_SIZE);
+      // The second request's response must never appear inside the first body
+      // window. The server closes so the client observes the short body.
+      expect({ desynced: r.desynced, closed: r.closed }).toEqual({ desynced: false, closed: true });
+      expect(r.bodyBytes).toBeLessThan(r.contentLength);
+    });
+  }
+});

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -1,11 +1,12 @@
 import type { Server } from "bun";
 import { afterAll, beforeAll, describe, expect, it, mock, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isLinux, isWindows, rmScope, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isASAN, isLinux, isWindows, rmScope, tempDir, tempDirWithFiles, tls as tlsCert } from "harness";
 import { mkfifo } from "mkfifo";
 import { once } from "node:events";
 import { truncateSync, unlinkSync } from "node:fs";
 import * as net from "node:net";
 import { join } from "node:path";
+import * as tls from "node:tls";
 
 const LARGE_SIZE = 1024 * 1024 * 8;
 const files = {
@@ -1145,12 +1146,12 @@ console.log("OK");
 // deploy), the server must close the connection rather than treating early
 // EOF as normal completion. Leaving the keep-alive socket open desyncs
 // HTTP/1.1 framing (RFC 9112 §6.2): the next response lands inside the first
-// response's declared Content-Length window. sendfile() is linux-only.
-describe.skipIf(!isLinux)("Bun.serve file body truncated mid-send (sendfile)", () => {
+// response's declared Content-Length window.
+describe("Bun.serve file body truncated mid-send", () => {
   const FILE_SIZE = 32 * 1024 * 1024; // well above localhost socket-buffer capacity
   const MARKER = "SECOND-RESPONSE-MARKER";
 
-  async function probe(route: boolean) {
+  async function probe(route: boolean, ssl: boolean) {
     using dir = tempDir("serve-file-truncate", { "big.bin": Buffer.alloc(FILE_SIZE, 0x41) });
     const file = join(String(dir), "big.bin");
 
@@ -1158,6 +1159,7 @@ describe.skipIf(!isLinux)("Bun.serve file body truncated mid-send (sendfile)", (
       port: 0,
       hostname: "127.0.0.1",
       idleTimeout: 0,
+      ...(ssl ? { tls: tlsCert } : {}),
       ...(route
         ? {
             routes: { "/big": Bun.file(file), "/marker": new Response(MARKER) },
@@ -1173,8 +1175,10 @@ describe.skipIf(!isLinux)("Bun.serve file body truncated mid-send (sendfile)", (
           }),
     });
 
-    const sock = net.connect(server.port, "127.0.0.1");
-    await once(sock, "connect");
+    const sock = ssl
+      ? tls.connect({ port: server.port, host: "127.0.0.1", rejectUnauthorized: false })
+      : net.connect(server.port, "127.0.0.1");
+    await once(sock, ssl ? "secureConnect" : "connect");
     sock.write("GET /big HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n\r\n");
 
     let head = "";
@@ -1216,9 +1220,9 @@ describe.skipIf(!isLinux)("Bun.serve file body truncated mid-send (sendfile)", (
     await canTruncate.promise;
     truncateSync(file, 1024);
 
-    // Drain until the server considers the request finished: the sendfile
-    // loop has observed sent==0 (early EOF) and either force-closed the
-    // socket (correct) or marked the response done (desync).
+    // Drain until the server considers the request finished: the file stream
+    // has observed early EOF and either force-closed the socket (correct) or
+    // marked the response done (desync).
     while (server.pendingRequests > 0 && !closed) await Bun.sleep(1);
 
     if (!closed) {
@@ -1230,12 +1234,17 @@ describe.skipIf(!isLinux)("Bun.serve file body truncated mid-send (sendfile)", (
     return { contentLength, bodyBytes, closed, desynced };
   }
 
-  for (const [name, route] of [
-    ["static route", true],
-    ["fetch handler", false],
-  ] as const) {
-    test.concurrent(name, async () => {
-      const r = await probe(route);
+  for (const v of [
+    // Plain TCP on Linux takes the sendfile backend; on macOS/Windows it
+    // takes the buffered-reader backend (can_sendfile returns false there).
+    { name: "static route", route: true, ssl: false, skip: !isLinux },
+    { name: "fetch handler", route: false, ssl: false, skip: !isLinux },
+    // SSL always takes the buffered-reader backend (no sendfile over TLS).
+    { name: "static route (ssl)", route: true, ssl: true, skip: false },
+    { name: "fetch handler (ssl)", route: false, ssl: true, skip: false },
+  ]) {
+    test.concurrent.skipIf(v.skip)(v.name, async () => {
+      const r = await probe(v.route, v.ssl);
       expect(r.contentLength).toBe(FILE_SIZE);
       // The second request's response must never appear inside the first body
       // window. The server closes so the client observes the short body.


### PR DESCRIPTION
## Problem

`Bun.serve` serving a `Bun.file` body: when the backing file is truncated while the response is being sent (log rotation, truncate+rewrite deploy, non-atomic asset rewrite), the server treats early EOF as normal completion. The body ends millions of bytes short of its declared `Content-Length` with no close, and on a keep-alive connection the next request's entire response (status line + headers + body) is delivered inside the first response's declared body region: an HTTP/1.1 framing desync (RFC 9112 6.2). With `idleTimeout: 0` the client stalls forever.

```
CL=33554432 delivered=2691072 owed=30863360;
  inside owed region: "HTTP/1.1 200 OK\r\nContent-Type: text/plain;..."
```

Node closes the connection after hitting EOF so the client detects the short body immediately.

## Cause

`FileResponseStream::on_sendfile` treats `sent == 0` the same as `remain == 0`:

```rust
if self.sendfile.remain == 0 || sent == 0 {
    self.end_sendfile();   // markDone, leave socket open for keep-alive
```

`sendfile(2)` returning 0 with bytes still owed means the input file's EOF is now below our offset. The advertised `Content-Length` can no longer be honoured, so the only framing-safe recovery is to close the connection. The buffered-reader backend (SSL / macOS / Windows / sub-1MiB files) has the same shape: early `ReadState::Eof` with `max_size > 0` was routed to `resp.end()`.

## Fix

On early EOF in either backend, `force_close()` the socket instead of marking the response done, so the client observes the short body and cannot desync. `on_complete` still fires for caller cleanup.

## Test

`test/js/bun/http/bun-serve-file.test.ts` gains a Linux-gated pair covering both the static-route path (`FileRoute`) and the `fetch` handler path (`RequestContext`): a 32 MiB file is truncated to 1 KiB mid-stream, the test waits for `server.pendingRequests == 0`, then asserts the socket closed with a short body and that a follow-up request was not served inside the first body window.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/bun-serve-file.test.ts

<!-- robobun:evidence:end -->