### PR TITLE
worker_threads: exit code 1 when a Worker dies from an unhandled rejection

### DIFF
--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1175,9 +1175,7 @@ fn on_unhandled_rejection(
     if !vm.script_allowed() {
         return;
     }
-    // The worker dies from this error: Node's exit code 1, which the 'exit' handlers run
-    // below may still change. `uncaught_exception` already set it on its way here; a
-    // rejection reported from an event-loop turn (`unhandled_rejection`) arrives with 0.
+    // The worker dies from this error: exit code 1, as in Node. The 'exit' listeners below may change it.
     vm.exit_handler.exit_code = 1;
 
     let mut error_instance = error_instance_or_exception

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1175,6 +1175,10 @@ fn on_unhandled_rejection(
     if !vm.script_allowed() {
         return;
     }
+    // The worker dies from this error: Node's exit code 1, which the 'exit' handlers run
+    // below may still change. `uncaught_exception` already set it on its way here; a
+    // rejection reported from an event-loop turn (`unhandled_rejection`) arrives with 0.
+    vm.exit_handler.exit_code = 1;
 
     let mut error_instance = error_instance_or_exception
         .to_error()

--- a/test/js/node/worker_threads/worker-error-exit-code.test.ts
+++ b/test/js/node/worker_threads/worker-error-exit-code.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Spawned: isBunTest short-circuits VirtualMachine::unhandled_rejection so the
+// in-process path is not the one users observe.
+async function run(workerSrc: string, expected: { err: string | null; code: number }) {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const { Worker } = require("node:worker_threads");
+       const w = new Worker(${JSON.stringify(workerSrc)}, { eval: true });
+       let err = null;
+       w.on("error", e => { err = e?.name + ": " + e?.message; });
+       w.on("exit", code => { console.log(JSON.stringify({ err, code })); });
+       w.postMessage("go");`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr: exitCode === 0 ? "" : stderr, exitCode }).toEqual({
+    stdout: JSON.stringify(expected),
+    stderr: "",
+    exitCode: 0,
+  });
+}
+
+describe.concurrent("exit code when a worker dies from an error", () => {
+  // The error escapes either a parentPort 'message' listener or a timer callback;
+  // in both the worker's loop is still alive (the port, the interval) when it dies.
+  const sites = {
+    "message handler": (body: string) => `require("node:worker_threads").parentPort.on("message", () => { ${body} });`,
+    "timer callback": (body: string) => `setInterval(() => {}, 1000); setTimeout(() => { ${body} }, 20);`,
+  };
+  for (const [site, wrap] of Object.entries(sites)) {
+    test(`unhandled promise rejection in a ${site} exits 1`, async () => {
+      await run(wrap(`Promise.reject(new Error("task-reject"));`), { err: "Error: task-reject", code: 1 });
+    });
+
+    test(`synchronous throw in a ${site} exits 1`, async () => {
+      await run(wrap(`throw new Error("task-throw");`), { err: "Error: task-throw", code: 1 });
+    });
+  }
+
+  test("unhandled rejection runs the worker's process.on('exit') with code 1", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { Worker } = require("node:worker_threads");
+         const w = new Worker(
+           'process.on("exit", c => require("node:worker_threads").parentPort.postMessage(c));' +
+           'require("node:worker_threads").parentPort.on("message", () => { Promise.reject(new Error("r")); });',
+           { eval: true },
+         );
+         let workerExitArg = null;
+         w.on("error", () => {});
+         w.on("message", c => { workerExitArg = c; });
+         w.on("exit", code => { console.log(JSON.stringify({ workerExitArg, code })); });
+         w.postMessage("go");`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr: exitCode === 0 ? "" : stderr, exitCode }).toEqual({
+      stdout: JSON.stringify({ workerExitArg: 1, code: 1 }),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("process.on('unhandledRejection') handler suppresses the nonzero exit", async () => {
+    await run(
+      `const { parentPort } = require("node:worker_threads");
+       process.on("unhandledRejection", () => parentPort.close());
+       parentPort.once("message", () => { Promise.reject(new Error("handled")); });`,
+      { err: null, code: 0 },
+    );
+  });
+});


### PR DESCRIPTION
### Problem
- A `node:worker_threads` Worker that dies from an unhandled promise rejection in an event-loop turn (a `parentPort` `'message'` listener, a timer callback) reports `exit` code 0 to the parent, and its own `process.on('exit')` listeners receive 0. Node reports 1. The `'error'` event is correct. A synchronous throw from the same places already exits 1.
- Cause: the worker's last-resort error hook `on_unhandled_rejection` (`src/jsc/web_worker.rs:1163`) never sets the exit code. The throw path reaches it through `VirtualMachine::uncaught_exception`, which sets `exit_handler.exit_code = 1` first (`src/jsc/VirtualMachine.rs`). The rejection path reaches it through `VirtualMachine::unhandled_rejection`, which in the default mode does not. The hook then runs the worker's `'exit'` listeners and `shutdown()` posts the untouched 0.

### Fix
- Set `exit_handler.exit_code = 1` in `on_unhandled_rejection`, after the "stop already requested" early return and before the worker's `'exit'` listeners run. Both entry paths now report the same code, and an `'exit'` listener can still change it, as in Node.
- A rejection that a `process.on('unhandledRejection')` listener claims never reaches the hook (`Bun__handleUnhandledRejection` returns first), so that case keeps exit code 0.
- Verified: `test/js/node/worker_threads/worker-error-exit-code.test.ts` (6 cases: rejection and throw from a message listener and from a timer callback, the worker's own `'exit'` argument, and suppression by an `'unhandledRejection'` listener). Without the fix the three rejection cases fail with `code: 0`.

### Background
- A worker's uncaught error ends in `on_unhandled_rejection`: it posts `'error'` to the parent, runs the worker's `process.on('exit')` listeners through `ExitHandler::dispatch_on_exit`, and requests the stop. `spin()` then calls `shutdown()`, which reads `exit_handler.exit_code` and reports it to the parent as the `'exit'` code.
- `VirtualMachine::unhandled_rejection` is what JSC's rejected-promise list drains into at the end of an event-loop turn. `VirtualMachine::uncaught_exception` is the path for a thrown exception (and for the entry module's own rejection).

<details><summary>Notes</summary>

- Measured on canary `1.4.3-canary.1+f42e98025` (one day after 1.4.2) against Node v26.3.0: the message-listener rejection still exits 0 (5/5 runs of the original repro), the timer-callback rejection with an interval keeping the loop alive exits 0. Both go through this hook. Both exit 1 with this change.
- Not covered here, different cause: a rejection from the callback that lets the worker's loop go idle (`setTimeout(() => Promise.reject(e), 20)` with nothing else alive) is never reported at all (no `'error'`, the worker's `'unhandledRejection'` listeners do not run, exit 0). The worker loop does not walk the rejected-promise list after its last turn. #37981 fixes that; its worker test asserts `code` is `not.toBe(13)` rather than `1` because of the bug fixed here, so the two changes are complementary.
- Fail-before on the current base was checked with the unfixed debug build of `f42e98025` (`src/jsc/web_worker.rs` is identical between `f42e98025` and this PR's base): 3 of 6 tests fail with `code: 0`. The passing run with the fix was done on the earlier base of this PR; the change is the same single assignment.
- Also ran `test/js/web/workers/worker.test.ts` and `test/js/node/worker_threads/worker-top-level-await.test.ts` on the earlier base.

</details>
