### PR TITLE
Bun.Terminal: write() returns bytes accepted, fire drain on POSIX

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7876,8 +7876,14 @@ declare module "bun" {
 
     /**
      * Write data to the terminal.
+     *
+     * All bytes are accepted; any portion that cannot be flushed to the PTY
+     * immediately is buffered and delivered later. The `drain` callback fires
+     * once buffered data has been flushed. Do not re-send any part of `data`
+     * based on the return value.
+     *
      * @param data The data to write (string or BufferSource)
-     * @returns The number of bytes written
+     * @returns The number of bytes accepted (the byte length of `data`)
      */
     write(data: string | BufferSource): number;
 

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -1439,12 +1439,20 @@ impl Terminal {
         // Suppress drain firing from the synchronous on_write calls that
         // StreamingWriter::write() makes while we still hold the `with_mut`
         // borrow; it is restored from `has_pending_data()` immediately after.
-        self.writer_has_buffered.set(false);
+        let had_buffered = self.writer_has_buffered.replace(false);
         let (write_result, has_pending) = self.writer.with_mut(|w| {
             let r = w.write(bytes);
             (r, w.has_pending_data())
         });
         self.writer_has_buffered.set(has_pending);
+        // A second write() can drain what an earlier one buffered; on_write saw
+        // the cleared flag, so fire drain here (outside `with_mut`).
+        #[cfg(unix)]
+        if had_buffered && !has_pending {
+            self.on_writer_ready();
+        }
+        #[cfg(not(unix))]
+        let _ = had_buffered;
 
         // StreamingWriter::write() buffers any bytes it couldn't flush
         // synchronously, so the full input has been accepted on every non-error

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -161,6 +161,12 @@ pub struct Terminal {
 
     /// State flags
     flags: Cell<Flags>,
+
+    /// The streaming writer has accepted bytes it hasn't flushed to the fd
+    /// yet. Set by `write()` from `has_pending_data()`; cleared when
+    /// `on_write` observes `Drained` so POSIX can fire the `drain` callback
+    /// (Windows fires it from `on_writable`).
+    writer_has_buffered: Cell<bool>,
 }
 
 bitflags::bitflags! {
@@ -458,6 +464,7 @@ impl Terminal {
             reader: JsCell::new(IOReader::init::<Terminal>()),
             this_value: JsCell::new(JsRef::empty()),
             flags: Cell::new(Flags::empty()),
+            writer_has_buffered: Cell::new(false),
         }));
         // SAFETY: just allocated, non-null, exclusively owned here. R-2: `&`
         // (not `&mut`) — every method below takes `&self`; field writes go
@@ -1423,31 +1430,32 @@ impl Terminal {
         // defer string_or_buffer.deinit() — Drop handles it.
 
         let bytes = string_or_buffer.slice();
+        let input_len = bytes.len();
 
-        if bytes.is_empty() {
+        if input_len == 0 {
             return Ok(JSValue::js_number(0.0));
         }
 
-        // Write using the streaming writer
-        let write_result = self.writer.with_mut(|w| w.write(bytes));
+        // Suppress drain firing from the synchronous on_write calls that
+        // StreamingWriter::write() makes while we still hold the `with_mut`
+        // borrow; it is restored from `has_pending_data()` immediately after.
+        self.writer_has_buffered.set(false);
+        let (write_result, has_pending) = self.writer.with_mut(|w| {
+            let r = w.write(bytes);
+            (r, w.has_pending_data())
+        });
+        self.writer_has_buffered.set(has_pending);
+
+        // StreamingWriter::write() buffers any bytes it couldn't flush
+        // synchronously, so the full input has been accepted on every non-error
+        // return. The per-arm counts are sync-flushed bytes (and on a buffered
+        // writer can even exceed `input_len` when prior data drains), so
+        // returning them would make callers re-send an already-queued tail.
         match write_result {
-            bun_io::WriteResult::Done(amt) => Ok(JSValue::js_number(
-                i32::try_from(amt).expect("int cast") as f64,
-            )),
-            bun_io::WriteResult::Wrote(amt) => Ok(JSValue::js_number(
-                i32::try_from(amt).expect("int cast") as f64,
-            )),
-            // On Windows the streaming writer buffers and returns .pending=0; the
-            // bytes were accepted, so report bytes.len to match POSIX semantics.
-            bun_io::WriteResult::Pending(amt) => {
-                let n = if cfg!(windows) { bytes.len() } else { amt };
-                Ok(JSValue::js_number(
-                    i32::try_from(n).expect("int cast") as f64
-                ))
-            }
             bun_io::WriteResult::Err(err) => {
                 Err(global_object.throw_value(err.to_js(global_object)))
             }
+            _ => Ok(JSValue::js_number(input_len as f64)),
         }
     }
 
@@ -1729,9 +1737,17 @@ impl Terminal {
     }
 
     fn on_write(&self, amount: usize, status: WriteStatus) {
-        let _ = status;
         bun_output::scoped_log!(Terminal, "onWrite: {} bytes", amount);
-        let _ = self;
+        let _ = amount;
+        // POSIX: `PosixStreamingWriter` never dispatches `on_ready`; detect the
+        // buffered→drained transition here instead. Windows fires the drain
+        // callback from `on_writable`, so skip to avoid double-firing.
+        #[cfg(unix)]
+        if status == WriteStatus::Drained && self.writer_has_buffered.replace(false) {
+            self.on_writer_ready();
+        }
+        #[cfg(not(unix))]
+        let _ = status;
     }
 
     // IOReader callbacks

--- a/test/js/bun/terminal/terminal-spawn.test.ts
+++ b/test/js/bun/terminal/terminal-spawn.test.ts
@@ -24,6 +24,82 @@ describe("Bun.Terminal subprocess integration", () => {
     expect(terminal.write(new TextEncoder().encode("abc"))).toBe(3);
   });
 
+  // The streaming writer buffers whatever it can't flush synchronously, so
+  // write() must report the full input as accepted. Before the fix it returned
+  // the synchronously-flushed count (~12-14KB on a PTY), and a caller that
+  // re-sent the "unwritten" tail duplicated stdin on the child. ConPTY injects
+  // escape sequences into the byte stream so exact counting is POSIX-only.
+  test.skipIf(isWindows)("write returns the full input length when the PTY buffer fills", async () => {
+    const N = 128 * 1024;
+    const childSrc = `
+      let buf = Buffer.alloc(0);
+      process.stdin.on("data", d => {
+        buf = Buffer.concat([buf, d]);
+        const idx = buf.indexOf(0);
+        if (idx >= 0) {
+          process.stdout.write("CHILD_READ " + idx + "\\n");
+          process.exit(0);
+        }
+      });
+      process.stdout.write("READY\\n");
+    `;
+
+    let output = "";
+    let drainCount = 0;
+    const ready = Promise.withResolvers<void>();
+    const done = Promise.withResolvers<string>();
+    const drained = Promise.withResolvers<void>();
+
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "-e", childSrc],
+      env: bunEnv,
+      terminal: {
+        data(_t, chunk) {
+          output += new TextDecoder().decode(chunk);
+          if (output.includes("READY")) ready.resolve();
+          const m = output.match(/CHILD_READ (\d+)/);
+          if (m) done.resolve(m[1]);
+        },
+        drain() {
+          drainCount++;
+          drained.resolve();
+        },
+        exit() {
+          done.reject(new Error("terminal exit before CHILD_READ; output=" + JSON.stringify(output)));
+        },
+      },
+    });
+    const terminal = proc.terminal!;
+    terminal.setRawMode(true);
+
+    await ready.promise;
+
+    // A single write that overflows the kernel PTY buffer: the writer accepts
+    // everything (buffering the tail), so the return must be the input length.
+    const payload = Buffer.alloc(N, 65);
+    const r1 = terminal.write(payload);
+    expect(r1).toBe(N);
+
+    // Second write while the first is still buffered: must also return its own
+    // input length (previously could include bytes drained from the first).
+    const r2 = terminal.write(Buffer.alloc(64, 66));
+    expect(r2).toBe(64);
+
+    // Terminator so the child can report without a timeout.
+    terminal.write(new Uint8Array([0]));
+
+    // Child must receive exactly N + 64 bytes before the terminator.
+    const childRead = Number(await done.promise);
+    expect(childRead).toBe(N + 64);
+
+    // Buffered data was drained to reach the child, so drain must have fired.
+    await drained.promise;
+    expect(drainCount).toBeGreaterThan(0);
+
+    await proc.exited;
+    terminal.close();
+  });
+
   test("resize succeeds", async () => {
     await using terminal = new Bun.Terminal({ cols: 80, rows: 24 });
     expect(() => terminal.resize(100, 30)).not.toThrow();

--- a/test/js/bun/terminal/terminal-spawn.test.ts
+++ b/test/js/bun/terminal/terminal-spawn.test.ts
@@ -65,7 +65,10 @@ describe("Bun.Terminal subprocess integration", () => {
           drained.resolve();
         },
         exit() {
-          done.reject(new Error("terminal exit before CHILD_READ; output=" + JSON.stringify(output)));
+          const err = new Error("terminal exit; output=" + JSON.stringify(output));
+          ready.reject(err);
+          done.reject(err);
+          drained.reject(err);
         },
       },
     });

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -660,9 +660,12 @@ describe("Bun.Terminal", () => {
       terminal.setRawMode(true);
 
       // First write is below CHUNK_SIZE so it buffers; second write exceeds
-      // CHUNK_SIZE so the combined buffer is flushed synchronously inside
-      // write(). The buffered→drained transition happens during the second
-      // with_mut call, which must still surface as a drain callback.
+      // CHUNK_SIZE (4K here) but fits in the kernel PTY input queue, so the
+      // combined buffer is flushed synchronously inside write() and drain
+      // must fire from the had_buffered && !has_pending check. On Apple
+      // Silicon CHUNK_SIZE is 16K so the second write also buffers and the
+      // test resolves via the async-poll path instead; the sync-flush branch
+      // has no target-specific code so Linux coverage is the regression guard.
       expect(terminal.write("hello")).toBe(5);
       expect(terminal.write(Buffer.alloc(5000, 66))).toBe(5000);
 

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -628,10 +628,7 @@ describe("Bun.Terminal", () => {
     });
   });
 
-  // On Windows the StreamingWriter is async so drain fires after each write.
-  // On POSIX, drain only fires after backpressure clears, which requires a
-  // reader on the slave side; with no child attached the buffer never drains.
-  describe.todoIf(!isWindows)("drain callback", () => {
+  describe("drain callback", () => {
     test("drain callback is invoked when writer is ready", async () => {
       const { promise, resolve } = Promise.withResolvers<void>();
       let drainCalled = false;

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -646,6 +646,31 @@ describe("Bun.Terminal", () => {
 
       expect(drainCalled).toBe(true);
     });
+
+    test.skipIf(isWindows)("drain fires when a second write flushes what the first buffered", async () => {
+      const { promise, resolve } = Promise.withResolvers<void>();
+      let drainCount = 0;
+
+      const terminal = new Bun.Terminal({
+        drain() {
+          drainCount++;
+          resolve();
+        },
+      });
+      terminal.setRawMode(true);
+
+      // First write is below CHUNK_SIZE so it buffers; second write exceeds
+      // CHUNK_SIZE so the combined buffer is flushed synchronously inside
+      // write(). The buffered→drained transition happens during the second
+      // with_mut call, which must still surface as a drain callback.
+      expect(terminal.write("hello")).toBe(5);
+      expect(terminal.write(Buffer.alloc(5000, 66))).toBe(5000);
+
+      await promise;
+      terminal.close();
+
+      expect(drainCount).toBeGreaterThan(0);
+    });
   });
 
   describe.concurrent("subprocess interaction", () => {

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows } from "harness";
 
 // Helper to enable echo on a terminal (echo is disabled by default to avoid duplication)
 function enableEcho(terminal: Bun.Terminal) {
@@ -647,7 +647,14 @@ describe("Bun.Terminal", () => {
       expect(drainCalled).toBe(true);
     });
 
-    test.skipIf(isWindows)("drain fires when a second write flushes what the first buffered", async () => {
+    // Reaching the `had_buffered && !has_pending` branch needs a second write
+    // whose combined size both exceeds CHUNK_SIZE (so should_buffer is false)
+    // and fits in the kernel PTY input queue (so the sync flush completes).
+    // On Linux the queue is ~12K so 5005 bytes works; on macOS it is smaller
+    // than 5005 with no slave reader, and on Apple Silicon CHUNK_SIZE is 16K,
+    // so neither constraint is satisfiable there. The branch under test has no
+    // target-specific code, so Linux is the regression guard.
+    test.skipIf(!isLinux)("drain fires when a second write flushes what the first buffered", async () => {
       const { promise, resolve } = Promise.withResolvers<void>();
       let drainCount = 0;
 
@@ -659,13 +666,6 @@ describe("Bun.Terminal", () => {
       });
       terminal.setRawMode(true);
 
-      // First write is below CHUNK_SIZE so it buffers; second write exceeds
-      // CHUNK_SIZE (4K here) but fits in the kernel PTY input queue, so the
-      // combined buffer is flushed synchronously inside write() and drain
-      // must fire from the had_buffered && !has_pending check. On Apple
-      // Silicon CHUNK_SIZE is 16K so the second write also buffers and the
-      // test resolves via the async-poll path instead; the sync-flush branch
-      // has no target-specific code so Linux coverage is the regression guard.
       expect(terminal.write("hello")).toBe(5);
       expect(terminal.write(Buffer.alloc(5000, 66))).toBe(5000);
 


### PR DESCRIPTION
### What does this PR do?

`terminal.write()` returned the count of bytes flushed to the PTY fd synchronously while the underlying `StreamingWriter` buffered the rest for later delivery. A caller following the documented contract ("@returns The number of bytes written") and re-sending the "unwritten" tail duplicated the child's stdin:

```js
const N = 128 * 1024;
const r1 = t.write(buf);            // r1 = 11776, but all 131072 accepted & buffered
t.write(buf.subarray(r1));          // docs say: send the rest
// child reads 250368 = N + (N - r1); the tail arrived twice
```

A second `write()` on a non-empty buffer could also return more than its own input, because the count included previously buffered bytes drained by that call. Separately, the `drain` callback never fired on POSIX (`PosixStreamingWriter` never dispatches `on_ready`).

Fix: `Terminal::write()` returns `bytes.len()` on every non-error result; the `StreamingWriter` always accepts the full input (buffering any unflushed tail), so there is nothing for the caller to re-send. This matches node-pty's fire-and-forget model. `Terminal` now records whether the writer has buffered data after each `write()` and, on POSIX, fires the `drain` callback when the poll path reports `WriteStatus::Drained` with buffered data outstanding (or when a later `write()` synchronously drains an earlier one's buffer). Windows keeps its existing `on_writable` path. The `.d.ts` doc for `write()` is clarified accordingly.

### How did you verify your code works?

New test in `test/js/bun/terminal/terminal-spawn.test.ts` spawns a child that counts bytes until a sentinel, writes 128KB + 64B, and asserts `write(128KB)` returns 131072, a second `write(64B)` returns 64 (not a combined-buffer count), the child receives exactly 131072 + 64 bytes, and `drain` fires after the buffered tail is flushed. The previously todo'd POSIX `drain callback is invoked when writer is ready` test in `terminal.test.ts` now passes and is un-todo'd, and a second drain test covers the sync-flush-of-prior-buffer path.

- `USE_SYSTEM_BUN=1 bun test terminal-spawn.test.ts -t "full input length"` fails (`Expected: 131072, Received: 11776`)
- `bun bd test test/js/bun/terminal/` passes (128 pass, 1 skip)
- `bun run rust:check-all` 10 ok, 0 failed

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/terminal/terminal-spawn.test.ts test/js/bun/terminal/terminal.test.ts

<!-- robobun:evidence:end -->