### PR TITLE
bunfig: print human-readable type names in mismatch errors

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1465,7 +1465,7 @@ impl Tag {
     pub fn type_name(self) -> &'static str {
         match self {
             Tag::EString => "string",
-            Tag::EArray => "array",
+            Tag::EArray | Tag::EArrayJSON => "array",
             Tag::EUnary => "unary",
             Tag::EBinary => "binary",
             Tag::EBoolean | Tag::EBranchBoolean => "boolean",
@@ -1487,7 +1487,7 @@ impl Tag {
             Tag::EMissing => "<missing>",
             Tag::ENumber => "number",
             Tag::EBigInt => "BigInt",
-            Tag::EObject => "object",
+            Tag::EObject | Tag::EObjectJSON => "object",
             Tag::ESpread => "...",
             Tag::ETemplate => "template",
             Tag::ERegExp => "regexp",

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1460,9 +1460,10 @@ impl Tag {
     }
 }
 
-impl fmt::Display for Tag {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
+impl Tag {
+    /// Human-readable variant name for diagnostics (`"string"`, `"boolean"`, …).
+    pub fn type_name(self) -> &'static str {
+        match self {
             Tag::EString => "string",
             Tag::EArray => "array",
             Tag::EUnary => "unary",
@@ -1498,8 +1499,14 @@ impl fmt::Display for Tag {
             Tag::EThis => "this",
             Tag::EClass => "class",
             Tag::ERequireString => "require",
-            other => <&'static str>::from(*other),
-        })
+            other => <&'static str>::from(other),
+        }
+    }
+}
+
+impl fmt::Display for Tag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.type_name())
     }
 }
 
@@ -2356,7 +2363,7 @@ impl Data {
     /// Human-readable variant name for diagnostics (`"string"`, `"object"`, …).
     #[inline]
     pub fn tag_name(&self) -> &'static str {
-        self.tag().into()
+        self.tag().type_name()
     }
 
     // Per-variant `as_*` accessors live alongside the enum decl above

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -219,7 +219,7 @@ impl<'a> Parser<'a> {
                 expr.loc,
                 format_args!(
                     "expected {} but received {}",
-                    <&str>::from(token),
+                    token.type_name(),
                     expr.data.tag_name()
                 ),
             );

--- a/src/install/PackageManager/security_scanner.rs
+++ b/src/install/PackageManager/security_scanner.rs
@@ -1803,14 +1803,6 @@ impl<'a> SecurityScanSubprocess<'a> {
     }
 }
 
-fn json_type_name(data: &ExprData) -> &'static str {
-    match data {
-        ExprData::EObjectJSON(_) => bun_ast::expr::Tag::EObject.into(),
-        ExprData::EArrayJSON(_) => bun_ast::expr::Tag::EArray.into(),
-        other => other.tag().into(),
-    }
-}
-
 fn parse_security_advisories_from_expr(
     manager: &PackageManager,
     advisories_expr: Expr,
@@ -1821,7 +1813,7 @@ fn parse_security_advisories_from_expr(
     let ExprData::EArrayJSON(array) = &advisories_expr.data else {
         Output::err_generic(
             "Security scanner 'advisories' field must be an array, got: {}",
-            (json_type_name(&advisories_expr.data),),
+            (advisories_expr.data.tag_name(),),
         );
         return Err(crate::Error::InvalidAdvisoriesFormat);
     };
@@ -1831,7 +1823,7 @@ fn parse_security_advisories_from_expr(
         if !matches!(item.data, ExprData::EObjectJSON(_)) {
             Output::err_generic(
                 "Security advisory at index {} must be an object, got: {}",
-                (i, json_type_name(&item.data)),
+                (i, item.data.tag_name()),
             );
             return Err(crate::Error::InvalidAdvisoryFormat);
         }

--- a/test/config/bunfig/bunfig-errors.test.ts
+++ b/test/config/bunfig/bunfig-errors.test.ts
@@ -21,11 +21,7 @@ describe.concurrent("bunfig.toml type-mismatch error messages", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     const errorLine = stderr.split("\n").find(l => l.startsWith("error:")) ?? stderr;
     expect(errorLine).toBe(`error: ${expected}`);

--- a/test/config/bunfig/bunfig-errors.test.ts
+++ b/test/config/bunfig/bunfig-errors.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+describe.concurrent("bunfig.toml type-mismatch error messages", () => {
+  const cases: [config: string, expected: string][] = [
+    [`smol = "yes"`, "expected boolean but received string"],
+    [`logLevel = 3`, "expected string but received number"],
+    [`telemetry = "no"`, "expected boolean but received string"],
+    [`define = 3`, "expected object but received number"],
+    [`[serve]\nport = "abc"`, "expected number but received string"],
+  ];
+
+  test.each(cases)("%s -> %s", async (config, expected) => {
+    using dir = tempDir("bunfig-type-mismatch", {
+      "bunfig.toml": config + "\n",
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "1"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    const errorLine = stderr.split("\n").find(l => l.startsWith("error:")) ?? stderr;
+    expect(errorLine).toBe(`error: ${expected}`);
+    expect(stderr).not.toMatch(/\be_(string|boolean|number|object|array|null)\b/);
+    expect(stdout).toBe("");
+    expect(exitCode).not.toBe(0);
+  });
+});


### PR DESCRIPTION
## Repro

```sh
d=$(mktemp -d); cd "$d"
printf 'smol = "yes"\n' > bunfig.toml
bun -e '1'
# error: expected e_boolean but received e_string
```

## Cause

`Data::tag_name()` in `src/ast/expr.rs` returned `self.tag().into()`, which resolves to the `strum::IntoStaticStr` derive (`#[strum(serialize_all = "snake_case")]`) and yields raw variant names like `e_boolean` / `e_string`. Its own doc comment promises the human-readable form (`"string"`, `"object"`, ...).

The correct mapping already existed in `impl fmt::Display for Tag` but was unused by `tag_name()`. `bunfig::Parser::expect` additionally formatted the expected tag via `<&str>::from(token)`, hitting the same strum derive.

## Fix

Extract the `Display` match into `Tag::type_name(self) -> &'static str`; route `Display`, `Data::tag_name()`, and `bunfig::Parser::expect` through it.

This also fixes the same leak in the pnpm-lock.yaml migration errors (`src/install/pnpm.rs`) and `bun create` example-list diagnostics (`src/runtime/cli/create_command.rs`), which both call `Data::tag_name()`.

## Verification

```
error: expected boolean but received string   # was: expected e_boolean but received e_string
error: expected string but received number    # was: expected string but received e_number
```

New test `test/config/bunfig/bunfig-errors.test.ts` asserts the rendered message for boolean/string/number/object mismatches across both the `expect()` and `expect_string()` code paths.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/config/bunfig/bunfig-errors.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ba58d8dca)

test/config/bunfig/bunfig-errors.test.ts:
22 |       stderr: "pipe",
23 |     });
24 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
25 | 
26 |     const errorLine = stderr.split("\n").find(l => l.startsWith("error:")) ?? stderr;
27 |     expect(errorLine).toBe(`error: ${expected}`);
                           ^
error: expect(received).toBe(expected)

Expected: "error: expected boolean but received string"
Received: "error: expected e_boolean but received e_string"

      at <anonymous> (/workspace/bun/test/config/bunfig/bunfig-errors.test.ts:27:23)
(fail) bunfig.toml type-mismatch error messages > smol = "yes" -> expected boolean but received stri
... (truncated)

release without fix: 5 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/config/bunfig/bunfig-errors.test.ts:
22 |       stderr: "pipe",
23 |     });
24 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
25 | 
26 |     const errorLine = stderr.split("\n").find(l => l.startsWith("error:")) ?? stderr;
27 |     expect(errorLine).toBe(`error: ${expected}`);
                           ^
error: expect(received).toBe(expected)

Expected: "error: expected boolean but received string"
Received: "error: expected e_boolean but received e_string"

      at <anonymous> (/workspace/bun/test/config/bunfig/bunfig-errors.test.ts:27:23)
22 |       stderr: "pipe",
23 |     });
24 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
25 | 
26 |     const errorLine = stderr.split("\n").find(l => l.startsWith("error:")) ?? stderr;
27 |     expect(errorLine).toBe(`error: ${expected}`);
                           ^
error: expect(received).toBe(expected)

Expected: "error: expected string but received number"
Received: "error: expected string but received e_number"

      at <anonymous> (/workspac
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/config/bunfig/bunfig-errors.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ba58d8dca)

test/config/bunfig/bunfig-errors.test.ts:
(pass) bunfig.toml type-mismatch error messages > smol = "yes" -> expected boolean but received string [250.04ms]
(pass) bunfig.toml type-mismatch error messages > logLevel = 3 -> expected string but received number [160.23ms]
(pass) bunfig.toml type-mismatch error messages > telemetry = "no" -> expected boolean but received string [247.90ms]
(pass) bunfig.toml type-mismatch error messages > define = 3 -> expected object but received number [248.69ms]
(pass) bunfig.toml type-mismatch error messages > [serve]
port = "abc" -> expected number but received string [252.73ms]

 5 pass
 0 fail
 20 expect() calls
Ran 5 tests across 1 file. [6.96s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     ba58d8dca3
  features     (none)

22 deps, 106 codegen, 1168 objects in 4484ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] gen bindgenv2
[2/1231] fetch zlib
[zlib] up to date
[3/1231] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[4/1231] fetch tinycc
[tinycc] up to date
[5/1230] fetch picohttpparser
[picohttpparser] up to date
[6/1230] subst deps/zlib/zconf.h
[7/1230] subst deps/zlib/zlib.h
[8/1181] fetch zstd
[zstd] up to date
[9/1150] gen .bind.ts → GeneratedBindings.cpp
[10/1150] fetch nodejs (prebuilt)
[nodejs] up to date
[11/1150] gen ErrorCode+*.h
[12/1150] subst deps/libjpeg-turbo/jconfig.h
[13/1150] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packa
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/expr.rs                                | 23 +++++++++++-------
 src/bunfig/bunfig.rs                           |  2 +-
 src/install/PackageManager/security_scanner.rs | 12 ++--------
 test/config/bunfig/bunfig-errors.test.ts       | 32 ++++++++++++++++++++++++++
 4 files changed, 50 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/ast/expr.rs                                     2      4      0
src/bunfig/bunfig.rs                                1      1      0
src/install/PackageManager/security_scanner.rs      1      3      0
test/config/bunfig/bunfig-errors.test.ts            0      2      0
```

</details>

<!-- robobun:evidence:end -->