### PR TITLE
test_runner: add message assertions for toContainEqual/toBeArrayOfSize labels

### DIFF
--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -2562,6 +2562,25 @@ describe("expect()", () => {
     expect(value).not.toContainEqual(expected);
   });
 
+  test("toContainEqual failure message includes Expected/Received labels", () => {
+    try {
+      expect([{ a: 1 }]).toContainEqual({ a: 2 });
+      expect.unreachable();
+    } catch (e) {
+      expect(e.message).toContain("\n\nExpected to contain: ");
+      expect(e.message).toContain("\nReceived: ");
+      expect(e.message).toContain("a: 2");
+      expect(e.message).toContain("a: 1");
+    }
+    try {
+      expect([{ a: 1 }]).not.toContainEqual({ a: 1 });
+      expect.unreachable();
+    } catch (e) {
+      expect(e.message).toContain("\n\nExpected to not contain: ");
+      expect(e.message).toContain("a: 1");
+    }
+  });
+
   test("toContainKey", () => {
     const o = { a: "foo", b: "bar", c: "baz" };
     expect(o).toContainKey("a");

--- a/test/js/bun/test/jest-extended.test.js
+++ b/test/js/bun/test/jest-extended.test.js
@@ -218,6 +218,23 @@ describe("jest-extended", () => {
     expect(new Array(2 ** 32 - 1)).toBeArrayOfSize(2 ** 32 - 1);
   });
 
+  test("toBeArrayOfSize() failure message includes Received label", () => {
+    try {
+      expect([1, 2]).toBeArrayOfSize(3);
+      expect.unreachable();
+    } catch (e) {
+      expect(e.message).toContain("\n\nReceived: ");
+      expect(e.message).toContain("1");
+    }
+    try {
+      expect([1, 2]).not.toBeArrayOfSize(2);
+      expect.unreachable();
+    } catch (e) {
+      expect(e.message).toContain("\n\nReceived: ");
+      expect(e.message).toContain("1");
+    }
+  });
+
   // test('toIncludeAllMembers()')
   // test('toIncludeAllPartialMembers()')
   // test('toIncludeAnyMembers()')


### PR DESCRIPTION
The "Expected to contain:" / "Received:" labels were being dropped from these matchers' failure messages (the format literal went to a discarded `_fmt` parameter instead of being baked into `format_args!`):

```
1.3.14: "expect(received).toContainEqual(expected)\n\nExpected to contain: {\n  a: 2,\n}\nReceived: [\n  {\n    a: 1,\n  }\n]\n"
1.4:    "expect(received).toContainEqual(expected){\n  a: 2,\n}[\n  {\n    a: 1,\n  }\n]"
```

The underlying bug was fixed by #34343 as part of migrating every matcher to the `throw!` macro (which takes the format literal as a first-class argument). This PR adds message-content assertions for all four affected paths (`toContainEqual`, `not.toContainEqual`, `toBeArrayOfSize`, `not.toBeArrayOfSize`) so the label text can't silently drift again.

Both tests fail on the 1.4 canary that predates #34343 and pass on current `main`.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/test/expect.test.js' 'test/js/bun/test/jest-extended.test.js'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/test/expect.test.js test/js/bun/test/jest-extended.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (49dc17712)

test/js/bun/test/jest-extended.test.js:
(pass) jest-extended > pass() [15.44ms]
(pass) jest-extended > fail() [11.49ms]
(pass) jest-extended > toBeEmpty() > "" [3.38ms]
(pass) jest-extended > toBeEmpty() > [] [0.41ms]
(pass) jest-extended > toBeEmpty() > {} [0.30ms]
(pass) jest-extended > toBeEmpty() > Set {} [0.22ms]
(pass) jest-extended > toBeEmpty() > Map {} [0.23ms]
(pass) jest-extended > toBeEmpty() > "" [0.22ms]
(pass) jest-extended > toBeEmpty() > [] [0.21ms]
(pass) jest-extended > toBeEmpty() > Uint8Array(0) [] [0.20ms]
(pass) jest-extended > toBeEmpty() > {} [0.30ms]
(pass) jest-extended > toBeEmpty() > <Buffer > [0.22ms]
(pass) jest-extended > toBeEmpty() > Headers {} [0.21ms]
(pass) jest-extended > toBeEmpty() > URLSearchParams {} [0.22ms]
(pass) jest-extended > toBeEmpty() > {} [0.26ms]
(pass) jest-extended > toBeEmpty() > {} [7.39ms]
(pass) jest-extended > toBeEmpty() > FileRef ("/tmp/jest-extended-7vwzvz/empty.txt") {  type: "text/plain;charset=utf-8"} [0.39ms]
(pass) jest-extended > not.toBeEmpty() > " " [1.31ms]
(pass) jest-extended > not.toBeEmpty() > [ "" ] [0.35ms]
(pass) jest-extended > not.toBeEmpty() > [ undefined ] [0.27ms]
(pass) jest-extended > not.toBeEmpty() > {  "": "",} [0.69ms]
(pass) jest-extended > not.toBeEmpty() > Set(1) {  "",} [0.34ms]
(pass) jest-extended > not.toBeEmpty() > Map(1) {  "": "",} [0.24ms]
(pass) jest-extended > not.toBeEmpty() > " " [0.24ms]
(pass) jest-extended > not.toBeEmpty() > [ empty item ] [0.31ms]
(pass) jest-extended > not.toBeEmpty() > Uint8Array(1) [ 0 ] [0.24ms]
(
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/test/expect.test.js        | 19 +++++++++++++++++++
 test/js/bun/test/jest-extended.test.js | 17 +++++++++++++++++
 2 files changed, 36 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
test/js/bun/test/expect.test.js             1      1      0
test/js/bun/test/jest-extended.test.js      1      1      0
```

</details>

<!-- robobun:evidence:end -->