### PR TITLE
js_parser: lower block-scoped TypeScript enums with let instead of var

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6452,7 +6452,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }]);
             let _ = arena;
 
-            if self.enclosing_namespace_arg_ref.is_none() {
+            if self.current_scope == self.module_scope {
                 // Top-level namespace: "var"
                 stmts.push(self.s(
                     S::Local {

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -2314,6 +2314,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
+        p.pop_scope();
         p.should_fold_typescript_constant_expressions =
             old_should_fold_typescript_constant_expressions;
 
@@ -2339,7 +2340,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             value_stmts.into_bump_slice_mut(),
             all_values_are_pure,
         )?;
-        p.pop_scope();
         Ok(())
     }
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1435,6 +1435,31 @@ export default class {
       void stderr;
     });
 
+    // https://github.com/evanw/esbuild/commit/108484982c8f1d74bd87ce172ae02a6ffe8ddce3
+    it("same-named enums in separate block scopes do not merge at runtime", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `{
+            enum a { b = 1 }
+          }
+          {
+            enum a { c = 2 }
+            console.log(JSON.stringify({ c: a.c, two: a[2], b: a.b, one: a[1] }));
+          }`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect({ stdout, exitCode }).toEqual({ stdout: '{"c":2,"two":"c"}\n', exitCode: 0 });
+      void stderr;
+    });
+
     const input5 = `namespace ns {
   export class ns {}
 }`;

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1431,9 +1431,8 @@ export default class {
 
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      expect(stderr).toBe("");
-      expect(stdout).toBe("ReferenceError\n");
-      expect(exitCode).toBe(0);
+      expect({ stdout, exitCode }).toEqual({ stdout: "ReferenceError\n", exitCode: 0 });
+      void stderr;
     });
 
     const input5 = `namespace ns {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1381,6 +1381,61 @@ export default class {
       ts.expectPrinted_(input4, output4);
     });
 
+    it("enum in a nested scope uses let", () => {
+      // tsc and esbuild both emit "let" for enums that aren't at the top level
+      // so the binding doesn't leak out of the enclosing block/function scope.
+      ts.expectPrinted_(
+        `{ enum x { y } }`,
+        `{
+  let x;
+  ((x) => {
+    x[x["y"] = 0] = "y";
+  })(x ||= {});
+}`,
+      );
+      ts.expectPrinted_(
+        `function f() { enum x { y } }`,
+        `function f() {
+  let x;
+  ((x) => {
+    x[x["y"] = 0] = "y";
+  })(x ||= {});
+}`,
+      );
+      // Top-level enum still emits "var" so sibling declarations can merge.
+      ts.expectPrinted_(
+        `enum x { y }`,
+        `var x;
+((x) => {
+  x[x["y"] = 0] = "y";
+})(x ||= {})`,
+      );
+    });
+
+    it("enum in a block scope does not leak into the enclosing scope at runtime", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `{ enum a { b = 1 } }
+          try {
+            console.log(a);
+          } catch (e) {
+            console.log(e instanceof ReferenceError ? "ReferenceError" : e.constructor.name);
+          }`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toBe("");
+      expect(stdout).toBe("ReferenceError\n");
+      expect(exitCode).toBe(0);
+    });
+
     const input5 = `namespace ns {
   export class ns {}
 }`;


### PR DESCRIPTION
## Repro

```sh
printf '{ enum a { b = 1 } }\nconsole.log(a)\n' > /tmp/r.ts
bun build /tmp/r.ts --no-bundle
```

```js
// bun (before)
{
  var a;
  ((a) => { a[a["b"] = 1] = "b"; })(a ||= {});
}
console.log(a);    // prints the enum object

// tsc / esbuild
{
  let a;
  ((a) => { a[a["b"] = 1] = "b"; })(a ||= {});
}
console.log(a);    // ReferenceError: a is not defined
```

The enum binding leaks out of the block because `var` hoists to the enclosing function.

## Cause

`generate_closure_for_type_script_namespace_or_enum` picked `var` whenever there was no enclosing TypeScript namespace (`enclosing_namespace_arg_ref.is_none()`). An enum inside a plain block or function body has no enclosing namespace, so it always got `var`.

This is a direct port of [evanw/esbuild@108484982](https://github.com/evanw/esbuild/commit/108484982c8f1d74bd87ce172ae02a6ffe8ddce3) ("ts enum: avoid merging siblings in nested blocks", shipped in esbuild v0.14.0, Nov 2021). Bun's parser was ported from esbuild roughly six months before that fix landed and was never synced. That commit made exactly these two changes:

- the var/let decision becomes `currentScope == moduleScope`
- the enum's scope is popped before the closure generator runs, so `currentScope` is the scope that contains the enum when the check happens

## Fix

- Change the var/let decision in `generate_closure_for_type_script_namespace_or_enum` to `current_scope == module_scope`.
- Pop the enum scope in `s_enum` before calling the closure generator, matching `s_namespace` and esbuild.

Top-level enums still emit `var` so sibling declarations keep merging. Namespaces are unchanged: they only appear at module scope or nested inside another namespace, where both checks give the same answer.

## Verification

New tests in the `generated closures` block of `transpiler.test.js`:

- `{ enum x { y } }` lowers to `let x`
- `function f() { enum x { y } }` lowers to `let x`
- top-level `enum x { y }` still lowers to `var x`
- runtime: `{ enum a {...} } console.log(a)` throws `ReferenceError`
- runtime: same-named enums in separate block scopes do not merge (esbuild's motivating e2e case)

```
USE_SYSTEM_BUN=1 bun test test/bundler/transpiler/transpiler.test.js -t "enum in a"  # 2 fail
bun bd test test/bundler/transpiler/transpiler.test.js                               # 173 pass, 0 fail
bun bd test test/bundler/esbuild/ts.test.ts                                          # 57 pass, 0 fail
bun bd test test/bundler/transpiler/ts-enum-redecl-panic.test.ts                     # 6 pass
```
