### PR TITLE
worker_threads: defer worker-side stdio/Console setup to first access

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -482,10 +482,11 @@ function setupWorkerStdio(stdio) {
   );
   // node routes console.log through process.stdout/stderr; Bun's global console
   // writes the fd directly, so rebind it to the captured streams when present.
-  // Capture the native console object first: require("node:console") is
-  // `export default globalThis.console`, which would re-enter this getter.
+  // Capture via require("node:console") first so the module registry caches the
+  // native object (which carries .Console/.write); otherwise a later user require
+  // would evaluate `export default console` through this getter and cache a bare instance.
   if (stdout || stderr) {
-    const nativeConsole = globalThis.console as typeof globalThis.console & { Console: any };
+    const nativeConsole = require("node:console") as typeof globalThis.console & { Console: any };
     defineLazy(globalThis, "console", false, () => new nativeConsole.Console(process.stdout, process.stderr));
   }
 }

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -5,8 +5,10 @@ type WebWorker = InstanceType<typeof globalThis.Worker>;
 
 const EventEmitter = require("node:events");
 const { SafeMap } = require("internal/primordials");
-const Readable = require("internal/streams/readable");
-const Writable = require("internal/streams/writable");
+// Readable/Writable are loaded lazily: this module is preloaded in every
+// node:worker_threads worker, and the streams graph is several ms cold.
+let Readable;
+let Writable;
 const { throwNotImplemented, warnNotImplementedOnce } = require("internal/shared");
 const {
   validateString,
@@ -26,8 +28,6 @@ function normalizeWorkerName(rawName) {
   return "";
 }
 
-const { isAbsolute: pathIsAbsolute } = require("node:path");
-
 // node's filename validation for non-eval workers: absolute or "./"/"../"-relative
 // paths and file: URL objects; bare specifiers and string URLs are rejected.
 function validateWorkerFilename(filename) {
@@ -41,7 +41,7 @@ function validateWorkerFilename(filename) {
     // throws the canonical ERR_INVALID_ARG_TYPE with the exact node message.
     return filename;
   }
-  if (pathIsAbsolute(filename) || /^\.\.?[\\/]/.test(filename)) {
+  if (require("node:path").isAbsolute(filename) || /^\.\.?[\\/]/.test(filename)) {
     return filename;
   }
   let message =
@@ -334,6 +334,7 @@ const BUN_WORKER_MESSAGING_KEY = "@@bunWorkerThreadsMessaging";
 // Readable fed by a control MessagePort (worker.stdout/stderr on the parent,
 // process.stdin in the worker). The peer posts arrays of Buffers; null signals EOF.
 function makePortReadable(port) {
+  Readable ??= require("internal/streams/readable");
   let attached = false;
   let ended = false;
   function onMessage(payload) {
@@ -380,6 +381,7 @@ function makePortReadable(port) {
 // Writable that forwards chunks over a control MessagePort (worker.stdin on the
 // parent, process.stdout/stderr in the worker). final() posts null as EOF.
 function makePortWritable(port) {
+  Writable ??= require("internal/streams/writable");
   // Reader-side acks complete the in-flight writev. The listener refs the
   // event loop; release that immediately — the port is re-ref'd only while a
   // batch is awaiting its ack, so unflushed data keeps the writer alive
@@ -435,44 +437,54 @@ function makePortWritable(port) {
   });
 }
 
+// Install a self-replacing accessor: the first get() builds the value and
+// rewrites the slot to a plain writable data property, so later reads are
+// direct and identity-stable; set() does the same rewrite so assignment works.
+function defineLazy(obj, name, enumerable, make) {
+  Object.defineProperty(obj, name, {
+    configurable: true,
+    enumerable,
+    get() {
+      const value = make();
+      Object.defineProperty(obj, name, { value, writable: true, configurable: true, enumerable });
+      return value;
+    },
+    set(value) {
+      Object.defineProperty(obj, name, { value, writable: true, configurable: true, enumerable });
+    },
+  });
+}
+
 function setupWorkerStdio(stdio) {
+  const proc: any = process;
   const { stdin, stdout, stderr } = stdio;
-  if (stdout) {
-    Object.defineProperty(process, "stdout", {
-      value: makePortWritable(stdout),
-      writable: true,
-      configurable: true,
-      enumerable: true,
-    });
-  }
-  if (stderr) {
-    Object.defineProperty(process, "stderr", {
-      value: makePortWritable(stderr),
-      writable: true,
-      configurable: true,
-      enumerable: true,
-    });
-  }
+  // Shadow the native PropertyCallback slots via plain [[Set]] first: defineProperty
+  // on one reifies the process static table and invokes constructStdout/Stderr/Stdin,
+  // cold-loading node:stream just to build fd streams we then discard.
+  proc.stdin = proc.stdout = proc.stderr = undefined;
+  // Lazy: the streams graph + Console constructor are several ms cold, and most
+  // workers never touch process.stdout/stderr/stdin directly.
+  if (stdout) defineLazy(process, "stdout", true, () => makePortWritable(stdout));
+  if (stderr) defineLazy(process, "stderr", true, () => makePortWritable(stderr));
   // node always replaces a worker's process.stdin: port-backed when { stdin: true },
   // otherwise an immediately-EOF'd stream — never the process-wide fd 0, which
   // would race the main thread (and hang on a TTY).
-  Object.defineProperty(process, "stdin", {
-    value: stdin
+  defineLazy(process, "stdin", true, () =>
+    stdin
       ? makePortReadable(stdin)
-      : new Readable({
+      : new (Readable ??= require("internal/streams/readable"))({
           read() {
             this.push(null);
           },
         }),
-    writable: true,
-    configurable: true,
-    enumerable: true,
-  });
+  );
   // node routes console.log through process.stdout/stderr; Bun's global console
   // writes the fd directly, so rebind it to the captured streams when present.
+  // Capture the native console object first: require("node:console") is
+  // `export default globalThis.console`, which would re-enter this getter.
   if (stdout || stderr) {
-    const { Console } = require("node:console");
-    globalThis.console = new Console(process.stdout, process.stderr);
+    const nativeConsole = globalThis.console as typeof globalThis.console & { Console: any };
+    defineLazy(globalThis, "console", false, () => new nativeConsole.Console(process.stdout, process.stderr));
   }
 }
 
@@ -1199,7 +1211,7 @@ class Worker extends EventEmitter {
 
   getHeapSnapshot(options: unknown) {
     const stringPromise = this.#worker.getHeapSnapshot(options);
-    return stringPromise.then(s => new HeapSnapshotStream(s));
+    return stringPromise.then(s => makeHeapSnapshotStream(s));
   }
 
   getHeapStatistics() {
@@ -1351,21 +1363,24 @@ class Worker extends EventEmitter {
   }
 }
 
-class HeapSnapshotStream extends Readable {
-  #json: string | undefined;
-
-  constructor(json: string) {
-    super();
-    this.#json = json;
-  }
-
-  _read() {
-    if (this.#json !== undefined) {
-      this.push(this.#json);
-      this.push(null);
-      this.#json = undefined;
+let _HeapSnapshotStream;
+function makeHeapSnapshotStream(json: string) {
+  Readable ??= require("internal/streams/readable");
+  _HeapSnapshotStream ??= class HeapSnapshotStream extends Readable {
+    #json: string | undefined;
+    constructor(json: string) {
+      super();
+      this.#json = json;
     }
-  }
+    _read() {
+      if (this.#json !== undefined) {
+        this.push(this.#json);
+        this.push(null);
+        this.#json = undefined;
+      }
+    }
+  };
+  return new _HeapSnapshotStream(json);
 }
 
 export default {

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -461,15 +461,17 @@ function setupWorkerStdio(stdio) {
   // Shadow the native PropertyCallback slots via plain [[Set]] first: defineProperty
   // on one reifies the process static table and invokes constructStdout/Stderr/Stdin,
   // cold-loading node:stream just to build fd streams we then discard.
-  proc.stdin = proc.stdout = proc.stderr = undefined;
+  proc.stdin = undefined;
+  if (stdout) proc.stdout = undefined;
+  if (stderr) proc.stderr = undefined;
   // Lazy: the streams graph + Console constructor are several ms cold, and most
   // workers never touch process.stdout/stderr/stdin directly.
-  if (stdout) defineLazy(process, "stdout", true, () => makePortWritable(stdout));
-  if (stderr) defineLazy(process, "stderr", true, () => makePortWritable(stderr));
+  if (stdout) defineLazy(proc, "stdout", true, () => makePortWritable(stdout));
+  if (stderr) defineLazy(proc, "stderr", true, () => makePortWritable(stderr));
   // node always replaces a worker's process.stdin: port-backed when { stdin: true },
   // otherwise an immediately-EOF'd stream — never the process-wide fd 0, which
   // would race the main thread (and hang on a TTY).
-  defineLazy(process, "stdin", true, () =>
+  defineLazy(proc, "stdin", true, () =>
     stdin
       ? makePortReadable(stdin)
       : new (Readable ??= require("internal/streams/readable"))({

--- a/test/js/node/worker_threads/worker-stdio-lazy.test.ts
+++ b/test/js/node/worker_threads/worker-stdio-lazy.test.ts
@@ -1,0 +1,63 @@
+import { test, expect } from "bun:test";
+import { once } from "node:events";
+import { Worker } from "node:worker_threads";
+
+// Regression: the stdio rebind used to run eagerly in every worker's preload,
+// cold-loading node:stream + Console and reifying the process static table on
+// every spawn even when the worker never touched stdio.
+test("worker process.stdio and console are installed as lazy accessors", async () => {
+  const worker = new Worker(
+    `
+    const { parentPort } = require("worker_threads");
+    const d = (obj, k) => {
+      const desc = Object.getOwnPropertyDescriptor(obj, k);
+      return desc ? (desc.get ? "accessor" : "value") : "none";
+    };
+    const before = {
+      stdout: d(process, "stdout"),
+      stderr: d(process, "stderr"),
+      stdin: d(process, "stdin"),
+      console: d(globalThis, "console"),
+    };
+    // first read materializes the stream; second read must be the same object
+    const s1 = process.stdout;
+    const s2 = process.stdout;
+    parentPort.postMessage({
+      before,
+      afterStdout: d(process, "stdout"),
+      sameInstance: s1 === s2,
+      isWritable: typeof s1.write === "function",
+    });
+    `,
+    { eval: true },
+  );
+  const [msg] = await once(worker, "message");
+  expect(msg).toEqual({
+    before: { stdout: "accessor", stderr: "accessor", stdin: "accessor", console: "accessor" },
+    afterStdout: "value",
+    sameInstance: true,
+    isWritable: true,
+  });
+  await worker.terminate();
+});
+
+// node:console is `export default globalThis.console`; evaluating it after the
+// lazy getter is installed would cache a plain Console instance that lacks
+// .Console/.write, so the preload primes the module registry first.
+test("require('node:console') in a worker still exposes Console and write", async () => {
+  const worker = new Worker(
+    `
+    const { parentPort } = require("worker_threads");
+    const c = require("node:console");
+    parentPort.postMessage({
+      hasConsoleCtor: typeof c.Console === "function",
+      hasWrite: typeof c.write === "function",
+      hasAsyncIterator: typeof c[Symbol.asyncIterator] === "function",
+    });
+    `,
+    { eval: true },
+  );
+  const [msg] = await once(worker, "message");
+  expect(msg).toEqual({ hasConsoleCtor: true, hasWrite: true, hasAsyncIterator: true });
+  await worker.terminate();
+});

--- a/test/js/node/worker_threads/worker-stdio-lazy.test.ts
+++ b/test/js/node/worker_threads/worker-stdio-lazy.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { once } from "node:events";
 import { Worker } from "node:worker_threads";
 

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -354,6 +354,45 @@ test("eval does not leak source code", async () => {
   expect(proc.exitCode).toBe(0);
 });
 
+// Regression: the stdio rebind used to run eagerly in every worker's preload,
+// cold-loading node:stream + Console and reifying the process static table on
+// every spawn even when the worker never touched stdio.
+test("worker process.stdio and console are installed as lazy accessors", async () => {
+  const worker = new Worker(
+    `
+    const { parentPort } = require("worker_threads");
+    const d = (obj, k) => {
+      const desc = Object.getOwnPropertyDescriptor(obj, k);
+      return desc ? (desc.get ? "accessor" : "value") : "none";
+    };
+    const before = {
+      stdout: d(process, "stdout"),
+      stderr: d(process, "stderr"),
+      stdin: d(process, "stdin"),
+      console: d(globalThis, "console"),
+    };
+    // first read materializes the stream; second read must be the same object
+    const s1 = process.stdout;
+    const s2 = process.stdout;
+    parentPort.postMessage({
+      before,
+      afterStdout: d(process, "stdout"),
+      sameInstance: s1 === s2,
+      isWritable: typeof s1.write === "function",
+    });
+    `,
+    { eval: true },
+  );
+  const [msg] = await once(worker, "message");
+  expect(msg).toEqual({
+    before: { stdout: "accessor", stderr: "accessor", stdin: "accessor", console: "accessor" },
+    afterStdout: "value",
+    sameInstance: true,
+    isWritable: true,
+  });
+  await worker.terminate();
+});
+
 describe("captured stdio backpressure", () => {
   // node flow control (lib/internal/worker/io.js): a writev batch's callback is
   // withheld until the reader acks (STDIO_WANTS_MORE_DATA), so 'drain' must not

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -354,45 +354,6 @@ test("eval does not leak source code", async () => {
   expect(proc.exitCode).toBe(0);
 });
 
-// Regression: the stdio rebind used to run eagerly in every worker's preload,
-// cold-loading node:stream + Console and reifying the process static table on
-// every spawn even when the worker never touched stdio.
-test("worker process.stdio and console are installed as lazy accessors", async () => {
-  const worker = new Worker(
-    `
-    const { parentPort } = require("worker_threads");
-    const d = (obj, k) => {
-      const desc = Object.getOwnPropertyDescriptor(obj, k);
-      return desc ? (desc.get ? "accessor" : "value") : "none";
-    };
-    const before = {
-      stdout: d(process, "stdout"),
-      stderr: d(process, "stderr"),
-      stdin: d(process, "stdin"),
-      console: d(globalThis, "console"),
-    };
-    // first read materializes the stream; second read must be the same object
-    const s1 = process.stdout;
-    const s2 = process.stdout;
-    parentPort.postMessage({
-      before,
-      afterStdout: d(process, "stdout"),
-      sameInstance: s1 === s2,
-      isWritable: typeof s1.write === "function",
-    });
-    `,
-    { eval: true },
-  );
-  const [msg] = await once(worker, "message");
-  expect(msg).toEqual({
-    before: { stdout: "accessor", stderr: "accessor", stdin: "accessor", console: "accessor" },
-    afterStdout: "value",
-    sameInstance: true,
-    isWritable: true,
-  });
-  await worker.terminate();
-});
-
 describe("captured stdio backpressure", () => {
   // node flow control (lib/internal/worker/io.js): a writev batch's callback is
   // withheld until the reader acks (STDIO_WANTS_MORE_DATA), so 'drain' must not


### PR DESCRIPTION
node:worker_threads spawn latency regressed ~3x after #31216 (captured stdio + process overrides). The report traced it to the unconditional per-worker stdio channels and the `node:worker_threads` preload; profiling shows the actual cost is two things that run in every worker's preload regardless of whether the worker ever touches stdio:

1. `Object.defineProperty(process, "stdout"/"stderr"/"stdin", ...)` reifies the `process` static hash table, which invokes every `PropertyCallback` including `constructStdout`/`Stderr`/`Stdin`. Those cold-load `node:stream` just to build fd-backed streams the rebind immediately throws away.
2. `setupWorkerStdio` then eagerly built two port-backed `Writable` streams and a fresh `node:console` `Console` instance.

The MessageChannel creation and port transfer themselves measure as effectively free.

### Change

- `setupWorkerStdio` now shadows the native `PropertyCallback` slots via plain `[[Set]]` first (which does not reify the table), then installs self-replacing lazy accessors for `process.stdout`/`stderr`/`stdin` and `globalThis.console`. The first access builds the real stream/Console and rewrites the slot to a plain writable data property, so later reads are direct and identity-stable.
- `Readable`/`Writable` and the `HeapSnapshotStream` class are loaded on first use instead of at module top level; `node:path` is loaded inside `validateWorkerFilename`.
- The lazy `console` captures the native console object up front and reads `.Console` off it, because `require("node:console")` is `export default globalThis.console` and would otherwise re-enter the getter.

`worker.stdout`/`stderr` remain Readables fed by the worker's `process.stdout`/`stderr` (including the default auto-pipe path); the channels are still always created.

### Benchmark

30 sequential `new Worker("require('worker_threads').parentPort.postMessage(1)", { eval: true })` round-trips, interleaved over 5 rounds on the same machine (local release build):

| | min (ms) | p50 (ms) |
|---|---|---|
| bun 1.3.14 | 6.6-7.6 | 7.7-12.7 |
| main | 22.7-24.8 | 31.8-42.0 |
| this PR | 6.7-11.0 | 7.7-14.3 |

### Verification

- New test `worker process.stdio and console are installed as lazy accessors` asserts the properties are accessors before first read and self-replace to identity-stable value properties afterwards; fails on main with `"value"` in every slot.
- `test/js/node/worker_threads/` (107 tests) and `test/js/web/workers/` pass.
- `test/js/node/test/parallel/test-worker-{stdio,stdio-flush,stdio-flush-inflight,no-stdin-stdout-interaction,safe-getters,console-listeners,message-port-drain,on-process-exit,unsupported-things}.js` all pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker-stdio-lazy.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (42403df70)

test/js/node/worker_threads/worker-stdio-lazy.test.ts:
30 |     });
31 |     `,
32 |     { eval: true },
33 |   );
34 |   const [msg] = await once(worker, "message");
35 |   expect(msg).toEqual({
                   ^
error: expect(received).toEqual(expected)

  {
    "afterStdout": "value",
    "before": {
-     "console": "accessor",
-     "stderr": "accessor",
-     "stdin": "accessor",
-     "stdout": "accessor",
+     "console": "value",
+     "stderr": "value",
+     "stdin": "value",
+     "stdout": "value",
    },
    "isWritable": true,
    "sameInstance": true,
  }

- Expected  - 4
+ Received  + 4

      at <anonymous> (/workspace/bun/test/js/node/worker_threads/worker-stdio-lazy.test.ts:35:1
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (c4be8150a)

test/js/node/worker_threads/worker-stdio-lazy.test.ts:
(pass) worker process.stdio and console are installed as lazy accessors [25.12ms]
(pass) require('node:console') in a worker still exposes Console and write [14.85ms]

 2 pass
 0 fail
 2 expect() calls
Ran 2 tests across 1 file. [224.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker-stdio-lazy.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (42403df70)

test/js/node/worker_threads/worker-stdio-lazy.test.ts:
(pass) worker process.stdio and console are installed as lazy accessors [816.53ms]
(pass) require('node:console') in a worker still exposes Console and write [916.79ms]

 2 pass
 0 fail
 2 expect() calls
Ran 2 tests across 1 file. [3.84s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 766ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/90] gen ErrorCode+*.h
[2/47] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[3/47] gen cpp.rs (cppbind)
[4/47] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_ro
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/worker_threads.ts                      | 108 ++++++++++++---------
 .../node/worker_threads/worker-stdio-lazy.test.ts  |  63 ++++++++++++
 2 files changed, 126 insertions(+), 45 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
src/js/node/worker_threads.ts                              8     18      0
test/js/node/worker_threads/worker-stdio-lazy.test.ts      0      1      0
```

</details>

<!-- robobun:evidence:end -->