### PR TITLE
deepEquals: compare own enumerable 'stack' on Error operands

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1261,7 +1261,9 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
                 return false;
             }
 
-            // check arbitrary enumerable properties. `.stack` is not checked.
+            // Check arbitrary own enumerable properties. The engine-installed `.stack` is
+            // non-enumerable, so DontEnumPropertiesMode::Exclude already skips it. A user-defined
+            // enumerable `stack` is compared like any other own enumerable key (matches Node.js).
             left->materializeErrorInfoIfNeeded(vm);
             RETURN_IF_EXCEPTION(scope, {});
             right->materializeErrorInfoIfNeeded(vm);
@@ -1285,7 +1287,6 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
             size_t i;
             for (i = 0; i < propertyArrayLength1; i++) {
                 Identifier i1 = a1[i];
-                if (i1 == vm.propertyNames->stack) continue;
                 PropertyName propertyName1 = PropertyName(i1);
 
                 JSValue prop1 = left->get(globalObject, propertyName1);
@@ -1315,7 +1316,6 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
             // for the remaining properties in the other object, make sure they are undefined
             for (; i < propertyArrayLength2; i++) {
                 Identifier i2 = a2[i];
-                if (i2 == vm.propertyNames->stack) continue;
                 PropertyName propertyName2 = PropertyName(i2);
 
                 JSValue prop2 = right->getIfPropertyExists(globalObject, propertyName2);

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -52,6 +52,19 @@ function withExtraProperty<T extends object>(value: T): T {
   return Object.assign(value, { extra: 1 });
 }
 
+function errorWithEnumerableStack(stack: string) {
+  const e = new Error("m");
+  Object.defineProperty(e, "stack", { value: stack, enumerable: true, writable: true, configurable: true });
+  return e;
+}
+
+function errorWithRecapturedStack() {
+  const e = new Error("m");
+  void e.stack;
+  Error.captureStackTrace(e);
+  return e;
+}
+
 function selfReferencingObject() {
   const object: Record<string, unknown> = {};
   object.self = object;
@@ -345,6 +358,37 @@ const cases: Case[] = [
     b: () => new Error("x", { cause: 2 }),
     strict: false,
     loose: false,
+  },
+  {
+    // An own enumerable `stack` is compared like any other own enumerable key.
+    name: "errors with differing own enumerable stack properties",
+    a: () => errorWithEnumerableStack("S1"),
+    b: () => errorWithEnumerableStack("S2"),
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "errors with matching own enumerable stack properties",
+    a: () => errorWithEnumerableStack("S1"),
+    b: () => errorWithEnumerableStack("S1"),
+    strict: true,
+    loose: true,
+  },
+  {
+    name: "an error with an own enumerable stack vs one without",
+    a: () => errorWithEnumerableStack("S1"),
+    b: () => new Error("m"),
+    strict: false,
+    loose: false,
+  },
+  {
+    // Error.captureStackTrace installs .stack as non-enumerable, so two such
+    // errors remain deep-equal even though their stack strings differ.
+    name: "two errors after Error.captureStackTrace with materialized info",
+    a: errorWithRecapturedStack,
+    b: errorWithRecapturedStack,
+    strict: true,
+    loose: true,
   },
 
   // Map and Set.


### PR DESCRIPTION
## What

`Bun.deepEquals` (and everything layered on it: `assert.deepStrictEqual` / `deepEqual` / `notDeepStrictEqual`, `util.isDeepStrictEqual`, `expect().toEqual` / `toStrictEqual`) was skipping any own property literally named `stack` when comparing `Error` instances, so a user-defined **enumerable** `stack` data property was never compared.

```js
import assert from "node:assert";
const mk = s => Object.defineProperty(new Error("m"), "stack",
  { value: s, enumerable: true, writable: true, configurable: true });

assert.deepStrictEqual(mk("S1"), mk("S2"));    // Node: throws.  Bun before: passes (false green)
assert.notDeepStrictEqual(mk("S1"), mk("S2")); // Node: passes.  Bun before: throws (false red)
```

## Cause

`specialObjectsDequal` in `src/jsc/bindings/bindings.cpp` walks own enumerable keys of both `ErrorInstance`s with `DontEnumPropertiesMode::Exclude`, but also had `if (name == vm.propertyNames->stack) continue;` in both loops. Node.js has no such by-name skip; it relies on the engine-installed `stack` being non-enumerable, which keeps it out of the enumerable walk.

The skip was originally papering over paths that installed `.stack` as enumerable; those were fixed in #34259 so `Error.captureStackTrace` and `formatStackTraceToJSValue` now install `.stack` as `DontEnum` on every path.

## Fix

Drop the two by-name `continue`s. `DontEnumPropertiesMode::Exclude` already excludes the default non-enumerable `stack`; a user-defined enumerable `stack` is now compared like any other own enumerable key, matching Node.js.

## Verified

- `assert.deepStrictEqual(mk("S1"), mk("S2"))` now throws; `notDeepStrictEqual` passes; `util.isDeepStrictEqual` returns `false`; `Bun.deepEquals` returns `false` (strict and loose).
- Two fresh errors with the same message (different default non-enumerable stacks) still compare equal.
- Two errors after `void e.stack; Error.captureStackTrace(e)` still compare equal (`.stack` is `DontEnum` per #34259).
- `test/js/node/assert/`, `test/js/node/v8/capture-stack-trace.test.js`, `deep-equals.spec.ts` all pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/assert/deep-equal.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (a3072cb4b)

test/js/node/assert/deep-equal.test.ts:
(pass) assert.deepStrictEqual > rejects 0 and -0 [60.60ms]
(pass) assert.deepStrictEqual > accepts NaN and NaN [4.36ms]
(pass) assert.deepStrictEqual > rejects [0] and [-0] [65.30ms]
(pass) assert.deepStrictEqual > rejects '1' and 1 [12.15ms]
(pass) assert.deepStrictEqual > rejects ['1'] and [1] [8.78ms]
(pass) assert.deepStrictEqual > rejects '+00000000' and false [5.72ms]
(pass) assert.deepStrictEqual > rejects '' and false [4.33ms]
(pass) assert.deepStrictEqual > rejects null and undefined [4.44ms]
(pass) assert.deepStrictEqual > rejects { a: -0 } and { a: 0 } [11.88ms]
(pass) assert.deepStrictEqual > rejects 1n and 1 [6.23ms]
(pass) assert.deepStrictEqual > rejects new Str
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (b0345901d)

test/js/node/assert/deep-equal.test.ts:
(pass) assert.deepStrictEqual > rejects 0 and -0 [3.42ms]
(pass) assert.deepStrictEqual > accepts NaN and NaN [0.10ms]
(pass) assert.deepStrictEqual > rejects [0] and [-0] [2.09ms]
(pass) assert.deepStrictEqual > rejects '1' and 1 [0.31ms]
(pass) assert.deepStrictEqual > rejects ['1'] and [1] [0.13ms]
(pass) assert.deepStrictEqual > rejects '+00000000' and false [0.06ms]
(pass) assert.deepStrictEqual > rejects '' and false [0.06ms]
(pass) assert.deepStrictEqual > rejects null and undefined [0.06ms]
(pass) assert.deepStrictEqual > rejects { a: -0 } and { a: 0 } [0.29ms]
(pass) assert.deepStrictEqual > rejects 1n and 1 [0.11ms]
(pass) assert.deepStrictEqual > rejects new String('a') and 'a' [0.37ms]
(pass) assert.deepStrictEqual > accepts two boxed equal strings [0.12ms]
(pass) assert.deepStrictEqual > accepts two boxed equal numbers [0.09ms]
(pass) assert.deepStrictEqual > rejects boxed -0 and boxed 0 [0.11ms]
(pass) assert.deepStrictEqual > accepts two boxed booleans [0.12ms]
(pass) assert.deepStrictEqual > accepts two boxed symbols [0.82ms]
(pass) assert.deepStrictEqual > accepts two boxe
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/assert/deep-equal.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (a3072cb4b)

test/js/node/assert/deep-equal.test.ts:
(pass) assert.deepStrictEqual > rejects 0 and -0 [65.84ms]
(pass) assert.deepStrictEqual > accepts NaN and NaN [4.44ms]
(pass) assert.deepStrictEqual > rejects [0] and [-0] [75.84ms]
(pass) assert.deepStrictEqual > rejects '1' and 1 [17.32ms]
(pass) assert.deepStrictEqual > rejects ['1'] and [1] [8.40ms]
(pass) assert.deepStrictEqual > rejects '+00000000' and false [5.31ms]
(pass) assert.deepStrictEqual > rejects '' and false [4.84ms]
(pass) assert.deepStrictEqual > rejects null and undefined [6.14ms]
(pass) assert.deepStrictEqual > rejects { a: -0 } and { a: 0 } [14.20ms]
(pass) assert.deepStrictEqual > rejects 1n and 1 [11.01ms]
(pass) assert.deepStrictEqual > rejects new St
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 885ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen cpp.rs (cppbind)
[2/23] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[3/23] gen JS modules (bundle-modules)
Preprocess modules (7927ms)
Bundle modules (53ms)
Postprocesss modules (383ms)
Bundle Functions (943ms)
Generate Code (145ms)

[9.47s] Bundled "src/js" for production
  1911 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[3/13] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component ru
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/bindings.cpp          |  6 ++---
 test/js/node/assert/deep-equal.test.ts | 44 ++++++++++++++++++++++++++++++++++
 2 files changed, 47 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 4 passed · 1 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/jsc/bindings/bindings.cpp               1      2      0
test/js/node/assert/deep-equal.test.ts      1      4      0
```

</details>

<!-- robobun:evidence:end -->