### PR TITLE
node:fs: drop removed `path` own property from Dirent

### DIFF
--- a/src/jsc/bindings/NodeDirent.cpp
+++ b/src/jsc/bindings/NodeDirent.cpp
@@ -136,14 +136,13 @@ private:
 JSC::Structure* createJSDirentObjectStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
 {
     auto* prototype = JSDirentPrototype::create(vm, globalObject, JSDirentPrototype::createStructure(vm, globalObject, globalObject->objectPrototype()));
-    auto structure = JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::FinalObjectType, 0), JSFinalObject::info(), NonArray, 4);
+    auto structure = JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::FinalObjectType, 0), JSFinalObject::info(), NonArray, 3);
 
     // Add property transitions for all dirent fields
     PropertyOffset offset = 0;
     structure = structure->addPropertyTransition(vm, structure, vm.propertyNames->name, 0, offset);
-    structure = structure->addPropertyTransition(vm, structure, Bun::builtinNames(vm).pathPublicName(), 0, offset);
-    structure = structure->addPropertyTransition(vm, structure, Bun::builtinNames(vm).dataPrivateName(), 0, offset);
     structure = structure->addPropertyTransition(vm, structure, Identifier::fromString(vm, "parentPath"_s), 0, offset);
+    structure = structure->addPropertyTransition(vm, structure, Bun::builtinNames(vm).dataPrivateName(), 0, offset);
 
     return structure;
 }
@@ -183,14 +182,12 @@ JSC_DEFINE_HOST_FUNCTION(constructDirent, (JSC::JSGlobalObject * globalObject, J
     auto* object = JSC::JSFinalObject::create(vm, structure);
     if (structure->id() != originalStructure->id()) {
         object->putDirect(vm, vm.propertyNames->name, name, 0);
-        object->putDirect(vm, Bun::builtinNames(vm).pathPublicName(), path, 0);
-        object->putDirect(vm, Bun::builtinNames(vm).dataPrivateName(), type, 0);
         object->putDirect(vm, Identifier::fromString(vm, "parentPath"_s), path, 0);
+        object->putDirect(vm, Bun::builtinNames(vm).dataPrivateName(), type, 0);
     } else {
         object->putDirectOffset(vm, 0, name);
         object->putDirectOffset(vm, 1, path);
         object->putDirectOffset(vm, 2, type);
-        object->putDirectOffset(vm, 3, path);
     }
 
     return JSValue::encode(object);
@@ -366,7 +363,6 @@ extern "C" JSC::EncodedJSValue Bun__Dirent__toJS(Zig::GlobalObject* globalObject
     object->putDirectOffset(vm, 0, nameValue);
     object->putDirectOffset(vm, 1, pathValue);
     object->putDirectOffset(vm, 2, typeValue);
-    object->putDirectOffset(vm, 3, pathValue);
 
     return JSValue::encode(object);
 }

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -950,8 +950,30 @@ it("Dirent has the expected fields", () => {
   const dirs = readdirSync(dir, { withFileTypes: true });
   expect(dirs.length).toBe(1);
   expect(dirs[0].name).toBe("file.txt");
-  expect(dirs[0].path).toBe(dir);
   expect(dirs[0].parentPath).toBe(dir);
+});
+
+// DEP0178: Node.js v24+ removed the deprecated `path` own property from Dirent.
+it("Dirent does not expose the removed `path` own property", () => {
+  const dir = tmpdirSync();
+  writeFileSync(join(dir, "file.txt"), "");
+
+  const [readdirEnt] = readdirSync(dir, { withFileTypes: true });
+  expect(Object.keys(readdirEnt).sort()).toEqual(["name", "parentPath"]);
+  expect("path" in readdirEnt).toBe(false);
+  expect(readdirEnt.parentPath).toBe(dir);
+  expect(readdirEnt.isFile()).toBe(true);
+
+  const [globEnt] = fs.globSync("*.txt", { cwd: dir, withFileTypes: true });
+  expect(Object.keys(globEnt).sort()).toEqual(["name", "parentPath"]);
+  expect("path" in globEnt).toBe(false);
+  expect(globEnt.isFile()).toBe(true);
+
+  const constructed = new Dirent("file.txt", 1, dir);
+  expect(Object.keys(constructed).sort()).toEqual(["name", "parentPath"]);
+  expect("path" in constructed).toBe(false);
+  expect(constructed.parentPath).toBe(dir);
+  expect(constructed.isFile()).toBe(true);
 });
 
 it("promises.readdir on a large folder", async () => {
@@ -3443,7 +3465,7 @@ describe("fs/promises", () => {
       const [bun, subprocess] = await Promise.all([
         (async function () {
           const files = await promises.readdir(full, { withFileTypes: true, recursive: true });
-          files.sort((a, b) => a.path.localeCompare(b.path));
+          files.sort((a, b) => a.parentPath.localeCompare(b.parentPath));
           return files;
         })(),
         (async function () {
@@ -3484,7 +3506,7 @@ describe("fs/promises", () => {
       const [bun, subprocess] = await Promise.all([
         (async function () {
           const files = readdirSync(full, { withFileTypes: true, recursive: true });
-          files.sort((a, b) => a.path.localeCompare(b.path));
+          files.sort((a, b) => a.parentPath.localeCompare(b.parentPath));
           return files;
         })(),
         (async function () {
@@ -3538,7 +3560,7 @@ describe("fs/promises", () => {
       // Sort the results for determinism.
       if (withFileTypes) {
         for (let i = 0; i < iterCount; i++) {
-          results[i].sort((a, b) => a.path.localeCompare(b.path));
+          results[i].sort((a, b) => a.parentPath.localeCompare(b.parentPath));
         }
       } else {
         for (let i = 0; i < iterCount; i++) {
@@ -3554,7 +3576,7 @@ describe("fs/promises", () => {
       if (!withFileTypes) {
         expect(results[0]).toContain(relative(full, import.meta.path));
       } else {
-        expect(results[0][0].path).toEqual(full);
+        expect(results[0][0].parentPath).toEqual(full);
       }
 
       const newMaxFD = getMaxFD();
@@ -3625,7 +3647,7 @@ describe("fs/promises", () => {
       if (!withFileTypes) {
         expect(results[0]).toContain(relative(full, import.meta.path));
       } else {
-        expect(results[0][0].path).toEqual(full);
+        expect(results[0][0].parentPath).toEqual(full);
       }
 
       const newMaxFD = getMaxFD();


### PR DESCRIPTION
## What does this PR do?

Node.js deprecated `Dirent.path` in v21 (DEP0178) in favor of `Dirent.parentPath`, and removed the property entirely in v24+. Bun was still shipping `path` as an own property on every Dirent alongside `parentPath`, so the object shape diverged from Node across all producers (`readdir`/`readdirSync` with `withFileTypes`, `fs.globSync` with `withFileTypes`, `opendir` entries, and `new fs.Dirent()`).

### Repro

```js
import * as fs from "node:fs";

const R = "/tmp/dirent-path";
fs.rmSync(R, { recursive: true, force: true });
fs.mkdirSync(R, { recursive: true });
fs.writeFileSync(`${R}/a.txt`, "x");

for (const [name, d] of [
  ["readdirSync wft", fs.readdirSync(R, { withFileTypes: true })[0]],
  ["globSync wft   ", fs.globSync("*.txt", { cwd: R, withFileTypes: true })[0]],
]) console.log(name, Object.keys(d).sort(), '"path" in d =', "path" in d);
```

Before (and Node <24):
```
readdirSync wft [ 'name', 'parentPath', 'path' ] "path" in d = true
globSync wft    [ 'name', 'parentPath', 'path' ] "path" in d = true
```

Node v24+ / after this PR:
```
readdirSync wft [ 'name', 'parentPath' ] "path" in d = false
globSync wft    [ 'name', 'parentPath' ] "path" in d = false
```

This matters for `Object.keys`, `JSON.stringify(dirent)`, spread shape, and feature detection like `"path" in d ? legacy : modern`, which takes the wrong branch under Bun today.

### Fix

In `src/jsc/bindings/NodeDirent.cpp`, drop the `path` property transition from the Dirent structure and from both `constructDirent` and `Bun__Dirent__toJS`. The remaining slots are reordered to `[name, parentPath, <private type>]` so `Object.keys` matches Node's `[name, parentPath]` and `getType()`'s fast-path offset (2) is unchanged.

### How did you verify your code works?

- New test `Dirent does not expose the removed "path" own property` in `test/js/node/fs/fs.test.ts` covering `readdirSync`, `fs.globSync`, and `new Dirent()`. Fails on `USE_SYSTEM_BUN=1`, passes on the debug build.
- Updated the handful of existing `fs.test.ts` assertions that read `dirent.path` to use `dirent.parentPath`.
- `bun bd test test/js/node/fs/fs.test.ts -t Dirent` and `-t readdir` (29 tests) pass.
- `bun bd test test/js/node/fs/glob.test.ts test/js/node/fs/dir.test.ts` (50 tests) pass.
- Manually verified `opendirSync().readSync()`, subclassed `new (class extends Dirent){}`, and `fs.promises.readdir()` all produce `[name, parentPath]` with `"path" in d === false` and working `isFile()`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->