### PR TITLE
js_parser: drop vestigial markup escapes from JSX closing-tag mismatch error

### DIFF
--- a/src/bundler/linker_context/OutputFileListBuilder.rs
+++ b/src/bundler/linker_context/OutputFileListBuilder.rs
@@ -151,7 +151,7 @@ impl OutputFileList {
         let index = self.index_for_chunk();
         debug_assert!(
             index < self.index_for_sourcemaps_and_bytecode.unwrap_or(u32::MAX),
-            "index ({}) \\< index_for_sourcemaps_and_bytecode ({})",
+            "index ({}) < index_for_sourcemaps_and_bytecode ({})",
             index,
             self.index_for_sourcemaps_and_bytecode.unwrap_or(u32::MAX),
         );
@@ -169,7 +169,7 @@ impl OutputFileList {
         };
         debug_assert!(
             index < self.additional_output_files_start,
-            "index ({}) \\< additional_output_files_start ({})",
+            "index ({}) < additional_output_files_start ({})",
             index,
             self.additional_output_files_start,
         );
@@ -185,7 +185,7 @@ impl OutputFileList {
         debug_assert!(
             self.index_for_sourcemaps_and_bytecode.unwrap_or(0)
                 <= self.additional_output_files_start,
-            "index_for_sourcemaps_and_bytecode ({}) \\< additional_output_files_start ({})",
+            "index_for_sourcemaps_and_bytecode ({}) < additional_output_files_start ({})",
             self.index_for_sourcemaps_and_bytecode.unwrap_or(0),
             self.additional_output_files_start,
         );

--- a/src/bundler/linker_context/OutputFileListBuilder.rs
+++ b/src/bundler/linker_context/OutputFileListBuilder.rs
@@ -185,7 +185,7 @@ impl OutputFileList {
         debug_assert!(
             self.index_for_sourcemaps_and_bytecode.unwrap_or(0)
                 <= self.additional_output_files_start,
-            "index_for_sourcemaps_and_bytecode ({}) < additional_output_files_start ({})",
+            "index_for_sourcemaps_and_bytecode ({}) <= additional_output_files_start ({})",
             self.index_for_sourcemaps_and_bytecode.unwrap_or(0),
             self.additional_output_files_start,
         );

--- a/src/js_parser/parse/parse_jsx.rs
+++ b/src/js_parser/parse/parse_jsx.rs
@@ -348,7 +348,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             Some(p.source),
                             end_tag.range,
                             format_args!(
-                                "Expected closing JSX tag to match opening tag \"\\<{}\\>\"",
+                                "Expected closing JSX tag to match opening tag \"<{}>\"",
                                 bstr::BStr::new(tag.name)
                             ),
                             format_args!("Opening tag here:"),

--- a/test/regression/issue/14477/14477.test.ts
+++ b/test/regression/issue/14477/14477.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
 test("JSXElement with mismatched closing tags produces a syntax error", async () => {
@@ -20,4 +20,38 @@ test("JSXElement with mismatched closing tags produces a syntax error", async ()
   // all subprocesses should fail.
   const exited = await Promise.all(bakery);
   expect(exited).toEqual(Array.from({ length: fixtures.length }, () => 1));
+});
+
+test.each([
+  { src: "console.log(<Foo></Bar>);", tag: "<Foo>" },
+  { src: "console.log(<div></p>);", tag: "<div>" },
+  { src: "console.log(<>x</b>);", tag: "<>" },
+])("JSX closing-tag mismatch error quotes $tag without escape characters", async ({ src, tag }) => {
+  const expected = `Expected closing JSX tag to match opening tag "${tag}"`;
+
+  // Bun.Transpiler: the error.message string a library reads.
+  let message = "";
+  try {
+    new Bun.Transpiler({ loader: "tsx" }).transformSync(src);
+  } catch (e) {
+    message = (e as Error).message;
+  }
+  expect(message).toContain(expected);
+  expect(message).not.toContain("\\");
+
+  // bun build: the CLI-rendered error.
+  using dir = tempDir("jsx-mismatch", { "in.tsx": src });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "./in.tsx"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain(expected);
+  expect(stderr).not.toContain("\\<");
+  expect(stderr).not.toContain("\\>");
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(1);
 });


### PR DESCRIPTION
### What

The JSX closing-tag mismatch error prints literal backslashes around the tag name:

```
$ printf 'console.log(<Foo></Bar>);\n' > mm.tsx
$ bun build mm.tsx
error: Expected closing JSX tag to match opening tag "\<Foo\>"
```

1.3.14 printed `"<Foo>"`. The bad bytes are in the `error.message` string thrown by `Bun.Transpiler.transformSync`, so this is a data bug rather than a terminal-rendering artifact.

### Why

`src/js_parser/parse/parse_jsx.rs:351` still carries the Zig-era `\<` / `\>` markup escapes in a `format_args!` passed to `Log::add_range_error_fmt_with_note`. The Zig `Log.allocPrint` ran `Output.prettyFmt` over every `add*Fmt` format string and stripped these; the Rust `alloc_print` intentionally renders `fmt::Arguments` verbatim (running a runtime markup pass would mangle interpolated user values containing `<`). The escapes are vestigial under the new contract.

Swept every `Log::add_*_fmt` call site: this is the only one. Three `debug_assert!` format strings in `OutputFileListBuilder.rs` had the same leftover (they render through `core::panic!`, also verbatim) and are cleaned up here as well.

### Test

`test/regression/issue/14477/14477.test.ts` previously asserted only exit code 1. It now also asserts the exact error text (no `\` characters, correct `"<Foo>"` / `"<div>"` / `"<>"` quoting) across both `Bun.Transpiler.transformSync` and `bun build`.

```
(pass) JSXElement with mismatched closing tags produces a syntax error
(pass) JSX closing-tag mismatch error quotes <Foo> without escape characters
(pass) JSX closing-tag mismatch error quotes <div> without escape characters
(pass) JSX closing-tag mismatch error quotes <> without escape characters
```

The `expect()` matcher `<...>` stripping and the `--help` flag-description stripping are the same bug class but distinct root causes on different output paths; they are tracked separately.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/14477/14477.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (27f0bcc7e)

test/regression/issue/14477/14477.test.ts:
2 | console.log(<Foo></Bar>);
                       ^
error: Expected closing JSX tag to match opening tag "\<Foo\>"
    at /workspace/bun/test/regression/issue/14477/component-mismatch.tsx:2:20

2 | console.log(<Foo></Bar>);
                 ^
note: Opening tag here:
   at /workspace/bun/test/regression/issue/14477/component-mismatch.tsx:2:14

Bun v1.4.0-debug+27f0bcc7e (Linux x64)
1 | console.log(<div></p>);
                       ^
error: Expected closing JSX tag to match opening tag "\<div\>"
    at /workspace/bun/test/regression/issue/14477/builtin-mismatch.tsx:1:20

1 | console.log(<div></p>);
                 ^
note: Opening tag here:
   at /workspace/bun/test/
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/regression/issue/14477/14477.test.ts:
1 | console.log(<div></p>);
                       ^
error: Expected closing JSX tag to match opening tag "\<div\>"
    at /workspace/bun/test/regression/issue/14477/builtin-mismatch.tsx:1:20

1 | console.log(<div></p>);
                 ^
note: Opening tag here:
   at /workspace/bun/test/regression/issue/14477/builtin-mismatch.tsx:1:14

Bun v1.4.0-canary.1+1498d7b77 (Linux x64)
2 | console.log(<Foo></Bar>);
                       ^
error: Expected closing JSX tag to match opening tag "\<Foo\>"
    at /workspace/bun/test/regression/issue/14477/component-mismatch.tsx:2:20

2 | console.log(<Foo></Bar>);
                 ^
note: Opening tag here:
   at /workspace/bun/test/regression/issue/14477/component-mismatch.tsx:2:14

Bun v1.4.0-canary.1+1498d7b77 (Linux x64)
3 | console.log(<div-:button></p>);
                               ^
error: Expected closing JSX tag to match opening tag "\<div-:button\>"
    at /workspace/bun/test/regression/issue/14477/non-identifier-mismatch.tsx:3:28

3 | console.log(<div-:button></p>);
                 ^
note: Opening tag here:
   at /workspace/bun/test/re
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/14477/14477.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (27f0bcc7e)

test/regression/issue/14477/14477.test.ts:
3 | console.log(<div-:button></p>);
                               ^
error: Expected closing JSX tag to match opening tag "<div-:button>"
    at /workspace/bun/test/regression/issue/14477/non-identifier-mismatch.tsx:3:28

3 | console.log(<div-:button></p>);
                 ^
note: Opening tag here:
   at /workspace/bun/test/regression/issue/14477/non-identifier-mismatch.tsx:3:14

Bun v1.4.0-debug+27f0bcc7e (Linux x64)
1 | console.log(<div></p>);
                       ^
error: Expected closing JSX tag to match opening tag "<div>"
    at /workspace/bun/test/regression/issue/14477/builtin-mismatch.tsx:1:20

1 | console.log(<div></p>);
                 ^
note: Opening ta
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 2002ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/90] gen ErrorCode+*.h
[2/47] gen cpp.rs (cppbind)
[3/47] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /wo
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../linker_context/OutputFileListBuilder.rs        |  6 ++--
 src/js_parser/parse/parse_jsx.rs                   |  2 +-
 test/regression/issue/14477/14477.test.ts          | 36 +++++++++++++++++++++-
 3 files changed, 39 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/bundler/linker_context/OutputFileListBuilder.rs      2      3      0
src/js_parser/parse/parse_jsx.rs                         1      1      0
test/regression/issue/14477/14477.test.ts                1      2      0
```

</details>

<!-- robobun:evidence:end -->