### PR TITLE
fs: fail WriteStream fast-path write() with ERR_STREAM_DESTROYED after destroy

### DIFF
--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -639,10 +639,10 @@ const kWriteMonkeyPatchDefense = Symbol("!");
 function writeFast(this: FSStream, data: any, encoding: any, cb: any) {
   if (this[kWriteMonkeyPatchDefense]) return writablePrototypeWrite.$call(this, data, encoding, cb);
 
-  // After end() the Writable contract requires write() to fail with
-  // ERR_STREAM_WRITE_AFTER_END and not reach the sink.
+  // After end()/destroy() the Writable contract requires write() to fail with
+  // ERR_STREAM_WRITE_AFTER_END / ERR_STREAM_DESTROYED and not reach the sink.
   const state = this._writableState;
-  if (state !== undefined && state.ending) {
+  if (state !== undefined && (state.ending || state.destroyed)) {
     return writablePrototypeWrite.$call(this, data, encoding, cb);
   }
 

--- a/test/js/node/child_process/child-process-stdio.test.js
+++ b/test/js/node/child_process/child-process-stdio.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe } from "harness";
-import { once } from "node:events";
 import { execSync, spawn } from "node:child_process";
+import { once } from "node:events";
 
 const CHILD_PROCESS_FILE = import.meta.dir + "/spawned-child.js";
 const OUT_FILE = import.meta.dir + "/stdio-test-out.txt";

--- a/test/js/node/child_process/child-process-stdio.test.js
+++ b/test/js/node/child_process/child-process-stdio.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe } from "harness";
+import { once } from "node:events";
 import { execSync, spawn } from "node:child_process";
 
 const CHILD_PROCESS_FILE = import.meta.dir + "/spawned-child.js";
@@ -115,5 +116,53 @@ describe("process.stdin", () => {
       env: bunEnv,
     });
     expect(result).toEqual("data: File read successfully");
+  });
+});
+
+describe("child.stdin", () => {
+  it("write() after child 'close' returns false and calls back with ERR_STREAM_DESTROYED", async () => {
+    const child = spawn(bunExe(), ["-e", ""], {
+      env: bunEnv,
+      stdio: ["pipe", "ignore", "ignore"],
+    });
+    await once(child, "close");
+
+    const { promise, resolve } = Promise.withResolvers();
+    const ret = child.stdin.write("dropped", resolve);
+    const cbErr = await promise;
+
+    expect({
+      ret,
+      cbCode: cbErr?.code,
+      destroyed: child.stdin.destroyed,
+      writable: child.stdin.writable,
+    }).toEqual({
+      ret: false,
+      cbCode: "ERR_STREAM_DESTROYED",
+      destroyed: true,
+      writable: false,
+    });
+  });
+
+  it("write() after child 'exit' (before 'close') returns false and calls back with ERR_STREAM_DESTROYED", async () => {
+    const child = spawn(bunExe(), ["-e", "process.stdin.once('data', () => process.exit(0))"], {
+      env: bunEnv,
+      stdio: ["pipe", "ignore", "ignore"],
+    });
+    child.stdin.on("error", () => {});
+    await new Promise((resolve, reject) => {
+      child.once("error", reject);
+      child.stdin.write("go\n", err => (err ? reject(err) : resolve()));
+    });
+    await once(child, "exit");
+
+    const { promise, resolve } = Promise.withResolvers();
+    const ret = child.stdin.write("late", resolve);
+    const cbErr = await promise;
+
+    expect({ ret, cbCode: cbErr?.code }).toEqual({
+      ret: false,
+      cbCode: "ERR_STREAM_DESTROYED",
+    });
   });
 });


### PR DESCRIPTION
## Repro

Writing to a spawned child's `stdin` after the child has exited returns `true` and calls the write callback with `null`, even though `stdin.destroyed === true` and `stdin.writable === false`. Node returns `false` and calls back with `ERR_STREAM_DESTROYED`.

```js
import { spawn } from "node:child_process";
import { once } from "node:events";

const child = spawn("true", { stdio: ["pipe", "ignore", "ignore"] });
await once(child, "close");

const ret = child.stdin.write("dropped", err =>
  console.log({ ret, cb: err ? err.code : "success", destroyed: child.stdin.destroyed }),
);
```

```
node: { ret: false, cb: 'ERR_STREAM_DESTROYED', destroyed: true }
bun : { ret: true,  cb: 'success',              destroyed: true }
```

Any code feeding a child pipeline (gzip, ffmpeg, a formatter) that flushes after the child dies believes the bytes were delivered: silent data loss with a success callback.

## Cause

`child.stdin` is a `fs.WriteStream` on the FileSink fast path. That path installs `writeFast` as an own `.write` which bypasses `Writable.prototype.write` entirely. It already deferred to the real Writable machinery when `state.ending` was set (so `end()` then `write()` correctly raised `ERR_STREAM_WRITE_AFTER_END`), but it never checked `state.destroyed`, so writes after `destroy()` reached the closed sink, which returned synchronously and mapped to `cb(null); return true`.

## Fix

Also defer to `Writable.prototype.write` when `state.destroyed` is set. The existing Writable `_write` helper already handles this case (`ERR_STREAM_DESTROYED`, callback via `process.nextTick`, `errorOrDestroy`), so routing through it gets the full Node contract for free.

## Verification

Added two tests in `test/js/node/child_process/child-process-stdio.test.js` covering write-after-`close` and write-after-`exit`. Both fail on stock bun with `{ ret: true, cbCode: undefined }` and pass with the fix.

Note: #33508 removes `writeFast` entirely in favor of going through `Writable.prototype.write` for buffer accounting, which would also fix this. This PR is the minimal targeted change in case that one takes longer to land.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/child_process/child-process-stdio.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (c1207a628)

test/js/node/child_process/child-process-stdio.test.js:
(pass) process.stdout > should allow us to write to it [1320.63ms]
(pass) process.stdin > should allow us to read from stdin in readable mode [1550.61ms]
(pass) process.stdin > should allow us to read from stdin via flowing mode [1548.14ms]
killed 1 dangling process
(pass) process.stdin > should allow us to read > 65kb from stdin [5110.24ms]
(pass) process.stdin > should allow us to read from a file [1575.38ms]
134 |     expect({
135 |       ret,
136 |       cbCode: cbErr?.code,
137 |       destroyed: child.stdin.destroyed,
138 |       writable: child.stdin.writable,
139 |     }).toEqual({
             ^
error: expect(received).toEqual(expected)
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (1db92f7fb)

test/js/node/child_process/child-process-stdio.test.js:
(pass) process.stdout > should allow us to write to it [25.67ms]
(pass) process.stdin > should allow us to read from stdin in readable mode [29.97ms]
(pass) process.stdin > should allow us to read from stdin via flowing mode [31.07ms]
(pass) process.stdin > should allow us to read > 65kb from stdin [39.69ms]
(pass) process.stdin > should allow us to read from a file [29.65ms]
(pass) child.stdin > write() after child 'close' returns false and calls back with ERR_STREAM_DESTROYED [2.82ms]
(pass) child.stdin > write() after child 'exit' (before 'close') returns false and calls back with ERR_STREAM_DESTROYED [29.01ms]

 7 pass
 0 fail
 8 expect() calls
Ran 7 tests across 1 file. [339.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/child_process/child-process-stdio.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (c1207a628)

test/js/node/child_process/child-process-stdio.test.js:
(pass) process.stdout > should allow us to write to it [1323.53ms]
(pass) process.stdin > should allow us to read from stdin in readable mode [1560.41ms]
(pass) process.stdin > should allow us to read from stdin via flowing mode [1564.60ms]
killed 1 dangling process
(pass) process.stdin > should allow us to read > 65kb from stdin [5083.47ms]
(pass) process.stdin > should allow us to read from a file [1680.26ms]
(pass) child.stdin > write() after child 'close' returns false and calls back with ERR_STREAM_DESTROYED [159.26ms]
(pass) child.stdin > write() after child 'exit' (before 'close') returns false and calls back with ERR_STREAM_DESTROYED [15
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 733ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/20] gen JS modules (bundle-modules)
Preprocess modules (7921ms)
Bundle modules (33ms)
Postprocesss modules (139ms)
Bundle Functions (814ms)
Generate Code (88ms)

[9.01s] Bundled "src/js" for production
  1911 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 202
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/fs/streams.ts                      |  6 +--
 .../node/child_process/child-process-stdio.test.js | 49 ++++++++++++++++++++++
 2 files changed, 52 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/js/internal/fs/streams.ts                               1      1      0
test/js/node/child_process/child-process-stdio.test.js      1      4      0
```

</details>

<!-- robobun:evidence:end -->