### PR TITLE
deps: lower mimalloc's default purge_delay to 100ms

### DIFF
--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "13eecae8f35a73c16bdcded9291d9b56b7fc0fca";
+const MIMALLOC_COMMIT = "a806f4c6fab3030e88013f5fdbab0b651a528548";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",


### PR DESCRIPTION
Pin bump only — one line. Picks up **oven-sh/mimalloc#6** (merged: `a806f4c6`).

## What's in it

**1. `purge_delay` 1000ms → 100ms.** Freed memory returns to the OS ~10× sooner. The 1s default is upstream dev3's, and dev3 has a reason for it: it purges *inline on the allocation path*, so the delay buys back real work. We purge on the scavenger thread, where the delay only sets how long a standing window of freed-but-resident memory sticks around. Upstream v2 shipped an effective 100ms (`10 × arena_purge_mult 10`) for years.

Measured on the canary before proposing it:
- reuse faster than the delay is still fully protected (30ms gaps: 2 soft faults, same RSS as at 1s)
- memory idle >100ms comes back ~10× sooner; the standing window shrinks by the same factor
- the churn cost only lands on free-intervals in the 100ms–1s band that then get reused (~0.34ms CPU/MB on realloc), and the madvise itself stays off the allocating thread — **597 of 608 madvise calls run on the scavenger** under busy churn
- 50ms is too low: per-arena expiry granularity makes it purge memory freed ~30ms ago, churning the reuse cycles it should protect

**2. The scavenger no longer pretends to exist in a forked child.** Pre-existing, found while reviewing the above. `_mi_process_fork_child` never cleared `_mi_scavenger_running`/`_mi_scavenger_joinable`, so a child inherited flags with no thread behind them: `_mi_arenas_purge_now` took the wake path and signalled nobody — **the child never returned memory to the OS at all** — and `_mi_scavenger_stop` joined a `pthread_t` naming no thread. Low exposure here (Bun spawns via `posix_spawn`, not bare `fork`). Covered by `case_c` in `test-fork-user-heap`: without the fix a child that frees 100MB stays at 101MB forever.

**3. The scavenger thread is named `mi-scavenger`** — it was showing up as an unlabelled second `bun` thread, which cost a wrong conclusion during the RSS investigation.

## Verified here

- Builds clean in Bun's unity `static.c` TU (a different compilation from mimalloc's own cmake).
- `MIMALLOC_VERBOSE=1` on the built binary echoes `option 'purge_delay': 100`.
- `Bun.serve` + `Bun.spawnSync` smoke pass.
- mimalloc's ctest: unchanged from before the bump — the same two pre-existing failures (`test-prof-adversarial` segfaults on gcc-11; `test-purge-holes` has a delay-independent `unformed_bytes` gauge ratchet). Neither is affected by this.

Deliberately scoped to the pin alone; the park-handoff work is separate (#34181).