### PR TITLE
socket: deliver the TLS verify error to error/close when rejectUnauthorized closes the connection

### DIFF
--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -1832,12 +1832,9 @@ impl<const SSL: bool> NewSocket<SSL> {
         if socket.is_detached() || socket.is_closed() {
             return;
         }
-        // Surface the verify error through the `error` handler before closing so
-        // a user who omitted the optional `handshake` callback still learns why
-        // the connection was dropped (Node emits `'error'` with the same code).
-        // Only when an `error` handler is defined: `handle_error` would route an
-        // undefined one to `uncaught_exception`, but the error is already
-        // available via `handshake`'s third argument and `close`'s second.
+        // Surface the verify error via `error` before closing (Node emits
+        // `'error'` here). Skip when no `error` handler is defined: without one
+        // `handle_error` routes to uncaught, and `handshake`/`close` already carry it.
         if let Some(handlers) = self.handlers_opt() {
             if !handlers.on_error().is_empty() {
                 let global = handlers.global_object;

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -1835,13 +1835,18 @@ impl<const SSL: bool> NewSocket<SSL> {
         // Surface the verify error through the `error` handler before closing so
         // a user who omitted the optional `handshake` callback still learns why
         // the connection was dropped (Node emits `'error'` with the same code).
+        // Only when an `error` handler is defined: `handle_error` would route an
+        // undefined one to `uncaught_exception`, but the error is already
+        // available via `handshake`'s third argument and `close`'s second.
         if let Some(handlers) = self.handlers_opt() {
-            let global = handlers.global_object;
-            if let Some(err_value) = self.stored_verify_error_to_js(&global) {
-                self.handle_error(err_value);
-                let socket = self.socket.get();
-                if socket.is_detached() || socket.is_closed() {
-                    return;
+            if !handlers.on_error().is_empty() {
+                let global = handlers.global_object;
+                if let Some(err_value) = self.stored_verify_error_to_js(&global) {
+                    self.handle_error(err_value);
+                    let socket = self.socket.get();
+                    if socket.is_detached() || socket.is_closed() {
+                        return;
+                    }
                 }
             }
         }

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -1832,6 +1832,19 @@ impl<const SSL: bool> NewSocket<SSL> {
         if socket.is_detached() || socket.is_closed() {
             return;
         }
+        // Surface the verify error through the `error` handler before closing so
+        // a user who omitted the optional `handshake` callback still learns why
+        // the connection was dropped (Node emits `'error'` with the same code).
+        if let Some(handlers) = self.handlers_opt() {
+            let global = handlers.global_object;
+            if let Some(err_value) = self.stored_verify_error_to_js(&global) {
+                self.handle_error(err_value);
+                let socket = self.socket.get();
+                if socket.is_detached() || socket.is_closed() {
+                    return;
+                }
+            }
+        }
         self.close_and_detach(uws::CloseCode::FastShutdown);
     }
 
@@ -2023,6 +2036,12 @@ impl<const SSL: bool> NewSocket<SSL> {
                 &sys::Error::from_code_int(err, sys::Tag::read),
                 &global,
             );
+        } else if SSL && this.flags.get().contains(Flags::REJECTED) {
+            // A rejectUnauthorized close: pass the stored verify error so
+            // `close(socket, error)` tells the user why we dropped the peer.
+            js_error = this
+                .stored_verify_error_to_js(&global)
+                .unwrap_or(JSValue::UNDEFINED);
         }
 
         if let Err(e) = callback.call(&global, this_value, &[this_value, js_error]) {

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -1836,7 +1836,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         // `'error'` here). Skip when no `error` handler is defined: without one
         // `handle_error` routes to uncaught, and `handshake`/`close` already carry it.
         if let Some(handlers) = self.handlers_opt() {
-            if !handlers.on_error().is_empty() {
+            if !handlers.on_error().is_empty() && !handlers.vm.is_shutting_down() {
                 let global = handlers.global_object;
                 if let Some(err_value) = self.stored_verify_error_to_js(&global) {
                     self.handle_error(err_value);

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -10,6 +10,7 @@ import {
   getMaxFD,
   isWindows,
   libcPathForDlopen,
+  normalizeBunSnapshot,
   tempDir,
   tls,
 } from "harness";
@@ -2201,6 +2202,7 @@ Reo=
             error(_socket, err) {
               errors.push(err);
               handshake.reject(err);
+              echoed.reject(err);
             },
             connectError(_socket, err) {
               handshake.reject(err);
@@ -2213,6 +2215,10 @@ Reo=
         server.stop(true);
         throw e;
       }
+
+      // Reject-path tests observe the error via `errors[]` and never await
+      // `echoed`; swallow here so that rejection is not unhandled.
+      echoed.promise.catch(() => {});
 
       return {
         server,
@@ -2565,12 +2571,11 @@ Reo=
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
-      expect(JSON.parse(stdout.trim())).toEqual([
-        "handshake:true:UNABLE_TO_VERIFY_LEAF_SIGNATURE",
-        "close:UNABLE_TO_VERIFY_LEAF_SIGNATURE",
-      ]);
-      expect(exitCode).toBe(0);
+      expect({ events: JSON.parse(stdout.trim()), stderr: normalizeBunSnapshot(stderr), exitCode }).toEqual({
+        events: ["handshake:true:UNABLE_TO_VERIFY_LEAF_SIGNATURE", "close:UNABLE_TO_VERIFY_LEAF_SIGNATURE"],
+        stderr: "",
+        exitCode: 0,
+      });
     });
 
     it("delivers the hostname-mismatch error through error/close when rejectUnauthorized closes the connection", async () => {

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -2148,6 +2148,7 @@ Reo=
   describe.concurrent("Bun.connect (server certificate)", () => {
     async function connectTo(serverTls: { key: string; cert: string }, clientTls: Record<string, unknown> | boolean) {
       const received: string[] = [];
+      const errors: Error[] = [];
       const handshake = Promise.withResolvers<{
         authorizedArg: boolean;
         authorizedGetter: boolean;
@@ -2198,8 +2199,8 @@ Reo=
               closed.resolve();
             },
             error(_socket, err) {
+              errors.push(err);
               handshake.reject(err);
-              echoed.reject(err);
             },
             connectError(_socket, err) {
               handshake.reject(err);
@@ -2217,6 +2218,7 @@ Reo=
         server,
         client,
         received,
+        errors,
         handshake,
         closed,
         echoed,
@@ -2264,6 +2266,7 @@ Reo=
       t.client.write("ping");
       await t.echoed.promise;
       expect(t.received.join("")).toBe("hello-from-server\nping");
+      expect(t.errors).toEqual([]);
     });
 
     it("closes an untrusted connection upgraded with only a secureContext", async () => {
@@ -2406,6 +2409,7 @@ Reo=
           error() {},
         },
       });
+      const errors: Error[] = [];
       using client = await Bun.connect({
         hostname: "127.0.0.1",
         port: server.port,
@@ -2424,8 +2428,8 @@ Reo=
             closed.resolve();
           },
           error(_socket, err) {
+            errors.push(err);
             opened.reject(err);
-            closed.reject(err);
           },
           connectError(_socket, err) {
             opened.reject(err);
@@ -2436,6 +2440,126 @@ Reo=
       expect(await opened.promise).toEqual({ authorized: false, error: UNTRUSTED_MESSAGE });
       await closed.promise;
       expect(received).toEqual([]);
+      expect(errors.map(e => e.message)).toEqual([UNTRUSTED_MESSAGE]);
+    });
+
+    it("delivers the verify error through error/close when rejectUnauthorized closes the connection (no handshake callback)", async () => {
+      const events: string[] = [];
+      const closed = Promise.withResolvers<void>();
+      using server = Bun.listen({
+        hostname: "127.0.0.1",
+        port: 0,
+        tls: { key: ROGUE_KEY, cert: ROGUE_CRT },
+        socket: { open() {}, data() {}, close() {}, error() {} },
+      });
+      using _client = await Bun.connect({
+        hostname: "127.0.0.1",
+        port: server.port,
+        tls: true,
+        socket: {
+          open() {
+            events.push("open");
+          },
+          data() {
+            events.push("data");
+          },
+          error(_socket, err) {
+            events.push(`error:${(err as any)?.code}:${err?.message}`);
+          },
+          connectError(_socket, err) {
+            events.push(`connectError:${(err as any)?.code}`);
+            closed.resolve();
+          },
+          close(_socket, err) {
+            events.push(`close:${(err as any)?.code}:${(err as any)?.message}`);
+            closed.resolve();
+          },
+        },
+      });
+      await closed.promise;
+      expect(events).toEqual([
+        "open",
+        `error:UNABLE_TO_VERIFY_LEAF_SIGNATURE:${UNTRUSTED_MESSAGE}`,
+        `close:UNABLE_TO_VERIFY_LEAF_SIGNATURE:${UNTRUSTED_MESSAGE}`,
+      ]);
+    });
+
+    it("delivers the verify error through error/close when rejectUnauthorized closes the connection (with handshake callback)", async () => {
+      const events: string[] = [];
+      const closed = Promise.withResolvers<void>();
+      using server = Bun.listen({
+        hostname: "127.0.0.1",
+        port: 0,
+        tls: { key: ROGUE_KEY, cert: ROGUE_CRT },
+        socket: { open() {}, data() {}, close() {}, error() {} },
+      });
+      using _client = await Bun.connect({
+        hostname: "127.0.0.1",
+        port: server.port,
+        tls: { ca: CA_CRT },
+        socket: {
+          handshake(_socket, authorized, err) {
+            events.push(`handshake:${authorized}:${(err as any)?.code}`);
+          },
+          data() {
+            events.push("data");
+          },
+          error(_socket, err) {
+            events.push(`error:${(err as any)?.code}:${err?.message}`);
+          },
+          connectError(_socket, err) {
+            events.push(`connectError:${(err as any)?.code}`);
+            closed.resolve();
+          },
+          close(_socket, err) {
+            events.push(`close:${(err as any)?.code}:${(err as any)?.message}`);
+            closed.resolve();
+          },
+        },
+      });
+      await closed.promise;
+      expect(events).toEqual([
+        "handshake:true:UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+        `error:UNABLE_TO_VERIFY_LEAF_SIGNATURE:${UNTRUSTED_MESSAGE}`,
+        `close:UNABLE_TO_VERIFY_LEAF_SIGNATURE:${UNTRUSTED_MESSAGE}`,
+      ]);
+    });
+
+    it("delivers the hostname-mismatch error through error/close when rejectUnauthorized closes the connection", async () => {
+      const events: string[] = [];
+      const closed = Promise.withResolvers<void>();
+      using server = Bun.listen({
+        hostname: "127.0.0.1",
+        port: 0,
+        tls: { key: SERVER_KEY, cert: SERVER_CRT },
+        socket: { open() {}, data() {}, close() {}, error() {} },
+      });
+      using _client = await Bun.connect({
+        hostname: "127.0.0.1",
+        port: server.port,
+        tls: { ca: CA_CRT, serverName: "wrong.example.com" },
+        socket: {
+          open() {
+            events.push("open");
+          },
+          data() {
+            events.push("data");
+          },
+          error(_socket, err) {
+            events.push(`error:${(err as any)?.code}`);
+          },
+          connectError(_socket, err) {
+            events.push(`connectError:${(err as any)?.code}`);
+            closed.resolve();
+          },
+          close(_socket, err) {
+            events.push(`close:${(err as any)?.code}`);
+            closed.resolve();
+          },
+        },
+      });
+      await closed.promise;
+      expect(events).toEqual(["open", "error:ERR_TLS_CERT_ALTNAME_INVALID", "close:ERR_TLS_CERT_ALTNAME_INVALID"]);
     });
 
     it("refuses writes issued from the handshake callback of a rejected connection", async () => {
@@ -2458,6 +2582,7 @@ Reo=
           error() {},
         },
       });
+      const errors: Error[] = [];
       using client = await Bun.connect({
         hostname: "127.0.0.1",
         port: server.port,
@@ -2472,8 +2597,8 @@ Reo=
             closed.resolve();
           },
           error(_socket, err) {
+            errors.push(err);
             handshake.reject(err);
-            closed.reject(err);
           },
           connectError(_socket, err) {
             handshake.reject(err);
@@ -2486,6 +2611,7 @@ Reo=
       await closed.promise;
       await serverClosed.promise;
       expect(serverReceived).toEqual([]);
+      expect(errors.map(e => e.message)).toEqual([UNTRUSTED_MESSAGE]);
     });
 
     it("closes a connection whose certificate does not match the hostname", async () => {

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -2525,6 +2525,54 @@ Reo=
       ]);
     });
 
+    it("delivers the verify error to close (not uncaughtException) when no error handler is defined", async () => {
+      using dir = tempDir("tls-reject-no-error-handler", {
+        "main.ts": `
+          const events: string[] = [];
+          process.on("uncaughtException", e => events.push("uncaught:" + (e as any)?.code));
+          using server = Bun.listen({
+            hostname: "127.0.0.1",
+            port: 0,
+            tls: { key: process.env.ROGUE_KEY!, cert: process.env.ROGUE_CRT! },
+            socket: { open() {}, data() {}, close() {}, error() {} },
+          });
+          const closed = Promise.withResolvers<void>();
+          await Bun.connect({
+            hostname: "127.0.0.1",
+            port: server.port,
+            tls: true,
+            socket: {
+              handshake(_s, authorized, err) {
+                events.push("handshake:" + authorized + ":" + (err as any)?.code);
+              },
+              data() {},
+              close(_s, err) {
+                events.push("close:" + (err as any)?.code);
+                closed.resolve();
+              },
+            },
+          });
+          await closed.promise;
+          await new Promise<void>(r => setImmediate(r));
+          console.log(JSON.stringify(events));
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "main.ts"],
+        env: { ...bunEnv, ROGUE_KEY, ROGUE_CRT },
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout.trim())).toEqual([
+        "handshake:true:UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+        "close:UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+      ]);
+      expect(exitCode).toBe(0);
+    });
+
     it("delivers the hostname-mismatch error through error/close when rejectUnauthorized closes the connection", async () => {
       const events: string[] = [];
       const closed = Promise.withResolvers<void>();

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -2532,41 +2532,38 @@ Reo=
     });
 
     it("delivers the verify error to close (not uncaughtException) when no error handler is defined", async () => {
-      using dir = tempDir("tls-reject-no-error-handler", {
-        "main.ts": `
-          const events: string[] = [];
-          process.on("uncaughtException", e => events.push("uncaught:" + (e as any)?.code));
-          using server = Bun.listen({
-            hostname: "127.0.0.1",
-            port: 0,
-            tls: { key: process.env.ROGUE_KEY!, cert: process.env.ROGUE_CRT! },
-            socket: { open() {}, data() {}, close() {}, error() {} },
-          });
-          const closed = Promise.withResolvers<void>();
-          await Bun.connect({
-            hostname: "127.0.0.1",
-            port: server.port,
-            tls: true,
-            socket: {
-              handshake(_s, authorized, err) {
-                events.push("handshake:" + authorized + ":" + (err as any)?.code);
-              },
-              data() {},
-              close(_s, err) {
-                events.push("close:" + (err as any)?.code);
-                closed.resolve();
-              },
+      const script = `
+        const events = [];
+        process.on("uncaughtException", e => events.push("uncaught:" + e?.code));
+        using server = Bun.listen({
+          hostname: "127.0.0.1",
+          port: 0,
+          tls: { key: process.env.ROGUE_KEY, cert: process.env.ROGUE_CRT },
+          socket: { open() {}, data() {}, close() {}, error() {} },
+        });
+        const closed = Promise.withResolvers();
+        await Bun.connect({
+          hostname: "127.0.0.1",
+          port: server.port,
+          tls: true,
+          socket: {
+            handshake(_s, authorized, err) {
+              events.push("handshake:" + authorized + ":" + err?.code);
             },
-          });
-          await closed.promise;
-          await new Promise<void>(r => setImmediate(r));
-          console.log(JSON.stringify(events));
-        `,
-      });
+            data() {},
+            close(_s, err) {
+              events.push("close:" + err?.code);
+              closed.resolve();
+            },
+          },
+        });
+        await closed.promise;
+        await new Promise(r => setImmediate(r));
+        console.log(JSON.stringify(events));
+      `;
       await using proc = Bun.spawn({
-        cmd: [bunExe(), "main.ts"],
+        cmd: [bunExe(), "-e", script],
         env: { ...bunEnv, ROGUE_KEY, ROGUE_CRT },
-        cwd: String(dir),
         stdout: "pipe",
         stderr: "pipe",
       });


### PR DESCRIPTION
### What

`Bun.connect({tls: true})` against a server whose certificate does not chain to a trusted root opens the socket and then closes it with no diagnostic: the `error` handler never fires, `connectError` never fires, and `close(socket, error)` receives `undefined`. A user whose only feedback channels are `error`/`connectError`/`close` sees a connection that opens and dies silently.

```js
const events = [];
await Bun.connect({
  tls: true, hostname: "127.0.0.1", port,
  socket: {
    open()             { events.push("open"); },
    error(_, e)        { events.push("error:" + e?.code); },   // never fires
    connectError(_, e) { events.push("connectError:" + e?.code); }, // never fires
    close(_, e)        { events.push("close:" + e); },         // "close:undefined"
  },
});
// before: ["open", "close:undefined"]
// after:  ["open", "error:UNABLE_TO_VERIFY_LEAF_SIGNATURE", "close:Error: unable to verify the first certificate"]
```

Node's `tls.connect()` emits `'error'` with `UNABLE_TO_VERIFY_LEAF_SIGNATURE` / `DEPTH_ZERO_SELF_SIGNED_CERT` / `ERR_TLS_CERT_ALTNAME_INVALID` in the same situation.

### Cause

`reject_unauthorized_connection()` (src/runtime/socket/socket_body.rs) was only `close_and_detach(FastShutdown)`. The verify error was stored on the socket and delivered to the optional `handshake` callback, but never routed through `error`, and `on_close` mapped the `FastShutdown` close code (2) to an `undefined` error argument.

### Fix

- `reject_unauthorized_connection` now dispatches the stored verify error through the `error` handler before closing.
- `on_close` passes the stored verify error as the `close` callback's error argument when the `REJECTED` flag is set.

`node:tls` is unaffected: its JS-layer `handshake` callback already emitted `'error'` via `destroy(verifyError)`, and the added native dispatch no-ops against an already-destroyed socket.

### Verification

New tests in `test/js/bun/net/socket.test.ts` assert the exact event sequence for an untrusted-chain rejection with and without a `handshake` callback, and for a hostname-mismatch rejection. Two existing tests in the same describe block now additionally assert the `error` handler received the verify error.

```
=== FAIL-BEFORE (src/ stashed) ===
(fail) ... closes an untrusted connection when no handshake callback is provided
(fail) ... delivers the verify error through error/close ... (no handshake callback)
(fail) ... delivers the verify error through error/close ... (with handshake callback)
(fail) ... delivers the hostname-mismatch error through error/close ...
(fail) ... refuses writes issued from the handshake callback of a rejected connection
 0 pass / 5 fail

=== PASS-AFTER (src/ restored) ===
 5 pass / 0 fail
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/net/socket.test.ts

<!-- robobun:evidence:end -->