### PR TITLE
spawn: keep maxBuffer armed after .stdout/.stderr stream getter is touched

### DIFF
--- a/src/io/MaxBuf.rs
+++ b/src/io/MaxBuf.rs
@@ -11,13 +11,25 @@ use core::ptr::NonNull;
 /// caller's stack would be a Stacked-Borrows violation. With `Cell` the whole
 /// re-entrancy path is `&MaxBuf`-only and the aliasing question disappears.
 pub struct MaxBuf {
-    /// `false` after subprocess finalize.
-    pub owned_by_subprocess: Cell<bool>,
+    /// Direct link to the owning `Subprocess` so overflow dispatch does not
+    /// depend on the pipe reader's parent vtable (which changes to `FileReader`
+    /// once the `.stdout`/`.stderr` stream getter is touched). `None` after
+    /// subprocess finalize or once the overflow callback has fired.
+    pub owned_by_subprocess: Cell<Option<Owner>>,
     /// `false` after pipereader finalize.
     pub owned_by_reader: Cell<bool>,
     /// If this goes negative, `on_max_buffer` is called on the subprocess.
     pub remaining_bytes: Cell<i64>,
     // (once both are cleared, it is freed)
+}
+
+/// Erased back-pointer to the owning `Subprocess` plus its overflow handler.
+/// `on_overflow` must call [`MaxBuf::remove_from_subprocess`] on the matching
+/// slot (so the callback fires at most once) and then kill the child.
+#[derive(Copy, Clone)]
+pub struct Owner {
+    pub ptr: NonNull<()>,
+    pub on_overflow: unsafe fn(NonNull<()>, NonNull<MaxBuf>),
 }
 
 /// How far the read that crosses `maxBuffer` may overshoot it: one Node-sized
@@ -44,20 +56,24 @@ impl MaxBuf {
         unsafe { this.as_ref() }
     }
 
-    pub fn create_for_subprocess(ptr: &mut Option<NonNull<MaxBuf>>, initial: Option<i64>) {
+    pub fn create_for_subprocess(
+        ptr: &mut Option<NonNull<MaxBuf>>,
+        initial: Option<i64>,
+        owner: Owner,
+    ) {
         let Some(initial) = initial else {
             *ptr = None;
             return;
         };
         *ptr = Some(bun_core::heap::into_raw_nn(Box::new(MaxBuf {
-            owned_by_subprocess: Cell::new(true),
+            owned_by_subprocess: Cell::new(Some(owner)),
             owned_by_reader: Cell::new(false),
             remaining_bytes: Cell::new(initial),
         })));
     }
 
     fn disowned(&self) -> bool {
-        !self.owned_by_subprocess.get() && !self.owned_by_reader.get()
+        self.owned_by_subprocess.get().is_none() && !self.owned_by_reader.get()
     }
 
     /// Module-private teardown. Safe `fn` because the precondition is the
@@ -77,8 +93,8 @@ impl MaxBuf {
     pub fn remove_from_subprocess(ptr: &mut Option<NonNull<MaxBuf>>) {
         let Some(this_nn) = *ptr else { return };
         let this = Self::live(&this_nn);
-        debug_assert!(this.owned_by_subprocess.get());
-        this.owned_by_subprocess.set(false);
+        debug_assert!(this.owned_by_subprocess.get().is_some());
+        this.owned_by_subprocess.set(None);
         *ptr = None;
         if this.disowned() {
             MaxBuf::destroy(this_nn);
@@ -117,23 +133,35 @@ impl MaxBuf {
     }
 
     /// Returns `true` if this read pushed the budget negative *and* the
-    /// subprocess still owns it (i.e. the caller should fire
-    /// `BufferedReaderParentLink::on_max_buffer_overflow`).
+    /// subprocess still owns it, in which case the owner's overflow callback
+    /// has already been fired (so the caller only needs to stop reading).
     ///
-    /// Takes `NonNull` (not `&mut self`) because the overflow callback the
-    /// caller fires next is contractually required to call
-    /// `remove_from_subprocess`, which writes `owned_by_subprocess` through a
-    /// sibling pointer to this same allocation. With `Cell` fields a shared
-    /// `&MaxBuf` is sufficient and the re-entrancy is sound; the single
-    /// `unsafe` is the `NonNull → &MaxBuf` projection (the back-ref invariant:
-    /// `this` is live while `owned_by_reader` is set, which every caller has
-    /// just checked via `Some(maxbuf)`).
+    /// Takes `NonNull` (not `&mut self`) because the overflow callback is
+    /// contractually required to call `remove_from_subprocess`, which writes
+    /// `owned_by_subprocess` through a sibling pointer to this same
+    /// allocation. With `Cell` fields a shared `&MaxBuf` is sufficient and the
+    /// re-entrancy is sound; the single `unsafe` is the `NonNull → &MaxBuf`
+    /// projection (the back-ref invariant: `this` is live while
+    /// `owned_by_reader` is set, which every caller has just checked via
+    /// `Some(maxbuf)`).
     pub fn on_read_bytes(this: NonNull<MaxBuf>, bytes: u64) -> bool {
-        let this = Self::live(&this);
+        let mb = Self::live(&this);
         let delta = i64::try_from(bytes).unwrap_or(0);
-        let remaining = this.remaining_bytes.get().checked_sub(delta).unwrap_or(-1);
-        this.remaining_bytes.set(remaining);
-        remaining < 0 && this.owned_by_subprocess.get()
+        let remaining = mb.remaining_bytes.get().checked_sub(delta).unwrap_or(-1);
+        mb.remaining_bytes.set(remaining);
+        if remaining >= 0 {
+            return false;
+        }
+        let Some(owner) = mb.owned_by_subprocess.get() else {
+            return false;
+        };
+        // SAFETY: `owner.ptr` is the `Subprocess` that called
+        // `create_for_subprocess`; it stays live while `owned_by_subprocess`
+        // is `Some` (cleared in `remove_from_subprocess`, called from
+        // `Subprocess::finalize` and from the callback itself). The callback
+        // never frees `this` — `owned_by_reader` is set on every caller path.
+        unsafe { (owner.on_overflow)(owner.ptr, this) };
+        true
     }
 
     /// Trims `buf` to the remaining budget plus `OVERREAD_ALLOWANCE`: unclamped,

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -82,12 +82,6 @@ pub trait BufferedReaderParent {
     unsafe fn on_reader_error(this: *mut Self, err: sys::Error);
     unsafe fn loop_(this: *mut Self) -> *mut Loop;
     unsafe fn event_loop(this: *mut Self) -> EventLoopHandle;
-    /// Fired when this reader's `MaxBuf` budget goes negative. Only
-    /// `SubprocessPipeReader` overrides this; the default no-ops because no
-    /// other parent type wires a `MaxBuf`.
-    unsafe fn on_max_buffer_overflow(this: *mut Self, maxbuf: NonNull<MaxBuf>) {
-        let _ = (this, maxbuf);
-    }
 }
 
 impl BufferedReaderVTable {
@@ -131,10 +125,6 @@ impl BufferedReaderVTable {
 
     pub(crate) fn on_reader_error(&self, err: sys::Error) {
         self.link().on_reader_error(err)
-    }
-
-    pub(crate) fn on_max_buffer_overflow(&self, maxbuf: NonNull<MaxBuf>) {
-        self.link().on_max_buffer_overflow(maxbuf)
     }
 }
 
@@ -560,11 +550,7 @@ impl PosixBufferedReader {
         let Some(maxbuf) = parent.maxbuf else {
             return false;
         };
-        if !MaxBuf::on_read_bytes(maxbuf, bytes_read as u64) {
-            return false;
-        }
-        parent.vtable.on_max_buffer_overflow(maxbuf);
-        true
+        MaxBuf::on_read_bytes(maxbuf, bytes_read as u64)
     }
 
     /// Closes the handle so the child cannot put more bytes in the pipe, then
@@ -1282,11 +1268,7 @@ impl WindowsBufferedReader {
         let Some(maxbuf) = self.maxbuf else {
             return false;
         };
-        if !MaxBuf::on_read_bytes(maxbuf, bytes_read as u64) {
-            return false;
-        }
-        self.vtable.on_max_buffer_overflow(maxbuf);
-        true
+        MaxBuf::on_read_bytes(maxbuf, bytes_read as u64)
     }
 
     fn _on_read_chunk(&mut self, buf: &[u8], has_more: ReadState) -> bool {

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -344,9 +344,6 @@ bun_dispatch::link_interface! {
         fn on_reader_error(err: bun_sys::Error);
         fn loop_ptr() -> *mut Loop;
         fn event_loop() -> EventLoopCtx;
-        // Only the `SubprocessPipeReader` arm acts on this; everything else
-        // no-ops (no other parent type wires a `MaxBuf`).
-        fn on_max_buffer_overflow(maxbuf: core::ptr::NonNull<max_buf::MaxBuf>);
     }
 }
 
@@ -367,8 +364,6 @@ bun_dispatch::link_interface! {
 ///     on_reader_error  = |this, err| (*this).on_reader_error(err);
 ///     loop_            = |this| (*this).loop_();
 ///     event_loop       = |this| (*this).event_loop_handle.as_event_loop_ctx();
-///     // ↓ optional — only `SubprocessPipeReader` overrides this
-///     on_max_buffer_overflow = |this, maxbuf| { ... };
 /// }
 /// ```
 ///
@@ -411,7 +406,6 @@ macro_rules! __impl_buffered_reader_parent_body {
         on_reader_error = |$re_this:ident, $re_err:ident| $re:expr;
         loop_ = |$l_this:ident| $lp:expr;
         event_loop = |$e_this:ident| $ev:expr;
-        $( on_max_buffer_overflow = |$mb_this:ident, $mb_buf:ident| $mb:block; )?
     ) => {
         // SAFETY (all generated methods): see `BufferedReaderParent` aliasing
         // contract — `this` is the `*mut Self` registered via `set_parent`; a
@@ -446,15 +440,6 @@ macro_rules! __impl_buffered_reader_parent_body {
             unsafe fn event_loop($e_this: *mut Self) -> $crate::EventLoopHandle {
                 unsafe { $ev }
             }
-            $(
-                #[allow(unused_unsafe, clippy::macro_metavars_in_unsafe)]
-                unsafe fn on_max_buffer_overflow(
-                    $mb_this: *mut Self,
-                    $mb_buf: ::core::ptr::NonNull<$crate::max_buf::MaxBuf>,
-                ) {
-                    unsafe { $mb }
-                }
-            )?
         }
     };
 }
@@ -482,8 +467,6 @@ macro_rules! buffered_reader_parent_link {
                     <$T as $crate::pipe_reader::BufferedReaderParent>::loop_(this),
                 event_loop() =>
                     <$T as $crate::pipe_reader::BufferedReaderParent>::event_loop(this),
-                on_max_buffer_overflow(maxbuf) =>
-                    <$T as $crate::pipe_reader::BufferedReaderParent>::on_max_buffer_overflow(this, maxbuf),
             }
         }
     };

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1341,11 +1341,15 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
 
     // Address-dependent fields, filled now that `subprocess` has a stable address.
     {
+        let owner = bun_io::max_buf::Owner {
+            ptr: subprocess_nn.cast::<()>(),
+            on_overflow: SubprocessT::on_max_buffer_overflow,
+        };
         let mut mb = None;
-        MaxBuf::create_for_subprocess(&mut mb, max_buffer);
+        MaxBuf::create_for_subprocess(&mut mb, max_buffer, owner);
         subprocess.stderr_maxbuf.set(mb);
         let mut mb = None;
-        MaxBuf::create_for_subprocess(&mut mb, max_buffer);
+        MaxBuf::create_for_subprocess(&mut mb, max_buffer, owner);
         subprocess.stdout_maxbuf.set(mb);
     }
 

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -679,6 +679,35 @@ impl Subprocess<'_> {
         let _ = self.try_kill(self.kill_signal);
     }
 
+    /// `MaxBuf::Owner::on_overflow` target. Routes straight from the `MaxBuf`
+    /// allocation to this `Subprocess`, independent of whichever pipe reader
+    /// currently holds the budget (the `.stdout`/`.stderr` getter transfers it
+    /// to a `FileReader`).
+    ///
+    /// # Safety
+    /// `sp` is the `Subprocess` passed to `MaxBuf::create_for_subprocess`; it
+    /// is live while the matching `*_maxbuf` slot is `Some` (cleared in
+    /// `finalize` and below).
+    pub(crate) unsafe fn on_max_buffer_overflow(
+        sp: NonNull<()>,
+        maxbuf: NonNull<MaxBuf::MaxBuf>,
+    ) {
+        // SAFETY: caller contract; all accessed fields are `Cell<_>`.
+        let sp = unsafe { sp.cast::<Subprocess<'static>>().as_ref() };
+        let kind = if sp.stdout_maxbuf.get() == Some(maxbuf) {
+            let mut mb = sp.stdout_maxbuf.get();
+            MaxBuf::MaxBuf::remove_from_subprocess(&mut mb);
+            sp.stdout_maxbuf.set(mb);
+            MaxBuf::Kind::Stdout
+        } else {
+            let mut mb = sp.stderr_maxbuf.get();
+            MaxBuf::MaxBuf::remove_from_subprocess(&mut mb);
+            sp.stderr_maxbuf.set(mb);
+            MaxBuf::Kind::Stderr
+        };
+        sp.on_max_buffer(kind);
+    }
+
     /// Close any still-open stdout/stderr pipe readers so the sync wait loop
     /// stops waiting for EOF after timeout/maxBuffer. Matches Node.js
     /// `SyncProcessRunner::Kill()`. Called outside any reader callback.

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -688,10 +688,7 @@ impl Subprocess<'_> {
     /// `sp` is the `Subprocess` passed to `MaxBuf::create_for_subprocess`; it
     /// is live while the matching `*_maxbuf` slot is `Some` (cleared in
     /// `finalize` and below).
-    pub(crate) unsafe fn on_max_buffer_overflow(
-        sp: NonNull<()>,
-        maxbuf: NonNull<MaxBuf::MaxBuf>,
-    ) {
+    pub(crate) unsafe fn on_max_buffer_overflow(sp: NonNull<()>, maxbuf: NonNull<MaxBuf::MaxBuf>) {
         // SAFETY: caller contract; all accessed fields are `Cell<_>`.
         let sp = unsafe { sp.cast::<Subprocess<'static>>().as_ref() };
         let kind = if sp.stdout_maxbuf.get() == Some(maxbuf) {

--- a/src/runtime/api/bun/subprocess/SubprocessPipeReader.rs
+++ b/src/runtime/api/bun/subprocess/SubprocessPipeReader.rs
@@ -413,24 +413,4 @@ bun_io::impl_buffered_reader_parent! {
     on_reader_error = |this, err| (*this).on_reader_error(err);
     loop_           = |this| (*this).loop_().cast();
     event_loop      = |this| (*this).event_loop_handle.as_event_loop_ctx();
-    on_max_buffer_overflow = |this, maxbuf| {
-        // Raw place read of the `process` backref (the embedded reader may
-        // hold `&mut self` higher on the stack, so no `&Self` is materialized).
-        let Some(process) = (*this).process else { return };
-        // `process` is the owning Subprocess back-pointer; live until
-        // `detach()`/finalize, both of which clear `(*this).process` first.
-        let sp = process.get();
-        let kind = if sp.stdout_maxbuf.get() == Some(maxbuf) {
-            let mut mb = sp.stdout_maxbuf.get();
-            bun_io::max_buf::MaxBuf::remove_from_subprocess(&mut mb);
-            sp.stdout_maxbuf.set(mb);
-            bun_io::max_buf::Kind::Stdout
-        } else {
-            let mut mb = sp.stderr_maxbuf.get();
-            bun_io::max_buf::MaxBuf::remove_from_subprocess(&mut mb);
-            sp.stderr_maxbuf.set(mb);
-            bun_io::max_buf::Kind::Stderr
-        };
-        sp.on_max_buffer(kind);
-    };
 }

--- a/test/js/bun/spawn/spawn-maxbuf.test.ts
+++ b/test/js/bun/spawn/spawn-maxbuf.test.ts
@@ -1,4 +1,4 @@
-import { bunExe } from "harness";
+import { bunEnv, bunExe } from "harness";
 
 const { isWindows } = require("../../node/test/common");
 
@@ -93,6 +93,52 @@ describe("maxBuffer caps the buffer while the child is still writing", () => {
     const stdout = await proc.stdout.bytes();
     expect(stdout.length).toBeGreaterThan(maxBuffer);
     expect(stdout.length).toBeLessThanOrEqual(bound);
+  });
+});
+
+// Touching `proc.stdout`/`proc.stderr` hands the buffered reader to a
+// `FileReader`; `maxBuffer` must still kill the child via the `MaxBuf` → `Subprocess`
+// owner link (it does not go through the reader's parent vtable).
+describe.each(["stdout", "stderr"] as const)("maxBuffer kills the process after .%s was accessed", fd => {
+  // The child writes well past `maxBuffer` and then blocks forever. Without the
+  // kill, `proc.exited` never resolves and the test times out.
+  const firehose = `process.${fd}.write(Buffer.alloc(300000, 65).toString()); setInterval(() => {}, 1e9);`;
+  const killSignal = isWindows ? "SIGKILL" : "SIGHUP";
+
+  test.concurrent("Bun.spawn (getter before exit)", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", firehose],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      maxBuffer: 1000,
+      killSignal,
+    });
+    const stream = proc[fd];
+    expect(stream).toBeInstanceOf(ReadableStream);
+    await proc.exited;
+    expect({ exitCode: proc.exitCode, signalCode: proc.signalCode }).toEqual({
+      exitCode: null,
+      signalCode: killSignal,
+    });
+  });
+
+  test.concurrent("Bun.spawn (stream consumed before exit)", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", firehose],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      maxBuffer: 1000,
+      killSignal,
+    });
+    const [bytes] = await Promise.all([proc[fd].bytes(), proc.exited]);
+    expect(bytes.length).toBeGreaterThan(1000);
+    expect(bytes.length).toBeLessThanOrEqual(1000 + 64 * 1024);
+    expect({ exitCode: proc.exitCode, signalCode: proc.signalCode }).toEqual({
+      exitCode: null,
+      signalCode: killSignal,
+    });
   });
 });
 


### PR DESCRIPTION
## Repro

```js
const p = Bun.spawn({
  cmd: [process.execPath, "-e",
    `process.stdout.write(Buffer.alloc(300000, 65).toString()); setInterval(() => {}, 1e9);`],
  stdout: "pipe", stderr: "ignore", maxBuffer: 1000,
});
p.stdout; // touching the getter is the whole difference
await p.exited;
console.log(p.signalCode);
// 1.3.14: SIGTERM (killed by maxBuffer)
// 1.4:    hangs forever
```

## Cause

Accessing `proc.stdout`/`proc.stderr` calls `ReadableStream::from_pipe`, which transfers the `BufferedReader` (including its `MaxBuf` budget) from the `SubprocessPipeReader` to a new `FileReader` via `PosixBufferedReader::from`. The transferred reader's vtable now points at `FileReader`.

The Rust port replaced Zig's direct `owned_by_subprocess: ?*Subprocess` pointer on `MaxBuf` with a bare `Cell<bool>`, and re-routed the overflow notification through the reader's parent vtable (`BufferedReaderParentLink::on_max_buffer_overflow`). Only the `SubprocessPipeReader` arm implemented that slot; `FileReader` used the default no-op. So once the getter had been touched, budget overflow silently returned and `Subprocess::on_max_buffer` was never called.

Even without the vtable transfer, the `SubprocessPipeReader` handler began with `let Some(process) = (*this).process else { return };`, and `to_readable_stream` clears that backref via `detach()`, so the dispatch path was broken on both sides.

## Fix

Restore the direct owner link: `MaxBuf` now carries an erased `Owner { ptr, on_overflow }` back-pointer to the `Subprocess`, populated at `create_for_subprocess` time. `MaxBuf::on_read_bytes` fires the callback itself when the budget goes negative, independent of whichever reader currently holds the budget. The `on_max_buffer_overflow` vtable slot (trait method, link-interface arm, macro support) is removed as dead code.

## Verification

New tests in `test/js/bun/spawn/spawn-maxbuf.test.ts` cover both stdout and stderr, and both the bare getter access and consuming the stream before exit:

```
# fail-before (release bun, no fix)
$ USE_SYSTEM_BUN=1 bun test test/js/bun/spawn/spawn-maxbuf.test.ts -t "after .std"
 4 fail  (all time out at await proc.exited)

# pass-after (debug build)
$ bun bd test test/js/bun/spawn/spawn-maxbuf.test.ts -t "after .std"
 4 pass  0 fail
```

Node's maxBuffer tests still pass:
```
$ bun bd test/js/node/test/parallel/test-child-process-spawnsync-maxbuf.js      # exit 0
$ bun bd test/js/node/test/parallel/test-child-process-execsync-maxbuf.js       # exit 0
$ bun bd test/js/node/test/parallel/test-child-process-execfilesync-maxbuf.js   # exit 0
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/spawn-maxbuf.test.ts

<!-- robobun:evidence:end -->