### PR TITLE
lexer: fix TOKEN_TO_STRING[TColon] showing " =" instead of ":"

### DIFF
--- a/src/ast/lexer_tables.rs
+++ b/src/ast/lexer_tables.rs
@@ -327,7 +327,7 @@ pub static TOKEN_TO_STRING: TokenEnumType = TokenEnumType({
     token_enums[T::TCloseBrace as usize] = b"\"}\"";
     token_enums[T::TCloseBracket as usize] = b"\"]\"";
     token_enums[T::TCloseParen as usize] = b"\")\"";
-    token_enums[T::TColon as usize] = b"\" =\"";
+    token_enums[T::TColon as usize] = b"\":\"";
     token_enums[T::TComma as usize] = b"\",\"";
     token_enums[T::TDot as usize] = b"\".\"";
     token_enums[T::TDotDotDot as usize] = b"\"...\"";

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -153,6 +153,13 @@ describe("Bun.Transpiler", () => {
       );
     });
 
+    it('reports Expected ":" for a conditional expression missing its colon', () => {
+      const err = ts.expectParseError;
+      err("let x = a ? b;", 'Expected ":" but found ";"');
+      err("(a ? b)", 'Expected ":" but found ")"');
+      err("x = a ? b c", 'Expected ":" but found "c"');
+    });
+
     it("contextual keywords used as plain identifiers keep their statements", () => {
       const exp = ts.expectPrinted_;
 


### PR DESCRIPTION
## Repro

```sh
$ printf "let x = a ? b;\n" > /tmp/pre.ts
$ bun build /tmp/pre.ts --no-bundle
error: Expected " =" but found ";"
```

Expected:

```
error: Expected ":" but found ";"
```

## Cause

`TOKEN_TO_STRING[TColon]` in `src/ast/lexer_tables.rs` was set to `b"\" =\""` instead of `b"\":\""`. This table feeds the `Expected <token> but found ...` parse error messages.

## Fix

One-character correction in the table entry for `TColon`.

## Verification

Added a test in `test/bundler/transpiler/transpiler.test.js` that asserts the parse error message for a conditional expression missing its colon. Fails on main with `Received: "Expected \" =\" but found \";\""`, passes with the fix.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (6c0ea50b7)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [4.92ms]
(pass) Bun.Transpiler > normalizes \r\n [6.49ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.19ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [6.60ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.66ms]
(pass) Bun.Transpiler > property access inlining > works [2.35ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.08ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [2.83ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [2.33ms]
153 |   
... (truncated)

release without fix: 22 skipped
bun test v1.4.0-canary.1 (dcbaf74db)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.10ms]
(pass) Bun.Transpiler > normalizes \r\n [0.14ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.10ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.11ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.03ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.03ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.04ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [0.04ms]
(pass) Bun.Transpiler > TypeScript > reports Expected ":" for a conditional expression missing its colon [0.15ms]
(pass) Bun.Transpiler > TypeScript > contextual keywords used as plain identifiers keep their statements [0.25ms]
(pass) Bun.Transpiler > TypeScript > does not crash when export default abstract is an expression followed by a class [0.15ms]
(pass) Bun.Transpiler > TypeScript > scope tracking stays balanced when a cont
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (6c0ea50b7)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [4.97ms]
(pass) Bun.Transpiler > normalizes \r\n [6.54ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.64ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [6.77ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.69ms]
(pass) Bun.Transpiler > property access inlining > works [2.41ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.15ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [2.82ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [2.31ms]
(pass) B
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 1622ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_ast v0.0.0 (/workspace/bun/src/ast)
[1m[92m   Compiling[0m bun_dotenv v0.0.0 (/workspace/bun/src/dotenv)
[1m[92m   Compiling[0m bun_install_types v0.0.0 (/workspace/bun/src/install_typ
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/lexer_tables.rs                    | 2 +-
 test/bundler/transpiler/transpiler.test.js | 7 +++++++
 2 files changed, 8 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/ast/lexer_tables.rs                         2      1      0
test/bundler/transpiler/transpiler.test.js      8      3      0
```

</details>

**root cause** · written by the author bot

The TOKEN_TO_STRING lookup table had a typo mapping the TColon token to the display string `" ="` instead of `":"`, causing parser error messages to read `Expected " =" but found ...` when a colon was expected. The fix corrects that single table entry to `b"\":\""` so the diagnostic renders the expected token correctly. A regression test was added that asserts the proper `Expected ":"` wording for a conditional expression missing its colon.

<!-- robobun:evidence:end -->