### PR TITLE
jsc: throw RangeError for deeply nested object/array literals instead of hanging

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -7,7 +7,7 @@
 // -lto variants built with ThinLTO (per-module summaries for cross-language
 // importing), and the Windows ICU data table filtered + per-item zstd
 // compressed (lazily decompressed via bun_icu_decompress.cpp).
-export const WEBKIT_VERSION = "4895f45dfbd0d1226c4d41799887bc0ecb9f341b";
+export const WEBKIT_VERSION = "autobuild-preview-pr-297-8b31a3bc";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -7,7 +7,7 @@
 // -lto variants built with ThinLTO (per-module summaries for cross-language
 // importing), and the Windows ICU data table filtered + per-item zstd
 // compressed (lazily decompressed via bun_icu_decompress.cpp).
-export const WEBKIT_VERSION = "autobuild-preview-pr-297-8b31a3bc";
+export const WEBKIT_VERSION = "autobuild-preview-pr-297-3946a08b";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/parser-deep-nesting.test.ts
+++ b/test/js/bun/jsc/parser-deep-nesting.test.ts
@@ -14,9 +14,10 @@ for (const [name, open, close] of [
   test(`deeply nested ${name} passed to eval() throws RangeError instead of hanging`, async () => {
     // 50000 is far beyond the stack limit on every platform and build config;
     // before the fix this hung forever (killed by the spawn timeout below).
+    const depth = 50000;
     const fixture = `
-      const src = "const y = " + Buffer.alloc(50000, ${JSON.stringify(open)}).toString()
-        + "1" + Buffer.alloc(50000, ${JSON.stringify(close)}).toString() + ";";
+      const src = "const y = " + Buffer.alloc(${depth * open.length}, ${JSON.stringify(open)}).toString()
+        + "1" + Buffer.alloc(${depth * close.length}, ${JSON.stringify(close)}).toString() + ";";
       try {
         eval(src);
         console.log("no-throw");

--- a/test/js/bun/jsc/parser-deep-nesting.test.ts
+++ b/test/js/bun/jsc/parser-deep-nesting.test.ts
@@ -1,0 +1,44 @@
+// JSC parser: once the native stack check fires on a deeply nested object/array
+// literal, save-point backtracking (assignment-expression -> destructuring
+// pattern -> member expression) used to clear the error and retry at every
+// nesting level, turning an O(depth) failure into an exponential reparse loop
+// that hung with unbounded memory growth. Now the first overflow is sticky and
+// eval() rejects with RangeError in constant time regardless of depth.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+for (const [name, open, close] of [
+  ["object literal", "{a:", "}"],
+  ["array literal", "[", "]"],
+] as const) {
+  test(`deeply nested ${name} passed to eval() throws RangeError instead of hanging`, async () => {
+    // 50000 is far beyond the stack limit on every platform and build config;
+    // before the fix this hung forever (killed by the spawn timeout below).
+    const fixture = `
+      const src = "const y = " + Buffer.alloc(50000, ${JSON.stringify(open)}).toString()
+        + "1" + Buffer.alloc(50000, ${JSON.stringify(close)}).toString() + ";";
+      try {
+        eval(src);
+        console.log("no-throw");
+      } catch (e) {
+        console.log(e.constructor.name + ": " + e.message);
+      }
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 20_000,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "RangeError: Maximum call stack size exceeded.",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  }, 30_000);
+}


### PR DESCRIPTION
Depends on oven-sh/WebKit#297. This PR bumps `WEBKIT_VERSION` to pick up that fix and adds a regression test; the preview release is `autobuild-preview-pr-297-3946a08b`.

## Reproduction

```sh
python3 -c "print('const y = ' + '{a:'*2600 + '1' + '}'*2600 + ';')" > nest2600.js
bun nest2600.js
```

1.4: 99% CPU, RSS climbs unboundedly (~500MB/s), never terminates.
1.3.14: `error: Maximum call stack size exceeded` in ~25ms (Bun's parser had larger stack frames and rejected before handing to JSC).
Node: `RangeError: Maximum call stack size exceeded` immediately.

The same hang is reachable directly via `eval()` on both 1.3.14 and 1.4, bypassing Bun's transpiler entirely.

## Cause

The hang is in JavaScriptCore's parser, not the bytecode compiler. When `failIfStackOverflow()` trips inside `parseAssignmentExpression` for a nested `{a:{a:...}}`, the failure propagates back to each enclosing level. At each level `maybeAssignmentPattern` is true (the token is `{`), so `swapSavePointForError` rewinds the lexer and clears `m_errorMessage`, then the same input is retried via `tryParseDestructuringPatternExpression`. That path reaches `parseAssignmentElement`, which on failure of its `parseDestructuringPattern` attempt calls `restoreSavePoint` (clearing the error again) and retries via `parseMemberExpression` -> `parseObjectLiteral` -> `parseAssignmentExpression`. Two alternate-production retries per nesting level multiply to exponential work; the process spins in `Parser::logError` / `StringPrintStream::vprintf` allocating error strings forever.

<details>
<summary>Sampled backtrace of the hang</summary>

```
WTF::StringPrintStream::vprintf                   StringPrintStream.cpp:64
WTF::PrintStream::printfVariableFormat            PrintStream.cpp:51
JSC::Parser<JSC::Lexer<unsigned char>>::logError  Parser.cpp:124
```

</details>

## Fix

`m_hasStackOverflow` is already set by `failWithStackOverflow()` and is not touched by `restoreSavePoint`. oven-sh/WebKit#297 makes `failIfStackOverflow()` consult it, so the first overflow short-circuits every subsequent recursion entry (`parseAssignmentExpression`, `parsePrimaryExpression`, `parseDestructuringPattern`) and the failure propagates in O(depth).

## Verification

With a local WebKit build carrying the fix:

```
file depth=2600   ok
file depth=3000   RangeError: Maximum call stack size exceeded.     (37ms)
file depth=100000 RangeError: Maximum call stack size exceeded.     (41ms)
eval depth=50000  RangeError: Maximum call stack size exceeded.
```

Destructuring, arrow functions, assignment patterns and array destructuring continue to parse normally. The new test drives the eval path so it exercises JSC directly regardless of Bun's transpiler stack-frame size; before the fix the spawned child is killed by the 20s timeout and the assertion fails on `signalCode: "SIGTERM"`.

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc/parser-deep-nesting.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/jsc/parser-deep-nesting.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ba687bb6f)

test/js/bun/jsc/parser-deep-nesting.test.ts:
(pass) deeply nested object literal passed to eval() throws RangeError instead of hanging [509.46ms]
(pass) deeply nested array literal passed to eval() throws RangeError instead of hanging [485.48ms]

 2 pass
 0 fail
 2 expect() calls
Ran 2 tests across 1 file. [3.54s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                |  2 +-
 test/js/bun/jsc/parser-deep-nesting.test.ts | 45 +++++++++++++++++++++++++++++
 2 files changed, 46 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
scripts/build/deps/webkit.ts                     3      2      0
test/js/bun/jsc/parser-deep-nesting.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->
