### PR TITLE
js_parser: disambiguate `a ? (b) : c => d` between ternary and arrow return type

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -825,6 +825,7 @@ impl Expr {
 pub enum EFlags {
     None,
     TsDecorator,
+    AfterQuestionAndBeforeColon,
 }
 
 // `is_missing` lives in the `init`/`allocate` impl block below.

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -131,6 +131,13 @@ impl<'a> ImportRecordList<'a> {
             Self::Borrowed(v) => v.len(),
         }
     }
+    #[inline]
+    pub(crate) fn truncate(&mut self, len: usize) {
+        match self {
+            Self::Owned(v) => v.truncate(len),
+            Self::Borrowed(v) => v.truncate(len),
+        }
+    }
 
     /// Transfer the
     /// backing storage into a `Vec<ImportRecord>` and leave `self` empty
@@ -330,6 +337,11 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// (found by fuzzing). Kept sorted for binary search; stays empty (no allocation)
     /// until a constraint attempt actually backtracks, which is rare in real code.
     pub ts_infer_constraint_backtracks: Vec<u32>,
+
+    /// Same idea for the `a ? (b) : T => body` check: verdict packed in the low
+    /// bit, keyed by the byte offset of the ":". See
+    /// `try_skip_type_script_arrow_return_type_after_question_with_backtracking`.
+    pub ts_arrow_after_question_memo: Vec<u32>,
 
     /// When this flag is enabled, we attempt to fold all expressions that
     /// TypeScript would consider to be "constant expressions". This flag is
@@ -9061,6 +9073,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             stack_check: bun_core::StackCheck::init(),
             reported_stack_overflow: core::cell::Cell::new(false),
             ts_infer_constraint_backtracks: Vec::new(),
+            ts_arrow_after_question_memo: Vec::new(),
             arena,
             then_catch_chain: ThenCatchChain {
                 next_target: null_expr_data(),

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -548,12 +548,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // attempt to convert the expressions to bindings first before deciding
             // whether this is an arrow function, and only pick an arrow function if
             // there were no conversion errors.
-            if p.lexer.token == T::TEqualsGreaterThan
-                || (Self::IS_TYPESCRIPT_ENABLED
-                    && invalid_log.is_empty()
-                    && p.try_skip_type_script_arrow_return_type_with_backtracking())
-                || opts.force_arrow_fn
+            let mut is_arrow_fn = p.lexer.token == T::TEqualsGreaterThan;
+            if !is_arrow_fn
+                && Self::IS_TYPESCRIPT_ENABLED
+                && p.lexer.token == T::TColon
+                && invalid_log.is_empty()
             {
+                is_arrow_fn = if opts.is_after_question_and_before_colon {
+                    p.try_skip_type_script_arrow_return_type_after_question_with_backtracking()
+                } else {
+                    p.try_skip_type_script_arrow_return_type_with_backtracking()
+                };
+            }
+            if is_arrow_fn || opts.force_arrow_fn {
                 p.maybe_comma_spread_error(comma_after_spread);
                 p.log_arrow_arg_errors(&mut arrow_arg_errors);
 

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -44,7 +44,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(p.new_expr(E::Super {}, loc))
     }
 
-    fn pfx_t_open_paren(p: &mut Self, level: Level) -> PResult<Expr> {
+    fn pfx_t_open_paren(p: &mut Self, level: Level, flags: EFlags) -> PResult<Expr> {
         let loc = p.lexer.loc();
         p.lexer.next()?;
 
@@ -62,7 +62,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return Ok(value);
         }
 
-        p.parse_paren_expr(loc, level, ParenExprOpts::default())
+        p.parse_paren_expr(
+            loc,
+            level,
+            ParenExprOpts {
+                is_after_question_and_before_colon: flags == EFlags::AfterQuestionAndBeforeColon,
+                ..Default::default()
+            },
+        )
     }
 
     #[inline]
@@ -1014,7 +1021,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             T::TOpenBrace => Self::pfx_t_open_brace(p, errors),
             T::TLessThan => Self::pfx_t_less_than(p, level, errors, flags),
             T::TImport => Self::pfx_t_import(p, level),
-            T::TOpenParen => Self::pfx_t_open_paren(p, level),
+            T::TOpenParen => Self::pfx_t_open_paren(p, level, flags),
             T::TPrivateIdentifier => Self::pfx_t_private_identifier(p, level),
             T::TIdentifier => Self::pfx_t_identifier(p, level),
             T::TFalse => Self::pfx_t_false(p),

--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -1,4 +1,6 @@
 #![warn(unused_must_use)]
+use bun_alloc::ArenaVecExt as _;
+
 use crate::Error;
 use crate::lexer::T;
 use crate::p::P;
@@ -1551,6 +1553,88 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return Err(crate::Error::Backtrack);
         }
         Ok(())
+    }
+
+    /// Like `skip_type_script_arrow_return_type_with_backtracking`, but for the
+    /// `a ? (b) : T => body` ambiguity: the arrow interpretation only wins when
+    /// another ":" follows the body to pair with the leading "?". tsc and
+    /// esbuild both decide this by speculatively parsing the body and checking
+    /// the token after it, so this helper also rewinds the parser state that a
+    /// body parse touches (scopes, log, and the position-keyed side tables),
+    /// unlike the lexer-only `lexer_backtracker_bool`.
+    pub fn try_skip_type_script_arrow_return_type_after_question_with_backtracking(
+        &mut self,
+    ) -> bool {
+        // The verdict depends only on the tokens from this ":", so reuse a prior
+        // attempt at the same offset (same guard as `ts_infer_constraint_backtracks`
+        // below: without it each nesting level runs the inner levels twice).
+        debug_assert!(self.lexer.start <= (u32::MAX >> 1) as usize);
+        let memo_key = self.lexer.start as u32;
+        let memo = &mut self.ts_arrow_after_question_memo;
+        match memo.binary_search_by(|e| (e >> 1).cmp(&memo_key)) {
+            Ok(i) => {
+                let ok = memo[i] & 1 != 0;
+                if ok {
+                    let _ = self.lexer.next();
+                    let _ = self.skip_typescript_return_type();
+                }
+                return ok;
+            }
+            Err(at) => memo.insert(at, memo_key << 1),
+        }
+
+        let old_comments = core::mem::take(&mut self.lexer.comments_to_preserve_before);
+        let old_lexer = self.lexer.snapshot();
+        let old_log_disabled = self.lexer.is_log_disabled;
+        let log = self.log();
+        let (old_errors, old_warnings, old_msgs) = (log.errors, log.warnings, log.msgs.len());
+        let old_current_scope = self.current_scope;
+        let old_scopes_len = self.scopes_in_order.len();
+        let old_enum_scopes_len = self.scopes_in_order_for_enum.len();
+        let old_imports_len = self.import_records.len();
+        let old_fn_or_arrow_data = self.fn_or_arrow_data_parse.clone();
+        let old_after_arrow_body_loc = self.after_arrow_body_loc;
+        self.lexer.is_log_disabled = true;
+
+        let ok = (|| -> Result<(), Error> {
+            self.skip_type_script_arrow_return_type_with_backtracking()?;
+            let args = bun_alloc::ArenaVec::new_in(self.arena).into_bump_slice_mut();
+            self.parse_arrow_body(args, &mut crate::parser::FnOrArrowDataParse::default())?;
+            if self.lexer.token != T::TColon {
+                return Err(crate::Error::Backtrack);
+            }
+            Ok(())
+        })()
+        .is_ok();
+
+        self.lexer.restore(&old_lexer);
+        self.lexer.comments_to_preserve_before = old_comments;
+        self.lexer.is_log_disabled = old_log_disabled;
+        let log = self.log();
+        log.errors = old_errors;
+        log.warnings = old_warnings;
+        log.msgs.truncate(old_msgs);
+        self.current_scope = old_current_scope;
+        self.discard_scopes_up_to(old_scopes_len);
+        while self.scopes_in_order_for_enum.len() > old_enum_scopes_len {
+            self.scopes_in_order_for_enum.pop();
+        }
+        self.import_records.truncate(old_imports_len);
+        self.fn_or_arrow_data_parse = old_fn_or_arrow_data;
+        self.after_arrow_body_loc = old_after_arrow_body_loc;
+
+        if ok {
+            // Nested attempts may have inserted entries since the reservation above.
+            let memo = &mut self.ts_arrow_after_question_memo;
+            if let Ok(i) = memo.binary_search_by(|e| (e >> 1).cmp(&memo_key)) {
+                memo[i] |= 1;
+            }
+            // Re-skip the return type for real; the arrow body is re-parsed by
+            // the caller with the real argument list.
+            let _ = self.lexer.next();
+            let _ = self.skip_typescript_return_type();
+        }
+        ok
     }
 
     // ─────────────────────── try_* wrappers ───────────────────────

--- a/src/js_parser/parse/parse_suffix.rs
+++ b/src/js_parser/parse/parse_suffix.rs
@@ -402,6 +402,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         level: Level,
         errors: Option<&mut DeferredErrors>,
         left: &mut Expr,
+        flags: EFlags,
     ) -> CResult {
         if level.gte(Level::Conditional) {
             return Ok(Continuation::Done);
@@ -448,7 +449,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // condition ? yes : no
         //             ^
-        p.parse_expr_with_flags(Level::Comma, EFlags::None, &mut e_if.yes)?;
+        p.parse_expr_with_flags(Level::Comma, EFlags::AfterQuestionAndBeforeColon, &mut e_if.yes)?;
 
         p.allow_in = old_allow_in;
 
@@ -458,7 +459,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // condition ? yes : no
         //                   ^
-        p.parse_expr_with_flags(Level::Comma, EFlags::None, &mut e_if.no)?;
+        // Propagate the flag so the inner "no" of "a ? b ? c : (d) : e => f"
+        // knows it is still between the outer "?" and ":".
+        let no_flags = if flags == EFlags::AfterQuestionAndBeforeColon {
+            flags
+        } else {
+            EFlags::None
+        };
+        p.parse_expr_with_flags(Level::Comma, no_flags, &mut e_if.no)?;
 
         // condition ? yes : no
         //                     ^
@@ -1544,7 +1552,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 T::TBarBar => Self::sfx_t_bar_bar(p, level, left, flags),
                 T::TAmpersandAmpersand => Self::sfx_t_ampersand_ampersand(p, level, left, flags),
-                T::TQuestion => Self::sfx_t_question(p, level, errors.as_deref_mut(), left),
+                T::TQuestion => Self::sfx_t_question(p, level, errors.as_deref_mut(), left, flags),
                 T::TQuestionDot => Self::sfx_t_question_dot(p, level, &mut optional_chain, left),
                 T::TTemplateHead => Self::sfx_t_template_head(
                     p,

--- a/src/js_parser/parse/parse_suffix.rs
+++ b/src/js_parser/parse/parse_suffix.rs
@@ -449,7 +449,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // condition ? yes : no
         //             ^
-        p.parse_expr_with_flags(Level::Comma, EFlags::AfterQuestionAndBeforeColon, &mut e_if.yes)?;
+        p.parse_expr_with_flags(
+            Level::Comma,
+            EFlags::AfterQuestionAndBeforeColon,
+            &mut e_if.yes,
+        )?;
 
         p.allow_in = old_allow_in;
 

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1512,6 +1512,7 @@ pub struct ParenExprOpts {
     pub async_range: bun_ast::Range,
     pub is_async: bool,
     pub force_arrow_fn: bool,
+    pub is_after_question_and_before_colon: bool,
 }
 
 impl Default for ParenExprOpts {
@@ -1520,6 +1521,7 @@ impl Default for ParenExprOpts {
             async_range: bun_ast::Range::NONE,
             is_async: false,
             force_arrow_fn: false,
+            is_after_question_and_before_colon: false,
         }
     }
 }

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -170,6 +170,104 @@ describe("Bun.Transpiler", () => {
       err("x = a ? b c", 'Expected ":" but found "c"');
     });
 
+    it("disambiguates `a ? (b) : c => d` between ternary and arrow-return-type", () => {
+      // In `a ? (b) : c => d`, `(b) : c => d` could be an arrow with return type
+      // `c`, or a parenthesized `b` followed by the ternary `:` and `c => d`. The
+      // TypeScript compiler picks the arrow only when another `:` follows the body
+      // to pair with the leading `?`.
+      const exp = ts.expectPrinted_;
+      const err = ts.expectParseError;
+
+      exp("x = a ? (b) : c => d", "x = a ? b : (c) => d;\n");
+      exp("x = a ? (b = c) : d", "x = a ? b = c : d;\n");
+      exp("x = a ? (b = c) : d => e", "x = a ? b = c : (d) => e;\n");
+      exp("x = a ? (b = c) : T => d : (e = f)", "x = a ? (b = c) => d : e = f;\n");
+      exp("x = a ? (b = c) : T => d : (e = f) : T => g", "x = a ? (b = c) => d : (e = f) => g;\n");
+      exp("x = a ? b ? c : (d = e) : f => g", "x = a ? b ? c : d = e : (f) => g;\n");
+      exp("x = a ? b ? (c = d) => e : (f = g) : h => i", "x = a ? b ? (c = d) => e : f = g : (h) => i;\n");
+      exp("x = a ? b ? (c = d) : T => e : (f = g) : h => i", "x = a ? b ? (c = d) => e : f = g : (h) => i;\n");
+      exp(
+        "x = a ? b ? (c = d) : T => e : (f = g) : (h = i) : T => j",
+        "x = a ? b ? (c = d) => e : f = g : (h = i) => j;\n",
+      );
+      exp("x = a ? (b) : T => c : d", "x = a ? (b) => c : d;\n");
+      exp("x = a ? b - (c) : d => e", "x = a ? b - c : (d) => e;\n");
+      exp("x = a ? b = (c) : T => d : e", "x = a ? b = (c) => d : e;\n");
+      exp("x = a ? (b) : c => { return d } : e", "x = a ? (b) => {\n  return d;\n} : e;\n");
+      exp("x = a ? (b) : c => { return d }", "x = a ? b : (c) => {\n  return d;\n};\n");
+
+      // Old-style <Type> cast before the paren reaches the same check via
+      // parse_prefix's TLessThan -> parse_prefix(flags) recursion.
+      exp("x = a ? <number[]>(b) : c => d", "x = a ? b : (c) => d;\n");
+      exp("x = a ? <number[]>(b) : T => d : e", "x = a ? (b) => d : e;\n");
+
+      // Newlines trigger the same backtracking path.
+      exp("x = (\n  a ? (b = c) : { d: e }\n)", "x = a ? b = c : { d: e };\n");
+
+      // Private identifiers inside the speculatively-parsed body must resolve.
+      exp(
+        "x = class { #y; y = a ? (b : T) : T => this.#y : c }",
+        "x = class {\n  #y;\n  y = a ? (b) => this.#y : c;\n};\n",
+      );
+
+      // "in" inside the speculatively-parsed body inside a for-init must be allowed.
+      exp("for (x = a ? () : T => b in c : d; ; ) ;", "for (x = a ? () => (b in c) : d;; )\n  ;\n");
+
+      // Legal comments scanned between "?" and "(" sit in the lexer's
+      // comments_to_preserve_before buffer; a block/import() arrow body clears
+      // that buffer during the speculative parse, so it is saved and restored
+      // around the speculation.
+      exp("x = a ? /*! L */ (b) : T => { let y = 1 } : c", "x = a ? (b) => {\n  /*! L */\n  let y = 1;\n} : c;\n");
+      exp("x = a ? /*! L */ (b) : c => { return d }", "x = a ? b : (c) => {\n  /*! L */\n  return d;\n};\n");
+      exp('x = a ? /*! L */ (b) : T => import("m") : c', 'x = a ? (b) => import("m") : c;\n');
+
+      // An enum in the speculatively-parsed body inserts a Loc-keyed entry in
+      // scopes_in_order_for_enum; the entry is popped before the real parse
+      // inserts at the same Loc.
+      exp(
+        "x = a ? (b) : T => { enum E { A } } : c",
+        'x = a ? (b) => {\n  let E;\n  ((E) => {\n    E[E["A"] = 0] = "A";\n  })(E ||= {});\n} : c;\n',
+      );
+      exp(
+        "x = a ? (b) : T => { enum E { A } }",
+        'x = a ? b : (T) => {\n  let E;\n  ((E) => {\n    E[E["A"] = 0] = "A";\n  })(E ||= {});\n};\n',
+      );
+
+      // Deeply nested arrow-in-yes-branch is memoized so each ":" is only
+      // speculated once instead of 2^n times. The first shape succeeds at every
+      // level (arrow), the second fails at every level (ternary).
+      {
+        let src = "0";
+        for (let i = 0; i < 25; i++) src = `(a ? (b) : T => ${src} : c)`;
+        let out = "0";
+        for (let i = 0; i < 25; i++) out = `a ? (b) => ${out} : c`;
+        exp(`let z = ${src};`, `let z = ${out};\n`);
+      }
+      {
+        let src = "0";
+        for (let i = 0; i < 25; i++) src = `(a ? (b) : T => ${src})`;
+        let out = "0";
+        for (let i = 0; i < 25; i++) out = `a ? b : (T) => ${out}`;
+        exp(`let z = ${src};`, `let z = ${out};\n`);
+      }
+
+      // scanImports pushes import()/require() records at parse time; speculative
+      // records are truncated so each source occurrence is reported once.
+      expect(transpiler.scanImports('x = a ? (b) : T => import("m") : c', "ts")).toEqual([
+        { kind: "dynamic-import", path: "m" },
+      ]);
+      expect(transpiler.scanImports('x = a ? (b) : T => import("m")', "ts")).toEqual([
+        { kind: "dynamic-import", path: "m" },
+      ]);
+      expect(transpiler.scanImports('x = a ? (b) : T => require("r") : c', "ts")).toEqual([
+        { kind: "require-call", path: "r" },
+      ]);
+
+      err("x = a ? (b = c) : T => d : (e = f) : g", 'Expected ";" but found ":"');
+      err("x = a ? - (b) : c => d : e", 'Expected ";" but found ":"');
+      err("x = a ? b - (c) : d => e : f", 'Expected ";" but found ":"');
+    });
+
     it("contextual keywords used as plain identifiers keep their statements", () => {
       const exp = ts.expectPrinted_;
 


### PR DESCRIPTION
## Repro

```
$ printf 'let x = a ? (b) : c => d;\n' > /tmp/r.ts
$ bun build /tmp/r.ts --no-bundle
error: Expected ":" but found ";"
```

esbuild and tsc both accept this and print `let x = a ? b : (c) => d;`.

## Cause

In TypeScript, `(b) : c => d` after `?` is ambiguous between an arrow function with return type `c` and a parenthesized `b` followed by the ternary's `:` and `c => d`. The TypeScript compiler picks the arrow only when another `:` follows the arrow body to pair with the leading `?`; otherwise the first `:` belongs to the ternary.

Bun always used the cheap lexer-only check (skip `: Type`, require `=>`) regardless of context, so in `a ? (b) : c => d` it greedily committed to the arrow `(b): c => d` and then failed to find the ternary's `:`.

Both tsc (`parseParenthesizedArrowFunctionExpression` inside `tryParse`) and esbuild (`isTypeScriptArrowReturnTypeAfterQuestionAndBeforeColon`) decide this by speculatively parsing the arrow body and checking whether a `:` follows; see evanw/esbuild#4241.

## Fix

`sfx_t_question` now passes `EFlags::AfterQuestionAndBeforeColon` when parsing the consequent, and propagates it to the alternate when already between an outer `?` and `:` (so nested ternaries like `a ? b ? c : (d) : e => f` work). `pfx_t_open_paren` forwards it to `parse_paren_expr` as `ParenExprOpts::is_after_question_and_before_colon`.

When that flag is set and the token after `)` is `:`, `parse_paren_expr` calls the new `try_skip_type_script_arrow_return_type_after_question_with_backtracking` in `parse_skip_typescript.rs` (alongside the other TypeScript backtrackers) instead of the cheap check. The helper wraps `skip_type_script_arrow_return_type_with_backtracking()` + `parse_arrow_body()` + a trailing-`:` check, and on either outcome rewinds the lexer plus the parser state a body parse touches: `discard_scopes_up_to`, log counts, `comments_to_preserve_before`, `scopes_in_order_for_enum`, `import_records`, `fn_or_arrow_data_parse`, `after_arrow_body_loc`. `symbols` is left un-truncated so stale entries in the `Ref`-keyed maps statement parsing populates stay keyed by unique indices and are never looked up.

The verdict is memoized by the byte offset of the leading `:` (same guard as `ts_infer_constraint_backtracks`) so deeply-nested inputs are O(n²) instead of O(2^n).

## Verification

New test in `test/bundler/transpiler/transpiler.test.js` covers esbuild's full matrix for this case plus the regression cases surfaced during review: nested-propagation, block bodies, `<Type>(b)` cast-before-paren, legal comments before `(`, `enum` in the body, private identifiers, `in` inside a for-init, `scanImports()` dedup, both n=25 memo verdicts, and the error cases. Fails on main, passes with this change. Full file: 172 pass, 0 fail.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (c8eb4967c)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.00ms]
(pass) Bun.Transpiler > normalizes \r\n [6.68ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.46ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [7.64ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.40ms]
(pass) Bun.Transpiler > property access inlining > works [2.66ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.32ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [18.27ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [2.91ms]
(pass) Bun
... (truncated)

release without fix: 15 failed, 22 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.11ms]
(pass) Bun.Transpiler > normalizes \r\n [0.15ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.09ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.11ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.04ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.03ms]
141 |     });
142 |     it("bails out on optional-chain index into enum", () => {
143 |       const pre = "enum Foo { A }\nenum Bar { 'a-b' = 1 }\n";
144 |       const lastLine = out => out.trimEnd().split("\n").at(-1);
145 |       expect(lastLine(ts.parsed(pre + 'export let y = Foo["A"];', false))).toBe("export let y = 0 /* A */;");
146 |       expect(lastLine(ts.parsed(pre + 'export let y = Foo?.["A"];', false))).toBe('export let y = Foo?.["A"];');
                                                                                   ^
error: expect(received).toBe(expected)

Expected: "export let y = F
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (c8eb4967c)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [4.82ms]
(pass) Bun.Transpiler > normalizes \r\n [6.51ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.12ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [7.13ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.10ms]
(pass) Bun.Transpiler > property access inlining > works [2.38ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.10ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [17.32ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [3.66ms]
(pass) Bun
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     c8eb4967c4
  features     (none)

22 deps, 106 codegen, 1169 objects in 815ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1232] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [14.00ms]
[2/1232] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1232] gen ErrorCode+*.h
[4/1232] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [6.00ms]
[5/1232] gen bindgenv2
[6/1232] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1232] fetch tinycc
[tinycc] up to date
[8/1231] gen .bin
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/expr.rs                              |  1 +
 src/js_parser/p.rs                           | 13 ++++
 src/js_parser/parse/mod.rs                   | 17 +++--
 src/js_parser/parse/parse_prefix.rs          | 13 +++-
 src/js_parser/parse/parse_skip_typescript.rs | 84 ++++++++++++++++++++++++
 src/js_parser/parse/parse_suffix.rs          | 18 ++++-
 src/js_parser/parser.rs                      |  2 +
 test/bundler/transpiler/transpiler.test.js   | 98 ++++++++++++++++++++++++++++
 8 files changed, 235 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/ast/expr.rs                                   2      3      0
src/js_parser/p.rs                               13      6      0
src/js_parser/parse/mod.rs                       11     10      0
src/js_parser/parse/parse_prefix.rs               5      4      0
src/js_parser/parse/parse_skip_typescript.rs      6      4      0
src/js_parser/parse/parse_suffix.rs               4      5      0
src/js_parser/parser.rs                           3      2      0
test/bundler/transpiler/transpiler.test.js        8     11      0
```

</details>

<!-- robobun:evidence:end -->