### PR TITLE
node:http: let the 'clientError' listener own the response and socket

### DIFF
--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -415,7 +415,14 @@ private:
         /* If we got fullptr that means the parser wants us to close the socket from error (same as calling the errorHandler) */
         if (httpErrorStatusCode) {
             if(httpContextData->onClientError) {
+                /* node:http 'clientError' owns the response and socket; re-arm
+                 * the parser for any further bytes, flush corked responses (JS
+                 * writes bypass the cork buffer), then hand off. */
+                httpResponseData->resetParserState();
+                ((AsyncSocket<SSL> *) s)->uncork();
                 httpContextData->onClientError(SSL, s, result.parserError, data, length);
+                us_socket_unref(s);
+                return s;
             }
             /* For errors, we only deliver them "at most once". We don't care if they get halfways delivered or not. */
             us_socket_write(s, httpErrorResponses[httpErrorStatusCode].data(), (int) httpErrorResponses[httpErrorStatusCode].length());

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -419,6 +419,7 @@ private:
                  * the parser for any further bytes, flush corked responses (JS
                  * writes bypass the cork buffer), then hand off. */
                 httpResponseData->resetParserState();
+                httpResponseData->isConnectRequest = false;
                 ((AsyncSocket<SSL> *) s)->uncork();
                 httpContextData->onClientError(SSL, s, result.parserError, data, length);
                 us_socket_unref(s);

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -414,6 +414,15 @@ namespace uWS
     struct HttpParser
     {
 
+    public:
+        /* Re-arm after a parse error when the caller keeps the socket open
+         * (node:http 'clientError' with a user listener): the next bytes
+         * start a fresh request instead of resuming mid-stream. */
+        void resetParserState() {
+            fallback.clear();
+            remainingStreamingBytes = 0;
+        }
+
     private:
         std::string fallback;
          /* This guy really has only 30 bits since we reserve two highest bits to chunked encoding parsing state */

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1022,7 +1022,7 @@ function onServerClientError(ssl: boolean, socket: unknown, errorCode: number, r
     // pipelined request in the same read may have corked the Duplex for its
     // ServerResponse, which would buffer this write and drop it on destroy.
     const handle = socket as any;
-    if (handle && !handle.closed && (!nodeSocket._httpMessage || !nodeSocket._httpMessage._headerSent)) {
+    if (handle && !handle.closed && (!nodeSocket._httpMessage || !nodeSocket._httpMessage.headersSent)) {
       let response;
       switch (errorCode) {
         case HttpParserError.HTTP_PARSER_ERROR_REQUEST_HEADER_FIELDS_TOO_LARGE:

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1010,9 +1010,35 @@ function onServerClientError(ssl: boolean, socket: unknown, errorCode: number, r
   if (!existingDuplex) {
     self.emit("connection", nodeSocket);
   }
-  self.emit("clientError", err, nodeSocket);
-  if (nodeSocket.listenerCount("error") > 0) {
-    nodeSocket.emit("error", err);
+  // Mirror Node.js's socketOnError (lib/_http_server.js): a 'clientError'
+  // listener owns the response and socket lifecycle; only when none is
+  // attached do we reply with the canned status and destroy.
+  nodeSocket.removeListener("error", onServerSocketError);
+  if (nodeSocket.listenerCount("error") === 0) {
+    nodeSocket.on("error", noopOnError);
+  }
+  if (!self.emit("clientError", err, nodeSocket)) {
+    // Write via the native handle (us_socket_write), not the Duplex: a
+    // pipelined request in the same read may have corked the Duplex for its
+    // ServerResponse, which would buffer this write and drop it on destroy.
+    const handle = socket as any;
+    if (handle && !handle.closed && (!nodeSocket._httpMessage || !nodeSocket._httpMessage._headerSent)) {
+      let response;
+      switch (errorCode) {
+        case HttpParserError.HTTP_PARSER_ERROR_REQUEST_HEADER_FIELDS_TOO_LARGE:
+          response = "HTTP/1.1 431 Request Header Fields Too Large\r\nConnection: close\r\n\r\n";
+          break;
+        case HttpParserError.HTTP_PARSER_ERROR_INVALID_HTTP_VERSION:
+          response = "HTTP/1.1 505 HTTP Version Not Supported\r\nConnection: close\r\n\r\n";
+          break;
+        default:
+          response = "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n";
+          break;
+      }
+      handle.write(response);
+      handle.end();
+    }
+    nodeSocket.destroy(err);
   }
 }
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1023,18 +1023,10 @@ function onServerClientError(ssl: boolean, socket: unknown, errorCode: number, r
     // ServerResponse, which would buffer this write and drop it on destroy.
     const handle = socket as any;
     if (handle && !handle.closed && (!nodeSocket._httpMessage || !nodeSocket._httpMessage.headersSent)) {
-      let response;
-      switch (errorCode) {
-        case HttpParserError.HTTP_PARSER_ERROR_REQUEST_HEADER_FIELDS_TOO_LARGE:
-          response = "HTTP/1.1 431 Request Header Fields Too Large\r\nConnection: close\r\n\r\n";
-          break;
-        case HttpParserError.HTTP_PARSER_ERROR_INVALID_HTTP_VERSION:
-          response = "HTTP/1.1 505 HTTP Version Not Supported\r\nConnection: close\r\n\r\n";
-          break;
-        default:
-          response = "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n";
-          break;
-      }
+      const response =
+        errorCode === HttpParserError.HTTP_PARSER_ERROR_REQUEST_HEADER_FIELDS_TOO_LARGE
+          ? "HTTP/1.1 431 Request Header Fields Too Large\r\nConnection: close\r\n\r\n"
+          : "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n";
       handle.write(response);
       handle.end();
     }

--- a/test/js/node/http/node-http-proxy.js
+++ b/test/js/node/http/node-http-proxy.js
@@ -32,12 +32,12 @@ export async function run() {
     req.pipe(proxyRequest); // Use pipe instead of manual data handling
   });
 
-  proxyServer.listen(0, "localhost", async () => {
+  proxyServer.listen(0, "127.0.0.1", async () => {
     const address = proxyServer.address();
 
     const options = {
       protocol: "http:",
-      hostname: "localhost",
+      hostname: "127.0.0.1",
       port: address.port,
       path: "/", // Change path to /
       headers: {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -3058,6 +3058,50 @@ describe("clientError listener owns the response and socket", () => {
       server.close();
     }
   });
+
+  it("does not inject a 400 mid-stream when the in-flight response already sent headers", async () => {
+    const server = createServer((req, res) => {
+      res.write("partial-");
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+    try {
+      const { closed, data } = await raw(port, "GET / HTTP/1.1\r\nHost: a\r\n\r\n*");
+      await closed;
+      // The handler's 200 may or may not reach the wire before the socket is
+      // destroyed; either way the canned 400 must not be spliced in after it.
+      expect(data()).not.toInclude("400 Bad Request");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("does not leave the socket in CONNECT-tunnel mode after a failed CONNECT", async () => {
+    // A CONNECT whose request-line parses but whose headers fail latched
+    // isConnectRequest=true; with the socket kept open, a subsequent byte
+    // would be routed as tunnel data (silently swallowed) instead of
+    // reaching the parser. Node.js reports a second clientError for it.
+    const errors: string[] = [];
+    const server = createServer(() => {});
+    server.on("clientError", (err: any) => errors.push(err.code));
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+    try {
+      const { socket, closed } = await raw(port, "CONNECT h:443 HTTP/1.1\r\nContent-Length: x\r\n\r\n");
+      while (errors.length < 1) await new Promise(r => setImmediate(r));
+      socket.write("*");
+      while (errors.length < 2) await new Promise(r => setImmediate(r));
+      socket.end();
+      await closed;
+      // Two errors: the failed CONNECT, then the '*' reached the parser.
+      expect(errors.length).toBe(2);
+    } finally {
+      server.closeAllConnections?.();
+      server.close();
+    }
+  });
 });
 
 it("clientError after a kept-alive request reuses the connection's socket and untracks it on close", async () => {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2951,7 +2951,7 @@ describe("clientError listener owns the response and socket", () => {
   // Node.js lib/_http_server.js socketOnError: when a 'clientError' listener is
   // attached, the server writes nothing and does not close; the listener owns
   // the response and the socket lifecycle. When no listener is attached the
-  // server writes a default 400/431/505 and destroys the socket.
+  // server writes a default 400 (or 431 for header overflow) and destroys.
   async function raw(port: number, bytes: string) {
     const socket = connect(port, "127.0.0.1");
     const closed = new Promise<void>(r => socket.on("close", () => r()));
@@ -3054,6 +3054,21 @@ describe("clientError listener owns the response and socket", () => {
       await closed;
       // Exactly the listener's bytes; no canned 400 prefixed or appended.
       expect(data()).toBe("HTTP/1.1 418 I'm a teapot\r\nConnection: close\r\n\r\n");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("writes 400 (not 505) for an invalid HTTP version when no listener is attached", async () => {
+    // Node.js's socketOnError has no 505 arm; HPE_INVALID_VERSION falls to 400.
+    const server = createServer(() => {});
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+    try {
+      const { closed, data } = await raw(port, "GET / HTTP/9.9\r\nHost: a\r\n\r\n");
+      await closed;
+      expect(data()).toBe("HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n");
     } finally {
       server.close();
     }

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1583,7 +1583,8 @@ describe("HTTP Server Security Tests - Advanced", () => {
       const mockHandler = createMockHandler();
       server.on("request", mockHandler);
       const { promise, resolve, reject } = Promise.withResolvers();
-      server.on("clientError", (err: any) => {
+      server.on("clientError", (err: any, sock) => {
+        sock.end("HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n");
         try {
           expect(err.code).toBe("HPE_INVALID_HEADER_TOKEN");
           resolve();
@@ -1604,7 +1605,8 @@ describe("HTTP Server Security Tests - Advanced", () => {
       const mockHandler = createMockHandler();
       server.on("request", mockHandler);
       const { promise, resolve, reject } = Promise.withResolvers();
-      server.on("clientError", (err: any) => {
+      server.on("clientError", (err: any, sock) => {
+        sock.end("HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n");
         try {
           expect(err.code).toBe("HPE_INTERNAL");
           resolve();
@@ -1625,7 +1627,8 @@ describe("HTTP Server Security Tests - Advanced", () => {
   describe("Transfer-Encoding Attacks", () => {
     test("rejects chunked requests with malformed chunk size", async () => {
       const { promise, resolve, reject } = Promise.withResolvers();
-      server.on("clientError", (err: any) => {
+      server.on("clientError", (err: any, sock) => {
+        sock.end("HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n");
         try {
           expect(err.code).toBe("HPE_INTERNAL");
           resolve();
@@ -1653,7 +1656,8 @@ describe("HTTP Server Security Tests - Advanced", () => {
 
     test("rejects chunked requests with invalid chunk ending", async () => {
       const { promise, resolve, reject } = Promise.withResolvers();
-      server.on("clientError", (err: any) => {
+      server.on("clientError", (err: any, sock) => {
+        sock.end("HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n");
         try {
           expect(err.code).toBe("HPE_INTERNAL");
           resolve();
@@ -1685,7 +1689,8 @@ describe("HTTP Server Security Tests - Advanced", () => {
       const mockHandler = createMockHandler();
       server.on("request", mockHandler);
       const { promise, resolve, reject } = Promise.withResolvers();
-      server.on("clientError", (err: any) => {
+      server.on("clientError", (err: any, sock) => {
+        sock.end("HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n");
         try {
           expect(err.code).toBe("HPE_INVALID_TRANSFER_ENCODING");
           resolve();
@@ -1716,7 +1721,8 @@ describe("HTTP Server Security Tests - Advanced", () => {
       const mockHandler = createMockHandler();
       server.on("request", mockHandler);
       const { promise, resolve, reject } = Promise.withResolvers();
-      server.on("clientError", (err: any) => {
+      server.on("clientError", (err: any, sock) => {
+        sock.end("HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n");
         try {
           expect(err.code).toBe("HPE_INVALID_HEADER_TOKEN");
           resolve();
@@ -1875,7 +1881,8 @@ describe("HTTP Server Security Tests - Advanced", () => {
       const mockHandler = createMockHandler();
       server.on("request", mockHandler);
       const { promise, resolve, reject } = Promise.withResolvers();
-      server.on("clientError", (err: any) => {
+      server.on("clientError", (err: any, sock) => {
+        sock.end("HTTP/1.1 505 HTTP Version Not Supported\r\nConnection: close\r\n\r\n");
         try {
           expect(err.code).toBe("HPE_INTERNAL");
           resolve();
@@ -1900,7 +1907,8 @@ describe("HTTP Server Security Tests - Advanced", () => {
       const mockHandler = createMockHandler();
       server.on("request", mockHandler);
       const { promise, resolve, reject } = Promise.withResolvers();
-      server.on("clientError", (err: any) => {
+      server.on("clientError", (err: any, sock) => {
+        sock.end("HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n");
         try {
           expect(err.code).toBe("HPE_INTERNAL");
           resolve();
@@ -2937,6 +2945,119 @@ it("removing transfer-encoding on a HEAD response keeps the connection alive", a
   } finally {
     server.close();
   }
+});
+
+describe("clientError listener owns the response and socket", () => {
+  // Node.js lib/_http_server.js socketOnError: when a 'clientError' listener is
+  // attached, the server writes nothing and does not close; the listener owns
+  // the response and the socket lifecycle. When no listener is attached the
+  // server writes a default 400/431/505 and destroys the socket.
+  async function raw(port: number, bytes: string) {
+    const socket = connect(port, "127.0.0.1");
+    const closed = new Promise<void>(r => socket.on("close", () => r()));
+    let data = "";
+    socket.on("data", d => (data += d.toString()));
+    socket.on("error", () => {});
+    await once(socket, "connect");
+    socket.write(bytes);
+    return { socket, closed, data: () => data };
+  }
+
+  it("does not write a default response or close when a listener is attached", async () => {
+    const errors: { code: string; raw: string }[] = [];
+    let serverSocket: any;
+    const server = createServer(() => {});
+    server.on("clientError", (err: any, sock: any) => {
+      serverSocket = sock;
+      errors.push({ code: err.code, raw: err.rawPacket.toString() });
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+    try {
+      const { socket, closed, data } = await raw(port, "*");
+      // Wait for each error before sending the next byte so writes never
+      // coalesce into one TCP read on the server (rawPacket stays one byte
+      // per event). Mirrors test-http-socket-error-listeners.js.
+      while (errors.length < 1) await new Promise(r => setImmediate(r));
+      for (let i = 0; i < 20; i++) {
+        const before = errors.length;
+        socket.write("*");
+        while (errors.length === before) await new Promise(r => setImmediate(r));
+      }
+      // The server wrote nothing to the peer.
+      expect({
+        count: errors.length,
+        wireBytes: data(),
+        allCodesInvalidMethod: errors.every(e => e.code === "HPE_INVALID_METHOD"),
+        allRawSingleByte: errors.every(e => e.raw === "*"),
+        writable: serverSocket.writable,
+        destroyed: serverSocket.destroyed,
+      }).toEqual({
+        count: 21,
+        wireBytes: "",
+        allCodesInvalidMethod: true,
+        allRawSingleByte: true,
+        writable: true,
+        destroyed: false,
+      });
+      socket.end();
+      await closed;
+    } finally {
+      server.closeAllConnections?.();
+      server.close();
+    }
+  });
+
+  it("writes 400 and destroys the socket when no listener is attached", async () => {
+    const socketErrors: any[] = [];
+    const server = createServer(() => {});
+    server.on("connection", s => s.on("error", e => socketErrors.push(e)));
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+    try {
+      const { closed, data } = await raw(port, "FOO /\r\n");
+      await closed;
+      expect(data()).toBe("HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n");
+      expect(socketErrors[0]?.code).toBe("HPE_INVALID_METHOD");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("writes 431 for a header overflow when no listener is attached", async () => {
+    const server = createServer(() => {});
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+    try {
+      const huge = Buffer.alloc(128 * 1024, 97).toString();
+      const { closed, data } = await raw(port, "GET / HTTP/1.1\r\nHost: a\r\nX-H: " + huge + "\r\n\r\n");
+      await closed;
+      expect(data()).toBe("HTTP/1.1 431 Request Header Fields Too Large\r\nConnection: close\r\n\r\n");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("delivers only the listener's response on the wire", async () => {
+    const server = createServer(() => {});
+    server.on("clientError", (_err, sock) => {
+      sock.end("HTTP/1.1 418 I'm a teapot\r\nConnection: close\r\n\r\n");
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+    try {
+      const { closed, data } = await raw(port, "*");
+      await closed;
+      // Exactly the listener's bytes; no canned 400 prefixed or appended.
+      expect(data()).toBe("HTTP/1.1 418 I'm a teapot\r\nConnection: close\r\n\r\n");
+    } finally {
+      server.close();
+    }
+  });
 });
 
 it("clientError after a kept-alive request reuses the connection's socket and untracks it on close", async () => {


### PR DESCRIPTION
## What

Node.js's contract for `server.on('clientError', handler)`: when a listener is attached, it owns the response and the socket lifecycle; Node writes nothing and does not close. Only when no listener is attached does `socketOnError` reply with a canned 400 (or 431 for header overflow) and destroy the socket.

Bun's uWS `HttpContext.h` called `onClientError` and then unconditionally wrote `httpErrorResponses[code]` + `shutdown` + `close`, so the peer always received a canned 400/431 and the connection always closed regardless of the listener. A listener that wanted to keep the connection open (e.g. `test/js/node/test/parallel/test-http-socket-error-listeners.js`, which expects 21 `clientError` events on one socket) saw exactly one event.

## Repro

```js
const http = require("http");
const net = require("net");
let i = 0, socket;
const server = http.createServer(() => {});
server.on("clientError", () => { if (i++ === 20) socket.end(); else socket.write("*"); });
server.listen(0, () => {
  socket = net.createConnection({ port: server.address().port });
  socket.on("connect", () => socket.write("*"));
  socket.on("data", d => console.error("data", d.length)); // bun before: 47-byte 400; node: nothing
  socket.on("close", () => server.close());
});
```

Node: 21 `clientError` events, no bytes on the wire. Bun before: 1 event, 47-byte 400 written, socket closed.

## Fix

- `packages/bun-uws/src/HttpParser.h`: add `resetParserState()` to clear `fallback` and `remainingStreamingBytes` so a socket the listener keeps open re-parses subsequent bytes from scratch (Node creates a fresh parser per error).
- `packages/bun-uws/src/HttpContext.h`: when `onClientError` is set (node:http servers only; Bun.serve never sets it), reset the parser and `isConnectRequest`, `uncork()`, call the handler, unref, and return the socket. The canned write + shutdown + close path stays in place for the no-handler case (Bun.serve).
- `src/js/node/_http_server.ts` `onServerClientError`: mirror Node's `socketOnError`. Swap the pre-attached `onServerSocketError` for a noop so a later `destroy(err)` does not crash as an unhandled `'error'` event, then `emit('clientError', err, socket)`. When it returns `false` (no listener), write the canned 400/431 through the native handle (a prior pipelined request in the same read may have corked the Duplex for its ServerResponse), then `destroy(err)`. The guard against writing over an in-flight response reads `headersSent` (which reflects `headerStateSymbol`) rather than `_headerSent`, which Bun's native-path ServerResponse never sets.

Eight existing security tests in `test/js/node/http/node-http.test.ts` asserted both a `clientError` listener and an auto-400; those listeners now write the response themselves, which is the Node-compatible shape.

## Verification

```
bun bd test test/js/node/http/node-http.test.ts -t "clientError listener owns"
```

Seven tests: listener attached (21 events, no wire bytes, socket stays open), no-listener 400, no-listener 431, no-listener 400 for an invalid HTTP version (Node has no 505 arm), listener writes a custom response (only its bytes on the wire), no 400 spliced into an in-flight response when `headersSent`, and a failed CONNECT does not leave the parser in tunnel mode. The first, fifth, sixth and seventh time out or fail without the src/packages change and pass with it; the full set matches Node.js.

Node parallel tests all pass: `test-http-socket-error-listeners.js`, `test-http-server-destroy-socket-on-client-error.js`, `test-http-header-overflow.js`, `test-http-blank-header.js`, `test-http-dummy-characters-smuggling.js`, `test-http-double-content-length.js`, `test-http-invalid-te.js`, `test-http-missing-header-separator-{cr,lf}.js`, `test-http-request-smuggling-content-length.js`, `test-http-transfer-encoding-smuggling.js`.

Bun.serve's behavior is unchanged (it never sets `onClientError`, so the canned response path still runs).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (9c595d1a5)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [376.58ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [71.15ms]
(pass) node:http > createServer > request & response body streaming (large) [119.31ms]
(pass) node:http > createServer > request & response body streaming (small) [74.46ms]
(pass) node:http > createServer > listen should return server [14.74ms]
(pass) node:http > createServer > listen callback should be bound to server [25.41ms]
(pass) node:http > createServer > should use the provided port [51.50ms]
(pass) node:http > createServer > should assign a random port when undefined [28.81ms]
(pass) node:http > createServer > option method should be uppercase
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (8e977092f)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [8.58ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [2.75ms]
(pass) node:http > createServer > request & response body streaming (large) [4.44ms]
(pass) node:http > createServer > request & response body streaming (small) [2.46ms]
(pass) node:http > createServer > listen should return server [1.23ms]
(pass) node:http > createServer > listen callback should be bound to server [1.75ms]
(pass) node:http > createServer > should use the provided port [1.73ms]
(pass) node:http > createServer > should assign a random port when undefined [0.83ms]
(pass) node:http > createServer > option method should be uppercase (#7250) [2.14ms]
(pass) node:http > response > set-cookie works with getHeader [0.08ms]
(pass) node:http > response > set-cookie works with getHeaders [0.09ms]
(pass) node:http > request > should not insert extraneous accept-encoding header [3.09ms]
(pass) node:http > request > multiple Set-Cookie headers works #6810 [10.68ms]
(pass) node:http > request > should make a standard GET request when passed string as first arg [4
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (9c595d1a5)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [378.10ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [71.42ms]
(pass) node:http > createServer > request & response body streaming (large) [125.41ms]
(pass) node:http > createServer > request & response body streaming (small) [80.96ms]
(pass) node:http > createServer > listen should return server [16.26ms]
(pass) node:http > createServer > listen callback should be bound to server [23.03ms]
(pass) node:http > createServer > should use the provided port [57.65ms]
(pass) node:http > createServer > should assign a random port when undefined [28.97ms]
(pass) node:http > createServer > option method should be uppercase
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 724ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/99] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[2/99] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[3/99] gen cpp.rs (cppbind)
[4/99] gen JS modules (bundle-modules)
Preprocess modules (6599ms)
Bundle modules (39ms)
Postprocesss modules (30ms)
Bundle Functions (698ms)
Generate Code (95ms)

[7.48s] Bundled "src/js" for production
  1912 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[4/99] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-uws/src/HttpContext.h   |   8 ++
 packages/bun-uws/src/HttpParser.h    |   9 ++
 src/js/node/_http_server.ts          |  24 ++++-
 test/js/node/http/node-http-proxy.js |   4 +-
 test/js/node/http/node-http.test.ts  | 196 +++++++++++++++++++++++++++++++++--
 5 files changed, 228 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
packages/bun-uws/src/HttpContext.h        6      4      0
packages/bun-uws/src/HttpParser.h         3      1      0
src/js/node/_http_server.ts               8      7      0
test/js/node/http/node-http-proxy.js      2      1      0
test/js/node/http/node-http.test.ts       9     11      0
```

</details>

<!-- robobun:evidence:end -->