### PR TITLE
Bun.TOML.parse: throw RangeError instead of primitive undefined on deep nesting

### DIFF
--- a/src/ast_jsc/lib.rs
+++ b/src/ast_jsc/lib.rs
@@ -7,7 +7,9 @@ use std::borrow::Cow;
 use bun_ast::{Data, Location, Log, Metadata, Msg};
 use bun_core::ZigString;
 
-use bun_jsc::{self as jsc, BuildMessage, JSGlobalObject, JSValue, JsResult, ResolveMessage};
+use bun_jsc::{
+    self as jsc, BuildMessage, JSGlobalObject, JSValue, JsResult, ResolveMessage, ZigStringJsc as _,
+};
 
 pub fn msg_from_js(global_object: &JSGlobalObject, file: Vec<u8>, err: JSValue) -> JsResult<Msg> {
     let mut zig_exception_holder = jsc::zig_exception::Holder::init();
@@ -51,7 +53,7 @@ pub fn log_to_js(this: &Log, global: &JSGlobalObject, message: &[u8]) -> JsResul
 
     let count = u16::try_from(msgs.len().min(errors_stack.len())).unwrap();
     match count {
-        0 => Ok(JSValue::UNDEFINED),
+        0 => Ok(ZigString::init(message).to_error_instance(global)),
         1 => {
             let msg = msgs[0].clone();
             Ok(match msg.metadata {

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1944,7 +1944,7 @@ impl LogJsc for bun_ast::Log {
         // Cap at 256 — the consumer's stack buffer holds at most 256 JSValues.
         let count = msgs.len().min(256);
         match count {
-            0 => Ok(JSValue::UNDEFINED),
+            0 => Ok(bun_core::ZigString::init(message.as_bytes()).to_error_instance(global)),
             1 => msg_to_js(&msgs[0], global),
             _ => {
                 // On-stack array: conservative GC stack scan keeps these

--- a/src/runtime/api/TOMLObject.rs
+++ b/src/runtime/api/TOMLObject.rs
@@ -33,7 +33,7 @@ pub fn parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
             // for now...
             let buffer_writer = js_printer::BufferWriter::init();
             let mut writer = js_printer::BufferPrinter::init(buffer_writer);
-            if js_printer::print_json(
+            match js_printer::print_json(
                 &mut writer,
                 parse_result,
                 source,
@@ -42,10 +42,14 @@ pub fn parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
                     mangled_props: None,
                     ..Default::default()
                 },
-            )
-            .is_err()
-            {
-                return Err(global.throw_value(log.to_js(global, "Failed to print toml")?));
+            ) {
+                Ok(_) => {}
+                Err(js_printer::Error::StackOverflow) => {
+                    return Err(global.throw_stack_overflow());
+                }
+                Err(_) => {
+                    return Err(global.throw_value(log.to_js(global, "Failed to print toml")?));
+                }
             }
 
             let slice = writer.ctx.buffer.slice();

--- a/test/js/bun/resolve/toml/toml-parse.test.ts
+++ b/test/js/bun/resolve/toml/toml-parse.test.ts
@@ -124,9 +124,14 @@ test("Bun.TOML.parse rejects array values without comma separators (#31252)", ()
 // Error::StackOverflow without logging a message; the empty log used to convert
 // to JSValue::UNDEFINED and get thrown verbatim.
 test("Bun.TOML.parse throws RangeError (not undefined) on deeply nested inline tables", async () => {
+  // Dense ladder: the depth band where the parser succeeds but the printer's stack
+  // check fires varies with frame size (debug vs release vs ASAN), so probe a
+  // geometric range rather than a single depth.
   const fixture = `
     const results = [];
-    for (const d of [2000, 4000, 8000, 12000, 16000, 20000, 28000, 40000, 100000]) {
+    const depths = [];
+    for (let d = 500; d <= 200000; d = Math.ceil(d * 1.25)) depths.push(d);
+    for (const d of depths) {
       const src = "a = " + Buffer.alloc(d * 6).fill("{ b = ").toString() + "1" + Buffer.alloc(d * 2).fill(" }").toString();
       try {
         Bun.TOML.parse(src);

--- a/test/js/bun/resolve/toml/toml-parse.test.ts
+++ b/test/js/bun/resolve/toml/toml-parse.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 test("Bun.TOML.parse with non-string input throws", () => {
   expect(() => Bun.TOML.parse(SharedArrayBuffer as any)).toThrow();
@@ -116,4 +117,47 @@ test("Bun.TOML.parse rejects array values without comma separators (#31252)", ()
   expect(Bun.TOML.parse("a = [1, 2, 3]")).toEqual({ a: [1, 2, 3] });
   // Trailing comma is legal TOML.
   expect(Bun.TOML.parse("a = [1, 2,]")).toEqual({ a: [1, 2] });
+});
+
+// Deeply nested inline tables must throw RangeError, not the primitive `undefined`.
+// When the printer's stack check fires before the parser's, the printer returns
+// Error::StackOverflow without logging a message; the empty log used to convert
+// to JSValue::UNDEFINED and get thrown verbatim.
+test("Bun.TOML.parse throws RangeError (not undefined) on deeply nested inline tables", async () => {
+  const fixture = `
+    const results = [];
+    for (const d of [2000, 4000, 8000, 12000, 16000, 20000, 28000, 40000, 100000]) {
+      const src = "a = " + Buffer.alloc(d * 6).fill("{ b = ").toString() + "1" + Buffer.alloc(d * 2).fill(" }").toString();
+      try {
+        Bun.TOML.parse(src);
+        results.push({ d, ok: true });
+      } catch (e) {
+        results.push({
+          d,
+          ok: false,
+          isRangeError: e instanceof RangeError,
+          type: e === undefined ? "undefined" : e?.constructor?.name ?? typeof e,
+        });
+      }
+    }
+    console.log(JSON.stringify(results));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const results: Array<{ d: number; ok: boolean; isRangeError?: boolean; type?: string }> = JSON.parse(stdout.trim());
+
+  const thrown = results.filter(r => !r.ok);
+  expect(thrown.length).toBeGreaterThan(0);
+  for (const r of thrown) {
+    expect({ d: r.d, type: r.type, isRangeError: r.isRangeError }).toEqual({
+      d: r.d,
+      type: "RangeError",
+      isRangeError: true,
+    });
+  }
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### What does this PR do?

Fixes `Bun.TOML.parse` throwing the primitive value `undefined` (not an Error object) on deeply nested inline tables. 1.3.14 threw `RangeError: Maximum call stack size exceeded.`; 1.4 throws `undefined` in a depth band where the parser succeeds but the printer does not.

**Repro:**
```js
const d = 20000;
const src = "a = " + "{ b = ".repeat(d) + "1" + " }".repeat(d);
try { Bun.TOML.parse(src); } catch (e) {
  console.log("typeof:", typeof e, "isUndefined:", e === undefined);
}
// 1.3.14: typeof: object    isUndefined: false  (RangeError)
// 1.4:    typeof: undefined isUndefined: true
```

**Cause:**

- `src/js_printer/lib.rs` `print_expr`/`print_object_json` set `stack_overflowed` and return `Err(Error::StackOverflow)` without appending a message to the `Log`. This check is new in the Rust printer.
- `src/runtime/api/TOMLObject.rs:48` collapsed every printer error to `throw_value(log.to_js(global, "Failed to print toml")?)` without mapping `Error::StackOverflow` to `throw_stack_overflow()`, unlike the parser arm 25 lines above.
- `src/jsc/lib.rs` `LogJsc::to_js` returned `JSValue::UNDEFINED` when the log was empty, discarding the `message` fallback. `throw_value(UNDEFINED)` then throws the primitive `undefined`.
- This became reachable because `src/parsers/toml.rs` dropped its hard depth cap in favor of `StackCheck`; the parser's smaller frames now recurse deeper than the printer can print, so the printer's check fires first.

**Fix:**

- `LogJsc::to_js`: when `msgs` is empty, build an `Error` from the `message` parameter instead of returning `UNDEFINED`. Every caller feeds the result straight to `throw_value`, so this is strictly better across all ~18 call sites.
- `TOMLObject.rs`: match on `print_json`'s result and map `js_printer::Error::StackOverflow` to `global.throw_stack_overflow()`, mirroring the parser arm.

### How did you verify your code works?

New test in `test/js/bun/resolve/toml/toml-parse.test.ts` spawns a subprocess that tries a ladder of nesting depths (2000..100000, covering both release and debug+ASAN printer-overflow bands) and asserts every thrown value is a `RangeError`.

- `USE_SYSTEM_BUN=1 bun test`: fails with `type: "undefined"` at d=16000
- `bun bd test` with `src/` stashed: fails with `type: "undefined"` at d=2000
- `bun bd test` with fix: passes, all 12 tests in the file green

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/toml/toml-parse.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (931bb730c)

test/js/bun/resolve/toml/toml-parse.test.ts:
(pass) Bun.TOML.parse with non-string input throws [25.76ms]
(pass) Bun.TOML.parse accepts \u{XX} at start of a basic string (#30893) [5.46ms]
(pass) Bun.TOML.parse rejects \x escape in quoted key at file start without panicking (#30893) [7.65ms]
(pass) Bun.TOML.parse rejects \u escape in quoted key at file start without panicking (#30893) [7.20ms]
(pass) Bun.TOML.parse handles trailing backslash-CR in multiline basic string (#30893) [3.66ms]
(pass) Bun.TOML.parse produces correct codepoints for \t and \f escapes [7.20ms]
(pass) Bun.TOML.parse normalizes literal CRLF to LF in multiline basic strings [4.36ms]
(pass) Bun.TOML.parse rejects out-of-range \u{...} escapes 
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/resolve/toml/toml-parse.test.ts:
(pass) Bun.TOML.parse with non-string input throws [0.98ms]
(pass) Bun.TOML.parse accepts \u{XX} at start of a basic string (#30893) [0.11ms]
(pass) Bun.TOML.parse rejects \x escape in quoted key at file start without panicking (#30893) [0.12ms]
(pass) Bun.TOML.parse rejects \u escape in quoted key at file start without panicking (#30893) [0.11ms]
(pass) Bun.TOML.parse handles trailing backslash-CR in multiline basic string (#30893) [0.05ms]
(pass) Bun.TOML.parse produces correct codepoints for \t and \f escapes [0.08ms]
(pass) Bun.TOML.parse normalizes literal CRLF to LF in multiline basic strings [0.05ms]
(pass) Bun.TOML.parse rejects out-of-range \u{...} escapes without overflowing (#30825) [0.23ms]
84 |   );
85 |   expect(() => Bun.TOML.parse('a = "\\u{110000}"')).toThrow("Unicode escape sequence is out of range");
86 | });
87 | 
88 | test("Bun.TOML.parse rejects \\u{...} escapes with no closing brace (#30825)", () => {
89 |   expect(() => Bun.TOML.parse('a = "\\u{41"')).toThrow("Syntax Error");
                                                    ^
error: expect(received).toThrow(
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/toml/toml-parse.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (931bb730c)

test/js/bun/resolve/toml/toml-parse.test.ts:
(pass) Bun.TOML.parse with non-string input throws [27.37ms]
(pass) Bun.TOML.parse accepts \u{XX} at start of a basic string (#30893) [4.64ms]
(pass) Bun.TOML.parse rejects \x escape in quoted key at file start without panicking (#30893) [7.51ms]
(pass) Bun.TOML.parse rejects \u escape in quoted key at file start without panicking (#30893) [7.09ms]
(pass) Bun.TOML.parse handles trailing backslash-CR in multiline basic string (#30893) [3.61ms]
(pass) Bun.TOML.parse produces correct codepoints for \t and \f escapes [6.87ms]
(pass) Bun.TOML.parse normalizes literal CRLF to LF in multiline basic strings [3.71ms]
(pass) Bun.TOML.parse rejects out-of-range \u{...} escapes 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     931bb730cb
  features     (none)

22 deps, 106 codegen, 1168 objects in 1862ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [58.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [4.00ms]
[3/1231] gen ErrorCode+*.h
[4/1231] fetch tinycc
[tinycc] up to date
[5/1230] gen bindgenv2
[6/1230] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1230] gen .bind.ts → GeneratedBindings.cpp
[8/1230] fetch zlib
[zlib] up to date
[9/1230] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast_jsc/lib.rs                          |  6 ++--
 src/jsc/lib.rs                              |  2 +-
 src/runtime/api/TOMLObject.rs               | 14 +++++----
 test/js/bun/resolve/toml/toml-parse.test.ts | 44 +++++++++++++++++++++++++++++
 4 files changed, 58 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/ast_jsc/lib.rs                               1      2      0
src/jsc/lib.rs                                   1      1      0
src/runtime/api/TOMLObject.rs                    1      1      0
test/js/bun/resolve/toml/toml-parse.test.ts      1      4      0
```

</details>

<!-- robobun:evidence:end -->