### PR TITLE
inspector: don't unref the debuggee's event loop for a connect that never ran

### DIFF
--- a/src/jsc/bindings/BunDebugger.cpp
+++ b/src/jsc/bindings/BunDebugger.cpp
@@ -93,7 +93,7 @@ public:
         : Inspector::FrontendChannel()
         , globalObject(globalObject)
         , scriptExecutionContextIdentifier(scriptExecutionContext.identifier())
-        , unrefOnDisconnect(shouldRefEventLoop)
+        , shouldRefEventLoop(shouldRefEventLoop)
     {
     }
 
@@ -115,7 +115,8 @@ public:
     {
         this->status = ConnectionStatus::Connected;
         auto* globalObject = context.jsGlobalObject();
-        if (this->unrefOnDisconnect) {
+        if (this->shouldRefEventLoop) {
+            this->unrefOnDisconnect = true;
             Bun__eventLoop__incrementRefConcurrently(static_cast<Zig::GlobalObject*>(globalObject)->bunVM(), 1);
         }
         globalObject->setInspectable(true);
@@ -433,6 +434,10 @@ public:
 
     std::atomic<ConnectionStatus> status = ConnectionStatus::Pending;
 
+    bool shouldRefEventLoop = false;
+
+    // Set only after the +1 in doConnect() actually happens; gates the -1 in
+    // disconnect() so a raced connect/close cannot leak an unbalanced unref.
     bool unrefOnDisconnect = false;
 
     bool hasEverConnected = false;

--- a/test/cli/inspect/inspect-connection-churn.test.ts
+++ b/test/cli/inspect/inspect-connection-churn.test.ts
@@ -26,13 +26,16 @@ test("rapid inspector connect/close does not unref the debuggee's event loop", a
   });
 
   let stderr = "";
+  let stderrTail = "";
   let inspectorUrl: URL | undefined;
   for await (const chunk of proc.stderr) {
-    stderr += Buffer.from(chunk).toString();
-    const lines = stderr.split("\n");
+    const text = Buffer.from(chunk).toString();
+    stderr += text;
+    stderrTail += text;
+    const lines = stderrTail.split("\n");
     // Leave the unterminated tail for the next chunk so a URL split across
     // reads is not parsed as a truncated endpoint.
-    stderr = lines.pop() ?? "";
+    stderrTail = lines.pop() ?? "";
     for (const line of lines) {
       const trimmed = line.trim();
       if (trimmed.startsWith("ws://")) {

--- a/test/cli/inspect/inspect-connection-churn.test.ts
+++ b/test/cli/inspect/inspect-connection-churn.test.ts
@@ -1,0 +1,96 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("rapid inspector connect/close does not unref the debuggee's event loop", async () => {
+  // A close that arrives before the queued context-thread connect task runs used to
+  // skip the +1 while the disconnect task still applied its -1. Enough raced cycles
+  // drove the debuggee's loop refcount to zero and it exited 0 mid-run.
+  using dir = tempDir("inspect-churn", {
+    "debuggee.js": `
+      Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("alive") });
+      let tick = 0;
+      setInterval(() => {
+        process.stdout.write("TICK " + ++tick + "\\n");
+        const until = Date.now() + 400;
+        while (Date.now() < until) {}
+      }, 50);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--inspect=127.0.0.1:0/insp", "debuggee.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  let stderr = "";
+  let inspectorUrl: URL | undefined;
+  for await (const chunk of proc.stderr) {
+    stderr += Buffer.from(chunk).toString();
+    for (const line of stderr.split("\n")) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith("ws://")) {
+        inspectorUrl = new URL(trimmed);
+        break;
+      }
+    }
+    if (inspectorUrl || stderr.includes("error")) break;
+  }
+  if (!inspectorUrl) throw new Error("inspector URL not found in stderr:\n" + stderr);
+
+  // Build a promise that resolves when the Nth TICK line is seen, and a way
+  // to await a given tick without polling time.
+  let ticksSeen = 0;
+  const tickWaiters: { n: number; resolve: () => void }[] = [];
+  (async () => {
+    let stdout = "";
+    for await (const chunk of proc.stdout) {
+      stdout += Buffer.from(chunk).toString();
+      while (stdout.includes("\n")) {
+        const nl = stdout.indexOf("\n");
+        const line = stdout.slice(0, nl);
+        stdout = stdout.slice(nl + 1);
+        if (line.startsWith("TICK ")) {
+          ticksSeen++;
+          for (const w of tickWaiters) if (ticksSeen >= w.n) w.resolve();
+        }
+      }
+    }
+  })();
+  const waitForTick = (n: number) =>
+    ticksSeen >= n
+      ? Promise.resolve()
+      : new Promise<void>(resolve => {
+          tickWaiters.push({ n, resolve });
+        });
+
+  // Wait until the debuggee is inside its first busy burst so the churn lands
+  // while the context thread is blocked.
+  await Promise.race([waitForTick(1), proc.exited.then(() => Promise.reject(new Error("exited before first tick")))]);
+
+  // Churn: rapid connect/close on the debugger thread while the debuggee's
+  // context thread is busy. The debugger-thread WS server stays responsive.
+  for (let i = 0; i < 40; i++) {
+    const ws = new WebSocket(inspectorUrl);
+    await new Promise<void>(resolve => {
+      ws.addEventListener("open", () => ws.close());
+      ws.addEventListener("close", () => resolve());
+      ws.addEventListener("error", () => resolve());
+    });
+  }
+
+  // The debuggee must survive past the tick that applies the accumulated
+  // concurrent-ref delta. Race the next few ticks against process exit.
+  const target = ticksSeen + 3;
+  const outcome = await Promise.race([
+    waitForTick(target).then(() => "alive" as const),
+    proc.exited.then(code => `exited code=${code} signal=${proc.signalCode}` as const),
+  ]);
+
+  expect({ outcome, ticksSeen: ticksSeen >= target ? `>=${target}` : ticksSeen }).toEqual({
+    outcome: "alive",
+    ticksSeen: `>=${target}`,
+  });
+});

--- a/test/cli/inspect/inspect-connection-churn.test.ts
+++ b/test/cli/inspect/inspect-connection-churn.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 test("rapid inspector connect/close does not unref the debuggee's event loop", async () => {

--- a/test/cli/inspect/inspect-connection-churn.test.ts
+++ b/test/cli/inspect/inspect-connection-churn.test.ts
@@ -29,14 +29,18 @@ test("rapid inspector connect/close does not unref the debuggee's event loop", a
   let inspectorUrl: URL | undefined;
   for await (const chunk of proc.stderr) {
     stderr += Buffer.from(chunk).toString();
-    for (const line of stderr.split("\n")) {
+    const lines = stderr.split("\n");
+    // Leave the unterminated tail for the next chunk so a URL split across
+    // reads is not parsed as a truncated endpoint.
+    stderr = lines.pop() ?? "";
+    for (const line of lines) {
       const trimmed = line.trim();
       if (trimmed.startsWith("ws://")) {
         inspectorUrl = new URL(trimmed);
         break;
       }
     }
-    if (inspectorUrl || stderr.includes("error")) break;
+    if (inspectorUrl || lines.some(l => l.includes("error"))) break;
   }
   if (!inspectorUrl) throw new Error("inspector URL not found in stderr:\n" + stderr);
 
@@ -72,12 +76,23 @@ test("rapid inspector connect/close does not unref the debuggee's event loop", a
 
   // Churn: rapid connect/close on the debugger thread while the debuggee's
   // context thread is busy. The debugger-thread WS server stays responsive.
+  let opened = 0;
   for (let i = 0; i < 40; i++) {
     const ws = new WebSocket(inspectorUrl);
-    await new Promise<void>(resolve => {
-      ws.addEventListener("open", () => ws.close());
-      ws.addEventListener("close", () => resolve());
-      ws.addEventListener("error", () => resolve());
+    await new Promise<void>((resolve, reject) => {
+      let didOpen = false;
+      ws.addEventListener("open", () => {
+        didOpen = true;
+        opened++;
+        ws.close();
+      });
+      ws.addEventListener("close", event => {
+        if (didOpen) resolve();
+        else reject(new Error("inspector WebSocket closed before opening", { cause: event }));
+      });
+      ws.addEventListener("error", event => {
+        reject(new Error("inspector WebSocket error", { cause: event }));
+      });
     });
   }
 
@@ -89,7 +104,8 @@ test("rapid inspector connect/close does not unref the debuggee's event loop", a
     proc.exited.then(code => `exited code=${code} signal=${proc.signalCode}` as const),
   ]);
 
-  expect({ outcome, ticksSeen: ticksSeen >= target ? `>=${target}` : ticksSeen }).toEqual({
+  expect({ opened, outcome, ticksSeen: ticksSeen >= target ? `>=${target}` : ticksSeen }).toEqual({
+    opened: 40,
     outcome: "alive",
     ticksSeen: `>=${target}`,
   });

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -696,6 +696,4 @@ test("rapid inspector connect/close does not unref the debuggee's event loop", a
     outcome: "alive",
     ticksSeen: `>=${target}`,
   });
-
-  proc.kill();
 });

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -1,7 +1,7 @@
 import { Subprocess, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isPosix, randomPort, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isPosix, randomPort, tempDir, tempDirWithFiles } from "harness";
 import { join } from "node:path";
 import stripAnsi from "strip-ansi";
 import { WebSocket } from "ws";
@@ -602,4 +602,100 @@ test("error.stack doesnt lose frames", () => {
 
   // We allow it to differ by the existence of <anonymous> as a string. But that's it.
   expect(no.split("\n").slice(0, -2).join("\n").trim()).toBe(yes.split("\n").slice(0, -2).join("\n").trim());
+});
+
+test("rapid inspector connect/close does not unref the debuggee's event loop", async () => {
+  // A close that arrives before the queued context-thread connect task runs used to
+  // skip the +1 while the disconnect task still applied its -1. Enough raced cycles
+  // drove the debuggee's loop refcount to zero and it exited 0 mid-run.
+  using dir = tempDir("inspect-churn", {
+    "debuggee.js": `
+      Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("alive") });
+      let tick = 0;
+      setInterval(() => {
+        process.stdout.write("TICK " + ++tick + "\\n");
+        const until = Date.now() + 400;
+        while (Date.now() < until) {}
+      }, 50);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--inspect=127.0.0.1:0/insp", "debuggee.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  let stderr = "";
+  let inspectorUrl: URL | undefined;
+  for await (const chunk of proc.stderr) {
+    stderr += Buffer.from(chunk).toString();
+    for (const line of stderr.split("\n")) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith("ws://")) {
+        inspectorUrl = new URL(trimmed);
+        break;
+      }
+    }
+    if (inspectorUrl || stderr.includes("error")) break;
+  }
+  if (!inspectorUrl) throw new Error("inspector URL not found in stderr:\n" + stderr);
+
+  // Build a promise that resolves when the Nth TICK line is seen, and a way
+  // to await a given tick without polling time.
+  let ticksSeen = 0;
+  const tickWaiters: { n: number; resolve: () => void }[] = [];
+  (async () => {
+    let stdout = "";
+    for await (const chunk of proc.stdout) {
+      stdout += Buffer.from(chunk).toString();
+      while (stdout.includes("\n")) {
+        const nl = stdout.indexOf("\n");
+        const line = stdout.slice(0, nl);
+        stdout = stdout.slice(nl + 1);
+        if (line.startsWith("TICK ")) {
+          ticksSeen++;
+          for (const w of tickWaiters) if (ticksSeen >= w.n) w.resolve();
+        }
+      }
+    }
+  })();
+  const waitForTick = (n: number) =>
+    ticksSeen >= n
+      ? Promise.resolve()
+      : new Promise<void>(resolve => {
+          tickWaiters.push({ n, resolve });
+        });
+
+  // Wait until the debuggee is inside its first busy burst so the churn lands
+  // while the context thread is blocked.
+  await Promise.race([waitForTick(1), proc.exited.then(() => Promise.reject(new Error("exited before first tick")))]);
+
+  // Churn: rapid connect/close on the debugger thread while the debuggee's
+  // context thread is busy. The debugger-thread WS server stays responsive.
+  for (let i = 0; i < 40; i++) {
+    const ws = new WebSocket(inspectorUrl);
+    await new Promise<void>(resolve => {
+      ws.addEventListener("open", () => ws.close());
+      ws.addEventListener("close", () => resolve());
+      ws.addEventListener("error", () => resolve());
+    });
+  }
+
+  // The debuggee must survive past the tick that applies the accumulated
+  // concurrent-ref delta. Race the next few ticks against process exit.
+  const target = ticksSeen + 3;
+  const outcome = await Promise.race([
+    waitForTick(target).then(() => "alive" as const),
+    proc.exited.then(code => `exited code=${code} signal=${proc.signalCode}` as const),
+  ]);
+
+  expect({ outcome, ticksSeen: ticksSeen >= target ? `>=${target}` : ticksSeen }).toEqual({
+    outcome: "alive",
+    ticksSeen: `>=${target}`,
+  });
+
+  proc.kill();
 });

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -1,7 +1,7 @@
 import { Subprocess, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isPosix, randomPort, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isPosix, randomPort, tempDirWithFiles } from "harness";
 import { join } from "node:path";
 import stripAnsi from "strip-ansi";
 import { WebSocket } from "ws";
@@ -602,98 +602,4 @@ test("error.stack doesnt lose frames", () => {
 
   // We allow it to differ by the existence of <anonymous> as a string. But that's it.
   expect(no.split("\n").slice(0, -2).join("\n").trim()).toBe(yes.split("\n").slice(0, -2).join("\n").trim());
-});
-
-test("rapid inspector connect/close does not unref the debuggee's event loop", async () => {
-  // A close that arrives before the queued context-thread connect task runs used to
-  // skip the +1 while the disconnect task still applied its -1. Enough raced cycles
-  // drove the debuggee's loop refcount to zero and it exited 0 mid-run.
-  using dir = tempDir("inspect-churn", {
-    "debuggee.js": `
-      Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("alive") });
-      let tick = 0;
-      setInterval(() => {
-        process.stdout.write("TICK " + ++tick + "\\n");
-        const until = Date.now() + 400;
-        while (Date.now() < until) {}
-      }, 50);
-    `,
-  });
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "--inspect=127.0.0.1:0/insp", "debuggee.js"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  let stderr = "";
-  let inspectorUrl: URL | undefined;
-  for await (const chunk of proc.stderr) {
-    stderr += Buffer.from(chunk).toString();
-    for (const line of stderr.split("\n")) {
-      const trimmed = line.trim();
-      if (trimmed.startsWith("ws://")) {
-        inspectorUrl = new URL(trimmed);
-        break;
-      }
-    }
-    if (inspectorUrl || stderr.includes("error")) break;
-  }
-  if (!inspectorUrl) throw new Error("inspector URL not found in stderr:\n" + stderr);
-
-  // Build a promise that resolves when the Nth TICK line is seen, and a way
-  // to await a given tick without polling time.
-  let ticksSeen = 0;
-  const tickWaiters: { n: number; resolve: () => void }[] = [];
-  (async () => {
-    let stdout = "";
-    for await (const chunk of proc.stdout) {
-      stdout += Buffer.from(chunk).toString();
-      while (stdout.includes("\n")) {
-        const nl = stdout.indexOf("\n");
-        const line = stdout.slice(0, nl);
-        stdout = stdout.slice(nl + 1);
-        if (line.startsWith("TICK ")) {
-          ticksSeen++;
-          for (const w of tickWaiters) if (ticksSeen >= w.n) w.resolve();
-        }
-      }
-    }
-  })();
-  const waitForTick = (n: number) =>
-    ticksSeen >= n
-      ? Promise.resolve()
-      : new Promise<void>(resolve => {
-          tickWaiters.push({ n, resolve });
-        });
-
-  // Wait until the debuggee is inside its first busy burst so the churn lands
-  // while the context thread is blocked.
-  await Promise.race([waitForTick(1), proc.exited.then(() => Promise.reject(new Error("exited before first tick")))]);
-
-  // Churn: rapid connect/close on the debugger thread while the debuggee's
-  // context thread is busy. The debugger-thread WS server stays responsive.
-  for (let i = 0; i < 40; i++) {
-    const ws = new WebSocket(inspectorUrl);
-    await new Promise<void>(resolve => {
-      ws.addEventListener("open", () => ws.close());
-      ws.addEventListener("close", () => resolve());
-      ws.addEventListener("error", () => resolve());
-    });
-  }
-
-  // The debuggee must survive past the tick that applies the accumulated
-  // concurrent-ref delta. Race the next few ticks against process exit.
-  const target = ticksSeen + 3;
-  const outcome = await Promise.race([
-    waitForTick(target).then(() => "alive" as const),
-    proc.exited.then(code => `exited code=${code} signal=${proc.signalCode}` as const),
-  ]);
-
-  expect({ outcome, ticksSeen: ticksSeen >= target ? `>=${target}` : ticksSeen }).toEqual({
-    outcome: "alive",
-    ticksSeen: `>=${target}`,
-  });
 });


### PR DESCRIPTION
## What

Rapid connect/close of `bun --inspect` websocket clients while the debuggee's JS thread is busy makes the debugged process exit 0 mid-run. A live `Bun.serve` + `setInterval` just stops.

## Repro

Spawn a debuggee that holds the event loop (server + repeating busy burst), then open/close an inspector websocket a few dozen times while the debuggee is inside a busy burst:

```
$ bun test test/cli/inspect/inspect.test.ts -t "rapid inspector connect/close"
  outcome: "exited code=0 signal=null"
```

The debuggee exits cleanly after the second interval tick even though it has an active server and timer.

## Cause

`BunInspectorConnection`'s constructor seeded `unrefOnDisconnect` from the `shouldRefEventLoop` argument, so it meant "should ref" rather than "did ref". The `+1` in `doConnect()` runs from a task queued to the debuggee's context thread and is gated on `status == Pending`; `jsFunctionDisconnect` flips `status` to `Disconnecting` synchronously on the debugger thread. When a close lands before the queued connect task runs, the task sees `Disconnecting`, skips `doConnect()` and the `+1` never happens, but the disconnect task still applies its unconditional `-1` because `unrefOnDisconnect` was already true. Net `-1` per raced cycle; once the loop's active count reaches zero the debuggee exits.

## Fix

Store the constructor flag as `shouldRefEventLoop` and only set `unrefOnDisconnect = true` inside `doConnect()` after the `+1` is actually taken. The disconnect path is unchanged; it now only unrefs when a matching ref exists.

## Verification

New test in `test/cli/inspect/inspect.test.ts` churns 40 inspector connections while the debuggee is in a 400 ms busy loop, then races three more interval ticks against process exit.

- before: fails 3/3 with `outcome: "exited code=0 signal=null"`, `ticksSeen: 2`
- after: passes 3/3, debuggee keeps ticking

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/inspect/inspect-connection-churn.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (0b7dca9f1)

test/cli/inspect/inspect-connection-churn.test.ts:
105 |   const outcome = await Promise.race([
106 |     waitForTick(target).then(() => "alive" as const),
107 |     proc.exited.then(code => `exited code=${code} signal=${proc.signalCode}` as const),
108 |   ]);
109 | 
110 |   expect({ opened, outcome, ticksSeen: ticksSeen >= target ? `>=${target}` : ticksSeen }).toEqual({
                                                                                                ^
error: expect(received).toEqual(expected)

  {
    "opened": 40,
-   "outcome": "alive",
-   "ticksSeen": ">=5",
+   "outcome": "exited code=0 signal=null",
+   "ticksSeen": 2,
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/wor
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (727b4d579)

test/cli/inspect/inspect-connection-churn.test.ts:
105 |   const outcome = await Promise.race([
106 |     waitForTick(target).then(() => "alive" as const),
107 |     proc.exited.then(code => `exited code=${code} signal=${proc.signalCode}` as const),
108 |   ]);
109 | 
110 |   expect({ opened, outcome, ticksSeen: ticksSeen >= target ? `>=${target}` : ticksSeen }).toEqual({
                                                                                                ^
error: expect(received).toEqual(expected)

  {
    "opened": 40,
-   "outcome": "alive",
-   "ticksSeen": ">=4",
+   "outcome": "exited code=0 signal=null",
+   "ticksSeen": 2,
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/cli/inspect/inspect-connection-churn.test.ts:110:91)
(fail) rapid inspector connect/close does not unref the debuggee's event loop [913.49ms]

 0 pass
 1 fail
 1 expect() calls
Ran 1 test across 1 file. [1085.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/inspect/inspect-connection-churn.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (0b7dca9f1)

test/cli/inspect/inspect-connection-churn.test.ts:
(pass) rapid inspector connect/close does not unref the debuggee's event loop [2608.14ms]

 1 pass
 0 fail
 1 expect() calls
Ran 1 test across 1 file. [4.61s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 759ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen cpp.rs (cppbind)
[2/23] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[3/23] gen JS modules (bundle-modules)
Preprocess modules (6947ms)
Bundle modules (32ms)
Postprocesss modules (163ms)
Bundle Functions (742ms)
Generate Code (92ms)

[8.00s] Bundled "src/js" for production
  1911 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[3/13] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rus
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/BunDebugger.cpp                  |   9 +-
 test/cli/inspect/inspect-connection-churn.test.ts | 115 ++++++++++++++++++++++
 2 files changed, 122 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/jsc/bindings/BunDebugger.cpp                       1      3      0
test/cli/inspect/inspect-connection-churn.test.ts      1      4      0
```

</details>

<!-- robobun:evidence:end -->