### PR TITLE
buffer: wrap negative ucs2 indexOf offset against raw byte length for Buffer needles

### DIFF
--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -1615,9 +1615,10 @@ static int64_t lastIndexOf(const uint8_t* thisPtr, int64_t thisLength, const uin
 // upper bound of the search range. Returns true when a real search should run,
 // with *offsetOut / *searchEndOut set; otherwise *immediateResult holds the
 // value to return (the clamped offset for an empty needle, or -1).
-static bool computeIndexOfRange(size_t haystackLength, double byteOffsetD, double endD, size_t needleLength, bool isForward, size_t* offsetOut, size_t* searchEndOut, int64_t* immediateResult)
+static bool computeIndexOfRange(size_t haystackLength, double byteOffsetD, double endD, size_t needleLength, bool isForward, bool isUTF16, size_t* offsetOut, size_t* searchEndOut, int64_t* immediateResult)
 {
     size_t searchEnd = static_cast<size_t>(std::min<double>(std::max<double>(endD, 0), static_cast<double>(haystackLength)));
+    if (isUTF16) searchEnd &= ~static_cast<size_t>(1);
     ssize_t optOffset = indexOfOffset(haystackLength, static_cast<ssize_t>(byteOffsetD), static_cast<ssize_t>(needleLength), isForward);
 
     if (needleLength == 0) {
@@ -1655,7 +1656,7 @@ static int64_t indexOfNumber(JSC::JSGlobalObject* lexicalGlobalObject, bool last
     size_t byteOffset = 0;
     size_t searchEnd = 0;
     int64_t immediateResult = -1;
-    if (!computeIndexOfRange(byteLength, byteOffsetD, endD, 1, !last, &byteOffset, &searchEnd, &immediateResult))
+    if (!computeIndexOfRange(byteLength, byteOffsetD, endD, 1, !last, false, &byteOffset, &searchEnd, &immediateResult))
         return immediateResult;
 
     auto span = std::span<const uint8_t>(typedVector, searchEnd);
@@ -1689,17 +1690,19 @@ static int64_t indexOfString(JSC::JSGlobalObject* lexicalGlobalObject, bool last
     auto* arrayValue = uncheckedDowncast<JSC::JSUint8Array>(JSC::JSValue::decode(encodedBuffer));
     size_t needleLength = arrayValue->byteLength();
 
-    size_t haystackLength = isUTF16Encoding(encoding) ? byteLength & ~static_cast<size_t>(1) : byteLength;
+    const bool isUTF16 = isUTF16Encoding(encoding);
+    // Node's IndexOfString rounds haystack_length down to even for UCS2 before
+    // IndexOfOffset (unlike IndexOfBuffer, which uses the raw byte length).
+    size_t haystackLength = isUTF16 ? byteLength & ~static_cast<size_t>(1) : byteLength;
 
     size_t byteOffset = 0;
     size_t searchEnd = 0;
     int64_t immediateResult = -1;
-    if (!computeIndexOfRange(haystackLength, byteOffsetD, endD, needleLength, !last, &byteOffset, &searchEnd, &immediateResult))
+    if (!computeIndexOfRange(haystackLength, byteOffsetD, endD, needleLength, !last, isUTF16, &byteOffset, &searchEnd, &immediateResult))
         return immediateResult;
-    if (isUTF16Encoding(encoding)) searchEnd &= ~static_cast<size_t>(1);
 
     const uint8_t* typedVectorValue = arrayValue->typedVector();
-    if (isUTF16Encoding(encoding)) {
+    if (isUTF16) {
         return last ? lastIndexOf16(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset)
                     : indexOf16(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset);
     }
@@ -1710,17 +1713,18 @@ static int64_t indexOfString(JSC::JSGlobalObject* lexicalGlobalObject, bool last
 static int64_t indexOfBuffer(JSC::JSGlobalObject* lexicalGlobalObject, bool last, const uint8_t* typedVector, size_t byteLength, double byteOffsetD, double endD, JSC::JSGenericTypedArrayView<JSC::Uint8Adaptor>* array, BufferEncodingType encoding)
 {
     size_t needleLength = array->byteLength();
-    size_t haystackLength = isUTF16Encoding(encoding) ? byteLength & ~static_cast<size_t>(1) : byteLength;
+    const bool isUTF16 = isUTF16Encoding(encoding);
 
     size_t byteOffset = 0;
     size_t searchEnd = 0;
     int64_t immediateResult = -1;
-    if (!computeIndexOfRange(haystackLength, byteOffsetD, endD, needleLength, !last, &byteOffset, &searchEnd, &immediateResult))
+    // Node's IndexOfBuffer wraps negative offsets against the raw byte length,
+    // then floors to 16-bit units only for the search itself.
+    if (!computeIndexOfRange(byteLength, byteOffsetD, endD, needleLength, !last, isUTF16, &byteOffset, &searchEnd, &immediateResult))
         return immediateResult;
-    if (isUTF16Encoding(encoding)) searchEnd &= ~static_cast<size_t>(1);
 
     const uint8_t* typedVectorValue = array->typedVector();
-    if (isUTF16Encoding(encoding)) {
+    if (isUTF16) {
         return last ? lastIndexOf16(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset)
                     : indexOf16(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset);
     }

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -2439,7 +2439,9 @@ for (let withOverridenBufferWrite of [false, true]) {
           expect(h3.lastIndexOf(n, 0, enc)).toBe(0);
           expect(h3.lastIndexOf(n, -4, enc)).toBe(-1);
           expect(h3.indexOf(n, -3, enc)).toBe(0);
+          expect(h3.indexOf(n, -2, enc)).toBe(-1);
           expect(h3.indexOf(n, -1, enc)).toBe(-1);
+          expect(h3.indexOf(n, 1, enc)).toBe(-1);
         }
 
         // Even-length haystack is unchanged.

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -2427,10 +2427,9 @@ for (let withOverridenBufferWrite of [false, true]) {
       });
 
       it("lastIndexOf/indexOf(Buffer, negativeOffset, 'ucs2') wraps against the raw byte length on odd-length haystacks", () => {
-        // Node's IndexOfBuffer wraps a negative byteOffset against the full
-        // byte length and only then floors to 16-bit units; truncating to an
-        // even length first makes `-byteLength` land before the start and
-        // return -1 for data that is present.
+        // Node's IndexOfBuffer wraps a negative byteOffset against the full byte
+        // length and only then floors to 16-bit units; truncating to even first
+        // makes `-byteLength` land before the start and miss present data.
         const h3 = Buffer.from("bbc", "latin1"); // <62 62 63>
         const n = Buffer.from("bb", "latin1"); // <62 62>
         for (const enc of ["ucs2", "utf16le"]) {

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -2426,6 +2426,60 @@ for (let withOverridenBufferWrite of [false, true]) {
         expect(b.lastIndexOf("b", [])).toBe(-1);
       });
 
+      it("lastIndexOf/indexOf(Buffer, negativeOffset, 'ucs2') wraps against the raw byte length on odd-length haystacks", () => {
+        // Node's IndexOfBuffer wraps a negative byteOffset against the full
+        // byte length and only then floors to 16-bit units; truncating to an
+        // even length first makes `-byteLength` land before the start and
+        // return -1 for data that is present.
+        const h3 = Buffer.from("bbc", "latin1"); // <62 62 63>
+        const n = Buffer.from("bb", "latin1"); // <62 62>
+        for (const enc of ["ucs2", "utf16le"]) {
+          expect(h3.lastIndexOf(n, -3, enc)).toBe(0);
+          expect(h3.lastIndexOf(n, -2, enc)).toBe(0);
+          expect(h3.lastIndexOf(n, 0, enc)).toBe(0);
+          expect(h3.lastIndexOf(n, -4, enc)).toBe(-1);
+          expect(h3.indexOf(n, -3, enc)).toBe(0);
+          expect(h3.indexOf(n, -1, enc)).toBe(-1);
+        }
+
+        // Even-length haystack is unchanged.
+        expect(Buffer.from("bbcc", "latin1").lastIndexOf(n, -4, "ucs2")).toBe(0);
+
+        // 5-byte haystack: the wrapped offset must also floor to the correct
+        // 16-bit unit so the rightmost match is found.
+        const h5 = Buffer.from([0x62, 0x62, 0x62, 0x62, 0x63]);
+        expect(h5.lastIndexOf(n, -5, "ucs2")).toBe(0);
+        expect(h5.lastIndexOf(n, -3, "ucs2")).toBe(2);
+        expect(h5.lastIndexOf(n, -6, "ucs2")).toBe(-1);
+        // Odd-length needle: only the whole 16-bit unit participates.
+        const n3 = Buffer.from([0x62, 0x62, 0x62]);
+        expect(h5.lastIndexOf(n3, -5, "ucs2")).toBe(0);
+        expect(h5.lastIndexOf(n3, 0, "ucs2")).toBe(0);
+
+        // Empty Buffer needle on an odd-length haystack: the clamped result
+        // must reflect the raw-byte wrap, bounded by the even search end.
+        const empty = Buffer.alloc(0);
+        expect(h3.lastIndexOf(empty, -3, "ucs2")).toBe(0);
+        expect(h3.lastIndexOf(empty, -1, "ucs2")).toBe(2);
+        expect(h3.lastIndexOf(empty, 3, "ucs2")).toBe(2);
+        expect(h3.lastIndexOf(empty, undefined, "ucs2")).toBe(2);
+
+        // 1-byte haystack has no 16-bit units.
+        const h1 = Buffer.from([0x62]);
+        expect(h1.lastIndexOf(n, 0, "ucs2")).toBe(-1);
+        expect(h1.lastIndexOf(n, -1, "ucs2")).toBe(-1);
+        expect(h1.lastIndexOf(empty, 0, "ucs2")).toBe(0);
+
+        // String needles: Node's IndexOfString truncates the haystack length to
+        // even BEFORE wrapping (unlike IndexOfBuffer), so -byteLength on an
+        // odd-length haystack is before the start.
+        const sn = "\u6262"; // encodes as <62 62> in ucs2
+        expect(h3.lastIndexOf(sn, -3, "ucs2")).toBe(-1);
+        expect(h3.lastIndexOf(sn, -2, "ucs2")).toBe(0);
+        expect(h5.lastIndexOf(sn, -5, "ucs2")).toBe(-1);
+        expect(h5.lastIndexOf(sn, -3, "ucs2")).toBe(0);
+      });
+
       it("lastIndexOf(value, encoding) defaults to searching from the end", () => {
         // When the second argument is an encoding string (no byteOffset), the
         // search must start from the end of the buffer, matching Node.js.


### PR DESCRIPTION
## Reproduction

```js
const h = Buffer.from("bbc", "latin1");  // <62 62 63>
const n = Buffer.from("bb", "latin1");   // <62 62>
h.lastIndexOf(n, -3, "ucs2");  // bun: -1, node: 0
```

On an odd-length haystack, `byteOffset === -buf.length` wrongly returns -1 for data that is present. The same applies to `utf16le`, to `indexOf` at certain offsets, and to the empty-needle clamp.

## Cause

`indexOfBuffer` computed `haystackLength = byteLength & ~1` for UTF-16 encodings and passed that to `computeIndexOfRange`, which wraps negative offsets as `length + offset`. With `byteLength = 3`, `-3 + (3 & ~1) = -1` lands in the "before the start: no match" arm.

Node's [`IndexOfBuffer`](https://github.com/nodejs/node/blob/v26.3.0/src/node_buffer.cc#L1120) uses the raw byte length for `IndexOfOffset` and only floors to 16-bit units for the search itself. Node's [`IndexOfString`](https://github.com/nodejs/node/blob/v26.3.0/src/node_buffer.cc#L991-L992), by contrast, *does* truncate the haystack length to even before `IndexOfOffset`. Bun was applying the string-needle behavior to both paths.

## Fix

- `indexOfBuffer` now passes the raw `byteLength` to `computeIndexOfRange`.
- `indexOfString` keeps the even-truncated `haystackLength` (matching Node).
- The `searchEnd &= ~1` step moves inside `computeIndexOfRange` (via a new `isUTF16` flag) so the empty-needle clamp uses the even-truncated search end, again matching Node.

## Verification

`bun bd test test/js/node/buffer.test.js` (616 pass), `test/js/node/buffer-indexOf-detach.test.ts` (13 pass), and `test/js/node/test/parallel/test-buffer-indexof.js` all pass. A differential sweep over haystack lengths 0..7, needle lengths 0..4, offsets `-(hlen+2)..hlen+2`, both directions and both encoding names is byte-identical to Node v26.3.0.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/buffer.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (a3fa56257)

test/js/node/buffer.test.js:
(pass) with native Buffer.write > #9120 fill [89.53ms]
(pass) with native Buffer.write > #9120 alloc [59.77ms]
(pass) with native Buffer.write > isAscii [62.06ms]
(pass) with native Buffer.write > isUtf8 [60.99ms]
(pass) with native Buffer.write > Buffer global is settable [57.03ms]
(pass) with native Buffer.write > length overflow [58.77ms]
(pass) with native Buffer.write > truncate input values [238.62ms]
(pass) with native Buffer.write > Buffer.allocUnsafe() [56.03ms]
(pass) with native Buffer.write > Buffer.from() [58.58ms]
(pass) with native Buffer.write > offset properties [59.89ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array [65.55ms]
(pass) with native Buffer.writ
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (0fe7a9039)

test/js/node/buffer.test.js:
(pass) with native Buffer.write > #9120 fill [2.61ms]
(pass) with native Buffer.write > #9120 alloc [2.08ms]
(pass) with native Buffer.write > isAscii [2.02ms]
(pass) with native Buffer.write > isUtf8 [2.04ms]
(pass) with native Buffer.write > Buffer global is settable [2.17ms]
(pass) with native Buffer.write > length overflow [2.86ms]
(pass) with native Buffer.write > truncate input values [2.60ms]
(pass) with native Buffer.write > Buffer.allocUnsafe() [2.07ms]
(pass) with native Buffer.write > Buffer.from() [2.19ms]
(pass) with native Buffer.write > offset properties [2.26ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array [3.11ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array (old constructor) [2.07ms]
(pass) with native Buffer.write > invalid encoding [2.23ms]
(pass) with native Buffer.write > create 0-length buffers [2.37ms]
(pass) with native Buffer.write > write() beyond end of buffer [2.73ms]
(pass) with native Buffer.write > write BigInt beyond 64-bit range [2.79ms]
(pass) with native Buffer.write > write BigInt64 with insufficient buffer space
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/buffer.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (a3fa56257)

test/js/node/buffer.test.js:
(pass) with native Buffer.write > #9120 fill [83.11ms]
(pass) with native Buffer.write > #9120 alloc [58.77ms]
(pass) with native Buffer.write > isAscii [63.11ms]
(pass) with native Buffer.write > isUtf8 [68.71ms]
(pass) with native Buffer.write > Buffer global is settable [63.01ms]
(pass) with native Buffer.write > length overflow [62.05ms]
(pass) with native Buffer.write > truncate input values [247.18ms]
(pass) with native Buffer.write > Buffer.allocUnsafe() [58.54ms]
(pass) with native Buffer.write > Buffer.from() [64.59ms]
(pass) with native Buffer.write > offset properties [64.76ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array [74.05ms]
(pass) with native Buffer.writ
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 753ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[2/8] gen cpp.rs (cppbind)
[2/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/worksp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSBuffer.cpp | 24 +++++++++++--------
 test/js/node/buffer.test.js   | 55 +++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 69 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/jsc/bindings/JSBuffer.cpp      2      4      0
test/js/node/buffer.test.js        2      3      0
```

</details>

<!-- robobun:evidence:end -->