### PR TITLE
Support solution-style tsconfig.json project references

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2599,46 +2599,34 @@ impl<'a> Resolver<'a> {
 
         if let Some(enclosing) = dir_info.enclosing_tsconfig_json {
             self.ensure_tsconfig_references(enclosing, dir_info.abs_path);
-            // Try path substitutions first
+            // A candidate's "paths" and then its "baseUrl" are tried before the next candidate.
             for tsconfig in enclosing.candidates_for_dir(dir_info.abs_path) {
-                if tsconfig.paths.count() == 0 {
-                    continue;
-                }
-                if self
-                    .match_tsconfig_paths(tsconfig, import_path, kind, out)
-                    .is_success()
-                {
-                    if let Some(debug) = self.debug_logs.as_mut() {
-                        if !core::ptr::eq(tsconfig, enclosing) {
-                            debug.add_note_fmt(format_args!(
-                                "Using referenced tsconfig \"{}\" for directory \"{}\"",
-                                bstr::BStr::new(&tsconfig.abs_path),
-                                bstr::BStr::new(dir_info.abs_path)
-                            ));
-                        }
-                        debug.decrease_indent();
-                    }
-                    return MatchStatus::Success;
-                }
-            }
-
-            // Try looking up the path relative to the base URL
-            for tsconfig in enclosing.candidates_for_dir(dir_info.abs_path) {
-                if !tsconfig.has_base_url() {
-                    continue;
-                }
-                let base: &[u8] = &tsconfig.base_url;
-                if let Some(abs) = self.fs_ref().abs_buf_checked(
-                    &[base, import_path],
-                    bufs!(load_as_file_or_directory_via_tsconfig_base_path),
-                ) {
-                    if self.load_as_file_or_directory(abs, kind, out).is_success() {
-                        if let Some(d) = self.debug_logs.as_mut() {
-                            d.decrease_indent();
-                        }
-                        return MatchStatus::Success;
+                let mut matched = tsconfig.paths.count() > 0
+                    && self
+                        .match_tsconfig_paths(tsconfig, import_path, kind, out)
+                        .is_success();
+                if !matched && tsconfig.has_base_url() {
+                    if let Some(abs) = self.fs_ref().abs_buf_checked(
+                        &[&tsconfig.base_url[..], import_path],
+                        bufs!(load_as_file_or_directory_via_tsconfig_base_path),
+                    ) {
+                        matched = self.load_as_file_or_directory(abs, kind, out).is_success();
                     }
                 }
+                if !matched {
+                    continue;
+                }
+                if let Some(debug) = self.debug_logs.as_mut() {
+                    if !core::ptr::eq(tsconfig, enclosing) {
+                        debug.add_note_fmt(format_args!(
+                            "Using referenced tsconfig \"{}\" for directory \"{}\"",
+                            bstr::BStr::new(&tsconfig.abs_path),
+                            bstr::BStr::new(dir_info.abs_path)
+                        ));
+                    }
+                    debug.decrease_indent();
+                }
+                return MatchStatus::Success;
             }
         }
 

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -986,13 +986,22 @@ impl<'a> Resolver<'a> {
         let Some(dir_info) = self.dir_info_cached(source_dir).ok().flatten() else {
             return MatchStatus::NotFound;
         };
-        let Some(tsconfig) = dir_info.enclosing_tsconfig_json else {
+        let Some(enclosing) = dir_info.enclosing_tsconfig_json else {
             return MatchStatus::NotFound;
         };
-        if tsconfig.paths.count() == 0 {
-            return MatchStatus::NotFound;
+        self.ensure_tsconfig_references(enclosing, source_dir);
+        for tsconfig in enclosing.candidates_for_dir(source_dir) {
+            if tsconfig.paths.count() == 0 {
+                continue;
+            }
+            if self
+                .match_tsconfig_paths(tsconfig, import_path, kind, out)
+                .is_success()
+            {
+                return MatchStatus::Success;
+            }
         }
-        self.match_tsconfig_paths(tsconfig, import_path, kind, out)
+        MatchStatus::NotFound
     }
 
     pub(crate) fn flush_debug_logs(&mut self, flush_mode: FlushMode) -> crate::CrateResult<()> {
@@ -1641,7 +1650,9 @@ impl<'a> Resolver<'a> {
                 }
             }
 
-            if let Some(tsconfig) = dir.enclosing_tsconfig_json {
+            if let Some(enclosing) = dir.enclosing_tsconfig_json {
+                self.ensure_tsconfig_references(enclosing, dir.abs_path);
+                let tsconfig = enclosing.for_source_dir(dir.abs_path);
                 result.jsx = tsconfig.merge_jsx(core::mem::take(&mut result.jsx));
                 result.flags.set_emit_decorator_metadata(
                     result.flags.emit_decorator_metadata() || tsconfig.emit_decorator_metadata,
@@ -1834,13 +1845,26 @@ impl<'a> Resolver<'a> {
 
             // First, check path overrides from the nearest enclosing TypeScript "tsconfig.json" file
             if let Ok(Some(dir_info)) = self.dir_info_cached(source_dir) {
-                if let Some(tsconfig) = dir_info.enclosing_tsconfig_json {
-                    if tsconfig.paths.count() > 0 {
+                if let Some(enclosing) = dir_info.enclosing_tsconfig_json {
+                    self.ensure_tsconfig_references(enclosing, source_dir);
+                    for tsconfig in enclosing.candidates_for_dir(source_dir) {
+                        if tsconfig.paths.count() == 0 {
+                            continue;
+                        }
                         let mut res = MatchResult::default();
                         if self
                             .match_tsconfig_paths(tsconfig, import_path, kind, &mut res)
                             .is_success()
                         {
+                            if !core::ptr::eq(tsconfig, enclosing) {
+                                if let Some(debug) = self.debug_logs.as_mut() {
+                                    debug.add_note_fmt(format_args!(
+                                        "Using referenced tsconfig \"{}\" for directory \"{}\"",
+                                        bstr::BStr::new(&tsconfig.abs_path),
+                                        bstr::BStr::new(source_dir)
+                                    ));
+                                }
+                            }
                             // We don't set the directory fd here because it might remap an entirely different directory
                             return ResultUnion::Success(Result {
                                 path_pair: res.path_pair,
@@ -2573,22 +2597,36 @@ impl<'a> Resolver<'a> {
 
         // First, check path overrides from the nearest enclosing TypeScript "tsconfig.json" file
 
-        if let Some(tsconfig) = dir_info.enclosing_tsconfig_json {
+        if let Some(enclosing) = dir_info.enclosing_tsconfig_json {
+            self.ensure_tsconfig_references(enclosing, dir_info.abs_path);
             // Try path substitutions first
-            if tsconfig.paths.count() > 0 {
+            for tsconfig in enclosing.candidates_for_dir(dir_info.abs_path) {
+                if tsconfig.paths.count() == 0 {
+                    continue;
+                }
                 if self
                     .match_tsconfig_paths(tsconfig, import_path, kind, out)
                     .is_success()
                 {
-                    if let Some(d) = self.debug_logs.as_mut() {
-                        d.decrease_indent();
+                    if let Some(debug) = self.debug_logs.as_mut() {
+                        if !core::ptr::eq(tsconfig, enclosing) {
+                            debug.add_note_fmt(format_args!(
+                                "Using referenced tsconfig \"{}\" for directory \"{}\"",
+                                bstr::BStr::new(&tsconfig.abs_path),
+                                bstr::BStr::new(dir_info.abs_path)
+                            ));
+                        }
+                        debug.decrease_indent();
                     }
                     return MatchStatus::Success;
                 }
             }
 
             // Try looking up the path relative to the base URL
-            if tsconfig.has_base_url() {
+            for tsconfig in enclosing.candidates_for_dir(dir_info.abs_path) {
+                if !tsconfig.has_base_url() {
+                    continue;
+                }
                 let base: &[u8] = &tsconfig.base_url;
                 if let Some(abs) = self.fs_ref().abs_buf_checked(
                     &[base, import_path],
@@ -4071,10 +4109,14 @@ impl<'a> Resolver<'a> {
         }
     }
 
+    /// `quiet` parses into a scratch log, keeping syntax errors and content
+    /// warnings from a referenced project's config out of the resolver Log
+    /// (where they would surface in unrelated resolution errors).
     pub(crate) fn parse_tsconfig(
         &mut self,
         file: &[u8],
         dirname_fd: FD,
+        quiet: bool,
     ) -> crate::CrateResult<Option<Box<TSConfigJSON>>> {
         // Since tsconfig.json is cached permanently, in our DirEntries cache
         // we must use the global allocator
@@ -4117,14 +4159,17 @@ impl<'a> Resolver<'a> {
         let source = bun_ast::Source::init_path_string_owned(key_path, contents);
         let file_dir = source.path.source_dir();
 
-        // SAFETY: BACKREF — `self.log` (see `log()` NOTE); disjoint from `self.caches`,
-        // narrow `&mut` for this call only.
-        let mut result =
-            match TSConfigJSON::parse(unsafe { &mut *self.log() }, &source, &mut self.caches.json)?
-            {
-                Some(r) => r,
-                None => return Ok(None),
-            };
+        let mut scratch_log = quiet.then(bun_ast::Log::init);
+        let log: &mut bun_ast::Log = match scratch_log.as_mut() {
+            Some(scratch) => scratch,
+            // SAFETY: BACKREF — `self.log` (see `log()` NOTE); disjoint from
+            // `self.caches`, narrow `&mut` for this call only.
+            None => unsafe { &mut *self.log() },
+        };
+        let mut result = match TSConfigJSON::parse(log, &source, &mut self.caches.json)? {
+            Some(r) => r,
+            None => return Ok(None),
+        };
 
         if result.has_base_url() {
             // this might leak
@@ -4150,10 +4195,268 @@ impl<'a> Resolver<'a> {
             result.base_url_for_paths = Box::from(abs);
         }
 
+        // Make "references" paths and the "files"/"include"/"exclude"
+        // coverage dirs absolute (relative to the declaring config file) so
+        // project selection can compare them against source directories.
+        // Unconditional even for already-absolute entries: ${configDir}
+        // substitution keeps the source dir's trailing slash, and the
+        // resulting double separator would defeat covers_dir's comparison.
+        for reference in result.references.iter_mut() {
+            let abs = self
+                .fs_ref()
+                .abs_buf(&[file_dir, &reference[..]], bufs!(tsconfig_base_url));
+            *reference = Box::from(abs);
+        }
+        for coverage in [result.files_dirs.as_mut(), result.include_dirs.as_mut()]
+            .into_iter()
+            .flatten()
+            .flat_map(|dirs| dirs.iter_mut())
+        {
+            let abs = self
+                .fs_ref()
+                .abs_buf(&[file_dir, &coverage.dir[..]], bufs!(tsconfig_base_url));
+            coverage.dir = Box::from(abs);
+        }
+        for dir in result.exclude_dirs.iter_mut() {
+            let abs = self
+                .fs_ref()
+                .abs_buf(&[file_dir, &dir[..]], bufs!(tsconfig_base_url));
+            *dir = Box::from(abs);
+        }
+
         // NOTE: return the `Box` so the caller (`dir_info_uncached`) takes
         // ownership — intermediate configs in an extends-chain are dropped via
         // `heap::take`, the final one is interned into the DirInfo cache.
         Ok(Some(result))
+    }
+
+    /// Chain-walk diagnostics: the resolver Log for direct config loads,
+    /// only the scoped debug logger when `quiet` (referenced projects, where
+    /// log entries would surface in unrelated resolution errors).
+    fn log_tsconfig_chain_debug(&mut self, quiet: bool, args: core::fmt::Arguments<'_>) {
+        if quiet {
+            debuglog!("{}", args);
+        } else {
+            let _ = self
+                .log_mut()
+                .add_debug_fmt(None, bun_ast::Loc::EMPTY, args);
+        }
+    }
+
+    /// Walks the `extends` chain of an already-parsed tsconfig and merges the
+    /// chain into a single config. Takes ownership of `tsconfig_json` and
+    /// returns the merged config (heap::alloc; the caller interns or frees it).
+    /// An oversized or cyclic chain stops walking and merges what was
+    /// collected rather than failing the directory load.
+    ///
+    /// `quiet` keeps chain-walk failures out of the resolver Log (used for
+    /// referenced projects); see `log_tsconfig_chain_debug`.
+    fn merge_tsconfig_extends_chain(
+        &mut self,
+        tsconfig_json: *mut TSConfigJSON,
+        quiet: bool,
+    ) -> *mut TSConfigJSON {
+        let mut parent_configs: BoundedArray<*mut TSConfigJSON, 64> = BoundedArray::default();
+        parent_configs
+            .append(tsconfig_json)
+            .expect("fresh BoundedArray has capacity");
+        // `current`/`parent_config_ptr`/`merged_config` are heap TSConfigJSON
+        // allocations from `parse_tsconfig` (heap::alloc); uniquely owned by
+        // this extends-chain walk and freed via heap::take below. Hold as
+        // `BackRef` (pointee outlives holder) so the loop body reads via safe
+        // `Deref` instead of three open-coded raw-ptr derefs.
+        let mut current =
+            bun_ptr::BackRef::from(core::ptr::NonNull::new(tsconfig_json).expect("heap alloc"));
+        while !current.extends.is_empty() {
+            let ts_dir_name = Dirname::dirname(&current.abs_path);
+            let abs_path = ResolvePath::join_abs_string_buf(
+                ts_dir_name,
+                bufs!(tsconfig_path_abs),
+                &[ts_dir_name, &current.extends],
+                bun_paths::Platform::AUTO,
+            );
+            let parent_config_maybe: Option<*mut TSConfigJSON> =
+                match self.parse_tsconfig(abs_path, FD::INVALID, quiet) {
+                    Ok(v) => v.map(bun_core::heap::into_raw),
+                    Err(err) => {
+                        self.log_tsconfig_chain_debug(
+                            quiet,
+                            format_args!(
+                                "{} loading tsconfig.json extends {}",
+                                bstr::BStr::new(err.name()),
+                                bun_core::fmt::quote(abs_path)
+                            ),
+                        );
+                        break;
+                    }
+                };
+            if let Some(parent_config) = parent_config_maybe {
+                if parent_configs.append(parent_config).is_err() {
+                    // Oversized (or cyclic) extends chain: stop walking and
+                    // merge what was collected instead of leaking the parsed
+                    // config and failing the whole resolution.
+                    // SAFETY: `parent_config` came from heap::into_raw above
+                    // and was not stored anywhere.
+                    TSConfigJSON::destroy(unsafe { bun_core::heap::take(parent_config) });
+                    self.log_tsconfig_chain_debug(
+                        quiet,
+                        format_args!(
+                            "tsconfig.json extends chain too long at {}",
+                            bun_core::fmt::quote(abs_path)
+                        ),
+                    );
+                    break;
+                }
+                current = bun_ptr::BackRef::from(
+                    core::ptr::NonNull::new(parent_config).expect("heap alloc"),
+                );
+            } else {
+                break;
+            }
+        }
+
+        let merged_config = parent_configs.pop().unwrap();
+        // starting from the base config (end of the list)
+        // successively apply the inheritable attributes to the next config
+        while let Some(parent_config_ptr) = parent_configs.pop() {
+            // SAFETY: see loop-wide note above.
+            let parent_config = unsafe { &mut *parent_config_ptr };
+            // SAFETY: see loop-wide note above.
+            let mc = unsafe { &mut *merged_config };
+            mc.emit_decorator_metadata =
+                mc.emit_decorator_metadata || parent_config.emit_decorator_metadata;
+            if let Some(v) = parent_config.use_define_for_class_fields {
+                mc.use_define_for_class_fields = Some(v);
+            }
+            if !parent_config.base_url.is_empty() {
+                mc.base_url = core::mem::take(&mut parent_config.base_url);
+            }
+            mc.jsx = parent_config.merge_jsx(mc.jsx.clone());
+            mc.jsx_flags.insert_all(parent_config.jsx_flags);
+
+            if let Some(value) = parent_config.preserve_imports_not_used_as_values {
+                mc.preserve_imports_not_used_as_values = Some(value);
+            }
+
+            // The merged config should read as the config file that was found
+            // on disk, not the base of its extends chain: `abs_path` feeds the
+            // default project coverage in `covers_dir` and debug output.
+            mc.abs_path = core::mem::take(&mut parent_config.abs_path);
+            // "references" is the one top-level key excluded from `extends`
+            // inheritance, so the outermost config always wins (even if empty).
+            mc.references = core::mem::take(&mut parent_config.references);
+            if parent_config.files_dirs.is_some() {
+                mc.files_dirs = core::mem::take(&mut parent_config.files_dirs);
+            }
+            if parent_config.include_dirs.is_some() {
+                mc.include_dirs = core::mem::take(&mut parent_config.include_dirs);
+            }
+            if !parent_config.exclude_dirs.is_empty() {
+                mc.exclude_dirs = core::mem::take(&mut parent_config.exclude_dirs);
+            }
+
+            // TypeScript replaces paths across extends (child overrides parent
+            // entirely), so when a more-specific config defines paths, replace
+            // rather than merge. base_url_for_paths is set whenever the paths
+            // key is present in the JSON (even if empty), so it discriminates
+            // "not defined" from "defined as {}" — the latter clears inherited
+            // paths per TypeScript semantics.
+            if !parent_config.base_url_for_paths.is_empty() {
+                // The previous merged_config.paths is being replaced;
+                // dropping the map frees the values automatically, so the
+                // PathsMap from the deeper config doesn't leak.
+                mc.paths = core::mem::take(&mut parent_config.paths);
+                mc.base_url_for_paths = core::mem::take(&mut parent_config.base_url_for_paths);
+            } else {
+                // paths were not moved to merged_config, so they're still owned
+                // by parent_config. base_url_for_paths.len == 0 implies the map
+                // is empty (it's only set when the `paths` key is present in the
+                // JSON), so this is a no-op but documents the ownership.
+                // (Drop handles parent_config.paths.)
+            }
+            // Every scalar/reference we need has been copied into merged_config
+            // (strings live in dirname_store or default_allocator and outlive the
+            // struct). The heap-allocated TSConfigJSON itself is no longer needed;
+            // without this, every intermediate config in an extends chain leaks on
+            // each dirInfoUncached() call, which is especially bad under HMR where
+            // bustDirCache triggers a re-parse of the whole chain on every reload.
+            // SAFETY: parent_config_ptr came from TSConfigJSON::new (heap::alloc)
+            TSConfigJSON::destroy(unsafe { bun_core::heap::take(parent_config_ptr) });
+        }
+        merged_config
+    }
+
+    /// Loads a solution-style tsconfig's referenced projects on the first
+    /// `covers_dir` miss, so path resolution can pick the referenced config
+    /// covering a source directory (see `TSConfigJSON::candidates_for_dir`).
+    /// Loading is lazy because the cwd's tsconfig is parsed on every startup
+    /// (`configure_linker`), including when a nearer config serves every
+    /// file and no referenced project could ever be selected.
+    fn ensure_tsconfig_references(&mut self, enclosing: &'static TSConfigJSON, source_dir: &[u8]) {
+        if enclosing.references.is_empty()
+            || enclosing.references_loaded()
+            || enclosing.covers_dir(source_dir)
+        {
+            return;
+        }
+        self.load_tsconfig_references(enclosing);
+    }
+
+    /// Loads the projects referenced by a solution-style tsconfig.
+    /// Transitive references are followed with a visited set; configs that
+    /// fail to load are debug-logged and skipped.
+    fn load_tsconfig_references(&mut self, root: &'static TSConfigJSON) {
+        // Bounds *attempted* loads, not successes, so a config full of broken
+        // references can't trigger unbounded filesystem reads.
+        const MAX_REFERENCES: usize = 64;
+        let mut visited: Vec<Box<[u8]>> = vec![Box::from(&root.abs_path[..])];
+        let mut queue: Vec<Box<[u8]>> = root.references.to_vec();
+        let mut configs: Vec<Box<TSConfigJSON>> = Vec::new();
+        let mut cursor = 0;
+        while cursor < queue.len() && visited.len() <= MAX_REFERENCES {
+            let reference = core::mem::take(&mut queue[cursor]);
+            cursor += 1;
+            // A "references[].path" not naming a .json file points at a
+            // project directory whose config is <path>/tsconfig.json.
+            let config_path: &[u8] = if strings::ends_with(&reference, b".json") {
+                &reference
+            } else {
+                self.fs_ref()
+                    .abs_buf(&[&reference, b"tsconfig.json"], bufs!(tsconfig_path_abs))
+            };
+            if visited.iter().any(|seen| &seen[..] == config_path) {
+                continue;
+            }
+            visited.push(Box::from(config_path));
+
+            // A load failure must not touch the resolver Log: a missing
+            // referenced project is normal, and extra log entries make
+            // unrelated resolution failures surface as AggregateError.
+            let parsed: *mut TSConfigJSON =
+                match self.parse_tsconfig(config_path, FD::INVALID, true) {
+                    Ok(Some(v)) => bun_core::heap::into_raw(v),
+                    Ok(None) => continue,
+                    Err(err) => {
+                        debuglog!(
+                            "{} loading tsconfig.json reference {}",
+                            bstr::BStr::new(err.name()),
+                            bun_core::fmt::quote(&visited[visited.len() - 1])
+                        );
+                        continue;
+                    }
+                };
+            let merged_ptr = self.merge_tsconfig_extends_chain(parsed, true);
+            // SAFETY: `merged_ptr` came from heap::alloc in
+            // `merge_tsconfig_extends_chain` and is uniquely owned here; the
+            // Box hands ownership to the root config below.
+            let merged: Box<TSConfigJSON> = unsafe { bun_core::heap::take(merged_ptr) };
+            if visited.len() <= MAX_REFERENCES {
+                queue.extend(merged.references.iter().cloned());
+            }
+            configs.push(merged);
+        }
+
+        root.set_reference_configs(configs.into_boxed_slice());
     }
 
     pub fn bin_dirs(&self) -> &[&'static [u8]] {
@@ -6544,6 +6847,7 @@ impl<'a> Resolver<'a> {
                     } else {
                         FD::ZERO
                     },
+                    false,
                 ) {
                     Ok(v) => v.map(bun_core::heap::into_raw),
                     Err(err) => {
@@ -6581,103 +6885,7 @@ impl<'a> Resolver<'a> {
                 // it is always overwritten when parsed_tsconfig.is_some(), and DirInfo defaults
                 // tsconfig_json to None otherwise.
                 if let Some(tsconfig_json) = parsed_tsconfig {
-                    let mut parent_configs: BoundedArray<*mut TSConfigJSON, 64> =
-                        BoundedArray::default();
-                    parent_configs.append(tsconfig_json)?;
-                    // `current`/`parent_config_ptr`/`merged_config` are heap TSConfigJSON
-                    // allocations from `parse_tsconfig` (heap::alloc); uniquely owned by
-                    // this extends-chain walk and freed via heap::take below. Hold as
-                    // `BackRef` (pointee outlives holder) so the loop body reads via safe
-                    // `Deref` instead of three open-coded raw-ptr derefs.
-                    let mut current = bun_ptr::BackRef::from(
-                        core::ptr::NonNull::new(tsconfig_json).expect("heap alloc"),
-                    );
-                    while !current.extends.is_empty() {
-                        let ts_dir_name = Dirname::dirname(&current.abs_path);
-                        let abs_path = ResolvePath::join_abs_string_buf(
-                            ts_dir_name,
-                            bufs!(tsconfig_path_abs),
-                            &[ts_dir_name, &current.extends],
-                            bun_paths::Platform::AUTO,
-                        );
-                        let parent_config_maybe: Option<*mut TSConfigJSON> =
-                            match self.parse_tsconfig(abs_path, FD::INVALID) {
-                                Ok(v) => v.map(bun_core::heap::into_raw),
-                                Err(err) => {
-                                    let _ = self.log_mut().add_debug_fmt(
-                                        None,
-                                        bun_ast::Loc::EMPTY,
-                                        format_args!(
-                                            "{} loading tsconfig.json extends {}",
-                                            bstr::BStr::new(err.name()),
-                                            bun_core::fmt::quote(abs_path)
-                                        ),
-                                    );
-                                    break;
-                                }
-                            };
-                        if let Some(parent_config) = parent_config_maybe {
-                            parent_configs.append(parent_config)?;
-                            current = bun_ptr::BackRef::from(
-                                core::ptr::NonNull::new(parent_config).expect("heap alloc"),
-                            );
-                        } else {
-                            break;
-                        }
-                    }
-
-                    let merged_config = parent_configs.pop().unwrap();
-                    // starting from the base config (end of the list)
-                    // successively apply the inheritable attributes to the next config
-                    while let Some(parent_config_ptr) = parent_configs.pop() {
-                        // SAFETY: see loop-wide note above.
-                        let parent_config = unsafe { &mut *parent_config_ptr };
-                        // SAFETY: see loop-wide note above.
-                        let mc = unsafe { &mut *merged_config };
-                        mc.emit_decorator_metadata =
-                            mc.emit_decorator_metadata || parent_config.emit_decorator_metadata;
-                        if let Some(v) = parent_config.use_define_for_class_fields {
-                            mc.use_define_for_class_fields = Some(v);
-                        }
-                        if !parent_config.base_url.is_empty() {
-                            mc.base_url = core::mem::take(&mut parent_config.base_url);
-                        }
-                        mc.jsx = parent_config.merge_jsx(mc.jsx.clone());
-                        mc.jsx_flags.insert_all(parent_config.jsx_flags);
-
-                        if let Some(value) = parent_config.preserve_imports_not_used_as_values {
-                            mc.preserve_imports_not_used_as_values = Some(value);
-                        }
-
-                        // TypeScript replaces paths across extends (child overrides parent
-                        // entirely), so when a more-specific config defines paths, replace
-                        // rather than merge. base_url_for_paths is set whenever the paths
-                        // key is present in the JSON (even if empty), so it discriminates
-                        // "not defined" from "defined as {}" — the latter clears inherited
-                        // paths per TypeScript semantics.
-                        if !parent_config.base_url_for_paths.is_empty() {
-                            // The previous merged_config.paths is being replaced;
-                            // dropping the map frees the values automatically, so the
-                            // PathsMap from the deeper config doesn't leak.
-                            mc.paths = core::mem::take(&mut parent_config.paths);
-                            mc.base_url_for_paths =
-                                core::mem::take(&mut parent_config.base_url_for_paths);
-                        } else {
-                            // paths were not moved to merged_config, so they're still owned
-                            // by parent_config. base_url_for_paths.len == 0 implies the map
-                            // is empty (it's only set when the `paths` key is present in the
-                            // JSON), so this is a no-op but documents the ownership.
-                            // (Drop handles parent_config.paths.)
-                        }
-                        // Every scalar/reference we need has been copied into merged_config
-                        // (strings live in dirname_store or default_allocator and outlive the
-                        // struct). The heap-allocated TSConfigJSON itself is no longer needed;
-                        // without this, every intermediate config in an extends chain leaks on
-                        // each dir_info_uncached() call, which is especially bad under HMR where
-                        // bust_dir_cache triggers a re-parse of the whole chain on every reload.
-                        // SAFETY: parent_config_ptr came from TSConfigJSON::new (heap::alloc)
-                        TSConfigJSON::destroy(unsafe { bun_core::heap::take(parent_config_ptr) });
-                    }
+                    let merged_config = self.merge_tsconfig_extends_chain(tsconfig_json, false);
                     // `merged_config` is a leaked Box (heap::alloc) interned into DirInfo; outlives the resolver.
                     info.tsconfig_json = Some(
                         core::ptr::NonNull::new(merged_config).expect("heap::alloc is non-null"),

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4109,9 +4109,7 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    /// `quiet` parses into a scratch log, keeping syntax errors and content
-    /// warnings from a referenced project's config out of the resolver Log
-    /// (where they would surface in unrelated resolution errors).
+    /// `quiet` discards the file's parse diagnostics instead of adding them to the resolver log.
     pub(crate) fn parse_tsconfig(
         &mut self,
         file: &[u8],
@@ -4195,34 +4193,24 @@ impl<'a> Resolver<'a> {
             result.base_url_for_paths = Box::from(abs);
         }
 
-        // Make "references" paths and the "files"/"include"/"exclude"
-        // coverage dirs absolute (relative to the declaring config file) so
-        // project selection can compare them against source directories.
-        // Unconditional even for already-absolute entries: ${configDir}
-        // substitution keeps the source dir's trailing slash, and the
-        // resulting double separator would defeat covers_dir's comparison.
-        for reference in result.references.iter_mut() {
+        // Absolute entries too: `${configDir}` leaves a trailing slash `covers_dir` would keep.
+        let absolutize = |path: &mut Box<[u8]>| {
             let abs = self
                 .fs_ref()
-                .abs_buf(&[file_dir, &reference[..]], bufs!(tsconfig_base_url));
-            *reference = Box::from(abs);
-        }
-        for coverage in [result.files_dirs.as_mut(), result.include_dirs.as_mut()]
+                .abs_buf(&[file_dir, &path[..]], bufs!(tsconfig_base_url));
+            *path = Box::from(abs);
+        };
+        result.references.iter_mut().for_each(absolutize);
+        result
+            .exclude_dirs
+            .iter_mut()
+            .flatten()
+            .for_each(absolutize);
+        [result.files_dirs.as_mut(), result.include_dirs.as_mut()]
             .into_iter()
             .flatten()
-            .flat_map(|dirs| dirs.iter_mut())
-        {
-            let abs = self
-                .fs_ref()
-                .abs_buf(&[file_dir, &coverage.dir[..]], bufs!(tsconfig_base_url));
-            coverage.dir = Box::from(abs);
-        }
-        for dir in result.exclude_dirs.iter_mut() {
-            let abs = self
-                .fs_ref()
-                .abs_buf(&[file_dir, &dir[..]], bufs!(tsconfig_base_url));
-            *dir = Box::from(abs);
-        }
+            .flatten()
+            .for_each(|coverage| absolutize(&mut coverage.dir));
 
         // NOTE: return the `Box` so the caller (`dir_info_uncached`) takes
         // ownership — intermediate configs in an extends-chain are dropped via
@@ -4230,9 +4218,6 @@ impl<'a> Resolver<'a> {
         Ok(Some(result))
     }
 
-    /// Chain-walk diagnostics: the resolver Log for direct config loads,
-    /// only the scoped debug logger when `quiet` (referenced projects, where
-    /// log entries would surface in unrelated resolution errors).
     fn log_tsconfig_chain_debug(&mut self, quiet: bool, args: core::fmt::Arguments<'_>) {
         if quiet {
             debuglog!("{}", args);
@@ -4243,14 +4228,9 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    /// Walks the `extends` chain of an already-parsed tsconfig and merges the
-    /// chain into a single config. Takes ownership of `tsconfig_json` and
-    /// returns the merged config (heap::alloc; the caller interns or frees it).
-    /// An oversized or cyclic chain stops walking and merges what was
-    /// collected rather than failing the directory load.
-    ///
-    /// `quiet` keeps chain-walk failures out of the resolver Log (used for
-    /// referenced projects); see `log_tsconfig_chain_debug`.
+    /// Merges `tsconfig_json`'s `extends` chain into one config, which the caller owns
+    /// (`heap::alloc`). A chain longer than 64 configs (a cycle) is merged as far as it got.
+    /// `quiet` is passed on to `parse_tsconfig`.
     fn merge_tsconfig_extends_chain(
         &mut self,
         tsconfig_json: *mut TSConfigJSON,
@@ -4292,11 +4272,7 @@ impl<'a> Resolver<'a> {
                 };
             if let Some(parent_config) = parent_config_maybe {
                 if parent_configs.append(parent_config).is_err() {
-                    // Oversized (or cyclic) extends chain: stop walking and
-                    // merge what was collected instead of leaking the parsed
-                    // config and failing the whole resolution.
-                    // SAFETY: `parent_config` came from heap::into_raw above
-                    // and was not stored anywhere.
+                    // SAFETY: `parent_config` came from heap::into_raw above and was not stored.
                     TSConfigJSON::destroy(unsafe { bun_core::heap::take(parent_config) });
                     self.log_tsconfig_chain_debug(
                         quiet,
@@ -4338,12 +4314,9 @@ impl<'a> Resolver<'a> {
                 mc.preserve_imports_not_used_as_values = Some(value);
             }
 
-            // The merged config should read as the config file that was found
-            // on disk, not the base of its extends chain: `abs_path` feeds the
-            // default project coverage in `covers_dir` and debug output.
+            // `covers_dir`'s default coverage is relative to the config on disk, not its base.
             mc.abs_path = core::mem::take(&mut parent_config.abs_path);
-            // "references" is the one top-level key excluded from `extends`
-            // inheritance, so the outermost config always wins (even if empty).
+            // tsc does not inherit "references" through "extends".
             mc.references = core::mem::take(&mut parent_config.references);
             if parent_config.files_dirs.is_some() {
                 mc.files_dirs = core::mem::take(&mut parent_config.files_dirs);
@@ -4351,7 +4324,7 @@ impl<'a> Resolver<'a> {
             if parent_config.include_dirs.is_some() {
                 mc.include_dirs = core::mem::take(&mut parent_config.include_dirs);
             }
-            if !parent_config.exclude_dirs.is_empty() {
+            if parent_config.exclude_dirs.is_some() {
                 mc.exclude_dirs = core::mem::take(&mut parent_config.exclude_dirs);
             }
 
@@ -4378,36 +4351,34 @@ impl<'a> Resolver<'a> {
             // (strings live in dirname_store or default_allocator and outlive the
             // struct). The heap-allocated TSConfigJSON itself is no longer needed;
             // without this, every intermediate config in an extends chain leaks on
-            // each dirInfoUncached() call, which is especially bad under HMR where
-            // bustDirCache triggers a re-parse of the whole chain on every reload.
+            // each dir_info_uncached() call, which is especially bad under HMR where
+            // bust_dir_cache triggers a re-parse of the whole chain on every reload.
             // SAFETY: parent_config_ptr came from TSConfigJSON::new (heap::alloc)
             TSConfigJSON::destroy(unsafe { bun_core::heap::take(parent_config_ptr) });
         }
         merged_config
     }
 
-    /// Loads a solution-style tsconfig's referenced projects on the first
-    /// `covers_dir` miss, so path resolution can pick the referenced config
-    /// covering a source directory (see `TSConfigJSON::candidates_for_dir`).
-    /// Loading is lazy because the cwd's tsconfig is parsed on every startup
-    /// (`configure_linker`), including when a nearer config serves every
-    /// file and no referenced project could ever be selected.
+    /// Loads `enclosing`'s referenced projects the first time a directory it does not cover
+    /// resolves through it. Not at parse time: the cwd's tsconfig is parsed on every startup,
+    /// usually without any of its references ever applying. `enclosing` is shared with every
+    /// other resolver thread, hence the `OnceLock`.
     fn ensure_tsconfig_references(&mut self, enclosing: &'static TSConfigJSON, source_dir: &[u8]) {
         if enclosing.references.is_empty()
-            || enclosing.references_loaded()
+            || enclosing.reference_configs.get().is_some()
             || enclosing.covers_dir(source_dir)
         {
             return;
         }
-        self.load_tsconfig_references(enclosing);
+        enclosing
+            .reference_configs
+            .get_or_init(|| self.load_tsconfig_references(enclosing));
     }
 
-    /// Loads the projects referenced by a solution-style tsconfig.
-    /// Transitive references are followed with a visited set; configs that
-    /// fail to load are debug-logged and skipped.
-    fn load_tsconfig_references(&mut self, root: &'static TSConfigJSON) {
-        // Bounds *attempted* loads, not successes, so a config full of broken
-        // references can't trigger unbounded filesystem reads.
+    /// Parses the projects reachable through `root.references`, in reference order
+    /// (breadth first), skipping ones that fail to load. Attempted loads are bounded, not
+    /// successful ones, so a tree of broken references cannot keep the resolver reading files.
+    fn load_tsconfig_references(&mut self, root: &TSConfigJSON) -> Box<[Box<TSConfigJSON>]> {
         const MAX_REFERENCES: usize = 64;
         let mut visited: Vec<Box<[u8]>> = vec![Box::from(&root.abs_path[..])];
         let mut queue: Vec<Box<[u8]>> = root.references.to_vec();
@@ -4416,8 +4387,7 @@ impl<'a> Resolver<'a> {
         while cursor < queue.len() && visited.len() <= MAX_REFERENCES {
             let reference = core::mem::take(&mut queue[cursor]);
             cursor += 1;
-            // A "references[].path" not naming a .json file points at a
-            // project directory whose config is <path>/tsconfig.json.
+            // A reference to a project directory means its tsconfig.json.
             let config_path: &[u8] = if strings::ends_with(&reference, b".json") {
                 &reference
             } else {
@@ -4429,9 +4399,7 @@ impl<'a> Resolver<'a> {
             }
             visited.push(Box::from(config_path));
 
-            // A load failure must not touch the resolver Log: a missing
-            // referenced project is normal, and extra log entries make
-            // unrelated resolution failures surface as AggregateError.
+            // A missing or broken referenced project is normal; nothing reaches the resolver log.
             let parsed: *mut TSConfigJSON =
                 match self.parse_tsconfig(config_path, FD::INVALID, true) {
                     Ok(Some(v)) => bun_core::heap::into_raw(v),
@@ -4446,17 +4414,14 @@ impl<'a> Resolver<'a> {
                     }
                 };
             let merged_ptr = self.merge_tsconfig_extends_chain(parsed, true);
-            // SAFETY: `merged_ptr` came from heap::alloc in
-            // `merge_tsconfig_extends_chain` and is uniquely owned here; the
-            // Box hands ownership to the root config below.
+            // SAFETY: `merge_tsconfig_extends_chain` returns a heap::alloc pointer it gives up.
             let merged: Box<TSConfigJSON> = unsafe { bun_core::heap::take(merged_ptr) };
             if visited.len() <= MAX_REFERENCES {
                 queue.extend(merged.references.iter().cloned());
             }
             configs.push(merged);
         }
-
-        root.set_reference_configs(configs.into_boxed_slice());
+        configs.into_boxed_slice()
     }
 
     pub fn bin_dirs(&self) -> &[&'static [u8]] {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4360,9 +4360,9 @@ impl<'a> Resolver<'a> {
     }
 
     /// Loads `enclosing`'s referenced projects the first time a directory it does not cover
-    /// resolves through it. Not at parse time: the cwd's tsconfig is parsed on every startup,
-    /// usually without any of its references ever applying. `enclosing` is shared with every
-    /// other resolver thread, hence the `OnceLock`.
+    /// resolves through it (not at parse time: the cwd's tsconfig is parsed on every startup,
+    /// usually without any reference applying). The load runs under the resolver mutex like
+    /// every other `parse_tsconfig` caller; the `OnceLock` publishes it to lock-free readers.
     fn ensure_tsconfig_references(&mut self, enclosing: &'static TSConfigJSON, source_dir: &[u8]) {
         if enclosing.references.is_empty()
             || enclosing.reference_configs.get().is_some()
@@ -4370,6 +4370,8 @@ impl<'a> Resolver<'a> {
         {
             return;
         }
+        // Callers reach this right after a `dir_info_cached` lookup, so the mutex is not held.
+        let _unlock = self.mutex.lock_guard();
         enclosing
             .reference_configs
             .get_or_init(|| self.load_tsconfig_references(enclosing));

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -114,6 +114,60 @@ impl JsonCache {
     }
 }
 
+/// A directory covered by a "files"/"include" entry, derived at parse time
+/// (dir is config-relative until the resolver absolutizes it).
+pub(crate) struct CoverageDir {
+    pub dir: Box<[u8]>,
+    /// Whether subdirectories are covered too. Only `**` globs and bare
+    /// directory includes recurse; file entries and single-`*` globs
+    /// (`vite.config.*`, `src/*.ts`) match files directly in `dir` only, so
+    /// a root-level entry must not claim the whole tree.
+    pub recursive: bool,
+}
+
+const SOURCE_EXTENSIONS: &[&[u8]] = &[
+    b".ts", b".tsx", b".mts", b".cts", b".js", b".jsx", b".mjs", b".cjs", b".json",
+];
+
+fn looks_like_file(path: &[u8]) -> bool {
+    SOURCE_EXTENSIONS
+        .iter()
+        .any(|ext| strings::ends_with(path, ext))
+}
+
+/// The directory an "include" pattern covers: the literal prefix before the
+/// first wildcard, truncated to the last separator (empty = the config dir).
+/// Recursion requires a `**` segment or a wildcard-free directory include.
+pub(crate) fn include_pattern_coverage(pattern: &[u8]) -> CoverageDir {
+    match strings::index_of_any(pattern, b"*?") {
+        Some(glob) => {
+            let prefix = &pattern[..glob];
+            let dir = match prefix.iter().rposition(|&c| bun_paths::is_sep_any(c)) {
+                Some(sep) => &prefix[..sep],
+                None => b"",
+            };
+            CoverageDir {
+                dir: Box::from(dir),
+                recursive: strings::contains(pattern, b"**"),
+            }
+        }
+        None => {
+            if looks_like_file(pattern) {
+                CoverageDir {
+                    dir: Box::from(bun_paths::dirname(pattern).unwrap_or(b"")),
+                    recursive: false,
+                }
+            } else {
+                // A bare directory include covers its whole subtree.
+                CoverageDir {
+                    dir: Box::from(pattern),
+                    recursive: true,
+                }
+            }
+        }
+    }
+}
+
 // Heuristic: you probably don't have 100 of these
 // Probably like 5-10
 // Array iteration is faster and deterministically ordered in that case.
@@ -145,6 +199,38 @@ pub struct TSConfigJSON {
     pub(crate) base_url_for_paths: Box<[u8]>,
 
     pub(crate) extends: Box<[u8]>,
+
+    /// Paths from "references[].path", made absolute by the resolver.
+    /// Non-empty for solution-style configs; consumed by the dir-info walk,
+    /// which loads them into `reference_configs`.
+    pub(crate) references: Box<[Box<[u8]>]>,
+
+    /// Parsed configs for `references`, owned by this (solution-style) config
+    /// and dropped with it. Loaded lazily by
+    /// `Resolver::load_tsconfig_references` on the first directory this
+    /// config does not cover; read via `reference_configs()`. The
+    /// `UnsafeCell` is sound because every access runs under the resolver
+    /// lock (like the DirInfo cache itself).
+    pub(crate) reference_configs: core::cell::UnsafeCell<Box<[Box<TSConfigJSON>]>>,
+
+    /// Whether `reference_configs` has been populated (set even when loading
+    /// produced nothing, so a broken solution is not retried per lookup).
+    pub(crate) references_loaded: core::cell::Cell<bool>,
+
+    /// Directories derived from the "files" entries (never recursive);
+    /// `None` when the key is absent. Absolute after `parse_tsconfig`.
+    pub(crate) files_dirs: Option<Box<[CoverageDir]>>,
+
+    /// Directories derived from the "include" patterns; `None` when the key
+    /// is absent. Absolute after `parse_tsconfig`.
+    pub(crate) include_dirs: Option<Box<[CoverageDir]>>,
+
+    /// Directories from wildcard-free "exclude" entries (always recursive);
+    /// vetoes `include` and default coverage, never `files`. Glob excludes
+    /// are ignored rather than over-excluding. Absolute after
+    /// `parse_tsconfig`.
+    pub(crate) exclude_dirs: Box<[Box<[u8]>]>,
+
     /// The verbatim values of "compilerOptions.paths". The keys are patterns to
     /// match and the values are arrays of fallback paths to search. Each key and
     /// each fallback path can optionally have a single "*" wildcard character.
@@ -172,6 +258,12 @@ impl Default for TSConfigJSON {
             base_url: Box::default(),
             base_url_for_paths: Box::default(),
             extends: Box::default(),
+            references: Box::default(),
+            reference_configs: core::cell::UnsafeCell::new(Box::default()),
+            references_loaded: core::cell::Cell::new(false),
+            files_dirs: None,
+            include_dirs: None,
+            exclude_dirs: Box::default(),
             paths: PathsMap::default(),
             jsx: options::jsx::Pragma::default(),
             jsx_flags: JsxFieldSet::empty(),
@@ -224,6 +316,100 @@ impl TSConfigJSON {
 
     pub(crate) fn has_base_url(&self) -> bool {
         !self.base_url.is_empty()
+    }
+
+    /// Read access to the lazily-loaded referenced projects.
+    pub(crate) fn reference_configs(&self) -> &[Box<TSConfigJSON>] {
+        // SAFETY: written at most once via `set_reference_configs` (under the
+        // resolver lock, which serializes all tsconfig access) before any
+        // reader observes `references_loaded() == true`.
+        unsafe { &*self.reference_configs.get() }
+    }
+
+    pub(crate) fn references_loaded(&self) -> bool {
+        self.references_loaded.get()
+    }
+
+    /// Publishes the loaded referenced projects; see `reference_configs`.
+    pub(crate) fn set_reference_configs(&self, configs: Box<[Box<TSConfigJSON>]>) {
+        // SAFETY: sole write site, serialized by the resolver lock; no
+        // `reference_configs()` borrow is live across a resolver call.
+        unsafe { *self.reference_configs.get() = configs };
+        self.references_loaded.set(true);
+    }
+
+    /// Whether files in `source_dir` belong to this project, judged by the
+    /// directories its "files"/"include" entries cover (minus wildcard-free
+    /// "exclude" directories). When neither key is present, TypeScript
+    /// defaults "include" to `**/*`, so the config covers its whole
+    /// directory subtree.
+    pub(crate) fn covers_dir(&self, source_dir: &[u8]) -> bool {
+        use bun_paths::resolve_path::{ParentEqual, is_parent_or_equal};
+        // `is_parent_or_equal` strips the parent's trailing separators but
+        // not the child's; a trailing slash on `source_dir` would turn an
+        // exact match into `Parent` and defeat non-recursive entries.
+        let mut source_dir = source_dir;
+        while let [head @ .., last] = source_dir {
+            if !bun_paths::is_sep_any(*last) {
+                break;
+            }
+            source_dir = head;
+        }
+        let matches = |c: &CoverageDir| match is_parent_or_equal(&c.dir, source_dir) {
+            ParentEqual::Equal => !c.dir.is_empty(),
+            ParentEqual::Parent => c.recursive && !c.dir.is_empty(),
+            ParentEqual::Unrelated => false,
+        };
+        // "files" entries are exempt from "exclude".
+        if self.files_dirs.iter().flatten().any(matches) {
+            return true;
+        }
+        let include_match = match (&self.include_dirs, &self.files_dirs) {
+            (Some(dirs), _) => dirs.iter().any(matches),
+            // Neither key: default "include" of `**/*` under the config dir.
+            (None, None) => {
+                let config_dir = bun_paths::dirname(&self.abs_path).unwrap_or(b"");
+                !config_dir.is_empty()
+                    && is_parent_or_equal(config_dir, source_dir) != ParentEqual::Unrelated
+            }
+            // "files" present without "include": include defaults to [].
+            (None, Some(_)) => false,
+        };
+        include_match
+            && !self.exclude_dirs.iter().any(|dir| {
+                !dir.is_empty() && is_parent_or_equal(dir, source_dir) != ParentEqual::Unrelated
+            })
+    }
+
+    /// Ordered configs to consult for files in `source_dir`. A config
+    /// covering the directory owns its files outright (references are never
+    /// consulted, matching tsc). Otherwise each loaded referenced project
+    /// covering the directory is tried in reference order, and the config
+    /// itself comes last so its own paths/baseUrl still apply when no
+    /// referenced project resolves the import (the common pre-references
+    /// workaround of putting paths on the solution root).
+    pub(crate) fn candidates_for_dir<'a, 'b>(
+        &'a self,
+        source_dir: &'b [u8],
+    ) -> impl Iterator<Item = &'a TSConfigJSON> + use<'a, 'b> {
+        let refs: &'a [Box<TSConfigJSON>] = if self.covers_dir(source_dir) {
+            &[]
+        } else {
+            self.reference_configs()
+        };
+        refs.iter()
+            .map(|r| &**r)
+            .filter(move |r| r.covers_dir(source_dir))
+            .chain(core::iter::once(self))
+    }
+
+    /// The primary config for files in `source_dir`: the first candidate
+    /// from `candidates_for_dir` (used where only one config can apply,
+    /// e.g. jsx/decorator options).
+    pub(crate) fn for_source_dir<'a>(&'a self, source_dir: &[u8]) -> &'a TSConfigJSON {
+        self.candidates_for_dir(source_dir)
+            .next()
+            .expect("candidates_for_dir always yields self")
     }
 
     pub fn merge_jsx(&self, current: options::jsx::Pragma) -> options::jsx::Pragma {
@@ -346,6 +532,10 @@ impl TSConfigJSON {
         // `jsxImportSource`) is preserved.
         let mut extends_value: Option<&bun_ast::E::JsonValue> = None;
         let mut compiler_opts: Option<&bun_ast::E::JsonValue> = None;
+        let mut references_value: Option<&bun_ast::E::JsonValue> = None;
+        let mut files_value: Option<&bun_ast::E::JsonValue> = None;
+        let mut include_value: Option<&bun_ast::E::JsonValue> = None;
+        let mut exclude_value: Option<&bun_ast::E::JsonValue> = None;
         if let bun_ast::ExprData::EObjectJSON(obj) = &json.data {
             for property in obj.get().properties() {
                 match property.key.slice() {
@@ -353,6 +543,12 @@ impl TSConfigJSON {
                     b"compilerOptions" if compiler_opts.is_none() => {
                         compiler_opts = Some(&property.value)
                     }
+                    b"references" if references_value.is_none() => {
+                        references_value = Some(&property.value)
+                    }
+                    b"files" if files_value.is_none() => files_value = Some(&property.value),
+                    b"include" if include_value.is_none() => include_value = Some(&property.value),
+                    b"exclude" if exclude_value.is_none() => exclude_value = Some(&property.value),
                     _ => {}
                 }
             }
@@ -363,6 +559,93 @@ impl TSConfigJSON {
                 if let Some(str) = extends_value.as_str() {
                     result.extends = Box::from(str);
                 }
+            }
+        }
+
+        // Parse "references" (solution-style configs). Like "extends", skipped
+        // inside node_modules.
+        if let Some(references_value) = references_value {
+            if !source.path.is_node_module() {
+                if let Some(array) = references_value.as_array() {
+                    let mut refs: Vec<Box<[u8]>> = Vec::with_capacity(array.items().len());
+                    for item in array.items() {
+                        if let Some(obj) = item.as_object() {
+                            if let Some(path) = obj.get(b"path").and_then(|v| v.as_str()) {
+                                if !path.is_empty() {
+                                    let path = match Self::str_replacing_templates(
+                                        Box::from(path),
+                                        source,
+                                    ) {
+                                        Ok(v) => v,
+                                        Err(_) => return Ok(None),
+                                    };
+                                    refs.push(path);
+                                }
+                            }
+                        }
+                    }
+                    result.references = refs.into_boxed_slice();
+                }
+            }
+        }
+
+        // Parse "files"/"include"/"exclude" into the directories they cover,
+        // used to pick the referenced project for a source directory. `Some`
+        // records that the key was present even when it covers nothing
+        // ("files": []).
+        if let Some(files_value) = files_value {
+            if let Some(array) = files_value.as_array() {
+                let mut dirs: Vec<CoverageDir> = Vec::with_capacity(array.items().len());
+                for item in array.items() {
+                    if let Some(str) = item.as_str() {
+                        let str = match Self::str_replacing_templates(Box::from(str), source) {
+                            Ok(v) => v,
+                            Err(_) => return Ok(None),
+                        };
+                        dirs.push(CoverageDir {
+                            dir: Box::from(bun_paths::dirname(&str).unwrap_or(b"")),
+                            recursive: false,
+                        });
+                    }
+                }
+                result.files_dirs = Some(dirs.into_boxed_slice());
+            }
+        }
+
+        if let Some(include_value) = include_value {
+            if let Some(array) = include_value.as_array() {
+                let mut dirs: Vec<CoverageDir> = Vec::with_capacity(array.items().len());
+                for item in array.items() {
+                    if let Some(str) = item.as_str() {
+                        let str = match Self::str_replacing_templates(Box::from(str), source) {
+                            Ok(v) => v,
+                            Err(_) => return Ok(None),
+                        };
+                        dirs.push(include_pattern_coverage(&str));
+                    }
+                }
+                result.include_dirs = Some(dirs.into_boxed_slice());
+            }
+        }
+
+        if let Some(exclude_value) = exclude_value {
+            if let Some(array) = exclude_value.as_array() {
+                let mut dirs: Vec<Box<[u8]>> = Vec::new();
+                for item in array.items() {
+                    if let Some(str) = item.as_str() {
+                        // Only wildcard-free directory entries; a glob or file
+                        // exclude cannot be applied at directory granularity
+                        // without over-excluding.
+                        if strings::index_of_any(str, b"*?").is_none() && !looks_like_file(str) {
+                            let str = match Self::str_replacing_templates(Box::from(str), source) {
+                                Ok(v) => v,
+                                Err(_) => return Ok(None),
+                            };
+                            dirs.push(str);
+                        }
+                    }
+                }
+                result.exclude_dirs = dirs.into_boxed_slice();
             }
         }
         let mut has_base_url = false;

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -121,14 +121,16 @@ pub(crate) struct CoverageDir {
     pub recursive: bool,
 }
 
-const SOURCE_EXTENSIONS: &[&[u8]] = &[
-    b".ts", b".tsx", b".mts", b".cts", b".js", b".jsx", b".mjs", b".cjs", b".json",
-];
-
-fn looks_like_file(path: &[u8]) -> bool {
-    SOURCE_EXTENSIONS
-        .iter()
-        .any(|ext| strings::ends_with(path, ext))
+/// tsc reads an entry whose last segment has an extension (`env.d.ts`, `src/App.vue`) as a
+/// file and any other entry as a directory. A leading dot (`.storybook`) is not an extension.
+fn names_file(entry: &[u8]) -> bool {
+    let last_segment = match strings::last_index_of_any(entry, b"/\\") {
+        Some(sep) => &entry[sep + 1..],
+        None => entry,
+    };
+    last_segment
+        .get(1..)
+        .is_some_and(|rest| strings::contains_char(rest, b'.'))
 }
 
 /// The directory an "include" entry covers: the literal prefix before its first
@@ -148,7 +150,7 @@ pub(crate) fn include_pattern_coverage(pattern: &[u8]) -> CoverageDir {
                 recursive: descends,
             }
         }
-        None if looks_like_file(pattern) => CoverageDir {
+        None if names_file(pattern) => CoverageDir {
             dir: Box::from(bun_paths::dirname(pattern).unwrap_or(b"")),
             recursive: false,
         },
@@ -575,7 +577,7 @@ impl TSConfigJSON {
         result.exclude_dirs = exclude.map(|exclude| {
             exclude
                 .into_iter()
-                .filter(|entry| !strings::contains_any(entry, b"*?") && !looks_like_file(entry))
+                .filter(|entry| !strings::contains_any(entry, b"*?"))
                 .collect()
         });
         let mut has_base_url = false;

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -114,14 +114,10 @@ impl JsonCache {
     }
 }
 
-/// A directory covered by a "files"/"include" entry, derived at parse time
-/// (dir is config-relative until the resolver absolutizes it).
+/// A directory covered by a "files"/"include" entry (absolute after `Resolver::parse_tsconfig`).
 pub(crate) struct CoverageDir {
     pub dir: Box<[u8]>,
-    /// Whether subdirectories are covered too. Only `**` globs and bare
-    /// directory includes recurse; file entries and single-`*` globs
-    /// (`vite.config.*`, `src/*.ts`) match files directly in `dir` only, so
-    /// a root-level entry must not claim the whole tree.
+    /// False when the entry only matches files directly in `dir` (`env.d.ts`, `src/*.ts`).
     pub recursive: bool,
 }
 
@@ -135,36 +131,31 @@ fn looks_like_file(path: &[u8]) -> bool {
         .any(|ext| strings::ends_with(path, ext))
 }
 
-/// The directory an "include" pattern covers: the literal prefix before the
-/// first wildcard, truncated to the last separator (empty = the config dir).
-/// Recursion requires a `**` segment or a wildcard-free directory include.
+/// The directory an "include" entry covers: the literal prefix before its first
+/// wildcard (empty = the config dir), or the entry itself when it names a directory.
 pub(crate) fn include_pattern_coverage(pattern: &[u8]) -> CoverageDir {
     match strings::index_of_any(pattern, b"*?") {
         Some(glob) => {
-            let prefix = &pattern[..glob];
-            let dir = match prefix.iter().rposition(|&c| bun_paths::is_sep_any(c)) {
+            let (prefix, rest) = pattern.split_at(glob);
+            let dir = match strings::last_index_of_any(prefix, b"/\\") {
                 Some(sep) => &prefix[..sep],
                 None => b"",
             };
+            // Segments after the wildcard (`packages/*/src`, `src/*/index.ts`) match below `dir`.
+            let descends = strings::contains_any(rest, b"/\\") || strings::contains(pattern, b"**");
             CoverageDir {
                 dir: Box::from(dir),
-                recursive: strings::contains(pattern, b"**"),
+                recursive: descends,
             }
         }
-        None => {
-            if looks_like_file(pattern) {
-                CoverageDir {
-                    dir: Box::from(bun_paths::dirname(pattern).unwrap_or(b"")),
-                    recursive: false,
-                }
-            } else {
-                // A bare directory include covers its whole subtree.
-                CoverageDir {
-                    dir: Box::from(pattern),
-                    recursive: true,
-                }
-            }
-        }
+        None if looks_like_file(pattern) => CoverageDir {
+            dir: Box::from(bun_paths::dirname(pattern).unwrap_or(b"")),
+            recursive: false,
+        },
+        None => CoverageDir {
+            dir: Box::from(pattern),
+            recursive: true,
+        },
     }
 }
 
@@ -200,36 +191,22 @@ pub struct TSConfigJSON {
 
     pub(crate) extends: Box<[u8]>,
 
-    /// Paths from "references[].path", made absolute by the resolver.
-    /// Non-empty for solution-style configs; consumed by the dir-info walk,
-    /// which loads them into `reference_configs`.
+    /// "references[].path" entries, absolute after `Resolver::parse_tsconfig`.
     pub(crate) references: Box<[Box<[u8]>]>,
 
-    /// Parsed configs for `references`, owned by this (solution-style) config
-    /// and dropped with it. Loaded lazily by
-    /// `Resolver::load_tsconfig_references` on the first directory this
-    /// config does not cover; read via `reference_configs()`. The
-    /// `UnsafeCell` is sound because every access runs under the resolver
-    /// lock (like the DirInfo cache itself).
-    pub(crate) reference_configs: core::cell::UnsafeCell<Box<[Box<TSConfigJSON>]>>,
+    /// Projects reachable through `references`, parsed by
+    /// `Resolver::ensure_tsconfig_references`. `OnceLock` because every resolver
+    /// thread shares this config through the DirInfo cache.
+    pub(crate) reference_configs: std::sync::OnceLock<Box<[Box<TSConfigJSON>]>>,
 
-    /// Whether `reference_configs` has been populated (set even when loading
-    /// produced nothing, so a broken solution is not retried per lookup).
-    pub(crate) references_loaded: core::cell::Cell<bool>,
-
-    /// Directories derived from the "files" entries (never recursive);
-    /// `None` when the key is absent. Absolute after `parse_tsconfig`.
+    /// Directories of the "files" entries; `None` when the key is absent.
     pub(crate) files_dirs: Option<Box<[CoverageDir]>>,
 
-    /// Directories derived from the "include" patterns; `None` when the key
-    /// is absent. Absolute after `parse_tsconfig`.
+    /// Directories covered by the "include" entries; `None` when the key is absent.
     pub(crate) include_dirs: Option<Box<[CoverageDir]>>,
 
-    /// Directories from wildcard-free "exclude" entries (always recursive);
-    /// vetoes `include` and default coverage, never `files`. Glob excludes
-    /// are ignored rather than over-excluding. Absolute after
-    /// `parse_tsconfig`.
-    pub(crate) exclude_dirs: Box<[Box<[u8]>]>,
+    /// Wildcard-free "exclude" entries (glob excludes are ignored); `None` when the key is absent.
+    pub(crate) exclude_dirs: Option<Box<[Box<[u8]>]>>,
 
     /// The verbatim values of "compilerOptions.paths". The keys are patterns to
     /// match and the values are arrays of fallback paths to search. Each key and
@@ -259,11 +236,10 @@ impl Default for TSConfigJSON {
             base_url_for_paths: Box::default(),
             extends: Box::default(),
             references: Box::default(),
-            reference_configs: core::cell::UnsafeCell::new(Box::default()),
-            references_loaded: core::cell::Cell::new(false),
+            reference_configs: std::sync::OnceLock::new(),
             files_dirs: None,
             include_dirs: None,
-            exclude_dirs: Box::default(),
+            exclude_dirs: None,
             paths: PathsMap::default(),
             jsx: options::jsx::Pragma::default(),
             jsx_flags: JsxFieldSet::empty(),
@@ -318,36 +294,11 @@ impl TSConfigJSON {
         !self.base_url.is_empty()
     }
 
-    /// Read access to the lazily-loaded referenced projects.
-    pub(crate) fn reference_configs(&self) -> &[Box<TSConfigJSON>] {
-        // SAFETY: written at most once via `set_reference_configs` (under the
-        // resolver lock, which serializes all tsconfig access) before any
-        // reader observes `references_loaded() == true`.
-        unsafe { &*self.reference_configs.get() }
-    }
-
-    pub(crate) fn references_loaded(&self) -> bool {
-        self.references_loaded.get()
-    }
-
-    /// Publishes the loaded referenced projects; see `reference_configs`.
-    pub(crate) fn set_reference_configs(&self, configs: Box<[Box<TSConfigJSON>]>) {
-        // SAFETY: sole write site, serialized by the resolver lock; no
-        // `reference_configs()` borrow is live across a resolver call.
-        unsafe { *self.reference_configs.get() = configs };
-        self.references_loaded.set(true);
-    }
-
-    /// Whether files in `source_dir` belong to this project, judged by the
-    /// directories its "files"/"include" entries cover (minus wildcard-free
-    /// "exclude" directories). When neither key is present, TypeScript
-    /// defaults "include" to `**/*`, so the config covers its whole
-    /// directory subtree.
+    /// Whether files in `source_dir` belong to this project per its "files"/"include"/"exclude"
+    /// (with neither "files" nor "include", tsc defaults to `**/*` under the config's directory).
     pub(crate) fn covers_dir(&self, source_dir: &[u8]) -> bool {
         use bun_paths::resolve_path::{ParentEqual, is_parent_or_equal};
-        // `is_parent_or_equal` strips the parent's trailing separators but
-        // not the child's; a trailing slash on `source_dir` would turn an
-        // exact match into `Parent` and defeat non-recursive entries.
+        // `is_parent_or_equal` strips trailing separators from its first argument only.
         let mut source_dir = source_dir;
         while let [head @ .., last] = source_dir {
             if !bun_paths::is_sep_any(*last) {
@@ -360,42 +311,35 @@ impl TSConfigJSON {
             ParentEqual::Parent => c.recursive && !c.dir.is_empty(),
             ParentEqual::Unrelated => false,
         };
-        // "files" entries are exempt from "exclude".
+        // "exclude" does not apply to "files".
         if self.files_dirs.iter().flatten().any(matches) {
             return true;
         }
         let include_match = match (&self.include_dirs, &self.files_dirs) {
             (Some(dirs), _) => dirs.iter().any(matches),
-            // Neither key: default "include" of `**/*` under the config dir.
             (None, None) => {
                 let config_dir = bun_paths::dirname(&self.abs_path).unwrap_or(b"");
                 !config_dir.is_empty()
                     && is_parent_or_equal(config_dir, source_dir) != ParentEqual::Unrelated
             }
-            // "files" present without "include": include defaults to [].
             (None, Some(_)) => false,
         };
         include_match
-            && !self.exclude_dirs.iter().any(|dir| {
+            && !self.exclude_dirs.iter().flatten().any(|dir| {
                 !dir.is_empty() && is_parent_or_equal(dir, source_dir) != ParentEqual::Unrelated
             })
     }
 
-    /// Ordered configs to consult for files in `source_dir`. A config
-    /// covering the directory owns its files outright (references are never
-    /// consulted, matching tsc). Otherwise each loaded referenced project
-    /// covering the directory is tried in reference order, and the config
-    /// itself comes last so its own paths/baseUrl still apply when no
-    /// referenced project resolves the import (the common pre-references
-    /// workaround of putting paths on the solution root).
+    /// The configs whose "paths"/"baseUrl" apply to files in `source_dir`, in priority order:
+    /// when this config does not cover the directory itself, each referenced project covering
+    /// it (in reference order), then this config, so a solution root's own "paths" still apply.
     pub(crate) fn candidates_for_dir<'a, 'b>(
         &'a self,
         source_dir: &'b [u8],
     ) -> impl Iterator<Item = &'a TSConfigJSON> + use<'a, 'b> {
-        let refs: &'a [Box<TSConfigJSON>] = if self.covers_dir(source_dir) {
-            &[]
-        } else {
-            self.reference_configs()
+        let refs: &'a [Box<TSConfigJSON>] = match self.reference_configs.get() {
+            Some(refs) if !self.covers_dir(source_dir) => refs,
+            _ => &[],
         };
         refs.iter()
             .map(|r| &**r)
@@ -403,9 +347,7 @@ impl TSConfigJSON {
             .chain(core::iter::once(self))
     }
 
-    /// The primary config for files in `source_dir`: the first candidate
-    /// from `candidates_for_dir` (used where only one config can apply,
-    /// e.g. jsx/decorator options).
+    /// The first of `candidates_for_dir`, for options that cannot fall through (jsx, decorators).
     pub(crate) fn for_source_dir<'a>(&'a self, source_dir: &[u8]) -> &'a TSConfigJSON {
         self.candidates_for_dir(source_dir)
             .next()
@@ -493,6 +435,25 @@ impl TSConfigJSON {
         Ok(Box::from(&written[..len]))
     }
 
+    /// The string entries of a "files"/"include"/"exclude" array. `Some` even when empty:
+    /// an empty key still disables tsc's default include and still overrides the base
+    /// config's key through "extends".
+    fn path_list(
+        value: Option<&bun_ast::E::JsonValue>,
+        source: &bun_ast::Source,
+    ) -> Result<Option<Vec<Box<[u8]>>>, bun_alloc::AllocError> {
+        let Some(array) = value.and_then(|value| value.as_array()) else {
+            return Ok(None);
+        };
+        let mut entries = Vec::with_capacity(array.items().len());
+        for item in array.items() {
+            if let Some(str) = item.as_str() {
+                entries.push(Self::str_replacing_templates(Box::from(str), source)?);
+            }
+        }
+        Ok(Some(entries))
+    }
+
     pub fn parse(
         log: &mut bun_ast::Log,
         source: &bun_ast::Source,
@@ -562,8 +523,6 @@ impl TSConfigJSON {
             }
         }
 
-        // Parse "references" (solution-style configs). Like "extends", skipped
-        // inside node_modules.
         if let Some(references_value) = references_value {
             if !source.path.is_node_module() {
                 if let Some(array) = references_value.as_array() {
@@ -589,65 +548,36 @@ impl TSConfigJSON {
             }
         }
 
-        // Parse "files"/"include"/"exclude" into the directories they cover,
-        // used to pick the referenced project for a source directory. `Some`
-        // records that the key was present even when it covers nothing
-        // ("files": []).
-        if let Some(files_value) = files_value {
-            if let Some(array) = files_value.as_array() {
-                let mut dirs: Vec<CoverageDir> = Vec::with_capacity(array.items().len());
-                for item in array.items() {
-                    if let Some(str) = item.as_str() {
-                        let str = match Self::str_replacing_templates(Box::from(str), source) {
-                            Ok(v) => v,
-                            Err(_) => return Ok(None),
-                        };
-                        dirs.push(CoverageDir {
-                            dir: Box::from(bun_paths::dirname(&str).unwrap_or(b"")),
-                            recursive: false,
-                        });
-                    }
-                }
-                result.files_dirs = Some(dirs.into_boxed_slice());
-            }
-        }
-
-        if let Some(include_value) = include_value {
-            if let Some(array) = include_value.as_array() {
-                let mut dirs: Vec<CoverageDir> = Vec::with_capacity(array.items().len());
-                for item in array.items() {
-                    if let Some(str) = item.as_str() {
-                        let str = match Self::str_replacing_templates(Box::from(str), source) {
-                            Ok(v) => v,
-                            Err(_) => return Ok(None),
-                        };
-                        dirs.push(include_pattern_coverage(&str));
-                    }
-                }
-                result.include_dirs = Some(dirs.into_boxed_slice());
-            }
-        }
-
-        if let Some(exclude_value) = exclude_value {
-            if let Some(array) = exclude_value.as_array() {
-                let mut dirs: Vec<Box<[u8]>> = Vec::new();
-                for item in array.items() {
-                    if let Some(str) = item.as_str() {
-                        // Only wildcard-free directory entries; a glob or file
-                        // exclude cannot be applied at directory granularity
-                        // without over-excluding.
-                        if strings::index_of_any(str, b"*?").is_none() && !looks_like_file(str) {
-                            let str = match Self::str_replacing_templates(Box::from(str), source) {
-                                Ok(v) => v,
-                                Err(_) => return Ok(None),
-                            };
-                            dirs.push(str);
-                        }
-                    }
-                }
-                result.exclude_dirs = dirs.into_boxed_slice();
-            }
-        }
+        let (files, include, exclude) = match (
+            Self::path_list(files_value, source),
+            Self::path_list(include_value, source),
+            Self::path_list(exclude_value, source),
+        ) {
+            (Ok(files), Ok(include), Ok(exclude)) => (files, include, exclude),
+            _ => return Ok(None),
+        };
+        result.files_dirs = files.map(|files| {
+            files
+                .iter()
+                .map(|file| CoverageDir {
+                    dir: Box::from(bun_paths::dirname(file).unwrap_or(b"")),
+                    recursive: false,
+                })
+                .collect()
+        });
+        result.include_dirs = include.map(|include| {
+            include
+                .iter()
+                .map(|p| include_pattern_coverage(p))
+                .collect()
+        });
+        // Glob excludes cannot be applied per directory without over-excluding; they are dropped.
+        result.exclude_dirs = exclude.map(|exclude| {
+            exclude
+                .into_iter()
+                .filter(|entry| !strings::contains_any(entry, b"*?") && !looks_like_file(entry))
+                .collect()
+        });
         let mut has_base_url = false;
 
         // Parse "compilerOptions"

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -1191,4 +1191,36 @@ describe("bundler", () => {
       },
     });
   });
+
+  // A solution-style root tsconfig ("files": [] + "references") takes jsx
+  // settings from the referenced project covering the file. Bundler only:
+  // `bun run` takes jsx from the cwd config.
+  itBundled("jsx/SolutionTsconfigReferences", {
+    files: {
+      "/tsconfig.json": /* json */ `{
+        "files": [],
+        "references": [{ "path": "./tsconfig.app.json" }]
+      }`,
+      "/tsconfig.app.json": /* json */ `{
+        "include": ["src"],
+        "compilerOptions": {
+          "jsx": "react",
+          "jsxFactory": "h",
+          "jsxFragmentFactory": "hFrag"
+        }
+      }`,
+      "/src/index.jsx": /* jsx */ `
+        function h(tag, props) { return { tag, props }; }
+        const hFrag = "fragment";
+        console.log(<a></a>);
+      `,
+    },
+    entryPoints: ["/src/index.jsx"],
+    target: "bun",
+    onAfterBundle(api) {
+      const file = api.readFile("out.js");
+      expect(file).toContain('h("a"');
+      expect(file).not.toContain("jsx-dev-runtime");
+    },
+  });
 });

--- a/test/js/bun/resolve/tsconfig-references.test.ts
+++ b/test/js/bun/resolve/tsconfig-references.test.ts
@@ -204,6 +204,27 @@ test.concurrent("solution root's own paths apply when the selected project has n
   expectRan(await run(String(dir), "src/index.ts"), "root-paths\n");
 });
 
+test.concurrent("the covering project's baseUrl is tried before the solution root's paths", async () => {
+  using dir = tempDir("tsconfig-refs-baseurl-before-root-paths", {
+    "tsconfig.json": JSON.stringify({
+      files: [],
+      references: [{ path: "./tsconfig.app.json" }],
+      compilerOptions: { paths: { "utils/*": ["./legacy-utils/*"] } },
+    }),
+    "tsconfig.app.json": JSON.stringify({
+      include: ["src"],
+      compilerOptions: { baseUrl: "./src" },
+    }),
+    "src/index.ts": `import { who } from "utils/who"; console.log(who);`,
+    "src/utils/who.ts": `export const who = "app-baseurl";`,
+    "legacy-utils/who.ts": `export const who = "root-paths";`,
+  });
+
+  // The root's paths are a fallback for imports the covering project cannot
+  // resolve at all, not a layer above that project's own baseUrl.
+  expectRan(await run(String(dir), "src/index.ts"), "app-baseurl\n");
+});
+
 test.concurrent("a single-star glob include covers only its directory", async () => {
   using dir = tempDir("tsconfig-refs-nonrecursive", {
     "tsconfig.json": JSON.stringify({

--- a/test/js/bun/resolve/tsconfig-references.test.ts
+++ b/test/js/bun/resolve/tsconfig-references.test.ts
@@ -492,6 +492,30 @@ test.concurrent("referenced project using 'files' instead of 'include'", async (
   expectRan(await run(String(dir), "src/main.ts"), "hi\n");
 });
 
+test.concurrent("an include entry naming a non-TypeScript file covers only its directory", async () => {
+  using dir = tempDir("tsconfig-refs-include-file", {
+    "tsconfig.json": JSON.stringify({
+      files: [],
+      references: [{ path: "./tsconfig.app.json" }],
+    }),
+    "tsconfig.app.json": JSON.stringify({
+      include: ["src/App.vue"],
+      compilerOptions: { paths: { "~/*": ["./src/*"] } },
+    }),
+    "src/App.vue": "<template />",
+    "src/main.ts": `import { greet } from "~/greet"; console.log(greet());`,
+    "src/greet.ts": `export function greet() { return "vue"; }`,
+    "src/nested/main.ts": `import { greet } from "~/greet"; console.log(greet());`,
+  });
+
+  // Any extension makes the entry a file entry (tsc's rule), so it claims src/
+  // like a "files" entry would, and like one it does not claim subdirectories.
+  expectRan(await run(String(dir), "src/main.ts"), "vue\n");
+  const nested = await run(String(dir), "src/nested/main.ts");
+  expect(nested.stderr).toContain("Cannot find module '~/greet'");
+  expect(nested.exitCode).not.toBe(0);
+});
+
 test.concurrent("referenced project combined with extends", async () => {
   using dir = tempDir("tsconfig-refs-extends", {
     "tsconfig.json": JSON.stringify({

--- a/test/js/bun/resolve/tsconfig-references.test.ts
+++ b/test/js/bun/resolve/tsconfig-references.test.ts
@@ -49,6 +49,41 @@ test.concurrent("paths come from the referenced project covering the file", asyn
   expectRan(await run(String(dir), "src/web/index.ts"), "web\n");
 });
 
+test.concurrent("worker threads resolving under the same solution root at once", async () => {
+  // main.ts sits outside the solution root, so the referenced projects are
+  // first needed by the workers' own resolvers, on several threads at the same
+  // time; the shared solution config must load them once and serve them all.
+  using dir = tempDir("tsconfig-refs-workers", {
+    "main.ts": `
+      const results = await Promise.all(
+        Array.from({ length: 4 }, () => {
+          const { promise, resolve, reject } = Promise.withResolvers();
+          const worker = new Worker(new URL("./app/src/worker.ts", import.meta.url).href);
+          worker.onmessage = event => {
+            worker.terminate();
+            resolve(event.data);
+          };
+          worker.onerror = event => reject(new Error(event.message));
+          return promise;
+        }),
+      );
+      console.log(results.join(","));
+    `,
+    "app/tsconfig.json": JSON.stringify({
+      files: [],
+      references: [{ path: "./tsconfig.app.json" }],
+    }),
+    "app/tsconfig.app.json": JSON.stringify({
+      include: ["src"],
+      compilerOptions: { paths: { "@/*": ["./src/*"] } },
+    }),
+    "app/src/worker.ts": `import { who } from "@/who"; postMessage(who);`,
+    "app/src/who.ts": `export const who = "app";`,
+  });
+
+  expectRan(await run(String(dir), "main.ts"), "app,app,app,app\n");
+});
+
 test.concurrent("a reference path may point at a project directory", async () => {
   // The referenced project's config lives away from the source tree so the
   // nearest enclosing config of main.ts is the solution root: resolution
@@ -195,6 +230,31 @@ test.concurrent("a single-star glob include covers only its directory", async ()
   expectRan(await run(String(dir), "src/nested/index.ts"), "deep\n");
 });
 
+test.concurrent("a wildcard before the last segment covers the directories below it", async () => {
+  using dir = tempDir("tsconfig-refs-mid-wildcard", {
+    "tsconfig.json": JSON.stringify({
+      files: [],
+      references: [{ path: "./tsconfig.packages.json" }, { path: "./tsconfig.apps.json" }],
+    }),
+    // tsc reads a directory-like last segment as packages/*/src/**/*.
+    "tsconfig.packages.json": JSON.stringify({
+      include: ["packages/*/src"],
+      compilerOptions: { paths: { "@/*": ["./packages-impl/*"] } },
+    }),
+    "tsconfig.apps.json": JSON.stringify({
+      include: ["apps/*/main.ts"],
+      compilerOptions: { paths: { "@/*": ["./apps-impl/*"] } },
+    }),
+    "packages/core/src/util/index.ts": `import { who } from "@/who"; console.log(who);`,
+    "apps/web/main.ts": `import { who } from "@/who"; console.log(who);`,
+    "packages-impl/who.ts": `export const who = "packages";`,
+    "apps-impl/who.ts": `export const who = "apps";`,
+  });
+
+  expectRan(await run(String(dir), "packages/core/src/util/index.ts"), "packages\n");
+  expectRan(await run(String(dir), "apps/web/main.ts"), "apps\n");
+});
+
 test.concurrent("include with ${configDir} selects the project", async () => {
   using dir = tempDir("tsconfig-refs-configdir", {
     "tsconfig.json": JSON.stringify({
@@ -235,6 +295,38 @@ test.concurrent("an excluded directory is not covered by the project", async () 
 
   expectRan(await run(String(dir), "src/index.ts"), "a\n");
   expectRan(await run(String(dir), "src/legacy/index.ts"), "b\n");
+});
+
+test.concurrent("exclude is inherited through extends unless the extending config sets its own", async () => {
+  using dir = tempDir("tsconfig-refs-exclude-extends", {
+    "tsconfig.json": JSON.stringify({
+      files: [],
+      references: [{ path: "./tsconfig.inherits.json" }, { path: "./tsconfig.overrides.json" }],
+    }),
+    "tsconfig.base.json": JSON.stringify({
+      exclude: ["src/generated"],
+    }),
+    "tsconfig.inherits.json": JSON.stringify({
+      extends: "./tsconfig.base.json",
+      include: ["src"],
+      compilerOptions: { paths: { "@/*": ["./inherits-impl/*"] } },
+    }),
+    "tsconfig.overrides.json": JSON.stringify({
+      extends: "./tsconfig.base.json",
+      include: ["src"],
+      exclude: [],
+      compilerOptions: { paths: { "@/*": ["./overrides-impl/*"] } },
+    }),
+    "src/index.ts": `import { who } from "@/who"; console.log(who);`,
+    "src/generated/index.ts": `import { who } from "@/who"; console.log(who);`,
+    "inherits-impl/who.ts": `export const who = "inherits";`,
+    "overrides-impl/who.ts": `export const who = "overrides";`,
+  });
+
+  // Both projects cover src/, so the first reference wins there. src/generated/
+  // is excluded by the inherited exclude but not by the empty one replacing it.
+  expectRan(await run(String(dir), "src/index.ts"), "inherits\n");
+  expectRan(await run(String(dir), "src/generated/index.ts"), "overrides\n");
 });
 
 test.concurrent("a tsconfig extending itself still resolves the directory", async () => {

--- a/test/js/bun/resolve/tsconfig-references.test.ts
+++ b/test/js/bun/resolve/tsconfig-references.test.ts
@@ -1,0 +1,552 @@
+// Solution-style tsconfig.json: a root config with "files": [] and
+// "references" delegates to the referenced project whose "files"/"include"
+// covers the importing file, like tsc does.
+// https://github.com/oven-sh/bun/issues/34234
+// https://github.com/oven-sh/bun/issues/4774
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+async function run(cwd: string, entry: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", entry],
+    env: bunEnv,
+    cwd,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+function expectRan(result: { stdout: string; stderr: string; exitCode: number }, stdout: string) {
+  expect(result.stderr).toBe("");
+  expect(result.stdout).toBe(stdout);
+  expect(result.exitCode).toBe(0);
+}
+
+test.concurrent("paths come from the referenced project covering the file", async () => {
+  using dir = tempDir("tsconfig-refs-basic", {
+    "tsconfig.json": JSON.stringify({
+      files: [],
+      references: [{ path: "./tsconfig.web.json" }, { path: "./tsconfig.server.json" }],
+    }),
+    "tsconfig.web.json": JSON.stringify({
+      include: ["src/web"],
+      compilerOptions: { paths: { "@/*": ["./src/web/*"] } },
+    }),
+    "tsconfig.server.json": JSON.stringify({
+      include: ["src/server"],
+      compilerOptions: { paths: { "@/*": ["./src/server/*"] } },
+    }),
+    "src/server/index.ts": `import { log } from "@/common/log"; log();`,
+    "src/server/common/log.ts": `export function log() { console.log("server"); }`,
+    "src/web/index.ts": `import { log } from "@/common/log"; log();`,
+    "src/web/common/log.ts": `export function log() { console.log("web"); }`,
+  });
+
+  // The same "@/*" alias maps to a different directory per project.
+  expectRan(await run(String(dir), "src/server/index.ts"), "server\n");
+  expectRan(await run(String(dir), "src/web/index.ts"), "web\n");
+});
+
+test.concurrent("a reference path may point at a project directory", async () => {
+  // The referenced project's config lives away from the source tree so the
+  // nearest enclosing config of main.ts is the solution root: resolution
+  // succeeds only if <path>/tsconfig.json is derived from the directory.
+  using dir = tempDir("tsconfig-refs-dir", {
+    "tsconfig.json": JSON.stringify({
+      files: [],
+      references: [{ path: "./configs/app" }],
+    }),
+    "configs/app/tsconfig.json": JSON.stringify({
+      include: ["../../src"],
+      compilerOptions: { paths: { "#lib/*": ["../../src/lib/*"] } },
+    }),
+    "src/main.ts": `import { value } from "#lib/value"; console.log(value);`,
+    "src/lib/value.ts": `export const value = 42;`,
+  });
+
+  expectRan(await run(String(dir), "src/main.ts"), "42\n");
+});
+
+test.concurrent("a file no referenced project covers gets no project paths", async () => {
+  using dir = tempDir("tsconfig-refs-uncovered", {
+    "tsconfig.json": JSON.stringify({
+      files: [],
+      references: [{ path: "./tsconfig.web.json" }, { path: "./tsconfig.server.json" }],
+    }),
+    "tsconfig.web.json": JSON.stringify({
+      include: ["src/web"],
+      compilerOptions: { paths: { "@/*": ["./src/web/*"] } },
+    }),
+    "tsconfig.server.json": JSON.stringify({
+      include: ["src/server"],
+      compilerOptions: { paths: { "@/*": ["./src/server/*"] } },
+    }),
+    "src/web/x.ts": `export const x = "web";`,
+    "src/server/x.ts": `export const x = "server";`,
+    "scripts/tool.ts": `import { x } from "@/x"; console.log(x);`,
+    "scripts/rel.ts": `import { y } from "./y"; console.log(y);`,
+    "scripts/y.ts": `export const y = "rel";`,
+  });
+
+  // Neither project's "@/*" alias leaks into the uncovered directory.
+  const tool = await run(String(dir), "scripts/tool.ts");
+  expect(tool.stderr).toContain("Cannot find module '@/x'");
+  expect(tool.exitCode).not.toBe(0);
+
+  // Ordinary resolution from the uncovered directory still works.
+  expectRan(await run(String(dir), "scripts/rel.ts"), "rel\n");
+});
+
+test.concurrent("solution root's own paths apply to files no referenced project covers", async () => {
+  using dir = tempDir("tsconfig-refs-root-fallback", {
+    "tsconfig.json": JSON.stringify({
+      files: [],
+      references: [{ path: "./tsconfig.app.json" }],
+      compilerOptions: { paths: { "#root/*": ["./lib/*"] } },
+    }),
+    "tsconfig.app.json": JSON.stringify({
+      include: ["src"],
+      compilerOptions: { paths: { "#app/*": ["./src/*"] } },
+    }),
+    "src/index.ts": `import { v } from "#app/v"; console.log(v);`,
+    "src/v.ts": `export const v = "app";`,
+    "scripts/tool.ts": `import { u } from "#root/u"; console.log(u);`,
+    "lib/u.ts": `export const u = "root";`,
+  });
+
+  // Covered file uses the referenced project's paths; uncovered file falls
+  // back to the solution config's own paths.
+  expectRan(await run(String(dir), "src/index.ts"), "app\n");
+  expectRan(await run(String(dir), "scripts/tool.ts"), "root\n");
+});
+
+test.concurrent("root-level file globs do not claim the whole tree (create-vue layout)", async () => {
+  // tsconfig.node.json is listed first but its include entries are
+  // root-level files and single-`*` globs, so they must cover only the root
+  // directory; src/** belongs to tsconfig.app.json.
+  using dir = tempDir("tsconfig-refs-vue", {
+    "tsconfig.json": JSON.stringify({
+      files: [],
+      references: [{ path: "./tsconfig.node.json" }, { path: "./tsconfig.app.json" }],
+    }),
+    "tsconfig.node.json": JSON.stringify({
+      include: ["vite.config.*", "env.d.ts"],
+      compilerOptions: { paths: { "@/*": ["./node-impl/*"] } },
+    }),
+    "tsconfig.app.json": JSON.stringify({
+      include: ["src/**/*", "src/**/*.vue"],
+      compilerOptions: { paths: { "@/*": ["./src/*"] } },
+    }),
+    "src/index.ts": `import { who } from "@/who"; console.log(who);`,
+    "src/who.ts": `export const who = "app";`,
+    "vite.config.ts": `import { who } from "@/who"; console.log(who);`,
+    "node-impl/who.ts": `export const who = "node";`,
+  });
+
+  expectRan(await run(String(dir), "src/index.ts"), "app\n");
+  expectRan(await run(String(dir), "vite.config.ts"), "node\n");
+});
+
+test.concurrent("solution root's own paths apply when the selected project has no matching key", async () => {
+  // The pre-references workaround for #4774 puts paths on the solution root;
+  // selecting a referenced project must not stop the root's paths from
+  // applying when the project declares none.
+  using dir = tempDir("tsconfig-refs-root-paths", {
+    "tsconfig.json": JSON.stringify({
+      files: [],
+      references: [{ path: "./tsconfig.app.json" }],
+      compilerOptions: { paths: { "@/*": ["./src/*"] } },
+    }),
+    "tsconfig.app.json": JSON.stringify({
+      include: ["src"],
+    }),
+    "src/index.ts": `import { v } from "@/v"; console.log(v);`,
+    "src/v.ts": `export const v = "root-paths";`,
+  });
+
+  expectRan(await run(String(dir), "src/index.ts"), "root-paths\n");
+});
+
+test.concurrent("a single-star glob include covers only its directory", async () => {
+  using dir = tempDir("tsconfig-refs-nonrecursive", {
+    "tsconfig.json": JSON.stringify({
+      files: [],
+      references: [{ path: "./tsconfig.top.json" }, { path: "./tsconfig.deep.json" }],
+    }),
+    "tsconfig.top.json": JSON.stringify({
+      include: ["src/*.ts"],
+      compilerOptions: { paths: { "@/*": ["./top-impl/*"] } },
+    }),
+    "tsconfig.deep.json": JSON.stringify({
+      include: ["src/**/*.ts"],
+      compilerOptions: { paths: { "@/*": ["./deep-impl/*"] } },
+    }),
+    "src/index.ts": `import { who } from "@/who"; console.log(who);`,
+    "src/nested/index.ts": `import { who } from "@/who"; console.log(who);`,
+    "top-impl/who.ts": `export const who = "top";`,
+    "deep-impl/who.ts": `export const who = "deep";`,
+  });
+
+  // src/*.ts matches files directly in src/ only; src/nested/ falls to the
+  // recursive reference.
+  expectRan(await run(String(dir), "src/index.ts"), "top\n");
+  expectRan(await run(String(dir), "src/nested/index.ts"), "deep\n");
+});
+
+test.concurrent("include with ${configDir} selects the project", async () => {
+  using dir = tempDir("tsconfig-refs-configdir", {
+    "tsconfig.json": JSON.stringify({
+      files: [],
+      references: [{ path: "./tsconfig.app.json" }],
+    }),
+    "tsconfig.app.json": JSON.stringify({
+      include: ["${configDir}/src"],
+      compilerOptions: { paths: { "@/*": ["${configDir}/src/*"] } },
+    }),
+    "src/index.ts": `import { v } from "@/v"; console.log(v);`,
+    "src/v.ts": `export const v = "configdir";`,
+  });
+
+  expectRan(await run(String(dir), "src/index.ts"), "configdir\n");
+});
+
+test.concurrent("an excluded directory is not covered by the project", async () => {
+  using dir = tempDir("tsconfig-refs-exclude", {
+    "tsconfig.json": JSON.stringify({
+      files: [],
+      references: [{ path: "./tsconfig.a.json" }, { path: "./tsconfig.b.json" }],
+    }),
+    "tsconfig.a.json": JSON.stringify({
+      include: ["src"],
+      exclude: ["src/legacy"],
+      compilerOptions: { paths: { "@/*": ["./a-impl/*"] } },
+    }),
+    "tsconfig.b.json": JSON.stringify({
+      include: ["src/legacy"],
+      compilerOptions: { paths: { "@/*": ["./b-impl/*"] } },
+    }),
+    "src/index.ts": `import { who } from "@/who"; console.log(who);`,
+    "src/legacy/index.ts": `import { who } from "@/who"; console.log(who);`,
+    "a-impl/who.ts": `export const who = "a";`,
+    "b-impl/who.ts": `export const who = "b";`,
+  });
+
+  expectRan(await run(String(dir), "src/index.ts"), "a\n");
+  expectRan(await run(String(dir), "src/legacy/index.ts"), "b\n");
+});
+
+test.concurrent("a tsconfig extending itself still resolves the directory", async () => {
+  // On older versions a cyclic extends chain failed the whole directory
+  // load; now the walk stops at the bound and merges what it has.
+  using dir = tempDir("tsconfig-extends-self", {
+    "tsconfig.json": JSON.stringify({
+      extends: "./tsconfig.json",
+      compilerOptions: { paths: { "@/*": ["./src/*"] } },
+    }),
+    "index.ts": `import { v } from "@/v"; console.log(v);`,
+    "src/v.ts": `export const v = "cycle";`,
+  });
+
+  expectRan(await run(String(dir), "index.ts"), "cycle\n");
+});
+
+test.concurrent("same directory covered by two references: first reference wins", async () => {
+  // Coverage is tracked per directory, not per glob, so extension-filtered
+  // includes over the same directory collapse to that directory and the
+  // first reference in order wins (tsc would assign main.ts to the node
+  // project). This pins the documented approximation.
+  using dir = tempDir("tsconfig-refs-order", {
+    "tsconfig.json": JSON.stringify({
+      files: [],
+      references: [{ path: "./tsconfig.web.json" }, { path: "./tsconfig.node.json" }],
+    }),
+    "tsconfig.web.json": JSON.stringify({
+      include: ["src/**/*.web.ts"],
+      compilerOptions: { paths: { "@/*": ["./src/webimpl/*"] } },
+    }),
+    "tsconfig.node.json": JSON.stringify({
+      include: ["src/**/*.ts"],
+      compilerOptions: { paths: { "@/*": ["./src/nodeimpl/*"] } },
+    }),
+    "src/main.ts": `import { who } from "@/who"; console.log(who);`,
+    "src/webimpl/who.ts": `export const who = "web";`,
+    "src/nodeimpl/who.ts": `export const who = "node";`,
+  });
+
+  expectRan(await run(String(dir), "src/main.ts"), "web\n");
+});
+
+test.concurrent("referenced config with extends and no include covers its own directory", async () => {
+  // The referenced config declares no "files"/"include", so it covers its
+  // own directory subtree; after the extends merge that must stay the
+  // outermost config's directory, not the base's. The non-standard file
+  // name keeps it from being picked up as the nearest enclosing config.
+  using dir = tempDir("tsconfig-refs-default-coverage", {
+    "tsconfig.json": JSON.stringify({
+      files: [],
+      references: [{ path: "./app/tsconfig.app.json" }],
+    }),
+    "app/tsconfig.app.json": JSON.stringify({
+      extends: "../base/tsconfig.base.json",
+    }),
+    "base/tsconfig.base.json": JSON.stringify({
+      compilerOptions: { paths: { "#shared/*": ["./shared/*"] } },
+    }),
+    "app/main.ts": `import { v } from "#shared/v"; console.log(v);`,
+    "base/shared/v.ts": `export const v = "inherited";`,
+  });
+
+  expectRan(await run(String(dir), "app/main.ts"), "inherited\n");
+});
+
+test.concurrent("references are not inherited through extends", async () => {
+  using dir = tempDir("tsconfig-refs-no-inherit", {
+    "tsconfig.json": JSON.stringify({
+      files: [],
+      references: [{ path: "./tsconfig.app.json" }],
+    }),
+    "tsconfig.app.json": JSON.stringify({
+      extends: "./tsconfig.base.json",
+      include: ["src"],
+      compilerOptions: { paths: { "#app/*": ["./src/*"] } },
+    }),
+    // "references" is the one top-level key excluded from extends
+    // inheritance, so this entry must never be followed via the app config.
+    "tsconfig.base.json": JSON.stringify({
+      references: [{ path: "./tsconfig.extra.json" }],
+    }),
+    "tsconfig.extra.json": JSON.stringify({
+      include: ["extra"],
+      compilerOptions: { paths: { "#x/*": ["./extra/impl/*"] } },
+    }),
+    "src/index.ts": `import { v } from "#app/v"; console.log(v);`,
+    "src/v.ts": `export const v = "app";`,
+    "extra/main.ts": `import { m } from "#x/m"; console.log(m);`,
+    "extra/impl/m.ts": `export const m = "leaked";`,
+  });
+
+  expectRan(await run(String(dir), "src/index.ts"), "app\n");
+
+  // If base's references leaked through extends, tsconfig.extra.json would
+  // load transitively and "#x/m" would resolve.
+  const leaked = await run(String(dir), "extra/main.ts");
+  expect(leaked.stderr).toContain("Cannot find module '#x/m'");
+  expect(leaked.exitCode).not.toBe(0);
+});
+
+test.concurrent("transitive reference loading stops at the 64-config cap", async () => {
+  const files: Record<string, string> = {
+    "tsconfig.json": JSON.stringify({ files: [], references: [{ path: "./tsconfig.c1.json" }] }),
+    "p64/index.ts": `import { v } from "#p64/v"; console.log(v);`,
+    "p64/v.ts": `export const v = "64";`,
+    "p65/index.ts": `import { v } from "#p65/v"; console.log(v);`,
+    "p65/v.ts": `export const v = "65";`,
+  };
+  for (let i = 1; i <= 65; i++) {
+    files[`tsconfig.c${i}.json`] = JSON.stringify({
+      ...(i < 65 ? { references: [{ path: `./tsconfig.c${i + 1}.json` }] } : {}),
+      include: [`p${i}`],
+      compilerOptions: { paths: { [`#p${i}/*`]: [`./p${i}/*`] } },
+    });
+  }
+  using dir = tempDir("tsconfig-refs-cap", files);
+
+  // The 64th config is the last one within the load budget.
+  expectRan(await run(String(dir), "p64/index.ts"), "64\n");
+
+  // The 65th is past the cap, so its paths never apply.
+  const past = await run(String(dir), "p65/index.ts");
+  expect(past.stderr).toContain("Cannot find module '#p65/v'");
+  expect(past.exitCode).not.toBe(0);
+});
+
+test.concurrent("referenced project using 'files' instead of 'include'", async () => {
+  using dir = tempDir("tsconfig-refs-files", {
+    "tsconfig.json": JSON.stringify({
+      files: [],
+      references: [{ path: "./tsconfig.app.json" }],
+    }),
+    "tsconfig.app.json": JSON.stringify({
+      files: ["src/main.ts"],
+      compilerOptions: { paths: { "~/*": ["./src/*"] } },
+    }),
+    "src/main.ts": `import { greet } from "~/greet"; console.log(greet());`,
+    "src/greet.ts": `export function greet() { return "hi"; }`,
+  });
+
+  expectRan(await run(String(dir), "src/main.ts"), "hi\n");
+});
+
+test.concurrent("referenced project combined with extends", async () => {
+  using dir = tempDir("tsconfig-refs-extends", {
+    "tsconfig.json": JSON.stringify({
+      files: [],
+      references: [{ path: "./tsconfig.app.json" }],
+    }),
+    "tsconfig.base.json": JSON.stringify({
+      compilerOptions: { paths: { "@app/*": ["./src/*"] } },
+    }),
+    "tsconfig.app.json": JSON.stringify({
+      extends: "./tsconfig.base.json",
+      include: ["src"],
+    }),
+    "src/index.ts": `import { n } from "@app/n"; console.log(n);`,
+    "src/n.ts": `export const n = 7;`,
+  });
+
+  expectRan(await run(String(dir), "src/index.ts"), "7\n");
+});
+
+test.concurrent("root config covering the file wins over references", async () => {
+  using dir = tempDir("tsconfig-refs-root-wins", {
+    "tsconfig.json": JSON.stringify({
+      include: ["src"],
+      references: [{ path: "./tsconfig.other.json" }],
+      compilerOptions: { paths: { "@/*": ["./src/root/*"] } },
+    }),
+    "tsconfig.other.json": JSON.stringify({
+      include: ["src"],
+      compilerOptions: { paths: { "@/*": ["./src/other/*"] } },
+    }),
+    "src/index.ts": `import { who } from "@/who"; console.log(who);`,
+    "src/root/who.ts": `export const who = "root";`,
+    "src/other/who.ts": `export const who = "other";`,
+  });
+
+  expectRan(await run(String(dir), "src/index.ts"), "root\n");
+});
+
+test.concurrent("transitive references are followed", async () => {
+  using dir = tempDir("tsconfig-refs-transitive", {
+    "tsconfig.json": JSON.stringify({
+      files: [],
+      references: [{ path: "./tsconfig.mid.json" }],
+    }),
+    "tsconfig.mid.json": JSON.stringify({
+      files: [],
+      references: [{ path: "./tsconfig.leaf.json" }],
+    }),
+    "tsconfig.leaf.json": JSON.stringify({
+      include: ["src"],
+      compilerOptions: { paths: { "@leaf/*": ["./src/*"] } },
+    }),
+    "src/index.ts": `import { n } from "@leaf/n"; console.log(n);`,
+    "src/n.ts": `export const n = 3;`,
+  });
+
+  expectRan(await run(String(dir), "src/index.ts"), "3\n");
+});
+
+test.concurrent("reference cycles do not hang", async () => {
+  using dir = tempDir("tsconfig-refs-cycle", {
+    "tsconfig.json": JSON.stringify({
+      files: [],
+      references: [{ path: "./tsconfig.a.json" }],
+    }),
+    "tsconfig.a.json": JSON.stringify({
+      include: ["a"],
+      references: [{ path: "./tsconfig.b.json" }],
+      compilerOptions: { paths: { "@/*": ["./a/*"] } },
+    }),
+    "tsconfig.b.json": JSON.stringify({
+      include: ["b"],
+      references: [{ path: "./tsconfig.a.json" }, { path: "./tsconfig.json" }],
+      compilerOptions: { paths: { "@/*": ["./b/*"] } },
+    }),
+    "a/index.ts": `import { who } from "@/who"; console.log(who);`,
+    "a/who.ts": `export const who = "a";`,
+    "b/index.ts": `import { who } from "@/who"; console.log(who);`,
+    "b/who.ts": `export const who = "b";`,
+  });
+
+  expectRan(await run(String(dir), "a/index.ts"), "a\n");
+
+  expectRan(await run(String(dir), "b/index.ts"), "b\n");
+});
+
+test.concurrent("a missing referenced config is skipped and stays out of error logs", async () => {
+  using dir = tempDir("tsconfig-refs-missing", {
+    "tsconfig.json": JSON.stringify({
+      files: [],
+      references: [
+        { path: "./tsconfig.missing.json" },
+        { path: "./tsconfig.broken.json" },
+        { path: "./tsconfig.app.json" },
+      ],
+    }),
+    // Syntax errors in a referenced config are skipped without polluting the
+    // resolver log either.
+    "tsconfig.broken.json": `{ "include": [invalid`,
+    // The broken "extends" exercises the quiet chain walk for referenced
+    // projects; the config still contributes its own paths.
+    "tsconfig.app.json": JSON.stringify({
+      extends: "./tsconfig.missing-base.json",
+      include: ["src"],
+      compilerOptions: { paths: { "@/*": ["./src/*"] } },
+    }),
+    "src/index.ts": `import { n } from "@/n"; console.log(n);`,
+    "src/n.ts": `export const n = 5;`,
+    // A failed reference load must not add log messages: a worker startup
+    // failure would surface as AggregateError instead of the single
+    // BuildMessage (seen with bun's own repo tsconfig, which references a
+    // directory without a tsconfig.json).
+    "worker.ts": `
+      const worker = new Worker("blob:i dont exist!");
+      worker.addEventListener("error", e => {
+        console.log(e.message);
+        process.exit(0);
+      });
+    `,
+  });
+
+  expectRan(await run(String(dir), "src/index.ts"), "5\n");
+  expectRan(
+    await run(String(dir), "worker.ts"),
+    'BuildMessage: ModuleNotFound resolving "blob:i dont exist!" (entry point)\n',
+  );
+});
+
+test.concurrent("baseUrl from the referenced project is used", async () => {
+  using dir = tempDir("tsconfig-refs-baseurl", {
+    "tsconfig.json": JSON.stringify({
+      files: [],
+      references: [{ path: "./tsconfig.app.json" }],
+    }),
+    "tsconfig.app.json": JSON.stringify({
+      include: ["src"],
+      compilerOptions: { baseUrl: "./src" },
+    }),
+    "src/index.ts": `import { n } from "util/n"; console.log(n);`,
+    "src/util/n.ts": `export const n = 9;`,
+  });
+
+  expectRan(await run(String(dir), "src/index.ts"), "9\n");
+});
+
+test.concurrent("bun build resolves through solution-style references", async () => {
+  using dir = tempDir("tsconfig-refs-build", {
+    "tsconfig.json": JSON.stringify({
+      files: [],
+      references: [{ path: "./tsconfig.server.json" }],
+    }),
+    "tsconfig.server.json": JSON.stringify({
+      include: ["src/server"],
+      compilerOptions: { paths: { "@/*": ["./src/server/*"] } },
+    }),
+    "src/server/index.ts": `import { log } from "@/log"; log();`,
+    "src/server/log.ts": `export function log() { console.log("built"); }`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "src/server/index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("Could not resolve");
+  expect(stdout).toContain("built");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #34234
Fixes #4774
Fixes #20172

### Problem

- With a solution-style root `tsconfig.json` (`"files": []` plus `"references"`), the files of the referenced projects get no `paths`. Aliases fail: `error: Cannot find module '@/common/log' from '/app/src/server/index.ts'`.
- The cause: `TSConfigJSON::parse` (`src/resolver/tsconfig_json.rs:352`) reads `extends` and `compilerOptions`, never `references`.

### Fix

- `TSConfigJSON::parse` records `references` and the directories that `files`, `include`, and `exclude` cover. The resolver loads the referenced projects lazily, under the resolver mutex. A `OnceLock` publishes them to all threads.
- The resolver tries each referenced project that covers the importing directory, in reference order, then the root config. For each one it tries `paths`, then `baseUrl`. If the root config covers the directory, the resolver uses only it, as in tsc.
- Selection is per directory, not per file as in tsc. Two referenced projects that cover one directory tie, and the first wins. A cyclic or too-long `extends` chain merges the configs it collected and no longer fails every import in its directory.
- Verified: `test/js/bun/resolve/tsconfig-references.test.ts` (27 tests, 24 fail on canary) and one `itBundled` case in `test/bundler/bundler_jsx.test.ts`. The other tsconfig and resolve suites pass.

### Background

- A solution-style tsconfig owns no files and names its referenced projects in `references`. tsc applies to each file the `compilerOptions` of the first referenced project whose `files` or `include` matches.
- The resolver attaches the nearest `tsconfig.json` to each directory and consults it per importing directory. It has no file name there, so coverage is per directory.
- The DirInfo cache is one per process. The main VM, Workers, and bundler threads share its `TSConfigJSON` objects and read them without a lock.

<details><summary>Notes</summary>

**Load**

- The trigger is the first lookup from a directory that the nearest config does not cover. The resolver parses the cwd's tsconfig on every startup, and most runs need no referenced project.
- `ensure_tsconfig_references` takes the resolver mutex because `parse_tsconfig` forms `&mut FileSystem`, and every other caller runs under that mutex. No call site holds the mutex already: each one follows a `dir_info_cached` lookup. The debug `Mutex` panics on a relock by the same thread, and the Worker and `bun build` tests exercise that path.
- The load reuses the `extends` merge (`merge_tsconfig_extends_chain`). It follows transitive references with a visited set and stops after 64 attempted loads.
- A referenced project that fails to load or parse goes to the debug log only. In the resolver log it attached to unrelated errors: a Worker's single `BuildMessage` became an `AggregateError`.
- `parse_tsconfig` always makes `references` and the coverage directories absolute. `${configDir}` leaves a trailing slash that would break the comparison.

**Coverage**

- A `files` entry covers only its directory. So does an `include` that names a file, which means an extension in the last segment (`env.d.ts`, `src/App.vue`). So does an `include` with a wildcard only in the last segment (`vite.config.*`, `src/*.ts`).
- A bare directory and a `**` glob cover the subtree. So does an `include` with segments after the wildcard (`packages/*/src`, `src/*/index.ts`). tsc reads `packages/*/src` as `packages/*/src/**/*`.
- A wildcard-free `exclude` entry removes `include` coverage, never `files` coverage. Glob `exclude` entries are ignored, because a match per directory would exclude too much.
- Each of `files`, `include`, and `exclude` is present or absent. Through `extends`, a config's own key (also an empty one) replaces the key of the base, as in tsc.
- create-vue lists `tsconfig.node.json` first, with root-level entries only (`vite.config.*`, `env.d.ts`). Those entries do not claim `src/**`, so `src/` goes to `tsconfig.app.json`.

**Selection**

- The root config comes last. Thus `paths` on the root (the workaround from #4774) still apply when no referenced project resolves the import. The `baseUrl` of a covering project wins over the `paths` of the root.
- The tie case: `src/**/*.web.ts` and `src/**/*.ts` both reduce to `src/`, and tsc matches the full glob. A test pins the first-wins behavior. The resolver debug log names the selected config.
- In `bun build`, the jsx, decorator, and class-field options follow the selected project, because they come from the resolve result. `bun run` and `bun test` take jsx from the cwd's config, as before.
- A tsconfig that extends itself failed with `Overflow` before. A test pins the new behavior.

**Tests**

- Selection: alias per project, root precedence, root `paths` fallback, `baseUrl`, uncovered directories, the first-wins tie.
- Coverage: `files`, a non-TS file entry, both wildcard shapes, the create-vue layout, `${configDir}`, `exclude` (direct and through `extends`).
- Load: a reference to a directory, `extends` with references, no inheritance of `references`, transitive references, the 64-load bound. Also cycles, missing and broken referenced configs, and four Workers under one root.
- Other: a tsconfig that extends itself, and `bun build`.
- Also run: `tsconfig-extends-leak`, `tsconfig-override`, `transpiler-tsconfig-uaf`, `bundler/esbuild/tsconfig`, `jsx-tsconfig-react-jsx`, `resolve`, `resolve-ts`, `test/internal/source-lints`, and `cargo clippy -p bun_resolver`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 3 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 25 failed, 5 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_jsx.test.ts test/js/bun/resolve/tsconfig-references.test.ts
bun test v1.4.3 (09bb54630)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [1244.16ms]
(pass) bundler > jsx/AutomaticProd [828.97ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [685.29ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [834.41ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [756.76ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [700.16ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [381.77ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [315.71ms]
(pass) bundler > jsx/ImportSourceDev [849.96ms]
(todo) bundler > jsx/ImportSourceProd
(pass) bundler > jsx/ClassicDev [721.43ms]
(pass) bundler > jsx/ClassicProd [791.27ms]
(pass) bundler > jsx/ClassicPragmaDev [854.89ms]
(pass) bundler > jsx/ClassicPragmaProd [757.58ms]
(todo) bundler > jsx/PragmaMultipleDev
(todo) bundler > jsx/PragmaMult
... (truncated)

release without fix: 25 failed, 5 skipped
bun test v1.4.3-canary.1 (09bb54630)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [39.07ms]
(pass) bundler > jsx/AutomaticProd [32.17ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [25.82ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [20.64ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [24.23ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [33.13ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [12.62ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [9.88ms]
(pass) bundler > jsx/ImportSourceDev [27.69ms]
(todo) bundler > jsx/ImportSourceProd
(pass) bundler > jsx/ClassicDev [20.96ms]
(pass) bundler > jsx/ClassicProd [25.67ms]
(pass) bundler > jsx/ClassicPragmaDev [24.66ms]
(pass) bundler > jsx/ClassicPragmaProd [24.48ms]
(todo) bundler > jsx/PragmaMultipleDev
(todo) bundler > jsx/PragmaMultipleProd
(pass) bundler > jsx/FactoryDev [26.89ms]
(pass) bundler > jsx/FactoryProd [34.83ms]
(pass) bundler > jsx/FactoryImportDev [28.55ms]
(pass) bundler > jsx/FactoryImportProd [37.50ms]
(pass) bundler > jsx/Factory
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 5 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_jsx.test.ts test/js/bun/resolve/tsconfig-references.test.ts
bun test v1.4.3 (09bb54630)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [1350.50ms]
(pass) bundler > jsx/AutomaticProd [949.06ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [833.17ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [835.71ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [883.79ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [857.29ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [371.69ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [300.13ms]
(pass) bundler > jsx/ImportSourceDev [921.16ms]
(todo) bundler > jsx/ImportSourceProd
(pass) bundler > jsx/ClassicDev [795.17ms]
(pass) bundler > jsx/ClassicProd [910.84ms]
(pass) bundler > jsx/ClassicPragmaDev [931.41ms]
(pass) bundler > jsx/ClassicPragmaProd [926.60ms]
(todo) bundler > jsx/PragmaMultipleDev
(todo) bundler > jsx/PragmaMult
... (truncated)

release with fix: 5 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     2b7b6ad427
  features     lto, baseline

23 deps, 131 codegen, 1176 objects in 803ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1254] mkdir stamps
[2/1254] mkdir codegen
[3/1254] mkdir pch
[4/1254] mkdir obj
[5/1254] install /workspace/bun
bun install v1.4.3-canary.1 (09bb54630)

Checked 22 installs across 61 packages (no changes) [10.00ms]
[6/1254] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (09bb54630)

Checked 1 install across 2 packages (no changes) [5.00ms]
[7/1254] fetch zlib
[zlib] up to date
[8/1254] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (09bb54630)

Checked 111 installs across 104 packages (no changes) [11.00ms]
[9/1254] gen ErrorCode+*.h
[10/1254] gen node-fallbacks/react-refresh.js
Bundled 1 module in 7ms

  react-refresh.js  4.81 KB  (entry point)

[11/1254] fetch picohttpparser
[picohttpparser] up to date
[12/1254] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[13/1254] fetch tinycc
[tinycc] up to 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/resolver/resolver.rs                        | 435 ++++++++++-----
 src/resolver/tsconfig_json.rs                   | 215 ++++++++
 test/bundler/bundler_jsx.test.ts                |  32 ++
 test/js/bun/resolve/tsconfig-references.test.ts | 689 ++++++++++++++++++++++++
 4 files changed, 1235 insertions(+), 136 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/resolver/resolver.rs                            13     22     34
src/resolver/tsconfig_json.rs                       13     19     34
test/bundler/bundler_jsx.test.ts                     0      0     11
test/js/bun/resolve/tsconfig-references.test.ts      3      7     28
```

</details>

<!-- robobun:evidence:end -->
