### PR TITLE
Bun.serve: flush buffered bytes when a direct stream's sync pull() calls controller.close()

### DIFF
--- a/docs/runtime/streams.mdx
+++ b/docs/runtime/streams.mdx
@@ -64,11 +64,14 @@ const stream = new ReadableStream({
   pull(controller) {
     controller.write("hello");
     controller.write("world");
+    controller.close(); // [!code ++]
   },
 });
 ```
 
 When using a direct `ReadableStream`, the destination handles all chunk queueing. The consumer of the stream receives exactly what is passed to `controller.write()`, without any encoding or modification.
+
+Call `controller.close()` when you're done writing. If `pull()` returns without closing, the destination stays open so you can keep writing through the captured controller and close later (this is how `react-dom/server`'s `renderToReadableStream` streams Suspense boundaries).
 
 ### Handling backpressure
 

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -402,10 +402,11 @@ JSC_DEFINE_HOST_FUNCTION(${controller}__close, (JSC::JSGlobalObject * lexicalGlo
 
     // close() with no argument is normal completion: flush buffered bytes and
     // terminate like end(). close(error) is the readStreamIntoSink abrupt
-    // path (rsisSinkClose): the sink is torn down without a clean terminator
+    // path (rsisSinkClose always appends exactly one argument, even when the
+    // reason is undefined): the sink is torn down without a clean terminator
     // so the peer observes truncation, and the pump's promise rejection
     // drives handle_reject_stream.
-    if (callFrame->argument(0).isUndefinedOrNull()) {
+    if (callFrame->argumentCount() == 0) {
         ${name}__endWithSink(ptr, lexicalGlobalObject);
     } else {
         ${name}__close(lexicalGlobalObject, ptr);

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -400,7 +400,16 @@ JSC_DEFINE_HOST_FUNCTION(${controller}__close, (JSC::JSGlobalObject * lexicalGlo
     ${name}__controllerDetached(ptr, JSC::JSValue::encode(controller));
     controller->m_sinkPtr = nullptr;
 
-    ${name}__close(lexicalGlobalObject, ptr);
+    // close() with no argument is normal completion: flush buffered bytes and
+    // terminate like end(). close(error) is the readStreamIntoSink abrupt
+    // path (rsisSinkClose): the sink is torn down without a clean terminator
+    // so the peer observes truncation, and the pump's promise rejection
+    // drives handle_reject_stream.
+    if (callFrame->argument(0).isUndefinedOrNull()) {
+        ${name}__endWithSink(ptr, lexicalGlobalObject);
+    } else {
+        ${name}__close(lexicalGlobalObject, ptr);
+    }
 
     // detach() must still fire onClose (it transitions the direct
     // ReadableStream to closed/errored and calls underlyingSource.cancel())

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1785,17 +1785,10 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         self.unregister_auto_flusher();
     }
 
+    /// Abort path: buffered bytes are intentionally left unflushed so the peer
+    /// observes a truncated body. `end_from_js` is the normal-completion path.
     pub fn end(&mut self, err: Option<SysError>) -> bun_sys::Result<()> {
         bun_core::scoped_log!(HTTPServerWritableLog, "end({:?})", err);
-
-        // controller.close() reaches here via js_close with err=None. Treat it
-        // as end(): flush buffered bytes and terminate the response. The
-        // err=Some branch below stays the abort path (no partial flush).
-        if err.is_none() {
-            if let Some(global) = self.global_this {
-                return self.end_from_js(global.get()).map(|_| ());
-            }
-        }
 
         if self.requested_end {
             return bun_sys::Result::Ok(());

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1785,9 +1785,17 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         self.unregister_auto_flusher();
     }
 
-    /// In this case, it's always an error
     pub fn end(&mut self, err: Option<SysError>) -> bun_sys::Result<()> {
         bun_core::scoped_log!(HTTPServerWritableLog, "end({:?})", err);
+
+        // controller.close() reaches here via js_close with err=None. Treat it
+        // as end(): flush buffered bytes and terminate the response. The
+        // err=Some branch below stays the abort path (no partial flush).
+        if err.is_none() {
+            if let Some(global) = self.global_this {
+                return self.end_from_js(global.get()).map(|_| ());
+            }
+        }
 
         if self.requested_end {
             return bun_sys::Result::Ok(());

--- a/test/js/bun/http/serve-direct-readable-stream.test.ts
+++ b/test/js/bun/http/serve-direct-readable-stream.test.ts
@@ -506,6 +506,82 @@ test("sync pull() that ends later streams the whole body", async () => {
   expect(response.status).toBe(200);
 });
 
+// controller.close() reached the sink via js_close -> HTTPServerWritable::end(None),
+// which set requested_end and returned without flushing the buffer. The response
+// then ended empty via the no-promise fallback in do_render_stream, so a sync
+// pull() that wrote and closed (the shape docs/runtime/streams.mdx teaches)
+// delivered zero bytes. close() now flushes like end().
+describe.each([1, 11, 2048, 200_000])("sync pull() that writes %d bytes and calls close()", size => {
+  const body = Buffer.alloc(size, "y").toString();
+
+  test("delivers the full body", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            pull(c: any) {
+              c.write(body);
+              c.close();
+            },
+          } as any),
+        );
+      },
+    });
+    const response = await fetch(server.url);
+    const text = await response.text();
+    expect({ status: response.status, length: text.length, matches: text === body }).toEqual({
+      status: 200,
+      length: size,
+      matches: true,
+    });
+  });
+
+  test("delivers the full body over TLS", async () => {
+    using server = Bun.serve({
+      port: 0,
+      tls,
+      fetch() {
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            pull(c: any) {
+              c.write(body);
+              c.close();
+            },
+          } as any),
+        );
+      },
+    });
+    const response = await fetch(server.url, { tls: { rejectUnauthorized: false } });
+    const text = await response.text();
+    expect({ status: response.status, length: text.length, matches: text === body }).toEqual({
+      status: 200,
+      length: size,
+      matches: true,
+    });
+  });
+});
+
+test("sync pull() that calls close() with nothing written ends the response", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response(
+        new ReadableStream({
+          type: "direct",
+          pull(c: any) {
+            c.close();
+          },
+        } as any),
+      );
+    },
+  });
+  const response = await fetch(server.url);
+  expect({ status: response.status, body: await response.text() }).toEqual({ status: 200, body: "" });
+});
+
 test("sync pull() that writes nothing and ends later still responds", async () => {
   let controller: any;
   const pulled = Promise.withResolvers<void>();

--- a/test/js/bun/http/serve-stream-body-error-fixture.ts
+++ b/test/js/bun/http/serve-stream-body-error-fixture.ts
@@ -73,6 +73,20 @@ const sources: Record<string, () => ReadableStream> = {
         throw new Error("boom");
       },
     }),
+  // Same, but controller.error() with no argument: the stored error is
+  // undefined (WHATWG default). The sink's abort close still receives exactly
+  // one (undefined) argument from rsisSinkClose, and the connection must be
+  // force-closed without a clean chunked terminator.
+  "mid-stream-nullish-error": () =>
+    new ReadableStream({
+      async pull(c) {
+        const { promise, resolve } = Promise.withResolvers<void>();
+        midStreamResolve = resolve;
+        c.enqueue("chunk-a");
+        await promise;
+        c.error();
+      },
+    }),
   // The client aborts the download mid-stream, which makes Bun cancel the body
   // stream; the source's cancel() then throws. That rejection belongs to a
   // promise Bun created internally and must not surface as unhandledRejection.

--- a/test/js/bun/http/serve-stream-body-error.test.ts
+++ b/test/js/bun/http/serve-stream-body-error.test.ts
@@ -98,6 +98,25 @@ test.concurrent("mid-stream error: the chunked body is not terminated as complet
   });
 });
 
+// controller.error() with no argument stores `undefined` as the reason;
+// rsisSinkClose forwards it to the sink controller's close(reason) with
+// exactly one (undefined) argument. The connection must still be force-closed
+// without a terminator.
+test.concurrent("mid-stream nullish error: the chunked body is not terminated as complete", async () => {
+  const { stdout, exitCode } = await runFixture("mid-stream-nullish-error");
+  expect({ result: JSON.parse(stdout), exitCode }).toEqual({
+    result: {
+      statusLine: "HTTP/1.1 200 OK",
+      cleanChunkedTerminator: false,
+      body: "7\r\nchunk-a\r\n",
+      errorCb: 0,
+      unhandled: 0,
+      secondStatusLine: "HTTP/1.1 200 OK",
+    },
+    exitCode: 0,
+  });
+});
+
 // Under `development: true` (the default for a plain script) the mid-stream
 // error is reported by handle_reject_stream, and the connection must still be
 // aborted: development mode never has a dev_server() for a plain Bun.serve,


### PR DESCRIPTION
### Repro

```ts
const s = Bun.serve({
  port: 0,
  fetch() {
    return new Response(new ReadableStream({
      type: "direct",
      pull(c) {
        c.write("hello world");
        c.close();
      },
    }));
  },
});
const r = await fetch(s.url);
console.log(r.status, JSON.stringify(await r.text()));
s.stop(true);
// before: 200 ""
// after:  200 "hello world"
```

Since #32140, a `type: "direct"` `ReadableStream` whose synchronous `pull()` returns without closing keeps the response open until `controller.end()` (react-dom/server.bun's `renderToReadableStream` depends on this to stream Suspense boundaries after `pull()` returns). That made the example at `docs/runtime/streams.mdx:62-68`, which writes and returns without calling `close()`, pin the connection until `idleTimeout` and surface `ECONNRESET` to the client. Adding the `controller.close()` the standard `ReadableStream` controller API expects then hit the bug above and still delivered zero bytes for writes below the auto-flush threshold, so there was no working shape for the documented synchronous case.

### Cause

`controller.close()` on the sink controller dispatches via the generated `${controller}__close`, which always called `${name}__close` -> `JSSink::js_close` -> `HTTPServerWritable::end(None)`. With buffered bytes, that path set `requested_end = true` and returned without flushing; the `readable_len > 0` branch was a no-op. Back in `readDirectStream` the stream is already `Closed`, so it returns `jsUndefined()`, and `do_render_stream`'s no-promise fallback runs `mark_done()` immediately before `finalize()`, so `finalize`'s `flush_no_wait()` branch is skipped, `destroy_sink` frees the buffer with the bytes still in it, and `render_missing()` ends the response empty.

`controller.end()` took the sibling path (`${name}__endWithSink` -> `end_from_js`), which flushes via `send_readable(0)` and parks a `pending_flush` on backpressure, so it always delivered the full body.

### Fix

The generated `${controller}__close` now routes on its argument: `close()` with no argument is normal completion and calls `${name}__endWithSink` (flush buffered bytes, terminate, park a `pending_flush` on backpressure for `do_render_stream` to wait on), matching `controller.end()`. `close(error)` is the `readStreamIntoSink` abrupt path (`rsisSinkClose(op, error)` invokes `.close(error)` when a default `ReadableStream` body errors) and keeps the existing `${name}__close` call so the sink is torn down without a clean terminator and `handle_reject_stream` force-closes the connection per RFC 9112 section 7.

The docs example is updated to call `controller.close()` and notes that returning without closing leaves the destination open for captured-controller writes (the React SSR pattern). Reverting to the 1.3.x auto-close on synchronous return would re-break #32137, so the #32140 contract is kept.

The no-promise fallback in `RequestContext.rs` is left in place: it is still the residual catch-all when `readDirectStream` returns `jsUndefined()` and is not dead after #32140.

### Tests

New cases in `test/js/bun/http/serve-direct-readable-stream.test.ts`:

- `sync pull() that writes N bytes and calls close()` for N in `{1, 11, 2048, 200000}` over HTTP and HTTPS. The 1- and 11-byte cases deliver `""` on the unfixed build; 2048 and 200000 happened to work because `write()` auto-flushed past `highWaterMark`, and stay as sibling coverage.
- `sync pull() that calls close() with nothing written` ends the response.

The existing React-pattern tests (`sync pull() that ends later ...`, `cancel() fires ...`, the h3 backpressure cases, and the AsyncLocalStorage leak test) all still pass. `serve-stream-body-error.test.ts` covers the `close(error)` abort path (mid-stream error on a default `ReadableStream` body must not send a clean chunked terminator), and `bake/dev/react-response.test.ts` and `direct-readable-stream.test.tsx` exercise react-dom's `server.bun` build end to end.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-direct-readable-stream.test.ts test/js/bun/http/serve-stream-body-error.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (699fcebc0)

test/js/bun/http/serve-direct-readable-stream.test.ts:
(pass) HTTPResponseSink displays correct message [86.89ms]
(pass) controller.end() after pull() resolved does not use the sink after free [894.04ms]
(pass) client disconnect after controller.end() with a parked pull() does not use the socket after free [2428.51ms]
(pass) client disconnect after controller.end() with a parked rejecting pull() does not use the socket after free [2389.59ms]
(pass) h3: controller.end() from a parked pull() disarms onAborted before the context is released [1237.07ms]
(pass) sync pull() throw after status is written does not re-render error() > body bytes already flushed:
... (truncated)

release without fix: 1 failed, 5 skipped
bun test v1.4.0-canary.1 (3cbdbea7c)

test/js/bun/http/serve-direct-readable-stream.test.ts:
(pass) HTTPResponseSink displays correct message [13.18ms]
(skip) controller.end() after pull() resolved does not use the sink after free
(skip) client disconnect after controller.end() with a parked pull() does not use the socket after free
(skip) client disconnect after controller.end() with a parked rejecting pull() does not use the socket after free
(skip) h3: controller.end() from a parked pull() disarms onAborted before the context is released
(pass) sync pull() throw after status is written does not re-render error() > body bytes already flushed: connection is force-closed [44.04ms]
(pass) sync pull() throw after status is written does not re-render error() > no body bytes flushed: stream is ended without splicing error() headers [44.54ms]
(pass) sync pull() that ends later streams the whole body [2.18ms]
(pass) sync pull() that writes 1 bytes and calls close() > delivers the full body [1.45ms]
(pass) sync pull() that writes 1 bytes and calls close() > delivers the full body over TLS [16.34ms]
(pass) sync pull() that writes 11 bytes and calls close() > delivers the fu
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-direct-readable-stream.test.ts test/js/bun/http/serve-stream-body-error.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (699fcebc0)

test/js/bun/http/serve-direct-readable-stream.test.ts:
(pass) HTTPResponseSink displays correct message [82.95ms]
(pass) controller.end() after pull() resolved does not use the sink after free [855.60ms]
(pass) client disconnect after controller.end() with a parked pull() does not use the socket after free [2368.19ms]
(pass) client disconnect after controller.end() with a parked rejecting pull() does not use the socket after free [2352.34ms]
(pass) h3: controller.end() from a parked pull() disarms onAborted before the context is released [1122.41ms]
(pass) sync pull() throw after status is written does not re-render error() > body bytes already flushed:
... (truncated)

release with fix: 5 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 1079ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/91] gen ErrorCode+*.h
[2/50] gen cpp.rs (cppbind)
[3/50] gen JSSink.{cpp,h,lut.h,rs}
generated_jssink.rs: 6 sinks, 72 exported symbols
Generating /workspace/bun/build/release/codegen/JSSink.lut.h from /workspace/bun/build/release/codegen/JSSink.lut.txt
[4/50] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Fou
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/streams.mdx                           |  3 +
 src/codegen/generate-jssink.ts                     | 12 +++-
 src/runtime/webcore/streams.rs                     |  3 +-
 .../bun/http/serve-direct-readable-stream.test.ts  | 76 ++++++++++++++++++++++
 .../js/bun/http/serve-stream-body-error-fixture.ts | 14 ++++
 test/js/bun/http/serve-stream-body-error.test.ts   | 19 ++++++
 6 files changed, 125 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
docs/runtime/streams.mdx                                   1      1      0
src/codegen/generate-jssink.ts                             2      3      0
src/runtime/webcore/streams.rs                             5      3      0
test/js/bun/http/serve-direct-readable-stream.test.ts      1      1      0
test/js/bun/http/serve-stream-body-error-fixture.ts        1      1      0
test/js/bun/http/serve-stream-body-error.test.ts           1      1      0
```

</details>

<!-- robobun:evidence:end -->