### PR TITLE
Bun.color: list accepted format strings in invalid-format error

### DIFF
--- a/src/css_jsc/color_js.rs
+++ b/src/css_jsc/color_js.rs
@@ -37,11 +37,24 @@ impl bun_jsc::FromJsEnum for OutputColorFormat {
         use bun_jsc::ComptimeStringMapExt as _;
         match OUTPUT_COLOR_FORMAT_MAP.from_js(global, v)? {
             Some(e) => Ok(e),
-            None => Err(global.throw_invalid_argument_type(
-                "color",
-                property_name,
-                "OutputColorFormat string",
-            )),
+            None => {
+                // List the accepted spellings straight from the lookup map so the
+                // error message can't drift from what the parser actually accepts.
+                let n = OUTPUT_COLOR_FORMAT_MAP.len();
+                let mut one_of = std::string::String::from("'");
+                for (i, key) in OUTPUT_COLOR_FORMAT_MAP.keys().enumerate() {
+                    one_of.push_str(std::str::from_utf8(key).expect("map keys are ASCII"));
+                    one_of.push('\'');
+                    if i + 2 < n {
+                        one_of.push_str(", '");
+                    } else if i + 2 == n {
+                        one_of.push_str(" or '");
+                    }
+                }
+                Err(global.throw_invalid_arguments(format_args!(
+                    "{property_name} must be one of {one_of}"
+                )))
+            }
         }
     }
 }

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -183,6 +183,49 @@ test.each(bad)("color(%s, 'css') === null", input => {
   expect(color(input)).toBeNull();
 });
 
+test("invalid format string lists the accepted values", () => {
+  let message!: string;
+  try {
+    // @ts-expect-error
+    color("red", "nope");
+    expect.unreachable();
+  } catch (e) {
+    message = (e as Error).message;
+  }
+  // Must not leak the internal Rust enum name.
+  expect(message).not.toContain("OutputColorFormat");
+  expect(message).toStartWith("format must be one of ");
+  // Every accepted spelling should appear in the message, so a user can copy one.
+  for (const ok of [
+    "ansi",
+    "ansi_16",
+    "ansi-16",
+    "ansi_16m",
+    "ansi-16m",
+    "ansi-24bit",
+    "ansi-truecolor",
+    "ansi_256",
+    "ansi-256",
+    "ansi256",
+    "css",
+    "hex",
+    "HEX",
+    "hsl",
+    "lab",
+    "number",
+    "rgb",
+    "rgba",
+    "[rgb]",
+    "[rgba]",
+    "[r,g,b,a]",
+    "{rgb}",
+    "{r,g,b}",
+    "{rgba}",
+  ]) {
+    expect(message).toContain(`'${ok}'`);
+  }
+});
+
 const weird = [
   ["rgb(-255, 0, 0)", "#000"],
   ["rgb(256, 0, 0)", "red"],


### PR DESCRIPTION
## Problem

```js
try { Bun.color("red", "nope"); } catch (e) { console.log(e.message); }
```

1.3.14:
```
format must be one of 'ansi', 'ansi_16', 'ansi_16m', 'ansi_256', 'css', 'hex', 'HEX', 'hsl', 'lab', 'number', 'rgb', 'rgba', '[rgb]', '[rgba]', '{rgb}' or '{rgba}'
```

1.4:
```
Expected format to be a OutputColorFormat string for 'color'.
```

The new message names an internal Rust type and drops every accepted spelling, so the user cannot recover from it.

## Cause

`src/css_jsc/color_js.rs`'s hand-written `impl FromJsEnum for OutputColorFormat` passes the literal `"OutputColorFormat string"` to `throw_invalid_argument_type`. The Zig baseline routed through `toEnumFromMap`, which auto-enumerated the enum's field names into the message. The Rust impl is bespoke because the Rust variants are CamelCase (`Ansi16m`, `RgbArray`) rather than the user-facing spellings.

## Fix

Enumerate `OUTPUT_COLOR_FORMAT_MAP.keys()` on the error path and format them into a `"must be one of '...'"` message, matching the `SignalCode` `FromJsEnum` precedent in `src/jsc/lib.rs`. The message now lists every accepted spelling (24, including aliases like `'ansi-256'` and `'ansi-truecolor'`, strictly more than the 16 the Zig version listed) and cannot drift from the lookup table.

After:
```
format must be one of '[r,g,b,a]', '[rgb]', '[rgba]', '{r,g,b}', '{rgb}', '{rgba}', 'ansi_256', 'ansi-256', 'ansi_16', 'ansi-16', 'ansi_16m', 'ansi-16m', 'ansi-24bit', 'ansi-truecolor', 'ansi', 'ansi256', 'css', 'hex', 'HEX', 'hsl', 'lab', 'number', 'rgb' or 'rgba'
```

## Verification

Added a test in `test/js/bun/css/color.test.ts` asserting the message does not contain `OutputColorFormat`, starts with `format must be one of `, and contains every accepted spelling quoted.

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/css/color.test.ts -t "invalid format"
(fail) invalid format string lists the accepted values
  Expected to not contain: "OutputColorFormat"
  Received: "Expected format to be a OutputColorFormat string for 'color'."

$ bun bd test test/js/bun/css/color.test.ts -t "invalid format"
(pass) invalid format string lists the accepted values
```

Full `color.test.ts` suite: 993 pass, 1 skip, 0 fail.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/color.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (94961a44c)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [4.53ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [2.61ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [3.21ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [3.44ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [26.72ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [3.25ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [3.69ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit")) [0.56ms]
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g
... (truncated)

release without fix: 143 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [5.94ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [0.07ms]
[38;5;	m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [0.03ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [0.09ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [26.25ms]
122 |     test(`color(${JSON.stringify(input)}, "ansi-24bit")`, () => {
123 |       expect(color(input, "ansi-24bit")).toMatchSnapshot();
124 |     });
125 | 
126 |     test(`color(${JSON.stringify(input)}, "ansi-16")`, () => {
127 |       expect(color(input, "ansi-16")).toMatchSnapshot();
                                            ^
error: expect(received).toMatchSnapshot(expected)

Expected: "[91m"
Received: "[38;5;	m"

      at <anonymous> (/workspace/bun/test/js/bun/css/color.test.ts:127:39)
(fail) color({"r":255,"g":0,"b":0}, "ansi-16") [12.61ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [0.14ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g"
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/color.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (94961a44c)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [7.46ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [2.94ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [2.11ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [3.83ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [35.36ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [2.25ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [1.91ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit")) [0.38ms]
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 3314ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/90] gen ErrorCode+*.h
[2/47] gen cpp.rs (cppbind)
[3/47] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /wo
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css_jsc/color_js.rs       | 23 ++++++++++++++++++-----
 test/js/bun/css/color.test.ts | 43 +++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 61 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/css_jsc/color_js.rs            1      1      0
test/js/bun/css/color.test.ts      3      1      0
```

</details>

<!-- robobun:evidence:end -->