### PR TITLE
child_process: latch stdin write EPIPE as 'error' + destroy, fail later writes with ERR_STREAM_DESTROYED

### DIFF
--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -593,7 +593,6 @@ function underscoreWriteFast(this: FSStream, data: any, encoding: any, cb: any) 
     this._write = _write;
     return this._write(data, encoding, cb);
   }
-  const hasCallback = typeof cb === "function";
   try {
     if (fileSink === true) {
       fileSink = this[kWriteStreamFastPath] = Bun.file(this.path).writer();
@@ -610,12 +609,7 @@ function underscoreWriteFast(this: FSStream, data: any, encoding: any, cb: any) 
         },
         err => {
           if (cb) cb(err);
-          // If no callback was provided, emit the error on the stream
-          // This matches Node.js behavior where unhandled write errors
-          // are emitted as 'error' events on the stream
-          if (!hasCallback) {
-            this.destroy(err);
-          }
+          require("internal/streams/destroy").errorOrDestroy(this, err);
         },
       );
       return false;
@@ -625,10 +619,7 @@ function underscoreWriteFast(this: FSStream, data: any, encoding: any, cb: any) 
     }
   } catch (e) {
     if (cb) process.nextTick(cb, e);
-    // If no callback was provided, emit the error on the stream
-    if (!hasCallback) {
-      this.destroy(e);
-    }
+    require("internal/streams/destroy").errorOrDestroy(this, e, true);
     return false;
   }
 }
@@ -639,10 +630,10 @@ const kWriteMonkeyPatchDefense = Symbol("!");
 function writeFast(this: FSStream, data: any, encoding: any, cb: any) {
   if (this[kWriteMonkeyPatchDefense]) return writablePrototypeWrite.$call(this, data, encoding, cb);
 
-  // After end() the Writable contract requires write() to fail with
-  // ERR_STREAM_WRITE_AFTER_END and not reach the sink.
+  // After end()/destroy() the Writable contract requires write() to fail with
+  // ERR_STREAM_WRITE_AFTER_END / ERR_STREAM_DESTROYED and not reach the sink.
   const state = this._writableState;
-  if (state !== undefined && state.ending) {
+  if (state !== undefined && (state.ending || state.destroyed)) {
     return writablePrototypeWrite.$call(this, data, encoding, cb);
   }
 
@@ -650,8 +641,7 @@ function writeFast(this: FSStream, data: any, encoding: any, cb: any) {
     cb = encoding;
     encoding = undefined;
   }
-  const hasCallback = typeof cb === "function";
-  if (!hasCallback) {
+  if (typeof cb !== "function") {
     cb = streamNoop;
   }
 
@@ -659,21 +649,20 @@ function writeFast(this: FSStream, data: any, encoding: any, cb: any) {
   if (fileSink && fileSink !== true) {
     const maybePromise = fileSink.write(data);
     if ($isPromise(maybePromise)) {
-      maybePromise
-        .then(() => {
+      // Two-arg then(): a throw from the fulfillment handler must not be
+      // mistaken for a write failure.
+      maybePromise.then(
+        () => {
           this.emit("drain"); // Emit drain event
           cb(null);
-        })
-        .catch(err => {
-          // Always call the callback with the error
+        },
+        err => {
           cb(err);
-          // If no callback was provided, emit the error on the stream
-          // This matches Node.js behavior where unhandled write errors
-          // are emitted as 'error' events on the stream
-          if (!hasCallback) {
-            this.destroy(err);
-          }
-        });
+          // Node.js onwriteError: callback AND destroy are both invoked; the
+          // callback is additive, not a replacement for the 'error' event.
+          require("internal/streams/destroy").errorOrDestroy(this, err);
+        },
+      );
       return false; // Indicate backpressure
     } else {
       cb(null);

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -405,6 +405,54 @@ describe("spawn()", () => {
       expect(child.stderr).not.toBeNull();
     });
   });
+
+  it.skipIf(isWindows)(
+    "stdin write failure (EPIPE) emits 'error' and destroys even with a write callback",
+    async () => {
+      // Child closes its own stdin fd, signals ready on stdout, then stays alive.
+      const child = spawn(
+        bunExe(),
+        ["-e", `require("fs").closeSync(0); process.stdout.write("ready\\n"); setInterval(() => {}, 1e5);`],
+        { env: bunEnv, stdio: ["pipe", "pipe", "ignore"] },
+      );
+      try {
+        await new Promise<void>((resolve, reject) => {
+          child.on("error", reject);
+          child.on("exit", () => reject(new Error("child exited before ready")));
+          child.stdout!.once("data", () => resolve());
+        });
+        child.removeAllListeners("error");
+        child.removeAllListeners("exit");
+
+        const errEv = Promise.withResolvers<any>();
+        const cb1 = Promise.withResolvers<any>();
+        child.stdin!.on("error", e => errEv.resolve(e));
+        child.stdin!.write(Buffer.alloc(65536, 0x41), e => cb1.resolve(e));
+
+        const [cb1Err, errEvErr] = await Promise.all([cb1.promise, errEv.promise]);
+
+        expect({
+          cb1: cb1Err?.code,
+          errEv: errEvErr?.code,
+          destroyed: child.stdin!.destroyed,
+          writable: child.stdin!.writable,
+        }).toEqual({
+          cb1: "EPIPE",
+          errEv: "EPIPE",
+          destroyed: true,
+          writable: false,
+        });
+
+        const cb2 = Promise.withResolvers<any>();
+        const r2 = child.stdin!.write("more-bytes", e => cb2.resolve(e));
+        const cb2Err = await cb2.promise;
+
+        expect({ r2, cb2: cb2Err?.code }).toEqual({ r2: false, cb2: "ERR_STREAM_DESTROYED" });
+      } finally {
+        child.kill("SIGKILL");
+      }
+    },
+  );
 });
 
 describe("execFile()", () => {


### PR DESCRIPTION
## Repro

```js
import { spawn } from "node:child_process";
const sleep = (ms) => new Promise((r) => setTimeout(r, ms));

const c = spawn("sh", ["-c", "exec 0<&-; sleep 1.5"], { stdio: ["pipe", "ignore", "ignore"] });
await sleep(400);
let errEv = "NO-ERROR-EVENT";
c.stdin.on("error", (e) => (errEv = e.code));
let cb1, cb2;
c.stdin.write(Buffer.alloc(65536, 0x41), (e) => (cb1 = e ? e.code : "success"));
await sleep(300);
console.log({ cb1, errEv, destroyed: c.stdin.destroyed, writable: c.stdin.writable });
const r2 = c.stdin.write("more-bytes", (e) => (cb2 = e ? e.code : "success"));
await sleep(300);
console.log({ r2, cb2 });
c.kill("SIGKILL");
```

|        | node v26.3.0 | bun 1.4.0 | bun (this PR) |
|--------|--------------|-----------|---------------|
| `cb1` / `errEv` | `EPIPE` / `EPIPE` | `EPIPE` / **no event** | `EPIPE` / `EPIPE` |
| `destroyed` / `writable` | `true` / `false` | **`false` / `true`** | `true` / `false` |
| `r2` / `cb2` | `false` / `ERR_STREAM_DESTROYED` | **`true` / `success`** | `false` / `ERR_STREAM_DESTROYED` |

A producer that doesn't attach a callback to every single write never learns the pipe broke; every write after the first failure vanishes into a dead pipe while reporting success.

## Cause

`child.stdin` is a `WriteStream` on the `FileSink` fast path (`writableFromFileSink`). Its `.write()` override `writeFast` in `src/js/internal/fs/streams.ts` bypasses the `Writable` state machine and, on sink rejection, called `cb(err)` but only `this.destroy(err)` when **no** callback was provided. Node's `onwriteError` calls the callback **and** `errorOrDestroy(stream, er)` unconditionally; the callback is additive, not a replacement for the `'error'` event.

Because the stream was never destroyed, the next `writeFast` call went straight to the (now-ended) sink again, which returned synchronously, and the success callback fired.

## Fix

- `writeFast` / `underscoreWriteFast`: route every sink write error through `errorOrDestroy()` regardless of whether a callback was supplied.
- `writeFast`: bail to `Writable.prototype.write` when the state is `destroyed` (in addition to `ending`), so a write after the first failure surfaces `ERR_STREAM_DESTROYED` instead of reaching the sink.
- Use two-arg `then(onFulfilled, onRejected)` so a throw from the fulfillment handler isn't caught as a write failure.

## Relation to #33485

\#33485 fixes the same `!hasCallback` guard in `writeFast` for the `process.stdout`-on-hung-up-tty case. It does not add the `state.destroyed` bail, so with that change alone the second write to a child's closed stdin still returns `true` with a success callback (verified against its branch). This PR is a superset on the `streams.ts` side and adds `child_process`-specific coverage; either can be closed in favor of the other once merged.

## Verification

```
bun bd test test/js/node/child_process/child_process.test.ts -t "stdin write failure"
```

Fails (timeout waiting for `'error'`) on 1.4.0, passes with the fix. Related suites all green: `fs.test.ts -t WriteStream`, `tty.test.ts`, `regression/issue/1632.test.ts`, `process-stdio.test.ts`, `child-process-stdio.test.js`, and node `test/parallel` `test-file-write-stream*`, `test-fs-write-stream-*`, `test-child-process-std*`, `test-process-external-stdio-close*`, `test-console-log-stdio-broken-dest`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/child_process/child_process.test.ts

<!-- robobun:evidence:end -->