### PR TITLE
structuredClone: throw DataCloneError when transferring a pinned ArrayBuffer

### DIFF
--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -954,10 +954,11 @@ impl JSValue {
     /// `as_array_buffer`, but pins the backing `JSC::ArrayBuffer` first so it
     /// cannot be detached. The pin does not prevent collection.
     ///
-    /// While pinned, a JS `transfer()`, `structuredClone(v, { transfer: [ab] })`
-    /// or `postMessage(v, [ab])` hands the destination a copy and leaves the
-    /// source attached rather than throwing. See `JSC__JSValue__pinArrayBuffer`
-    /// in bindings.cpp for why. Release the pin with `ArrayBuffer::unpin`.
+    /// While pinned, JS `ab.transfer()` hands the destination a copy and leaves
+    /// the source attached; `structuredClone(v, { transfer: [ab] })` and
+    /// `postMessage(v, [ab])` throw a `DataCloneError` DOMException. See
+    /// `JSC__JSValue__pinArrayBuffer` in bindings.cpp for the full picture.
+    /// Release the pin with `ArrayBuffer::unpin`.
     pub fn as_pinned_arraybuffer(self, global: &JSGlobalObject) -> Option<ArrayBuffer> {
         if !JSC__JSValue__pinArrayBuffer(self) {
             return None;

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3144,19 +3144,19 @@ bool JSC__JSValue__asArrayBuffer(
 // unpinned rather than rejected. Returns false if `value` has no ArrayBuffer
 // impl.
 //
-// A pin does not make detaching fail, it makes it copy. `pin()` clears
-// `ArrayBuffer::isDetachable()`, and `ArrayBuffer::transferTo()` answers an
-// undetachable buffer by copying the bytes into the destination and reporting
-// success (`if (!isDetachable()) m_contents.copyTo(result)`). So while a borrow
-// is live, `ab.transfer()`, `structuredClone(v, { transfer: [ab] })` and
-// `port.postMessage(v, [ab])` each return normally, give the destination an
-// independent copy, and leave `ab` attached; the bytes being read never move.
+// `pin()` clears `ArrayBuffer::isDetachable()`. JSC's `ArrayBuffer::transferTo()`
+// answers an undetachable buffer by copying the bytes into the destination and
+// reporting success (`if (!isDetachable()) m_contents.copyTo(result)`), so while a
+// borrow is live `ab.transfer()` returns normally, gives the destination an
+// independent copy, and leaves `ab` attached; the bytes being read never move.
 //
-// That departs from ES2024, where transfer() must detach or throw, and from
-// Node, which detaches. It is deliberate: the borrow stays zero-copy in the
-// common case and memory-safe in every case, at the cost of a transfer that
-// silently no-ops for as long as a borrowing op (zlib, fs, crypto, shell,
-// Bun.Image, SQL blob binds, ...) happens to be in flight over that buffer.
+// `structuredClone(v, { transfer: [ab] })` and `port.postMessage(v, [ab])`
+// instead throw a `DataCloneError` DOMException for a pinned buffer (see the
+// `!isDetachable()` check in SerializedScriptValue's transfer-list validation),
+// so a transfer that cannot detach fails loudly rather than silently copying.
+// The borrow stays zero-copy in the common case and memory-safe in every case;
+// once the borrowing op (zlib, fs, crypto, shell, Bun.Image, SQL blob binds,
+// ...) completes and unpins, the buffer becomes detachable again.
 static JSC::ArrayBuffer* arrayBufferImpl(JSC::JSValue value)
 {
     if (auto* jb = dynamicDowncast<JSC::JSArrayBuffer>(value))

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -6408,6 +6408,10 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
                 throwVMTypeError(&lexicalGlobalObject, scope, errorMessageForTransfer(arrayBuffer));
                 RELEASE_AND_RETURN(scope, Exception { ExistingExceptionError });
             }
+            // Not detached/shared/locked yet not detachable: a native borrow holds a
+            // pin(). transferTo() would copy; fail closed per StructuredSerializeWithTransfer.
+            if (!arrayBuffer->isDetachable())
+                return Exception { DataCloneError, "Cannot transfer an ArrayBuffer that is in use by an asynchronous I/O operation"_s };
             arrayBuffers.append(WTF::move(arrayBuffer));
             continue;
         }

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -5977,6 +5977,14 @@ static ExceptionOr<std::unique_ptr<ArrayBufferContentsArray>> transferArrayBuffe
     if (arrayBuffers.isEmpty())
         return nullptr;
 
+    // Re-check detachability after serialization: an own accessor getter invoked by
+    // CloneSerializer can pin() a buffer that passed the up-front transfer-list check.
+    // Reject before any transferTo() so no sibling is left detached on failure.
+    for (auto& ab : arrayBuffers) {
+        if (ab && !ab->isDetachable())
+            return Exception { DataCloneError, "Cannot transfer an ArrayBuffer that is in use by an asynchronous I/O operation"_s };
+    }
+
     auto contents = makeUnique<ArrayBufferContentsArray>(arrayBuffers.size());
 
     HashSet<JSC::ArrayBuffer*> visited;

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1,7 +1,14 @@
 import { deserialize, serialize } from "bun:jsc";
 import { openSync } from "fs";
 import { bunEnv, bunExe, tls } from "harness";
-import { createPrivateKey, createPublicKey, createSecretKey, KeyObject, randomFill, X509Certificate } from "node:crypto";
+import {
+  createPrivateKey,
+  createPublicKey,
+  createSecretKey,
+  KeyObject,
+  randomFill,
+  X509Certificate,
+} from "node:crypto";
 import { BlockList } from "node:net";
 import zlib from "node:zlib";
 import { join } from "path";

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -557,12 +557,13 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
               port1.postMessage(ab, [ab]);
             } catch (e) {
               error = e;
+            } finally {
+              port1.close();
+              port2.close();
             }
             expect(error).toBeInstanceOf(DOMException);
             expect((error as DOMException).name).toBe("DataCloneError");
             expect(ab.byteLength).toBe(1 << 16);
-            port1.close();
-            port2.close();
             await promise;
           });
           test("a sibling ArrayBuffer in the same transfer list is not detached on rejection", async () => {

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1,8 +1,9 @@
 import { deserialize, serialize } from "bun:jsc";
 import { openSync } from "fs";
 import { bunEnv, bunExe, tls } from "harness";
-import { createPrivateKey, createPublicKey, createSecretKey, KeyObject, X509Certificate } from "node:crypto";
+import { createPrivateKey, createPublicKey, createSecretKey, KeyObject, randomFill, X509Certificate } from "node:crypto";
 import { BlockList } from "node:net";
+import zlib from "node:zlib";
 import { join } from "path";
 
 // Terminal object types that were never entered into the structured clone object
@@ -501,6 +502,81 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
           const cloned = structuredCloneFn({ buffer }, { transfer: new Set([buffer]) as any });
           expect(cloned.buffer.byteLength).toBe(8);
           expect(buffer.byteLength).toBe(0);
+        });
+        // An in-flight async native op pins the backing ArrayBuffer so its bytes
+        // can't move. A transfer that cannot detach must throw DataCloneError per
+        // HTML StructuredSerializeWithTransfer, not silently copy.
+        describe("pinned ArrayBuffer cannot be transferred while an async op borrows it", () => {
+          const pinners = [
+            ["zlib.gzip", (u8: Uint8Array, cb: () => void) => zlib.gzip(u8, cb)],
+            ["zlib.deflate", (u8: Uint8Array, cb: () => void) => zlib.deflate(u8, cb)],
+            ["zlib.brotliCompress", (u8: Uint8Array, cb: () => void) => zlib.brotliCompress(u8, cb)],
+          ] as const;
+          test.each(pinners)("%s: structuredClone transfer throws DataCloneError", async (_name, pin) => {
+            const ab = new ArrayBuffer(1 << 16);
+            const u8 = new Uint8Array(ab).fill(65);
+            const { promise, resolve } = Promise.withResolvers<void>();
+            pin(u8, () => resolve());
+
+            let error: unknown;
+            try {
+              structuredCloneFn(ab, { transfer: [ab] });
+            } catch (e) {
+              error = e;
+            }
+            expect(error).toBeInstanceOf(DOMException);
+            expect((error as DOMException).name).toBe("DataCloneError");
+            expect((error as DOMException).code).toBe(DOMException.DATA_CLONE_ERR);
+            // The rejected transfer must not have detached or mutated the source.
+            expect(ab.byteLength).toBe(1 << 16);
+            expect(u8[0]).toBe(65);
+
+            await promise;
+            // Once the async op completes and unpins, transfer detaches normally.
+            const cloned = structuredCloneFn(ab, { transfer: [ab] });
+            expect(ab.byteLength).toBe(0);
+            expect(cloned.byteLength).toBe(1 << 16);
+            expect(new Uint8Array(cloned)[0]).toBe(65);
+          });
+          test("MessagePort.postMessage transfer throws DataCloneError", async () => {
+            const ab = new ArrayBuffer(1 << 16);
+            const u8 = new Uint8Array(ab).fill(65);
+            const { promise, resolve } = Promise.withResolvers<void>();
+            zlib.gzip(u8, () => resolve());
+
+            const { port1, port2 } = new MessageChannel();
+            let error: unknown;
+            try {
+              port1.postMessage(ab, [ab]);
+            } catch (e) {
+              error = e;
+            }
+            expect(error).toBeInstanceOf(DOMException);
+            expect((error as DOMException).name).toBe("DataCloneError");
+            expect(ab.byteLength).toBe(1 << 16);
+            port1.close();
+            port2.close();
+            await promise;
+          });
+          test("a sibling ArrayBuffer in the same transfer list is not detached on rejection", async () => {
+            const pinned = new ArrayBuffer(1 << 16);
+            const other = new ArrayBuffer(8);
+            const { promise, resolve } = Promise.withResolvers<void>();
+            zlib.gzip(new Uint8Array(pinned), () => resolve());
+
+            expect(() => structuredCloneFn({ pinned, other }, { transfer: [other, pinned] })).toThrow(DOMException);
+            // The whole transfer step is rejected before any buffer is detached.
+            expect(other.byteLength).toBe(8);
+            expect(pinned.byteLength).toBe(1 << 16);
+            await promise;
+          });
+          test("randomFill does not block transfer (negative control)", () => {
+            const ab = new ArrayBuffer(1 << 16);
+            randomFill(new Uint8Array(ab), () => {});
+            const cloned = structuredCloneFn(ab, { transfer: [ab] });
+            expect(ab.byteLength).toBe(0);
+            expect(cloned.byteLength).toBe(1 << 16);
+          });
         });
       });
     }

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -577,6 +577,30 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
             expect(pinned.byteLength).toBe(1 << 16);
             await promise;
           });
+          test("a getter that pins the buffer during serialization still throws DataCloneError", async () => {
+            const ab = new ArrayBuffer(1 << 16);
+            const other = new ArrayBuffer(8);
+            const { promise, resolve } = Promise.withResolvers<void>();
+            const value = Object.defineProperty({ ab, other }, "p", {
+              enumerable: true,
+              get() {
+                zlib.gzip(new Uint8Array(ab), () => resolve());
+                return 1;
+              },
+            });
+            let error: unknown;
+            try {
+              structuredCloneFn(value, { transfer: [other, ab] });
+            } catch (e) {
+              error = e;
+            }
+            expect(error).toBeInstanceOf(DOMException);
+            expect((error as DOMException).name).toBe("DataCloneError");
+            // Re-checked after serialization, before any sibling is detached.
+            expect(ab.byteLength).toBe(1 << 16);
+            expect(other.byteLength).toBe(8);
+            await promise;
+          });
           test("randomFill does not block transfer (negative control)", () => {
             const ab = new ArrayBuffer(1 << 16);
             randomFill(new Uint8Array(ab), () => {});


### PR DESCRIPTION
## Problem

While an async native job (`zlib.gzip`, `zlib.deflate`, `fs.writeFile`, ...) is in flight over a buffer, transferring that buffer's `ArrayBuffer` via `structuredClone` or `postMessage` is a silent no-op: the destination receives a copy and the source stays attached. HTML [StructuredSerializeWithTransfer](https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer) requires a `DataCloneError` when a transfer cannot detach.

```js
const zlib = require("node:zlib");
const ab = new ArrayBuffer(1 << 20);
new Uint8Array(ab).fill(65);
zlib.gzip(new Uint8Array(ab), () => {});
structuredClone(ab, { transfer: [ab] });
console.log("detached =", ab.byteLength === 0);
// before: detached = false  (no exception; source still live, destination is a copy)
// node:   detached = true
```

Via worker `postMessage` both sides end up holding live full-size buffers with no error raised.

## Cause

The async-job path pins the backing store with `JSC::ArrayBuffer::pin()`, which bumps `m_pinCount`. That clears `isDetachable()` but not `isLocked()`, so the existing `isLocked()` pre-check in `SerializedScriptValue::create`'s transfer-list loop does not reject it. `ArrayBuffer::transferTo()` answers an undetachable buffer with `m_contents.copyTo(result)` and returns `true`, so the later `transferArrayBuffers()` step "succeeds" without detaching.

## Fix

Add a `!isDetachable()` check to the transfer-list validation, after the detached/shared/locked checks. At that point `!isDetachable()` implies `m_pinCount > 0`, i.e. a native borrow is live; throw `DataCloneError` with a message naming the condition. The pin itself is unchanged (it is what makes the off-thread read memory-safe); once the async op completes and unpins, the buffer is detachable again and transfer works normally.

Updated the `JSC__JSValue__pinArrayBuffer` and `as_pinned_arraybuffer` doc comments to describe the new transfer behaviour.

## Tests

Added to `test/js/web/workers/structured-clone.test.ts` under the existing `transferables` group:

- `zlib.gzip` / `zlib.deflate` / `zlib.brotliCompress` each throw `DataCloneError` while in flight, leave the source attached, and allow a normal detaching transfer after the callback fires
- `MessagePort.postMessage` transfer throws `DataCloneError` for a pinned buffer
- a sibling buffer in the same transfer list is not detached when the call is rejected
- negative control: `crypto.randomFill` (which does not pin) still allows transfer

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/structured-clone.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (90e0449f9)

test/js/web/workers/structured-clone.test.ts:
(pass) structuredClone > primitive undefined [8.44ms]
(pass) structuredClone > primitive null [1.30ms]
(pass) structuredClone > primitive true [1.10ms]
(pass) structuredClone > primitive false [1.44ms]
(pass) structuredClone > primitive string, empty string [0.79ms]
(pass) structuredClone > primitive string, lone high surrogate [0.74ms]
(pass) structuredClone > primitive string, lone low surrogate [0.74ms]
(pass) structuredClone > primitive string, NUL [0.76ms]
(pass) structuredClone > primitive string, astral character [1.16ms]
(pass) structuredClone > primitive number, 0.2 [0.79ms]
(pass) structuredClone > primitive number, 0 [0.71ms]
(pass) structuredClone > pri
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (837bd68c9)

test/js/web/workers/structured-clone.test.ts:
(pass) structuredClone > primitive undefined [0.16ms]
(pass) structuredClone > primitive null [0.02ms]
(pass) structuredClone > primitive true
(pass) structuredClone > primitive false
(pass) structuredClone > primitive string, empty string
(pass) structuredClone > primitive string, lone high surrogate
(pass) structuredClone > primitive string, lone low surrogate
(pass) structuredClone > primitive string, NUL
(pass) structuredClone > primitive string, astral character
(pass) structuredClone > primitive number, 0.2
(pass) structuredClone > primitive number, 0
(pass) structuredClone > primitive number, -0
(pass) structuredClone > primitive number, NaN
(pass) structuredClone > primitive number, Infinity
(pass) structuredClone > primitive number, -Infinity
(pass) structuredClone > primitive number, 9007199254740992
(pass) structuredClone > primitive number, -9007199254740992 [0.04ms]
(pass) structuredClone > primitive number, 9007199254740994 [0.03ms]
(pass) structuredClone > primitive number, -9007199254740994
(pass) structuredClone > primitive BigInt, 0n
(pass) structuredClone > primiti
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/structured-clone.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (90e0449f9)

test/js/web/workers/structured-clone.test.ts:
(pass) structuredClone > primitive undefined [6.98ms]
(pass) structuredClone > primitive null [0.90ms]
(pass) structuredClone > primitive true [0.72ms]
(pass) structuredClone > primitive false [1.19ms]
(pass) structuredClone > primitive string, empty string [0.55ms]
(pass) structuredClone > primitive string, lone high surrogate [0.54ms]
(pass) structuredClone > primitive string, lone low surrogate [0.55ms]
(pass) structuredClone > primitive string, NUL [0.56ms]
(pass) structuredClone > primitive string, astral character [0.88ms]
(pass) structuredClone > primitive number, 0.2 [0.59ms]
(pass) structuredClone > primitive number, 0 [0.59ms]
(pass) structuredClone > pri
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 899ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/90] gen ErrorCode+*.h
[2/47] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[3/47] gen cpp.rs (cppbind)
[4/47] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_ro
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/JSValue.rs                                 |   9 +-
 src/jsc/bindings/bindings.cpp                      |  24 ++---
 src/jsc/bindings/webcore/SerializedScriptValue.cpp |  12 +++
 test/js/web/workers/structured-clone.test.ts       | 110 ++++++++++++++++++++-
 4 files changed, 138 insertions(+), 17 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/JSValue.rs                                      1      1      0
src/jsc/bindings/bindings.cpp                           1      1      0
src/jsc/bindings/webcore/SerializedScriptValue.cpp      3      4      0
test/js/web/workers/structured-clone.test.ts            7      8      0
```

</details>

<!-- robobun:evidence:end -->