### PR TITLE
console.table: match Node's column model (symbol keys, properties dedup, Set, depth, key order)

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -995,8 +995,14 @@ impl<'a> TablePrinter<'a> {
             });
         }
 
+        // Map/Set route every row through fixed Key/Values columns and never
+        // read the properties filter (Node returns from its map/setlike
+        // branches before `properties` is consulted).
+        let setlike =
+            self.jstype.is_map() || self.jstype.is_set() || self.jstype == jsc::JSType::SetIterator;
+
         // if the "properties" arg was provided, pre-populate the columns
-        if !self.properties.is_undefined() {
+        if !self.properties.is_undefined() && !setlike {
             let mut properties_iter = jsc::JSArrayIterator::init(self.properties, global_object)?;
             while let Some(value) = properties_iter.next()? {
                 let name = value.to_bun_string(global_object)?;

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -703,6 +703,28 @@ struct CollectedRow {
 
 const PADDING: u32 = 1;
 
+/// Parse `s` as a canonical ES array index (0 .. 2^32-2, no leading zeros).
+fn parse_array_index(s: &[u8]) -> Option<u32> {
+    if s.is_empty() || s.len() > 10 {
+        return None;
+    }
+    if s[0] == b'0' {
+        return if s.len() == 1 { Some(0) } else { None };
+    }
+    let mut n: u64 = 0;
+    for &c in s {
+        if !c.is_ascii_digit() {
+            return None;
+        }
+        n = n * 10 + u64::from(c - b'0');
+    }
+    if n < u64::from(u32::MAX) {
+        Some(n as u32)
+    } else {
+        None
+    }
+}
+
 impl<'a> TablePrinter<'a> {
     pub fn init(
         global_object: &'a JSGlobalObject,
@@ -722,7 +744,7 @@ impl<'a> TablePrinter<'a> {
                 // from a temporary is rejected (E0509).
                 let mut f = Formatter::new(global_object);
                 f.single_line = true;
-                f.max_depth = 5;
+                f.max_depth = 0;
                 f.can_throw_stack_overflow = true;
                 f.stack_check = StackCheck::init();
                 f
@@ -792,6 +814,16 @@ impl<'a> TablePrinter<'a> {
             return Ok(row);
         }
 
+        // Set entries always go to the "Values" column as a whole, even when
+        // the entry is an object (Node.js routes Set/SetIterator through a
+        // dedicated setlike branch that never explodes per-property columns).
+        if self.jstype.is_set() {
+            let cell = self.format_cell::<ENABLE_ANSI_COLORS>(cell_text, row_value)?;
+            self.values_col_width = Some(self.values_col_width.unwrap_or(1).max(cell.width));
+            row.values_cell = Some(cell);
+            return Ok(row);
+        }
+
         if let Some(obj) = row_value.get_object() {
             // object ->
             //  - if "properties" arg was provided: iterate the already-created
@@ -812,9 +844,11 @@ impl<'a> TablePrinter<'a> {
                 let mut cols_iter = jsc::JSPropertyIterator::init(
                     self.global_object,
                     obj,
-                    jsc::PropertyIteratorOptions {
+                    jsc::JSPropertyIteratorOptions {
                         skip_empty_name: false,
                         include_value: true,
+                        include_symbols: false,
+                        ..Default::default()
                     },
                 )?;
 
@@ -965,10 +999,12 @@ impl<'a> TablePrinter<'a> {
         if !self.properties.is_undefined() {
             let mut properties_iter = jsc::JSArrayIterator::init(self.properties, global_object)?;
             while let Some(value) = properties_iter.next()? {
-                columns.push(Column {
-                    name: value.to_bun_string(global_object)?,
-                    width: 1,
-                });
+                let name = value.to_bun_string(global_object)?;
+                if columns[1..].iter().any(|col| col.name.eql(&name)) {
+                    name.deref();
+                    continue;
+                }
+                columns.push(Column { name, width: 1 });
             }
         }
 
@@ -1035,9 +1071,11 @@ impl<'a> TablePrinter<'a> {
                 let mut rows_iter = jsc::JSPropertyIterator::init(
                     global_object,
                     tabular_obj,
-                    jsc::PropertyIteratorOptions {
+                    jsc::JSPropertyIteratorOptions {
                         skip_empty_name: false,
                         include_value: true,
+                        include_symbols: false,
+                        ..Default::default()
                     },
                 )?;
 
@@ -1050,6 +1088,47 @@ impl<'a> TablePrinter<'a> {
                         rows_iter.value,
                     )?;
                     rows.push(row);
+                }
+            }
+        }
+
+        // Node builds the column set by assigning into a null-proto object and
+        // then reading it back via `Object.keys`, so the final column order is
+        // the spec's OrdinaryOwnPropertyKeys order: array-index names sorted
+        // numerically first, then string names in first-seen (insertion) order.
+        // Reproduce that by stably partitioning the data columns.
+        if columns.len() > 2 && !self.jstype.is_map() {
+            let n = columns.len() - 1;
+            let mut order: Vec<usize> = (0..n).collect();
+            let keys: Vec<Option<u32>> = columns[1..]
+                .iter()
+                .map(|c| {
+                    let utf8 = c.name.to_utf8();
+                    parse_array_index(utf8.slice())
+                })
+                .collect();
+            order.sort_by(|&a, &b| match (keys[a], keys[b]) {
+                (Some(x), Some(y)) => x.cmp(&y),
+                (Some(_), None) => core::cmp::Ordering::Less,
+                (None, Some(_)) => core::cmp::Ordering::Greater,
+                (None, None) => a.cmp(&b),
+            });
+            if order.iter().enumerate().any(|(i, &o)| i != o) {
+                let mut new_cols: Vec<Column> = Vec::with_capacity(columns.len());
+                new_cols.push(core::mem::take(&mut columns[0]));
+                for &o in &order {
+                    new_cols.push(core::mem::take(&mut columns[1 + o]));
+                }
+                *columns = new_cols;
+                for row in rows.iter_mut() {
+                    let old = core::mem::take(&mut row.cells);
+                    let mut new_cells: Vec<Option<CellRef>> = vec![None; n];
+                    for (new_i, &old_i) in order.iter().enumerate() {
+                        if let Some(cell) = old.get(old_i).copied().flatten() {
+                            new_cells[new_i] = Some(cell);
+                        }
+                    }
+                    row.cells = new_cells;
                 }
             }
         }

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -817,7 +817,7 @@ impl<'a> TablePrinter<'a> {
         // Set entries always go to the "Values" column as a whole, even when
         // the entry is an object (Node.js routes Set/SetIterator through a
         // dedicated setlike branch that never explodes per-property columns).
-        if self.jstype.is_set() {
+        if self.jstype.is_set() || self.jstype == jsc::JSType::SetIterator {
             let cell = self.format_cell::<ENABLE_ANSI_COLORS>(cell_text, row_value)?;
             self.values_col_width = Some(self.values_col_width.unwrap_or(1).max(cell.width));
             row.values_cell = Some(cell);

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -754,6 +754,13 @@ impl<'a> TablePrinter<'a> {
         })
     }
 
+    /// Node's `setlike` predicate: `isSet(v) || isSetIterator(v)`. `WeakSet`
+    /// is not setlike (no `[[SetData]]`), so it falls through to plain-object
+    /// handling just like any other non-iterable object.
+    fn is_setlike(&self) -> bool {
+        self.jstype == jsc::JSType::Set || self.jstype == jsc::JSType::SetIterator
+    }
+
     /// Format `value` exactly once (bare for strings, quoted otherwise),
     /// appending its rendered bytes to the shared `cell_text` scratch, and
     /// return the recorded byte range plus its visible width.
@@ -817,7 +824,7 @@ impl<'a> TablePrinter<'a> {
         // Set entries always go to the "Values" column as a whole, even when
         // the entry is an object (Node.js routes Set/SetIterator through a
         // dedicated setlike branch that never explodes per-property columns).
-        if self.jstype.is_set() || self.jstype == jsc::JSType::SetIterator {
+        if self.is_setlike() {
             let cell = self.format_cell::<ENABLE_ANSI_COLORS>(cell_text, row_value)?;
             self.values_col_width = Some(self.values_col_width.unwrap_or(1).max(cell.width));
             row.values_cell = Some(cell);
@@ -998,11 +1005,10 @@ impl<'a> TablePrinter<'a> {
         // Map/Set route every row through fixed Key/Values columns and never
         // read the properties filter (Node returns from its map/setlike
         // branches before `properties` is consulted).
-        let setlike =
-            self.jstype.is_map() || self.jstype.is_set() || self.jstype == jsc::JSType::SetIterator;
+        let ignores_properties = self.jstype.is_map() || self.is_setlike();
 
         // if the "properties" arg was provided, pre-populate the columns
-        if !self.properties.is_undefined() && !setlike {
+        if !self.properties.is_undefined() && !ignores_properties {
             let mut properties_iter = jsc::JSArrayIterator::init(self.properties, global_object)?;
             while let Some(value) = properties_iter.next()? {
                 let name = value.to_bun_string(global_object)?;

--- a/src/jsc/JSPropertyIterator.rs
+++ b/src/jsc/JSPropertyIterator.rs
@@ -6,10 +6,10 @@ use bun_core as bstr;
 
 /// Runtime flag set passed to [`JSPropertyIterator::init`].
 ///
-/// `Default` is `own_properties_only = true`,
-/// `observable = true`, `only_non_index_properties = false`.
+/// `Default` is `own_properties_only = true`, `observable = true`,
+/// `only_non_index_properties = false`, `include_symbols = true`.
 // Runtime flags (not const generics) because the branches gate per-property work, not a
-// hot inner loop, and the monomorphization fan-out would be 32 instantiations. Profile
+// hot inner loop, and the monomorphization fan-out would be 2^N instantiations. Profile
 // if hot.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct JSPropertyIteratorOptions {
@@ -50,7 +50,7 @@ impl Default for JSPropertyIteratorOptions {
     }
 }
 
-/// Two-field shorthand of [`JSPropertyIteratorOptions`]; the remaining three options
+/// Two-field shorthand of [`JSPropertyIteratorOptions`]; the remaining options
 /// take the default values via the `From` conversion.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct PropertyIteratorOptions {

--- a/src/jsc/JSPropertyIterator.rs
+++ b/src/jsc/JSPropertyIterator.rs
@@ -18,10 +18,11 @@ pub struct JSPropertyIteratorOptions {
     pub own_properties_only: bool,
     pub observable: bool,
     pub only_non_index_properties: bool,
+    pub include_symbols: bool,
 }
 
 impl JSPropertyIteratorOptions {
-    /// Shorthand for the most common call-site shape; the remaining three
+    /// Shorthand for the most common call-site shape; the remaining
     /// options take the [`Default`] values.
     pub const fn new(skip_empty_name: bool, include_value: bool) -> Self {
         Self {
@@ -30,6 +31,7 @@ impl JSPropertyIteratorOptions {
             own_properties_only: true,
             observable: true,
             only_non_index_properties: false,
+            include_symbols: true,
         }
     }
 }
@@ -43,6 +45,7 @@ impl Default for JSPropertyIteratorOptions {
             own_properties_only: true,
             observable: true,
             only_non_index_properties: false,
+            include_symbols: true,
         }
     }
 }
@@ -147,6 +150,7 @@ impl<'a> JSPropertyIterator<'a> {
             &mut len,
             options.own_properties_only,
             options.only_non_index_properties,
+            options.include_symbols,
         )?;
         if cfg!(debug_assertions) {
             if len > 0 {
@@ -259,6 +263,7 @@ impl JSPropertyIteratorImpl {
         count: &mut usize,
         own_properties_only: bool,
         only_non_index_properties: bool,
+        include_symbols: bool,
     ) -> JsResult<Option<NonNull<JSPropertyIteratorImpl>>> {
         // may return null without an exception
         let raw = from_js_host_call_generic(global_object, || {
@@ -268,6 +273,7 @@ impl JSPropertyIteratorImpl {
                 count,
                 own_properties_only,
                 only_non_index_properties,
+                include_symbols,
             )
         })?;
         Ok(NonNull::new(raw))
@@ -320,6 +326,7 @@ unsafe extern "C" {
         count: &mut usize,
         own_properties_only: bool,
         only_non_index_properties: bool,
+        include_symbols: bool,
     ) -> *mut JSPropertyIteratorImpl;
     safe fn Bun__JSPropertyIterator__getNameAndValue(
         iter: &mut JSPropertyIteratorImpl,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5992,6 +5992,7 @@ impl VirtualMachine {
                     own_properties_only: true,
                     observable: false,
                     only_non_index_properties: true,
+                    include_symbols: true,
                 },
             )?;
             let longest_name = iterator.get_longest_property_name().min(10);

--- a/src/jsc/bindings/JSPropertyIterator.cpp
+++ b/src/jsc/bindings/JSPropertyIterator.cpp
@@ -36,7 +36,7 @@ public:
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(JSPropertyIterator);
 };
 
-extern "C" JSPropertyIterator* Bun__JSPropertyIterator__create(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue encodedValue, size_t* count, bool own_properties_only, bool only_non_index_properties)
+extern "C" JSPropertyIterator* Bun__JSPropertyIterator__create(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue encodedValue, size_t* count, bool own_properties_only, bool only_non_index_properties, bool include_symbols)
 {
     auto& vm = JSC::getVM(globalObject);
     JSC::JSValue value = JSValue::decode(encodedValue);
@@ -45,7 +45,7 @@ extern "C" JSPropertyIterator* Bun__JSPropertyIterator__create(JSC::JSGlobalObje
     ASSERT(count);
 
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSC::PropertyNameArrayBuilder array(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Exclude);
+    JSC::PropertyNameArrayBuilder array(vm, include_symbols ? PropertyNameMode::StringsAndSymbols : PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
 
     if (object->hasNonReifiedStaticProperties()) [[unlikely]] {
         object->reifyAllStaticProperties(globalObject);

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -674,7 +674,7 @@ pub(crate) fn inspect_table(
         enable_colors: false,
         add_newline: false,
         flush: false,
-        max_depth: 5,
+        max_depth: 0,
         quote_strings: true,
         ordered_properties: false,
         single_line: true,
@@ -698,7 +698,7 @@ pub(crate) fn inspect_table(
         value,
         properties,
     )?;
-    table_printer.value_formatter.depth = format_options.max_depth;
+    table_printer.value_formatter.max_depth = format_options.max_depth;
     table_printer.value_formatter.ordered_properties = format_options.ordered_properties;
     table_printer.value_formatter.single_line = format_options.single_line;
 

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -154,6 +154,7 @@ const PROP_ITER_OPTS: JSPropertyIteratorOptions = JSPropertyIteratorOptions {
     own_properties_only: true,
     observable: true,
     only_non_index_properties: false,
+    include_symbols: true,
 };
 
 impl Config {

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -1340,6 +1340,7 @@ impl Expect {
                     own_properties_only: false,
                     observable: true,
                     only_non_index_properties: false,
+                    include_symbols: true,
                 },
             )?;
 

--- a/test/js/bun/console/console-table.test.ts
+++ b/test/js/bun/console/console-table.test.ts
@@ -4,12 +4,9 @@ import { bunEnv, bunExe } from "harness";
 
 // `console.table` and `Bun.inspect.table` share the same native TablePrinter,
 // so we can render in-process instead of spawning a subprocess per case.
-// Two differences to mirror so the existing snapshots stay valid:
-//   1. When the first argument is not an object, `console.table` falls back to
-//      `console.log`-style formatting, whereas `Bun.inspect.table` returns "".
-//   2. `console.table` formats cell values starting at depth 0, whereas
-//      `Bun.inspect.table` starts at `max_depth` (5). Pass `{ depth: 0 }`
-//      explicitly so nested objects in cells render the same way.
+// One difference to mirror so the existing snapshots stay valid: when the
+// first argument is not an object, `console.table` falls back to
+// `console.log`-style formatting, whereas `Bun.inspect.table` returns "".
 function renderTable(...args: any[]): string {
   const [data, properties] = args;
   if (typeof data !== "object" || data === null) {
@@ -19,6 +16,16 @@ function renderTable(...args: any[]): string {
   return properties === undefined
     ? Bun.inspect.table(data, { depth: 0 })
     : Bun.inspect.table(data, properties, { depth: 0 });
+}
+
+// Strip cell contents, keeping only the header row's column names, so column
+// model assertions don't depend on per-cell formatter output.
+function columnNames(out: string): string[] {
+  const header = out.split("\n")[1] ?? "";
+  return header
+    .split("│")
+    .slice(2, -1)
+    .map(s => s.trim());
 }
 
 describe("console.table", () => {
@@ -164,6 +171,108 @@ describe("console.table", () => {
   test.each(cases)("expected output for: %s", (label, { args }) => {
     const actualOutput = renderTable(...args());
     expect(actualOutput).toMatchSnapshot();
+  });
+
+  // https://nodejs.org/api/console.html#consoletabletabulardata-properties
+  // Node builds the column union by assigning into a null-proto object keyed by
+  // the ObjectKeys of each row, then reading it back with ObjectKeys. That
+  // means: symbol keys are excluded, duplicate keys dedupe, and the final
+  // column order is array-index names (sorted numerically) before string names
+  // (first-seen). Set entries always render in a single Values column.
+  describe("column model (node compat)", () => {
+    test("symbol keys on a row are not columns", () => {
+      const out = Bun.inspect.table([{ a: 1, [Symbol("s")]: 2, [Symbol("s")]: 3 }]);
+      expect(columnNames(out)).toEqual(["a"]);
+      expect(out).toBe(`┌───┬───┐\n│   │ a │\n├───┼───┤\n│ 0 │ 1 │\n└───┴───┘\n`);
+    });
+
+    test("symbol-keyed rows on a plain-object table are skipped", () => {
+      const out = Bun.inspect.table({ x: { a: 1 }, [Symbol("y")]: { b: 2 } });
+      expect(columnNames(out)).toEqual(["a"]);
+      expect(out).toBe(`┌───┬───┐\n│   │ a │\n├───┼───┤\n│ x │ 1 │\n└───┴───┘\n`);
+    });
+
+    test("properties filter is deduplicated", () => {
+      const out = Bun.inspect.table([{ a: 1, b: 2 }], ["b", "b", "a"]);
+      expect(columnNames(out)).toEqual(["b", "a"]);
+      expect(out).toBe(`┌───┬───┬───┐\n│   │ b │ a │\n├───┼───┼───┤\n│ 0 │ 2 │ 1 │\n└───┴───┴───┘\n`);
+    });
+
+    test("Set of objects renders a single Values column", () => {
+      const out = Bun.inspect.table(new Set([1, { a: 2 }]));
+      expect(columnNames(out)).toEqual(["Values"]);
+      expect(out).toBe(
+        `┌───┬──────────┐\n│   │ Values   │\n├───┼──────────┤\n│ 0 │ 1        │\n│ 1 │ { a: 2 } │\n└───┴──────────┘\n`,
+      );
+    });
+
+    test("multi-row column union puts integer-like keys first", () => {
+      expect(columnNames(Bun.inspect.table([{ b: 1 }, { a: 2, "7": 3 }]))).toEqual(["7", "b", "a"]);
+      expect(columnNames(Bun.inspect.table([{ b: 1, "1": 2 }, { "0": 3, a: 4 }]))).toEqual(["0", "1", "b", "a"]);
+      expect(columnNames(Bun.inspect.table([{ "10": 1 }, { "2": 2 }, { "1": 3 }]))).toEqual(["1", "2", "10"]);
+      // 4294967295 is not an array index; "01" and "-1" are string keys
+      expect(columnNames(Bun.inspect.table([{ "4294967295": 1 }, { "4294967294": 2 }]))).toEqual([
+        "4294967294",
+        "4294967295",
+      ]);
+      expect(columnNames(Bun.inspect.table([{ "01": 1 }, { "0": 2 }]))).toEqual(["0", "01"]);
+      expect(columnNames(Bun.inspect.table([{ "-1": 1 }, { "0": 2 }]))).toEqual(["0", "-1"]);
+    });
+
+    test("multi-row column union places cells in the right columns", () => {
+      expect(Bun.inspect.table([{ b: 1 }, { a: 2, "7": 3 }])).toBe(
+        `┌───┬───┬───┬───┐\n│   │ 7 │ b │ a │\n├───┼───┼───┼───┤\n│ 0 │   │ 1 │   │\n│ 1 │ 3 │   │ 2 │\n└───┴───┴───┴───┘\n`,
+      );
+    });
+
+    test("properties filter is reordered and deduplicated together", () => {
+      const out = Bun.inspect.table([{ a: 1, "7": 2 }], ["a", "7", "a", "7"]);
+      expect(columnNames(out)).toEqual(["7", "a"]);
+      expect(out).toBe(`┌───┬───┬───┐\n│   │ 7 │ a │\n├───┼───┼───┤\n│ 0 │ 2 │ 1 │\n└───┴───┴───┘\n`);
+    });
+
+    test("single-row integer-key order is unchanged", () => {
+      expect(columnNames(Bun.inspect.table([{ a: 1, "0": 2, "42": 3, b: 4 }]))).toEqual(["0", "42", "a", "b"]);
+    });
+
+    // Checked via a spawned process so the assertion exercises console.table
+    // itself, and so cell depth is the console.table default rather than
+    // whatever Bun.inspect.table's option processing chose.
+    test("console.table clamps cell depth and applies the column model", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `console.table([{ a: { x: { y: { z: 9 } } } }]);
+console.table([{ a: 1, [Symbol("s")]: 2 }]);
+console.table([{ a: 1, b: 2 }], ["b", "b", "a"]);
+console.table(new Set([1, { a: 2 }]));
+console.table([{ b: 1 }, { a: 2, "7": 3 }]);`,
+        ],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const tables = stdout.split(/\n(?=┌)/);
+      expect(tables).toHaveLength(5);
+
+      // (d) depth clamp: nested object under `x` must be truncated, not expanded
+      expect(tables[0]).toContain("[Object");
+      expect(tables[0]).not.toContain("z: 9");
+
+      const cols = (t: string) =>
+        (t.split("\n")[1] ?? "")
+          .split("│")
+          .slice(2, -1)
+          .map(s => s.trim());
+      expect(cols(tables[1])).toEqual(["a"]);
+      expect(cols(tables[2])).toEqual(["b", "a"]);
+      expect(cols(tables[3])).toEqual(["Values"]);
+      expect(cols(tables[4])).toEqual(["7", "b", "a"]);
+
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    });
   });
 });
 

--- a/test/js/bun/console/console-table.test.ts
+++ b/test/js/bun/console/console-table.test.ts
@@ -206,6 +206,14 @@ describe("console.table", () => {
       );
     });
 
+    test("SetIterator of objects renders a single Values column", () => {
+      const out = Bun.inspect.table(new Set([1, { a: 2 }]).values());
+      expect(columnNames(out)).toEqual(["Values"]);
+      expect(out).toBe(
+        `┌───┬──────────┐\n│   │ Values   │\n├───┼──────────┤\n│ 0 │ 1        │\n│ 1 │ { a: 2 } │\n└───┴──────────┘\n`,
+      );
+    });
+
     test("multi-row column union puts integer-like keys first", () => {
       expect(columnNames(Bun.inspect.table([{ b: 1 }, { a: 2, "7": 3 }]))).toEqual(["7", "b", "a"]);
       expect(

--- a/test/js/bun/console/console-table.test.ts
+++ b/test/js/bun/console/console-table.test.ts
@@ -214,6 +214,12 @@ describe("console.table", () => {
       );
     });
 
+    test("properties filter is ignored for Set and Map inputs", () => {
+      expect(columnNames(Bun.inspect.table(new Set([{ a: 1 }]), ["a"]))).toEqual(["Values"]);
+      expect(columnNames(Bun.inspect.table(new Set([{ a: 1 }]).values(), ["a"]))).toEqual(["Values"]);
+      expect(columnNames(Bun.inspect.table(new Map([["k", { a: 1 }]]), ["a"]))).toEqual(["Key", "Values"]);
+    });
+
     test("multi-row column union puts integer-like keys first", () => {
       expect(columnNames(Bun.inspect.table([{ b: 1 }, { a: 2, "7": 3 }]))).toEqual(["7", "b", "a"]);
       expect(

--- a/test/js/bun/console/console-table.test.ts
+++ b/test/js/bun/console/console-table.test.ts
@@ -281,15 +281,10 @@ console.table([{ b: 1 }, { a: 2, "7": 3 }]);`,
       expect(tables[0]).toContain("[Object");
       expect(tables[0]).not.toContain("z: 9");
 
-      const cols = (t: string) =>
-        (t.split("\n")[1] ?? "")
-          .split("│")
-          .slice(2, -1)
-          .map(s => s.trim());
-      expect(cols(tables[1])).toEqual(["a"]);
-      expect(cols(tables[2])).toEqual(["b", "a"]);
-      expect(cols(tables[3])).toEqual(["Values"]);
-      expect(cols(tables[4])).toEqual(["7", "b", "a"]);
+      expect(columnNames(tables[1])).toEqual(["a"]);
+      expect(columnNames(tables[2])).toEqual(["b", "a"]);
+      expect(columnNames(tables[3])).toEqual(["Values"]);
+      expect(columnNames(tables[4])).toEqual(["7", "b", "a"]);
 
       expect(stderr).toBe("");
       expect(exitCode).toBe(0);

--- a/test/js/bun/console/console-table.test.ts
+++ b/test/js/bun/console/console-table.test.ts
@@ -208,7 +208,14 @@ describe("console.table", () => {
 
     test("multi-row column union puts integer-like keys first", () => {
       expect(columnNames(Bun.inspect.table([{ b: 1 }, { a: 2, "7": 3 }]))).toEqual(["7", "b", "a"]);
-      expect(columnNames(Bun.inspect.table([{ b: 1, "1": 2 }, { "0": 3, a: 4 }]))).toEqual(["0", "1", "b", "a"]);
+      expect(
+        columnNames(
+          Bun.inspect.table([
+            { b: 1, "1": 2 },
+            { "0": 3, a: 4 },
+          ]),
+        ),
+      ).toEqual(["0", "1", "b", "a"]);
       expect(columnNames(Bun.inspect.table([{ "10": 1 }, { "2": 2 }, { "1": 3 }]))).toEqual(["1", "2", "10"]);
       // 4294967295 is not an array index; "01" and "-1" are string keys
       expect(columnNames(Bun.inspect.table([{ "4294967295": 1 }, { "4294967294": 2 }]))).toEqual([

--- a/test/js/bun/console/console-table.test.ts
+++ b/test/js/bun/console/console-table.test.ts
@@ -13,9 +13,7 @@ function renderTable(...args: any[]): string {
     // console.log(x): bare strings print raw, everything else is inspected.
     return (typeof data === "string" ? data : Bun.inspect(data)) + "\n";
   }
-  return properties === undefined
-    ? Bun.inspect.table(data, { depth: 0 })
-    : Bun.inspect.table(data, properties, { depth: 0 });
+  return properties === undefined ? Bun.inspect.table(data) : Bun.inspect.table(data, properties);
 }
 
 // Strip cell contents, keeping only the header row's column names, so column
@@ -275,7 +273,7 @@ console.table([{ b: 1 }, { a: 2, "7": 3 }]);`,
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       const tables = stdout.split(/\n(?=┌)/);
-      expect(tables).toHaveLength(5);
+      expect({ stderr, tableCount: tables.length }).toEqual({ stderr: "", tableCount: 5 });
 
       // (d) depth clamp: nested object under `x` must be truncated, not expanded
       expect(tables[0]).toContain("[Object");
@@ -286,7 +284,6 @@ console.table([{ b: 1 }, { a: 2, "7": 3 }]);`,
       expect(columnNames(tables[3])).toEqual(["Values"]);
       expect(columnNames(tables[4])).toEqual(["7", "b", "a"]);
 
-      expect(stderr).toBe("");
       expect(exitCode).toBe(0);
     });
   });


### PR DESCRIPTION
## What

`console.table`'s column model diverged from Node.js in five ways that change which data a table shows, not just how it looks.

```js
console.table([{ a: 1, [Symbol("s")]: 2, [Symbol("s")]: 3 }]);
// (a) node: column a only.  bun: columns a,s (description collision, s=3 last-wins)

console.table([{ a: 1, b: 2 }], ["b", "b", "a"]);
// (b) node: columns b,a (deduped).  bun: b,b,a

console.table(new Set([1, { a: 2 }]));
// (c) node: one Values column.  bun: columns a,Values (objects exploded)

console.table([{ a: { x: { y: { z: 9 } } } }]);
// (d) node cell: "{ x: [Object] }".  bun: "{ x: { y: { z: 9 } } }"

console.table([{ b: 1 }, { a: 2, "7": 3 }]);
// (e) node columns: 7,b,a (integer-like keys first).  bun: b,7,a (first-seen)
```

## Cause

Node [builds](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/console/constructor.js) the column union by assigning into a null-proto object keyed by `ObjectKeys(row)`, then reading it back via `ObjectKeys(map)`. That gives it three properties for free: symbol keys are excluded, duplicate keys dedupe, and the final order is `OrdinaryOwnPropertyKeys` (array-index names sorted numerically first, then string names in insertion order). Set/SetIterator go through a dedicated `setlike` branch that never explodes per-property columns, and cell values are inspected at depth 0.

Bun's `TablePrinter` (`src/jsc/ConsoleObject.rs`) instead kept columns in a first-seen `Vec` keyed by the stringified property name from a `JSPropertyIterator` that yields symbols, appended the `properties` filter verbatim, let Set rows fall through to the generic object-explode path, and formatted cells at `max_depth = 5`.

## Fix

- **(a)** Add an `include_symbols` flag to `JSPropertyIterator` (default `true` so every existing caller keeps its behaviour) and set it `false` for both the per-row column scan and the outer row scan in `TablePrinter`.
- **(b)** Dedupe the `properties` filter when pre-populating columns.
- **(c)** Add an `is_set()` branch in `collect_row` that routes every Set entry to the Values column.
- **(d)** Set the cell formatter's `max_depth` to 0. `Bun.inspect.table` is updated to apply its `depth` option to `max_depth` (it was writing to the formatter's current `depth`, which happened to give the same one-level output via a different accident) with a matching default of 0.
- **(e)** After collecting rows, stably partition the data columns so array-index names (0 to 2^32-2, canonical form) sort numerically first and string names stay in first-seen order, then remap each row's cells accordingly.

## Verification

New `column model (node compat)` describe block in `test/js/bun/console/console-table.test.ts` covering all five cases plus the integer-index edge cases (`4294967295`, `01`, `-1`, numeric sort `1/2/10`). 8 of the 9 new tests fail on `USE_SYSTEM_BUN=1`; all 9 pass under `bun bd`. All pre-existing `console-table.test.ts` and `bun-inspect-table.test.ts` snapshots continue to match.

Not addressed here (cell-rendering cosmetics outside the column model): Node additionally renders cells whose value is a non-array object with more than two own keys as a bare `[Object]` (depth -1), and clamps arrays at `maxArrayLength: 3`. Those are formatter-level refinements and would need separate work in `Formatter`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/console/console-table.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (be529eb73)

test/js/bun/console/console-table.test.ts:
┌───┐
│   │
├───┤
└───┘
┌───┐
│   │
├───┤
└───┘
(pass) console.table > throws when second arg is invalid [11.97ms]
(pass) console.table > expected output for: not object (number) [15.37ms]
(pass) console.table > expected output for: not object (string) [3.16ms]
(pass) console.table > expected output for: object - empty [2.28ms]
(pass) console.table > expected output for: object [3.36ms]
(pass) console.table > expected output for: array - empty [1.95ms]
(pass) console.table > expected output for: array - plain [3.80ms]
(pass) console.table > expected output for: array - object [2.67ms]
(pass) console.tabl
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (be529eb73)

test/js/bun/console/console-table.test.ts:
┌───┐
│   │
├───┤
└───┘
┌───┐
│   │
├───┤
└───┘
(pass) console.table > throws when second arg is invalid [0.12ms]
(pass) console.table > expected output for: not object (number) [0.42ms]
(pass) console.table > expected output for: not object (string) [0.03ms]
(pass) console.table > expected output for: object - empty [0.02ms]
(pass) console.table > expected output for: object [0.03ms]
(pass) console.table > expected output for: array - empty [0.01ms]
(pass) console.table > expected output for: array - plain [0.02ms]
(pass) console.table > expected output for: array - object [0.01ms]
(pass) console.table > expected output for: array - objects with diff props [0.01ms]
(pass) console.table > expected output for: array - mixed [0.02ms]
(pass) console.table > expected output for: set [0.02ms]
(pass) console.table > expected output for: map [0.03ms]
(pass) console.table > expected output for: properties [0.02ms]
(pass) console.table > expected output for: properties - empty [0.01ms]
(pass) console.table > expected output for:
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/console/console-table.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (be529eb73)

test/js/bun/console/console-table.test.ts:
┌───┐
│   │
├───┤
└───┘
┌───┐
│   │
├───┤
└───┘
(pass) console.table > throws when second arg is invalid [6.82ms]
(pass) console.table > expected output for: not object (number) [8.64ms]
(pass) console.table > expected output for: not object (string) [1.75ms]
(pass) console.table > expected output for: object - empty [1.33ms]
(pass) console.table > expected output for: object [2.12ms]
(pass) console.table > expected output for: array - empty [1.13ms]
(pass) console.table > expected output for: array - plain [2.01ms]
(pass) console.table > expected output for: array - object [1.51ms]
(pass) console.table 
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 744ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[2/7] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[3/7] gen cpp.rs (cppbind)
[3/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/sr
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConsoleObject.rs                  | 107 +++++++++++++++++++++--
 src/jsc/JSPropertyIterator.rs             |  17 ++--
 src/jsc/VirtualMachine.rs                 |   1 +
 src/jsc/bindings/JSPropertyIterator.cpp   |   4 +-
 src/runtime/api/BunObject.rs              |   4 +-
 src/runtime/api/JSTranspiler.rs           |   1 +
 src/runtime/test_runner/expect.rs         |   1 +
 test/js/bun/console/console-table.test.ts | 140 ++++++++++++++++++++++++++++--
 8 files changed, 249 insertions(+), 26 deletions(-)
```

</details>

**gate history** · 4 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/jsc/ConsoleObject.rs                       6     13      0
src/jsc/JSPropertyIterator.rs                  3      5      0
src/jsc/VirtualMachine.rs                      1      1      0
src/jsc/bindings/JSPropertyIterator.cpp        1      1      0
src/runtime/api/BunObject.rs                   1      2      0
src/runtime/api/JSTranspiler.rs                1      1      0
src/runtime/test_runner/expect.rs              1      1      0
test/js/bun/console/console-table.test.ts      5      8      0
```

</details>

<!-- robobun:evidence:end -->