### PR TITLE
perf_hooks: return one cached frozen array from PerformanceObserver.supportedEntryTypes

### DIFF
--- a/src/js/node/perf_hooks.ts
+++ b/src/js/node/perf_hooks.ts
@@ -116,6 +116,11 @@ $toClass(PerformanceResourceTiming, "PerformanceResourceTiming", PerformanceEntr
 const kNodeObserver = Symbol("kNodeObserver");
 const kObserverCallback = Symbol("kObserverCallback");
 
+// Web IDL FrozenArray<DOMString>: one frozen, identity-stable array per class.
+const kSupportedEntryTypes = Object.freeze(
+  [...new Set([...(NodePerformanceObserver.supportedEntryTypes ?? []), ...kNodeEntryTypes])].sort(),
+);
+
 /**
  * The native (WebCore) observer only understands mark/measure/resource.
  * Node-only entry types ('net', 'dns', ...) are routed to the JS-side
@@ -131,7 +136,7 @@ class PerformanceObserverForNodeTypes extends NodePerformanceObserver {
 
   /** The native list plus the Node-only types routed through the JS registry. */
   static get supportedEntryTypes() {
-    return [...new Set([...(NodePerformanceObserver.supportedEntryTypes ?? []), ...kNodeEntryTypes])].sort();
+    return kSupportedEntryTypes;
   }
 
   observe(options) {

--- a/src/jsc/bindings/webcore/JSPerformanceObserver.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceObserver.cpp
@@ -265,19 +265,20 @@ JSC_DEFINE_CUSTOM_GETTER(jsPerformanceObserverConstructor, (JSGlobalObject * lex
     return JSValue::encode(JSPerformanceObserver::getConstructor(JSC::getVM(lexicalGlobalObject), prototype->globalObject()));
 }
 
-static inline JSValue jsPerformanceObserverConstructor_supportedEntryTypesGetter(JSGlobalObject& lexicalGlobalObject)
-{
-    auto& vm = JSC::getVM(&lexicalGlobalObject);
-    auto throwScope = DECLARE_THROW_SCOPE(vm);
-    auto* context = uncheckedDowncast<JSDOMGlobalObject>(&lexicalGlobalObject)->scriptExecutionContext();
-    if (!context) [[unlikely]]
-        return jsUndefined();
-    RELEASE_AND_RETURN(throwScope, (toJS<IDLFrozenArray<IDLDOMString>>(lexicalGlobalObject, *uncheckedDowncast<JSDOMGlobalObject>(&lexicalGlobalObject), throwScope, PerformanceObserver::supportedEntryTypes(*context))));
-}
-
 JSC_DEFINE_CUSTOM_GETTER(jsPerformanceObserverConstructor_supportedEntryTypes, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
 {
-    return IDLAttribute<JSPerformanceObserver>::getStatic<jsPerformanceObserverConstructor_supportedEntryTypesGetter>(*lexicalGlobalObject, thisValue, attributeName);
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    auto* context = uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject)->scriptExecutionContext();
+    if (!context) [[unlikely]]
+        return JSValue::encode(jsUndefined());
+    JSValue result = toJS<IDLFrozenArray<IDLDOMString>>(*lexicalGlobalObject, *uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject), throwScope, PerformanceObserver::supportedEntryTypes(*context));
+    RETURN_IF_EXCEPTION(throwScope, {});
+    // [SameObject]: memoize the frozen array on the constructor so subsequent
+    // reads return the identical object.
+    if (auto* thisObject = JSValue::decode(thisValue).getObject())
+        thisObject->putDirect(vm, attributeName, result, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly));
+    return JSValue::encode(result);
 }
 
 static inline JSC::EncodedJSValue jsPerformanceObserverPrototypeFunction_observeBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSPerformanceObserver>::ClassParameter castedThis)

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -39,6 +39,7 @@ describe("PerformanceObserver.supportedEntryTypes", () => {
     expect(Object.isFrozen(a)).toBe(true);
     expect(b).toBe(a);
     expect(() => (a as string[]).push("evil")).toThrow(TypeError);
+    expect(globalThis.PerformanceObserver.supportedEntryTypes.includes("evil")).toBe(false);
     expect(globalThis.PerformanceObserver.supportedEntryTypes).toBe(a);
   });
 });

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "bun:test";
-import perf from "perf_hooks";
+import { describe, expect, test } from "bun:test";
+import perf, { PerformanceObserver } from "perf_hooks";
 
 test("stubs", () => {
   expect(perf.performance.nodeTiming).toBeObject();
@@ -20,4 +20,25 @@ test("doesn't throw", () => {
   expect(() => performance.now()).not.toThrow();
   expect(() => performance.timeOrigin).not.toThrow();
   expect(() => performance.markResourceTiming()).not.toThrow();
+});
+
+describe("PerformanceObserver.supportedEntryTypes", () => {
+  test("node:perf_hooks returns the same frozen array on every access", () => {
+    const a = PerformanceObserver.supportedEntryTypes;
+    const b = PerformanceObserver.supportedEntryTypes;
+    expect(Object.isFrozen(a)).toBe(true);
+    expect(b).toBe(a);
+    expect(() => (a as string[]).push("evil")).toThrow(TypeError);
+    expect(PerformanceObserver.supportedEntryTypes.includes("evil")).toBe(false);
+    expect(PerformanceObserver.supportedEntryTypes).toBe(a);
+  });
+
+  test("globalThis.PerformanceObserver returns the same frozen array on every access", () => {
+    const a = globalThis.PerformanceObserver.supportedEntryTypes;
+    const b = globalThis.PerformanceObserver.supportedEntryTypes;
+    expect(Object.isFrozen(a)).toBe(true);
+    expect(b).toBe(a);
+    expect(() => (a as string[]).push("evil")).toThrow(TypeError);
+    expect(globalThis.PerformanceObserver.supportedEntryTypes).toBe(a);
+  });
 });


### PR DESCRIPTION
### What

`PerformanceObserver.supportedEntryTypes` is declared as `[SameObject] static readonly attribute FrozenArray<DOMString>` in Web IDL, and Node returns one cached `Object.freeze()`d array. Bun did not match either property:

```js
import { PerformanceObserver } from "node:perf_hooks";

const a = PerformanceObserver.supportedEntryTypes;
const b = PerformanceObserver.supportedEntryTypes;

a === b             // node: true   bun: false (new array per access)
Object.isFrozen(a)  // node: true   bun: false
a.push("evil")      // node: throws TypeError   bun: accepted, then discarded on next read

const g = globalThis.PerformanceObserver.supportedEntryTypes;
Object.isFrozen(g)  // both: true
g === globalThis.PerformanceObserver.supportedEntryTypes
                    // node: true   bun: false
```

Feature-detection code that caches the array, checks identity across reads, or relies on the frozen contract behaves differently on Bun; a mutation Node rejects with a `TypeError` was silently accepted and dropped.

### Fix

- `src/js/node/perf_hooks.ts`: the static getter rebuilt `[...new Set(...)].sort()` on every call with no freeze. The merged list (native types + Node-only types) is fixed at module load, so compute and `Object.freeze` it once and return the cached instance from the getter. Matches `lib/internal/perf/observe.js` in Node.
- `src/jsc/bindings/webcore/JSPerformanceObserver.cpp`: the static custom getter allocated a new `IDLFrozenArray` on every call. On first access it now `putDirect`s the result onto the constructor, replacing the custom-value slot with a plain read-only data property (the self-replacing getter pattern also used in `BundlerMetafile.cpp`). Subsequent reads return the identical object.

### Verification

New tests in `test/js/node/perf_hooks/perf_hooks.test.ts` covering both classes: `Object.isFrozen`, identity across reads, and `push()` throws `TypeError`. Both fail on main (the node:perf_hooks one on `isFrozen`, the global one on identity) and pass with the fix.

Existing `perf_hooks.test.ts`, `performance-observer-leak.test.ts`, `test/js/deno/performance/performance.test.ts`, `test/js/web/timers/performance.test.js`, `test-net-perf_hooks.js`, and `test-performance-measure.js` all still pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/perf_hooks/perf_hooks.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f811aa883)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [10.52ms]
(pass) doesn't throw [15.37ms]
24 | 
25 | describe("PerformanceObserver.supportedEntryTypes", () => {
26 |   test("node:perf_hooks returns the same frozen array on every access", () => {
27 |     const a = PerformanceObserver.supportedEntryTypes;
28 |     const b = PerformanceObserver.supportedEntryTypes;
29 |     expect(Object.isFrozen(a)).toBe(true);
                                    ^
error: expect(received).toBe(expected)

Expected: true
Received: false

      at <anonymous> (/workspace/bun/test/js/node/perf_hooks/perf_hooks.test.ts:29:32)
(fail) PerformanceObserver.supportedEntryTypes > node:perf_hooks returns the same frozen array on ever
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [0.06ms]
(pass) doesn't throw [0.13ms]
24 | 
25 | describe("PerformanceObserver.supportedEntryTypes", () => {
26 |   test("node:perf_hooks returns the same frozen array on every access", () => {
27 |     const a = PerformanceObserver.supportedEntryTypes;
28 |     const b = PerformanceObserver.supportedEntryTypes;
29 |     expect(Object.isFrozen(a)).toBe(true);
                                    ^
error: expect(received).toBe(expected)

Expected: true
Received: false

      at <anonymous> (/workspace/bun/test/js/node/perf_hooks/perf_hooks.test.ts:29:32)
(fail) PerformanceObserver.supportedEntryTypes > node:perf_hooks returns the same frozen array on every access [0.35ms]
35 | 
36 |   test("globalThis.PerformanceObserver returns the same frozen array on every access", () => {
37 |     const a = globalThis.PerformanceObserver.supportedEntryTypes;
38 |     const b = globalThis.PerformanceObserver.supportedEntryTypes;
39 |     expect(Object.isFrozen(a)).toBe(true);
40 |     expect(b).toBe(a);
                   ^
error: expect(received).toBe(expected)

Expected: [ "mark", "mea
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/perf_hooks/perf_hooks.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f811aa883)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [12.05ms]
(pass) doesn't throw [15.46ms]
(pass) PerformanceObserver.supportedEntryTypes > node:perf_hooks returns the same frozen array on every access [6.42ms]
(pass) PerformanceObserver.supportedEntryTypes > globalThis.PerformanceObserver returns the same frozen array on every access [4.74ms]

 4 pass
 0 fail
 24 expect() calls
Ran 4 tests across 1 file. [2.05s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 739ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen cpp.rs (cppbind)
[2/22] gen JS modules (bundle-modules)
Preprocess modules (6603ms)
Bundle modules (73ms)
Postprocesss modules (24ms)
Bundle Functions (641ms)
Generate Code (76ms)

[7.43s] Bundled "src/js" for production
  1911 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[2/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/perf_hooks.ts                          |  7 +++++-
 src/jsc/bindings/webcore/JSPerformanceObserver.cpp | 21 ++++++++---------
 test/js/node/perf_hooks/perf_hooks.test.ts         | 26 ++++++++++++++++++++--
 3 files changed, 41 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/js/node/perf_hooks.ts                               2      2      0
src/jsc/bindings/webcore/JSPerformanceObserver.cpp      1      2      0
test/js/node/perf_hooks/perf_hooks.test.ts              2      3      0
```

</details>

<!-- robobun:evidence:end -->