### PR TITLE
install: dedupe a transitive wide range onto a root/workspace range across majors

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2137,8 +2137,8 @@ fn get_or_put_resolved_package_with_find_result(
     // SAFETY: `this_ptr` is the sole live `&mut PackageManager` here and
     // `package` was returned by value above, so nothing aliases the lockfile.
     let lockfile = unsafe { &mut *(*this_ptr).lockfile };
-    if lockfile.is_workspace_dependency(dependency_id)
-        || (version.tag == dependency::version::Tag::Npm && version.npm().version.is_exact())
+    if (version.tag == dependency::version::Tag::Npm && version.npm().version.is_exact())
+        || lockfile.is_workspace_dependency(dependency_id)
     {
         lockfile.mark_local_pin(package.meta.id);
     }

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2134,23 +2134,13 @@ fn get_or_put_resolved_package_with_find_result(
     )?)?;
 
     debug_assert!(package.meta.id != invalid_package_id);
-    // Record locally-pinned appends so `Lockfile::get_package_id`'s
-    // order-independence guard leaves them alone: dependencies declared in a
-    // local package.json (root or workspace) are enqueued before any
-    // network-ordered transitive, and an exact `=X.Y.Z` resolves to one
-    // version regardless of order. Everything else the guard may treat as a
-    // network-order artefact.
-    let is_local_pin = {
-        // SAFETY: `this_ptr` is the sole live `&mut PackageManager` here;
-        // `is_workspace_dependency` reads `lockfile.packages` only (disjoint
-        // from `package`, which was returned by-value above).
-        unsafe { &*(*this_ptr).lockfile }.is_workspace_dependency(dependency_id)
-            || (version.tag == dependency::version::Tag::Npm && version.npm().version.is_exact())
-    };
-    if is_local_pin {
-        // SAFETY: `this_ptr` is the sole live `&mut PackageManager` here;
-        // `mark_local_pin` touches `lockfile.local_pinned` only.
-        unsafe { &mut *(*this_ptr).lockfile }.mark_local_pin(package.meta.id);
+    // SAFETY: `this_ptr` is the sole live `&mut PackageManager` here and
+    // `package` was returned by value above, so nothing aliases the lockfile.
+    let lockfile = unsafe { &mut *(*this_ptr).lockfile };
+    if lockfile.is_workspace_dependency(dependency_id)
+        || (version.tag == dependency::version::Tag::Npm && version.npm().version.is_exact())
+    {
+        lockfile.mark_local_pin(package.meta.id);
     }
     // Use scopeguard so success_fn runs on every
     // return below (including the `?` paths). The guard owns the raw pointer so the

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2134,14 +2134,23 @@ fn get_or_put_resolved_package_with_find_result(
     )?)?;
 
     debug_assert!(package.meta.id != invalid_package_id);
-    // Record exact-version pins so `Lockfile::get_package_id`'s
-    // order-independence guard can tell them apart from range-resolved
-    // entries (which it treats as network-order artefacts).
-    if version.tag == dependency::version::Tag::Npm && version.npm().version.is_exact() {
+    // Record locally-pinned appends so `Lockfile::get_package_id`'s
+    // order-independence guard leaves them alone: dependencies declared in a
+    // local package.json (root or workspace) are enqueued before any
+    // network-ordered transitive, and an exact `=X.Y.Z` resolves to one
+    // version regardless of order. Everything else the guard may treat as a
+    // network-order artefact.
+    let is_local_pin = {
         // SAFETY: `this_ptr` is the sole live `&mut PackageManager` here;
-        // `lockfile.exact_pinned` is disjoint from `package` (returned
-        // by-value above).
-        unsafe { &mut *(*this_ptr).lockfile }.mark_exact_pin(package.meta.id);
+        // `is_workspace_dependency` reads `lockfile.packages` only (disjoint
+        // from `package`, which was returned by-value above).
+        unsafe { &*(*this_ptr).lockfile }.is_workspace_dependency(dependency_id)
+            || (version.tag == dependency::version::Tag::Npm && version.npm().version.is_exact())
+    };
+    if is_local_pin {
+        // SAFETY: `this_ptr` is the sole live `&mut PackageManager` here;
+        // `mark_local_pin` touches `lockfile.local_pinned` only.
+        unsafe { &mut *(*this_ptr).lockfile }.mark_local_pin(package.meta.id);
     }
     // Use scopeguard so success_fn runs on every
     // return below (including the `?` paths). The guard owns the raw pointer so the

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -203,11 +203,8 @@ pub struct Lockfile {
     /// Runtime-only — never serialised.
     pub(crate) loaded_package_count: PackageID,
 
-    /// Packages appended for a root/workspace package.json dependency or for an
-    /// exact `=X.Y.Z` dependency. Both resolve independently of manifest
-    /// arrival order, so `get_package_id` may dedupe onto them freely; the
-    /// order-independence guard there only applies to the remaining
-    /// (transitive, range-resolved) entries.
+    /// Packages appended for a root/workspace package.json dependency or an
+    /// exact `=X.Y.Z` dependency; exempt from the guard in `get_package_id`.
     ///
     /// Runtime-only — never serialised.
     pub(crate) local_pinned: DynamicBitSet,
@@ -2042,11 +2039,9 @@ impl Lockfile {
             if !npm_v.satisfies(existing_ver, buf, buf) {
                 return false;
             }
-            // Order-independence guard: a wide range may not collapse onto a
-            // lower major that a sibling's manifest happened to append first.
-            // Lockfile-loaded entries (`loaded_package_count`) and
-            // `local_pinned` entries are order-independent and exempt; a lower
-            // entry within the same major is still ^-compatible and allowed.
+            // A wide range must not collapse onto a lower major that a sibling's
+            // manifest merely happened to append first. Lockfile-loaded and
+            // `local_pinned` entries do not depend on manifest order.
             if id >= loaded_watermark && !local_pinned.is_set_allow_out_of_bound(id as usize, false)
             {
                 if let Some(floor) = resolved_npm_floor {

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -203,14 +203,13 @@ pub struct Lockfile {
     /// Runtime-only — never serialised.
     pub(crate) loaded_package_count: PackageID,
 
-    /// `bit[id] == true` ⇔ package `id` was appended for a dependency that is
-    /// either (a) declared in a local package.json (root or any workspace), or
-    /// (b) an exact `=X.Y.Z` anywhere in the tree. `get_package_id`'s
-    /// order-independence guard never blocks deduping to one of these: a local
-    /// dependency is enqueued before any network-ordered transitive, and an
-    /// exact pin resolves to exactly one version regardless of manifest
-    /// arrival order, so deduping to either is deterministic. Runtime-only —
-    /// never serialised; sized lazily in `mark_local_pin`.
+    /// Packages appended for a root/workspace package.json dependency or for an
+    /// exact `=X.Y.Z` dependency. Both resolve independently of manifest
+    /// arrival order, so `get_package_id` may dedupe onto them freely; the
+    /// order-independence guard there only applies to the remaining
+    /// (transitive, range-resolved) entries.
+    ///
+    /// Runtime-only — never serialised.
     pub(crate) local_pinned: DynamicBitSet,
 }
 
@@ -1984,8 +1983,7 @@ impl Lockfile {
         self.loaded_package_count = self.packages.len() as PackageID;
     }
 
-    /// Record that package `id` was appended for a dependency whose resolution
-    /// order is deterministic (see the `local_pinned` field doc).
+    /// See `local_pinned`.
     #[inline]
     pub(crate) fn mark_local_pin(&mut self, id: PackageID) {
         let i = id as usize;
@@ -2044,24 +2042,11 @@ impl Lockfile {
             if !npm_v.satisfies(existing_ver, buf, buf) {
                 return false;
             }
-            // Order-independence guard. We refuse to dedupe a wide range to a
-            // *lower* existing entry only when ALL of the following hold:
-            //   - the entry was appended in this resolve session
-            //     (lockfile-loaded entries are the user's existing pin),
-            //   - the entry was NOT appended for a dependency declared in a
-            //     local package.json (root or workspace) nor for an exact
-            //     `=X.Y.Z` — either is processed in a deterministic order
-            //     independent of manifest arrival, so deduping onto it is
-            //     stable and npm-compatible (`dragon test 2` /
-            //     "dependency from root satisfies range from dependency" /
-            //     "transitive wide range dedupes onto root range"),
-            //   - the manifest's best-match is a *different major* (within a
-            //     major, deduping to an older patch is the long-standing
-            //     behaviour and the worst case is still ^-compatible).
-            // What this leaves is exactly the cross-parent network-order
-            // flake: a wide range (`*`, `>=X`) collapsing onto a sibling's
-            // *transitive range-resolved* lower major depending on whose
-            // manifest landed first ("text lockfile is hoisted").
+            // Order-independence guard: a wide range may not collapse onto a
+            // lower major that a sibling's manifest happened to append first.
+            // Lockfile-loaded entries (`loaded_package_count`) and
+            // `local_pinned` entries are order-independent and exempt; a lower
+            // entry within the same major is still ^-compatible and allowed.
             if id >= loaded_watermark && !local_pinned.is_set_allow_out_of_bound(id as usize, false)
             {
                 if let Some(floor) = resolved_npm_floor {

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -203,14 +203,15 @@ pub struct Lockfile {
     /// Runtime-only — never serialised.
     pub(crate) loaded_package_count: PackageID,
 
-    /// `bit[id] == true` ⇔ package `id` was appended for a dependency whose
-    /// version range was an exact `=X.Y.Z` (i.e. the user — root or workspace
-    /// — pinned this exact version somewhere in the tree). `get_package_id`'s
-    /// order-independence guard never blocks deduping to one of these: an
-    /// exact pin is a deliberate choice, not an artifact of which manifest
-    /// happened to land first. Runtime-only — never serialised; sized lazily
-    /// in `mark_exact_pin`.
-    pub(crate) exact_pinned: DynamicBitSet,
+    /// `bit[id] == true` ⇔ package `id` was appended for a dependency that is
+    /// either (a) declared in a local package.json (root or any workspace), or
+    /// (b) an exact `=X.Y.Z` anywhere in the tree. `get_package_id`'s
+    /// order-independence guard never blocks deduping to one of these: a local
+    /// dependency is enqueued before any network-ordered transitive, and an
+    /// exact pin resolves to exactly one version regardless of manifest
+    /// arrival order, so deduping to either is deterministic. Runtime-only —
+    /// never serialised; sized lazily in `mark_local_pin`.
+    pub(crate) local_pinned: DynamicBitSet,
 }
 
 pub(crate) type PackageList = self::package::List<u64>;
@@ -1971,7 +1972,7 @@ impl Lockfile {
             // session-appended, so the order-independence guard in
             // `get_package_id` applies from id 0.
             loaded_package_count: 0,
-            exact_pinned: DynamicBitSet::default(),
+            local_pinned: DynamicBitSet::default(),
         }
     }
 
@@ -1983,15 +1984,15 @@ impl Lockfile {
         self.loaded_package_count = self.packages.len() as PackageID;
     }
 
-    /// Record that package `id` was appended via an exact-version dependency
-    /// (`=X.Y.Z`). See the `exact_pinned` field doc.
+    /// Record that package `id` was appended for a dependency whose resolution
+    /// order is deterministic (see the `local_pinned` field doc).
     #[inline]
-    pub(crate) fn mark_exact_pin(&mut self, id: PackageID) {
+    pub(crate) fn mark_local_pin(&mut self, id: PackageID) {
         let i = id as usize;
-        if self.exact_pinned.bit_length() <= i {
-            bun_core::handle_oom(self.exact_pinned.resize(i + 1, false));
+        if self.local_pinned.bit_length() <= i {
+            bun_core::handle_oom(self.local_pinned.resize(i + 1, false));
         }
-        self.exact_pinned.set(i);
+        self.local_pinned.set(i);
     }
 
     pub(crate) fn get_package_id(
@@ -2030,7 +2031,7 @@ impl Lockfile {
         let buf = self.buffers.string_bytes.as_slice();
 
         let loaded_watermark = self.loaded_package_count;
-        let exact_pinned = &self.exact_pinned;
+        let local_pinned = &self.local_pinned;
         let try_satisfies_dedupe = |id: PackageID| -> bool {
             let existing = &resolutions[id as usize];
             if existing.tag != ResolutionTag::Npm {
@@ -2047,18 +2048,21 @@ impl Lockfile {
             // *lower* existing entry only when ALL of the following hold:
             //   - the entry was appended in this resolve session
             //     (lockfile-loaded entries are the user's existing pin),
-            //   - the entry was NOT appended for an exact-`=X.Y.Z` dependency
-            //     (an exact pin anywhere in the tree is a deliberate choice,
-            //     not a network-order artefact — `dragon test 2` /
-            //     "dependency from root satisfies range from dependency"),
+            //   - the entry was NOT appended for a dependency declared in a
+            //     local package.json (root or workspace) nor for an exact
+            //     `=X.Y.Z` — either is processed in a deterministic order
+            //     independent of manifest arrival, so deduping onto it is
+            //     stable and npm-compatible (`dragon test 2` /
+            //     "dependency from root satisfies range from dependency" /
+            //     "transitive wide range dedupes onto root range"),
             //   - the manifest's best-match is a *different major* (within a
             //     major, deduping to an older patch is the long-standing
             //     behaviour and the worst case is still ^-compatible).
             // What this leaves is exactly the cross-parent network-order
             // flake: a wide range (`*`, `>=X`) collapsing onto a sibling's
-            // *range-resolved* lower major depending on whose manifest landed
-            // first ("text lockfile is hoisted").
-            if id >= loaded_watermark && !exact_pinned.is_set_allow_out_of_bound(id as usize, false)
+            // *transitive range-resolved* lower major depending on whose
+            // manifest landed first ("text lockfile is hoisted").
+            if id >= loaded_watermark && !local_pinned.is_set_allow_out_of_bound(id as usize, false)
             {
                 if let Some(floor) = resolved_npm_floor {
                     if existing_ver.order(floor, buf, buf) == Ordering::Less

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -4568,6 +4568,109 @@ describe("hoisting", async () => {
       lockfile,
     );
   });
+
+  test("transitive wide range dedupes onto root range across majors", async () => {
+    // Root declares `hoist-lockfile-shared: ^1.0.1` (resolves to 1.0.2).
+    // `hoist-lockfile-1` depends on `hoist-lockfile-shared: *` (best-match 2.0.2).
+    // The `*` satisfies 1.0.2, so it must dedupe onto the root's copy instead of
+    // nesting a second install at 2.0.2 (npm also dedupes here).
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: {
+          "hoist-lockfile-1": "1.0.0",
+          "hoist-lockfile-shared": "^1.0.1",
+        },
+      }),
+    );
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stderr: "pipe",
+      stdout: "pipe",
+      env,
+    });
+
+    const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    expect(err).toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+      expect.stringContaining("bun install v1."),
+      "",
+      "+ hoist-lockfile-1@1.0.0",
+      expect.stringContaining("+ hoist-lockfile-shared@1.0.2"),
+      "",
+      "2 packages installed",
+    ]);
+    expect(await file(join(packageDir, "node_modules", "hoist-lockfile-shared", "package.json")).json()).toMatchObject({
+      name: "hoist-lockfile-shared",
+      version: "1.0.2",
+    });
+    expect(await exists(join(packageDir, "node_modules", "hoist-lockfile-1", "node_modules"))).toBeFalse();
+    expect(exitCode).toBe(0);
+    assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
+
+    // Second install from the saved lockfile must not rewrite it.
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+    const second = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stderr: "pipe",
+      stdout: "pipe",
+      env,
+    });
+    const [out2, err2, exitCode2] = await Promise.all([second.stdout.text(), second.stderr.text(), second.exited]);
+    expect(err2).not.toContain("Saved lockfile");
+    expect(err2).not.toContain("error:");
+    expect(out2).toContain("2 packages installed");
+    expect(await exists(join(packageDir, "node_modules", "hoist-lockfile-1", "node_modules"))).toBeFalse();
+    expect(exitCode2).toBe(0);
+  });
+
+  test("transitive wide range dedupes onto workspace range across majors", async () => {
+    // Same as above but the narrow range lives in a workspace package.json.
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        workspaces: ["pkg-a"],
+      }),
+    );
+    await mkdir(join(packageDir, "pkg-a"));
+    await write(
+      join(packageDir, "pkg-a", "package.json"),
+      JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+        dependencies: {
+          "hoist-lockfile-1": "1.0.0",
+          "hoist-lockfile-shared": "^1.0.1",
+        },
+      }),
+    );
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stderr: "pipe",
+      stdout: "pipe",
+      env,
+    });
+
+    const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    expect(err).toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(out).toContain("packages installed");
+    expect(await file(join(packageDir, "node_modules", "hoist-lockfile-shared", "package.json")).json()).toMatchObject({
+      name: "hoist-lockfile-shared",
+      version: "1.0.2",
+    });
+    expect(await exists(join(packageDir, "node_modules", "hoist-lockfile-1", "node_modules"))).toBeFalse();
+    expect(exitCode).toBe(0);
+    assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
+  });
 });
 
 describe("transitive file dependencies", () => {

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -4662,7 +4662,11 @@ describe("hoisting", async () => {
     const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
     expect(err).toContain("Saved lockfile");
     expect(err).not.toContain("error:");
-    expect(out).toContain("packages installed");
+    expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+      expect.stringContaining("bun install v1."),
+      "",
+      "3 packages installed",
+    ]);
     expect(await file(join(packageDir, "node_modules", "hoist-lockfile-shared", "package.json")).json()).toMatchObject({
       name: "hoist-lockfile-shared",
       version: "1.0.2",


### PR DESCRIPTION
## What

On a fresh resolve, a transitive wide range (`*`, `>=1.0.0`) that satisfies an already-resolved root/workspace dependency was being refused a dedupe when the manifest's best-match was a different major, nesting a duplicate copy instead. npm and bun 1.3.x both dedupe here.

## Repro

```jsonc
// package.json
{ "dependencies": { "hoist-lockfile-1": "1.0.0", "hoist-lockfile-shared": "^1.0.1" } }
// hoist-lockfile-1 depends on "hoist-lockfile-shared": "*"
// hoist-lockfile-shared has versions 1.0.1, 1.0.2, 2.0.1, 2.0.2
```

Before: `3 packages installed`, `node_modules/hoist-lockfile-1/node_modules/hoist-lockfile-shared@2.0.2` nested.
After / npm: `2 packages installed`, single `hoist-lockfile-shared@1.0.2`.

Real-world: a fresh `jest ^29.7.0` + `ts-jest ^29.1.5` + `@types/node ^20.14.0` install went from 1 copy of `@types/node` to 17 (node_modules 63M -> 107M), and the duplication is written into `bun.lock`.

## Cause

`try_satisfies_dedupe` in `Lockfile::get_package_id` has an order-independence guard that refuses a cross-major satisfies-dedupe onto any session-appended entry that was not appended for an exact `=X.Y.Z` dependency. The guard exists to keep the "text lockfile is hoisted" snapshot deterministic when every constraint on a package is transitive (network-ordered manifest arrival).

It over-fires: a package appended for a **root/workspace** range dependency is also "session-appended, not exact", so the guard blocks deduping onto it even though root/workspace dependencies are read from disk and enqueued onto the manifest task queue before any network-ordered transitive can be, making the dedupe deterministic.

## Fix

Broaden the guard's exemption bitset (renamed `exact_pinned` -> `local_pinned`) to also include packages appended for a dependency declared in any local `package.json` (root or workspace), via `Lockfile::is_workspace_dependency` at the append site in `get_or_put_resolved_package_with_find_result`. The guard now fires only when the existing entry was appended for a transitive range in this session, which is the actual flake condition. The `text lockfile is hoisted` snapshot is unchanged.

## Verification

```
bun bd test test/cli/install/bun-install-registry.test.ts -t "transitive wide range dedupes"
```

Two new tests (root-declared and workspace-declared variants) fail on `main` with "3 packages installed" / nested `node_modules/hoist-lockfile-1/node_modules`, and pass with this change.

Rebased onto main after #38333 landed (the `exact_pinned` guard it scopes is unchanged there). Re-verified on that base: the two tests still fail with main's `src/install` and pass with this diff; `bun-install-registry.test.ts`, `bun-dedupe.test.ts`, `hoist.test.ts`, `bun-lock.test.ts`, `nested-overrides.test.ts`, `overrides.test.ts` and `bun-update-lockfile-sync.test.ts` pass (579 tests). The earlier verdaccio bind change to `test/harness.ts` was dropped from this PR since main fixed it separately.

Real-world instance of this on current main: the `@types/node` `"*"` cross-major nesting seen in the 1.4 release-readiness install corpus.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-registry.test.ts

<!-- robobun:evidence:end -->
