### PR TITLE
worker_threads: reject function for options.env with ERR_INVALID_ARG_TYPE

### DIFF
--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -263,7 +263,8 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSWorkerDOMConstructor::
         }
 
         if (!shareEnv) {
-            if (envValue && !(envValue.isObject() || envValue.isUndefinedOrNull())) {
+            // isObject() is true for functions; node's validateObject rejects them.
+            if (envValue && !envValue.isUndefinedOrNull() && (!envValue.isObject() || envValue.isCallable())) {
                 return Bun::ERR::INVALID_ARG_TYPE(throwScope, globalObject, "options.env"_s, "object or one of undefined, null, or worker_threads.SHARE_ENV"_s, envValue);
             }
             JSObject* envObject = nullptr;

--- a/test/js/node/worker_threads/worker-env-validation.test.ts
+++ b/test/js/node/worker_threads/worker-env-validation.test.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "bun:test";
+import { Worker } from "node:worker_threads";
+
+test("env: function is rejected with ERR_INVALID_ARG_TYPE, not accepted as an env object", () => {
+  const fn = () => {};
+  (fn as any).OWNPROP = "x";
+  for (const env of [fn, function named() {}, class C {}, async () => {}]) {
+    expect(() => new Worker("1", { eval: true, env: env as any })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
+  }
+  // object-likes that node accepts (validateObject with kValidateObjectAllowArray) must stay accepted
+  for (const env of [[], new Date(), /re/]) {
+    let w: Worker;
+    expect(() => (w = new Worker("1", { eval: true, env: env as any }))).not.toThrow();
+    w!.unref();
+    w!.terminate();
+  }
+});

--- a/test/js/node/worker_threads/worker-env-validation.test.ts
+++ b/test/js/node/worker_threads/worker-env-validation.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { Worker } from "node:worker_threads";
 
 test("env: function is rejected with ERR_INVALID_ARG_TYPE, not accepted as an env object", () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1366,23 +1366,6 @@ test("*Internal introspection methods are DontEnum on Worker.prototype", () => {
   expect(enumerable).not.toContain("cpuUsageInternal");
 });
 
-test("env: function is rejected with ERR_INVALID_ARG_TYPE, not accepted as an env object", () => {
-  const fn = () => {};
-  (fn as any).OWNPROP = "x";
-  for (const env of [fn, function named() {}, class C {}, async () => {}]) {
-    expect(() => new Worker("1", { eval: true, env: env as any })).toThrow(
-      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
-    );
-  }
-  // object-likes that node accepts (validateObject with kValidateObjectAllowArray) must stay accepted
-  for (const env of [[], new Date(), /re/]) {
-    let w: Worker;
-    expect(() => (w = new Worker("1", { eval: true, env: env as any }))).not.toThrow();
-    w!.unref();
-    w!.terminate();
-  }
-});
-
 describe("env: SHARE_ENV shares the spawning thread's env, not a process-wide one", () => {
   async function run(mode: string) {
     const proc = Bun.spawn({

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1366,6 +1366,23 @@ test("*Internal introspection methods are DontEnum on Worker.prototype", () => {
   expect(enumerable).not.toContain("cpuUsageInternal");
 });
 
+test("env: function is rejected with ERR_INVALID_ARG_TYPE, not accepted as an env object", () => {
+  const fn = () => {};
+  (fn as any).OWNPROP = "x";
+  for (const env of [fn, function named() {}, class C {}, async () => {}]) {
+    expect(() => new Worker("1", { eval: true, env: env as any })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
+  }
+  // object-likes that node accepts (validateObject with kValidateObjectAllowArray) must stay accepted
+  for (const env of [[], new Date(), /re/]) {
+    let w: Worker;
+    expect(() => (w = new Worker("1", { eval: true, env: env as any }))).not.toThrow();
+    w!.unref();
+    w!.terminate();
+  }
+});
+
 describe("env: SHARE_ENV shares the spawning thread's env, not a process-wide one", () => {
   async function run(mode: string) {
     const proc = Bun.spawn({


### PR DESCRIPTION
## What

`new Worker(file, { env: someFunction })` was accepted. The function's own enumerable properties silently became the worker's entire environment (parent env dropped, no error). Node throws a synchronous `ERR_INVALID_ARG_TYPE` from the constructor.

```js
import { Worker } from "node:worker_threads";
const fn = () => {};
fn.OWNPROP = "fn-own";
new Worker(src, { env: fn });
// node:  TypeError [ERR_INVALID_ARG_TYPE]: The "options.env" property must be of type object ...
// bun:   worker boots with process.env = { OWNPROP: "fn-own" } (parent env gone)
```

## Cause

`JSWorker.cpp:266` gates the option with `envValue.isObject()`, which is `true` for functions in JSC. The accepted function then flows into the `getOwnPropertyNames` snapshot loop, so its own properties become the whole env. Node's `validateObject` (called with `kValidateObjectAllowArray | kValidateObjectAllowNullable`) uses a `typeof`-based check that excludes functions.

## Fix

Add `envValue.isCallable()` to the rejection condition, matching `Bun::V::validateObject` and node's validator. Arrays / Date / RegExp remain accepted (node parity); only callables are newly rejected.

## Verification

New test in `test/js/node/worker_threads/worker-env-validation.test.ts` covers arrow, named function, class, and async arrow (all throw `ERR_INVALID_ARG_TYPE`), plus `[]` / `Date` / `RegExp` still accepted.

```
git stash push -- src/ && bun bd test ... -t "env: function is rejected"   # fails (fn accepted, no throw)
git stash pop   && bun bd test ... -t "env: function is rejected"          # passes (7 asserts)
```

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker-env-validation.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (468546b13)

test/js/node/worker_threads/worker-env-validation.test.ts:
3 | 
4 | test("env: function is rejected with ERR_INVALID_ARG_TYPE, not accepted as an env object", () => {
5 |   const fn = () => {};
6 |   (fn as any).OWNPROP = "x";
7 |   for (const env of [fn, function named() {}, class C {}, async () => {}]) {
8 |     expect(() => new Worker("1", { eval: true, env: env as any })).toThrow(
                                                                       ^
error: expect(received).toThrow(expected)

Expected constructor: ExpectObjectContaining

Received function did not throw
Received value: Worker {
  _events: [Object: null prototype] {},
  _eventsCount: 0,
  _maxListeners: undefined,
  [Symbol(kC
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (2725df325)

test/js/node/worker_threads/worker-env-validation.test.ts:
(pass) env: function is rejected with ERR_INVALID_ARG_TYPE, not accepted as an env object [6.26ms]

 1 pass
 0 fail
 7 expect() calls
Ran 1 test across 1 file. [323.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker-env-validation.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (468546b13)

test/js/node/worker_threads/worker-env-validation.test.ts:
(pass) env: function is rejected with ERR_INVALID_ARG_TYPE, not accepted as an env object [394.66ms]

 1 pass
 0 fail
 7 expect() calls
Ran 1 test across 1 file. [3.60s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 1054ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen cpp.rs (cppbind)
[2/5] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[2/5] link bun-profile
[3/5] bun-profile --revision
1.4.0-canary.1+2725df325
[5/5] strip bun
[build] done
bun test v1.4.0-canary.1 (2725df325)

test/js/node/worker_threads/worker-env-validation.test.ts:
(pass) env: function is rejected with ERR_INVALID_ARG_TYPE, not accepted as an env object [30.74ms]

 1 pass
 0 fail
 7 expect() calls
Ran 1 test across 1 file. [374.00ms]
__F:0:S:0
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/JSWorker.cpp                 |  3 ++-
 .../node/worker_threads/worker-env-validation.test.ts | 19 +++++++++++++++++++
 2 files changed, 21 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/bindings/webcore/JSWorker.cpp                         1      1      0
…st/js/node/worker_threads/worker-env-validation.test.ts      0      1      0
```

</details>

<!-- robobun:evidence:end -->