### PR TITLE
Error.captureStackTrace: install .stack as non-enumerable

### DIFF
--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -93,7 +93,7 @@ static JSValue formatStackTraceToJSValue(JSC::VM& vm, Zig::GlobalObject* globalO
         if (prepareStackTraceCallData.type != JSC::CallData::Type::None) {
             // In Node, if you console.log(error.stack) inside Error.prepareStackTrace
             // it will display the stack as a formatted string, so we have to do the same.
-            errorObject->putDirect(vm, vm.propertyNames->stack, stackStringValue, 0);
+            errorObject->putDirect(vm, vm.propertyNames->stack, stackStringValue, JSC::PropertyAttribute::DontEnum | 0);
 
             JSC::MarkedArgumentBuffer arguments;
             arguments.append(errorObject);
@@ -741,7 +741,7 @@ JSC_DEFINE_CUSTOM_GETTER(errorInstanceLazyStackCustomGetter, (JSGlobalObject * g
         errorObject->setStackFrames(vm, {});
     }
     RETURN_IF_EXCEPTION(scope, {});
-    errorObject->putDirect(vm, vm.propertyNames->stack, result, 0);
+    errorObject->putDirect(vm, vm.propertyNames->stack, result, JSC::PropertyAttribute::DontEnum | 0);
     return JSValue::encode(result);
 }
 
@@ -750,7 +750,7 @@ JSC_DEFINE_CUSTOM_SETTER(errorInstanceLazyStackCustomSetter, (JSGlobalObject * g
     auto& vm = JSC::getVM(globalObject);
     JSValue decodedValue = JSValue::decode(thisValue);
     if (auto* object = decodedValue.getObject()) {
-        object->putDirect(vm, vm.propertyNames->stack, JSValue::decode(value), 0);
+        object->putDirect(vm, vm.propertyNames->stack, JSValue::decode(value), JSC::PropertyAttribute::DontEnum | 0);
     }
 
     return true;
@@ -790,7 +790,7 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace, (JSC::JSGlobalOb
             String sourceURL;
             JSValue result = computeErrorInfoToJSValue(vm, stackTrace, line, column, sourceURL, errorObject, nullptr);
             RETURN_IF_EXCEPTION(scope, {});
-            errorObject->putDirect(vm, vm.propertyNames->stack, result, 0);
+            errorObject->putDirect(vm, vm.propertyNames->stack, result, JSC::PropertyAttribute::DontEnum | 0);
         } else {
             // Not yet materialized — safe to install new frames with a lazy getter.
             instance->setStackFrames(vm, WTF::move(stackTrace));
@@ -803,7 +803,7 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace, (JSC::JSGlobalOb
             }
             RETURN_IF_EXCEPTION(scope, {});
 
-            instance->putDirectCustomAccessor(vm, vm.propertyNames->stack, globalObject->m_lazyStackCustomGetterSetter.get(globalObject), JSC::PropertyAttribute::CustomAccessor | 0);
+            instance->putDirectCustomAccessor(vm, vm.propertyNames->stack, globalObject->m_lazyStackCustomGetterSetter.get(globalObject), JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::CustomAccessor | 0);
         }
     } else {
         OrdinalNumber line;
@@ -811,7 +811,7 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace, (JSC::JSGlobalOb
         String sourceURL;
         JSValue result = computeErrorInfoToJSValue(vm, stackTrace, line, column, sourceURL, errorObject, nullptr);
         RETURN_IF_EXCEPTION(scope, {});
-        errorObject->putDirect(vm, vm.propertyNames->stack, result, 0);
+        errorObject->putDirect(vm, vm.propertyNames->stack, result, JSC::PropertyAttribute::DontEnum | 0);
     }
 
     return JSC::JSValue::encode(JSC::jsUndefined());

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -305,53 +305,56 @@ test("Error.captureStackTrace installs .stack as non-enumerable", () => {
       enumerable: false,
       configurable: true,
     });
+    // V8 installs an accessor (no `writable`), Bun installs a data property; both
+    // must allow assignment. Only `writable: false` would be a regression.
+    expect(d.writable).not.toBe(false);
     expect(Object.prototype.propertyIsEnumerable.call(target, "stack")).toBe(false);
   };
 
   // plain object target
   const o = { a: 1 };
   Error.captureStackTrace(o);
-  expectNonEnumerableStack(o);
   expect(Object.keys(o)).toEqual(["a"]);
   expect(JSON.stringify(o)).toBe('{"a":1}');
   const forIn = [];
   for (const k in o) forIn.push(k);
   expect(forIn).toEqual(["a"]);
+  expectNonEnumerableStack(o);
   expect(typeof o.stack).toBe("string");
+  o.stack = "overwritten";
+  expect(o.stack).toBe("overwritten");
+  expectNonEnumerableStack(o);
 
   // plain object with Error.prepareStackTrace set
   Error.prepareStackTrace = (err, sites) => "from-prepare";
   try {
     const o2 = {};
     Error.captureStackTrace(o2);
-    expectNonEnumerableStack(o2);
     expect(Object.keys(o2)).toEqual([]);
+    expectNonEnumerableStack(o2);
     expect(o2.stack).toBe("from-prepare");
   } finally {
     Error.prepareStackTrace = origPrepareStackTrace;
   }
 
-  // ErrorInstance whose .stack has not been materialized yet
+  // ErrorInstance whose .stack has not been materialized yet. Object.keys must
+  // run before any descriptor lookup: getOwnPropertyDescriptor would trip
+  // ErrorInstance::materializeErrorInfoIfNeeded, which overwrites with its own
+  // DontEnum and hides the attribute on the captureStackTrace accessor path.
   const lazy = new Error("lazy");
   Error.captureStackTrace(lazy);
-  expectNonEnumerableStack(lazy);
   expect(Object.keys(lazy)).toEqual([]);
-  void lazy.stack;
   expectNonEnumerableStack(lazy);
 
   // ErrorInstance whose .stack has already been materialized
   const materialized = new Error("materialized");
   void materialized.stack;
   Error.captureStackTrace(materialized);
-  expectNonEnumerableStack(materialized);
   expect(Object.keys(materialized)).toEqual([]);
-
-  // assigning to .stack after captureStackTrace keeps it non-enumerable
-  const assigned = new Error("assigned");
-  Error.captureStackTrace(assigned);
-  assigned.stack = "assigned-value";
-  expectNonEnumerableStack(assigned);
-  expect(assigned.stack).toBe("assigned-value");
+  expectNonEnumerableStack(materialized);
+  materialized.stack = "overwritten";
+  expect(materialized.stack).toBe("overwritten");
+  expectNonEnumerableStack(materialized);
 });
 
 test("prepare stack trace call sites", () => {

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -347,10 +347,9 @@ test("Error.captureStackTrace installs .stack as non-enumerable", () => {
     Error.prepareStackTrace = origPrepareStackTrace;
   }
 
-  // ErrorInstance whose .stack has not been materialized yet. Object.keys must
-  // run before any descriptor lookup: getOwnPropertyDescriptor would trip
-  // ErrorInstance::materializeErrorInfoIfNeeded, which overwrites with its own
-  // DontEnum and hides the attribute on the captureStackTrace accessor path.
+  // Object.keys must run before any descriptor lookup: getOwnPropertyDescriptor trips
+  // ErrorInstance::materializeErrorInfoIfNeeded, which overwrites with its own DontEnum
+  // and would mask the attribute captureStackTrace installed on the accessor path.
   const lazy = new Error("lazy");
   Error.captureStackTrace(lazy);
   expect(Object.keys(lazy)).toEqual([]);

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -297,6 +297,63 @@ test("capture stack trace edge cases", () => {
   expect(Error.captureStackTrace({}, true)).toBe(undefined);
 });
 
+test("Error.captureStackTrace installs .stack as non-enumerable", () => {
+  // V8 installs .stack with enumerable: false regardless of target type.
+  const expectNonEnumerableStack = target => {
+    const d = Object.getOwnPropertyDescriptor(target, "stack");
+    expect({ enumerable: d.enumerable, configurable: d.configurable }).toEqual({
+      enumerable: false,
+      configurable: true,
+    });
+    expect(Object.prototype.propertyIsEnumerable.call(target, "stack")).toBe(false);
+  };
+
+  // plain object target
+  const o = { a: 1 };
+  Error.captureStackTrace(o);
+  expectNonEnumerableStack(o);
+  expect(Object.keys(o)).toEqual(["a"]);
+  expect(JSON.stringify(o)).toBe('{"a":1}');
+  const forIn = [];
+  for (const k in o) forIn.push(k);
+  expect(forIn).toEqual(["a"]);
+  expect(typeof o.stack).toBe("string");
+
+  // plain object with Error.prepareStackTrace set
+  Error.prepareStackTrace = (err, sites) => "from-prepare";
+  try {
+    const o2 = {};
+    Error.captureStackTrace(o2);
+    expectNonEnumerableStack(o2);
+    expect(Object.keys(o2)).toEqual([]);
+    expect(o2.stack).toBe("from-prepare");
+  } finally {
+    Error.prepareStackTrace = origPrepareStackTrace;
+  }
+
+  // ErrorInstance whose .stack has not been materialized yet
+  const lazy = new Error("lazy");
+  Error.captureStackTrace(lazy);
+  expectNonEnumerableStack(lazy);
+  expect(Object.keys(lazy)).toEqual([]);
+  void lazy.stack;
+  expectNonEnumerableStack(lazy);
+
+  // ErrorInstance whose .stack has already been materialized
+  const materialized = new Error("materialized");
+  void materialized.stack;
+  Error.captureStackTrace(materialized);
+  expectNonEnumerableStack(materialized);
+  expect(Object.keys(materialized)).toEqual([]);
+
+  // assigning to .stack after captureStackTrace keeps it non-enumerable
+  const assigned = new Error("assigned");
+  Error.captureStackTrace(assigned);
+  assigned.stack = "assigned-value";
+  expectNonEnumerableStack(assigned);
+  expect(assigned.stack).toBe("assigned-value");
+});
+
 test("prepare stack trace call sites", () => {
   function f1() {
     f2();
@@ -892,8 +949,7 @@ test("Error.captureStackTrace applies stackTraceLimit after caller removal", () 
     function recurse(depth) {
       if (depth === 0) return target();
       // Not a tail call — keeps each frame on the stack.
-      const r = recurse(depth - 1);
-      return { ...r };
+      return recurse(depth - 1) || null;
     }
     noInline(recurse);
 

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -325,11 +325,21 @@ test("Error.captureStackTrace installs .stack as non-enumerable", () => {
   expect(o.stack).toBe("overwritten");
   expectNonEnumerableStack(o);
 
-  // plain object with Error.prepareStackTrace set
-  Error.prepareStackTrace = (err, sites) => "from-prepare";
+  // plain object with Error.prepareStackTrace set. Inside the callback, .stack
+  // holds the temporary default-formatted string; observing it there pins the
+  // attribute on that write, which the final putDirect would otherwise mask.
+  let insidePrepare;
+  Error.prepareStackTrace = (err, sites) => {
+    insidePrepare = {
+      keys: Object.keys(err),
+      enumerable: Object.getOwnPropertyDescriptor(err, "stack").enumerable,
+    };
+    return "from-prepare";
+  };
   try {
     const o2 = {};
     Error.captureStackTrace(o2);
+    expect(insidePrepare).toEqual({ keys: [], enumerable: false });
     expect(Object.keys(o2)).toEqual([]);
     expectNonEnumerableStack(o2);
     expect(o2.stack).toBe("from-prepare");


### PR DESCRIPTION
## Repro

```js
const o = {};
Error.captureStackTrace(o);
console.log(Object.getOwnPropertyDescriptor(o, "stack").enumerable);
// Node v26.3.0: false
// Bun 1.4.0:    true

const o2 = { a: 1 };
Error.captureStackTrace(o2);
console.log(Object.keys(o2), JSON.stringify(o2));
// Node: [ 'a' ] {"a":1}
// Bun:  [ 'a', 'stack' ] {"a":1,"stack":"Error\n    at ..."}
```

V8 installs the captured `stack` property with `enumerable: false` regardless of whether the target is an `Error` or a plain object. Bun matched that for an unmaterialized `ErrorInstance` read through `getOwnPropertyDescriptor` (where JSC's own `materializeErrorInfoIfNeeded` writes with `DontEnum`) but not for a plain-object target, nor for an `ErrorInstance` whose error info had already been materialized before the call, nor for `Object.keys` on a freshly-captured `ErrorInstance`.

## Cause

`errorConstructorFuncCaptureStackTrace` and the surrounding helpers in `src/jsc/bindings/FormatStackTraceForJS.cpp` wrote `.stack` via `putDirect(vm, vm.propertyNames->stack, ..., 0)`. Attributes `0` means enumerable, so `.stack` showed up in `Object.keys`, `for..in`, `JSON.stringify`, and object spread on those targets.

## Fix

All six `.stack` write sites in that file now pass `PropertyAttribute::DontEnum`, the same attribute JSC's `ErrorInstance::materializeErrorInfoIfNeeded` already uses:

- the plain-object branch of `errorConstructorFuncCaptureStackTrace`
- the materialized-`ErrorInstance` branch
- the lazy custom accessor installed on an unmaterialized `ErrorInstance`
- the temporary `.stack` written before calling `Error.prepareStackTrace`
- the lazy getter/setter that replace the accessor with a data property (these two are defence-in-depth: `ErrorInstance::getOwnPropertySlot` / `::put` materialize and overwrite the accessor before the custom getter/setter can run, so their attributes are not observable from JS today; they are changed for consistency with every other `.stack` write)

The `applies stackTraceLimit after caller removal` test was propagating its result object through `return { ...r }`, which only worked while `.stack` was enumerable; that spread is replaced with `return recurse(depth - 1) || null`, which still defeats tail-call elimination and preserves the captured object (verified against Node).

## Verification

New test in `test/js/node/v8/capture-stack-trace.test.js` asserts `enumerable: false, configurable: true, writable !== false` and `Object.keys` / `JSON.stringify` / `for..in` across: a plain-object target, a plain-object target with `Error.prepareStackTrace` set, an unmaterialized `ErrorInstance`, and a materialized `ErrorInstance`, plus behavioural assignment checks. `Object.keys` runs before any descriptor lookup in each block so the assertions observe the attribute `captureStackTrace` installed rather than the one `materializeErrorInfoIfNeeded` would write on first `getOwnPropertySlot`. Every assertion was first checked against Node v26.3.0.

```
bun-1.3.14 test capture-stack-trace.test.js   # new test fails (Object.keys shows "stack")
bun bd test capture-stack-trace.test.js       # 42 pass, 0 fail
```

Also green: `test/js/node/assert/`, `test/js/bun/sourcemap/`, `test/js/bun/util/fuzzy-wuzzy.test.ts`.
