### PR TITLE
js_parser: allow optional tuple labels that are keywords

### DIFF
--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -354,8 +354,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     self.lexer.next()?;
 
                     // "[import: number]"
+                    // "[import?: number]"
                     if opts.contains(SkipTypeOptions::AllowTupleLabels)
-                        && self.lexer.token == T::TColon
+                        && (self.lexer.token == T::TColon || self.lexer.token == T::TQuestion)
                     {
                         return Ok(());
                     }
@@ -384,8 +385,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     self.lexer.next()?;
 
                     // "[new: number]"
+                    // "[new?: number]"
                     if opts.contains(SkipTypeOptions::AllowTupleLabels)
-                        && self.lexer.token == T::TColon
+                        && (self.lexer.token == T::TColon || self.lexer.token == T::TQuestion)
                     {
                         return Ok(());
                     }
@@ -418,13 +420,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                             // Valid:
                             //   "[keyof: string]"
+                            //   "[keyof?: string]"
                             //   "{[keyof: string]: number}"
                             //   "{[keyof in string]: number}"
                             //
                             // Invalid:
                             //   "A extends B ? keyof : string"
                             //
-                            if (self.lexer.token != T::TColon && self.lexer.token != T::TIn)
+                            if (self.lexer.token != T::TColon
+                                && self.lexer.token != T::TQuestion
+                                && self.lexer.token != T::TIn)
                                 || (!opts.contains(SkipTypeOptions::IsIndexSignature)
                                     && !opts.contains(SkipTypeOptions::AllowTupleLabels))
                             {
@@ -443,7 +448,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         TsIdentKind::PrefixReadonly => {
                             self.lexer.next()?;
 
-                            if (self.lexer.token != T::TColon && self.lexer.token != T::TIn)
+                            if (self.lexer.token != T::TColon
+                                && self.lexer.token != T::TQuestion
+                                && self.lexer.token != T::TIn)
                                 || (!opts.contains(SkipTypeOptions::IsIndexSignature)
                                     && !opts.contains(SkipTypeOptions::AllowTupleLabels))
                             {
@@ -467,7 +474,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             // "type Foo = Bar extends [infer T extends string] ? T : null"
                             // "type Foo = Bar extends [infer T extends string ? infer T : never] ? T : null"
                             // "type Foo = { [infer in Bar]: number }"
-                            if (self.lexer.token != T::TColon && self.lexer.token != T::TIn)
+                            // "type Foo = [infer?: number]"
+                            if (self.lexer.token != T::TColon
+                                && self.lexer.token != T::TQuestion
+                                && self.lexer.token != T::TIn)
                                 || (!opts.contains(SkipTypeOptions::IsIndexSignature)
                                     && !opts.contains(SkipTypeOptions::AllowTupleLabels))
                             {
@@ -642,8 +652,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     self.lexer.next()?;
 
                     // "[typeof: number]"
+                    // "[typeof?: number]"
                     if opts.contains(SkipTypeOptions::AllowTupleLabels)
-                        && self.lexer.token == T::TColon
+                        && (self.lexer.token == T::TColon || self.lexer.token == T::TQuestion)
                     {
                         return Ok(());
                     }
@@ -754,7 +765,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         }
                         self.lexer.next()?;
 
-                        if self.lexer.token != T::TColon {
+                        if self.lexer.token != T::TColon && self.lexer.token != T::TQuestion {
                             self.lexer.expect(T::TColon)?;
                         }
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -646,6 +646,14 @@ function foo() {}
       exp("let x: [keyof: string]", "let x;\n");
       exp("let x: [readonly: string]", "let x;\n");
       exp("let x: [infer: string]", "let x;\n");
+      exp("let x: [keyof?: string]", "let x;\n");
+      exp("let x: [readonly?: string]", "let x;\n");
+      exp("let x: [infer?: string]", "let x;\n");
+      exp("let x: [import?: string]", "let x;\n");
+      exp("let x: [new?: string]", "let x;\n");
+      exp("let x: [typeof?: string]", "let x;\n");
+      exp("let x: [function?: string]", "let x;\n");
+      exp("let x: [a: number, readonly?: string, ...infer: number[]]", "let x;\n");
       err("let x: A extends B ? keyof : string", "Unexpected :");
       err("let x: A extends B ? readonly : string", "Unexpected :");
       err("let x: A extends B ? infer : string", 'Expected identifier but found ":"');


### PR DESCRIPTION
## What does this PR do?

TypeScript tuple element labels can be names that collide with type-position keywords. Bun already recognized these as labels when followed by `:`, but not when followed by `?` for an optional element.

### Repro

```ts
type T = [readonly?: string];
```

```
error: Unexpected ?
    at r.ts:1:19
```

All seven affected keywords failed the same way: `readonly`, `keyof`, `infer`, `new`, `typeof`, `import`, `function`. tsc and esbuild both accept these.

### Cause

`skip_type_script_type_with_opts` in `src/js_parser/parse/parse_skip_typescript.rs` only looked for `TColon` after the keyword when deciding whether to treat it as a tuple label and return to the outer tuple loop. esbuild's `internal/js_parser/ts_parser.go` checks `TColon || TQuestion` at the same sites; the outer tuple loop already consumes the optional `?` and the following `:`.

### Fix

Accept `TQuestion` alongside `TColon` at the seven sites (import, new, keyof, readonly, infer, typeof, and the keyword fallthrough for `function`), matching esbuild.

### Verification

Added optional-label cases for all seven keywords to the existing "types" block in `test/bundler/transpiler/transpiler.test.js`, next to the existing `[keyof: string]` / `[readonly: string]` / `[infer: string]` cases. Verified the existing negative cases (`A extends B ? keyof : string`, `{[new: string]: number}`, etc.) still error, and that `readonly`/`keyof`/`typeof`/`new`/`import`/`infer` used as actual type operators inside tuples still parse correctly.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (21ca8139c)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [8.49ms]
(pass) Bun.Transpiler > normalizes \r\n [11.15ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [7.59ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [12.28ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [5.31ms]
(pass) Bun.Transpiler > property access inlining > works [5.81ms]
(pass) Bun.Transpiler > property access inlining > works nested [4.31ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [5.78ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [4.43ms]
(pass)
... (truncated)

release without fix: 1 failed, 22 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.17ms]
(pass) Bun.Transpiler > normalizes \r\n [0.27ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.16ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.22ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.07ms]
(pass) Bun.Transpiler > property access inlining > works [0.06ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.06ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.12ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [0.11ms]
(pass) Bun.Transpiler > TypeScript > contextual keywords used as plain identifiers keep their statements [0.39ms]
(pass) Bun.Transpiler > TypeScript > does not crash when export default abstract is an expression followed by a class [0.37ms]
(pass) Bun.Transpiler > TypeScript > scope tracking stays balanced when a contextual keyword starts a larger expression [0.39ms]
(pass) Bun.Transpiler > TypeScript > scope tracking stays balan
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (21ca8139c)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [9.02ms]
(pass) Bun.Transpiler > normalizes \r\n [12.29ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [8.25ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [12.80ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [5.39ms]
(pass) Bun.Transpiler > property access inlining > works [4.99ms]
(pass) Bun.Transpiler > property access inlining > works nested [4.40ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [5.70ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [5.63ms]
(pass)
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 1086ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
ninja: no work to do.
[build] done
bun test v1.4.0-canary.1 (21ca8139c)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.15ms]
(pass) Bun.Transpiler > normalizes \r\n [0.24ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.13ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.19ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.06ms]
(pass) Bun.Transpiler > property access inlining > works [0.08ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.05ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.07ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing ty
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/parse/parse_skip_typescript.rs | 25 ++++++++++++++++++-------
 test/bundler/transpiler/transpiler.test.js   |  8 ++++++++
 2 files changed, 26 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/js_parser/parse/parse_skip_typescript.rs      2      1      0
test/bundler/transpiler/transpiler.test.js        2      1      0
```

</details>

<!-- robobun:evidence:end -->