### PR TITLE
bun:test: stop expect() failure messages from consuming <...> spans in user data

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -791,38 +791,6 @@ impl JSGlobalObject {
         self.throw_value(instance)
     }
 
-    pub fn throw_pretty(&self, args: Arguments<'_>) -> JsError {
-        // The format string of an already-captured `Arguments<'_>` can't be
-        // rewritten, so render first, then run the `<tag>` → ANSI/strip pass
-        // at runtime via `pretty_fmt_rt`.
-        //
-        // Formatting can fail mid-write (e.g. user `Symbol.toPrimitive` throws
-        // while stringifying the Received value). `pretty_fmt_rt` would
-        // `format!` into a `String`, and `format!` panics if a `Display` impl
-        // returns `fmt::Error` when the underlying writer didn't — so render
-        // via fallible `write!` here: on failure, clear the pending JS
-        // exception and throw with whatever was written so far.
-        let enabled = Output::enable_ansi_colors_stderr();
-        use core::fmt::Write;
-        let mut buf: Vec<u8> = Vec::with_capacity(2048);
-        if write!(WriteVec(&mut buf), "{}", args).is_err() {
-            // if an exception occurs in the middle of formatting the error
-            // message, it's better to just return what we have than an error
-            // about an error. Clear any pending JS exception (e.g. from
-            // Symbol.toPrimitive) so that throwValue doesn't hit
-            // assertNoException.
-            let _ = self.clear_exception_except_termination();
-        }
-        #[allow(clippy::disallowed_methods)] // template built at runtime from caller args
-        let pretty = Output::pretty_fmt_rt(buf.as_slice(), enabled);
-        let instance = ZigString::init_utf8(&pretty).to_error_instance(self);
-        if instance.is_empty() {
-            debug_assert!(self.has_exception());
-            return JsError::Thrown;
-        }
-        self.throw_value(instance)
-    }
-
     /// Queue a native callback as a microtask. Callers supply the C-ABI
     /// trampoline directly; the wrapper only erases the context pointer type.
     pub fn queue_microtask_callback<C>(

--- a/src/jsc/bindgen_test.rs
+++ b/src/jsc/bindgen_test.rs
@@ -39,7 +39,7 @@ pub fn add(global: &JSGlobalObject, a: i32, b: i32) -> JsResult<i32> {
             // Binding functions can propagate out-of-memory and JS exceptions
             // directly; other failures (like this integer overflow) must be
             // converted into a thrown error. Remember to be descriptive.
-            Err(global.throw_pretty(format_args!("Integer overflow while adding")))
+            Err(global.throw(format_args!("Integer overflow while adding")))
         }
     }
 }

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -549,7 +549,7 @@ pub(crate) fn braces(
     // `u32::MAX`, so a tiny nested input can otherwise request a huge `Vec`.
     const MAX_BRACE_EXPANSIONS: u32 = 65536;
     if expansion_count > MAX_BRACE_EXPANSIONS {
-        return Err(global.throw_pretty(format_args!(
+        return Err(global.throw(format_args!(
             "Too many brace expansions ({} > {})",
             expansion_count, MAX_BRACE_EXPANSIONS
         )));
@@ -571,12 +571,10 @@ pub(crate) fn braces(
         Ok(()) => {}
         Err(Braces::ParserError::OutOfMemory) => return Err(jsc::JsError::OutOfMemory),
         Err(Braces::ParserError::UnexpectedToken) => {
-            return Err(
-                global.throw_pretty(format_args!("Unexpected token while expanding braces"))
-            );
+            return Err(global.throw(format_args!("Unexpected token while expanding braces")));
         }
         Err(Braces::ParserError::TooManyBraces) => {
-            return Err(global.throw_pretty(format_args!("Too many braces in brace expansion")));
+            return Err(global.throw(format_args!("Too many braces in brace expansion")));
         }
     }
 

--- a/src/runtime/shell/ParsedShellScript.rs
+++ b/src/runtime/shell/ParsedShellScript.rs
@@ -277,13 +277,13 @@ fn create_parsed_shell_script_impl(
                 if let Some(lex) = out_lex_result.as_ref() {
                     debug_assert!(!lex.errors.is_empty());
                     let str = lex.combine_errors(arena);
-                    return Err(global.throw_pretty(format_args!("{}", bstr::BStr::new(str))));
+                    return Err(global.throw(format_args!("{}", bstr::BStr::new(str))));
                 }
 
                 if let Some(p) = out_parser.as_mut() {
                     debug_assert!(!p.errors.is_empty());
                     let errstr = p.combine_errors();
-                    return Err(global.throw_pretty(format_args!("{}", bstr::BStr::new(errstr))));
+                    return Err(global.throw(format_args!("{}", bstr::BStr::new(errstr))));
                 }
 
                 return Err(global.throw_error(err, "failed to lex/parse shell"));

--- a/src/runtime/shell/shell_body.rs
+++ b/src/runtime/shell/shell_body.rs
@@ -1172,7 +1172,7 @@ pub mod testing_apis {
 
         if !lex_result.errors.is_empty() {
             let str = lex_result.combine_errors(&arena);
-            return Err(global.throw_pretty(format_args!("{}", bstr::BStr::new(str))));
+            return Err(global.throw(format_args!("{}", bstr::BStr::new(str))));
         }
 
         let mut test_tokens: Vec<test::TestToken> = Vec::with_capacity(lex_result.tokens.len());
@@ -1248,12 +1248,12 @@ pub mod testing_apis {
                 // `out_lex_result` is populated by `parse()` only on lex errors.
                 if let Some(lex) = out_lex_result.as_ref() {
                     let str = lex.combine_errors(&arena);
-                    return Err(global.throw_pretty(format_args!("{}", bstr::BStr::new(str))));
+                    return Err(global.throw(format_args!("{}", bstr::BStr::new(str))));
                 }
 
                 if let Some(p) = out_parser.as_mut() {
                     let errstr = p.combine_errors();
-                    return Err(global.throw_pretty(format_args!("{}", bstr::BStr::new(errstr))));
+                    return Err(global.throw(format_args!("{}", bstr::BStr::new(errstr))));
                 }
 
                 return Err(global.throw_error(err, "failed to lex/parse shell"));

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -18,6 +18,7 @@ use super::diff_format::DiffFormatter;
 use super::execution::ExpectAssertions;
 use super::jest::Jest;
 use super::expect::{JSValueTestExt, FormatterTestExt, make_formatter};
+use crate::expect_throw as throw;
 
 use bun_jsc::js_error_to_write_error;
 
@@ -222,34 +223,73 @@ impl Expect {
         args: &'static str,
         not: bool,
     ) -> &'static str {
-        // Rust has no compile-time string concat across runtime call sites (all ~188 callers pass literals, but the `not` bool is runtime
-        // in some), so emulate via a process-lifetime intern table: each
-        // unique (matcher, args, not) triple is rendered exactly once and the
-        // boxed str is owned by the static `CACHE` for the rest of the
-        // process. Returning
-        // `&'static str` keeps the ~188 call sites and `throw()`'s `signature:
-        // &'static str` parameter unchanged.
+        // Rust has no compile-time string concat across runtime call sites
+        // (all ~188 callers pass literals, but the `not` bool is runtime in
+        // some), so emulate via a process-lifetime intern table: each unique
+        // (matcher, args, not) triple is rendered exactly once and the boxed
+        // str is owned by the static `CACHE` for the rest of the process.
+        //
+        // The `<tag>` → ANSI rewrite is applied here, once, and both colour
+        // variants are cached; the returned header is ready to emit verbatim.
+        // All inputs are `'static` template literals (never user data), so the
+        // one-time markup pass can never touch user-supplied bytes.
         use bun_collections::HashMap;
         use std::sync::OnceLock;
         type Key = (&'static str, &'static str, bool);
-        static CACHE: OnceLock<bun_threading::Guarded<HashMap<Key, Box<str>>>> = OnceLock::new();
+        static CACHE: OnceLock<bun_threading::Guarded<HashMap<Key, [Box<str>; 2]>>> =
+            OnceLock::new();
         let cache = CACHE.get_or_init(Default::default);
+        let colors = Output::enable_ansi_colors_stderr();
 
         let mut map = cache.lock();
-        if let Some(s) = map.get(&(matcher_name, args, not)) {
+        if let Some(pair) = map.get(&(matcher_name, args, not)) {
             // SAFETY: `CACHE` is process-static and entries are never removed
             // or mutated, so the `Box<str>` allocation outlives the program.
-            return unsafe { &*std::ptr::from_ref::<str>(s.as_ref()) };
+            return unsafe { &*std::ptr::from_ref::<str>(pair[colors as usize].as_ref()) };
         }
-        const RECEIVED: &str = "<d>expect(<r><red>received<r><d>).<r>";
-        let s: Box<str> = if not {
-            format!("{RECEIVED}not<d>.<r>{matcher_name}<d>(<r>{args}<d>)<r>")
-        } else {
-            format!("{RECEIVED}{matcher_name}<d>(<r>{args}<d>)<r>")
-        }
-        .into_boxed_str();
-        let ptr = std::ptr::from_ref::<str>(s.as_ref());
-        map.insert((matcher_name, args, not), s);
+        let render = |enabled: bool| -> Box<str> {
+            #[allow(clippy::disallowed_methods)] // `args` is a `'static` template literal
+            let params = Output::pretty_fmt_rt(args.as_bytes(), enabled);
+            if enabled {
+                if not {
+                    format!(
+                        bun_core::pretty_fmt!(
+                            "<d>expect(<r><red>received<r><d>).<r>not<d>.<r>{}<d>(<r>{}<d>)<r>",
+                            true
+                        ),
+                        matcher_name, params,
+                    )
+                } else {
+                    format!(
+                        bun_core::pretty_fmt!(
+                            "<d>expect(<r><red>received<r><d>).<r>{}<d>(<r>{}<d>)<r>",
+                            true
+                        ),
+                        matcher_name, params,
+                    )
+                }
+            } else if not {
+                format!(
+                    bun_core::pretty_fmt!(
+                        "<d>expect(<r><red>received<r><d>).<r>not<d>.<r>{}<d>(<r>{}<d>)<r>",
+                        false
+                    ),
+                    matcher_name, params,
+                )
+            } else {
+                format!(
+                    bun_core::pretty_fmt!(
+                        "<d>expect(<r><red>received<r><d>).<r>{}<d>(<r>{}<d>)<r>",
+                        false
+                    ),
+                    matcher_name, params,
+                )
+            }
+            .into_boxed_str()
+        };
+        let pair = [render(false), render(true)];
+        let ptr = std::ptr::from_ref::<str>(pair[colors as usize].as_ref());
+        map.insert((matcher_name, args, not), pair);
         // SAFETY: just inserted into process-static `CACHE`; never removed.
         unsafe { &*ptr }
     }
@@ -260,11 +300,12 @@ impl Expect {
         matcher_name: impl fmt::Display,
         matcher_params: impl fmt::Display,
         flags: Flags,
-        // Rust can't splice runtime args into a const format
-        // string, so callers pre-render the message body (prose + args) into a
-        // single `fmt::Arguments` here. `<tag>` markers in the rendered body
-        // are still rewritten by `throw_pretty`'s post-render `pretty_fmt_rt`
-        // pass, so the prose may contain `<r>`/`<red>`/etc.
+        // Callers pre-render the message body (prose + substituted user data)
+        // into a single `fmt::Arguments`. `<tag>` markers in the caller's
+        // *template* must already be ANSI/stripped at the call site (via the
+        // `throw!`-style compile-time pass); this sink emits `message`,
+        // `matcher_name`, and `matcher_params` verbatim so user data containing
+        // `<…>` is never scanned.
         message: fmt::Arguments<'_>,
     ) -> JsError {
         let colors = Output::enable_ansi_colors_stderr();
@@ -307,14 +348,31 @@ impl Expect {
                 }
             }
         };
-        // Matches the semantics of `Expect.throw`: empty label → default
+        // Matches the semantics of `throw_rendered`: empty label → default
         // signature header, non-empty label → user's label header.
         if custom_label.is_empty() {
-            global_this.throw_pretty(format_args!(
-                "<d>expect(<r><red>received<r><d>).<r>{chain}{matcher_name}<d>(<r>{matcher_params}<d>)<r>\n\n{message}",
-            ))
+            // Apply markup to the header *template* pieces only; interpolate
+            // `chain` (already ANSI/stripped above), `matcher_name`,
+            // `matcher_params`, `message` verbatim.
+            if colors {
+                global_this.throw(format_args!(
+                    bun_core::pretty_fmt!(
+                        "<d>expect(<r><red>received<r><d>).<r>{}{}<d>(<r>{}<d>)<r>\n\n{}",
+                        true
+                    ),
+                    chain, matcher_name, matcher_params, message,
+                ))
+            } else {
+                global_this.throw(format_args!(
+                    bun_core::pretty_fmt!(
+                        "<d>expect(<r><red>received<r><d>).<r>{}{}<d>(<r>{}<d>)<r>\n\n{}",
+                        false
+                    ),
+                    chain, matcher_name, matcher_params, message,
+                ))
+            }
         } else {
-            global_this.throw_pretty(format_args!("{custom_label}\n\n{message}"))
+            global_this.throw(format_args!("{custom_label}\n\n{message}"))
         }
     }
 
@@ -387,6 +445,40 @@ impl Expect {
         )
     }
 
+    /// Shared failure path for the three `.resolves`/`.rejects` mismatch cases
+    /// in `process_promise`. The body template's only markup is `<red>…<r>`
+    /// around `received`, so it's applied here; `expected`/`label`/`received`
+    /// are emitted verbatim.
+    #[allow(clippy::too_many_arguments)]
+    fn throw_promise_matcher_error(
+        global_this: &JSGlobalObject,
+        custom_label: bun_core::String,
+        matcher_name: impl fmt::Display,
+        matcher_params: impl fmt::Display,
+        flags: Flags,
+        expected: &'static str,
+        label: &'static str,
+        received: impl fmt::Display,
+    ) -> JsError {
+        if Output::enable_ansi_colors_stderr() {
+            Self::throw_pretty_matcher_error(
+                global_this, custom_label, matcher_name, matcher_params, flags,
+                format_args!(
+                    bun_core::pretty_fmt!("{}<r>\n{}<red>{}<r>\n", true),
+                    expected, label, received,
+                ),
+            )
+        } else {
+            Self::throw_pretty_matcher_error(
+                global_this, custom_label, matcher_name, matcher_params, flags,
+                format_args!(
+                    bun_core::pretty_fmt!("{}<r>\n{}<red>{}<r>\n", false),
+                    expected, label, received,
+                ),
+            )
+        }
+    }
+
     /// Processes the async flags (resolves/rejects), waiting for the async value if needed.
     /// If no flags, returns the original value
     /// If either flag is set, waits for the result, and returns either it as a JSValue, or null if the expectation failed (in which case if silent is false, also throws a js exception)
@@ -415,16 +507,11 @@ impl Expect {
                             Promise::Rejects => {
                                 if !silent {
                                     let mut formatter = ConsoleObject::Formatter::new(global_this).with_quote_strings(true);
-                                    return Err(Self::throw_pretty_matcher_error(
-                                        global_this,
-                                        custom_label,
-                                        matcher_name,
-                                        matcher_params,
-                                        flags,
-                                        format_args!(
-                                            "Expected promise that rejects<r>\nReceived promise that resolved: <red>{}<r>\n",
-                                            value.to_fmt(&mut formatter),
-                                        ),
+                                    return Err(Self::throw_promise_matcher_error(
+                                        global_this, custom_label, matcher_name, matcher_params, flags,
+                                        "Expected promise that rejects",
+                                        "Received promise that resolved: ",
+                                        value.to_fmt(&mut formatter),
                                     ));
                                 }
                                 return Err(JsError::Thrown);
@@ -436,16 +523,11 @@ impl Expect {
                             Promise::Resolves => {
                                 if !silent {
                                     let mut formatter = ConsoleObject::Formatter::new(global_this).with_quote_strings(true);
-                                    return Err(Self::throw_pretty_matcher_error(
-                                        global_this,
-                                        custom_label,
-                                        matcher_name,
-                                        matcher_params,
-                                        flags,
-                                        format_args!(
-                                            "Expected promise that resolves<r>\nReceived promise that rejected: <red>{}<r>\n",
-                                            value.to_fmt(&mut formatter),
-                                        ),
+                                    return Err(Self::throw_promise_matcher_error(
+                                        global_this, custom_label, matcher_name, matcher_params, flags,
+                                        "Expected promise that resolves",
+                                        "Received promise that rejected: ",
+                                        value.to_fmt(&mut formatter),
                                     ));
                                 }
                                 return Err(JsError::Thrown);
@@ -460,16 +542,11 @@ impl Expect {
                 } else {
                     if !silent {
                         let mut formatter = ConsoleObject::Formatter::new(global_this).with_quote_strings(true);
-                        return Err(Self::throw_pretty_matcher_error(
-                            global_this,
-                            custom_label,
-                            matcher_name,
-                            matcher_params,
-                            flags,
-                            format_args!(
-                                "Expected promise<r>\nReceived: <red>{}<r>\n",
-                                value.to_fmt(&mut formatter),
-                            ),
+                        return Err(Self::throw_promise_matcher_error(
+                            global_this, custom_label, matcher_name, matcher_params, flags,
+                            "Expected promise",
+                            "Received: ",
+                            value.to_fmt(&mut formatter),
                         ));
                     }
                     Err(JsError::Thrown)
@@ -666,45 +743,24 @@ impl Expect {
         Ok(expect_js_value)
     }
 
-    /// Matcher failure path. The 75 `expect/to*.rs` matchers all call this as
-    /// `return this.throw(global, SIGNATURE, format_args!(..))`, so the return
-    /// type is `JsResult<JSValue>` (always `Err`) to slot directly into a
-    /// host_fn body without `Err(..)` wrapping at every call site.
-    pub fn throw(
+    /// Matcher failure sink. Invoked via the `throw!` macro — never directly
+    /// — so the `<tag>` → ANSI rewrite has already been applied to the
+    /// *template literal* at compile time; `args` therefore carries rendered
+    /// user data and is emitted verbatim. `signature` is the pre-processed
+    /// header returned by `get_signature` (ANSI or stripped, per stderr
+    /// colour state). Nothing here scans bytes for `<…>` markers.
+    pub fn throw_rendered(
         &self,
         global_this: &JSGlobalObject,
         signature: &'static str,
         args: fmt::Arguments<'_>,
     ) -> JsResult<JSValue> {
-        // No compile-time string concat across runtime call sites, so
-        // render at runtime.
         Err(if self.custom_label.is_empty() {
-            global_this.throw_pretty(format_args!("{signature}{args}"))
+            global_this.throw(format_args!("{signature}{args}"))
         } else {
-            global_this.throw_pretty(format_args!("{}{args}", self.custom_label))
+            // custom_label is user-supplied; emit verbatim.
+            global_this.throw(format_args!("{}{args}", self.custom_label))
         })
-    }
-
-    /// Legacy 4-arg form used by a handful of internal call sites in this file
-    /// (snapshot/mock helpers) that take a separate `fmt` literal.
-    /// Folds `fmt` into `args` and delegates.
-    #[inline]
-    pub fn throw_fmt(
-        &self,
-        global_this: &JSGlobalObject,
-        signature: &'static str,
-        _fmt: &'static str,
-        args: fmt::Arguments<'_>,
-    ) -> JsResult<JSValue> {
-        // Rust cannot interpolate a runtime-literal format string, so every
-        // caller bakes the rendered tail (literal text + substitutions) into
-        // `args`; `_fmt` is kept only for documentation.
-        // If `args` is empty but `_fmt` is not, a caller forgot to migrate.
-        debug_assert!(
-            _fmt.is_empty() || args.as_str() != Some(""),
-            "throw_fmt: caller passed non-empty fmt tail {_fmt:?} but empty args — message body would be dropped",
-        );
-        self.throw(global_this, signature, args)
     }
 
     // extern shim emitted by `#[bun_jsc::JsClass]` codegen (TypeClass__construct/__call); bare `#[host_fn]` cannot target an associated fn without a receiver.
@@ -753,7 +809,7 @@ impl Expect {
 
         if not {
             let signature = Self::get_signature("pass", "", true);
-            return this.throw_fmt(global_this, signature, "\n\n{s}\n", format_args!("\n\n{}\n", bstr::BStr::new(msg.slice())));
+            return throw!(this, global_this, signature, "\n\n{}\n", bstr::BStr::new(msg.slice()));
         }
 
         // should never reach here
@@ -799,7 +855,7 @@ impl Expect {
         let msg = _msg.to_slice();
 
         let signature = Self::get_signature("fail", "", true);
-        this.throw_fmt(global_this, signature, "\n\n{s}\n", format_args!("\n\n{}\n", bstr::BStr::new(msg.slice())))
+        throw!(this, global_this, signature, "\n\n{}\n", bstr::BStr::new(msg.slice()))
     }
 }
 
@@ -1006,7 +1062,7 @@ impl Expect {
         // jest counts inline snapshots towards the snapshot counter for some reason
         let Some(runner) = Jest::runner() else {
             let signature = Self::get_signature(fn_name, "", false);
-            return this.throw_fmt(global_this, signature, "", format_args!("\n\n<b>Matcher error<r>: Snapshot matchers cannot be used outside of a test\n"));
+            return throw!(this, global_this, signature, "\n\n<b>Matcher error<r>: Snapshot matchers cannot be used outside of a test\n");
         };
         match runner.snapshots.add_count(this, b"") {
             Ok(_) => {}
@@ -1046,7 +1102,7 @@ impl Expect {
                     global_this: Some(global_this),
                     ..Default::default()
                 };
-                return Err(global_this.throw_pretty(format_args!("{signature}\n\n{diff_format}\n")));
+                return throw!(this, global_this, signature, "\n\n{}\n", diff_format);
             }
         } else {
             needs_write = true;
@@ -1057,20 +1113,16 @@ impl Expect {
                 if !update {
                     let signature = Self::get_signature(fn_name, "", false);
                     // Only creating new snapshots can reach here (updating with mismatches errors earlier with diff)
-                    return this.throw_fmt(
-                        global_this,
-                        signature,
-                        "",
-                        format_args!(
-                            "\n\n<b>Matcher error<r>: Inline snapshot creation is disabled in CI environments unless --update-snapshots is used.\nTo override, set the environment variable CI=false.\n\nReceived: {}",
-                            bstr::BStr::new(&pretty_value),
-                        ),
+                    return throw!(
+                        this, global_this, signature,
+                        "\n\n<b>Matcher error<r>: Inline snapshot creation is disabled in CI environments unless --update-snapshots is used.\nTo override, set the environment variable CI=false.\n\nReceived: {}",
+                        bstr::BStr::new(&pretty_value),
                     );
                 }
             }
             let Some(buntest_strong) = this.bun_test() else {
                 let signature = Self::get_signature(fn_name, "", false);
-                return this.throw_fmt(global_this, signature, "", format_args!("\n\n<b>Matcher error<r>: Snapshot matchers cannot be used outside of a test\n"));
+                return throw!(this, global_this, signature, "\n\n<b>Matcher error<r>: Snapshot matchers cannot be used outside of a test\n");
             };
             let buntest = buntest_strong.get();
 
@@ -1087,17 +1139,13 @@ impl Expect {
 
             if !srcloc.str.eql_utf8(fget_source_path_text) {
                 let signature = Self::get_signature(fn_name, "", false);
-                return this.throw_fmt(
-                    global_this,
-                    signature,
-                    "",
-                    format_args!(
-                        "\n\n<b>Matcher error<r>: Inline snapshot matchers must be called from the test file:\n  Expected to be called from file: <green>{:?}<r>\n  {} called from file: <red>{:?}<r>\n",
-                        bstr::BStr::new(fget_source_path_text),
-                        fn_name,
-                        // `{:?}` on BStr renders a quoted, escaped string
-                        bstr::BStr::new(srcloc.str.to_utf8().slice()),
-                    ),
+                return throw!(
+                    this, global_this, signature,
+                    "\n\n<b>Matcher error<r>: Inline snapshot matchers must be called from the test file:\n  Expected to be called from file: <green>{:?}<r>\n  {} called from file: <red>{:?}<r>\n",
+                    bstr::BStr::new(fget_source_path_text),
+                    fn_name,
+                    // `{:?}` on BStr renders a quoted, escaped string
+                    bstr::BStr::new(srcloc.str.to_utf8().slice()),
                 );
             }
 
@@ -1128,7 +1176,7 @@ impl Expect {
         if let Some(_prop_matchers) = property_matchers {
             if !value.is_object() {
                 let signature = Self::get_signature(fn_name, "<green>properties<r><d>, <r>hint", false);
-                return self.throw_fmt(global_this, signature, "", format_args!("\n\n<b>Matcher error: <red>received<r> values must be an object when the matcher has <green>properties<r>\n")).map(drop);
+                return throw!(self, global_this, signature, "\n\n<b>Matcher error: <red>received<r> values must be an object when the matcher has <green>properties<r>\n").map(drop);
             }
 
             let prop_matchers = _prop_matchers;
@@ -1137,10 +1185,11 @@ impl Expect {
                 // TODO: print diff with properties from propertyMatchers
                 let signature = Self::get_signature(fn_name, "<green>propertyMatchers<r>", false);
                 let mut formatter = ConsoleObject::Formatter::new(global_this);
-                return Err(global_this.throw_pretty(format_args!(
-                    "{signature}\n\nExpected <green>propertyMatchers<r> to match properties from received object\n\nReceived: {}\n",
-                    value.to_fmt(&mut formatter)
-                )));
+                return throw!(
+                    self, global_this, signature,
+                    "\n\nExpected <green>propertyMatchers<r> to match properties from received object\n\nReceived: {}\n",
+                    value.to_fmt(&mut formatter),
+                ).map(drop);
             }
         }
 
@@ -1236,7 +1285,7 @@ impl Expect {
                 global_this: Some(global_this),
                 ..Default::default()
             };
-            return Err(global_this.throw_pretty(format_args!("{signature}\n\n{diff_format}\n")));
+            return throw!(self, global_this, signature, "\n\n{}\n", diff_format);
         }
 
         Ok(JSValue::UNDEFINED)
@@ -1317,9 +1366,10 @@ impl Expect {
         let args = args_.slice();
 
         if args.is_empty() || !args[0].is_object() {
-            return Err(global_this.throw_pretty(format_args!(
+            return Err(crate::throw_pretty_static!(
+                global_this,
                 "<d>expect.<r>extend<d>(<r>matchers<d>)<r>\n\nExpected an object containing matchers\n",
-            )));
+            ));
         }
 
         // SAFETY: FFI call with valid &JSGlobalObject
@@ -1814,12 +1864,12 @@ impl fmt::Display for CustomMatcherParamsFormatter<'_> {
                             // skip the first param from the matcher_fn, which is the received value
                             if param_index > 1 {
                                 if self.colors {
-                                    write!(writer, "{}", Output::pretty_fmt::<true>("<r><d>, <r><green>"))?;
+                                    writer.write_str(bun_core::pretty_fmt!("<r><d>, <r><green>", true))?;
                                 } else {
                                     writer.write_str(", ")?;
                                 }
                             } else if self.colors {
-                                writer.write_str("<green>")?;
+                                writer.write_str(bun_core::output::ansi::GREEN)?;
                             }
                             let param_name_trimmed = bun_core::trim(param_name, b" ");
                             if !param_name_trimmed.is_empty() {
@@ -1831,7 +1881,7 @@ impl fmt::Display for CustomMatcherParamsFormatter<'_> {
                         param_index += 1;
                     }
                     if param_index > 1 && self.colors {
-                        writer.write_str("<r>")?;
+                        writer.write_str(bun_core::output::ansi::RESET)?;
                     }
                     return Ok(()); // don't do fallback
                 }
@@ -2020,10 +2070,10 @@ impl Expect {
         }
         let mut formatter = make_formatter(global);
         let signature = Self::get_signature(matcher_name, "", not);
-        this.throw(
-            global,
-            signature,
-            format_args!("\n\nReceived: <red>{}<r>\n", value.to_fmt(&mut formatter)),
+        throw!(
+            this, global, signature,
+            "\n\nReceived: <red>{}<r>\n",
+            value.to_fmt(&mut formatter),
         )
     }
 
@@ -2088,24 +2138,20 @@ impl Expect {
         let mut f2 = make_formatter(global);
         let signature = Self::get_signature(matcher_name, "<green>expected<r>", not);
         if not {
-            this.throw(
-                global,
-                signature,
-                format_args!(
-                    "\n\nExpected to not {verb}: <green>{}<r>\nReceived: <red>{}<r>\n",
-                    expected.to_fmt(&mut f1),
-                    value.to_fmt(&mut f2),
-                ),
+            throw!(
+                this, global, signature,
+                "\n\nExpected to not {}: <green>{}<r>\nReceived: <red>{}<r>\n",
+                verb,
+                expected.to_fmt(&mut f1),
+                value.to_fmt(&mut f2),
             )
         } else {
-            this.throw(
-                global,
-                signature,
-                format_args!(
-                    "\n\nExpected to {verb}: <green>{}<r>\nReceived: <red>{}<r>\n",
-                    expected.to_fmt(&mut f1),
-                    value.to_fmt(&mut f2),
-                ),
+            throw!(
+                this, global, signature,
+                "\n\nExpected to {}: <green>{}<r>\nReceived: <red>{}<r>\n",
+                verb,
+                expected.to_fmt(&mut f1),
+                value.to_fmt(&mut f2),
             )
         }
     }
@@ -2214,26 +2260,20 @@ impl Expect {
         let mut f2 = make_formatter(global);
         let signature = Self::get_signature(matcher_name, "<green>expected<r>", not);
         if not {
-            this.throw(
-                global,
-                signature,
-                format_args!(
-                    "\n\nExpected to not {}: <green>{}<r>\nReceived: <red>{}<r>\n",
-                    msgs.not_verb,
-                    expected.to_fmt(&mut f1),
-                    received.to_fmt(&mut f2),
-                ),
+            throw!(
+                this, global, signature,
+                "\n\nExpected to not {}: <green>{}<r>\nReceived: <red>{}<r>\n",
+                msgs.not_verb,
+                expected.to_fmt(&mut f1),
+                received.to_fmt(&mut f2),
             )
         } else {
-            this.throw(
-                global,
-                signature,
-                format_args!(
-                    "\n\nExpected to {}: <green>{}<r>\nReceived: <red>{}<r>\n",
-                    msgs.verb,
-                    expected.to_fmt(&mut f1),
-                    received.to_fmt(&mut f2),
-                ),
+            throw!(
+                this, global, signature,
+                "\n\nExpected to {}: <green>{}<r>\nReceived: <red>{}<r>\n",
+                msgs.verb,
+                expected.to_fmt(&mut f1),
+                received.to_fmt(&mut f2),
             )
         }
     }
@@ -2356,8 +2396,10 @@ impl ExpectStringMatching {
         let args = call_frame.arguments();
 
         if args.is_empty() || (!args[0].is_string() && !args[0].is_reg_exp()) {
-            const FMT: &str = "<d>expect.<r>stringContaining<d>(<r>string<d>)<r>\n\nExpected a string or regular expression\n";
-            return Err(global_this.throw_pretty(format_args!("{FMT}")));
+            return Err(crate::throw_pretty_static!(
+                global_this,
+                "<d>expect.<r>stringContaining<d>(<r>string<d>)<r>\n\nExpected a string or regular expression\n",
+            ));
         }
 
         let test_value = args[0];
@@ -2382,9 +2424,10 @@ impl ExpectCloseTo {
         let args = args_buf.slice();
 
         if args.is_empty() || !args[0].is_number() {
-            return Err(global_this.throw_pretty(format_args!(
+            return Err(crate::throw_pretty_static!(
+                global_this,
                 "<d>expect.<r>closeTo<d>(<r>number<d>, precision?)<r>\n\nExpected a number value",
-            )));
+            ));
         }
         let number_value = args[0];
 
@@ -2393,9 +2436,10 @@ impl ExpectCloseTo {
             precision_value = JSValue::js_number_from_int32(2); // default value from jest
         }
         if !precision_value.is_number() {
-            return Err(global_this.throw_pretty(format_args!(
+            return Err(crate::throw_pretty_static!(
+                global_this,
                 "<d>expect.<r>closeTo<d>(number, <r>precision?<d>)<r>\n\nPrecision must be a number or undefined",
-            )));
+            ));
         }
 
         let instance_jsvalue = ExpectCloseTo { flags: Cell::new(Flags::default()) }.to_js(global_this);
@@ -2421,8 +2465,10 @@ impl ExpectObjectContaining {
         let args = args_buf.slice();
 
         if args.is_empty() || !args[0].is_object() {
-            const FMT: &str = "<d>expect.<r>objectContaining<d>(<r>object<d>)<r>\n\nExpected an object\n";
-            return Err(global_this.throw_pretty(format_args!("{FMT}")));
+            return Err(crate::throw_pretty_static!(
+                global_this,
+                "<d>expect.<r>objectContaining<d>(<r>object<d>)<r>\n\nExpected an object\n",
+            ));
         }
 
         let object_value = args[0];
@@ -2447,8 +2493,10 @@ impl ExpectStringContaining {
         let args = args_buf.slice();
 
         if args.is_empty() || !args[0].is_string() {
-            const FMT: &str = "<d>expect.<r>stringContaining<d>(<r>string<d>)<r>\n\nExpected a string\n";
-            return Err(global_this.throw_pretty(format_args!("{FMT}")));
+            return Err(crate::throw_pretty_static!(
+                global_this,
+                "<d>expect.<r>stringContaining<d>(<r>string<d>)<r>\n\nExpected a string\n",
+            ));
         }
 
         let string_value = args[0];
@@ -2482,8 +2530,10 @@ impl ExpectAny {
         let constructor = arguments[0];
         constructor.ensure_still_alive();
         if !constructor.is_constructor() {
-            const FMT: &str = "<d>expect.<r>any<d>(<r>constructor<d>)<r>\n\nExpected a constructor\n";
-            return Err(global_this.throw_pretty(format_args!("{FMT}")));
+            return Err(crate::throw_pretty_static!(
+                global_this,
+                "<d>expect.<r>any<d>(<r>constructor<d>)<r>\n\nExpected a constructor\n",
+            ));
         }
 
         let asymmetric_matcher_constructor_type = AsymmetricMatcherConstructorType::from_js(global_this, constructor)?;
@@ -2519,8 +2569,10 @@ impl ExpectArrayContaining {
         let args = args_buf.slice();
 
         if args.is_empty() || !args[0].js_type().is_array() {
-            const FMT: &str = "<d>expect.<r>arrayContaining<d>(<r>array<d>)<r>\n\nExpected a array\n";
-            return Err(global_this.throw_pretty(format_args!("{FMT}")));
+            return Err(crate::throw_pretty_static!(
+                global_this,
+                "<d>expect.<r>arrayContaining<d>(<r>array<d>)<r>\n\nExpected a array\n",
+            ));
         }
 
         let array_value = args[0];
@@ -3069,16 +3121,13 @@ pub mod mock {
             if !arr.js_type().is_array() {
                 let mut formatter = make_formatter(global);
                 return Err(match kind {
-                    MockKind::CallsWithSig => this
-                        .throw(
-                            global,
-                            Self::get_signature(matcher_name, matcher_params, false),
-                            format_args!(
-                                "\n\nMatcher error: <red>received<r> value must be a mock function\nReceived: {}",
-                                value.to_fmt(&mut formatter),
-                            ),
-                        )
-                        .unwrap_err(),
+                    MockKind::CallsWithSig => throw!(
+                        this, global,
+                        Self::get_signature(matcher_name, matcher_params, false),
+                        "\n\nMatcher error: <red>received<r> value must be a mock function\nReceived: {}",
+                        value.to_fmt(&mut formatter),
+                    )
+                    .unwrap_err(),
                     MockKind::Calls | MockKind::Returns => global.throw(format_args!(
                         "Expected value must be a mock function: {}",
                         value.to_fmt(&mut formatter),

--- a/src/runtime/test_runner/expect/toBe.rs
+++ b/src/runtime/test_runner/expect/toBe.rs
@@ -1,5 +1,6 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
+use super::throw;
 use super::DiffFormatter;
 use super::Expect;
 
@@ -41,10 +42,11 @@ impl Expect {
 
         if not {
             let signature = Expect::get_signature("toBe", "<green>expected<r>", true);
-            return this.throw(
+            return throw!(
+                this,
                 global_this,
                 signature,
-                format_args!("\n\nExpected: not <green>{}<r>\n", right.to_fmt(&mut formatter)),
+                "\n\nExpected: not <green>{}<r>\n", right.to_fmt(&mut formatter),
             );
         }
 
@@ -53,36 +55,34 @@ impl Expect {
             // Rust format strings must be literals, so branch the call on
             // `has_custom_label` instead.
             if !has_custom_label {
-                return this.throw(
+                return throw!(
+                    this,
                     global_this,
                     signature,
-                    format_args!(
-                        concat!(
-                            "\n\n<d>If this test should pass, replace \"toBe\" with \"toEqual\" or \"toStrictEqual\"<r>",
-                            "\n\nExpected: <green>{}<r>\n",
-                            "Received: serializes to the same string\n",
-                        ),
-                        right.to_fmt(&mut formatter),
+                    concat!(
+                        "\n\n<d>If this test should pass, replace \"toBe\" with \"toEqual\" or \"toStrictEqual\"<r>",
+                        "\n\nExpected: <green>{}<r>\n",
+                        "Received: serializes to the same string\n",
                     ),
+                    right.to_fmt(&mut formatter),
                 );
             } else {
-                return this.throw(
+                return throw!(
+                    this,
                     global_this,
                     signature,
-                    format_args!(
-                        concat!(
-                            "\n\nExpected: <green>{}<r>\n",
-                            "Received: serializes to the same string\n",
-                        ),
-                        right.to_fmt(&mut formatter),
+                    concat!(
+                        "\n\nExpected: <green>{}<r>\n",
+                        "Received: serializes to the same string\n",
                     ),
+                    right.to_fmt(&mut formatter),
                 );
             }
         }
 
         if right.is_string() && left.is_string() {
             let diff_format = DiffFormatter { expected: Some(right), received: Some(left), expected_string: None, received_string: None, global_this: Some(global_this), not };
-            return this.throw(global_this, signature, format_args!("\n\n{}\n", diff_format));
+            return throw!(this, global_this, signature, "\n\n{}\n", diff_format);
         }
 
         // The `ZigFormatter` adapter holds `&'a mut Formatter`, so two live adapters
@@ -90,14 +90,13 @@ impl Expect {
         // received value — `make_formatter` is a trivial struct init with no shared
         // state between values.
         let mut formatter2 = super::make_formatter(global_this);
-        return this.throw(
+        return throw!(
+            this,
             global_this,
             signature,
-            format_args!(
-                "\n\nExpected: <green>{}<r>\nReceived: <red>{}<r>\n",
-                right.to_fmt(&mut formatter),
-                left.to_fmt(&mut formatter2),
-            ),
+            "\n\nExpected: <green>{}<r>\nReceived: <red>{}<r>\n",
+            right.to_fmt(&mut formatter),
+            left.to_fmt(&mut formatter2),
         );
     }
 }

--- a/src/runtime/test_runner/expect/toBeArrayOfSize.rs
+++ b/src/runtime/test_runner/expect/toBeArrayOfSize.rs
@@ -1,6 +1,7 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use super::Expect;
 use super::get_signature;
+use super::throw;
 
 // Free fn (this module can't open `impl Expect`); bridged into `impl Expect` by the
 // `__forward_matcher!` macro in expect.rs, where the JsClass codegen host_fn shim picks it up.
@@ -48,20 +49,22 @@ pub(crate) fn to_be_array_of_size(
 
     if not {
         let signature = get_signature("toBeArrayOfSize", "", true);
-        return this.throw_fmt(
+        return throw!(
+            this,
             global,
             signature,
             concat!("\n\n", "Received: <red>{}<r>\n"),
-            format_args!("{}", received),
+            received,
         );
     }
 
     let signature = get_signature("toBeArrayOfSize", "", false);
-    this.throw_fmt(
+    throw!(
+        this,
         global,
         signature,
         concat!("\n\n", "Received: <red>{}<r>\n"),
-        format_args!("{}", received),
+        received,
     )
 }
 

--- a/src/runtime/test_runner/expect/toBeCloseTo.rs
+++ b/src/runtime/test_runner/expect/toBeCloseTo.rs
@@ -2,6 +2,7 @@ use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
 use super::Expect;
 use super::get_signature;
+use super::throw;
 
 impl Expect {
     #[bun_jsc::host_fn(method)]
@@ -84,48 +85,24 @@ impl Expect {
         let expected_fmt = expected_.to_fmt(&mut formatter);
         let received_fmt = received_.to_fmt(&mut formatter2);
 
-        const EXPECTED_LINE: &str = "Expected: <green>{}<r>\n";
-        const RECEIVED_LINE: &str = "Received: <red>{}<r>\n";
-        const EXPECTED_PRECISION: &str = "Expected precision: {}\n";
-        const EXPECTED_DIFFERENCE: &str = "Expected difference: \\< <green>{}<r>\n";
-        const RECEIVED_DIFFERENCE: &str = "Received difference: <red>{}<r>\n";
-
-        const SUFFIX_FMT: &str = const_format::concatcp!(
-            "\n\n",
-            EXPECTED_LINE,
-            RECEIVED_LINE,
-            "\n",
-            EXPECTED_PRECISION,
-            EXPECTED_DIFFERENCE,
-            RECEIVED_DIFFERENCE,
-        );
-
-        // TODO(refactor): `format_args!` requires a literal fmt string, so SUFFIX_FMT cannot
-        // be threaded as a runtime arg. Decide `Expect::throw` signature — likely
-        // `fn throw(&self, &JSGlobalObject, &str, fmt::Arguments) -> JsResult<JSValue>` and inline
-        // SUFFIX_FMT into the `format_args!` call (or make `throw!` a macro).
         if not {
             let signature = get_signature("toBeCloseTo", "<green>expected<r>, precision", true);
-            return this.throw_fmt(
+            return throw!(
+                this,
                 global,
                 signature,
-                SUFFIX_FMT,
-                format_args!(
-                    "\n\nExpected: <green>{}<r>\nReceived: <red>{}<r>\n\nExpected precision: {}\nExpected difference: \\< <green>{}<r>\nReceived difference: <red>{}<r>\n",
-                    expected_fmt, received_fmt, precision, expected_diff, actual_diff
-                ),
+                "\n\nExpected: <green>{}<r>\nReceived: <red>{}<r>\n\nExpected precision: {}\nExpected difference: \\< <green>{}<r>\nReceived difference: <red>{}<r>\n",
+                expected_fmt, received_fmt, precision, expected_diff, actual_diff
             );
         }
 
         let signature = get_signature("toBeCloseTo", "<green>expected<r>, precision", false);
-        this.throw_fmt(
+        throw!(
+            this,
             global,
             signature,
-            SUFFIX_FMT,
-            format_args!(
-                "\n\nExpected: <green>{}<r>\nReceived: <red>{}<r>\n\nExpected precision: {}\nExpected difference: \\< <green>{}<r>\nReceived difference: <red>{}<r>\n",
-                expected_fmt, received_fmt, precision, expected_diff, actual_diff
-            ),
+            "\n\nExpected: <green>{}<r>\nReceived: <red>{}<r>\n\nExpected precision: {}\nExpected difference: \\< <green>{}<r>\nReceived difference: <red>{}<r>\n",
+            expected_fmt, received_fmt, precision, expected_diff, actual_diff
         )
     }
 }

--- a/src/runtime/test_runner/expect/toBeEmpty.rs
+++ b/src/runtime/test_runner/expect/toBeEmpty.rs
@@ -2,7 +2,7 @@ use core::ffi::c_void;
 
 use bun_jsc::{CallFrame, JSGlobalObject, JSPropertyIterator, JSPropertyIteratorOptions, JSValue, JsResult, VM};
 
-use super::Expect;
+use super::{throw, Expect};
 
 // Free fn (this module can't open `impl Expect`); bridged into `impl Expect` by the
 // `__forward_matcher!` macro in expect.rs, where the JsClass codegen host_fn shim picks it up.
@@ -63,10 +63,13 @@ pub(crate) fn to_be_empty(
             }
         } else {
             let signature = Expect::get_signature("toBeEmpty", "", false);
-            return Err(global.throw_pretty(format_args!(
-                "{signature}\n\nExpected value to be a string, object, or iterable\n\nReceived: <red>{}<r>\n",
+            return throw!(
+                this,
+                global,
+                signature,
+                "\n\nExpected value to be a string, object, or iterable\n\nReceived: <red>{}<r>\n",
                 value.to_fmt(&mut formatter)
-            )));
+            );
         }
     } else if actual_length.is_nan() {
         return Err(global.throw(format_args!(
@@ -79,10 +82,13 @@ pub(crate) fn to_be_empty(
 
     if not && pass {
         let signature = Expect::get_signature("toBeEmpty", "", true);
-        return Err(global.throw_pretty(format_args!(
-            "{signature}\n\nExpected value <b>not<r> to be a string, object, or iterable\n\nReceived: <red>{}<r>\n",
+        return throw!(
+            this,
+            global,
+            signature,
+            "\n\nExpected value <b>not<r> to be a string, object, or iterable\n\nReceived: <red>{}<r>\n",
             value.to_fmt(&mut formatter)
-        )));
+        );
     }
 
     if not {
@@ -94,16 +100,22 @@ pub(crate) fn to_be_empty(
 
     if not {
         let signature = Expect::get_signature("toBeEmpty", "", true);
-        return Err(global.throw_pretty(format_args!(
-            "{signature}\n\nExpected value <b>not<r> to be empty\n\nReceived: <red>{}<r>\n",
+        return throw!(
+            this,
+            global,
+            signature,
+            "\n\nExpected value <b>not<r> to be empty\n\nReceived: <red>{}<r>\n",
             value.to_fmt(&mut formatter)
-        )));
+        );
     }
 
     let signature = Expect::get_signature("toBeEmpty", "", false);
-    Err(global.throw_pretty(format_args!(
-        "{signature}\n\nExpected value to be empty\n\nReceived: <red>{}<r>\n",
+    throw!(
+        this,
+        global,
+        signature,
+        "\n\nExpected value to be empty\n\nReceived: <red>{}<r>\n",
         value.to_fmt(&mut formatter)
-    )))
+    )
 }
 

--- a/src/runtime/test_runner/expect/toBeEmptyObject.rs
+++ b/src/runtime/test_runner/expect/toBeEmptyObject.rs
@@ -1,5 +1,6 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use super::Expect;
+use super::throw;
 
 // Free fn (this module can't open `impl Expect`); bridged into `impl Expect` by the
 // `__forward_matcher!` macro in expect.rs, where the JsClass codegen host_fn shim picks it up.
@@ -25,18 +26,20 @@ pub(crate) fn to_be_empty_object(
 
     if not {
         let signature = Expect::get_signature("toBeEmptyObject", "", true);
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!("\n\nReceived: <red>{}<r>\n", received),
+            "\n\nReceived: <red>{}<r>\n", received,
         );
     }
 
     let signature = Expect::get_signature("toBeEmptyObject", "", false);
-    this.throw(
+    throw!(
+        this,
         global,
         signature,
-        format_args!("\n\nReceived: <red>{}<r>\n", received),
+        "\n\nReceived: <red>{}<r>\n", received,
     )
 }
 

--- a/src/runtime/test_runner/expect/toBeInstanceOf.rs
+++ b/src/runtime/test_runner/expect/toBeInstanceOf.rs
@@ -2,6 +2,7 @@ use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
 use super::Expect;
 use super::get_signature;
+use super::throw;
 
 // Free fn (this module can't open `impl Expect`); bridged into `impl Expect` by the
 // `__forward_matcher!` macro in expect.rs, where the JsClass codegen host_fn shim picks it up.
@@ -59,24 +60,22 @@ pub(crate) fn to_be_instance_of(
         // `expected_line`/`received_line` are inlined here because Rust `concat!`
         // only accepts literals (and `format_args!` needs a literal anyway).
         let signature = get_signature("toBeInstanceOf", "<green>expected<r>", true);
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                "\n\nExpected constructor: not <green>{}<r>\nReceived value: <red>{}<r>\n",
-                expected_fmt, value_fmt,
-            ),
+            "\n\nExpected constructor: not <green>{}<r>\nReceived value: <red>{}<r>\n",
+            expected_fmt, value_fmt,
         );
     }
 
     let signature = get_signature("toBeInstanceOf", "<green>expected<r>", false);
-    this.throw(
+    throw!(
+        this,
         global,
         signature,
-        format_args!(
-            "\n\nExpected constructor: <green>{}<r>\nReceived value: <red>{}<r>\n",
-            expected_fmt, value_fmt,
-        ),
+        "\n\nExpected constructor: <green>{}<r>\nReceived value: <red>{}<r>\n",
+        expected_fmt, value_fmt,
     )
     })();
     this.post_match(global);

--- a/src/runtime/test_runner/expect/toBeObject.rs
+++ b/src/runtime/test_runner/expect/toBeObject.rs
@@ -1,6 +1,6 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
-use super::Expect;
+use super::{throw, Expect};
 
 impl Expect {
     #[bun_jsc::host_fn(method)]
@@ -31,24 +31,22 @@ impl Expect {
 
         if not {
             let signature = Expect::get_signature("toBeObject", "", true);
-            return this.throw(
+            return throw!(
+                this,
                 global,
                 signature,
-                format_args!(
-                    "\n\nExpected value <b>not<r> to be an object\n\nReceived: <red>{}<r>\n",
-                    received
-                ),
+                "\n\nExpected value <b>not<r> to be an object\n\nReceived: <red>{}<r>\n",
+                received
             );
         }
 
         let signature = Expect::get_signature("toBeObject", "", false);
-        this.throw(
+        throw!(
+            this,
             global,
             signature,
-            format_args!(
-                "\n\nExpected value to be an object\n\nReceived: <red>{}<r>\n",
-                received
-            ),
+            "\n\nExpected value to be an object\n\nReceived: <red>{}<r>\n",
+            received
         )
         })();
         this.post_match(global);

--- a/src/runtime/test_runner/expect/toBeOneOf.rs
+++ b/src/runtime/test_runner/expect/toBeOneOf.rs
@@ -4,6 +4,7 @@ use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, VM};
 
 use super::Expect;
 use super::get_signature;
+use super::throw;
 
 struct ExpectedEntry<'a> {
     global_this: &'a JSGlobalObject,
@@ -90,33 +91,31 @@ pub(crate) fn to_be_one_of(
     let mut formatter2 = super::make_formatter(global_this);
     if not {
         let signature = get_signature("toBeOneOf", "<green>expected<r>", true);
-        return this.throw(
+        return throw!(
+            this,
             global_this,
             signature,
-            format_args!(
-                concat!(
-                    "\n\n",
-                    "Expected to not be one of: <green>{}<r>\nReceived: <red>{}<r>\n",
-                ),
-                list_value.to_fmt(&mut formatter),
-                expected.to_fmt(&mut formatter2),
+            concat!(
+                "\n\n",
+                "Expected to not be one of: <green>{}<r>\nReceived: <red>{}<r>\n",
             ),
+            list_value.to_fmt(&mut formatter),
+            expected.to_fmt(&mut formatter2),
         );
     }
 
     let signature = get_signature("toBeOneOf", "<green>expected<r>", false);
-    return this.throw(
+    return throw!(
+        this,
         global_this,
         signature,
-        format_args!(
-            concat!(
-                "\n\n",
-                "Expected to be one of: <green>{}<r>\n",
-                "Received: <red>{}<r>\n",
-            ),
-            list_value.to_fmt(&mut formatter),
-            expected.to_fmt(&mut formatter2),
+        concat!(
+            "\n\n",
+            "Expected to be one of: <green>{}<r>\n",
+            "Received: <red>{}<r>\n",
         ),
+        list_value.to_fmt(&mut formatter),
+        expected.to_fmt(&mut formatter2),
     );
 }
 

--- a/src/runtime/test_runner/expect/toBeTypeOf.rs
+++ b/src/runtime/test_runner/expect/toBeTypeOf.rs
@@ -1,6 +1,7 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use super::Expect;
 use super::get_signature;
+use super::throw;
 
 bun_core::comptime_string_map! {
     static JS_TYPE_OF_MAP: &'static [u8] = {
@@ -86,35 +87,33 @@ pub(crate) fn to_be_type_of(
 
     if not {
         let signature = get_signature("toBeTypeOf", "", true);
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                concat!(
-                    "\n\n",
-                    "Expected type: not <green>{}<r>\n",
-                    "Received type: <red>\"{}\"<r>\nReceived value: <red>{}<r>\n",
-                ),
-                expected_str,
-                bstr::BStr::new(what_is_the_type),
-                received,
-            ),
-        );
-    }
-
-    let signature = get_signature("toBeTypeOf", "", false);
-    this.throw(
-        global,
-        signature,
-        format_args!(
             concat!(
                 "\n\n",
-                "Expected type: <green>{}<r>\n",
+                "Expected type: not <green>{}<r>\n",
                 "Received type: <red>\"{}\"<r>\nReceived value: <red>{}<r>\n",
             ),
             expected_str,
             bstr::BStr::new(what_is_the_type),
             received,
+        );
+    }
+
+    let signature = get_signature("toBeTypeOf", "", false);
+    throw!(
+        this,
+        global,
+        signature,
+        concat!(
+            "\n\n",
+            "Expected type: <green>{}<r>\n",
+            "Received type: <red>\"{}\"<r>\nReceived value: <red>{}<r>\n",
         ),
+        expected_str,
+        bstr::BStr::new(what_is_the_type),
+        received,
     )
 }

--- a/src/runtime/test_runner/expect/toBeValidDate.rs
+++ b/src/runtime/test_runner/expect/toBeValidDate.rs
@@ -3,6 +3,7 @@ use super::make_formatter;
 
 use super::Expect;
 use super::get_signature;
+use super::throw;
 
 // Free fn (this module can't open `impl Expect`); bridged into `impl Expect` by the
 // `__forward_matcher!` macro in expect.rs, where the JsClass codegen host_fn shim picks it up.
@@ -28,17 +29,19 @@ pub(crate) fn to_be_valid_date(
 
     if not {
         let signature = get_signature("toBeValidDate", "", true);
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!("\n\nReceived: <red>{}<r>\n", received),
+            "\n\nReceived: <red>{}<r>\n", received,
         );
     }
 
     let signature = get_signature("toBeValidDate", "", false);
-    this.throw(
+    throw!(
+        this,
         global,
         signature,
-        format_args!("\n\nReceived: <red>{}<r>\n", received),
+        "\n\nReceived: <red>{}<r>\n", received,
     )
 }

--- a/src/runtime/test_runner/expect/toBeWithin.rs
+++ b/src/runtime/test_runner/expect/toBeWithin.rs
@@ -1,6 +1,6 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
-use super::Expect;
+use super::{throw, Expect};
 
 impl Expect {
     #[bun_jsc::host_fn(method)]
@@ -73,19 +73,18 @@ impl Expect {
                 "<green>start<r><d>, <r><green>end<r>",
                 true,
             );
-            return this.throw(
+            return throw!(
+                this,
                 global,
                 signature,
-                format_args!(
-                    concat!(
-                        "\n\n",
-                        "Expected: not between <green>{}<r> <d>(inclusive)<r> and <green>{}<r> <d>(exclusive)<r>\n",
-                        "Received: <red>{}<r>\n",
-                    ),
-                    start_fmt,
-                    end_fmt,
-                    received_fmt,
+                concat!(
+                    "\n\n",
+                    "Expected: not between <green>{}<r> <d>(inclusive)<r> and <green>{}<r> <d>(exclusive)<r>\n",
+                    "Received: <red>{}<r>\n",
                 ),
+                start_fmt,
+                end_fmt,
+                received_fmt,
             );
         }
 
@@ -94,19 +93,18 @@ impl Expect {
             "<green>start<r><d>, <r><green>end<r>",
             false,
         );
-        this.throw(
+        throw!(
+            this,
             global,
             signature,
-            format_args!(
-                concat!(
-                    "\n\n",
-                    "Expected: between <green>{}<r> <d>(inclusive)<r> and <green>{}<r> <d>(exclusive)<r>\n",
-                    "Received: <red>{}<r>\n",
-                ),
-                start_fmt,
-                end_fmt,
-                received_fmt,
+            concat!(
+                "\n\n",
+                "Expected: between <green>{}<r> <d>(inclusive)<r> and <green>{}<r> <d>(exclusive)<r>\n",
+                "Received: <red>{}<r>\n",
             ),
+            start_fmt,
+            end_fmt,
+            received_fmt,
         )
     }
 }

--- a/src/runtime/test_runner/expect/toContain.rs
+++ b/src/runtime/test_runner/expect/toContain.rs
@@ -5,6 +5,7 @@ use bun_core::strings;
 
 use super::Expect;
 use super::get_signature;
+use super::throw;
 
 impl Expect {
     #[bun_jsc::host_fn(method)]
@@ -114,33 +115,31 @@ impl Expect {
         let mut formatter2 = super::make_formatter(global);
         if not {
             let signature = get_signature("toContain", "<green>expected<r>", true);
-            return this.throw(
+            return throw!(
+                this,
                 global,
                 signature,
-                format_args!(
-                    concat!(
-                        "\n\n",
-                        "Expected to not contain: <green>{}<r>\nReceived: <red>{}<r>\n",
-                    ),
-                    expected.to_fmt(&mut formatter),
-                    value.to_fmt(&mut formatter2),
+                concat!(
+                    "\n\n",
+                    "Expected to not contain: <green>{}<r>\nReceived: <red>{}<r>\n",
                 ),
+                expected.to_fmt(&mut formatter),
+                value.to_fmt(&mut formatter2),
             );
         }
 
         let signature = get_signature("toContain", "<green>expected<r>", false);
-        this.throw(
+        throw!(
+            this,
             global,
             signature,
-            format_args!(
-                concat!(
-                    "\n\n",
-                    "Expected to contain: <green>{}<r>\n",
-                    "Received: <red>{}<r>\n",
-                ),
-                expected.to_fmt(&mut formatter),
-                value.to_fmt(&mut formatter2),
+            concat!(
+                "\n\n",
+                "Expected to contain: <green>{}<r>\n",
+                "Received: <red>{}<r>\n",
             ),
+            expected.to_fmt(&mut formatter),
+            value.to_fmt(&mut formatter2),
         )
     }
 }

--- a/src/runtime/test_runner/expect/toContainEqual.rs
+++ b/src/runtime/test_runner/expect/toContainEqual.rs
@@ -3,7 +3,7 @@ use core::ffi::c_void;
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, VM};
 use bun_core::strings;
 
-use super::{get_signature, Expect};
+use super::{get_signature, throw, Expect};
 
 struct ExpectedEntry<'a> {
     global_this: &'a JSGlobalObject,
@@ -113,16 +113,18 @@ pub(crate) fn to_contain_equal(
     let expected_fmt = expected.to_fmt(&mut formatter2);
     if not {
         let signature: &str = get_signature("toContainEqual", "<green>expected<r>", true);
-        return this.throw_fmt(
+        return throw!(
+            this,
             global,
             signature,
             concat!("\n\n", "Expected to not contain: <green>{}<r>\n"),
-            format_args!("{}", expected_fmt),
+            expected_fmt,
         );
     }
 
     let signature: &str = get_signature("toContainEqual", "<green>expected<r>", false);
-    this.throw_fmt(
+    throw!(
+        this,
         global,
         signature,
         concat!(
@@ -130,6 +132,7 @@ pub(crate) fn to_contain_equal(
             "Expected to contain: <green>{}<r>\n",
             "Received: <red>{}<r>\n"
         ),
-        format_args!("{}{}", expected_fmt, value_fmt),
+        expected_fmt,
+        value_fmt,
     )
 }

--- a/src/runtime/test_runner/expect/toEqual.rs
+++ b/src/runtime/test_runner/expect/toEqual.rs
@@ -1,5 +1,6 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
+use super::throw;
 use super::DiffFormatter;
 use super::Expect;
 
@@ -42,10 +43,10 @@ impl Expect {
 
         if not {
             let signature: &str = Expect::get_signature("toEqual", "<green>expected<r>", true);
-            return this.throw(global, signature, format_args!("\n\n{}\n", diff_formatter));
+            return throw!(this, global, signature, "\n\n{}\n", diff_formatter);
         }
 
         let signature: &str = Expect::get_signature("toEqual", "<green>expected<r>", false);
-        this.throw(global, signature, format_args!("\n\n{}\n", diff_formatter))
+        throw!(this, global, signature, "\n\n{}\n", diff_formatter)
     }
 }

--- a/src/runtime/test_runner/expect/toEqualIgnoringWhitespace.rs
+++ b/src/runtime/test_runner/expect/toEqualIgnoringWhitespace.rs
@@ -1,5 +1,6 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use super::Expect;
+use super::throw;
 
 // Matches ' ' and '\t'..'\r' (0x09–0x0D) — includes VT (0x0B), which Rust's
 // u8::is_ascii_whitespace does not.
@@ -100,23 +101,21 @@ pub(crate) fn to_equal_ignoring_whitespace(
 
     if not {
         let signature = Expect::get_signature("toEqualIgnoringWhitespace", "<green>expected<r>", true);
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                concat!("\n\n", "Expected: not <green>{}<r>\n", "Received: <red>{}<r>\n"),
-                expected_fmt, value_fmt
-            ),
+            concat!("\n\n", "Expected: not <green>{}<r>\n", "Received: <red>{}<r>\n"),
+            expected_fmt, value_fmt
         );
     }
 
     let signature = Expect::get_signature("toEqualIgnoringWhitespace", "<green>expected<r>", false);
-    this.throw(
+    throw!(
+        this,
         global,
         signature,
-        format_args!(
-            concat!("\n\n", "Expected: <green>{}<r>\n", "Received: <red>{}<r>\n"),
-            expected_fmt, value_fmt
-        ),
+        concat!("\n\n", "Expected: <green>{}<r>\n", "Received: <red>{}<r>\n"),
+        expected_fmt, value_fmt
     )
 }

--- a/src/runtime/test_runner/expect/toHaveBeenCalled.rs
+++ b/src/runtime/test_runner/expect/toHaveBeenCalled.rs
@@ -1,5 +1,6 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use super::Expect;
+use super::throw;
 
 pub(crate) fn to_have_been_called(
     this: &Expect,
@@ -30,31 +31,29 @@ pub(crate) fn to_have_been_called(
     // handle failure
     if not {
         let signature = Expect::get_signature("toHaveBeenCalled", "", true);
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                concat!(
-                    "\n\n",
-                    "Expected number of calls: <green>0<r>\n",
-                    "Received number of calls: <red>{}<r>\n",
-                ),
-                calls_length
+            concat!(
+                "\n\n",
+                "Expected number of calls: <green>0<r>\n",
+                "Received number of calls: <red>{}<r>\n",
             ),
+            calls_length
         );
     }
 
     let signature = Expect::get_signature("toHaveBeenCalled", "", false);
-    this.throw(
+    throw!(
+        this,
         global,
         signature,
-        format_args!(
-            concat!(
-                "\n\n",
-                "Expected number of calls: \\>= <green>1<r>\n",
-                "Received number of calls: <red>{}<r>\n",
-            ),
-            calls_length
+        concat!(
+            "\n\n",
+            "Expected number of calls: \\>= <green>1<r>\n",
+            "Received number of calls: <red>{}<r>\n",
         ),
+        calls_length
     )
 }

--- a/src/runtime/test_runner/expect/toHaveBeenCalledOnce.rs
+++ b/src/runtime/test_runner/expect/toHaveBeenCalledOnce.rs
@@ -1,6 +1,7 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use super::Expect;
 use super::get_signature;
+use super::throw;
 
 pub(crate) fn to_have_been_called_once(
     this: &Expect,
@@ -30,31 +31,29 @@ pub(crate) fn to_have_been_called_once(
     // handle failure
     if not {
         let signature = get_signature("toHaveBeenCalledOnce", "<green>expected<r>", true);
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                concat!(
-                    "\n\n",
-                    "Expected number of calls: not <green>1<r>\n",
-                    "Received number of calls: <red>{}<r>\n",
-                ),
-                calls_length,
+            concat!(
+                "\n\n",
+                "Expected number of calls: not <green>1<r>\n",
+                "Received number of calls: <red>{}<r>\n",
             ),
+            calls_length,
         );
     }
 
     let signature = get_signature("toHaveBeenCalledOnce", "<green>expected<r>", false);
-    this.throw(
+    throw!(
+        this,
         global,
         signature,
-        format_args!(
-            concat!(
-                "\n\n",
-                "Expected number of calls: <green>1<r>\n",
-                "Received number of calls: <red>{}<r>\n",
-            ),
-            calls_length,
+        concat!(
+            "\n\n",
+            "Expected number of calls: <green>1<r>\n",
+            "Received number of calls: <red>{}<r>\n",
         ),
+        calls_length,
     )
 }

--- a/src/runtime/test_runner/expect/toHaveBeenCalledTimes.rs
+++ b/src/runtime/test_runner/expect/toHaveBeenCalledTimes.rs
@@ -1,6 +1,7 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use super::Expect;
 use super::get_signature;
+use super::throw;
 
 pub(crate) fn to_have_been_called_times(
     this: &Expect,
@@ -38,33 +39,31 @@ pub(crate) fn to_have_been_called_times(
     // handle failure
     if not {
         let signature = get_signature("toHaveBeenCalledTimes", "<green>expected<r>", true);
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                concat!(
-                    "\n\n",
-                    "Expected number of calls: not <green>{}<r>\n",
-                    "Received number of calls: <red>{}<r>\n"
-                ),
-                times,
-                calls.get_length(global)?,
-            ),
-        );
-    }
-
-    let signature = get_signature("toHaveBeenCalledTimes", "<green>expected<r>", false);
-    this.throw(
-        global,
-        signature,
-        format_args!(
             concat!(
                 "\n\n",
-                "Expected number of calls: <green>{}<r>\n",
+                "Expected number of calls: not <green>{}<r>\n",
                 "Received number of calls: <red>{}<r>\n"
             ),
             times,
             calls.get_length(global)?,
+        );
+    }
+
+    let signature = get_signature("toHaveBeenCalledTimes", "<green>expected<r>", false);
+    throw!(
+        this,
+        global,
+        signature,
+        concat!(
+            "\n\n",
+            "Expected number of calls: <green>{}<r>\n",
+            "Received number of calls: <red>{}<r>\n"
         ),
+        times,
+        calls.get_length(global)?,
     )
 }

--- a/src/runtime/test_runner/expect/toHaveBeenCalledWith.rs
+++ b/src/runtime/test_runner/expect/toHaveBeenCalledWith.rs
@@ -2,6 +2,7 @@ use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
 use super::DiffFormatter;
 use super::mock;
+use super::throw;
 use super::Expect;
 
 pub(crate) fn to_have_been_called_with(
@@ -64,25 +65,23 @@ pub(crate) fn to_have_been_called_with(
 
     if this.flags.get().not() {
         let signature = Expect::get_signature("toHaveBeenCalledWith", "<green>...expected<r>", true);
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                "\n\nExpected mock function not to have been called with: <green>{}<r>\nBut it was.",
-                expected_args_js_array.to_fmt(&mut formatter),
-            ),
+            "\n\nExpected mock function not to have been called with: <green>{}<r>\nBut it was.",
+            expected_args_js_array.to_fmt(&mut formatter),
         );
     }
     let signature = Expect::get_signature("toHaveBeenCalledWith", "<green>...expected<r>", false);
 
     if calls_count == 0 {
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                "\n\nExpected: <green>{}<r>\nBut it was not called.",
-                expected_args_js_array.to_fmt(&mut formatter),
-            ),
+            "\n\nExpected: <green>{}<r>\nBut it was not called.",
+            expected_args_js_array.to_fmt(&mut formatter),
         );
     }
 
@@ -97,7 +96,7 @@ pub(crate) fn to_have_been_called_with(
             global_this: Some(global),
             not: false,
         };
-        return this.throw(global, signature, format_args!("\n\n{}\n", diff_format));
+        return throw!(this, global, signature, "\n\n{}\n", diff_format);
     }
 
     // If there are multiple calls, list them all to help debugging.
@@ -110,14 +109,13 @@ pub(crate) fn to_have_been_called_with(
         formatter: core::cell::RefCell::new(&mut list_fmt),
     };
 
-    this.throw(
+    throw!(
+        this,
         global,
         signature,
-        format_args!(
-            "\n\n    <green>Expected<r>: {}\n    <red>Received<r>:\n{}\n\n    Number of calls: {}\n",
-            expected_args_js_array.to_fmt(&mut formatter),
-            list_formatter,
-            calls_count,
-        ),
+        "\n\n    <green>Expected<r>: {}\n    <red>Received<r>:\n{}\n\n    Number of calls: {}\n",
+        expected_args_js_array.to_fmt(&mut formatter),
+        list_formatter,
+        calls_count,
     )
 }

--- a/src/runtime/test_runner/expect/toHaveBeenLastCalledWith.rs
+++ b/src/runtime/test_runner/expect/toHaveBeenLastCalledWith.rs
@@ -1,6 +1,7 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
 use super::DiffFormatter;
+use super::throw;
 use super::{Expect, get_signature};
 
 pub(crate) fn to_have_been_last_called_with(
@@ -59,25 +60,23 @@ pub(crate) fn to_have_been_last_called_with(
 
     if this.flags.get().not() {
         let signature = get_signature("toHaveBeenLastCalledWith", "<green>...expected<r>", true);
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                "\n\nExpected last call not to be with: <green>{}<r>\nBut it was.",
-                expected_args_js_array.to_fmt(&mut formatter),
-            ),
+            "\n\nExpected last call not to be with: <green>{}<r>\nBut it was.",
+            expected_args_js_array.to_fmt(&mut formatter),
         );
     }
     let signature = get_signature("toHaveBeenLastCalledWith", "<green>...expected<r>", false);
 
     if total_calls == 0 {
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                "\n\nExpected: <green>{}<r>\nBut it was not called.",
-                expected_args_js_array.to_fmt(&mut formatter),
-            ),
+            "\n\nExpected: <green>{}<r>\nBut it was not called.",
+            expected_args_js_array.to_fmt(&mut formatter),
         );
     }
 
@@ -89,5 +88,5 @@ pub(crate) fn to_have_been_last_called_with(
         global_this: Some(global),
         not: false,
     };
-    this.throw(global, signature, format_args!("\n\n{}\n", diff_format))
+    throw!(this, global, signature, "\n\n{}\n", diff_format)
 }

--- a/src/runtime/test_runner/expect/toHaveBeenNthCalledWith.rs
+++ b/src/runtime/test_runner/expect/toHaveBeenNthCalledWith.rs
@@ -1,6 +1,7 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use super::DiffFormatter;
 use super::Expect;
+use super::throw;
 
 pub(crate) fn to_have_been_nth_called_with(
     this: &Expect,
@@ -70,29 +71,27 @@ pub(crate) fn to_have_been_nth_called_with(
 
     if this.flags.get().not() {
         let signature = Expect::get_signature("toHaveBeenNthCalledWith", "<green>n<r>, <green>...expected<r>", true);
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                "\n\nExpected call #{} not to be with: <green>{}<r>\nBut it was.",
-                nth_call_num,
-                expected_args_js_array.to_fmt(&mut formatter),
-            ),
+            "\n\nExpected call #{} not to be with: <green>{}<r>\nBut it was.",
+            nth_call_num,
+            expected_args_js_array.to_fmt(&mut formatter),
         );
     }
     let signature = Expect::get_signature("toHaveBeenNthCalledWith", "<green>n<r>, <green>...expected<r>", false);
 
     // Handle case where function was not called enough times
     if total_calls < nth_call_num {
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                "\n\nThe mock function was called {} time{}, but call {} was requested.",
-                total_calls,
-                if total_calls == 1 { "" } else { "s" },
-                nth_call_num,
-            ),
+            "\n\nThe mock function was called {} time{}, but call {} was requested.",
+            total_calls,
+            if total_calls == 1 { "" } else { "s" },
+            nth_call_num,
         );
     }
 
@@ -105,9 +104,10 @@ pub(crate) fn to_have_been_nth_called_with(
         global_this: Some(global),
         not: false,
     };
-    this.throw(
+    throw!(
+        this,
         global,
         signature,
-        format_args!("\n\nCall #{}:\n{}\n", nth_call_num, diff_format),
+        "\n\nCall #{}:\n{}\n", nth_call_num, diff_format,
     )
 }

--- a/src/runtime/test_runner/expect/toHaveLastReturnedWith.rs
+++ b/src/runtime/test_runner/expect/toHaveLastReturnedWith.rs
@@ -4,6 +4,7 @@ use bun_jsc::console_object::Formatter;
 
 use super::DiffFormatter;
 use super::Expect;
+use super::throw;
 
 pub(crate) fn to_have_last_returned_with(
     this: &Expect,
@@ -60,36 +61,35 @@ pub(crate) fn to_have_last_returned_with(
     let signature = Expect::get_signature("toHaveBeenLastReturnedWith", "<green>expected<r>", false);
 
     if this.flags.get().not() {
-        return this.throw(
+        return throw!(
+            this,
             global_this,
             Expect::get_signature("toHaveBeenLastReturnedWith", "<green>expected<r>", true),
-            format_args!(
-                concat!(
-                    "\n\n",
-                    "Expected mock function not to have last returned: <green>{}<r>\n",
-                    "But it did.\n",
-                ),
-                expected.to_fmt(&mut formatter),
+            concat!(
+                "\n\n",
+                "Expected mock function not to have last returned: <green>{}<r>\n",
+                "But it did.\n",
             ),
+            expected.to_fmt(&mut formatter),
         );
     }
 
     if calls_count == 0 {
-        return this.throw(
+        return throw!(
+            this,
             global_this,
             signature,
-            format_args!(concat!("\n\n", "The mock function was not called.")),
+            concat!("\n\n", "The mock function was not called."),
         );
     }
 
     if last_call_threw {
-        return this.throw(
+        return throw!(
+            this,
             global_this,
             signature,
-            format_args!(
-                concat!("\n\n", "The last call threw an error: <red>{}<r>\n"),
-                last_error_value.to_fmt(&mut formatter),
-            ),
+            concat!("\n\n", "The last call threw an error: <red>{}<r>\n"),
+            last_error_value.to_fmt(&mut formatter),
         );
     }
 
@@ -103,20 +103,19 @@ pub(crate) fn to_have_last_returned_with(
             global_this: Some(global_this),
             not: false,
         };
-        return this.throw(global_this, signature, format_args!("\n\n{}\n", diff_format));
+        return throw!(this, global_this, signature, "\n\n{}\n", diff_format);
     }
 
     // The `ZigFormatter` adapter holds `&'a mut Formatter`, so two live adapters cannot alias
     // the same backing formatter. Use a second formatter for the received value —
     // `make_formatter` is a trivial struct init with no shared state between values.
     let mut formatter2 = super::make_formatter(global_this);
-    this.throw(
+    throw!(
+        this,
         global_this,
         signature,
-        format_args!(
-            "\n\nExpected: <green>{}<r>\nReceived: <red>{}<r>",
-            expected.to_fmt(&mut formatter),
-            last_return_value.to_fmt(&mut formatter2),
-        ),
+        "\n\nExpected: <green>{}<r>\nReceived: <red>{}<r>",
+        expected.to_fmt(&mut formatter),
+        last_return_value.to_fmt(&mut formatter2),
     )
 }

--- a/src/runtime/test_runner/expect/toHaveLength.rs
+++ b/src/runtime/test_runner/expect/toHaveLength.rs
@@ -2,6 +2,7 @@ use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
 use super::Expect;
 use super::get_signature;
+use super::throw;
 
 pub(crate) fn to_have_length(
     this: &Expect,
@@ -80,20 +81,20 @@ pub(crate) fn to_have_length(
     // handle failure
     if not {
         let signature: &str = get_signature("toHaveLength", "<green>expected<r>", true);
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!("\n\nExpected length: not <green>{}<r>\n", expected_length),
+            "\n\nExpected length: not <green>{}<r>\n", expected_length,
         );
     }
 
     let signature: &str = get_signature("toHaveLength", "<green>expected<r>", false);
-    this.throw(
+    throw!(
+        this,
         global,
         signature,
-        format_args!(
-            "\n\nExpected length: <green>{}<r>\nReceived length: <red>{}<r>\n",
-            expected_length, actual_length,
-        ),
+        "\n\nExpected length: <green>{}<r>\nReceived length: <red>{}<r>\n",
+        expected_length, actual_length,
     )
 }

--- a/src/runtime/test_runner/expect/toHaveNthReturnedWith.rs
+++ b/src/runtime/test_runner/expect/toHaveNthReturnedWith.rs
@@ -1,6 +1,7 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
 use super::DiffFormatter;
+use super::throw;
 use super::{Expect, get_signature};
 
 pub(crate) fn to_have_nth_returned_with(
@@ -72,39 +73,36 @@ pub(crate) fn to_have_nth_returned_with(
     let signature = get_signature("toHaveNthReturnedWith", "<green>n<r>, <green>expected<r>", false);
 
     if this.flags.get().not() {
-        return this.throw(
+        return throw!(
+            this,
             global,
             get_signature("toHaveNthReturnedWith", "<green>n<r>, <green>expected<r>", true),
-            format_args!(
-                "\n\nExpected mock function not to have returned on call {}: <green>{}<r>\nBut it did.\n",
-                n,
-                expected.to_fmt(&mut formatter),
-            ),
+            "\n\nExpected mock function not to have returned on call {}: <green>{}<r>\nBut it did.\n",
+            n,
+            expected.to_fmt(&mut formatter),
         );
     }
 
     if !nth_call_exists {
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                "\n\nThe mock function was called {} time{}, but call {} was requested.\n",
-                calls_count,
-                if calls_count == 1 { "" } else { "s" },
-                n,
-            ),
+            "\n\nThe mock function was called {} time{}, but call {} was requested.\n",
+            calls_count,
+            if calls_count == 1 { "" } else { "s" },
+            n,
         );
     }
 
     if nth_call_threw {
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                "\n\nCall {} threw an error: <red>{}<r>\n",
-                n,
-                nth_error_value.to_fmt(&mut formatter),
-            ),
+            "\n\nCall {} threw an error: <red>{}<r>\n",
+            n,
+            nth_error_value.to_fmt(&mut formatter),
         );
     }
 
@@ -118,21 +116,21 @@ pub(crate) fn to_have_nth_returned_with(
             global_this: Some(global),
             not: false,
         };
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!("\n\nCall {}:\n{}\n", n, diff_format),
+            "\n\nCall {}:\n{}\n", n, diff_format,
         );
     }
 
-    this.throw(
+    throw!(
+        this,
         global,
         signature,
-        format_args!(
-            "\n\nCall {}:\nExpected: <green>{}<r>\nReceived: <red>{}<r>",
-            n,
-            expected.to_fmt(&mut formatter),
-            nth_return_value.to_fmt(&mut formatter2),
-        ),
+        "\n\nCall {}:\nExpected: <green>{}<r>\nReceived: <red>{}<r>",
+        n,
+        expected.to_fmt(&mut formatter),
+        nth_return_value.to_fmt(&mut formatter2),
     )
 }

--- a/src/runtime/test_runner/expect/toHaveProperty.rs
+++ b/src/runtime/test_runner/expect/toHaveProperty.rs
@@ -1,6 +1,7 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use bun_core::ZigString;
 
+use super::throw;
 use super::DiffFormatter;
 use super::Expect;
 
@@ -78,27 +79,25 @@ pub(crate) fn to_have_property(
             let signature =
                 Expect::get_signature("toHaveProperty", "<green>path<r><d>, <r><green>value<r>", true);
             if !received_property.is_empty() {
-                return this.throw(
+                return throw!(
+                    this,
                     global,
                     signature,
-                    format_args!(
-                        "\n\nExpected path: <green>{}<r>\n\nExpected value: not <green>{}<r>\n",
-                        expected_property_path.to_fmt(&mut formatter),
-                        expected_property_value.to_fmt(&mut formatter2),
-                    ),
+                    "\n\nExpected path: <green>{}<r>\n\nExpected value: not <green>{}<r>\n",
+                    expected_property_path.to_fmt(&mut formatter),
+                    expected_property_value.to_fmt(&mut formatter2),
                 );
             }
         }
 
         let signature = Expect::get_signature("toHaveProperty", "<green>path<r>", true);
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                "\n\nExpected path: not <green>{}<r>\n\nReceived value: <red>{}<r>\n",
-                expected_property_path.to_fmt(&mut formatter),
-                received_property.to_fmt(&mut formatter2),
-            ),
+            "\n\nExpected path: not <green>{}<r>\n\nReceived value: <red>{}<r>\n",
+            expected_property_path.to_fmt(&mut formatter),
+            received_property.to_fmt(&mut formatter2),
         );
     }
 
@@ -114,27 +113,25 @@ pub(crate) fn to_have_property(
                 ..Default::default()
             };
 
-            return this.throw(global, signature, format_args!("\n\n{}\n", diff_format));
+            return throw!(this, global, signature, "\n\n{}\n", diff_format);
         }
 
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                "\n\nExpected path: <green>{}<r>\n\nExpected value: <green>{}<r>\n\nUnable to find property\n",
-                expected_property_path.to_fmt(&mut formatter),
-                expected_property_value.to_fmt(&mut formatter2),
-            ),
+            "\n\nExpected path: <green>{}<r>\n\nExpected value: <green>{}<r>\n\nUnable to find property\n",
+            expected_property_path.to_fmt(&mut formatter),
+            expected_property_value.to_fmt(&mut formatter2),
         );
     }
 
     let signature = Expect::get_signature("toHaveProperty", "<green>path<r>", false);
-    this.throw(
+    throw!(
+        this,
         global,
         signature,
-        format_args!(
-            "\n\nExpected path: <green>{}<r>\n\nUnable to find property\n",
-            expected_property_path.to_fmt(&mut formatter),
-        ),
+        "\n\nExpected path: <green>{}<r>\n\nUnable to find property\n",
+        expected_property_path.to_fmt(&mut formatter),
     )
 }

--- a/src/runtime/test_runner/expect/toHaveReturned.rs
+++ b/src/runtime/test_runner/expect/toHaveReturned.rs
@@ -1,6 +1,7 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
 use super::mock;
+use super::throw;
 use super::Expect;
 
 #[derive(PartialEq, Eq, Clone, Copy)]
@@ -83,28 +84,25 @@ fn to_have_returned_times_fn(
     }
 
     let signature = Expect::get_signature(mode.tag_name(), "<green>expected<r>", not);
-    // `throw` runs pretty_fmt over the *rendered* string, so `<`/`>` in these
-    // operands must be backslash-escaped to survive the tag pass.
     let (str_, spc): (&'static str, &'static str) = match mode {
         Mode::ToHaveReturned => match not {
-            false => ("\\>= ", "   "),
-            true => ("\\< ", "  "),
+            false => (">= ", "   "),
+            true => ("< ", "  "),
         },
         Mode::ToHaveReturnedTimes => match not {
             false => ("== ", "   "),
             true => ("!= ", "   "),
         },
     };
-    this.throw(
+    throw!(
+        this,
         global,
         signature,
-        format_args!(
-            "\n\n\
-             Expected number of succesful returns: {}<green>{}<r>\n\
-             Received number of succesful returns: {}<red>{}<r>\n\
-             Received number of calls:             {}<red>{}<r>\n",
-            str_, expected_success_count, spc, actual_success_count, spc, total_call_count,
-        ),
+        "\n\n\
+         Expected number of succesful returns: {}<green>{}<r>\n\
+         Received number of succesful returns: {}<red>{}<r>\n\
+         Received number of calls:             {}<red>{}<r>\n",
+        str_, expected_success_count, spc, actual_success_count, spc, total_call_count,
     )
 }
 

--- a/src/runtime/test_runner/expect/toHaveReturnedWith.rs
+++ b/src/runtime/test_runner/expect/toHaveReturnedWith.rs
@@ -2,6 +2,7 @@ use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
 use super::DiffFormatter;
 use super::mock;
+use super::throw;
 use super::Expect;
 
 pub(crate) fn to_have_returned_with(
@@ -65,13 +66,12 @@ pub(crate) fn to_have_returned_with(
 
     if this.flags.get().not() {
         let not_signature: &str = Expect::get_signature("toHaveReturnedWith", "<green>expected<r>", true);
-        return this.throw(
+        return throw!(
+            this,
             global,
             not_signature,
-            format_args!(
-                "\n\nExpected mock function not to have returned: <green>{}<r>\n",
-                expected.to_fmt(&mut formatter),
-            ),
+            "\n\nExpected mock function not to have returned: <green>{}<r>\n",
+            expected.to_fmt(&mut formatter),
         );
     }
 
@@ -90,21 +90,20 @@ pub(crate) fn to_have_returned_with(
                 global_this: Some(global),
                 not: false,
             };
-            return this.throw(global, signature, format_args!("\n\n{}\n", diff_format));
+            return throw!(this, global, signature, "\n\n{}\n", diff_format);
         }
 
         // The `ZigFormatter` adapter holds `&'a mut Formatter`, so two live adapters cannot alias
         // the same backing formatter. Use a second formatter for the received value —
         // `make_formatter` is a trivial struct init with no shared state between values.
         let mut formatter2 = super::make_formatter(global);
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                "\n\nExpected: <green>{}<r>\nReceived: <red>{}<r>",
-                expected.to_fmt(&mut formatter),
-                received.to_fmt(&mut formatter2),
-            ),
+            "\n\nExpected: <green>{}<r>\nReceived: <red>{}<r>",
+            expected.to_fmt(&mut formatter),
+            received.to_fmt(&mut formatter2),
         );
     }
 
@@ -119,16 +118,15 @@ pub(crate) fn to_have_returned_with(
             returns,
             formatter: core::cell::RefCell::new(&mut list_fmt),
         };
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                "\n\nSome calls errored:\n\n    Expected: {}\n    Received:\n{}\n\n    Number of returns: {}\n    Number of calls:   {}\n",
-                expected.to_fmt(&mut formatter),
-                list_formatter,
-                successful_returns_count,
-                calls_count,
-            ),
+            "\n\nSome calls errored:\n\n    Expected: {}\n    Received:\n{}\n\n    Number of returns: {}\n    Number of calls:   {}\n",
+            expected.to_fmt(&mut formatter),
+            list_formatter,
+            successful_returns_count,
+            calls_count,
         );
     } else {
         // Case: No errors, but no match (and multiple returns)
@@ -137,15 +135,14 @@ pub(crate) fn to_have_returned_with(
             successful_returns: &successful_returns,
             formatter: core::cell::RefCell::new(&mut list_fmt),
         };
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                "\n\n    <green>Expected<r>: {}\n    <red>Received<r>:\n{}\n\n    Number of returns: {}\n",
-                expected.to_fmt(&mut formatter),
-                list_formatter,
-                successful_returns_count,
-            ),
+            "\n\n    <green>Expected<r>: {}\n    <red>Received<r>:\n{}\n\n    Number of returns: {}\n",
+            expected.to_fmt(&mut formatter),
+            list_formatter,
+            successful_returns_count,
         );
     }
 }

--- a/src/runtime/test_runner/expect/toIncludeRepeated.rs
+++ b/src/runtime/test_runner/expect/toIncludeRepeated.rs
@@ -1,7 +1,7 @@
 use bstr::ByteSlice;
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
-use super::{Expect, get_signature};
+use super::{Expect, get_signature, throw};
 
 impl Expect {
     #[bun_jsc::host_fn(method)]
@@ -100,74 +100,68 @@ impl Expect {
         if not {
             if count_as_num == 0 {
                 let signature: &str = get_signature("toIncludeRepeated", "<green>expected<r>", true);
-                return this.throw(
+                return throw!(
+                    this,
                     global,
                     signature,
-                    format_args!(
-                        concat!("\n\n", "Expected to include: <green>{}<r> \n", "Received: <red>{}<r>\n"),
-                        substring_fmt,
-                        expect_string_fmt
-                    ),
+                    concat!("\n\n", "Expected to include: <green>{}<r> \n", "Received: <red>{}<r>\n"),
+                    substring_fmt,
+                    expect_string_fmt,
                 );
             } else if count_as_num == 1 {
                 let signature: &str = get_signature("toIncludeRepeated", "<green>expected<r>", true);
-                return this.throw(
+                return throw!(
+                    this,
                     global,
                     signature,
-                    format_args!(
-                        concat!("\n\n", "Expected not to include: <green>{}<r> \n", "Received: <red>{}<r>\n"),
-                        substring_fmt,
-                        expect_string_fmt
-                    ),
+                    concat!("\n\n", "Expected not to include: <green>{}<r> \n", "Received: <red>{}<r>\n"),
+                    substring_fmt,
+                    expect_string_fmt,
                 );
             } else {
                 let signature: &str = get_signature("toIncludeRepeated", "<green>expected<r>", true);
-                return this.throw(
+                return throw!(
+                    this,
                     global,
                     signature,
-                    format_args!(
-                        concat!("\n\n", "Expected not to include: <green>{}<r> <green>{}<r> times \n", "Received: <red>{}<r>\n"),
-                        substring_fmt,
-                        times_fmt,
-                        expect_string_fmt
-                    ),
+                    concat!("\n\n", "Expected not to include: <green>{}<r> <green>{}<r> times \n", "Received: <red>{}<r>\n"),
+                    substring_fmt,
+                    times_fmt,
+                    expect_string_fmt,
                 );
             }
         }
 
         if count_as_num == 0 {
             let signature: &str = get_signature("toIncludeRepeated", "<green>expected<r>", false);
-            this.throw(
+            throw!(
+                this,
                 global,
                 signature,
-                format_args!(
-                    concat!("\n\n", "Expected to not include: <green>{}<r>\n", "Received: <red>{}<r>\n"),
-                    substring_fmt,
-                    expect_string_fmt
-                ),
+                concat!("\n\n", "Expected to not include: <green>{}<r>\n", "Received: <red>{}<r>\n"),
+                substring_fmt,
+                expect_string_fmt,
             )
         } else if count_as_num == 1 {
             let signature: &str = get_signature("toIncludeRepeated", "<green>expected<r>", false);
-            this.throw(
+            throw!(
+                this,
                 global,
                 signature,
-                format_args!(
-                    concat!("\n\n", "Expected to include: <green>{}<r>\n", "Received: <red>{}<r>\n"),
-                    substring_fmt,
-                    expect_string_fmt
-                ),
+                concat!("\n\n", "Expected to include: <green>{}<r>\n", "Received: <red>{}<r>\n"),
+                substring_fmt,
+                expect_string_fmt,
             )
         } else {
             let signature: &str = get_signature("toIncludeRepeated", "<green>expected<r>", false);
-            this.throw(
+            throw!(
+                this,
                 global,
                 signature,
-                format_args!(
-                    concat!("\n\n", "Expected to include: <green>{}<r> <green>{}<r> times \n", "Received: <red>{}<r>\n"),
-                    substring_fmt,
-                    times_fmt,
-                    expect_string_fmt
-                ),
+                concat!("\n\n", "Expected to include: <green>{}<r> <green>{}<r> times \n", "Received: <red>{}<r>\n"),
+                substring_fmt,
+                times_fmt,
+                expect_string_fmt,
             )
         }
     }

--- a/src/runtime/test_runner/expect/toMatch.rs
+++ b/src/runtime/test_runner/expect/toMatch.rs
@@ -2,6 +2,7 @@ use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use super::JSValueTestExt;
 
 use super::Expect;
+use super::throw;
 
 pub(crate) fn to_match(
     this: &Expect,
@@ -60,33 +61,31 @@ pub(crate) fn to_match(
 
     if not {
         let signature = Expect::get_signature("toMatch", "<green>expected<r>", true);
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                concat!(
-                    "\n\n",
-                    "Expected substring or pattern: not <green>{}<r>\n",
-                    "Received: <red>{}<r>\n",
-                ),
-                expected_fmt,
-                value_fmt,
-            ),
-        );
-    }
-
-    let signature = Expect::get_signature("toMatch", "<green>expected<r>", false);
-    this.throw(
-        global,
-        signature,
-        format_args!(
             concat!(
                 "\n\n",
-                "Expected substring or pattern: <green>{}<r>\n",
+                "Expected substring or pattern: not <green>{}<r>\n",
                 "Received: <red>{}<r>\n",
             ),
             expected_fmt,
             value_fmt,
+        );
+    }
+
+    let signature = Expect::get_signature("toMatch", "<green>expected<r>", false);
+    throw!(
+        this,
+        global,
+        signature,
+        concat!(
+            "\n\n",
+            "Expected substring or pattern: <green>{}<r>\n",
+            "Received: <red>{}<r>\n",
         ),
+        expected_fmt,
+        value_fmt,
     )
 }

--- a/src/runtime/test_runner/expect/toMatchInlineSnapshot.rs
+++ b/src/runtime/test_runner/expect/toMatchInlineSnapshot.rs
@@ -1,6 +1,7 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use bun_core::ZigString;
 
+use super::throw;
 use super::Expect;
 
 pub(crate) fn to_match_inline_snapshot(
@@ -21,12 +22,11 @@ pub(crate) fn to_match_inline_snapshot(
     let not = this.flags.get().not();
     if not {
         let signature = Expect::get_signature("toMatchInlineSnapshot", "", true);
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                "\n\n<b>Matcher error<r>: Snapshot matchers cannot be used with <b>not<r>\n"
-            ),
+            "\n\n<b>Matcher error<r>: Snapshot matchers cannot be used with <b>not<r>\n",
         );
     }
 
@@ -42,12 +42,11 @@ pub(crate) fn to_match_inline_snapshot(
             } else if arguments[0].is_object() {
                 property_matchers = Some(arguments[0]);
             } else {
-                return this.throw(
+                return throw!(
+                    this,
                     global,
                     "",
-                    format_args!(
-                        "\n\nMatcher error: Expected first argument to be a string or object\n"
-                    ),
+                    "\n\nMatcher error: Expected first argument to be a string or object\n",
                 );
             }
         }
@@ -58,12 +57,11 @@ pub(crate) fn to_match_inline_snapshot(
                     "<green>properties<r><d>, <r>hint",
                     false,
                 );
-                return this.throw(
+                return throw!(
+                    this,
                     global,
                     signature,
-                    format_args!(
-                        "\n\nMatcher error: Expected <green>properties<r> must be an object\n"
-                    ),
+                    "\n\nMatcher error: Expected <green>properties<r> must be an object\n",
                 );
             }
 

--- a/src/runtime/test_runner/expect/toMatchObject.rs
+++ b/src/runtime/test_runner/expect/toMatchObject.rs
@@ -1,5 +1,6 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use super::DiffFormatter;
+use super::throw;
 use super::{get_signature, Expect};
 
 pub(crate) fn to_match_object(
@@ -13,26 +14,19 @@ pub(crate) fn to_match_object(
     let args = args_buf.slice();
 
     if !received_object.is_object() {
-        let matcher_error =
-            "\n\n<b>Matcher error<r>: <red>received<r> value must be a non-null object\n";
-        if not {
-            let signature: &str = get_signature("toMatchObject", "<green>expected<r>", true);
-            return this.throw(global, signature, format_args!("{matcher_error}"));
-        }
-
-        let signature: &str = get_signature("toMatchObject", "<green>expected<r>", false);
-        return this.throw(global, signature, format_args!("{matcher_error}"));
+        let signature: &str = get_signature("toMatchObject", "<green>expected<r>", not);
+        return throw!(
+            this, global, signature,
+            "\n\n<b>Matcher error<r>: <red>received<r> value must be a non-null object\n",
+        );
     }
 
     if args.len() < 1 || !args[0].is_object() {
-        let matcher_error =
-            "\n\n<b>Matcher error<r>: <green>expected<r> value must be a non-null object\n";
-        if not {
-            let signature: &str = get_signature("toMatchObject", "", true);
-            return this.throw(global, signature, format_args!("{matcher_error}"));
-        }
-        let signature: &str = get_signature("toMatchObject", "", false);
-        return this.throw(global, signature, format_args!("{matcher_error}"));
+        let signature: &str = get_signature("toMatchObject", "", not);
+        return throw!(
+            this, global, signature,
+            "\n\n<b>Matcher error<r>: <green>expected<r> value must be a non-null object\n",
+        );
     }
 
     let property_matchers = args[0];
@@ -58,9 +52,9 @@ pub(crate) fn to_match_object(
 
     if not {
         let signature: &str = get_signature("toMatchObject", "<green>expected<r>", true);
-        return this.throw(global, signature, format_args!("\n\n{}\n", diff_formatter));
+        return throw!(this, global, signature, "\n\n{}\n", diff_formatter);
     }
 
     let signature: &str = get_signature("toMatchObject", "<green>expected<r>", false);
-    this.throw(global, signature, format_args!("\n\n{}\n", diff_formatter))
+    throw!(this, global, signature, "\n\n{}\n", diff_formatter)
 }

--- a/src/runtime/test_runner/expect/toMatchSnapshot.rs
+++ b/src/runtime/test_runner/expect/toMatchSnapshot.rs
@@ -3,6 +3,7 @@ use bun_core::ZigString;
 
 use super::Expect;
 use super::get_signature;
+use super::throw;
 
 pub(crate) fn to_match_snapshot(
     this: &Expect,
@@ -23,21 +24,21 @@ pub(crate) fn to_match_snapshot(
     let not = this.flags.get().not();
     if not {
         let signature = get_signature("toMatchSnapshot", "", true);
-        return this.throw_fmt(
+        return throw!(
+            this,
             global,
             signature,
-            "",
-            format_args!("\n\n<b>Matcher error<r>: Snapshot matchers cannot be used with <b>not<r>\n"),
+            "\n\n<b>Matcher error<r>: Snapshot matchers cannot be used with <b>not<r>\n",
         );
     }
 
     let Some(buntest_strong) = this.bun_test() else {
         let signature = get_signature("toMatchSnapshot", "", true);
-        return this.throw_fmt(
+        return throw!(
+            this,
             global,
             signature,
-            "",
-            format_args!("\n\n<b>Matcher error<r>: Snapshot matchers cannot be used outside of a test\n"),
+            "\n\n<b>Matcher error<r>: Snapshot matchers cannot be used outside of a test\n",
         );
     };
     let _ = buntest_strong; // released by Drop at scope exit.
@@ -52,11 +53,11 @@ pub(crate) fn to_match_snapshot(
             } else if arguments[0].is_object() {
                 property_matchers = Some(arguments[0]);
             } else {
-                return this.throw_fmt(
+                return throw!(
+                    this,
                     global,
                     "",
-                    "",
-                    format_args!("\n\nMatcher error: Expected first argument to be a string or object\n"),
+                    "\n\nMatcher error: Expected first argument to be a string or object\n",
                 );
             }
         }
@@ -64,11 +65,11 @@ pub(crate) fn to_match_snapshot(
             if !arguments[0].is_object() {
                 let signature =
                     get_signature("toMatchSnapshot", "<green>properties<r><d>, <r>hint", false);
-                return this.throw_fmt(
+                return throw!(
+                    this,
                     global,
                     signature,
-                    "",
-                    format_args!("\n\nMatcher error: Expected <green>properties<r> must be an object\n"),
+                    "\n\nMatcher error: Expected <green>properties<r> must be an object\n",
                 );
             }
 
@@ -77,11 +78,11 @@ pub(crate) fn to_match_snapshot(
             if arguments[1].is_string() {
                 arguments[1].to_zig_string(&mut hint_string, global)?;
             } else {
-                return this.throw_fmt(
+                return throw!(
+                    this,
                     global,
                     "",
-                    "",
-                    format_args!("\n\nMatcher error: Expected second argument to be a string\n"),
+                    "\n\nMatcher error: Expected second argument to be a string\n",
                 );
             }
         }

--- a/src/runtime/test_runner/expect/toSatisfy.rs
+++ b/src/runtime/test_runner/expect/toSatisfy.rs
@@ -3,6 +3,7 @@ use bun_core::ZigString;
 
 use super::Expect;
 use super::get_signature;
+use super::throw;
 
 pub(crate) fn to_satisfy(this: &Expect, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     // toSatisfy bypasses get_value (no .resolves/.rejects handling), so it cannot use
@@ -54,10 +55,11 @@ pub(crate) fn to_satisfy(this: &Expect, global: &JSGlobalObject, frame: &CallFra
 
     if not {
         let signature = get_signature("toSatisfy", "<green>expected<r>", true);
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!("\n\nExpected: not <green>{}<r>\n", predicate.to_fmt(&mut formatter)),
+            "\n\nExpected: not <green>{}<r>\n", predicate.to_fmt(&mut formatter),
         );
     }
 
@@ -66,13 +68,12 @@ pub(crate) fn to_satisfy(this: &Expect, global: &JSGlobalObject, frame: &CallFra
     // `to_fmt(&mut Formatter)` borrows exclusively, so use a second formatter for the
     // received value (matches the toBeGreaterThan.rs pattern).
     let mut formatter2 = super::make_formatter(global);
-    this.throw(
+    throw!(
+        this,
         global,
         signature,
-        format_args!(
-            "\n\nExpected: <green>{}<r>\nReceived: <red>{}<r>\n",
-            predicate.to_fmt(&mut formatter),
-            value.to_fmt(&mut formatter2),
-        ),
+        "\n\nExpected: <green>{}<r>\nReceived: <red>{}<r>\n",
+        predicate.to_fmt(&mut formatter),
+        value.to_fmt(&mut formatter2),
     )
 }

--- a/src/runtime/test_runner/expect/toStrictEqual.rs
+++ b/src/runtime/test_runner/expect/toStrictEqual.rs
@@ -1,5 +1,6 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
+use super::throw;
 use super::DiffFormatter;
 use super::Expect;
 
@@ -44,10 +45,10 @@ impl Expect {
 
         if not {
             let signature = Expect::get_signature("toStrictEqual", "<green>expected<r>", true);
-            return this.throw(global, signature, format_args!("\n\n{}\n", diff_formatter));
+            return throw!(this, global, signature, "\n\n{}\n", diff_formatter);
         }
 
         let signature = Expect::get_signature("toStrictEqual", "<green>expected<r>", false);
-        this.throw(global, signature, format_args!("\n\n{}\n", diff_formatter))
+        throw!(this, global, signature, "\n\n{}\n", diff_formatter)
     }
 }

--- a/src/runtime/test_runner/expect/toThrow.rs
+++ b/src/runtime/test_runner/expect/toThrow.rs
@@ -9,6 +9,7 @@ use super::Expect;
 use super::ExpectAny;
 use super::expect_any_js;
 use super::get_signature;
+use super::throw;
 
 pub(crate) fn to_throw(
     this: &Expect,
@@ -85,18 +86,24 @@ pub(crate) fn to_throw(
                     .get_truthy(global, "message")?
                     .unwrap_or(JSValue::UNDEFINED);
                 let mut formatter2 = super::make_formatter(global);
-                return Err(global.throw_pretty(format_args!(
-                    "{signature_no_args}\n\nError name: <red>{}<r>\nError message: <red>{}<r>\n",
+                return throw!(
+                    this,
+                    global,
+                    signature_no_args,
+                    "\n\nError name: <red>{}<r>\nError message: <red>{}<r>\n",
                     name.to_fmt(&mut formatter),
                     message.to_fmt(&mut formatter2),
-                )));
+                );
             }
 
             // non error thrown
-            return Err(global.throw_pretty(format_args!(
-                "{signature_no_args}\n\nThrown value: <red>{}<r>\n",
+            return throw!(
+                this,
+                global,
+                signature_no_args,
+                "\n\nThrown value: <red>{}<r>\n",
                 result.to_fmt(&mut formatter),
-            )));
+            );
         }
 
         if expected_value.is_string() {
@@ -121,14 +128,13 @@ pub(crate) fn to_throw(
             }
 
             let mut formatter2 = super::make_formatter(global);
-            return this.throw(
+            return throw!(
+                this,
                 global,
                 signature,
-                format_args!(
-                    "\n\nExpected substring: not <green>{}<r>\nReceived message: <red>{}<r>\n",
-                    expected_value.to_fmt(&mut formatter),
-                    received_message.to_fmt(&mut formatter2),
-                ),
+                "\n\nExpected substring: not <green>{}<r>\nReceived message: <red>{}<r>\n",
+                expected_value.to_fmt(&mut formatter),
+                received_message.to_fmt(&mut formatter2),
             );
         }
 
@@ -154,14 +160,13 @@ pub(crate) fn to_throw(
             }
 
             let mut formatter2 = super::make_formatter(global);
-            return this.throw(
+            return throw!(
+                this,
                 global,
                 signature,
-                format_args!(
-                    "\n\nExpected pattern: not <green>{}<r>\nReceived message: <red>{}<r>\n",
-                    expected_value.to_fmt(&mut formatter),
-                    received_message.to_fmt(&mut formatter2),
-                ),
+                "\n\nExpected pattern: not <green>{}<r>\nReceived message: <red>{}<r>\n",
+                expected_value.to_fmt(&mut formatter),
+                received_message.to_fmt(&mut formatter2),
             );
         }
 
@@ -181,13 +186,12 @@ pub(crate) fn to_throw(
                 return Ok(JSValue::UNDEFINED);
             }
 
-            return this.throw(
+            return throw!(
+                this,
                 global,
                 signature,
-                format_args!(
-                    "\n\nExpected message: not <green>{}<r>\n",
-                    expected_message.to_fmt(&mut formatter),
-                ),
+                "\n\nExpected message: not <green>{}<r>\n",
+                expected_message.to_fmt(&mut formatter),
             );
         }
 
@@ -200,14 +204,13 @@ pub(crate) fn to_throw(
         let received_message: JSValue = result
             .fast_get(global, bun_jsc::BuiltinName::Message)?
             .unwrap_or(JSValue::UNDEFINED);
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                "\n\nExpected constructor: not <green>{}<r>\n\nReceived message: <red>{}<r>\n",
-                expected_class,
-                received_message.to_fmt(&mut formatter),
-            ),
+            "\n\nExpected constructor: not <green>{}<r>\n\nReceived message: <red>{}<r>\n",
+            expected_class,
+            received_message.to_fmt(&mut formatter),
         );
     }
 
@@ -246,25 +249,23 @@ pub(crate) fn to_throw(
 
             let mut formatter2 = super::make_formatter(global);
             if let Some(received_message) = received_message_opt {
-                return this.throw(
+                return throw!(
+                    this,
                     global,
                     signature,
-                    format_args!(
-                        "\n\nExpected substring: <green>{}<r>\nReceived message: <red>{}<r>\n",
-                        expected_value.to_fmt(&mut formatter),
-                        received_message.to_fmt(&mut formatter2),
-                    ),
+                    "\n\nExpected substring: <green>{}<r>\nReceived message: <red>{}<r>\n",
+                    expected_value.to_fmt(&mut formatter),
+                    received_message.to_fmt(&mut formatter2),
                 );
             }
 
-            return this.throw(
+            return throw!(
+                this,
                 global,
                 signature,
-                format_args!(
-                    "\n\nExpected substring: <green>{}<r>\nReceived value: <red>{}<r>",
-                    expected_value.to_fmt(&mut formatter),
-                    result.to_fmt(&mut formatter2),
-                ),
+                "\n\nExpected substring: <green>{}<r>\nReceived value: <red>{}<r>",
+                expected_value.to_fmt(&mut formatter),
+                result.to_fmt(&mut formatter2),
             );
         }
 
@@ -287,26 +288,24 @@ pub(crate) fn to_throw(
             let mut formatter2 = super::make_formatter(global);
             if let Some(received_message) = received_message_opt {
                 let signature: &'static str = get_signature("toThrow", "<green>expected<r>", false);
-                return this.throw(
+                return throw!(
+                    this,
                     global,
                     signature,
-                    format_args!(
-                        "\n\nExpected pattern: <green>{}<r>\nReceived message: <red>{}<r>\n",
-                        expected_value.to_fmt(&mut formatter),
-                        received_message.to_fmt(&mut formatter2),
-                    ),
+                    "\n\nExpected pattern: <green>{}<r>\nReceived message: <red>{}<r>\n",
+                    expected_value.to_fmt(&mut formatter),
+                    received_message.to_fmt(&mut formatter2),
                 );
             }
 
             let signature: &'static str = get_signature("toThrow", "<green>expected<r>", false);
-            return this.throw(
+            return throw!(
+                this,
                 global,
                 signature,
-                format_args!(
-                    "\n\nExpected pattern: <green>{}<r>\nReceived value: <red>{}<r>",
-                    expected_value.to_fmt(&mut formatter),
-                    result.to_fmt(&mut formatter2),
-                ),
+                "\n\nExpected pattern: <green>{}<r>\nReceived value: <red>{}<r>",
+                expected_value.to_fmt(&mut formatter),
+                result.to_fmt(&mut formatter2),
             );
         }
 
@@ -324,14 +323,13 @@ pub(crate) fn to_throw(
 
             let mut formatter = Formatter::new(global).with_quote_strings(true);
             let mut formatter2 = super::make_formatter(global);
-            return this.throw(
+            return throw!(
+                this,
                 global,
                 signature,
-                format_args!(
-                    "\n\nExpected value: <green>{}<r>\nReceived value: <red>{}<r>\n",
-                    expected_value.to_fmt(&mut formatter2),
-                    result.to_fmt(&mut formatter),
-                ),
+                "\n\nExpected value: <green>{}<r>\nReceived value: <red>{}<r>\n",
+                expected_value.to_fmt(&mut formatter2),
+                result.to_fmt(&mut formatter),
             );
         }
 
@@ -352,25 +350,23 @@ pub(crate) fn to_throw(
             let mut formatter2 = super::make_formatter(global);
 
             if let Some(received_message) = received_message_opt {
-                return this.throw(
+                return throw!(
+                    this,
                     global,
                     signature,
-                    format_args!(
-                        "\n\nExpected message: <green>{}<r>\nReceived message: <red>{}<r>\n",
-                        expected_message.to_fmt(&mut formatter),
-                        received_message.to_fmt(&mut formatter2),
-                    ),
+                    "\n\nExpected message: <green>{}<r>\nReceived message: <red>{}<r>\n",
+                    expected_message.to_fmt(&mut formatter),
+                    received_message.to_fmt(&mut formatter2),
                 );
             }
 
-            return this.throw(
+            return throw!(
+                this,
                 global,
                 signature,
-                format_args!(
-                    "\n\nExpected message: <green>{}<r>\nReceived value: <red>{}<r>\n",
-                    expected_message.to_fmt(&mut formatter),
-                    result.to_fmt(&mut formatter2),
-                ),
+                "\n\nExpected message: <green>{}<r>\nReceived value: <red>{}<r>\n",
+                expected_message.to_fmt(&mut formatter),
+                result.to_fmt(&mut formatter2),
             );
         }
 
@@ -387,20 +383,26 @@ pub(crate) fn to_throw(
         let signature: &'static str = get_signature("toThrow", "<green>expected<r>", false);
 
         if let Some(received_message) = received_message_opt {
-            return Err(global.throw_pretty(format_args!(
-                "{signature}\n\nExpected constructor: <green>{}<r>\nReceived constructor: <red>{}<r>\n\nReceived message: <red>{}<r>\n",
+            return throw!(
+                this,
+                global,
+                signature,
+                "\n\nExpected constructor: <green>{}<r>\nReceived constructor: <red>{}<r>\n\nReceived message: <red>{}<r>\n",
                 expected_class,
                 received_class,
                 received_message.to_fmt(&mut formatter),
-            )));
+            );
         }
 
-        return Err(global.throw_pretty(format_args!(
-            "{signature}\n\nExpected constructor: <green>{}<r>\nReceived constructor: <red>{}<r>\n\nReceived value: <red>{}<r>\n",
+        return throw!(
+            this,
+            global,
+            signature,
+            "\n\nExpected constructor: <green>{}<r>\nReceived constructor: <red>{}<r>\n\nReceived value: <red>{}<r>\n",
             expected_class,
             received_class,
             result.to_fmt(&mut formatter),
-        )));
+        );
     }
 
     // did not throw
@@ -412,63 +414,58 @@ pub(crate) fn to_throw(
 
     if expected_value.is_empty() || expected_value.is_undefined() {
         let signature: &'static str = get_signature("toThrow", "", false);
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                "\n\nReceived function did not throw\nReceived value: <red>{}<r>\n",
-                result.to_fmt(&mut formatter),
-            ),
+            "\n\nReceived function did not throw\nReceived value: <red>{}<r>\n",
+            result.to_fmt(&mut formatter),
         );
     }
 
     let signature: &'static str = get_signature("toThrow", "<green>expected<r>", false);
 
     if expected_value.is_string() {
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                "\n\nExpected substring: <green>{}<r>\n\nReceived function did not throw\nReceived value: <red>{}<r>\n",
-                expected_value.to_fmt(&mut formatter),
-                result.to_fmt(&mut formatter2),
-            ),
+            "\n\nExpected substring: <green>{}<r>\n\nReceived function did not throw\nReceived value: <red>{}<r>\n",
+            expected_value.to_fmt(&mut formatter),
+            result.to_fmt(&mut formatter2),
         );
     }
 
     if expected_value.is_reg_exp() {
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                "\n\nExpected pattern: <green>{}<r>\n\nReceived function did not throw\nReceived value: <red>{}<r>\n",
-                expected_value.to_fmt(&mut formatter),
-                result.to_fmt(&mut formatter2),
-            ),
+            "\n\nExpected pattern: <green>{}<r>\n\nReceived function did not throw\nReceived value: <red>{}<r>\n",
+            expected_value.to_fmt(&mut formatter),
+            result.to_fmt(&mut formatter2),
         );
     }
 
     if let Some(expected_message) = expected_value.fast_get(global, bun_jsc::BuiltinName::Message)? {
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!(
-                "\n\nExpected message: <green>{}<r>\n\nReceived function did not throw\nReceived value: <red>{}<r>\n",
-                expected_message.to_fmt(&mut formatter),
-                result.to_fmt(&mut formatter2),
-            ),
+            "\n\nExpected message: <green>{}<r>\n\nReceived function did not throw\nReceived value: <red>{}<r>\n",
+            expected_message.to_fmt(&mut formatter),
+            result.to_fmt(&mut formatter2),
         );
     }
 
     let mut expected_class = ZigString::EMPTY;
     expected_value.get_class_name(global, &mut expected_class)?;
-    this.throw(
+    throw!(
+        this,
         global,
         signature,
-        format_args!(
-            "\n\nExpected constructor: <green>{}<r>\n\nReceived function did not throw\nReceived value: <red>{}<r>\n",
-            expected_class,
-            result.to_fmt(&mut formatter),
-        ),
+        "\n\nExpected constructor: <green>{}<r>\n\nReceived function did not throw\nReceived value: <red>{}<r>\n",
+        expected_class,
+        result.to_fmt(&mut formatter),
     )
 }

--- a/src/runtime/test_runner/expect/toThrowErrorMatchingInlineSnapshot.rs
+++ b/src/runtime/test_runner/expect/toThrowErrorMatchingInlineSnapshot.rs
@@ -1,6 +1,7 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use bun_core::ZigString;
 
+use super::throw;
 use super::Expect;
 
 pub(crate) fn to_throw_error_matching_inline_snapshot(
@@ -20,10 +21,11 @@ pub(crate) fn to_throw_error_matching_inline_snapshot(
     let not = this.flags.get().not();
     if not {
         let signature = Expect::get_signature("toThrowErrorMatchingInlineSnapshot", "", true);
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!("\n\n<b>Matcher error<r>: Snapshot matchers cannot be used with <b>not<r>\n"),
+            "\n\n<b>Matcher error<r>: Snapshot matchers cannot be used with <b>not<r>\n",
         );
     }
 
@@ -36,18 +38,20 @@ pub(crate) fn to_throw_error_matching_inline_snapshot(
                 has_expected = true;
                 arguments[0].to_zig_string(&mut expected_string, global)?;
             } else {
-                return this.throw(
+                return throw!(
+                    this,
                     global,
                     "",
-                    format_args!("\n\nMatcher error: Expected first argument to be a string\n"),
+                    "\n\nMatcher error: Expected first argument to be a string\n",
                 );
             }
         }
         _ => {
-            return this.throw(
+            return throw!(
+                this,
                 global,
                 "",
-                format_args!("\n\nMatcher error: Expected zero or one arguments\n"),
+                "\n\nMatcher error: Expected zero or one arguments\n",
             );
         }
     }
@@ -67,10 +71,11 @@ pub(crate) fn to_throw_error_matching_inline_snapshot(
     )?;
     let Some(value) = this.fn_to_err_string_or_undefined(global, received)? else {
         let signature = Expect::get_signature("toThrowErrorMatchingInlineSnapshot", "", false);
-        return this.throw(
+        return throw!(
+            this,
             global,
             signature,
-            format_args!("\n\n<b>Matcher error<r>: Received function did not throw\n"),
+            "\n\n<b>Matcher error<r>: Received function did not throw\n",
         );
     };
 

--- a/src/runtime/test_runner/expect/toThrowErrorMatchingSnapshot.rs
+++ b/src/runtime/test_runner/expect/toThrowErrorMatchingSnapshot.rs
@@ -3,6 +3,7 @@ use bun_core::ZigString;
 
 use super::Expect;
 use super::get_signature;
+use super::throw;
 
 pub(crate) fn to_throw_error_matching_snapshot(
     this: &Expect,
@@ -22,21 +23,21 @@ pub(crate) fn to_throw_error_matching_snapshot(
     let not = this.flags.get().not();
     if not {
         let signature = get_signature("toThrowErrorMatchingSnapshot", "", true);
-        return this.throw_fmt(
+        return throw!(
+            this,
             global,
             signature,
-            "",
-            format_args!("\n\n<b>Matcher error<r>: Snapshot matchers cannot be used with <b>not<r>\n"),
+            "\n\n<b>Matcher error<r>: Snapshot matchers cannot be used with <b>not<r>\n",
         );
     }
 
     let Some(bun_test_strong) = this.bun_test() else {
         let signature = get_signature("toThrowErrorMatchingSnapshot", "", true);
-        return this.throw_fmt(
+        return throw!(
+            this,
             global,
             signature,
-            "",
-            format_args!("\n\n<b>Matcher error<r>: Snapshot matchers cannot be used outside of a test\n"),
+            "\n\n<b>Matcher error<r>: Snapshot matchers cannot be used outside of a test\n",
         );
     };
     let _ = &bun_test_strong;
@@ -48,20 +49,20 @@ pub(crate) fn to_throw_error_matching_snapshot(
             if arguments[0].is_string() {
                 arguments[0].to_zig_string(&mut hint_string, global)?;
             } else {
-                return this.throw_fmt(
+                return throw!(
+                    this,
                     global,
                     "",
-                    "",
-                    format_args!("\n\nMatcher error: Expected first argument to be a string\n"),
+                    "\n\nMatcher error: Expected first argument to be a string\n",
                 );
             }
         }
         _ => {
-            return this.throw_fmt(
+            return throw!(
+                this,
                 global,
                 "",
-                "",
-                format_args!("\n\nMatcher error: Expected zero or one arguments\n"),
+                "\n\nMatcher error: Expected zero or one arguments\n",
             );
         }
     }
@@ -79,11 +80,11 @@ pub(crate) fn to_throw_error_matching_snapshot(
     )?
     else {
         let signature = get_signature("toThrowErrorMatchingSnapshot", "", false);
-        return this.throw_fmt(
+        return throw!(
+            this,
             global,
             signature,
-            "",
-            format_args!("\n\n<b>Matcher error<r>: Received function did not throw\n"),
+            "\n\n<b>Matcher error<r>: Received function did not throw\n",
         );
     };
 

--- a/src/runtime/test_runner/mod.rs
+++ b/src/runtime/test_runner/mod.rs
@@ -48,6 +48,91 @@ macro_rules! unary_predicate_matcher {
     };
 }
 
+/// `expect_throw!(this, global, signature, "<template>", args...)` — matcher
+/// failure sink. Applies the `<tag>` → ANSI/strip rewrite to the *template
+/// literal* at compile time via `pretty_fmt!`, then substitutes the positional
+/// `args` via `format_args!`. User data in `args` (and in any `{named}`
+/// captures) is never scanned for `<…>` markup, so angle-bracketed strings in
+/// Received/Expected render verbatim.
+///
+/// Each `$arg` is evaluated once, bound by `&` into a `match` tuple, and the
+/// bound idents feed both colour branches; side-effecting args are not
+/// duplicated. The template must use positional `{}` only — `format_args!`
+/// refuses implicit `{name}` captures when the template literal comes from a
+/// macro expansion.
+///
+/// Exported at the crate root (like `unary_predicate_matcher!`) so both
+/// `expect_core` (expect.rs) and the `expect/to*.rs` submodules can invoke it
+/// without a module cycle; re-exported as `throw!` inside the `expect` façade.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __expect_throw_dispatch {
+    // peel: pair next arg with next pool name
+    (@go $this:expr, $global:expr, $sig:expr, $fmt:expr;
+        bound = [$(($n:ident $v:expr))*];
+        args  = [$a:expr, $($rest:expr,)*];
+        pool  = [$name:ident $($pool:ident)*]
+    ) => {
+        $crate::__expect_throw_dispatch!(@go $this, $global, $sig, $fmt;
+            bound = [$(($n $v))* ($name $a)];
+            args  = [$($rest,)*];
+            pool  = [$($pool)*]
+        )
+    };
+    // base: no positional args left. `$this`/`$global` are always plain idents
+    // at every call site (this/self, global/global_this); duplicating them
+    // across the two colour branches is side-effect-free and avoids moving a
+    // `PostMatchGuard`/`scopeguard` before its natural scope end.
+    (@go $this:expr, $global:expr, $sig:expr, $fmt:expr;
+        bound = [$(($n:ident $v:expr))*];
+        args  = [];
+        pool  = [$($pool:ident)*]
+    ) => {
+        match ($sig, $( &($v), )*) {
+            (__sig, $($n,)*) => {
+                if ::bun_core::Output::enable_ansi_colors_stderr() {
+                    ($this).throw_rendered(
+                        $global, __sig,
+                        ::core::format_args!(::bun_core::pretty_fmt!($fmt, true) $(, $n)*),
+                    )
+                } else {
+                    ($this).throw_rendered(
+                        $global, __sig,
+                        ::core::format_args!(::bun_core::pretty_fmt!($fmt, false) $(, $n)*),
+                    )
+                }
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! expect_throw {
+    ($this:expr, $global:expr, $sig:expr, $fmt:expr $(, $arg:expr)* $(,)?) => {
+        $crate::__expect_throw_dispatch!(@go $this, $global, $sig, $fmt;
+            bound = [];
+            args  = [$($arg,)*];
+            pool  = [__p0 __p1 __p2 __p3 __p4 __p5 __p6 __p7
+                     __p8 __p9 __p10 __p11 __p12 __p13 __p14 __p15]
+        )
+    };
+}
+
+/// `throw_pretty_static!(global, "<template>")` — throw a colour-marked error
+/// whose template has no user-data substitutions. The `<tag>` → ANSI rewrite
+/// is done at compile time for both colour states; nothing is scanned at
+/// runtime. Replacement for `global.throw_pretty(format_args!("…"))`.
+#[macro_export]
+macro_rules! throw_pretty_static {
+    ($global:expr, $fmt:expr $(,)?) => {
+        if ::bun_core::Output::enable_ansi_colors_stderr() {
+            ($global).throw(::core::format_args!(::bun_core::pretty_fmt!($fmt, true)))
+        } else {
+            ($global).throw(::core::format_args!(::bun_core::pretty_fmt!($fmt, false)))
+        }
+    };
+}
+
 cfg_jsc! {
     #[path = "bun_test.rs"]       pub mod bun_test;
     #[path = "Collection.rs"]     pub mod collection;
@@ -112,27 +197,8 @@ pub mod expect {
         Expect::get_signature(matcher_name, args, not)
     }
 
-    /// Const-context twin of `get_signature`. Rust
-    /// has no const-fn string concat, so call sites that need a `&'static
-    /// str` constant (e.g. inside `const_format::concatcp!`) use this macro
-    /// instead. `use super::get_signature;` imports both the fn (value
-    /// namespace) and this macro (macro namespace), so runtime callers keep
-    /// `get_signature(...)` and const callers write `get_signature!(...)`.
-    macro_rules! __get_signature {
-        ($matcher:expr, $args:expr, true $(,)?) => {
-            ::const_format::concatcp!(
-                "<d>expect(<r><red>received<r><d>).<r>not<d>.<r>",
-                $matcher, "<d>(<r>", $args, "<d>)<r>",
-            )
-        };
-        ($matcher:expr, $args:expr, false $(,)?) => {
-            ::const_format::concatcp!(
-                "<d>expect(<r><red>received<r><d>).<r>",
-                $matcher, "<d>(<r>", $args, "<d>)<r>",
-            )
-        };
-    }
-    pub(crate) use __get_signature as get_signature;
+    // Matcher failure sink — see `expect_throw!` at the top of this file.
+    pub(crate) use crate::expect_throw as throw;
 
     // ── call-convention adapters over `bun_jsc` inherents ────────────
     // The matcher modules were written against a slightly different
@@ -312,21 +378,15 @@ pub mod expect {
     pub enum BigIntCompare { LessThan, Equal, GreaterThan, Undefined }
 
     /// Two-argument `throw_*` adapters — matcher modules call
-    /// `global.throw_pretty(FMT, format_args!(FMT, ..))`.
+    /// `global.throw2(FMT, format_args!(FMT, ..))`.
     /// Rust's `Arguments<'_>` already encloses the format string,
     /// so the leading `&str` is redundant; these shims drop it and forward to
-    /// the bun_jsc inherents (`throw_pretty` runs the `<r>/<d>` → ANSI/strip
-    /// pass at runtime; `throw`/`throw_invalid_arguments` do not).
+    /// the bun_jsc inherents.
     pub trait JSGlobalObjectTestExt {
-        fn throw_pretty(&self, fmt: &str, args: core::fmt::Arguments<'_>) -> JsError;
         fn throw2(&self, fmt: &str, args: core::fmt::Arguments<'_>) -> JsError;
         fn throw_invalid_arguments2(&self, fmt: &str, args: core::fmt::Arguments<'_>) -> JsError;
     }
     impl JSGlobalObjectTestExt for JSGlobalObject {
-        #[inline]
-        fn throw_pretty(&self, _fmt: &str, args: core::fmt::Arguments<'_>) -> JsError {
-            JSGlobalObject::throw_pretty(self, args)
-        }
         #[inline]
         fn throw2(&self, _fmt: &str, args: core::fmt::Arguments<'_>) -> JsError {
             self.throw(args)
@@ -356,15 +416,15 @@ pub mod expect {
     pub(super) enum OrderingRelation { Gt, Ge, Lt, Le }
 
     impl OrderingRelation {
-        /// Operator glyph pre-escaped for `throw_pretty` (`<`/`>` would
-        /// otherwise be parsed as colour-tag delimiters).
+        /// Operator glyph for the failure message. Substituted as a positional
+        /// arg (never scanned for `<tag>` markup), so `<`/`>` are literal.
         #[inline]
         fn glyph(self) -> &'static str {
             match self {
-                Self::Gt => r"\>",
-                Self::Ge => r"\>=",
-                Self::Lt => r"\<",
-                Self::Le => r"\<=",
+                Self::Gt => ">",
+                Self::Ge => ">=",
+                Self::Lt => "<",
+                Self::Le => "<=",
             }
         }
         /// number×number arm.
@@ -463,20 +523,16 @@ pub mod expect {
             let glyph = rel.glyph();
             let signature = Expect::get_signature(name, "<green>expected<r>", not);
             if not {
-                return this.throw(
-                    global,
-                    signature,
-                    format_args!(
-                        "\n\nExpected: not {glyph} <green>{expected_fmt}<r>\nReceived: <red>{value_fmt}<r>\n"
-                    ),
+                return throw!(
+                    this, global, signature,
+                    "\n\nExpected: not {} <green>{}<r>\nReceived: <red>{}<r>\n",
+                    glyph, expected_fmt, value_fmt,
                 );
             }
-            this.throw(
-                global,
-                signature,
-                format_args!(
-                    "\n\nExpected: {glyph} <green>{expected_fmt}<r>\nReceived: <red>{value_fmt}<r>\n"
-                ),
+            throw!(
+                this, global, signature,
+                "\n\nExpected: {} <green>{}<r>\nReceived: <red>{}<r>\n",
+                glyph, expected_fmt, value_fmt,
             )
         }
     }

--- a/test/js/bun/test/expect-failure-message-angle-brackets.test.ts
+++ b/test/js/bun/test/expect-failure-message-angle-brackets.test.ts
@@ -1,0 +1,143 @@
+// expect() failure messages must render user data verbatim: angle-bracketed
+// strings (HTML/JSX/XML) were being consumed by the `<tag>` → ANSI markup pass
+// because the pass ran over the rendered message instead of the template.
+
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+const fixture = /* ts */ `
+import { test, expect } from "bun:test";
+
+test("toBe html", () => {
+  expect('<div class="active">Hello</div>').toBe('<div class="inactive">Hello</div>');
+});
+test("toContain", () => {
+  expect("hello").toContain("<i>");
+});
+test("toHaveProperty", () => {
+  expect({}).toHaveProperty("<b>key</b>");
+});
+test("not.toBe", () => {
+  expect("<red>x</red>").not.toBe("<red>x</red>");
+});
+test("toThrow", () => {
+  expect(() => {
+    throw new Error("<u>underlined</u>");
+  }).not.toThrow();
+});
+test("custom label", () => {
+  expect("a", "<blue>label</blue>").toBe("b");
+});
+test("pass msg", () => {
+  expect(0).not.pass("<magenta>nope</magenta>");
+});
+test("toBeGreaterThan glyph", () => {
+  expect(1).toBeGreaterThan(2);
+});
+test("resolves non-promise", async () => {
+  await expect("<d>plain</d>").resolves.toBe(1);
+});
+test("custom matcher message", () => {
+  expect.extend({
+    toBeFoo(received) {
+      return { pass: false, message: () => "want <i>foo</i> got " + received };
+    },
+  });
+  // @ts-ignore
+  expect("<b>bar</b>").toBeFoo();
+});
+`;
+
+async function run(env: Record<string, string | undefined>) {
+  using dir = tempDir("expect-angle", { "angle.test.ts": fixture });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "angle.test.ts"],
+    env: { ...bunEnv, ...env },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+describe("expect() failure messages preserve <...> in user data", () => {
+  test("colors disabled: angle-bracketed strings render verbatim", async () => {
+    const { stderr, exitCode } = await run({ NO_COLOR: "1", FORCE_COLOR: undefined });
+
+    // toBe on HTML strings: Expected/Received must show the full string, not
+    // just the text between tags.
+    expect(stderr).toContain('Expected: "<div class="inactive">Hello</div>"');
+    expect(stderr).toContain('Received: "<div class="active">Hello</div>"');
+
+    // toContain("<i>"): must show the literal "<i>", not an empty span.
+    expect(stderr).toContain('Expected to contain: "<i>"');
+
+    // toHaveProperty: the path string is user data.
+    expect(stderr).toContain('Expected path: "<b>key</b>"');
+
+    // not.toBe: a string that happens to match a colour tag name.
+    expect(stderr).toContain('Expected: not "<red>x</red>"');
+
+    // toThrow: error message from a thrown Error is user data.
+    expect(stderr).toContain('Error message: "<u>underlined</u>"');
+
+    // expect(v, label): the custom label is user data. The label heads the
+    // error line so match it immediately after `error: `.
+    expect(stderr).toContain("error: <blue>label</blue>");
+
+    // .not.pass(msg): the message is user data.
+    expect(stderr).toContain("<magenta>nope</magenta>");
+
+    // toBeGreaterThan: the `>` glyph must still render.
+    expect(stderr).toContain("Expected: > 2");
+
+    // .resolves on a non-promise: received value is user data.
+    expect(stderr).toContain('Received: "<d>plain</d>"');
+
+    // expect.extend: the custom matcher's returned message is user data.
+    expect(stderr).toContain("want <i>foo</i> got <b>bar</b>");
+
+    expect(exitCode).toBe(1);
+  });
+
+  test("colors enabled: user data is not interpreted as ANSI markup", async () => {
+    const { stderr, exitCode } = await run({ FORCE_COLOR: "1", NO_COLOR: undefined });
+
+    // `<i>` → `\x1b[3m` would be the bug: user data interpreted as markup.
+    // Match the exact `"<payload>"` span the failure message emits.
+    expect(stderr).not.toContain('"\x1b[3m"');
+    // With the fix the green-wrapped expected value is the literal "<i>".
+    expect(stderr).toContain('\x1b[32m"<i>"\x1b[0m');
+
+    // toBe on HTML strings: the diff body (not the source snippet) must carry
+    // the tag text. The diff colours the changed span mid-string, so match the
+    // trailing `…Hello</div>"` + reset which is common to both and proves the
+    // `</div>` was not stripped.
+    expect(stderr).toContain('active">Hello</div>"\x1b[0m');
+    expect(stderr).toContain('\x1b[32m"<div class="');
+
+    // `<red>` in user data must not become a red escape inside the quoted
+    // value; it must appear literally after the *template's* green escape.
+    expect(stderr).toContain('\x1b[32m"<red>x</red>"\x1b[0m');
+
+    // The custom label is user data — must not emit a blue escape. The label
+    // heads the bold error line.
+    expect(stderr).toContain("\x1b[1m<blue>label</blue>");
+
+    // `<d>` in user data must not emit a dim escape inside the quoted value.
+    expect(stderr).toContain('"<d>plain</d>"');
+
+    // Custom matcher returned message is user data.
+    expect(stderr).toContain("want <i>foo</i> got <b>bar</b>");
+
+    // Template markup (the green around Expected values) must still work.
+    expect(stderr).toContain("\x1b[32m");
+
+    expect(exitCode).toBe(1);
+  });
+});

--- a/test/js/bun/test/expect-failure-message-angle-brackets.test.ts
+++ b/test/js/bun/test/expect-failure-message-angle-brackets.test.ts
@@ -2,7 +2,7 @@
 // strings (HTML/JSX/XML) were being consumed by the `<tag>` → ANSI markup pass
 // because the pass ran over the rendered message instead of the template.
 
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 const fixture = /* ts */ `
@@ -57,11 +57,7 @@ async function run(env: Record<string, string | undefined>) {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { stdout, stderr, exitCode };
 }
 


### PR DESCRIPTION
## What

`expect()` failure messages were running the `<tag>` -> ANSI/strip rewrite over the fully rendered string (template + substituted user data). Any `<...>` span in a Received/Expected value was parsed as markup and consumed.

```ts
test("t", () => expect('<div class="active">Hello</div>').toBe('<div class="inactive">Hello</div>'));
// 1.4:    Expected: "Hello"  /  Received: "Hello"        <-- identical strings reported unequal
// 1.3.14: Expected: "<div class="inactive">Hello</div>"  /  Received: "<div class="active">Hello</div>"
```

Under `FORCE_COLOR=1` it was worse: `toContain("<i>")` emitted a live `\x1b[3m` italic escape, interpreting user data as markup.

Affects `toBe`, `toContain`, `toHaveProperty`, `toThrow`, `not.*`, `.resolves`/`.rejects`, `expect(v, label)`, `.pass`/`.fail` messages, and `expect.extend` custom-matcher messages.

## Cause

`JSGlobalObject::throw_pretty(args: Arguments<'_>)` rendered the entire `args` (template literal + user-data substitutions) into one buffer, then ran `pretty_fmt_rt` over that buffer. The Zig baseline applied `Output.prettyFmt` to the **comptime template** and substituted args via `createErrorInstance` afterwards, so user data was never scanned.

## Fix

Restore the template-first contract by moving the `<tag>` rewrite to compile time everywhere in the matcher failure path:

- New `expect_throw!` macro (re-exported as `throw!` in the `expect` module) applies `pretty_fmt!` to the template literal at compile time for both colour branches, then substitutes positional args via `format_args!`. User data in the args is never scanned.
- `Expect::throw` becomes `throw_rendered`, a pure concat sink that emits its input verbatim. `get_signature` caches the ANSI/stripped header pair so the failure path does no runtime markup work.
- Every matcher failure site (~130 across 40+ files) converts from `this.throw(g, sig, format_args!(tpl, ..))` to `throw!(this, g, sig, tpl, ..)`.
- `JSGlobalObject::throw_pretty` and the `JSGlobalObjectTestExt::throw_pretty` shim are deleted; the template-only callers move to a compile-time `throw_pretty_static!` macro or plain `throw` (shell/BunObject messages had no markup to begin with).
- `throw_pretty_matcher_error` and `CustomMatcherParamsFormatter` now emit `matcher_name`/`matcher_params`/`message` verbatim, so a custom matcher's returned message string is no longer scanned for markup.
- Dropped the pre-escaped `\<` / `\>` operator glyphs in `toHaveReturned` / `OrderingRelation` now that operands are substituted verbatim.

## Verification

New `test/js/bun/test/expect-failure-message-angle-brackets.test.ts` spawns a child `bun test` and asserts, for both `NO_COLOR` and `FORCE_COLOR`:

- `<div ...>Hello</div>` appears verbatim in the Expected/Received lines
- `toContain("<i>")` shows the literal `"<i>"` (and under colours, does **not** emit `"\x1b[3m"`)
- `<b>`/`<u>`/`<red>`/`<d>`/`<blue>`/`<magenta>` in property paths, thrown Error messages, custom labels, `.pass()` messages, `.resolves` received values, and `expect.extend` messages all render verbatim
- the `>` glyph in `toBeGreaterThan` failure output still renders
- template markup (green/red around expected/received) still works

Fails on 1.4.0-canary; passes with this change. `test/js/bun/test/expect.test.js` (406 tests) passes unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 45 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect-failure-message-angle-brackets.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (60254a39a)

test/js/bun/test/expect-failure-message-angle-brackets.test.ts:
65 |   test("colors disabled: angle-bracketed strings render verbatim", async () => {
66 |     const { stderr, exitCode } = await run({ NO_COLOR: "1", FORCE_COLOR: undefined });
67 | 
68 |     // toBe on HTML strings: Expected/Received must show the full string, not
69 |     // just the text between tags.
70 |     expect(stderr).toContain('Expected: "<div class="inactive">Hello</div>"');
                        ^
error: expect(received).toContain(expected)

Expected to contain: "Expected: \"Hello\""
Received: "\nangle.test.ts:\n1 | \n2 | import { test, expect } from \"bun:test\";\n3 | \n4 | test(\"toBe html\", () = {\n5 |   expec
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/test/expect-failure-message-angle-brackets.test.ts:
65 |   test("colors disabled: angle-bracketed strings render verbatim", async () => {
66 |     const { stderr, exitCode } = await run({ NO_COLOR: "1", FORCE_COLOR: undefined });
67 | 
68 |     // toBe on HTML strings: Expected/Received must show the full string, not
69 |     // just the text between tags.
70 |     expect(stderr).toContain('Expected: "<div class="inactive">Hello</div>"');
                        ^
error: expect(received).toContain(expected)

Expected to contain: "Expected: \"Hello\""
Received: "\nangle.test.ts:\n1 | \n2 | import { test, expect } from \"bun:test\";\n3 | \n4 | test(\"toBe html\", () = {\n5 |   expect('<div class=\"active\">Hello</div>').toBe('<div class=\"inactive\">Hello</div>');\n                                                ^\nerror: expect(received).toBe(expected)\n\nExpected: \"Hello\"\nReceived: \"Hello\"\n\n      at <anonymous> (/tmp/expect-angle_M54n1e/angle.test.ts:5:45)\n(fail) toBe html [1.09ms]\n3 | \n4 | test(\"toBe html\", () => {\n5 |   expect('<div class=\"active\">Hello</div>').toBe('<div class=\"inactive\">Hello</di
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect-failure-message-angle-brackets.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (60254a39a)

test/js/bun/test/expect-failure-message-angle-brackets.test.ts:
(pass) expect() failure messages preserve <...> in user data > colors disabled: angle-bracketed strings render verbatim [893.89ms]
(pass) expect() failure messages preserve <...> in user data > colors enabled: user data is not interpreted as ANSI markup [842.06ms]

 2 pass
 0 fail
 22 expect() calls
Ran 2 tests across 1 file. [6.24s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     60254a39a8
  features     (none)

22 deps, 106 codegen, 1168 objects in 1773ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] gen bindgenv2
[2/1231] fetch zlib
[zlib] up to date
[3/1231] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[4/1231] fetch tinycc
[tinycc] up to date
[5/1230] fetch picohttpparser
[picohttpparser] up to date
[6/1230] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[7/1230] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[8/1230] gen ProcessBindingBuffer.lut.h
Generating /workspace/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/JSGlobalObject.rs                          |  32 --
 src/jsc/bindgen_test.rs                            |   2 +-
 src/runtime/api/BunObject.rs                       |   8 +-
 src/runtime/shell/ParsedShellScript.rs             |   4 +-
 src/runtime/shell/shell_body.rs                    |   6 +-
 src/runtime/test_runner/expect.rs                  | 425 ++++++++++++---------
 src/runtime/test_runner/expect/toBe.rs             |  47 ++-
 src/runtime/test_runner/expect/toBeArrayOfSize.rs  |  11 +-
 src/runtime/test_runner/expect/toBeCloseTo.rs      |  41 +-
 src/runtime/test_runner/expect/toBeEmpty.rs        |  38 +-
 src/runtime/test_runner/expect/toBeEmptyObject.rs  |  11 +-
 src/runtime/test_runner/expect/toBeInstanceOf.rs   |  19 +-
 src/runtime/test_runner/expect/toBeObject.rs       |  20 +-
 src/runtime/test_runner/expect/toBeOneOf.rs        |  33 +-
 src/runtime/test_runner/expect/toBeTypeOf.rs       |  39 +-
 src/runtime/test_runner/expect/toBeValidDate.rs    |  11 +-
 src/runtime/test_runner/expect/toBeWithin.rs       |  40 +-
 src/runtime/test_runner/expect/toContain.rs        |  33 +-
 src/runtime/test_runner/expect/toContainEqual.rs   |  13 +-
 src/runtime/test_runner/expect/toEqual.rs          |   5 +-
 .../expect/toEqualIgnoringWhitespace.rs            |  19 +-
 src/runtime/test_runner/expect/toHaveBeenCalled.rs |  31 +-
 .../test_runner/expect/toHaveBeenCalledOnce.rs     |  31 +-
 .../test_runner/expect/toHaveBeenCalledTimes.rs    |  35 +-
 .../test_runner/expect/toHaveBeenCalledWith.rs     |  34 +-
 .../test_runner/expect/toHaveBeenLastCalledWith.rs |  21 +-
 .../test_runner/expect/toHaveBeenNthCalledWith.rs  |  30 +-
 .../test_runner/expect/toHaveLastReturnedWith.rs   |  43 +--
 src/runtime/test_runner/expect/toHaveLength.rs     |  15 +-
 .../test_runner/expect/toHaveNthReturnedWith.rs    |  54 ++-
 src/runtime/test_runner/expect/toHaveProperty.rs   |  45 +--
 src/runtime/test_runner/expect/toHaveReturned.rs   |  22 +-
 .../test_
... (truncated)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/jsc/JSGlobalObject.rs                              2      1      0
src/jsc/bindgen_test.rs                                1      1      0
src/runtime/api/BunObject.rs                           1      2      0
src/runtime/shell/ParsedShellScript.rs                 1      1      0
src/runtime/shell/shell_body.rs                        1      2      0
src/runtime/test_runner/expect.rs                     13     37      0
src/runtime/test_runner/expect/toBe.rs                 2      0      0
src/runtime/test_runner/expect/toBeArrayOfSize.rs      0      0      0
src/runtime/test_runner/expect/toBeCloseTo.rs          1      1      0
src/runtime/test_runner/expect/toBeEmpty.rs            2      0      0
src/runtime/test_runner/expect/toBeEmptyObject.rs      0      0      0
src/runtime/test_runner/expect/toBeInstanceOf.rs       0      0      0
src/runtime/test_runner/expect/toBeObject.rs           0      0      0
src/runtime/test_runner/expect/toBeOneOf.rs            0      0      0
src/runtime/test_runner/expect/toBeTypeOf.rs           0      0      0
src/runtime/test_runner/expect/toBeValidDate.rs        0      0      0
(+ 29 more files)
```

</details>

<!-- robobun:evidence:end -->