### PR TITLE
cli: restore `<name>`/`<package>` placeholders in package-manager `--help`

### DIFF
--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -24,15 +24,13 @@ use std::sync::OnceLock;
 use super::package_manager_options as Options;
 
 /// `Output.pretty(text, .{})` — runtime `<tag>` → ANSI rewrite of a help-text
-/// literal then write to stdout. The help strings are runtime `&str`s so we
-/// use the runtime expander.
+/// literal then write to stdout. Must be a single rewrite pass: feeding the
+/// result through `format_args!` into `Output::pretty` would run the rewriter
+/// again on the already-unescaped `\<name\>` placeholders and delete them.
 #[inline]
 #[allow(clippy::disallowed_methods)] // template is a runtime &str parameter
 fn pretty_help(text: &str) {
-    Output::pretty(format_args!(
-        "{}",
-        Output::pretty_fmt_rt(text, Output::enable_ansi_colors_stdout())
-    ));
+    Output::pretty(text);
 }
 
 type ParamType = clap::Param<clap::Help>;
@@ -280,7 +278,7 @@ const AUDIT_PARAMS: &[ParamType] = &[
     ),
     clap::param!("--json                                 Output in JSON format"),
     clap::param!(
-        "--audit-level <STR>                    Only print advisories with severity greater than or equal to <level> (low, moderate, high, critical)"
+        "--audit-level <STR>                    Only print advisories with severity greater than or equal to \\<level\\> (low, moderate, high, critical)"
     ),
     clap::param!("--ignore <STR>...                      Ignore specific CVE IDs from audit"),
 ];

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -23,10 +23,9 @@ use std::sync::OnceLock;
 
 use super::package_manager_options as Options;
 
-/// `Output.pretty(text, .{})` — runtime `<tag>` → ANSI rewrite of a help-text
-/// literal then write to stdout. Must be a single rewrite pass: feeding the
-/// result through `format_args!` into `Output::pretty` would run the rewriter
-/// again on the already-unescaped `\<name\>` placeholders and delete them.
+/// `Output.pretty(text, .{})` — single-pass `<tag>` → ANSI rewrite of a help
+/// template to stdout. Don't wrap in `format_args!`: a second rewrite pass
+/// would delete the already-unescaped `\<name\>` placeholders as unknown tags.
 #[inline]
 #[allow(clippy::disallowed_methods)] // template is a runtime &str parameter
 fn pretty_help(text: &str) {

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -476,7 +476,7 @@ pub(crate) const BUILD_ONLY_PARAMS: &[ParamType] = concat_params!(
             "-e, --external <STR>...          Exclude module from transpilation (can use * wildcards). ex: -e react"
         ),
         parse_param!(
-            "--allow-unresolved <STR>...      Allow unresolved dynamic import()/require() specifiers matching these glob patterns. Use '<empty>' for opaque specifiers. Default is '*' (allow all)."
+            "--allow-unresolved <STR>...      Allow unresolved dynamic import()/require() specifiers matching these glob patterns. Use '\\<empty\\>' for opaque specifiers. Default is '*' (allow all)."
         ),
         parse_param!(
             "--reject-unresolved              Fail the build on any dynamic import()/require() specifier that cannot be resolved at build time."
@@ -559,7 +559,7 @@ pub(crate) const TEST_ONLY_PARAMS: &[ParamType] = &[
     ),
     parse_param!("-u, --update-snapshots           Update snapshot files"),
     parse_param!(
-        "--rerun-each <NUMBER>            Re-run each test file <NUMBER> times, helps catch certain bugs"
+        "--rerun-each <NUMBER>            Re-run each test file \\<NUMBER\\> times, helps catch certain bugs"
     ),
     parse_param!(
         "--retry <NUMBER>                 Default retry count for all tests, overridden by per-test { retry: N }"
@@ -582,7 +582,7 @@ pub(crate) const TEST_ONLY_PARAMS: &[ParamType] = &[
         "--coverage-dir <STR>             Directory for coverage files. Defaults to 'coverage'."
     ),
     parse_param!(
-        "--bail <NUMBER>?                 Exit the test suite after <NUMBER> failures. If you do not specify a number, it defaults to 1."
+        "--bail <NUMBER>?                 Exit the test suite after \\<NUMBER\\> failures. If you do not specify a number, it defaults to 1."
     ),
     parse_param!(
         "-t, --test-name-pattern/--grep <STR>    Run only tests with a name that matches the given regex."

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -126,6 +126,56 @@ describe("bun", () => {
       }
     });
   });
+  describe("--help preserves <placeholder> text", () => {
+    const env = { ...bunEnv, NO_COLOR: "1" };
+    const usage: [string, string][] = [
+      ["install", "bun install [flags] <name>@<version>"],
+      ["add", "bun add [flags] <package><@version>"],
+      ["remove", "bun remove [flags] [<packages>]"],
+      ["update", "bun update [flags] <name>@<version>"],
+      ["link", "bun link [flags] [<packages>]"],
+      ["patch", "bun patch [flags or options] <package>@<version>"],
+      ["patch-commit", "bun patch-commit [flags or options] <directory>"],
+      ["info", "bun info [flags] <package>[@<version>]"],
+    ];
+    test.concurrent.each(usage)("bun %s --help usage line", async (cmd, expected) => {
+      await using proc = Bun.spawn({ cmd: [bunExe(), cmd, "--help"], env, stderr: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const line = (stdout + stderr).split(/\r?\n/).find(l => l.startsWith("Usage:")) ?? "";
+      expect(line).toBe(`Usage: ${expected}`);
+      expect(exitCode).toBe(0);
+    });
+
+    const flags: [string, string, string][] = [
+      ["audit", "--audit-level", "greater than or equal to <level> (low,"],
+      ["test", "--rerun-each", "Re-run each test file <NUMBER> times"],
+      ["test", "--bail", "Exit the test suite after <NUMBER> failures"],
+      ["build", "--allow-unresolved", "Use '<empty>' for opaque specifiers"],
+    ];
+    test.concurrent.each(flags)("bun %s --help keeps placeholder in %s description", async (cmd, flag, expected) => {
+      await using proc = Bun.spawn({ cmd: [bunExe(), cmd, "--help"], env, stderr: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const line = (stdout + stderr).split(/\r?\n/).find(l => l.includes(flag)) ?? "";
+      expect(line).toContain(expected);
+      expect(exitCode).toBe(0);
+    });
+
+    test("bun add --help usage line is intact with FORCE_COLOR=1", async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "add", "--help"],
+        env: { ...bunEnv, NO_COLOR: undefined, FORCE_COLOR: "1" },
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const out = stdout + stderr;
+      // <blue>\<package\><r> renders to \x1b[34m<package>\x1b[0m, not \x1b[34m\x1b[0m
+      expect(out).toContain("\x1b[34m<package>\x1b[0m");
+      // raw tag markup must not leak through
+      expect(out).not.toContain("<blue>");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("test command line arguments", () => {
     test("test --config, issue #4128", () => {
       const path = `${tmpdir()}/bunfig-${Date.now()}.toml`;


### PR DESCRIPTION
## Repro

```sh
for c in install add remove update link patch patch-commit info; do
  bun $c --help 2>&1 | sed -n '/^Usage:/p'
done
bun audit --help | grep audit-level
bun test --help | grep -E 'rerun-each|--bail'
```

Before:
```
Usage: bun install [flags] @
Usage: bun add [flags] 
Usage: bun remove [flags] []
Usage: bun update [flags] @
Usage: bun link [flags] []
Usage: bun patch [flags or options] @
Usage: bun patch-commit [flags or options] 
Usage: bun info [flags] [@]
      --audit-level=<val>    Only print advisories with severity greater than or equal to  (low, moderate, high, critical)
      --rerun-each=<val>              Re-run each test file  times, helps catch certain bugs
      --bail=<val>                    Exit the test suite after  failures. If you do not specify a number, it defaults to 1.
```

Raw-byte proof under `FORCE_COLOR=1` (placeholders are gone, not just uncolored):
```
^[[1mUsage^[[0m: ^[[1m^[[32mbun add^[[0m ^[[36m[flags]^[[0m ^[[34m^[[0m^[[2m^[[0m
```

## Cause

`pretty_help` in `src/install/PackageManager/CommandLineArguments.rs` ran the `<tag>` rewriter twice:

```rust
fn pretty_help(text: &str) {
    Output::pretty(format_args!(
        "{}",
        Output::pretty_fmt_rt(text, Output::enable_ansi_colors_stdout())
    ));
}
```

Pass 1 (`pretty_fmt_rt` -> `pretty_fmt_runtime`) honors the `\<` escape, turning the template's `\<name\>` into a literal `<name>`. Pass 2: `Output::pretty` with `fmt::Arguments` renders the already-rewritten string and runs `pretty_fmt_runtime` again (via `impl PrettyFmtInput for &fmt::Arguments`). The now-unescaped `<name>` is an unknown tag, which the runtime rewriter silently drops (`output.rs` unknown-tag arm). Zig called `Output.pretty(intro_text, .{})` once.

Separately, the `--audit-level`, `--rerun-each`, `--bail`, and `--allow-unresolved` param descriptions had unescaped `<level>`/`<NUMBER>`/`<empty>` that `pretty_help_desc` stripped on its (single) rewrite pass.

## Fix

- `pretty_help` now passes the template straight to `Output::pretty(&str)`, a single pass matching the Zig call shape.
- Escaped the four unescaped placeholders in param description literals.

## Verification

New `describe("--help preserves <placeholder> text")` block in `test/cli/bun.test.ts` covers the usage lines for all eight affected pm subcommands, the four flag-description placeholders, and the `FORCE_COLOR=1` path. All 13 cases fail on current canary and pass with this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 13 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/bun.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (569031f8c)

test/cli/bun.test.ts:
(pass) bun > NO_COLOR > respects NO_COLOR="1" to disable color [150.80ms]
(pass) bun > NO_COLOR > respects NO_COLOR="0" to disable color [169.45ms]
(pass) bun > NO_COLOR > respects NO_COLOR="foo" to disable color [135.05ms]
(pass) bun > NO_COLOR > respects NO_COLOR=" " to disable color [184.24ms]
(todo) bun > NO_COLOR > respects NO_COLOR="" to enable color
(todo) bun > NO_COLOR > respects NO_COLOR=undefined to enable color
(pass) bun > revision > revision generates version numbers correctly [289.94ms]
(pass) bun > getcompletes > getcompletes should not panic and should not be empty [479.48ms]
(pass) bun > getcompletes > getcompletes keeps scripts whose names start with 'pre'/'post' when no sibling script exists 
... (truncated)

release without fix: 13 failed, 2 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/cli/bun.test.ts:
(pass) bun > NO_COLOR > respects NO_COLOR="1" to disable color [3.14ms]
(pass) bun > NO_COLOR > respects NO_COLOR="0" to disable color [22.26ms]
(pass) bun > NO_COLOR > respects NO_COLOR="foo" to disable color [3.96ms]
(pass) bun > NO_COLOR > respects NO_COLOR=" " to disable color [4.63ms]
(todo) bun > NO_COLOR > respects NO_COLOR="" to enable color
(todo) bun > NO_COLOR > respects NO_COLOR=undefined to enable color
(pass) bun > revision > revision generates version numbers correctly [8.00ms]
(pass) bun > getcompletes > getcompletes should not panic and should not be empty [7.45ms]
(pass) bun > getcompletes > getcompletes keeps scripts whose names start with 'pre'/'post' when no sibling script exists [22.86ms]
154 |     ];
155 |     test.concurrent.each(flags)("bun %s --help keeps placeholder in %s description", async (cmd, flag, expected) => {
156 |       await using proc = Bun.spawn({ cmd: [bunExe(), cmd, "--help"], env, stderr: "pipe" });
157 |       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
158 |       const line = (stdout + stderr).spli
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/bun.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (569031f8c)

test/cli/bun.test.ts:
(pass) bun > NO_COLOR > respects NO_COLOR="1" to disable color [279.94ms]
(pass) bun > NO_COLOR > respects NO_COLOR="0" to disable color [217.58ms]
(pass) bun > NO_COLOR > respects NO_COLOR="foo" to disable color [216.84ms]
(pass) bun > NO_COLOR > respects NO_COLOR=" " to disable color [191.34ms]
(todo) bun > NO_COLOR > respects NO_COLOR="" to enable color
(todo) bun > NO_COLOR > respects NO_COLOR=undefined to enable color
(pass) bun > revision > revision generates version numbers correctly [417.26ms]
(pass) bun > getcompletes > getcompletes should not panic and should not be empty [247.47ms]
(pass) bun > getcompletes > getcompletes keeps scripts whose names start with 'pre'/'post' when no sibling script exists 
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 1643ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/90] gen ErrorCode+*.h
[2/47] gen cpp.rs (cppbind)
[3/47] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /wo
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/PackageManager/CommandLineArguments.rs | 13 +++---
 src/runtime/cli/Arguments.rs                       |  6 +--
 test/cli/bun.test.ts                               | 50 ++++++++++++++++++++++
 3 files changed, 58 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/install/PackageManager/CommandLineArguments.rs      2      2      0
src/runtime/cli/Arguments.rs                            1      1      0
test/cli/bun.test.ts                                    1      2      0
```

</details>

<!-- robobun:evidence:end -->