### PR TITLE
build --compile: resolve cross-compile cache via full BUN_INSTALL/XDG chain

### DIFF
--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -7,7 +7,7 @@ use crate::bun_fs::FileSystem;
 use crate::lockfile_real::package::PackageColumns;
 use crate::repository::Repository;
 use bun_core::ZStr;
-use bun_core::{Global, Output, ZBox, env_var, fmt as bun_fmt};
+use bun_core::{Global, Output, ZBox, fmt as bun_fmt};
 use bun_dotenv::Loader as DotEnvLoader;
 use bun_install::lockfile::{Format as LockfileFormat, LoadResult, Lockfile};
 use bun_install::resolution::Tag as ResolutionTag;
@@ -377,44 +377,11 @@ pub struct CacheDir {
 }
 
 pub fn fetch_cache_directory_path(env: &mut DotEnvLoader, options: Option<&Options>) -> CacheDir {
-    if let Some(dir) = env.get(b"BUN_INSTALL_CACHE_DIR") {
-        return CacheDir {
-            path: FileSystem::instance().abs(&[dir]).to_vec(),
-        };
-    }
-
-    if let Some(opts) = options {
-        if !opts.cache_directory.is_empty() {
-            return CacheDir {
-                path: FileSystem::instance().abs(&[opts.cache_directory]).to_vec(),
-            };
-        }
-    }
-
-    if let Some(dir) = env.get(b"BUN_INSTALL") {
-        let parts: [&[u8]; 3] = [dir, b"install/", b"cache/"];
-        return CacheDir {
-            path: FileSystem::instance().abs(&parts).to_vec(),
-        };
-    }
-
-    if let Some(dir) = env_var::XDG_CACHE_HOME.get() {
-        let parts: [&[u8]; 4] = [dir, b".bun/", b"install/", b"cache/"];
-        return CacheDir {
-            path: FileSystem::instance().abs(&parts).to_vec(),
-        };
-    }
-
-    if let Some(dir) = env_var::HOME.get() {
-        let parts: [&[u8]; 4] = [dir, b".bun/", b"install/", b"cache/"];
-        return CacheDir {
-            path: FileSystem::instance().abs(&parts).to_vec(),
-        };
-    }
-
-    let fallback_parts: [&[u8]; 1] = [b"node_modules/.bun-cache"];
     CacheDir {
-        path: FileSystem::instance().abs(&fallback_parts).to_vec(),
+        path: bun_options_types::install_cache::fetch_cache_directory_path(
+            env,
+            options.map(|opts| opts.cache_directory),
+        ),
     }
 }
 

--- a/src/options_types/compile_target.rs
+++ b/src/options_types/compile_target.rs
@@ -191,7 +191,7 @@ impl CompileTarget {
         &self,
         buf: &'a mut PathBuffer,
         version_str: &'a ZStr,
-        _env: &mut bun_dotenv::Loader,
+        env: &mut bun_dotenv::Loader,
         needs_download: &mut bool,
     ) -> &'a ZStr {
         if self.is_default() {
@@ -212,8 +212,7 @@ impl CompileTarget {
             return version_str;
         }
 
-        // T1 fallback ignores `_env` (full env-override chain lives in bun_install).
-        let cache_dir = bun_sys::fetch_cache_directory_path();
+        let cache_dir = fetch_cache_directory_path(env);
         let dest = path::resolve_path::join_abs_string_buf_z::<path::platform::Auto>(
             path::fs::FileSystem::instance().top_level_dir(),
             &mut buf[..],
@@ -229,7 +228,37 @@ impl CompileTarget {
 
     // `download_to_path` moved up to `bun_standalone_graph` so it can name
     // `bun_http::AsyncHTTP` directly; this struct stays data-only.
+}
 
+/// Resolve the bun install cache directory for the cross-compile base binary.
+/// Mirrors `bun_install::PackageManager::fetch_cache_directory_path(env, None)`,
+/// which this crate cannot name directly (`bun_install` depends on us).
+fn fetch_cache_directory_path(env: &bun_dotenv::Loader) -> Vec<u8> {
+    use path::resolve_path::{join_abs_string, platform};
+    let top = path::fs::FileSystem::instance().top_level_dir();
+
+    if let Some(dir) = env.get(b"BUN_INSTALL_CACHE_DIR") {
+        return join_abs_string::<platform::Loose>(top, &[dir]).to_vec();
+    }
+
+    if let Some(dir) = env.get(b"BUN_INSTALL") {
+        return join_abs_string::<platform::Loose>(top, &[dir, b"install/", b"cache/"]).to_vec();
+    }
+
+    if let Some(dir) = env_var::XDG_CACHE_HOME.get() {
+        return join_abs_string::<platform::Loose>(top, &[dir, b".bun/", b"install/", b"cache/"])
+            .to_vec();
+    }
+
+    if let Some(dir) = env_var::HOME.get() {
+        return join_abs_string::<platform::Loose>(top, &[dir, b".bun/", b"install/", b"cache/"])
+            .to_vec();
+    }
+
+    join_abs_string::<platform::Loose>(top, &[b"node_modules/.bun-cache"]).to_vec()
+}
+
+impl CompileTarget {
     pub fn is_supported(&self) -> bool {
         match self.os {
             OperatingSystem::Windows => {

--- a/src/options_types/compile_target.rs
+++ b/src/options_types/compile_target.rs
@@ -212,7 +212,7 @@ impl CompileTarget {
             return version_str;
         }
 
-        let cache_dir = fetch_cache_directory_path(env);
+        let cache_dir = crate::install_cache::fetch_cache_directory_path(env, None);
         let dest = path::resolve_path::join_abs_string_buf_z::<path::platform::Auto>(
             path::fs::FileSystem::instance().top_level_dir(),
             &mut buf[..],
@@ -228,37 +228,7 @@ impl CompileTarget {
 
     // `download_to_path` moved up to `bun_standalone_graph` so it can name
     // `bun_http::AsyncHTTP` directly; this struct stays data-only.
-}
 
-/// Resolve the bun install cache directory for the cross-compile base binary.
-/// Mirrors `bun_install::PackageManager::fetch_cache_directory_path(env, None)`,
-/// which this crate cannot name directly (`bun_install` depends on us).
-fn fetch_cache_directory_path(env: &bun_dotenv::Loader) -> Vec<u8> {
-    use path::resolve_path::{join_abs_string, platform};
-    let top = path::fs::FileSystem::instance().top_level_dir();
-
-    if let Some(dir) = env.get(b"BUN_INSTALL_CACHE_DIR") {
-        return join_abs_string::<platform::Loose>(top, &[dir]).to_vec();
-    }
-
-    if let Some(dir) = env.get(b"BUN_INSTALL") {
-        return join_abs_string::<platform::Loose>(top, &[dir, b"install/", b"cache/"]).to_vec();
-    }
-
-    if let Some(dir) = env_var::XDG_CACHE_HOME.get() {
-        return join_abs_string::<platform::Loose>(top, &[dir, b".bun/", b"install/", b"cache/"])
-            .to_vec();
-    }
-
-    if let Some(dir) = env_var::HOME.get() {
-        return join_abs_string::<platform::Loose>(top, &[dir, b".bun/", b"install/", b"cache/"])
-            .to_vec();
-    }
-
-    join_abs_string::<platform::Loose>(top, &[b"node_modules/.bun-cache"]).to_vec()
-}
-
-impl CompileTarget {
     pub fn is_supported(&self) -> bool {
         match self.os {
             OperatingSystem::Windows => {

--- a/src/options_types/install_cache.rs
+++ b/src/options_types/install_cache.rs
@@ -1,0 +1,41 @@
+//! Where `bun install` keeps its package cache. `bun_install` passes its bunfig
+//! `cache_directory` as the override; `CompileTarget::exe_path` uses the same
+//! chain to cache the cross-compile base executable.
+
+use bun_core::env_var;
+use bun_dotenv::Loader;
+use bun_paths::resolve_path::{join_abs_string, platform};
+
+/// `$BUN_INSTALL_CACHE_DIR`, then `cache_directory_override`, then
+/// `$BUN_INSTALL/install/cache`, `$XDG_CACHE_HOME/.bun/install/cache`,
+/// `$HOME/.bun/install/cache`, else `node_modules/.bun-cache`. Absolute, joined
+/// against the top-level dir.
+pub fn fetch_cache_directory_path(
+    env: &Loader,
+    cache_directory_override: Option<&[u8]>,
+) -> Vec<u8> {
+    let top = bun_paths::fs::FileSystem::instance().top_level_dir();
+    let abs = |parts: &[&[u8]]| join_abs_string::<platform::Loose>(top, parts).to_vec();
+
+    if let Some(dir) = env.get(b"BUN_INSTALL_CACHE_DIR") {
+        return abs(&[dir]);
+    }
+
+    if let Some(dir) = cache_directory_override.filter(|d| !d.is_empty()) {
+        return abs(&[dir]);
+    }
+
+    if let Some(dir) = env.get(b"BUN_INSTALL") {
+        return abs(&[dir, b"install/", b"cache/"]);
+    }
+
+    if let Some(dir) = env_var::XDG_CACHE_HOME.get() {
+        return abs(&[dir, b".bun/", b"install/", b"cache/"]);
+    }
+
+    if let Some(dir) = env_var::HOME.get() {
+        return abs(&[dir, b".bun/", b"install/", b"cache/"]);
+    }
+
+    abs(&[b"node_modules/.bun-cache"])
+}

--- a/src/options_types/install_cache.rs
+++ b/src/options_types/install_cache.rs
@@ -1,15 +1,8 @@
-//! Where `bun install` keeps its package cache. `bun_install` passes its bunfig
-//! `cache_directory` as the override; `CompileTarget::exe_path` uses the same
-//! chain to cache the cross-compile base executable.
-
 use bun_core::env_var;
 use bun_dotenv::Loader;
 use bun_paths::resolve_path::{join_abs_string, platform};
 
-/// `$BUN_INSTALL_CACHE_DIR`, then `cache_directory_override`, then
-/// `$BUN_INSTALL/install/cache`, `$XDG_CACHE_HOME/.bun/install/cache`,
-/// `$HOME/.bun/install/cache`, else `node_modules/.bun-cache`. Absolute, joined
-/// against the top-level dir.
+/// The `bun install` package cache directory, absolute.
 pub fn fetch_cache_directory_path(
     env: &Loader,
     cache_directory_override: Option<&[u8]>,

--- a/src/options_types/lib.rs
+++ b/src/options_types/lib.rs
@@ -8,6 +8,7 @@ pub mod compile_target;
 pub mod context;
 pub mod error;
 pub mod global_cache;
+pub mod install_cache;
 pub mod jsx;
 pub mod offline_mode;
 pub mod schema;

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -2317,21 +2317,24 @@ pub(crate) fn download_to_path(
                     } else {
                         bun_core::zstr!("bun")
                     };
-                    let mv = bun_sys::move_file_z(tmpdir.fd(), src_name, Fd::INVALID, dest_z);
-                    if mv.is_err() {
+                    if let Err(mv_err) =
+                        bun_sys::move_file_z(tmpdir.fd(), src_name, Fd::INVALID, dest_z)
+                    {
                         if !did_retry {
                             did_retry = true;
                             let dirname = path::dirname_simple(dest_z.as_bytes());
                             if !dirname.is_empty() {
-                                let _ = bun_sys::Dir::cwd().make_path(dirname);
+                                if let Err(mk_err) = bun_sys::Dir::cwd().make_path(dirname) {
+                                    refresher.root.end();
+                                    return Err(crate::Error::CacheWriteFailed(mk_err.into()));
+                                }
                                 continue;
                             }
 
                             // fallthrough, failed for another reason
                         }
                         refresher.root.end();
-                        // Return error without printing - let caller handle the messaging
-                        return Err(crate::Error::ExtractionFailed);
+                        return Err(crate::Error::CacheWriteFailed(mv_err.into()));
                     }
                     break;
                 }
@@ -2392,6 +2395,12 @@ pub fn target_executable(
                     crate::Error::ExtractionFailed => CompileError::fmt(format_args!(
                         "Failed to extract executable for '{}'. The download may be incomplete.",
                         target
+                    )),
+                    crate::Error::CacheWriteFailed(errno) => CompileError::fmt(format_args!(
+                        "Failed to write cached executable for '{}' to {}: {}",
+                        target,
+                        bun_core::fmt::quote(dest_z.as_bytes()),
+                        <&'static str>::from(errno),
                     )),
                     _ => CompileError::fmt(format_args!(
                         "Failed to download '{}': {}",

--- a/src/standalone_graph/error.rs
+++ b/src/standalone_graph/error.rs
@@ -10,6 +10,8 @@ pub enum Error {
     InvalidResponse,
     #[error("ExtractionFailed")]
     ExtractionFailed,
+    #[error("CacheWriteFailed")]
+    CacheWriteFailed(bun_errno::SystemErrno),
     #[error("InvalidSourceMap")]
     InvalidSourceMap,
     #[error("SourceMapTooLarge")]
@@ -43,6 +45,7 @@ impl Error {
             Self::NetworkError => "NetworkError",
             Self::InvalidResponse => "InvalidResponse",
             Self::ExtractionFailed => "ExtractionFailed",
+            Self::CacheWriteFailed(e) => <&'static str>::from(e),
             Self::InvalidSourceMap => "InvalidSourceMap",
             Self::SourceMapTooLarge => "SourceMapTooLarge",
             Self::Sys(e) => <&'static str>::from(e),

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -9193,22 +9193,6 @@ pub fn write_file_with_path_buffer(
     r.map(|_| buffer.len())
 }
 
-/// `bun.fetchCacheDirectoryPath` — resolve `$BUN_INSTALL_CACHE_DIR` /
-/// `$XDG_CACHE_HOME/.bun/install/cache` / `$HOME/.bun/install/cache`.
-/// full env-override chain lives in `bun_install`; this is the
-/// fallback so the symbol resolves at T1. Returns an owned path (caller frees).
-pub fn fetch_cache_directory_path() -> Vec<u8> {
-    if let Some(v) = bun_core::getenv_z(bun_core::zstr!("BUN_INSTALL_CACHE_DIR")) {
-        return v.to_vec();
-    }
-    if let Some(home) = bun_core::getenv_z(bun_core::zstr!("HOME")) {
-        let mut p = home.to_vec();
-        p.extend_from_slice(b"/.bun/install/cache");
-        return p;
-    }
-    b".bun-cache".to_vec()
-}
-
 // ──────────────────────────────────────────────────────────────────────────
 // OUTPUT_SINK — bun_core's stderr vtable, installed by us at init (B-0 hook).
 // ──────────────────────────────────────────────────────────────────────────

--- a/test/bundler/compile-cross-cache-dir.test.ts
+++ b/test/bundler/compile-cross-cache-dir.test.ts
@@ -1,0 +1,163 @@
+// `bun build --compile --target=<not-host>` caches the downloaded base
+// executable under the bun install cache. That directory must be resolved
+// through the same env-override chain `bun install` uses
+// (BUN_INSTALL_CACHE_DIR -> BUN_INSTALL -> XDG_CACHE_HOME -> HOME),
+// not a stub that only reads HOME.
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Target darwin so inject() takes the Mach-O path on every host. The cached
+// "binary" is a minimal Mach-O with a __BUN/__bun section big enough for the
+// module graph, so the build completes in milliseconds without touching the
+// network or the real (1GB) debug bun executable.
+const VERSION_STR = "bun-darwin-x64-v1.0.99";
+const TARGET_FLAG = "--target=bun-darwin-x64-modern-v1.0.99";
+
+function machoTemplate(): Buffer {
+  const MH_MAGIC_64 = 0xfeedfacf;
+  const CPU_TYPE_X86_64 = 0x01000007;
+  const MH_EXECUTE = 2;
+  const LC_SEGMENT_64 = 0x19;
+  const bunFileOff = 0x4000;
+  const fileSize = 0x8100;
+  const segCmdSize = 72;
+  const sectSize = 80;
+  const sizeofcmds = segCmdSize + sectSize + segCmdSize;
+  const buf = Buffer.alloc(fileSize);
+  const writeName = (off: number, name: string) => buf.write(name, off, 16, "latin1");
+
+  buf.writeUInt32LE(MH_MAGIC_64, 0);
+  buf.writeInt32LE(CPU_TYPE_X86_64, 4);
+  buf.writeInt32LE(3, 8);
+  buf.writeUInt32LE(MH_EXECUTE, 12);
+  buf.writeUInt32LE(2, 16);
+  buf.writeUInt32LE(sizeofcmds, 20);
+
+  let o = 32;
+  buf.writeUInt32LE(LC_SEGMENT_64, o);
+  buf.writeUInt32LE(segCmdSize + sectSize, o + 4);
+  writeName(o + 8, "__BUN");
+  buf.writeBigUInt64LE(0x1_0000_4000n, o + 24);
+  buf.writeBigUInt64LE(0x4000n, o + 32);
+  buf.writeBigUInt64LE(BigInt(bunFileOff), o + 40);
+  buf.writeBigUInt64LE(0x4000n, o + 48);
+  buf.writeInt32LE(7, o + 56);
+  buf.writeInt32LE(3, o + 60);
+  buf.writeUInt32LE(1, o + 64);
+
+  o += segCmdSize;
+  writeName(o, "__bun");
+  writeName(o + 16, "__BUN");
+  buf.writeBigUInt64LE(0x1_0000_4000n, o + 32);
+  buf.writeBigUInt64LE(0x4000n, o + 40);
+  buf.writeUInt32LE(bunFileOff, o + 48);
+  buf.writeUInt32LE(14, o + 52);
+
+  o += sectSize;
+  buf.writeUInt32LE(LC_SEGMENT_64, o);
+  buf.writeUInt32LE(segCmdSize, o + 4);
+  writeName(o + 8, "__LINKEDIT");
+  buf.writeBigUInt64LE(0x1_0000_8000n, o + 24);
+  buf.writeBigUInt64LE(0x1000n, o + 32);
+  buf.writeBigUInt64LE(BigInt(bunFileOff + 0x4000), o + 40);
+  buf.writeBigUInt64LE(0x100n, o + 48);
+  buf.writeInt32LE(1, o + 56);
+  buf.writeInt32LE(1, o + 60);
+
+  return buf;
+}
+
+function placeValidBinary(root: string, relCacheDir: string) {
+  const cacheDir = join(root, relCacheDir);
+  mkdirSync(cacheDir, { recursive: true });
+  writeFileSync(join(cacheDir, VERSION_STR), machoTemplate());
+}
+
+function placeMarker(root: string, relCacheDir: string, marker: string) {
+  const cacheDir = join(root, relCacheDir);
+  mkdirSync(cacheDir, { recursive: true });
+  writeFileSync(join(cacheDir, VERSION_STR), marker);
+}
+
+async function build(cwd: string, env: NodeJS.Dict<string | undefined>) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--compile", TARGET_FLAG, join(cwd, "entry.js"), "--outfile", join(cwd, "out")],
+    env: env as NodeJS.Dict<string>,
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe.concurrent("bun build --compile cross-compile cache directory resolution", () => {
+  for (const [label, envVar, relCacheDir] of [
+    ["BUN_INSTALL", "BUN_INSTALL", join("override", "install", "cache")],
+    ["XDG_CACHE_HOME", "XDG_CACHE_HOME", join("override", ".bun", "install", "cache")],
+  ] as const) {
+    test(`honors $${label} ahead of $HOME`, async () => {
+      using dir = tempDir("compile-cross-cache", {
+        "entry.js": `console.log("ok");`,
+      });
+      const root = String(dir);
+
+      // Wrong answer: the HOME-derived cache location. A bogus marker here makes
+      // the inject step fail loudly if the override is ignored.
+      placeMarker(root, join("home", ".bun", "install", "cache"), "WRONG-HOME-CACHE");
+      // Correct answer: the higher-precedence override, pre-populated with a
+      // valid Mach-O so no download is needed.
+      placeValidBinary(root, relCacheDir);
+
+      const env = {
+        ...bunEnv,
+        BUN_INSTALL_CACHE_DIR: undefined,
+        BUN_INSTALL: undefined,
+        XDG_CACHE_HOME: undefined,
+        HOME: join(root, "home"),
+        USERPROFILE: join(root, "home"),
+        [envVar]: join(root, "override"),
+      };
+
+      const { stdout, stderr, exitCode } = await build(root, env);
+      expect({ stdout, stderr, exitCode }).toEqual({
+        stdout: expect.not.stringContaining("Download"),
+        stderr: expect.not.stringContaining("error:"),
+        exitCode: 0,
+      });
+      expect(await Bun.file(join(root, "out")).exists()).toBe(true);
+    });
+  }
+
+  test("falls back to node_modules/.bun-cache when no HOME-family var is set", async () => {
+    using dir = tempDir("compile-cross-cache", {
+      "entry.js": `console.log("ok");`,
+    });
+    const root = String(dir);
+
+    // Stub fallback was `$cwd/.bun-cache`; the faithful port falls back to
+    // `$cwd/node_modules/.bun-cache`. Seed both so neither code path needs
+    // network: the build succeeds only when the node_modules path wins.
+    placeMarker(root, ".bun-cache", "WRONG-STUB-FALLBACK");
+    placeValidBinary(root, join("node_modules", ".bun-cache"));
+
+    const env = {
+      ...bunEnv,
+      BUN_INSTALL_CACHE_DIR: undefined,
+      BUN_INSTALL: undefined,
+      XDG_CACHE_HOME: undefined,
+      HOME: undefined,
+      USERPROFILE: undefined,
+    };
+
+    const { stdout, stderr, exitCode } = await build(root, env);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: expect.not.stringContaining("Download"),
+      stderr: expect.not.stringContaining("error:"),
+      exitCode: 0,
+    });
+    expect(await Bun.file(join(root, "out")).exists()).toBe(true);
+  });
+});

--- a/test/bundler/compile-cross-cache-dir.test.ts
+++ b/test/bundler/compile-cross-cache-dir.test.ts
@@ -121,9 +121,8 @@ describe.concurrent("bun build --compile cross-compile cache directory resolutio
         [envVar]: join(root, "override"),
       };
 
-      const { stdout, stderr, exitCode } = await build(root, env);
-      expect({ stdout, stderr, exitCode }).toEqual({
-        stdout: expect.not.stringContaining("Download"),
+      const { stderr, exitCode } = await build(root, env);
+      expect({ stderr, exitCode }).toEqual({
         stderr: expect.not.stringContaining("error:"),
         exitCode: 0,
       });
@@ -152,9 +151,8 @@ describe.concurrent("bun build --compile cross-compile cache directory resolutio
       USERPROFILE: undefined,
     };
 
-    const { stdout, stderr, exitCode } = await build(root, env);
-    expect({ stdout, stderr, exitCode }).toEqual({
-      stdout: expect.not.stringContaining("Download"),
+    const { stderr, exitCode } = await build(root, env);
+    expect({ stderr, exitCode }).toEqual({
       stderr: expect.not.stringContaining("error:"),
       exitCode: 0,
     });

--- a/test/bundler/compile-cross-cache-dir.test.ts
+++ b/test/bundler/compile-cross-cache-dir.test.ts
@@ -4,9 +4,9 @@
 // (BUN_INSTALL_CACHE_DIR -> BUN_INSTALL -> XDG_CACHE_HOME -> HOME),
 // not a stub that only reads HOME.
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { bunEnv, bunExe, tempDir } from "harness";
 
 // Target darwin so inject() takes the Mach-O path on every host. The cached
 // "binary" is a minimal Mach-O with a __BUN/__bun section big enough for the

--- a/test/bundler/compile-cross-cache-dir.test.ts
+++ b/test/bundler/compile-cross-cache-dir.test.ts
@@ -4,7 +4,7 @@
 // (BUN_INSTALL_CACHE_DIR -> BUN_INSTALL -> XDG_CACHE_HOME -> HOME),
 // not a stub that only reads HOME.
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -130,7 +130,9 @@ describe.concurrent("bun build --compile cross-compile cache directory resolutio
     });
   }
 
-  test("falls back to node_modules/.bun-cache when no HOME-family var is set", async () => {
+  // Windows always provides USERPROFILE to new processes, so the "no HOME"
+  // branch can't be reached there; the precedence tests above cover Windows.
+  test.skipIf(isWindows)("falls back to node_modules/.bun-cache when no HOME-family var is set", async () => {
     using dir = tempDir("compile-cross-cache", {
       "entry.js": `console.log("ok");`,
     });


### PR DESCRIPTION
### Problem
- `bun build --compile --target=<other>` ignores `BUN_INSTALL` and `XDG_CACHE_HOME` when it looks for the cached base executable. It re-downloads into `$HOME/.bun/install/cache` on every build. With a read-only `$HOME` and a writable `$BUN_INSTALL` the build fails with `Failed to extract executable for 'bun-darwin-aarch64-vX'. The download may be incomplete.` where 1.3.14 succeeded.
- The cause: `CompileTarget::exe_path` (`src/options_types/compile_target.rs:190`) took its env loader as `_env` and called `bun_sys::fetch_cache_directory_path`, a porting stub that read only `BUN_INSTALL_CACHE_DIR` and `HOME` through raw `getenv`.

### Fix
- Move the cache directory chain that `bun install` already uses into `bun_options_types::install_cache::fetch_cache_directory_path`. The chain is `BUN_INSTALL_CACHE_DIR`, the bunfig `cache_directory`, `BUN_INSTALL/install/cache`, `XDG_CACHE_HOME/.bun/install/cache`, `HOME/.bun/install/cache`, then `node_modules/.bun-cache`. `bun_install` now delegates to it and passes its bunfig override. `exe_path` calls it with no override and reads through the env loader it already receives. The `bun_sys` stub is removed.
- Correct because both callers resolve against the same `top_level_dir` with the same `join_abs_string::<Loose>` that `FileSystem::abs` used, so `bun install` behavior does not change and the compile path gains the missing branches.
- When the move of the downloaded executable into the cache fails, the error now names the path and the errno (`Failed to write cached executable for '<target>' to "<path>": EACCES`) through a new `Error::CacheWriteFailed(SystemErrno)`.
- Verified: `test/bundler/compile-cross-cache-dir.test.ts` (3 tests, all fail on the released bun, pass on the debug build). Also ran `bun-pm.test.ts` (cache), `bun-install.test.ts` (the `BUN_INSTALL_CACHE_DIR` cases), `bundler_compile.test.ts` (Mach-O template).

### Background
- The base executable for a cross-compile is the bun binary for the target platform. Bun downloads it from npm once and keeps it under the install cache, named like `bun-darwin-x64-v1.0.99`.
- `bun_install` depends on `bun_options_types`, so `CompileTarget` could not call the `bun_install` helper directly. The shared function lives in `bun_options_types`, which both crates reach.
- The test writes a minimal Mach-O into the expected cache location and a bogus marker into the `HOME` location. Targeting darwin makes every host take the Mach-O inject path, so the build succeeds only when the override wins, without any network access.

<details><summary>Notes</summary>

- Fail-before on the released build: the `HOME` marker is picked, Mach-O parsing fails, exit 1. With no `HOME` at all, the stub fell back to `./.bun-cache` and the build tried a network download.
- The `node_modules/.bun-cache` fallback test is skipped on Windows. Windows always supplies `USERPROFILE` to a child process, so that branch is unreachable there. The two precedence tests run on Windows.
- The `UnsupportedTarget` variant that an earlier revision matched on was removed on main as dead code (#36474) and is not reintroduced.
- While writing the test: `MachoFile::init` panics (`range end index 32 out of range`) on an input shorter than the Mach-O header. Reported separately.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/compile-cross-cache-dir.test.ts

<!-- robobun:evidence:end -->