### PR TITLE
JSCTaskScheduler: skip DeferredWorkTimer tasks once a worker is terminating

### DIFF
--- a/src/jsc/bindings/JSCTaskScheduler.cpp
+++ b/src/jsc/bindings/JSCTaskScheduler.cpp
@@ -1,5 +1,6 @@
 #include "config.h"
 #include <JavaScriptCore/VM.h>
+#include <JavaScriptCore/GlobalObjectMethodTable.h>
 #include "JSCTaskScheduler.h"
 #include "BunClientData.h"
 
@@ -96,7 +97,7 @@ void JSCTaskScheduler::onCancelPendingWork(WebCore::JSVMClientData* clientData, 
         Bun__eventLoop__incrementRefConcurrently(bunVM, -1);
 }
 
-static void runPendingWork(void* bunVM, Bun::JSCTaskScheduler& scheduler, JSCDeferredWorkTask* job)
+static void runPendingWork(JSC::VM& vm, void* bunVM, Bun::JSCTaskScheduler& scheduler, JSCDeferredWorkTask* job)
 {
     Locker<Lock> holder { scheduler.m_lock };
     auto pendingTicket = scheduler.m_pendingTicketsKeepingEventLoopAlive.take(job->ticket);
@@ -108,7 +109,16 @@ static void runPendingWork(void* bunVM, Bun::JSCTaskScheduler& scheduler, JSCDef
     holder.unlockEarly();
 
     if (pendingTicket && !pendingTicket->isCancelled()) {
-        job->task(job->ticket.get());
+        // Match DeferredWorkTimer::doWork: drop the task once script execution
+        // has stopped (worker.terminate()) or a TerminationException is pending.
+        // Task bodies (JSFinalizationRegistry::runFinalizationCleanup, waitAsync
+        // resolve) enter Interpreter::executeCallImpl, whose entry
+        // scope.assertNoException() aborts if the exception is already set.
+        auto* owner = job->ticket->scriptExecutionOwner();
+        auto* globalObject = owner->globalObject();
+        auto status = globalObject->globalObjectMethodTable()->scriptExecutionStatus(globalObject, owner);
+        if (status == JSC::ScriptExecutionStatus::Running && !vm.hasPendingTerminationException())
+            job->task(job->ticket.get());
     }
 
     delete job;
@@ -119,7 +129,7 @@ extern "C" void Bun__runDeferredWork(Bun::JSCDeferredWorkTask* job)
     auto& vm = job->vm();
     auto clientData = WebCore::clientData(vm);
 
-    runPendingWork(clientData->bunVM, clientData->deferredWorkTimer, job);
+    runPendingWork(vm, clientData->bunVM, clientData->deferredWorkTimer, job);
 }
 
 // Flip m_isShuttingDown from the owning JS thread before the final concurrent-

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -176,3 +176,61 @@ test.skipIf(!isASAN)(
   },
   timeout,
 );
+
+// Regression: Bun's DeferredWorkTimer replacement (JSCTaskScheduler) ran a
+// queued task even when script execution had stopped and a TerminationException
+// was pending, so JSFinalizationRegistry::runFinalizationCleanup entered
+// Interpreter::executeCallImpl with the exception set and tripped its
+// scope.assertNoException(). The sequence: terminate() lands between the
+// worker's entry-module completion and its first event-loop tick; spin()'s
+// initial GC collects the registered target and schedules the cleanup task;
+// an earlier task on the same tick throws the TerminationException; the next
+// tick runs the cleanup task with the exception still pending.
+test.skipIf(!isASAN && !isDebug)(
+  "terminate() with a pending FinalizationRegistry cleanup doesn't trip executeCallImpl assertNoException",
+  async () => {
+    const workerSrc = `
+      const reg = new FinalizationRegistry(() => {});
+      (function () { reg.register({}, 1); })();
+      globalThis.keepReg = reg;
+      setInterval(() => {}, 1e9);
+      postMessage("go");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { Worker } = require("node:worker_threads");
+        const src = ${JSON.stringify(workerSrc)};
+        for (let i = 0; i < 5; i++) {
+          const w = new Worker(src, { eval: true });
+          await new Promise((resolve, reject) => {
+            w.on("message", () => w.terminate());
+            w.on("error", reject);
+            w.on("exit", resolve);
+          });
+        }
+        console.log("done");
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({
+      stderr,
+      stdout: stdout.trim(),
+      exitCode,
+      signalCode: proc.signalCode,
+    }).toEqual({
+      stderr: "",
+      stdout: "done",
+      exitCode: 0,
+      signalCode: null,
+    });
+  },
+  timeout,
+);


### PR DESCRIPTION
Debug/ASAN abort when `worker.terminate()` lands while a `FinalizationRegistry` has a pending cleanup in the worker:

```
ASSERTION FAILED: (null)
!exception()
JavaScriptCore/ExceptionScope.h(61) : void JSC::ExceptionScope::assertNoException()
```

### Repro

```js
import { Worker } from "node:worker_threads";
const src = `
  const reg = new FinalizationRegistry(() => {});
  (function () { reg.register({}, 1); })();
  globalThis.keepReg = reg;
  setInterval(() => {}, 1e9);
  postMessage("go");
`;
const w = new Worker(src, { eval: true });
w.on("message", () => w.terminate());
await new Promise(r => w.on("exit", r));
```

Aborts reliably on a debug build. Also reachable via `fs.promises.open` in a worker (which registers a `FileHandle` with a `FinalizationRegistry`), which is how #34260 tripped over it, and via `node:diagnostics_channel` subscribe/unsubscribe (any dc-based APM in a worker pool).

### Cause

JSC schedules `FinalizationRegistry` cleanup (and `Atomics.waitAsync`, Wasm streaming compilation) through `DeferredWorkTimer`. JSC's own `DeferredWorkTimer::doWork` checks `scriptExecutionStatus` before each task and drops it on `Stopped`; it also bails when `vm.hasPendingTerminationException()`. Bun's replacement, `JSCTaskScheduler::runPendingWork`, does neither.

Sequence:

1. Worker entry module finishes (`setInterval` registered, `postMessage` sent).
2. Parent receives the message and calls `terminate()`; `notifyNeedTermination` sets the termination trap.
3. `spin()`'s initial `run_gc()` collects the registered target; `JSFinalizationRegistry::finalizeUnconditionally` schedules a `JSCDeferredWorkTask`.
4. The first event-loop tick runs a `CppTask` whose post-run `return_if_exception` handles the trap and throws the `TerminationException`; `tick()` returns with it pending. The `JSCDeferredWorkTask` is still in the queue.
5. `spin()`'s loop calls `tick()` again before its `requested_terminate` check. The `JSCDeferredWorkTask` runs, `runFinalizationCleanup` calls `JSC::call`, and `Interpreter::executeCallImpl`'s entry `scope.assertNoException()` fires.

Stack:

```
#5  JSC::JSFinalizationRegistry::runFinalizationCleanup
#6  JSC::JSFinalizationRegistry::finalizeUnconditionally::$_2::operator()
#9  Bun::runPendingWork
#10 Bun__runDeferredWork
#17 bun_jsc::event_loop::EventLoop::tick
#19 bun_jsc::web_worker::WebWorker::spin
```

### Fix

`runPendingWork`: gate on `scriptExecutionStatus == Running && !vm.hasPendingTerminationException()`, matching `DeferredWorkTimer::doWork`. The task is dropped instead of entering JS.

A dropped `FinalizationRegistry` cleanup is the expected behaviour: node runs no user JS after `terminate()`. Main-thread cleanups still fire, including after a transient `vm.runInNewContext(..., {timeout})` termination, since `scriptExecutionStatus` only reports `Stopped` for worker terminate or VM shutdown.

The `onScheduleWorkSoon` half of this (dropping tasks scheduled during `teardownJSCVM`'s `collectNow`) is already covered by `m_isShuttingDown`.

### Verification

New case in `test/js/web/workers/worker-terminate-lifetime.test.ts` (debug/ASAN-gated; the assert compiles to a no-op in release):

- `git stash push -- src/ && bun bd test ... -t FinalizationRegistry` → `SIGABRT`, `ASSERTION FAILED: !exception()`
- `git stash pop && bun bd test ... -t FinalizationRegistry` → pass
- `FinalizationRegistry` still fires on the main thread, including after `vm.runInNewContext(..., {timeout})` times out
- `test/js/web/atomics.test.ts`, `test/regression/issue/atomics-waitasync-wtftimer-uaf.test.ts` pass

Adjacent: #30857 adds exception reporting after the task runs in the same block; this change gates before it runs. Both are needed; whichever lands second rebases.
