### PR TITLE
console: collapse %% after format args are exhausted; %j of undefined prints 'undefined'

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2482,11 +2482,33 @@ pub mod formatter {
                             break;
                         }
 
+                        // `%%` consumes no argument, so collapse it before the
+                        // argument-exhaustion guard below (Node.js always
+                        // collapses `%%` regardless of remaining args).
+                        if slice[i as usize] == b'%' {
+                            // print up to and including the first %
+                            let end = &slice[0..i as usize];
+                            writer.write_all(end);
+                            // then skip the second % so we dont hit it again
+                            slice = &slice[slice.len().min((i + 1) as usize)..];
+                            len = slice.len() as u32;
+                            // Start the next iteration at `slice[1]`,
+                            // not `slice[0]`. (This is itself an
+                            // off-by-one vs the WHATWG spec; tracked
+                            // separately.)
+                            i = 1;
+                            continue;
+                        }
+
                         // borrowck — `writer` holds `&mut self.estimated_line_length`,
                         // so route `remaining_values` reads/writes through the `RawSlice`
                         // field directly instead of the `&self` helper methods.
                         if self.remaining_values.is_empty() {
-                            break;
+                            // No argument to consume: leave `%X` literal in the
+                            // output and keep scanning so later `%%` escapes
+                            // still collapse (Node.js behavior).
+                            i += 1;
+                            continue;
                         }
 
                         let token: PercentTag = match slice[i as usize] {
@@ -2497,20 +2519,6 @@ pub mod formatter {
                             b'd' | b'i' => PercentTag::I,
                             b'c' => PercentTag::C,
                             b'j' => PercentTag::J,
-                            b'%' => {
-                                // print up to and including the first %
-                                let end = &slice[0..i as usize];
-                                writer.write_all(end);
-                                // then skip the second % so we dont hit it again
-                                slice = &slice[slice.len().min((i + 1) as usize)..];
-                                len = slice.len() as u32;
-                                // Start the next iteration at `slice[1]`,
-                                // not `slice[0]`. (This is itself an
-                                // off-by-one vs the WHATWG spec; tracked
-                                // separately.)
-                                i = 1;
-                                continue;
-                            }
                             _ => {
                                 i += 1;
                                 continue;
@@ -2711,12 +2719,17 @@ pub mod formatter {
                                 // +1 WTF ref on every exit (incl. the `?` below).
                                 let mut str = OwnedString::new(BunString::empty());
                                 next_value.json_stringify_fast(global, &mut str)?;
-                                writer.add_for_new_line(str.length());
-                                writer.print(format_args!("{str}"));
+                                if str.is_empty() {
+                                    // JSON.stringify returned `undefined` (for
+                                    // undefined/function/symbol). Node.js string-
+                                    // coerces that to the literal "undefined".
+                                    writer.add_for_new_line("undefined".len());
+                                    writer.write_all(b"undefined");
+                                } else {
+                                    writer.add_for_new_line(str.length());
+                                    writer.print(format_args!("{str}"));
+                                }
                             }
-                        }
-                        if self.remaining_values.is_empty() {
-                            break;
                         }
                     }
                     _ => {}

--- a/test/js/web/console/console-log.test.ts
+++ b/test/js/web/console/console-log.test.ts
@@ -143,6 +143,43 @@ NamedError: console.error a named error
 `);
 });
 
+it("console.log: %% collapses after format args are exhausted, %j of undefined prints 'undefined'", async () => {
+  const src = `
+    console.log("%s %%", "x");
+    console.log("%d %f %j %%", 1, 2, 3);
+    console.log("%s %% %% %%", "x");
+    console.log("%s %s %% end", "a");
+    console.log("100%%", "extra");
+    console.log("[%j]", undefined);
+    console.log("[%j]", function () {});
+    console.log("[%j]", Symbol("s"));
+    console.log("[%j]", null);
+    console.log("[%j]", { a: 1 });
+  `;
+  await using proc = spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.replaceAll("\r\n", "\n"), stderr, exitCode }).toEqual({
+    stdout:
+      "x %\n" +
+      "1 2 3 %\n" +
+      "x % % %\n" +
+      "a %s % end\n" +
+      "100% extra\n" +
+      "[undefined]\n" +
+      "[undefined]\n" +
+      "[undefined]\n" +
+      "[null]\n" +
+      '[{"a":1}]\n',
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
 it("console.log with SharedArrayBuffer", () => {
   // console.log(x) === Bun.inspect(x) + "\n" written to stdout.
   expect(Bun.inspect(new ArrayBuffer(0))).toBe("ArrayBuffer(0) []");


### PR DESCRIPTION
## Repro

```js
console.log("%s %%", "x");           // node: "x %"         bun: "x %%"
console.log("%d %f %j %%", 1, 2, 3); // node: "1 2 3 %"     bun: "1 2 3 %%"
console.log("%s %s %% end", "a");    // node: "a %s % end"  bun: "a %s %% end"
console.log("[%j]", undefined);      // node: "[undefined]" bun: "[]"
console.log("[%j]", () => {});       // node: "[undefined]" bun: "[]"
```

## Cause

`write_with_formatting` in `src/jsc/ConsoleObject.rs` checked `remaining_values.is_empty()` *before* matching the specifier byte. The argument-free `%%` escape therefore never reached its handler once values ran out: the loop broke and the remaining format string (including `%%`) was written literally. A second `is_empty()` break after each consumed token had the same effect for `%%` appearing after the last consumed arg.

For `%j`, `JSON.stringify` returns `undefined` for `undefined`, functions, and symbols. Node.js string-coerces that result to the literal `"undefined"`; Bun wrote the empty stringify result, producing nothing.

## Fix

* Handle `%%` before the exhaustion guard.
* On exhaustion, keep scanning instead of breaking so later `%%` escapes still collapse while unmatched `%s`/`%d`/... stay literal (matches Node.js).
* Drop the redundant post-token `is_empty()` break.
* For `%j`, write `"undefined"` when the stringify result is empty.

The pre-existing `i = 1` off-by-one after `%%` (commented as tracked separately) is preserved unchanged.

## Verification

New test in `test/js/web/console/console-log.test.ts` covers trailing `%%` after exhaustion, multiple `%%`, literal `%s` followed by `%%`, and `%j` of `undefined`/function/symbol/null/object. Fails on 1.4.0 (7 lines diff), passes with this change. Existing `console-log.test.ts` and `util-format.test.js` continue to pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/console/console-log.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (3f9d96a27)

test/js/web/console/console-log.test.ts:
(pass) should log to console correctly [932.69ms]
(pass) long arrays get cutoff [3.13ms]
(pass) console.group [455.33ms]
161 |     env: bunEnv,
162 |     stdout: "pipe",
163 |     stderr: "pipe",
164 |   });
165 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
166 |   expect({ stdout: stdout.replaceAll("\r\n", "\n"), stderr, exitCode }).toEqual({
                                                                              ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "stderr": "",
    "stdout": 
- "x %
- 1 2 3 %
- x % % %
- a %s % end
+ "x %%
+ 1 2 3 %%
+ x %% %% %%
+ a %s %% end
  100
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (a21606870)

test/js/web/console/console-log.test.ts:
(pass) should log to console correctly [33.67ms]
(pass) long arrays get cutoff [0.10ms]
(pass) console.group [15.84ms]
(pass) console.log: %% collapses after format args are exhausted, %j of undefined prints 'undefined' [11.82ms]
(pass) console.log with SharedArrayBuffer [0.09ms]

 5 pass
 0 fail
 2 snapshots, 10 expect() calls
Ran 5 tests across 1 file. [212.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/console/console-log.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (3f9d96a27)

test/js/web/console/console-log.test.ts:
(pass) should log to console correctly [940.41ms]
(pass) long arrays get cutoff [3.36ms]
(pass) console.group [465.37ms]
(pass) console.log: %% collapses after format args are exhausted, %j of undefined prints 'undefined' [433.25ms]
(pass) console.log with SharedArrayBuffer [4.51ms]

 5 pass
 0 fail
 2 snapshots, 10 expect() calls
Ran 5 tests across 1 file. [3.83s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 723ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConsoleObject.rs                | 53 ++++++++++++++++++++-------------
 test/js/web/console/console-log.test.ts | 37 +++++++++++++++++++++++
 2 files changed, 70 insertions(+), 20 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/jsc/ConsoleObject.rs                     4      3      0
test/js/web/console/console-log.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->