### PR TITLE
js_parser: treat "async as T" / "async satisfies T" as a cast, not an arrow

### DIFF
--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1552,6 +1552,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         result
     }
 
+    #[inline]
+    fn check_for_arrow_after_the_current_token(&mut self) -> bool {
+        self.next_token_matches(|p| p.lexer.token == T::TEqualsGreaterThan)
+    }
+
     /// This parses an expression. This assumes we've already parsed the "async"
     /// keyword and are currently looking at the following token.
     pub fn parse_async_prefix_expr(
@@ -1599,36 +1604,22 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     if level.lte(Level::Assign) {
                         // p.markLoweredSyntaxFeature();
 
-                        let arg_ident = p.lexer.identifier;
-                        let arg_loc = p.lexer.loc();
-
                         // In TypeScript, "async <ident>" not followed by "=>" treats "async" as
                         // a plain identifier (e.g. "async as T"), matching tsc's two-token
                         // lookahead in isUnParenthesizedAsyncArrowFunctionWorker (TypeScript#8444).
-                        let is_arrow_fn = if Self::IS_TYPESCRIPT_ENABLED {
-                            let old_lexer = p.lexer.snapshot();
-                            p.lexer.is_log_disabled = true;
-                            let ok = matches!(p.lexer.next(), Ok(()))
-                                && p.lexer.token == T::TEqualsGreaterThan;
-                            if ok {
-                                p.lexer.is_log_disabled = old_lexer.is_log_disabled;
-                            } else {
-                                p.lexer.restore(&old_lexer);
-                            }
-                            ok
-                        } else {
-                            p.lexer.next()?;
-                            true
-                        };
+                        let is_arrow_fn = !Self::IS_TYPESCRIPT_ENABLED
+                            || p.check_for_arrow_after_the_current_token();
 
                         if is_arrow_fn {
-                            let ref_ = p.store_name_in_ref(arg_ident)?;
+                            let ref_ = p.store_name_in_ref(p.lexer.identifier)?;
+                            let arg_loc = p.lexer.loc();
                             let arg_binding = p.b(B::Identifier { r#ref: ref_ }, arg_loc);
                             let args: &'a mut [G::Arg] =
                                 p.arena.alloc_slice_fill_with(1, |_| G::Arg {
                                     binding: arg_binding,
                                     ..Default::default()
                                 });
+                            p.lexer.next()?;
 
                             let _ = p.push_scope_for_parse_pass(
                                 js_ast::scope::Kind::FunctionArgs,

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1603,11 +1603,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     if level.lte(Level::Assign) {
                         // p.markLoweredSyntaxFeature();
 
-                        // In TypeScript, "async as" / "async satisfies" (or any identifier not
-                        // followed by "=>") must treat "async" as an identifier, not the start
-                        // of an async arrow. TypeScript resolves this with a two-token lookahead
-                        // in "isUnParenthesizedAsyncArrowFunctionWorker"; see
-                        // https://github.com/microsoft/TypeScript/pull/8444.
+                        // In TypeScript, "async <ident>" not followed by "=>" treats "async" as
+                        // a plain identifier (e.g. "async as T"), matching tsc's two-token
+                        // lookahead in isUnParenthesizedAsyncArrowFunctionWorker (TypeScript#8444).
                         let is_arrow_fn = !Self::IS_TYPESCRIPT_ENABLED
                             || p.check_for_arrow_after_the_current_token();
 

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1552,11 +1552,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         result
     }
 
-    #[inline]
-    fn check_for_arrow_after_the_current_token(&mut self) -> bool {
-        self.next_token_matches(|p| p.lexer.token == T::TEqualsGreaterThan)
-    }
-
     /// This parses an expression. This assumes we've already parsed the "async"
     /// keyword and are currently looking at the following token.
     pub fn parse_async_prefix_expr(
@@ -1604,22 +1599,36 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     if level.lte(Level::Assign) {
                         // p.markLoweredSyntaxFeature();
 
+                        let arg_ident = p.lexer.identifier;
+                        let arg_loc = p.lexer.loc();
+
                         // In TypeScript, "async <ident>" not followed by "=>" treats "async" as
                         // a plain identifier (e.g. "async as T"), matching tsc's two-token
                         // lookahead in isUnParenthesizedAsyncArrowFunctionWorker (TypeScript#8444).
-                        let is_arrow_fn = !Self::IS_TYPESCRIPT_ENABLED
-                            || p.check_for_arrow_after_the_current_token();
+                        let is_arrow_fn = if Self::IS_TYPESCRIPT_ENABLED {
+                            let old_lexer = p.lexer.snapshot();
+                            p.lexer.is_log_disabled = true;
+                            let ok = matches!(p.lexer.next(), Ok(()))
+                                && p.lexer.token == T::TEqualsGreaterThan;
+                            if ok {
+                                p.lexer.is_log_disabled = old_lexer.is_log_disabled;
+                            } else {
+                                p.lexer.restore(&old_lexer);
+                            }
+                            ok
+                        } else {
+                            p.lexer.next()?;
+                            true
+                        };
 
                         if is_arrow_fn {
-                            let ref_ = p.store_name_in_ref(p.lexer.identifier)?;
-                            let arg_loc = p.lexer.loc();
+                            let ref_ = p.store_name_in_ref(arg_ident)?;
                             let arg_binding = p.b(B::Identifier { r#ref: ref_ }, arg_loc);
                             let args: &'a mut [G::Arg] =
                                 p.arena.alloc_slice_fill_with(1, |_| G::Arg {
                                     binding: arg_binding,
                                     ..Default::default()
                                 });
-                            p.lexer.next()?;
 
                             let _ = p.push_scope_for_parse_pass(
                                 js_ast::scope::Kind::FunctionArgs,

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1541,6 +1541,21 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(stmts)
     }
 
+    /// One-token lookahead: does "=>" immediately follow the current token?
+    /// The lexer is always restored, even if scanning the next token fails.
+    fn check_for_arrow_after_the_current_token(&mut self) -> bool {
+        let old_lexer = self.lexer.snapshot();
+        let old_log_disabled = self.lexer.is_log_disabled;
+        self.lexer.is_log_disabled = true;
+
+        let is_arrow_after_this_token =
+            matches!(self.lexer.next(), Ok(())) && self.lexer.token == T::TEqualsGreaterThan;
+
+        self.lexer.restore(&old_lexer);
+        self.lexer.is_log_disabled = old_log_disabled;
+        is_arrow_after_this_token
+    }
+
     /// This parses an expression. This assumes we've already parsed the "async"
     /// keyword and are currently looking at the following token.
     pub fn parse_async_prefix_expr(
@@ -1588,36 +1603,47 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     if level.lte(Level::Assign) {
                         // p.markLoweredSyntaxFeature();
 
-                        let ref_ = p.store_name_in_ref(p.lexer.identifier)?;
-                        let arg_loc = p.lexer.loc();
-                        let arg_binding = p.b(B::Identifier { r#ref: ref_ }, arg_loc);
-                        let args: &'a mut [G::Arg] = p.arena.alloc_slice_fill_with(1, |_| G::Arg {
-                            binding: arg_binding,
-                            ..Default::default()
-                        });
-                        p.lexer.next()?;
+                        // In TypeScript, "async as" / "async satisfies" (or any identifier not
+                        // followed by "=>") must treat "async" as an identifier, not the start
+                        // of an async arrow. TypeScript resolves this with a two-token lookahead
+                        // in "isUnParenthesizedAsyncArrowFunctionWorker"; see
+                        // https://github.com/microsoft/TypeScript/pull/8444.
+                        let is_arrow_fn = !Self::IS_TYPESCRIPT_ENABLED
+                            || p.check_for_arrow_after_the_current_token();
 
-                        let _ = p.push_scope_for_parse_pass(
-                            js_ast::scope::Kind::FunctionArgs,
-                            async_range.loc,
-                        )?;
+                        if is_arrow_fn {
+                            let ref_ = p.store_name_in_ref(p.lexer.identifier)?;
+                            let arg_loc = p.lexer.loc();
+                            let arg_binding = p.b(B::Identifier { r#ref: ref_ }, arg_loc);
+                            let args: &'a mut [G::Arg] =
+                                p.arena.alloc_slice_fill_with(1, |_| G::Arg {
+                                    binding: arg_binding,
+                                    ..Default::default()
+                                });
+                            p.lexer.next()?;
 
-                        let mut data = FnOrArrowDataParse {
-                            allow_await: AwaitOrYield::AllowExpr,
-                            needs_async_loc: args[0].binding.loc,
-                            ..Default::default()
-                        };
-                        // Pop the scope on the error path too.
-                        let mut arrow_body = match p.parse_arrow_body(args, &mut data) {
-                            Ok(body) => body,
-                            Err(e) => {
-                                p.pop_scope();
-                                return Err(e);
-                            }
-                        };
-                        arrow_body.is_async = true;
-                        p.pop_scope();
-                        return Ok(p.new_expr(arrow_body, async_range.loc));
+                            let _ = p.push_scope_for_parse_pass(
+                                js_ast::scope::Kind::FunctionArgs,
+                                async_range.loc,
+                            )?;
+
+                            let mut data = FnOrArrowDataParse {
+                                allow_await: AwaitOrYield::AllowExpr,
+                                needs_async_loc: args[0].binding.loc,
+                                ..Default::default()
+                            };
+                            // Pop the scope on the error path too.
+                            let mut arrow_body = match p.parse_arrow_body(args, &mut data) {
+                                Ok(body) => body,
+                                Err(e) => {
+                                    p.pop_scope();
+                                    return Err(e);
+                                }
+                            };
+                            arrow_body.is_async = true;
+                            p.pop_scope();
+                            return Ok(p.new_expr(arrow_body, async_range.loc));
+                        }
                     }
                 }
 

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1556,6 +1556,21 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         is_arrow_after_this_token
     }
 
+    /// One-token lookahead: is the contextual keyword "of" the next token?
+    /// Used to detect the literal "async of" sequence in a for-loop header.
+    pub(crate) fn check_for_of_after_the_current_token(&mut self) -> bool {
+        let old_lexer = self.lexer.snapshot();
+        let old_log_disabled = self.lexer.is_log_disabled;
+        self.lexer.is_log_disabled = true;
+
+        let is_of_after_this_token =
+            matches!(self.lexer.next(), Ok(())) && self.lexer.is_contextual_keyword(b"of");
+
+        self.lexer.restore(&old_lexer);
+        self.lexer.is_log_disabled = old_log_disabled;
+        is_of_after_this_token
+    }
+
     /// This parses an expression. This assumes we've already parsed the "async"
     /// keyword and are currently looking at the following token.
     pub fn parse_async_prefix_expr(

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1541,34 +1541,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(stmts)
     }
 
-    /// One-token lookahead: does "=>" immediately follow the current token?
-    /// The lexer is always restored, even if scanning the next token fails.
-    fn check_for_arrow_after_the_current_token(&mut self) -> bool {
+    /// One-token lookahead: advance past the current token, evaluate `pred`,
+    /// then unconditionally restore the lexer (including `is_log_disabled`).
+    #[inline]
+    pub(crate) fn next_token_matches(&mut self, pred: impl FnOnce(&Self) -> bool) -> bool {
         let old_lexer = self.lexer.snapshot();
-        let old_log_disabled = self.lexer.is_log_disabled;
         self.lexer.is_log_disabled = true;
-
-        let is_arrow_after_this_token =
-            matches!(self.lexer.next(), Ok(())) && self.lexer.token == T::TEqualsGreaterThan;
-
+        let result = matches!(self.lexer.next(), Ok(())) && pred(self);
         self.lexer.restore(&old_lexer);
-        self.lexer.is_log_disabled = old_log_disabled;
-        is_arrow_after_this_token
+        result
     }
 
-    /// One-token lookahead: is the contextual keyword "of" the next token?
-    /// Used to detect the literal "async of" sequence in a for-loop header.
-    pub(crate) fn check_for_of_after_the_current_token(&mut self) -> bool {
-        let old_lexer = self.lexer.snapshot();
-        let old_log_disabled = self.lexer.is_log_disabled;
-        self.lexer.is_log_disabled = true;
-
-        let is_of_after_this_token =
-            matches!(self.lexer.next(), Ok(())) && self.lexer.is_contextual_keyword(b"of");
-
-        self.lexer.restore(&old_lexer);
-        self.lexer.is_log_disabled = old_log_disabled;
-        is_of_after_this_token
+    #[inline]
+    fn check_for_arrow_after_the_current_token(&mut self) -> bool {
+        self.next_token_matches(|p| p.lexer.token == T::TEqualsGreaterThan)
     }
 
     /// This parses an expression. This assumes we've already parsed the "async"

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -535,7 +535,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let mut bad_async_range: Option<bun_ast::Range> = None;
             if !is_for_await
                 && p.lexer.is_contextual_keyword(b"async")
-                && p.check_for_of_after_the_current_token()
+                && p.next_token_matches(|p| p.lexer.is_contextual_keyword(b"of"))
             {
                 bad_async_range = Some(p.lexer.range());
             }

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -529,6 +529,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 bad_let_range = Some(p.lexer.range());
             }
 
+            // "for (async of" is disallowed by the [lookahead != async of] restriction
+            // on for-of. "for await (async of" is allowed. Capture the range here and
+            // clear it below if the initializer parses to anything other than a bare
+            // "async" identifier (e.g. "async.x", "async of => {}").
+            let mut bad_async_range: Option<bun_ast::Range> = None;
+            if !is_for_await && p.lexer.is_contextual_keyword(b"async") {
+                bad_async_range = Some(p.lexer.range());
+            }
+
             // Track the decl slice separately so we can reference it after `decls` is moved into
             // an arena-backed S::Local. The Vec's heap buffer stays put across the move; the
             // arena outlives this fn, so the lifetime-erased view remains valid.
@@ -582,12 +591,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     match res.stmt_or_expr {
                         js_ast::StmtOrExpr::Stmt(stmt) => {
                             bad_let_range = None;
+                            bad_async_range = None;
                             // Keep the "let"/"using" declarations visible to the for-in/for-of
                             // checks below ("forbid_initializers"), like the "var"/"const" arms.
                             decls_ptr = bun_ast::StoreSlice::new(res.decls.slice());
                             init_ = Some(stmt);
                         }
                         js_ast::StmtOrExpr::Expr(expr) => {
+                            if !matches!(expr.data, js_ast::ExprData::EIdentifier(_)) {
+                                bad_async_range = None;
+                            }
                             init_ = Some(p.s(
                                 S::SExpr {
                                     value: expr,
@@ -610,6 +623,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         Some(p.source),
                         r,
                         b"\"let\" must be wrapped in parentheses to be used as an expression here",
+                    );
+                    return Err(crate::Error::SyntaxError);
+                }
+
+                if let Some(r) = bad_async_range {
+                    let full = bun_ast::Range {
+                        loc: r.loc,
+                        len: p.lexer.range().end().start - r.loc.start,
+                    };
+                    p.log().add_range_error(
+                        Some(p.source),
+                        full,
+                        b"For loop initializers cannot start with \"async of\"",
                     );
                     return Err(crate::Error::SyntaxError);
                 }

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -530,10 +530,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
 
             // "for (async of" is disallowed by the [lookahead != async of] restriction
-            // on for-of; "for await (async of" is allowed. Cleared below if the init
-            // parses to anything other than a bare "async" identifier.
+            // on for-of; "for await (async of" is allowed. Cleared below when the init
+            // parses to anything other than a bare identifier (e.g. "async of => {}").
             let mut bad_async_range: Option<bun_ast::Range> = None;
-            if !is_for_await && p.lexer.is_contextual_keyword(b"async") {
+            if !is_for_await
+                && p.lexer.is_contextual_keyword(b"async")
+                && p.check_for_of_after_the_current_token()
+            {
                 bad_async_range = Some(p.lexer.range());
             }
 

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -530,9 +530,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
 
             // "for (async of" is disallowed by the [lookahead != async of] restriction
-            // on for-of. "for await (async of" is allowed. Capture the range here and
-            // clear it below if the initializer parses to anything other than a bare
-            // "async" identifier (e.g. "async.x", "async of => {}").
+            // on for-of; "for await (async of" is allowed. Cleared below if the init
+            // parses to anything other than a bare "async" identifier.
             let mut bad_async_range: Option<bun_ast::Range> = None;
             if !is_for_await && p.lexer.is_contextual_keyword(b"async") {
                 bad_async_range = Some(p.lexer.range());

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1276,6 +1276,7 @@ export default class {
       // lookahead above stops the arrow commit; see the [lookahead != async of]
       // restriction on the for-of grammar.
       ts.expectParseError("for (async of [7]);", 'For loop initializers cannot start with "async of"');
+      ts.expectParseError("for (async\nof [7]);", 'For loop initializers cannot start with "async of"');
       ts.expectPrinted_("for (async.x of [7]);", "for (async.x of [7])\n  ;\n");
       ts.expectPrinted_("for (async as any of [7]);", "for ((async) of [7])\n  ;\n");
       ts.expectPrinted_("for (async satisfies T of [7]);", "for ((async) of [7])\n  ;\n");
@@ -2271,6 +2272,11 @@ console.log(<div {...obj} key="after" />);`),
 
       // The keyword spelling is a syntax error, which is why the parentheses matter
       expect(() => parsed("for (async of [7]);", false, false)).toThrow();
+      expectParseError("for (async\nof [7]);", 'For loop initializers cannot start with "async of"');
+      expectPrinted_(
+        "async function f() { for await (async\nof [7]); }",
+        "async function f() {\n  for await ((async) of [7])\n    ;\n}",
+      );
     });
 
     it("await", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1252,6 +1252,21 @@ export default class {
       );
     });
 
+    it("identifier named async followed by as/satisfies is not an arrow function", () => {
+      // https://github.com/evanw/esbuild/issues/4027
+      // https://github.com/microsoft/TypeScript/pull/8444
+      ts.expectPrinted_("function f(async?) { g(async as boolean) }", "function f(async) {\n  g(async);\n}");
+      ts.expectPrinted_("function f(async?) { g(async satisfies boolean) }", "function f(async) {\n  g(async);\n}");
+      ts.expectPrinted_("function f(async?) { g(async in x) }", "function f(async) {\n  g(async in x);\n}");
+      ts.expectPrinted_("function f() { g(async as => boolean) }", "function f() {\n  g(async (as) => boolean);\n}");
+      ts.expectPrinted_("function f() { g(async satisfies => boolean) }", "function f() {\n  g(async (satisfies) => boolean);\n}");
+      ts.expectPrinted_("let async = true; let x = async as boolean;", "let async = true;\nlet x = async;\n");
+      ts.expectPrinted_("let async = true; console.log(async satisfies boolean);", "let async = true;\nconsole.log(async);\n");
+      ts.expectPrinted_("const async = 1; export default async as any;", "const async = 1;\nexport default async;\n");
+      ts.expectPrinted_("let f = async x => {}", "let f = async (x) => {}");
+      ts.expectParseError("function f(async) { g(async as) }", "Unexpected )");
+    });
+
     it("satisfies", () => {
       ts.expectPrinted_("const t1 = { a: 1 } satisfies I1;", "const t1 = { a: 1 };\n");
       ts.expectPrinted_("const t2 = { a: 1, b: 1 } satisfies I1;", "const t2 = { a: 1, b: 1 };\n");

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1277,6 +1277,9 @@ export default class {
       // restriction on the for-of grammar.
       ts.expectParseError("for (async of [7]);", 'For loop initializers cannot start with "async of"');
       ts.expectPrinted_("for (async.x of [7]);", "for (async.x of [7])\n  ;\n");
+      ts.expectPrinted_("for (async as any of [7]);", "for ((async) of [7])\n  ;\n");
+      ts.expectPrinted_("for (async satisfies T of [7]);", "for ((async) of [7])\n  ;\n");
+      ts.expectPrinted_("for (async! of [7]);", "for ((async) of [7])\n  ;\n");
       ts.expectPrinted_("for (async of => {};;);", "for (async (of) => {};; )\n  ;\n");
       ts.expectPrinted_(
         "async function f() { for await (async of [7]); }",

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1259,9 +1259,15 @@ export default class {
       ts.expectPrinted_("function f(async?) { g(async satisfies boolean) }", "function f(async) {\n  g(async);\n}");
       ts.expectPrinted_("function f(async?) { g(async in x) }", "function f(async) {\n  g(async in x);\n}");
       ts.expectPrinted_("function f() { g(async as => boolean) }", "function f() {\n  g(async (as) => boolean);\n}");
-      ts.expectPrinted_("function f() { g(async satisfies => boolean) }", "function f() {\n  g(async (satisfies) => boolean);\n}");
+      ts.expectPrinted_(
+        "function f() { g(async satisfies => boolean) }",
+        "function f() {\n  g(async (satisfies) => boolean);\n}",
+      );
       ts.expectPrinted_("let async = true; let x = async as boolean;", "let async = true;\nlet x = async;\n");
-      ts.expectPrinted_("let async = true; console.log(async satisfies boolean);", "let async = true;\nconsole.log(async);\n");
+      ts.expectPrinted_(
+        "let async = true; console.log(async satisfies boolean);",
+        "let async = true;\nconsole.log(async);\n",
+      );
       ts.expectPrinted_("const async = 1; export default async as any;", "const async = 1;\nexport default async;\n");
       ts.expectPrinted_("let f = async x => {}", "let f = async (x) => {}");
       ts.expectParseError("function f(async) { g(async as) }", "Unexpected )");

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1271,6 +1271,17 @@ export default class {
       ts.expectPrinted_("const async = 1; export default async as any;", "const async = 1;\nexport default async;\n");
       ts.expectPrinted_("let f = async x => {}", "let f = async (x) => {}");
       ts.expectParseError("function f(async) { g(async as) }", "Unexpected )");
+
+      // "for (async of" must stay rejected in TypeScript mode once the
+      // lookahead above stops the arrow commit; see the [lookahead != async of]
+      // restriction on the for-of grammar.
+      ts.expectParseError("for (async of [7]);", 'For loop initializers cannot start with "async of"');
+      ts.expectPrinted_("for (async.x of [7]);", "for (async.x of [7])\n  ;\n");
+      ts.expectPrinted_("for (async of => {};;);", "for (async (of) => {};; )\n  ;\n");
+      ts.expectPrinted_(
+        "async function f() { for await (async of [7]); }",
+        "async function f() {\n  for await ((async) of [7])\n    ;\n}",
+      );
     });
 
     it("satisfies", () => {


### PR DESCRIPTION
### Problem

A variable or parameter literally named `async` cannot be followed by a TypeScript `as`/`satisfies` cast:

```ts
function f(async?) { return g(async as boolean) }
```

```console
$ bun build repro.ts --no-bundle
error: Expected "=>" but found "boolean"
```

Both `tsc` and esbuild accept this and emit `g(async)`.

### Cause

`parse_async_prefix_expr` commits to `async <ident> => ...` as soon as it sees any identifier after `async`, then fails in `parse_arrow_body` when `=>` is not the next token. TypeScript's parser resolves this ambiguity with a two-token lookahead (`isUnParenthesizedAsyncArrowFunctionWorker`, microsoft/TypeScript#8444), and esbuild ported the same lookahead in evanw/esbuild@df815ac for evanw/esbuild#4027.

### Fix

In TypeScript mode, before committing to `async ident => ...`, snapshot the lexer, advance one token, and check whether it is `=>`. If it is, parse the async arrow as before. If it is not, fall through and treat `async` as a plain identifier so the suffix parser can handle `as`/`satisfies`/`in`/etc. A new `next_token_matches` helper owns the snapshot/advance/restore sequence.

Because the lookahead removes the accidental rejection of `for (async of [7])`, `t_for` now enforces the `[lookahead != async of]` grammar restriction directly via a `bad_async_range` guard next to the existing `bad_let_range`, keyed on the literal `async` `of` token sequence. That guard runs in both JS and TS mode, so `for (async\nof x);` is now rejected with `For loop initializers cannot start with "async of"` in JS mode too (it was previously accepted there); this matches V8 and the spec. `for await (async of ...)`, `for (async of => {};;)`, `for (async.x of ...)`, `for ((async) of ...)`, `for (\u0061sync of ...)`, `for (async as T of ...)` and `for (async! of ...)` are all still accepted.

### Verification

New cases in `test/bundler/transpiler/transpiler.test.js` cover `async as T`, `async satisfies T`, `async in x`, `async as => ...` (still an arrow with parameter `as`), statement-level and `export default` positions, a real `async x => ...`, the `for (async of` rejection in both loaders (single-line and with a newline), and the for-of edge cases listed above. The new test block fails on the current release (`Expected "=>" but found "boolean"`) and passes with this change; the rest of `transpiler.test.js` (172 pass) is unaffected.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (985542c44)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [4.91ms]
(pass) Bun.Transpiler > normalizes \r\n [6.75ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.16ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [6.57ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.61ms]
(pass) Bun.Transpiler > property access inlining > works [2.40ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.11ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [2.82ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [2.39ms]
(pass) B
... (truncated)

release without fix: 22 skipped
bun test v1.4.0-canary.1 (3638fd1a6)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [4.33ms]
(pass) Bun.Transpiler > normalizes \r\n [0.29ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [1.21ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.17ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.03ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.02ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.04ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [0.04ms]
(pass) Bun.Transpiler > TypeScript > contextual keywords used as plain identifiers keep their statements [0.27ms]
(pass) Bun.Transpiler > TypeScript > does not crash when export default abstract is an expression followed by a class [0.24ms]
(pass) Bun.Transpiler > TypeScript > scope tracking stays balanced when a contextual keyword starts a larger expression [0.21ms]
(pass) Bun.Transpiler > TypeScript > scope tracking stays balan
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (985542c44)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.11ms]
(pass) Bun.Transpiler > normalizes \r\n [6.46ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.36ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [6.60ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.59ms]
(pass) Bun.Transpiler > property access inlining > works [2.46ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.10ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [2.77ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [2.27ms]
(pass) B
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 794ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/parse/mod.rs                 | 86 +++++++++++++++++++++---------
 src/js_parser/parse/parse_stmt.rs          | 28 ++++++++++
 test/bundler/transpiler/transpiler.test.js | 41 ++++++++++++++
 3 files changed, 129 insertions(+), 26 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser/parse/mod.rs                     13     10      0
src/js_parser/parse/parse_stmt.rs               7      8      0
test/bundler/transpiler/transpiler.test.js      6     10      0
```

</details>

<!-- robobun:evidence:end -->