### PR TITLE
js_parser: stop dropping side effects when folding !/typeof on array/object/class literals

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1341,19 +1341,17 @@ impl Tag {
     }
 
     pub fn typeof_(tag: Tag) -> Option<&'static [u8]> {
+        // This must only return `Some` when the operand is guaranteed to have
+        // no side effects. Array/object/class literals are omitted because
+        // their elements, properties, and static initializers can run code.
         Some(match tag {
-            Tag::EArray
-            | Tag::EObject
-            | Tag::EArrayJSON
-            | Tag::EObjectJSON
-            | Tag::ENull
-            | Tag::ERegExp => b"object",
+            Tag::EArrayJSON | Tag::EObjectJSON | Tag::ENull | Tag::ERegExp => b"object",
             Tag::EUndefined => b"undefined",
             Tag::EBoolean | Tag::EBranchBoolean => b"boolean",
             Tag::ENumber => b"number",
             Tag::EBigInt => b"bigint",
             Tag::EString => b"string",
-            Tag::EClass | Tag::EFunction | Tag::EArrow => b"function",
+            Tag::EFunction | Tag::EArrow => b"function",
             _ => return None,
         })
     }

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1044,19 +1044,21 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         // like .e_import_identifier tracking works
                         // Reminder that this can only be done after
                         // `target` is visited.
-                        if let Some(rewrite) = p.maybe_rewrite_property_access(
-                            expr.loc,
-                            e_.target,
-                            s.data.slice(),
-                            unwrapped.loc,
-                            IdentifierOpts::default()
-                                .with_is_call_target(is_call_target)
-                                // .is_template_tag = is_template_tag,
-                                .with_is_delete_target(is_delete_target)
-                                .with_assign_target(in_.assign_target),
-                        ) {
-                            *e = rewrite;
-                            return;
+                        if e_.optional_chain.is_none() {
+                            if let Some(rewrite) = p.maybe_rewrite_property_access(
+                                expr.loc,
+                                e_.target,
+                                s.data.slice(),
+                                unwrapped.loc,
+                                IdentifierOpts::default()
+                                    .with_is_call_target(is_call_target)
+                                    // .is_template_tag = is_template_tag,
+                                    .with_is_delete_target(is_delete_target)
+                                    .with_assign_target(in_.assign_target),
+                            ) {
+                                *e = rewrite;
+                                return;
+                            }
                         }
                     }
                 }
@@ -1256,7 +1258,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         }
 
                         let side_effects = SideEffects::to_boolean(p, &e_.value.data);
-                        if side_effects.ok {
+                        if side_effects.ok
+                            && side_effects.side_effects == SideEffects::NoSideEffects
+                        {
                             *e = p.new_expr(
                                 E::Boolean {
                                     value: !side_effects.value,

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1259,7 +1259,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                         let side_effects = SideEffects::to_boolean(p, &e_.value.data);
                         if side_effects.ok
-                            && side_effects.side_effects == SideEffects::NoSideEffects
+                            && (side_effects.side_effects == SideEffects::NoSideEffects
+                                || p.expr_can_be_removed_if_unused(&e_.value))
                         {
                             *e = p.new_expr(
                                 E::Boolean {

--- a/test/bundler/transpiler/simplifier-side-effects.test.ts
+++ b/test/bundler/transpiler/simplifier-side-effects.test.ts
@@ -1,107 +1,25 @@
-import { describe, expect, test } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-// The simplifier used to fold `![array]`, `!{obj}`, `typeof [array]`, etc. to a
-// constant while discarding side effects inside the literal. It also inlined
-// `Enum?.["A"]` to the member's constant value, dropping the optional chain.
+// Runtime proof that side effects inside array/object literals under `!` and
+// `typeof` are not discarded by the simplifier. The transpiler-output
+// assertions for these shapes live in transpiler.test.js under
+// "constant folding" and "property access inlining".
 
-describe("simplifier preserves side effects inside literals", () => {
-  function transform(code: string): string {
-    return new Bun.Transpiler({ loader: "js" }).transformSync(code);
-  }
-
-  function transformMin(code: string): string {
-    return new Bun.Transpiler({ loader: "js", minify: { syntax: true } }).transformSync(code);
-  }
-
-  for (const min of [false, true]) {
-    const label = min ? " (minify)" : "";
-    const tx = min ? transformMin : transform;
-
-    test(`![sideEffect()] keeps the call${label}`, () => {
-      expect(tx("const r = ![sideEffect()];")).toContain("sideEffect()");
-    });
-
-    test(`!{x: sideEffect()} keeps the call${label}`, () => {
-      expect(tx("const r = !{ x: sideEffect() };")).toContain("sideEffect()");
-    });
-
-    test(`!(class { static x = sideEffect(); }) keeps the call${label}`, () => {
-      expect(tx("const r = !(class { static x = sideEffect(); });")).toContain("sideEffect()");
-    });
-
-    test(`!void sideEffect() keeps the call${label}`, () => {
-      expect(tx("const r = !void sideEffect();")).toContain("sideEffect()");
-    });
-
-    test(`!![sideEffect()] keeps the call${label}`, () => {
-      expect(tx("const r = !![sideEffect()];")).toContain("sideEffect()");
-    });
-
-    test(`typeof [sideEffect()] keeps the call${label}`, () => {
-      expect(tx("const r = typeof [sideEffect()];")).toContain("sideEffect()");
-    });
-
-    test(`typeof {x: sideEffect()} keeps the call${label}`, () => {
-      expect(tx("const r = typeof { x: sideEffect() };")).toContain("sideEffect()");
-    });
-
-    test(`typeof class { static x = sideEffect(); } keeps the call${label}`, () => {
-      expect(tx("const r = typeof class { static x = sideEffect(); };")).toContain("sideEffect()");
-    });
-
-    test(`typeof [sideEffect()] === 'object' keeps the call${label}`, () => {
-      expect(tx("const r = typeof [sideEffect()] === 'object';")).toContain("sideEffect()");
-    });
-  }
-
-  test("pure literals still fold under !", () => {
-    expect(transform("export const r = !null;").trim()).toBe("export const r = true;");
-    expect(transform("export const r = !undefined;").trim()).toBe("export const r = true;");
-    expect(transform("export const r = !0;").trim()).toBe("export const r = true;");
-    expect(transform('export const r = !"x";').trim()).toBe("export const r = false;");
-    expect(transform("export const r = !function(){};").trim()).toBe("export const r = false;");
+test("side effects inside ![...] / typeof [...] run at runtime", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `let n = 0; const fx = () => { n++; return 1 }; ` +
+        `const a = ![fx()]; const b = !{ x: fx() }; const c = typeof [fx()]; ` +
+        `const d = !(fx(), true); const e = !typeof fx(); ` +
+        `console.log(n, a, b, c, d, e);`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
   });
-
-  test("typeof pure primitives still fold", () => {
-    expect(transform("export const r = typeof null;").trim()).toBe('export const r = "object";');
-    expect(transform("export const r = typeof 123;").trim()).toBe('export const r = "number";');
-    expect(transform("export const r = typeof (() => {});").trim()).toBe('export const r = "function";');
-  });
-
-  test("side effects inside ![...] run at runtime", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `let n = 0; const fx = () => { n++; return 1 }; ` +
-          `const a = ![fx()]; const b = !{ x: fx() }; const c = typeof [fx()]; ` +
-          `console.log(n, a, b, c);`,
-      ],
-      env: bunEnv,
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout).toBe("3 false false object\n");
-    expect(exitCode).toBe(0);
-  });
-});
-
-describe("enum optional-chain index is not inlined", () => {
-  const transpiler = new Bun.Transpiler({ loader: "ts" });
-
-  test("Foo?.['A'] keeps the optional-chain access", () => {
-    const out = transpiler.transformSync(`enum Foo { A }\nexport let y = Foo?.["A"];`);
-    expect(out).toContain(`Foo?.["A"]`);
-  });
-
-  test("Foo?.['A']() keeps the optional-chain call", () => {
-    const out = transpiler.transformSync(`enum Foo { A }\nexport let y = Foo?.["A"]();`);
-    expect(out).toContain(`let y = Foo?.["A"]();`);
-  });
-
-  test("Foo['A'] without optional chain is still inlined", () => {
-    const out = transpiler.transformSync(`enum Foo { A }\nexport let y = Foo["A"];`);
-    expect(out).toMatch(/let y = 0\b/);
-  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("5 false false object false false\n");
+  expect(exitCode).toBe(0);
 });

--- a/test/bundler/transpiler/simplifier-side-effects.test.ts
+++ b/test/bundler/transpiler/simplifier-side-effects.test.ts
@@ -1,10 +1,8 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-// Runtime proof that side effects inside array/object literals under `!` and
-// `typeof` are not discarded by the simplifier. The transpiler-output
-// assertions for these shapes live in transpiler.test.js under
-// "constant folding" and "property access inlining".
+// Runtime proof that side effects under `!`/`typeof` are preserved by the
+// simplifier. Transpiler-output assertions live in transpiler.test.js.
 
 test("side effects inside ![...] / typeof [...] run at runtime", async () => {
   await using proc = Bun.spawn({

--- a/test/bundler/transpiler/simplifier-side-effects.test.ts
+++ b/test/bundler/transpiler/simplifier-side-effects.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// The simplifier used to fold `![array]`, `!{obj}`, `typeof [array]`, etc. to a
+// constant while discarding side effects inside the literal. It also inlined
+// `Enum?.["A"]` to the member's constant value, dropping the optional chain.
+
+describe("simplifier preserves side effects inside literals", () => {
+  function transform(code: string): string {
+    return new Bun.Transpiler({ loader: "js" }).transformSync(code);
+  }
+
+  function transformMin(code: string): string {
+    return new Bun.Transpiler({ loader: "js", minify: { syntax: true } }).transformSync(code);
+  }
+
+  for (const min of [false, true]) {
+    const label = min ? " (minify)" : "";
+    const tx = min ? transformMin : transform;
+
+    test(`![sideEffect()] keeps the call${label}`, () => {
+      expect(tx("const r = ![sideEffect()];")).toContain("sideEffect()");
+    });
+
+    test(`!{x: sideEffect()} keeps the call${label}`, () => {
+      expect(tx("const r = !{ x: sideEffect() };")).toContain("sideEffect()");
+    });
+
+    test(`!(class { static x = sideEffect(); }) keeps the call${label}`, () => {
+      expect(tx("const r = !(class { static x = sideEffect(); });")).toContain("sideEffect()");
+    });
+
+    test(`!void sideEffect() keeps the call${label}`, () => {
+      expect(tx("const r = !void sideEffect();")).toContain("sideEffect()");
+    });
+
+    test(`!![sideEffect()] keeps the call${label}`, () => {
+      expect(tx("const r = !![sideEffect()];")).toContain("sideEffect()");
+    });
+
+    test(`typeof [sideEffect()] keeps the call${label}`, () => {
+      expect(tx("const r = typeof [sideEffect()];")).toContain("sideEffect()");
+    });
+
+    test(`typeof {x: sideEffect()} keeps the call${label}`, () => {
+      expect(tx("const r = typeof { x: sideEffect() };")).toContain("sideEffect()");
+    });
+
+    test(`typeof class { static x = sideEffect(); } keeps the call${label}`, () => {
+      expect(tx("const r = typeof class { static x = sideEffect(); };")).toContain("sideEffect()");
+    });
+
+    test(`typeof [sideEffect()] === 'object' keeps the call${label}`, () => {
+      expect(tx("const r = typeof [sideEffect()] === 'object';")).toContain("sideEffect()");
+    });
+  }
+
+  test("pure literals still fold under !", () => {
+    expect(transform("export const r = !null;").trim()).toBe("export const r = true;");
+    expect(transform("export const r = !undefined;").trim()).toBe("export const r = true;");
+    expect(transform("export const r = !0;").trim()).toBe("export const r = true;");
+    expect(transform('export const r = !"x";').trim()).toBe("export const r = false;");
+    expect(transform("export const r = !function(){};").trim()).toBe("export const r = false;");
+  });
+
+  test("typeof pure primitives still fold", () => {
+    expect(transform("export const r = typeof null;").trim()).toBe('export const r = "object";');
+    expect(transform("export const r = typeof 123;").trim()).toBe('export const r = "number";');
+    expect(transform("export const r = typeof (() => {});").trim()).toBe('export const r = "function";');
+  });
+
+  test("side effects inside ![...] run at runtime", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `let n = 0; const fx = () => { n++; return 1 }; ` +
+          `const a = ![fx()]; const b = !{ x: fx() }; const c = typeof [fx()]; ` +
+          `console.log(n, a, b, c);`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("3 false false object\n");
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe("enum optional-chain index is not inlined", () => {
+  const transpiler = new Bun.Transpiler({ loader: "ts" });
+
+  test("Foo?.['A'] keeps the optional-chain access", () => {
+    const out = transpiler.transformSync(`enum Foo { A }\nexport let y = Foo?.["A"];`);
+    expect(out).toContain(`Foo?.["A"]`);
+  });
+
+  test("Foo?.['A']() keeps the optional-chain call", () => {
+    const out = transpiler.transformSync(`enum Foo { A }\nexport let y = Foo?.["A"]();`);
+    expect(out).toContain(`let y = Foo?.["A"]();`);
+  });
+
+  test("Foo['A'] without optional chain is still inlined", () => {
+    const out = transpiler.transformSync(`enum Foo { A }\nexport let y = Foo["A"];`);
+    expect(out).toMatch(/let y = 0\b/);
+  });
+});

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -139,6 +139,16 @@ describe("Bun.Transpiler", () => {
     it("works nested", () => {
       ts.expectPrintedMin_('const a = ["hey"][0][0];', 'const a = "h"');
     });
+    it("bails out on optional-chain index into enum", () => {
+      const pre = "enum Foo { A }\nenum Bar { 'a-b' = 1 }\n";
+      const lastLine = out => out.trimEnd().split("\n").at(-1);
+      expect(lastLine(ts.parsed(pre + 'export let y = Foo["A"];', false))).toBe("export let y = 0 /* A */;");
+      expect(lastLine(ts.parsed(pre + 'export let y = Foo?.["A"];', false))).toBe('export let y = Foo?.["A"];');
+      expect(lastLine(ts.parsed(pre + 'export let y = Foo?.["A"]();', false))).toBe('export let y = Foo?.["A"]();');
+      expect(lastLine(ts.parsed(pre + 'export let y = Bar?.["a-b"];', false))).toBe('export let y = Bar?.["a-b"];');
+      expect(lastLine(ts.parsedMin(pre + 'export let y = Foo?.["A"];', false))).toBe("export let y = Foo?.A;");
+      expect(lastLine(ts.parsedMin(pre + 'export let y = Bar?.["a-b"];', false))).toBe('export let y = Bar?.["a-b"];');
+    });
   });
 
   describe("TypeScript", () => {
@@ -3554,10 +3564,28 @@ console.log(foo, array);
       expectPrinted("typeof ['boolean']", 'typeof ["boolean"]');
       expectPrinted("typeof [sideEffect()]", "typeof [sideEffect()]");
       expectPrinted("typeof {x: sideEffect()}", "typeof { x: sideEffect() }");
+      expectPrinted("typeof class { static x = sideEffect(); }", "typeof class {\n  static x = sideEffect();\n}");
 
       expectPrinted('typeof [] === "object"', 'typeof [] === "object"');
       expectPrinted("typeof {foo: 123} === typeof {bar: 123}", "typeof { foo: 123 } === typeof { bar: 123 }");
       expectPrinted("typeof {foo: 123} !== typeof 123", 'typeof { foo: 123 } !== "number"');
+
+      // `!` folds to a boolean only when the operand has no side effects or
+      // can be proven removable. Side-effecting operands are left intact.
+      expectPrinted("![]", "!1");
+      expectPrinted("!{}", "!1");
+      expectPrinted("![1, 2, 3]", "!1");
+      expectPrinted("!{ a: 1 }", "!1");
+      expectPrinted("![sideEffect()]", "![sideEffect()]");
+      expectPrinted("!{ x: sideEffect() }", "!{ x: sideEffect() }");
+      expectPrinted("!(class { static x = sideEffect(); })", "!class {\n  static x = sideEffect();\n}");
+      expectPrinted("!void sideEffect()", "!void sideEffect()");
+      expectPrinted("!!void sideEffect()", "!!void sideEffect()");
+      expectPrinted("!![sideEffect()]", "!![sideEffect()]");
+      expectPrinted("!(sideEffect(), true)", "(sideEffect(), !1)");
+      expectPrinted("!(sideEffect() || 1)", "!(sideEffect() || 1)");
+      expectPrinted("!(sideEffect() && 0)", "!(sideEffect() && 0)");
+      expectPrinted("!typeof sideEffect()", "!typeof sideEffect()");
 
       expectPrinted("undefined === undefined", "!0");
       expectPrinted("undefined !== undefined", "!1");

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3544,16 +3544,20 @@ console.log(foo, array);
       expectPrinted("typeof 'abc'", '"string"');
       expectPrinted("typeof function() {}", '"function"');
       expectPrinted("typeof (() => {})", '"function"');
-      expectPrinted("typeof {}", '"object"');
-      expectPrinted("typeof {foo: 123}", '"object"');
-      expectPrinted("typeof []", '"object"');
-      expectPrinted("typeof [0]", '"object"');
-      expectPrinted("typeof [null]", '"object"');
-      expectPrinted("typeof ['boolean']", '"object"');
+      // Array/object/class literals may contain side effects in their
+      // elements/properties, so `typeof` is not folded for them.
+      expectPrinted("typeof {}", "typeof {}");
+      expectPrinted("typeof {foo: 123}", "typeof { foo: 123 }");
+      expectPrinted("typeof []", "typeof []");
+      expectPrinted("typeof [0]", "typeof [0]");
+      expectPrinted("typeof [null]", "typeof [null]");
+      expectPrinted("typeof ['boolean']", 'typeof ["boolean"]');
+      expectPrinted("typeof [sideEffect()]", "typeof [sideEffect()]");
+      expectPrinted("typeof {x: sideEffect()}", "typeof { x: sideEffect() }");
 
-      expectPrinted('typeof [] === "object"', "!0");
-      expectPrinted("typeof {foo: 123} === typeof {bar: 123}", "!0");
-      expectPrinted("typeof {foo: 123} !== typeof 123", "!0");
+      expectPrinted('typeof [] === "object"', 'typeof [] === "object"');
+      expectPrinted("typeof {foo: 123} === typeof {bar: 123}", "typeof { foo: 123 } === typeof { bar: 123 }");
+      expectPrinted("typeof {foo: 123} !== typeof 123", 'typeof { foo: 123 } !== "number"');
 
       expectPrinted("undefined === undefined", "!0");
       expectPrinted("undefined !== undefined", "!1");


### PR DESCRIPTION
## Problem

The expression simplifier folds `!expr` and `typeof expr` to a constant without checking whether the operand has side effects, so calls inside array/object/class literals are silently deleted:

```sh
$ printf 'const r = ![sideEffect()];\n' | bun build --no-bundle -
const r = false;           # sideEffect() is gone

$ printf 'const r = typeof [sideEffect()];\n' | bun build --no-bundle -
const r = "object";        # sideEffect() is gone
```

esbuild keeps both unchanged (`const r = ![sideEffect()];` / `const r = typeof [sideEffect()];`).

A related issue in the same visitor: enum constant inlining runs on `Foo?.["A"]` (computed optional-chain access), turning `Foo?.["A"]()` into `0()`. The dotted form `Foo?.A` was already guarded.

```sh
$ printf 'enum Foo { A }\nlet y = Foo?.["A"]()\n' | bun build --no-bundle -
...
let y = 0 /* A */();       # optional chain dropped
```

## Cause

* `e_unary` / `UnNot` called `SideEffects::to_boolean()` but only checked `.ok`, ignoring the `CouldHaveSideEffects` flag that `EArray`/`EObject`/`EClass` correctly set.
* `Tag::typeof_` returned `Some("object")` / `Some("function")` for `EArray`/`EObject`/`EClass`, but its contract (and doc comment) is that the operand has no side effects. Array elements, object properties, and class static initializers can run arbitrary code.
* `e_index` called `maybe_rewrite_property_access` without the `optional_chain.is_none()` guard that `e_dot` already has (and that esbuild applies to both).

## Fix

* `UnNot`: require `side_effects == NoSideEffects` before replacing with an `EBoolean`, matching esbuild's `UnOpNot` path.
* `Tag::typeof_`: drop `EArray`/`EObject`/`EClass`. `EArrayJSON`/`EObjectJSON`/`ERegExp` remain since they are pure literals. This matches esbuild's `TypeofWithoutSideEffects`.
* `e_index`: guard `maybe_rewrite_property_access` with `optional_chain.is_none()`.

The existing `constant folding` assertions for `typeof []` / `typeof {}` are updated to reflect that these are no longer folded, matching esbuild's behaviour.

## Verification

```sh
$ USE_SYSTEM_BUN=1 bun test test/bundler/transpiler/simplifier-side-effects.test.ts
# 3 pass, 21 fail

$ bun bd test test/bundler/transpiler/simplifier-side-effects.test.ts
# 24 pass, 0 fail
```

Also ran `transpiler.test.js`, `bundler_minify.test.ts`, `esbuild/dce.test.ts`, `esbuild/default.test.ts`, `bundler_edgecase.test.ts`, `bundler_string.test.ts`: all pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/simplifier-side-effects.test.ts test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (66d74a438)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [4.80ms]
(pass) Bun.Transpiler > normalizes \r\n [6.43ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.23ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [6.75ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.68ms]
(pass) Bun.Transpiler > property access inlining > works [2.42ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.11ms]
141 |     });
142 |     it("bails out on optional-chain index into enum", () => {
143 |       const pre = "enum Foo { A }\nenu
... (truncated)

release without fix: 22 skipped
bun test v1.4.0-canary.1 (0dc53862f)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [2.32ms]
(pass) Bun.Transpiler > normalizes \r\n [0.75ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [1.94ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.14ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.03ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.02ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [0.28ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.04ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [0.03ms]
(pass) Bun.Transpiler > TypeScript > contextual keywords used as plain identifiers keep their statements [0.24ms]
(pass) Bun.Transpiler > TypeScript > does not crash when export default abstract is an expression followed by a class [0.24ms]
(pass) Bun.Transpiler > TypeScript > scope tracking stays balanced when a contextual key
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/simplifier-side-effects.test.ts test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (66d74a438)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [4.67ms]
(pass) Bun.Transpiler > normalizes \r\n [6.38ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.20ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [6.92ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.62ms]
(pass) Bun.Transpiler > property access inlining > works [2.41ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.10ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [17.31ms]
(pass) Bun.Transpiler
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 755ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/expr.rs                                    | 12 +++--
 src/js_parser/visit/visit_expr.rs                  | 33 ++++++++------
 .../transpiler/simplifier-side-effects.test.ts     | 23 ++++++++++
 test/bundler/transpiler/transpiler.test.js         | 52 +++++++++++++++++-----
 4 files changed, 89 insertions(+), 31 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/ast/expr.rs                                              2      1      0
src/js_parser/visit/visit_expr.rs                            6      3      0
test/bundler/transpiler/simplifier-side-effects.test.ts      0      5      0
test/bundler/transpiler/transpiler.test.js                   2      5      0
```

</details>

<!-- robobun:evidence:end -->