### PR TITLE
worker_threads: drain port-backed stdio on process.exit()

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -404,7 +404,7 @@ function makePortWritable(port) {
   }
   port.on("message", onAck);
   port.unref();
-  return new Writable({
+  const stream = new Writable({
     decodeStrings: false,
     writev(chunks, cb) {
       const payload = new Array(chunks.length);
@@ -442,24 +442,42 @@ function makePortWritable(port) {
       cb(err);
     },
   });
+  // process.on('exit') runs this while _exiting is already true: completing the
+  // parked cb re-enters writev with every buffered chunk, which then completes
+  // synchronously — so writes queued before process.exit() still reach the port.
+  stream.flushInFlightForExit = onAck;
+  return stream;
 }
 
 function setupWorkerStdio(stdio) {
   const { stdin, stdout, stderr } = stdio;
+  let stdoutStream;
+  let stderrStream;
   if (stdout) {
+    stdoutStream = makePortWritable(stdout);
     Object.defineProperty(process, "stdout", {
-      value: makePortWritable(stdout),
+      value: stdoutStream,
       writable: true,
       configurable: true,
       enumerable: true,
     });
   }
   if (stderr) {
+    stderrStream = makePortWritable(stderr);
     Object.defineProperty(process, "stderr", {
-      value: makePortWritable(stderr),
+      value: stderrStream,
       writable: true,
       configurable: true,
       enumerable: true,
+    });
+  }
+  // node's flushSync (internal/bootstrap/switches/is_not_main_thread): complete
+  // the parked writev cb on exit so the Writable flushes its buffered chunks,
+  // which writev's _exiting branch then posts synchronously.
+  if (stdoutStream || stderrStream) {
+    process.on("exit", function flushSync() {
+      stdoutStream?.flushInFlightForExit();
+      stderrStream?.flushInFlightForExit();
     });
   }
   // node always replaces a worker's process.stdin: port-backed when { stdin: true },

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -386,6 +386,8 @@ function makePortReadable(port, incrementsPortRef) {
   return stream;
 }
 
+const kStdioWantsMoreDataCallback = Symbol("kStdioWantsMoreDataCallback");
+
 // Writable that forwards chunks over a control MessagePort (worker.stdin on the
 // parent, process.stdout/stderr in the worker). final() posts null as EOF.
 function makePortWritable(port) {
@@ -442,7 +444,7 @@ function makePortWritable(port) {
       cb(err);
     },
   });
-  stream.flushInFlightForExit = onAck;
+  stream[kStdioWantsMoreDataCallback] = onAck;
   return stream;
 }
 
@@ -471,8 +473,8 @@ function setupWorkerStdio(stdio) {
   if (stdoutStream || stderrStream) {
     // node's flushSync (internal/bootstrap/switches/is_not_main_thread)
     process.on("exit", function flushSync() {
-      stdoutStream?.flushInFlightForExit();
-      stderrStream?.flushInFlightForExit();
+      stdoutStream?.[kStdioWantsMoreDataCallback]();
+      stderrStream?.[kStdioWantsMoreDataCallback]();
     });
   }
   // node always replaces a worker's process.stdin: port-backed when { stdin: true },

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -468,9 +468,8 @@ function setupWorkerStdio(stdio) {
       enumerable: true,
     });
   }
-  // node's flushSync (internal/bootstrap/switches/is_not_main_thread): complete
-  // the parked writev cb on exit so buffered chunks post via the _exiting branch.
   if (stdoutStream || stderrStream) {
+    // node's flushSync (internal/bootstrap/switches/is_not_main_thread)
     process.on("exit", function flushSync() {
       stdoutStream?.flushInFlightForExit();
       stderrStream?.flushInFlightForExit();

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -442,9 +442,6 @@ function makePortWritable(port) {
       cb(err);
     },
   });
-  // process.on('exit') runs this while _exiting is already true: completing the
-  // parked cb re-enters writev with every buffered chunk, which then completes
-  // synchronously — so writes queued before process.exit() still reach the port.
   stream.flushInFlightForExit = onAck;
   return stream;
 }
@@ -472,8 +469,7 @@ function setupWorkerStdio(stdio) {
     });
   }
   // node's flushSync (internal/bootstrap/switches/is_not_main_thread): complete
-  // the parked writev cb on exit so the Writable flushes its buffered chunks,
-  // which writev's _exiting branch then posts synchronously.
+  // the parked writev cb on exit so buffered chunks post via the _exiting branch.
   if (stdoutStream || stderrStream) {
     process.on("exit", function flushSync() {
       stdoutStream?.flushInFlightForExit();

--- a/test/js/node/worker_threads/worker-stdio-exit-drain.test.ts
+++ b/test/js/node/worker_threads/worker-stdio-exit-drain.test.ts
@@ -71,8 +71,7 @@ describe("captured stdio drains on synchronous process.exit()", () => {
 describe("auto-piped stdio drains on synchronous process.exit()", () => {
   const N = 300;
   function parentScript(exitCall: string) {
-    const workerBody =
-      `for (let i = 0; i < ${N}; i++) console.log("W" + i);` + `console.error("WERR");` + exitCall;
+    const workerBody = `for (let i = 0; i < ${N}; i++) console.log("W" + i);` + `console.error("WERR");` + exitCall;
     return (
       `const { Worker } = require("node:worker_threads");` +
       `const w = new Worker(${JSON.stringify(workerBody)}, { eval: true });` +

--- a/test/js/node/worker_threads/worker-stdio-exit-drain.test.ts
+++ b/test/js/node/worker_threads/worker-stdio-exit-drain.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { once } from "node:events";
+import { Worker } from "worker_threads";
+
+// A writev issued before process.exit() parks its cb awaiting a reader ack that
+// never arrives; without an exit-time flush every chunk buffered after the first
+// batch is dropped (node registers a process.on('exit') that completes the cb).
+describe("captured stdio drains on synchronous process.exit()", () => {
+  async function collect(worker: Worker, stream: "stdout" | "stderr") {
+    worker[stream].setEncoding("utf8");
+    let out = "";
+    worker[stream].on("data", d => (out += d));
+    const ended = once(worker[stream], "end");
+    const [code] = await once(worker, "exit");
+    await ended;
+    return { out, code };
+  }
+
+  test.each(["stdout", "stderr"] as const)("console.%s output is not lost", async stream => {
+    const method = stream === "stdout" ? "log" : "error";
+    const worker = new Worker(
+      `console.${method}("A"); console.${method}("B"); console.${method}("C"); process.exit(0);`,
+      { eval: true, [stream]: true },
+    );
+    const { out, code } = await collect(worker, stream);
+    expect({ out, code }).toEqual({ out: "A\nB\nC\n", code: 0 });
+  });
+
+  test.each(["stdout", "stderr"] as const)("raw process.%s.write output is not lost", async stream => {
+    const worker = new Worker(
+      `process.${stream}.write("A\\n"); process.${stream}.write("B\\n"); process.${stream}.write("C\\n"); process.exit(0);`,
+      { eval: true, [stream]: true },
+    );
+    const { out, code } = await collect(worker, stream);
+    expect({ out, code }).toEqual({ out: "A\nB\nC\n", code: 0 });
+  });
+
+  test("many writes before exit all reach the parent", async () => {
+    const worker = new Worker(`for (let i = 0; i < 100; i++) console.log("line", i); process.exit(0);`, {
+      eval: true,
+      stdout: true,
+    });
+    const { out, code } = await collect(worker, "stdout");
+    const lines = out.split("\n").filter(Boolean);
+    expect({ first: lines[0], last: lines.at(-1), count: lines.length, code }).toEqual({
+      first: "line 0",
+      last: "line 99",
+      count: 100,
+      code: 0,
+    });
+  });
+
+  test("writes from a user process.on('exit') handler reach the parent", async () => {
+    const worker = new Worker(
+      `
+      process.on("exit", () => { console.log("from-exit"); process.stdout.write("tail\\n"); });
+      console.log("before");
+      process.exit(0);
+      `,
+      { eval: true, stdout: true },
+    );
+    const { out, code } = await collect(worker, "stdout");
+    expect({ out, code }).toEqual({ out: "before\nfrom-exit\ntail\n", code: 0 });
+  });
+});

--- a/test/js/node/worker_threads/worker-stdio-exit-drain.test.ts
+++ b/test/js/node/worker_threads/worker-stdio-exit-drain.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import { once } from "node:events";
 import { Worker } from "worker_threads";
 
@@ -61,5 +62,56 @@ describe("captured stdio drains on synchronous process.exit()", () => {
     );
     const { out, code } = await collect(worker, "stdout");
     expect({ out, code }).toEqual({ out: "before\nfrom-exit\ntail\n", code: 0 });
+  });
+});
+
+// Default worker stdio (no { stdout: true }) is also port-backed and auto-pipes
+// to the parent's stdout/stderr: the same parked-writev drop applies, so a
+// worker that logs N lines then calls process.exit() must surface all N.
+describe("auto-piped stdio drains on synchronous process.exit()", () => {
+  const N = 300;
+  function parentScript(exitCall: string) {
+    const workerBody =
+      `for (let i = 0; i < ${N}; i++) console.log("W" + i);` + `console.error("WERR");` + exitCall;
+    return (
+      `const { Worker } = require("node:worker_threads");` +
+      `const w = new Worker(${JSON.stringify(workerBody)}, { eval: true });` +
+      `w.on("exit", c => console.error("[worker exit " + c + "]"));`
+    );
+  }
+
+  test("worker console.log lines all reach the parent's stdout", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", parentScript("process.exit(0);")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const lines = stdout.split("\n").filter(Boolean);
+    expect({
+      first: lines[0],
+      last: lines.at(-1),
+      count: lines.length,
+      stderr: stderr.split("\n").filter(Boolean).sort(),
+    }).toEqual({
+      first: "W0",
+      last: `W${N - 1}`,
+      count: N,
+      stderr: ["WERR", "[worker exit 0]"],
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("without process.exit() all lines already arrive", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", parentScript("")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.split("\n").filter(Boolean).length).toBe(N);
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/worker_threads/worker-stdio-exit-drain.test.ts
+++ b/test/js/node/worker_threads/worker-stdio-exit-drain.test.ts
@@ -6,7 +6,7 @@ import { Worker } from "worker_threads";
 // A writev issued before process.exit() parks its cb awaiting a reader ack that
 // never arrives; without an exit-time flush every chunk buffered after the first
 // batch is dropped (node registers a process.on('exit') that completes the cb).
-describe("captured stdio drains on synchronous process.exit()", () => {
+describe.concurrent("captured stdio drains on synchronous process.exit()", () => {
   async function collect(worker: Worker, stream: "stdout" | "stderr") {
     worker[stream].setEncoding("utf8");
     let out = "";
@@ -68,7 +68,7 @@ describe("captured stdio drains on synchronous process.exit()", () => {
 // Default worker stdio (no { stdout: true }) is also port-backed and auto-pipes
 // to the parent's stdout/stderr: the same parked-writev drop applies, so a
 // worker that logs N lines then calls process.exit() must surface all N.
-describe("auto-piped stdio drains on synchronous process.exit()", () => {
+describe.concurrent("auto-piped stdio drains on synchronous process.exit()", () => {
   const N = 300;
   function parentScript(exitCall: string) {
     const workerBody = `for (let i = 0; i < ${N}; i++) console.log("W" + i);` + `console.error("WERR");` + exitCall;
@@ -119,7 +119,7 @@ describe("auto-piped stdio drains on synchronous process.exit()", () => {
 // runs process.on('exit') with _exiting === true, so the same flush applies:
 // logs written before the crash must all reach the parent. Subprocess-spawned
 // so the worker's uncaught-error handling is the runtime's, not bun:test's.
-describe("auto-piped stdio drains when a worker dies from an uncaught error", () => {
+describe.concurrent("auto-piped stdio drains when a worker dies from an uncaught error", () => {
   const N = 300;
 
   async function run(trailer: string) {

--- a/test/js/node/worker_threads/worker-stdio-exit-drain.test.ts
+++ b/test/js/node/worker_threads/worker-stdio-exit-drain.test.ts
@@ -114,3 +114,54 @@ describe("auto-piped stdio drains on synchronous process.exit()", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// A worker that dies from an uncaught exception or unhandled rejection still
+// runs process.on('exit') with _exiting === true, so the same flush applies:
+// logs written before the crash must all reach the parent. Subprocess-spawned
+// so the worker's uncaught-error handling is the runtime's, not bun:test's.
+describe("auto-piped stdio drains when a worker dies from an uncaught error", () => {
+  const N = 300;
+
+  async function run(trailer: string) {
+    const workerBody = `for (let i = 0; i < ${N}; i++) console.log("LINE-" + i); ${trailer}`;
+    const parent =
+      `const { Worker } = require("node:worker_threads");` +
+      `const w = new Worker(${JSON.stringify(workerBody)}, { eval: true });` +
+      `w.on("error", e => console.error("[worker error " + e.message + "]"));` +
+      `w.on("exit", c => console.error("[worker exit " + c + "]"));`;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", parent],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return {
+      lines: stdout.split("\n").filter(Boolean),
+      stderr: stderr.split("\n").filter(Boolean).sort(),
+      exitCode,
+    };
+  }
+
+  test("uncaught exception after N logs", async () => {
+    const { lines, stderr, exitCode } = await run(`throw new Error("CRASH-AFTER-LOGS");`);
+    expect({ first: lines[0], last: lines.at(-1), count: lines.length, stderr }).toEqual({
+      first: "LINE-0",
+      last: `LINE-${N - 1}`,
+      count: N,
+      stderr: ["[worker error CRASH-AFTER-LOGS]", "[worker exit 1]"],
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("unhandled rejection after N logs", async () => {
+    const { lines, stderr, exitCode } = await run(`Promise.reject(new Error("REJECT-AFTER-LOGS"));`);
+    expect({ first: lines[0], last: lines.at(-1), count: lines.length, stderr }).toEqual({
+      first: "LINE-0",
+      last: `LINE-${N - 1}`,
+      count: N,
+      stderr: ["[worker error REJECT-AFTER-LOGS]", "[worker exit 1]"],
+    });
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -477,68 +477,6 @@ describe("captured stdio backpressure", () => {
   });
 });
 
-// A writev issued before process.exit() parks its cb awaiting a reader ack that
-// never arrives; without an exit-time flush every chunk buffered after the first
-// batch is dropped (node registers a process.on('exit') that completes the cb).
-describe("captured stdio drains on synchronous process.exit()", () => {
-  async function collect(worker: Worker, stream: "stdout" | "stderr") {
-    worker[stream].setEncoding("utf8");
-    let out = "";
-    worker[stream].on("data", d => (out += d));
-    const ended = once(worker[stream], "end");
-    const [code] = await once(worker, "exit");
-    await ended;
-    return { out, code };
-  }
-
-  test.each(["stdout", "stderr"] as const)("console.%s output is not lost", async stream => {
-    const method = stream === "stdout" ? "log" : "error";
-    const worker = new Worker(
-      `console.${method}("A"); console.${method}("B"); console.${method}("C"); process.exit(0);`,
-      { eval: true, [stream]: true },
-    );
-    const { out, code } = await collect(worker, stream);
-    expect({ out, code }).toEqual({ out: "A\nB\nC\n", code: 0 });
-  });
-
-  test.each(["stdout", "stderr"] as const)("raw process.%s.write output is not lost", async stream => {
-    const worker = new Worker(
-      `process.${stream}.write("A\\n"); process.${stream}.write("B\\n"); process.${stream}.write("C\\n"); process.exit(0);`,
-      { eval: true, [stream]: true },
-    );
-    const { out, code } = await collect(worker, stream);
-    expect({ out, code }).toEqual({ out: "A\nB\nC\n", code: 0 });
-  });
-
-  test("many writes before exit all reach the parent", async () => {
-    const worker = new Worker(`for (let i = 0; i < 100; i++) console.log("line", i); process.exit(0);`, {
-      eval: true,
-      stdout: true,
-    });
-    const { out, code } = await collect(worker, "stdout");
-    const lines = out.split("\n").filter(Boolean);
-    expect({ first: lines[0], last: lines.at(-1), count: lines.length, code }).toEqual({
-      first: "line 0",
-      last: "line 99",
-      count: 100,
-      code: 0,
-    });
-  });
-
-  test("writes from a user process.on('exit') handler reach the parent", async () => {
-    const worker = new Worker(
-      `
-      process.on("exit", () => { console.log("from-exit"); process.stdout.write("tail\\n"); });
-      console.log("before");
-      process.exit(0);
-      `,
-      { eval: true, stdout: true },
-    );
-    const { out, code } = await collect(worker, "stdout");
-    expect({ out, code }).toEqual({ out: "before\nfrom-exit\ntail\n", code: 0 });
-  });
-});
-
 describe("worker event", () => {
   test("is emitted on the next tick with the right value", () => {
     const { promise, resolve } = Promise.withResolvers();

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -477,6 +477,68 @@ describe("captured stdio backpressure", () => {
   });
 });
 
+// A writev issued before process.exit() parks its cb awaiting a reader ack that
+// never arrives; without an exit-time flush every chunk buffered after the first
+// batch is dropped (node registers a process.on('exit') that completes the cb).
+describe("captured stdio drains on synchronous process.exit()", () => {
+  async function collect(worker: Worker, stream: "stdout" | "stderr") {
+    worker[stream].setEncoding("utf8");
+    let out = "";
+    worker[stream].on("data", d => (out += d));
+    const ended = once(worker[stream], "end");
+    const [code] = await once(worker, "exit");
+    await ended;
+    return { out, code };
+  }
+
+  test.each(["stdout", "stderr"] as const)("console.%s output is not lost", async stream => {
+    const method = stream === "stdout" ? "log" : "error";
+    const worker = new Worker(
+      `console.${method}("A"); console.${method}("B"); console.${method}("C"); process.exit(0);`,
+      { eval: true, [stream]: true },
+    );
+    const { out, code } = await collect(worker, stream);
+    expect({ out, code }).toEqual({ out: "A\nB\nC\n", code: 0 });
+  });
+
+  test.each(["stdout", "stderr"] as const)("raw process.%s.write output is not lost", async stream => {
+    const worker = new Worker(
+      `process.${stream}.write("A\\n"); process.${stream}.write("B\\n"); process.${stream}.write("C\\n"); process.exit(0);`,
+      { eval: true, [stream]: true },
+    );
+    const { out, code } = await collect(worker, stream);
+    expect({ out, code }).toEqual({ out: "A\nB\nC\n", code: 0 });
+  });
+
+  test("many writes before exit all reach the parent", async () => {
+    const worker = new Worker(`for (let i = 0; i < 100; i++) console.log("line", i); process.exit(0);`, {
+      eval: true,
+      stdout: true,
+    });
+    const { out, code } = await collect(worker, "stdout");
+    const lines = out.split("\n").filter(Boolean);
+    expect({ first: lines[0], last: lines.at(-1), count: lines.length, code }).toEqual({
+      first: "line 0",
+      last: "line 99",
+      count: 100,
+      code: 0,
+    });
+  });
+
+  test("writes from a user process.on('exit') handler reach the parent", async () => {
+    const worker = new Worker(
+      `
+      process.on("exit", () => { console.log("from-exit"); process.stdout.write("tail\\n"); });
+      console.log("before");
+      process.exit(0);
+      `,
+      { eval: true, stdout: true },
+    );
+    const { out, code } = await collect(worker, "stdout");
+    expect({ out, code }).toEqual({ out: "before\nfrom-exit\ntail\n", code: 0 });
+  });
+});
+
 describe("worker event", () => {
   test("is emitted on the next tick with the right value", () => {
     const { promise, resolve } = Promise.withResolvers();


### PR DESCRIPTION
## What

A worker that writes to stdout/stderr and then exits synchronously loses every chunk buffered after the first `writev` batch. Exit code is clean; the loss is silent. Applies to `process.exit()`, an uncaught exception, and an unhandled rejection alike.

Since #31216 every `node:worker_threads` worker's stdio is port-backed (auto-piped to the parent's stdout/stderr when `{stdout: true}` is not set), so this hits the default path too:

```js
// worker-log-exit.mjs
import { Worker, isMainThread } from "node:worker_threads";
import { fileURLToPath } from "node:url";
if (isMainThread) {
  const w = new Worker(fileURLToPath(import.meta.url));
  w.on("exit", c => console.error("[worker exit " + c + "]"));
} else {
  for (let i = 0; i < 300; i++) console.log("W" + i);
  process.exit(0); // or: throw new Error("...")
}
// node v26.3.0 ->  W0 .. W299, [worker exit 0]  (300/300)
// bun (before) ->  W0, [worker exit 0]          (1/300)
```

Same with captured stdio:

```js
const { Worker } = require("worker_threads");
const w = new Worker('console.log("A");console.log("B");console.log("C");process.exit(0);',
                     { eval: true, stdout: true });
let out = "";
w.stdout.setEncoding("utf8").on("data", d => out += d);
w.on("exit", c => console.log(JSON.stringify(out), c));
// node v26.3.0  ->  "A\nB\nC\n" 0
// bun (before)  ->  "A\n" 0
```

Affects `console.log`, `console.error`, and raw `process.stdout.write` / `process.stderr.write` alike.

## Why

`makePortWritable`'s `writev` posts the payload over the MessagePort and parks its completion callback awaiting a reader ack. Inside a synchronous exit there are no event-loop turns left to deliver that ack, so the Writable never re-enters `writev` and everything queued in its internal buffer after the first batch is dropped. The existing `process._exiting` escape hatch inside `writev` is unreachable: by the time `_exiting` is true the stream is already blocked on the parked callback.

Node handles this in `internal/bootstrap/switches/is_not_main_thread`: when the worker stdio is created it registers `process.on('exit', flushSync)`, which calls `kStdioWantsMoreDataCallback` on stdout and stderr. That completes the parked callback while `_exiting` is already true, so the stream flushes its buffered chunks and each subsequent `writev` posts and completes synchronously. The `exit` event fires on every worker exit path (explicit `process.exit()`, uncaught exception, unhandled rejection) with `_exiting === true`, so one handler covers all three.

## Fix

Expose the ack-completion as `flushInFlightForExit` on the port-backed Writable, and register a `process.on('exit')` handler in `setupWorkerStdio` that calls it on both streams.

## Verification

```
(pass) captured stdio drains on synchronous process.exit() > console.stdout output is not lost
(pass) captured stdio drains on synchronous process.exit() > console.stderr output is not lost
(pass) captured stdio drains on synchronous process.exit() > raw process.stdout.write output is not lost
(pass) captured stdio drains on synchronous process.exit() > raw process.stderr.write output is not lost
(pass) captured stdio drains on synchronous process.exit() > many writes before exit all reach the parent
(pass) captured stdio drains on synchronous process.exit() > writes from a user process.on('exit') handler reach the parent
(pass) auto-piped stdio drains on synchronous process.exit() > worker console.log lines all reach the parent's stdout
(pass) auto-piped stdio drains on synchronous process.exit() > without process.exit() all lines already arrive
(pass) auto-piped stdio drains when a worker dies from an uncaught error > uncaught exception after N logs
(pass) auto-piped stdio drains when a worker dies from an uncaught error > unhandled rejection after N logs
```

The six captured-stdio tests, the auto-piped `process.exit()` test, and both uncaught-error tests fail without the `src/` change (first batch only, `count: 1`) and pass with it (`count: 300`). The existing backpressure tests (`stdout write completion is withheld until the parent reads`, `large stdout survives writev batching and repeated acks`) still pass, so the ack-gated flow control is intact.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 8 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker-stdio-exit-drain.test.ts
bun test v1.4.0 (3ff7865b7)

test/js/node/worker_threads/worker-stdio-exit-drain.test.ts:
22 |     const worker = new Worker(
23 |       `console.${method}("A"); console.${method}("B"); console.${method}("C"); process.exit(0);`,
24 |       { eval: true, [stream]: true },
25 |     );
26 |     const { out, code } = await collect(worker, stream);
27 |     expect({ out, code }).toEqual({ out: "A\nB\nC\n", code: 0 });
                               ^
error: expect(received).toEqual(expected)

  {
    "code": 0,
    "out": 
  "A
- B
- C
  "
  ,
  }

- Expected  - 2
+ Received  + 0

      at <anonymous> (/workspace/bun/test/js/node/worker_threads/worker-stdio-exit-drain.test.ts:27:27)
(fail) captured stdio drains on synchronous process.exit() > console.stdout output is not lost [1846.96ms]
22 |     const worker = new Worker(
23 |       `console.${method}("A"); console.${method}("B"); console.${method}("C"); process.exit(0);`,
24 |       { eval: true, [stream]: true },
25 |     );
26 
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (accf6bb7b)

test/js/node/worker_threads/worker-stdio-exit-drain.test.ts:
(pass) captured stdio drains on synchronous process.exit() > console.stdout output is not lost [31.52ms]
(pass) captured stdio drains on synchronous process.exit() > console.stderr output is not lost [29.45ms]
(pass) captured stdio drains on synchronous process.exit() > raw process.stderr.write output is not lost [28.87ms]
(pass) captured stdio drains on synchronous process.exit() > raw process.stdout.write output is not lost [29.31ms]
(pass) captured stdio drains on synchronous process.exit() > writes from a user process.on('exit') handler reach the parent [29.34ms]
(pass) captured stdio drains on synchronous process.exit() > many writes before exit all reach the parent [30.57ms]
(pass) auto-piped stdio drains on synchronous process.exit() > worker console.log lines all reach the parent's stdout [50.93ms]
(pass) auto-piped stdio drains when a worker dies from an uncaught error > uncaught exception after N logs [49.47ms]
(pass) auto-piped stdio drains when a worker dies from an uncaught error > unhandled rejection after N logs [48.97ms]
(pass) auto-piped stdio drains o
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker-stdio-exit-drain.test.ts
bun test v1.4.0 (3ff7865b7)

test/js/node/worker_threads/worker-stdio-exit-drain.test.ts:
(pass) captured stdio drains on synchronous process.exit() > console.stdout output is not lost [1846.71ms]
(pass) captured stdio drains on synchronous process.exit() > console.stderr output is not lost [1755.88ms]
(pass) captured stdio drains on synchronous process.exit() > raw process.stdout.write output is not lost [1807.38ms]
(pass) captured stdio drains on synchronous process.exit() > raw process.stderr.write output is not lost [1805.66ms]
(pass) captured stdio drains on synchronous process.exit() > many writes before exit all reach the parent [1929.76ms]
(pass) captured stdio drains on synchronous process.exit() > writes from a user process.on('exit') handler reach the parent [1715.16ms]
(pass) auto-piped stdio drains on synchronous process.exit() > worker console.log lines all reach the parent's stdout [3174.60ms]
(pass) auto-piped stdio drains when a worker dies from an uncaught er
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 660ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (8791ms)
Bundle modules (85ms)
Postprocesss modules (225ms)
Bundle Functions (767ms)
Generate Code (31ms)

[9.92s] Bundled "src/js" for production
  2569 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[1/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/worker_threads.ts                      |  21 ++-
 .../worker_threads/worker-stdio-exit-drain.test.ts | 167 +++++++++++++++++++++
 2 files changed, 185 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 4 passed · 3 rejected · iteration 8

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/node/worker_threads.ts                                14     25      0
…/js/node/worker_threads/worker-stdio-exit-drain.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->