### PR TITLE
js_parser: reject yield/await/this/return that leak into TS enum and namespace bodies

### DIFF
--- a/src/js_parser/parse/parse_typescript.rs
+++ b/src/js_parser/parse/parse_typescript.rs
@@ -582,6 +582,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let old_fn_or_arrow_data = p.fn_or_arrow_data_parse.clone();
         p.fn_or_arrow_data_parse = FnOrArrowDataParse {
             is_this_disallowed: true,
+            // See the namespace body: preserve is_top_level for parse_fn.rs's
+            // react-hooks suppression consume.
+            is_top_level: old_fn_or_arrow_data.is_top_level,
             ..Default::default()
         };
 

--- a/src/js_parser/parse/parse_typescript.rs
+++ b/src/js_parser/parse/parse_typescript.rs
@@ -4,7 +4,7 @@ use bun_collections::VecExt;
 use crate::Error;
 use crate::lexer::{self as js_lexer, T};
 use crate::p::P;
-use crate::parser::{ParseStatementOptions, Ref, ScopeOrder};
+use crate::parser::{FnOrArrowDataParse, ParseStatementOptions, Ref, ScopeOrder};
 use bun_alloc::{ArenaVec as BumpVec, ArenaVecExt as _};
 use bun_ast::expr::EFlags;
 use bun_ast::flags;
@@ -195,7 +195,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let old_has_non_local_export_declare_inside_namespace =
             p.has_non_local_export_declare_inside_namespace;
+        let old_fn_or_arrow_data = p.fn_or_arrow_data_parse.clone();
         p.has_non_local_export_declare_inside_namespace = false;
+        p.fn_or_arrow_data_parse = FnOrArrowDataParse {
+            is_this_disallowed: true,
+            is_return_disallowed: true,
+            ..Default::default()
+        };
 
         // Parse the statements inside the namespace
         let mut stmts: BumpVec<'_, Stmt> = BumpVec::new_in(p.arena);
@@ -229,6 +235,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.has_non_local_export_declare_inside_namespace;
         p.has_non_local_export_declare_inside_namespace =
             old_has_non_local_export_declare_inside_namespace;
+        p.fn_or_arrow_data_parse = old_fn_or_arrow_data;
 
         // Add any exported members from this namespace's body as members of the
         // associated namespace object.
@@ -568,6 +575,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         p.lexer.expect(T::TOpenBrace)?;
 
+        let old_fn_or_arrow_data = p.fn_or_arrow_data_parse.clone();
+        p.fn_or_arrow_data_parse = FnOrArrowDataParse {
+            is_this_disallowed: true,
+            ..Default::default()
+        };
+
         // Parse the body
         let mut values: BumpVec<'_, EnumValue> = BumpVec::new_in(p.arena);
         while p.lexer.token != T::TCloseBrace {
@@ -627,6 +640,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             p.lexer.next()?;
         }
+
+        p.fn_or_arrow_data_parse = old_fn_or_arrow_data;
 
         if !opts.is_typescript_declare {
             // Avoid a collision with the enum closure argument variable if the

--- a/src/js_parser/parse/parse_typescript.rs
+++ b/src/js_parser/parse/parse_typescript.rs
@@ -200,6 +200,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.fn_or_arrow_data_parse = FnOrArrowDataParse {
             is_this_disallowed: true,
             is_return_disallowed: true,
+            // parse_fn.rs reads is_top_level to consume a react-hooks
+            // suppression after a namespace member function; every other
+            // consumer is gated on allow_await == AllowExpr (AllowIdent here).
+            is_top_level: old_fn_or_arrow_data.is_top_level,
             ..Default::default()
         };
 

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -579,6 +579,32 @@ describe("bundler", () => {
     },
   });
 
+  itBundled("react-compiler/SuppressionInsideTSNamespaceDoesNotLeak", {
+    files: {
+      "/entry.tsx": /* tsx */ `
+        namespace N {
+          export function Foo() {
+            // eslint-disable-next-line react-hooks/rules-of-hooks
+            useState();
+          }
+        }
+        export function Component({ name }: { name: string }) {
+          return <div>Hello {name}</div>;
+        }
+      `,
+    },
+    reactCompiler: true,
+    backend: "cli",
+    external: ["react", "react/compiler-runtime", "react/jsx-runtime", "react/jsx-dev-runtime"],
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // The next-line suppression inside the namespace member must be consumed
+      // there and not bail the compiler out of the sibling Component.
+      expect(out).toContain("react/compiler-runtime");
+      expect(out).toMatch(/\b_c\(\d+\)/);
+    },
+  });
+
   // Stub react packages shared by the unbound-ref regression tests below.
   const stubReact = {
     "/node_modules/react/index.js": /* js */ `

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -599,8 +599,10 @@ describe("Bun.Transpiler", () => {
       err("async function f() { enum x { y = await 1 } }", '"await" can only be used inside an "async" function');
       err("enum x { y = await 1 }", '"await" can only be used inside an "async" function');
       err("enum x { y = this }", 'Cannot use "this" here');
+      err("enum x { y = () => this }", 'Cannot use "this" here');
       err("class C { m() { enum x { y = this } } }", 'Cannot use "this" here');
       err("declare enum x { y = await 1 }", '"await" can only be used inside an "async" function');
+      err("declare enum x { y = this }", 'Cannot use "this" here');
 
       // A nested function establishes its own context, so these remain valid.
       exp(
@@ -610,6 +612,10 @@ describe("Bun.Transpiler", () => {
       exp(
         "async function f() { enum x { y = (async () => await 1)() } }",
         'async function f() {\n  var x;\n  ((x) => {\n    x[x["y"] = (async () => await 1)()] = "y";\n  })(x ||= {});\n}',
+      );
+      exp(
+        "enum x { y = (function() { return this })() }",
+        'var x;\n((x) => {\n  x[x["y"] = function() {\n    return this;\n  }()] = "y";\n})(x ||= {})',
       );
     });
 
@@ -622,7 +628,10 @@ describe("Bun.Transpiler", () => {
       err("namespace x { return 1; }", "A return statement cannot be used here");
       err("namespace x { return; }", "A return statement cannot be used here");
       err("namespace x { const y: string = this; }", 'Cannot use "this" here');
+      err("namespace x { export const y = () => this; }", 'Cannot use "this" here');
       err("namespace x.y { return 1; }", "A return statement cannot be used here");
+      err("module x { return 1; }", "A return statement cannot be used here");
+      err("declare namespace x { export const y = this; }", 'Cannot use "this" here');
       err("namespace x { for await (const y of []); }", 'Cannot use "await" outside an async function');
 
       // The namespace body lowers into a non-async arrow, where "await" is a
@@ -636,6 +645,15 @@ describe("Bun.Transpiler", () => {
       exp(
         "namespace x { export const y = async () => await 1; }",
         "var x;\n((x) => {\n  x.y = async () => await 1;\n})(x ||= {})",
+      );
+      // Class methods and fields introduce their own "this" binding.
+      exp(
+        "namespace x { export class C { m() { return this } } }",
+        "var x;\n((x) => {\n\n  class C {\n    m() {\n      return this;\n    }\n  }\n  x.C = C;\n})(x ||= {})",
+      );
+      exp(
+        "namespace x { export class C { f = this } }",
+        "var x;\n((x) => {\n\n  class C {\n    f = this;\n  }\n  x.C = C;\n})(x ||= {})",
       );
     });
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -589,7 +589,7 @@ describe("Bun.Transpiler", () => {
       err("enum [] { a }", 'Expected identifier but found "["');
     });
 
-    it("rejects yield/await/this in enum initializers", () => {
+    it("rejects yield/await/this/super in enum initializers", () => {
       const err = ts.expectParseError;
       const exp = ts.expectPrinted_;
 
@@ -597,10 +597,15 @@ describe("Bun.Transpiler", () => {
       // generator/async context must not leak into initializer expressions.
       err("function *f() { enum x { y = yield 1 } }", 'Cannot use "yield" outside a generator function');
       err("async function f() { enum x { y = await 1 } }", '"await" can only be used inside an "async" function');
+      err("async function f() { const enum x { y = await 1 } }", '"await" can only be used inside an "async" function');
+      err("let g = async () => { enum x { y = await 1 } }", '"await" can only be used inside an "async" function');
       err("enum x { y = await 1 }", '"await" can only be used inside an "async" function');
       err("enum x { y = this }", 'Cannot use "this" here');
       err("enum x { y = () => this }", 'Cannot use "this" here');
       err("class C { m() { enum x { y = this } } }", 'Cannot use "this" here');
+      err("class C extends B { m() { enum x { y = super.foo } } }", 'Unexpected "super"');
+      err("class C extends B { constructor() { super(); enum x { y = super() } } }", 'Unexpected "super"');
+      err("class C { static { enum x { y = super.foo } } }", 'Unexpected "super"');
       err("declare enum x { y = await 1 }", '"await" can only be used inside an "async" function');
       err("declare enum x { y = this }", 'Cannot use "this" here');
 
@@ -616,6 +621,20 @@ describe("Bun.Transpiler", () => {
       exp(
         "enum x { y = (function() { return this })() }",
         'var x;\n((x) => {\n  x[x["y"] = function() {\n    return this;\n  }()] = "y";\n})(x ||= {})',
+      );
+      // The enclosing context is restored after the body: sibling statements
+      // keep their yield/await/super permissions.
+      exp(
+        "function *f() { enum x { y = 1 } yield 1; }",
+        'function* f() {\n  var x;\n  ((x) => {\n    x[x["y"] = 1] = "y";\n  })(x ||= {});\n  yield 1;\n}',
+      );
+      exp(
+        "async function f() { enum x { y = 1 } await 1; }",
+        'async function f() {\n  var x;\n  ((x) => {\n    x[x["y"] = 1] = "y";\n  })(x ||= {});\n  await 1;\n}',
+      );
+      exp(
+        "class C extends B { m() { enum x { y = 1 } super.foo(); } }",
+        'class C extends B {\n  m() {\n    var x;\n    ((x) => {\n      x[x["y"] = 1] = "y";\n    })(x ||= {});\n    super.foo();\n  }\n}',
       );
     });
 
@@ -654,6 +673,12 @@ describe("Bun.Transpiler", () => {
       exp(
         "namespace x { export class C { f = this } }",
         "var x;\n((x) => {\n\n  class C {\n    f = this;\n  }\n  x.C = C;\n})(x ||= {})",
+      );
+      // The enclosing context is restored after the body: top-level await is
+      // still accepted immediately after a namespace.
+      exp(
+        "namespace x { export const y = 1; } await 1;",
+        "var x;\n((x) => {\n  x.y = 1;\n})(x ||= {});\nawait 1",
       );
     });
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -589,6 +589,56 @@ describe("Bun.Transpiler", () => {
       err("enum [] { a }", 'Expected identifier but found "["');
     });
 
+    it("rejects yield/await/this in enum initializers", () => {
+      const err = ts.expectParseError;
+      const exp = ts.expectPrinted_;
+
+      // The enum body is lowered into an arrow IIFE, so an enclosing function's
+      // generator/async context must not leak into initializer expressions.
+      err("function *f() { enum x { y = yield 1 } }", 'Cannot use "yield" outside a generator function');
+      err("async function f() { enum x { y = await 1 } }", '"await" can only be used inside an "async" function');
+      err("enum x { y = await 1 }", '"await" can only be used inside an "async" function');
+      err("enum x { y = this }", 'Cannot use "this" here');
+      err("class C { m() { enum x { y = this } } }", 'Cannot use "this" here');
+      err("declare enum x { y = await 1 }", '"await" can only be used inside an "async" function');
+
+      // A nested function establishes its own context, so these remain valid.
+      exp(
+        "function *f() { enum x { y = (function*() { yield 1 })() } }",
+        'function* f() {\n  var x;\n  ((x) => {\n    x[x["y"] = function* () {\n      yield 1;\n    }()] = "y";\n  })(x ||= {});\n}',
+      );
+      exp(
+        "async function f() { enum x { y = (async () => await 1)() } }",
+        'async function f() {\n  var x;\n  ((x) => {\n    x[x["y"] = (async () => await 1)()] = "y";\n  })(x ||= {});\n}',
+      );
+    });
+
+    it("rejects await/this/return in namespace bodies", () => {
+      const err = ts.expectParseError;
+      const exp = ts.expectPrinted_;
+
+      err("namespace x { export const y = await 1; }", '"await" can only be used inside an "async" function');
+      err("namespace x { await 1; }", '"await" can only be used inside an "async" function');
+      err("namespace x { return 1; }", "A return statement cannot be used here");
+      err("namespace x { return; }", "A return statement cannot be used here");
+      err("namespace x { const y: string = this; }", 'Cannot use "this" here');
+      err("namespace x.y { return 1; }", "A return statement cannot be used here");
+      err("namespace x { for await (const y of []); }", 'Cannot use "await" outside an async function');
+
+      // The namespace body lowers into a non-async arrow, where "await" is a
+      // valid binding identifier; the module-level reserved-word rule must
+      // not leak into it.
+      exp("namespace x { let await = 1; }", "var x;\n((x) => {\n  let await = 1;\n})(x ||= {})");
+      exp(
+        "namespace x { export function f() { return 1; } }",
+        "var x;\n((x) => {\n  function f() {\n    return 1;\n  }\n  x.f = f;\n})(x ||= {})",
+      );
+      exp(
+        "namespace x { export const y = async () => await 1; }",
+        "var x;\n((x) => {\n  x.y = async () => await 1;\n})(x ||= {})",
+      );
+    });
+
     it("doesn't crash with functions assigned to enum values", () => {
       const exp = ts.expectPrinted_;
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -676,10 +676,7 @@ describe("Bun.Transpiler", () => {
       );
       // The enclosing context is restored after the body: top-level await is
       // still accepted immediately after a namespace.
-      exp(
-        "namespace x { export const y = 1; } await 1;",
-        "var x;\n((x) => {\n  x.y = 1;\n})(x ||= {});\nawait 1",
-      );
+      exp("namespace x { export const y = 1; } await 1;", "var x;\n((x) => {\n  x.y = 1;\n})(x ||= {});\nawait 1");
     });
 
     it("doesn't crash with functions assigned to enum values", () => {


### PR DESCRIPTION
## Repro

```sh
$ printf 'function *f() { enum x { y = yield 1 } }\n' | bun build --no-bundle /dev/stdin --loader=ts
function* f() {
  var x;
  ((x) => {
    x[x["y"] = yield 1] = "y";
  })(x ||= {});
}
```

`yield` inside a non-generator arrow is a load-time `SyntaxError` in every engine. esbuild and tsc both reject the input:

```
✘ [ERROR] Cannot use "yield" outside a generator function
```

Siblings that emit the same kind of invalid output on main:

| input | emitted into the arrow IIFE |
| --- | --- |
| `async function f() { enum x { y = await 1 } }` | `await 1` |
| `enum x { y = await 1 }` (top-level await) | `await 1` |
| `class C { m() { enum x { y = this } } }` | `this` (wrong binding) |
| `namespace x { await 1; }` | `await 1` |
| `namespace x { return 1; }` | `return 1` |
| `namespace x { for await (const y of []); }` | `for await` |

and one case of the opposite polarity: `namespace x { let await = 1; }` is valid TS that esbuild accepts but bun rejects, because the module-level `ForbidAll` for `await` leaked into the body.

## Cause

`parse_typescript_enum_stmt` parses initializers with `p.parse_expr(Level::Comma)` and `parse_type_script_namespace_stmt` parses the body with `p.parse_stmts_up_to(...)`, neither resetting `p.fn_or_arrow_data_parse` first. `allow_yield`, `allow_await`, `allow_super_*`, `is_top_level`, `is_this_disallowed` and `is_return_disallowed` all inherit from the enclosing function / module, so `yield`/`await` parse as expressions and end up inside the lowered arrow.

esbuild saves `fnOrArrowDataParse`, assigns a fresh zero-valued struct (`isThisDisallowed: true`, plus `isReturnDisallowed: true` for namespaces), and restores it after the body ([ts_parser.go](https://github.com/evanw/esbuild/blob/main/internal/js_parser/ts_parser.go)).

## Fix

Mirror esbuild in both sites: save `fn_or_arrow_data_parse`, replace with `FnOrArrowDataParse { is_this_disallowed: true, ..Default::default() }` (and `is_return_disallowed: true` for namespaces), restore after the body. The `Default` sets `allow_await`/`allow_yield` to `AllowIdent`, so the existing recovery in `parse_prefix.rs` reports `Cannot use "yield" outside a generator function` / `"await" can only be used inside an "async" function`.

Nested functions inside an initializer establish their own context (they overwrite `fn_or_arrow_data_parse` themselves), so `enum x { y = (function*() { yield 1 })() }` and `namespace x { export const y = async () => await 1; }` remain valid.

## Verification

Two new `it()` blocks in `test/bundler/transpiler/transpiler.test.js` (18 assertions) covering the enum and namespace cases above, plus the dotted `namespace x.y { ... }` form and `declare enum`.

```
$ USE_SYSTEM_BUN=1 bun test test/bundler/transpiler/transpiler.test.js -t "rejects yield|rejects await"
2 fail
$ bun bd test test/bundler/transpiler/transpiler.test.js -t "rejects yield|rejects await"
2 pass
```

`test/bundler/transpiler/transpiler.test.js` full file: 173 pass, 0 fail. `test/bundler/esbuild/ts.test.ts`: 57 pass, 0 fail.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/react-compiler.test.ts test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (3b34d0fec)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [7.34ms]
(pass) Bun.Transpiler > normalizes \r\n [10.81ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [7.68ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [10.62ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [4.29ms]
(pass) Bun.Transpiler > property access inlining > works [3.87ms]
(pass) Bun.Transpiler > property access inlining > works nested [3.32ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [4.62ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctl
... (truncated)

release without fix: 22 skipped
bun test v1.4.0-canary.1 (954851635)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.12ms]
(pass) Bun.Transpiler > normalizes \r\n [0.14ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.07ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.11ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.03ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.02ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.04ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [0.04ms]
(pass) Bun.Transpiler > TypeScript > contextual keywords used as plain identifiers keep their statements [0.25ms]
(pass) Bun.Transpiler > TypeScript > does not crash when export default abstract is an expression followed by a class [0.25ms]
(pass) Bun.Transpiler > TypeScript > scope tracking stays balanced when a contextual keyword starts a larger expression [0.21ms]
(pass) Bun.Transpiler > TypeScript > scope tracking stays balan
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/react-compiler.test.ts test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (3b34d0fec)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [4.71ms]
(pass) Bun.Transpiler > normalizes \r\n [9.25ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [6.56ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [10.37ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [4.14ms]
(pass) Bun.Transpiler > property access inlining > works [3.81ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.78ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [3.03ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 800ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/parse/parse_typescript.rs        | 24 ++++++-
 test/bundler/transpiler/react-compiler.test.ts | 26 ++++++++
 test/bundler/transpiler/transpiler.test.js     | 90 ++++++++++++++++++++++++++
 3 files changed, 139 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/js_parser/parse/parse_typescript.rs             6      9      0
test/bundler/transpiler/react-compiler.test.ts      1      1      0
test/bundler/transpiler/transpiler.test.js          3      7      0
```

</details>

<!-- robobun:evidence:end -->