### PR TITLE
usockets: route us_* allocator macros through mimalloc when ASAN is disabled

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -915,11 +915,7 @@ SSL_CTX *us_ssl_ctx_build_raw(struct us_bun_socket_context_options_t options,
   }
 
   if (options.passphrase) {
-#ifdef _WIN32
-    SSL_CTX_set_default_passwd_cb_userdata(ssl_context, (void *)_strdup(options.passphrase));
-#else
-    SSL_CTX_set_default_passwd_cb_userdata(ssl_context, (void *)strdup(options.passphrase));
-#endif
+    SSL_CTX_set_default_passwd_cb_userdata(ssl_context, (void *)us_strdup(options.passphrase));
     SSL_CTX_set_default_passwd_cb(ssl_context, passphrase_cb);
   }
 

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -246,7 +246,7 @@ static void us_ssl_pending_session_free(void *parent, void *ptr, CRYPTO_EX_DATA 
   struct us_ssl_pending_session_t *pending = ptr;
   while (pending) {
     struct us_ssl_pending_session_t *next = pending->next;
-    free(pending);
+    us_free(pending);
     pending = next;
   }
 }
@@ -264,7 +264,7 @@ static void us_ssl_keylog_cb(const SSL *cssl, const char *line) {
     return;
   }
   struct us_ssl_pending_session_t *pending =
-      malloc(sizeof(struct us_ssl_pending_session_t) + line_len + 1);
+      us_malloc(sizeof(struct us_ssl_pending_session_t) + line_len + 1);
   if (!pending) {
     return;
   }
@@ -296,7 +296,7 @@ static void ssl_flush_pending_keylog(struct us_socket_t *s) {
     if (!us_socket_is_closed(s) && s->ssl) {
       us_dispatch_keylog(s, pending->data, (int)pending->length);
     }
-    free(pending);
+    us_free(pending);
     pending = next;
   }
 }
@@ -316,7 +316,7 @@ static int us_ssl_new_session_cb(SSL *ssl, SSL_SESSION *session) {
     return 0;
   }
   struct us_ssl_pending_session_t *pending =
-      malloc(sizeof(struct us_ssl_pending_session_t) + (size_t)length);
+      us_malloc(sizeof(struct us_ssl_pending_session_t) + (size_t)length);
   if (!pending) {
     return 0;
   }
@@ -354,7 +354,7 @@ static void ssl_flush_pending_session(struct us_socket_t *s) {
     if (!us_socket_is_closed(s) && s->ssl) {
       us_dispatch_session(s, pending->data, (int)pending->length);
     }
-    free(pending);
+    us_free(pending);
     pending = next;
   }
 }
@@ -423,7 +423,7 @@ static int us_ssl_pop_pending(SSL *ssl, int idx, unsigned char *out, int out_cap
   } else {
     memcpy(out, pending->data, (size_t)len);
   }
-  free(pending);
+  us_free(pending);
   return len;
 }
 
@@ -1129,10 +1129,11 @@ int us_ssl_ctx_add_ca_cert(SSL_CTX *ctx, const char *content) {
 
 /* node:tls `pfx` support: parse a PKCS#12 blob and hand back PEM-encoded
  * key / certificate / extra-chain strings the regular key/cert/ca options can
- * consume. Returns 1 on success; the three out-strings are malloc'd and the
- * caller frees them with free(). On failure returns 0 and sets *err_reason to
- * a static tag: "parse" (not PKCS#12), "mac" (bad passphrase / corrupt),
- * "key" (no private key), "cert" (no certificate). */
+ * consume. Returns 1 on success; the three out-strings are libc malloc'd (not
+ * us_malloc) because the Rust caller releases them with libc free(). On
+ * failure returns 0 and sets *err_reason to a static tag: "parse" (not
+ * PKCS#12), "mac" (bad passphrase / corrupt), "key" (no private key),
+ * "cert" (no certificate). */
 static int pem_from_bio(BIO *bio, char **out, size_t *out_len) {
   char *mem = NULL;
   long n = BIO_get_mem_data(bio, &mem);

--- a/packages/bun-usockets/src/crypto/root_certs_linux.cpp
+++ b/packages/bun-usockets/src/crypto/root_certs_linux.cpp
@@ -1,6 +1,7 @@
 #ifndef _WIN32
 #ifndef __APPLE__
 
+#include "libusockets.h"
 #include <dirent.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -105,7 +106,7 @@ extern "C" void us_load_system_certificates_linux(STACK_OF(X509) **system_certs)
   
   // If SSL_CERT_DIR is set, load from each directory (colon-separated)
   if (ssl_cert_dir && strlen(ssl_cert_dir) > 0) {
-    char* dir_copy = strdup(ssl_cert_dir);
+    char* dir_copy = us_strdup(ssl_cert_dir);
     if (dir_copy) {
       char* token = strtok(dir_copy, ":");
       while (token != NULL) {
@@ -115,7 +116,7 @@ extern "C" void us_load_system_certificates_linux(STACK_OF(X509) **system_certs)
         }
         token = strtok(NULL, ":");
       }
-      free(dir_copy);
+      us_free(dir_copy);
     }
   }
   

--- a/packages/bun-usockets/src/crypto/sni_tree.cpp
+++ b/packages/bun-usockets/src/crypto/sni_tree.cpp
@@ -23,6 +23,7 @@
 
 #ifndef LIBUS_NO_SSL
 
+#include "libusockets.h"
 #include <map>
 #include <memory>
 #include <string_view>
@@ -43,8 +44,8 @@ struct sni_node {
 
     ~sni_node() {
         for (auto &p : children) {
-            /* The data of our string_views are managed by malloc */
-            free((void *) p.first.data());
+            /* The data of our string_views are managed by us_malloc */
+            us_free((void *) p.first.data());
 
             /* Call destructor passed to sni_free only if we hold data.
              * This is important since sni_remove does not have sni_free_cb set */
@@ -79,8 +80,8 @@ void *removeUser(struct sni_node *root, unsigned int label, std::string_view *la
      * This ends up being where we remove all nodes */
     if (it->second.get()->children.empty() && it->second.get()->user == nullptr) {
 
-        /* The data of our string_views are managed by malloc */
-        free((void *) it->first.data());
+        /* The data of our string_views are managed by us_malloc */
+        us_free((void *) it->first.data());
 
         /* This can only happen with user set to null, otherwise we use sni_free_cb which is unset by sni_remove */
         root->children.erase(it);
@@ -142,7 +143,7 @@ extern "C" {
             auto it = root->children.find(label);
             if (it == root->children.end()) {
                 /* Duplicate this label for our kept string_view of it */
-                void *labelString = malloc(label.length());
+                void *labelString = us_malloc(label.length());
                 memcpy(labelString, label.data(), label.length());
 
                 it = root->children.emplace(std::string_view((char *) labelString, label.length()),

--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -40,15 +40,15 @@ static void check_cb(uv_check_t *p) {
 }
 
 /* Not used for polls, since polls need two frees */
-static void close_cb_free(uv_handle_t *h) { free(h->data); }
+static void close_cb_free(uv_handle_t *h) { us_free(h->data); }
 
 /* This one is different for polls, since we need two frees here */
 static void close_cb_free_poll(uv_handle_t *h) {
   /* It is only in case we called us_poll_stop then quickly us_poll_free that we
    * enter this. Most of the time, actual freeing is done by us_poll_free. */
   if (h->data) {
-    free(h->data);
-    free(h);
+    us_free(h->data);
+    us_free(h);
   }
 }
 
@@ -73,7 +73,7 @@ void us_poll_init(struct us_poll_t *p, LIBUS_SOCKET_DESCRIPTOR fd,
 void us_poll_free(struct us_poll_t *p, struct us_loop_t *loop) {
   // poll was resized and dont own uv_poll_t anymore
   if(!p->uv_p) {
-    free(p);
+    us_free(p);
     return;
   }
   /* The idea here is like so; in us_poll_stop we call uv_close after setting
@@ -85,8 +85,8 @@ void us_poll_free(struct us_poll_t *p, struct us_loop_t *loop) {
   if (uv_is_closing((uv_handle_t *)p->uv_p)) {
     p->uv_p->data = p;
   } else {
-    free(p->uv_p);
-    free(p);
+    us_free(p->uv_p);
+    us_free(p);
   }
 }
 
@@ -157,18 +157,18 @@ struct us_loop_t *us_create_loop(void *hint,
                                  void (*post_cb)(struct us_loop_t *loop),
                                  unsigned int ext_size) {
   struct us_loop_t *loop =
-      (struct us_loop_t *)calloc(1, sizeof(struct us_loop_t) + ext_size);
+      (struct us_loop_t *)us_calloc(1, sizeof(struct us_loop_t) + ext_size);
 
   loop->uv_loop = hint ? hint : uv_loop_new();
   loop->is_default = hint != 0;
 
-  loop->uv_pre = malloc(sizeof(uv_prepare_t));
+  loop->uv_pre = us_malloc(sizeof(uv_prepare_t));
   uv_prepare_init(loop->uv_loop, loop->uv_pre);
   uv_prepare_start(loop->uv_pre, prepare_cb);
   uv_unref((uv_handle_t *)loop->uv_pre);
   loop->uv_pre->data = loop;
 
-  loop->uv_check = malloc(sizeof(uv_check_t));
+  loop->uv_check = us_malloc(sizeof(uv_check_t));
   uv_check_init(loop->uv_loop, loop->uv_check);
   uv_unref((uv_handle_t *)loop->uv_check);
   uv_check_start(loop->uv_check, check_cb);
@@ -208,7 +208,7 @@ void us_loop_free(struct us_loop_t *loop) {
   }
 
   // now we can free our part
-  free(loop);
+  us_free(loop);
 }
 
 extern void Bun__JSC_onBeforeWait(void *jsc_vm, uint64_t now_ns);
@@ -232,8 +232,8 @@ void us_loop_run(struct us_loop_t *loop) {
 struct us_poll_t *us_create_poll(struct us_loop_t *loop, int fallthrough,
                                  unsigned int ext_size) {
   struct us_poll_t *p =
-      (struct us_poll_t *)malloc(sizeof(struct us_poll_t) + ext_size);
-  p->uv_p = malloc(sizeof(uv_poll_t));
+      (struct us_poll_t *)us_malloc(sizeof(struct us_poll_t) + ext_size);
+  p->uv_p = us_malloc(sizeof(uv_poll_t));
   p->uv_p->data = p;
   return p;
 }
@@ -250,7 +250,7 @@ struct us_poll_t *us_poll_resize(struct us_poll_t *p, struct us_loop_t *loop,
   unsigned int new_size = sizeof(struct us_poll_t) + ext_size;
   if(new_size <= old_size) return p;
 
-  struct us_poll_t *new_p = calloc(1, new_size);
+  struct us_poll_t *new_p = us_calloc(1, new_size);
   memcpy(new_p, p, old_size);
 
   new_p->uv_p->data = new_p;

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -17,6 +17,14 @@
 // clang-format off
 #pragma once
 
+/* <stdint.h> pulls in glibc's <features.h>, which locks the feature-test
+ * macros for the rest of the TU. bsd.h needs _GNU_SOURCE for mmsghdr/accept4
+ * but is included after us, so set it here before any system header (including
+ * whatever mimalloc.h transitively pulls in). */
+#if !defined(_WIN32) && !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
+
 #if defined(__SANITIZE_ADDRESS__)
 #define LIBUS_ASAN 1
 #elif defined(__has_feature)
@@ -119,13 +127,6 @@
 #define LIBUS_SOCKET_DESCRIPTOR SOCKET
 #else
 #define LIBUS_SOCKET_DESCRIPTOR int
-#endif
-
-/* <stdint.h> pulls in glibc's <features.h>, which locks the feature-test
- * macros for the rest of the TU. bsd.h needs _GNU_SOURCE for mmsghdr/accept4
- * but is included after us, so set it here before any system header. */
-#if !defined(_WIN32) && !defined(_GNU_SOURCE)
-#define _GNU_SOURCE
 #endif
 
 #include "stddef.h"

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -16,20 +16,48 @@
  */
 // clang-format off
 #pragma once
+
+#if defined(__SANITIZE_ADDRESS__)
+#define LIBUS_ASAN 1
+#elif defined(__has_feature)
+#if __has_feature(address_sanitizer)
+#define LIBUS_ASAN 1
+#endif
+#endif
+
+#if !defined(LIBUS_ASAN)
+#include "mimalloc.h"
+#ifndef us_calloc
+#define us_calloc mi_calloc
+#endif
+#ifndef us_malloc
+#define us_malloc mi_malloc
+#endif
+#ifndef us_realloc
+#define us_realloc mi_realloc
+#endif
+#ifndef us_free
+#define us_free mi_free
+#endif
+#ifndef us_strdup
+#define us_strdup mi_strdup
+#endif
+#else
 #ifndef us_calloc
 #define us_calloc calloc
 #endif
-
 #ifndef us_malloc
 #define us_malloc malloc
 #endif
-
 #ifndef us_realloc
 #define us_realloc realloc
 #endif
-
 #ifndef us_free
 #define us_free free
+#endif
+#ifndef us_strdup
+#define us_strdup strdup
+#endif
 #endif
 
 #ifndef LIBUSOCKETS_H

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -128,8 +128,8 @@ void us_internal_loop_data_init(struct us_loop_t *loop, void (*wakeup_cb)(struct
     loop->data.sweep_next_tick_ns = -1;
 #endif
     loop->data.sweep_timer_count = 0;
-    loop->data.recv_buf = malloc(LIBUS_RECV_BUFFER_LENGTH + LIBUS_RECV_BUFFER_PADDING * 2);
-    loop->data.send_buf = malloc(LIBUS_SEND_BUFFER_LENGTH);
+    loop->data.recv_buf = us_malloc(LIBUS_RECV_BUFFER_LENGTH + LIBUS_RECV_BUFFER_PADDING * 2);
+    loop->data.send_buf = us_malloc(LIBUS_SEND_BUFFER_LENGTH);
     /* Every read on this loop writes into recv_buf; a NULL here makes each one
      * fail with EFAULT for the life of the process. */
     if (!loop->data.recv_buf || !loop->data.send_buf) Bun__outOfMemory();
@@ -149,8 +149,8 @@ void us_internal_loop_data_free(struct us_loop_t *loop) {
     us_internal_free_loop_ssl_data(loop);
 #endif
 
-    free(loop->data.recv_buf);
-    free(loop->data.send_buf);
+    us_free(loop->data.recv_buf);
+    us_free(loop->data.send_buf);
 
 #ifdef LIBUS_USE_LIBUV
     us_timer_close(loop->data.sweep_timer, 0);

--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -402,7 +402,7 @@ static int us_quic_alpn_select(SSL *ssl, const unsigned char **out, unsigned cha
 
 static void *us_quic_hsi_create(void *hsi_ctx, lsquic_stream_t *s, int is_push) {
     (void) hsi_ctx; (void) s; (void) is_push;
-    return calloc(1, sizeof(struct us_quic_hset));
+    return us_calloc(1, sizeof(struct us_quic_hset));
 }
 
 static struct lsxpack_header *us_quic_hsi_prepare(void *hset_p, struct lsxpack_header *hdr, size_t space) {
@@ -412,7 +412,7 @@ static struct lsxpack_header *us_quic_hsi_prepare(void *hset_p, struct lsxpack_h
     if (need > h->cap) {
         unsigned int ncap = h->cap ? h->cap : 512;
         while (ncap < need) ncap *= 2;
-        char *nb = (char *) realloc(h->buf, ncap);
+        char *nb = (char *) us_realloc(h->buf, ncap);
         if (!nb) return NULL;
         h->buf = nb;
         h->cap = ncap;
@@ -436,7 +436,7 @@ static int us_quic_hsi_process(void *hset_p, struct lsxpack_header *hdr) {
     if (h->count == h->hcap) {
         unsigned int ncap = h->hcap ? h->hcap * 2 : 16;
         struct us_quic_header_t *nh = (struct us_quic_header_t *)
-            realloc(h->headers, ncap * sizeof(*nh));
+            us_realloc(h->headers, ncap * sizeof(*nh));
         if (!nh) return -1;
         h->headers = nh;
         h->hcap = ncap;
@@ -463,9 +463,9 @@ static void us_quic_hset_finalize(struct us_quic_hset *h) {
 
 static void us_quic_hset_free(struct us_quic_hset *h) {
     if (!h) return;
-    free(h->buf);
-    free(h->headers);
-    free(h);
+    us_free(h->buf);
+    us_free(h->headers);
+    us_free(h);
 }
 
 static void us_quic_hsi_discard(void *hset_p) {
@@ -481,7 +481,7 @@ static lsquic_conn_ctx_t *us_quic_on_new_conn(void *if_ctx, lsquic_conn_t *conn)
         return NULL;
     }
     us_quic_socket_t *qs = (us_quic_socket_t *)
-        calloc(1, sizeof(us_quic_socket_t) + ctx->conn_ext_size);
+        us_calloc(1, sizeof(us_quic_socket_t) + ctx->conn_ext_size);
     if (!qs) return NULL;
     qs->conn = conn;
     qs->ctx = ctx;
@@ -510,8 +510,8 @@ static void us_quic_on_conn_closed(lsquic_conn_t *conn) {
     for (us_quic_socket_t **pp = &ctx->conns; *pp; pp = &(*pp)->next) {
         if (*pp == qs) { *pp = qs->next; break; }
     }
-    free(qs->hostname);
-    free(qs);
+    us_free(qs->hostname);
+    us_free(qs);
 #ifndef LIBUS_USE_LIBUV
     ctx->loop->num_polls--;
 #endif
@@ -540,7 +540,7 @@ static lsquic_stream_ctx_t *us_quic_on_new_stream(void *if_ctx, lsquic_stream_t 
     us_quic_socket_context_t *ctx = (us_quic_socket_context_t *) if_ctx;
     if (stream == NULL) return NULL; /* going-away */
     us_quic_stream_t *s = (us_quic_stream_t *)
-        calloc(1, sizeof(us_quic_stream_t) + ctx->stream_ext_size);
+        us_calloc(1, sizeof(us_quic_stream_t) + ctx->stream_ext_size);
     if (!s) { lsquic_stream_close(stream); return NULL; }
     s->stream = stream;
     s->ctx = ctx;
@@ -598,7 +598,7 @@ static void us_quic_on_close(lsquic_stream_t *stream, lsquic_stream_ctx_t *h) {
     if (s->ctx->on_stream_close) s->ctx->on_stream_close(s);
     s->stream = NULL;
     us_quic_hset_free(s->hset);
-    free(s);
+    us_free(s);
 }
 
 static void us_quic_on_reset(lsquic_stream_t *stream, lsquic_stream_ctx_t *h, int how) {
@@ -674,7 +674,7 @@ us_quic_socket_context_t *us_create_quic_socket_context(
     us_quic_prepare_ssl_ctx(ssl);
 
     us_quic_socket_context_t *ctx = (us_quic_socket_context_t *)
-        calloc(1, sizeof(us_quic_socket_context_t) + ext_size);
+        us_calloc(1, sizeof(us_quic_socket_context_t) + ext_size);
     if (!ctx) { SSL_CTX_free(ssl); return NULL; }
     ctx->loop = loop;
     ctx->ssl_ctx = ssl;
@@ -715,7 +715,7 @@ us_quic_socket_context_t *us_create_quic_socket_context(
     ctx->engine = lsquic_engine_new(LSENG_HTTP_SERVER, &api);
     if (!ctx->engine) {
         SSL_CTX_free(ssl);
-        free(ctx);
+        us_free(ctx);
         return NULL;
     }
 
@@ -734,11 +734,11 @@ int us_quic_socket_context_add_server_name(us_quic_socket_context_t *ctx,
     us_quic_prepare_ssl_ctx(ssl);
     if (ctx->sni_count == ctx->sni_cap) {
         unsigned ncap = ctx->sni_cap ? ctx->sni_cap * 2 : 4;
-        struct us_quic_sni *n = (struct us_quic_sni *) realloc(ctx->sni, ncap * sizeof(*n));
+        struct us_quic_sni *n = (struct us_quic_sni *) us_realloc(ctx->sni, ncap * sizeof(*n));
         if (!n) { SSL_CTX_free(ssl); return -1; }
         ctx->sni = n; ctx->sni_cap = ncap;
     }
-    char *name = strdup(hostname);
+    char *name = us_strdup(hostname);
     if (!name) { SSL_CTX_free(ssl); return -1; }
     ctx->sni[ctx->sni_count].name = name;
     ctx->sni[ctx->sni_count].ctx = ssl;
@@ -774,16 +774,16 @@ void us_quic_socket_context_free(us_quic_socket_context_t *ctx) {
     if (ctx->engine) { lsquic_engine_destroy(ctx->engine); ctx->engine = NULL; }
     if (ctx->ssl_ctx) { SSL_CTX_free(ctx->ssl_ctx); ctx->ssl_ctx = NULL; }
     for (unsigned i = 0; i < ctx->sni_count; i++) {
-        free(ctx->sni[i].name);
+        us_free(ctx->sni[i].name);
         SSL_CTX_free(ctx->sni[i].ctx);
     }
-    free(ctx->sni);
+    us_free(ctx->sni);
     for (us_quic_listen_socket_t *ls = ctx->closed_listeners; ls; ) {
         us_quic_listen_socket_t *next = ls->next;
-        free(ls);
+        us_free(ls);
         ls = next;
     }
-    free(ctx);
+    us_free(ctx);
 }
 
 void *us_quic_socket_context_ext(us_quic_socket_context_t *ctx) { return ctx + 1; }
@@ -829,7 +829,7 @@ us_quic_listen_socket_t *us_quic_socket_context_listen(
 {
     ctx->stream_ext_size = stream_ext_size;
 
-    us_quic_listen_socket_t *ls = (us_quic_listen_socket_t *) calloc(1, sizeof(*ls));
+    us_quic_listen_socket_t *ls = (us_quic_listen_socket_t *) us_calloc(1, sizeof(*ls));
     if (!ls) return NULL;
     ls->ctx = ctx;
 
@@ -837,7 +837,7 @@ us_quic_listen_socket_t *us_quic_socket_context_listen(
     ls->udp = us_create_udp_socket(ctx->loop,
         us_quic_udp_on_data, us_quic_udp_on_drain, us_quic_udp_on_close, NULL,
         host, (unsigned short) port, flags, &err, ls);
-    if (!ls->udp) { free(ls); return NULL; }
+    if (!ls->udp) { us_free(ls); return NULL; }
     us_quic_set_dontfrag(ls->udp);
 
     /* Record actual bound address — packet_in needs sa_local. */
@@ -957,13 +957,13 @@ int us_quic_stream_send_headers(us_quic_stream_t *s,
         total += headers[i].name_len + headers[i].value_len;
 
     char stackbuf[1024];
-    char *buf = total <= sizeof(stackbuf) ? stackbuf : (char *) malloc(total);
+    char *buf = total <= sizeof(stackbuf) ? stackbuf : (char *) us_malloc(total);
     struct lsxpack_header stackh[32];
     struct lsxpack_header *xh = count <= 32 ? stackh
-        : (struct lsxpack_header *) calloc(count, sizeof(*xh));
+        : (struct lsxpack_header *) us_calloc(count, sizeof(*xh));
     if (!buf || !xh) {
-        if (buf != stackbuf) free(buf);
-        if (xh != stackh) free(xh);
+        if (buf != stackbuf) us_free(buf);
+        if (xh != stackh) us_free(xh);
         return -1;
     }
 
@@ -983,8 +983,8 @@ int us_quic_stream_send_headers(us_quic_stream_t *s,
 
     lsquic_http_headers_t lh = { .count = (int) count, .headers = xh };
     int r = lsquic_stream_send_headers(s->stream, &lh, end_stream);
-    if (buf != stackbuf) free(buf);
-    if (xh != stackh) free(xh);
+    if (buf != stackbuf) us_free(buf);
+    if (xh != stackh) us_free(xh);
     if (end_stream && r == 0) lsquic_stream_shutdown(s->stream, 1);
     /* Mark the context dirty so drainQuicIfNecessary picks up header-only
      * responses (204/304) that never call us_quic_stream_write. */
@@ -1135,7 +1135,7 @@ us_quic_socket_context_t *us_create_quic_client_context(
     SSL_CTX_set_custom_verify(ssl, SSL_VERIFY_PEER, us_quic_client_verify);
 
     us_quic_socket_context_t *ctx = (us_quic_socket_context_t *)
-        calloc(1, sizeof(us_quic_socket_context_t) + ext_size);
+        us_calloc(1, sizeof(us_quic_socket_context_t) + ext_size);
     if (!ctx) { SSL_CTX_free(ssl); return NULL; }
     ctx->loop = loop;
     ctx->ssl_ctx = ssl;
@@ -1163,7 +1163,7 @@ us_quic_socket_context_t *us_create_quic_client_context(
     ctx->engine = lsquic_engine_new(LSENG_HTTP, &api);
     if (!ctx->engine) {
         SSL_CTX_free(ssl);
-        free(ctx);
+        us_free(ctx);
         return NULL;
     }
 
@@ -1198,7 +1198,7 @@ static int us_quic_resolve(const char *host, int port, struct sockaddr_storage *
  * (closed in context_free via the `listeners` list). */
 static us_quic_listen_socket_t *us_quic_client_endpoint(us_quic_socket_context_t *ctx) {
     if (ctx->client_udp) return ctx->client_udp;
-    us_quic_listen_socket_t *ls = (us_quic_listen_socket_t *) calloc(1, sizeof(*ls));
+    us_quic_listen_socket_t *ls = (us_quic_listen_socket_t *) us_calloc(1, sizeof(*ls));
     if (!ls) return NULL;
     ls->ctx = ctx;
     int err = 0;
@@ -1211,7 +1211,7 @@ static us_quic_listen_socket_t *us_quic_client_endpoint(us_quic_socket_context_t
             us_quic_udp_on_data, us_quic_udp_on_drain, us_quic_udp_on_close, NULL,
             "0.0.0.0", 0, 0, &err, ls);
     }
-    if (!ls->udp) { free(ls); return NULL; }
+    if (!ls->udp) { us_free(ls); return NULL; }
     us_quic_set_dontfrag(ls->udp);
     socklen_t sl = sizeof(ls->local);
     getsockname(us_poll_fd((struct us_poll_t *) ls->udp), (struct sockaddr *) &ls->local, &sl);
@@ -1251,7 +1251,7 @@ static us_quic_socket_t *us_quic_connect_addr(us_quic_socket_context_t *ctx,
     if (qs) {
         qs->reject_unauthorized = reject_unauthorized;
         if (sni) {
-            qs->hostname = strdup(sni);
+            qs->hostname = us_strdup(sni);
             if (!qs->hostname) {
                 lsquic_conn_close(conn);
                 return NULL;
@@ -1354,13 +1354,13 @@ int us_quic_socket_context_connect(
         return *out_qs ? 1 : -1;
     }
 
-    struct us_quic_pending_connect_s *pc = calloc(1, sizeof(*pc));
+    struct us_quic_pending_connect_s *pc = us_calloc(1, sizeof(*pc));
     if (!pc) { Bun__addrinfo_freeRequest(ai_req, 1); return -1; }
     pc->ctx = ctx;
-    pc->sni = sni ? strdup(sni) : NULL;
+    pc->sni = sni ? us_strdup(sni) : NULL;
     if (sni && !pc->sni) {
         Bun__addrinfo_freeRequest(ai_req, 1);
-        free(pc);
+        us_free(pc);
         return -1;
     }
     pc->port = port;
@@ -1388,15 +1388,15 @@ us_quic_socket_t *us_quic_pending_connect_resolved(
             pc->reject_unauthorized);
     }
     Bun__addrinfo_freeRequest(pc->ai_req, qs == NULL);
-    free(pc->sni);
-    free(pc);
+    us_free(pc->sni);
+    us_free(pc);
     return qs;
 }
 
 void us_quic_pending_connect_cancel(struct us_quic_pending_connect_s *pc) {
     Bun__addrinfo_freeRequest(pc->ai_req, 1);
-    free(pc->sni);
-    free(pc);
+    us_free(pc->sni);
+    us_free(pc);
 }
 
 void us_quic_socket_make_stream(us_quic_socket_t *s) {


### PR DESCRIPTION
## What

Map `us_malloc`/`us_free`/`us_calloc`/`us_realloc`/`us_strdup` in `libusockets.h` to `mi_malloc`/`mi_free`/`mi_calloc`/`mi_realloc`/`mi_strdup` when the build is not instrumented with AddressSanitizer. Under ASAN the macros continue to resolve to libc so the interceptors see every allocation.

On Linux release builds this is effectively a no-op (mimalloc already overrides the global allocator), but on macOS and Windows the override is disabled, so usockets was calling straight into libc malloc.

## Call-site conversion

Every raw `malloc`/`calloc`/`realloc`/`free`/`strdup` in `packages/bun-usockets/src/` is now routed through the `us_*` macros so alloc/free pairs stay on the same allocator once `us_free` becomes `mi_free`:

- `crypto/openssl.c`: key passphrase (`strdup` -> `us_strdup`), pending session/keylog queue
- `eventing/libuv.c` (Windows): loop/poll/timer/async handles and their shared `close_cb_free`
- `loop.c`: recv/send buffers
- `quic.c`: header sets, sockets, streams, contexts, listen sockets, SNI table, pending connects, send-header scratch
- `crypto/sni_tree.cpp`: label storage
- `crypto/root_certs_linux.cpp`: `SSL_CERT_DIR` token buffer

### Intentionally left as libc

`us_ssl_parse_pkcs12` (`pem_from_bio` and its error-path frees) still uses libc `malloc`/`free`: the out-strings cross the FFI boundary and are released via libc `free()` in `src/runtime/api/bun/SecureContext.rs`. Converting here would create a `mi_malloc` -> libc `free` mismatch on macOS/Windows.

## Verification

```
# linux release (mi_* path)
$ nm build/release/obj/packages/bun-usockets/src/quic.c.o | grep -E 'U (mi_|malloc|calloc|free|realloc|strdup)'
                 U mi_calloc
                 U mi_free
                 U mi_malloc
                 U mi_realloc
                 U mi_strdup

# linux debug (ASAN path, unchanged)
$ nm build/debug/obj/packages/bun-usockets/src/context.c.o | grep -E 'mi_|calloc'
                 U calloc

# windows debug (mi_* path, no override)
$ llvm-nm build/debug/obj/packages/bun-usockets/src/eventing/libuv.c.obj | grep mi_
                 U mi_calloc
                 U mi_free
                 U mi_malloc
```

`serve-http3.test.ts` (quic.c), `bun-serve-ssl.test.ts` (sni_tree), and `fetch.tls.test.ts` pass on both linux debug (ASAN) and release. Windows debug build at `4d8f2ca` succeeds.
