### PR TITLE
url: throw Node-compatible ERR_INVALID_URL from new URL() and href setter

### DIFF
--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -1151,6 +1151,26 @@ JSC::EncodedJSValue INVALID_ARG_VALUE(JSC::ThrowScope& throwScope, JSC::JSGlobal
     return {};
 }
 
+JSC::EncodedJSValue INVALID_URL(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, const WTF::String& input)
+{
+    auto& vm = JSC::getVM(globalObject);
+    // Don't include URL in message. (See https://github.com/nodejs/node/pull/38614)
+    auto* err = createError(globalObject, ErrorCode::ERR_INVALID_URL, "Invalid URL"_s);
+    err->putDirect(vm, vm.propertyNames->input, JSC::jsString(vm, input));
+    throwScope.throwException(globalObject, err);
+    throwScope.release();
+    return {};
+}
+JSC::EncodedJSValue INVALID_URL(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, const WTF::String& input, const WTF::String& base)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto* err = createError(globalObject, ErrorCode::ERR_INVALID_URL, "Invalid URL"_s);
+    err->putDirect(vm, vm.propertyNames->input, JSC::jsString(vm, input));
+    err->putDirect(vm, Identifier::fromString(vm, "base"_s), JSC::jsString(vm, base));
+    throwScope.throwException(globalObject, err);
+    throwScope.release();
+    return {};
+}
 JSC::EncodedJSValue INVALID_URL_SCHEME(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, const WTF::String& expectedScheme)
 {
     auto message = makeString("The URL must be of scheme "_s, expectedScheme);

--- a/src/jsc/bindings/ErrorCode.h
+++ b/src/jsc/bindings/ErrorCode.h
@@ -154,6 +154,9 @@ JSC::EncodedJSValue DLOPEN_DISABLED(JSC::ThrowScope&, JSC::JSGlobalObject*, ASCI
 
 // URL
 
+/// `Invalid URL` with `.input` (and `.base` when provided) set on the error
+JSC::EncodedJSValue INVALID_URL(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, const WTF::String& input);
+JSC::EncodedJSValue INVALID_URL(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, const WTF::String& input, const WTF::String& base);
 /// `URL must be of scheme {expectedScheme}`
 JSC::EncodedJSValue INVALID_URL_SCHEME(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, const WTF::String& expectedScheme);
 /// `File URL host must be "localhost" or empty on {platform}`

--- a/src/jsc/bindings/webcore/JSDOMURL.cpp
+++ b/src/jsc/bindings/webcore/JSDOMURL.cpp
@@ -34,6 +34,7 @@
 #include "JSDOMConvertNullable.h"
 #include "JSDOMConvertStrings.h"
 #include "JSDOMExceptionHandling.h"
+#include "ErrorCode.h"
 #include "JSDOMGlobalObject.h"
 #include "JSDOMGlobalObjectInlines.h"
 #include "JSDOMOperation.h"
@@ -162,9 +163,12 @@ template<> EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSDOMURLDOMConstructor::const
     EnsureStillAliveScope argument1 = callFrame->argument(1);
     auto base = argument1.value().isUndefined() ? String() : convert<IDLUSVString>(*lexicalGlobalObject, argument1.value());
     RETURN_IF_EXCEPTION(throwScope, {});
-    auto object = base.isEmpty() ? DOMURL::create(WTF::move(url)) : DOMURL::create(WTF::move(url), WTF::move(base));
-    if constexpr (IsExceptionOr<decltype(object)>)
-        RETURN_IF_EXCEPTION(throwScope, {});
+    auto object = base.isEmpty() ? DOMURL::create(url) : DOMURL::create(url, base);
+    if (object.hasException()) [[unlikely]] {
+        if (argument1.value().isUndefined())
+            return Bun::ERR::INVALID_URL(throwScope, lexicalGlobalObject, url);
+        return Bun::ERR::INVALID_URL(throwScope, lexicalGlobalObject, url, base);
+    }
     static_assert(TypeOrExceptionOrUnderlyingType<decltype(object)>::isRef);
     auto jsValue = toJSNewlyCreated<IDLInterface<DOMURL>>(*lexicalGlobalObject, *castedThis->globalObject(), throwScope, WTF::move(object));
     if constexpr (IsExceptionOr<decltype(object)>)
@@ -299,9 +303,11 @@ static inline bool setJSDOMURL_hrefSetter(JSGlobalObject& lexicalGlobalObject, J
     auto& impl = thisObject.wrapped();
     auto nativeValue = convert<IDLUSVString>(lexicalGlobalObject, value);
     RETURN_IF_EXCEPTION(throwScope, false);
-    invokeFunctorPropagatingExceptionIfNecessary(lexicalGlobalObject, throwScope, [&] {
-        return impl.setHref(WTF::move(nativeValue));
-    });
+    auto result = impl.setHref(nativeValue);
+    if (result.hasException()) [[unlikely]] {
+        Bun::ERR::INVALID_URL(throwScope, &lexicalGlobalObject, nativeValue);
+        return false;
+    }
     return true;
 }
 

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -1,22 +1,83 @@
 import { describe, expect, it } from "bun:test";
+import http from "node:http";
 
 describe("url", () => {
   it("URL throws", () => {
-    expect(() => new URL("")).toThrow('"" cannot be parsed as a URL');
-    expect(() => new URL(" ")).toThrow('" " cannot be parsed as a URL');
-    expect(() => new URL("boop", "http!/example.com")).toThrow(
-      '"boop" cannot be parsed as a URL against "http!/example.com"',
+    expect(() => new URL("")).toThrow(
+      expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_URL", message: "Invalid URL", input: "" }),
+    );
+    expect(() => new URL(" ")).toThrow(
+      expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_URL", message: "Invalid URL", input: " " }),
     );
     expect(() => new URL("boop", "http!/example.com")).toThrow(
       expect.objectContaining({
+        name: "TypeError",
         code: "ERR_INVALID_URL",
+        message: "Invalid URL",
+        input: "boop",
+        base: "http!/example.com",
       }),
     );
+  });
 
-    // redact
-    expect(() => new URL("boop", "https!!username:password@example.com")).toThrow(
-      '"boop" cannot be parsed as a URL against <redacted>',
-    );
+  it("ERR_INVALID_URL matches Node.js (message, input, base)", () => {
+    const capture = (fn: () => void) => {
+      let err: any;
+      try {
+        fn();
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeInstanceOf(TypeError);
+      return err;
+    };
+
+    // message is the constant "Invalid URL" and .input is the string-coerced argument
+    {
+      const e = capture(() => new URL("not a url"));
+      expect({ name: e.name, code: e.code, message: e.message, input: e.input }).toEqual({
+        name: "TypeError",
+        code: "ERR_INVALID_URL",
+        message: "Invalid URL",
+        input: "not a url",
+      });
+      expect(Object.prototype.hasOwnProperty.call(e, "base")).toBe(false);
+    }
+
+    // with base, .base is set to the string-coerced base argument
+    {
+      const e = capture(() => new URL("not a url", "also not"));
+      expect({ code: e.code, message: e.message, input: e.input, base: e.base }).toEqual({
+        code: "ERR_INVALID_URL",
+        message: "Invalid URL",
+        input: "not a url",
+        base: "also not",
+      });
+    }
+
+    // href setter also throws the Node-shape error
+    {
+      const e = capture(() => {
+        const u = new URL("http://a");
+        u.href = "not a url";
+      });
+      expect({ name: e.name, code: e.code, message: e.message, input: e.input }).toEqual({
+        name: "TypeError",
+        code: "ERR_INVALID_URL",
+        message: "Invalid URL",
+        input: "not a url",
+      });
+    }
+
+    // node:http request propagates the same error from new URL()
+    {
+      const e = capture(() => http.request("not a url"));
+      expect({ code: e.code, message: e.message, input: e.input }).toEqual({
+        code: "ERR_INVALID_URL",
+        message: "Invalid URL",
+        input: "not a url",
+      });
+    }
   });
 
   it("should have correct origin and protocol", () => {


### PR DESCRIPTION
## What

`new URL("not a url")` now throws a `TypeError` with `message === "Invalid URL"`, `code === "ERR_INVALID_URL"`, and `.input === "not a url"` (plus `.base` when a base argument was passed), matching Node.js 26. The `href` setter gets the same treatment.

## Why

```js
function show(t, f) { try { f() } catch (e) { console.log(t, e.code, JSON.stringify(e.message), JSON.stringify(e.input)) } }
show("new URL",      () => new URL("not a url"));
show("http.request", () => require("http").request("not a url"));
```

| | message | `.input` |
| --- | --- | --- |
| Node 26 | `"Invalid URL"` | `"not a url"` |
| Bun 1.3.14 | `"Invalid URL"` | `"Invalid URL: not a url"` (wrong value) |
| Bun 1.4 (before) | `"\"not a url\" cannot be parsed as a URL."` | absent |
| Bun (this PR) | `"Invalid URL"` | `"not a url"` |

The node:http client rewrite (#31587) switched `_http_client.ts` to call `new URL(urlStr)` directly, exactly as Node's own `lib/_http_client.js` does. That exposed a pre-existing gap: Bun's `URL` constructor was surfacing JSC's message text and never attached `.input`, so `http.request("not a url")` moved *away* from Node on both `.message` and `.input`.

Rather than re-wrap the call in `_http_client.ts`, the URL constructor and `href` setter now throw through a shared `Bun::ERR::INVALID_URL` helper (message `"Invalid URL"`, `.input`, optional `.base`). This fixes `new URL()`, `url.href = ...`, `http.request`, `https.request`, and any other `new URL()` caller in one place, and keeps `_http_client.ts` byte-identical to Node's structure.

Verified against Node v26.3.0.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/url/url.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ba0a5f6ec)

test/js/web/url/url.test.ts:
1 | import { describe, expect, it } from "bun:test";
2 | import http from "node:http";
3 | 
4 | describe("url", () => {
5 |   it("URL throws", () => {
6 |     expect(() => new URL("")).toThrow(
                                  ^
error: expect(received).toThrow(expected)

Expected value: ObjectContaining {
  name: "TypeError",
  code: "ERR_INVALID_URL",
  message: "Invalid URL",
  input: "",
}
Received value: 1 | import { describe, expect, it } from "bun:test";
2 | import http from "node:http";
3 | 
4 | describe("url", () = {
5 |   it("URL throws", () => {
6 |     expect(() => new URL("")).toThrow(
                     ^
TypeError: "" cannot be parsed as a URL.
 code: "ERR_INVALID_URL"

      at <a
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (bb779a5ff)

test/js/web/url/url.test.ts:
(pass) url > URL throws [10.37ms]
(pass) url > ERR_INVALID_URL matches Node.js (message, input, base) [4.77ms]
(pass) url > should have correct origin and protocol [0.22ms]
(pass) url > blob urls [0.12ms]
(pass) url > prints [5.40ms]
(pass) url > works [0.44ms]
(pass) url > URL.canParse > URL.canParse(undefined, undefined) [0.06ms]
(pass) url > URL.canParse > URL.canParse(a:b, undefined)
(pass) url > URL.canParse > URL.canParse(undefined, a:b)
(pass) url > URL.canParse > URL.canParse(a:/b, undefined)
(pass) url > URL.canParse > URL.canParse(undefined, a:/b)
(pass) url > URL.canParse > URL.canParse(https://test:test, undefined)
(pass) url > URL.canParse > URL.canParse(a, https://b/)
(pass) url > URL.canParse > URL.canParse.length should be 1 [0.03ms]
(pass) url > URLSearchParams constructed from an object interleaves Get with value conversion [0.17ms]

 15 pass
 0 fail
 93 expect() calls
Ran 15 tests across 1 file. [663.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/url/url.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ba0a5f6ec)

test/js/web/url/url.test.ts:
(pass) url > URL throws [27.46ms]
(pass) url > ERR_INVALID_URL matches Node.js (message, input, base) [48.42ms]
(pass) url > should have correct origin and protocol [14.59ms]
(pass) url > blob urls [10.07ms]
(pass) url > prints [8.34ms]
(pass) url > works [15.83ms]
(pass) url > URL.canParse > URL.canParse(undefined, undefined) [2.13ms]
(pass) url > URL.canParse > URL.canParse(a:b, undefined) [0.49ms]
(pass) url > URL.canParse > URL.canParse(undefined, a:b) [0.86ms]
(pass) url > URL.canParse > URL.canParse(a:/b, undefined) [0.30ms]
(pass) url > URL.canParse > URL.canParse(undefined, a:/b) [0.37ms]
(pass) url > URL.canParse > URL.canParse(https://test:test, undefined) [0.33ms]
(pass) url > URL.canPar
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 1416ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/90] gen ErrorCode+*.h
[2/90] gen cpp.rs (cppbind)
[3/90] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /wo
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ErrorCode.cpp        | 20 +++++++++
 src/jsc/bindings/ErrorCode.h          |  3 ++
 src/jsc/bindings/webcore/JSDOMURL.cpp | 18 +++++---
 test/js/web/url/url.test.ts           | 77 +++++++++++++++++++++++++++++++----
 4 files changed, 104 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/jsc/bindings/ErrorCode.cpp             2      1      0
src/jsc/bindings/ErrorCode.h               2      1      0
src/jsc/bindings/webcore/JSDOMURL.cpp      1      3      0
test/js/web/url/url.test.ts                2      3      0
```

</details>

<!-- robobun:evidence:end -->