### PR TITLE
test(serve-body-leak): give release-asan the same 60s per-test timeout as debug

### DIFF
--- a/test/js/bun/http/serve-body-leak.test.ts
+++ b/test/js/bun/http/serve-body-leak.test.ts
@@ -194,7 +194,9 @@ for (const test_info of [
         process.kill?.();
       }
     },
-    isDebug ? 60_000 : 40_000,
+    // release-asan runs streaming-echo at ~31s median (27-39s over 35 CI runs),
+    // so 40s leaves no margin on a slow runner; give ASAN the same 60s as debug.
+    isDebug || isASAN ? 60_000 : 40_000,
   );
 }
 


### PR DESCRIPTION
`test/js/bun/http/serve-body-leak.test.ts` went red on the debian 13 x64-asan lane in [build 73611](https://buildkite.com/bun/bun/builds/73611): the "should not leak memory when streaming the body and echoing it back" case timed out at 40s on all four retries. The PR under test (#33580, tty `setRawMode`) does not touch anything related, so this is the test's own budget.

### Cause

This is not a hang and not a code regression. Scraping the timestamped logs from 35 recent x64-asan runs (builds 73562-73623) plus 4 pre-#33193 runs:

| case | release (debian 13 x64) | release-asan (debian 13 x64-asan) |
|---|---|---|
| `callIgnore` | ~5s | 15-24s |
| `callStreamingEcho` | ~8s | **27-39s** (median ~31s) |
| total file | ~40-47s | ~125-195s |

The streaming-echo case has been running at ~31s median on ASAN since well before the webstreams rewrite (pre-#33193 samples: 28.2 / 30.9 / 28.2 / 31.6s), so the 40s budget has always been tight there. On build 73611 every case in the file ran ~35% slower than typical (the shard landed on a slower EC2 instance; `callIgnore` 23.6s vs a typical ~17s), which is enough to push echo past 40s. A local 15000-request `/streaming-echo` probe against a debug build runs at a flat ~395 req/s with no stalls, confirming throughput, not a hang.

The file already scales its `end_memory` threshold for ASAN (#32520), and `scripts/runner.node.mjs` already applies a 3x ASAN multiplier to the default `--timeout` for the same reason, but that multiplier does not reach tests that pass their own explicit third-argument timeout. Skipping on ASAN was tried in #28301 and reverted in #28337; this change keeps the test running there with a budget that matches the measured cost.

### Fix

```diff
-    isDebug ? 60_000 : 40_000,
+    isDebug || isASAN ? 60_000 : 40_000,
```

Matches the `isDebug || isASAN` convention already used by 16 other test files for timeouts/iteration counts. 60s is ~2x the ASAN median and ~1.4x the extrapolated worst case (73611). Release lanes stay at 40s.

### Verification

- `USE_SYSTEM_BUN=1 bun test test/js/bun/http/serve-body-leak.test.ts`: 8 pass, echo 11.4s (release, budget unchanged at 40s).
- `bun bd test test/js/bun/http/serve-body-leak.test.ts -t 'ignoring the body'`: passes; file parses and the unchanged isDebug=60s branch applies under the debug build.
- `/tmp/echo-probe.ts` against debug build: 15000 `/streaming-echo` requests at a steady ~395 req/s, no stalls.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->