### PR TITLE
test: update block-scoped enum lowering expectations to let

### DIFF
--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -768,11 +768,11 @@ describe("Bun.Transpiler", () => {
       // A nested function establishes its own context, so these remain valid.
       exp(
         "function *f() { enum x { y = (function*() { yield 1 })() } }",
-        'function* f() {\n  var x;\n  ((x) => {\n    x[x["y"] = function* () {\n      yield 1;\n    }()] = "y";\n  })(x ||= {});\n}',
+        'function* f() {\n  let x;\n  ((x) => {\n    x[x["y"] = function* () {\n      yield 1;\n    }()] = "y";\n  })(x ||= {});\n}',
       );
       exp(
         "async function f() { enum x { y = (async () => await 1)() } }",
-        'async function f() {\n  var x;\n  ((x) => {\n    x[x["y"] = (async () => await 1)()] = "y";\n  })(x ||= {});\n}',
+        'async function f() {\n  let x;\n  ((x) => {\n    x[x["y"] = (async () => await 1)()] = "y";\n  })(x ||= {});\n}',
       );
       exp(
         "enum x { y = (function() { return this })() }",
@@ -782,15 +782,15 @@ describe("Bun.Transpiler", () => {
       // keep their yield/await/super permissions.
       exp(
         "function *f() { enum x { y = 1 } yield 1; }",
-        'function* f() {\n  var x;\n  ((x) => {\n    x[x["y"] = 1] = "y";\n  })(x ||= {});\n  yield 1;\n}',
+        'function* f() {\n  let x;\n  ((x) => {\n    x[x["y"] = 1] = "y";\n  })(x ||= {});\n  yield 1;\n}',
       );
       exp(
         "async function f() { enum x { y = 1 } await 1; }",
-        'async function f() {\n  var x;\n  ((x) => {\n    x[x["y"] = 1] = "y";\n  })(x ||= {});\n  await 1;\n}',
+        'async function f() {\n  let x;\n  ((x) => {\n    x[x["y"] = 1] = "y";\n  })(x ||= {});\n  await 1;\n}',
       );
       exp(
         "class C extends B { m() { enum x { y = 1 } super.foo(); } }",
-        'class C extends B {\n  m() {\n    var x;\n    ((x) => {\n      x[x["y"] = 1] = "y";\n    })(x ||= {});\n    super.foo();\n  }\n}',
+        'class C extends B {\n  m() {\n    let x;\n    ((x) => {\n      x[x["y"] = 1] = "y";\n    })(x ||= {});\n    super.foo();\n  }\n}',
       );
     });
 


### PR DESCRIPTION
### What

`#34249` changed TypeScript enum lowering so that only **module-scope** enums emit `var`; an enum in a function, method, or block body now emits `let`.

`#34250` merged four minutes earlier and added `it("rejects yield/await/this/super in enum initializers")`, whose expectations still assert `var x` for **block-scoped** enums. Each PR was green against a `main` that lacked the other's change, so the collision only appeared once both had landed — and since `main` pushes run no test shards, nothing caught it.

The result is that `main` asserts output its own parser no longer produces. `test/bundler/transpiler/transpiler.test.js` currently fails on every PR that merges `main`.

### The fix

Updates the five stale expectations to `let`. All five are enums nested in a function or method body:

| Line | Case |
|---|---|
| 771 | `function *f() { enum x { y = (function*() { yield 1 })() } }` |
| 775 | `async function f() { enum x { y = (async () => await 1)() } }` |
| 785 | `function *f() { enum x { y = 1 } yield 1; }` |
| 789 | `async function f() { enum x { y = 1 } await 1; }` |
| 793 | `class C extends B { m() { enum x { y = 1 } super.foo(); } }` |

Deliberately unchanged:

- **Line 779** — `enum x { y = (function() { return this })() }` is top-level, so `var` is still correct.
- **Namespace expectations** — namespaces only appear at module scope or nested in another namespace, where both the old and new predicates agree.

### Note for reviewers

Only the line-771 failure is visible in CI: `expectPrinted_` throws at the first mismatch, masking the other four. A fix touching only the reported line would go red again on the next one, so all five are updated together.

### Verification

Ran `test/bundler/transpiler/transpiler.test.js` against a build containing `#34249`:

- pristine `main`: 176 pass / 4 fail
- with this change: 177 pass / 3 fail

The change flips exactly the one enum test and touches nothing else. The 3 remaining failures are unrelated to this diff — they are skew between that build and two commits that landed after it (`#34254`, `#34258`), and build from source in CI.

Also swept the repo for any other assertion of enum-lowering text (the closure IIFE shape `(x ||= {})` / `(x = x || {})`). Only two files assert it: this one, and `test/js/node/module/require-extensions.test.ts:129`, whose fixture declares a top-level enum and is correctly `var`.
