### PR TITLE
console.table: honor console.group indent on every line

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -546,7 +546,7 @@ fn message_with_type_and_level_(
                 JSValue::UNDEFINED
             };
             let mut table_printer = TablePrinter::init(global, level, tabular_data, properties)?;
-            table_printer.value_formatter.indent += u32::from(default_indent);
+            table_printer.group_indent = u32::from(default_indent);
 
             if enable_colors {
                 let _ = table_printer.print_table::<true>(writer);
@@ -614,6 +614,8 @@ pub struct TablePrinter<'a> {
     /// Per-cell value formatter. Public so callers (e.g. `Bun.inspect.table`)
     /// can override `depth` / `ordered_properties` / `single_line` after init.
     pub value_formatter: Formatter<'a>,
+    /// `console.group` indent level, written as a prefix on every emitted line.
+    pub group_indent: u32,
 
     tabular_data: JSValue,
     properties: JSValue,
@@ -717,6 +719,7 @@ impl<'a> TablePrinter<'a> {
             properties,
             is_iterable: tabular_data.is_iterable(global_object)?,
             jstype: tabular_data.js_type(),
+            group_indent: 0,
             value_formatter: {
                 // `Formatter` has a `Drop` impl, so struct-update
                 // from a temporary is rejected (E0509).
@@ -876,6 +879,10 @@ impl<'a> TablePrinter<'a> {
         Ok(())
     }
 
+    fn write_group_indent(&self, writer: &mut dyn bun_io::Write) {
+        formatter::write_indent_n(self.group_indent, writer).ok();
+    }
+
     fn print_row(
         &self,
         writer: &mut dyn bun_io::Write,
@@ -883,6 +890,7 @@ impl<'a> TablePrinter<'a> {
         row: &CollectedRow,
         cell_text: &[u8],
     ) {
+        self.write_group_indent(writer);
         writer.write_all("│".as_bytes()).ok();
         {
             let needed = columns[0].width.saturating_sub(row.key.width());
@@ -1073,6 +1081,7 @@ impl<'a> TablePrinter<'a> {
                 );
             }
 
+            self.write_group_indent(writer);
             writer.write_all("┌".as_bytes()).ok();
             for (i, col) in columns.iter().enumerate() {
                 if i > 0 {
@@ -1086,7 +1095,9 @@ impl<'a> TablePrinter<'a> {
                 .ok();
             }
 
-            writer.write_all("┐\n│".as_bytes()).ok();
+            writer.write_all("┐\n".as_bytes()).ok();
+            self.write_group_indent(writer);
+            writer.write_all("│".as_bytes()).ok();
 
             for (i, col) in columns.iter().enumerate() {
                 if i > 0 {
@@ -1105,7 +1116,9 @@ impl<'a> TablePrinter<'a> {
                 writer.splat_byte_all(b' ', needed + PADDING as usize).ok();
             }
 
-            writer.write_all("│\n├".as_bytes()).ok();
+            writer.write_all("│\n".as_bytes()).ok();
+            self.write_group_indent(writer);
+            writer.write_all("├".as_bytes()).ok();
             for (i, col) in columns.iter().enumerate() {
                 if i > 0 {
                     writer.write_all("┼".as_bytes()).ok();
@@ -1127,6 +1140,7 @@ impl<'a> TablePrinter<'a> {
 
         // print the table bottom border
         {
+            self.write_group_indent(writer);
             writer.write_all("└".as_bytes()).ok();
             Self::write_string_n_times(
                 writer,

--- a/test/js/bun/console/console-table.test.ts
+++ b/test/js/bun/console/console-table.test.ts
@@ -363,3 +363,51 @@ console.log("calls=" + calls);`,
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: box("1") + "calls=1\n", stderr: "", exitCode: 0 });
   });
 });
+
+// Every line of the table frame must carry the current console.group indent,
+// matching Node. Previously only the cell-value formatter received the indent,
+// so the frame rendered at column 0 while sibling console.log lines indented.
+test("console.table inside console.group indents every line", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `console.table([{ a: 0 }]);
+console.group("G1");
+console.log("marker");
+console.table([{ a: 1 }, { a: 2 }]);
+console.group("G2");
+console.table([{ a: 3 }]);
+console.groupEnd();
+console.groupEnd();
+console.table([{ a: 4 }]);`,
+    ],
+    env: { ...bunEnv, NO_COLOR: "1" },
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const box = (indent: string, vals: number[]) =>
+    [
+      "┌───┬───┐",
+      "│   │ a │",
+      "├───┼───┤",
+      ...vals.map((v, i) => `│ ${i} │ ${v} │`),
+      "└───┴───┘",
+    ]
+      .map(l => indent + l + "\n")
+      .join("");
+
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout:
+      box("", [0]) +
+      "G1\n" +
+      "  marker\n" +
+      box("  ", [1, 2]) +
+      "  G2\n" +
+      box("    ", [3]) +
+      box("", [4]),
+    stderr: "",
+    exitCode: 0,
+  });
+});

--- a/test/js/bun/console/console-table.test.ts
+++ b/test/js/bun/console/console-table.test.ts
@@ -388,25 +388,12 @@ console.table([{ a: 4 }]);`,
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   const box = (indent: string, vals: number[]) =>
-    [
-      "┌───┬───┐",
-      "│   │ a │",
-      "├───┼───┤",
-      ...vals.map((v, i) => `│ ${i} │ ${v} │`),
-      "└───┴───┘",
-    ]
+    ["┌───┬───┐", "│   │ a │", "├───┼───┤", ...vals.map((v, i) => `│ ${i} │ ${v} │`), "└───┴───┘"]
       .map(l => indent + l + "\n")
       .join("");
 
   expect({ stdout, stderr, exitCode }).toEqual({
-    stdout:
-      box("", [0]) +
-      "G1\n" +
-      "  marker\n" +
-      box("  ", [1, 2]) +
-      "  G2\n" +
-      box("    ", [3]) +
-      box("", [4]),
+    stdout: box("", [0]) + "G1\n" + "  marker\n" + box("  ", [1, 2]) + "  G2\n" + box("    ", [3]) + box("", [4]),
     stderr: "",
     exitCode: 0,
   });


### PR DESCRIPTION
### What

`console.table` inside `console.group` rendered the entire table frame at column 0, while sibling `console.log` lines and Node's table indented by the group level.

```js
console.group("G");
console.log("marker");
console.table([{ a: 1 }]);
console.groupEnd();
```

Before:

```
G
  marker
┌───┬───┐
│   │ a │
├───┼───┤
│ 0 │ 1 │
└───┴───┘
```

After (matches Node):

```
G
  marker
  ┌───┬───┐
  │   │ a │
  ├───┼───┤
  │ 0 │ 1 │
  └───┴───┘
```

### Cause

`src/jsc/ConsoleObject.rs` handed `default_indent` only to `table_printer.value_formatter.indent`, which is the per-cell value formatter (and is a no-op under `single_line = true`). `print_table` and `print_row` write the `┌ │ ├ └` frame bytes directly to the writer without ever writing an indent prefix.

### Fix

Add a `group_indent: u32` field on `TablePrinter`, set it from the console's `default_indent` at the `console.table` call site, and write it via `formatter::write_indent_n` at the start of every emitted line: top border, column-names row, separator, each data row, bottom border. `Bun.inspect.table` leaves `group_indent` at its default 0 and is unchanged.

### Verification

New test `console.table inside console.group indents every line` in `test/js/bun/console/console-table.test.ts` covers indent level 0, 1, 2 (nested groups), multi-row tables, and return to level 0 after `groupEnd`. Fails on `USE_SYSTEM_BUN=1`, passes on the debug build. Existing `console-table`, `bun-inspect-table`, `console-table-iterators`, and `console-log` (`console.group`) suites still pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/console/console-table.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (8908e3d1c)

test/js/bun/console/console-table.test.ts:
┌───┐
│   │
├───┤
└───┘
┌───┐
│   │
├───┤
└───┘
(pass) console.table > throws when second arg is invalid [7.01ms]
(pass) console.table > expected output for: not object (number) [8.54ms]
(pass) console.table > expected output for: not object (string) [1.29ms]
(pass) console.table > expected output for: object - empty [1.81ms]
(pass) console.table > expected output for: object [2.09ms]
(pass) console.table > expected output for: array - empty [1.20ms]
(pass) console.table > expected output for: array - plain [1.78ms]
(pass) console.table > expected output for: array - object [1.54ms]
(pass) console.table 
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (8908e3d1c)

test/js/bun/console/console-table.test.ts:
┌───┐
│   │
├───┤
└───┘
┌───┐
│   │
├───┤
└───┘
(pass) console.table > throws when second arg is invalid [4.47ms]
(pass) console.table > expected output for: not object (number) [3.49ms]
(pass) console.table > expected output for: not object (string) [0.05ms]
(pass) console.table > expected output for: object - empty [0.03ms]
(pass) console.table > expected output for: object [1.33ms]
(pass) console.table > expected output for: array - empty [0.03ms]
(pass) console.table > expected output for: array - plain [0.04ms]
(pass) console.table > expected output for: array - object [0.02ms]
(pass) console.table > expected output for: array - objects with diff props [0.02ms]
(pass) console.table > expected output for: array - mixed [0.02ms]
(pass) console.table > expected output for: set [0.03ms]
(pass) console.table > expected output for: map [0.03ms]
(pass) console.table > expected output for: properties [0.02ms]
(pass) console.table > expected output for: properties - empty [0.01ms]
(pass) console.table > expected output for:
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/console/console-table.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (8908e3d1c)

test/js/bun/console/console-table.test.ts:
┌───┐
│   │
├───┤
└───┘
┌───┐
│   │
├───┤
└───┘
(pass) console.table > throws when second arg is invalid [7.24ms]
(pass) console.table > expected output for: not object (number) [8.80ms]
(pass) console.table > expected output for: not object (string) [1.34ms]
(pass) console.table > expected output for: object - empty [1.77ms]
(pass) console.table > expected output for: object [1.62ms]
(pass) console.table > expected output for: array - empty [1.66ms]
(pass) console.table > expected output for: array - plain [1.83ms]
(pass) console.table > expected output for: array - object [1.64ms]
(pass) console.table 
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 740ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[9
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConsoleObject.rs                  | 20 +++++++++++++++---
 test/js/bun/console/console-table.test.ts | 35 +++++++++++++++++++++++++++++++
 2 files changed, 52 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/jsc/ConsoleObject.rs                       2      7      0
test/js/bun/console/console-table.test.ts      2      1      0
```

</details>

**root cause** · written by the author bot

The console.table renderer passed the active console.group indentation only to the cell value formatter, which was a no-op in single-line mode, while the functions that emit the table's border, separator, and row lines wrote directly to the output stream with no leading indent. The fix stores the group indentation on the TablePrinter and writes it as a prefix at the start of every emitted line, so the entire table frame is shifted to match the current group level. The other caller of TablePrinter leaves the new field at its zero default and is unaffected.

<!-- robobun:evidence:end -->