### PR TITLE
test: close the /proc FileHandle in test-fs-promises-file-handle-readFile

### DIFF
--- a/test/js/node/test/parallel/test-fs-promises-file-handle-readFile.js
+++ b/test/js/node/test/parallel/test-fs-promises-file-handle-readFile.js
@@ -46,7 +46,7 @@ async function validateReadFileProc() {
   if (!common.isLinux)
     return;
 
-  const fileHandle = await open('/proc/sys/kernel/hostname', 'r');
+  await using fileHandle = await open('/proc/sys/kernel/hostname', 'r');
   const hostname = await fileHandle.readFile();
   assert.ok(hostname.length > 0);
 }


### PR DESCRIPTION
## What

Sync `validateReadFileProc()` with upstream nodejs/node@2eeb65fa81 (`const` to `await using`) so the `/proc/sys/kernel/hostname` FileHandle is disposed.

## Why

#33693 added a FinalizationRegistry that throws `ERR_INVALID_STATE` when a `FileHandle` is collected without `close()` (DEP0137 end-of-life). This test opened the hostname fd and never closed it; whenever GC happened to run during the later `doReadAndCancel()` section, the registry fired and the process exited 1 with:

```
error: A FileHandle object was closed during garbage collection. This used to be allowed with a deprecation warning but is now considered an error. Please close FileHandle objects explicitly. File descriptor: 9 (/proc/sys/kernel/hostname)
 code: "ERR_INVALID_STATE"
      at onFileHandleCollected (node:fs/promises:119:78)
```

It has been in the `flaky` annotation on 140 of the last 400 Buildkite builds (Linux lanes only, heaviest on `x64-asan` where GC pressure is highest).

#33693 already fixed three other vendored tests the same way; this one was missed because it is Linux-only and GC-timing-dependent. Upstream Node made the same change in nodejs/node@2eeb65fa81.

## Verification

```
$ bun bd test/js/node/test/parallel/test-fs-promises-file-handle-readFile.js
# exit 0
```

The failure is GC-timing-dependent so a deterministic fail-before is not available locally; the evidence is the CI annotation count plus the fact that the unclosed handle is the only one in the file whose path matches the error's `(/proc/sys/kernel/hostname)`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->