### PR TITLE
parser(ts): keep "export {}" ESM marker when all specifiers are type-only

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -232,6 +232,14 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub latest_return_had_semicolon: bool,
     pub has_import_meta: bool,
     pub has_es_module_syntax: bool,
+    /// TypeScript: whether any export other than an empty `export {}` clause
+    /// will appear in the output. Lets the visit pass drop redundant empty
+    /// export clauses that would only serve as an ESM module marker.
+    pub has_nonempty_export_stmt: bool,
+    /// Count of `SExportClause` statements that had items after parsing; used
+    /// with `has_nonempty_export_stmt` so an empty clause visited before a
+    /// later non-empty one can still be dropped.
+    pub remaining_export_clauses_with_items: u32,
     pub top_level_await_keyword: bun_ast::Range,
     pub fn_or_arrow_data_parse: FnOrArrowDataParse,
     pub fn_or_arrow_data_visit: FnOrArrowDataVisit,
@@ -9096,6 +9104,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             latest_return_had_semicolon: false,
             has_import_meta: false,
             has_es_module_syntax: false,
+            has_nonempty_export_stmt: false,
+            remaining_export_clauses_with_items: 0,
             top_level_await_keyword: bun_ast::Range::NONE,
             fn_or_arrow_data_parse,
             fn_or_arrow_data_visit: FnOrArrowDataVisit::default(),

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -869,20 +869,14 @@ impl<'a> Parser<'a> {
                     js_ast::StmtData::SExportDefault(_)
                     | js_ast::StmtData::SExportStar(_)
                     | js_ast::StmtData::SExportFrom(_) => p.has_nonempty_export_stmt = true,
-                    js_ast::StmtData::SLocal(s) if s.is_export => {
-                        p.has_nonempty_export_stmt = true
-                    }
-                    js_ast::StmtData::SClass(s) if s.is_export => {
-                        p.has_nonempty_export_stmt = true
-                    }
+                    js_ast::StmtData::SLocal(s) if s.is_export => p.has_nonempty_export_stmt = true,
+                    js_ast::StmtData::SClass(s) if s.is_export => p.has_nonempty_export_stmt = true,
                     js_ast::StmtData::SFunction(s)
                         if s.func.flags.contains(js_ast::Flags::Function::IsExport) =>
                     {
                         p.has_nonempty_export_stmt = true
                     }
-                    js_ast::StmtData::SEnum(s) if s.is_export => {
-                        p.has_nonempty_export_stmt = true
-                    }
+                    js_ast::StmtData::SEnum(s) if s.is_export => p.has_nonempty_export_stmt = true,
                     js_ast::StmtData::SNamespace(s) if s.is_export => {
                         p.has_nonempty_export_stmt = true
                     }

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -859,6 +859,41 @@ impl<'a> Parser<'a> {
         let mut visit_tracer = bun_core::perf::trace("JSParser::visit");
         p.prepare_for_visit_pass()?;
 
+        if TS {
+            // Type-stripping can leave redundant `export {}` clauses behind. Scan
+            // for exports that definitely survive so the visit pass can drop them;
+            // top-level await alone also marks the output as ESM.
+            p.has_nonempty_export_stmt = p.top_level_await_keyword.len > 0;
+            for stmt in stmts.iter() {
+                match &stmt.data {
+                    js_ast::StmtData::SExportDefault(_)
+                    | js_ast::StmtData::SExportStar(_)
+                    | js_ast::StmtData::SExportFrom(_) => p.has_nonempty_export_stmt = true,
+                    js_ast::StmtData::SLocal(s) if s.is_export => {
+                        p.has_nonempty_export_stmt = true
+                    }
+                    js_ast::StmtData::SClass(s) if s.is_export => {
+                        p.has_nonempty_export_stmt = true
+                    }
+                    js_ast::StmtData::SFunction(s)
+                        if s.func.flags.contains(js_ast::Flags::Function::IsExport) =>
+                    {
+                        p.has_nonempty_export_stmt = true
+                    }
+                    js_ast::StmtData::SEnum(s) if s.is_export => {
+                        p.has_nonempty_export_stmt = true
+                    }
+                    js_ast::StmtData::SNamespace(s) if s.is_export => {
+                        p.has_nonempty_export_stmt = true
+                    }
+                    js_ast::StmtData::SExportClause(s) if !s.items.is_empty() => {
+                        p.remaining_export_clauses_with_items += 1;
+                    }
+                    _ => {}
+                }
+            }
+        }
+
         if p.options.features.react_compiler.is_enabled() {
             let rc_options = bun_react_compiler::ReactCompilerOptions {
                 enabled: true,

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -866,9 +866,21 @@ impl<'a> Parser<'a> {
             p.has_nonempty_export_stmt = p.top_level_await_keyword.len > 0;
             for stmt in stmts.iter() {
                 match &stmt.data {
-                    js_ast::StmtData::SExportDefault(_)
-                    | js_ast::StmtData::SExportStar(_)
-                    | js_ast::StmtData::SExportFrom(_) => p.has_nonempty_export_stmt = true,
+                    js_ast::StmtData::SExportStar(_) | js_ast::StmtData::SExportFrom(_) => {
+                        p.has_nonempty_export_stmt = true
+                    }
+                    // `export default Foo` is dropped during visit when `Foo` names a
+                    // local type (interface/type alias), so only non-identifier values
+                    // are known to survive here.
+                    js_ast::StmtData::SExportDefault(s)
+                        if !matches!(
+                            &s.value,
+                            js_ast::StmtOrExpr::Expr(e)
+                                if matches!(e.data, js_ast::ExprData::EIdentifier(_))
+                        ) =>
+                    {
+                        p.has_nonempty_export_stmt = true
+                    }
                     js_ast::StmtData::SLocal(s) if s.is_export => p.has_nonempty_export_stmt = true,
                     js_ast::StmtData::SClass(s) if s.is_export => p.has_nonempty_export_stmt = true,
                     js_ast::StmtData::SFunction(s)

--- a/src/js_parser/parse/parse_import_export.rs
+++ b/src/js_parser/parse/parse_import_export.rs
@@ -195,6 +195,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             name,
                             original_name: original_name.into(),
                         });
+                    } else {
+                        // "import { type as }"
+                        had_type_only_imports = true;
                     }
                 } else {
                     let is_identifier_inner = p.lexer.token == T::TIdentifier;

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1314,15 +1314,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 p.lexer.expect_or_insert_semicolon()?;
 
-                if Self::IS_TYPESCRIPT_ENABLED {
-                    // export {type Foo};
-                    // ->
-                    // nothing
-                    // https://www.typescriptlang.org/play?useDefineForClassFields=true&esModuleInterop=false&declaration=false&target=99&isolatedModules=false&ts=4.5.4#code/KYDwDg9gTgLgBDAnmYcDeAxCEC+cBmUEAtnAOQBGAhlGQNwBQQA
-                    if export_clause.clauses.is_empty() && export_clause.had_type_only_exports {
-                        return Ok(p.s(S::TypeScript {}, loc));
-                    }
-                }
+                // Note: do not remove empty export statements since TypeScript uses them
+                // as module markers ("export { type Foo }" becomes "export {}").
                 p.has_es_module_syntax = true;
                 Ok(p.s(
                     S::ExportClause {

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -472,6 +472,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             }
                         }
                     }
+                    // This default export survives type-stripping; later empty
+                    // `export {}` clauses can be dropped as redundant.
+                    p.has_nonempty_export_stmt = true;
                 }
 
                 if !data.default_name.ref_.is_symbol() {

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -256,8 +256,25 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // Truncate `data.items` to `end` by reslicing the arena view.
         data.items.truncate(end);
 
+        if TYPESCRIPT && items_len > 0 {
+            p.remaining_export_clauses_with_items =
+                p.remaining_export_clauses_with_items.saturating_sub(1);
+        }
+
         if remove_for_tree_shaking {
             return Ok(());
+        }
+
+        if TYPESCRIPT {
+            if end == 0 {
+                // Drop a redundant empty `export {}` when something else already
+                // marks the output as ESM (another export, TLA, or a later export
+                // clause that still has items to visit).
+                if p.has_nonempty_export_stmt || p.remaining_export_clauses_with_items > 0 {
+                    return Ok(());
+                }
+            }
+            p.has_nonempty_export_stmt = true;
         }
 
         stmts.push(*stmt);

--- a/test/bundler/bundler_promiseall_deadcode.test.ts
+++ b/test/bundler/bundler_promiseall_deadcode.test.ts
@@ -164,7 +164,7 @@ describe("bundler", () => {
         var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
         AsyncEntryPoint2();
 
-        //# debugId=42062903F19477CF64756E2164756E21
+        //# debugId=8E8163A4572579B664756E2164756E21
         //# sourceMappingURL=out.js.map
         "
       `);
@@ -410,7 +410,7 @@ describe("bundler", () => {
         var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
         AsyncEntryPoint2();
 
-        //# debugId=BF876FBF618133C264756E2164756E21
+        //# debugId=AFB8B7823E5142AC64756E2164756E21
         //# sourceMappingURL=out.js.map
         "
       `);

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2926,6 +2926,12 @@ console.log(resolve.length)
     expectPrinted_("export { type A }; export { type B };", "export {}");
     expectPrinted_("export { type A }; export { unbound };", "export {}");
     expectPrinted_("await 0; export { type A };", "await 0");
+    // "export default <TypeName>" is itself dropped during visit, so it must not
+    // cause the only remaining "export {}" marker to be dropped as well.
+    expectPrinted_("interface Foo {} export default Foo; export {};", "export {}");
+    expectPrinted_("interface Foo {} export default Foo; export { type Bar };", "export {}");
+    expectPrinted_("export { type A }; interface Foo {} export default Foo;", "export {}");
+    expectPrinted_("const Foo = 1; export default Foo; export { type A };", "const Foo = 1;\nexport default Foo");
 
     // "import { type as }" is a type-only import of the identifier "as" and
     // must be dropped entirely; previously it leaked a bare "import 'mod'".

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2900,7 +2900,24 @@ console.log(resolve.length)
     expectPrinted_("export { x, \\u0074ype y } from 'mod'", 'export { x } from "mod"');
     expectPrinted_("export { x, type if } from 'mod'", 'export { x } from "mod"');
     expectPrinted_("export { x, type y as if }; let x", "export { x };\nlet x");
-    expectPrinted_("export { type x };", "");
+
+    // "export { type x }" must leave an "export {}" ESM marker behind rather than
+    // erasing the statement entirely. This matches esbuild and tsc.
+    expectPrinted_("export { type x };", "export {}");
+    expectPrinted_("export { type x as y };", "export {}");
+    expectPrinted_("export { type as };", "export {}");
+    expectPrinted_("export { type x, type y };", "export {}");
+    expectPrinted_("export { \\u0074ype x };", "export {}");
+    // With "from" the whole re-export is still dropped (nothing to import).
+    expectPrinted_("export { type x } from 'mod';", "");
+    expectPrinted_("export { type as } from 'mod';", "");
+
+    // "import { type as }" is a type-only import of the identifier "as" and
+    // must be dropped entirely; previously it leaked a bare "import 'mod'".
+    expectPrinted_("import { type as } from 'mod';", "");
+    expectPrinted_("import { type as, x } from 'mod'; x", 'import { x } from "mod";\nx');
+    expectPrinted_("import { type foo } from 'mod';", "");
+    expectPrinted_("import { type as xxx } from 'mod'; xxx", 'import { type as xxx } from "mod";\nxxx');
   });
 
   it("delete + optional chain", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2912,6 +2912,21 @@ console.log(resolve.length)
     expectPrinted_("export { type x } from 'mod';", "");
     expectPrinted_("export { type as } from 'mod';", "");
 
+    // The resulting "export {}" is redundant when something else already marks
+    // the output as ESM, so it is dropped regardless of source order (tsc does
+    // the same; esbuild always keeps it).
+    expectPrinted_("export const a = 1; export { type B };", "export const a = 1");
+    expectPrinted_("export { type B }; export const a = 1;", "export const a = 1");
+    expectPrinted_("export default 1; export { type B };", "export default 1");
+    expectPrinted_("export function f() {} export { type B };", "export function f() {}");
+    expectPrinted_("export class C {} export { type B };", "export class C {\n}");
+    expectPrinted_("export * from 'mod'; export { type B };", 'export * from "mod"');
+    expectPrinted_("let b = 1; export { type A }; export { b };", "let b = 1;\n\nexport { b }");
+    expectPrinted_("let b = 1; export { b }; export { type A };", "let b = 1;\n\nexport { b }");
+    expectPrinted_("export { type A }; export { type B };", "export {}");
+    expectPrinted_("export { type A }; export { unbound };", "export {}");
+    expectPrinted_("await 0; export { type A };", "await 0");
+
     // "import { type as }" is a type-only import of the identifier "as" and
     // must be dropped entirely; previously it leaked a bare "import 'mod'".
     expectPrinted_("import { type as } from 'mod';", "");

--- a/test/regression/issue/cyclic-imports-async-bundler.test.js
+++ b/test/regression/issue/cyclic-imports-async-bundler.test.js
@@ -180,7 +180,7 @@ test("cyclic imports with async dependencies should generate async wrappers", as
     var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() => exports_AsyncEntryPoint);
     AsyncEntryPoint2();
 
-    //# debugId=2020261114B67BB564756E2164756E21
+    //# debugId=859D9F276EDC88CD64756E2164756E21
     //# sourceMappingURL=entryBuild.js.map
     "
   `);


### PR DESCRIPTION
## Problem

When every specifier in an `export { ... }` clause is `type`-only, Bun erased the whole statement:

```ts
// input
export { type foo }
```

```js
// bun build --no-bundle (before)
/* empty output */

// esbuild / tsc
export {};
```

Dropping the statement entirely loses the ESM module marker, so downstream tools and runtimes may treat the output as a script rather than a module (top-level `this`, strict mode, etc).

A related bug: `import { type as } from "mod"` (a type-only import of the identifier `as`) was falling through a missing `else` branch in `parse_import_clause` and leaking a bare `import "mod";` into the output instead of being dropped.

## Fix

* `parse_stmt.rs`: remove the early-return to `S::TypeScript` for the non-`from` `export { ... }` case and fall through to an empty `S::ExportClause`, which prints as `export {};`. The `export { type foo } from "bar"` path still drops the whole re-export since there is nothing to import.
* `parse_import_export.rs`: add the missing `else` branch for `import { type as }` so `had_type_only_imports` is set and the statement is dropped.
* `parse_entry.rs` / `visit_stmt.rs`: drop the resulting `export {};` clause whenever another export statement (or top-level `await`) already marks the output as ESM, so type-only exports alongside real exports no longer leave a redundant marker behind. This matches tsc; esbuild always keeps the redundant clause. The check is order-independent and TypeScript-only.

## Verification

`test/bundler/transpiler/transpiler.test.js` "type only exports" now covers:

| Input | Before | After |
| --- | --- | --- |
| `export { type x }` | *(empty)* | `export {};` |
| `export { type as }` | *(empty)* | `export {};` |
| `export { type x } from 'mod'` | *(empty)* | *(empty)* |
| `export const a = 1; export { type B }` | `export const a = 1;` | `export const a = 1;` |
| `export { type B }; export const a = 1` | `export const a = 1;` | `export const a = 1;` |
| `export { type A }; export { b }` | `export { b };` | `export { b };` |
| `export { type A }; export { type B }` | *(empty)* | `export {};` |
| `import { type as } from 'mod'` | `import"mod";` | *(empty)* |

The previous assertion `expectPrinted_("export { type x };", "")` is updated to expect `"export {}"`. Two `bundler_promiseall_deadcode` snapshots update their `debugId` hash only (fixture entries pair `await` with a now-redundant `export {};`; bundled code is unchanged).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_promiseall_deadcode.test.ts test/bundler/transpiler/transpiler.test.js test/regression/issue/cyclic-imports-async-bundler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (8b8edc35e)

test/bundler/bundler_promiseall_deadcode.test.ts:
72 |       },
73 |     },
74 |     onAfterBundle(api) {
75 |       const bundled = api.readFile("out.js");
76 | 
77 |       expect(bundled).toMatchInlineSnapshot(`
                           ^
error: expect(received).toMatchInlineSnapshot(expected)

@@ -86,9 +86,9 @@
  
  // entry.ts
  var { AsyncEntryPoint: AsyncEntryPoint2 } = await Promise.resolve().then(() = exports_AsyncEntryPoint);
  AsyncEntryPoint2();
  
- //# debugId=8E8163A4572579B664756E2164756E21
+ //# debugId=42062903F19477CF64756E2164756E21
  //# sourceMappingURL=out.js.map
  "
  

- Expected 
... (truncated)

release without fix: 1 failed, 22 skipped
bun test v1.4.0-canary.1 (ab13882c1)

test/bundler/bundler_promiseall_deadcode.test.ts:
(pass) bundler > bundler/__promiseAll is tree-shaken when only one async import exists but __esm remains [27.93ms]
(pass) bundler > bundler/__promiseAll is included when multiple async imports exist with __esm [18.50ms]
(pass) bundler > bundler/__promiseAll is tree-shaken when no async imports despite circular deps with __esm [18.27ms]

test/regression/issue/cyclic-imports-async-bundler.test.js:
(pass) cyclic imports with async dependencies should generate async wrappers [27.01ms]

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.07ms]
(pass) Bun.Transpiler > normalizes \r\n [0.12ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.07ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.16ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.03ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.02ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.04ms]
(pa
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_promiseall_deadcode.test.ts test/bundler/transpiler/transpiler.test.js test/regression/issue/cyclic-imports-async-bundler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (8b8edc35e)

test/bundler/bundler_promiseall_deadcode.test.ts:
(pass) bundler > bundler/__promiseAll is tree-shaken when only one async import exists but __esm remains [1254.48ms]
(pass) bundler > bundler/__promiseAll is included when multiple async imports exist with __esm [980.13ms]
(pass) bundler > bundler/__promiseAll is tree-shaken when no async imports despite circular deps with __esm [832.64ms]

test/regression/issue/cyclic-imports-async-bundler.test.js:
(pass) cyclic imports with async dependencies should generate async wrappers [1153.92ms]

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > ha
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 751ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                                 | 10 ++++++
 src/js_parser/parse/parse_entry.rs                 | 41 ++++++++++++++++++++++
 src/js_parser/parse/parse_import_export.rs         |  3 ++
 src/js_parser/parse/parse_stmt.rs                  | 11 ++----
 src/js_parser/visit/visit_stmt.rs                  | 20 +++++++++++
 test/bundler/bundler_promiseall_deadcode.test.ts   |  4 +--
 test/bundler/transpiler/transpiler.test.js         | 40 ++++++++++++++++++++-
 .../issue/cyclic-imports-async-bundler.test.js     |  2 +-
 8 files changed, 118 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js_parser/p.rs                                            6      2      0
src/js_parser/parse/parse_entry.rs                            2      3      0
src/js_parser/parse/parse_import_export.rs                    2      1      0
src/js_parser/parse/parse_stmt.rs                             5      1      0
src/js_parser/visit/visit_stmt.rs                             4      2      0
test/bundler/bundler_promiseall_deadcode.test.ts              0      0      0
test/bundler/transpiler/transpiler.test.js                    1      4      0
…t/regression/issue/cyclic-imports-async-bundler.test.js      0      0      0
```

</details>

<!-- robobun:evidence:end -->