### PR TITLE
Resolve --require preloads with the require export condition

### DIFF
--- a/docs/snippets/cli/run.mdx
+++ b/docs/snippets/cli/run.mdx
@@ -134,7 +134,7 @@ bun run <file or script>
 </ParamField>
 
 <ParamField path="--require" type="string">
-  Alias of --preload, for Node.js compatibility
+  Like --preload, but resolves with CommonJS require semantics, for Node.js compatibility
 </ParamField>
 
 <ParamField path="--import" type="string">

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -19,7 +19,7 @@ use bun_parsers::toml::TOML;
 use bun_install_types::NodeLinker::FromExprError;
 use bun_options_types::LoaderExt as _;
 use bun_options_types::code_coverage_options::Reporters as CoverageReporters;
-use bun_options_types::context::{MacroImportReplacementMap, MacroMap, MacroOptions};
+use bun_options_types::context::{MacroImportReplacementMap, MacroMap, MacroOptions, Preload};
 use bun_options_types::global_cache::GlobalCache;
 use bun_options_types::offline_mode::PREFER as OFFLINE_PREFER;
 use bun_options_types::schema::api;
@@ -249,12 +249,12 @@ impl<'a> Parser<'a> {
         match &expr.data {
             ExprData::EArray(array) => {
                 let items = array.items.slice();
-                let mut preloads: Vec<Box<[u8]>> = Vec::with_capacity(items.len());
+                let mut preloads: Vec<Preload> = Vec::with_capacity(items.len());
                 for item in items {
                     self.expect_string(item)?;
                     if let ExprData::EString(s) = &item.data {
                         if s.len() > 0 {
-                            preloads.push(estring_to_owned(s, self.bump));
+                            preloads.push(Preload::import(estring_to_owned(s, self.bump)));
                         }
                     }
                 }
@@ -262,7 +262,7 @@ impl<'a> Parser<'a> {
             }
             ExprData::EString(s) => {
                 if s.len() > 0 {
-                    self.ctx.preloads = vec![estring_to_owned(s, self.bump)];
+                    self.ctx.preloads = vec![Preload::import(estring_to_owned(s, self.bump))];
                 }
             }
             ExprData::ENull(_) => {}

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -183,7 +183,7 @@ pub struct VirtualMachine {
     /// `KeepAlive::unref_on_next_tick_concurrently` increments it from OTHER
     /// threads.
     pub pending_unref_counter: core::sync::atomic::AtomicI32,
-    pub preload: Vec<Box<[u8]>>,
+    pub preload: Vec<bun_options_types::context::Preload>,
     pub unhandled_pending_rejection_to_capture: Option<*mut JSValue>,
     // Note: layering — the concrete `bun_standalone_graph::Graph` lives
     // in a higher-tier crate. The resolver already broke that cycle with the

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -105,7 +105,7 @@ pub struct WebWorker {
     inherit_exec_argv: bool,
     /// Heap-owned by this struct; freed in `destroy()`.
     unresolved_specifier: Box<[u8]>,
-    preloads: Vec<Box<[u8]>>,
+    preloads: Vec<bun_options_types::context::Preload>,
     /// Owned NUL-terminated bytes.
     name: bun_core::ZBox,
 
@@ -504,14 +504,17 @@ impl WebWorker {
         let preload_modules: &[BunString] =
             unsafe { bun_core::ffi::slice(preload_modules_ptr, preload_modules_len) };
 
-        let mut preloads: Vec<Box<[u8]>> = Vec::with_capacity(preload_modules_len);
+        let mut preloads: Vec<bun_options_types::context::Preload> =
+            Vec::with_capacity(preload_modules_len);
         for module in preload_modules {
             let utf8_slice = module.to_utf8();
             // node: builtin specifiers skip the file resolver — the worker-side
             // module loader resolves them. Lets node:worker_threads run its
             // bootstrap (stdio rebinding) as a preload.
             if utf8_slice.slice().starts_with(b"node:") {
-                preloads.push(utf8_slice.slice().to_vec().into_boxed_slice());
+                preloads.push(bun_options_types::context::Preload::import(
+                    utf8_slice.slice().to_vec().into_boxed_slice(),
+                ));
                 continue;
             }
             // SAFETY: `parent_ref` is the live VM on the calling (parent)
@@ -524,7 +527,9 @@ impl WebWorker {
                     temp_log,
                 )
             } {
-                preloads.push(preload.to_vec().into_boxed_slice());
+                preloads.push(bun_options_types::context::Preload::import(
+                    preload.to_vec().into_boxed_slice(),
+                ));
             }
 
             if !error_message.is_empty() {

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1048,7 +1048,7 @@ impl WebWorker {
         }
 
         // `preloads` is owned by `self` (heap `WebWorker` outlives the VM).
-        // `preload: Vec<Box<[u8]>>` — clone the boxes (cheap, ≤handful).
+        // Clone the entries into the VM (cheap, ≤handful).
         vm.as_mut().preload.clone_from(&self.preloads);
 
         // Resolve the entry point on the worker thread (the parent only stored

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -42,8 +42,43 @@ pub struct ContextData {
     pub sequential: bool,
     pub no_exit_on_error: bool,
 
-    pub preloads: Vec<Box<[u8]>>,
+    pub preloads: Vec<Preload>,
     pub has_loaded_global_config: bool,
+}
+
+/// How a preload module was requested. `--require` resolves with CommonJS
+/// `require` semantics (e.g. the `require` export condition); `--preload`,
+/// `--import`, and bunfig `preload` resolve as ESM imports.
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub enum PreloadKind {
+    Import,
+    Require,
+}
+
+/// A module to load before the entry point, from `--preload` / `--require` /
+/// `--import` or bunfig `preload`.
+#[derive(Clone)]
+pub struct Preload {
+    pub specifier: Box<[u8]>,
+    pub kind: PreloadKind,
+}
+
+impl Preload {
+    #[inline]
+    pub fn import(specifier: Box<[u8]>) -> Self {
+        Self {
+            specifier,
+            kind: PreloadKind::Import,
+        }
+    }
+
+    #[inline]
+    pub fn require(specifier: Box<[u8]>) -> Self {
+        Self {
+            specifier,
+            kind: PreloadKind::Require,
+        }
+    }
 }
 
 impl Default for ContextData {

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -129,8 +129,8 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
     vm.event_loop_ref().ensure_waker();
     {
         let b = &mut vm.transpiler;
-        // preload/argv are `Vec<Box<[u8]>>`; clone because the VM owns its
-        // fields. Startup-only, so the copies are not hot.
+        // clone preload/argv because the VM owns its fields. Startup-only,
+        // so the copies are not hot.
         vm.preload.clone_from(&ctx.preloads);
         vm.argv.clone_from(&ctx.passthrough);
         vm.arena = NonNull::new(&raw mut arena);

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -199,7 +199,9 @@ pub(crate) const RUNTIME_PARAMS_: &[ParamType] = &[
     parse_param!(
         "-r, --preload <STR>...            Import a module before other modules are loaded"
     ),
-    parse_param!("--require <STR>...                Like --preload, but resolves with CommonJS require semantics, for Node.js compatibility"),
+    parse_param!(
+        "--require <STR>...                Like --preload, but resolves with CommonJS require semantics, for Node.js compatibility"
+    ),
     parse_param!("--import <STR>...                 Alias of --preload, for Node.js compatibility"),
     parse_param!("--inspect <STR>?                  Activate Bun's debugger"),
     parse_param!(

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -18,7 +18,9 @@ use bun_core::{self, FeatureFlags, Global, Output, env_var};
 use bun_jsc::RegularExpression;
 use bun_jsc::regular_expression::Flags as RegexFlags;
 use bun_options_types::code_coverage_options::Reporters as CoverageReporters;
-use bun_options_types::context::{Debugger, DebuggerEnable, HotReload, MacroOptions, Shard};
+use bun_options_types::context::{
+    Debugger, DebuggerEnable, HotReload, MacroOptions, Preload, Shard,
+};
 use bun_options_types::schema::api;
 use bun_paths::resolve_path;
 use bun_paths::{PathBuffer, platform};
@@ -197,7 +199,7 @@ pub(crate) const RUNTIME_PARAMS_: &[ParamType] = &[
     parse_param!(
         "-r, --preload <STR>...            Import a module before other modules are loaded"
     ),
-    parse_param!("--require <STR>...                Alias of --preload, for Node.js compatibility"),
+    parse_param!("--require <STR>...                Like --preload, but resolves with CommonJS require semantics, for Node.js compatibility"),
     parse_param!("--import <STR>...                 Alias of --preload, for Node.js compatibility"),
     parse_param!("--inspect <STR>?                  Activate Bun's debugger"),
     parse_param!(
@@ -947,21 +949,23 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
                 + preloads3.len()
                 + (if preload4.is_some() { 1usize } else { 0usize });
             if total_preloads > 0 {
-                let mut all: Vec<Box<[u8]>> = Vec::with_capacity(total_preloads);
+                let mut all: Vec<Preload> = Vec::with_capacity(total_preloads);
                 if !ctx.preloads.is_empty() {
                     all.append(&mut ctx.preloads);
                 }
                 for p in preloads {
-                    all.push(Box::<[u8]>::from(*p));
+                    all.push(Preload::import(Box::<[u8]>::from(*p)));
                 }
+                // `--require` keeps CommonJS semantics (Node parity): it must
+                // resolve package exports with the `require` condition.
                 for p in preloads2 {
-                    all.push(Box::<[u8]>::from(*p));
+                    all.push(Preload::require(Box::<[u8]>::from(*p)));
                 }
                 for p in preloads3 {
-                    all.push(Box::<[u8]>::from(*p));
+                    all.push(Preload::import(Box::<[u8]>::from(*p)));
                 }
                 if let Some(p) = preload4 {
-                    all.push(Box::<[u8]>::from(p));
+                    all.push(Preload::import(Box::<[u8]>::from(p)));
                 }
                 ctx.preloads = all;
             }

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -963,7 +963,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         // SAFETY: `init` returns the unique freshly-boxed VM on this thread.
         let vm = unsafe { &mut *vm_ptr };
 
-        // `vm.preload`/`vm.argv` are `Vec<Box<[u8]>>` on both sides;
+        // `vm.preload`/`vm.argv` have the same element types on both sides;
         // hand the CLI's vectors over wholesale (process-lifetime, never freed).
         vm.preload = std::mem::take(&mut ctx.preloads);
         vm.argv = std::mem::take(&mut ctx.passthrough);

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -368,11 +368,20 @@ fn build_worker_argv(ctx: &Command::ContextData) -> crate::Result<Box<[bun_spawn
         argv.push(lit(b"-t\0"));
         argv.push(dupe_z(pattern));
     }
+    // `Arguments::parse` rebuilds `ctx.preloads` in fixed bucket order
+    // (--preload, --require, --import), so emit import-kind entries that
+    // follow a require as --import to reproduce the coordinator's order.
+    let mut seen_require = false;
     for preload in ctx.preloads.iter() {
-        argv.push(lit(match preload.kind {
-            PreloadKind::Require => b"--require\0",
+        let flag: &'static [u8] = match preload.kind {
+            PreloadKind::Require => {
+                seen_require = true;
+                b"--require\0"
+            }
+            PreloadKind::Import if seen_require => b"--import\0",
             PreloadKind::Import => b"--preload\0",
-        }));
+        };
+        argv.push(lit(flag));
         argv.push(dupe_z(&preload.specifier));
     }
     if let Some(define) = &ctx.args.define {

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -10,7 +10,7 @@ use std::io::Write as _;
 use bun_core::ZBox;
 use bun_core::{Global, Output};
 use bun_jsc::virtual_machine::VirtualMachine;
-use bun_options_types::context::MacroOptions;
+use bun_options_types::context::{MacroOptions, PreloadKind};
 use bun_ptr::Interned;
 use bun_resolver::fs::{FileSystem, RealFS};
 use bun_sys::{Fd, FdDirExt, FdExt};
@@ -369,8 +369,11 @@ fn build_worker_argv(ctx: &Command::ContextData) -> crate::Result<Box<[bun_spawn
         argv.push(dupe_z(pattern));
     }
     for preload in ctx.preloads.iter() {
-        argv.push(lit(b"--preload\0"));
-        argv.push(dupe_z(preload));
+        argv.push(lit(match preload.kind {
+            PreloadKind::Require => b"--require\0",
+            PreloadKind::Import => b"--preload\0",
+        }));
+        argv.push(dupe_z(&preload.specifier));
     }
     if let Some(define) = &ctx.args.define {
         debug_assert_eq!(define.keys.len(), define.values.len());

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -841,8 +841,8 @@ unsafe fn load_preloads(vm: *mut VirtualMachine) -> bun_jsc::CrateResult<*mut JS
     // only load preloads once.
     // SAFETY: per fn contract.
     if !unsafe { &*vm }.test_isolation_enabled {
-        // `Vec::clear` drops the `Box<[u8]>`
-        // payloads but keeps capacity.
+        // `Vec::clear` drops each entry (freeing its
+        // specifier) but keeps capacity.
         // SAFETY: per fn contract — `vm` is the live per-thread VM.
         unsafe { (*vm).preload.clear() };
     }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -22,6 +22,7 @@
 
 use bun_core::WTFStringImplExt as _;
 use bun_options_types::LoaderExt as _;
+use bun_options_types::context::PreloadKind;
 use core::cell::Cell;
 use core::ffi::c_void;
 use core::ptr;
@@ -690,7 +691,14 @@ unsafe fn load_preloads(vm: *mut VirtualMachine) -> bun_jsc::CrateResult<*mut JS
         // SAFETY: `i < n`; the `Box<[u8]>` allocation is stable across the
         // `resolve_and_auto_install` call below (which only touches
         // `vm.transpiler.resolver`, not `vm.preload`).
-        let preload: *const [u8] = unsafe { &raw const *(&(*vm).preload)[i] };
+        let preload: *const [u8] = unsafe { &raw const *(&(*vm).preload)[i].specifier };
+        // `--require` preloads resolve with CommonJS `require` semantics
+        // (e.g. the `require` export condition), matching Node.
+        // SAFETY: `i < n`; plain enum field read.
+        let import_kind = match unsafe { &(&(*vm).preload)[i] }.kind {
+            PreloadKind::Require => ImportKind::Require,
+            PreloadKind::Import => ImportKind::Stmt,
+        };
         // SAFETY: `preload` points at a live boxed slice for this iteration
         // (heap-stable `Box<[u8]>` payload; nothing below mutates `vm.preload`).
         let preload_slice: &[u8] = unsafe { &*preload };
@@ -713,7 +721,7 @@ unsafe fn load_preloads(vm: *mut VirtualMachine) -> bun_jsc::CrateResult<*mut JS
                 (*vm).transpiler.resolver.resolve_and_auto_install(
                     &*top_level_dir,
                     normalized,
-                    ImportKind::Stmt,
+                    import_kind,
                     global_cache,
                 )
             } {

--- a/test/cli/run/preload-test.test.js
+++ b/test/cli/run/preload-test.test.js
@@ -1,7 +1,7 @@
 import { spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
 import { mkdirSync, realpathSync } from "fs";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { tmpdir } from "os";
 import { join } from "path";
 const preloadModule = `
@@ -209,5 +209,50 @@ plugin({
       expect(stdout.toString()).toBe("");
       expect(exitCode).toBe(1);
     }
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/34226
+describe("preload export conditions", () => {
+  test.concurrent.each([
+    ["--require", "require"],
+    ["--import", "import"],
+    ["--preload", "import"],
+  ])("%s resolves dual package exports with the '%s' condition", async (flag, expected) => {
+    using dir = tempDir("preload-conditions", {
+      "main.js": `console.log("main");`,
+      "node_modules/dual-preload/package.json": JSON.stringify({
+        name: "dual-preload",
+        version: "1.0.0",
+        type: "module",
+        exports: {
+          ".": {
+            import: "./import.js",
+            require: "./require.cjs",
+          },
+        },
+      }),
+      "node_modules/dual-preload/import.js": `console.log("import");`,
+      "node_modules/dual-preload/require.cjs": `console.log("require");`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), flag, "dual-preload", "main.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect({ stdout, exitCode, stderr: stderr.includes("error") ? stderr : "" }).toEqual({
+      stdout: `${expected}\nmain\n`,
+      exitCode: 0,
+      stderr: "",
+    });
   });
 });

--- a/test/cli/run/preload-test.test.js
+++ b/test/cli/run/preload-test.test.js
@@ -243,11 +243,7 @@ describe("preload export conditions", () => {
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect({ stdout, exitCode, stderr: stderr.includes("error") ? stderr : "" }).toEqual({
       stdout: `${expected}\nmain\n`,

--- a/test/cli/run/preload-test.test.js
+++ b/test/cli/run/preload-test.test.js
@@ -213,12 +213,12 @@ plugin({
 });
 
 // https://github.com/oven-sh/bun/issues/34226
-describe("preload export conditions", () => {
-  test.concurrent.each([
-    ["--require", "require"],
-    ["--import", "import"],
-    ["--preload", "import"],
-  ])("%s resolves dual package exports with the '%s' condition", async (flag, expected) => {
+describe.each([
+  ["--require", "require"],
+  ["--import", "import"],
+  ["--preload", "import"],
+])("preload export conditions: %s", (flag, expected) => {
+  test.concurrent(`resolves dual package exports with the '${expected}' condition`, async () => {
     using dir = tempDir("preload-conditions", {
       "main.js": `console.log("main");`,
       "node_modules/dual-preload/package.json": JSON.stringify({


### PR DESCRIPTION
Fixes #34226

### Problem

`--preload`, `--require`, and `--import` were flattened into a single untyped preload list and every entry was resolved as an ESM import (`ImportKind::Stmt`). For a package with conditional exports, `bun --require dual-preload main.js` selected the `import` condition:

```console
$ node --require dual-preload main.js
require
main

$ bun --require dual-preload main.js   # before this change
import
main
```

### Fix

Preload entries now carry their kind (`Preload { specifier, kind }` in `bun_options_types::context`):

- `--require` entries resolve with `ImportKind::Require`, so the resolver applies CommonJS require semantics (the `require` export condition, same as `require()` calls).
- `--preload`, `--import`, `BUN_INSPECT_PRELOAD`, bunfig `preload`, and worker `preload` options keep ESM import semantics.
- The parallel test runner (`bun test --parallel`) forwards require-kind preloads to workers as `--require` instead of `--preload`.

Intentionally unchanged: `-r` stays a documented alias of `--preload` (ESM), matching Bun's existing docs and behavior. The open NODE_OPTIONS work (#34101) can tag its parsed `--require`/`--import` flags with the same kind when it lands.

### Verification

New tests in `test/cli/run/preload-test.test.js` cover `--require` (expects `require`), `--import` and `--preload` (expect `import`) against a dual-export package. The `--require` case fails on the unfixed build and passes with this change; existing preload and worker preload tests still pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 11 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 3 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/preload-test.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (6cd255dfd)

test/cli/run/preload-test.test.js:
(todo) preload > works
(todo) preload > works from CLI
(todo) preload > as entry point > works from CLI
(pass) preload > throws an error when preloaded module fails to execute [839.94ms]
(pass) preload > throws an error when preloaded module not found [754.23ms]
243 |       stderr: "pipe",
244 |     });
245 | 
246 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
247 | 
248 |     expect({ stdout, exitCode, stderr: stderr.includes("error") ? stderr : "" }).toEqual({
                                                                                       ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "
... (truncated)

release without fix: 3 skipped
bun test v1.4.0-canary.1 (25cf0e9e9)

test/cli/run/preload-test.test.js:
(todo) preload > works
(todo) preload > works from CLI
(todo) preload > as entry point > works from CLI
(pass) preload > throws an error when preloaded module fails to execute [23.15ms]
(pass) preload > throws an error when preloaded module not found [20.72ms]
(pass) preload export conditions: --require > resolves dual package exports with the 'require' condition [13.06ms]
(pass) preload export conditions: --import > resolves dual package exports with the 'import' condition [12.33ms]
(pass) preload export conditions: --preload > resolves dual package exports with the 'import' condition [11.77ms]

 5 pass
 3 todo
 0 fail
 15 expect() calls
Ran 8 tests across 1 file. [192.00ms]
__F:0:S:3
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 3 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/preload-test.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (6cd255dfd)

test/cli/run/preload-test.test.js:
(todo) preload > works
(todo) preload > works from CLI
(todo) preload > as entry point > works from CLI
(pass) preload > throws an error when preloaded module fails to execute [843.35ms]
(pass) preload > throws an error when preloaded module not found [756.82ms]
(pass) preload export conditions: --require > resolves dual package exports with the 'require' condition [469.78ms]
(pass) preload export conditions: --import > resolves dual package exports with the 'import' condition [431.07ms]
(pass) preload export conditions: --preload > resolves dual package exports with the 'import' condition [430.06ms]

 5 pass
 3 todo
 0 fail
 15 expect() calls
Ran 8 tests across 1 file. [4.10s]
__F:0:S:3

release with fix: 3 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 768ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/snippets/cli/run.mdx               |  2 +-
 src/bunfig/bunfig.rs                    |  8 +++---
 src/jsc/VirtualMachine.rs               |  2 +-
 src/jsc/web_worker.rs                   | 15 ++++++++----
 src/options_types/context.rs            | 37 +++++++++++++++++++++++++++-
 src/runtime/bake/production.rs          |  4 +--
 src/runtime/cli/Arguments.rs            | 20 +++++++++------
 src/runtime/cli/run_command.rs          |  2 +-
 src/runtime/cli/test/parallel/runner.rs | 18 +++++++++++---
 src/runtime/jsc_hooks.rs                | 16 +++++++++---
 test/cli/run/preload-test.test.js       | 43 ++++++++++++++++++++++++++++++++-
 11 files changed, 137 insertions(+), 30 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
docs/snippets/cli/run.mdx                    1      1      0
src/bunfig/bunfig.rs                         2      3      0
src/jsc/VirtualMachine.rs                    1      1      0
src/jsc/web_worker.rs                        3      3      0
src/options_types/context.rs                 1      1      0
src/runtime/bake/production.rs               1      1      0
src/runtime/cli/Arguments.rs                 2      2      0
src/runtime/cli/run_command.rs               1      2      0
src/runtime/cli/test/parallel/runner.rs      2      2      0
src/runtime/jsc_hooks.rs                     2      4      0
test/cli/run/preload-test.test.js            3      3      0
```

</details>

**root cause** · written by the author bot

Bun flattened --require, --import, and --preload into a single untyped preload list and resolved every entry with import semantics, so a --require preload selected the import branch of a package's conditional exports instead of the require branch as Node does. The fix introduces a Preload type that pairs each specifier with a PreloadKind, threading that kind from CLI parsing and bunfig through the virtual machine, web workers, the bake production path, and parallel test worker argv forwarding. When loading preloads, entries marked as require are resolved with require import semantics, so du…

<!-- robobun:evidence:end -->