### PR TITLE
test: use tempDir in log-test.test.ts instead of hardcoded /tmp path

### DIFF
--- a/test/cli/run/log-test.test.ts
+++ b/test/cli/run/log-test.test.ts
@@ -1,18 +1,16 @@
 import { spawnSync } from "bun";
 import { expect, it } from "bun:test";
-import * as fs from "fs";
-import { bunEnv, bunExe } from "harness";
-import { dirname, join, resolve } from "path";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 it("should not log .env when quiet", async () => {
-  writeDirectoryTree("/tmp/log-test-silent", {
+  using dir = tempDir("log-test-silent", {
     ".env": "FOO=bar",
     "bunfig.toml": `logLevel = "error"`,
     "index.ts": "export default console.log('Here');",
   });
   const { stderr } = spawnSync({
     cmd: [bunExe(), "index.ts"],
-    cwd: "/tmp/log-test-silent",
+    cwd: String(dir),
     env: bunEnv,
   });
 
@@ -20,7 +18,7 @@ it("should not log .env when quiet", async () => {
 });
 
 it("should log .env by default", async () => {
-  writeDirectoryTree("/tmp/log-test-silent", {
+  using dir = tempDir("log-test-silent", {
     ".env": "FOO=bar",
     "bunfig.toml": ``,
     "index.ts": "export default console.log('Here');",
@@ -28,27 +26,9 @@ it("should log .env by default", async () => {
 
   const { stderr } = spawnSync({
     cmd: [bunExe(), "index.ts"],
-    cwd: "/tmp/log-test-silent",
+    cwd: String(dir),
     env: bunEnv,
   });
 
   expect(stderr?.toString().includes(".env")).toBe(false);
 });
-
-function writeDirectoryTree(base: string, paths: Record<string, any>) {
-  base = resolve(base);
-  for (const path of Object.keys(paths)) {
-    const content = paths[path];
-    const joined = join(base, path);
-
-    try {
-      fs.mkdirSync(join(base, dirname(path)), { recursive: true });
-    } catch (e) {}
-
-    try {
-      fs.unlinkSync(joined);
-    } catch (e) {}
-
-    fs.writeFileSync(joined, content);
-  }
-}


### PR DESCRIPTION
## Failure

`test/cli/run/log-test.test.ts` went red on macOS aarch64 in [build 73489](https://buildkite.com/bun/bun/builds/73489):

```
EACCES: permission denied, open '/tmp/log-test-silent/.env'
    path: "/tmp/log-test-silent/.env",
 syscall: "open",
   errno: -13,
      at writeDirectoryTree (.../test/cli/run/log-test.test.ts:52:8)
```

## Cause

Since it was added in 2023 this test has written its fixture to the hardcoded path `/tmp/log-test-silent`. The macOS CI hosts are persistent bare-metal machines that now run buildkite agents under more than one local user. When a run under one user leaves `/tmp/log-test-silent` behind with the default `drwxr-xr-x` mode, a subsequent run under a different user cannot unlink or rewrite its contents and the `fs.writeFileSync` call fails with `EACCES`. No source change triggered this; it is a latent non-hermetic test that surfaced when a second agent user started leaving the directory behind.

## Fix

Use `tempDir` from `harness` so each run gets a unique, user-owned temporary directory that is removed via `using` on exit. The assertions and the files written (`.env`, `bunfig.toml`, `index.ts`) are unchanged, so the same `.env`-loading / `logLevel` code path is still exercised. The bespoke `writeDirectoryTree` helper is no longer needed and is removed.

## Verification

```
bun bd test test/cli/run/log-test.test.ts
 2 pass
 0 fail
```

Confirmed on the affected host that `/tmp` contains entries owned by both `ciadmin` and `administrator`, which is what makes the fixed path unsafe.