### PR TITLE
exe_format/macho: reject inputs shorter than the Mach-O header instead of panicking

### DIFF
--- a/src/exe_format/macho.rs
+++ b/src/exe_format/macho.rs
@@ -51,13 +51,23 @@ impl MachoFile {
         obj_file: &[u8],
         blob_to_embed_length: usize,
     ) -> Result<Box<MachoFile>, MachoError> {
+        // `--compile-executable-path` accepts arbitrary files; reject inputs too short
+        // for the header or whose load-command table runs past EOF so the slice sites
+        // in `iterator()` and below stay in bounds instead of panicking.
+        let header_size = size_of::<macho::mach_header_64>();
+        if obj_file.len() < header_size {
+            return Err(MachoError::InvalidObject);
+        }
+        let header: macho::mach_header_64 = read_struct(&obj_file[..header_size]);
+        let cmds_end = (header.sizeofcmds as usize)
+            .checked_add(header_size)
+            .ok_or(MachoError::InvalidObject)?;
+        if cmds_end > obj_file.len() {
+            return Err(MachoError::InvalidObject);
+        }
+
         let mut data: Vec<u8> = Vec::with_capacity(obj_file.len() + blob_to_embed_length);
         data.extend_from_slice(obj_file);
-
-        // data.len() >= sizeof(mach_header_64) is assumed by caller (obj_file is a Mach-O);
-        // the slice index panics on a short input rather than reading OOB.
-        let header: macho::mach_header_64 =
-            read_struct(&data[..size_of::<macho::mach_header_64>()]);
 
         Ok(Box::new(MachoFile {
             header,
@@ -557,7 +567,16 @@ pub(crate) struct MachoSigner {
 impl MachoSigner {
     pub(crate) fn init(obj: &[u8]) -> Result<Box<MachoSigner>, MachoError> {
         let header_size = size_of::<macho::mach_header_64>();
+        if obj.len() < header_size {
+            return Err(MachoError::InvalidObject);
+        }
         let header: macho::mach_header_64 = read_struct(&obj[..header_size]);
+        let cmds_end = (header.sizeofcmds as usize)
+            .checked_add(header_size)
+            .ok_or(MachoError::InvalidObject)?;
+        if cmds_end > obj.len() {
+            return Err(MachoError::InvalidObject);
+        }
 
         let mut sig_off: usize = 0;
         let mut sig_sz: usize = 0;

--- a/src/exe_format/macho.rs
+++ b/src/exe_format/macho.rs
@@ -46,25 +46,31 @@ macro_rules! shift_fields {
     }};
 }
 
+/// Read and validate the `mach_header_64` at the start of `obj`.
+/// `--compile-executable-path` accepts arbitrary files, so reject inputs too
+/// short for the header or whose load-command table runs past EOF; callers
+/// slice `obj[header_size..][..header.sizeofcmds]` on the returned header.
+fn read_macho_header(obj: &[u8]) -> Result<macho::mach_header_64, MachoError> {
+    let header_size = size_of::<macho::mach_header_64>();
+    if obj.len() < header_size {
+        return Err(MachoError::InvalidObject);
+    }
+    let header: macho::mach_header_64 = read_struct(&obj[..header_size]);
+    let cmds_end = (header.sizeofcmds as usize)
+        .checked_add(header_size)
+        .ok_or(MachoError::InvalidObject)?;
+    if cmds_end > obj.len() {
+        return Err(MachoError::InvalidObject);
+    }
+    Ok(header)
+}
+
 impl MachoFile {
     pub fn init(
         obj_file: &[u8],
         blob_to_embed_length: usize,
     ) -> Result<Box<MachoFile>, MachoError> {
-        // `--compile-executable-path` accepts arbitrary files; reject inputs too short
-        // for the header or whose load-command table runs past EOF so the slice sites
-        // in `iterator()` and below stay in bounds instead of panicking.
-        let header_size = size_of::<macho::mach_header_64>();
-        if obj_file.len() < header_size {
-            return Err(MachoError::InvalidObject);
-        }
-        let header: macho::mach_header_64 = read_struct(&obj_file[..header_size]);
-        let cmds_end = (header.sizeofcmds as usize)
-            .checked_add(header_size)
-            .ok_or(MachoError::InvalidObject)?;
-        if cmds_end > obj_file.len() {
-            return Err(MachoError::InvalidObject);
-        }
+        let header = read_macho_header(obj_file)?;
 
         let mut data: Vec<u8> = Vec::with_capacity(obj_file.len() + blob_to_embed_length);
         data.extend_from_slice(obj_file);
@@ -567,16 +573,7 @@ pub(crate) struct MachoSigner {
 impl MachoSigner {
     pub(crate) fn init(obj: &[u8]) -> Result<Box<MachoSigner>, MachoError> {
         let header_size = size_of::<macho::mach_header_64>();
-        if obj.len() < header_size {
-            return Err(MachoError::InvalidObject);
-        }
-        let header: macho::mach_header_64 = read_struct(&obj[..header_size]);
-        let cmds_end = (header.sizeofcmds as usize)
-            .checked_add(header_size)
-            .ok_or(MachoError::InvalidObject)?;
-        if cmds_end > obj.len() {
-            return Err(MachoError::InvalidObject);
-        }
+        let header = read_macho_header(obj)?;
 
         let mut sig_off: usize = 0;
         let mut sig_sz: usize = 0;

--- a/src/exe_format/macho.rs
+++ b/src/exe_format/macho.rs
@@ -111,7 +111,7 @@ impl MachoFile {
                 macho::LC::SEGMENT_64 => {
                     let command = entry
                         .cast::<macho::segment_command_64>()
-                        .expect("unreachable");
+                        .ok_or(MachoError::InvalidObject)?;
                     if command.seg_name() == b"__BUN" {
                         if command.nsects > 0 {
                             let section_offset = entry.data.as_ptr() as usize - base_addr;
@@ -492,7 +492,7 @@ impl MachoFile {
             if cmd.cmd == macho::LC::SEGMENT_64 {
                 let seg = entry
                     .cast::<macho::segment_command_64>()
-                    .expect("unreachable");
+                    .ok_or(MachoError::InvalidObject)?;
                 if seg.fileoff < prev_end {
                     return Err(MachoError::OverlappingSegments);
                 }
@@ -599,7 +599,7 @@ impl MachoSigner {
             if cmd.cmd() == macho::LC::SEGMENT_64 {
                 let seg = cmd
                     .cast::<macho::segment_command_64>()
-                    .expect("unreachable");
+                    .ok_or(MachoError::InvalidObject)?;
 
                 // Store segment info
                 if seg.seg_name() == SEG_LINKEDIT {
@@ -628,7 +628,7 @@ impl MachoSigner {
                 macho::LC::CODE_SIGNATURE => {
                     let cs = cmd
                         .cast::<macho::linkedit_data_command>()
-                        .expect("unreachable");
+                        .ok_or(MachoError::InvalidObject)?;
                     sig_off = cs.dataoff as usize;
                     sig_sz = cs.datasize as usize;
                     cs_cmd_off = cmd.data.as_ptr() as usize - obj.as_ptr() as usize;

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1278,12 +1278,13 @@ test("compile --compile-executable-path rejects a template shorter than the exec
     return { stdout, stderr, exitCode };
   };
 
-  for (const [target, template, wantErr] of [
-    ["bun-darwin-x64", "tiny", "InvalidObject"],
-    ["bun-darwin-x64", "badcmds", "InvalidObject"],
-    ["bun-darwin-x64", "shortseg", "InvalidObject"],
-    ["bun-linux-x64", "tiny", "InvalidElfFile"],
-    ["bun-windows-x64", "tiny", "InvalidPEFile"],
+  for (const [target, template, wantErr, outName] of [
+    ["bun-darwin-x64", "tiny", "InvalidObject", "out-tiny"],
+    ["bun-darwin-x64", "badcmds", "InvalidObject", "out-badcmds"],
+    ["bun-darwin-x64", "shortseg", "InvalidObject", "out-shortseg"],
+    ["bun-linux-x64", "tiny", "InvalidElfFile", "out-tiny"],
+    // build_command.rs appends .exe to the outfile for Windows targets.
+    ["bun-windows-x64", "tiny", "InvalidPEFile", "out-tiny.exe"],
   ] as const) {
     const { stderr, exitCode } = await run(target, template);
     expect({ target, template, stderr }).toEqual({
@@ -1291,7 +1292,7 @@ test("compile --compile-executable-path rejects a template shorter than the exec
       template,
       stderr: expect.stringContaining(wantErr),
     });
-    expect(await Bun.file(join(cwd, `out-${template}`)).exists()).toBe(false);
+    expect(await Bun.file(join(cwd, outName)).exists()).toBe(false);
     expect(exitCode).toBe(1);
   }
 }, 60_000);

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1234,16 +1234,27 @@ test("compile --compile-executable-path rejects a template shorter than the exec
   });
   const cwd = String(dir);
 
+  const machHeader = (ncmds: number, sizeofcmds: number) => {
+    const b = Buffer.alloc(32);
+    b.writeUInt32LE(0xfeedfacf, 0); // MH_MAGIC_64
+    b.writeInt32LE(0x01000007, 4); // CPU_TYPE_X86_64
+    b.writeInt32LE(3, 8); // cpusubtype
+    b.writeUInt32LE(2, 12); // filetype = MH_EXECUTE
+    b.writeUInt32LE(ncmds, 16);
+    b.writeUInt32LE(sizeofcmds, 20);
+    return b;
+  };
+
   // mach_header_64 with ncmds=2 sizeofcmds=10000 but only 8 trailing bytes — exercises the
   // load-command-table bounds check in MachoFile::init (iterator() would otherwise slice OOB).
-  const hdr = Buffer.alloc(40);
-  hdr.writeUInt32LE(0xfeedfacf, 0); // MH_MAGIC_64
-  hdr.writeInt32LE(0x01000007, 4); // CPU_TYPE_X86_64
-  hdr.writeInt32LE(3, 8); // cpusubtype
-  hdr.writeUInt32LE(2, 12); // filetype = MH_EXECUTE
-  hdr.writeUInt32LE(2, 16); // ncmds
-  hdr.writeUInt32LE(10000, 20); // sizeofcmds (past EOF)
-  await Bun.write(join(cwd, "badcmds"), hdr);
+  await Bun.write(join(cwd, "badcmds"), Buffer.concat([machHeader(2, 10000), Buffer.alloc(8)]));
+
+  // mach_header_64 + one LC_SEGMENT_64 whose cmdsize (8) is smaller than sizeof(segment_command_64)
+  // (72) — exercises the cast-site guard in write_section().
+  const lc = Buffer.alloc(8);
+  lc.writeUInt32LE(0x19, 0); // LC_SEGMENT_64
+  lc.writeUInt32LE(8, 4); // cmdsize
+  await Bun.write(join(cwd, "shortseg"), Buffer.concat([machHeader(1, 8), lc]));
 
   const run = async (target: string, template: string) => {
     await using proc = Bun.spawn({
@@ -1270,6 +1281,7 @@ test("compile --compile-executable-path rejects a template shorter than the exec
   for (const [target, template, wantErr] of [
     ["bun-darwin-x64", "tiny", "InvalidObject"],
     ["bun-darwin-x64", "badcmds", "InvalidObject"],
+    ["bun-darwin-x64", "shortseg", "InvalidObject"],
     ["bun-linux-x64", "tiny", "InvalidElfFile"],
     ["bun-windows-x64", "tiny", "InvalidPEFile"],
   ] as const) {

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1222,3 +1222,64 @@ test("compile --compile-executable-path rejects a Mach-O template whose __BUN se
     expect(exitCode).toBe(0);
   }
 }, 60_000);
+
+test("compile --compile-executable-path rejects a template shorter than the executable-format header", async () => {
+  // `--compile-executable-path` accepts an arbitrary file. A file shorter than the target
+  // format's fixed header (or one whose header advertises more load-command bytes than the
+  // file contains) must surface as a clean error instead of a slice-index panic.
+  using dir = tempDir("compile-template-short-header", {
+    "entry.js": `console.log(1);`,
+    // 19 bytes: shorter than mach_header_64 (32), Elf64_Ehdr (64), IMAGE_DOS_HEADER (64).
+    "tiny": "WRONG-STUB-FALLBACK",
+  });
+  const cwd = String(dir);
+
+  // mach_header_64 with ncmds=2 sizeofcmds=10000 but only 8 trailing bytes — exercises the
+  // load-command-table bounds check in MachoFile::init (iterator() would otherwise slice OOB).
+  const hdr = Buffer.alloc(40);
+  hdr.writeUInt32LE(0xfeedfacf, 0); // MH_MAGIC_64
+  hdr.writeInt32LE(0x01000007, 4); // CPU_TYPE_X86_64
+  hdr.writeInt32LE(3, 8); // cpusubtype
+  hdr.writeUInt32LE(2, 12); // filetype = MH_EXECUTE
+  hdr.writeUInt32LE(2, 16); // ncmds
+  hdr.writeUInt32LE(10000, 20); // sizeofcmds (past EOF)
+  await Bun.write(join(cwd, "badcmds"), hdr);
+
+  const run = async (target: string, template: string) => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "build",
+        "--compile",
+        `--target=${target}`,
+        "--compile-executable-path",
+        join(cwd, template),
+        join(cwd, "entry.js"),
+        "--outfile",
+        join(cwd, `out-${template}`),
+      ],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  };
+
+  for (const [target, template, wantErr] of [
+    ["bun-darwin-x64", "tiny", "InvalidObject"],
+    ["bun-darwin-x64", "badcmds", "InvalidObject"],
+    ["bun-linux-x64", "tiny", "InvalidElfFile"],
+    ["bun-windows-x64", "tiny", "InvalidPEFile"],
+  ] as const) {
+    const { stderr, exitCode } = await run(target, template);
+    expect({ target, template, stderr }).toEqual({
+      target,
+      template,
+      stderr: expect.stringContaining(wantErr),
+    });
+    expect(await Bun.file(join(cwd, `out-${template}`)).exists()).toBe(false);
+    expect(exitCode).toBe(1);
+  }
+}, 60_000);


### PR DESCRIPTION
## Problem

`bun build --compile --target=bun-darwin-* --compile-executable-path <file>` panics when the template file is not a well-formed Mach-O:

```sh
$ printf 'WRONG-STUB-FALLBACK' > tiny   # 19 bytes
$ bun build --compile --target=bun-darwin-x64 x.js --compile-executable-path ./tiny --outfile out
panic: range end index 32 out of range for slice of length 19
oh no: Bun has crashed. This indicates a bug in Bun, not your code.
```

Three variants reach a panic:
1. file shorter than `mach_header_64` (32 bytes): `range end index 32 out of range for slice of length 19`
2. valid 32-byte header whose `sizeofcmds` points past EOF: `range end index 10000 out of range for slice of length 8` from `iterator()`
3. `LC_SEGMENT_64` load command whose `cmdsize` is smaller than `sizeof(segment_command_64)`: `panic: unreachable` from `.cast().expect("unreachable")`

## Cause

`MachoFile::init` / `MachoSigner::init` sliced the header and load-command table without checking `data.len()`. The load-command walkers (`write_section`, `validate_segments`, `MachoSigner::init`) assume a well-formed Mach-O and `.expect("unreachable")` on an undersized `cmdsize`. `--compile-executable-path` accepts an arbitrary file, so these are user-reachable.

`ElfFile::init` (`validate_elf64_le`) and `PEFile::init` already bounds-check their inputs and return `InvalidElfFile` / `InvalidPEFile`; Mach-O was the only format without these guards.

## Fix

- `MachoFile::init` / `MachoSigner::init`: reject inputs shorter than `mach_header_64`, and inputs where `header_size + header.sizeofcmds` (with overflow check) exceeds the file length. Validation runs before the `Vec::with_capacity` allocation.
- Replace the four `.cast::<T>().expect("unreachable")` sites with `.ok_or(MachoError::InvalidObject)?`, matching the `require(size)` pattern `update_load_command_offsets` already uses.

## Test

Added to `test/bundler/bundler_compile.test.ts` alongside the existing `OffsetOutOfRange` template-validation test. Covers all three Mach-O variants plus regression coverage that ELF and PE continue to reject short templates cleanly. Each case asserts the named error appears in stderr, no output file is produced, and the build exits 1.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_compile.test.ts

<!-- robobun:evidence:end -->