### PR TITLE
fix(glob): count escape backslashes at the right offset in detect_glob_syntax

### DIFF
--- a/src/glob/lib.rs
+++ b/src/glob/lib.rs
@@ -32,8 +32,12 @@ pub fn detect_glob_syntax(potential_pattern: &[u8]) -> bool {
         while !slice.is_empty() {
             if let Some(idx) = slice.iter().position(|&b| b == token) {
                 // Check for even number of backslashes preceding the
-                // token to know that it's not escaped
-                let mut i = idx;
+                // token to know that it's not escaped. `idx` is relative to
+                // `slice`, so rebase it onto `potential_pattern` before
+                // counting — otherwise, once an escaped token has been
+                // skipped, the backslashes are counted at the wrong offset
+                // (e.g. `\*x*` reported no glob syntax).
+                let mut i = potential_pattern.len() - slice.len() + idx;
                 let mut backslash_count: u16 = 0;
 
                 while i > 0 && potential_pattern[i - 1] == b'\\' {
@@ -52,4 +56,39 @@ pub fn detect_glob_syntax(potential_pattern: &[u8]) -> bool {
     }
 
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::detect_glob_syntax;
+
+    #[test]
+    fn detects_unescaped_tokens() {
+        assert!(detect_glob_syntax(b"*.ts"));
+        assert!(detect_glob_syntax(b"a/{b,c}/d"));
+        assert!(detect_glob_syntax(b"a[bc]d"));
+        assert!(detect_glob_syntax(b"a?c"));
+        assert!(detect_glob_syntax(b"!foo"));
+    }
+
+    #[test]
+    fn ignores_escaped_tokens() {
+        assert!(!detect_glob_syntax(b"a\\*b"));
+        assert!(!detect_glob_syntax(b"a\\{b\\}c"));
+        assert!(!detect_glob_syntax(b"plain/path.txt"));
+        // even backslash count = escaped backslash, unescaped token
+        assert!(detect_glob_syntax(b"a\\\\*b"));
+    }
+
+    #[test]
+    fn detects_unescaped_token_after_escaped_one() {
+        // Regression: backslashes were counted at a slice-relative offset,
+        // so any unescaped token after an escaped one went undetected.
+        assert!(detect_glob_syntax(b"\\*x*"));
+        assert!(detect_glob_syntax(b"\\{a\\}{b,c}"));
+        assert!(detect_glob_syntax(b"\\?a?"));
+        assert!(detect_glob_syntax(b"\\[a\\]b[cd]"));
+        // ...while all-escaped stays undetected
+        assert!(!detect_glob_syntax(b"\\*x\\*"));
+    }
 }


### PR DESCRIPTION
### What does this PR do?

Fixes an indexing bug in `detect_glob_syntax` (`src/glob/lib.rs`): the function searches for special tokens (`*`, `{`, `[`, `?`) in a slice that advances past escaped occurrences, but counts the preceding backslashes at the **slice-relative** index into the **full** pattern:

```rust
if let Some(idx) = slice.iter().position(|&b| b == token) {
    let mut i = idx;                                   // relative to `slice`
    while i > 0 && potential_pattern[i - 1] == b'\\' { // indexes the full pattern
```

The first iteration is correct (`slice == potential_pattern`), so the bug only fires after at least one escaped token has been skipped: every later token is then checked at the wrong offset.

**Example:** `\\*x*` (escaped star, then a real one) returns `false`. Walking it: the first `*` is correctly seen as escaped and skipped; the second `*` at slice index 1 checks `potential_pattern[0]` — the backslash at the front of the string, not the `x` that actually precedes it — and is wrongly treated as escaped too.

**Impact:** `detect_glob_syntax` gates workspace expansion in `bun install` (`WorkspaceMap.rs`) — a `workspaces` entry with an escaped token followed by an unescaped one is treated as a literal path instead of being expanded as a glob.

**Fix:** rebase the match index onto the full pattern before counting:

```rust
let mut i = potential_pattern.len() - slice.len() + idx;
```

### How did you verify your code works?

Added unit tests to `src/glob/lib.rs` covering unescaped, escaped, and escaped-then-unescaped tokens for all four special tokens, plus the even-backslash (escaped backslash) case. The regression cases fail before this change and pass after.