### PR TITLE
bundler: route builtins through onResolve for target 'bun'; add `external: false`

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -823,10 +823,10 @@ To disallow _any_ runtime external reference, set `external` to `false`. Any imp
 
 ```ts title="build.ts" icon="/icons/typescript.svg"
 await Bun.build({
-  entrypoints: ['./index.tsx'],
-  outdir: './out',
+  entrypoints: ["./index.tsx"],
+  outdir: "./out",
   external: false,
-})
+});
 ```
 
 ### packages

--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -819,6 +819,16 @@ To mark all imports as external, use the wildcard `*`:
   </Tab>
 </Tabs>
 
+To disallow _any_ runtime external reference, set `external` to `false`. Any import that would otherwise be emitted as a runtime external (Node.js/Bun builtins such as `node:fs`, `fs`, `bun:sqlite`) fails the build with an error naming the importing file. This cannot be combined with `packages: "external"`.
+
+```ts title="build.ts" icon="/icons/typescript.svg"
+await Bun.build({
+  entrypoints: ['./index.tsx'],
+  outdir: './out',
+  external: false,
+})
+```
+
 ### packages
 
 Controls whether package dependencies are included in the bundle. Possible values: `bundle` (default), `external`. Bun treats any import whose path does not start with `.`, `..`, or `/` as a package.
@@ -1679,7 +1689,7 @@ interface BuildConfig {
   root?: string; // project root
   splitting?: boolean; // default false, enable code splitting
   plugins?: BunPlugin[];
-  external?: string[];
+  external?: string[] | false;
   packages?: "bundle" | "external";
   publicPath?: string;
   define?: Record<string, string>;

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2658,10 +2658,11 @@ declare module "bun" {
      *
      * - `string[]` (default `[]`): each entry is matched against the import
      *   specifier; `*` is supported as a wildcard.
-     * - `false`: no module may be left external. Any import of a Node.js or
-     *   Bun builtin (e.g. `node:fs`, `fs`, `bun:sqlite`) that cannot be
-     *   bundled fails the build. Cannot be combined with
-     *   `packages: "external"`.
+     * - `false`: no module may be left external. Any import that would
+     *   otherwise be emitted as a runtime external reference (Node.js/Bun
+     *   builtins such as `node:fs`, `fs`, `bun:sqlite`, `ws`; subpath
+     *   imports that map to a builtin) fails the build. Cannot be combined
+     *   with `packages: "external"`.
      */
     external?: string[] | false;
     /**

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2652,7 +2652,18 @@ declare module "bun" {
     root?: string; // project root
     plugins?: BunPlugin[];
     // manifest?: boolean; // whether to return manifest
-    external?: string[];
+    /**
+     * Specifies which import paths are left unresolved in the output as
+     * external references to be resolved at runtime.
+     *
+     * - `string[]` (default `[]`): each entry is matched against the import
+     *   specifier; `*` is supported as a wildcard.
+     * - `false`: no module may be left external. Any import of a Node.js or
+     *   Bun builtin (e.g. `node:fs`, `fs`, `bun:sqlite`) that cannot be
+     *   bundled fails the build. Cannot be combined with
+     *   `packages: "external"`.
+     */
+    external?: string[] | false;
     /**
      * Control whether dynamic `import()`, `require()`, or `require.resolve()` specifiers (non-literal
      * arguments like `` `./locales/${lang}.json` ``) are allowed to pass through

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1668,7 +1668,6 @@ pub mod bv2_impl {
             self.client_transpiler = Some(NonNull::from(&mut *ct).into());
             Ok(ct)
         }
-
     }
 
     /// Applies the target 'bun' builtin externalization to an `ImportRecord` whose

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1669,6 +1669,86 @@ pub mod bv2_impl {
             Ok(ct)
         }
 
+    }
+
+    /// Applies the target 'bun' builtin externalization to an `ImportRecord` whose
+    /// specifier names a hardcoded alias or `bun:` module: rewrites the path and
+    /// sets `IS_EXTERNAL_WITHOUT_SIDE_EFFECTS`. Returns whether the record matched.
+    fn mark_bun_builtin_external(
+        import_record: &mut ImportRecord,
+        rewrite_jest_for_tests: bool,
+    ) -> bool {
+        if let Some(replacement) = bun_resolve_builtins::HardcodedModule::Alias::get(
+            import_record.path.text,
+            Target::Bun,
+            bun_resolve_builtins::HardcodedModule::Cfg {
+                rewrite_jest_for_tests,
+            },
+        ) {
+            // When bundling node builtins, remove the "node:" prefix.
+            // This supports special use cases where the bundle is put
+            // into a non-node module resolver that doesn't support
+            // node's prefix. https://github.com/oven-sh/bun/issues/18545
+            import_record.path.text = if replacement.node_builtin && !replacement.node_only_prefix {
+                &replacement.path.as_bytes()[5..]
+            } else {
+                replacement.path.as_bytes()
+            };
+            import_record.tag = replacement.tag;
+            import_record.source_index = Index::INVALID;
+            import_record
+                .flags
+                .insert(bun_ast::ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS);
+            return true;
+        }
+
+        if import_record.path.text.starts_with(b"bun:") {
+            let new_text: &'static [u8] = &import_record.path.text[b"bun:".len()..];
+            import_record.path = bun_paths::fs::Path::init(new_text);
+            import_record.path.namespace = b"bun";
+            import_record.source_index = Index::INVALID;
+            import_record
+                .flags
+                .insert(bun_ast::ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS);
+            return true;
+        }
+
+        false
+    }
+
+    impl<'a> BundleV2<'a> {
+        fn fail_disallowed_external(
+            &mut self,
+            importer_source_index: u32,
+            bake_graph: bake::Graph,
+            range: bun_ast::Range,
+            kind: ImportKind,
+            specifier: &[u8],
+        ) {
+            let source: &bun_ast::Source =
+                &self.graph.input_files.items_source()[importer_source_index as usize];
+            // SAFETY: log lives in DevServer/transpiler, disjoint from `self.graph.input_files`.
+            let log: &mut bun_ast::Log = unsafe {
+                bun_ptr::detach_lifetime_mut(
+                    self.log_for_resolution_failures(source.path.text, bake_graph),
+                )
+            };
+            let source: &bun_ast::Source =
+                &self.graph.input_files.items_source()[importer_source_index as usize];
+            bun_ast::Log::add_resolve_error_with_text_dupe(
+                log,
+                Some(source),
+                range,
+                format_args!(
+                    "Cannot {} \"{}\" because 'external' is set to false",
+                    bstr::BStr::new(kind.error_label()),
+                    bstr::BStr::new(specifier),
+                ),
+                specifier,
+                kind,
+            );
+        }
+
         /// By calling this function, it implies that the returned log *will* be
         /// written to. For DevServer, this allocates a per-file log for the sources
         /// it is called on. Function must be called on the bundle thread.
@@ -2208,37 +2288,25 @@ pub mod bv2_impl {
                 }
             }
 
-            if self.transpiler.options.disallow_external
-                && options::is_builtin_specifier(&import_record.specifier)
-            {
-                // SAFETY: log lives in DevServer/transpiler, disjoint from `self.graph`.
-                let log: &mut bun_ast::Log = unsafe {
-                    bun_ptr::detach_lifetime_mut(self.log_for_resolution_failures(
-                        &import_record.source_file,
-                        target.bake_graph(),
-                    ))
-                };
-                let source: Option<&bun_ast::Source> = Some(
-                    &self.graph.input_files.items_source()
-                        [import_record.importer_source_index as usize],
-                );
-                bun_ast::Log::add_resolve_error_with_text_dupe(
-                    log,
-                    source,
-                    import_record.range,
-                    format_args!(
-                        "Cannot {} builtin module \"{}\" because 'external' is set to false",
-                        bstr::BStr::new(import_record.kind.error_label()),
-                        bstr::BStr::new(&import_record.specifier),
-                    ),
-                    &import_record.specifier,
-                    import_record.kind,
-                );
+            if target.is_bun() {
+                let rewrite_jest_for_tests = self.transpiler.options.rewrite_jest_for_tests;
+                let disallow_external = self.transpiler.options.disallow_external;
                 let record: &mut ImportRecord = &mut self.graph.ast.items_import_records_mut()
                     [import_record.importer_source_index as usize]
                     .as_mut_slice()[import_record.import_record_index as usize];
-                record.path.is_disabled = true;
-                return;
+                if mark_bun_builtin_external(record, rewrite_jest_for_tests) {
+                    if disallow_external {
+                        record.path.is_disabled = true;
+                        self.fail_disallowed_external(
+                            import_record.importer_source_index,
+                            target.bake_graph(),
+                            import_record.range,
+                            import_record.kind,
+                            &import_record.specifier,
+                        );
+                    }
+                    return;
+                }
             }
 
             let mut had_busted_dir_cache = false;
@@ -2402,6 +2470,19 @@ pub mod bv2_impl {
             };
 
             if resolve_result.flags.is_external() {
+                if self.transpiler.options.disallow_external {
+                    let record: &mut ImportRecord = &mut self.graph.ast.items_import_records_mut()
+                        [import_record.importer_source_index as usize]
+                        .as_mut_slice()[import_record.import_record_index as usize];
+                    record.path.is_disabled = true;
+                    self.fail_disallowed_external(
+                        import_record.importer_source_index,
+                        target.bake_graph(),
+                        import_record.range,
+                        import_record.kind,
+                        &import_record.specifier,
+                    );
+                }
                 return;
             }
 
@@ -5938,72 +6019,24 @@ pub mod bv2_impl {
                     continue;
                 }
 
-                if self.transpiler.options.disallow_external
-                    && options::is_builtin_specifier(import_record.path.text)
+                if ctx.target.is_bun()
+                    && mark_bun_builtin_external(
+                        import_record,
+                        self.transpiler.options.rewrite_jest_for_tests,
+                    )
                 {
-                    // SAFETY: log lives in DevServer/transpiler, disjoint from `self.graph`.
-                    let log: &mut bun_ast::Log =
-                        unsafe {
-                            bun_ptr::detach_lifetime_mut(self.log_for_resolution_failures(
-                                source.path.text,
-                                ctx.target.bake_graph(),
-                            ))
-                        };
-                    bun_ast::Log::add_resolve_error_with_text_dupe(
-                        log,
-                        Some(source),
-                        import_record.range,
-                        format_args!(
-                            "Cannot {} builtin module \"{}\" because 'external' is set to false",
-                            bstr::BStr::new(import_record.kind.error_label()),
-                            bstr::BStr::new(&import_record.path.text),
-                        ),
-                        import_record.path.text,
-                        import_record.kind,
-                    );
-                    last_error = Some(Error::ModuleNotFound);
-                    import_record.path.is_disabled = true;
+                    if self.transpiler.options.disallow_external {
+                        self.fail_disallowed_external(
+                            source.index.0,
+                            ctx.target.bake_graph(),
+                            import_record.range,
+                            import_record.kind,
+                            import_record.original_path,
+                        );
+                        last_error = Some(Error::ModuleNotFound);
+                        import_record.path.is_disabled = true;
+                    }
                     continue;
-                }
-
-                if ctx.target.is_bun() {
-                    if let Some(replacement) = bun_resolve_builtins::HardcodedModule::Alias::get(
-                        import_record.path.text,
-                        Target::Bun,
-                        bun_resolve_builtins::HardcodedModule::Cfg {
-                            rewrite_jest_for_tests: self.transpiler.options.rewrite_jest_for_tests,
-                        },
-                    ) {
-                        // When bundling node builtins, remove the "node:" prefix.
-                        // This supports special use cases where the bundle is put
-                        // into a non-node module resolver that doesn't support
-                        // node's prefix. https://github.com/oven-sh/bun/issues/18545
-                        import_record.path.text =
-                            if replacement.node_builtin && !replacement.node_only_prefix {
-                                &replacement.path.as_bytes()[5..]
-                            } else {
-                                replacement.path.as_bytes()
-                            };
-                        import_record.tag = replacement.tag;
-                        import_record.source_index = Index::INVALID;
-                        import_record
-                            .flags
-                            .insert(bun_ast::ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS);
-                        continue;
-                    }
-
-                    if import_record.path.text.starts_with(b"bun:") {
-                        let new_text: &'static [u8] = &import_record.path.text[b"bun:".len()..];
-                        import_record.path = bun_paths::fs::Path::init(new_text);
-                        import_record.path.namespace = b"bun";
-                        import_record.source_index = Index::INVALID;
-                        import_record
-                            .flags
-                            .insert(bun_ast::ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS);
-
-                        // don't link bun
-                        continue;
-                    }
                 }
 
                 // By default, we treat .sqlite files as external.
@@ -6336,6 +6369,18 @@ pub mod bv2_impl {
                 };
 
                 if resolve_result.flags.is_external() {
+                    if self.transpiler.options.disallow_external {
+                        self.fail_disallowed_external(
+                            source.index.0,
+                            ctx.target.bake_graph(),
+                            import_record.range,
+                            import_record.kind,
+                            import_record.original_path,
+                        );
+                        last_error = Some(Error::ModuleNotFound);
+                        import_record.path.is_disabled = true;
+                        continue;
+                    }
                     if resolve_result.flags.is_external_and_rewrite_import_path()
                         && !strings::eql_long(
                             resolve_result.path_pair.primary.text,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2208,6 +2208,39 @@ pub mod bv2_impl {
                 }
             }
 
+            if self.transpiler.options.disallow_external
+                && options::is_builtin_specifier(&import_record.specifier)
+            {
+                // SAFETY: log lives in DevServer/transpiler, disjoint from `self.graph`.
+                let log: &mut bun_ast::Log = unsafe {
+                    bun_ptr::detach_lifetime_mut(self.log_for_resolution_failures(
+                        &import_record.source_file,
+                        target.bake_graph(),
+                    ))
+                };
+                let source: Option<&bun_ast::Source> = Some(
+                    &self.graph.input_files.items_source()
+                        [import_record.importer_source_index as usize],
+                );
+                bun_ast::Log::add_resolve_error_with_text_dupe(
+                    log,
+                    source,
+                    import_record.range,
+                    format_args!(
+                        "Cannot {} builtin module \"{}\" because 'external' is set to false",
+                        bstr::BStr::new(import_record.kind.error_label()),
+                        bstr::BStr::new(&import_record.specifier),
+                    ),
+                    &import_record.specifier,
+                    import_record.kind,
+                );
+                let record: &mut ImportRecord = &mut self.graph.ast.items_import_records_mut()
+                    [import_record.importer_source_index as usize]
+                    .as_mut_slice()[import_record.import_record_index as usize];
+                record.path.is_disabled = true;
+                return;
+            }
+
             let mut had_busted_dir_cache = false;
             let resolve_result: _resolver::Result = loop {
                 // SAFETY: see `transpiler` note above.
@@ -5895,6 +5928,43 @@ pub mod bv2_impl {
                     continue;
                 }
 
+                if self.enqueue_on_resolve_plugin_if_needed(
+                    source.index.0,
+                    import_record,
+                    source.path.text,
+                    i as u32,
+                    ctx.target,
+                ) {
+                    continue;
+                }
+
+                if self.transpiler.options.disallow_external
+                    && options::is_builtin_specifier(import_record.path.text)
+                {
+                    // SAFETY: log lives in DevServer/transpiler, disjoint from `self.graph`.
+                    let log: &mut bun_ast::Log = unsafe {
+                        bun_ptr::detach_lifetime_mut(self.log_for_resolution_failures(
+                            source.path.text,
+                            ctx.target.bake_graph(),
+                        ))
+                    };
+                    bun_ast::Log::add_resolve_error_with_text_dupe(
+                        log,
+                        Some(source),
+                        import_record.range,
+                        format_args!(
+                            "Cannot {} builtin module \"{}\" because 'external' is set to false",
+                            bstr::BStr::new(import_record.kind.error_label()),
+                            bstr::BStr::new(&import_record.path.text),
+                        ),
+                        import_record.path.text,
+                        import_record.kind,
+                    );
+                    last_error = Some(Error::ModuleNotFound);
+                    import_record.path.is_disabled = true;
+                    continue;
+                }
+
                 if ctx.target.is_bun() {
                     if let Some(replacement) = bun_resolve_builtins::HardcodedModule::Alias::get(
                         import_record.path.text,
@@ -5947,16 +6017,6 @@ pub mod bv2_impl {
                     import_record
                         .flags
                         .insert(bun_ast::ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS);
-                }
-
-                if self.enqueue_on_resolve_plugin_if_needed(
-                    source.index.0,
-                    import_record,
-                    source.path.text,
-                    i as u32,
-                    ctx.target,
-                ) {
-                    continue;
                 }
 
                 // borrowck — `transpiler_for_target` returns `&mut Transpiler`

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4692,6 +4692,25 @@ pub mod bv2_impl {
                 }
                 jsc_api::JSBundler::ResolveValue::Success(result) => {
                     let mut out_source_index: Option<Index> = None;
+                    if result.external
+                        && this.transpiler.options.disallow_external
+                        && resolve.import_record.kind != ImportKind::EntryPointBuild
+                    {
+                        let record: &mut ImportRecord =
+                            &mut this.graph.ast.items_import_records_mut()
+                                [resolve.import_record.importer_source_index as usize]
+                                .as_mut_slice()
+                                [resolve.import_record.import_record_index as usize];
+                        record.path.is_disabled = true;
+                        this.fail_disallowed_external(
+                            resolve.import_record.importer_source_index,
+                            resolve.import_record.original_target.bake_graph(),
+                            resolve.import_record.range,
+                            resolve.import_record.kind,
+                            &resolve.import_record.specifier,
+                        );
+                        return;
+                    }
                     if !result.external {
                         // SAFETY: `result.{path,namespace}` are `Box<[u8]>` whose heap
                         // allocations are moved into `this.free_list` below (in the
@@ -5918,6 +5937,8 @@ pub mod bv2_impl {
             let source = ctx.source;
             let loader = ctx.loader;
             let source_dir = source.path.source_dir();
+            let disallow_external =
+                self.transpiler.options.disallow_external && !source.index.is_runtime();
             let mut estimated_resolve_queue_count: usize = 0;
             for import_record in ctx.import_records.iter_mut() {
                 if import_record
@@ -6024,7 +6045,7 @@ pub mod bv2_impl {
                         self.transpiler.options.rewrite_jest_for_tests,
                     )
                 {
-                    if self.transpiler.options.disallow_external {
+                    if disallow_external {
                         self.fail_disallowed_external(
                             source.index.0,
                             ctx.target.bake_graph(),
@@ -6368,7 +6389,7 @@ pub mod bv2_impl {
                 };
 
                 if resolve_result.flags.is_external() {
-                    if self.transpiler.options.disallow_external {
+                    if disallow_external {
                         self.fail_disallowed_external(
                             source.index.0,
                             ctx.target.bake_graph(),

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2301,9 +2301,10 @@ pub mod bv2_impl {
                 }
             }
 
+            let disallow_external = self.transpiler.options.disallow_external
+                && import_record.importer_source_index != Index::RUNTIME.get();
             if target.is_bun() {
                 let rewrite_jest_for_tests = self.transpiler.options.rewrite_jest_for_tests;
-                let disallow_external = self.transpiler.options.disallow_external;
                 let record: &mut ImportRecord = &mut self.graph.ast.items_import_records_mut()
                     [import_record.importer_source_index as usize]
                     .as_mut_slice()[import_record.import_record_index as usize];
@@ -2483,7 +2484,7 @@ pub mod bv2_impl {
             };
 
             if resolve_result.flags.is_external() {
-                if self.transpiler.options.disallow_external && !import_record.kind.is_from_css() {
+                if disallow_external && !import_record.kind.is_from_css() {
                     let record: &mut ImportRecord = &mut self.graph.ast.items_import_records_mut()
                         [import_record.importer_source_index as usize]
                         .as_mut_slice()[import_record.import_record_index as usize];
@@ -4709,6 +4710,7 @@ pub mod bv2_impl {
                     if result.external
                         && this.transpiler.options.disallow_external
                         && resolve.import_record.kind != ImportKind::EntryPointBuild
+                        && resolve.import_record.importer_source_index != Index::RUNTIME.get()
                     {
                         let record: &mut ImportRecord =
                             &mut this.graph.ast.items_import_records_mut()

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1718,22 +1718,18 @@ pub mod bv2_impl {
     impl<'a> BundleV2<'a> {
         fn fail_disallowed_external(
             &mut self,
-            importer_source_index: u32,
+            source: &bun_ast::Source,
             bake_graph: bake::Graph,
             range: bun_ast::Range,
             kind: ImportKind,
             specifier: &[u8],
         ) {
-            let source: &bun_ast::Source =
-                &self.graph.input_files.items_source()[importer_source_index as usize];
-            // SAFETY: log lives in DevServer/transpiler, disjoint from `self.graph.input_files`.
+            // SAFETY: log lives in DevServer/transpiler, disjoint from the caller-owned `source`.
             let log: &mut bun_ast::Log = unsafe {
                 bun_ptr::detach_lifetime_mut(
                     self.log_for_resolution_failures(source.path.text, bake_graph),
                 )
             };
-            let source: &bun_ast::Source =
-                &self.graph.input_files.items_source()[importer_source_index as usize];
             bun_ast::Log::add_resolve_error_with_text_dupe(
                 log,
                 Some(source),
@@ -1746,6 +1742,24 @@ pub mod bv2_impl {
                 specifier,
                 kind,
             );
+        }
+
+        fn fail_disallowed_external_from_graph(
+            &mut self,
+            importer_source_index: u32,
+            bake_graph: bake::Graph,
+            range: bun_ast::Range,
+            kind: ImportKind,
+            specifier: &[u8],
+        ) {
+            // SAFETY: `input_files` is not mutated across the `fail_disallowed_external`
+            // call; detach so `&mut self` reborrow below type-checks.
+            let source: &bun_ast::Source = unsafe {
+                &*std::ptr::from_ref(
+                    &self.graph.input_files.items_source()[importer_source_index as usize],
+                )
+            };
+            self.fail_disallowed_external(source, bake_graph, range, kind, specifier);
         }
 
         /// By calling this function, it implies that the returned log *will* be
@@ -2296,7 +2310,7 @@ pub mod bv2_impl {
                 if mark_bun_builtin_external(record, rewrite_jest_for_tests) {
                     if disallow_external {
                         record.path.is_disabled = true;
-                        self.fail_disallowed_external(
+                        self.fail_disallowed_external_from_graph(
                             import_record.importer_source_index,
                             target.bake_graph(),
                             import_record.range,
@@ -2469,12 +2483,12 @@ pub mod bv2_impl {
             };
 
             if resolve_result.flags.is_external() {
-                if self.transpiler.options.disallow_external {
+                if self.transpiler.options.disallow_external && !import_record.kind.is_from_css() {
                     let record: &mut ImportRecord = &mut self.graph.ast.items_import_records_mut()
                         [import_record.importer_source_index as usize]
                         .as_mut_slice()[import_record.import_record_index as usize];
                     record.path.is_disabled = true;
-                    self.fail_disallowed_external(
+                    self.fail_disallowed_external_from_graph(
                         import_record.importer_source_index,
                         target.bake_graph(),
                         import_record.range,
@@ -4702,7 +4716,7 @@ pub mod bv2_impl {
                                 .as_mut_slice()
                                 [resolve.import_record.import_record_index as usize];
                         record.path.is_disabled = true;
-                        this.fail_disallowed_external(
+                        this.fail_disallowed_external_from_graph(
                             resolve.import_record.importer_source_index,
                             resolve.import_record.original_target.bake_graph(),
                             resolve.import_record.range,
@@ -6029,6 +6043,32 @@ pub mod bv2_impl {
                     continue;
                 }
 
+                // By default, we treat .sqlite files as external.
+                if import_record.loader == Some(Loader::Sqlite) {
+                    if disallow_external {
+                        self.fail_disallowed_external(
+                            source,
+                            ctx.target.bake_graph(),
+                            import_record.range,
+                            import_record.kind,
+                            import_record.original_path,
+                        );
+                        last_error = Some(Error::ModuleNotFound);
+                        import_record.path.is_disabled = true;
+                        continue;
+                    }
+                    import_record
+                        .flags
+                        .insert(bun_ast::ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS);
+                    continue;
+                }
+
+                if import_record.loader == Some(Loader::SqliteEmbedded) {
+                    import_record
+                        .flags
+                        .insert(bun_ast::ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS);
+                }
+
                 if self.enqueue_on_resolve_plugin_if_needed(
                     source.index.0,
                     import_record,
@@ -6047,7 +6087,7 @@ pub mod bv2_impl {
                 {
                     if disallow_external {
                         self.fail_disallowed_external(
-                            source.index.0,
+                            source,
                             ctx.target.bake_graph(),
                             import_record.range,
                             import_record.kind,
@@ -6057,20 +6097,6 @@ pub mod bv2_impl {
                         import_record.path.is_disabled = true;
                     }
                     continue;
-                }
-
-                // By default, we treat .sqlite files as external.
-                if import_record.loader == Some(Loader::Sqlite) {
-                    import_record
-                        .flags
-                        .insert(bun_ast::ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS);
-                    continue;
-                }
-
-                if import_record.loader == Some(Loader::SqliteEmbedded) {
-                    import_record
-                        .flags
-                        .insert(bun_ast::ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS);
                 }
 
                 // borrowck — `transpiler_for_target` returns `&mut Transpiler`
@@ -6389,9 +6415,9 @@ pub mod bv2_impl {
                 };
 
                 if resolve_result.flags.is_external() {
-                    if disallow_external {
+                    if disallow_external && !import_record.kind.is_from_css() {
                         self.fail_disallowed_external(
-                            source.index.0,
+                            source,
                             ctx.target.bake_graph(),
                             import_record.range,
                             import_record.kind,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5942,12 +5942,13 @@ pub mod bv2_impl {
                     && options::is_builtin_specifier(import_record.path.text)
                 {
                     // SAFETY: log lives in DevServer/transpiler, disjoint from `self.graph`.
-                    let log: &mut bun_ast::Log = unsafe {
-                        bun_ptr::detach_lifetime_mut(self.log_for_resolution_failures(
-                            source.path.text,
-                            ctx.target.bake_graph(),
-                        ))
-                    };
+                    let log: &mut bun_ast::Log =
+                        unsafe {
+                            bun_ptr::detach_lifetime_mut(self.log_for_resolution_failures(
+                                source.path.text,
+                                ctx.target.bake_graph(),
+                            ))
+                        };
                     bun_ast::Log::add_resolve_error_with_text_dupe(
                         log,
                         Some(source),

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4711,6 +4711,7 @@ pub mod bv2_impl {
                         && this.transpiler.options.disallow_external
                         && resolve.import_record.kind != ImportKind::EntryPointBuild
                         && resolve.import_record.importer_source_index != Index::RUNTIME.get()
+                        && !resolve.import_record.kind.is_from_css()
                     {
                         let record: &mut ImportRecord =
                             &mut this.graph.ast.items_import_records_mut()

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2303,7 +2303,7 @@ pub mod bv2_impl {
 
             let disallow_external = self.transpiler.options.disallow_external
                 && import_record.importer_source_index != Index::RUNTIME.get();
-            if target.is_bun() {
+            if target.is_bun() && !import_record.kind.is_from_css() {
                 let rewrite_jest_for_tests = self.transpiler.options.rewrite_jest_for_tests;
                 let record: &mut ImportRecord = &mut self.graph.ast.items_import_records_mut()
                     [import_record.importer_source_index as usize]
@@ -6083,6 +6083,7 @@ pub mod bv2_impl {
                 }
 
                 if ctx.target.is_bun()
+                    && !import_record.kind.is_from_css()
                     && mark_bun_builtin_external(
                         import_record,
                         self.transpiler.options.rewrite_jest_for_tests,

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -111,6 +111,15 @@ pub fn is_node_builtin(str: &[u8]) -> bool {
     bun_resolve_builtins::Alias::has(str, bun_ast::Target::Node, Default::default())
 }
 
+/// True for any specifier that names a Node.js or Bun builtin module (bare
+/// or prefixed). Used by the `external: false` build option.
+pub fn is_builtin_specifier(str: &[u8]) -> bool {
+    str == b"bun"
+        || str.starts_with(b"bun:")
+        || str.starts_with(b"node:")
+        || is_node_builtin(str)
+}
+
 const DEFAULT_WILDCARD_PATTERNS: &[(&[u8], &[u8])] = &[
     (b"/bun:", b""),
     // (b"/src:", b""),
@@ -1257,6 +1266,7 @@ pub struct BundleOptions<'a> {
 
     pub trim_unused_imports: Option<bool>,
     pub mark_builtins_as_external: bool,
+    pub disallow_external: bool,
     pub server_components: bool,
     pub hot_module_reloading: bool,
     pub react_fast_refresh: bool,
@@ -1475,6 +1485,7 @@ impl<'a> BundleOptions<'a> {
             allow_runtime: self.allow_runtime,
             trim_unused_imports: self.trim_unused_imports,
             mark_builtins_as_external: self.mark_builtins_as_external,
+            disallow_external: self.disallow_external,
             server_components: self.server_components,
             hot_module_reloading: self.hot_module_reloading,
             react_fast_refresh: self.react_fast_refresh,
@@ -1770,6 +1781,7 @@ impl<'a> BundleOptions<'a> {
             allow_runtime: true,
             trim_unused_imports: None,
             mark_builtins_as_external: false,
+            disallow_external: false,
             server_components: false,
             hot_module_reloading: false,
             react_fast_refresh: false,

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -111,12 +111,6 @@ pub fn is_node_builtin(str: &[u8]) -> bool {
     bun_resolve_builtins::Alias::has(str, bun_ast::Target::Node, Default::default())
 }
 
-/// True for any specifier that names a Node.js or Bun builtin module (bare
-/// or prefixed). Used by the `external: false` build option.
-pub fn is_builtin_specifier(str: &[u8]) -> bool {
-    str == b"bun" || str.starts_with(b"bun:") || str.starts_with(b"node:") || is_node_builtin(str)
-}
-
 const DEFAULT_WILDCARD_PATTERNS: &[(&[u8], &[u8])] = &[
     (b"/bun:", b""),
     // (b"/src:", b""),

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -114,10 +114,7 @@ pub fn is_node_builtin(str: &[u8]) -> bool {
 /// True for any specifier that names a Node.js or Bun builtin module (bare
 /// or prefixed). Used by the `external: false` build option.
 pub fn is_builtin_specifier(str: &[u8]) -> bool {
-    str == b"bun"
-        || str.starts_with(b"bun:")
-        || str.starts_with(b"node:")
-        || is_node_builtin(str)
+    str == b"bun" || str.starts_with(b"bun:") || str.starts_with(b"node:") || is_node_builtin(str)
 }
 
 const DEFAULT_WILDCARD_PATTERNS: &[(&[u8], &[u8])] = &[

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -139,6 +139,7 @@ pub mod js_bundler {
         pub tree_shaking: Option<bool>,
         pub names: Names,
         pub external: StringSet,
+        pub disallow_external: bool,
         pub allow_unresolved: Option<StringSet>,
         pub source_map: options::SourceMapOption,
         pub public_path: OwnedString,
@@ -205,6 +206,7 @@ pub mod js_bundler {
                 tree_shaking: None,
                 names: Names::default(),
                 external: StringSet::default(),
+                disallow_external: false,
                 allow_unresolved: None,
                 source_map: options::SourceMapOption::None,
                 public_path: OwnedString::default(),
@@ -926,12 +928,24 @@ pub mod js_bundler {
                 drop(path);
             }
 
-            if let Some(externals) = config.get_own_array(global_this, "external")? {
-                let mut iter = externals.array_iterator(global_this)?;
-                while let Some(entry_point) = iter.next()? {
-                    let slice = entry_point.to_slice_or_null(global_this)?;
-                    this.external.insert(slice.slice())?;
-                    drop(slice);
+            if let Some(externals) =
+                config.get_own(global_this, &BunString::static_str("external"))?
+            {
+                if externals.is_boolean() {
+                    this.disallow_external = !externals.as_boolean();
+                } else if !externals.is_undefined_or_null() {
+                    if externals.is_cell() && externals.js_type().is_array() {
+                        let mut iter = externals.array_iterator(global_this)?;
+                        while let Some(entry_point) = iter.next()? {
+                            let slice = entry_point.to_slice_or_null(global_this)?;
+                            this.external.insert(slice.slice())?;
+                            drop(slice);
+                        }
+                    } else {
+                        return Err(global_this.throw_invalid_arguments(format_args!(
+                            "external must be an array of strings or false"
+                        )));
+                    }
                 }
             }
 
@@ -1255,6 +1269,12 @@ pub mod js_bundler {
                         compile.outfile.append_slice_exact(outfile)?;
                     }
                 }
+            }
+
+            if this.disallow_external && this.packages == options::PackagesOption::External {
+                return Err(global_this.throw_invalid_arguments(format_args!(
+                    "external: false cannot be combined with packages: \"external\""
+                )));
             }
 
             // ESM bytecode requires compile because module_info (import/export metadata)

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -931,21 +931,19 @@ pub mod js_bundler {
             if let Some(externals) =
                 config.get_own(global_this, &BunString::static_str("external"))?
             {
-                if externals.is_boolean() {
-                    this.disallow_external = !externals.as_boolean();
-                } else if !externals.is_undefined_or_null() {
-                    if externals.is_cell() && externals.js_type().is_array() {
-                        let mut iter = externals.array_iterator(global_this)?;
-                        while let Some(entry_point) = iter.next()? {
-                            let slice = entry_point.to_slice_or_null(global_this)?;
-                            this.external.insert(slice.slice())?;
-                            drop(slice);
-                        }
-                    } else {
-                        return Err(global_this.throw_invalid_arguments(format_args!(
-                            "external must be an array of strings or false"
-                        )));
+                if externals.is_boolean() && !externals.as_boolean() {
+                    this.disallow_external = true;
+                } else if externals.is_cell() && externals.js_type().is_array() {
+                    let mut iter = externals.array_iterator(global_this)?;
+                    while let Some(entry_point) = iter.next()? {
+                        let slice = entry_point.to_slice_or_null(global_this)?;
+                        this.external.insert(slice.slice())?;
+                        drop(slice);
                     }
+                } else if !externals.is_undefined_or_null() {
+                    return Err(global_this.throw_invalid_arguments(format_args!(
+                        "external must be an array of strings or false"
+                    )));
                 }
             }
 

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -917,6 +917,7 @@ impl CompletionStruct for JSBundleCompletionTask {
         transpiler.options.inlining = config.minify.syntax;
         transpiler.options.source_map = config.source_map;
         transpiler.options.packages = config.packages;
+        transpiler.options.disallow_external = config.disallow_external;
         transpiler.options.allow_unresolved = match &config.allow_unresolved {
             Some(a) => options::AllowUnresolved::from_strings(
                 a.keys().to_vec().into_boxed_slice(),

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1496,7 +1496,7 @@ describe("Bun.build external: false", () => {
   ];
 
   test.each(cases)("target $target rejects $specifier", async ({ target, specifier, code, files }) => {
-    using dir = tempDir("external-false", { "entry.js": code, ...files });
+    using dir = tempDir("external-false", { "entry.js": `// line 1\n${code}`, ...files });
     const result = await buildNoThrow({
       entrypoints: [join(String(dir), "entry.js")],
       target,
@@ -1505,6 +1505,7 @@ describe("Bun.build external: false", () => {
     const logs = result.logs.map(m => ({
       message: String((m as any).message ?? m),
       file: (m as any).position?.file ?? "",
+      line: (m as any).position?.line,
     }));
     expect({ success: result.success, logs }).toEqual({
       success: false,
@@ -1512,9 +1513,44 @@ describe("Bun.build external: false", () => {
         {
           message: expect.stringContaining(`"${specifier}" because 'external' is set to false`),
           file: expect.stringContaining("entry.js"),
+          line: 2,
         },
       ],
     });
+  });
+
+  test("rejects a runtime-external sqlite import", async () => {
+    using dir = tempDir("external-false-sqlite", {
+      "entry.js": 'import db from "./data.db" with { type: "sqlite" }; console.log(db);',
+      "data.db": "",
+    });
+    const result = await buildNoThrow({
+      entrypoints: [join(String(dir), "entry.js")],
+      target: "bun",
+      external: false,
+    });
+    expect(result.success).toBe(false);
+    const messages = result.logs.map(m => String((m as any).message ?? m));
+    expect(messages.join("\n")).toContain("\"./data.db\" because 'external' is set to false");
+  });
+
+  test("CSS url() references are not module externals", async () => {
+    using dir = tempDir("external-false-css", {
+      "entry.css":
+        ".a { fill: url(#f); }\n" +
+        ".b { background: url(data:image/png;base64,AA==); }\n" +
+        ".c { background: url(https://cdn.example/x.png); }\n",
+    });
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "entry.css")],
+      target: "bun",
+      external: false,
+    });
+    expect(result.success).toBe(true);
+    const out = await result.outputs[0].text();
+    expect(out).toContain("#f");
+    expect(out).toContain("data:image/png;base64,AA==");
+    expect(out).toContain("https://cdn.example/x.png");
   });
 
   test("target browser bundles polyfillable builtins", async () => {

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1629,6 +1629,30 @@ describe("Bun.build external: false", () => {
     expect(result.success).toBe(true);
   });
 
+  test("plugin onResolve returning { external: true } for a CSS url() is not a module external", async () => {
+    using dir = tempDir("external-false-plugin-css-external", {
+      "entry.css": ".a { background: url(virtual:img); }",
+    });
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "entry.css")],
+      target: "bun",
+      external: false,
+      plugins: [
+        {
+          name: "css-ext",
+          setup(build) {
+            build.onResolve({ filter: /^virtual:img$/ }, args => ({
+              path: args.path,
+              external: true,
+            }));
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+    expect(await result.outputs[0].text()).toContain("virtual:img");
+  });
+
   test("plugin onResolve returning { external: true } is rejected under external: false", async () => {
     using dir = tempDir("external-false-plugin-external", {
       "entry.js": 'import x from "some-pkg"; console.log(x);',

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1477,29 +1477,52 @@ test("Bun.build can be called thousands of times in one process without crashing
 }, 180_000);
 
 describe("Bun.build external: false", () => {
-  const cases: Array<["bun" | "node" | "browser", string, string]> = [
-    ["bun", "node:fs", 'import fs from "node:fs"; console.log(fs);'],
-    ["bun", "fs", 'import fs from "fs"; console.log(fs);'],
-    ["bun", "bun:sqlite", 'import { Database } from "bun:sqlite"; console.log(Database);'],
-    ["bun", "bun", 'import { serve } from "bun"; console.log(serve);'],
-    ["bun", "net", 'const net = require("net"); console.log(net);'],
-    ["node", "node:fs", 'import fs from "node:fs"; console.log(fs);'],
-    ["node", "path", 'import path from "path"; console.log(path);'],
-    ["browser", "node:fs", 'import fs from "node:fs"; console.log(fs);'],
+  type Case = { target: "bun" | "node" | "browser"; specifier: string; code: string; files?: Record<string, string> };
+  const cases: Case[] = [
+    { target: "bun", specifier: "node:fs", code: 'import fs from "node:fs"; console.log(fs);' },
+    { target: "bun", specifier: "fs", code: 'import fs from "fs"; console.log(fs);' },
+    { target: "bun", specifier: "bun:sqlite", code: 'import { Database } from "bun:sqlite"; console.log(Database);' },
+    { target: "bun", specifier: "bun", code: 'import { serve } from "bun"; console.log(serve);' },
+    { target: "bun", specifier: "net", code: 'const net = require("net"); console.log(net);' },
+    { target: "bun", specifier: "ws", code: 'import WebSocket from "ws"; console.log(WebSocket);' },
+    {
+      target: "bun",
+      specifier: "#fs",
+      code: 'import { readFileSync } from "#fs"; console.log(readFileSync);',
+      files: { "package.json": JSON.stringify({ imports: { "#fs": "node:fs" } }) },
+    },
+    { target: "node", specifier: "node:fs", code: 'import fs from "node:fs"; console.log(fs);' },
+    { target: "node", specifier: "path", code: 'import path from "path"; console.log(path);' },
   ];
 
-  test.each(cases)("target %s rejects builtin %s", async (target, specifier, code) => {
-    using dir = tempDir("external-false", { "entry.js": code });
+  test.each(cases)("target $target rejects $specifier", async ({ target, specifier, code, files }) => {
+    using dir = tempDir("external-false", { "entry.js": code, ...files });
     const result = await buildNoThrow({
       entrypoints: [join(String(dir), "entry.js")],
       target,
       external: false,
     });
-    expect(result.success).toBe(false);
     const messages = result.logs.map(m => String((m as any).message ?? m));
-    expect(messages.join("\n")).toContain(`builtin module "${specifier}" because 'external' is set to false`);
+    expect({ success: result.success, messages: messages.join("\n") }).toEqual({
+      success: false,
+      messages: expect.stringContaining(`"${specifier}" because 'external' is set to false`),
+    });
     const position = (result.logs[0] as any)?.position;
     expect(position?.file).toContain("entry.js");
+  });
+
+  test("target browser bundles polyfillable builtins", async () => {
+    using dir = tempDir("external-false-browser", {
+      "entry.js": 'import path from "path"; console.log(path.join("a", "b"));',
+    });
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "entry.js")],
+      target: "browser",
+      external: false,
+    });
+    expect(result.success).toBe(true);
+    const out = await result.outputs[0].text();
+    expect(out).not.toContain('from "path"');
   });
 
   test("succeeds with no builtin imports", async () => {
@@ -1515,27 +1538,30 @@ describe("Bun.build external: false", () => {
     expect(result.success).toBe(true);
   });
 
-  test("still fails when a matching onResolve plugin returns undefined", async () => {
-    using dir = tempDir("external-false-plugin-fallthrough", {
-      "entry.js": 'import fs from "node:fs"; console.log(fs);',
-    });
-    const result = await buildNoThrow({
-      entrypoints: [join(String(dir), "entry.js")],
-      target: "node",
-      external: false,
-      plugins: [
-        {
-          name: "noop",
-          setup(build) {
-            build.onResolve({ filter: /.*/ }, () => undefined);
+  test.each(["bun", "node"] as const)(
+    "still fails when a matching onResolve plugin returns undefined (target %s)",
+    async target => {
+      using dir = tempDir("external-false-plugin-fallthrough", {
+        "entry.js": 'import fs from "node:fs"; console.log(fs);',
+      });
+      const result = await buildNoThrow({
+        entrypoints: [join(String(dir), "entry.js")],
+        target,
+        external: false,
+        plugins: [
+          {
+            name: "noop",
+            setup(build) {
+              build.onResolve({ filter: /.*/ }, () => undefined);
+            },
           },
-        },
-      ],
-    });
-    expect(result.success).toBe(false);
-    const messages = result.logs.map(m => String((m as any).message ?? m));
-    expect(messages.join("\n")).toContain("builtin module \"node:fs\" because 'external' is set to false");
-  });
+        ],
+      });
+      expect(result.success).toBe(false);
+      const messages = result.logs.map(m => String((m as any).message ?? m));
+      expect(messages.join("\n")).toContain("\"node:fs\" because 'external' is set to false");
+    },
+  );
 
   test("plugin onResolve can redirect a builtin under external: false", async () => {
     using dir = tempDir("external-false-plugin", {
@@ -1575,13 +1601,13 @@ describe("Bun.build external: false", () => {
     ).toThrow('external: false cannot be combined with packages: "external"');
   });
 
-  test("non-array non-boolean value is rejected", () => {
+  test.each(["node:fs", true, 42])("invalid external value %p is rejected", value => {
     using dir = tempDir("external-invalid", { "entry.js": "console.log(1);" });
     expect(() =>
       Bun.build({
         entrypoints: [join(String(dir), "entry.js")],
         // @ts-expect-error
-        external: "node:fs",
+        external: value,
       }),
     ).toThrow("external must be an array of strings or false");
   });

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1502,13 +1502,19 @@ describe("Bun.build external: false", () => {
       target,
       external: false,
     });
-    const messages = result.logs.map(m => String((m as any).message ?? m));
-    expect({ success: result.success, messages: messages.join("\n") }).toEqual({
+    const logs = result.logs.map(m => ({
+      message: String((m as any).message ?? m),
+      file: (m as any).position?.file ?? "",
+    }));
+    expect({ success: result.success, logs }).toEqual({
       success: false,
-      messages: expect.stringContaining(`"${specifier}" because 'external' is set to false`),
+      logs: [
+        {
+          message: expect.stringContaining(`"${specifier}" because 'external' is set to false`),
+          file: expect.stringContaining("entry.js"),
+        },
+      ],
     });
-    const position = (result.logs[0] as any)?.position;
-    expect(position?.file).toContain("entry.js");
   });
 
   test("target browser bundles polyfillable builtins", async () => {
@@ -1525,18 +1531,22 @@ describe("Bun.build external: false", () => {
     expect(out).not.toContain('from "path"');
   });
 
-  test("succeeds with no builtin imports", async () => {
-    using dir = tempDir("external-false-ok", {
-      "entry.js": 'import { foo } from "./foo.js"; console.log(foo);',
-      "foo.js": "export const foo = 1;",
-    });
-    const result = await Bun.build({
-      entrypoints: [join(String(dir), "entry.js")],
-      target: "bun",
-      external: false,
-    });
-    expect(result.success).toBe(true);
-  });
+  test.each(["bun", "node"] as const)(
+    "succeeds with no builtin imports (target %s)",
+    async target => {
+      using dir = tempDir("external-false-ok", {
+        "entry.js": 'import { foo } from "./foo.js"; console.log(foo);',
+        "foo.js": "export const foo = 1;",
+      });
+      const result = await Bun.build({
+        entrypoints: [join(String(dir), "entry.js")],
+        target,
+        external: false,
+      });
+      expect(result.success).toBe(true);
+      expect(await result.outputs[0].text()).not.toContain("node:module");
+    },
+  );
 
   test.each(["bun", "node"] as const)(
     "still fails when a matching onResolve plugin returns undefined (target %s)",
@@ -1562,6 +1572,31 @@ describe("Bun.build external: false", () => {
       expect(messages.join("\n")).toContain("\"node:fs\" because 'external' is set to false");
     },
   );
+
+  test("plugin onResolve returning { external: true } is rejected under external: false", async () => {
+    using dir = tempDir("external-false-plugin-external", {
+      "entry.js": 'import x from "some-pkg"; console.log(x);',
+    });
+    const result = await buildNoThrow({
+      entrypoints: [join(String(dir), "entry.js")],
+      target: "bun",
+      external: false,
+      plugins: [
+        {
+          name: "mark-external",
+          setup(build) {
+            build.onResolve({ filter: /^some-pkg$/ }, args => ({
+              path: args.path,
+              external: true,
+            }));
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+    const messages = result.logs.map(m => String((m as any).message ?? m));
+    expect(messages.join("\n")).toContain("\"some-pkg\" because 'external' is set to false");
+  });
 
   test("plugin onResolve can redirect a builtin under external: false", async () => {
     using dir = tempDir("external-false-plugin", {

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1475,3 +1475,118 @@ test("Bun.build can be called thousands of times in one process without crashing
   expect(stdout.trim()).toBe("OK 400");
   expect(exitCode).toBe(0);
 }, 180_000);
+
+describe("Bun.build external: false", () => {
+  const cases: Array<["bun" | "node" | "browser", string, string]> = [
+    ["bun", "node:fs", 'import fs from "node:fs"; console.log(fs);'],
+    ["bun", "fs", 'import fs from "fs"; console.log(fs);'],
+    ["bun", "bun:sqlite", 'import { Database } from "bun:sqlite"; console.log(Database);'],
+    ["bun", "bun", 'import { serve } from "bun"; console.log(serve);'],
+    ["bun", "net", 'const net = require("net"); console.log(net);'],
+    ["node", "node:fs", 'import fs from "node:fs"; console.log(fs);'],
+    ["node", "path", 'import path from "path"; console.log(path);'],
+    ["browser", "node:fs", 'import fs from "node:fs"; console.log(fs);'],
+  ];
+
+  test.each(cases)("target %s rejects builtin %s", async (target, specifier, code) => {
+    using dir = tempDir("external-false", { "entry.js": code });
+    const result = await buildNoThrow({
+      entrypoints: [join(String(dir), "entry.js")],
+      target,
+      external: false,
+    });
+    expect(result.success).toBe(false);
+    const messages = result.logs.map(m => String((m as any).message ?? m));
+    expect(messages.join("\n")).toContain(
+      `builtin module "${specifier}" because 'external' is set to false`,
+    );
+    const position = (result.logs[0] as any)?.position;
+    expect(position?.file).toContain("entry.js");
+  });
+
+  test("succeeds with no builtin imports", async () => {
+    using dir = tempDir("external-false-ok", {
+      "entry.js": 'import { foo } from "./foo.js"; console.log(foo);',
+      "foo.js": "export const foo = 1;",
+    });
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "entry.js")],
+      target: "bun",
+      external: false,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("still fails when a matching onResolve plugin returns undefined", async () => {
+    using dir = tempDir("external-false-plugin-fallthrough", {
+      "entry.js": 'import fs from "node:fs"; console.log(fs);',
+    });
+    const result = await buildNoThrow({
+      entrypoints: [join(String(dir), "entry.js")],
+      target: "node",
+      external: false,
+      plugins: [
+        {
+          name: "noop",
+          setup(build) {
+            build.onResolve({ filter: /.*/ }, () => undefined);
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+    const messages = result.logs.map(m => String((m as any).message ?? m));
+    expect(messages.join("\n")).toContain(
+      'builtin module "node:fs" because \'external\' is set to false',
+    );
+  });
+
+  test("plugin onResolve can redirect a builtin under external: false", async () => {
+    using dir = tempDir("external-false-plugin", {
+      "entry.js": 'import { readFileSync } from "node:fs"; console.log(readFileSync());',
+      "shim.js": 'export const readFileSync = () => "shimmed!";',
+    });
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "entry.js")],
+      target: "bun",
+      external: false,
+      plugins: [
+        {
+          name: "shim-fs",
+          setup(build) {
+            build.onResolve({ filter: /^node:fs$/ }, () => ({
+              path: join(String(dir), "shim.js"),
+            }));
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+    const out = await result.outputs[0].text();
+    expect(out).toContain("shimmed!");
+    expect(out).not.toContain('from "fs"');
+  });
+
+  test("packages: 'external' is rejected", () => {
+    using dir = tempDir("external-false-pkgs", { "entry.js": "console.log(1);" });
+    expect(() =>
+      Bun.build({
+        entrypoints: [join(String(dir), "entry.js")],
+        target: "bun",
+        external: false,
+        packages: "external",
+      }),
+    ).toThrow('external: false cannot be combined with packages: "external"');
+  });
+
+  test("non-array non-boolean value is rejected", () => {
+    using dir = tempDir("external-invalid", { "entry.js": "console.log(1);" });
+    expect(() =>
+      Bun.build({
+        entrypoints: [join(String(dir), "entry.js")],
+        // @ts-expect-error
+        external: "node:fs",
+      }),
+    ).toThrow("external must be an array of strings or false");
+  });
+});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1600,11 +1600,34 @@ describe("Bun.build external: false", () => {
           },
         ],
       });
-      expect(result.success).toBe(false);
       const messages = result.logs.map(m => String((m as any).message ?? m));
-      expect(messages.join("\n")).toContain("\"node:fs\" because 'external' is set to false");
+      expect({ success: result.success, messages }).toEqual({
+        success: false,
+        messages: [expect.stringContaining("\"node:fs\" because 'external' is set to false")],
+      });
     },
   );
+
+  test("succeeds with no builtin imports and a broad noop plugin (target node)", async () => {
+    using dir = tempDir("external-false-noop-node", {
+      "entry.js": 'import { foo } from "./foo.js"; console.log(foo);',
+      "foo.js": "export const foo = 1;",
+    });
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "entry.js")],
+      target: "node",
+      external: false,
+      plugins: [
+        {
+          name: "noop",
+          setup(build) {
+            build.onResolve({ filter: /.*/ }, () => undefined);
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
 
   test("plugin onResolve returning { external: true } is rejected under external: false", async () => {
     using dir = tempDir("external-false-plugin-external", {

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1531,22 +1531,19 @@ describe("Bun.build external: false", () => {
     expect(out).not.toContain('from "path"');
   });
 
-  test.each(["bun", "node"] as const)(
-    "succeeds with no builtin imports (target %s)",
-    async target => {
-      using dir = tempDir("external-false-ok", {
-        "entry.js": 'import { foo } from "./foo.js"; console.log(foo);',
-        "foo.js": "export const foo = 1;",
-      });
-      const result = await Bun.build({
-        entrypoints: [join(String(dir), "entry.js")],
-        target,
-        external: false,
-      });
-      expect(result.success).toBe(true);
-      expect(await result.outputs[0].text()).not.toContain("node:module");
-    },
-  );
+  test.each(["bun", "node"] as const)("succeeds with no builtin imports (target %s)", async target => {
+    using dir = tempDir("external-false-ok", {
+      "entry.js": 'import { foo } from "./foo.js"; console.log(foo);',
+      "foo.js": "export const foo = 1;",
+    });
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "entry.js")],
+      target,
+      external: false,
+    });
+    expect(result.success).toBe(true);
+    expect(await result.outputs[0].text()).not.toContain("node:module");
+  });
 
   test.each(["bun", "node"] as const)(
     "still fails when a matching onResolve plugin returns undefined (target %s)",

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1497,9 +1497,7 @@ describe("Bun.build external: false", () => {
     });
     expect(result.success).toBe(false);
     const messages = result.logs.map(m => String((m as any).message ?? m));
-    expect(messages.join("\n")).toContain(
-      `builtin module "${specifier}" because 'external' is set to false`,
-    );
+    expect(messages.join("\n")).toContain(`builtin module "${specifier}" because 'external' is set to false`);
     const position = (result.logs[0] as any)?.position;
     expect(position?.file).toContain("entry.js");
   });
@@ -1536,9 +1534,7 @@ describe("Bun.build external: false", () => {
     });
     expect(result.success).toBe(false);
     const messages = result.logs.map(m => String((m as any).message ?? m));
-    expect(messages.join("\n")).toContain(
-      'builtin module "node:fs" because \'external\' is set to false',
-    );
+    expect(messages.join("\n")).toContain("builtin module \"node:fs\" because 'external' is set to false");
   });
 
   test("plugin onResolve can redirect a builtin under external: false", async () => {

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -26,6 +26,11 @@ describe("bundler", () => {
           expect(resolved.sort()).toEqual(["net", "node:fs", "path"]);
           // Falling through to default resolution keeps them external.
           api.expectFile("out.js").toContain('require("net")');
+          if (target === "bun") {
+            // https://github.com/oven-sh/bun/issues/18545
+            api.expectFile("out.js").toContain('from "fs"');
+            api.expectFile("out.js").not.toContain('from "node:fs"');
+          }
         },
       };
     });

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -3,6 +3,80 @@ import path, { dirname, join, resolve } from "node:path";
 import { itBundled } from "./expectBundled";
 
 describe("bundler", () => {
+  for (const target of ["bun", "node"] as const) {
+    itBundled(`plugin/OnResolveSeesNodeBuiltins#${target}`, () => {
+      const resolved: string[] = [];
+      return {
+        target,
+        files: {
+          "index.ts": /* ts */ `
+            import fs from "node:fs";
+            import path from "path";
+            const net = require("net");
+            console.log(fs, path, net);
+          `,
+        },
+        plugins(builder) {
+          builder.onResolve({ filter: /^(node:fs|path|net)$/ }, args => {
+            resolved.push(args.path);
+            return undefined;
+          });
+        },
+        onAfterBundle(api) {
+          expect(resolved.sort()).toEqual(["net", "node:fs", "path"]);
+          // Falling through to default resolution keeps them external.
+          api.expectFile("out.js").toContain('require("net")');
+        },
+      };
+    });
+
+    itBundled(`plugin/OnResolveRedirectsNodeBuiltin#${target}`, () => {
+      return {
+        target,
+        files: {
+          "index.ts": /* ts */ `
+            import { readFileSync } from "node:fs";
+            console.log(readFileSync());
+          `,
+          "shim.ts": /* ts */ `
+            export const readFileSync = () => "shimmed!";
+          `,
+        },
+        plugins(builder) {
+          builder.onResolve({ filter: /^node:fs$/ }, args => {
+            return { path: join(dirname(args.importer), "shim.ts") };
+          });
+        },
+        run: { stdout: "shimmed!" },
+      };
+    });
+  }
+
+  itBundled("plugin/OnResolveBuiltinsUnmatchedFilter#bun", () => {
+    const resolved: string[] = [];
+    return {
+      target: "bun",
+      files: {
+        "index.ts": /* ts */ `
+          import fs from "node:fs";
+          import { foo } from "./local.ts";
+          console.log(fs, foo);
+        `,
+        "local.ts": `export const foo = 1;`,
+      },
+      plugins(builder) {
+        builder.onResolve({ filter: /^\.\// }, args => {
+          resolved.push(args.path);
+          return undefined;
+        });
+      },
+      onAfterBundle(api) {
+        expect(resolved).toEqual(["./local.ts"]);
+        api.expectFile("out.js").toContain('from "fs"');
+      },
+    };
+  });
+
   const loadFixture = {
     "index.ts": /* ts */ `
       import { foo } from "./foo.magic";


### PR DESCRIPTION
Two related additions to builtin handling in `Bun.build`.

### 1. `onResolve` sees builtin specifiers under `target: 'bun'` (esbuild parity)

Previously, for `target: 'bun'`, the inline builtin short-circuit in `resolve_import_records` ran before `onResolve` plugin dispatch, so plugins never saw `node:fs`, bare `path`, `bun:sqlite`, etc. esbuild passes builtins through `onResolve` under `platform: 'node'`, and Bun's own `target: 'node'` already did too.

The plugin dispatch now runs before the builtin short-circuit. When a plugin filter matches a builtin and returns a path, the import is redirected; returning `undefined` falls through to the existing externalize (including the `node:` prefix strip and `IS_EXTERNAL_WITHOUT_SIDE_EFFECTS` flag, now applied on the `run_resolver` fallthrough too so a no-op observing plugin does not change output). Builds with no plugin whose filter matches a builtin specifier are unchanged; the native filter pre-check skips the JS round-trip.

```js
await Bun.build({
  entrypoints: ["./entry.ts"],
  target: "bun",
  plugins: [{
    name: "shim-fs",
    setup(build) {
      build.onResolve({ filter: /^node:fs$/ }, () => ({
        path: require.resolve("./fs-shim.ts"),
      }));
    },
  }],
});
```

### 2. `external: false`

When set, any import that the bundler would leave as a runtime external reference fails the build with an error naming the importer:

```
error: Cannot import "node:fs" because 'external' is set to false
    at ./src/util.ts:1:19
```

The check fires at each point where an import is decided external, so it covers Node/Bun builtins (`node:fs`, `fs`, `bun:sqlite`, `bun`), Bun's npm-alias table (`ws`, `undici`, `node-fetch` under `target: 'bun'`), package.json subpath imports that map to a builtin (`"#fs": "node:fs"`), and a plugin `onResolve` returning `{external: true}`. It does not fire on `target: 'browser'` polyfills (`path`, `buffer`, ...), which are bundled. The bundler's own generated runtime module is exempt so `target: 'node'` stays usable.

Plugins run first, so a redirecting `onResolve` can satisfy a builtin under `external: false`. Combining with `packages: "external"` is a config error; `external: true` and other non-array values are rejected.

Use case: builds that require platform capabilities be injected into the entry point by the host rather than imported, so a stray `import fs from "node:fs"` anywhere in the graph fails the build.

### Tests

- `test/bundler/bundler_plugin.test.ts`: `onResolve` receives `node:fs` / `path` / `require("net")` for both `bun` and `node` targets; can redirect them; falling through keeps the `node:` prefix strip for target `bun`; a non-matching filter leaves the existing externalize path untouched.
- `test/bundler/bun-build-api.test.ts`: `external: false` rejects builtins (both specifier forms, ESM and CJS), `ws`, and `#fs` subpath imports across bun/node with exactly one error from the importing file; browser `path` polyfill succeeds; no-builtin-import graphs succeed for bun and node; a matching plugin returning `undefined` still fails; a plugin returning `{external: true}` fails; a redirecting plugin satisfies the constraint; `packages: "external"`, `external: true`, and non-array/non-`false` values are rejected.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-api.test.ts test/bundler/bundler_plugin.test.ts

<!-- robobun:evidence:end -->