### PR TITLE
Bun.serve: refuse CONNECT before dispatch

### DIFF
--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -767,6 +767,11 @@ public:
         return std::move(*this);
     }
 
+    TemplatedApp &&setRejectConnect(bool value) {
+        httpContext->getSocketContextData()->flags.rejectConnect = value;
+        return std::move(*this);
+    }
+
     TemplatedApp &&setFlags(bool requireHostHeader, bool useStrictMethodValidation) {
         httpContext->getSocketContextData()->flags.requireHostHeader = requireHostHeader;
         httpContext->getSocketContextData()->flags.useStrictMethodValidation = useStrictMethodValidation;

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -297,6 +297,14 @@ private:
                 return nullptr;
             }
 
+            /* Bun.serve is not a proxy; an authority-form CONNECT must not reach the
+             * fetch handler (RFC 9110 9.3.6). node:http leaves rejectConnect false and
+             * routes CONNECT through its own 'connect' event / close path instead. */
+            if (httpResponseData->isConnectRequest && httpContextData->flags.rejectConnect) {
+                us_socket_close((us_socket_t *) s, 0, nullptr);
+                return nullptr;
+            }
+
             /* Mark pending request and emit it */
             httpResponseData->state = HttpResponseData<SSL>::HTTP_RESPONSE_PENDING;
 

--- a/packages/bun-uws/src/HttpContextData.h
+++ b/packages/bun-uws/src/HttpContextData.h
@@ -34,6 +34,7 @@ struct HttpFlags {
     bool requireHostHeader: 1 = true;
     bool isAuthorized: 1 = false;
     bool useStrictMethodValidation: 1 = false;
+    bool rejectConnect: 1 = false;
 };
 
 template <bool SSL>

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2443,6 +2443,11 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             ffi::NodeHTTP_assignOnNodeJSCompat(SSL, std::ptr::from_mut(app).cast::<c_void>());
         }
 
+        // Bun.serve cannot satisfy CONNECT (RFC 9110 9.3.6); close the socket
+        // before routing so the fetch handler never sees an authority-form URL.
+        // node:http handles CONNECT via its own 'connect' event / close path.
+        app.set_reject_connect(!has_node_http);
+
         route_list_value
     }
 

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -132,6 +132,10 @@ impl<const SSL: bool> App<SSL> {
         )
     }
 
+    pub fn set_reject_connect(&mut self, value: bool) {
+        c::uws_app_set_reject_connect(Self::SSL_FLAG, self.as_raw(), value)
+    }
+
     pub fn set_max_http_header_size(&mut self, max_header_size: u64) {
         c::uws_app_set_max_http_header_size(Self::SSL_FLAG, self.as_raw(), max_header_size)
     }
@@ -512,6 +516,7 @@ pub mod c {
             require_host_header: bool,
             use_strict_method_validation: bool,
         );
+        pub(crate) safe fn uws_app_set_reject_connect(ssl: i32, app: &mut uws_app_t, value: bool);
         pub(crate) safe fn uws_app_set_max_http_header_size(
             ssl: i32,
             app: &mut uws_app_t,

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -550,6 +550,15 @@ extern "C"
       uwsApp->setFlags(require_host_header, use_strict_method_validation);
     }
   }
+  void uws_app_set_reject_connect(int ssl, uws_app_t *app, bool value) {
+    if (ssl) {
+      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+      uwsApp->setRejectConnect(value);
+    } else {
+      uWS::App *uwsApp = (uWS::App *)app;
+      uwsApp->setRejectConnect(value);
+    }
+  }
 
   void uws_app_destroy(int ssl, uws_app_t *app)
   {

--- a/test/js/bun/http/bun-serve-connect.test.ts
+++ b/test/js/bun/http/bun-serve-connect.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+import { once } from "node:events";
+import * as net from "node:net";
+
+// RFC 9110 9.3.6: an origin server that is not acting as a tunnel must not
+// respond 2xx to CONNECT. Bun.serve is never a proxy, so CONNECT is refused
+// (socket closed, no bytes written) and never reaches the fetch handler.
+// Matches Node.js http.Server with no 'connect' listener.
+
+async function sendRaw(port: number, bytes: string): Promise<{ received: string; serverClosed: boolean }> {
+  const chunks: Buffer[] = [];
+  const socket = net.connect({ port, host: "127.0.0.1" });
+  await once(socket, "connect");
+  socket.write(bytes);
+  // Under the bug the server answers and leaves the connection open (keep-alive),
+  // so 'close' never fires on its own. Race data-vs-close; if any bytes arrive,
+  // tear the socket down ourselves so the test fails on the assertion instead
+  // of timing out.
+  const serverClosed = await new Promise<boolean>((resolve, reject) => {
+    socket.on("data", d => {
+      chunks.push(d);
+      socket.destroy();
+    });
+    socket.on("error", reject);
+    socket.on("close", () => resolve(chunks.length === 0));
+  });
+  return { received: Buffer.concat(chunks).toString("latin1"), serverClosed };
+}
+
+describe("Bun.serve CONNECT", () => {
+  test("fetch handler never sees CONNECT; socket is closed with no response", async () => {
+    let handlerSaw: string | null = null;
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        handlerSaw = `${req.method} ${req.url}`;
+        return new Response("hello from the handler");
+      },
+    });
+
+    const { received, serverClosed } = await sendRaw(
+      server.port,
+      "CONNECT h.test:80 HTTP/1.1\r\nHost: h.test:80\r\n\r\n",
+    );
+
+    expect({ handlerSaw, received, serverClosed }).toEqual({
+      handlerSaw: null,
+      received: "",
+      serverClosed: true,
+    });
+
+    // The server itself stays up; a normal request on a fresh connection works.
+    const res = await fetch(`http://127.0.0.1:${server.port}/ok`);
+    expect(await res.text()).toBe("hello from the handler");
+    expect(handlerSaw).toBe(`GET http://127.0.0.1:${server.port}/ok`);
+  });
+
+  test("routes catch-all handler never sees CONNECT", async () => {
+    let handlerSaw: string | null = null;
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      routes: {
+        "/*": req => {
+          handlerSaw = `${req.method} ${req.url}`;
+          return new Response("from route");
+        },
+      },
+    });
+
+    const { received, serverClosed } = await sendRaw(
+      server.port,
+      "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n",
+    );
+
+    expect({ handlerSaw, received, serverClosed }).toEqual({
+      handlerSaw: null,
+      received: "",
+      serverClosed: true,
+    });
+  });
+
+  test("routes-only server (no fetch handler) closes on CONNECT", async () => {
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      routes: {
+        "/hello": () => new Response("hi"),
+      },
+    });
+
+    const { received, serverClosed } = await sendRaw(
+      server.port,
+      "CONNECT h.test:80 HTTP/1.1\r\nHost: h.test:80\r\n\r\n",
+    );
+
+    expect({ received, serverClosed }).toEqual({ received: "", serverClosed: true });
+  });
+
+  test("pipelined bytes after CONNECT are discarded, not parsed as HTTP", async () => {
+    const seen: string[] = [];
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        seen.push(`${req.method} ${new URL(req.url).pathname}`);
+        return new Response("ok");
+      },
+    });
+
+    const pipelined =
+      "CONNECT h.test:80 HTTP/1.1\r\nHost: h.test:80\r\n\r\n" +
+      "GET /smuggled HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n";
+    const { received, serverClosed } = await sendRaw(server.port, pipelined);
+
+    expect({ seen, received, serverClosed }).toEqual({ seen: [], received: "", serverClosed: true });
+  });
+});

--- a/test/js/bun/http/bun-serve-connect.test.ts
+++ b/test/js/bun/http/bun-serve-connect.test.ts
@@ -2,20 +2,18 @@ import { describe, expect, test } from "bun:test";
 import { once } from "node:events";
 import * as net from "node:net";
 
-// RFC 9110 9.3.6: an origin server that is not acting as a tunnel must not
-// respond 2xx to CONNECT. Bun.serve is never a proxy, so CONNECT is refused
-// (socket closed, no bytes written) and never reaches the fetch handler.
-// Matches Node.js http.Server with no 'connect' listener.
+// RFC 9110 9.3.6: a non-tunnel origin must not answer 2xx to CONNECT. Bun.serve
+// is never a proxy, so CONNECT is refused (socket closed, zero bytes) before the
+// fetch handler, matching Node's http.Server with no 'connect' listener.
 
 async function sendRaw(port: number, bytes: string): Promise<{ received: string; serverClosed: boolean }> {
   const chunks: Buffer[] = [];
   const socket = net.connect({ port, host: "127.0.0.1" });
   await once(socket, "connect");
   socket.write(bytes);
-  // Under the bug the server answers and leaves the connection open (keep-alive),
-  // so 'close' never fires on its own. Race data-vs-close; if any bytes arrive,
-  // tear the socket down ourselves so the test fails on the assertion instead
-  // of timing out.
+  // Race data-vs-close: if any bytes arrive, destroy the socket so a regression
+  // fails on the received/serverClosed assertion instead of hanging on a
+  // kept-alive connection until the test timeout.
   const serverClosed = await new Promise<boolean>((resolve, reject) => {
     socket.on("data", d => {
       chunks.push(d);


### PR DESCRIPTION
## Repro

```js
import net from "node:net";
let saw = null;
const srv = Bun.serve({
  port: 0, hostname: "127.0.0.1",
  fetch(req) { saw = `${req.method} ${req.url}`; return new Response("hi"); },
});
const s = net.connect(srv.port, "127.0.0.1", () =>
  s.write("CONNECT h.test:80 HTTP/1.1\r\nHost: h.test:80\r\n\r\n"));
s.on("data", d => console.log(d.toString("latin1").split("\r\n")[0]));
setTimeout(() => { console.log("handler saw:", saw); srv.stop(true); s.destroy(); }, 500);
// before: HTTP/1.1 200 OK
//         handler saw: CONNECT h.test:80
// after:  handler saw: null          (zero response bytes, socket closed)
// node (http.Server, no 'connect' listener): same as after
```

## Cause

`HttpParser.h` already recognises authority-form `CONNECT host:port` and threads `isConnect` through to `HttpResponseData::isConnectRequest`. The node:http path consumes that flag (routes to the `'connect'` event, or closes when there is no listener). Bun.serve never looks at it: the request drops straight into the router, the catch-all `/*` handler runs with `req.url` set to the raw authority (`new URL("h.test:80")` parses as protocol `h.test:`, pathname `"80"`), and whatever the handler returns is written to the still-open connection.

RFC 9110 9.3.6: a 2xx to CONNECT means "tunnel established" and MUST NOT carry Content-Length or Transfer-Encoding. A proxy-capable client (or an open-proxy scanner) that reaches a Bun.serve origin gets a success-shaped tunnel response and then ships opaque bytes that Bun parses as the next HTTP request on the kept-alive connection.

## Fix

Add a `rejectConnect` bit to uWS `HttpFlags`. Inside the request-handler lambda in `HttpContext.h`, before routing, close the socket (no bytes written) when `isConnectRequest && rejectConnect`. `set_routes()` sets the flag whenever the server is not running under `onNodeHTTPRequest`, so Bun.serve always refuses CONNECT and node:http keeps its existing behaviour. Closing with zero bytes matches Node's `http.Server` with no `'connect'` listener.

The check lives in the shared uWS dispatch path, so it covers every Bun.serve entry point (the `fetch` handler, `routes: {...}`, static routes, the no-handler 404) without per-trampoline checks.

## Verification

`test/js/bun/http/bun-serve-connect.test.ts`:

- fetch handler never sees CONNECT; socket closed with no response; a follow-up GET on a fresh connection still works
- `routes: { "/*": handler }` never sees CONNECT
- routes-only server (no fetch handler) closes on CONNECT instead of answering 404
- bytes pipelined after CONNECT are discarded, not parsed as HTTP

All four fail on the released bun (the handler receives `CONNECT h.test:80` and a 200/404 goes on the wire) and pass with this change. The existing `test/js/node/http/node-http-connect.test.ts` suite (node:http CONNECT event, tunnel handover, backpressure) still passes.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-connect.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (73281ae9d)

test/js/bun/http/bun-serve-connect.test.ts:
40 |     const { received, serverClosed } = await sendRaw(
41 |       server.port,
42 |       "CONNECT h.test:80 HTTP/1.1\r\nHost: h.test:80\r\n\r\n",
43 |     );
44 | 
45 |     expect({ handlerSaw, received, serverClosed }).toEqual({
                                                        ^
error: expect(received).toEqual(expected)

  {
-   "handlerSaw": null,
-   "received": "",
-   "serverClosed": true,
+   "handlerSaw": "CONNECT h.test:80",
+   "received": 
+ "HTTP/1.1 200 OK
+ content-type: text/plain;charset=utf-8
+ Date: Wed, 15 Jul 2026 19:14:30 GMT
+ Content-Length: 22
+ 
+ hello from the handler"
+ ,
+   "serverClosed": false,
  }

- Expected  - 3
+ Received 
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (73281ae9d)

test/js/bun/http/bun-serve-connect.test.ts:
(pass) Bun.serve CONNECT > fetch handler never sees CONNECT; socket is closed with no response [7.05ms]
(pass) Bun.serve CONNECT > routes catch-all handler never sees CONNECT [1.49ms]
(pass) Bun.serve CONNECT > routes-only server (no fetch handler) closes on CONNECT [0.96ms]
(pass) Bun.serve CONNECT > pipelined bytes after CONNECT are discarded, not parsed as HTTP [1.01ms]

 4 pass
 0 fail
 6 expect() calls
Ran 4 tests across 1 file. [175.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-connect.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (73281ae9d)

test/js/bun/http/bun-serve-connect.test.ts:
(pass) Bun.serve CONNECT > fetch handler never sees CONNECT; socket is closed with no response [410.17ms]
(pass) Bun.serve CONNECT > routes catch-all handler never sees CONNECT [64.05ms]
(pass) Bun.serve CONNECT > routes-only server (no fetch handler) closes on CONNECT [42.41ms]
(pass) Bun.serve CONNECT > pipelined bytes after CONNECT are discarded, not parsed as HTTP [74.81ms]

 4 pass
 0 fail
 6 expect() calls
Ran 4 tests across 1 file. [3.00s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 929ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[2/13] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[3/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[4/13] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[5/13] cxx obj/src/jsc/bindings/bindings.cpp.o
[6/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[7/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[8/13] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[9/13] gen cpp.rs (cppbind)
[9/13] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update o
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-uws/src/App.h                 |   5 ++
 packages/bun-uws/src/HttpContext.h         |   8 ++
 packages/bun-uws/src/HttpContextData.h     |   1 +
 src/runtime/server/mod.rs                  |   5 ++
 src/uws_sys/App.rs                         |   5 ++
 src/uws_sys/libuwsockets.cpp               |   9 +++
 test/js/bun/http/bun-serve-connect.test.ts | 117 +++++++++++++++++++++++++++++
 7 files changed, 150 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
packages/bun-uws/src/App.h                      1      1      0
packages/bun-uws/src/HttpContext.h              3      1      0
packages/bun-uws/src/HttpContextData.h          1      1      0
src/runtime/server/mod.rs                       8      2      0
src/uws_sys/App.rs                              2      2      0
src/uws_sys/libuwsockets.cpp                    1      1      0
test/js/bun/http/bun-serve-connect.test.ts      1      8      0
```

</details>

<!-- robobun:evidence:end -->