### PR TITLE
Stop inlining process.env dot-reads in Worker-thread transpiles

### DIFF
--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -43,7 +43,10 @@ bun_core::declare_scope!(cache, visible);
 /// path reinstates the bug for any previously-cached TLA module (#30887).
 /// Version 23: `jsx.runtime`/`jsx.development` participate in the features hash,
 /// and tsconfig `"jsx": "react-jsx"` now emits the production runtime (#4227).
-const EXPECTED_VERSION: u32 = 23;
+/// Version 24: Worker threads no longer inline `process.env.X` dot-reads.
+/// Entries written by a pre-fix worker carry the writing process's env values
+/// as string literals; a cache hit reinstates the bug (#34210).
+const EXPECTED_VERSION: u32 = 24;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -976,6 +976,11 @@ impl WebWorker {
         unsafe {
             let b = &mut (*vm).transpiler;
             b.resolver.env_loader = NonNull::new(b.env);
+            // Match the main thread (run_command.rs): never inline
+            // `process.env.X` dot-reads as literals — they'd be baked into
+            // the shared on-disk runtime transpiler cache.
+            b.options.env.behavior =
+                bun_options_types::schema::api::DotEnvBehavior::LoadAllWithoutInlining;
 
             if let Some(graph) = parent.standalone_module_graph {
                 (hooks.apply_standalone_runtime_flags)(b, graph);

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -976,9 +976,7 @@ impl WebWorker {
         unsafe {
             let b = &mut (*vm).transpiler;
             b.resolver.env_loader = NonNull::new(b.env);
-            // Match the main thread (run_command.rs): never inline
-            // `process.env.X` dot-reads as literals — they'd be baked into
-            // the shared on-disk runtime transpiler cache.
+            // Match run_command.rs: no `process.env.X` dot-read inlining at runtime.
             b.options.env.behavior =
                 bun_options_types::schema::api::DotEnvBehavior::LoadAllWithoutInlining;
 

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -223,6 +223,24 @@ describe("transpiler cache", () => {
     expect(b.stdout == "production 5");
     expect(newCacheCount()).toBe(0);
   });
+  test("does not inline process.env in Worker threads", () => {
+    // https://github.com/oven-sh/bun/issues/34210
+    writeFileSync(
+      join(temp_dir, "big-env.js"),
+      dummyFile((50 * 1024 * 1.5) | 0, "1", { code: "process.env.TRANSPILER_CACHE_TEST_ID" }),
+    );
+    writeFileSync(join(temp_dir, "worker-entry.js"), `await import("./big-env.js");`);
+    writeFileSync(join(temp_dir, "worker-main.js"), `new Worker(new URL("./worker-entry.js", import.meta.url));`);
+
+    const a = bunRun(join(temp_dir, "worker-main.js"), { ...env, TRANSPILER_CACHE_TEST_ID: "first" });
+    expect(a.stdout).toBe("first");
+    expect(newCacheCount()).toBe(1);
+
+    // A second process with a different env must not observe the first
+    // process's value through the shared cache entry.
+    const b = bunRun(join(temp_dir, "worker-main.js"), { ...env, TRANSPILER_CACHE_TEST_ID: "second" });
+    expect(b.stdout).toBe("second");
+  });
   test("--feature flag invalidates cache", () => {
     // feature() can only appear in an if/ternary, so wrap it
     const code = `import { feature } from "bun:bundle";\nif (feature("SUPER_SECRET")) console.log("enabled"); else console.log("disabled");`;

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -236,10 +236,9 @@ describe("transpiler cache", () => {
     expect(a.stdout).toBe("first");
     expect(newCacheCount()).toBe(1);
 
-    // A second process with a different env must not observe the first
-    // process's value through the shared cache entry.
     const b = bunRun(join(temp_dir, "worker-main.js"), { ...env, TRANSPILER_CACHE_TEST_ID: "second" });
     expect(b.stdout).toBe("second");
+    expect(newCacheCount()).toBe(0);
   });
   test("--feature flag invalidates cache", () => {
     // feature() can only appear in an if/ternary, so wrap it

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1420,10 +1420,7 @@ test("*Internal introspection methods are DontEnum on Worker.prototype", () => {
 });
 
 test("env: {} scrubs the launch environment from the worker's process.env", async () => {
-  // Spawn so the launch environ we're scrubbing is known and not the test
-  // runner's own. The worker reads the vars as literal dot accesses, which is
-  // the form the worker transpiler was previously inlining from the parent's
-  // env loader even when `env: {}` installed an empty plain object.
+  // https://github.com/oven-sh/bun/issues/34210
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1419,6 +1419,42 @@ test("*Internal introspection methods are DontEnum on Worker.prototype", () => {
   expect(enumerable).not.toContain("cpuUsageInternal");
 });
 
+test("env: {} scrubs the launch environment from the worker's process.env", async () => {
+  // Spawn so the launch environ we're scrubbing is known and not the test
+  // runner's own. The worker reads the vars as literal dot accesses, which is
+  // the form the worker transpiler was previously inlining from the parent's
+  // env loader even when `env: {}` installed an empty plain object.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const { Worker } = require("node:worker_threads");
+       const src = \`const { parentPort } = require("node:worker_threads");
+         parentPort.postMessage({
+           keys: Object.keys(process.env),
+           secret: process.env.LAUNCH_SECRET ?? null,
+           only: process.env.ONLY ?? null,
+           inSecret: "LAUNCH_SECRET" in process.env,
+           node_env: process.env.NODE_ENV ?? null,
+         });\`;
+       const w = new Worker(src, { eval: true, env: { ONLY: "1" } });
+       w.once("message", m => { console.log(JSON.stringify(m)); w.terminate(); });`,
+    ],
+    env: { ...bunEnv, LAUNCH_SECRET: "s3cr3t", NODE_ENV: "production" },
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout.trim())).toEqual({
+    keys: ["ONLY"],
+    secret: null,
+    only: "1",
+    inSecret: false,
+    node_env: null,
+  });
+  expect(exitCode).toBe(0);
+});
+
 describe("env: SHARE_ENV shares the spawning thread's env, not a process-wide one", () => {
   async function run(mode: string) {
     const proc = Bun.spawn({


### PR DESCRIPTION
Fixes #34210

### Repro

A module over the runtime transpiler cache minimum size, dynamically imported inside a Worker, run twice with different env values and a shared cache:

```sh
MY_TEST_IDENTITY=FIRST_VALUE bun main.ts   # DOT: FIRST_VALUE
MY_TEST_IDENTITY=SECOND_VALUE bun main.ts  # DOT: FIRST_VALUE  (stale, run 1's value)
```

where `main.ts` does `new Worker(...)` and the worker dynamically imports a large module that reads `process.env.MY_TEST_IDENTITY`. The cached `.pile` entry contains the first run's value as a string literal.

The same inlining also defeats `new Worker(file, { env: {} })`: the worker's `process.env` object is the requested empty map (enumeration, `in`, `hasOwnProperty` all agree), but a literal `process.env.HOME` read still returns the launch value because the transpiler substituted it at parse time.

```js
// LAUNCH_SECRET=s3cr3t bun repro.mjs
const w = new Worker(`parentPort.postMessage({
  keys: Object.keys(process.env),
  secret: process.env.LAUNCH_SECRET,
  inSecret: "LAUNCH_SECRET" in process.env,
})`, { eval: true, env: {} });
// bun before: { keys: [], secret: "s3cr3t", inSecret: false }
// node/after: { keys: [], secret: undefined, inSecret: false }
```

### Cause

The main thread sets `env.behavior = DotEnvBehavior::LoadAllWithoutInlining` before `configure_defines()` (src/runtime/cli/run_command.rs), and so do the test runner, repl, bake, and standalone paths. The Worker-thread VM startup path (`WebWorker::start_vm` in src/jsc/web_worker.rs) never did, so the worker's transpiler ran with the `Target::Bun` default of `LoadAll` and baked every `process.env.X` dot-read into the transpiled output as a `DotDefine`. That output lands in the shared on-disk runtime transpiler cache, which is keyed by content and features only, so every later process with different env values got the first process's values as compile-time constants. And because the define table is built from the worker's `env_loader` (cloned from the parent's launch environ) rather than the `options.env` map installed on `m_processEnvObject`, an explicit `env: {}` cannot scrub the literal reads.

### Fix

Set `LoadAllWithoutInlining` on the worker VM's transpiler before `configure_defines()`, matching the main thread. This stops the inlining, stops poisoned cache entries from being written, and lets the plain `process.env` object installed for an explicit `env:` option be the sole source of truth for dot reads. The standalone-graph branch right below already set it via `apply_standalone_runtime_flags`.

### Verification

- `test/cli/run/transpiler-cache.test.ts` ("does not inline process.env in Worker threads") runs the two-process repro with a shared cache dir; fails on the unfixed build (prints the first run's value), passes with the fix.
- `test/js/node/worker_threads/worker_threads.test.ts` ("env: {} scrubs the launch environment from the worker's process.env") spawns a worker with `env: { ONLY: "1" }` under a process that has `LAUNCH_SECRET`/`NODE_ENV` set, and asserts literal `process.env.LAUNCH_SECRET` / `process.env.NODE_ENV` reads come back `null`; fails before (`"s3cr3t"` / `"production"`), passes after.
- Full `test/js/node/worker_threads/worker_threads.test.ts` (92 tests) and `test/cli/run/transpiler-cache.test.ts` pass on the debug build.