### PR TITLE
expect: restore label text in toContainEqual/toBeArrayOfSize failure messages

### DIFF
--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -685,28 +685,6 @@ impl Expect {
         })
     }
 
-    /// Legacy 4-arg form used by a handful of internal call sites in this file
-    /// (snapshot/mock helpers) that take a separate `fmt` literal.
-    /// Folds `fmt` into `args` and delegates.
-    #[inline]
-    pub fn throw_fmt(
-        &self,
-        global_this: &JSGlobalObject,
-        signature: &'static str,
-        _fmt: &'static str,
-        args: fmt::Arguments<'_>,
-    ) -> JsResult<JSValue> {
-        // Rust cannot interpolate a runtime-literal format string, so every
-        // caller bakes the rendered tail (literal text + substitutions) into
-        // `args`; `_fmt` is kept only for documentation.
-        // If `args` is empty but `_fmt` is not, a caller forgot to migrate.
-        debug_assert!(
-            _fmt.is_empty() || args.as_str() != Some(""),
-            "throw_fmt: caller passed non-empty fmt tail {_fmt:?} but empty args — message body would be dropped",
-        );
-        self.throw(global_this, signature, args)
-    }
-
     // extern shim emitted by `#[bun_jsc::JsClass]` codegen (TypeClass__construct/__call); bare `#[host_fn]` cannot target an associated fn without a receiver.
     pub fn constructor(global_this: &JSGlobalObject, _frame: &CallFrame) -> JsResult<*mut Expect> {
         Err(global_this.throw(format_args!("expect() cannot be called with new")))
@@ -753,7 +731,7 @@ impl Expect {
 
         if not {
             let signature = Self::get_signature("pass", "", true);
-            return this.throw_fmt(global_this, signature, "\n\n{s}\n", format_args!("\n\n{}\n", bstr::BStr::new(msg.slice())));
+            return this.throw(global_this, signature, format_args!("\n\n{}\n", bstr::BStr::new(msg.slice())));
         }
 
         // should never reach here
@@ -799,7 +777,7 @@ impl Expect {
         let msg = _msg.to_slice();
 
         let signature = Self::get_signature("fail", "", true);
-        this.throw_fmt(global_this, signature, "\n\n{s}\n", format_args!("\n\n{}\n", bstr::BStr::new(msg.slice())))
+        this.throw(global_this, signature, format_args!("\n\n{}\n", bstr::BStr::new(msg.slice())))
     }
 }
 
@@ -1006,7 +984,7 @@ impl Expect {
         // jest counts inline snapshots towards the snapshot counter for some reason
         let Some(runner) = Jest::runner() else {
             let signature = Self::get_signature(fn_name, "", false);
-            return this.throw_fmt(global_this, signature, "", format_args!("\n\n<b>Matcher error<r>: Snapshot matchers cannot be used outside of a test\n"));
+            return this.throw(global_this, signature, format_args!("\n\n<b>Matcher error<r>: Snapshot matchers cannot be used outside of a test\n"));
         };
         match runner.snapshots.add_count(this, b"") {
             Ok(_) => {}
@@ -1057,10 +1035,9 @@ impl Expect {
                 if !update {
                     let signature = Self::get_signature(fn_name, "", false);
                     // Only creating new snapshots can reach here (updating with mismatches errors earlier with diff)
-                    return this.throw_fmt(
+                    return this.throw(
                         global_this,
                         signature,
-                        "",
                         format_args!(
                             "\n\n<b>Matcher error<r>: Inline snapshot creation is disabled in CI environments unless --update-snapshots is used.\nTo override, set the environment variable CI=false.\n\nReceived: {}",
                             bstr::BStr::new(&pretty_value),
@@ -1070,7 +1047,7 @@ impl Expect {
             }
             let Some(buntest_strong) = this.bun_test() else {
                 let signature = Self::get_signature(fn_name, "", false);
-                return this.throw_fmt(global_this, signature, "", format_args!("\n\n<b>Matcher error<r>: Snapshot matchers cannot be used outside of a test\n"));
+                return this.throw(global_this, signature, format_args!("\n\n<b>Matcher error<r>: Snapshot matchers cannot be used outside of a test\n"));
             };
             let buntest = buntest_strong.get();
 
@@ -1087,10 +1064,9 @@ impl Expect {
 
             if !srcloc.str.eql_utf8(fget_source_path_text) {
                 let signature = Self::get_signature(fn_name, "", false);
-                return this.throw_fmt(
+                return this.throw(
                     global_this,
                     signature,
-                    "",
                     format_args!(
                         "\n\n<b>Matcher error<r>: Inline snapshot matchers must be called from the test file:\n  Expected to be called from file: <green>{:?}<r>\n  {} called from file: <red>{:?}<r>\n",
                         bstr::BStr::new(fget_source_path_text),
@@ -1128,7 +1104,7 @@ impl Expect {
         if let Some(_prop_matchers) = property_matchers {
             if !value.is_object() {
                 let signature = Self::get_signature(fn_name, "<green>properties<r><d>, <r>hint", false);
-                return self.throw_fmt(global_this, signature, "", format_args!("\n\n<b>Matcher error: <red>received<r> values must be an object when the matcher has <green>properties<r>\n")).map(drop);
+                return self.throw(global_this, signature, format_args!("\n\n<b>Matcher error: <red>received<r> values must be an object when the matcher has <green>properties<r>\n")).map(drop);
             }
 
             let prop_matchers = _prop_matchers;

--- a/src/runtime/test_runner/expect/toBeArrayOfSize.rs
+++ b/src/runtime/test_runner/expect/toBeArrayOfSize.rs
@@ -44,24 +44,27 @@ pub(crate) fn to_be_array_of_size(
     }
 
     let mut formatter = super::make_formatter(global);
-    let received = value.to_fmt(&mut formatter);
 
     if not {
         let signature = get_signature("toBeArrayOfSize", "", true);
-        return this.throw_fmt(
+        return this.throw(
             global,
             signature,
-            concat!("\n\n", "Received: <red>{}<r>\n"),
-            format_args!("{}", received),
+            format_args!(
+                concat!("\n\n", "Received: <red>{}<r>\n"),
+                value.to_fmt(&mut formatter),
+            ),
         );
     }
 
     let signature = get_signature("toBeArrayOfSize", "", false);
-    this.throw_fmt(
+    this.throw(
         global,
         signature,
-        concat!("\n\n", "Received: <red>{}<r>\n"),
-        format_args!("{}", received),
+        format_args!(
+            concat!("\n\n", "Received: <red>{}<r>\n"),
+            value.to_fmt(&mut formatter),
+        ),
     )
 }
 

--- a/src/runtime/test_runner/expect/toBeCloseTo.rs
+++ b/src/runtime/test_runner/expect/toBeCloseTo.rs
@@ -84,46 +84,40 @@ impl Expect {
         let expected_fmt = expected_.to_fmt(&mut formatter);
         let received_fmt = received_.to_fmt(&mut formatter2);
 
-        const EXPECTED_LINE: &str = "Expected: <green>{}<r>\n";
-        const RECEIVED_LINE: &str = "Received: <red>{}<r>\n";
-        const EXPECTED_PRECISION: &str = "Expected precision: {}\n";
-        const EXPECTED_DIFFERENCE: &str = "Expected difference: \\< <green>{}<r>\n";
-        const RECEIVED_DIFFERENCE: &str = "Received difference: <red>{}<r>\n";
-
-        const SUFFIX_FMT: &str = const_format::concatcp!(
-            "\n\n",
-            EXPECTED_LINE,
-            RECEIVED_LINE,
-            "\n",
-            EXPECTED_PRECISION,
-            EXPECTED_DIFFERENCE,
-            RECEIVED_DIFFERENCE,
-        );
-
-        // TODO(refactor): `format_args!` requires a literal fmt string, so SUFFIX_FMT cannot
-        // be threaded as a runtime arg. Decide `Expect::throw` signature — likely
-        // `fn throw(&self, &JSGlobalObject, &str, fmt::Arguments) -> JsResult<JSValue>` and inline
-        // SUFFIX_FMT into the `format_args!` call (or make `throw!` a macro).
         if not {
             let signature = get_signature("toBeCloseTo", "<green>expected<r>, precision", true);
-            return this.throw_fmt(
+            return this.throw(
                 global,
                 signature,
-                SUFFIX_FMT,
                 format_args!(
-                    "\n\nExpected: <green>{}<r>\nReceived: <red>{}<r>\n\nExpected precision: {}\nExpected difference: \\< <green>{}<r>\nReceived difference: <red>{}<r>\n",
+                    concat!(
+                        "\n\n",
+                        "Expected: <green>{}<r>\n",
+                        "Received: <red>{}<r>\n",
+                        "\n",
+                        "Expected precision: {}\n",
+                        "Expected difference: \\< <green>{}<r>\n",
+                        "Received difference: <red>{}<r>\n",
+                    ),
                     expected_fmt, received_fmt, precision, expected_diff, actual_diff
                 ),
             );
         }
 
         let signature = get_signature("toBeCloseTo", "<green>expected<r>, precision", false);
-        this.throw_fmt(
+        this.throw(
             global,
             signature,
-            SUFFIX_FMT,
             format_args!(
-                "\n\nExpected: <green>{}<r>\nReceived: <red>{}<r>\n\nExpected precision: {}\nExpected difference: \\< <green>{}<r>\nReceived difference: <red>{}<r>\n",
+                concat!(
+                    "\n\n",
+                    "Expected: <green>{}<r>\n",
+                    "Received: <red>{}<r>\n",
+                    "\n",
+                    "Expected precision: {}\n",
+                    "Expected difference: \\< <green>{}<r>\n",
+                    "Received difference: <red>{}<r>\n",
+                ),
                 expected_fmt, received_fmt, precision, expected_diff, actual_diff
             ),
         )

--- a/src/runtime/test_runner/expect/toContainEqual.rs
+++ b/src/runtime/test_runner/expect/toContainEqual.rs
@@ -109,27 +109,30 @@ pub(crate) fn to_contain_equal(
     // Formatter for the expected value.
     let mut formatter = super::make_formatter(global);
     let mut formatter2 = super::make_formatter(global);
-    let value_fmt = value.to_fmt(&mut formatter);
-    let expected_fmt = expected.to_fmt(&mut formatter2);
     if not {
         let signature: &str = get_signature("toContainEqual", "<green>expected<r>", true);
-        return this.throw_fmt(
+        return this.throw(
             global,
             signature,
-            concat!("\n\n", "Expected to not contain: <green>{}<r>\n"),
-            format_args!("{}", expected_fmt),
+            format_args!(
+                concat!("\n\n", "Expected to not contain: <green>{}<r>\n"),
+                expected.to_fmt(&mut formatter2),
+            ),
         );
     }
 
     let signature: &str = get_signature("toContainEqual", "<green>expected<r>", false);
-    this.throw_fmt(
+    this.throw(
         global,
         signature,
-        concat!(
-            "\n\n",
-            "Expected to contain: <green>{}<r>\n",
-            "Received: <red>{}<r>\n"
+        format_args!(
+            concat!(
+                "\n\n",
+                "Expected to contain: <green>{}<r>\n",
+                "Received: <red>{}<r>\n",
+            ),
+            expected.to_fmt(&mut formatter2),
+            value.to_fmt(&mut formatter),
         ),
-        format_args!("{}{}", expected_fmt, value_fmt),
     )
 }

--- a/src/runtime/test_runner/expect/toMatchSnapshot.rs
+++ b/src/runtime/test_runner/expect/toMatchSnapshot.rs
@@ -23,20 +23,18 @@ pub(crate) fn to_match_snapshot(
     let not = this.flags.get().not();
     if not {
         let signature = get_signature("toMatchSnapshot", "", true);
-        return this.throw_fmt(
+        return this.throw(
             global,
             signature,
-            "",
             format_args!("\n\n<b>Matcher error<r>: Snapshot matchers cannot be used with <b>not<r>\n"),
         );
     }
 
     let Some(buntest_strong) = this.bun_test() else {
         let signature = get_signature("toMatchSnapshot", "", true);
-        return this.throw_fmt(
+        return this.throw(
             global,
             signature,
-            "",
             format_args!("\n\n<b>Matcher error<r>: Snapshot matchers cannot be used outside of a test\n"),
         );
     };
@@ -52,9 +50,8 @@ pub(crate) fn to_match_snapshot(
             } else if arguments[0].is_object() {
                 property_matchers = Some(arguments[0]);
             } else {
-                return this.throw_fmt(
+                return this.throw(
                     global,
-                    "",
                     "",
                     format_args!("\n\nMatcher error: Expected first argument to be a string or object\n"),
                 );
@@ -64,10 +61,9 @@ pub(crate) fn to_match_snapshot(
             if !arguments[0].is_object() {
                 let signature =
                     get_signature("toMatchSnapshot", "<green>properties<r><d>, <r>hint", false);
-                return this.throw_fmt(
+                return this.throw(
                     global,
                     signature,
-                    "",
                     format_args!("\n\nMatcher error: Expected <green>properties<r> must be an object\n"),
                 );
             }
@@ -77,9 +73,8 @@ pub(crate) fn to_match_snapshot(
             if arguments[1].is_string() {
                 arguments[1].to_zig_string(&mut hint_string, global)?;
             } else {
-                return this.throw_fmt(
+                return this.throw(
                     global,
-                    "",
                     "",
                     format_args!("\n\nMatcher error: Expected second argument to be a string\n"),
                 );

--- a/src/runtime/test_runner/expect/toThrowErrorMatchingSnapshot.rs
+++ b/src/runtime/test_runner/expect/toThrowErrorMatchingSnapshot.rs
@@ -22,20 +22,18 @@ pub(crate) fn to_throw_error_matching_snapshot(
     let not = this.flags.get().not();
     if not {
         let signature = get_signature("toThrowErrorMatchingSnapshot", "", true);
-        return this.throw_fmt(
+        return this.throw(
             global,
             signature,
-            "",
             format_args!("\n\n<b>Matcher error<r>: Snapshot matchers cannot be used with <b>not<r>\n"),
         );
     }
 
     let Some(bun_test_strong) = this.bun_test() else {
         let signature = get_signature("toThrowErrorMatchingSnapshot", "", true);
-        return this.throw_fmt(
+        return this.throw(
             global,
             signature,
-            "",
             format_args!("\n\n<b>Matcher error<r>: Snapshot matchers cannot be used outside of a test\n"),
         );
     };
@@ -48,18 +46,16 @@ pub(crate) fn to_throw_error_matching_snapshot(
             if arguments[0].is_string() {
                 arguments[0].to_zig_string(&mut hint_string, global)?;
             } else {
-                return this.throw_fmt(
+                return this.throw(
                     global,
-                    "",
                     "",
                     format_args!("\n\nMatcher error: Expected first argument to be a string\n"),
                 );
             }
         }
         _ => {
-            return this.throw_fmt(
+            return this.throw(
                 global,
-                "",
                 "",
                 format_args!("\n\nMatcher error: Expected zero or one arguments\n"),
             );
@@ -79,10 +75,9 @@ pub(crate) fn to_throw_error_matching_snapshot(
     )?
     else {
         let signature = get_signature("toThrowErrorMatchingSnapshot", "", false);
-        return this.throw_fmt(
+        return this.throw(
             global,
             signature,
-            "",
             format_args!("\n\n<b>Matcher error<r>: Received function did not throw\n"),
         );
     };

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -2562,6 +2562,38 @@ describe("expect()", () => {
     expect(value).not.toContainEqual(expected);
   });
 
+  describe("failure messages include label text and blank-line separator", () => {
+    function messageOf(fn) {
+      try {
+        fn();
+      } catch (e) {
+        return ANY(e).message;
+      }
+      throw new Error("expected to throw");
+    }
+
+    test("toContainEqual", () => {
+      const msg = messageOf(() => expect([{ a: 1 }]).toContainEqual({ a: 2 }));
+      expect(msg).toStartWith("expect(received).toContainEqual(expected)\n\nExpected to contain: ");
+      expect(msg).toContain("\nReceived: ");
+    });
+
+    test("not.toContainEqual", () => {
+      const msg = messageOf(() => expect([{ a: 1 }]).not.toContainEqual({ a: 1 }));
+      expect(msg).toStartWith("expect(received).not.toContainEqual(expected)\n\nExpected to not contain: ");
+    });
+
+    test("toBeArrayOfSize", () => {
+      const msg = messageOf(() => expect([1]).toBeArrayOfSize(2));
+      expect(msg).toStartWith("expect(received).toBeArrayOfSize()\n\nReceived: ");
+    });
+
+    test("not.toBeArrayOfSize", () => {
+      const msg = messageOf(() => expect([1]).not.toBeArrayOfSize(1));
+      expect(msg).toStartWith("expect(received).not.toBeArrayOfSize()\n\nReceived: ");
+    });
+  });
+
   test("toContainKey", () => {
     const o = { a: "foo", b: "bar", c: "baz" };
     expect(o).toContainKey("a");


### PR DESCRIPTION
## Reproduction

```ts
import { test, expect } from "bun:test";
test("t", () => {
  try { expect([{a:1}]).toContainEqual({a:2}); } catch (e) { console.log(JSON.stringify(e.message)); }
});
```

```
1.3.14: "expect(received).toContainEqual(expected)\n\nExpected to contain: {\n  a: 2,\n}\nReceived: [\n  {\n    a: 1,\n  }\n]\n"
1.4:    "expect(received).toContainEqual(expected){\n  a: 2,\n}[\n  {\n    a: 1,\n  }\n]"
```

Same for `toBeArrayOfSize`: `"expect(received).toBeArrayOfSize()[ 1 ]"` (was `"...\n\nReceived: [ 1 ]\n"`).

## Cause

`Expect::throw_fmt` (`src/runtime/test_runner/expect.rs`) takes a separate `_fmt: &'static str` that is discarded; every caller is expected to bake the rendered tail into `args`. Four call sites in `toContainEqual.rs` and `toBeArrayOfSize.rs` still passed their label text (`"Expected to contain:"`, `"Received:"`, leading `\n\n`) only in `_fmt` with bare substitutions in `args`, so the labels and separator were dropped.

The `debug_assert!` guarding against this cannot fire: `fmt::Arguments::as_str()` returns `None` whenever substitutions are present, so `args.as_str() != Some("")` is always true for `format_args!("{}", x)`.

## Fix

- Rewrite the four broken sites to nest `concat!(...)` inside `format_args!(...)` and call `throw()` directly, matching the shape already used by `toContain.rs`.
- Migrate the remaining `throw_fmt` callers (all of which already baked the full body into `args`) to `throw()` and delete `throw_fmt` along with its dead `debug_assert!`, so the mistake cannot recur.
- Remove the now-dead `SUFFIX_FMT` scaffolding and `TODO(refactor)` in `toBeCloseTo.rs`.

## Verification

New tests in `test/js/bun/test/expect.test.js` assert the failure message for all four variants (`toContainEqual`, `.not.toContainEqual`, `toBeArrayOfSize`, `.not.toBeArrayOfSize`) starts with the signature, the `\n\n` separator, and the label. All four fail on 1.4 canary and pass with this change. Full `expect.test.js` (410 pass) and `jest-extended.test.js` (57 pass) are green.