### PR TITLE
console: make groupCollapsed indent like group

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -426,7 +426,10 @@ fn message_with_type_and_level_(
     // `defer console.default_indent +|= (message_type == StartGroup) as u16;`
     // Capture the raw pointer (Copy) by `move` so no borrow of the local is
     // held across the body; dereference only at scope-exit.
-    let is_start_group = message_type == MessageType::StartGroup;
+    let is_start_group = matches!(
+        message_type,
+        MessageType::StartGroup | MessageType::StartGroupCollapsed
+    );
     let _indent_guard = scopeguard::guard(console, move |console| {
         // SAFETY: see `vm_console` — points at the live boxed
         // `ConsoleObject` for this VM; JS-thread-only.
@@ -437,7 +440,7 @@ fn message_with_type_and_level_(
         }
     });
 
-    if message_type == MessageType::StartGroup && len == 0 {
+    if is_start_group && len == 0 {
         // undefined is printed if passed explicitly.
         return Ok(());
     }

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -423,7 +423,7 @@ fn message_with_type_and_level_(
     len: usize,
 ) -> JsResult<()> {
     let console: *mut ConsoleObject = vm_console(global);
-    // `defer console.default_indent +|= (message_type == StartGroup) as u16;`
+    // `defer console.default_indent +|= is_start_group as u16;`
     // Capture the raw pointer (Copy) by `move` so no borrow of the local is
     // held across the body; dereference only at scope-exit.
     let is_start_group = matches!(

--- a/test/js/web/console/console-log.test.ts
+++ b/test/js/web/console/console-log.test.ts
@@ -143,6 +143,36 @@ NamedError: console.error a named error
 `);
 });
 
+it("console.groupCollapsed", async () => {
+  const code = [
+    `console.groupCollapsed("c1");`,
+    `console.log("A");`,
+    `console.group("g1");`,
+    `console.log("B");`,
+    `console.groupEnd();`,
+    `console.groupEnd();`,
+    `console.groupCollapsed();`,
+    `console.log("C");`,
+    `console.groupEnd();`,
+    `console.groupCollapsed(undefined);`,
+    `console.log("E");`,
+    `console.groupEnd();`,
+    `console.log("D");`,
+  ].join("\n");
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.replaceAll("\r\n", "\n"), stderr, exitCode }).toEqual({
+    stdout: "c1\n  A\n  g1\n    B\n  C\nundefined\n  E\nD\n",
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
 it("console.log with SharedArrayBuffer", () => {
   // console.log(x) === Bun.inspect(x) + "\n" written to stdout.
   expect(Bun.inspect(new ArrayBuffer(0))).toBe("ArrayBuffer(0) []");


### PR DESCRIPTION
## What does this PR do?

Outside an inspector, WHATWG console and Node both treat `console.groupCollapsed` identically to `console.group`. Bun's native console had two gaps:

1. `console.groupCollapsed(label)` printed the label but never increased the indent level, so the group body printed at the parent level.
2. `console.groupCollapsed()` with no arguments printed a bare `undefined` line; Node prints nothing.

### Repro

```js
console.groupCollapsed("c1");
console.log("A");            // node: "  A"    bun: "A"
console.group("g1");
console.log("B");            // node: "    B"  bun: "  B"
console.groupEnd(); console.groupEnd();
console.groupCollapsed();    // bun printed "undefined"; node prints nothing
console.log("C");            // node: "  C"    bun: "C"
console.groupEnd();
console.log("D");
```

### Cause

In `src/jsc/ConsoleObject.rs` `message_with_type_and_level_`, the indent guard was `message_type == MessageType::StartGroup`, so `StartGroupCollapsed` never bumped `default_indent`. The empty-args early return at the same site tested `StartGroup` only, so no-arg `groupCollapsed()` fell through to the formatter.

### Fix

Both checks now accept `StartGroupCollapsed` as well via a shared `is_start_group` `matches!`. Output is now byte-identical to Node v26.

### How did you verify your code works?

Added `console.groupCollapsed` test in `test/js/web/console/console-log.test.ts` covering indentation, nesting inside `groupCollapsed`, no-arg suppression, explicit-`undefined` label printing, and restoration to zero indent after `groupEnd`. Fails on main, passes with the fix. Existing `console.group` test still passes.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/console/console-log.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (4ab4c083c)

test/js/web/console/console-log.test.ts:
(pass) should log to console correctly [917.94ms]
(pass) long arrays get cutoff [3.13ms]
(pass) console.group [455.15ms]
164 |     env: bunEnv,
165 |     stdout: "pipe",
166 |     stderr: "pipe",
167 |   });
168 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
169 |   expect({ stdout: stdout.replaceAll("\r\n", "\n"), stderr, exitCode }).toEqual({
                                                                              ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "stderr": "",
    "stdout": 
  "c1
-   A
-   g1
-     B
-   C
+ A
+ g1
+   B
+ undefined
+ C
  undefined
-   E
+ E
  D
 
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (4a797da14)

test/js/web/console/console-log.test.ts:
(pass) should log to console correctly [21.35ms]
(pass) long arrays get cutoff [0.08ms]
(pass) console.group [11.67ms]
(pass) console.groupCollapsed [11.02ms]
(pass) console.log with SharedArrayBuffer [0.09ms]

 5 pass
 0 fail
 2 snapshots, 10 expect() calls
Ran 5 tests across 1 file. [230.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/console/console-log.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (4ab4c083c)

test/js/web/console/console-log.test.ts:
(pass) should log to console correctly [915.58ms]
(pass) long arrays get cutoff [3.35ms]
(pass) console.group [450.82ms]
(pass) console.groupCollapsed [433.11ms]
(pass) console.log with SharedArrayBuffer [4.40ms]

 5 pass
 0 fail
 2 snapshots, 10 expect() calls
Ran 5 tests across 1 file. [3.78s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 733ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConsoleObject.rs                |  9 ++++++---
 test/js/web/console/console-log.test.ts | 30 ++++++++++++++++++++++++++++++
 2 files changed, 36 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/jsc/ConsoleObject.rs                     2      2      0
test/js/web/console/console-log.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->