### PR TITLE
Buffer: carry size_t through toString/write so length 2^32 doesn't wrap to 0

### DIFF
--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -323,7 +323,7 @@ static std::optional<JSString*> resolveEncodingString(JSC::ThrowScope& scope, JS
 // Matches Node's validateOffset (lib/buffer.js), which is validateInteger and
 // therefore renders its range as ">= min && <= max", unlike boundsError's
 // ">= min and <= max".
-uint32_t validateOffset(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSC::JSValue value, JSC::JSValue name, uint32_t min, uint32_t max)
+size_t validateOffset(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSC::JSValue value, JSC::JSValue name, size_t min, size_t max)
 {
     if (!value.isNumber()) [[unlikely]]
         return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, name, "number"_s, value);
@@ -332,10 +332,9 @@ uint32_t validateOffset(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObjec
         return Bun::ERR::OUT_OF_RANGE(scope, globalObject, name, "an integer"_s, value);
     if (value_num < min || value_num > max) [[unlikely]]
         return Bun::ERR::OUT_OF_RANGE(scope, globalObject, name, makeString(">= "_s, min, " && <= "_s, max), value);
-    uint32_t result = JSC::toInt32(value_num);
-    return result;
+    return static_cast<size_t>(value_num);
 }
-uint32_t validateOffset(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSC::JSValue value, WTF::ASCIILiteral name, uint32_t min, uint32_t max)
+size_t validateOffset(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSC::JSValue value, WTF::ASCIILiteral name, size_t min, size_t max)
 {
     if (!value.isNumber()) [[unlikely]]
         return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, name, "number"_s, value);
@@ -344,8 +343,7 @@ uint32_t validateOffset(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObjec
         return Bun::ERR::OUT_OF_RANGE(scope, globalObject, name, "an integer"_s, value);
     if (value_num < min || value_num > max) [[unlikely]]
         return Bun::ERR::OUT_OF_RANGE(scope, globalObject, name, makeString(">= "_s, min, " && <= "_s, max), value);
-    uint32_t result = JSC::toInt32(value_num);
-    return result;
+    return static_cast<size_t>(value_num);
 }
 
 namespace WebCore {
@@ -414,7 +412,7 @@ JSC::EncodedJSValue JSBuffer__bufferFromPointerAndLengthAndDeinit(JSC::JSGlobalO
 namespace WebCore {
 using namespace JSC;
 
-static JSC::EncodedJSValue writeToBuffer(JSC::JSGlobalObject* lexicalGlobalObject, JSArrayBufferView* castedThis, JSString* str, uint32_t offset, uint32_t length, BufferEncodingType encoding)
+static JSC::EncodedJSValue writeToBuffer(JSC::JSGlobalObject* lexicalGlobalObject, JSArrayBufferView* castedThis, JSString* str, size_t offset, size_t length, BufferEncodingType encoding)
 {
     if (str->length() == 0) [[unlikely]]
         return JSC::JSValue::encode(JSC::jsNumber(0));
@@ -2291,9 +2289,9 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_toStringBody(JSC::JSGlobalO
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    uint32_t start = 0;
-    uint32_t end = castedThis->byteLength();
-    uint32_t byteLength = end;
+    size_t start = 0;
+    size_t end = castedThis->byteLength();
+    size_t byteLength = end;
     WebCore::BufferEncodingType encoding = WebCore::BufferEncodingType::utf8;
 
     if (end == 0)
@@ -2315,15 +2313,13 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_toStringBody(JSC::JSGlobalO
 
     auto fstart = arg2.toNumber(lexicalGlobalObject);
     RETURN_IF_EXCEPTION(scope, {});
-    if (fstart < 0) {
-        fstart = 0;
-        goto lstart;
-    }
-    if (fstart > byteLength) {
+    if (!(fstart >= 0)) {
+        start = 0;
+    } else if (fstart > byteLength) {
         return JSC::JSValue::encode(JSC::jsEmptyString(vm));
+    } else {
+        start = static_cast<size_t>(fstart);
     }
-    start = truncateDoubleToUint32(fstart);
-lstart:
 
     if (!arg3.isUndefined()) {
         auto lend = arg3.toLength(lexicalGlobalObject);
@@ -2582,8 +2578,8 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_writeBody(JSC::JSGlobalObje
     auto lengthValue = callFrame->argument(2);
     auto encodingValue = callFrame->argument(3);
 
-    uint32_t offset;
-    uint32_t length;
+    size_t offset;
+    size_t length;
 
     if (offsetValue.isUndefined()) {
         Bun::V::validateString(scope, lexicalGlobalObject, stringValue, "string"_s);
@@ -2611,7 +2607,7 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_writeBody(JSC::JSGlobalObje
         length = castedThis->byteLength();
         offset = validateOffset(scope, lexicalGlobalObject, offsetValue, "offset"_s, 0, length);
         RETURN_IF_EXCEPTION(scope, {});
-        uint32_t remaining = castedThis->byteLength() - offset;
+        size_t remaining = castedThis->byteLength() - offset;
 
         if (lengthValue.isUndefined()) {
             length = remaining;
@@ -2642,10 +2638,10 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_writeBody(JSC::JSGlobalObje
         throwTypeError(lexicalGlobalObject, scope, "ArrayBufferView is detached"_s);
         return {};
     }
-    uint32_t currentByteLength = castedThis->byteLength();
+    size_t currentByteLength = castedThis->byteLength();
     if (offset >= currentByteLength)
         RELEASE_AND_RETURN(scope, JSValue::encode(jsNumber(0)));
-    uint32_t currentRemaining = currentByteLength - offset;
+    size_t currentRemaining = currentByteLength - offset;
     if (length > currentRemaining) length = currentRemaining;
 
     RELEASE_AND_RETURN(scope, writeToBuffer(lexicalGlobalObject, castedThis, str, offset, length, encoding));

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -2,6 +2,7 @@ import { Buffer, SlowBuffer, isAscii, isUtf8, kMaxLength } from "buffer";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, gc, isASAN, isDebug, nodeExe, withoutAggressiveGC } from "harness";
 import { createHash } from "node:crypto";
+import os from "node:os";
 import { join } from "node:path";
 import vm from "node:vm";
 
@@ -4530,3 +4531,62 @@ describe("Buffer.prototype.toString binary-to-text encodings", () => {
     });
   });
 });
+
+// MAX_LENGTH is 2**32 on 64-bit: a buffer of exactly that length must not
+// hit the uint32 truncation path that made toString()/write() see length 0.
+it.skipIf(os.totalmem() < 10 * 1024 ** 3)(
+  "Buffer of length exactly MAX_LENGTH (2**32) supports toString/write without uint32 wrap",
+  async () => {
+    const script = `
+      const assert = require("assert");
+      const N = 2 ** 32;
+      const b = Buffer.alloc(N);
+      assert.strictEqual(b.length, N);
+      b.set([0x71, 0x72, 0x73], N - 3);
+
+      const out = {};
+      for (const enc of ["latin1", "utf8", "hex", "base64", "ucs2"]) {
+        try { b.toString(enc); out["full_" + enc] = "no throw"; }
+        catch (e) { out["full_" + enc] = e.code; }
+      }
+      out.ranged_latin1 = b.toString("latin1", N - 4, N);
+      out.ranged_hex = b.toString("hex", N - 4, N);
+      out.ranged_utf8_start0 = b.toString("utf8", 0, 3);
+      out.write_ret = b.write("xyz", N - 3);
+      out.after_write = b.toString("latin1", N - 3, N);
+      out.write_enc_ret = b.write("ab", N - 2, "latin1");
+      out.after_write_enc = b.toString("latin1", N - 2, N);
+      out.write_full = b.write("hi");
+      try { b.write("x", N + 1); out.write_oob = "no throw"; }
+      catch (e) { out.write_oob = e.code; }
+      console.log(JSON.stringify(out));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...bunEnv, BUN_GARBAGE_COLLECTOR_LEVEL: "0" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr }).toEqual({
+      stdout: JSON.stringify({
+        full_latin1: "ERR_STRING_TOO_LONG",
+        full_utf8: "ERR_STRING_TOO_LONG",
+        full_hex: "ERR_STRING_TOO_LONG",
+        full_base64: "ERR_STRING_TOO_LONG",
+        full_ucs2: "ERR_STRING_TOO_LONG",
+        ranged_latin1: "\x00qrs",
+        ranged_hex: "00717273",
+        ranged_utf8_start0: "\x00\x00\x00",
+        write_ret: 3,
+        after_write: "xyz",
+        write_enc_ret: 2,
+        after_write_enc: "ab",
+        write_full: 2,
+        write_oob: "ERR_OUT_OF_RANGE",
+      }),
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  },
+);


### PR DESCRIPTION
## Reproduction

```js
// needs ~4 GiB RAM
import { constants } from "node:buffer";
console.log(constants.MAX_LENGTH);      // 4294967296
const N = 2 ** 32;
const b = Buffer.alloc(N);              // succeeds, b.length === 4294967296
b.set([0x71, 0x72, 0x73], N - 3);

b.toString("latin1");                   // bun: ""        node: throws ERR_STRING_TOO_LONG
b.toString("latin1", N - 4, N);         // bun: ""        node: "\x00qrs"
b.write("xyz", N - 3);                  // bun: throws ERR_OUT_OF_RANGE (max=0)   node: 3
```

`buffer.constants.MAX_LENGTH` is `2**32` on 64-bit and `Buffer.alloc(2**32)` succeeds, but the first `toString()` on the result silently returned `""` and `write()` at any offset threw `ERR_OUT_OF_RANGE ... must be >= 0 && <= 0`.

## Cause

`jsBufferPrototypeFunction_toStringBody` and `jsBufferPrototypeFunction_writeBody` in `src/jsc/bindings/JSBuffer.cpp` loaded `castedThis->byteLength()` into `uint32_t`, so `2**32` truncated to `0`:

* `toStringBody` hit its `if (end == 0) return jsEmptyString` fast path for every encoding, and its ranged form compared against the wrapped `byteLength`.
* `writeBody` passed `max = 0` to `validateOffset`, so every offset failed the range check.

`validateOffset` and `writeToBuffer` also took `uint32_t` offset/length.

## Fix

Widen start/end/offset/length/byteLength to `size_t` through `validateOffset`, `writeToBuffer`, `toStringBody`, and `writeBody`. `jsBufferToString` / `jsBufferToStringFromBytes` already used `size_t` and already throw `ERR_STRING_TOO_LONG` for oversized output, so once the true length reaches them the full-buffer `toString()` throws as Node does.

The `start` coercion in `toStringBody` previously relied on `truncateDoubleToUint32` turning NaN into 0; the replacement checks `!(fstart >= 0)` explicitly before casting.

Indexed element access (`b[2**32 - 1] === undefined`) is a separate JSC-level `Uint8Array` indexing limitation (2^32-1 is not an ECMA array index) and is not addressed here; it reproduces on a plain `new Uint8Array(2**32)` as well.

## Verification

New test in `test/js/node/buffer.test.js` spawns a subprocess that allocates a `Buffer.alloc(2**32)` and asserts for every encoding that full `toString()` throws `ERR_STRING_TOO_LONG`, ranged `toString()` returns the correct bytes, and `write()` near the top writes and reads back correctly. Output matches Node byte-for-byte. The test is skipped on machines with < 10 GiB RAM.

```
USE_SYSTEM_BUN=1 bun test test/js/node/buffer.test.js -t "Buffer of length exactly MAX_LENGTH"   # fails
bun bd test test/js/node/buffer.test.js -t "Buffer of length exactly MAX_LENGTH"                  # passes
bun bd test test/js/node/buffer.test.js                                                           # 615 pass, 1 skip
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/buffer.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (10610464c)

test/js/node/buffer.test.js:
(pass) with native Buffer.write > #9120 fill [79.22ms]
(pass) with native Buffer.write > #9120 alloc [57.28ms]
(pass) with native Buffer.write > isAscii [59.16ms]
(pass) with native Buffer.write > isUtf8 [58.86ms]
(pass) with native Buffer.write > Buffer global is settable [56.54ms]
(pass) with native Buffer.write > length overflow [57.07ms]
(pass) with native Buffer.write > truncate input values [234.22ms]
(pass) with native Buffer.write > Buffer.allocUnsafe() [55.51ms]
(pass) with native Buffer.write > Buffer.from() [56.28ms]
(pass) with native Buffer.write > offset properties [61.55ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array [71.60ms]
(pass) with native Buffer.writ
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (6a95f68f8)

test/js/node/buffer.test.js:
(pass) with native Buffer.write > #9120 fill [4.75ms]
(pass) with native Buffer.write > #9120 alloc [1.80ms]
(pass) with native Buffer.write > isAscii [1.68ms]
(pass) with native Buffer.write > isUtf8 [1.75ms]
(pass) with native Buffer.write > Buffer global is settable [1.68ms]
(pass) with native Buffer.write > length overflow [2.56ms]
(pass) with native Buffer.write > truncate input values [2.14ms]
(pass) with native Buffer.write > Buffer.allocUnsafe() [1.82ms]
(pass) with native Buffer.write > Buffer.from() [1.77ms]
(pass) with native Buffer.write > offset properties [1.77ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array [2.13ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array (old constructor) [1.95ms]
(pass) with native Buffer.write > invalid encoding [1.93ms]
(pass) with native Buffer.write > create 0-length buffers [1.74ms]
(pass) with native Buffer.write > write() beyond end of buffer [2.04ms]
(pass) with native Buffer.write > write BigInt beyond 64-bit range [2.07ms]
(pass) with native Buffer.write > write BigInt64 with insufficient buffer space
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/buffer.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (10610464c)

test/js/node/buffer.test.js:
(pass) with native Buffer.write > #9120 fill [82.26ms]
(pass) with native Buffer.write > #9120 alloc [59.33ms]
(pass) with native Buffer.write > isAscii [58.97ms]
(pass) with native Buffer.write > isUtf8 [58.20ms]
(pass) with native Buffer.write > Buffer global is settable [55.19ms]
(pass) with native Buffer.write > length overflow [60.36ms]
(pass) with native Buffer.write > truncate input values [232.60ms]
(pass) with native Buffer.write > Buffer.allocUnsafe() [54.13ms]
(pass) with native Buffer.write > Buffer.from() [56.35ms]
(pass) with native Buffer.write > offset properties [55.64ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array [65.13ms]
(pass) with native Buffer.writ
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 739ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/24] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[2/24] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[3/24] gen cpp.rs (cppbind)
[4/24] gen JS modules (bundle-modules)
Preprocess modules (6810ms)
Bundle modules (31ms)
Postprocesss modules (157ms)
Bundle Functions (723ms)
Generate Code (97ms)

[7.83s] Bundled "src/js" for production
  1911 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[4/11] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
inf
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSBuffer.cpp | 40 +++++++++++++----------------
 test/js/node/buffer.test.js   | 60 +++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 78 insertions(+), 22 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/jsc/bindings/JSBuffer.cpp      3      6      0
test/js/node/buffer.test.js        2      2      0
```

</details>

<!-- robobun:evidence:end -->