### PR TITLE
Bun.TOML.parse: throw RangeError, not undefined, when the printer's stack guard trips

### DIFF
--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1944,7 +1944,9 @@ impl LogJsc for bun_ast::Log {
         // Cap at 256 — the consumer's stack buffer holds at most 256 JSValues.
         let count = msgs.len().min(256);
         match count {
-            0 => Ok(JSValue::UNDEFINED),
+            // Every caller throws the result, so an empty log must still yield
+            // a real Error; returning UNDEFINED here surfaces as `throw undefined`.
+            0 => Ok(global.create_error_instance(format_args!("{}", message))),
             1 => msg_to_js(&msgs[0], global),
             _ => {
                 // On-stack array: conservative GC stack scan keeps these

--- a/src/runtime/api/TOMLObject.rs
+++ b/src/runtime/api/TOMLObject.rs
@@ -33,7 +33,7 @@ pub fn parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
             // for now...
             let buffer_writer = js_printer::BufferWriter::init();
             let mut writer = js_printer::BufferPrinter::init(buffer_writer);
-            if js_printer::print_json(
+            if let Err(err) = js_printer::print_json(
                 &mut writer,
                 parse_result,
                 source,
@@ -42,10 +42,14 @@ pub fn parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
                     mangled_props: None,
                     ..Default::default()
                 },
-            )
-            .is_err()
-            {
-                return Err(global.throw_value(log.to_js(global, "Failed to print toml")?));
+            ) {
+                // The printer never writes to `log`; throwing `log.to_js(...)`
+                // here produced a literal `throw undefined` in JS.
+                return Err(match err {
+                    js_printer::Error::StackOverflow => global.throw_stack_overflow(),
+                    js_printer::Error::Alloc(_) => global.throw_out_of_memory(),
+                    _ => global.throw(format_args!("Failed to print toml: {}", err)),
+                });
             }
 
             let slice = writer.ctx.buffer.slice();

--- a/test/js/bun/resolve/toml/toml.test.js
+++ b/test/js/bun/resolve/toml/toml.test.js
@@ -112,3 +112,41 @@ it("Bun.TOML.parse throws on deeply nested inline tables instead of crashing", (
     "a = " + Buffer.alloc(depth * 6, "{ b = ").toString() + "1" + Buffer.alloc(depth * 2, " }").toString();
   expect(() => Bun.TOML.parse(deepToml)).toThrow(RangeError);
 });
+
+it("Bun.TOML.parse never throws undefined for deeply nested inline tables", () => {
+  // In a depth window the parser's stack guard stays quiet but the printer's
+  // trips; the printer logs nothing, so the old error path did `throw undefined`.
+  // The window moves with frame size, so calibrate by doubling, then sweep.
+  const thrown = d => {
+    const s = "a = " + Buffer.alloc(d * 6, "{ b = ").toString() + "1" + Buffer.alloc(d * 2, " }").toString();
+    try {
+      Bun.TOML.parse(s);
+      return null;
+    } catch (e) {
+      return { e };
+    }
+  };
+
+  let hi = 0;
+  for (let d = 500; d <= 200_000; d *= 2) {
+    if (thrown(d) !== null) {
+      hi = d;
+      break;
+    }
+  }
+  expect(hi).toBeGreaterThan(0);
+
+  const lo = hi >> 1;
+  const step = Math.max(1, lo >> 2);
+  let threw = 0;
+  for (let d = lo + step; d <= hi * 4; d += step) {
+    const r = thrown(d);
+    if (r === null) continue;
+    threw++;
+    if (!(r.e instanceof Error)) {
+      throw new Error(`depth ${d}: Bun.TOML.parse threw a non-Error value: ${String(r.e)}`);
+    }
+    expect(r.e).toBeInstanceOf(RangeError);
+  }
+  expect(threw).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Problem

At certain inline-table nesting depths (roughly 14k-28k in release, 1k-2.5k in debug+ASAN), `Bun.TOML.parse` throws a literal `undefined` instead of a `RangeError`:

```js
const s = "a = " + "{ b = ".repeat(20000) + "1" + " }".repeat(20000);
try { Bun.TOML.parse(s); } catch (e) { console.log(e.name, e.message); }
// TypeError: undefined is not an object (evaluating 'e.name')  -> exit 1
```

1.3.14 threw a proper `RangeError: Maximum call stack size exceeded` at every depth.

## Cause

The TOML parser's stack guard (`is_safe_to_recurse()` in `parse_value`) and the JSON printer's stack guard (`print_object_json`) use the same threshold, but the printer's per-level frames are larger. So there is a depth window where the parse succeeds and `print_json` then returns `Err(Error::StackOverflow)` without writing anything to `log`.

The `print_json` error arm in `TOMLObject.rs` threw `log.to_js(global, "Failed to print toml")`, and `Log::to_js` at `src/jsc/lib.rs` returns `JSValue::UNDEFINED` when the log is empty. `throw_value(UNDEFINED)` surfaces in JS as `throw undefined`.

## Fix

- `src/runtime/api/TOMLObject.rs`: match on the `print_json` error and route `StackOverflow` through `global.throw_stack_overflow()` (same as the parser arm), `Alloc` through `throw_out_of_memory()`, and anything else through a real `Error` with a message.
- `src/jsc/lib.rs`: `Log::to_js` now returns `create_error_instance(message)` for an empty log instead of `UNDEFINED`. Every caller throws the result, so this makes the class of bug unreachable.

## Test

Added a self-calibrating sweep in `test/js/bun/resolve/toml/toml.test.js`: find the first depth that throws by doubling, then sweep around it and assert every thrown value is a `RangeError`. The window moves with frame size (build config / arch / OS), so a fixed depth would miss it on some lanes.

Verified:
- `USE_SYSTEM_BUN=1 bun test` fails: `depth 14000: Bun.TOML.parse threw a non-Error value: undefined`
- `bun bd test` with `src/` stashed fails: `depth 625: Bun.TOML.parse threw a non-Error value: undefined`
- `bun bd test` with the fix passes: 9/9