### PR TITLE
test(cli/upgrade): tolerate the canary re-upload 404 and add a hermetic FILE_SHARE_DELETE test

### DIFF
--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -99,84 +99,86 @@ describe.concurrent(() => {
   });
 
   it("zero arguments, should succeed", async () => {
-    const tagName = bunExe().includes("-debug") ? "canary" : `bun-v${Bun.version}`;
-    using server = Bun.serve({
-      tls: tls,
-      port: 0,
-      async fetch() {
-        return new Response(
-          JSON.stringify({
-            "tag_name": tagName,
-            "assets": [
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-windows-x64.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-windows-x64.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-windows-x64-baseline.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-windows-x64-baseline.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-windows-aarch64.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-windows-aarch64.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-linux-x64.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-linux-x64.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-linux-x64-baseline.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-linux-x64-baseline.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-linux-aarch64.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-linux-aarch64.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-darwin-x64.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-darwin-x64.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-darwin-x64-baseline.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-darwin-x64-baseline.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-darwin-aarch64.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-darwin-aarch64.zip`,
-              },
-            ],
-          }),
-        );
+    const cwd = tmpdirSync();
+    await using proc = spawn({
+      cmd: [bunExe(), "upgrade"],
+      cwd,
+      stdout: null,
+      stdin: "pipe",
+      stderr: "pipe",
+      env: {
+        ...env,
+        // Canary builds hard-code the github.com download URL and never
+        // consult GITHUB_API_DOMAIN, so point at a dead proxy to fail the
+        // download locally instead of depending on the live canary release.
+        HTTPS_PROXY: "http://127.0.0.1:1",
+        HTTP_PROXY: "http://127.0.0.1:1",
       },
     });
 
-    // On windows, open the temporary directory without FILE_SHARE_DELETE before spawning
-    // the upgrade process. This is to test for EBUSY errors
-    openTempDirWithoutSharingDelete();
-    const cwd = tmpdirSync();
-    const execPath = join(cwd, basename(bunExe()));
-    await copyFile(bunExe(), execPath);
+    const err = await proc.stderr.text();
+    // Should not contain error message
+    expect(err.split(/\r?\n/)).not.toContain(
+      "error: This command updates Bun itself, and does not take package names.",
+    );
+    await proc.exited;
+  });
+});
 
+// https://github.com/oven-sh/bun/pull/10387 : upgrading must not EBUSY on
+// Windows when another handle holds the OS temp dir without FILE_SHARE_DELETE.
+// The open/close helpers are no-ops on other platforms.
+it("completes the download when the OS temp dir is held open without FILE_SHARE_DELETE", async () => {
+  const tagName = "bun-v9.8.7";
+  const assetNames: string[] = [];
+  for (const os of ["windows", "linux", "darwin"]) {
+    for (const arch of ["x64", "aarch64"]) {
+      for (const abi of ["", "-musl"]) {
+        for (const cpu of ["", "-baseline"]) {
+          assetNames.push(`bun-${os}-${arch}${abi}${cpu}.zip`);
+        }
+      }
+    }
+  }
+
+  let apiHits = 0;
+  using server = Bun.serve({
+    tls: tls,
+    port: 0,
+    async fetch(req) {
+      const { pathname } = new URL(req.url);
+      if (pathname.startsWith("/releases/")) {
+        return new Response("this is not a real zip archive");
+      }
+      apiHits++;
+      return new Response(
+        JSON.stringify({
+          "tag_name": tagName,
+          "assets": assetNames.map(name => ({
+            "url": "foo",
+            "content_type": "application/zip",
+            "name": name,
+            "browser_download_url": `https://${server.hostname}:${server.port}/releases/${tagName}/${name}`,
+          })),
+        }),
+      );
+    },
+  });
+
+  const cwd = tmpdirSync();
+  const execPath = join(cwd, basename(bunExe()));
+  await copyFile(bunExe(), execPath);
+
+  // On Windows, hold a handle to the OS temp directory without FILE_SHARE_DELETE
+  // for the whole upgrade run so EBUSY handling is actually exercised.
+  openTempDirWithoutSharingDelete();
+  let stderr: string;
+  let exitCode: number;
+  try {
     await using proc = Bun.spawn({
-      cmd: [execPath, "upgrade"],
+      // --stable routes through GITHUB_API_DOMAIN (the canary path hard-codes
+      // github.com and would never touch this mock).
+      cmd: [execPath, "upgrade", "--stable"],
       cwd,
       stdout: null,
       stdin: "pipe",
@@ -185,18 +187,23 @@ describe.concurrent(() => {
         ...env,
         NODE_TLS_REJECT_UNAUTHORIZED: "0",
         GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
+        ASAN_OPTIONS: [env.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
       },
     });
 
+    [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  } finally {
     closeTempDirHandle();
+  }
 
-    // Should not contain error message
-    expect(await proc.stderr.text()).not.toContain("error:");
-    // Reap the subprocess: stderr can close before the child exits, and an
-    // unreaped child is force-killed by the test runner at test end without
-    // draining the Subprocess refcount — LSan then flags it as a leak.
-    await proc.exited;
-  });
+  // The release metadata must have been served by the local mock.
+  expect(apiHits).toBeGreaterThan(0);
+  // The upgrade reached the download/temp-dir stage with our fake release.
+  expect(stderr).toContain("9.8.7");
+  // No EBUSY while staging into the temp directory.
+  expect(stderr).not.toContain("EBUSY");
+  // The payload is not a real zip, so extraction fails cleanly.
+  expect(exitCode).toBe(1);
 });
 
 it("recreates the staging directory in the temp dir instead of reusing a pre-existing one", async () => {

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -99,29 +99,39 @@ describe.concurrent(() => {
   });
 
   it("zero arguments, should succeed", async () => {
+    // On Windows, hold the temp dir open without FILE_SHARE_DELETE for the
+    // whole run to exercise EBUSY handling. The canary path hard-codes
+    // github.com, so this also doubles as the one live end-to-end check.
+    openTempDirWithoutSharingDelete();
     const cwd = tmpdirSync();
-    await using proc = spawn({
-      cmd: [bunExe(), "upgrade"],
-      cwd,
-      stdout: null,
-      stdin: "pipe",
-      stderr: "pipe",
-      env: {
-        ...env,
-        // Canary builds hard-code the github.com download URL and never
-        // consult GITHUB_API_DOMAIN, so point at a dead proxy to fail the
-        // download locally instead of depending on the live canary release.
-        HTTPS_PROXY: "http://127.0.0.1:1",
-        HTTP_PROXY: "http://127.0.0.1:1",
-      },
-    });
+    const execPath = join(cwd, basename(bunExe()));
+    await copyFile(bunExe(), execPath);
 
-    const err = await proc.stderr.text();
-    // Should not contain error message
-    expect(err.split(/\r?\n/)).not.toContain(
-      "error: This command updates Bun itself, and does not take package names.",
-    );
-    await proc.exited;
+    let stderr: string;
+    try {
+      await using proc = Bun.spawn({
+        cmd: [execPath, "upgrade"],
+        cwd,
+        stdout: null,
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      [stderr] = await Promise.all([proc.stderr.text(), proc.exited]);
+    } finally {
+      closeTempDirHandle();
+    }
+
+    expect(stderr).not.toContain("This command updates Bun itself, and does not take package names.");
+
+    // The canary release on github.com is periodically rebuilt by deleting the
+    // old assets and uploading new ones, leaving a short window where the
+    // asset 404s. That window is not a bug in `bun upgrade`.
+    if (stderr.includes("Canary builds are not available for this platform yet")) {
+      console.warn("bun upgrade: skipped live end-to-end assertions, canary asset 404'd (release re-upload window)");
+    } else {
+      expect(stderr).not.toContain("error:");
+    }
   });
 });
 
@@ -142,12 +152,14 @@ it("completes the download when the OS temp dir is held open without FILE_SHARE_
   }
 
   let apiHits = 0;
+  let downloadHits = 0;
   using server = Bun.serve({
     tls: tls,
     port: 0,
     async fetch(req) {
       const { pathname } = new URL(req.url);
       if (pathname.startsWith("/releases/")) {
+        downloadHits++;
         return new Response("this is not a real zip archive");
       }
       apiHits++;
@@ -187,6 +199,13 @@ it("completes the download when the OS temp dir is held open without FILE_SHARE_
         ...env,
         NODE_TLS_REJECT_UNAUTHORIZED: "0",
         GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
+        // Clear ambient proxy configuration so the mock is reached directly.
+        HTTPS_PROXY: "",
+        HTTP_PROXY: "",
+        https_proxy: "",
+        http_proxy: "",
+        NO_PROXY: "",
+        no_proxy: "",
         ASAN_OPTIONS: [env.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
       },
     });
@@ -196,9 +215,9 @@ it("completes the download when the OS temp dir is held open without FILE_SHARE_
     closeTempDirHandle();
   }
 
-  // The release metadata must have been served by the local mock.
-  expect(apiHits).toBeGreaterThan(0);
-  // The upgrade reached the download/temp-dir stage with our fake release.
+  // Both the release metadata and the archive must have been served locally;
+  // the archive fetch is what proves we reached filesystem.tmpdir().
+  expect({ apiHits, downloadHits }).toEqual({ apiHits: 1, downloadHits: 1 });
   expect(stderr).toContain("9.8.7");
   // No EBUSY while staging into the temp directory.
   expect(stderr).not.toContain("EBUSY");


### PR DESCRIPTION
## Problem

`test/cli/install/bun-upgrade.test.ts` went red on the darwin-aarch64 lane in build [73614](https://buildkite.com/bun/bun/builds/73614):

```
error: expect(received).not.toContain(expected)
Expected to not contain: "error:"
Received: "Downloading... error: Canary builds are not available for this platform yet
   Release: https://github.com/oven-sh/bun/releases/tag/canary
  Filename: bun-darwin-aarch64.zip"
```

## Cause

The `zero arguments, should succeed` test starts a local TLS server and passes `GITHUB_API_DOMAIN=<mock>` so the upgrade command would fetch release metadata from it. But `GITHUB_API_DOMAIN` is only read inside `get_latest_version`, and that function is only called on the `--stable` path. On canary builds (every CI build has `IS_CANARY = true`) `bun upgrade` constructs a hard-coded `https://github.com/oven-sh/bun/releases/download/canary/<zip>` URL and downloads it directly, so the mock is never consulted and the test pulls the real canary archive from github.com on every run. Confirmed by request-counting the mock: it sees zero hits on a canary build.

Build 73614 ran 03:57 to 06:17 UTC on 2026-07-16; the `bun-darwin-aarch64.zip` asset on the canary release was re-created at 06:03:07 UTC. The test caught the brief 404 window between the old asset being removed and the new one appearing. The mock server was introduced in #10387 but the canary path predates it and has always been a direct download.

Two adjacent issues surfaced while investigating:

- `closeTempDirHandle()` is called immediately after `Bun.spawn()` returns, so the Windows `FILE_SHARE_DELETE` handle is released before the child process has done anything. The original `spawnSync` version held it for the whole run; the async rewrite (bf1e4922b4) inadvertently dropped that guarantee.
- The mock server also pointed every `browser_download_url` at an external R2 host, so even on the `--stable` path the archive download left the machine.

## Fix

Keep the live end-to-end check (it is the only thing that exercises the full download/extract/verify/install path against a real release), but stop the one known non-bug transient from turning CI red, and add a hermetic backstop for the Windows temp-dir path.

- **`zero arguments, should succeed`**: drop the mock server (dead code on canary builds), hold the Windows `FILE_SHARE_DELETE` handle for the entire child run instead of releasing it right after `Bun.spawn()`, and only back off the broad `expect(stderr).not.toContain("error:")` when stderr carries exactly the `Canary builds are not available for this platform yet` 404 that marks the canary release re-upload window. Any other `error:` still fails the test. The argument-parser assertion is always enforced.
- **New `completes the download when the OS temp dir is held open without FILE_SHARE_DELETE`**: a hermetic variant that passes `--stable` so `GITHUB_API_DOMAIN` is honored, serves both the release JSON and the archive from a local server (with ambient proxy env vars cleared in both casings), holds the temp-dir handle for the whole run, and asserts the mock saw exactly one metadata and one archive request. This covers the temp-dir staging path deterministically so it stays exercised even when the live test has to back off its broad assertion.

Both tests intentionally wrap the upgrade in the `FILE_SHARE_DELETE` handle: the live test matches what #10387 originally set out to cover, the hermetic test guarantees the path is reached regardless of external network state.

No `src/` changes; this is a test-only robustness fix. The stash-src fail-before check does not apply.

Verified: all 9 tests in the file pass on linux-x64 (debug) and windows-x64 (debug).

Fixes #11482