### PR TITLE
Fix four crashes: HTMLRewriter disturbed body, S3 locked-stream upload, ConnectionsList closed parser, shell brace expansion

### DIFF
--- a/src/jsc/bindings/node/http/JSConnectionsList.cpp
+++ b/src/jsc/bindings/node/http/JSConnectionsList.cpp
@@ -93,6 +93,11 @@ JSArray* JSConnectionsList::idle(JSGlobalObject* globalObject)
             continue;
         }
 
+        // A close()d parser stays in the set but has no impl anymore.
+        if (!parser->impl()) {
+            continue;
+        }
+
         if (parser->impl()->lastMessageStart() == 0) {
             result->putDirectIndex(globalObject, i++, parser);
         }
@@ -144,6 +149,11 @@ JSArray* JSConnectionsList::expired(JSGlobalObject* globalObject, uint64_t heade
     while (iter->next(globalObject, item)) {
         JSHTTPParser* parser = dynamicDowncast<JSHTTPParser>(item);
         if (!parser) {
+            continue;
+        }
+
+        // A close()d parser stays in the set but has no impl anymore.
+        if (!parser->impl()) {
             continue;
         }
 

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -325,14 +325,19 @@ impl Expansion {
                 &mut expanded[..],
                 lexer_output.contains_nested,
             ) {
-                if matches!(e, braces::ParserError::TooManyBraces) {
-                    let msg = "too many braces in brace expansion".to_string();
-                    me.state =
-                        ExpansionState::Err(Box::new(ShellErr::Custom(msg.into_bytes().into())));
-                    return;
-                }
-                // An unexpected token from brace expansion is a parser bug.
-                panic!("unexpected error from Braces.expand: {e:?}");
+                // Every expand error is reachable from user input (e.g. >u16::MAX
+                // tokens hits UnexpectedToken); surface a catchable shell error
+                // like Bun.braces() instead of panicking.
+                let msg = match e {
+                    braces::ParserError::TooManyBraces => "too many braces in brace expansion",
+                    braces::ParserError::UnexpectedToken => {
+                        "unexpected token while expanding braces"
+                    }
+                    braces::ParserError::OutOfMemory => "out of memory while expanding braces",
+                };
+                me.state =
+                    ExpansionState::Err(Box::new(ShellErr::Custom(msg.as_bytes().to_vec().into())));
+                return;
             }
             drop(arena);
             expanded

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -325,15 +325,14 @@ impl Expansion {
                 &mut expanded[..],
                 lexer_output.contains_nested,
             ) {
-                // Every expand error is reachable from user input (e.g. >u16::MAX
-                // tokens hits UnexpectedToken); surface a catchable shell error
-                // like Bun.braces() instead of panicking.
+                // >u16::MAX tokens hits UnexpectedToken from user input; surface
+                // both non-OOM variants as catchable shell errors like Bun.braces().
                 let msg = match e {
                     braces::ParserError::TooManyBraces => "too many braces in brace expansion",
                     braces::ParserError::UnexpectedToken => {
                         "unexpected token while expanding braces"
                     }
-                    braces::ParserError::OutOfMemory => "out of memory while expanding braces",
+                    braces::ParserError::OutOfMemory => bun_core::out_of_memory(),
                 };
                 me.state =
                     ExpansionState::Err(Box::new(ShellErr::Custom(msg.as_bytes().to_vec().into())));

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -2422,9 +2422,13 @@ impl<'a> ValueBufferer<'a> {
                 webcore::readable_stream::Source::Invalid => {
                     return Err(crate::Error::InvalidStream);
                 }
-                // toBlobIfPossible should've caught this
+                // to_blob_if_possible converts these unless the stream was
+                // already disturbed (or a lazy File source was consumed) —
+                // surface that as the catchable "body already used" error.
                 webcore::readable_stream::Source::Blob(_)
-                | webcore::readable_stream::Source::File(_) => unreachable!(),
+                | webcore::readable_stream::Source::File(_) => {
+                    return Err(crate::Error::StreamAlreadyUsed);
+                }
                 webcore::readable_stream::Source::JavaScript
                 | webcore::readable_stream::Source::Direct => {
                     // this is broken right now

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -910,11 +910,6 @@ pub fn upload_stream(
         }));
     // SAFETY: freshly heap-allocated; exclusive access here.
     let ctx = unsafe { &mut *ctx_ptr };
-    // Wire the task's callbacks BEFORE init_exact_refs: a stream that ends
-    // synchronously inside init reaches resolve_thunk through task.fail, which
-    // must not see a null callback_context.
-    task.callback_context = ctx_ptr.cast::<c_void>();
-    task.on_writable = Some(on_writable_thunk);
     // +1 because the ctx refs the sink
     ctx.sink = Some(ResumableSink::init_exact_refs(
         &global_static,
@@ -922,6 +917,8 @@ pub fn upload_stream(
         ctx_ptr,
         2,
     ));
+    task.callback_context = ctx_ptr.cast::<c_void>();
+    task.on_writable = Some(on_writable_thunk);
     task.continue_stream();
     Ok(ctx.end_promise.value())
 }

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -766,8 +766,7 @@ pub fn upload_stream(
         credentials.deref();
         return Ok(bun_jsc::JSPromise::rejected_promise(
             global_this,
-            bun_core::String::static_("ReadableStream is locked")
-                .to_error_instance(global_this),
+            bun_core::String::static_("ReadableStream is locked").to_error_instance(global_this),
         )
         .to_js());
     }

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -759,6 +759,18 @@ pub fn upload_stream(
         )
         .to_js());
     }
+    // A merely-locked stream would otherwise end synchronously inside
+    // ResumableSink::init_exact_refs, firing resolve_thunk before
+    // task.callback_context is assigned below (null deref).
+    if readable_stream.is_locked(global_this) {
+        credentials.deref();
+        return Ok(bun_jsc::JSPromise::rejected_promise(
+            global_this,
+            bun_core::String::static_("ReadableStream is locked")
+                .to_error_instance(global_this),
+        )
+        .to_js());
+    }
 
     match readable_stream.ptr {
         ReadableStreamPtr::Invalid => {
@@ -899,6 +911,11 @@ pub fn upload_stream(
         }));
     // SAFETY: freshly heap-allocated; exclusive access here.
     let ctx = unsafe { &mut *ctx_ptr };
+    // Wire the task's callbacks BEFORE init_exact_refs: a stream that ends
+    // synchronously inside init reaches resolve_thunk through task.fail, which
+    // must not see a null callback_context.
+    task.callback_context = ctx_ptr.cast::<c_void>();
+    task.on_writable = Some(on_writable_thunk);
     // +1 because the ctx refs the sink
     ctx.sink = Some(ResumableSink::init_exact_refs(
         &global_static,
@@ -906,8 +923,6 @@ pub fn upload_stream(
         ctx_ptr,
         2,
     ));
-    task.callback_context = ctx_ptr.cast::<c_void>();
-    task.on_writable = Some(on_writable_thunk);
     task.continue_stream();
     Ok(ctx.end_promise.value())
 }

--- a/test/js/bun/s3/s3-fd-validation.test.ts
+++ b/test/js/bun/s3/s3-fd-validation.test.ts
@@ -71,7 +71,13 @@ test("Bun.write(s3file, response) with a locked or disturbed body rejects instea
   await expect(Bun.write(client.file("k"), locked)).rejects.toThrow("ReadableStream is locked");
 
   // A disturbed body is rejected one layer earlier, synchronously.
-  const disturbed = new Response(new ReadableStream({ pull(c) { c.enqueue(new Uint8Array(1)); } }));
+  const disturbed = new Response(
+    new ReadableStream({
+      pull(c) {
+        c.enqueue(new Uint8Array(1));
+      },
+    }),
+  );
   await disturbed.body!.getReader().read();
   expect(() => Bun.write(client.file("k"), disturbed)).toThrow("ReadableStream has already been used");
 });

--- a/test/js/bun/s3/s3-fd-validation.test.ts
+++ b/test/js/bun/s3/s3-fd-validation.test.ts
@@ -56,3 +56,22 @@ test("S3 file type option containing CR/LF or other control characters is not re
     expect(seen.headers.get("x-amz-acl")).toBeNull();
   }
 });
+
+test("Bun.write(s3file, response) with a locked or disturbed body rejects instead of crashing", async () => {
+  const client = new Bun.S3Client({
+    accessKeyId: "a",
+    secretAccessKey: "b",
+    bucket: "c",
+    // Never reached: both rejections happen synchronously before any request.
+    endpoint: "http://127.0.0.1:1",
+  });
+
+  const locked = new Response(new ReadableStream({ pull() {} }));
+  locked.body!.getReader(); // lock without disturbing
+  await expect(Bun.write(client.file("k"), locked)).rejects.toThrow("ReadableStream is locked");
+
+  // A disturbed body is rejected one layer earlier, synchronously.
+  const disturbed = new Response(new ReadableStream({ pull(c) { c.enqueue(new Uint8Array(1)); } }));
+  await disturbed.body!.getReader().read();
+  expect(() => Bun.write(client.file("k"), disturbed)).toThrow("ReadableStream has already been used");
+});

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -971,6 +971,21 @@ booga"
       const { stdout } = await $`{echo,a,b,c} {d,e,f}`;
       expect(stdout.toString()).toEqual("a b c d e f\n");
     });
+
+    describe("degenerate inputs", () => {
+      // These lex to zero expansions (the lexer rolls back to plain text);
+      // the word must pass through literally like bash, not crash.
+      doTest("},{", "},{");
+      doTest("a},{b", "a},{b");
+      doTest("}{", "}{");
+
+      test("more than 65535 tokens fails with a catchable error", async () => {
+        const word = "{" + Array(32768).fill("a").join(",") + "}";
+        const { stderr, exitCode } = await $`echo ${{ raw: word }}`.quiet();
+        expect(stderr.toString()).toContain("unexpected token while expanding braces");
+        expect(exitCode).toBe(1);
+      });
+    });
   });
 
   describe("variables", () => {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -982,7 +982,7 @@ booga"
       test("more than 65535 tokens fails with a catchable error", async () => {
         const word = "{" + Array(32768).fill("a").join(",") + "}";
         const { stderr, exitCode } = await $`echo ${{ raw: word }}`.quiet();
-        expect(stderr.toString()).toContain("unexpected token while expanding braces");
+        expect(stderr.toString()).toBe("bun: unexpected token while expanding braces\n");
         expect(exitCode).toBe(1);
       });
     });

--- a/test/js/node/http/node-http-parser.test.ts
+++ b/test/js/node/http/node-http-parser.test.ts
@@ -240,12 +240,15 @@ describe("ConnectionsList", () => {
     closed.initialize(HTTPParser.REQUEST, {}, 0, 0, list);
     closed.close();
 
-    // Both parsers are iterated; the close()d one must be skipped, not
-    // dereferenced. A freshly initialized parser is not idle (see above).
-    expect(list.idle()).toEqual([]);
-    expect(list.expired()).toEqual([]);
-    expect(list.all()).toEqual([alive, closed]);
-    alive.close();
+    try {
+      // Both parsers are iterated; the close()d one must be skipped, not
+      // dereferenced. A freshly initialized parser is not idle (see above).
+      expect(list.idle()).toEqual([]);
+      expect(list.expired()).toEqual([]);
+      expect(list.all()).toEqual([alive, closed]);
+    } finally {
+      alive.close();
+    }
   });
 
   test("works with HTTPParser", () => {

--- a/test/js/node/http/node-http-parser.test.ts
+++ b/test/js/node/http/node-http-parser.test.ts
@@ -232,6 +232,22 @@ describe("ConnectionsList", () => {
     expect(list.expired()).toEqual([]);
   });
 
+  test("idle() and expired() skip a close()d parser instead of crashing", () => {
+    const list = new ConnectionsList();
+    const alive = new HTTPParser();
+    const closed = new HTTPParser();
+    alive.initialize(HTTPParser.REQUEST, {}, 0, 0, list);
+    closed.initialize(HTTPParser.REQUEST, {}, 0, 0, list);
+    closed.close();
+
+    // Both parsers are iterated; the close()d one must be skipped, not
+    // dereferenced. A freshly initialized parser is not idle (see above).
+    expect(list.idle()).toEqual([]);
+    expect(list.expired()).toEqual([]);
+    expect(list.all()).toEqual([alive, closed]);
+    alive.close();
+  });
+
   test("works with HTTPParser", () => {
     const p1 = new HTTPParser();
     p1.name = "parser1";

--- a/test/js/node/http/node-http-parser.test.ts
+++ b/test/js/node/http/node-http-parser.test.ts
@@ -241,10 +241,11 @@ describe("ConnectionsList", () => {
     closed.close();
 
     try {
-      // Both parsers are iterated; the close()d one must be skipped, not
-      // dereferenced. A freshly initialized parser is not idle (see above).
       expect(list.idle()).toEqual([]);
-      expect(list.expired()).toEqual([]);
+      // expired() short-circuits when both timeouts are 0, so pass 1ms to
+      // actually iterate; only assert the closed parser is skipped since
+      // `alive` may legitimately appear.
+      expect(list.expired(1, 1)).not.toContain(closed);
       expect(list.all()).toEqual([alive, closed]);
     } finally {
       alive.close();

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -107,6 +107,22 @@ describe("HTMLRewriter", () => {
     expect(() => new HTMLRewriter().transform(Symbol("ok"))).toThrow();
   });
 
+  it("HTMLRewriter throws instead of crashing on a disturbed-then-unlocked body", async () => {
+    // in-memory (Blob-source) body
+    const resp = new Response(Buffer.alloc(1200, "x").toString());
+    const reader = resp.body.getReader();
+    await reader.read();
+    reader.releaseLock();
+    expect(() => new HTMLRewriter().transform(resp)).toThrow("Stream already used");
+
+    // file-backed (File-source) body
+    const fileResp = new Response(Bun.file(import.meta.path));
+    const fileReader = fileResp.body.getReader();
+    await fileReader.read();
+    fileReader.releaseLock();
+    expect(() => new HTMLRewriter().transform(fileResp)).toThrow("Stream already used");
+  });
+
   describe("transform rejects when the upstream body fails", () => {
     // Sends response headers plus a partial HTML body, then resets the
     // connection once the test calls `release()`. The transformed body must


### PR DESCRIPTION
Four independent crash fixes, one commit each (plus a small test-polish commit). Each was reproduced as a process abort / null deref on current main before the fix, and each now surfaces as a catchable error (or correct behavior) instead.

### 1. `HTMLRewriter.transform()` aborts on a disturbed-then-unlocked body

`buffer_locked_body_value` assumed `to_blob_if_possible` always consumes Blob/File stream sources, but `to_any_blob` returns `None` once the stream is disturbed (or a lazy File source was consumed), so those sources legitimately reached the `unreachable!()` arm — a panic/abort even in release builds:

```js
const resp = new Response("x".repeat(1200));
const r = resp.body.getReader();
await r.read();
r.releaseLock();
new HTMLRewriter().transform(resp); // abort
```

Now returns the catchable `Stream already used` error, matching the adjacent locked-stream path. Applies to both memory-backed and file-backed bodies.

### 2. S3: uploading from a locked `ReadableStream` null-derefs

`upload_stream` rejected a *disturbed* stream early but lost the *locked* check, so a merely-locked stream fell through to `ResumableSink::init_exact_refs`, whose synchronous-failure path fires `resolve_thunk` through `task.fail` — before `task.callback_context` is assigned. Null deref (SEGV in release):

```js
const s3 = new Bun.S3Client({ accessKeyId: "a", secretAccessKey: "b", bucket: "c" });
const resp = new Response(new ReadableStream({ pull() {} }));
resp.body.getReader(); // lock without disturbing
await Bun.write(s3.file("k"), resp); // null deref
```

Restore the early rejected-promise (`ReadableStream is locked` — v1.3 behavior; the check was dropped in the port), and wire `callback_context`/`on_writable` before `init_exact_refs` so any synchronous sink teardown goes through a valid context.

### 3. `node:http`: `ConnectionsList.idle()`/`expired()` null-deref on a `close()`d parser

`close()` frees the parser's impl but leaves the cell in the list's sets, and `impl()` returns `nullptr` afterwards. Every `HTTPParser` prototype entry guards on that — `idle()` and `expired()` were the only two iteration sites missing the check:

```js
const { HTTPParser, ConnectionsList } = process.binding("http_parser");
const list = new ConnectionsList();
const p = new HTTPParser();
p.initialize(HTTPParser.REQUEST, {}, 0, 0, list);
p.close();
list.idle(); // null deref
```

Skip impl-less parsers like the sibling sites do.

### 4. Bun shell: brace expansion panics on `},{` and on token overflow

Two panics in `do_brace_expand`, both absent from the `Bun.braces()` twin which already had the guards:

- Words like `},{` carry brace tokens but lex to zero expansions, so `braces::expand` wrote `out[0]` into an empty slice — index-out-of-bounds abort.
- A word with more than `u16::MAX` brace tokens (e.g. `{a,a,...}` with 32768 alternatives — under the existing 65536-expansion cap) made `braces::expand` return `UnexpectedToken`, which was treated as a parser bug and panicked.

```js
await Bun.$`echo },{`; // abort
```

Zero-expansion words now pass through as literal text (bash behavior: `echo },{` prints `},{`), and every expand error becomes a catchable shell error.

### Tests

Each fix ships regression tests in the existing suite for its module (`html-rewriter.test.js`, `s3-fd-validation.test.ts`, `node-http-parser.test.ts`, `bunshell.test.ts`); each crashing input is covered, plus the neighboring behavior (file-backed HTMLRewriter body, disturbed-stream S3 rejection, mixed open/closed parser lists, literal passthrough and glob composition for braces).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/bunshell.test.ts

<!-- robobun:evidence:end -->