### PR TITLE
parser: apply ASI when TS contextual keywords precede a newline

### DIFF
--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -353,9 +353,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 T::TOpenBracket
                                     | T::TNumericLiteral
                                     | T::TStringLiteral
-                                    | T::TAsterisk
                                     | T::TPrivateIdentifier
-                            );
+                            )
+                            || (p.lexer.token == T::TAsterisk
+                                && (opts.is_async || (raw != b"get" && raw != b"set")));
 
                         // If so, check for a modifier keyword
                         if could_be_modifier_keyword {
@@ -417,6 +418,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                         // https://github.com/oven-sh/bun/issues/1907
                                         if opts.is_class
                                             && Self::IS_TYPESCRIPT_ENABLED
+                                            && !p.lexer.has_newline_before
                                             && raw == b"declare"
                                         {
                                             let scope_index = p.scopes_in_order.len();
@@ -440,6 +442,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     PropertyModifierKeyword::PAbstract => {
                                         if opts.is_class
                                             && Self::IS_TYPESCRIPT_ENABLED
+                                            && !p.lexer.has_newline_before
                                             && !opts.is_ts_abstract
                                             && raw == b"abstract"
                                         {
@@ -464,6 +467,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     PropertyModifierKeyword::PAccessor => {
                                         // "accessor" keyword for auto-accessor fields (TC39 standard decorators)
                                         if opts.is_class
+                                            && !p.lexer.has_newline_before
                                             && p.options.features.standard_decorators
                                             && PropertyModifierKeyword::find(raw)
                                                 == Some(PropertyModifierKeyword::PAccessor)

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1140,7 +1140,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
 
                 // "@decorator export default abstract = 1"
+                // "@decorator export default abstract \n class Foo {}"
                 if opts.ts_decorators.is_some() {
+                    if is_identifier
+                        && name == b"abstract"
+                        && p.lexer.has_newline_before
+                        && matches!(expr.data, js_ast::ExprData::EIdentifier(_))
+                    {
+                        let r = js_lexer::range_of_identifier(p.source, expr.loc);
+                        p.log()
+                            .add_range_error(Some(p.source), r, b"Unexpected \"abstract\"");
+                        return Err(crate::Error::SyntaxError);
+                    }
                     p.lexer.expected(T::TClass)?;
                 }
 
@@ -1779,7 +1790,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 // "interface \n Foo {}"
                 // "export interface \n Foo {}"
-                if opts.is_export {
+                // "declare interface \n Foo {}"
+                if opts.is_export || opts.is_typescript_declare {
                     let r = js_lexer::range_of_identifier(p.source, loc);
                     p.log()
                         .add_range_error(Some(p.source), r, b"Unexpected \"interface\"");
@@ -1792,13 +1804,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 {
                     return Ok(Some(p.parse_class_stmt(loc, opts)?));
                 }
-                if opts.ts_decorators.is_some() {
+                if opts.ts_decorators.is_some() || opts.is_typescript_declare {
                     let r = js_lexer::range_of_identifier(p.source, loc);
-                    p.log().add_error(
-                        Some(p.source),
-                        r.end(),
-                        b"Unexpected newline after \"abstract\"",
-                    );
+                    p.log()
+                        .add_range_error(Some(p.source), r, b"Unexpected \"abstract\"");
                     return Err(crate::Error::SyntaxError);
                 }
             }
@@ -1816,13 +1825,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             js_lexer::TypescriptStmtKeyword::TsStmtDeclare => {
                 if p.lexer.has_newline_before {
-                    if opts.ts_decorators.is_some() {
+                    if opts.ts_decorators.is_some() || opts.is_typescript_declare {
                         let r = js_lexer::range_of_identifier(p.source, loc);
-                        p.log().add_error(
-                            Some(p.source),
-                            r.end(),
-                            b"Unexpected newline after \"declare\"",
-                        );
+                        p.log()
+                            .add_range_error(Some(p.source), r, b"Unexpected \"declare\"");
                         return Err(crate::Error::SyntaxError);
                     }
                     return Ok(None);

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1090,6 +1090,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     && is_identifier
                     && (p.lexer.token == T::TClass || opts.ts_decorators.is_some())
                     && name == b"abstract"
+                    && !p.lexer.has_newline_before
                     && matches!(expr.data, js_ast::ExprData::EIdentifier(_))
                 {
                     let mut stmt_opts = ParseStatementOptions {
@@ -1765,17 +1766,34 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             js_lexer::TypescriptStmtKeyword::TsStmtInterface => {
                 // "interface Foo {}"
-                let mut stmt_opts = ParseStatementOptions {
-                    is_module_scope: opts.is_module_scope,
-                    ..Default::default()
-                };
+                // "export default interface Foo {}"
+                // "export default interface \n Foo {}"
+                if !p.lexer.has_newline_before || opts.is_name_optional {
+                    let mut stmt_opts = ParseStatementOptions {
+                        is_module_scope: opts.is_module_scope,
+                        ..Default::default()
+                    };
 
-                p.skip_type_script_interface_stmt(&mut stmt_opts)?;
-                return Ok(Some(p.s(S::TypeScript {}, loc)));
+                    p.skip_type_script_interface_stmt(&mut stmt_opts)?;
+                    return Ok(Some(p.s(S::TypeScript {}, loc)));
+                }
+                // "interface \n Foo {}"
+                // "export interface \n Foo {}"
+                if opts.is_export {
+                    let r = js_lexer::range_of_identifier(p.source, loc);
+                    p.log()
+                        .add_range_error(Some(p.source), r, b"Unexpected \"interface\"");
+                    return Err(crate::Error::SyntaxError);
+                }
             }
             js_lexer::TypescriptStmtKeyword::TsStmtAbstract => {
-                if p.lexer.token == T::TClass || opts.ts_decorators.is_some() {
+                if !p.lexer.has_newline_before
+                    && (p.lexer.token == T::TClass || opts.ts_decorators.is_some())
+                {
                     return Ok(Some(p.parse_class_stmt(loc, opts)?));
+                }
+                if opts.ts_decorators.is_some() {
+                    p.lexer.expected(T::TClass)?;
                 }
             }
             js_lexer::TypescriptStmtKeyword::TsStmtGlobal => {
@@ -1791,6 +1809,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             }
             js_lexer::TypescriptStmtKeyword::TsStmtDeclare => {
+                if p.lexer.has_newline_before {
+                    if opts.ts_decorators.is_some() {
+                        p.lexer.expected(T::TClass)?;
+                    }
+                    return Ok(None);
+                }
                 opts.lexical_decl = LexicalDecl::AllowAll;
                 opts.is_typescript_declare = true;
 

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1793,7 +1793,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     return Ok(Some(p.parse_class_stmt(loc, opts)?));
                 }
                 if opts.ts_decorators.is_some() {
-                    p.lexer.expected(T::TClass)?;
+                    let r = js_lexer::range_of_identifier(p.source, loc);
+                    p.log().add_error(
+                        Some(p.source),
+                        r.end(),
+                        b"Unexpected newline after \"abstract\"",
+                    );
+                    return Err(crate::Error::SyntaxError);
                 }
             }
             js_lexer::TypescriptStmtKeyword::TsStmtGlobal => {
@@ -1811,7 +1817,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             js_lexer::TypescriptStmtKeyword::TsStmtDeclare => {
                 if p.lexer.has_newline_before {
                     if opts.ts_decorators.is_some() {
-                        p.lexer.expected(T::TClass)?;
+                        let r = js_lexer::range_of_identifier(p.source, loc);
+                        p.log().add_error(
+                            Some(p.source),
+                            r.end(),
+                            b"Unexpected newline after \"declare\"",
+                        );
+                        return Err(crate::Error::SyntaxError);
                     }
                     return Ok(None);
                 }

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1860,10 +1860,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 let after_declare_range = p.lexer.range();
                 let scope_index = p.scopes_in_order.len();
                 let stmt = p.parse_stmt(opts)?;
-                // Anything that we don't expect is a syntax error ("declare foo",
-                // "declare interface \n Foo {}", "declare type \n Foo = number").
-                // esbuild rewinds its lexer and calls `Unexpected()` here; we
-                // point at the token range captured before recursing instead.
+                // Anything unexpected is a syntax error ("declare foo", "declare type \n Foo").
+                // esbuild rewinds its lexer here; we point at the range captured above instead.
                 if !matches!(
                     &stmt.data,
                     js_ast::StmtData::STypeScript(_)

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -924,7 +924,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 // "export declare class Foo {}"
                                 opts.is_export = true;
                                 opts.lexical_decl = LexicalDecl::AllowAll;
-                                opts.is_typescript_declare = true;
                                 return p.parse_stmt(opts);
                             }
                         }
@@ -1790,8 +1789,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 // "interface \n Foo {}"
                 // "export interface \n Foo {}"
-                // "declare interface \n Foo {}"
-                if opts.is_export || opts.is_typescript_declare {
+                if opts.is_export {
                     let r = js_lexer::range_of_identifier(p.source, loc);
                     p.log()
                         .add_range_error(Some(p.source), r, b"Unexpected \"interface\"");
@@ -1804,7 +1802,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 {
                     return Ok(Some(p.parse_class_stmt(loc, opts)?));
                 }
-                if opts.ts_decorators.is_some() || opts.is_typescript_declare {
+                if opts.ts_decorators.is_some() {
                     let r = js_lexer::range_of_identifier(p.source, loc);
                     p.log()
                         .add_range_error(Some(p.source), r, b"Unexpected \"abstract\"");
@@ -1825,7 +1823,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             js_lexer::TypescriptStmtKeyword::TsStmtDeclare => {
                 if p.lexer.has_newline_before {
-                    if opts.ts_decorators.is_some() || opts.is_typescript_declare {
+                    if opts.ts_decorators.is_some() {
                         let r = js_lexer::range_of_identifier(p.source, loc);
                         p.log()
                             .add_range_error(Some(p.source), r, b"Unexpected \"declare\"");
@@ -1859,8 +1857,29 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
 
                 // "declare const x: any"
+                let after_declare_range = p.lexer.range();
                 let scope_index = p.scopes_in_order.len();
                 let stmt = p.parse_stmt(opts)?;
+                // Anything that we don't expect is a syntax error ("declare foo",
+                // "declare interface \n Foo {}", "declare type \n Foo = number").
+                // esbuild rewinds its lexer and calls `Unexpected()` here; we
+                // point at the token range captured before recursing instead.
+                if !matches!(
+                    &stmt.data,
+                    js_ast::StmtData::STypeScript(_)
+                        | js_ast::StmtData::SLocal(_)
+                        | js_ast::StmtData::SEmpty(_)
+                ) {
+                    p.log().add_range_error_fmt(
+                        Some(p.source),
+                        after_declare_range,
+                        format_args!(
+                            "Unexpected {}",
+                            bun_core::fmt::quote(p.source.text_for_range(after_declare_range))
+                        ),
+                    );
+                    return Err(crate::Error::SyntaxError);
+                }
                 if let Some(decs) = &opts.ts_decorators {
                     p.discard_scopes_up_to(decs.scope_index);
                 } else {

--- a/test/bundler/transpiler/scope-mismatch-panic.test.ts
+++ b/test/bundler/transpiler/scope-mismatch-panic.test.ts
@@ -102,8 +102,6 @@ describe("TypeScript 'declare' statements discard scopes of dropped statements",
   // Each of these parses a statement after "declare" that records scopes during the
   // parse pass and is then dropped. The recorded scopes used to be left behind, so
   // visiting the following class statement hit "Scope mismatch while visiting".
-  // Two earlier cases ("declare foo: bar" and "declare module : es2015") have since
-  // become parse errors (matching esbuild) and are covered in transpiler.test.js.
   const cases: [name: string, source: string, expected: string[]][] = [
     [
       "declare const with an arrow function initializer followed by a class",

--- a/test/bundler/transpiler/scope-mismatch-panic.test.ts
+++ b/test/bundler/transpiler/scope-mismatch-panic.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
 
 describe("scope mismatch panic regression test", () => {
   test("should not panic with scope mismatch when arrow function is followed by array literal", async () => {
@@ -28,7 +29,7 @@ const Layout = () => {
     // With the fix, it should fail with a normal ReferenceError for 'app'
     await using proc = Bun.spawn({
       cmd: [bunExe(), "index.tsx"],
-      env: bunEnv,
+      env: { ...bunEnv, NODE_PATH: join(import.meta.dir, "..", "..", "node_modules") },
       cwd: String(dir),
       stderr: "pipe",
       stdout: "pipe",

--- a/test/bundler/transpiler/scope-mismatch-panic.test.ts
+++ b/test/bundler/transpiler/scope-mismatch-panic.test.ts
@@ -101,13 +101,9 @@ describe("TypeScript 'declare' statements discard scopes of dropped statements",
   // Each of these parses a statement after "declare" that records scopes during the
   // parse pass and is then dropped. The recorded scopes used to be left behind, so
   // visiting the following class statement hit "Scope mismatch while visiting".
+  // Two earlier cases ("declare foo: bar" and "declare module : es2015") have since
+  // become parse errors (matching esbuild) and are covered in transpiler.test.js.
   const cases: [name: string, source: string, expected: string[]][] = [
-    [
-      "declare module with an invalid name followed by a class",
-      "declare module : es2015\nclass Foo {}\n",
-      ["class Foo"],
-    ],
-    ["declare followed by a labeled statement and a class", "declare foo: bar\nclass Foo {}\n", ["class Foo"]],
     [
       "declare const with an arrow function initializer followed by a class",
       "declare const x = () => {};\nclass Foo {}\n",

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -237,6 +237,8 @@ describe("Bun.Transpiler", () => {
       err("declare module\nFoo { sideEffect() }", 'Unexpected "module"');
       err("declare declare\nlet x = 1", 'Unexpected "declare"');
       err("declare foo", 'Unexpected "foo"');
+      err("declare foo: bar", 'Unexpected "foo"');
+      err("declare module : es2015", 'Unexpected "module"');
       err("export declare interface\nFoo {}", 'Unexpected "interface"');
       err("export declare abstract\nclass Foo {}", 'Unexpected "abstract"');
       // All valid "declare X" forms still emit nothing.

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -228,15 +228,33 @@ describe("Bun.Transpiler", () => {
       // "get"/"set" without the generator star still bind to the next key across a newline.
       exp("class A { get\n x() { return 1 } }", "class A {\n  get x() {\n    return 1;\n  }\n}");
 
-      // "declare <keyword>" with a newline cannot fall through to SExpr because that would
-      // leave the remainder as live runtime code. Match esbuild and reject instead.
+      // "declare X" where X is not a valid ambient declaration is rejected, so a
+      // newline-split keyword cannot leave the remainder as live runtime code.
       err("declare interface\nFoo\n{ sideEffect() }", 'Unexpected "interface"');
       err("declare abstract\nclass Foo {}", 'Unexpected "abstract"');
+      err("declare type\nFoo = number", 'Unexpected "type"');
+      err("declare namespace\nFoo { sideEffect() }", 'Unexpected "namespace"');
+      err("declare module\nFoo { sideEffect() }", 'Unexpected "module"');
+      err("declare declare\nlet x = 1", 'Unexpected "declare"');
+      err("declare foo", 'Unexpected "foo"');
       err("export declare interface\nFoo {}", 'Unexpected "interface"');
       err("export declare abstract\nclass Foo {}", 'Unexpected "abstract"');
-      err("declare declare\nlet x = 1", 'Unexpected "declare"');
-      // "export abstract \n class" falls through silently like esbuild (export is discarded).
+      // All valid "declare X" forms still emit nothing.
+      exp("declare function f(): void", "");
+      exp("declare class C {}", "");
+      exp("declare enum E { A }", "");
+      exp("declare namespace N { let x: number }", "");
+      exp("declare abstract class C {}", "");
+      exp("export declare function f(): void", "");
+      exp("export declare const x: number", "");
+      // "export abstract \n class" and "export declare \n class" fall through silently like esbuild.
       exp("export abstract\nclass Foo {}\nnew Foo", "abstract;\n\nclass Foo {\n}\nnew Foo;\n");
+      exp("export declare\nclass Foo {}\nnew Foo", "declare;\n\nclass Foo {\n}\nnew Foo;\n");
+      // Inside an ambient body the flag is propagated for body semantics, but the whole
+      // block is erased regardless, so newline-split keywords in the body are harmless.
+      exp("declare namespace N { abstract\nclass Foo {} }", "");
+      exp("declare namespace N { declare\nlet x: number }", "");
+      exp("declare global { abstract\nclass Foo {} }\nexport {}", "export {};\n");
 
       // Decorators before "declare"/"abstract" with a newline must still demand a class.
       err("function dec(c){return c}\n@dec declare\nclass Foo {}", 'Unexpected "declare"');

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -176,6 +176,66 @@ describe("Bun.Transpiler", () => {
       exp("declare class Foo {}", "");
     });
 
+    it("contextual keywords followed by a newline apply ASI instead of acting as modifiers", () => {
+      const exp = ts.expectPrinted_;
+      const err = ts.expectParseError;
+
+      // Statement-level "declare": a newline splits into "declare;" + the following declaration.
+      exp("declare\nfunction foo() { return 1 }\nfoo()", "declare;\nfunction foo() {\n  return 1;\n}\nfoo();\n");
+      exp("declare\nlet x = 1\nuse(x)", "declare;\nlet x = 1;\nuse(x);\n");
+      exp("declare\nclass Foo {}\nnew Foo", "declare;\n\nclass Foo {\n}\nnew Foo;\n");
+      exp("declare function foo(): void", "");
+      exp("declare let x: number", "");
+
+      // Statement-level "abstract": a newline splits into "abstract;" + "class Foo {}".
+      exp("abstract\nclass Foo {}\nnew Foo", "abstract;\n\nclass Foo {\n}\nnew Foo;\n");
+      exp("abstract class Foo { abstract bar(): void }\nnew Foo", "class Foo {\n}\nnew Foo;\n");
+
+      // Statement-level "interface": a newline splits into three statements.
+      exp("interface\nFoo\n{ sideEffect() }", "interface;\nFoo;\n{\n  sideEffect();\n}");
+      exp("interface Foo { x: number }", "");
+
+      // "export interface \n Foo {}" is a syntax error, matching esbuild.
+      err("export interface\nFoo {}", 'Unexpected "interface"');
+      // "export default interface \n Foo {}" is allowed (the interface name can be on the next line).
+      exp("export default interface\nFoo {}", "");
+      exp("export default interface Foo {}", "");
+
+      // "export default abstract \n class A {}" exports the identifier `abstract` and declares A separately.
+      exp(
+        "export default abstract\nclass A { foo() { return 1 } }\nnew A",
+        "export default abstract;\n\nclass A {\n  foo() {\n    return 1;\n  }\n}\nnew A;\n",
+      );
+      exp("export default abstract class A {}", "export default class A {\n}");
+
+      // Class body "declare": a newline makes it a field named "declare" followed by a method.
+      exp(
+        "class Foo { declare\n foo() { return 1 } }\nnew Foo().foo()",
+        "class Foo {\n  declare;\n  foo() {\n    return 1;\n  }\n}\nnew Foo().foo();\n",
+      );
+      exp("class Foo { declare foo: number }", "class Foo {\n}");
+
+      // Class body "abstract": a newline makes it a field named "abstract" followed by a method.
+      exp(
+        "abstract class A { abstract\n foo() {} }\nnew A",
+        "class A {\n  abstract;\n  foo() {}\n}\nnew A;\n",
+      );
+      exp("abstract class A { abstract foo(): void }\nnew A", "class A {\n}\nnew A;\n");
+
+      // Class body "accessor": a newline makes it a field named "accessor" followed by a field.
+      exp("class A { accessor\n x = 1 }\nnew A", "class A {\n  accessor;\n  x = 1;\n}\nnew A;\n");
+
+      // Class body "get"/"set" followed by "*": the asterisk starts a generator; the prior word is a field.
+      exp("class A { get\n *x() {} }\nnew A", "class A {\n  get;\n  *x() {}\n}\nnew A;\n");
+      exp("class A { set\n *x() {} }\nnew A", "class A {\n  set;\n  *x() {}\n}\nnew A;\n");
+      // "get"/"set" without the generator star still bind to the next key across a newline.
+      exp("class A { get\n x() { return 1 } }", "class A {\n  get x() {\n    return 1;\n  }\n}");
+
+      // Decorators before "declare"/"abstract" with a newline must still demand a class.
+      err("function dec(c){return c}\n@dec declare\nclass Foo {}", 'Expected "class" but found "class"');
+      err("function dec(c){return c}\n@dec abstract\nclass Foo {}", 'Expected "class" but found "class"');
+    });
+
     it("does not crash when export default abstract is an expression followed by a class", () => {
       const exp = ts.expectPrinted_;
       const err = ts.expectParseError;

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -250,10 +250,12 @@ describe("Bun.Transpiler", () => {
       // "export abstract \n class" and "export declare \n class" fall through silently like esbuild.
       exp("export abstract\nclass Foo {}\nnew Foo", "abstract;\n\nclass Foo {\n}\nnew Foo;\n");
       exp("export declare\nclass Foo {}\nnew Foo", "declare;\n\nclass Foo {\n}\nnew Foo;\n");
+      exp("export declare\nlet x = 1\nuse(x)", "declare;\nlet x = 1;\nuse(x);\n");
       // Inside an ambient body the flag is propagated for body semantics, but the whole
       // block is erased regardless, so newline-split keywords in the body are harmless.
       exp("declare namespace N { abstract\nclass Foo {} }", "");
       exp("declare namespace N { declare\nlet x: number }", "");
+      exp('declare module "m" { abstract\n class Foo {} }', "");
       exp("declare global { abstract\nclass Foo {} }\nexport {}", "export {};\n");
 
       // Decorators before "declare"/"abstract" with a newline must still demand a class.

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -228,9 +228,20 @@ describe("Bun.Transpiler", () => {
       // "get"/"set" without the generator star still bind to the next key across a newline.
       exp("class A { get\n x() { return 1 } }", "class A {\n  get x() {\n    return 1;\n  }\n}");
 
+      // "declare <keyword>" with a newline cannot fall through to SExpr because that would
+      // leave the remainder as live runtime code. Match esbuild and reject instead.
+      err("declare interface\nFoo\n{ sideEffect() }", 'Unexpected "interface"');
+      err("declare abstract\nclass Foo {}", 'Unexpected "abstract"');
+      err("export declare interface\nFoo {}", 'Unexpected "interface"');
+      err("export declare abstract\nclass Foo {}", 'Unexpected "abstract"');
+      err("declare declare\nlet x = 1", 'Unexpected "declare"');
+      // "export abstract \n class" falls through silently like esbuild (export is discarded).
+      exp("export abstract\nclass Foo {}\nnew Foo", "abstract;\n\nclass Foo {\n}\nnew Foo;\n");
+
       // Decorators before "declare"/"abstract" with a newline must still demand a class.
-      err("function dec(c){return c}\n@dec declare\nclass Foo {}", 'Unexpected newline after "declare"');
-      err("function dec(c){return c}\n@dec abstract\nclass Foo {}", 'Unexpected newline after "abstract"');
+      err("function dec(c){return c}\n@dec declare\nclass Foo {}", 'Unexpected "declare"');
+      err("function dec(c){return c}\n@dec abstract\nclass Foo {}", 'Unexpected "abstract"');
+      err("function dec(c){return c}\n@dec export default abstract\nclass Foo {}", 'Unexpected "abstract"');
     });
 
     it("does not crash when export default abstract is an expression followed by a class", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -229,8 +229,8 @@ describe("Bun.Transpiler", () => {
       exp("class A { get\n x() { return 1 } }", "class A {\n  get x() {\n    return 1;\n  }\n}");
 
       // Decorators before "declare"/"abstract" with a newline must still demand a class.
-      err("function dec(c){return c}\n@dec declare\nclass Foo {}", 'Expected "class" but found "class"');
-      err("function dec(c){return c}\n@dec abstract\nclass Foo {}", 'Expected "class" but found "class"');
+      err("function dec(c){return c}\n@dec declare\nclass Foo {}", 'Unexpected newline after "declare"');
+      err("function dec(c){return c}\n@dec abstract\nclass Foo {}", 'Unexpected newline after "abstract"');
     });
 
     it("does not crash when export default abstract is an expression followed by a class", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -216,10 +216,7 @@ describe("Bun.Transpiler", () => {
       exp("class Foo { declare foo: number }", "class Foo {\n}");
 
       // Class body "abstract": a newline makes it a field named "abstract" followed by a method.
-      exp(
-        "abstract class A { abstract\n foo() {} }\nnew A",
-        "class A {\n  abstract;\n  foo() {}\n}\nnew A;\n",
-      );
+      exp("abstract class A { abstract\n foo() {} }\nnew A", "class A {\n  abstract;\n  foo() {}\n}\nnew A;\n");
       exp("abstract class A { abstract foo(): void }\nnew A", "class A {\n}\nnew A;\n");
 
       // Class body "accessor": a newline makes it a field named "accessor" followed by a field.


### PR DESCRIPTION
### Problem

Bun's TS parser treats `declare`, `abstract`, `interface`, and `accessor` as modifiers even when a newline follows them, silently deleting the declaration that comes after. esbuild and tsc both apply ASI and treat the keyword as a standalone identifier expression (statement level) or class field (class body).

```console
$ printf 'declare\nfunction foo() { return 1 }\nconsole.log(foo())\n' > r.ts
$ bun build r.ts --no-bundle
console.log(foo());                 # function body gone; ReferenceError at runtime
$ npx esbuild r.ts
declare;
function foo() { return 1; }
console.log(foo());
```

```console
$ printf 'class Foo { declare\n foo() { return 1 } }\nconsole.log(new Foo().foo())\n' > r2.ts
$ bun build r2.ts --no-bundle
class Foo {}                        # method deleted; new Foo().foo() throws
console.log(new Foo().foo());
```

Sibling shapes with the same bug: `abstract\nclass A {}`, `interface\nA\n{ sideEffect() }`, `abstract class A { abstract\nfoo() {} }`, `export default abstract\nclass A {}`, `class A { accessor\n x = 1 }`. Also `class A { get\n*x() {} }` was rejected with `Unexpected *`; esbuild/tsc parse a field `get` followed by a generator `*x`.

### Cause

esbuild (`internal/js_parser/js_parser.go`) gates each of these paths on `!p.lexer.HasNewlineBefore` before committing to the modifier interpretation, and validates the body of every `declare` statement after the recursive parse. Bun's port lost both:

- `TsStmtDeclare`, `TsStmtInterface`, `TsStmtAbstract` in `parse_stmt_fallthrough_ts_keyword` had no newline check.
- The `export default abstract` class path had no newline check.
- Class-body `PDeclare`, `PAbstract`, `PAccessor` in `parse_property` had no newline check.
- `could_be_modifier_keyword` counted `*` after `get`/`set` as a modifier follow-up; esbuild excludes it.
- `TsStmtDeclare` unconditionally wrapped whatever the recursive parse returned in `S::TypeScript{}`, so a newline-split keyword that fell through to `SExpr` silently left the rest of the input as live runtime statements (`declare type\nFoo = number` emitted `Foo = number;`).

### Fix

- Add the missing `!p.lexer.has_newline_before` gates at each site above.
- In `TsStmtDeclare`, after the recursive `parse_stmt`, reject any result that is not `STypeScript`/`SLocal`/`SEmpty` with `Unexpected "<token>"` pointing at the token captured before recursion. This uniformly catches `declare {interface,abstract,type,namespace,module,declare}\n`, `declare foo`, and `declare foo: bar` while accepting every valid ambient form and everything inside ambient bodies (`declare namespace { ... }`, `declare module "m" { ... }`, `declare global { ... }`).
- `export default interface \n Foo {}` stays accepted (esbuild explicitly allows a newline there) via the existing `is_name_optional` flag. `export interface \n Foo {}` now reports `Unexpected "interface"` like esbuild. `@decorator` followed by `declare`/`abstract` split by a newline reports `Unexpected "declare"`/`"abstract"` instead of the self-contradictory `Expected "class" but found "class"`.
- Drop the redundant `is_typescript_declare = true` pre-set in `t_export`'s `SDeclare` arm (the `declare` arm sets it itself).

### Verification

New test in `test/bundler/transpiler/transpiler.test.js` (`contextual keywords followed by a newline apply ASI instead of acting as modifiers`) covers 50 assertions across every shape above: the ASI cases, no-newline control cases, every valid `declare X` form, every rejected `declare X` form, ambient-body cases (accepted), `export abstract\n`/`export declare\n` (accepted), and the decorator variants. Fails at the first assertion on the unfixed build.

Two cases in `test/bundler/transpiler/scope-mismatch-panic.test.ts` (`declare foo: bar` and `declare module : es2015`) were previously accepted and are now parse errors matching esbuild; their assertions moved to the new test block.

- `bun bd test test/bundler/transpiler/transpiler.test.js` — 172 pass, 0 fail
- `bun bd test test/bundler/esbuild/ts.test.ts` — 57 pass, 0 fail
- `bun bd test test/bundler/transpiler/{decorators,decorator-metadata,es-decorators}.test.ts test/bundler/bundler_decorator_metadata.test.ts` — 78 pass, 0 fail

Related: #29201 independently adds the `accessor` newline check while lifting the `standard_decorators` gate; whichever lands second has a one-hunk rebase on that branch.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/scope-mismatch-panic.test.ts test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (8e0d9d11c)

test/bundler/transpiler/scope-mismatch-panic.test.ts:
(pass) scope mismatch panic regression test > should not panic with scope mismatch when arrow function is followed by array literal [741.41ms]
(pass) scope mismatch panic regression test > should not panic with simpler arrow function followed by array [440.32ms]
(pass) scope mismatch panic regression test > correctly rejects direct indexing into block body arrow function [428.17ms]
(pass) macro tagged templates visit their interpolations > tagged template macro with arrow interpolation in dead code is erased [431.69ms]
(pass) macro tagged templates visit their interpolations > tagged template macro with arr
... (truncated)

release without fix: 22 skipped
bun test v1.4.0-canary.1 (21df53534)

test/bundler/transpiler/scope-mismatch-panic.test.ts:
(pass) scope mismatch panic regression test > should not panic with scope mismatch when arrow function is followed by array literal [22.06ms]
(pass) scope mismatch panic regression test > should not panic with simpler arrow function followed by array [13.58ms]
(pass) scope mismatch panic regression test > correctly rejects direct indexing into block body arrow function [11.90ms]
(pass) macro tagged templates visit their interpolations > tagged template macro with arrow interpolation in dead code is erased [12.44ms]
(pass) macro tagged templates visit their interpolations > tagged template macro with arrow interpolation reports the macro error [13.21ms]
(pass) macro tagged templates visit their interpolations > member-expression macro tag with function interpolation reports the macro error [11.90ms]
(pass) TypeScript 'declare' statements discard scopes of dropped statements > declare global containing nested blocks followed by a class [24.10ms]
(pass) TypeScript 'declare' statements discard scopes of dropped statements > declare const with an arrow function initializer followe
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/scope-mismatch-panic.test.ts test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (8e0d9d11c)

test/bundler/transpiler/scope-mismatch-panic.test.ts:
(pass) scope mismatch panic regression test > should not panic with scope mismatch when arrow function is followed by array literal [740.34ms]
(pass) scope mismatch panic regression test > should not panic with simpler arrow function followed by array [440.90ms]
(pass) scope mismatch panic regression test > correctly rejects direct indexing into block body arrow function [435.01ms]
(pass) macro tagged templates visit their interpolations > tagged template macro with arrow interpolation reports the macro error [438.93ms]
(pass) macro tagged templates visit their interpolations > tagged template macro with ar
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 761ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/parse/parse_property.rs              |  8 +-
 src/js_parser/parse/parse_stmt.rs                  | 75 ++++++++++++++++--
 .../transpiler/scope-mismatch-panic.test.ts        |  9 +--
 test/bundler/transpiler/transpiler.test.js         | 90 ++++++++++++++++++++++
 4 files changed, 165 insertions(+), 17 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/js_parser/parse/parse_property.rs                     3      4      0
src/js_parser/parse/parse_stmt.rs                        11     15      0
test/bundler/transpiler/scope-mismatch-panic.test.ts      3      5      0
test/bundler/transpiler/transpiler.test.js                4     10      0
```

</details>

<!-- robobun:evidence:end -->