### PR TITLE
cli: keep unknown <tag> placeholders in --help descriptions

### DIFF
--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -2065,7 +2065,9 @@ pub fn pretty_fmt_args<A: FmtTuple>(
 /// Colour table lives in `bun_output_tags`; the state machine is kept duplicated
 /// vs `bun_core_macros::rewrite` because the two intentionally diverge in the
 /// `{` arm (proc-macro rewrites specs `{s}`→`{}`; this side copies braces
-/// verbatim) and on unknown tags (proc-macro errors; this side emits `""`).
+/// verbatim) and on unknown tags (proc-macro errors; this side emits the tag
+/// verbatim so prose placeholders such as `<NUMBER>` in `--help` descriptions
+/// survive).
 pub fn pretty_fmt_runtime(fmt: &[u8], is_enabled: bool) -> Vec<u8> {
     let mut out = Vec::with_capacity(fmt.len() * 4);
     let mut i = 0usize;
@@ -2097,6 +2099,7 @@ pub fn pretty_fmt_runtime(fmt: &[u8], is_enabled: bool) -> Vec<u8> {
                 }
             }
             b'<' => {
+                let tag_open = i;
                 i += 1;
                 let mut is_reset = i < fmt.len() && fmt[i] == b'/';
                 if is_reset {
@@ -2107,18 +2110,18 @@ pub fn pretty_fmt_runtime(fmt: &[u8], is_enabled: bool) -> Vec<u8> {
                     i += 1;
                 }
                 let color_name = &fmt[start..i];
-                let color_str: &str = 'picker: {
-                    if let Some(lit) = color_map::get(color_name) {
-                        break 'picker lit;
-                    } else if color_name == b"r" {
-                        is_reset = true;
-                        break 'picker "";
-                    } else {
-                        // Unknown tag: the `pretty_fmt!` proc-macro rejects
-                        // this at its call sites; this runtime path drops the
-                        // tag.
-                        break 'picker "";
-                    }
+                let color_str: &str = if let Some(lit) = color_map::get(color_name) {
+                    lit
+                } else if color_name == b"r" {
+                    is_reset = true;
+                    ""
+                } else {
+                    // Unknown tag: emit verbatim (including the closing `>` if
+                    // present) so prose placeholders like `<NUMBER>` survive.
+                    let end = if i < fmt.len() { i + 1 } else { i };
+                    out.extend_from_slice(&fmt[tag_open..end]);
+                    i = end;
+                    continue;
                 };
                 if is_enabled {
                     out.extend_from_slice(if is_reset {
@@ -3031,6 +3034,36 @@ mod pretty_fmt_tests {
         // mistaken for a tag.
         assert_eq!(pretty_fmt!("\\<folder\\>", true), "<folder>");
         assert_eq!(pretty_fmt!("\\<folder\\>", false), "<folder>");
+    }
+
+    #[test]
+    fn unknown_tags_pass_through_verbatim() {
+        // Prose placeholders in `--help` descriptions must not be stripped.
+        assert_eq!(
+            pretty_fmt_runtime(b"Re-run each test file <NUMBER> times", false),
+            b"Re-run each test file <NUMBER> times",
+        );
+        assert_eq!(
+            pretty_fmt_runtime(b"Re-run each test file <NUMBER> times", true),
+            b"Re-run each test file <NUMBER> times",
+        );
+        assert_eq!(
+            pretty_fmt_runtime(b"equal to <level> (low, moderate)", false),
+            b"equal to <level> (low, moderate)",
+        );
+        assert_eq!(
+            pretty_fmt_runtime(b"Use '<empty>' for opaque specifiers", true),
+            b"Use '<empty>' for opaque specifiers",
+        );
+        // Known markup in the same string is still resolved.
+        assert_eq!(
+            pretty_fmt_runtime(b"<d>default<r> after <NUMBER> runs", false),
+            b"default after <NUMBER> runs",
+        );
+        assert_eq!(
+            pretty_fmt_runtime(b"<d>default<r> after <NUMBER> runs", true),
+            b"\x1b[2mdefault\x1b[0m after <NUMBER> runs",
+        );
     }
 
     #[test]

--- a/src/bun_core_macros/lib.rs
+++ b/src/bun_core_macros/lib.rs
@@ -86,7 +86,8 @@ use bun_output_tags::{RESET, color_for};
 /// vs `bun_core::output::pretty_fmt_runtime` because the two intentionally
 /// diverge in the `{` arm (this side rewrites legacy specs `{s}`→`{}` for the
 /// emitted `format_args!` template; runtime copies braces verbatim) and on
-/// unknown tags (this side `Err`→`compile_error!`; runtime emits `""`).
+/// unknown tags (this side `Err`→`compile_error!`; runtime emits the tag
+/// verbatim so prose placeholders survive).
 fn rewrite(fmt: &str, is_enabled: bool) -> Result<String, String> {
     let bytes = fmt.as_bytes();
     let mut out = String::with_capacity(bytes.len() * 2);

--- a/src/clap_macros/lib.rs
+++ b/src/clap_macros/lib.rs
@@ -304,6 +304,7 @@ fn pretty_rewrite(fmt: &[u8], is_enabled: bool) -> Vec<u8> {
                 }
             }
             b'<' => {
+                let tag_open = i;
                 i += 1;
                 let mut is_reset = i < fmt.len() && fmt[i] == b'/';
                 if is_reset {
@@ -320,12 +321,12 @@ fn pretty_rewrite(fmt: &[u8], is_enabled: bool) -> Vec<u8> {
                     is_reset = true;
                     ""
                 } else {
-                    // Unknown tag: `pretty_fmt_runtime` (the path this replaces)
-                    // drops it silently. Match
-                    // the lenient runtime behaviour — a compile error would be
-                    // stricter than what shipped, and param specs don't carry
-                    // unknown tags anyway.
-                    ""
+                    // Unknown tag: emit verbatim so prose placeholders such as
+                    // `<NUMBER>` / `<level>` in param descriptions survive.
+                    let end = if i < fmt.len() { i + 1 } else { i };
+                    out.extend_from_slice(&fmt[tag_open..end]);
+                    i = end;
+                    continue;
                 };
                 if is_enabled {
                     out.extend_from_slice(if is_reset {

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -24,15 +24,13 @@ use std::sync::OnceLock;
 use super::package_manager_options as Options;
 
 /// `Output.pretty(text, .{})` — runtime `<tag>` → ANSI rewrite of a help-text
-/// literal then write to stdout. The help strings are runtime `&str`s so we
-/// use the runtime expander.
+/// literal then write to stdout. Single pass: `Output::pretty(&str)` already
+/// runs `pretty_fmt_runtime`, so wrapping in `format_args!` would rewrite the
+/// already-unescaped `\<name\>` placeholders a second time.
 #[inline]
 #[allow(clippy::disallowed_methods)] // template is a runtime &str parameter
 fn pretty_help(text: &str) {
-    Output::pretty(format_args!(
-        "{}",
-        Output::pretty_fmt_rt(text, Output::enable_ansi_colors_stdout())
-    ));
+    Output::pretty(text);
 }
 
 type ParamType = clap::Param<clap::Help>;

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -147,11 +147,14 @@ describe("bun", () => {
       ["build", "--allow-unresolved", "Use '<empty>' for opaque specifiers"],
     ];
     describe.each([{ NO_COLOR: "1" }, { FORCE_COLOR: "1" }])("%j", env => {
-      test.concurrent.each(descFlags)("bun %s --help keeps placeholder in %s description", async (cmd, flag, expected) => {
-        const { out, exitCode } = await help(cmd, env);
-        expect(line(out, flag)).toContain(expected);
-        expect(exitCode).toBe(0);
-      });
+      test.concurrent.each(descFlags)(
+        "bun %s --help keeps placeholder in %s description",
+        async (cmd, flag, expected) => {
+          const { out, exitCode } = await help(cmd, env);
+          expect(line(out, flag)).toContain(expected);
+          expect(exitCode).toBe(0);
+        },
+      );
     });
 
     const pmUsage: [string, string][] = [

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -126,6 +126,53 @@ describe("bun", () => {
       }
     });
   });
+  describe("--help", () => {
+    function help(cmd: string, env: Record<string, string | undefined>) {
+      const { stdout, exitCode } = spawnSync({
+        cmd: [bunExe(), cmd, "--help"],
+        env: { ...bunEnv, NO_COLOR: undefined, FORCE_COLOR: undefined, ...env },
+      });
+      expect(exitCode).toBe(0);
+      return stdout.toString();
+    }
+    function line(out: string, flag: string) {
+      const l = out.split("\n").find(l => l.includes(flag));
+      expect(l).toBeDefined();
+      return l!;
+    }
+
+    for (const env of [{ NO_COLOR: "1" }, { FORCE_COLOR: "1" }]) {
+      const label = Object.keys(env)[0];
+      test(`keeps prose <placeholder>s in flag descriptions (${label})`, () => {
+        const testHelp = help("test", env);
+        expect(line(testHelp, "--rerun-each")).toContain("Re-run each test file <NUMBER> times");
+        expect(line(testHelp, "--bail")).toContain("after <NUMBER> failures");
+
+        const auditHelp = help("audit", env);
+        expect(line(auditHelp, "--audit-level")).toContain("equal to <level> (low, moderate, high, critical)");
+
+        const buildHelp = help("build", env);
+        expect(line(buildHelp, "--allow-unresolved")).toContain("Use '<empty>' for opaque specifiers");
+      });
+    }
+
+    test("still strips <d>/<r> colour markup from flag descriptions (NO_COLOR)", () => {
+      const runHelp = help("run", { NO_COLOR: "1" });
+      const tsconfig = line(runHelp, "--tsconfig-override");
+      expect(tsconfig).toContain("Default $cwd/tsconfig.json");
+      expect(tsconfig).not.toContain("<d>");
+      expect(tsconfig).not.toContain("<r>");
+    });
+
+    test("still resolves <d>/<r> colour markup in flag descriptions (FORCE_COLOR)", () => {
+      const runHelp = help("run", { FORCE_COLOR: "1" });
+      const tsconfig = line(runHelp, "--tsconfig-override");
+      expect(tsconfig).toContain("Default \x1b[2m$cwd\x1b[0m/tsconfig.json");
+      expect(tsconfig).not.toContain("<d>");
+      expect(tsconfig).not.toContain("<r>");
+    });
+  });
+
   describe("test command line arguments", () => {
     test("test --config, issue #4128", () => {
       const path = `${tmpdir()}/bunfig-${Date.now()}.toml`;

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -127,49 +127,72 @@ describe("bun", () => {
     });
   });
   describe("--help", () => {
-    function help(cmd: string, env: Record<string, string | undefined>) {
-      const { stdout, exitCode } = spawnSync({
+    async function help(cmd: string, env: Record<string, string | undefined>) {
+      await using proc = Bun.spawn({
         cmd: [bunExe(), cmd, "--help"],
         env: { ...bunEnv, NO_COLOR: undefined, FORCE_COLOR: undefined, ...env },
+        stderr: "pipe",
       });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { out: stdout + stderr, exitCode };
+    }
+    function line(out: string, needle: string) {
+      return out.split(/\r?\n/).find(l => l.includes(needle)) ?? "<no matching line>";
+    }
+
+    const descFlags: [string, string, string][] = [
+      ["test", "--rerun-each", "Re-run each test file <NUMBER> times"],
+      ["test", "--bail", "Exit the test suite after <NUMBER> failures"],
+      ["audit", "--audit-level", "equal to <level> (low, moderate, high, critical)"],
+      ["build", "--allow-unresolved", "Use '<empty>' for opaque specifiers"],
+    ];
+    describe.each([{ NO_COLOR: "1" }, { FORCE_COLOR: "1" }])("%j", env => {
+      test.concurrent.each(descFlags)("bun %s --help keeps placeholder in %s description", async (cmd, flag, expected) => {
+        const { out, exitCode } = await help(cmd, env);
+        expect(line(out, flag)).toContain(expected);
+        expect(exitCode).toBe(0);
+      });
+    });
+
+    const pmUsage: [string, string][] = [
+      ["install", "bun install [flags] <name>@<version>"],
+      ["add", "bun add [flags] <package><@version>"],
+      ["remove", "bun remove [flags] [<packages>]"],
+      ["update", "bun update [flags] <name>@<version>"],
+      ["link", "bun link [flags] [<packages>]"],
+      ["patch", "bun patch [flags or options] <package>@<version>"],
+      ["patch-commit", "bun patch-commit [flags or options] <directory>"],
+      ["info", "bun info [flags] <package>[@<version>]"],
+    ];
+    test.concurrent.each(pmUsage)("bun %s --help usage line keeps placeholders", async (cmd, expected) => {
+      const { out, exitCode } = await help(cmd, { NO_COLOR: "1" });
+      expect(line(out, "Usage:")).toBe(`Usage: ${expected}`);
       expect(exitCode).toBe(0);
-      return stdout.toString();
-    }
-    function line(out: string, flag: string) {
-      const l = out.split("\n").find(l => l.includes(flag));
-      expect(l).toBeDefined();
-      return l!;
-    }
+    });
 
-    for (const env of [{ NO_COLOR: "1" }, { FORCE_COLOR: "1" }]) {
-      const label = Object.keys(env)[0];
-      test(`keeps prose <placeholder>s in flag descriptions (${label})`, () => {
-        const testHelp = help("test", env);
-        expect(line(testHelp, "--rerun-each")).toContain("Re-run each test file <NUMBER> times");
-        expect(line(testHelp, "--bail")).toContain("after <NUMBER> failures");
+    test("bun add --help usage line keeps placeholders (FORCE_COLOR)", async () => {
+      const { out, exitCode } = await help("add", { FORCE_COLOR: "1" });
+      expect(out).toContain("\x1b[34m<package>\x1b[0m");
+      expect(out).not.toContain("<blue>");
+      expect(exitCode).toBe(0);
+    });
 
-        const auditHelp = help("audit", env);
-        expect(line(auditHelp, "--audit-level")).toContain("equal to <level> (low, moderate, high, critical)");
-
-        const buildHelp = help("build", env);
-        expect(line(buildHelp, "--allow-unresolved")).toContain("Use '<empty>' for opaque specifiers");
-      });
-    }
-
-    test("still strips <d>/<r> colour markup from flag descriptions (NO_COLOR)", () => {
-      const runHelp = help("run", { NO_COLOR: "1" });
-      const tsconfig = line(runHelp, "--tsconfig-override");
+    test("still strips <d>/<r> colour markup from flag descriptions (NO_COLOR)", async () => {
+      const { out, exitCode } = await help("run", { NO_COLOR: "1" });
+      const tsconfig = line(out, "--tsconfig-override");
       expect(tsconfig).toContain("Default $cwd/tsconfig.json");
       expect(tsconfig).not.toContain("<d>");
       expect(tsconfig).not.toContain("<r>");
+      expect(exitCode).toBe(0);
     });
 
-    test("still resolves <d>/<r> colour markup in flag descriptions (FORCE_COLOR)", () => {
-      const runHelp = help("run", { FORCE_COLOR: "1" });
-      const tsconfig = line(runHelp, "--tsconfig-override");
+    test("still resolves <d>/<r> colour markup in flag descriptions (FORCE_COLOR)", async () => {
+      const { out, exitCode } = await help("run", { FORCE_COLOR: "1" });
+      const tsconfig = line(out, "--tsconfig-override");
       expect(tsconfig).toContain("Default \x1b[2m$cwd\x1b[0m/tsconfig.json");
       expect(tsconfig).not.toContain("<d>");
       expect(tsconfig).not.toContain("<r>");
+      expect(exitCode).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Repro

```console
$ bun test --help | grep rerun-each
# before: --rerun-each=<val>   Re-run each test file  times, helps catch certain bugs
# after:  --rerun-each=<val>   Re-run each test file <NUMBER> times, helps catch certain bugs

$ bun audit --help | grep audit-level
# before: ...greater than or equal to  (low, moderate, high, critical)
# after:  ...greater than or equal to <level> (low, moderate, high, critical)

$ bun install --help | grep ^Usage:
# before: Usage: bun install [flags] @
# after:  Usage: bun install [flags] <name>@<version>
```

Also affected: `bun test --help` `--bail`, `bun build --help` `--allow-unresolved`, and the `Usage:` lines of `add`/`remove`/`update`/`link`/`patch`/`patch-commit`/`info`.

## Cause

Both help-rendering paths run the `<tag>` markup rewriter over param descriptions:

- compile-time (non-TTY) path: `src/clap_macros/lib.rs` `pretty_rewrite`, which bakes `Help::msg_plain`
- runtime colour path: `src/clap/lib.rs` `pretty_help_desc` → `bun_core::output::pretty_fmt_runtime`

Both rewriters dropped any `<...>` whose body was not a known colour tag, so prose placeholders like `<NUMBER>`, `<level>`, `<empty>` were silently deleted. 1.3.14's `clap.zig` printed the description as a runtime `{s}` argument to a comptime-expanded `Output.pretty` template, so it was never scanned for tags.

Separately, `pretty_help` in `src/install/PackageManager/CommandLineArguments.rs` wrapped `Output::pretty_fmt_rt(text, ...)` in `Output::pretty(format_args!(...))`, running the rewriter twice: pass 1 turned `\<name\>` into a literal `<name>`, and pass 2 dropped it as an unknown tag.

## Fix

Emit tags whose body is not in the colour table (and not `r`) verbatim in both rewriters. Known markup (`<d>`, `<r>`, `<red>`, `</b>`, …) is still processed, so the `--tsconfig-override` case where `<d>$cwd<r>` is intentionally stripped/colourised keeps working. The compile-time `pretty_fmt!` proc-macro in `bun_core_macros` still `compile_error!`s on unknown tags, so template authors keep their guardrail.

`pretty_help` is also collapsed to a single `Output::pretty(text)` pass (the `&str` overload already runs the rewriter once).

## Verification

`test/cli/bun.test.ts` gains a `--help` block that asserts, under both `NO_COLOR` and `FORCE_COLOR`:
- `<NUMBER>`/`<level>`/`<empty>` survive in the four affected flag descriptions
- the eight package-manager `Usage:` lines are intact
- `<d>`/`<r>` are still stripped / turned into ANSI on the `--tsconfig-override` line

plus a `pretty_fmt_runtime` unit test for the mixed-known-and-unknown case.

Supersedes #34317 (which took the narrower escape-the-strings route; the `pretty_help` single-pass change and `Usage:` test coverage from that PR are folded in here).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 17 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/bun.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (52d0b3d2c)

test/cli/bun.test.ts:
(pass) bun > NO_COLOR > respects NO_COLOR="1" to disable color [160.02ms]
(pass) bun > NO_COLOR > respects NO_COLOR="0" to disable color [147.65ms]
(pass) bun > NO_COLOR > respects NO_COLOR="foo" to disable color [138.78ms]
(pass) bun > NO_COLOR > respects NO_COLOR=" " to disable color [176.41ms]
(todo) bun > NO_COLOR > respects NO_COLOR="" to enable color
(todo) bun > NO_COLOR > respects NO_COLOR=undefined to enable color
(pass) bun > revision > revision generates version numbers correctly [400.29ms]
(pass) bun > getcompletes > getcompletes should not panic and should not be empty [236.55ms]
(pass) bun > getcompletes > getcompletes keeps scripts whose names start with 'pre'/'post' when no sibling script exists 
... (truncated)

release without fix: 2 skipped
bun test v1.4.0-canary.1 (52d0b3d2c)

test/cli/bun.test.ts:
(pass) bun > NO_COLOR > respects NO_COLOR="1" to disable color [5.52ms]
(pass) bun > NO_COLOR > respects NO_COLOR="0" to disable color [4.04ms]
(pass) bun > NO_COLOR > respects NO_COLOR="foo" to disable color [2.93ms]
(pass) bun > NO_COLOR > respects NO_COLOR=" " to disable color [5.61ms]
(todo) bun > NO_COLOR > respects NO_COLOR="" to enable color
(todo) bun > NO_COLOR > respects NO_COLOR=undefined to enable color
(pass) bun > revision > revision generates version numbers correctly [9.56ms]
(pass) bun > getcompletes > getcompletes should not panic and should not be empty [3.48ms]
(pass) bun > getcompletes > getcompletes keeps scripts whose names start with 'pre'/'post' when no sibling script exists [25.78ms]
(pass) bun > --help > {"NO_COLOR":"1"} > bun test --help keeps placeholder in --bail description [69.31ms]
(pass) bun > --help > {"NO_COLOR":"1"} > bun audit --help keeps placeholder in --audit-level description [68.80ms]
(pass) bun > --help > {"NO_COLOR":"1"} > bun test --help keeps placeholder in --rerun-each description [71.33ms]
(pass) bun > --help > {"NO_COLOR":"1"} > bun build --help keeps placeh
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/bun.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (52d0b3d2c)

test/cli/bun.test.ts:
(pass) bun > NO_COLOR > respects NO_COLOR="1" to disable color [169.69ms]
(pass) bun > NO_COLOR > respects NO_COLOR="0" to disable color [243.52ms]
(pass) bun > NO_COLOR > respects NO_COLOR="foo" to disable color [258.19ms]
(pass) bun > NO_COLOR > respects NO_COLOR=" " to disable color [245.54ms]
(todo) bun > NO_COLOR > respects NO_COLOR="" to enable color
(todo) bun > NO_COLOR > respects NO_COLOR=undefined to enable color
(pass) bun > revision > revision generates version numbers correctly [539.90ms]
(pass) bun > getcompletes > getcompletes should not panic and should not be empty [294.19ms]
(pass) bun > getcompletes > getcompletes keeps scripts whose names start with 'pre'/'post' when no sibling script exists 
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 2168ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/90] gen ErrorCode+*.h
[2/47] gen cpp.rs (cppbind)
[3/47] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /wo
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/output.rs                             | 59 +++++++++++++----
 src/bun_core_macros/lib.rs                         |  3 +-
 src/clap_macros/lib.rs                             | 13 ++--
 src/install/PackageManager/CommandLineArguments.rs | 10 ++-
 test/cli/bun.test.ts                               | 73 ++++++++++++++++++++++
 5 files changed, 132 insertions(+), 26 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/bun_core/output.rs                                  8      2      0
src/bun_core_macros/lib.rs                              1      1      0
src/clap_macros/lib.rs                                  2      1      0
src/install/PackageManager/CommandLineArguments.rs      2      1      0
test/cli/bun.test.ts                                    1      2      0
```

</details>

<!-- robobun:evidence:end -->