### PR TITLE
js_parser: accept `!`, `#name`, and `export @dec` in standard decorator grammar

### DIFF
--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -824,7 +824,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         match p.lexer.token {
-            T::TClass | T::TConst | T::TFunction | T::TVar => {
+            T::TClass | T::TConst | T::TFunction | T::TVar | T::TAt => {
                 opts.is_export = true;
                 p.parse_stmt(opts)
             }

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -111,8 +111,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // "@decorator export declare abstract class Foo {}"
             // "@decorator export default class Foo {}"
             // "@decorator export default abstract class Foo {}"
+            // (but reject "export @decorator export class Foo {}")
             if p.lexer.token != T::TClass
-                && p.lexer.token != T::TExport
+                && !(p.lexer.token == T::TExport && !opts.is_export)
                 && !(Self::IS_TYPESCRIPT_ENABLED && p.lexer.is_contextual_keyword(b"abstract"))
                 && !(Self::IS_TYPESCRIPT_ENABLED && p.lexer.is_contextual_keyword(b"declare"))
             {

--- a/src/js_parser/parse/parse_typescript.rs
+++ b/src/js_parser/parse/parse_typescript.rs
@@ -76,7 +76,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     ///   @ DecoratorParenthesizedExpression
     pub fn parse_standard_decorator(&mut self) -> Result<ExprNodeIndex, Error> {
         let p = self;
-        let loc = p.lexer.loc();
 
         // @(Expression) — parenthesized, any expression allowed
         if p.lexer.token == T::TOpenParen {
@@ -92,6 +91,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return Err(crate::Error::SyntaxError);
         }
 
+        let loc = p.lexer.loc();
         let ident = p.lexer.identifier;
         let ref_ = p.store_name_in_ref(ident)?;
         let mut expr = p.new_expr(
@@ -103,64 +103,99 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         );
         p.lexer.next()?;
 
-        // Skip TypeScript type arguments after the identifier (e.g., @foo<T>)
-        if Self::IS_TYPESCRIPT_ENABLED {
-            let _ = p.skip_type_script_type_arguments::<false, false>()?;
-        }
+        loop {
+            match p.lexer.token {
+                T::TExclamation => {
+                    // Skip over TypeScript non-null assertions
+                    if p.lexer.has_newline_before {
+                        break;
+                    }
+                    if !Self::IS_TYPESCRIPT_ENABLED {
+                        p.lexer.unexpected()?;
+                        return Err(crate::Error::SyntaxError);
+                    }
+                    p.lexer.next()?;
+                }
 
-        // DecoratorMemberExpression: Identifier (.Identifier)*
-        while p.lexer.token == T::TDot || p.lexer.token == T::TQuestionDot {
-            // Forbid optional chaining in decorators
-            if p.lexer.token == T::TQuestionDot {
-                let err_loc = p.lexer.loc();
-                p.log().add_error(
-                    Some(p.source),
-                    err_loc,
-                    b"Optional chaining is not allowed in decorator expressions",
-                );
-                return Err(crate::Error::SyntaxError);
+                T::TDot | T::TQuestionDot => {
+                    // The grammar for "DecoratorMemberExpression" currently forbids "?."
+                    if p.lexer.token == T::TQuestionDot {
+                        p.log().add_range_error(
+                            Some(p.source),
+                            p.lexer.range(),
+                            b"Optional chaining is not allowed in decorator expressions; wrap the expression in parentheses to use it as a decorator",
+                        );
+                    }
+                    p.lexer.next()?;
+
+                    if p.lexer.token == T::TPrivateIdentifier && p.allow_private_identifiers {
+                        let name = p.lexer.identifier;
+                        let name_loc = p.lexer.loc();
+                        p.lexer.next()?;
+                        let ref_ = p.store_name_in_ref(name)?;
+                        let index = p.new_expr(E::PrivateIdentifier { ref_ }, name_loc);
+                        expr = p.new_expr(
+                            E::Index {
+                                target: expr,
+                                index,
+                                optional_chain: None,
+                            },
+                            loc,
+                        );
+                    } else {
+                        if !p.lexer.is_identifier_or_keyword() {
+                            p.lexer.expect(T::TIdentifier)?;
+                            return Err(crate::Error::SyntaxError);
+                        }
+                        let name = E::Str::new(p.lexer.identifier);
+                        let name_loc = p.lexer.loc();
+                        p.lexer.next()?;
+                        expr = p.new_expr(
+                            E::Dot {
+                                target: expr,
+                                name,
+                                name_loc,
+                                ..Default::default()
+                            },
+                            loc,
+                        );
+                    }
+                }
+
+                T::TOpenParen => {
+                    let args = p.parse_call_args()?;
+                    expr = p.new_expr(
+                        E::Call {
+                            target: expr,
+                            args: args.list,
+                            close_paren_loc: args.loc,
+                            ..Default::default()
+                        },
+                        loc,
+                    );
+
+                    // The grammar for "DecoratorCallExpression" is terminal
+                    if p.lexer.token == T::TDot {
+                        p.log().add_range_error(
+                            Some(p.source),
+                            p.lexer.range(),
+                            b"A decorator call expression cannot be followed by a property access; wrap the expression in parentheses to use it as a decorator",
+                        );
+                        continue;
+                    }
+                    break;
+                }
+
+                _ => {
+                    // "@x<y>" / "@x.y<z>"
+                    if Self::IS_TYPESCRIPT_ENABLED
+                        && p.skip_type_script_type_arguments::<false, false>()?
+                    {
+                        continue;
+                    }
+                    break;
+                }
             }
-
-            p.lexer.next()?;
-
-            if !p.lexer.is_identifier_or_keyword() {
-                p.lexer.expect(T::TIdentifier)?;
-                return Err(crate::Error::SyntaxError);
-            }
-
-            let name = E::Str::new(p.lexer.identifier);
-            let name_loc = p.lexer.loc();
-            p.lexer.next()?;
-
-            expr = p.new_expr(
-                E::Dot {
-                    target: expr,
-                    name,
-                    name_loc,
-                    ..Default::default()
-                },
-                loc,
-            );
-
-            // Skip TypeScript type arguments after member access (e.g., @foo.bar<T>)
-            if Self::IS_TYPESCRIPT_ENABLED {
-                let _ = p.skip_type_script_type_arguments::<false, false>()?;
-            }
-        }
-
-        // DecoratorCallExpression: DecoratorMemberExpression Arguments
-        // Only a single call is allowed, no chaining after the call
-        if p.lexer.token == T::TOpenParen {
-            let args = p.parse_call_args()?;
-            expr = p.new_expr(
-                E::Call {
-                    target: expr,
-                    args: args.list,
-                    close_paren_loc: args.loc,
-                    ..Default::default()
-                },
-                loc,
-            );
         }
 
         Ok(expr)

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -425,10 +425,38 @@ describe("ES Decorators", () => {
       expect(exitCode).toBe(0);
     });
 
-    test("private name in decorator member expression", async () => {
+    test("type arguments in decorator member expression are stripped", async () => {
       const { stdout, stderr, exitCode } = await runDecoratorTS(`
+        function dec<T>(cls: any, ctx: any) {
+          console.log(ctx.kind, ctx.name);
+          return cls;
+        }
+        const ns = {
+          dec: function<T>(tag: string) {
+            return function(cls: any, ctx: any) {
+              console.log(tag, ctx.name);
+              return cls;
+            };
+          },
+        };
+        @dec<string>
+        class A {}
+        @ns.dec<string>("hello")
+        class B {}
+        @ns<string>.dec<number>("bye")
+        class C {}
+        console.log("done");
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("class A\nhello B\nbye C\ndone\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.each(["ts", "js"])("private name in decorator member expression (.%s)", async ext => {
+      const run = ext === "ts" ? runDecoratorTS : runDecorator;
+      const { stdout, stderr, exitCode } = await run(`
         class Outer {
-          static #dec(cls: any, ctx: any) {
+          static #dec(cls, ctx) {
             console.log(ctx.kind, ctx.name);
             return cls;
           }
@@ -442,23 +470,23 @@ describe("ES Decorators", () => {
       expect(exitCode).toBe(0);
     });
 
-    test("export before decorator", async () => {
+    test.each(["ts", "js"])("export before decorator (.%s)", async ext => {
       using dir = tempDir("es-dec-export", {
         "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
-        "dep.ts": `
-          function dec(cls: any, ctx: any) {
+        [`dep.${ext}`]: `
+          function dec(cls, ctx) {
             console.log(ctx.kind, ctx.name);
             return cls;
           }
           export @dec class Foo {}
         `,
-        "test.ts": `
+        [`test.${ext}`]: `
           import { Foo } from "./dep";
           console.log(typeof Foo);
         `,
       });
       await using proc = Bun.spawn({
-        cmd: [bunExe(), "test.ts"],
+        cmd: [bunExe(), `test.${ext}`],
         env: bunEnv,
         cwd: String(dir),
         stderr: "pipe",
@@ -478,11 +506,36 @@ describe("ES Decorators", () => {
       expect(exitCode).not.toBe(0);
     });
 
+    test("optional chaining in decorator is rejected with a hint", async () => {
+      const { stderr, exitCode } = await runDecoratorTS(`
+        @x?.y class Foo {}
+      `);
+      expect(stderr).toContain("Optional chaining is not allowed in decorator expressions");
+      expect(stderr).toContain("wrap the expression in parentheses");
+      expect(exitCode).not.toBe(0);
+    });
+
     test("property access after call in decorator is rejected", async () => {
       const { stderr, exitCode } = await runDecoratorTS(`
         @x().y class Foo {}
       `);
       expect(stderr).toContain("wrap the expression in parentheses");
+      expect(exitCode).not.toBe(0);
+    });
+
+    test("decorators on both sides of export are rejected", async () => {
+      const { stderr, exitCode } = await runDecoratorTS(`
+        @x export @y class Foo {}
+      `);
+      expect(stderr).toContain('Expected "class" but found "@"');
+      expect(exitCode).not.toBe(0);
+    });
+
+    test("repeated export around a decorator is rejected", async () => {
+      const { stderr, exitCode } = await runDecoratorTS(`
+        export @dec export class Foo {}
+      `);
+      expect(stderr).toContain('Expected "class" but found "export"');
       expect(exitCode).not.toBe(0);
     });
   });

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -474,7 +474,7 @@ describe("ES Decorators", () => {
         const ns = { dec(cls, ctx) { return cls; } };
         @ns!.dec class Foo {}
       `);
-      expect(stderr).toContain("!");
+      expect(stderr).toContain("error: Unexpected !");
       expect(exitCode).not.toBe(0);
     });
 

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -390,6 +390,101 @@ describe("ES Decorators", () => {
       expect(stdout).toBe("hello bar\ndone\n");
       expect(exitCode).toBe(0);
     });
+
+    async function runDecoratorTS(code: string) {
+      using dir = tempDir("es-dec-ts", {
+        "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
+        "test.ts": code,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, stderr: filterStderr(rawStderr), exitCode };
+    }
+
+    test("non-null assertion in decorator member expression", async () => {
+      const { stdout, stderr, exitCode } = await runDecoratorTS(`
+        const ns = {
+          dec(cls: any, ctx: any) {
+            console.log(ctx.kind, ctx.name);
+            return cls;
+          },
+        };
+        @ns!.dec
+        class Foo {}
+        @ns!.dec!
+        class Bar {}
+        console.log("done");
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("class Foo\nclass Bar\ndone\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("private name in decorator member expression", async () => {
+      const { stdout, stderr, exitCode } = await runDecoratorTS(`
+        class Outer {
+          static #dec(cls: any, ctx: any) {
+            console.log(ctx.kind, ctx.name);
+            return cls;
+          }
+          static Inner = @Outer.#dec class Inner {};
+        }
+        new Outer.Inner();
+        console.log("done");
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("class Inner\ndone\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("export before decorator", async () => {
+      using dir = tempDir("es-dec-export", {
+        "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
+        "dep.ts": `
+          function dec(cls: any, ctx: any) {
+            console.log(ctx.kind, ctx.name);
+            return cls;
+          }
+          export @dec class Foo {}
+        `,
+        "test.ts": `
+          import { Foo } from "./dep";
+          console.log(typeof Foo);
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(filterStderr(rawStderr)).toBe("");
+      expect(stdout).toBe("class Foo\nfunction\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("non-null assertion in decorator is rejected in JavaScript", async () => {
+      const { stderr, exitCode } = await runDecorator(`
+        const ns = { dec(cls, ctx) { return cls; } };
+        @ns!.dec class Foo {}
+      `);
+      expect(stderr).toContain("!");
+      expect(exitCode).not.toBe(0);
+    });
+
+    test("property access after call in decorator is rejected", async () => {
+      const { stderr, exitCode } = await runDecoratorTS(`
+        @x().y class Foo {}
+      `);
+      expect(stderr).toContain("wrap the expression in parentheses");
+      expect(exitCode).not.toBe(0);
+    });
   });
 
   describe("metadata", () => {


### PR DESCRIPTION
## What

The TC39/standard decorator member-expression parser only handled `.ident` chains followed by at most one trailing call. TypeScript and esbuild accept several additional shapes that Bun was rejecting with a hard parse error.

## Repro

```ts
@x!.y class Foo {}                 // error: Expected "class" but found "!"
class Foo { #x = @y.#x class {} }  // error: Expected identifier but found "#x"
export @x class Foo {}             // error: Unexpected @
```

All three are accepted by both `tsc` and `esbuild`.

## Cause

`parse_standard_decorator` in `src/js_parser/parse/parse_typescript.rs` implemented only the minimal `Identifier(.Identifier)*(args)?` grammar. esbuild's `parseDecorator` (`internal/js_parser/js_parser.go` ~6924) loops over `!` / `.` / `?.` / `#name` / `(` / type-args at each step.

Separately, `t_export` in `parse_stmt.rs` had no `TAt` arm, so `export @dec class` fell through to `lexer.unexpected()`.

## Fix

* `parse_standard_decorator` now mirrors esbuild's loop: it consumes `!` (TypeScript only, no newline before), private identifiers after `.`, and TypeScript type arguments at each step of the member chain. Property access after a call and `?.` remain errors but recover with a hint to wrap the expression in parentheses.
* `t_export` gains a `T::TAt` match arm so `export @dec class` routes through the existing decorator-then-class path. The pre-existing guard in `t_export` still rejects `@x export @y class`.

## Tests

Added to `test/bundler/transpiler/es-decorators.test.ts` under "decorator expressions":
* non-null assertion in decorator member expression (`@ns!.dec`, `@ns!.dec!`)
* private name in decorator member expression (`@Outer.#dec`)
* `export @dec class Foo {}` (verifies the export binding works)
* `!` remains a syntax error in `.js` files
* property access after a call reports the wrap-in-parentheses hint

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/es-decorators.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (561267012)

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [532.10ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [512.98ms]
(pass) ES Decorators > class decorators > class decorator can replace class [496.66ms]
(pass) ES Decorators > class decorators > multiple class decorators apply in reverse order [498.60ms]
(pass) ES Decorators > method decorators > instance method decorator [498.83ms]
(pass) ES Decorators > method decorators > static method decorator [494.84ms]
(pass) ES Decorators > method decorators > method decorator context has correct access [501.54ms]
(pass) ES Decorators > getter decorators > getter decorat
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (b9284b2ec)

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [14.35ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [14.03ms]
(pass) ES Decorators > class decorators > class decorator can replace class [14.37ms]
(pass) ES Decorators > class decorators > multiple class decorators apply in reverse order [14.05ms]
(pass) ES Decorators > method decorators > instance method decorator [15.19ms]
(pass) ES Decorators > method decorators > static method decorator [17.68ms]
(pass) ES Decorators > method decorators > method decorator context has correct access [17.95ms]
(pass) ES Decorators > getter decorators > getter decorator [15.99ms]
(pass) ES Decorators > setter decorators > setter decorator [15.04ms]
(pass) ES Decorators > field decorators > field decorator receives undefined value [15.43ms]
(pass) ES Decorators > field decorators > multiple field decorators [14.18ms]
(pass) ES Decorators > field decorators > static field decorator [13.70ms]
(pass) ES Decorators > non-ASCII string-literal keys > Bun.Transpiler output preserves the key [0.70ms]
(p
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/es-decorators.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (561267012)

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [536.93ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [511.68ms]
(pass) ES Decorators > class decorators > class decorator can replace class [517.63ms]
(pass) ES Decorators > class decorators > multiple class decorators apply in reverse order [488.82ms]
(pass) ES Decorators > method decorators > instance method decorator [498.89ms]
(pass) ES Decorators > method decorators > static method decorator [488.10ms]
(pass) ES Decorators > method decorators > method decorator context has correct access [483.22ms]
(pass) ES Decorators > getter decorators > getter decorat
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 820ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/parse/parse_stmt.rs             |   5 +-
 src/js_parser/parse/parse_typescript.rs       | 145 +++++++++++++++----------
 test/bundler/transpiler/es-decorators.test.ts | 148 ++++++++++++++++++++++++++
 3 files changed, 241 insertions(+), 57 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/js_parser/parse/parse_stmt.rs                  5      4      0
src/js_parser/parse/parse_typescript.rs            1      1      0
test/bundler/transpiler/es-decorators.test.ts      4      5      0
```

</details>

<!-- robobun:evidence:end -->