### PR TITLE
worker_threads: don't hang when captured stdout/stderr is never consumed

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -333,17 +333,15 @@ const BUN_WORKER_MESSAGING_KEY = "@@bunWorkerThreadsMessaging";
 
 // Readable fed by a control MessagePort (worker.stdout/stderr on the parent,
 // process.stdin in the worker). The peer posts arrays of Buffers; null signals EOF.
-function makePortReadable(port) {
-  let attached = false;
+function makePortReadable(port, incrementsPortRef) {
   let ended = false;
+  let startedReading = false;
   function onMessage(payload) {
     if (payload === null) {
       if (ended === false) {
         ended = true;
         stream.push(null);
       }
-      // Drop the listener so the control port stops holding the event loop
-      // open once the stream has ended.
       port.off("message", onMessage);
     } else if (ended === false) {
       for (let i = 0; i < payload.length; i++) {
@@ -351,26 +349,33 @@ function makePortReadable(port) {
       }
     }
   }
-  // Attach the 'message' listener lazily on first read(): a listener refs the event
-  // loop, which would keep a { stdin: true } worker alive even if stdin is never read.
   const stream = new Readable({
     read() {
-      if (attached === false && ended === false) {
-        attached = true;
-        port.on("message", onMessage);
+      if (startedReading === false && incrementsPortRef) {
+        startedReading = true;
+        port.ref();
       }
       // Tell the writer we want more data; it completes its in-flight writev
       // on receipt (node's STDIO_WANTS_MORE_DATA).
       if (ended === false) port.postMessage(true);
     },
   });
+  // Attach eagerly so the peer's writev is ack'd (via push -> maybeReadMore ->
+  // _read) even when no one consumes this stream; unref immediately so an
+  // unconsumed captured stream never pins the loop on its own (node's model).
+  port.on("message", onMessage);
+  port.unref();
+  stream.on("end", () => {
+    if (startedReading && incrementsPortRef) {
+      startedReading = false;
+      port.unref();
+    }
+  });
   // Lets the parent end worker.stdout/stderr when the worker exits abruptly.
   stream.endFromOwner = function () {
     if (ended === false) {
       ended = true;
       stream.push(null);
-      // Drop the listener so the port stops holding the event loop open once
-      // the owner (worker exit) has ended the stream.
       port.off("message", onMessage);
     }
   };
@@ -458,7 +463,7 @@ function setupWorkerStdio(stdio) {
   // would race the main thread (and hang on a TTY).
   Object.defineProperty(process, "stdin", {
     value: stdin
-      ? makePortReadable(stdin)
+      ? makePortReadable(stdin, true)
       : new Readable({
           read() {
             this.push(null);
@@ -926,8 +931,6 @@ class Worker extends EventEmitter {
   #stdin;
   #stdout;
   #stderr;
-  #stdoutAutoPipe = false;
-  #stderrAutoPipe = false;
 
   // this is used by terminate();
   // either is the exit code if exited, a promise resolving to the exit code, or undefined if we haven't sent .terminate() yet
@@ -988,19 +991,19 @@ class Worker extends EventEmitter {
       }
       // worker.stdout/stderr are always Readables fed by the worker; without capture
       // they auto-pipe to the parent's stdio so output still surfaces.
+      const stdoutAutoPipe = !options.stdout;
+      const stderrAutoPipe = !options.stderr;
       {
         const channel = new MessageChannel();
         this.#stdoutPort = channel.port1;
         stdioForWorker.stdout = channel.port2;
         stdioTransfer.push(channel.port2);
-        if (!options.stdout) this.#stdoutAutoPipe = true;
       }
       {
         const channel = new MessageChannel();
         this.#stderrPort = channel.port1;
         stdioForWorker.stderr = channel.port2;
         stdioTransfer.push(channel.port2);
-        if (!options.stderr) this.#stderrAutoPipe = true;
       }
       // Control channel for postMessageToThread; wrap workerData so the control and
       // stdio ports ride along transferred.
@@ -1040,18 +1043,15 @@ class Worker extends EventEmitter {
         preload: ["node:worker_threads", ...($isArray(userPreload) ? userPreload : userPreload ? [userPreload] : [])],
       } as NodeWorkerOptions;
       this.#worker = new WebWorker(filename, options as Bun.WorkerOptions, this);
-      // Uncaptured stdio forwards to the parent's stdio. Keep these ports unref'd:
-      // the worker's own ref keeps the parent alive, and unref() must still let it exit.
-      if (this.#stdoutAutoPipe) {
-        // 'data' instead of pipe(): pipe() adds an error listener on the shared
-        // process.stdout per worker, tripping MaxListenersExceededWarning.
-        this.stdout.on("data", chunk => process.stdout.write(chunk));
-        this.#stdoutPort.unref();
-      }
-      if (this.#stderrAutoPipe) {
-        this.stderr.on("data", chunk => process.stderr.write(chunk));
-        this.#stderrPort.unref();
-      }
+      // Create the readables eagerly so the worker's writev is ack'd even when
+      // worker.stdout/stderr is never touched; only captured streams ref their
+      // port on first read (node's kIncrementsPortRef).
+      this.#stdout = makePortReadable(this.#stdoutPort, !stdoutAutoPipe);
+      this.#stderr = makePortReadable(this.#stderrPort, !stderrAutoPipe);
+      // 'data' instead of pipe(): pipe() adds an error listener on the shared
+      // process.stdout per worker, tripping MaxListenersExceededWarning.
+      if (stdoutAutoPipe) this.#stdout.on("data", chunk => process.stdout.write(chunk));
+      if (stderrAutoPipe) this.#stderr.on("data", chunk => process.stderr.write(chunk));
     } catch (e) {
       // Restore any transferList handles that were already neutered by
       // packJSTransferables, so their fds aren't orphaned.
@@ -1099,19 +1099,13 @@ class Worker extends EventEmitter {
   }
 
   ref() {
+    // stdio ports are not touched here (node's ref()/unref() only touch the
+    // handle and the public port); their ref state tracks in-flight I/O.
     this.#worker.ref();
-    // Captured stdio ports follow the worker's ref state; auto-piped ports stay
-    // unref'd (the worker's own ref governs them).
-    if (!this.#stdoutAutoPipe) this.#stdoutPort?.ref();
-    if (!this.#stderrAutoPipe) this.#stderrPort?.ref();
-    this.#stdinPort?.ref();
   }
 
   unref() {
     this.#worker.unref();
-    if (!this.#stdoutAutoPipe) this.#stdoutPort?.unref();
-    if (!this.#stderrAutoPipe) this.#stderrPort?.unref();
-    this.#stdinPort?.unref();
   }
 
   get stdin() {
@@ -1126,23 +1120,11 @@ class Worker extends EventEmitter {
   }
 
   get stdout() {
-    if (this.#stdoutPort === undefined) return null;
-    if (this.#stdout === undefined) {
-      this.#stdout = makePortReadable(this.#stdoutPort);
-      // If the worker already exited, end immediately: a late first access
-      // would otherwise ref the parent loop with no release (peer gone) -> hang.
-      if (this.#exited) this.#stdout.endFromOwner();
-    }
-    return this.#stdout;
+    return this.#stdout ?? null;
   }
 
   get stderr() {
-    if (this.#stderrPort === undefined) return null;
-    if (this.#stderr === undefined) {
-      this.#stderr = makePortReadable(this.#stderrPort);
-      if (this.#exited) this.#stderr.endFromOwner();
-    }
-    return this.#stderr;
+    return this.#stderr ?? null;
   }
 
   get performance() {

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -365,7 +365,11 @@ function makePortReadable(port, incrementsPortRef) {
   // unconsumed captured stream never pins the loop on its own (node's model).
   port.on("message", onMessage);
   port.unref();
-  stream.on("end", () => {
+  // 'close' covers natural EOF and destroy(); release the read-time ref and
+  // drop the listener so a destroyed captured stream can't pin an unref'd worker.
+  stream.on("close", () => {
+    ended = true;
+    port.off("message", onMessage);
     if (startedReading && incrementsPortRef) {
       startedReading = false;
       port.unref();

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -463,7 +463,12 @@ describe("captured stdio backpressure", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout: stdout.trim(), stderr: exitCode === 0 ? "" : stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    expect({
+      stdout: stdout.trim(),
+      stderr: exitCode === 0 ? "" : stderr,
+      exitCode,
+      signalCode: proc.signalCode,
+    }).toEqual({
       stdout: JSON.stringify({ code: 0, cb: true, out: "o", err: "e" }),
       stderr: "",
       exitCode: 0,

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1,4 +1,5 @@
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { describe, expect, it, setDefaultTimeout, test } from "bun:test";
+import { bunEnv, bunExe, isDebug, tmpdirSync } from "harness";
 import { once } from "node:events";
 import fs from "node:fs";
 import { join, relative, resolve } from "node:path";
@@ -21,6 +22,10 @@ import wt, {
   Worker,
   workerData,
 } from "worker_threads";
+
+// Worker startup under debug/ASAN is slow enough that several tests here cannot
+// finish inside the 5s default.
+setDefaultTimeout(isDebug ? 90_000 : 10_000);
 
 test("support eval in worker", async () => {
   const worker = new Worker(`postMessage(1 + 1)`, {
@@ -421,6 +426,49 @@ describe("captured stdio backpressure", () => {
     for await (const data of worker.stdout) received += data.length;
     expect(received).toBe(128 * 8 * 1024);
     await worker.terminate();
+  });
+
+  // An unconsumed captured stream must not keep the worker (or parent) alive on its
+  // own. Regression: the lazy message listener meant the worker's writev ack never
+  // arrived, so its stdio port stayed ref'd and neither side could exit.
+  test("captured stdio that is never consumed does not prevent exit", async () => {
+    // One worker writing to both captured streams is enough to trip the hang.
+    const script = `
+      const { Worker } = require("node:worker_threads");
+      const { once } = require("node:events");
+      const src = [
+        'process.stdout.write("o", () => require("node:worker_threads").parentPort.postMessage("cb"));',
+        'process.stderr.write("e");',
+      ].join("");
+      const w = new Worker(src, { eval: true, stdout: true, stderr: true });
+      // Touching the getter must not matter either.
+      void w.stderr;
+      void w.stdout;
+      let cb = false;
+      w.on("message", () => (cb = true));
+      // The condition under test is "process exits on its own"; the watchdog turns
+      // a hang into a fast, distinguishable failure instead of the suite timeout.
+      w.on("online", () => setTimeout(() => process.exit(42), ${isDebug ? 20_000 : 5_000}).unref());
+      const [code] = await once(w, "exit");
+      // Data was pushed into the Readable buffer even though nothing consumed it,
+      // and stays readable after the worker has exited.
+      const out = w.stdout.read()?.toString() ?? null;
+      const err = w.stderr.read()?.toString() ?? null;
+      console.log(JSON.stringify({ code, cb, out, err }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr: exitCode === 0 ? "" : stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: JSON.stringify({ code: 0, cb: true, out: "o", err: "e" }),
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
   });
 });
 


### PR DESCRIPTION
## Repro

```js
import { Worker } from "node:worker_threads";
const w = new Worker(`console.error("from worker")`, { eval: true, stderr: true });
w.on("exit", c => console.log("exit", c));
// node / bun 1.3.14 -> exit 0 (rc 0)
// bun main         -> no output, hangs forever
```

Any `{ stdout: true }` / `{ stderr: true }` worker that writes to the captured stream hangs the process forever if the parent never drains `worker.stdout` / `worker.stderr`. Introduced by #31216.

Matrix on `main`:
```
{stderr:true} + worker writes nothing             -> exit 0
{stderr:true} + console.error + w.stderr.resume() -> exit 0
{stderr:true} + console.error + `void w.stderr`   -> HANG
{stdout:true,stderr:true} + log+error, no reader  -> HANG
```

## Cause

Worker stdio rides a dedicated `MessageChannel` per stream. On the worker side, `process.stderr` is a `Writable` whose `_writev` posts the chunk and then `ref()`s its port, parking the callback until an ack (node's `STDIO_WANTS_MORE_DATA`) arrives.

On the parent side, `makePortReadable` attached its `'message'` listener lazily inside `_read()`:

```js
read() {
  if (attached === false && ended === false) {
    attached = true;
    port.on("message", onMessage);
  }
  if (ended === false) port.postMessage(true); // the ack
}
```

and the `worker.stderr` `Readable` was itself created lazily in the getter. So with no reader, the listener was never attached and `_read()` never ran, no ack was ever posted, and the worker's stdio port stayed ref'd: the worker's event loop never idled, the parent's `'exit'` never fired, and the process hung.

Node's parent-side listener is always attached; on `STDIO_PAYLOAD` it calls `readable.push(chunk)`, and for writes below the Readable's `highWaterMark` `push()` schedules `maybeReadMore_` -> `read()` -> `_read()`, which posts the ack. Verified:

```
$ node -e '... process.stderr.write("x", () => parentPort.postMessage("ACK")) ...'
msg: ACK_RECEIVED   exit 0
$ bun-debug (main)
msg: NO_ACK_AFTER_1s   <hang>
```

(Node also hangs when the write exceeds `highWaterMark` and is never read; that is the intended backpressure and the existing "stdout write completion is withheld until the parent reads" test covers it.)

## Fix

`makePortReadable` now attaches the `'message'` listener eagerly and `unref()`s the port immediately, so incoming chunks are always pushed into the Readable buffer and `_read()` fires the ack via `maybeReadMore`. The port being unref'd means an unconsumed captured stream never pins the loop on its own. An `incrementsPortRef` parameter mirrors node's `kIncrementsPortRef`: captured streams `ref()` on first `_read()` and `unref()` on `'end'`; auto-piped streams never do.

The `Worker` constructor now creates `#stdout`/`#stderr` eagerly (like node), and `worker.ref()`/`unref()` no longer touch the stdio ports (node's only touch the handle and the public port; stdio port ref state tracks in-flight I/O).

## Verification

New test in `worker_threads.test.ts` spawns a subprocess with `{ stdout: true, stderr: true }`, writes to both, never reads, and asserts: the worker's write callback fires, the worker exits with code 0, the process exits on its own, and the captured bytes are readable from `worker.stdout`/`worker.stderr` afterwards. Matches node's output byte-for-byte.

- `git stash push -- src/ && bun bd test ... -t "never consumed"` -> **fails** (subprocess watchdog exits 42; `stdout` empty)
- with fix -> **passes** (`{"code":0,"cb":true,"out":"o","err":"e"}`, exit 0)
- whole file: 91/91 pass under `bun bd test`
- `test-worker-stdio*.js`, `test-worker-no-stdin-stdout-interaction.js`, `test-worker-safe-getters.js`, `test-worker-terminate-unrefed.js`, `test-worker-terminate-ref-public-port.js` all pass
- existing backpressure tests ("withheld until the parent reads", "large stdout survives") unchanged and passing

Also adds `setDefaultTimeout(isDebug ? 90_000 : 10_000)` to the file: worker startup under debug/ASAN already exceeds the 5s default for a dozen unrelated tests on `main`. #33357 makes the same change; whichever lands second is a one-line conflict.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f45c5be6c)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [2371.88ms]
(pass) all worker_threads module properties are present [42.38ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [42.27ms]
(pass) all worker_threads worker instance properties are present [199.67ms]
(pass) threadId module and worker property is consistent [282.37ms]
(pass) receiveMessageOnPort works across threads [1887.38ms]
(pass) receiveMessageOnPort works as FIFO [13.85ms]
(pass) you can override globalThis.postMessage [1726.30ms]
(pass) support require in eval [1756.25ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (9d29a5343)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [29.50ms]
(pass) all worker_threads module properties are present [0.53ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [0.61ms]
(pass) all worker_threads worker instance properties are present [3.28ms]
(pass) threadId module and worker property is consistent [4.35ms]
(pass) receiveMessageOnPort works across threads [27.43ms]
(pass) receiveMessageOnPort works as FIFO [0.36ms]
(pass) you can override globalThis.postMessage [25.90ms]
(pass) support require in eval [25.07ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [26.20ms]
(pass) support require in eval for a file that doesnt exist [24.08ms]
(pass) support worker eval that throws [24.71ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [127.23ms]
(pass) execArgv option > provides empty execArgv when passed an empty array [73.73ms]
(pass) execArgv option > can specify an array of strings [64.11ms]
(pass) eval does not leak source code [1957.8
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f45c5be6c)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1772.68ms]
(pass) all worker_threads module properties are present [38.51ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [37.11ms]
(pass) all worker_threads worker instance properties are present [235.73ms]
(pass) threadId module and worker property is consistent [230.85ms]
(pass) receiveMessageOnPort works across threads [1861.26ms]
(pass) receiveMessageOnPort works as FIFO [14.94ms]
(pass) you can override globalThis.postMessage [1813.98ms]
(pass) support require in eval [1839.57ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 953ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/90] gen ErrorCode+*.h
[2/47] gen cpp.rs (cppbind)
[3/47] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /wor
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/worker_threads.ts                      | 86 +++++++++-------------
 test/js/node/worker_threads/worker_threads.test.ts | 55 +++++++++++++-
 2 files changed, 90 insertions(+), 51 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/js/node/worker_threads.ts                           9     10      0
test/js/node/worker_threads/worker_threads.test.ts      4     10      0
```

</details>

<!-- robobun:evidence:end -->