### PR TITLE
sqlite: create the database's parent directory by default

### DIFF
--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -43,6 +43,16 @@ declare module "bun:sqlite" {
     create?: boolean;
 
     /**
+     * When the database is created, also create its parent directory if it
+     * doesn't exist. Has no effect on read-only or in-memory databases.
+     *
+     * Mirrors the `createPath` option of {@link Bun.write}.
+     *
+     * @default true
+     */
+    createPath?: boolean;
+
+    /**
      * Open the database as read-write
      *
      * Equivalent to {@link constants.SQLITE_OPEN_READWRITE}

--- a/src/js/bun/sqlite.ts
+++ b/src/js/bun/sqlite.ts
@@ -424,7 +424,29 @@ class Database implements SqliteTypes.Database {
       initializeSQL();
     }
 
-    this.#handle = SQL.open(anonymous ? ":memory:" : filename, flags, this);
+    const dbFilename = anonymous ? ":memory:" : filename;
+    try {
+      this.#handle = SQL.open(dbFilename, flags, this);
+    } catch (openError) {
+      // Mirror `Bun.write`'s `createPath` default: if the open failed only
+      // because the parent directory is missing, create it and retry once.
+      // The happy path (directory exists) pays no extra syscall.
+      const createPath = typeof options === "object" && options ? options.createPath : undefined;
+      const dir =
+        !anonymous &&
+        (flags & constants.SQLITE_OPEN_CREATE) !== 0 &&
+        createPath !== false &&
+        !filename.startsWith("file:")
+          ? require("node:path").dirname(filename)
+          : ".";
+      const fs = require("node:fs");
+      if (dir !== "." && dir !== filename && !fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+        this.#handle = SQL.open(dbFilename, flags, this);
+      } else {
+        throw openError;
+      }
+    }
     this.filename = filename;
   }
 

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -2,7 +2,7 @@ import { spawnSync } from "bun";
 import { constants, Database, SQLiteError } from "bun:sqlite";
 import { describe, expect, it } from "bun:test";
 import { existsSync, readdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isMacOS, isMacOSVersionAtLeast, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isMacOS, isMacOSVersionAtLeast, isWindows, tempDir, tempDirWithFiles } from "harness";
 import { tmpdir } from "os";
 import path from "path";
 
@@ -2770,5 +2770,53 @@ it("exec/run with an embedded NUL byte in the SQL string does not hang", async (
     stderr: "",
     signalCode: null,
     exitCode: 0,
+  });
+});
+
+describe("createPath (create parent directories)", () => {
+  it("creates missing parent directories by default", () => {
+    const base = tempDirWithFiles("sqlite-createpath-default", { "empty.txt": "" });
+    const dbPath = path.join(base, "nested", "deeper", "data.db");
+    const db = new Database(dbPath);
+    db.exec("CREATE TABLE t (id INTEGER)");
+    db.close();
+    expect(existsSync(dbPath)).toBe(true);
+  });
+
+  it("creates missing parent directories with { create: true }", () => {
+    const base = tempDirWithFiles("sqlite-createpath-create", { "empty.txt": "" });
+    const db = new Database(path.join(base, "made", "data.db"), { create: true });
+    db.close();
+    expect(existsSync(path.join(base, "made"))).toBe(true);
+  });
+
+  it("does not create directories when { createPath: false }", () => {
+    const base = tempDirWithFiles("sqlite-createpath-off", { "empty.txt": "" });
+    const missingDir = path.join(base, "missing");
+    // create is still on, so only createPath: false suppresses the mkdir
+    expect(() => new Database(path.join(missingDir, "data.db"), { create: true, createPath: false })).toThrow();
+    expect(existsSync(missingDir)).toBe(false);
+  });
+
+  it("does not create directories for a read-only database", () => {
+    const base = tempDirWithFiles("sqlite-createpath-readonly", { "empty.txt": "" });
+    const missingDir = path.join(base, "ro");
+    expect(() => new Database(path.join(missingDir, "data.db"), { readonly: true })).toThrow();
+    expect(existsSync(missingDir)).toBe(false);
+  });
+
+  it("opens a database in an existing directory without creating subdirectories", () => {
+    const base = tempDirWithFiles("sqlite-createpath-flat", { "empty.txt": "" });
+    const dbPath = path.join(base, "flat.db");
+    const db = new Database(dbPath);
+    db.close();
+    expect(existsSync(dbPath)).toBe(true);
+  });
+
+  it("still opens in-memory databases", () => {
+    const db = new Database(":memory:");
+    db.exec("CREATE TABLE t (id INTEGER)");
+    expect(db.query("SELECT 1 AS x").get()).toEqual({ x: 1 });
+    db.close();
   });
 });


### PR DESCRIPTION
## Summary

`new Database("./nested/dir/data.db")` throws `SQLiteError: unable to open database file` when `./nested/dir/` does not exist, even though the database file itself is created by default (#3888).

This mirrors `Bun.write`, which already creates the parent directory by default via a `createPath` option (default `true`). When opening the database fails only because the parent directory is missing, Bun now creates it and retries.

## Changes

- `src/js/bun/sqlite.ts` — on open failure, if the database would be created (`SQLITE_OPEN_CREATE`), `createPath` is not `false`, and the parent directory is missing, create it and retry once. The happy path (directory already exists) does no extra syscall, and any other open failure keeps its original SQLite error.
- `packages/bun-types/sqlite.d.ts` — add `createPath?: boolean` (default `true`) to `DatabaseOptions`.
- `test/js/bun/sqlite/sqlite.test.js` — cover the default, `{ create: true }`, `{ createPath: false }`, read-only, flat-file, and in-memory cases.

## Verification

- `bun bd test test/js/bun/sqlite/sqlite.test.js -t createPath` — 6 pass.
- The two auto-mkdir tests fail on an unpatched build (`USE_SYSTEM_BUN=1`) with `unable to open database file`, confirming they exercise the fix.

Closes #3888.
