### PR TITLE
Error.stackTraceLimit: sync the JS property with the limit stack captures use

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -523,7 +523,6 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
 
     globalObject->setConsole(console_client);
     globalObject->isThreadLocalDefaultGlobalObject = true;
-    globalObject->setStackTraceLimit(DEFAULT_ERROR_STACK_TRACE_LIMIT); // Node.js defaults to 10
     Bun__setDefaultGlobalObject(globalObject);
     JSC::gcProtect(globalObject);
 
@@ -633,7 +632,6 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__createForTestIsolation(Zig::G
 
     globalObject->setConsole(console_client);
     globalObject->isThreadLocalDefaultGlobalObject = true;
-    globalObject->setStackTraceLimit(DEFAULT_ERROR_STACK_TRACE_LIMIT);
     Bun__setDefaultGlobalObject(globalObject);
     JSC::gcProtect(globalObject);
 
@@ -1936,6 +1934,10 @@ JSC_DEFINE_CUSTOM_SETTER(moduleNamespacePrototypeSetESModuleMarker, (JSGlobalObj
 
 void GlobalObject::finishCreation(VM& vm)
 {
+    // Node.js defaults to 10. Must run before Base::finishCreation() materializes
+    // errorConstructor(), which snapshots this value into Error.stackTraceLimit.
+    setStackTraceLimit(DEFAULT_ERROR_STACK_TRACE_LIMIT);
+
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
 

--- a/src/runtime/bake/BakeGlobalObject.cpp
+++ b/src/runtime/bake/BakeGlobalObject.cpp
@@ -261,7 +261,6 @@ extern "C" GlobalObject* BakeCreateProdGlobal(void* console)
     JSC::gcProtect(global);
 
     global->setConsole(console);
-    global->setStackTraceLimit(10); // Node.js defaults to 10
     global->isThreadLocalDefaultGlobalObject = true;
 
     // if (shouldDisableStopIfNecessaryTimer) {

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -925,6 +925,34 @@ test("captureStackTrace does not crash when stackTraceLimit is non-numeric", () 
   }
 });
 
+test("Error.stackTraceLimit default matches the limit captureStackTrace applies", async () => {
+  // Run in a fresh process so nothing has written to Error.stackTraceLimit yet.
+  const src = `
+    function depth(n) {
+      if (n) return 0 + depth(n - 1);
+      const e = {};
+      Error.captureStackTrace(e);
+      return e.stack.split("\\n").length - 1;
+    }
+    const reported = Error.stackTraceLimit;
+    const before = depth(30);
+    Error.stackTraceLimit = Error.stackTraceLimit;
+    const after = depth(30);
+    process.stdout.write(JSON.stringify({ reported, before, after }));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const { reported, before, after } = JSON.parse(stdout);
+  // Node.js defaults to 10 and the reported value must match the applied limit.
+  expect({ reported, before, after }).toEqual({ reported: 10, before: 10, after: 10 });
+  expect(exitCode).toBe(0);
+});
+
 test("call sites inside a WebSocket message listener only contain script frames when the message arrives with the upgrade response", async () => {
   // Runs in its own process: which dispatch path delivers the message (and therefore
   // which frames are on the stack under the listener) depends on prior event-loop state.

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -946,11 +946,9 @@ test("Error.stackTraceLimit default matches the limit captureStackTrace applies"
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
   const { reported, before, after } = JSON.parse(stdout);
   // Node.js defaults to 10 and the reported value must match the applied limit.
-  expect({ reported, before, after }).toEqual({ reported: 10, before: 10, after: 10 });
-  expect(exitCode).toBe(0);
+  expect({ reported, before, after, exitCode }).toEqual({ reported: 10, before: 10, after: 10, exitCode: 0 });
 });
 
 test("call sites inside a WebSocket message listener only contain script frames when the message arrives with the upgrade response", async () => {


### PR DESCRIPTION
## Problem

In a fresh process, `Error.stackTraceLimit` reads `100` but `Error.captureStackTrace` and `new Error().stack` truncate at 10 frames. The two stay out of sync until something writes to `Error.stackTraceLimit` (even `Error.stackTraceLimit = Error.stackTraceLimit`), after which captures start honoring the property.

```js
console.log(Error.stackTraceLimit);                // 100
function f(n) { if (n) return 0 + f(n - 1); const e = {}; Error.captureStackTrace(e); return e.stack.split("\n").length - 1; }
console.log(f(30));                                // 10  (capped by the internal cache)
Error.stackTraceLimit = Error.stackTraceLimit;     // no-op write
console.log(f(30));                                // 32  (now capped by the property value)
```

Node.js prints `10` for the property and `10` for every capture.

This surfaced as a test-ordering failure in #34256: running `deep-equal.test.ts` (which saves/restores `Error.stackTraceLimit` through `node:assert`) before `capture-stack-trace.test.js` changed the latter's observed frame count.

## Cause

`JSGlobalObject`'s constructor seeds `m_stackTraceLimit` with JSC's default (`Options::defaultErrorStackTraceLimit()` = 100). `Zig::GlobalObject` then overwrote it to `DEFAULT_ERROR_STACK_TRACE_LIMIT` (10, matching Node) *after* `create()` returned, but by that point `Base::finishCreation()` had already materialized the `Error` constructor, which stores `jsNumber(globalObject->stackTraceLimit())` as the `Error.stackTraceLimit` data property. `ErrorConstructor::put` syncs the cache on write, so the first write (of any value) hides the mismatch.

## Fix

Move the `setStackTraceLimit(DEFAULT_ERROR_STACK_TRACE_LIMIT)` call to the top of `GlobalObject::finishCreation()`, before `Base::finishCreation()` runs, so the `Error` constructor snapshots the Node-compatible default. The two post-create calls become dead and are removed.

After this change `Error.stackTraceLimit` reports `10` in a fresh process (matching Node), and `captureStackTrace` behaves identically before and after the first write.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/v8/capture-stack-trace.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (75de622dc)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [13.24ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [8.19ms]
(pass) capture stack trace [7.33ms]
(pass) capture stack trace with message [7.03ms]
(pass) capture stack trace with constructor [5.00ms]
(pass) capture stack trace limit [23.82ms]
(pass) prepare stack trace [12.11ms]
(pass) capture stack trace second argument [18.30ms]
(pass) capture stack trace edge cases [15.91ms]
(pass) prepare stack trace call sites [23.50ms]
(pass) sanity check [15.18ms]
(pass) CallFrame isEval works as expected [8.24ms]
(pass) CallFrame isTopLevel returns false for Function constructor [9.22ms]
(pass) CallFrame.p.getThisgetFunction: strict/slopp
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (6555e83c1)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [0.45ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [0.09ms]
(pass) capture stack trace [0.06ms]
(pass) capture stack trace with message [0.06ms]
(pass) capture stack trace with constructor [0.06ms]
(pass) capture stack trace limit [0.23ms]
(pass) prepare stack trace [0.11ms]
(pass) capture stack trace second argument [0.16ms]
(pass) capture stack trace edge cases [0.10ms]
(pass) prepare stack trace call sites [0.11ms]
(pass) sanity check [0.11ms]
(pass) CallFrame isEval works as expected [0.10ms]
(pass) CallFrame isTopLevel returns false for Function constructor [0.09ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [0.13ms]
(pass) CallFrame.p.isConstructor [0.04ms]
(pass) CallFrame.p.isNative [0.03ms]
(pass) return non-strings from Error.prepareStackTrace [0.03ms]
(pass) CallFrame.p.toString [0.03ms]
(pass) err.stack should invoke prepareStackTrace [0.27ms]
(pass) Error.prepareStackTrace inside a node:vm works [4.81ms]
(pass) Error.captureStackTrace inside error constructor works [0.09ms]
(pass) Error.prepareStackTrace has 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/v8/capture-stack-trace.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (75de622dc)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [15.86ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [7.39ms]
(pass) capture stack trace [8.05ms]
(pass) capture stack trace with message [7.08ms]
(pass) capture stack trace with constructor [5.01ms]
(pass) capture stack trace limit [24.54ms]
(pass) prepare stack trace [10.61ms]
(pass) capture stack trace second argument [17.39ms]
(pass) capture stack trace edge cases [11.41ms]
(pass) prepare stack trace call sites [12.98ms]
(pass) sanity check [13.18ms]
(pass) CallFrame isEval works as expected [6.77ms]
(pass) CallFrame isTopLevel returns false for Function constructor [8.48ms]
(pass) CallFrame.p.getThisgetFunction: strict/slopp
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 779ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/unified/UnifiedSource-src_runtime_bake-0.cpp.o
[2/7] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[3/7] gen cpp.rs (cppbind)
[3/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ZigGlobalObject.cpp        |  6 ++++--
 src/runtime/bake/BakeGlobalObject.cpp       |  1 -
 test/js/node/v8/capture-stack-trace.test.js | 26 ++++++++++++++++++++++++++
 3 files changed, 30 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/jsc/bindings/ZigGlobalObject.cpp             4      3      0
src/runtime/bake/BakeGlobalObject.cpp            1      1      0
test/js/node/v8/capture-stack-trace.test.js      3      3      0
```

</details>

<!-- robobun:evidence:end -->