### PR TITLE
redis: raise the RESP line-length cap from 512KB to 512MB

### DIFF
--- a/src/runtime/valkey_jsc/protocol_jsc.rs
+++ b/src/runtime/valkey_jsc/protocol_jsc.rs
@@ -42,6 +42,7 @@ pub fn valkey_error_to_js(
         RedisError::ConnectionTimeout => JscError::REDIS_CONNECTION_TIMEOUT,
         RedisError::IdleTimeout => JscError::REDIS_IDLE_TIMEOUT,
         RedisError::NestingDepthExceeded => JscError::REDIS_INVALID_RESPONSE,
+        RedisError::LineTooLong => JscError::REDIS_INVALID_RESPONSE,
         RedisError::JSError => return global.take_exception(JsError::Thrown),
         RedisError::OutOfMemory => {
             let _ = global.throw_out_of_memory();

--- a/src/runtime/valkey_jsc/protocol_jsc.rs
+++ b/src/runtime/valkey_jsc/protocol_jsc.rs
@@ -42,7 +42,6 @@ pub fn valkey_error_to_js(
         RedisError::ConnectionTimeout => JscError::REDIS_CONNECTION_TIMEOUT,
         RedisError::IdleTimeout => JscError::REDIS_IDLE_TIMEOUT,
         RedisError::NestingDepthExceeded => JscError::REDIS_INVALID_RESPONSE,
-        RedisError::LineTooLong => JscError::REDIS_INVALID_RESPONSE,
         RedisError::JSError => return global.take_exception(JsError::Thrown),
         RedisError::OutOfMemory => {
             let _ = global.throw_out_of_memory();

--- a/src/valkey/valkey_protocol.rs
+++ b/src/valkey/valkey_protocol.rs
@@ -32,7 +32,6 @@ pub enum RedisError {
     ConnectionTimeout,
     IdleTimeout,
     NestingDepthExceeded,
-    LineTooLong,
 }
 
 bun_core::impl_tag_error!(RedisError);
@@ -249,20 +248,15 @@ impl<'a> ValkeyReader<'a> {
 
     pub fn read_until_crlf(&mut self) -> Result<&'a [u8], RedisError> {
         let buffer = &self.buffer[self.pos..];
-        let limit = buffer.len().min(Self::MAX_LINE_LEN + 1);
-        let start = self.crlf_skip.min(limit);
+        let start = self.crlf_skip.min(buffer.len());
         self.crlf_skip = 0;
-        for (i, &byte) in buffer.iter().enumerate().take(limit).skip(start) {
+        for (i, &byte) in buffer.iter().enumerate().skip(start) {
             if byte == b'\r' && buffer.len() > i + 1 && buffer[i + 1] == b'\n' {
                 let result = &buffer[0..i];
                 self.pos += i + 2;
                 return Ok(result);
             }
         }
-        if buffer.len() > Self::MAX_LINE_LEN + 1 {
-            return Err(RedisError::LineTooLong);
-        }
-
         Err(RedisError::InvalidResponse)
     }
 
@@ -343,8 +337,6 @@ impl<'a> ValkeyReader<'a> {
     /// machine stops buffering instead of growing the read buffer toward an
     /// attacker-chosen size.
     const MAX_BULK_LEN: i64 = 512 * 1024 * 1024;
-
-    const MAX_LINE_LEN: usize = 512 * 1024;
 
     /// Caps an aggregate's `Vec::with_capacity` so the total bytes reserved
     /// across the whole parse — every nesting level combined — never exceed

--- a/src/valkey/valkey_protocol.rs
+++ b/src/valkey/valkey_protocol.rs
@@ -32,6 +32,7 @@ pub enum RedisError {
     ConnectionTimeout,
     IdleTimeout,
     NestingDepthExceeded,
+    LineTooLong,
 }
 
 bun_core::impl_tag_error!(RedisError);
@@ -248,14 +249,18 @@ impl<'a> ValkeyReader<'a> {
 
     pub fn read_until_crlf(&mut self) -> Result<&'a [u8], RedisError> {
         let buffer = &self.buffer[self.pos..];
-        let start = self.crlf_skip.min(buffer.len());
+        let limit = buffer.len().min(Self::MAX_LINE_LEN + 1);
+        let start = self.crlf_skip.min(limit);
         self.crlf_skip = 0;
-        for (i, &byte) in buffer.iter().enumerate().skip(start) {
+        for (i, &byte) in buffer.iter().enumerate().take(limit).skip(start) {
             if byte == b'\r' && buffer.len() > i + 1 && buffer[i + 1] == b'\n' {
                 let result = &buffer[0..i];
                 self.pos += i + 2;
                 return Ok(result);
             }
+        }
+        if buffer.len() > Self::MAX_LINE_LEN + 1 {
+            return Err(RedisError::LineTooLong);
         }
         Err(RedisError::InvalidResponse)
     }
@@ -337,6 +342,11 @@ impl<'a> ValkeyReader<'a> {
     /// machine stops buffering instead of growing the read buffer toward an
     /// attacker-chosen size.
     const MAX_BULK_LEN: i64 = 512 * 1024 * 1024;
+
+    /// Maximum accepted length for a CRLF-terminated RESP line (`+ - : _ , # (`).
+    /// Mirrors `MAX_BULK_LEN` so line-terminated replies get the same
+    /// buffer-growth bound as length-prefixed blobs; the spec places no limit.
+    const MAX_LINE_LEN: usize = Self::MAX_BULK_LEN as usize;
 
     /// Caps an aggregate's `Vec::with_capacity` so the total bytes reserved
     /// across the whole parse — every nesting level combined — never exceed

--- a/test/js/valkey/reliability/resp-nesting-depth.test.ts
+++ b/test/js/valkey/reliability/resp-nesting-depth.test.ts
@@ -286,10 +286,7 @@ describe("Valkey: RESP line-terminated replies (>512KB)", () => {
 
   test("surfaces an error (`-`) reply longer than 512KB with its original text", async () => {
     const body = "ERR user_script:1: " + Buffer.alloc(600_000, "e").toString();
-    const { server, port } = await createMockRedisServer([
-      Buffer.from(`-${body}\r\n`),
-      Buffer.from("+PONG\r\n"),
-    ]);
+    const { server, port } = await createMockRedisServer([Buffer.from(`-${body}\r\n`), Buffer.from("+PONG\r\n")]);
     try {
       const client = new Bun.RedisClient(`redis://127.0.0.1:${port}`, {
         autoReconnect: false,

--- a/test/js/valkey/reliability/resp-nesting-depth.test.ts
+++ b/test/js/valkey/reliability/resp-nesting-depth.test.ts
@@ -239,6 +239,79 @@ describe("Valkey: RESP Nesting Depth Handling", () => {
   });
 });
 
+describe("Valkey: RESP line-terminated replies (>512KB)", () => {
+  // The Zig parser scanned for CRLF over the whole buffer. A later hardening
+  // pass capped the scan window at 512KB, which rejects valid RESP simple
+  // strings and error replies that a real server emits (Lua
+  // redis.status_reply(...) / redis.error_reply(...) with a long payload).
+  // https://redis.io/docs/latest/develop/reference/protocol-spec/ places no
+  // length limit on `+` / `-` lines.
+
+  async function roundtrip(payload: Buffer): Promise<any> {
+    const { server, port } = await createMockRedisServer([payload, Buffer.from("+PONG\r\n")]);
+    try {
+      const client = new Bun.RedisClient(`redis://127.0.0.1:${port}`, {
+        autoReconnect: false,
+        connectionTimeout: 5000,
+      });
+      try {
+        const reply = await client.send("PING", []);
+        // The client must still be usable for the next command: a parse
+        // failure here used to latch `failed` and reject forever.
+        const pong = await client.send("PING", []);
+        return { reply, pong };
+      } finally {
+        client.close();
+      }
+    } finally {
+      server.close();
+    }
+  }
+
+  test("accepts a simple string (`+`) reply longer than 512KB", async () => {
+    const body = Buffer.alloc(600_000, "x").toString();
+    const { reply, pong } = await roundtrip(Buffer.from(`+${body}\r\n`));
+    expect(typeof reply).toBe("string");
+    expect(reply.length).toBe(600_000);
+    expect(pong).toBe("PONG");
+  });
+
+  test("accepts a simple string at exactly 512KB + 1 bytes", async () => {
+    // 524288 worked, 524289 was rejected by an off-by-one in the scan window.
+    const body = Buffer.alloc(512 * 1024 + 1, "y").toString();
+    const { reply, pong } = await roundtrip(Buffer.from(`+${body}\r\n`));
+    expect(reply.length).toBe(512 * 1024 + 1);
+    expect(pong).toBe("PONG");
+  });
+
+  test("surfaces an error (`-`) reply longer than 512KB with its original text", async () => {
+    const body = "ERR user_script:1: " + Buffer.alloc(600_000, "e").toString();
+    const { server, port } = await createMockRedisServer([
+      Buffer.from(`-${body}\r\n`),
+      Buffer.from("+PONG\r\n"),
+    ]);
+    try {
+      const client = new Bun.RedisClient(`redis://127.0.0.1:${port}`, {
+        autoReconnect: false,
+        connectionTimeout: 5000,
+      });
+      try {
+        const rejection = await client.send("EVAL", ["script", "0"]).then(
+          () => null,
+          (e: any) => e,
+        );
+        expect(rejection?.message).toBe(body);
+        // Client must survive and serve the next command.
+        expect(await client.send("PING", [])).toBe("PONG");
+      } finally {
+        client.close();
+      }
+    } finally {
+      server.close();
+    }
+  });
+});
+
 describe("Valkey: RESP push frame routing", () => {
   test("resolves a pending command with its own reply when an out-of-band push frame precedes it", async () => {
     const payload = Buffer.from(

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -132,10 +132,9 @@ test.concurrent("RedisClient survives GC across many short-lived instances", asy
 });
 
 // A RESP scalar line (simple string, error, integer, ...) must end with CRLF.
-// The reader imposes no length cap on the line (the RESP spec has none and
-// Lua `redis.status_reply`/`redis.error_reply` emit arbitrary payloads), so a
-// server that closes mid-line rejects the pending command with a
-// connection-closed error rather than a protocol error.
+// The reader caps line-terminated replies at MAX_BULK_LEN (512 MB), so a 600 KB
+// unterminated line is treated as a partial reply; when the server closes
+// mid-line the pending command is rejected as connection-closed.
 test.concurrent("rejects a RESP simple-string reply whose line terminator never arrives", async () => {
   // Minimal mock Redis server: replies +OK to the HELLO handshake, then
   // answers the next command with `payload`.

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -132,10 +132,10 @@ test.concurrent("RedisClient survives GC across many short-lived instances", asy
 });
 
 // A RESP scalar line (simple string, error, integer, ...) must end with CRLF.
-// The reader bounds how many bytes it will accumulate while waiting for that
-// terminator (MAX_LINE_LEN = 512 KiB), so a server that streams an endless
-// unterminated line gets a protocol error promptly instead of the client
-// buffering and rescanning the whole line on every socket read.
+// The reader imposes no length cap on the line (the RESP spec has none and
+// Lua `redis.status_reply`/`redis.error_reply` emit arbitrary payloads), so a
+// server that closes mid-line rejects the pending command with a
+// connection-closed error rather than a protocol error.
 test.concurrent("rejects a RESP simple-string reply whose line terminator never arrives", async () => {
   // Minimal mock Redis server: replies +OK to the HELLO handshake, then
   // answers the next command with `payload`.
@@ -161,12 +161,9 @@ test.concurrent("rejects a RESP simple-string reply whose line terminator never 
     });
   }
 
-  // 1) A simple-string reply whose CRLF terminator never arrives. Once more
-  //    than 512 KiB of the line has accumulated, the client must fail the
-  //    reply with a protocol error rather than keep waiting for a terminator
-  //    that never comes. (The server closes the socket after the payload so
-  //    that a client which keeps waiting still settles the promise -- with a
-  //    connection-closed error instead of the expected protocol error.)
+  // 1) A simple-string reply whose CRLF terminator never arrives. The reader
+  //    treats the unterminated bytes as a partial reply and keeps waiting; when
+  //    the server closes, the pending command is rejected as connection-closed.
   {
     const unterminated = Buffer.from("+" + Buffer.alloc(600_000, "A").toString());
     const { server, port } = await listen(unterminated, true);
@@ -179,7 +176,7 @@ test.concurrent("rejects a RESP simple-string reply whose line terminator never 
         await client.send("PING", []);
         expect.unreachable();
       } catch (error: any) {
-        expect(error.code).toBe("ERR_REDIS_INVALID_RESPONSE");
+        expect(error.code).toBe("ERR_REDIS_CONNECTION_CLOSED");
       } finally {
         client.close();
       }
@@ -188,8 +185,7 @@ test.concurrent("rejects a RESP simple-string reply whose line terminator never 
     }
   }
 
-  // 2) A large but properly terminated simple string under the bound still
-  //    parses.
+  // 2) A large, properly terminated simple string still parses.
   {
     const value = Buffer.alloc(100_000, "B").toString();
     const { server, port } = await listen(Buffer.from("+" + value + "\r\n"), false);

--- a/test/js/valkey/valkey-incremental-scan.test.ts
+++ b/test/js/valkey/valkey-incremental-scan.test.ts
@@ -127,9 +127,8 @@ describe.concurrent("Valkey reply torn across socket reads", () => {
 });
 
 describe("Valkey incremental reply scanning", () => {
-  // Sizes chosen so the reply line stays under the protocol's 512 KiB line
-  // limit while still being large enough that re-scanning the accumulated
-  // partial line on every socket read would dominate the runtime.
+  // Sizes chosen large enough that re-scanning the accumulated partial line on
+  // every socket read would dominate the runtime.
   const HEAD_BYTES = 410_000;
   const CHUNK_BYTES = 2;
   const CHUNK_COUNT = 25_000;


### PR DESCRIPTION
## What

A RESP simple string (`+`) or error (`-`) reply longer than 512KB is rejected with `ERR_REDIS_INVALID_RESPONSE "Failed to read data (buffer path)"`, after which the client rejects every subsequent command with `ERR_REDIS_CONNECTION_CLOSED` while still reporting `connected: true`. 1.3.14 resolved the same reply fine.

## Repro

```js
// against redis-server 8.4.0
await client.send("EVAL", ["return redis.status_reply(string.rep('x', 600000))", "0"]);
// 1.3.14: resolves, length 600000; subsequent ping: PONG
// 1.4:    rejects ERR_REDIS_INVALID_RESPONSE "Failed to read data (buffer path)"
//         subsequent ping: rejects ERR_REDIS_CONNECTION_CLOSED
// boundary: 524288 OK, 524289 fails
```

## Cause

`read_until_crlf` in `src/valkey/valkey_protocol.rs` was capped at `MAX_LINE_LEN = 512 * 1024` by a later hardening pass; the 1.3.14 Zig parser (`readUntilCRLF`) scanned the whole buffer. The cap backs every line-terminated RESP type (`+ - : _ , # (`). The RESP spec places no length limit on these, and a real Redis server emits arbitrary-length `+` / `-` lines for Lua `redis.status_reply()` / `redis.error_reply()`. Bulk strings (`$`) carry a length prefix and were never affected.

## Fix

Raise `MAX_LINE_LEN` to match `MAX_BULK_LEN` (512MB, the server-side `proto-max-bulk-len` default), so line-terminated replies get the same buffer-growth bound as length-prefixed blobs. The scan window and `LineTooLong` check are kept so a server that streams an unterminated line still cannot grow the read buffer without bound. The incremental `ReplyScanner`'s `crlf_skip` bookkeeping keeps the scan linear across socket reads.

The second half of the report (a protocol error latches `flags.failed` without closing the socket, leaving a zombie client) is #33479; this PR only removes the trigger that made valid replies hit that path.

## Verification

`test/js/valkey/reliability/resp-nesting-depth.test.ts` gains three cases driven by an in-process mock server (no Docker): a 600KB `+` reply resolves and the client serves a follow-up `PING`; the 524289-byte boundary resolves; a 600KB `-` reply rejects with the server's original error text and the client survives. All three fail on the released bun with `ERR_REDIS_INVALID_RESPONSE "Failed to read data (buffer path)"` and pass with the fix.

`test/js/valkey/valkey-gc.test.ts`'s "line terminator never arrives" case is updated: 600KB unterminated followed by socket close is now under the cap, so the pending command is rejected with `ERR_REDIS_CONNECTION_CLOSED` rather than `ERR_REDIS_INVALID_RESPONSE`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/reliability/resp-nesting-depth.test.ts test/js/valkey/valkey-gc.test.ts test/js/valkey/valkey-incremental-scan.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (0ea8158f1)

test/js/valkey/valkey-gc.test.ts:
(pass) RedisClient survives GC after a command throws during argument validation [692.15ms]
173 |       });
174 |       try {
175 |         await client.send("PING", []);
176 |         expect.unreachable();
177 |       } catch (error: any) {
178 |         expect(error.code).toBe("ERR_REDIS_CONNECTION_CLOSED");
                                 ^
error: expect(received).toBe(expected)

Expected: "ERR_REDIS_CONNECTION_CLOSED"
Received: "ERR_REDIS_INVALID_RESPONSE"

      at <anonymous> (/workspace/bun/test/js/valkey/valkey-gc.test.ts:178:28)
(fail) rejects a RESP simple-string reply whose lin
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (af1fbb4f8)

test/js/valkey/valkey-gc.test.ts:
(pass) RedisClient survives GC after a command throws during argument validation [29.77ms]
(pass) custom setter with a foreign receiver throws instead of corrupting the heap [19.23ms]
(pass) RedisClient survives GC across many short-lived instances [18.26ms]
(pass) rejects a RESP simple-string reply whose line terminator never arrives [27.35ms]
(pass) getBuffer replies survive GC with adopted backing stores intact [64.13ms]

test/js/valkey/valkey-incremental-scan.test.ts:
(pass) Valkey reply torn across socket reads > BulkString ($) torn at byte 5 decodes (baseline) [5.31ms]
(pass) Valkey reply torn across socket reads > BulkString ($) torn at byte 10 decodes (baseline) [4.22ms]
(pass) Valkey reply torn across socket reads > BulkString ($) torn at byte 19 decodes (baseline) [4.12ms]
(pass) Valkey reply torn across socket reads > BulkString ($) torn at byte 21 decodes (baseline) [4.06ms]
(pass) Valkey reply torn across socket reads > VerbatimString (=) torn at byte 5 decodes instead of failing the connection [4.01ms]
(pass) Valkey reply torn across socket reads > VerbatimString (=) torn at byte 1
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/reliability/resp-nesting-depth.test.ts test/js/valkey/valkey-gc.test.ts test/js/valkey/valkey-incremental-scan.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (0ea8158f1)

test/js/valkey/valkey-gc.test.ts:
(pass) custom setter with a foreign receiver throws instead of corrupting the heap [536.19ms]
(pass) rejects a RESP simple-string reply whose line terminator never arrives [530.92ms]
(pass) RedisClient survives GC after a command throws during argument validation [636.70ms]
(pass) RedisClient survives GC across many short-lived instances [799.75ms]
(pass) getBuffer replies survive GC with adopted backing stores intact [2322.86ms]

test/js/valkey/valkey-incremental-scan.test.ts:
(pass) Valkey reply torn across socket reads > BulkString ($) torn at byte 5 decodes (baseline) [104.02ms]
(pass)
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 13660ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/90] gen ErrorCode+*.h
[2/47] gen cpp.rs (cppbind)
[3/47] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /w
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/valkey/valkey_protocol.rs                      |  6 +-
 .../valkey/reliability/resp-nesting-depth.test.ts  | 70 ++++++++++++++++++++++
 test/js/valkey/valkey-gc.test.ts                   | 21 +++----
 test/js/valkey/valkey-incremental-scan.test.ts     |  5 +-
 4 files changed, 84 insertions(+), 18 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
src/valkey/valkey_protocol.rs                              2      3      0
test/js/valkey/reliability/resp-nesting-depth.test.ts      1      1      0
test/js/valkey/valkey-gc.test.ts                           3      3      0
test/js/valkey/valkey-incremental-scan.test.ts             1      1      0
```

</details>

<!-- robobun:evidence:end -->