### PR TITLE
node:tty: give WriteStream its own prototype instead of aliasing fs.WriteStream.prototype

### DIFF
--- a/src/js/node/tty.ts
+++ b/src/js/node/tty.ts
@@ -124,8 +124,8 @@ function WriteStream(fd): void {
 
 Object.defineProperty(WriteStream, "prototype", {
   get() {
-    const Real = fs.WriteStream.prototype;
-    Object.defineProperty(WriteStream, "prototype", { value: Real });
+    const Prototype = Object.create(fs.WriteStream.prototype);
+    Object.defineProperty(WriteStream, "prototype", { value: Prototype });
 
     WriteStream.prototype._refreshSize = function () {
       const oldCols = this.columns;
@@ -188,7 +188,7 @@ Object.defineProperty(WriteStream, "prototype", {
       })();
     };
 
-    return Real;
+    return Prototype;
   },
   enumerable: true,
   configurable: true,

--- a/src/js/node/tty.ts
+++ b/src/js/node/tty.ts
@@ -26,6 +26,7 @@ $toClass(ReadStream, "ReadStream", fs.ReadStream);
 Object.defineProperty(ReadStream, "prototype", {
   get() {
     const Prototype = Object.create(fs.ReadStream.prototype);
+    Object.defineProperty(Prototype, "constructor", { value: ReadStream, writable: true, configurable: true });
 
     // Add ref/unref methods to make tty.ReadStream behave like Node.js
     // where TTY streams have socket-like behavior
@@ -125,6 +126,7 @@ function WriteStream(fd): void {
 Object.defineProperty(WriteStream, "prototype", {
   get() {
     const Prototype = Object.create(fs.WriteStream.prototype);
+    Object.defineProperty(Prototype, "constructor", { value: WriteStream, writable: true, configurable: true });
     Object.defineProperty(WriteStream, "prototype", { value: Prototype });
 
     WriteStream.prototype._refreshSize = function () {

--- a/test/js/node/stream/tty-streams.fixture.js
+++ b/test/js/node/stream/tty-streams.fixture.js
@@ -84,8 +84,8 @@ describe("TTY", () => {
   it("process.stdio tty", () => {
     // this isnt run in a tty, so stdin will not appear to be a tty
     expect(process.stdin instanceof fs.ReadStream).toBe(true);
-    expect(process.stdout instanceof tty.WriteStream).toBe(true);
-    expect(process.stderr instanceof tty.WriteStream).toBe(true);
+    expect(process.stdout instanceof tty.WriteStream).toBe(tty.isatty(1));
+    expect(process.stderr instanceof tty.WriteStream).toBe(tty.isatty(2));
     expect(process.stdin.isTTY).toBeUndefined();
 
     if (tty.isatty(1)) {

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -1,6 +1,131 @@
 import { describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { WriteStream } from "node:tty";
+import tty from "node:tty";
+import fs from "node:fs";
+import path from "node:path";
+
+describe("WriteStream.prototype is distinct from fs.WriteStream.prototype", () => {
+  test("tty.WriteStream.prototype is its own object inheriting from fs.WriteStream.prototype", () => {
+    expect(tty.WriteStream.prototype).not.toBe(fs.WriteStream.prototype);
+    expect(Object.getPrototypeOf(tty.WriteStream.prototype)).toBe(fs.WriteStream.prototype);
+  });
+
+  test("fs.WriteStream instances do not carry tty methods and are not instanceof tty.WriteStream", async () => {
+    using dir = tempDir("tty-writestream-proto", { "out.txt": "" });
+    const ws = fs.createWriteStream(path.join(String(dir), "out.txt"));
+    ws.on("error", () => {});
+    const closed = new Promise<void>(resolve => ws.once("close", () => resolve()));
+    try {
+      expect({
+        instanceofTTY: ws instanceof tty.WriteStream,
+        instanceofFS: ws instanceof fs.WriteStream,
+        cursorTo: typeof (ws as any).cursorTo,
+        getColorDepth: typeof (ws as any).getColorDepth,
+        getWindowSize: typeof (ws as any).getWindowSize,
+        hasColors: typeof (ws as any).hasColors,
+        clearLine: typeof (ws as any).clearLine,
+        moveCursor: typeof (ws as any).moveCursor,
+      }).toEqual({
+        instanceofTTY: false,
+        instanceofFS: true,
+        cursorTo: "undefined",
+        getColorDepth: "undefined",
+        getWindowSize: "undefined",
+        hasColors: "undefined",
+        clearLine: "undefined",
+        moveCursor: "undefined",
+      });
+    } finally {
+      ws.destroy();
+      await closed;
+    }
+  });
+
+  test("mutating tty.WriteStream.prototype does not leak onto fs.WriteStream.prototype", () => {
+    try {
+      (tty.WriteStream.prototype as any).___probe = 1;
+      expect((fs.WriteStream.prototype as any).___probe).toBeUndefined();
+    } finally {
+      delete (tty.WriteStream.prototype as any).___probe;
+    }
+  });
+
+  test("piped process.stdout is not instanceof tty.WriteStream and lacks tty methods", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const tty = require("node:tty");
+         const fs = require("node:fs");
+         const out = process.stdout;
+         process.stdout.write(JSON.stringify({
+           isTTY: !!out.isTTY,
+           instanceofTTY: out instanceof tty.WriteStream,
+           cursorTo: typeof out.cursorTo,
+           getColorDepth: typeof out.getColorDepth,
+           getWindowSize: typeof out.getWindowSize,
+           protoIdentity: tty.WriteStream.prototype === fs.WriteStream.prototype,
+         }));`,
+      ],
+      env: bunEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      isTTY: false,
+      instanceofTTY: false,
+      cursorTo: "undefined",
+      getColorDepth: "undefined",
+      getWindowSize: "undefined",
+      protoIdentity: false,
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("tty.WriteStream instances still have tty methods and correct instanceof chain", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const tty = require("node:tty");
+         const fs = require("node:fs");
+         const stream = require("node:stream");
+         const ws = new tty.WriteStream(1);
+         process.stdout.write(JSON.stringify({
+           instanceofTTY: ws instanceof tty.WriteStream,
+           instanceofFS: ws instanceof fs.WriteStream,
+           instanceofWritable: ws instanceof stream.Writable,
+           protoIsTTYProto: Object.getPrototypeOf(ws) === tty.WriteStream.prototype,
+           cursorTo: typeof ws.cursorTo,
+           getColorDepth: typeof ws.getColorDepth,
+           getWindowSize: typeof ws.getWindowSize,
+           hasColors: typeof ws.hasColors,
+           _refreshSize: typeof ws._refreshSize,
+           write: typeof ws.write,
+         }));`,
+      ],
+      env: bunEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      instanceofTTY: true,
+      instanceofFS: true,
+      instanceofWritable: true,
+      protoIsTTYProto: true,
+      cursorTo: "function",
+      getColorDepth: "function",
+      getWindowSize: "function",
+      hasColors: "function",
+      _refreshSize: "function",
+      write: "function",
+    });
+    expect(exitCode).toBe(0);
+  });
+});
 
 describe("ReadStream.prototype.setRawMode", () => {
   // Regression: on Windows, the `fd === 0` branch returned early on success

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, it, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
-import { WriteStream } from "node:tty";
-import tty from "node:tty";
 import fs from "node:fs";
 import path from "node:path";
+import tty, { WriteStream } from "node:tty";
 
 describe("WriteStream.prototype is distinct from fs.WriteStream.prototype", () => {
   test("tty.WriteStream.prototype is its own object inheriting from fs.WriteStream.prototype", () => {

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -10,6 +10,23 @@ describe("WriteStream.prototype is distinct from fs.WriteStream.prototype", () =
     expect(Object.getPrototypeOf(tty.WriteStream.prototype)).toBe(fs.WriteStream.prototype);
   });
 
+  test("tty.{Read,Write}Stream.prototype.constructor point at the tty classes", () => {
+    expect(tty.WriteStream.prototype.constructor).toBe(tty.WriteStream);
+    expect(tty.ReadStream.prototype.constructor).toBe(tty.ReadStream);
+    expect(Object.getOwnPropertyDescriptor(tty.WriteStream.prototype, "constructor")).toEqual({
+      value: tty.WriteStream,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+    expect(Object.getOwnPropertyDescriptor(tty.ReadStream.prototype, "constructor")).toEqual({
+      value: tty.ReadStream,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  });
+
   test("fs.WriteStream instances do not carry tty methods and are not instanceof tty.WriteStream", async () => {
     using dir = tempDir("tty-writestream-proto", { "out.txt": "" });
     const ws = fs.createWriteStream(path.join(String(dir), "out.txt"));


### PR DESCRIPTION
## What does this PR do?

`tty.WriteStream.prototype` was literally the same object as `fs.WriteStream.prototype`. The lazy prototype getter assigned `fs.WriteStream.prototype` directly and then added all of the tty methods (`cursorTo`, `getColorDepth`, `getWindowSize`, `hasColors`, `clearLine`, `moveCursor`, `_refreshSize`, `Symbol.asyncIterator`) onto it.

As a result, every `fs.WriteStream` instance and every non-TTY `process.stdout` / `process.stderr` in the program:

- answered `instanceof tty.WriteStream` as `true`
- carried the full tty method surface (`typeof ws.getColorDepth === "function"` on a file stream)
- returned `[undefined, undefined]` from `getWindowSize()` on a file stream

These are the two standard feature-detection idioms terminal and color libraries use, so redirected output could be misidentified as a terminal and receive ANSI escape sequences. Mutating `tty.WriteStream.prototype` also mutated `fs.WriteStream.prototype` process-wide.

`tty.ReadStream` already handled this correctly with `Object.create(fs.ReadStream.prototype)`; this change mirrors that for `WriteStream`.

## Repro

```js
import tty from "node:tty";
import fs from "node:fs";

const ws = fs.createWriteStream("/tmp/f.txt");
console.log(fs.WriteStream.prototype === tty.WriteStream.prototype);
// node: false    bun before: true
console.log(ws instanceof tty.WriteStream);
// node: false    bun before: true
console.log(typeof ws.cursorTo, typeof ws.getColorDepth, typeof ws.getWindowSize);
// node: undefined x3    bun before: function x3
```

## How did you verify your code works?

New tests in `test/js/node/tty.test.ts` cover:

- `tty.WriteStream.prototype` is a distinct object whose `[[Prototype]]` is `fs.WriteStream.prototype`
- `fs.createWriteStream(...)` instances are not `instanceof tty.WriteStream` and have no tty methods
- mutating `tty.WriteStream.prototype` does not leak onto `fs.WriteStream.prototype`
- piped `process.stdout` is not `instanceof tty.WriteStream` and has no tty methods
- `tty.WriteStream` instances still have the full tty method set and the expected `instanceof` chain

Also updated `test/js/node/stream/tty-streams.fixture.js`, which was asserting the old (incorrect) behavior for piped stdio, to gate on `tty.isatty(fd)` the way Node does.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/tty.test.ts

<!-- robobun:evidence:end -->