### PR TITLE
resolver: dedupe DirnameStore interns across bust+reread and Route::parse

### DIFF
--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -59,6 +59,7 @@ const rustIdentifierPaths: Record<string, string> = {
   "escapeRegExp.rs": "string/escapeRegExp.rs",
   "event_loop.rs": "jsc/event_loop.rs",
   "ffi.rs": "runtime/ffi/ffi.rs",
+  "filesystem_router.rs": "runtime/api/filesystem_router.rs",
   "h2_frame_parser.rs": "runtime/api/bun/h2_frame_parser.rs",
   "hosted_git_info.rs": "install/hosted_git_info.rs",
   "http/H2Client.rs": "http/H2Client.rs",

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -52,6 +52,8 @@ const shellParse = $newRustFunction("shell.rs", "TestingAPIs.shellParse", 2);
 
 export const sslCtxLiveCount = $newRustFunction("SecureContext.rs", "jsLiveCount", 0);
 
+export const dirnameStoreAppendCount = $newRustFunction("filesystem_router.rs", "jsDirnameStoreAppendCount", 0);
+
 export const napiThreadsafeFunctionLiveCount = $newRustFunction("napi_body.rs", "jsThreadsafeFunctionLiveCount", 0);
 
 export const escapeRegExp = $newRustFunction("escapeRegExp.rs", "jsEscapeRegExp", 1);

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1368,11 +1368,10 @@ pub mod fs {
                 // its `dir` field is DirnameStore-interned (&'static).
                 unsafe { (*existing).dir }
             } else if !had_handle {
-                DirnameStore::instance().append_slice(dir_maybe_trail_slash)?
+                DirnameStore::instance().intern_slice(dir_maybe_trail_slash)?
             } else {
-                // Intern into DirnameStore so the cache entry never dangles —
-                // `append_slice` is a bump-pointer copy, cost is bounded.
-                DirnameStore::instance().append_slice(dir)?
+                // Intern into DirnameStore so the cache entry never dangles.
+                DirnameStore::instance().intern_slice(dir)?
             };
 
             // Cache miss: read the directory entries

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -122,11 +122,82 @@ pub mod fs {
                     // SAFETY: see `append_slice`.
                     unsafe { &*$backing() }.exists(value)
                 }
+                /// Total number of `append*` calls (inline + overflow). Exposed via
+                /// `bun:internal-for-testing` so leak tests can assert "N reloads
+                /// performed zero new appends".
+                pub fn append_count(&self) -> u32 {
+                    // SAFETY: see `append_slice`.
+                    let b = unsafe { &*$backing() };
+                    let _g = b.mutex.lock();
+                    b.slice_buf_used as u32 + b.overflow_list.count
+                }
             }
         };
     }
     string_store_impl!(DirnameStore, DIRNAME_STORE_ZST, dirname_store_backing);
     string_store_impl!(FilenameStore, FILENAME_STORE_ZST, filename_store_backing);
+
+    thread_local! {
+        static DIRNAME_INTERN: core::cell::RefCell<
+            bun_collections::HashMap<&'static [u8], ()>,
+        > = core::cell::RefCell::new(bun_collections::HashMap::new());
+    }
+
+    impl DirnameStore {
+        /// Content-deduplicated [`append_slice`]. `BSSStringList::append` does not
+        /// dedupe, so a bust-then-reread cycle (hot reload, `FileSystemRouter.reload`)
+        /// would otherwise re-append the same directory path on every miss, exhausting
+        /// the store's slot capacity and leaking one heap buffer per overflow append.
+        pub fn intern_slice(&self, value: &[u8]) -> crate::CrateResult<&'static [u8]> {
+            if self.exists(value) {
+                // SAFETY: `exists` is a pointer-range check — `value` lies wholly
+                // within the process-lifetime backing buffer, so widening is sound.
+                return Ok(unsafe { core::slice::from_raw_parts(value.as_ptr(), value.len()) });
+            }
+            DIRNAME_INTERN.with_borrow_mut(|set| {
+                if let Some((interned, ())) = set.get_key_value(value) {
+                    return Ok(*interned);
+                }
+                let interned = self.append_slice(value)?;
+                set.insert(interned, ());
+                Ok(interned)
+            })
+        }
+
+        /// Content-deduplicated [`append_parts`]. See [`intern_slice`].
+        pub fn intern_parts(&self, parts: &[&[u8]]) -> crate::CrateResult<&'static [u8]> {
+            const STACK: usize = 512;
+            let total: usize = parts.iter().map(|p| p.len()).sum();
+            let mut stack = [0u8; STACK];
+            let mut heap: Vec<u8>;
+            let scratch: &mut [u8] = if total <= STACK {
+                &mut stack[..total]
+            } else {
+                heap = vec![0u8; total];
+                &mut heap[..]
+            };
+            let mut at = 0;
+            for p in parts {
+                scratch[at..at + p.len()].copy_from_slice(p);
+                at += p.len();
+            }
+            self.intern_slice(&scratch[..at])
+        }
+
+        /// Content-deduplicated [`append_lower_case`]. See [`intern_slice`].
+        pub fn intern_lower_case(&self, value: &[u8]) -> crate::CrateResult<&'static [u8]> {
+            const STACK: usize = 256;
+            let mut stack = [0u8; STACK];
+            let mut heap: Vec<u8>;
+            let scratch: &mut [u8] = if value.len() <= STACK {
+                &mut stack[..value.len()]
+            } else {
+                heap = vec![0u8; value.len()];
+                &mut heap[..]
+            };
+            self.intern_slice(bun_core::strings::copy_lowercase(value, scratch))
+        }
+    }
 
     macro_rules! string_store_append_impl {
         ($t:ty, $backing:ident) => {

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -126,10 +126,15 @@ pub mod fs {
                 /// `bun:internal-for-testing` so leak tests can assert "N reloads
                 /// performed zero new appends".
                 pub fn append_count(&self) -> u32 {
-                    // SAFETY: see `append_slice`.
-                    let b = unsafe { &*$backing() };
-                    let _g = b.mutex.lock();
-                    b.slice_buf_used as u32 + b.overflow_list.count
+                    let this = $backing();
+                    // SAFETY: `this` is the live process-lifetime singleton; `Mutex: Sync`
+                    // so concurrent `&Mutex` formation is sound. With the inner mutex
+                    // held no other thread holds `&mut *this`, so the raw-place reads
+                    // of `slice_buf_used` / `overflow_list.count` are race-free.
+                    unsafe {
+                        let _g = (*this).mutex.lock();
+                        (*this).slice_buf_used as u32 + (*this).overflow_list.count
+                    }
                 }
             }
         };
@@ -137,11 +142,11 @@ pub mod fs {
     string_store_impl!(DirnameStore, DIRNAME_STORE_ZST, dirname_store_backing);
     string_store_impl!(FilenameStore, FILENAME_STORE_ZST, filename_store_backing);
 
-    thread_local! {
-        static DIRNAME_INTERN: core::cell::RefCell<
-            bun_collections::HashMap<&'static [u8], ()>,
-        > = core::cell::RefCell::new(bun_collections::HashMap::new());
-    }
+    // Process-wide (not thread-local): the backing store is process-global, so the
+    // dedupe index must match its lifetime or resolver worker threads each re-append.
+    static DIRNAME_INTERN: std::sync::LazyLock<
+        bun_core::Mutex<bun_collections::HashMap<&'static [u8], ()>>,
+    > = std::sync::LazyLock::new(Default::default);
 
     impl DirnameStore {
         /// Content-deduplicated [`append_slice`]. `BSSStringList::append` does not
@@ -154,14 +159,13 @@ pub mod fs {
                 // within the process-lifetime backing buffer, so widening is sound.
                 return Ok(unsafe { core::slice::from_raw_parts(value.as_ptr(), value.len()) });
             }
-            DIRNAME_INTERN.with_borrow_mut(|set| {
-                if let Some((interned, ())) = set.get_key_value(value) {
-                    return Ok(*interned);
-                }
-                let interned = self.append_slice(value)?;
-                set.insert(interned, ());
-                Ok(interned)
-            })
+            let mut set = DIRNAME_INTERN.lock();
+            if let Some((interned, ())) = set.get_key_value(value) {
+                return Ok(*interned);
+            }
+            let interned = self.append_slice(value)?;
+            set.insert(interned, ());
+            Ok(interned)
         }
 
         /// Content-deduplicated [`append_parts`]. See [`intern_slice`].

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -3509,7 +3509,7 @@ impl<'a> Resolver<'a> {
                     unsafe { &*existing }.dir
                 } else {
                     Fs::file_system::DirnameStore::instance()
-                        .append_slice(dir_path)
+                        .intern_slice(dir_path)
                         .expect("unreachable")
                 },
                 self.generation,
@@ -4517,9 +4517,9 @@ impl<'a> Resolver<'a> {
                     let input = &path[..input_path_len];
                     if input[input.len() - 1] != SEP {
                         let parts: [&[u8]; 2] = [input, SEP_STR.as_bytes()];
-                        _safe_path = Some(self.fs_ref().dirname_store.append_parts(&parts)?);
+                        _safe_path = Some(self.fs_ref().dirname_store.intern_parts(&parts)?);
                     } else {
-                        _safe_path = Some(self.fs_ref().dirname_store.append_slice(input)?);
+                        _safe_path = Some(self.fs_ref().dirname_store.intern_slice(input)?);
                     }
                 }
 
@@ -4578,7 +4578,7 @@ impl<'a> Resolver<'a> {
                         unsafe { &*existing }.dir
                     } else {
                         Fs::file_system::DirnameStore::instance()
-                            .append_slice(dir_path)
+                            .intern_slice(dir_path)
                             .expect("unreachable")
                     },
                     self.generation,

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -1128,8 +1128,9 @@ impl Route {
                     // `route_file_buf` and avoids needing lifetime transmutes
                     // below.
                     let dirname_store = FileSystem::instance().dirname_store();
-                    let public_path: &'static [u8] =
-                        dirname_store.intern_slice(public_path).expect("unreachable");
+                    let public_path: &'static [u8] = dirname_store
+                        .intern_slice(public_path)
+                        .expect("unreachable");
                     let name: &'static [u8] = &public_path[name_offset..][0..name_len];
                     let match_name: &'static [u8] = if has_uppercase {
                         dirname_store
@@ -1144,8 +1145,9 @@ impl Route {
                     (public_path, name, match_name)
                 } else {
                     let dirname_store = FileSystem::instance().dirname_store();
-                    let public_path: &'static [u8] =
-                        dirname_store.intern_slice(public_path).expect("unreachable");
+                    let public_path: &'static [u8] = dirname_store
+                        .intern_slice(public_path)
+                        .expect("unreachable");
                     (
                         public_path,
                         Route::INDEX_ROUTE_NAME,

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -1123,17 +1123,17 @@ impl Route {
                     let name_offset = name.as_ptr() as usize - public_path.as_ptr() as usize;
                     let name_len = name.len();
 
-                    // NOTE: DirnameStore::append returns `&'static [u8]` (process-
+                    // NOTE: DirnameStore::intern_* returns `&'static [u8]` (process-
                     // lifetime arena), so rebinding here drops the borrow on
                     // `route_file_buf` and avoids needing lifetime transmutes
                     // below.
                     let dirname_store = FileSystem::instance().dirname_store();
                     let public_path: &'static [u8] =
-                        dirname_store.append(public_path).expect("unreachable");
+                        dirname_store.intern_slice(public_path).expect("unreachable");
                     let name: &'static [u8] = &public_path[name_offset..][0..name_len];
                     let match_name: &'static [u8] = if has_uppercase {
                         dirname_store
-                            .append_lower_case(&name[1..])
+                            .intern_lower_case(&name[1..])
                             .expect("unreachable")
                     } else {
                         &name[1..]
@@ -1145,7 +1145,7 @@ impl Route {
                 } else {
                     let dirname_store = FileSystem::instance().dirname_store();
                     let public_path: &'static [u8] =
-                        dirname_store.append(public_path).expect("unreachable");
+                        dirname_store.intern_slice(public_path).expect("unreachable");
                     (
                         public_path,
                         Route::INDEX_ROUTE_NAME,
@@ -1233,7 +1233,7 @@ impl Route {
 
                 abs_path_str = FileSystem::instance()
                     .dirname_store()
-                    .append(_abs)
+                    .intern_slice(_abs)
                     .expect("unreachable");
 
                 // SAFETY: sole mutation; `base_`/`extname` (which may borrow
@@ -1251,7 +1251,7 @@ impl Route {
                 );
                 let interned: &'static [u8] = FileSystem::instance()
                     .dirname_store()
-                    .append(normalized)
+                    .intern_slice(normalized)
                     .expect("unreachable");
                 Interned::from_static(interned)
             };
@@ -1269,13 +1269,13 @@ impl Route {
             }
 
             // NOTE: name/match_name/public_path are already `&'static` via
-            // DirnameStore::append above. `entry.base()` borrows the entry (it
-            // may be inline-stored for ≤31-byte names); intern it
+            // DirnameStore::intern_slice above. `entry.base()` borrows the entry
+            // (it may be inline-stored for ≤31-byte names); intern it
             // explicitly to get `&'static` without a lifetime transmute.
             // SAFETY: read-only reborrow; the `&mut` write above is dead.
             let basename: &'static [u8] = FileSystem::instance()
                 .dirname_store()
-                .append(unsafe { &*entry }.base())
+                .intern_slice(unsafe { &*entry }.base())
                 .expect("unreachable");
 
             Some(Route {

--- a/src/runtime/api/filesystem_router.rs
+++ b/src/runtime/api/filesystem_router.rs
@@ -53,6 +53,18 @@ pub use crate::bake::framework_router::JSFrameworkRouter as FrameworkFileSystemR
 
 pub(crate) const DEFAULT_EXTENSIONS: &[&[u8]] = &[b"tsx", b"jsx", b"ts", b"mjs", b"cjs", b"js"];
 
+/// Exposed via `bun:internal-for-testing` so leak tests can assert
+/// `reload()` performed zero new `DirnameStore` appends.
+#[bun_jsc::host_fn]
+pub fn js_dirname_store_append_count(
+    _global: &JSGlobalObject,
+    _callframe: &CallFrame,
+) -> JsResult<JSValue> {
+    Ok(JSValue::js_number(
+        Fs::DirnameStore::instance().append_count() as f64,
+    ))
+}
+
 // ── local shims ───────────────────────────────────────────────────────────
 // `to_js` lives on the `bun_jsc::ZigStringJsc` extension trait; `from_bytes`
 // auto-detects UTF-8.

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -402,6 +402,35 @@ it("reload() works", () => {
   expect(router.match("/posts")!.name).toBe("/posts");
 });
 
+it("reload() does not re-intern directory paths into DirnameStore on every bust+reread", () => {
+  const { dirnameStoreAppendCount } = require("bun:internal-for-testing") as {
+    dirnameStoreAppendCount: () => number;
+  };
+  const files: Record<string, string> = { "pages/sub/nested.tsx": "export default 1;\n" };
+  for (let i = 0; i < 20; i++) files[`pages/p${i}.tsx`] = "export default 1;\n";
+  using dir = tempDir("fsr-reload-dirname-intern", files);
+
+  const router = new Bun.FileSystemRouter({
+    dir: path.join(String(dir), "pages"),
+    style: "nextjs",
+    fileExtensions: [".tsx"],
+  });
+  // First reload primes the intern cache for the bust+reread paths.
+  router.reload();
+  const before = dirnameStoreAppendCount();
+  for (let i = 0; i < 50; i++) router.reload();
+  const delta = dirnameStoreAppendCount() - before;
+  // Without the fix each reload re-appended identical bytes into the never-freed
+  // store: `dir_info_cached_miss` re-interned safe_path + DirEntry.dir per dir
+  // (6 per reload here) and `Route::parse` re-interned public_path/abs_path/
+  // basename per route (63 per reload here), so 50 reloads grew the store by
+  // ~3450 slots and eventually overflowed it with `AllocError`.
+  expect({ delta, match: router.match("/sub/nested")?.filePath.endsWith("nested.tsx") }).toEqual({
+    delta: 0,
+    match: true,
+  });
+});
+
 it("reload() works with new dirs/files", () => {
   const { dir } = make(["posts.tsx"]);
 

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -1,4 +1,5 @@
 import { FileSystemRouter } from "bun";
+import { dirnameStoreAppendCount } from "bun:internal-for-testing";
 import { expect, it } from "bun:test";
 import fs, { mkdirSync, rmSync } from "fs";
 import { bunEnv, bunExe, isASAN, isMacOS, isWindows, normalizeBunSnapshot, tempDir, tmpdirSync } from "harness";
@@ -403,9 +404,6 @@ it("reload() works", () => {
 });
 
 it("reload() does not re-intern directory paths into DirnameStore on every bust+reread", () => {
-  const { dirnameStoreAppendCount } = require("bun:internal-for-testing") as {
-    dirnameStoreAppendCount: () => number;
-  };
   const files: Record<string, string> = { "pages/sub/nested.tsx": "export default 1;\n" };
   for (let i = 0; i < 20; i++) files[`pages/p${i}.tsx`] = "export default 1;\n";
   using dir = tempDir("fsr-reload-dirname-intern", files);


### PR DESCRIPTION
## Repro

```js
const { dirnameStoreAppendCount } = require("bun:internal-for-testing");
// pages/ with 20 .tsx files plus pages/sub/ with 1 .tsx file
const router = new Bun.FileSystemRouter({ dir: pagesDir, style: "nextjs", fileExtensions: [".tsx"] });
router.reload();
let prev = dirnameStoreAppendCount();
for (let i = 0; i < 50; i++) router.reload();
console.log(dirnameStoreAppendCount() - prev); // 3450 before, 0 after
```

Run long enough and it panics:

```
panic: unreachable: AllocError
  <bun_router::Route>::parse  src/router/lib.rs
    FileSystem::instance().dirname_store().append(_abs).expect("unreachable")
```

## Cause

`BSSStringList::append` does not dedupe by content, so the same bytes can be appended repeatedly into the never-freed `DirnameStore`. Two paths do that on every `reload()` (and on every `--hot` / `--watch` file change):

- `Resolver::dir_info_cached_miss` (and its sibling `dir_info_for_resolution`): after `bust_dir_cache` removes a directory from both caches, the next `read_dir_info` miss re-interns the directory's `_safe_path` (`append_parts`/`append_slice`) and, because the orphaned `DirEntry` slot is unreachable, `DirEntry.dir` (`append_slice`). 2 appends for the root dir and 4 for each subdir per reload.
- `Route::parse`: re-interns each route's `public_path`, `abs_path`, `basename`, and lowercased `match_name`. 3 to 4 appends per route per reload.
- `RealFS::read_directory_with_iterator`: same `DirEntry.dir` shape as the resolver path, reached via `load_as_file` after a bust.

For the repro above that is 69 appends per reload, independent of anything but route/dir counts. The store's `slice_buf` (4096 slots) plus overflow list cap out around 8.4M appends, after which `append` returns `AllocError` and the `.expect("unreachable")` panics; every overflow append before that leaks a heap buffer.

## Fix

Add content-deduplicating wrappers on `DirnameStore`:

- `intern_slice(value)`: `exists()` pointer-range fast path (slice already lives in the store's inline buffer), else probe a process-wide `Mutex<HashMap<&'static [u8], ()>>` keyed by content; hit returns the prior intern, miss appends once and records it. The lookup, append, and insert happen under the same lock so concurrent resolver workers cannot race past each other.
- `intern_parts(parts)` / `intern_lower_case(value)`: stack-scratch concat/lowercase then delegate to `intern_slice`.

Route the bust-cycle-sensitive call sites through them:

- `resolver.rs`: `_safe_path` in `dir_info_cached_miss`, and `DirEntry.dir` in both `dir_info_cached_miss` and `dir_info_for_resolution`.
- `lib.rs`: `DirEntry.dir` in `read_directory_with_iterator`.
- `router/lib.rs`: all six `DirnameStore` appends in `Route::parse` (including the Windows `cfg` arm).

After the first reload, every subsequent `reload()` over an unchanged tree performs zero new `DirnameStore` appends.

Also expose `DirnameStore::append_count` via `bun:internal-for-testing`; reads `slice_buf_used`/`overflow_list.count` as raw-place projections under the store's inner mutex (no whole-struct `&BSSStringList` before locking).

## Why this fix

The invariant that the process-lifetime `DirnameStore` should not grow when no new paths are seen belongs on `DirnameStore` itself, not in each caller. The dedup map is process-wide to match the backing store's lifetime; the callers this PR touches already hold `RESOLVER_MUTEX` or run on the JS thread, so there is no new contention.

## Verification

- New test `reload() does not re-intern directory paths into DirnameStore on every bust+reread` in `test/js/bun/util/filesystem_router.test.ts`: 21 routes over 2 dirs, 50 reloads, asserts `dirnameStoreAppendCount()` delta is exactly 0 and `match()` still works.
  - Without the call-site changes (probe only): delta = 3450, test fails.
  - With the fix: delta = 0, test passes.
- Full `filesystem_router.test.ts` (30/30), `resolve.test.ts` (43/43), `import-meta.test.js` + `require.test.ts` (42/42) all green under `bun bd`.
- `bun run rust:check-all` clean on all targets including the Windows arm in `Route::parse`.

## Relationship to other PRs

Supersedes #34276 (which added a router-local `intern_route_path` thread-local; this PR puts the dedup on `DirnameStore` so the resolver's own re-interns are covered in the same place). #29919 addresses the `DirEntry`/`EntryStore` reuse side of the same bust cycle and is complementary.
