### PR TITLE
s3: coerce numeric options (expiresIn, partSize, queueSize, retry) like 1.3.x did

### DIFF
--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1928,7 +1928,20 @@ impl CoerceTo for i32 {
 }
 impl CoerceTo for i64 {
     fn coerce_from(v: JSValue, global: &JSGlobalObject) -> JsResult<i64> {
-        v.coerce_to_int64(global)
+        if v.is_int32() {
+            return Ok(v.as_int32() as i64);
+        }
+        if let Some(num) = v.get_number() {
+            return Ok(if num.is_nan() { 0 } else { num as i64 });
+        }
+        if v.is_big_int() {
+            return v.coerce_to_int64(global);
+        }
+        // `JSC__JSValue__coerceToInt64` falls through to 32-bit `toInt32` for
+        // non-number, non-BigInt cells (strings wrap at 2^31). Go through full
+        // ToNumber here so string inputs above 2^31 round-trip to i64.
+        let num = v.to_number(global)?;
+        Ok(if num.is_nan() { 0 } else { num as i64 })
     }
 }
 

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1529,6 +1529,25 @@ impl JSValue {
         crate::call_check_slow(global, || JSC__JSValue__push(self, global, out))
     }
 
+    /// `JSValue.getOptional` — loose, coercing property fetch.
+    /// Absent / `undefined` / `null` → `None`; anything else is run through
+    /// [`coerce`](Self::coerce) (ToNumber for integer `T`). Distinct from
+    /// [`get_optional_int`], which validates the property is already an
+    /// in-range integer and throws otherwise.
+    pub fn get_optional<T: CoerceTo>(
+        self,
+        global: &JSGlobalObject,
+        property_name: impl AsRef<[u8]>,
+    ) -> JsResult<Option<T>> {
+        let Some(prop) = self.get(global, property_name)? else {
+            return Ok(None);
+        };
+        if prop.is_undefined_or_null() {
+            return Ok(None);
+        }
+        Ok(Some(prop.coerce::<T>(global)?))
+    }
+
     /// `JSValue.getOptionalInt` — typed integer property
     /// fetch with `validateIntegerRange` clamping. Returns `None` if the
     /// property is absent.
@@ -1905,6 +1924,11 @@ impl CoerceTo for i32 {
             return Ok(if num.is_nan() { 0 } else { num as i32 });
         }
         v.coerce_to_i32(global)
+    }
+}
+impl CoerceTo for i64 {
+    fn coerce_from(v: JSValue, global: &JSGlobalObject) -> JsResult<i64> {
+        v.coerce_to_int64(global)
     }
 }
 

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -711,7 +711,7 @@ pub(crate) fn get_presign_url_from(
                     }
                 };
             }
-            if let Some(expires_) = options.get_optional_int::<i32>(global, "expiresIn")? {
+            if let Some(expires_) = options.get_optional::<i32>(global, "expiresIn")? {
                 if expires_ <= 0 {
                     return Err(global.throw_invalid_arguments(format_args!(
                         "expiresIn must be greather than 0"

--- a/src/runtime/webcore/s3/credentials_jsc.rs
+++ b/src/runtime/webcore/s3/credentials_jsc.rs
@@ -168,7 +168,7 @@ pub(crate) fn get_credentials_with_options(
                 new_credentials.changed_credentials = true;
             }
 
-            if let Some(page_size) = opts.get_optional_int::<i64>(global_object, "pageSize")? {
+            if let Some(page_size) = opts.get_optional::<i64>(global_object, "pageSize")? {
                 if page_size < MultiPartUploadOptions::MIN_SINGLE_UPLOAD_SIZE as i64
                     || page_size > MultiPartUploadOptions::MAX_SINGLE_UPLOAD_SIZE as i64
                 {
@@ -185,7 +185,7 @@ pub(crate) fn get_credentials_with_options(
                     new_credentials.options.part_size = page_size as u64;
                 }
             }
-            if let Some(part_size) = opts.get_optional_int::<i64>(global_object, "partSize")? {
+            if let Some(part_size) = opts.get_optional::<i64>(global_object, "partSize")? {
                 if part_size < MultiPartUploadOptions::MIN_SINGLE_UPLOAD_SIZE as i64
                     || part_size > MultiPartUploadOptions::MAX_SINGLE_UPLOAD_SIZE as i64
                 {
@@ -203,7 +203,7 @@ pub(crate) fn get_credentials_with_options(
                 }
             }
 
-            if let Some(queue_size) = opts.get_optional_int::<i32>(global_object, "queueSize")? {
+            if let Some(queue_size) = opts.get_optional::<i32>(global_object, "queueSize")? {
                 if queue_size < 1 {
                     return Err(global_object.throw_range_error(
                         queue_size as i64,
@@ -218,7 +218,7 @@ pub(crate) fn get_credentials_with_options(
                 }
             }
 
-            if let Some(retry) = opts.get_optional_int::<i32>(global_object, "retry")? {
+            if let Some(retry) = opts.get_optional::<i32>(global_object, "retry")? {
                 if !(0..=255).contains(&retry) {
                     return Err(global_object.throw_range_error(
                         retry as i64,

--- a/test/js/bun/s3/s3-numeric-options-coerce.test.ts
+++ b/test/js/bun/s3/s3-numeric-options-coerce.test.ts
@@ -43,6 +43,24 @@ describe("S3Client upload options coercion", () => {
     expect(Bun.inspect(make({ partSize: 10485760.5 }))).toContain("partSize: 10485760");
   });
 
+  test("partSize string above 2^31 does not wrap to 32 bits", () => {
+    expect(Bun.inspect(make({ partSize: "5000000000" }))).toContain("partSize: 5000000000");
+    expect(Bun.inspect(make({ partSize: "5368709120" }))).toContain("partSize: 5368709120");
+  });
+
+  test("partSize string out of range reports the received value, not a wrapped negative", () => {
+    let err: unknown;
+    try {
+      make({ partSize: "6000000000" });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(RangeError);
+    const message = (err as RangeError).message;
+    expect(message).toContain(">= 5242880 and <= 5368709120");
+    expect(message).toContain("Received 6000000000");
+  });
+
   test("pageSize (legacy alias) accepts a numeric string", () => {
     expect(Bun.inspect(make({ pageSize: "10485760" }))).toContain("partSize: 10485760");
   });

--- a/test/js/bun/s3/s3-numeric-options-coerce.test.ts
+++ b/test/js/bun/s3/s3-numeric-options-coerce.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+
+// Bun 1.3.x accepted these options via a coercing reader (ToNumber → truncate),
+// so numeric strings (from env vars), floats, and Infinity all worked. The Rust
+// port initially swapped in a strict validator; these tests pin the 1.3.x
+// coercing behaviour.
+
+const base = { accessKeyId: "AK", secretAccessKey: "SK", bucket: "b" } as const;
+
+function presignExpires(expiresIn: unknown): string | null {
+  const url = Bun.s3.presign("k", { ...base, expiresIn: expiresIn as number });
+  return new URL(url).searchParams.get("X-Amz-Expires");
+}
+
+describe("presign expiresIn coercion", () => {
+  test.each([
+    ["3600", "3600"],
+    ["60", "60"],
+    [1.5, "1"],
+    [3599.9999, "3599"],
+    [Infinity, String(2 ** 31 - 1)],
+    [2 ** 31, String(2 ** 31 - 1)],
+  ] as const)("expiresIn: %p -> X-Amz-Expires=%s", (input, expected) => {
+    expect(presignExpires(input)).toBe(expected);
+  });
+
+  test("expiresIn: null is ignored (default 86400)", () => {
+    expect(presignExpires(null)).toBe("86400");
+  });
+
+  test("expiresIn: 0 still throws (field-specific validation)", () => {
+    expect(() => presignExpires(0)).toThrow("expiresIn must be greather than 0");
+  });
+});
+
+describe("S3Client upload options coercion", () => {
+  function make(opts: Record<string, unknown>) {
+    return new Bun.S3Client({ ...base, region: "us-east-1", ...opts } as any);
+  }
+
+  test("partSize accepts numeric strings and floats", () => {
+    expect(Bun.inspect(make({ partSize: "10485760" }))).toContain("partSize: 10485760");
+    expect(Bun.inspect(make({ partSize: 10485760.5 }))).toContain("partSize: 10485760");
+  });
+
+  test("pageSize (legacy alias) accepts a numeric string", () => {
+    expect(Bun.inspect(make({ pageSize: "10485760" }))).toContain("partSize: 10485760");
+  });
+
+  test("queueSize accepts numeric strings and floats", () => {
+    expect(Bun.inspect(make({ queueSize: "8" }))).toContain("queueSize: 8");
+    expect(Bun.inspect(make({ queueSize: 8.9 }))).toContain("queueSize: 8");
+  });
+
+  test("retry accepts numeric strings and floats", () => {
+    expect(Bun.inspect(make({ retry: "3" }))).toContain("retry: 3");
+    expect(Bun.inspect(make({ retry: 3.7 }))).toContain("retry: 3");
+  });
+
+  test("null upload options are ignored", () => {
+    const inspected = Bun.inspect(make({ partSize: null, queueSize: null, retry: null }));
+    expect(inspected).toContain("partSize: 5242880");
+    expect(inspected).toContain("queueSize: 5");
+    expect(inspected).toContain("retry: 3");
+  });
+
+  test("partSize out of range reports the partSize-specific bounds", () => {
+    let err: unknown;
+    try {
+      make({ partSize: 1e18 });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(RangeError);
+    expect((err as RangeError).message).toContain(">= 5242880 and <= 5368709120");
+  });
+
+  test("field-specific range checks still apply after coercion", () => {
+    expect(() => make({ retry: "300" })).toThrow(RangeError);
+    expect(() => make({ queueSize: "0" })).toThrow(RangeError);
+    expect(() => make({ partSize: "1024" })).toThrow(RangeError);
+  });
+});


### PR DESCRIPTION
## Problem

Bun 1.3.x read the S3 numeric options `expiresIn`, `partSize`, `pageSize`, `queueSize`, and `retry` via `JSValue.getOptional`, which coerces via `ToNumber` and truncates. The Rust port wired all five sites to `get_optional_int`, the *strict* twin that validates the value is already an in-range integer. The names are near-identical but the semantics are not.

```js
const base = { accessKeyId: "AK", secretAccessKey: "SK", bucket: "b" };
Bun.s3.presign("k", { ...base, expiresIn: "3600" });
// 1.3.14: X-Amz-Expires=3600
// 1.4:    TypeError: The "expiresIn" property must be of type number. Received string

new Bun.S3Client({ ...base, partSize: "10485760", queueSize: "8", retry: "3" });
// 1.3.14: accepted
// 1.4:    TypeError: The "partSize" property must be of type number. Received string
```

This breaks code that passes these options straight from env vars (always strings). It also degrades the `partSize` out-of-range message from the field's real bounds (`>= 5242880 and <= 5368709120`) to the generic safe-integer range, because `get_optional_int`'s blanket bound trips first.

## Fix

Add `JSValue::get_optional<T: CoerceTo>` (a direct port of Zig `getOptional` / `coerceOptional`) plus `CoerceTo for i64`, and switch the five S3 call sites back to the coercing reader. The field-specific range checks that follow each read are unchanged, so they fire again with their proper bounds.

## Verification

```
"1.5" -> 1
"3599.9999" -> 3599
"Infinity" -> 2147483647
"2147483648" -> 2147483647
"60" -> 60
"3600" -> 3600
partSize "10485760" OK
partSize "10485760.5" OK
queueSize "8" OK
retry "3" OK
partSize "1000000000000000000" -> THROW ERR_OUT_OF_RANGE The value of "partSize" is out of range. It must be >= 5242880 and <= 5368709120. Received 1000000000000000000
```

`test/js/bun/s3/s3-numeric-options-coerce.test.ts`: 15 pass with the fix, all throw `ERR_INVALID_ARG_TYPE` / `ERR_OUT_OF_RANGE` without it.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 16 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-numeric-options-coerce.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (7b83190df)

test/js/bun/s3/s3-numeric-options-coerce.test.ts:
 6 | // coercing behaviour.
 7 | 
 8 | const base = { accessKeyId: "AK", secretAccessKey: "SK", bucket: "b" } as const;
 9 | 
10 | function presignExpires(expiresIn: unknown): string | null {
11 |   const url = Bun.s3.presign("k", { ...base, expiresIn: expiresIn as number });
                          ^
TypeError: The "expiresIn" property must be of type number. Received string
      at presignExpires (/workspace/bun/test/js/bun/s3/s3-numeric-options-coerce.test.ts:11:22)
      at <anonymous> (/workspace/bun/test/js/bun/s3/s3-numeric-options-coerce.test.ts:24:12)
(fail) presign expiresIn coercion > expiresIn: "3600" -> X-Amz-Expires=3600 [10.89ms]
 6 | //
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (09dd57647)

test/js/bun/s3/s3-numeric-options-coerce.test.ts:
(pass) presign expiresIn coercion > expiresIn: "3600" -> X-Amz-Expires=3600 [6.56ms]
(pass) presign expiresIn coercion > expiresIn: "60" -> X-Amz-Expires=60 [0.11ms]
(pass) presign expiresIn coercion > expiresIn: 1.5 -> X-Amz-Expires=1 [0.02ms]
(pass) presign expiresIn coercion > expiresIn: 3599.9999 -> X-Amz-Expires=3599 [0.02ms]
(pass) presign expiresIn coercion > expiresIn: Infinity -> X-Amz-Expires=2147483647 [0.02ms]
(pass) presign expiresIn coercion > expiresIn: 2147483648 -> X-Amz-Expires=2147483647 [0.02ms]
(pass) presign expiresIn coercion > expiresIn: null is ignored (default 86400) [0.13ms]
(pass) presign expiresIn coercion > expiresIn: 0 still throws (field-specific validation) [1.47ms]
(pass) S3Client upload options coercion > partSize accepts numeric strings and floats [1.49ms]
(pass) S3Client upload options coercion > partSize string above 2^31 does not wrap to 32 bits [0.13ms]
(pass) S3Client upload options coercion > partSize string out of range reports the received value, not a wrapped negative [1.17ms]
(pass) S3Client upload options coercion > pageSize (legacy 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-numeric-options-coerce.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (7b83190df)

test/js/bun/s3/s3-numeric-options-coerce.test.ts:
(pass) presign expiresIn coercion > expiresIn: "3600" -> X-Amz-Expires=3600 [14.58ms]
(pass) presign expiresIn coercion > expiresIn: "60" -> X-Amz-Expires=60 [5.71ms]
(pass) presign expiresIn coercion > expiresIn: 1.5 -> X-Amz-Expires=1 [4.77ms]
(pass) presign expiresIn coercion > expiresIn: 3599.9999 -> X-Amz-Expires=3599 [3.45ms]
(pass) presign expiresIn coercion > expiresIn: Infinity -> X-Amz-Expires=2147483647 [3.56ms]
(pass) presign expiresIn coercion > expiresIn: 2147483648 -> X-Amz-Expires=2147483647 [3.41ms]
(pass) presign expiresIn coercion > expiresIn: null is ignored (default 86400) [4.54ms]
(pass) presign expiresIn coercion > expiresIn: 0 stil
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 1712ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/90] gen ErrorCode+*.h
[2/47] gen cpp.rs (cppbind)
[3/47] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /wo
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/JSValue.rs                               |  37 +++++++++
 src/runtime/webcore/S3File.rs                    |   2 +-
 src/runtime/webcore/s3/credentials_jsc.rs        |   8 +-
 test/js/bun/s3/s3-numeric-options-coerce.test.ts | 101 +++++++++++++++++++++++
 4 files changed, 143 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/jsc/JSValue.rs                                    5      2      0
src/runtime/webcore/S3File.rs                         1      1      0
src/runtime/webcore/s3/credentials_jsc.rs             2      1      0
test/js/bun/s3/s3-numeric-options-coerce.test.ts      0      2      0
```

</details>

<!-- robobun:evidence:end -->