### PR TITLE
shell: drop empty brace-expansion words from argv

### DIFF
--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -439,9 +439,9 @@ impl Cmd {
             }
         }
 
-        // Empty/null argv[0] → exit
-        // with the exit code from a sole command-substitution (stashed by
-        // `child_done` from `Expansion::out_exit_code`), else 0.
+        // No argv at all → exit with the sole command-substitution's exit
+        // code (stashed by `child_done` from `Expansion::out_exit_code`),
+        // else 0. An empty argv[0] word is a real command name: error.
         let first_arg: Vec<u8> = {
             let me = interp.as_cmd(this);
             match me.args.first() {
@@ -449,7 +449,14 @@ impl Cmd {
                     // strip the trailing NUL we just added
                     a[..a.len() - 1].to_vec()
                 }
-                _ => {
+                Some(_) => {
+                    return Builtin::cmd_write_failing_error(
+                        interp,
+                        this,
+                        format_args!("bun: command not found: \n"),
+                    );
+                }
+                None => {
                     let exit = me.exit_code.unwrap_or(0);
                     let parent = me.base.parent;
                     return interp.child_done(parent, this, exit);

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -337,9 +337,9 @@ impl Expansion {
         }
         drop(arena);
 
-        // Push each variant as its own word; word boundaries are recorded via
-        // `bounds`. An unquoted empty variant is dropped (bash null argument
-        // removal); `has_quoted_empty` is word-level so `{,""}` over-keeps.
+        // Push each variant as its own word. Unquoted empty variants are
+        // dropped (bash null-argument removal). `has_quoted_empty` is
+        // word-level: `{,""}` over-keeps, `"$VAR"` (no quoted flag) under-keeps.
         let mut pushed_any = !me.out.buf.is_empty();
         for s in expanded {
             if s.is_empty() && !me.has_quoted_empty {

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -338,11 +338,17 @@ impl Expansion {
         drop(arena);
 
         // Push each variant as its own word; word boundaries are recorded
-        // via `bounds`.
+        // via `bounds`. An unquoted empty variant is dropped (bash "null
+        // argument removal"): `{a,}`/`{,a}`/`{a,,b}` all lose the empty.
+        let mut pushed_any = !me.out.buf.is_empty();
         for s in expanded {
-            if !me.out.buf.is_empty() {
+            if s.is_empty() && !me.has_quoted_empty {
+                continue;
+            }
+            if pushed_any {
                 me.out.bounds.push(me.out.buf.len() as u32);
             }
+            pushed_any = true;
             me.out.buf.extend_from_slice(&s);
         }
 

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -337,9 +337,9 @@ impl Expansion {
         }
         drop(arena);
 
-        // Push each variant as its own word; word boundaries are recorded
-        // via `bounds`. An unquoted empty variant is dropped (bash "null
-        // argument removal"): `{a,}`/`{,a}`/`{a,,b}` all lose the empty.
+        // Push each variant as its own word; word boundaries are recorded via
+        // `bounds`. An unquoted empty variant is dropped (bash null argument
+        // removal); `has_quoted_empty` is word-level so `{,""}` over-keeps.
         let mut pushed_any = !me.out.buf.is_empty();
         for s in expanded {
             if s.is_empty() && !me.has_quoted_empty {
@@ -631,6 +631,11 @@ impl Expansion {
                 let mut hi = stdout.len();
                 while hi > 0 && matches!(stdout[hi - 1], b' ' | b'\n' | b'\r' | b'\t') {
                     hi -= 1;
+                }
+                if hi == 0 {
+                    // A quoted `"$(...)"` that produces no output is a quoted
+                    // empty: `"$(true)"` is one empty argv word, not zero.
+                    me.has_quoted_empty = true;
                 }
                 me.current_out.extend_from_slice(&stdout[..hi]);
             } else {

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 
 describe("$.braces", () => {
   test("no-op", () => {
@@ -224,16 +224,5 @@ describe("brace expansion drops empty argv words", () => {
   test("echo {a,} has no trailing space", async () => {
     const out = await $`echo {a,}`.nothrow().text();
     expect(out).toBe("a\n");
-  });
-
-  // `/usr/bin/printf` argc witness from the report (POSIX only; Windows has
-  // no coreutils printf at that path).
-  test.skipIf(isWindows)("printf '[%s]' {a,} renders [a]", async () => {
-    const out = await $`/usr/bin/printf '[%s]' {a,}`.nothrow().text();
-    expect(out).toBe("[a]");
-  });
-  test.skipIf(isWindows)("printf '[%s]' {a,,b} renders [a][b]", async () => {
-    const out = await $`/usr/bin/printf '[%s]' {a,,b}`.nothrow().text();
-    expect(out).toBe("[a][b]");
   });
 });

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir } from "harness";
 
 describe("$.braces", () => {
   test("no-op", () => {
@@ -163,5 +163,73 @@ console.log(JSON.stringify(Bun.$.braces("echo {a,b}")));`,
       ["echo a","echo b"]"
     `);
     expect(exitCode).toBe(0);
+  });
+});
+
+// An unquoted empty brace alternative must not become an argv word (bash null
+// argument removal). Bun kept non-leading empties and dropped leading ones only
+// by accident, so `printf '[%s]' {a,}` emitted `[a][]` instead of `[a]`.
+describe("brace expansion drops empty argv words", () => {
+  // Observe argv directly via a spawned process so the assertion is on argc,
+  // not on `echo` rendering.
+  const script = "console.log(JSON.stringify(process.argv.slice(1)))";
+  const argv = async (pattern: string): Promise<string[]> => {
+    const out = await $`${bunExe()} -e ${script} -- ${{ raw: pattern }}`.env(bunEnv).nothrow().text();
+    return JSON.parse(out.trim());
+  };
+
+  const cases: Array<[string, string[]]> = [
+    // trailing / middle / leading unquoted empties all drop
+    ["{a,}", ["a"]],
+    ["{,a}", ["a"]],
+    ["{a,,b}", ["a", "b"]],
+    ["{a,,}", ["a"]],
+    ["{,a,}", ["a"]],
+    // all-empty expands to zero argv words
+    ["{,}", []],
+    ["{,,}", []],
+    // affixed: the variant is non-empty so nothing is dropped
+    ["x{,}y", ["xy", "xy"]],
+    ["x{a,}", ["xa", "x"]],
+    ["{a,}x", ["ax", "x"]],
+    // products: only the one fully-empty variant drops
+    ["{a,}{b,}", ["ab", "a", "b"]],
+    ["{,a}{,b}", ["b", "a", "ab"]],
+    ["{,}{,}", []],
+    // nested
+    ["{a,{b,}}", ["a", "b"]],
+    ["{{a,},b}", ["a", "b"]],
+    // a quoted empty in the compound word keeps empty variants as real words
+    ['""{a,}', ["a", ""]],
+    ['""{,a}', ["", "a"]],
+    ['{a,}""', ["a", ""]],
+    ['{"",a}', ["", "a"]],
+    ['{a,""}', ["a", ""]],
+    // non-empty cases stay unchanged
+    ["{a,b}", ["a", "b"]],
+  ];
+
+  for (const [pattern, expected] of cases) {
+    test.concurrent(`${pattern} -> ${JSON.stringify(expected)}`, async () => {
+      expect(await argv(pattern)).toEqual(expected);
+    });
+  }
+
+  // The phantom empty word was a real operand, not just rendering: without the
+  // fix `echo {a,}` prints "a \n" (trailing space) instead of "a\n".
+  test("echo {a,} has no trailing space", async () => {
+    const out = await $`echo {a,}`.nothrow().text();
+    expect(out).toBe("a\n");
+  });
+
+  // `/usr/bin/printf` argc witness from the report (POSIX only; Windows has
+  // no coreutils printf at that path).
+  test.skipIf(isWindows)("printf '[%s]' {a,} renders [a]", async () => {
+    const out = await $`/usr/bin/printf '[%s]' {a,}`.nothrow().text();
+    expect(out).toBe("[a]");
+  });
+  test.skipIf(isWindows)("printf '[%s]' {a,,b} renders [a][b]", async () => {
+    const out = await $`/usr/bin/printf '[%s]' {a,,b}`.nothrow().text();
+    expect(out).toBe("[a][b]");
   });
 });

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -226,3 +226,33 @@ describe("brace expansion drops empty argv words", () => {
     expect(out).toBe("a\n");
   });
 });
+
+// A quoted empty word as argv[0] is a real (empty) command name and fails,
+// rather than silently exiting 0 or shifting to the next arg. An unquoted
+// `$(...)` producing no output leaves argv empty and keeps the POSIX rule.
+describe("empty argv[0] is command-not-found", () => {
+  const run = async (s: string) => {
+    const r = await $`${{ raw: s }}`.nothrow().quiet();
+    return { stdout: r.stdout.toString(), stderr: r.stderr.toString(), exitCode: r.exitCode };
+  };
+
+  for (const s of ['""', '"$(true)"', '"" echo hi', '"$(true)" echo hi']) {
+    test(s, async () => {
+      expect(await run(s)).toEqual({
+        stdout: "",
+        stderr: "bun: command not found: \n",
+        exitCode: 1,
+      });
+    });
+  }
+
+  test("$(true) alone exits 0", async () => {
+    expect(await run("$(true)")).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+  });
+  test("$(false) alone exits 1", async () => {
+    expect(await run("$(false)")).toEqual({ stdout: "", stderr: "", exitCode: 1 });
+  });
+  test("$(true) echo hi runs echo", async () => {
+    expect(await run("$(true) echo hi")).toEqual({ stdout: "hi\n", stderr: "", exitCode: 0 });
+  });
+});

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -205,6 +205,10 @@ describe("brace expansion drops empty argv words", () => {
     ['{a,}""', ["a", ""]],
     ['{"",a}', ["", "a"]],
     ['{a,""}', ["a", ""]],
+    // a quoted cmd-subst producing no output is a quoted empty
+    ['"$(true)"', [""]],
+    ['"$(true)"{a,}', ["a", ""]],
+    ['"$(true)"{,a}', ["", "a"]],
     // non-empty cases stay unchanged
     ["{a,b}", ["a", "b"]],
   ];


### PR DESCRIPTION
## What

An unquoted empty alternative in a brace group became a real empty argv word when it was not the first variant:

```js
import { $ } from "bun";
await $`/usr/bin/printf '[%s]' {a,}`;    // [a][]    (bash: [a])
await $`/usr/bin/printf '[%s]' {a,,b}`;  // [a][][b] (bash: [a][b])
await $`/usr/bin/printf '[%s]' {,a}`;    // [a]      (already correct, by accident)
```

Any command that treats argc as meaningful received a phantom `""` operand, and `echo {a,}` emitted a trailing space that breaks byte-exact consumers. Bun also disagreed with itself by position: a leading empty was dropped, a trailing or middle one was kept.

## Cause

`do_brace_expand` pushes every expanded variant into `out.buf`, recording a word boundary with `if !me.out.buf.is_empty()`. That check uses "buffer non-empty" as a proxy for "a prior word exists", which:

- records no boundary for a leading empty variant (so it silently merges into the next word, appearing dropped), and
- records a boundary for every non-leading empty variant (so it becomes a real empty argv word).

Neither branch implements bash's null-argument removal; the leading case only looked correct.

## Fix

Skip variants that expand to the empty string unless the compound word contains a quoted `""` (`has_quoted_empty`), and track "a word has been pushed" explicitly so a surviving empty variant still records a boundary. This now matches bash for leading/middle/trailing, products (`{a,}{b,}` → 3 words), nesting, and all-empty (`{,}` → 0 words), and additionally fixes `{"",a}` / `""{,a}` which previously lost the quoted empty.

Note: #30998 takes the opposite approach (keep every empty as a word, so `{,,,}` → 4 args). Bash 5.2 produces 0 args for `{,,,}` and 1 for `{a,}`, which is what this PR implements.

## Verification

```
bun bd test test/js/bun/shell/brace.test.ts
```

24 new cases assert argv directly via a spawned process; 12 of them fail on current main.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 16 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/brace.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (daa56265e)

test/js/bun/shell/brace.test.ts:
(pass) $.braces > no-op [3.88ms]
(pass) $.braces > 2 [2.84ms]
(pass) $.braces > 3 [3.41ms]
(pass) $.braces > nested [3.32ms]
(pass) $.braces > nested 2 [2.72ms]
(pass) $.braces > nested sibling product [3.22ms]
(pass) $.braces > nested sibling product with surrounding text [3.34ms]
(pass) $.braces > nested sibling product mixed with variants [2.91ms]
(pass) $.braces > nested sibling product triple [4.98ms]
(pass) $.braces > very deeply nested [4.37ms]
(pass) $.braces > empty string [5.07ms]
(pass) $.braces > unicode [4.63ms]
(pass) brace + glob composition > src/*.{ts,tsx} globs after brace expansion [105.68ms]
(pass) brace + glob composition > {src,lib}/*.ts composes a brace prefix with a 
... (truncated)

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (051916d9d)

test/js/bun/shell/brace.test.ts:
(pass) $.braces > no-op [4.08ms]
(pass) $.braces > 2 [0.93ms]
(pass) $.braces > 3 [0.08ms]
(pass) $.braces > nested [0.78ms]
(pass) $.braces > nested 2 [0.08ms]
(pass) $.braces > nested sibling product [0.05ms]
(pass) $.braces > nested sibling product with surrounding text [0.04ms]
(pass) $.braces > nested sibling product mixed with variants [0.05ms]
(pass) $.braces > nested sibling product triple [0.08ms]
(pass) $.braces > very deeply nested [0.10ms]
(pass) $.braces > empty string [0.73ms]
(pass) $.braces > unicode [0.07ms]
(pass) brace + glob composition > src/*.{ts,tsx} globs after brace expansion [8.97ms]
(pass) brace + glob composition > {src,lib}/*.ts composes a brace prefix with a glob [0.96ms]
(pass) brace + glob composition > an interpolated comma inside a brace group is one literal branch [3.11ms]
(pass) $.braces input bounds > rejects a word with an excessive number of brace groups instead of crashing [26.12ms]
(pass) brace expansion drops empty argv words > {a,} -> ["a"] [23.60ms]
(pass) brace expansion drops empty argv words > x{a,} -> ["xa","x"] [22.21ms]
(pass) brace expansion drop
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/brace.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (daa56265e)

test/js/bun/shell/brace.test.ts:
(pass) $.braces > no-op [3.44ms]
(pass) $.braces > 2 [3.05ms]
(pass) $.braces > 3 [2.32ms]
(pass) $.braces > nested [3.15ms]
(pass) $.braces > nested 2 [3.19ms]
(pass) $.braces > nested sibling product [2.43ms]
(pass) $.braces > nested sibling product with surrounding text [2.96ms]
(pass) $.braces > nested sibling product mixed with variants [2.68ms]
(pass) $.braces > nested sibling product triple [3.01ms]
(pass) $.braces > very deeply nested [2.42ms]
(pass) $.braces > empty string [2.86ms]
(pass) $.braces > unicode [1.99ms]
(pass) brace + glob composition > src/*.{ts,tsx} globs after brace expansion [92.70ms]
(pass) brace + glob composition > {src,lib}/*.ts composes a brace prefix with a g
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 978ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/90] gen ErrorCode+*.h
[2/47] gen cpp.rs (cppbind)
[3/47] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[4/47] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_ro
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/shell/states/Cmd.rs       | 15 ++++--
 src/runtime/shell/states/Expansion.rs | 17 +++++--
 test/js/bun/shell/brace.test.ts       | 91 +++++++++++++++++++++++++++++++++++
 3 files changed, 116 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/runtime/shell/states/Cmd.rs            1      1      0
src/runtime/shell/states/Expansion.rs      3      6      0
test/js/bun/shell/brace.test.ts            2     11      0
```

</details>

<!-- robobun:evidence:end -->