### PR TITLE
compile: reject writes under /$bunfs/ with EROFS instead of escaping to real fs

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -350,6 +350,24 @@ fn standalone_module_graph_get() -> Option<*mut bun_standalone_graph::Graph> {
     bun_standalone_graph::Graph::get()
 }
 
+/// Inside a standalone executable, the `/$bunfs/` (POSIX) / `B:\~BUN\`
+/// (Windows) prefix is a reserved virtual root. Writes must not fall through
+/// to the real filesystem and create a literal `/$bunfs/` tree on disk.
+#[inline]
+fn reject_standalone_write(path: &[u8], syscall: sys::Tag) -> Maybe<()> {
+    if standalone_module_graph_get().is_some()
+        && bun_standalone_graph::is_bun_standalone_file_path(path)
+    {
+        return Err(sys::Error {
+            errno: E::EROFS as _,
+            syscall,
+            path: path.into(),
+            ..Default::default()
+        });
+    }
+    Ok(())
+}
+
 /// Local shim for `Maybe(void)::aborted` (node.rs:302). `bun_sys::Maybe` is
 /// `core::result::Result`, which has no `aborted()` constructor; inline the
 /// sentinel error directly.
@@ -738,6 +756,33 @@ mod _async_tasks {
             match F {
                 NodeFSFunctionEnum::Open => {
                     let args: &args::Open = args_as!(args::Open);
+                    let bun_flags = args.flags.as_int();
+                    if bun_flags
+                        & (sys::O::WRONLY
+                            | sys::O::RDWR
+                            | sys::O::CREAT
+                            | sys::O::APPEND
+                            | sys::O::TRUNC)
+                        != 0
+                    {
+                        if let Err(err) =
+                            reject_standalone_write(args.path.slice(), sys::Tag::open)
+                        {
+                            // SAFETY: identity write — `R == ret::Open` for this `F`.
+                            unsafe {
+                                core::ptr::write(
+                                    &mut task.result as *mut Maybe<R> as *mut Maybe<ret::Open>,
+                                    Err(err),
+                                )
+                            };
+                            let task_ptr: *mut Self = task;
+                            task.global_object()
+                                .bun_vm()
+                                .event_loop_mut()
+                                .enqueue_task(Task::init(task_ptr));
+                            return task.promise.value();
+                        }
+                    }
                     let path = if strings::eql_comptime(args.path.slice(), b"/dev/null") {
                         ZStr::from_static(b"\\\\.\\NUL\0")
                     } else {
@@ -1835,6 +1880,10 @@ mod _async_tasks {
             let this = unsafe { &**_done };
 
             let args = &this.args;
+            if let Err(err) = reject_standalone_write(args.dest.slice(), sys::Tag::copyfile) {
+                this.finish_concurrently(Err(err));
+                return;
+            }
             let mut src_buf = OSPathBuffer::uninit();
             let mut dest_buf = OSPathBuffer::uninit();
             let name_too_long = |path: &PathLike| sys::Error {
@@ -4867,6 +4916,7 @@ impl NodeFS {
                 Ok(())
             }
             PathOrFileDescriptor::Path(path_) => {
+                reject_standalone_write(path_.slice(), sys::Tag::open)?;
                 let path = path_.slice_z(&mut self.sync_error_buf);
                 let fd = Syscall::open(path, FileSystemFlags::A.as_int(), args.mode)?;
                 let _close = scopeguard::guard(fd, |fd| fd.close());
@@ -5057,6 +5107,7 @@ impl NodeFS {
     }
 
     pub fn copy_file(&mut self, args: &args::CopyFile, _: Flavor) -> Maybe<ret::CopyFile> {
+        reject_standalone_write(args.dest.slice(), sys::Tag::copyfile)?;
         match self.copy_file_inner(args) {
             Ok(_) => Ok(()),
             Err(err) => Err(sys::Error {
@@ -5535,6 +5586,7 @@ impl NodeFS {
     }
 
     pub fn chown(&mut self, args: &args::Chown, _: Flavor) -> Maybe<ret::Chown> {
+        reject_standalone_write(args.path.slice(), sys::Tag::chown)?;
         #[cfg(windows)]
         {
             return match Syscall::chown(
@@ -5554,6 +5606,7 @@ impl NodeFS {
     }
 
     pub fn chmod(&mut self, args: &args::Chmod, _: Flavor) -> Maybe<ret::Chmod> {
+        reject_standalone_write(args.path.slice(), sys::Tag::chmod)?;
         let path = args.path.slice_z(&mut self.sync_error_buf);
         #[cfg(windows)]
         {
@@ -5677,6 +5730,7 @@ impl NodeFS {
     }
 
     pub fn lchmod(&mut self, args: &args::LCHmod, _: Flavor) -> Maybe<ret::Lchmod> {
+        reject_standalone_write(args.path.slice(), sys::Tag::lchmod)?;
         #[cfg(windows)]
         {
             let _ = args;
@@ -5704,6 +5758,7 @@ impl NodeFS {
     }
 
     pub fn lchown(&mut self, args: &args::LChown, _: Flavor) -> Maybe<ret::Lchown> {
+        reject_standalone_write(args.path.slice(), sys::Tag::lchown)?;
         // On Windows `Syscall::lchown` routes through uv_fs_lchown, which is
         // a no-op success, matching Node.
         let path = args.path.slice_z(&mut self.sync_error_buf);
@@ -5714,6 +5769,7 @@ impl NodeFS {
     }
 
     pub fn link(&mut self, args: &args::Link, _: Flavor) -> Maybe<ret::Link> {
+        reject_standalone_write(args.new_path.slice(), sys::Tag::link)?;
         let mut to_buf = PathBuffer::uninit();
         let from = args.old_path.slice_z(&mut self.sync_error_buf);
         let to = args.new_path.slice_z(&mut to_buf);
@@ -5775,6 +5831,7 @@ impl NodeFS {
                 ..Default::default()
             });
         }
+        reject_standalone_write(args.path.slice(), sys::Tag::mkdir)?;
         if args.recursive {
             self.mkdir_recursive(args)
         } else {
@@ -6068,6 +6125,7 @@ impl NodeFS {
     }
 
     pub fn mkdtemp(&mut self, args: &args::MkdirTemp, _: Flavor) -> Maybe<ret::Mkdtemp> {
+        reject_standalone_write(args.prefix.slice(), sys::Tag::mkdtemp)?;
         let prefix_buf = &mut self.sync_error_buf;
         let prefix_slice = args.prefix.slice();
         let len = prefix_slice.len().min(prefix_buf.len().saturating_sub(7));
@@ -6130,6 +6188,12 @@ impl NodeFS {
     }
 
     pub fn open(&mut self, args: &args::Open, _: Flavor) -> Maybe<ret::Open> {
+        let flags = args.flags.as_int();
+        if flags & (sys::O::WRONLY | sys::O::RDWR | sys::O::CREAT | sys::O::APPEND | sys::O::TRUNC)
+            != 0
+        {
+            reject_standalone_write(args.path.slice(), sys::Tag::open)?;
+        }
         let path = if cfg!(windows) && args.path.slice() == b"/dev/null" {
             // SAFETY: literal is NUL-terminated; len excludes the sentinel.
             ZStr::from_static(b"\\\\.\\NUL\0")
@@ -7448,6 +7512,7 @@ impl NodeFS {
     ) -> Maybe<ret::WriteFile> {
         let fd = match &args.file {
             PathOrFileDescriptor::Path(p) => {
+                reject_standalone_write(p.slice(), sys::Tag::open)?;
                 let path = p.slice_z_with_force_copy::<true>(pathbuf);
                 // O_TRUNC is dropped on purpose: keeping the existing blocks
                 // allocated makes rewriting a large file cheaper, and the resize
@@ -7751,6 +7816,8 @@ impl NodeFS {
         Self::realpath;
 
     pub fn rename(&mut self, args: &args::Rename, _: Flavor) -> Maybe<ret::Rename> {
+        reject_standalone_write(args.old_path.slice(), sys::Tag::rename)?;
+        reject_standalone_write(args.new_path.slice(), sys::Tag::rename)?;
         let from_buf = &mut self.sync_error_buf;
         let mut to_buf = PathBuffer::uninit();
         let from = args.old_path.slice_z(from_buf);
@@ -7762,6 +7829,7 @@ impl NodeFS {
     }
 
     pub fn rmdir(&mut self, args: &args::RmDir, _: Flavor) -> Maybe<ret::Rmdir> {
+        reject_standalone_write(args.path.slice(), sys::Tag::rmdir)?;
         if args.recursive {
             // On Windows a rooted-but-driveless path ("/tmp/foo") must resolve
             // against the cwd drive.
@@ -7802,6 +7870,7 @@ impl NodeFS {
     }
 
     pub fn rm(&mut self, args: &args::Rm, _: Flavor) -> Maybe<ret::Rm> {
+        reject_standalone_write(args.path.slice(), sys::Tag::rm)?;
         // We cannot use removefileat() on macOS because it does not handle write-protected files as expected.
         if args.recursive {
             // See the matching comment in `rmdir`: pre-resolve the path on
@@ -7912,6 +7981,7 @@ impl NodeFS {
     }
 
     pub fn symlink(&mut self, args: &args::Symlink, _: Flavor) -> Maybe<ret::Symlink> {
+        reject_standalone_write(args.new_path.slice(), sys::Tag::symlink)?;
         let mut to_buf = PathBuffer::uninit();
         #[cfg(windows)]
         {
@@ -8026,6 +8096,7 @@ impl NodeFS {
     }
 
     fn truncate_inner(&mut self, path: &PathLike, len: u64, flags: i32) -> Maybe<ret::Truncate> {
+        reject_standalone_write(path.slice(), sys::Tag::truncate)?;
         // Mask `len` to a `u63` envelope so the `i64` cast is always in range,
         // rather than `try_from().unwrap()`-panicking
         // on a hostile `> i64::MAX` value.
@@ -8081,6 +8152,7 @@ impl NodeFS {
     }
 
     pub fn unlink(&mut self, args: &args::Unlink, _: Flavor) -> Maybe<ret::Unlink> {
+        reject_standalone_write(args.path.slice(), sys::Tag::unlink)?;
         #[cfg(windows)]
         {
             return match Syscall::unlink(args.path.slice_z(&mut self.sync_error_buf)) {
@@ -8138,6 +8210,7 @@ impl NodeFS {
     }
 
     pub fn utimes(&mut self, args: &args::Utimes, _: Flavor) -> Maybe<ret::Utimes> {
+        reject_standalone_write(args.path.slice(), sys::Tag::utime)?;
         #[cfg(windows)]
         {
             let mut req = UvFsReq::new();
@@ -8175,6 +8248,7 @@ impl NodeFS {
     }
 
     pub fn lutimes(&mut self, args: &args::Lutimes, _: Flavor) -> Maybe<ret::Lutimes> {
+        reject_standalone_write(args.path.slice(), sys::Tag::lutime)?;
         #[cfg(windows)]
         {
             let mut req = UvFsReq::new();
@@ -8224,6 +8298,7 @@ impl NodeFS {
     /// This function is `cpSync`, but only if you pass `{ recursive: ..., force: ..., errorOnExist: ..., mode: ... }'
     /// The other options like `filter` use a JS fallback, see `src/js/internal/fs/cp.ts`
     pub fn cp(&mut self, args: &args::Cp, _: Flavor) -> Maybe<ret::Cp> {
+        reject_standalone_write(args.dest.slice(), sys::Tag::copyfile)?;
         let mut src_buf = OSPathBuffer::uninit();
         let mut dest_buf = OSPathBuffer::uninit();
         let name_too_long = |path: &PathLike| sys::Error {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -350,28 +350,14 @@ fn standalone_module_graph_get() -> Option<*mut bun_standalone_graph::Graph> {
     bun_standalone_graph::Graph::get()
 }
 
-/// True for any path at or under the reserved virtual root, including the
-/// bare prefix with no trailing separator (e.g. `path.dirname(import.meta.dir)`).
-#[inline]
-fn is_reserved_standalone_path(path: &[u8]) -> bool {
-    #[cfg(windows)]
-    let path = without_nt_prefix(path);
-    bun_standalone_graph::is_bun_standalone_file_path(path)
-        || path
-            == &bun_standalone_graph::BASE_PATH.as_bytes()
-                [..bun_standalone_graph::BASE_PATH.len() - 1]
-        || (cfg!(windows)
-            && path
-                == &bun_standalone_graph::BASE_PUBLIC_PATH.as_bytes()
-                    [..bun_standalone_graph::BASE_PUBLIC_PATH.len() - 1])
-}
-
 /// Inside a standalone executable, the `/$bunfs/` (POSIX) / `B:\~BUN\`
 /// (Windows) prefix is a reserved virtual root. Writes must not fall through
 /// to the real filesystem and create a literal `/$bunfs/` tree on disk.
 #[inline]
 fn reject_standalone_write(path: &[u8], syscall: sys::Tag) -> Maybe<()> {
-    if standalone_module_graph_get().is_some() && is_reserved_standalone_path(path) {
+    if standalone_module_graph_get().is_some()
+        && bun_standalone_graph::is_reserved_standalone_path(path)
+    {
         return Err(sys::Error {
             errno: E::EROFS as _,
             syscall,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -765,8 +765,7 @@ mod _async_tasks {
                             | sys::O::TRUNC)
                         != 0
                     {
-                        if let Err(err) =
-                            reject_standalone_write(args.path.slice(), sys::Tag::open)
+                        if let Err(err) = reject_standalone_write(args.path.slice(), sys::Tag::open)
                         {
                             // SAFETY: identity write — `R == ret::Open` for this `F`.
                             unsafe {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -767,13 +767,7 @@ mod _async_tasks {
                     {
                         if let Err(err) = reject_standalone_write(args.path.slice(), sys::Tag::open)
                         {
-                            // SAFETY: identity write — `R == ret::Open` for this `F`.
-                            unsafe {
-                                core::ptr::write(
-                                    &mut task.result as *mut Maybe<R> as *mut Maybe<ret::Open>,
-                                    Err(err),
-                                )
-                            };
+                            task.result = Err(err);
                             let task_ptr: *mut Self = task;
                             task.global_object()
                                 .bun_vm()

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -350,14 +350,26 @@ fn standalone_module_graph_get() -> Option<*mut bun_standalone_graph::Graph> {
     bun_standalone_graph::Graph::get()
 }
 
+/// True for any path at or under the reserved virtual root, including the
+/// bare prefix with no trailing separator (e.g. `path.dirname(import.meta.dir)`).
+#[inline]
+fn is_reserved_standalone_path(path: &[u8]) -> bool {
+    #[cfg(windows)]
+    let path = without_nt_prefix(path);
+    bun_standalone_graph::is_bun_standalone_file_path(path)
+        || path == &bun_standalone_graph::BASE_PATH.as_bytes()[..bun_standalone_graph::BASE_PATH.len() - 1]
+        || (cfg!(windows)
+            && path
+                == &bun_standalone_graph::BASE_PUBLIC_PATH.as_bytes()
+                    [..bun_standalone_graph::BASE_PUBLIC_PATH.len() - 1])
+}
+
 /// Inside a standalone executable, the `/$bunfs/` (POSIX) / `B:\~BUN\`
 /// (Windows) prefix is a reserved virtual root. Writes must not fall through
 /// to the real filesystem and create a literal `/$bunfs/` tree on disk.
 #[inline]
 fn reject_standalone_write(path: &[u8], syscall: sys::Tag) -> Maybe<()> {
-    if standalone_module_graph_get().is_some()
-        && bun_standalone_graph::is_bun_standalone_file_path(path)
-    {
+    if standalone_module_graph_get().is_some() && is_reserved_standalone_path(path) {
         return Err(sys::Error {
             errno: E::EROFS as _,
             syscall,
@@ -7151,6 +7163,17 @@ impl NodeFS {
         let path_is_path = matches!(args.path, PathOrFileDescriptor::Path(_));
         let fd_maybe_windows: FD = match &args.path {
             PathOrFileDescriptor::Path(p) => {
+                let flags = args.flag.as_int();
+                if flags
+                    & (sys::O::WRONLY
+                        | sys::O::RDWR
+                        | sys::O::CREAT
+                        | sys::O::APPEND
+                        | sys::O::TRUNC)
+                    != 0
+                {
+                    reject_standalone_write(p.slice(), sys::Tag::open)?;
+                }
                 let path = p.slice_z(&mut self.sync_error_buf);
 
                 if let Some(graph) = standalone_module_graph_get() {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -357,7 +357,9 @@ fn is_reserved_standalone_path(path: &[u8]) -> bool {
     #[cfg(windows)]
     let path = without_nt_prefix(path);
     bun_standalone_graph::is_bun_standalone_file_path(path)
-        || path == &bun_standalone_graph::BASE_PATH.as_bytes()[..bun_standalone_graph::BASE_PATH.len() - 1]
+        || path
+            == &bun_standalone_graph::BASE_PATH.as_bytes()
+                [..bun_standalone_graph::BASE_PATH.len() - 1]
         || (cfg!(windows)
             && path
                 == &bun_standalone_graph::BASE_PUBLIC_PATH.as_bytes()

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5385,6 +5385,21 @@ fn validate_writable_blob(global_this: &JSGlobalObject, blob: &Blob) -> JsResult
             "Cannot write to a Blob backed by bytes, which are always read-only"
         )));
     }
+    if let store::Data::File(f) = &store.data {
+        if let PathOrFileDescriptor::Path(p) = &f.pathlike {
+            if bun_standalone_graph::Graph::get().is_some()
+                && bun_standalone_graph::is_bun_standalone_file_path(p.slice())
+            {
+                let err = bun_sys::Error {
+                    errno: bun_sys::E::EROFS as _,
+                    syscall: bun_sys::Tag::open,
+                    path: p.slice().into(),
+                    ..Default::default()
+                };
+                return Err(global_this.throw_value(err.to_js(global_this)));
+            }
+        }
+    }
     Ok(())
 }
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5085,7 +5085,7 @@ pub fn write_file_internal(
             _ => None,
         };
         if let Some(p) = dest_path {
-            if bun_standalone_graph::is_bun_standalone_file_path(p) {
+            if bun_standalone_graph::is_reserved_standalone_path(p) {
                 let err = bun_sys::Error {
                     errno: bun_sys::E::EROFS as _,
                     syscall: bun_sys::Tag::open,
@@ -5388,7 +5388,7 @@ fn validate_writable_blob(global_this: &JSGlobalObject, blob: &Blob) -> JsResult
     if let store::Data::File(f) = &store.data {
         if let PathOrFileDescriptor::Path(p) = &f.pathlike {
             if bun_standalone_graph::Graph::get().is_some()
-                && bun_standalone_graph::is_bun_standalone_file_path(p.slice())
+                && bun_standalone_graph::is_reserved_standalone_path(p.slice())
             {
                 let err = bun_sys::Error {
                     errno: bun_sys::E::EROFS as _,

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5067,6 +5067,41 @@ pub fn write_file_internal(
         }
     }
 
+    // Inside a compiled executable, the `/$bunfs/` virtual root is reserved:
+    // writes must not fall through and create a real `/$bunfs/` tree on disk.
+    if bun_standalone_graph::Graph::get().is_some() {
+        let dest_path: Option<&[u8]> = match path_or_blob {
+            PathOrBlob::Path(PathOrFileDescriptor::Path(p)) => Some(p.slice()),
+            PathOrBlob::Blob(b) => match b.store.get() {
+                Some(store) => match &store.data {
+                    store::Data::File(f) => match &f.pathlike {
+                        PathOrFileDescriptor::Path(p) => Some(p.slice()),
+                        PathOrFileDescriptor::Fd(_) => None,
+                    },
+                    _ => None,
+                },
+                None => None,
+            },
+            _ => None,
+        };
+        if let Some(p) = dest_path {
+            if bun_standalone_graph::is_bun_standalone_file_path(p) {
+                let err = bun_sys::Error {
+                    errno: bun_sys::E::EROFS as _,
+                    syscall: bun_sys::Tag::open,
+                    path: p.into(),
+                    ..Default::default()
+                };
+                return Ok(
+                    JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                        global_this,
+                        err.to_js(global_this),
+                    ),
+                );
+            }
+        }
+    }
+
     let input_store: Option<StoreRef> = if let PathOrBlob::Blob(ref b) = *path_or_blob {
         b.store.get().clone()
     } else {

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -140,6 +140,17 @@ pub fn is_bun_standalone_file_path(str_: &[u8]) -> bool {
     }
 }
 
+/// True for any path at or under the reserved virtual root, including the bare
+/// prefix without a trailing separator (`path.dirname(import.meta.dir)`).
+/// Used by the write guards in `node:fs` and `Bun.write`.
+pub fn is_reserved_standalone_path(str_: &[u8]) -> bool {
+    #[cfg(windows)]
+    let str_ = strings::paths::without_nt_prefix::<u8>(str_);
+    is_bun_standalone_file_path_canonicalized(str_)
+        || str_ == &BASE_PATH.as_bytes()[..BASE_PATH.len() - 1]
+        || (cfg!(windows) && str_ == &BASE_PUBLIC_PATH.as_bytes()[..BASE_PUBLIC_PATH.len() - 1])
+}
+
 impl StandaloneModuleGraph {
     // Callers mutate `wtf_string` / `cached_blob`, so these accessors take
     // `&mut self`. Switching to `UnsafeCell` per-`File`

--- a/src/standalone_graph/lib.rs
+++ b/src/standalone_graph/lib.rs
@@ -10,4 +10,5 @@ pub mod StandaloneModuleGraph;
 // Re-export the flat surface most downstream callers use.
 pub use StandaloneModuleGraph::{
     BASE_PATH, BASE_PUBLIC_PATH, File, StandaloneModuleGraph as Graph, is_bun_standalone_file_path,
+    is_reserved_standalone_path,
 };

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -505,6 +505,13 @@ describe("bundler", () => {
         await runAsync("Bun.write-string", () => Bun.write(newPath, "x"));
         await runAsync("Bun.write-bytes", () => Bun.write(newPath, new Uint8Array(4)));
         await runAsync("Bun.write-file", () => Bun.write(Bun.file(newPath), "x"));
+        await runAsync("Bun.file.writer", async () => {
+          const w = Bun.file(newPath).writer();
+          w.write("x");
+          await w.end();
+        });
+        await runAsync("Bun.file.write", () => Bun.file(newPath).write("x"));
+        await runAsync("Bun.file.unlink", () => Bun.file(newPath).unlink());
 
         // Embedded reads must keep working.
         results["readFileSync"] = fs.readFileSync(embedded, "utf8");
@@ -549,6 +556,9 @@ describe("bundler", () => {
         "Bun.write-string": "EROFS",
         "Bun.write-bytes": "EROFS",
         "Bun.write-file": "EROFS",
+        "Bun.file.writer": "EROFS",
+        "Bun.file.write": "EROFS",
+        "Bun.file.unlink": "EROFS",
         "readFileSync": "EMBEDDED-BYTES",
         "statSync.size": 14,
         "existsSync": true,

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -449,6 +449,113 @@ describe("bundler", () => {
     outfile: "dist/out",
     run: { stdout: "Hello, world!", setCwd: true },
   });
+  // Writes aimed at the virtual `/$bunfs/` root must not fall through to the
+  // real filesystem and create a literal `/$bunfs/` directory at `/`.
+  itBundled("compile/EmbeddedFilesReadOnly", {
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        import embedded from "./a.txt" with { type: "file" };
+        import fs from "node:fs";
+        import fsp from "node:fs/promises";
+
+        const vroot = import.meta.dir;
+        const newPath = vroot + "/new.txt";
+
+        const results: Record<string, unknown> = {};
+        const run = (name: string, fn: () => unknown) => {
+          try { fn(); results[name] = "OK"; }
+          catch (e: any) { results[name] = e?.code ?? e?.message; }
+        };
+        const runAsync = async (name: string, fn: () => Promise<unknown>) => {
+          try { await fn(); results[name] = "OK"; }
+          catch (e: any) { results[name] = e?.code ?? e?.message; }
+        };
+
+        // Mutating node:fs ops on a path under the virtual root.
+        run("writeFileSync", () => fs.writeFileSync(newPath, "x"));
+        run("writeFileSync-embedded", () => fs.writeFileSync(embedded, "x"));
+        run("appendFileSync", () => fs.appendFileSync(newPath, "x"));
+        run("mkdirSync", () => fs.mkdirSync(vroot + "/sub"));
+        run("mkdirSync-recursive", () => fs.mkdirSync(vroot + "/a/b", { recursive: true }));
+        run("openSync-w", () => fs.closeSync(fs.openSync(newPath, "w")));
+        run("openSync-a", () => fs.closeSync(fs.openSync(newPath, "a")));
+        run("openSync-r+", () => fs.closeSync(fs.openSync(newPath, "r+")));
+        run("unlinkSync", () => fs.unlinkSync(embedded));
+        run("rmSync", () => fs.rmSync(embedded));
+        run("rmdirSync", () => fs.rmdirSync(vroot));
+        run("renameSync-from", () => fs.renameSync(embedded, "/tmp/x"));
+        run("renameSync-to", () => fs.renameSync("/tmp/x", newPath));
+        run("symlinkSync", () => fs.symlinkSync("/tmp/x", newPath));
+        run("linkSync", () => fs.linkSync("/tmp/x", newPath));
+        run("truncateSync", () => fs.truncateSync(embedded, 0));
+        run("chmodSync", () => fs.chmodSync(embedded, 0o644));
+        run("chownSync", () => fs.chownSync(embedded, 0, 0));
+        run("utimesSync", () => fs.utimesSync(embedded, 0, 0));
+        run("copyFileSync-dest", () => fs.copyFileSync(process.execPath, newPath));
+
+        // Representative async variants.
+        await runAsync("writeFile", () => fsp.writeFile(newPath, "x"));
+        await runAsync("mkdir", () => fsp.mkdir(vroot + "/sub"));
+        await runAsync("unlink", () => fsp.unlink(embedded));
+        await runAsync("open-w", async () => (await fsp.open(newPath, "w")).close());
+        await runAsync("cp-dest", () => fsp.cp(process.execPath, newPath));
+
+        // Bun.write
+        await runAsync("Bun.write-string", () => Bun.write(newPath, "x"));
+        await runAsync("Bun.write-bytes", () => Bun.write(newPath, new Uint8Array(4)));
+        await runAsync("Bun.write-file", () => Bun.write(Bun.file(newPath), "x"));
+
+        // Embedded reads must keep working.
+        results["readFileSync"] = fs.readFileSync(embedded, "utf8");
+        results["statSync.size"] = fs.statSync(embedded).size;
+        results["existsSync"] = fs.existsSync(embedded);
+
+        // No real virtual-root directory leaked onto disk.
+        const realRoot = process.platform === "win32" ? "B:\\\\~BUN" : "/$bunfs";
+        results["realRootExists"] = fs.existsSync(realRoot);
+
+        console.log(JSON.stringify(results));
+      `,
+      "/a.txt": "EMBEDDED-BYTES",
+    },
+    run: {
+      stdout: JSON.stringify({
+        "writeFileSync": "EROFS",
+        "writeFileSync-embedded": "EROFS",
+        "appendFileSync": "EROFS",
+        "mkdirSync": "EROFS",
+        "mkdirSync-recursive": "EROFS",
+        "openSync-w": "EROFS",
+        "openSync-a": "EROFS",
+        "openSync-r+": "EROFS",
+        "unlinkSync": "EROFS",
+        "rmSync": "EROFS",
+        "rmdirSync": "EROFS",
+        "renameSync-from": "EROFS",
+        "renameSync-to": "EROFS",
+        "symlinkSync": "EROFS",
+        "linkSync": "EROFS",
+        "truncateSync": "EROFS",
+        "chmodSync": "EROFS",
+        "chownSync": "EROFS",
+        "utimesSync": "EROFS",
+        "copyFileSync-dest": "EROFS",
+        "writeFile": "EROFS",
+        "mkdir": "EROFS",
+        "unlink": "EROFS",
+        "open-w": "EROFS",
+        "cp-dest": "EROFS",
+        "Bun.write-string": "EROFS",
+        "Bun.write-bytes": "EROFS",
+        "Bun.write-file": "EROFS",
+        "readFileSync": "EMBEDDED-BYTES",
+        "statSync.size": 14,
+        "existsSync": true,
+        "realRootExists": false,
+      }),
+    },
+  });
   itBundled("compile/Bun.isStandaloneExecutable", {
     compile: true,
     assetNaming: "[name].[ext]",

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -518,6 +518,7 @@ describe("bundler", () => {
         });
         await runAsync("Bun.file.write", () => Bun.file(newPath).write("x"));
         await runAsync("Bun.file.unlink", () => Bun.file(newPath).unlink());
+        await runAsync("Bun.write-bare", () => Bun.write(bare, "x"));
 
         // Embedded reads must keep working.
         results["readFileSync"] = fs.readFileSync(embedded, "utf8");
@@ -569,6 +570,7 @@ describe("bundler", () => {
         "Bun.file.writer": "EROFS",
         "Bun.file.write": "EROFS",
         "Bun.file.unlink": "EROFS",
+        "Bun.write-bare": "EROFS",
         "readFileSync": "EMBEDDED-BYTES",
         "statSync.size": 14,
         "existsSync": true,

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -458,9 +458,11 @@ describe("bundler", () => {
         import embedded from "./a.txt" with { type: "file" };
         import fs from "node:fs";
         import fsp from "node:fs/promises";
+        import path from "node:path";
 
         const vroot = import.meta.dir;
         const newPath = vroot + "/new.txt";
+        const bare = path.dirname(vroot);
 
         const results: Record<string, unknown> = {};
         const run = (name: string, fn: () => unknown) => {
@@ -493,6 +495,10 @@ describe("bundler", () => {
         run("chownSync", () => fs.chownSync(embedded, 0, 0));
         run("utimesSync", () => fs.utimesSync(embedded, 0, 0));
         run("copyFileSync-dest", () => fs.copyFileSync(process.execPath, newPath));
+        run("readFileSync-w+", () => fs.readFileSync(newPath, { flag: "w+" }));
+        run("readFileSync-a+", () => fs.readFileSync(newPath, { flag: "a+" }));
+        run("mkdirSync-bare", () => fs.mkdirSync(bare));
+        run("rmSync-bare", () => fs.rmSync(bare, { recursive: true, force: true }));
 
         // Representative async variants.
         await runAsync("writeFile", () => fsp.writeFile(newPath, "x"));
@@ -548,6 +554,10 @@ describe("bundler", () => {
         "chownSync": "EROFS",
         "utimesSync": "EROFS",
         "copyFileSync-dest": "EROFS",
+        "readFileSync-w+": "EROFS",
+        "readFileSync-a+": "EROFS",
+        "mkdirSync-bare": "EROFS",
+        "rmSync-bare": "EROFS",
         "writeFile": "EROFS",
         "mkdir": "EROFS",
         "unlink": "EROFS",


### PR DESCRIPTION
## What

Inside a `bun build --compile` executable, `import.meta.dir` resolves to the virtual `/$bunfs/root` (`B:\~BUN\` on Windows). Writes aimed at paths under that prefix fell through to the real filesystem:

```js
// compiled with `bun build --compile`, run as root (common for containers)
import p from './a.txt' with { type: 'file' };   // embedded, content 'EMBEDDED-BYTES'
import fs from 'node:fs';

await Bun.write(import.meta.dir + '/new.txt', 'ESCAPED');
fs.existsSync('/$bunfs/root/new.txt');          // => true: a real /$bunfs tree now exists at /

fs.writeFileSync(p, 'SHADOW-BYTES');             // no throw once the real dir exists

fs.readFileSync(p, 'utf8');                      // EMBEDDED-BYTES
await Bun.file(p).text();                        // EMBEDDED-BYTES
const fd = fs.openSync(p, 'r');
fs.readSync(fd, buf, 0, 64, 0);                  // SHADOW-BYTES
```

A compiled binary that attempts a virtual write permanently dirties the host's root filesystem, two compiled binaries on one host then share and fight over the same real `/$bunfs` alias, and once shadowed, fd-based consumers see different content than buffer-based readers of the identical path.

## Cause

Only `readFile`, `stat` and `exists` check the standalone module graph before touching the real fs. Every other path-taking operation (`writeFile`, `open`, `mkdir`, `unlink`, `rename`, `Bun.write`, ...) goes straight to the syscall wrapper with no prefix check.

## Fix

Add a shared `reject_standalone_write(path, syscall)` helper that returns `EROFS` when running inside a standalone executable and `path` is under the `/$bunfs/` / `B:\~BUN\` prefix. Call it at the top of every mutating `node:fs` operation and in `Bun.write`'s `write_file_internal`.

Operations guarded: `writeFile`, `appendFile`, `mkdir`, `mkdtemp`, `open` (with write/create/append/trunc flags, sync and the Windows async libuv path), `unlink`, `rm`, `rmdir`, `rename` (both sides), `symlink`, `link`, `truncate`, `chmod`, `chown`, `lchmod`, `lchown`, `utimes`, `lutimes`, `copyFile` (dest), `cp` (dest, sync and async), and `Bun.write` (string path and `Bun.file(path)` destinations).

Read-only open and read operations are unchanged; `readFile`/`stat`/`exists` keep serving embedded content.

## Verification

New `compile/EmbeddedFilesReadOnly` in `test/bundler/bundler_compile.test.ts` compiles a fixture that exercises all of the above and asserts every mutating op returns `EROFS`, embedded reads still return the original bytes, and no real `/$bunfs` directory is created on disk.

```
bun bd test bundler_compile.test.ts -t EmbeddedFilesReadOnly   # pass
USE_SYSTEM_BUN=1 bun test ... -t EmbeddedFilesReadOnly         # fail (ENOENT/OK instead of EROFS, realRootExists:true)
```

Supersedes #34187 (which only covered `Bun.write` with an `ERR_INVALID_ARG_TYPE` throw).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_compile.test.ts

<!-- robobun:evidence:end -->