### PR TITLE
worker: mark the context terminating before the final concurrent-queue drain

### DIFF
--- a/src/jsc/bindings/ScriptExecutionContext.cpp
+++ b/src/jsc/bindings/ScriptExecutionContext.cpp
@@ -253,6 +253,18 @@ void ScriptExecutionContext::removeFromContextsMap()
     allScriptExecutionContextsMap().remove(m_identifier);
 }
 
+void ScriptExecutionContext::markTerminating()
+{
+    // postTaskTo() holds this lock across its isTerminating() check and
+    // postTaskConcurrently() enqueue. Taking it here establishes an ordering
+    // with every concurrent poster: either its whole critical section ran
+    // before ours (task enqueued, and the caller's subsequent concurrent-queue
+    // drain will see it), or ours ran first (poster observes true and drops
+    // the task instead of enqueueing onto a queue that will never drain).
+    Locker locker { allScriptExecutionContextsMapLock };
+    m_isTerminating.store(true, std::memory_order_release);
+}
+
 ScriptExecutionContext* executionContext(JSC::JSGlobalObject* globalObject)
 {
     if (!globalObject || !globalObject->inherits<JSDOMGlobalObject>())
@@ -288,6 +300,12 @@ extern "C" JSC::JSGlobalObject* ScriptExecutionContextIdentifier__getGlobalObjec
     auto* context = ScriptExecutionContext::getScriptExecutionContext(id);
     if (!context) return nullptr;
     return context->globalObject();
+}
+
+extern "C" void ScriptExecutionContext__markTerminating(JSC::JSGlobalObject* globalObject)
+{
+    if (auto* context = defaultGlobalObject(globalObject)->scriptExecutionContext())
+        context->markTerminating();
 }
 
 } // namespace WebCore

--- a/src/jsc/bindings/ScriptExecutionContext.h
+++ b/src/jsc/bindings/ScriptExecutionContext.h
@@ -130,7 +130,10 @@ public:
 
     // Set once when the context is permanently shutting down (WebWorker__teardownJSCVM).
     // Unlike VM::hasTerminationRequest(), never set transiently (node:vm {timeout}).
-    void markTerminating() { m_isTerminating.store(true, std::memory_order_release); }
+    // Takes allScriptExecutionContextsMapLock so it serializes with postTaskTo's
+    // check-then-enqueue; a caller that drains the concurrent queue after this
+    // returns will observe every task enqueued before the flag flipped.
+    void markTerminating();
     bool isTerminating() const { return m_isTerminating.load(std::memory_order_acquire); }
 
     // Non-null once this thread joins a `worker_threads` SHARE_ENV tree; every

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -204,6 +204,9 @@ unsafe extern "C" {
     // ABI-identical to non-null `*const`); C++ mutating VM state through it is
     // interior to the cell.
     safe fn WebWorker__teardownJSCVM(global: &JSGlobalObject);
+    // safe: opaque `&JSGlobalObject` handle (see above); takes the contexts-map
+    // lock and flips an atomic flag, no Rust-visible state touched.
+    safe fn ScriptExecutionContext__markTerminating(global: &JSGlobalObject);
     // safe: `cpp_worker` is an opaque round-trip pointer owned by C++ (allocated
     // there, stored in `WebWorker.cpp_worker`, and only ever passed back to C++
     // — never dereferenced as Rust data); same contract as `JSC__VM__holdAPILock`'s
@@ -1277,6 +1280,15 @@ impl WebWorker {
                 // is step 3 below).
                 rare.close_all_socket_groups(unsafe { &*vm_ptr });
             }
+            // Stop cross-thread posters first: markTerminating() serializes
+            // with postTaskTo() on the contexts-map lock, so after this call
+            // every task another thread has already enqueued is visible to the
+            // drain below and no new one can land. teardownJSCVM() will call
+            // it again (redundantly) after the drain; without this earlier
+            // call a parent-side MessagePort ack (worker stdio backpressure)
+            // posted in the gap would sit in concurrent_tasks past the raw VM
+            // dealloc and leak under LSan.
+            ScriptExecutionContext__markTerminating(vm.global());
             // Reclaim queued CppTasks (the per-worker stdio/messaging
             // MessagePort drain tasks that can be in self.tasks mid-tick when
             // terminate() lands, and any Worker dispatchExit close task from a

--- a/test/js/node/worker_threads/worker-shutdown-post-leak.test.ts
+++ b/test/js/node/worker_threads/worker-shutdown-post-leak.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isWindows } from "harness";
+import { join } from "path";
+
+// A worker's shutdown used to drain its concurrent queue and only then mark
+// the context terminating. A cross-thread postTaskTo landing in between (the
+// parent's stdio-backpressure ack, any MessagePort scheduleDrain) was enqueued
+// onto a queue that is never drained again, leaking the ConcurrentTask +
+// EventLoopTask. The window is a handful of instructions so debug builds
+// essentially never hit it; CI's release-asan lane does (see
+// test/js/node/test/parallel/test-worker-stdio-flush.js). This runs the
+// worker-stdio-on-exit scenario under LSan as a guard on the asan lane.
+test.skipIf(!isASAN || isWindows)(
+  "cross-thread MessagePort post during worker shutdown does not leak a ConcurrentTask",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const { Worker } = require("worker_threads");
+          const assert = require("assert");
+          const w = new Worker(
+            'process.on("exit", () => {' +
+            '  process.stdout.write(" ");' +
+            '  process.stdout.write("world");' +
+            '});' +
+            'process.stdout.write("hello");',
+            { eval: true, stdout: true },
+          );
+          let data = "";
+          w.stdout.setEncoding("utf8");
+          w.stdout.on("data", chunk => { data += chunk; });
+          w.on("exit", () => assert.strictEqual(data, "hello world"));
+        `,
+      ],
+      env: {
+        ...bunEnv,
+        BUN_DESTRUCT_VM_ON_EXIT: "1",
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+        LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+  },
+);

--- a/test/js/node/worker_threads/worker_destruction.test.ts
+++ b/test/js/node/worker_threads/worker_destruction.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import "harness";
-import { bunEnv, bunExe, isASAN, isBroken, isWindows } from "harness";
+import { isBroken } from "harness";
 import { join } from "path";
 
 describe("Worker destruction", () => {
@@ -11,50 +11,4 @@ describe("Worker destruction", () => {
       expect([join(import.meta.dir, "worker_thread_check.ts"), method]).toRun();
     });
   });
-
-  // A worker's shutdown drains its concurrent queue and only then marks the
-  // context terminating. A cross-thread postTaskTo that lands in between
-  // (parent acking a worker.stdout write, a MessagePort scheduleDrain) used to
-  // be enqueued onto a queue that is never drained again, leaking the
-  // ConcurrentTask + EventLoopTask. The window is a handful of instructions so
-  // debug builds essentially never hit it; CI's release-asan lane does (see
-  // test/js/node/test/parallel/test-worker-stdio-flush.js). This test runs the
-  // worker-stdio-on-exit scenario under LSan as a guard.
-  test.skipIf(!isASAN || isWindows)(
-    "cross-thread MessagePort post during worker shutdown does not leak a ConcurrentTask",
-    async () => {
-      await using proc = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "-e",
-          `
-            const { Worker } = require("worker_threads");
-            const assert = require("assert");
-            const w = new Worker(
-              'process.on("exit", () => {' +
-              '  process.stdout.write(" ");' +
-              '  process.stdout.write("world");' +
-              '});' +
-              'process.stdout.write("hello");',
-              { eval: true, stdout: true },
-            );
-            let data = "";
-            w.stdout.setEncoding("utf8");
-            w.stdout.on("data", chunk => { data += chunk; });
-            w.on("exit", () => assert.strictEqual(data, "hello world"));
-          `,
-        ],
-        env: {
-          ...bunEnv,
-          BUN_DESTRUCT_VM_ON_EXIT: "1",
-          ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
-          LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
-        },
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
-    },
-  );
 });

--- a/test/js/node/worker_threads/worker_destruction.test.ts
+++ b/test/js/node/worker_threads/worker_destruction.test.ts
@@ -28,7 +28,7 @@ describe("Worker destruction", () => {
           bunExe(),
           "-e",
           `
-            const { Worker, isMainThread } = require("worker_threads");
+            const { Worker } = require("worker_threads");
             const assert = require("assert");
             const w = new Worker(
               'process.on("exit", () => {' +
@@ -56,6 +56,5 @@ describe("Worker destruction", () => {
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
     },
-    30_000,
   );
 });

--- a/test/js/node/worker_threads/worker_destruction.test.ts
+++ b/test/js/node/worker_threads/worker_destruction.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import "harness";
-import { isBroken } from "harness";
+import { bunEnv, bunExe, isASAN, isBroken, isWindows } from "harness";
 import { join } from "path";
 
 describe("Worker destruction", () => {
@@ -11,4 +11,51 @@ describe("Worker destruction", () => {
       expect([join(import.meta.dir, "worker_thread_check.ts"), method]).toRun();
     });
   });
+
+  // A worker's shutdown drains its concurrent queue and only then marks the
+  // context terminating. A cross-thread postTaskTo that lands in between
+  // (parent acking a worker.stdout write, a MessagePort scheduleDrain) used to
+  // be enqueued onto a queue that is never drained again, leaking the
+  // ConcurrentTask + EventLoopTask. The window is a handful of instructions so
+  // debug builds essentially never hit it; CI's release-asan lane does (see
+  // test/js/node/test/parallel/test-worker-stdio-flush.js). This test runs the
+  // worker-stdio-on-exit scenario under LSan as a guard.
+  test.skipIf(!isASAN || isWindows)(
+    "cross-thread MessagePort post during worker shutdown does not leak a ConcurrentTask",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const { Worker, isMainThread } = require("worker_threads");
+            const assert = require("assert");
+            const w = new Worker(
+              'process.on("exit", () => {' +
+              '  process.stdout.write(" ");' +
+              '  process.stdout.write("world");' +
+              '});' +
+              'process.stdout.write("hello");',
+              { eval: true, stdout: true },
+            );
+            let data = "";
+            w.stdout.setEncoding("utf8");
+            w.stdout.on("data", chunk => { data += chunk; });
+            w.on("exit", () => assert.strictEqual(data, "hello world"));
+          `,
+        ],
+        env: {
+          ...bunEnv,
+          BUN_DESTRUCT_VM_ON_EXIT: "1",
+          ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+          LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    },
+    30_000,
+  );
 });


### PR DESCRIPTION
## Problem

`test/js/node/test/parallel/test-worker-stdio-flush.js` went red on the `debian 13 x64-asan` lane of [build 73374](https://buildkite.com/bun/bun/builds/73374) with:

```
==18202==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 32 byte(s) in 1 object(s) allocated from:
    #9  ConcurrentTask::new src/event_loop/ConcurrentTask.rs:305
    #10 ConcurrentTask::create src/event_loop/ConcurrentTask.rs:319
    #12 bun_jsc::virtual_machine_exports::queue_task_concurrently src/jsc/virtual_machine_exports.rs:140
    #13 ScriptExecutionContext::postTaskConcurrently src/jsc/bindings/ScriptExecutionContext.cpp:266
    #14 ScriptExecutionContext::postTaskTo src/jsc/bindings/ScriptExecutionContext.cpp:125
    #15 MessagePortPipe::scheduleDrain src/jsc/bindings/webcore/MessagePortPipe.cpp:74
    #16 MessagePort::postMessage src/jsc/bindings/webcore/MessagePort.cpp:143
```

The leaked allocation is a `ConcurrentTask` (and the `EventLoopTask` it wraps) left in an exiting worker's `concurrent_tasks` queue after the queue has been drained for the last time.

## Cause

`WebWorker::shutdown()` runs `process.on('exit')` handlers, then drains the worker's concurrent queue via `release_queued_tasks_for_shutdown()`, then enters `WebWorker__teardownJSCVM` which (first thing) calls `ctx->markTerminating()`. `ScriptExecutionContext::postTaskTo` already refuses to enqueue onto a terminating context, but between the drain and the flag flip there is a short window where a cross-thread poster still sees `isTerminating() == false` and enqueues.

In the failing test the worker writes to `process.stdout` inside its `exit` handler. The parent's captured-stdout reader acks each chunk with `port.postMessage(true)` (`src/js/node/worker_threads.ts` `makePortReadable._read`), which routes through `MessagePortPipe::scheduleDrain` to `postTaskTo(workerCtxId, ...)`. When the ack lands in that window it is pushed onto the worker's `concurrent_tasks`; nothing drains it again, and the worker's VM box is `dealloc`'d raw, so LSan reports the `ConcurrentTask` as a direct leak.

The window is a few assignments plus one FFI call wide, so it hits probabilistically; the `release-asan` build is fast enough to line up occasionally, debug essentially never.

The ordering was introduced in #31216; #29917 described the same gap ("a task posted between this drain and `removeFromContextsMap()` inside `teardownJSCVM` still leaks") but left it open.

## Fix

- `ScriptExecutionContext::markTerminating()` now takes `allScriptExecutionContextsMapLock`, the same lock `postTaskTo` holds across its `isTerminating()` check and `postTaskConcurrently()` enqueue. That makes the flag flip a proper fence against concurrent posters: any `postTaskTo` critical section either runs entirely before `markTerminating()` (its task is visible to the subsequent drain) or entirely after (it observes `true` and drops).
- `WebWorker::shutdown()` calls the new `extern "C" ScriptExecutionContext__markTerminating` immediately before `release_queued_tasks_for_shutdown()`, closing the window. The later `markTerminating()` inside `WebWorker__teardownJSCVM` is now redundant but harmless.

No behaviour change for `process.on('exit')` itself: that runs before the new call, so a parent ack posted while the handler is running is still enqueued and then freed by the drain (never executed, same as before). Only posts that would have landed after the drain are now dropped instead of leaked.

## Verification

The gap is too narrow to reproduce unassisted against a debug build: 200 iterations of the Node test with the CI LSan env, and 150 worker shutdowns with 64 Atomics-synchronized MessagePorts each, all pass on an unpatched `bun bd`. Widening the gap with a temporary `std::thread::sleep(5ms)` between `release_queued_tasks_for_shutdown()` and `WebWorker__teardownJSCVM` makes it deterministic:

| build | `test-worker-stdio-flush.js` under LSan | 200-port Atomics-synchronized probe |
| --- | --- | --- |
| unpatched + 5 ms sleep | 5/5 leak (`32 byte(s) ConcurrentTask`) | 5/5 leak |
| this PR + 5 ms sleep | 10/10 clean | 5/5 clean |
| this PR (no sleep) | 50/50 clean | clean |

`test/js/node/worker_threads/worker-shutdown-post-leak.test.ts` runs the worker-stdio-on-exit scenario under `detect_leaks=1` as an ASAN-lane guard (in a fresh file so it actually runs; `worker_destruction.test.ts` is ASAN-quarantined via `test/expectations.txt`). The race is not observable on the debug gate without `src/` instrumentation, so the fail-before half will not fire there; `test-worker-stdio-flush.js` on the release-asan lane remains the primary signal.

Related: #31216 (introduced the ordering), #29917 (described but left the remaining window).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/worker_threads/worker-shutdown-post-leak.test.ts

<!-- robobun:evidence:end -->