### PR TITLE
Swap order of install progress and message

### DIFF
--- a/src/bun_core/Progress.rs
+++ b/src/bun_core/Progress.rs
@@ -606,37 +606,33 @@ impl Progress {
                     maybe_node = (*maybe_node).recently_updated_child.load(Ordering::Acquire);
                 }
                 let current_item = completed_items + 1;
+                let mut had_counter = false;
 
                 if need_ellipse {
                     self.buf_write(&mut end, format_args!("... "));
                 }
                 need_ellipse = false;
                 if !name.is_empty() || eti > 0 {
-                    if !name.is_empty() {
-                        self.buf_write(&mut end, format_args!("{}", crate::fmt::s(name)));
-                        need_ellipse = true;
-                    }
                     if eti > 0 {
-                        if need_ellipse {
-                            self.buf_write(&mut end, format_args!(" "));
-                        }
+                        had_counter = true;
                         match unit {
-                            Unit::None => self
-                                .buf_write(&mut end, format_args!("[{}/{}] ", current_item, eti)),
+                            Unit::None => self.buf_write(
+                                &mut end,
+                                format_args!("[{}/{}] ", current_item, eti)
+                            ),
                             Unit::Files => self.buf_write(
                                 &mut end,
                                 format_args!("[{}/{} files] ", current_item, eti),
                             ),
                             // Raw byte counts are printed until an IEC-units
                             // (KiB/MiB) formatting helper lands.
-                            Unit::Bytes => self
-                                .buf_write(&mut end, format_args!("[{}/{}] ", current_item, eti)),
+                            Unit::Bytes => self.buf_write(&
+                                mut end,
+                                format_args!("[{}/{}] ", current_item, eti)
+                            ),
                         }
-                        need_ellipse = false;
                     } else if completed_items != 0 {
-                        if need_ellipse {
-                            self.buf_write(&mut end, format_args!(" "));
-                        }
+                        had_counter = true;
                         match unit {
                             Unit::None => {
                                 self.buf_write(&mut end, format_args!("[{}] ", current_item))
@@ -649,7 +645,10 @@ impl Progress {
                                 self.buf_write(&mut end, format_args!("[{}] ", current_item))
                             }
                         }
-                        need_ellipse = false;
+                    }
+                    if !name.is_empty() {
+                        self.buf_write(&mut end, format_args!("{}", crate::fmt::s(name)));
+                        need_ellipse = !had_counter;
                     }
                 }
             }

--- a/src/install/PackageManager/ProgressStrings.rs
+++ b/src/install/PackageManager/ProgressStrings.rs
@@ -20,7 +20,7 @@ impl ProgressStrings {
         ProgressStrings::DOWNLOAD_NO_EMOJI_
     )
     .as_bytes();
-    pub const DOWNLOAD_EMOJI: &'static str = "  🔍 ";
+    pub const DOWNLOAD_EMOJI: &'static str = "🔍 ";
 
     pub const EXTRACT_NO_EMOJI_: &'static str = "Resolving & extracting";
     const EXTRACT_NO_EMOJI: &'static [u8] =
@@ -30,7 +30,7 @@ impl ProgressStrings {
         ProgressStrings::EXTRACT_NO_EMOJI_
     )
     .as_bytes();
-    pub const EXTRACT_EMOJI: &'static str = "  🚚 ";
+    pub const EXTRACT_EMOJI: &'static str = "🚚 ";
 
     pub const INSTALL_NO_EMOJI_: &'static str = "Installing";
     const INSTALL_NO_EMOJI: &'static [u8] =
@@ -40,13 +40,13 @@ impl ProgressStrings {
         ProgressStrings::INSTALL_NO_EMOJI_
     )
     .as_bytes();
-    pub const INSTALL_EMOJI: &'static str = "  📦 ";
+    pub const INSTALL_EMOJI: &'static str = "📦 ";
 
     pub const SAVE_NO_EMOJI_: &'static str = "Saving lockfile";
     const SAVE_NO_EMOJI: &'static [u8] = ProgressStrings::SAVE_NO_EMOJI_.as_bytes();
     const SAVE_WITH_EMOJI: &'static [u8] =
         concatcp!(ProgressStrings::SAVE_EMOJI, ProgressStrings::SAVE_NO_EMOJI_).as_bytes();
-    pub const SAVE_EMOJI: &'static str = "  🔒 ";
+    pub const SAVE_EMOJI: &'static str = "🔒 ";
 
     pub const SCRIPT_NO_EMOJI_: &'static str = "Running script";
     const SCRIPT_NO_EMOJI: &'static [u8] =
@@ -56,7 +56,7 @@ impl ProgressStrings {
         ProgressStrings::SCRIPT_NO_EMOJI_
     )
     .as_bytes();
-    pub const SCRIPT_EMOJI: &'static str = "  ⚙️  ";
+    pub const SCRIPT_EMOJI: &'static str = "⚙️ ";
 
     #[inline]
     pub fn download() -> &'static [u8] {


### PR DESCRIPTION
### What does this PR do?
swaps the order of the install counter with the installation step (closes https://github.com/oven-sh/bun/issues/14124, https://github.com/oven-sh/bun/issues/31363 and https://github.com/oven-sh/bun/issues/480). It also changes the messages to remove the now unnecessary padding.
### How did you verify your code works? 
I ran tests in multiple repos including bun init, bun install, and bun add...all of them worked perfectly as expected