### PR TITLE
install: honor bun.lockb trustedDependencies sentinel in `bun pm untrusted`/`trust`

### DIFF
--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -3352,7 +3352,10 @@ impl Lockfile {
             };
             let hash = SemverStringBuilder::string_hash(trusted_name) as u32;
             let name_is_trusted = match trusted_dependencies.get(&hash) {
-                Some(name) => !name.is_empty() && **name == *trusted_name,
+                // Empty stored name is the legacy bun.lockb sentinel (the
+                // binary format stores only truncated hashes, no names); it
+                // means "hash-only match" and must accept.
+                Some(name) => name.is_empty() || **name == *trusted_name,
                 None => false,
             };
             if !name_is_trusted {

--- a/test/cli/install/bun-lockb.test.ts
+++ b/test/cli/install/bun-lockb.test.ts
@@ -428,3 +428,71 @@ it("rejects a binary lockfile whose git resolved tag contains path separators", 
   expect(await exists(join(packageDir, "node_modules", "dep"))).toBe(false);
   expect(code).not.toBe(0);
 });
+
+it("honors trustedDependencies loaded from a binary lockfile in `bun pm untrusted`/`trust`", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: false } });
+
+  // The postinstall appends a line so we can count how many times it ran.
+  const ran = join(packageDir, "ran.txt");
+  await write(
+    join(packageDir, "dep", "package.json"),
+    JSON.stringify({
+      name: "dep",
+      version: "1.0.0",
+      scripts: { postinstall: `${bunExe()} -e "require('fs').appendFileSync('../../ran.txt', 'RAN\\n')"` },
+    }),
+  );
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "lockb-trusted",
+      version: "1.0.0",
+      dependencies: { dep: "file:./dep" },
+      trustedDependencies: ["dep"],
+    }),
+  );
+
+  await runBunInstall(env, packageDir);
+  expect(await exists(join(packageDir, "bun.lockb"))).toBe(true);
+  expect(await exists(join(packageDir, "bun.lock"))).toBe(false);
+  expect(await file(ran).text()).toBe("RAN\n");
+
+  // `bun pm untrusted` must report zero: the only script-bearing package is
+  // listed in trustedDependencies. The binary lockfile stores only truncated
+  // name hashes; the loader's empty-name sentinel must be treated as a match.
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "pm", "untrusted"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [out, rawErr, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    const err = stderrForInstall(rawErr);
+    expect(err).not.toContain("error:");
+    expect(out).toContain("Found 0 untrusted dependencies with scripts");
+    expect(out).not.toContain("node_modules/dep");
+    expect(code).toBe(0);
+  }
+
+  // `bun pm trust dep` must refuse (already trusted) and must not re-run the
+  // postinstall.
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "pm", "trust", "dep"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [out, rawErr, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    const err = stderrForInstall(rawErr);
+    expect(err).toContain("0 scripts ran");
+    expect(err).toContain("already trusted");
+    expect(out).not.toContain("postinstall");
+    expect(code).toBe(1);
+  }
+
+  expect(await file(ran).text()).toBe("RAN\n");
+});


### PR DESCRIPTION
## What

In projects whose lockfile is the legacy binary `bun.lockb`, `bun pm untrusted` listed every package with lifecycle scripts as blocked even when it was in `trustedDependencies` and its postinstall had already run during install. `bun pm trust <pkg>` then re-executed the postinstall a second time. The same project with a text `bun.lock` correctly reported 0 untrusted.

## Repro

```sh
D=$(mktemp -d); cd "$D"; mkdir -p dep
echo '{"name":"root","version":"1.0.0","dependencies":{"dep":"file:./dep"},"trustedDependencies":["dep"]}' > package.json
echo '{"name":"dep","version":"1.0.0","scripts":{"postinstall":"echo RAN >> ../../ran.txt"}}' > dep/package.json
printf '[install]\nsaveTextLockfile = false\n' > bunfig.toml
bun install --no-summary
bun pm untrusted
# before: ./node_modules/dep @dep  » [postinstall]: ...  "blocked during install"
# after:  Found 0 untrusted dependencies with scripts.
```

## Cause

The binary lockfile format stores only truncated u32 name hashes for `trustedDependencies`, not the names. The loader (`src/install/lockfile/bun.lockb.rs`) inserts an empty `Box<[u8]>` as the documented "name unknown, hash-only match" sentinel (see the `TrustedDependenciesSet` doc comment).

`Lockfile::has_trusted_dependency` compared the stored name against the candidate with `!name.is_empty() && **name == *trusted_name`, so an empty stored name never matched. Every `trustedDependencies` entry loaded from a `bun.lockb` therefore failed. `bun install` was unaffected because it repopulates the map from `package.json` with real names before consulting it; `bun pm untrusted` / `bun pm trust` read the lockfile as loaded.

Regressed in #31339, which flipped the original `name.is_empty() || **name == *alias` check.

## Fix

Restore the sentinel semantics in `has_trusted_dependency`: an empty stored name means "hash-only match" and accepts. Entries that do carry a name still compare it to guard against truncated-hash collisions.

## Verification

New test in `test/cli/install/bun-lockb.test.ts` creates a project with a `file:` dependency that has a postinstall appending to a counter file, a `trustedDependencies` entry for it, and `saveTextLockfile = false`. After install it asserts `bun pm untrusted` reports 0 untrusted, `bun pm trust dep` refuses with "0 scripts ran" / "already trusted", and the postinstall ran exactly once. Fails on main at the `Found 0 untrusted` assertion, passes with this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-lockb.test.ts

<!-- robobun:evidence:end -->