### PR TITLE
worker_threads: use '[worker eval]'/'.' for __filename/__dirname in eval workers

### DIFF
--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -205,6 +205,13 @@ static bool evaluateCommonJSModuleOnce(JSC::VM& vm, Zig::GlobalObject* globalObj
     initializeModuleObject();
     RETURN_IF_EXCEPTION(scope, false);
 
+    // worker_threads `eval: true` entry: node passes "[worker eval]" / "." to
+    // the CJS wrapper, not the internal blob URL we loaded the source from.
+    if (Bun__VM__specifierIsWorkerEvalEntry(globalObject->bunVM(), JSValue::encode(filename))) [[unlikely]] {
+        filename = JSC::jsString(vm, WTF::String("[worker eval]"_s));
+        dirname = JSC::jsString(vm, WTF::String("."_s));
+    }
+
     MarkedArgumentBuffer args;
     auto exports = moduleObject->exportsObject();
     RETURN_IF_EXCEPTION(scope, false);
@@ -1485,7 +1492,6 @@ std::optional<JSC::SourceCode> createCommonJSModule(
     }
 
     if (!moduleObject) {
-        JSString* specifierKey = requireMapKey;
         size_t index = sourceURL.reverseFind(PLATFORM_SEP, sourceURL.length());
         JSString* dirname;
         JSString* filename = requireMapKey;
@@ -1494,10 +1500,6 @@ std::optional<JSC::SourceCode> createCommonJSModule(
             RETURN_IF_EXCEPTION(scope, {});
         } else {
             dirname = jsEmptyString(vm);
-        }
-        if (Bun__VM__specifierIsWorkerEvalEntry(globalObject->bunVM(), JSValue::encode(specifierKey))) [[unlikely]] {
-            filename = JSC::jsString(vm, WTF::String("[worker eval]"_s));
-            dirname = JSC::jsString(vm, WTF::String("."_s));
         }
         auto requireMap = globalObject->requireMap();
         if (requireMap->size() == 0) {
@@ -1527,7 +1529,7 @@ std::optional<JSC::SourceCode> createCommonJSModule(
             WebCore::clientData(vm)->builtinNames().exportsPublicName(),
             JSC::constructEmptyObject(globalObject, globalObject->objectPrototype()), 0);
 
-        requireMap->set(globalObject, specifierKey, moduleObject);
+        requireMap->set(globalObject, filename, moduleObject);
         RETURN_IF_EXCEPTION(scope, {});
     } else {
         sourceOrigin = Zig::toSourceOrigin(sourceURL, isBuiltIn);
@@ -1607,7 +1609,6 @@ std::optional<JSC::SourceCode> createCommonJSModule(
     }
 
     if (!moduleObject) {
-        JSString* specifierKey = requireMapKey;
         size_t index = sourceURL.reverseFind(PLATFORM_SEP, sourceURL.length());
         JSString* dirname;
         JSString* filename = requireMapKey;
@@ -1616,10 +1617,6 @@ std::optional<JSC::SourceCode> createCommonJSModule(
             RETURN_IF_EXCEPTION(scope, {});
         } else {
             dirname = jsEmptyString(vm);
-        }
-        if (Bun__VM__specifierIsWorkerEvalEntry(globalObject->bunVM(), JSValue::encode(specifierKey))) [[unlikely]] {
-            filename = JSC::jsString(vm, WTF::String("[worker eval]"_s));
-            dirname = JSC::jsString(vm, WTF::String("."_s));
         }
         auto requireMap = globalObject->requireMap();
         if (requireMap->size() == 0) {
@@ -1635,7 +1632,7 @@ std::optional<JSC::SourceCode> createCommonJSModule(
             WebCore::clientData(vm)->builtinNames().exportsPublicName(),
             JSC::constructEmptyObject(globalObject, globalObject->objectPrototype()), 0);
 
-        requireMap->set(globalObject, specifierKey, moduleObject);
+        requireMap->set(globalObject, filename, moduleObject);
         RETURN_IF_EXCEPTION(scope, {});
     }
 

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -109,6 +109,7 @@ static bool canPerformFastEnumeration(Structure* s)
 }
 
 extern "C" bool Bun__VM__specifierIsEvalEntryPoint(void*, EncodedJSValue);
+extern "C" bool Bun__VM__specifierIsWorkerEvalEntry(void*, EncodedJSValue);
 extern "C" void Bun__VM__setEntryPointEvalResultCJS(void*, EncodedJSValue);
 
 static bool evaluateCommonJSModuleOnce(JSC::VM& vm, Zig::GlobalObject* globalObject, JSCommonJSModule* moduleObject, JSString* dirname, JSValue filename)
@@ -1484,6 +1485,7 @@ std::optional<JSC::SourceCode> createCommonJSModule(
     }
 
     if (!moduleObject) {
+        JSString* specifierKey = requireMapKey;
         size_t index = sourceURL.reverseFind(PLATFORM_SEP, sourceURL.length());
         JSString* dirname;
         JSString* filename = requireMapKey;
@@ -1492,6 +1494,10 @@ std::optional<JSC::SourceCode> createCommonJSModule(
             RETURN_IF_EXCEPTION(scope, {});
         } else {
             dirname = jsEmptyString(vm);
+        }
+        if (Bun__VM__specifierIsWorkerEvalEntry(globalObject->bunVM(), JSValue::encode(specifierKey))) [[unlikely]] {
+            filename = JSC::jsString(vm, WTF::String("[worker eval]"_s));
+            dirname = JSC::jsString(vm, WTF::String("."_s));
         }
         auto requireMap = globalObject->requireMap();
         if (requireMap->size() == 0) {
@@ -1521,7 +1527,7 @@ std::optional<JSC::SourceCode> createCommonJSModule(
             WebCore::clientData(vm)->builtinNames().exportsPublicName(),
             JSC::constructEmptyObject(globalObject, globalObject->objectPrototype()), 0);
 
-        requireMap->set(globalObject, filename, moduleObject);
+        requireMap->set(globalObject, specifierKey, moduleObject);
         RETURN_IF_EXCEPTION(scope, {});
     } else {
         sourceOrigin = Zig::toSourceOrigin(sourceURL, isBuiltIn);
@@ -1601,6 +1607,7 @@ std::optional<JSC::SourceCode> createCommonJSModule(
     }
 
     if (!moduleObject) {
+        JSString* specifierKey = requireMapKey;
         size_t index = sourceURL.reverseFind(PLATFORM_SEP, sourceURL.length());
         JSString* dirname;
         JSString* filename = requireMapKey;
@@ -1609,6 +1616,10 @@ std::optional<JSC::SourceCode> createCommonJSModule(
             RETURN_IF_EXCEPTION(scope, {});
         } else {
             dirname = jsEmptyString(vm);
+        }
+        if (Bun__VM__specifierIsWorkerEvalEntry(globalObject->bunVM(), JSValue::encode(specifierKey))) [[unlikely]] {
+            filename = JSC::jsString(vm, WTF::String("[worker eval]"_s));
+            dirname = JSC::jsString(vm, WTF::String("."_s));
         }
         auto requireMap = globalObject->requireMap();
         if (requireMap->size() == 0) {
@@ -1624,7 +1635,7 @@ std::optional<JSC::SourceCode> createCommonJSModule(
             WebCore::clientData(vm)->builtinNames().exportsPublicName(),
             JSC::constructEmptyObject(globalObject, globalObject->objectPrototype()), 0);
 
-        requireMap->set(globalObject, filename, moduleObject);
+        requireMap->set(globalObject, specifierKey, moduleObject);
         RETURN_IF_EXCEPTION(scope, {});
     }
 

--- a/src/runtime/hw_exports.rs
+++ b/src/runtime/hw_exports.rs
@@ -146,6 +146,20 @@ pub fn specifier_is_eval_entry_point(this: &mut VirtualMachine, specifier: JSVal
     false
 }
 
+/// Exported as `Bun__VM__specifierIsWorkerEvalEntry`. True when this VM is a
+/// worker_threads `eval: true` worker and `specifier` is its entry blob URL.
+// HOST_EXPORT(Bun__VM__specifierIsWorkerEvalEntry, c)
+pub fn specifier_is_worker_eval_entry(this: &mut VirtualMachine, specifier: JSValue) -> bool {
+    if !this.worker_ref().is_some_and(|w| w.eval_mode()) {
+        return false;
+    }
+    let global = this.global();
+    let specifier_str = bun_core::OwnedString::new(
+        bun_jsc::bun_string_jsc::from_js(specifier, global).expect("unexpected exception"),
+    );
+    specifier_str.eql_utf8(this.main())
+}
+
 /// `export fn Bun__closeChildIPC(global)` — defers the actual socket close to
 /// the next tick on the event loop.
 // HOST_EXPORT(Bun__closeChildIPC, c)

--- a/test/js/node/worker_threads/worker_threads-eval-identity.test.ts
+++ b/test/js/node/worker_threads/worker_threads-eval-identity.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { Worker } from "node:worker_threads";
 
 test("eval worker __filename/__dirname match node's '[worker eval]' / '.'", async () => {

--- a/test/js/node/worker_threads/worker_threads-eval-identity.test.ts
+++ b/test/js/node/worker_threads/worker_threads-eval-identity.test.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "bun:test";
+import { Worker } from "node:worker_threads";
+
+test("eval worker __filename/__dirname match node's '[worker eval]' / '.'", async () => {
+  const code = `
+    const { parentPort } = require("node:worker_threads");
+    parentPort.postMessage({ f: __filename, d: __dirname, a1: process.argv[1] });
+  `;
+  const run = () =>
+    new Promise((resolve, reject) => {
+      const w = new Worker(code, { eval: true });
+      w.on("message", m => {
+        w.terminate().then(() => resolve(m), reject);
+      });
+      w.on("error", reject);
+    });
+  const [r1, r2] = await Promise.all([run(), run()]);
+  expect(r1).toEqual({ f: "[worker eval]", d: ".", a1: "[worker eval]" });
+  expect(r2).toEqual(r1);
+});

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -295,7 +295,7 @@ test("support require in eval for a file that doesnt exist", async () => {
     worker.on("message", resolve);
     worker.on("error", resolve);
   });
-  expect(result.toString()).toInclude(`error: Cannot find module './fixture-invalid.js' from 'blob:`);
+  expect(result.toString()).toInclude(`error: Cannot find module './fixture-invalid.js' from '[worker eval]'`);
   await worker.terminate();
 });
 
@@ -308,6 +308,24 @@ test("support worker eval that throws", async () => {
   expect(result.toString()).toInclude("Unexpected throw");
   expect(result.name).toBe("SyntaxError");
   await worker.terminate();
+});
+
+test("eval worker __filename/__dirname match node's '[worker eval]' / '.'", async () => {
+  const code = `
+    const { parentPort } = require("node:worker_threads");
+    parentPort.postMessage({ f: __filename, d: __dirname, a1: process.argv[1] });
+  `;
+  const run = () =>
+    new Promise((resolve, reject) => {
+      const w = new Worker(code, { eval: true });
+      w.on("message", m => {
+        w.terminate().then(() => resolve(m), reject);
+      });
+      w.on("error", reject);
+    });
+  const [r1, r2] = await Promise.all([run(), run()]);
+  expect(r1).toEqual({ f: "[worker eval]", d: ".", a1: "[worker eval]" });
+  expect(r2).toEqual(r1);
 });
 
 describe("execArgv option", async () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -295,7 +295,7 @@ test("support require in eval for a file that doesnt exist", async () => {
     worker.on("message", resolve);
     worker.on("error", resolve);
   });
-  expect(result.toString()).toInclude(`error: Cannot find module './fixture-invalid.js' from '[worker eval]'`);
+  expect(result.toString()).toInclude(`error: Cannot find module './fixture-invalid.js' from 'blob:`);
   await worker.terminate();
 });
 
@@ -308,24 +308,6 @@ test("support worker eval that throws", async () => {
   expect(result.toString()).toInclude("Unexpected throw");
   expect(result.name).toBe("SyntaxError");
   await worker.terminate();
-});
-
-test("eval worker __filename/__dirname match node's '[worker eval]' / '.'", async () => {
-  const code = `
-    const { parentPort } = require("node:worker_threads");
-    parentPort.postMessage({ f: __filename, d: __dirname, a1: process.argv[1] });
-  `;
-  const run = () =>
-    new Promise((resolve, reject) => {
-      const w = new Worker(code, { eval: true });
-      w.on("message", m => {
-        w.terminate().then(() => resolve(m), reject);
-      });
-      w.on("error", reject);
-    });
-  const [r1, r2] = await Promise.all([run(), run()]);
-  expect(r1).toEqual({ f: "[worker eval]", d: ".", a1: "[worker eval]" });
-  expect(r2).toEqual(r1);
 });
 
 describe("execArgv option", async () => {


### PR DESCRIPTION
### What does this PR do?

In `new Worker(code, { eval: true })` workers, `__filename` and `__dirname` were derived from the per-worker `blob:` URL that Bun uses internally to hand the source to the VM. Every eval worker saw a different random `blob:<uuid>` for `__filename` and `""` for `__dirname`, and disagreed with its own `process.argv[1]` (which already correctly reports `"[worker eval]"`).

```js
import { Worker } from "node:worker_threads";
const code = `
const { parentPort } = require("node:worker_threads");
parentPort.postMessage({ f: __filename, d: __dirname, a1: process.argv[1] });
`;
const run = () => new Promise((res, rej) => {
  const w = new Worker(code, { eval: true });
  w.on("message", res); w.on("error", rej);
});
console.log(await run());
console.log(await run());
```

Before:
```
{ f: 'blob:46142dbd-8c1d-4c2f-bdee-...', d: '', a1: '[worker eval]' }
{ f: 'blob:a03ac4ea-8501-494a-9cbd-...', d: '', a1: '[worker eval]' }
```

After (matches Node.js):
```
{ f: '[worker eval]', d: '.', a1: '[worker eval]' }
{ f: '[worker eval]', d: '.', a1: '[worker eval]' }
```

### Cause

`createCommonJSModule` derives the module's filename/dirname from the source URL, and the CommonJS wrapper receives those as `__filename`/`__dirname`. For `blob:<uuid>` there is no path separator, so `dirname` falls back to `""` and `filename` stays as the blob URL. `process.argv` already special-cases eval workers in `node_process.rs`, but the CJS wrapper did not.

### Fix

Add `Bun__VM__specifierIsWorkerEvalEntry` (true when the VM belongs to an `eval: true` worker and the specifier is its entry blob URL) and check it in `evaluateCommonJSModuleOnce` just before the wrapper arguments are assembled. When it matches, pass `"[worker eval]"` / `"."` as `__filename` / `__dirname` instead of the blob URL. `module.filename`, the require map key, and resolve/require error messages are unchanged.

### How did you verify your code works?

```sh
bun bd test test/js/node/worker_threads/worker_threads-eval-identity.test.ts
```

Fails on main with `f: "blob:<uuid>"`, `d: ""`; passes with this change. Non-eval workers and relative `require()` from eval workers verified unchanged.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 3 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads-eval-identity.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (9d2ba5655)

test/js/node/worker_threads/worker_threads-eval-identity.test.ts:
13 |         w.terminate().then(() => resolve(m), reject);
14 |       });
15 |       w.on("error", reject);
16 |     });
17 |   const [r1, r2] = await Promise.all([run(), run()]);
18 |   expect(r1).toEqual({ f: "[worker eval]", d: ".", a1: "[worker eval]" });
                  ^
error: expect(received).toEqual(expected)

  {
    "a1": "[worker eval]",
-   "d": ".",
-   "f": "[worker eval]",
+   "d": "",
+   "f": "blob:7ed9c2fd-f5ad-4d7f-a3cf-b25efb7b50f7",
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/node/worker_threads/worker_threads-eval-identity.test.ts:18:14)
(fail) eval worker __file
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (9d2ba5655)

test/js/node/worker_threads/worker_threads-eval-identity.test.ts:
(pass) eval worker __filename/__dirname match node's '[worker eval]' / '.' [34.99ms]

 1 pass
 0 fail
 2 expect() calls
Ran 1 test across 1 file. [220.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads-eval-identity.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (9d2ba5655)

test/js/node/worker_threads/worker_threads-eval-identity.test.ts:
(pass) eval worker __filename/__dirname match node's '[worker eval]' / '.' [1878.88ms]

 1 pass
 0 fail
 2 expect() calls
Ran 1 test across 1 file. [4.12s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 774ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen cpp.rs (cppbind)
[2/7] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 243 extern-C blocks audited
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/wor
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSCommonJSModule.cpp                |  8 ++++++++
 src/runtime/hw_exports.rs                            | 14 ++++++++++++++
 .../worker_threads-eval-identity.test.ts             | 20 ++++++++++++++++++++
 3 files changed, 42 insertions(+)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/bindings/JSCommonJSModule.cpp                        10      9      0
src/runtime/hw_exports.rs                                     2      1      0
…ode/worker_threads/worker_threads-eval-identity.test.ts      0      1      0
```

</details>

<!-- robobun:evidence:end -->