### PR TITLE
parser(ts): require bare '>' to close type arguments in expression position

### DIFF
--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -155,7 +155,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // does and it probably doesn't have that high of a performance overhead
             // because "extends" clauses aren't that frequent, so it should be ok.
             if Self::IS_TYPESCRIPT_ENABLED {
-                let _ = p.skip_type_script_type_arguments::<false>()?; // isInsideJSXElement
+                let _ = p.skip_type_script_type_arguments::<false, false>()?; // isInsideJSXElement
             }
         }
 

--- a/src/js_parser/parse/parse_jsx.rs
+++ b/src/js_parser/parse/parse_jsx.rs
@@ -25,7 +25,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // The tag may have TypeScript type arguments: "<Foo<T>/>"
         if TYPESCRIPT {
             // Pass a flag to the type argument skipper because we need to call
-            let _ = p.skip_type_script_type_arguments::<true>()?;
+            let _ = p.skip_type_script_type_arguments::<true, false>()?;
         }
 
         let mut previous_string_with_backslash_loc = bun_ast::Loc::default();

--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -635,7 +635,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                     // "let foo: any \n <number>foo" must not become a single type
                     if check_type_parameters && !self.lexer.has_newline_before {
-                        let _ = self.skip_type_script_type_arguments::<false>()?;
+                        let _ = self.skip_type_script_type_arguments::<false, false>()?;
                     }
                 }
                 T::TTypeof => {
@@ -679,7 +679,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         }
 
                         if !self.lexer.has_newline_before {
-                            let _ = self.skip_type_script_type_arguments::<false>()?;
+                            let _ = self.skip_type_script_type_arguments::<false, false>()?;
                         }
                     }
                 }
@@ -908,7 +908,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                     // "{ <A extends B>(): c.d \n <E extends F>(): g.h }" must not become a single type
                     if !self.lexer.has_newline_before {
-                        let _ = self.skip_type_script_type_arguments::<false>()?;
+                        let _ = self.skip_type_script_type_arguments::<false, false>()?;
                     }
                 }
                 T::TOpenBracket => {
@@ -1372,7 +1372,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(())
     }
 
-    pub fn skip_type_script_type_arguments<const IS_INSIDE_JSX_ELEMENT: bool>(
+    pub fn skip_type_script_type_arguments<
+        const IS_INSIDE_JSX_ELEMENT: bool,
+        const IS_PARSE_TYPE_ARGUMENTS_IN_EXPRESSION: bool,
+    >(
         &mut self,
     ) -> Result<bool, Error> {
         self.mark_type_script_only();
@@ -1397,7 +1400,24 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         // This type argument list must end with a ">"
-        self.lexer.expect_greater_than::<IS_INSIDE_JSX_ELEMENT>()?;
+        if !IS_PARSE_TYPE_ARGUMENTS_IN_EXPRESSION {
+            // Normally TypeScript allows any token starting with ">". For example,
+            // "Array<Array<number>>()" is a type argument list even though there's
+            // a ">>" token, because ">>" starts with ">".
+            self.lexer.expect_greater_than::<IS_INSIDE_JSX_ELEMENT>()?;
+        } else {
+            // However, when emulating the TypeScript compiler's
+            // "parseTypeArgumentsInExpression" function, only the ">" token
+            // itself is allowed. For example, "x < y >= z" is not a type argument
+            // list. Nested type arguments ("Array<Array<number>>()") still work
+            // because the inner list is in a type context and already stripped one
+            // ">" from the ">>" before we see the outer closer here.
+            if IS_INSIDE_JSX_ELEMENT {
+                self.lexer.expect_inside_jsx_element(T::TGreaterThan)?;
+            } else {
+                self.lexer.expect(T::TGreaterThan)?;
+            }
+        }
         Ok(true)
     }
 
@@ -1501,7 +1521,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     pub fn skip_type_script_type_arguments_with_backtracking(&mut self) -> Result<bool, Error> {
-        if self.skip_type_script_type_arguments::<false>()? {
+        if self.skip_type_script_type_arguments::<false, true>()? {
             // Check the token after this and backtrack if it's the wrong one
             if !self.can_follow_type_arguments_in_expression() {
                 return Err(crate::Error::Backtrack);

--- a/src/js_parser/parse/parse_suffix.rs
+++ b/src/js_parser/parse/parse_suffix.rs
@@ -189,7 +189,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     return Err(crate::Error::SyntaxError);
                 }
 
-                let _ = p.skip_type_script_type_arguments::<false>()?;
+                let _ = p.skip_type_script_type_arguments::<false, false>()?;
                 if p.lexer.token != T::TOpenParen {
                     p.lexer.expected(T::TOpenParen)?;
                 }

--- a/src/js_parser/parse/parse_typescript.rs
+++ b/src/js_parser/parse/parse_typescript.rs
@@ -105,7 +105,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // Skip TypeScript type arguments after the identifier (e.g., @foo<T>)
         if Self::IS_TYPESCRIPT_ENABLED {
-            let _ = p.skip_type_script_type_arguments::<false>()?;
+            let _ = p.skip_type_script_type_arguments::<false, false>()?;
         }
 
         // DecoratorMemberExpression: Identifier (.Identifier)*
@@ -144,7 +144,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             // Skip TypeScript type arguments after member access (e.g., @foo.bar<T>)
             if Self::IS_TYPESCRIPT_ENABLED {
-                let _ = p.skip_type_script_type_arguments::<false>()?;
+                let _ = p.skip_type_script_type_arguments::<false, false>()?;
             }
         }
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -475,9 +475,9 @@ describe("Bun.Transpiler", () => {
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      if (exitCode !== 0) expect(stderr).toBe("");
+      expect({ stdout: stdout.trim(), exitCode }).toEqual({
         stdout: JSON.stringify([["s", false, "p:5"], 5, [true, false], 1]),
-        stderr: "",
         exitCode: 0,
       });
     });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -426,6 +426,62 @@ describe("Bun.Transpiler", () => {
       expect(exitCode).toBe(0);
     }, 90_000);
 
+    it("type arguments in expression require a bare '>' closer", () => {
+      // TypeScript's "parseTypeArgumentsInExpression" only accepts a bare ">"
+      // to close the list, so a ">=" (or ">>", ">>>", ">>=", ">>>=") forces
+      // backtracking to the relational/shift interpretation. Previously we
+      // split the ">=" and committed to the type-argument parse, turning e.g.
+      // "f('s', x < 0, x >= 0 ? a : b)" into "f('s', x = b)".
+      const exp = ts.expectPrinted_;
+
+      exp('f("s", x < 0, x >= 0 ? "p:" + x : undefined);', 'f("s", x < 0, x >= 0 ? "p:" + x : undefined);\n');
+      exp("f(x < y, x >= z);", "f(x < y, x >= z);\n");
+      exp("const a = (x < 0, x >= 0 ? y : z);", "const a = (x < 0, x >= 0 ? y : z);\n");
+      exp("f<x>=g<y>;", "f < x >= g;\n");
+      exp("f<x>>g<y>;", "f < x >> g;\n");
+      exp("f<x>>>g<y>;", "f < x >>> g;\n");
+      exp("new C(a < b, a >= b);", "new C(a < b, a >= b);\n");
+
+      // Nested type arguments still work: the inner list runs in a type
+      // context and strips one ">" from ">>" before the outer closer sees it.
+      exp("f<Array<number>>();", "f();\n");
+      exp("f<Array<Array<number>>>();", "f();\n");
+      exp("new f<Array<number>>();", "new f;\n");
+      exp("const g = f<Array<number>>;", "const g = f;\n");
+
+      // A bare ">" followed by "=" on the next token still commits.
+      exp("f<x> = g<y>;", "f = g;\n");
+    });
+
+    it("does not turn '<' ... '>=' into an assignment at runtime", async () => {
+      const source = `
+        const out: unknown[] = [];
+        const f = (...a: unknown[]) => out.push(a);
+        let x: number = 5;
+        f("s", x < 0, x >= 0 ? "p:" + x : undefined);
+        out.push(x);
+        class C { constructor(...a: unknown[]) { out.push(a); } }
+        let a: number = 1, b: number = 2;
+        new C(a < b, a >= b);
+        out.push(a);
+        console.log(JSON.stringify(out));
+      `;
+      using dir = tempDir("ts-ge-type-args", { "entry.ts": source });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "entry.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+        stdout: JSON.stringify([["s", false, "p:5"], 5, [true, false], 1]),
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
     it.todo("instantiation expressions", async () => {
       const exp = ts.expectPrinted_;
       const err = ts.expectParseError;
@@ -468,7 +524,7 @@ describe("Bun.Transpiler", () => {
       exp("f.x<<T>() => T>;", "f.x;\n");
       exp("f['x']<<T>() => T>;", 'f["x"];\n');
       exp("f<x>g<y>;", "f < x > g;\n");
-      exp("f<x>=g<y>;", "f = g;\n");
+      exp("f<x>=g<y>;", "f < x >= g;\n");
       exp("f<x>>g<y>;", "f < x >> g;\n");
       exp("f<x>>>g<y>;", "f < x >>> g;\n");
       err("f<x>>=g<y>;", "Invalid assignment target");


### PR DESCRIPTION
## What does this PR do?

Fixes a TypeScript parser bug where a `<` / `>=` pair straddling a comma was misparsed as a type argument list, silently changing program semantics.

### Repro

```ts
declare function f(a: string, b: boolean, c?: string): void;
declare let x: number;
f("s", x < 0, x >= 0 ? "p:" + x : undefined);
```

Before this PR, `bun build` emits:

```js
f("s", x = undefined);
```

The second argument is dropped and `x` is clobbered by an assignment. Both `tsc` and `esbuild` emit the input unchanged:

```js
f("s", x < 0, x >= 0 ? "p:" + x : undefined);
```

### Cause

When the suffix parser sees `x <` in expression position, it speculatively tries to parse a type argument list. `skip_type_script_type_arguments` always closed the list via `expect_greater_than`, which splits `>=` into `>` (consumed) and `=` (current token). `can_follow_type_arguments_in_expression` then sees `=`, which is not a start-of-expression token, and commits to the type-argument interpretation. The type arguments `<0, x>` are stripped, leaving `x = (0 ? "p:" + x : undefined)`, and constant folding turns the conditional into `undefined`.

TypeScript's own `parseTypeArgumentsInExpression` only accepts a bare `>` token here; a `>=` (or `>>`, `>>>`, `>>=`, `>>>=`) at that position must backtrack to the relational/shift interpretation. esbuild implements the same rule via [`isParseTypeArgumentsInExpression`](https://github.com/evanw/esbuild/blob/main/internal/js_parser/ts_parser.go).

### Fix

Add an `IS_PARSE_TYPE_ARGUMENTS_IN_EXPRESSION` const parameter to `skip_type_script_type_arguments`. When set (only from the expression-context backtracker), the list must close on a literal `TGreaterThan` rather than anything `expect_greater_than` would split. Nested type arguments such as `f<Array<number>>()` continue to work because the inner list runs in a type context and has already peeled one `>` from `>>` before the outer closer is checked.

### Verification

New tests in `test/bundler/transpiler/transpiler.test.js` cover the original repro, the `f(x < y, x >= z)` sibling, the `new C(...)` path, nested type arguments, and a runtime check that `x` is not reassigned. The existing (todo'd) `f<x>=g<y>` expectation is corrected to match tsc/esbuild.

```
$ USE_SYSTEM_BUN=1 bun test test/bundler/transpiler/transpiler.test.js -t "type arguments in expression|does not turn"
2 fail
$ bun bd test test/bundler/transpiler/transpiler.test.js -t "type arguments in expression|does not turn"
2 pass
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (e49bca6c3)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.01ms]
(pass) Bun.Transpiler > normalizes \r\n [6.36ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [3.97ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [6.39ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.52ms]
(pass) Bun.Transpiler > property access inlining > works [2.33ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.12ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [2.74ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [2.26ms]
(pass) B
... (truncated)

release without fix: 8 failed, 22 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.10ms]
(pass) Bun.Transpiler > normalizes \r\n [0.15ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.09ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.12ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.04ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.03ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.05ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [0.07ms]
(pass) Bun.Transpiler > TypeScript > contextual keywords used as plain identifiers keep their statements [0.42ms]
(pass) Bun.Transpiler > TypeScript > does not crash when export default abstract is an expression followed by a class [0.36ms]
(pass) Bun.Transpiler > TypeScript > scope tracking stays balanced when a contextual keyword starts a larger expression [0.32ms]
(pass) Bun.Transpiler > TypeScript > scope tracking stays balan
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (e49bca6c3)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [4.98ms]
(pass) Bun.Transpiler > normalizes \r\n [6.52ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.25ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [6.76ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.80ms]
(pass) Bun.Transpiler > property access inlining > works [2.46ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.46ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [2.87ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [2.42ms]
(pass) B
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 725ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/parse/mod.rs                   |  2 +-
 src/js_parser/parse/parse_jsx.rs             |  2 +-
 src/js_parser/parse/parse_skip_typescript.rs | 32 ++++++++++++---
 src/js_parser/parse/parse_suffix.rs          |  2 +-
 src/js_parser/parse/parse_typescript.rs      |  4 +-
 test/bundler/transpiler/transpiler.test.js   | 58 +++++++++++++++++++++++++++-
 6 files changed, 88 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/js_parser/parse/mod.rs                        1      1      0
src/js_parser/parse/parse_jsx.rs                  1      1      0
src/js_parser/parse/parse_skip_typescript.rs      3      3      0
src/js_parser/parse/parse_suffix.rs               2      1      0
src/js_parser/parse/parse_typescript.rs           1      1      0
test/bundler/transpiler/transpiler.test.js        2      3      0
```

</details>

<!-- robobun:evidence:end -->