### PR TITLE
watcher(linux): drop inotify event on WatchItemIndex overflow instead of aborting

### DIFF
--- a/src/watcher/INotifyWatcher.rs
+++ b/src/watcher/INotifyWatcher.rs
@@ -451,7 +451,21 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
                 .iter()
                 .position(|&x| x == event.watch_descriptor)
             {
-                Some(idx) => WatchItemIndex::try_from(idx).unwrap(),
+                // WatchItemIndex is u16; nothing caps watchlist length, so drop
+                // an unrepresentable position instead of aborting the process
+                // from the watcher thread (panic = "abort").
+                Some(idx) => match WatchItemIndex::try_from(idx) {
+                    Ok(idx) => idx,
+                    Err(_) => {
+                        bun_core::scoped_log!(
+                            watcher,
+                            "watchlist index {} exceeds WatchItemIndex (u16), dropping event",
+                            idx
+                        );
+                        events_processed += 1;
+                        continue;
+                    }
+                },
                 None => {
                     events_processed += 1;
                     continue;

--- a/src/watcher/INotifyWatcher.rs
+++ b/src/watcher/INotifyWatcher.rs
@@ -447,25 +447,23 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
                 }
             }
 
+            // WatchItemIndex is u16 with u16::MAX reserved as NO_WATCH_ITEM;
+            // nothing caps watchlist length, so drop unrepresentable positions
+            // instead of aborting from the watcher thread (panic = "abort").
             let idx = match eventlist_index
                 .iter()
                 .position(|&x| x == event.watch_descriptor)
             {
-                // WatchItemIndex is u16; nothing caps watchlist length, so drop
-                // an unrepresentable position instead of aborting the process
-                // from the watcher thread (panic = "abort").
-                Some(idx) => match WatchItemIndex::try_from(idx) {
-                    Ok(idx) => idx,
-                    Err(_) => {
-                        bun_core::scoped_log!(
-                            watcher,
-                            "watchlist index {} exceeds WatchItemIndex (u16), dropping event",
-                            idx
-                        );
-                        events_processed += 1;
-                        continue;
-                    }
-                },
+                Some(idx) if idx < WatchItemIndex::MAX as usize => idx as WatchItemIndex,
+                Some(idx) => {
+                    bun_core::scoped_log!(
+                        watcher,
+                        "watchlist index {} >= WatchItemIndex::MAX, dropping event",
+                        idx
+                    );
+                    events_processed += 1;
+                    continue;
+                }
                 None => {
                     events_processed += 1;
                     continue;
@@ -512,7 +510,9 @@ fn process_inotify_event_batch(
     watch_events.sort_unstable_by(|a, b| WatchEvent::sort_by_index(*a, *b));
 
     let mut last_event_index: usize = 0;
-    let mut last_event_id: WatchItemIndex = WatchItemIndex::MAX;
+    // The sentinel must be wider than WatchItemIndex (u16) so it can never
+    // collide with a real index (incl. NO_WATCH_ITEM = 65535).
+    let mut last_event_id: u32 = u32::MAX;
 
     for i in 0..watch_events.len() {
         if watch_events[i].name_len > 0 {
@@ -527,14 +527,14 @@ fn process_inotify_event_batch(
             }
         }
 
-        if watch_events[i].index == last_event_id {
+        if u32::from(watch_events[i].index) == last_event_id {
             // reshaped for borrowck — split_at_mut to get two disjoint &mut.
             let (head, tail) = watch_events.split_at_mut(i);
             head[last_event_index].merge(tail[0]);
             continue;
         }
         last_event_index = i;
-        last_event_id = watch_events[i].index;
+        last_event_id = u32::from(watch_events[i].index);
     }
     if watch_events.is_empty() {
         return Ok(());


### PR DESCRIPTION
Two unguarded int casts in the file watcher turn what Zig handled tolerantly into a process abort from the FileWatcher thread (`Cargo.toml` sets `panic = "abort"`, and `try_from` is a real runtime check not compiled out in release).

### Site 1: kevent(2) returning -1 (macOS/FreeBSD)

`src/watcher/KEventWatcher.rs:84-87`: the coalesce guard is `count < 64`, so a kevent error return of -1 falls into `usize::try_from(-1).expect("int cast")` and aborts.

**Already fixed in #31695** (uses the EINTR-retrying `bun_sys::kevent` wrapper so `count` is `usize` and real errors propagate as `Err`). Not touched here.

### Site 2: watchlist position >= 65536 (Linux)

`src/watcher/INotifyWatcher.rs:454`:

```rust
Some(idx) => WatchItemIndex::try_from(idx).unwrap(),   // WatchItemIndex = u16
```

Nothing caps watchlist length (`Watcher.rs:687`/`:783`), so a project with >65535 watched paths can reach a position that doesn't fit in `u16`, and the `.unwrap()` aborts the process from the watcher thread. The Zig baseline (`INotifyWatcher.zig:281`) used `@intCast`, which is unchecked in Linux ReleaseFast builds, so the same input silently truncated and routed the event to the wrong entry. Wrong, but the process lived.

**Fix:** on overflow, `scoped_log!` and skip the event (`events_processed += 1; continue;`), matching the adjacent `None` arm for an unknown watch descriptor.

### Verification

Source-level finding; reproducing requires >65535 inotify watches on a single module graph, which is impractical and flaky in CI (depends on `fs.inotify.max_user_watches`). `cargo check -p bun_watcher` and `cargo clippy -p bun_watcher` are clean, and `test/cli/hot/watch-many-dirs.test.ts` (the existing inotify stress test) still passes with the debug build.