### PR TITLE
console: match Node.js output for timeEnd/timeLog (stdout, "label: duration", 1000 ms threshold)

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -5922,6 +5922,48 @@ thread_local! {
     static PENDING_TIME_LOGS_LOADED: Cell<bool> = const { Cell::new(false) };
 }
 
+/// Write `label: <duration>` to `w` using Node.js's `console.timeEnd` /
+/// `console.timeLog` formatting rules (see Node's `internal/util/debuglog.js`
+/// `formatTime`): `<n>ms` below one second, `<n.nnn>s` below one minute, then
+/// `m:ss.mmm` / `h:mm:ss.mmm` above that.
+fn write_timer_label_and_duration(w: &mut bun_core::io::Writer, label: &[u8], ms: f64) {
+    const SECOND: f64 = 1_000.0;
+    const MINUTE: f64 = 60.0 * SECOND;
+    const HOUR: f64 = 60.0 * MINUTE;
+
+    let _ = w.write_all(label);
+    let _ = w.write_all(b": ");
+
+    if ms >= MINUTE {
+        let mut rem = ms;
+        let hours = if rem >= HOUR {
+            let h = (rem / HOUR).floor();
+            rem -= h * HOUR;
+            h as u64
+        } else {
+            0
+        };
+        let minutes = {
+            let m = (rem / MINUTE).floor();
+            rem -= m * MINUTE;
+            m as u64
+        };
+        let seconds = rem / SECOND;
+        if hours != 0 {
+            let _ = write!(w, "{hours}:{minutes:02}:{seconds:06.3} (h:mm:ss.mmm)");
+        } else {
+            let _ = write!(w, "{minutes}:{seconds:06.3} (m:ss.mmm)");
+        }
+    } else if ms >= SECOND {
+        let _ = write!(w, "{:.3}s", ms / SECOND);
+    } else {
+        // Node: `Number(ms.toFixed(3))` — round to three decimals, then print
+        // with JS number formatting (trailing zeros stripped).
+        let rounded = (ms * 1000.0).round() / 1000.0;
+        let _ = write!(w, "{}ms", bun_core::fmt::double(rounded));
+    }
+}
+
 #[unsafe(no_mangle)]
 #[crate::host_call]
 pub extern "C" fn Bun__ConsoleObject__time(
@@ -5949,7 +5991,7 @@ pub extern "C" fn Bun__ConsoleObject__time(
 #[crate::host_call]
 pub extern "C" fn Bun__ConsoleObject__timeEnd(
     _console: *mut ConsoleObject,
-    _global: &JSGlobalObject,
+    global: &JSGlobalObject,
     chars: *const u8,
     len: usize,
 ) {
@@ -5967,15 +6009,15 @@ pub extern "C" fn Bun__ConsoleObject__timeEnd(
     };
     let Some(value) = prev else { return };
     // get the duration in microseconds, then display it in milliseconds
-    Output::print_elapsed(
-        (value.read() / bun_core::time::NS_PER_US) as f64 / bun_core::time::US_PER_MS as f64,
-    );
-    match len {
-        0 => Output::print_errorln(format_args!("")),
-        _ => Output::print_errorln(format_args!(" {}", bstr::BStr::new(slice))),
-    }
+    let elapsed_ms =
+        (value.read() / bun_core::time::NS_PER_US) as f64 / bun_core::time::US_PER_MS as f64;
 
-    Output::flush();
+    // SAFETY: top-level JS-thread host call ⇒ exclusive access to the
+    // set-once `VirtualMachine.console` box.
+    let writer = unsafe { vm_console_mut(global) }.writer();
+    write_timer_label_and_duration(writer, slice, elapsed_ms);
+    let _ = writer.write_all(b"\n");
+    let _ = writer.flush();
 }
 
 #[unsafe(no_mangle)]
@@ -5999,14 +6041,16 @@ pub extern "C" fn Bun__ConsoleObject__timeLog(
         return;
     };
     // get the duration in microseconds, then display it in milliseconds
-    Output::print_elapsed(
-        (value.read() / bun_core::time::NS_PER_US) as f64 / bun_core::time::US_PER_MS as f64,
-    );
-    match len {
-        0 => {}
-        _ => Output::print_error(format_args!(" {}", bstr::BStr::new(slice))),
-    }
-    Output::flush();
+    let elapsed_ms =
+        (value.read() / bun_core::time::NS_PER_US) as f64 / bun_core::time::US_PER_MS as f64;
+
+    let console = vm_console(global);
+    // SAFETY: see [`vm_console`] — points at the live boxed `ConsoleObject` for
+    // this VM; JS-thread-only. Kept as a raw deref (not `vm_console_mut`) so the
+    // resulting `writer` borrow does not pin a long-lived `&mut ConsoleObject`
+    // across the `fmt.format(...)` calls below, which can re-enter JS.
+    let mut writer = unsafe { (*console).writer() };
+    write_timer_label_and_duration(writer, slice, elapsed_ms);
 
     // print the arguments
     // `Formatter` has a `Drop` impl, so struct-update from a
@@ -6017,19 +6061,14 @@ pub extern "C" fn Bun__ConsoleObject__timeLog(
         .unwrap_or(DEFAULT_CONSOLE_LOG_DEPTH);
     fmt.stack_check = StackCheck::init();
     fmt.can_throw_stack_overflow = true;
-    let console = vm_console(global);
-    // SAFETY: see [`vm_console`] — points at the live boxed `ConsoleObject` for
-    // this VM; JS-thread-only. Kept as a raw deref (not `vm_console_mut`) so the
-    // resulting `writer` borrow does not pin a long-lived `&mut ConsoleObject`
-    // across the `fmt.format(...)` calls below, which can re-enter JS.
-    let mut writer = unsafe { (*console).error_writer() };
+    let enable_colors = Output::enable_ansi_colors_stdout();
     // SAFETY: caller passes a valid (args, args_len) pair.
     for &arg in unsafe { bun_core::ffi::slice(args, args_len) } {
         let Ok(tag) = formatter::Tag::get(arg, global) else {
             return;
         };
         let _ = bun_io::Write::write_all(&mut writer, b" ");
-        if Output::enable_ansi_colors_stderr() {
+        if enable_colors {
             let _ = fmt.format::<true>(tag, &mut writer, arg, global);
         } else {
             let _ = fmt.format::<false>(tag, &mut writer, arg, global);

--- a/test/js/web/console/console-timeLog.expected.txt
+++ b/test/js/web/console/console-timeLog.expected.txt
@@ -1,18 +1,18 @@
-[0.00ms] label
-[0.06ms] label Hello World!
-[0.09ms] label a %s b c d
-[0.11ms] label 0 -0 123 -123 123.567 -123.567 Infinity -Infinity
-[0.14ms] label true false
-[0.15ms] label null undefined
-[0.17ms] label Symbol(Symbol Description)
-[0.22ms] label 2000-06-27T02:24:34.304Z
-[0.29ms] label [ 123, 456, 789 ]
-[0.34ms] label {
+label: 0.00ms
+label: 0.06ms Hello World!
+label: 0.09ms a %s b c d
+label: 0.11ms 0 -0 123 -123 123.567 -123.567 Infinity -Infinity
+label: 0.14ms true false
+label: 0.15ms null undefined
+label: 0.17ms Symbol(Symbol Description)
+label: 0.22ms 2000-06-27T02:24:34.304Z
+label: 0.29ms [ 123, 456, 789 ]
+label: 0.34ms {
   name: "foo",
 }
-[0.37ms] label {
+label: 0.37ms {
   a: 123,
   b: 456,
   c: 789,
 }
-[0.39ms] label
+label: 0.39ms

--- a/test/js/web/console/console-timeLog.test.ts
+++ b/test/js/web/console/console-timeLog.test.ts
@@ -4,7 +4,7 @@ import { bunEnv, bunExe } from "harness";
 import { join } from "node:path";
 
 // Matches Node.js: `label: 0.123ms`, `label: 1.234s`, `label: 1:02.345 (m:ss.mmm)`, ...
-const DURATION = /[\d.]+ms|[\d.]+s|[\d:.]+ \((?:h:mm|m):ss\.mmm\)/;
+const DURATION = /(?:[\d.]+ms|[\d.]+s|[\d:.]+ \((?:h:mm|m):ss\.mmm\))/;
 
 it.concurrent("console.time/timeLog/timeEnd write to stdout, not stderr", async () => {
   await using proc = Bun.spawn({
@@ -67,7 +67,7 @@ it.concurrent("console.timeEnd scales to seconds at >=1000ms", async () => {
     cmd: [
       bunExe(),
       "-e",
-      // Busy-wait just past one second so the elapsed time lands in [1000, 2000)ms.
+      // Busy-wait just past one second so the elapsed time is >= 1000 ms.
       `console.time("sc"); const t0=Date.now(); while (Date.now()-t0 < 1100) {} console.timeEnd("sc");`,
     ],
     env: bunEnv,
@@ -76,7 +76,7 @@ it.concurrent("console.timeEnd scales to seconds at >=1000ms", async () => {
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  expect(stdout).toMatch(/^sc: 1\.\d{3}s\n$/);
+  expect(stdout).toMatch(/^sc: \d+\.\d{3}s\n$/);
   expect(exitCode).toBe(0);
 });
 
@@ -108,7 +108,7 @@ describe("duplicate / unknown labels", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     // Node emits a warning on duplicate console.time; Bun currently does not.
     // Either way the original timer must be kept, so the duration is >= 1s.
-    expect(stdout).toMatch(/^d: 1\.\d{3}s\n$/);
+    expect(stdout).toMatch(/^d: \d+\.\d{3}s\n$/);
     expect(exitCode).toBe(0);
   });
 

--- a/test/js/web/console/console-timeLog.test.ts
+++ b/test/js/web/console/console-timeLog.test.ts
@@ -1,7 +1,27 @@
 import { file, spawn } from "bun";
-import { expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { join } from "node:path";
+
+// Matches Node.js: `label: 0.123ms`, `label: 1.234s`, `label: 1:02.345 (m:ss.mmm)`, ...
+const DURATION = /[\d.]+ms|[\d.]+s|[\d:.]+ \((?:h:mm|m):ss\.mmm\)/;
+
+it.concurrent("console.time/timeLog/timeEnd write to stdout, not stderr", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `console.time("t"); console.timeLog("t", "x"); console.timeEnd("t");`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout.split("\n")).toEqual([
+    expect.stringMatching(new RegExp(String.raw`^t: ${DURATION.source} x$`)),
+    expect.stringMatching(new RegExp(String.raw`^t: ${DURATION.source}$`)),
+    "",
+  ]);
+  expect(exitCode).toBe(0);
+});
 
 it.concurrent("console.timeEnd with empty label emits exactly one trailing newline", async () => {
   await using proc = Bun.spawn({
@@ -11,8 +31,8 @@ it.concurrent("console.timeEnd with empty label emits exactly one trailing newli
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toBe("");
-  expect(stderr).toMatch(/^\[[\d.]+[mnµ]?s\]\n$/);
+  expect(stderr).toBe("");
+  expect(stdout).toMatch(new RegExp(String.raw`^: ${DURATION.source}\n$`));
   expect(exitCode).toBe(0);
 });
 
@@ -24,25 +44,103 @@ it.concurrent("console.timeEnd with non-empty label emits exactly one trailing n
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toBe("");
-  expect(stderr).toMatch(/^\[[\d.]+[mnµ]?s\] abc\n$/);
+  expect(stderr).toBe("");
+  expect(stdout).toMatch(new RegExp(String.raw`^abc: ${DURATION.source}\n$`));
   expect(exitCode).toBe(0);
 });
 
+it.concurrent("console.timeEnd prints ms below one second", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `console.time("fast"); console.timeEnd("fast");`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toMatch(/^fast: \d+(?:\.\d{1,3})?ms\n$/);
+  expect(exitCode).toBe(0);
+});
+
+it.concurrent("console.timeEnd scales to seconds at >=1000ms", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      // Busy-wait just past one second so the elapsed time lands in [1000, 2000)ms.
+      `console.time("sc"); const t0=Date.now(); while (Date.now()-t0 < 1100) {} console.timeEnd("sc");`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toMatch(/^sc: 1\.\d{3}s\n$/);
+  expect(exitCode).toBe(0);
+});
+
+it.concurrent("console.timeEnd uses the default label when none is given", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `console.time(); console.timeEnd();`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toMatch(new RegExp(String.raw`^default: ${DURATION.source}\n$`));
+  expect(exitCode).toBe(0);
+});
+
+describe("duplicate / unknown labels", () => {
+  it.concurrent("console.time on an existing label keeps the original timer", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `console.time("d"); const t0=Date.now(); while (Date.now()-t0 < 1100) {} console.time("d"); console.timeEnd("d");`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // Node emits a warning on duplicate console.time; Bun currently does not.
+    // Either way the original timer must be kept, so the duration is >= 1s.
+    expect(stdout).toMatch(/^d: 1\.\d{3}s\n$/);
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("console.timeEnd / timeLog on an unknown label produce no stdout", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `console.timeLog("nope"); console.timeEnd("nope");`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(0);
+  });
+});
+
 it("should log to console correctly", async () => {
-  const { stderr, exited } = spawn({
+  const { stdout, stderr, exited } = spawn({
     cmd: [bunExe(), join(import.meta.dir, "console-timeLog.js")],
     stdin: null,
     stdout: "pipe",
     stderr: "pipe",
     env: bunEnv,
   });
-  expect(await exited).toBe(0);
-  const outText = await stderr.text();
+  const [outText, errText, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+  expect(errText).toBe("");
   const expectedText = (await file(join(import.meta.dir, "console-timeLog.expected.txt")).text()).replaceAll(
     "\r\n",
     "\n",
   );
 
-  expect(outText.replace(/^\[.+?s\] /gm, "")).toBe(expectedText.replace(/^\[.+?s\] /gm, ""));
+  const normalize = (s: string) => s.replace(new RegExp(String.raw`^(.*?): ${DURATION.source}`, "gm"), "$1: <time>");
+  expect(normalize(outText)).toBe(normalize(expectedText));
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
`console.timeEnd` and `console.timeLog` wrote `[<n>ms] label` to **stderr**, scaling to seconds only above 1500 ms. Node.js documents and prints `label: <n>ms` on **stdout**, scaling at 1000 ms, so shell redirects and log parsers written against the documented shape received nothing from Bun.

Supersedes #32423, which switched the stream but kept the Bun-specific format and threshold.

## Repro

```js
console.time("fast");
console.timeLog("fast", "extra", 42);
console.timeEnd("fast");
```

```console
$ node repro.mjs                    # stdout
fast: 0.05ms extra 42
fast: 0.1ms

$ bun repro.mjs 2>/dev/null         # nothing on stdout
$ bun repro.mjs 2>&1 >/dev/null     # all on stderr, different grammar
[0.01ms] fast extra 42
[0.03ms] fast
```

And with a >1 s timer, Node prints `sc: 1.201s` while Bun printed `[1199.23ms] sc` (no scaling until 1500 ms).

## Cause

`Bun__ConsoleObject__timeEnd` / `timeLog` in `src/jsc/ConsoleObject.rs` called `Output::print_elapsed`, which is the CLI-style stderr helper in `src/bun_core/output.rs`: `pretty_error!` with a `[{:.2}ms]` template and a `0..=1500` match arm for the ms/s split. The label was appended afterwards via `print_error{,ln}`, and `timeLog`'s extra arguments went through the console's `error_writer()`.

## Fix

Add `write_timer_label_and_duration`, a dedicated stdout formatter that mirrors Node's `internal/util/debuglog.js` `formatTime`:

- `< 1000 ms`: `Number(ms.toFixed(3)) + "ms"` (round to three decimals, trailing zeros stripped)
- `< 60 s`: `seconds.toFixed(3) + "s"`
- `< 1 h`: `m:ss.mmm (m:ss.mmm)`
- `>= 1 h`: `h:mm:ss.mmm (h:mm:ss.mmm)`

`timeEnd` and `timeLog` now write `label: <duration>` to the console's stdout writer; `timeLog`'s extra arguments follow the duration on the same line and pick the stdout colour setting.

Unchanged behaviours, now covered by tests:

- Duplicate `console.time(label)` keeps the original timer.
- `timeEnd` / `timeLog` on an unknown label produce no stdout output.

## Verification

`test/js/web/console/console-timeLog.test.ts` asserts the stream, the `label: <duration>` grammar, the 1000 ms threshold, the default label, and the duplicate/unknown-label cases.

- `USE_SYSTEM_BUN=1 bun test test/js/web/console/console-timeLog.test.ts` fails 8/9
- `bun bd test test/js/web/console/console-timeLog.test.ts` passes 9/9
- `bun bd test test/js/web/console/` passes 16/16

Fixes #12031

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/console/console-timeLog.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (c3b6b145c)

test/js/web/console/console-timeLog.test.ts:
12 |     env: bunEnv,
13 |     stdout: "pipe",
14 |     stderr: "pipe",
15 |   });
16 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
17 |   expect(stderr).toBe("");
                      ^
error: expect(received).toBe(expected)

- ""
+ "[0.06ms] t x
+ [0.21ms] t
+ "

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/js/web/console/console-timeLog.test.ts:17:18)
(fail) console.time/timeLog/timeEnd write to stdout, not stderr [445.49ms]
29 |     env: bunEnv,
30 |     stdout: "pipe",
31 |     stderr: "pipe",
32 |   });
33 |   const [stdout, stderr, exitCode] = await Promise.all([p
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (ead1fa5ab)

test/js/web/console/console-timeLog.test.ts:
(pass) console.time/timeLog/timeEnd write to stdout, not stderr [13.05ms]
(pass) console.timeEnd with empty label emits exactly one trailing newline [11.21ms]
(pass) console.timeEnd prints ms below one second [10.56ms]
(pass) console.timeEnd with non-empty label emits exactly one trailing newline [11.43ms]
(pass) console.timeEnd uses the default label when none is given [10.61ms]
(pass) duplicate / unknown labels > console.timeEnd / timeLog on an unknown label produce no stdout [10.50ms]
(pass) duplicate / unknown labels > console.time on an existing label keeps the original timer [1110.80ms]
(pass) console.timeEnd scales to seconds at >=1000ms [1111.53ms]
(pass) should log to console correctly [13.94ms]

 9 pass
 0 fail
 25 expect() calls
Ran 9 tests across 1 file. [1275.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/console/console-timeLog.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (c3b6b145c)

test/js/web/console/console-timeLog.test.ts:
(pass) console.time/timeLog/timeEnd write to stdout, not stderr [445.76ms]
(pass) console.timeEnd with empty label emits exactly one trailing newline [447.19ms]
(pass) console.timeEnd with non-empty label emits exactly one trailing newline [453.55ms]
(pass) console.timeEnd prints ms below one second [455.25ms]
(pass) console.timeEnd uses the default label when none is given [439.10ms]
(pass) duplicate / unknown labels > console.timeEnd / timeLog on an unknown label produce no stdout [423.37ms]
(pass) console.timeEnd scales to seconds at >=1000ms [1532.11ms]
(pass) duplicate / unknown labels > console.time on an existing label keeps the original timer [1530.16ms]
(pas
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 711ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConsoleObject.rs                         |  87 ++++++++++++-----
 test/js/web/console/console-timeLog.expected.txt |  24 ++---
 test/js/web/console/console-timeLog.test.ts      | 116 +++++++++++++++++++++--
 3 files changed, 182 insertions(+), 45 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/jsc/ConsoleObject.rs                              7      7      0
test/js/web/console/console-timeLog.expected.txt      1      1      0
test/js/web/console/console-timeLog.test.ts           1      4      0
```

</details>

<!-- robobun:evidence:end -->