### PR TITLE
Windows x64 ASAN: wire the release-asan build and get it running

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -171,6 +171,7 @@ const buildPlatforms = [
   // stays non-LTO (no windows-arm64-lto WebKit prebuilt, see config.ts).
   { os: "windows", arch: "x64", crossCompile: true, distro: "debian", release: "13" },
   { os: "windows", arch: "aarch64", crossCompile: true, distro: "debian", release: "13" },
+  { os: "windows", arch: "x64", profile: "asan", crossCompile: true, distro: "debian", release: "13" },
 ];
 
 /**
@@ -197,6 +198,7 @@ const testPlatforms = [
   { os: "linux", arch: "aarch64", abi: "musl", distro: "alpine", release: "3.23", tier: "latest" },
   { os: "linux", arch: "x64", abi: "musl", distro: "alpine", release: "3.23", tier: "latest" },
   { os: "windows", arch: "x64", release: "2019", tier: "oldest" },
+  { os: "windows", arch: "x64", release: "2019", profile: "asan", tier: "oldest" },
   { os: "windows", arch: "aarch64", release: "11", tier: "latest" },
 ];
 
@@ -426,8 +428,12 @@ function getTestAgent(platform, options) {
 
   // TODO: delete this block when we upgrade to mimalloc v3
   if (os === "windows") {
+    // ASAN needs ~1:8 shadow memory plus a 256 MB quarantine per process;
+    // the D4ds_v6's 16 GiB is too tight. E-series has 4× the RAM at the
+    // same vCPU (same rationale as the linux r-family asan branch below).
+    const instanceType = profile === "asan" ? "Standard_E4ds_v6" : getAzureVmSize(os, arch, "test");
     return getEc2Agent(platform, options, {
-      instanceType: getAzureVmSize(os, arch, "test"),
+      instanceType,
       cpuCount: 2,
       threadsPerCore: 1,
     });

--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -34,6 +34,7 @@ import { bunExeName, shouldStrip, type Config } from "./config.ts";
 import { generateDepVersionsHeader } from "./depVersionsHeader.ts";
 import { allDeps } from "./deps/index.ts";
 import { lolhtml } from "./deps/lolhtml.ts";
+import { windowsAsanRuntime } from "./deps/webkit.ts";
 import { assert } from "./error.ts";
 import { bunIncludes, computeFlags, extraFlagsFor, linkDepends } from "./flags.ts";
 import { writeIfChanged } from "./fs.ts";
@@ -112,9 +113,41 @@ function systemLibs(cfg: Config): string[] {
       "ws2_32.lib",
       "delayimp.lib", // required for /delayload: in release
     );
+    if (cfg.asan) {
+      // The import lib and the thunk themselves are on the link line via
+      // webkit.provides.libs; the thunk additionally needs /WHOLEARCHIVE
+      // (it's the allocator-override set that clang-cl's own driver emits
+      // for `-fsanitize=address /MT`, see oven-sh/WebKit#240). slash():
+      // lld-link options take forward slashes regardless of host.
+      libs.push(`/WHOLEARCHIVE:${slash(windowsAsanRuntime(cfg).thunkLib)}`);
+    }
   }
 
   return libs;
+}
+
+/**
+ * Windows ASAN: copy clang_rt.asan_dynamic-x86_64.dll next to the linked
+ * exe. The static ASAN runtime was removed in LLVM 17, so even /MT builds
+ * load ASAN from this DLL; without it beside bun.exe the process fails at
+ * image load with STATUS_DLL_NOT_FOUND. The DLL ships inside the WebKit
+ * -asan prebuilt (version-matched to the instrumentation in JSC/WTF).
+ *
+ * Returns the emitted DLL path, or undefined when not a Windows ASAN build.
+ * Added to the `bun` phony and as an implicit input of the smoke test so
+ * native builds can actually run the binary.
+ */
+function emitWindowsAsanRuntime(n: Ninja, cfg: Config, exe: string): string | undefined {
+  if (!(cfg.windows && cfg.asan && cfg.webkit === "prebuilt")) return undefined;
+  const { dll } = windowsAsanRuntime(cfg);
+  const out = resolve(dirname(exe), "clang_rt.asan_dynamic-x86_64.dll");
+  n.rule("copy_asan_dll", {
+    command: cfg.host.os === "windows" ? `cmd /c "copy /Y $in $out >nul"` : `cp $in $out`,
+    description: "copy $out",
+    restat: true,
+  });
+  n.build({ outputs: [out], rule: "copy_asan_dll", inputs: [dll] });
+  return out;
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -495,6 +528,7 @@ export function emitBun(n: Ninja, cfg: Config, sources: Sources): BunOutput {
     // flags.ts.
     linkerMapOutput: cfg.linux && cfg.release && !cfg.asan && !cfg.valgrind ? linkerMapPath(cfg) : undefined,
   });
+  const asanDll = emitWindowsAsanRuntime(n, cfg, exe);
 
   // ─── Step 8: post-link (strip + dsymutil) ───
   // Plain release only: produce stripped `bun` alongside `bun-profile`.
@@ -516,7 +550,7 @@ export function emitBun(n: Ninja, cfg: Config, sources: Sources): BunOutput {
   // literal file named `bun` (which would collide with the phony). When
   // strip runs, `ninja bun` builds the actual stripped file; no phony needed.
   if (strippedExe === undefined) {
-    n.phony("bun", [exe]);
+    n.phony("bun", asanDll !== undefined ? [exe, asanDll] : [exe]);
   }
 
   // ─── Step 9: smoke test ───
@@ -529,7 +563,7 @@ export function emitBun(n: Ninja, cfg: Config, sources: Sources): BunOutput {
   // ASAN binaries to run from subprocesses (shadow memory layout conflict
   // with ELF_ET_DYN_BASE, see sanitizers/856). We try with setarch first,
   // fall back to direct invocation.
-  emitSmokeTest(n, cfg, exe, exeName);
+  emitSmokeTest(n, cfg, exe, exeName, asanDll);
 
   return { exe, strippedExe, dsym, deps, codegen, rustObjects, objects: allObjects };
 }
@@ -637,6 +671,7 @@ function emitLinkOnly(n: Ninja, cfg: Config): BunOutput {
     implicitInputs: [...linkImplicitInputs(cfg), ...shims.implicitInputs],
     linkerMapOutput: cfg.linux && cfg.release && !cfg.asan && !cfg.valgrind ? linkerMapPath(cfg) : undefined,
   });
+  const asanDll = emitWindowsAsanRuntime(n, cfg, exe);
 
   // Strip + smoke test — same as full mode.
   let strippedExe: string | undefined;
@@ -645,8 +680,8 @@ function emitLinkOnly(n: Ninja, cfg: Config): BunOutput {
     strippedExe = emitStrip(n, cfg, exe, flags.stripflags);
     if (cfg.darwin) dsym = emitDsymutil(n, cfg, exe, exeName);
   }
-  if (strippedExe === undefined) n.phony("bun", [exe]);
-  emitSmokeTest(n, cfg, exe, exeName);
+  if (strippedExe === undefined) n.phony("bun", asanDll !== undefined ? [exe, asanDll] : [exe]);
+  emitSmokeTest(n, cfg, exe, exeName, asanDll);
 
   return {
     exe,
@@ -746,11 +781,11 @@ function emitRustAndLink(n: Ninja, cfg: Config, sources: Sources): BunOutput {
  * linker didn't catch (missing symbol only referenced at init, ICU ABI
  * mismatch, etc.).
  */
-function emitSmokeTest(n: Ninja, cfg: Config, exe: string, exeName: string): void {
+function emitSmokeTest(n: Ninja, cfg: Config, exe: string, exeName: string, asanDll?: string): void {
   // Skip when the binary can't run on this host (different os/arch/abi) —
   // `ninja check` becomes a no-op alias for the exe.
   if (!cfg.canRunOnHost) {
-    n.phony("check", [exe]);
+    n.phony("check", asanDll !== undefined ? [exe, asanDll] : [exe]);
     return;
   }
   const stamp = resolve(cfg.buildDir, `${exeName}.smoke-test-passed`);
@@ -791,6 +826,8 @@ function emitSmokeTest(n: Ninja, cfg: Config, exe: string, exeName: string): voi
     outputs: [stamp],
     rule: "smoke_test",
     inputs: [exe],
+    // Windows ASAN: the DLL must be beside the exe before it can run.
+    ...(asanDll !== undefined ? { implicitInputs: [asanDll] } : {}),
   });
 
   // Phony target — `ninja check` runs the smoke test.

--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -139,14 +139,24 @@ function systemLibs(cfg: Config): string[] {
  */
 function emitWindowsAsanRuntime(n: Ninja, cfg: Config, exe: string): string | undefined {
   if (!(cfg.windows && cfg.asan && cfg.webkit === "prebuilt")) return undefined;
-  const { dll } = windowsAsanRuntime(cfg);
+  const { importLib, dll } = windowsAsanRuntime(cfg);
   const out = resolve(dirname(exe), "clang_rt.asan_dynamic-x86_64.dll");
+  // The DLL is not a declared output of the WebKit fetch (only provides.libs
+  // are, and adding a .dll there would flow it into the link inputs). Depend
+  // on the import lib — it IS a declared fetch output and the DLL is its
+  // sibling — and name the DLL path via a per-edge $src so ninja escapes it.
   n.rule("copy_asan_dll", {
-    command: cfg.host.os === "windows" ? `cmd /c "copy /Y $in $out >nul"` : `cp $in $out`,
+    command: cfg.host.os === "windows" ? `cmd /c copy /Y $src $out >nul` : `cp $src $out`,
     description: "copy $out",
     restat: true,
   });
-  n.build({ outputs: [out], rule: "copy_asan_dll", inputs: [dll] });
+  n.build({
+    outputs: [out],
+    rule: "copy_asan_dll",
+    inputs: [],
+    implicitInputs: [importLib],
+    vars: { src: cfg.host.os === "windows" ? dll.replaceAll("/", "\\") : dll },
+  });
   return out;
 }
 

--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -472,6 +472,13 @@ export function emitBun(n: Ninja, cfg: Config, sources: Sources): BunOutput {
     // builds in ~30s), so the upload overlaps the cxx compile instead of
     // waiting for it. Own pool so it doesn't take a compile slot. ci.ts's
     // uploadArtifacts() then only handles the archive.
+    // Windows ASAN: also upload the runtime DLL so link-only's
+    // emitWindowsAsanRuntime can copy it next to the exe. The DLL is not a
+    // declared fetch output (only provides.libs are; putting the DLL there
+    // would flow it into link inputs), so it's only in the paths variable —
+    // the import lib in `inputs` proves the fetch has placed the sibling DLL.
+    const uploadPaths =
+      cfg.windows && cfg.asan && cfg.webkit === "prebuilt" ? [...depLibs, windowsAsanRuntime(cfg).dll] : depLibs;
     let depUploadStamp: string | undefined;
     if (cfg.buildkite && depLibs.length > 0) {
       n.pool("bk_upload", 1);
@@ -493,7 +500,7 @@ export function emitBun(n: Ninja, cfg: Config, sources: Sources): BunOutput {
         outputs: [depUploadStamp],
         rule: "bk_upload",
         inputs: depLibs,
-        vars: { paths: depLibs.map(p => relative(cfg.buildDir, p)).join(";") },
+        vars: { paths: uploadPaths.map(p => relative(cfg.buildDir, p)).join(";") },
       });
     }
 

--- a/scripts/build/ci.ts
+++ b/scripts/build/ci.ts
@@ -16,6 +16,7 @@ import { generateOrderFile } from "../orderfile/generate.ts";
 import * as utils from "../utils.mjs";
 import { bunExeName, shouldStrip, type BunOutput } from "./bun.ts";
 import type { Config } from "./config.ts";
+import { windowsAsanRuntime } from "./deps/webkit.ts";
 import { BuildError } from "./error.ts";
 import { crossFeaturesJson } from "./features-json.ts";
 import { orderFilePath, usesOrderFile } from "./flags.ts";
@@ -269,6 +270,11 @@ export function uploadArtifacts(cfg: Config, output: BunOutput): void {
       for (const lib of dep.libs) {
         depPaths.push(relative(cfg.buildDir, lib));
       }
+    }
+    // Matches the bk_upload edge in bun.ts: link-only needs the DLL to
+    // place next to bun-asan.exe.
+    if (cfg.windows && cfg.asan && cfg.webkit === "prebuilt") {
+      depPaths.push(relative(cfg.buildDir, windowsAsanRuntime(cfg).dll));
     }
     console.log(`Uploading ${depPaths.length} dep libs...`);
     upload(depPaths, cfg.buildDir);

--- a/scripts/build/ci.ts
+++ b/scripts/build/ci.ts
@@ -408,6 +408,10 @@ export function packageAndUpload(cfg: Config, output: BunOutput): void {
   // Debug symbols / linker map — platform-specific extras.
   if (cfg.windows) {
     files.push(`${exeName}.pdb`);
+    // The ASAN runtime is a DLL even for /MT builds (LLVM 17 removed the
+    // static runtime); bun-asan.exe fails image load without it beside
+    // the exe. emitWindowsAsanRuntime() has already copied it there.
+    if (cfg.asan) files.push("clang_rt.asan_dynamic-x86_64.dll");
   } else if (cfg.darwin) {
     files.push(`${exeName}.dSYM`);
   }

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -774,12 +774,22 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
   // libclang_rt.asan, and there's no -asan WebKit prebuilt for it.
   // Darwin cross: force off. The Linux LLVM toolchain doesn't ship the
   // darwin ASAN/UBSan runtime dylibs (libclang_rt.*_osx_dynamic.dylib).
-  // Windows cross: force off. The host clang doesn't ship the windows
-  // clang_rt.asan runtime libs, so the link would fail.
+  // Windows arm64: force off. LLVM ships no Windows ARM64 ASAN runtime,
+  // and there's no -asan WebKit prebuilt for it. Windows x64 is supported
+  // (native and cross) — the clang_rt.asan runtime ships inside the
+  // bun-webkit-windows-amd64-asan prebuilt, so the host clang's resource
+  // dir doesn't need it.
   const asan =
-    abi === "android" || freebsd || darwinCross || (windows && host.os !== "windows")
-      ? false
-      : (partial.asan ?? asanDefault);
+    abi === "android" || freebsd || darwinCross || (windows && arm64) ? false : (partial.asan ?? asanDefault);
+  // Windows: only a release -asan WebKit prebuilt exists (oven-sh/WebKit#240);
+  // there is no bun-webkit-windows-amd64-debug-asan. Fail early with a clear
+  // message rather than 404ing on the tarball fetch.
+  if (windows && asan && debug) {
+    throw new BuildError(
+      "Windows ASAN is release-only (no bun-webkit-windows-amd64-debug-asan prebuilt exists)",
+      { hint: "Use --profile=release-asan, or build the missing WebKit variant first" },
+    );
+  }
 
   // Assertions: default on in debug OR asan. ASAN coupling is ABI-critical:
   // the -asan WebKit prebuilt is built with ASSERT_ENABLED=1, which gates

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -785,10 +785,9 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
   // there is no bun-webkit-windows-amd64-debug-asan. Fail early with a clear
   // message rather than 404ing on the tarball fetch.
   if (windows && asan && debug) {
-    throw new BuildError(
-      "Windows ASAN is release-only (no bun-webkit-windows-amd64-debug-asan prebuilt exists)",
-      { hint: "Use --profile=release-asan, or build the missing WebKit variant first" },
-    );
+    throw new BuildError("Windows ASAN is release-only (no bun-webkit-windows-amd64-debug-asan prebuilt exists)", {
+      hint: "Use --profile=release-asan, or build the missing WebKit variant first",
+    });
   }
 
   // Assertions: default on in debug OR asan. ASAN coupling is ABI-critical:

--- a/scripts/build/deps/libuv.ts
+++ b/scripts/build/deps/libuv.ts
@@ -51,7 +51,7 @@ export const libuv: Dependency = {
   // comment as the rationale.
   patches: ["patches/libuv/win-poll-rearm-before-callback.patch", "patches/libuv/win-poll-abort-with-disconnect.patch"],
 
-  build: () => ({
+  build: cfg => ({
     kind: "direct",
     sources: [...SHARED.map(s => `src/${s}.c`), ...WIN.map(s => `src/win/${s}.c`)],
     includes: ["include", "src"],
@@ -67,6 +67,9 @@ export const libuv: Dependency = {
       "/clang:-fno-strict-aliasing",
       "-Wno-int-conversion",
       "/wd4996",
+      // globalFlags sets -DNDEBUG for release; undo it here so libuv's own
+      // assert()s stay live in assertions builds (release-asan included).
+      ...(cfg.assertions ? ["-UNDEBUG"] : []),
     ],
   }),
 

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -128,6 +128,25 @@ function bmallocLib(cfg: Config): string {
 }
 
 /**
+ * Windows ASAN runtime — shipped inside the -asan WebKit prebuilt
+ * (oven-sh/WebKit#240) so the link has a version-matched import lib and
+ * thunk regardless of what the host LLVM's resource dir contains. The DLL
+ * must sit next to bun.exe at runtime (the static ASAN runtime was removed
+ * in LLVM 17; /MT still uses the DLL via the static_runtime_thunk).
+ *
+ * Absolute paths against the prebuilt destDir. Prebuilt-only: local mode
+ * builds its own runtime via ENABLE_SANITIZERS and these paths won't exist.
+ */
+export function windowsAsanRuntime(cfg: Config): { importLib: string; thunkLib: string; dll: string } {
+  const lib = resolve(prebuiltDestDir(cfg), "lib");
+  return {
+    importLib: resolve(lib, "clang_rt.asan_dynamic-x86_64.lib"),
+    thunkLib: resolve(lib, "clang_rt.asan_static_runtime_thunk-x86_64.lib"),
+    dll: resolve(lib, "clang_rt.asan_dynamic-x86_64.dll"),
+  };
+}
+
+/**
  * ICU libs — prebuilt bundles them on linux/windows. macOS uses system ICU.
  * Local mode: system ICU on posix (linked via -licu* in bun.ts); built from
  * source on Windows (see icuDir/icuLibs).
@@ -397,6 +416,17 @@ export const webkit: Dependency = {
       // "file not found" at link time (not silent omission + cryptic
       // undefined symbols).
       const libs = [...coreLibs(cfg), ...prebuiltIcuLibs(cfg), bmallocLib(cfg)];
+      // Windows ASAN: the tarball also ships the clang_rt.asan import lib
+      // and /MT runtime thunk (see windowsAsanRuntime). Listing them here
+      // makes emitPrebuilt declare them as fetch outputs and flows both
+      // into depLibs for full and link-only modes. The /WHOLEARCHIVE: for
+      // the thunk is added at the link step (bun.ts).
+      if (cfg.windows && cfg.asan) {
+        libs.push(
+          "lib/clang_rt.asan_dynamic-x86_64.lib",
+          "lib/clang_rt.asan_static_runtime_thunk-x86_64.lib",
+        );
+      }
 
       const includes = ["include"];
       // Linux/windows: ICU headers under wtf/unicode. macOS: deleted by

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -422,10 +422,7 @@ export const webkit: Dependency = {
       // into depLibs for full and link-only modes. The /WHOLEARCHIVE: for
       // the thunk is added at the link step (bun.ts).
       if (cfg.windows && cfg.asan) {
-        libs.push(
-          "lib/clang_rt.asan_dynamic-x86_64.lib",
-          "lib/clang_rt.asan_static_runtime_thunk-x86_64.lib",
-        );
+        libs.push("lib/clang_rt.asan_dynamic-x86_64.lib", "lib/clang_rt.asan_static_runtime_thunk-x86_64.lib");
       }
 
       const includes = ["include"];

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -774,17 +774,8 @@ export const defines: Flag[] = [
 
   // ─── Config-dependent ───
   {
-    // Not on Windows ASAN: the bun-webkit-windows-amd64-asan prebuilt is
-    // built without ENABLE_ASSERTS (oven-sh/WebKit Dockerfile.windows does
-    // not set it for the sanitizer leg like the Linux/macOS Dockerfiles do),
-    // so ASSERT_ENABLED-gated inline calls in JSC headers
-    // (ObjectInitializationScope, DoesGCCheck::verifyCanGC, StrongRefTracker,
-    // Structure::checkConsistency, ...) have no definition in the .lib and
-    // the link fails. This also matters for ABI: ASSERT_ENABLED gates struct
-    // fields. Drop this gate once the WebKit windows-asan leg builds with
-    // ENABLE_ASSERTS=ON.
     flag: "ASSERT_ENABLED=1",
-    when: c => c.assertions && !(c.windows && c.asan),
+    when: c => c.assertions,
     desc: "Enable runtime assertions",
   },
   {

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -991,21 +991,29 @@ export const linkerFlags: Flag[] = [
     desc: "Emit PDB so the crash handler can symbolize stack traces",
   },
   {
+    // SAFEICF (lld-specific) only folds functions whose address is never
+    // taken (it honours .llvm_addrsig; objects without one — MSVC CRT
+    // import libs, the prebuilt ICU data — are treated conservatively), so
+    // JSC ClassInfo native constructors — stored as pointers and compared
+    // for identity — stay distinct. /OPT:ICF (aggressive) folded
+    // callBigIntConstructor with constructBigInt → "not a constructor",
+    // and broke expect.any(Constructor); see commit 218430c731. Mirrors
+    // Linux `-Wl,-icf=safe`. lldtailmerge (lld-specific; MSVC link.exe has
+    // no equivalent) tail-merges string literals across TUs.
+    //
+    // Not under ASAN: the runtime registers a redzone + descriptor per TU
+    // for every instrumented global (string literals included). ICF and tail
+    // merging then give two distinct registrations the same address, which
+    // the runtime reports as an odr-violation at startup (e.g. "127.0.0.1"
+    // size 10 vs "127.0.0.1\0" size 11).
+    flag: ["/OPT:SAFEICF", "/OPT:lldtailmerge"],
+    when: c => c.windows && c.release && !c.asan,
+    desc: "Safe identical-COMDAT folding and string-literal tail merging",
+  },
+  {
     flag: [
       "/LTCG",
       "/OPT:REF",
-      // SAFEICF (lld-specific) only folds functions whose address is never
-      // taken (it honours .llvm_addrsig; objects without one — MSVC CRT
-      // import libs, the prebuilt ICU data — are treated conservatively), so
-      // JSC ClassInfo native constructors — stored as pointers and compared
-      // for identity — stay distinct. /OPT:ICF (aggressive) folded
-      // callBigIntConstructor with constructBigInt → "not a constructor",
-      // and broke expect.any(Constructor); see commit 218430c731. Mirrors
-      // Linux `-Wl,-icf=safe`.
-      "/OPT:SAFEICF",
-      // String-literal tail merging (lld-specific; MSVC link.exe has no
-      // equivalent). Helps .rdata the same way --icf handles .rodata.cst on ELF.
-      "/OPT:lldtailmerge",
       // 512-byte section file alignment (default is 4 KB). Was present in
       // the pre-ninja CMake config; harmless to page-in cost since sections
       // are few and large.

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -344,14 +344,8 @@ export const globalFlags: Flag[] = [
     // re-tokenization in nested dep configures. -Xclang <arg> pair gets
     // split by cmake's try_compile → "unknown argument". Also more correct:
     // /clang: passes to the driver, -Xclang to cc1.
-    // Not under ASAN: bisected the post-ZGO_create CreateThread crash
-    // (oven-sh/bun#34352) down to "each CreateThread needs a recent thread
-    // exit to succeed"; with this flag thread_local dtors never register
-    // via __cxa_thread_atexit, so thread exit skips the dynamic-TLS dtor
-    // chain. Hypothesis under test: that chain is what primes the next
-    // CreateThread's TLS-callback path under ASAN.
     flag: "/clang:-fno-c++-static-destructors",
-    when: c => c.windows && !c.asan,
+    when: c => c.windows,
     lang: "cxx",
     desc: "Skip static destructors at exit (clang-cl syntax)",
   },

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -428,8 +428,15 @@ export const globalFlags: Flag[] = [
 
   // ─── Windows-specific codegen ───
   {
+    // Not under ASAN: `/GF` emits each string literal as a SELECT_ANY
+    // COMDAT so identical literals merge at link time. That places
+    // ASAN-instrumented literals (from bun's own TUs) at the same address
+    // as uninstrumented ones (from ICU in the WebKit prebuilt), and reads
+    // through the uninstrumented pointer land in the instrumented copy's
+    // redzone. Observed as a global-buffer-overflow from ICU's
+    // `u_getTimeZoneFilesDirectory` on first VM init.
     flag: "/GF",
-    when: c => c.windows,
+    when: c => c.windows && !c.asan,
     desc: "String pooling (merge identical string literals)",
   },
   {

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -646,6 +646,17 @@ export const bunOnlyFlags: Flag[] = [
     desc: "Raise constexpr limits (JSC uses heavy constexpr; the embedded module registry literals are large)",
   },
   {
+    // Only needed with assertions: ASSERT_UNDER_CONSTEXPR_CONTEXT in
+    // ASCIILiteral's ctor loops every byte of the embedded module registry
+    // literals (NodeHttp2Code is ~170 KB) and blows clang's default limit.
+    // Plain release Windows has ASSERT_ENABLED=0, so the loop is a no-op
+    // there. /clang: prefix — clang-cl has no /constexpr: spelling of its own.
+    flag: ["/clang:-fconstexpr-steps=6000000", "/clang:-fconstexpr-depth=54"],
+    when: c => c.windows && c.assertions,
+    lang: "cxx",
+    desc: "Raise constexpr limits (Windows assertions build: ASCIILiteral per-byte ASSERT loop)",
+  },
+  {
     flag: ["-fno-pic", "-fno-pie"],
     when: c => c.unix && c.abi !== "android",
     desc: "No position-independent code (we're a final executable)",

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -344,8 +344,14 @@ export const globalFlags: Flag[] = [
     // re-tokenization in nested dep configures. -Xclang <arg> pair gets
     // split by cmake's try_compile → "unknown argument". Also more correct:
     // /clang: passes to the driver, -Xclang to cc1.
+    // Not under ASAN: bisected the post-ZGO_create CreateThread crash
+    // (oven-sh/bun#34352) down to "each CreateThread needs a recent thread
+    // exit to succeed"; with this flag thread_local dtors never register
+    // via __cxa_thread_atexit, so thread exit skips the dynamic-TLS dtor
+    // chain. Hypothesis under test: that chain is what primes the next
+    // CreateThread's TLS-callback path under ASAN.
     flag: "/clang:-fno-c++-static-destructors",
-    when: c => c.windows,
+    when: c => c.windows && !c.asan,
     lang: "cxx",
     desc: "Skip static destructors at exit (clang-cl syntax)",
   },

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -311,6 +311,16 @@ export const globalFlags: Flag[] = [
     when: c => c.asan,
     desc: "AddressSanitizer (also forwarded to deps for ABI consistency)",
   },
+  {
+    // The MS STL's std::string/std::vector container-overflow annotations
+    // call into stl_asan.lib, which is a separate VS component that the
+    // xwin splat doesn't ship (and the WebKit -asan prebuilt was built
+    // with these disabled too — keeping them in sync avoids ODR mismatch
+    // on WTF::Vector-adjacent inlines). Core ASAN checks are unaffected.
+    flag: ["-D_DISABLE_STRING_ANNOTATION", "-D_DISABLE_VECTOR_ANNOTATION"],
+    when: c => c.windows && c.asan,
+    desc: "Windows ASAN: disable MS STL container annotations (stl_asan.lib not in xwin splat)",
+  },
 
   // ─── C++ language behavior ───
   {
@@ -808,6 +818,17 @@ export const linkerFlags: Flag[] = [
     flag: "-fsanitize=address",
     when: c => c.unix && c.asan,
     desc: "Link ASAN runtime",
+  },
+  {
+    // clang-cl -fsanitize=address embeds a /INFERASANLIBS directive in each
+    // object; lld-link then searches its own lib paths for the runtime.
+    // We link the version-matched runtime from the WebKit prebuilt
+    // explicitly (bun.ts emitWindowsAsanRuntime), so suppress inference to
+    // avoid picking up a mismatched-version lib from the host toolchain or
+    // failing the link when the cross sysroot has none.
+    flag: "/INFERASANLIBS:NO",
+    when: c => c.windows && c.asan,
+    desc: "Windows ASAN: link the bundled runtime explicitly, not by inference",
   },
   {
     flag: "-fsanitize=null",

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -428,16 +428,28 @@ export const globalFlags: Flag[] = [
 
   // ─── Windows-specific codegen ───
   {
-    // Not under ASAN: `/GF` emits each string literal as a SELECT_ANY
-    // COMDAT so identical literals merge at link time. That places
-    // ASAN-instrumented literals (from bun's own TUs) at the same address
-    // as uninstrumented ones (from ICU in the WebKit prebuilt), and reads
-    // through the uninstrumented pointer land in the instrumented copy's
-    // redzone. Observed as a global-buffer-overflow from ICU's
-    // `u_getTimeZoneFilesDirectory` on first VM init.
     flag: "/GF",
     when: c => c.windows && !c.asan,
     desc: "String pooling (merge identical string literals)",
+  },
+  {
+    // `/O2` implies `/GF`, so it has to be explicitly disabled. With `/GF`
+    // on, each string literal is a SELECT_ANY COMDAT named by content
+    // (`??_C@_00...`), so an ASAN-instrumented `""` from bun's TUs and an
+    // uninstrumented `""` from ICU (shipped uninstrumented inside the
+    // WebKit -asan prebuilt) share a name and the linker keeps one copy.
+    // The ASAN descriptor for the instrumented copy still registers and
+    // poisons `[size, size_with_redzone)` past the kept section's end, so
+    // ICU's first read of its own `""` trips global-buffer-overflow in
+    // `u_getTimeZoneFilesDirectory` on first VM init. With `/GF-`, bun's
+    // literals are private unnamed constants that never share a COMDAT with
+    // ICU's. (WTF/JSC inside the prebuilt were also compiled with `/GF`,
+    // but `jsc.exe` from the same tarball runs clean, so the WTF/ICU
+    // pairing alone is benign; it's the three-way merge with bun's
+    // descriptors that poisons the wrong region.)
+    flag: "/GF-",
+    when: c => c.windows && c.asan,
+    desc: "Windows ASAN: keep string literals private so they can't COMDAT-merge with uninstrumented ICU",
   },
   {
     flag: "/GA",

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -755,8 +755,17 @@ export const defines: Flag[] = [
 
   // ─── Config-dependent ───
   {
+    // Not on Windows ASAN: the bun-webkit-windows-amd64-asan prebuilt is
+    // built without ENABLE_ASSERTS (oven-sh/WebKit Dockerfile.windows does
+    // not set it for the sanitizer leg like the Linux/macOS Dockerfiles do),
+    // so ASSERT_ENABLED-gated inline calls in JSC headers
+    // (ObjectInitializationScope, DoesGCCheck::verifyCanGC, StrongRefTracker,
+    // Structure::checkConsistency, ...) have no definition in the .lib and
+    // the link fails. This also matters for ABI: ASSERT_ENABLED gates struct
+    // fields. Drop this gate once the WebKit windows-asan leg builds with
+    // ENABLE_ASSERTS=ON.
     flag: "ASSERT_ENABLED=1",
-    when: c => c.assertions,
+    when: c => c.assertions && !(c.windows && c.asan),
     desc: "Enable runtime assertions",
   },
   {

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -779,7 +779,7 @@ async function runTests() {
           env.BUN_JSC_validateExceptionChecks = "1";
           env.BUN_JSC_dumpSimulatedThrows = "1";
         }
-        if ((basename(execPath).includes("asan") || !isCI) && shouldValidateLeakSan(testPath)) {
+        if (!isWindows && (basename(execPath).includes("asan") || !isCI) && shouldValidateLeakSan(testPath)) {
           env.BUN_DESTRUCT_VM_ON_EXIT = "1";
           env.ASAN_OPTIONS = "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=1:abort_on_error=1";
           // prettier-ignore
@@ -1586,7 +1586,7 @@ async function spawnBunTest(execPath, testPath, opts = { cwd }) {
     env.BUN_JSC_validateExceptionChecks = "1";
     env.BUN_JSC_dumpSimulatedThrows = "1";
   }
-  if ((basename(execPath).includes("asan") || !isCI) && shouldValidateLeakSan(relative(cwd, absPath))) {
+  if (!isWindows && (basename(execPath).includes("asan") || !isCI) && shouldValidateLeakSan(relative(cwd, absPath))) {
     env.BUN_DESTRUCT_VM_ON_EXIT = "1";
     env.ASAN_OPTIONS = "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=1:abort_on_error=1";
     // prettier-ignore

--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -237,8 +237,13 @@ macro_rules! arena_format {
     }};
 }
 
-/// `bun.use_mimalloc` — false under ASAN, where the global allocator is `std::alloc::System`.
-pub const USE_MIMALLOC: bool = cfg!(not(bun_asan));
+/// `bun.use_mimalloc` — true when mimalloc is the `#[global_allocator]`.
+/// False only under ASAN on Unix, where `std::alloc::System` is installed so
+/// the ASAN interceptor sees every allocation. Windows ASAN stays on mimalloc
+/// (built with `MI_TRACK_ASAN=1`) because its libc has no `posix_memalign`
+/// and `std::alloc::System` on Windows is `HeapAlloc`, which would diverge
+/// from `default_alloc`'s libc malloc/free.
+pub const USE_MIMALLOC: bool = cfg!(not(all(bun_asan, unix)));
 
 // ── Allocator-vtable modules: per-module disposition (PORTING.md §Allocators) ──
 //
@@ -259,13 +264,21 @@ pub mod max_heap_allocator;
 pub mod nullable_allocator;
 pub mod stack_fallback;
 
-/// Raw alloc/free matching the `#[global_allocator]` (`mi_*` normally, libc under ASAN).
+/// Raw alloc/free matching the `#[global_allocator]` (`mi_*` normally, libc under ASAN on Unix).
 pub mod default_alloc {
     use core::ffi::c_void;
 
+    // Unix ASAN routes through libc so the interceptor owns every allocation.
+    // Windows ASAN stays on mimalloc (see `USE_MIMALLOC` above): the libc
+    // crate has no `posix_memalign` on MSVC, and `_aligned_malloc` requires a
+    // matching `_aligned_free` that this module's single `free` entry point
+    // can't dispatch to. mimalloc is built with `MI_TRACK_ASAN=1`, so redzone
+    // poisoning still catches heap overflow on that path.
+    const ASAN_LIBC: bool = cfg!(all(bun_asan, unix));
+
     #[inline]
     pub fn malloc(size: usize) -> *mut c_void {
-        if cfg!(bun_asan) {
+        if ASAN_LIBC {
             // SAFETY: `libc::malloc` has no input preconditions; null on failure.
             unsafe { libc::malloc(size) }
         } else {
@@ -275,7 +288,7 @@ pub mod default_alloc {
 
     #[inline]
     pub fn zalloc(size: usize) -> *mut c_void {
-        if cfg!(bun_asan) {
+        if ASAN_LIBC {
             // SAFETY: `libc::calloc` has no input preconditions; null on failure.
             unsafe { libc::calloc(1, size) }
         } else {
@@ -285,7 +298,7 @@ pub mod default_alloc {
 
     #[inline]
     pub fn calloc(count: usize, size: usize) -> *mut c_void {
-        if cfg!(bun_asan) {
+        if ASAN_LIBC {
             // SAFETY: `libc::calloc` has no input preconditions; null on failure.
             unsafe { libc::calloc(count, size) }
         } else {
@@ -297,7 +310,7 @@ pub mod default_alloc {
     /// `ptr` must be null or a live allocation from the default allocator.
     #[inline]
     pub unsafe fn realloc(ptr: *mut c_void, new_size: usize) -> *mut c_void {
-        if cfg!(bun_asan) {
+        if ASAN_LIBC {
             // SAFETY: caller guarantees `ptr` is null or a live libc allocation
             // (the default allocator under ASAN).
             unsafe { libc::realloc(ptr, new_size) }
@@ -311,7 +324,7 @@ pub mod default_alloc {
     /// `ptr` must be null or a live allocation from the default allocator.
     #[inline]
     pub unsafe fn free(ptr: *mut c_void) {
-        if cfg!(bun_asan) {
+        if ASAN_LIBC {
             // SAFETY: caller guarantees `ptr` is null or a live libc allocation
             // (the default allocator under ASAN).
             unsafe { libc::free(ptr) }
@@ -328,11 +341,10 @@ pub mod default_alloc {
         if ptr.is_null() {
             return 0;
         }
-        // Under `bun_asan` the global allocator is `std::alloc::System`, so the
+        // Under Unix ASAN the global allocator is `std::alloc::System`, so the
         // size must come from libc, not mimalloc — and the symbol differs per
-        // OS (`malloc_usable_size` on Linux, `malloc_size` on macOS). `bun_asan`
-        // is only ever set on Linux or macOS, so the catch-all (non-asan, every
-        // `check-all` target including Windows) stays on mimalloc.
+        // OS (`malloc_usable_size` on Linux, `malloc_size` on macOS). Windows
+        // ASAN and every non-asan build stay on mimalloc (see `ASAN_LIBC`).
         #[cfg(all(bun_asan, target_os = "linux"))]
         return unsafe { libc::malloc_usable_size(ptr.cast_mut()) };
         #[cfg(all(bun_asan, target_os = "macos"))]
@@ -346,13 +358,13 @@ pub mod default_alloc {
     // The aligned variants are `#[cfg]`-split (not `if cfg!()`) because the
     // posix_memalign/malloc_usable_size symbols don't exist on Windows.
 
-    #[cfg(not(bun_asan))]
+    #[cfg(not(all(bun_asan, unix)))]
     #[inline]
     pub fn malloc_aligned(size: usize, align: usize) -> *mut c_void {
         crate::mimalloc::mi_malloc_auto_align(size, align)
     }
 
-    #[cfg(bun_asan)]
+    #[cfg(all(bun_asan, unix))]
     #[inline]
     pub fn malloc_aligned(size: usize, align: usize) -> *mut c_void {
         if align <= crate::MAX_ALIGN_T {
@@ -366,13 +378,13 @@ pub mod default_alloc {
         p
     }
 
-    #[cfg(not(bun_asan))]
+    #[cfg(not(all(bun_asan, unix)))]
     #[inline]
     pub fn zalloc_aligned(size: usize, align: usize) -> *mut c_void {
         crate::mimalloc::mi_zalloc_auto_align(size, align)
     }
 
-    #[cfg(bun_asan)]
+    #[cfg(all(bun_asan, unix))]
     #[inline]
     pub fn zalloc_aligned(size: usize, align: usize) -> *mut c_void {
         if align <= crate::MAX_ALIGN_T {
@@ -387,7 +399,7 @@ pub mod default_alloc {
 
     /// # Safety
     /// `ptr` must be null or a live allocation from the default allocator with the given `align`.
-    #[cfg(not(bun_asan))]
+    #[cfg(not(all(bun_asan, unix)))]
     #[inline]
     pub unsafe fn realloc_aligned(ptr: *mut c_void, new_size: usize, align: usize) -> *mut c_void {
         // SAFETY: caller guarantees `ptr` is null or a live mimalloc allocation
@@ -397,7 +409,7 @@ pub mod default_alloc {
 
     /// # Safety
     /// `ptr` must be null or a live allocation from the default allocator with the given `align`.
-    #[cfg(bun_asan)]
+    #[cfg(all(bun_asan, unix))]
     #[inline]
     pub unsafe fn realloc_aligned(ptr: *mut c_void, new_size: usize, align: usize) -> *mut c_void {
         if align <= crate::MAX_ALIGN_T {

--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -237,13 +237,8 @@ macro_rules! arena_format {
     }};
 }
 
-/// `bun.use_mimalloc` — true when mimalloc is the `#[global_allocator]`.
-/// False only under ASAN on Unix, where `std::alloc::System` is installed so
-/// the ASAN interceptor sees every allocation. Windows ASAN stays on mimalloc
-/// (built with `MI_TRACK_ASAN=1`) because its libc has no `posix_memalign`
-/// and `std::alloc::System` on Windows is `HeapAlloc`, which would diverge
-/// from `default_alloc`'s libc malloc/free.
-pub const USE_MIMALLOC: bool = cfg!(not(all(bun_asan, unix)));
+/// `bun.use_mimalloc` — false under ASAN, where the global allocator is `std::alloc::System`.
+pub const USE_MIMALLOC: bool = cfg!(not(bun_asan));
 
 // ── Allocator-vtable modules: per-module disposition (PORTING.md §Allocators) ──
 //
@@ -264,21 +259,13 @@ pub mod max_heap_allocator;
 pub mod nullable_allocator;
 pub mod stack_fallback;
 
-/// Raw alloc/free matching the `#[global_allocator]` (`mi_*` normally, libc under ASAN on Unix).
+/// Raw alloc/free matching the `#[global_allocator]` (`mi_*` normally, libc under ASAN).
 pub mod default_alloc {
     use core::ffi::c_void;
 
-    // Unix ASAN routes through libc so the interceptor owns every allocation.
-    // Windows ASAN stays on mimalloc (see `USE_MIMALLOC` above): the libc
-    // crate has no `posix_memalign` on MSVC, and `_aligned_malloc` requires a
-    // matching `_aligned_free` that this module's single `free` entry point
-    // can't dispatch to. mimalloc is built with `MI_TRACK_ASAN=1`, so redzone
-    // poisoning still catches heap overflow on that path.
-    const ASAN_LIBC: bool = cfg!(all(bun_asan, unix));
-
     #[inline]
     pub fn malloc(size: usize) -> *mut c_void {
-        if ASAN_LIBC {
+        if cfg!(bun_asan) {
             // SAFETY: `libc::malloc` has no input preconditions; null on failure.
             unsafe { libc::malloc(size) }
         } else {
@@ -288,7 +275,7 @@ pub mod default_alloc {
 
     #[inline]
     pub fn zalloc(size: usize) -> *mut c_void {
-        if ASAN_LIBC {
+        if cfg!(bun_asan) {
             // SAFETY: `libc::calloc` has no input preconditions; null on failure.
             unsafe { libc::calloc(1, size) }
         } else {
@@ -298,7 +285,7 @@ pub mod default_alloc {
 
     #[inline]
     pub fn calloc(count: usize, size: usize) -> *mut c_void {
-        if ASAN_LIBC {
+        if cfg!(bun_asan) {
             // SAFETY: `libc::calloc` has no input preconditions; null on failure.
             unsafe { libc::calloc(count, size) }
         } else {
@@ -310,7 +297,7 @@ pub mod default_alloc {
     /// `ptr` must be null or a live allocation from the default allocator.
     #[inline]
     pub unsafe fn realloc(ptr: *mut c_void, new_size: usize) -> *mut c_void {
-        if ASAN_LIBC {
+        if cfg!(bun_asan) {
             // SAFETY: caller guarantees `ptr` is null or a live libc allocation
             // (the default allocator under ASAN).
             unsafe { libc::realloc(ptr, new_size) }
@@ -324,10 +311,12 @@ pub mod default_alloc {
     /// `ptr` must be null or a live allocation from the default allocator.
     #[inline]
     pub unsafe fn free(ptr: *mut c_void) {
-        if ASAN_LIBC {
+        if cfg!(bun_asan) {
             // SAFETY: caller guarantees `ptr` is null or a live libc allocation
-            // (the default allocator under ASAN).
-            unsafe { libc::free(ptr) }
+            // (the default allocator under ASAN). On Windows, an over-aligned
+            // `malloc_aligned` result points into the interior of a larger
+            // ASAN chunk; `alloc_begin` recovers the original pointer.
+            unsafe { libc::free(alloc_begin(ptr)) }
         } else {
             // SAFETY: caller guarantees `ptr` is null or a live mimalloc allocation.
             unsafe { crate::mimalloc::mi_free(ptr) }
@@ -341,50 +330,103 @@ pub mod default_alloc {
         if ptr.is_null() {
             return 0;
         }
-        // Under Unix ASAN the global allocator is `std::alloc::System`, so the
+        // Under `bun_asan` the global allocator is `std::alloc::System`, so the
         // size must come from libc, not mimalloc — and the symbol differs per
-        // OS (`malloc_usable_size` on Linux, `malloc_size` on macOS). Windows
-        // ASAN and every non-asan build stay on mimalloc (see `ASAN_LIBC`).
+        // OS (`malloc_usable_size` on Linux, `malloc_size` on macOS, the ASAN
+        // runtime's `__sanitizer_get_allocated_size` on Windows, subtracting
+        // any over-alignment slack so callers see only the usable tail). The
+        // catch-all (non-asan, every `check-all` target including Windows)
+        // stays on mimalloc.
         #[cfg(all(bun_asan, target_os = "linux"))]
         return unsafe { libc::malloc_usable_size(ptr.cast_mut()) };
         #[cfg(all(bun_asan, target_os = "macos"))]
         return unsafe { libc::malloc_size(ptr) };
+        #[cfg(all(bun_asan, windows))]
+        return unsafe {
+            let begin = asan_win::__sanitizer_get_allocated_begin(ptr);
+            if begin.is_null() {
+                return 0;
+            }
+            let total = asan_win::__sanitizer_get_allocated_size(begin);
+            total - (ptr.addr() - begin.addr())
+        };
         // SAFETY: caller guarantees `ptr` is a live mimalloc allocation (the
         // non-null check above already handled null).
-        #[cfg(not(any(all(bun_asan, target_os = "linux"), all(bun_asan, target_os = "macos"))))]
+        #[cfg(not(bun_asan))]
         return unsafe { crate::mimalloc::mi_usable_size(ptr) };
     }
 
     // The aligned variants are `#[cfg]`-split (not `if cfg!()`) because the
     // posix_memalign/malloc_usable_size symbols don't exist on Windows.
 
-    #[cfg(not(all(bun_asan, unix)))]
+    // Windows ASAN: the clang_rt runtime does NOT intercept `_aligned_malloc`,
+    // so routing over-aligned requests there would pair an uninstrumented CRT
+    // allocation with ASAN's `free`. Instead, over-allocate with plain
+    // `malloc` (ASAN-intercepted) and bump into alignment; `free()` and
+    // `usable_size()` above recover the true chunk start via
+    // `__sanitizer_get_allocated_begin` so no header is needed and the
+    // single-entry `free(ptr)` contract is preserved.
+    #[cfg(all(bun_asan, windows))]
+    mod asan_win {
+        use core::ffi::c_void;
+        unsafe extern "C" {
+            pub(super) safe fn __sanitizer_get_allocated_begin(ptr: *const c_void) -> *mut c_void;
+            pub(super) fn __sanitizer_get_allocated_size(ptr: *const c_void) -> usize;
+        }
+    }
+
+    /// Map an interior pointer returned by `malloc_aligned` back to the chunk
+    /// start that `free` / `realloc` must see. Only Windows ASAN produces
+    /// interior pointers (bump-aligned over-allocations); everywhere else this
+    /// is the identity, so it stays `#[inline]` and folds away.
+    #[inline]
+    fn alloc_begin(ptr: *mut c_void) -> *mut c_void {
+        #[cfg(all(bun_asan, windows))]
+        if !ptr.is_null() {
+            return asan_win::__sanitizer_get_allocated_begin(ptr);
+        }
+        ptr
+    }
+
+    #[cfg(not(bun_asan))]
     #[inline]
     pub fn malloc_aligned(size: usize, align: usize) -> *mut c_void {
         crate::mimalloc::mi_malloc_auto_align(size, align)
     }
 
-    #[cfg(all(bun_asan, unix))]
+    #[cfg(bun_asan)]
     #[inline]
     pub fn malloc_aligned(size: usize, align: usize) -> *mut c_void {
         if align <= crate::MAX_ALIGN_T {
             return unsafe { libc::malloc(size) };
         }
-        let mut p: *mut c_void = core::ptr::null_mut();
-        let align = align.max(core::mem::size_of::<*mut c_void>());
-        if unsafe { libc::posix_memalign(&mut p, align, size) } != 0 {
-            return core::ptr::null_mut();
+        #[cfg(unix)]
+        {
+            let mut p: *mut c_void = core::ptr::null_mut();
+            let align = align.max(core::mem::size_of::<*mut c_void>());
+            if unsafe { libc::posix_memalign(&mut p, align, size) } != 0 {
+                return core::ptr::null_mut();
+            }
+            p
         }
-        p
+        #[cfg(windows)]
+        {
+            let raw = unsafe { libc::malloc(size + align - 1) };
+            if raw.is_null() {
+                return raw;
+            }
+            let mask = align - 1;
+            raw.map_addr(|a| (a + mask) & !mask)
+        }
     }
 
-    #[cfg(not(all(bun_asan, unix)))]
+    #[cfg(not(bun_asan))]
     #[inline]
     pub fn zalloc_aligned(size: usize, align: usize) -> *mut c_void {
         crate::mimalloc::mi_zalloc_auto_align(size, align)
     }
 
-    #[cfg(all(bun_asan, unix))]
+    #[cfg(bun_asan)]
     #[inline]
     pub fn zalloc_aligned(size: usize, align: usize) -> *mut c_void {
         if align <= crate::MAX_ALIGN_T {
@@ -399,7 +441,7 @@ pub mod default_alloc {
 
     /// # Safety
     /// `ptr` must be null or a live allocation from the default allocator with the given `align`.
-    #[cfg(not(all(bun_asan, unix)))]
+    #[cfg(not(bun_asan))]
     #[inline]
     pub unsafe fn realloc_aligned(ptr: *mut c_void, new_size: usize, align: usize) -> *mut c_void {
         // SAFETY: caller guarantees `ptr` is null or a live mimalloc allocation
@@ -409,7 +451,7 @@ pub mod default_alloc {
 
     /// # Safety
     /// `ptr` must be null or a live allocation from the default allocator with the given `align`.
-    #[cfg(all(bun_asan, unix))]
+    #[cfg(bun_asan)]
     #[inline]
     pub unsafe fn realloc_aligned(ptr: *mut c_void, new_size: usize, align: usize) -> *mut c_void {
         if align <= crate::MAX_ALIGN_T {
@@ -423,7 +465,7 @@ pub mod default_alloc {
             unsafe {
                 let copy = usable_size(ptr).min(new_size);
                 core::ptr::copy_nonoverlapping(ptr.cast::<u8>(), new_ptr.cast::<u8>(), copy);
-                libc::free(ptr);
+                libc::free(alloc_begin(ptr));
             }
         }
         new_ptr

--- a/src/bun_bin/lib.rs
+++ b/src/bun_bin/lib.rs
@@ -45,14 +45,13 @@ use bun_core::Global;
 use bun_core::StackCheck;
 use bun_core::output;
 
-/// mimalloc as the process allocator. Windows ASAN stays on mimalloc too
-/// (see `bun_alloc::USE_MIMALLOC`).
-#[cfg(not(all(bun_asan, unix)))]
+/// mimalloc as the process allocator.
+#[cfg(not(bun_asan))]
 #[global_allocator]
 static ALLOC: bun_alloc::Mimalloc = bun_alloc::Mimalloc;
 
-/// Under Unix ASAN, use the system allocator so the interceptor sees every allocation.
-#[cfg(all(bun_asan, unix))]
+/// Under ASAN, use the system allocator so the interceptor sees every allocation.
+#[cfg(bun_asan)]
 #[global_allocator]
 static ALLOC: std::alloc::System = std::alloc::System;
 

--- a/src/bun_bin/lib.rs
+++ b/src/bun_bin/lib.rs
@@ -163,40 +163,6 @@ pub extern "C" fn __lsan_default_suppressions() -> *const core::ffi::c_char {
 /// the entire process — guaranteed by the C runtime that calls this symbol.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn main(argc: c_int, argv: *const *const c_char) -> c_int {
-    // Windows ASAN workaround: the current bun-webkit-windows-amd64-asan
-    // prebuilt was compiled with `/GF` (implied by `/O2`), which emits string
-    // literals as content-sized COMDATs while the ASAN descriptors record
-    // `size_with_redzone`. `__asan_register_globals` (already run by the CRT
-    // before main) therefore poisoned redzones that extend past section
-    // boundaries into adjacent globals, and the first read of such a global
-    // (ICU's `""` during `JSC::VM::VM`) reports a spurious
-    // global-buffer-overflow. Unpoison the whole image's static data once
-    // here so those stale redzones are cleared. This forfeits
-    // global-buffer-overflow detection; heap/stack/UAF are unaffected.
-    // Remove once a WebKit prebuilt with `/GF-` (oven-sh/WebKit#298) is
-    // pinned and the `ASSERT_ENABLED` gate in flags.ts is dropped.
-    #[cfg(all(bun_asan, windows))]
-    {
-        unsafe extern "system" {
-            fn GetModuleHandleW(name: *const u16) -> *mut core::ffi::c_void;
-        }
-        let base = unsafe { GetModuleHandleW(core::ptr::null()) };
-        if !base.is_null() {
-            // DOS header e_lfanew at +0x3c → NT headers; OptionalHeader is at
-            // NT+0x18; SizeOfImage is at OptionalHeader+0x38 (PE32+).
-            // SAFETY: `base` is the exe image mapped by the loader; the PE
-            // header layout is fixed by the Windows ABI.
-            let size = unsafe {
-                let e_lfanew = base.cast::<u8>().add(0x3c).cast::<u32>().read_unaligned() as usize;
-                base.cast::<u8>()
-                    .add(e_lfanew + 0x18 + 0x38)
-                    .cast::<u32>()
-                    .read_unaligned() as usize
-            };
-            bun_core::asan::unpoison(base.cast(), size);
-        }
-    }
-
     // 0. Capture argv FIRST — before the crash handler, whose panic path
     //    dumps the command line via `bun_core::argv()`.
     //    SAFETY: `argc`/`argv` come from the C runtime; the argv block lives

--- a/src/bun_bin/lib.rs
+++ b/src/bun_bin/lib.rs
@@ -163,6 +163,40 @@ pub extern "C" fn __lsan_default_suppressions() -> *const core::ffi::c_char {
 /// the entire process — guaranteed by the C runtime that calls this symbol.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn main(argc: c_int, argv: *const *const c_char) -> c_int {
+    // Windows ASAN workaround: the current bun-webkit-windows-amd64-asan
+    // prebuilt was compiled with `/GF` (implied by `/O2`), which emits string
+    // literals as content-sized COMDATs while the ASAN descriptors record
+    // `size_with_redzone`. `__asan_register_globals` (already run by the CRT
+    // before main) therefore poisoned redzones that extend past section
+    // boundaries into adjacent globals, and the first read of such a global
+    // (ICU's `""` during `JSC::VM::VM`) reports a spurious
+    // global-buffer-overflow. Unpoison the whole image's static data once
+    // here so those stale redzones are cleared. This forfeits
+    // global-buffer-overflow detection; heap/stack/UAF are unaffected.
+    // Remove once a WebKit prebuilt with `/GF-` (oven-sh/WebKit#298) is
+    // pinned and the `ASSERT_ENABLED` gate in flags.ts is dropped.
+    #[cfg(all(bun_asan, windows))]
+    {
+        unsafe extern "system" {
+            fn GetModuleHandleW(name: *const u16) -> *mut core::ffi::c_void;
+        }
+        let base = unsafe { GetModuleHandleW(core::ptr::null()) };
+        if !base.is_null() {
+            // DOS header e_lfanew at +0x3c → NT headers; OptionalHeader is at
+            // NT+0x18; SizeOfImage is at OptionalHeader+0x38 (PE32+).
+            // SAFETY: `base` is the exe image mapped by the loader; the PE
+            // header layout is fixed by the Windows ABI.
+            let size = unsafe {
+                let e_lfanew = base.cast::<u8>().add(0x3c).cast::<u32>().read_unaligned() as usize;
+                base.cast::<u8>()
+                    .add(e_lfanew + 0x18 + 0x38)
+                    .cast::<u32>()
+                    .read_unaligned() as usize
+            };
+            bun_core::asan::unpoison(base.cast(), size);
+        }
+    }
+
     // 0. Capture argv FIRST — before the crash handler, whose panic path
     //    dumps the command line via `bun_core::argv()`.
     //    SAFETY: `argc`/`argv` come from the C runtime; the argv block lives

--- a/src/bun_bin/lib.rs
+++ b/src/bun_bin/lib.rs
@@ -187,8 +187,13 @@ pub unsafe extern "C" fn main(argc: c_int, argv: *const *const c_char) -> c_int 
     // (env conversion).
     #[cfg(windows)]
     {
+        // Under ASAN the `#[global_allocator]` is `System`, so routing libuv
+        // through mimalloc would give it a different heap than the rest of
+        // the process and hide its allocations from the interceptor. Leave
+        // libuv on the CRT allocator (ASAN-intercepted) in that build.
         // SAFETY: mimalloc fns match the libuv allocator signatures; called
         // exactly once before any uv handle is created.
+        #[cfg(not(bun_asan))]
         unsafe {
             let _ = bun_sys::windows::libuv::uv_replace_allocator(
                 Some(bun_alloc::mimalloc::mi_malloc),

--- a/src/bun_bin/lib.rs
+++ b/src/bun_bin/lib.rs
@@ -81,7 +81,19 @@ pub extern "C" fn __asan_default_options() -> *const core::ffi::c_char {
     // `leak:uws_create_app` silently stops matching and CI reports the
     // suppressed allocations as leaks. If local debug crashes feel slow to
     // print, set `ASAN_OPTIONS=symbolize=0` in your shell instead.
-    c"detect_stack_use_after_return=0:detect_leaks=0".as_ptr()
+    //
+    // Windows: `/GF` string pooling and COFF COMDAT folding give distinct
+    // per-TU ASAN global registrations the same address, which the ODR
+    // checker reports as a violation at startup. The linker-side folds are
+    // already gated off for ASAN (flags.ts SAFEICF/lldtailmerge), but `/GF`
+    // is per-TU at compile time and there is no COFF equivalent of ELF's
+    // odr-indicator, so disable the check. LSan is not implemented on
+    // Windows; leaving detect_leaks=0 keeps the option string uniform.
+    if cfg!(windows) {
+        c"detect_stack_use_after_return=0:detect_leaks=0:detect_odr_violation=0".as_ptr()
+    } else {
+        c"detect_stack_use_after_return=0:detect_leaks=0".as_ptr()
+    }
 }
 
 /// LSAN built-in suppressions, merged with whatever `LSAN_OPTIONS=suppressions=`

--- a/src/bun_bin/lib.rs
+++ b/src/bun_bin/lib.rs
@@ -45,13 +45,14 @@ use bun_core::Global;
 use bun_core::StackCheck;
 use bun_core::output;
 
-/// mimalloc as the process allocator.
-#[cfg(not(bun_asan))]
+/// mimalloc as the process allocator. Windows ASAN stays on mimalloc too
+/// (see `bun_alloc::USE_MIMALLOC`).
+#[cfg(not(all(bun_asan, unix)))]
 #[global_allocator]
 static ALLOC: bun_alloc::Mimalloc = bun_alloc::Mimalloc;
 
-/// Under ASAN, use the system allocator so the interceptor sees every allocation.
-#[cfg(bun_asan)]
+/// Under Unix ASAN, use the system allocator so the interceptor sees every allocation.
+#[cfg(all(bun_asan, unix))]
 #[global_allocator]
 static ALLOC: std::alloc::System = std::alloc::System;
 

--- a/src/bun_core/debug.rs
+++ b/src/bun_core/debug.rs
@@ -262,8 +262,6 @@ impl StackIterator {
     }
 }
 
-pub(crate) const PC_OFFSET: usize = StackIterator::PC_OFFSET;
-
 /// Capture the current thread's call stack.
 ///
 /// POSIX: walk frame pointers. Windows: `RtlCaptureStackBackTrace` via

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -2306,9 +2306,9 @@ pub use strings_impl::*;
 /// from `immutable`, so this is the only public path.
 pub use crate::string::immutable as strings;
 
-// `true` when mimalloc is the `#[global_allocator]`; `false` under Unix ASAN
-// where `std::alloc::System` is installed instead. Mirrors `bun_alloc::USE_MIMALLOC`.
-pub const USE_MIMALLOC: bool = cfg!(not(all(bun_asan, unix)));
+// `true` when mimalloc is the `#[global_allocator]`; `false` under ASAN where
+// `std::alloc::System` is installed instead. Mirrors `bun_alloc::USE_MIMALLOC`.
+pub const USE_MIMALLOC: bool = cfg!(not(bun_asan));
 pub mod debug_allocator_data {
     /// Only referenced from `debug_assert!` — dead in release builds.
     #[allow(dead_code)]

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -2912,12 +2912,30 @@ pub fn return_address() -> usize {
     if cfg!(miri) {
         return 0;
     }
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    // The `[fp + PC_OFFSET]` slot is in the caller's stack area past the
+    // current frame's locals. Under `-Zsanitizer=address` a Rust-level
+    // pointer deref of that slot is instrumented and can land in a region
+    // ASAN has marked `f8` (stack-use-after-scope) for an inlined sibling
+    // scope, tripping a false positive. Fold the load into the same asm
+    // block so ASAN never sees it.
+    #[cfg(target_arch = "x86_64")]
     {
-        let fp = debug::frame_address();
-        // SAFETY: `fp` is this function's own valid frame pointer; the
-        // return-address slot at `[fp + PC_OFFSET]` is always mapped.
-        unsafe { *((fp + debug::PC_OFFSET) as *const usize) }
+        let pc: usize;
+        // SAFETY: rbp is the frame pointer (`-Cforce-frame-pointers=yes`);
+        // `[rbp + 8]` is the saved return address per the x86-64 ABI.
+        unsafe {
+            core::arch::asm!("mov {}, [rbp + 8]", out(reg) pc, options(nostack, preserves_flags))
+        };
+        pc
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        let pc: usize;
+        // SAFETY: x29 is the frame pointer; `[x29, #8]` is the saved LR.
+        unsafe {
+            core::arch::asm!("ldr {}, [x29, #8]", out(reg) pc, options(nostack, preserves_flags))
+        };
+        pc
     }
     #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
     {

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -2306,9 +2306,9 @@ pub use strings_impl::*;
 /// from `immutable`, so this is the only public path.
 pub use crate::string::immutable as strings;
 
-// `true` when mimalloc is the `#[global_allocator]`; `false` under ASAN where
-// `std::alloc::System` is installed instead. Mirrors `bun_alloc::USE_MIMALLOC`.
-pub const USE_MIMALLOC: bool = cfg!(not(bun_asan));
+// `true` when mimalloc is the `#[global_allocator]`; `false` under Unix ASAN
+// where `std::alloc::System` is installed instead. Mirrors `bun_alloc::USE_MIMALLOC`.
+pub const USE_MIMALLOC: bool = cfg!(not(all(bun_asan, unix)));
 pub mod debug_allocator_data {
     /// Only referenced from `debug_assert!` — dead in release builds.
     #[allow(dead_code)]

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2149,6 +2149,19 @@ impl VirtualMachine {
         // no `&mut` is held across the FFI re-entry (`Bun__getVM()` —
         // ZigGlobalObject.cpp:473/961).
         unsafe { (*vm).regular_event_loop.ensure_waker() };
+        // Windows ASAN: without one full thread create+exit cycle before
+        // `Zig__GlobalObject__create`, the first `CreateThread` issued after it
+        // crashes the new thread before `asan_thread_start` can register it
+        // (STATUS_ACCESS_VIOLATION, no ASAN report). JSC's helper threads
+        // (created inside ZGO_create) are long-lived and do not exit, so they
+        // do not exercise the thread-exit TLS/FLS path that appears to prime
+        // whatever the next CreateThread needs. Bisected empirically; see
+        // oven-sh/bun#34352 for the probe methodology. The `join()` is what
+        // matters: a detached sleeping thread does not help.
+        #[cfg(all(bun_asan, windows))]
+        {
+            let _ = std::thread::spawn(|| {}).join();
+        }
         // `console`/`worker_ptr` are opaque round-trip pointers C++ stores into
         // the new global. `worker_ptr` is the C++ `WebCore::Worker*` (or null on
         // the main thread).

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -6184,12 +6184,13 @@ extern "C" void Bun__JSValue__protect(JSC::EncodedJSValue encodedValue)
         gcProtect(cell);
     }
 }
-#if ASSERT_ENABLED
+// Not gated on ASSERT_ENABLED: the Rust caller is gated on
+// cfg(debug_assertions), which can be true when ASSERT_ENABLED is 0
+// (Windows ASAN). CallFrame::describeFrame() itself is always exported.
 CPP_DECL const char* Bun__CallFrame__describeFrame(JSC::CallFrame* callFrame)
 {
     return callFrame->describeFrame();
 }
-#endif
 
 extern "C" double Bun__JSC__operationMathPow(double x, double y)
 {


### PR DESCRIPTION
Wires up `--profile=release-asan` for Windows x64 (native and cross), adds the CI build/test lanes, and gets `bun-asan.exe` building, linking, and running a useful subset of commands. Bumps WebKit to `365cb024` for oven-sh/WebKit#298 (windows-asan assertions + `/GF-`).

### What works

| | |
|---|---|
| `bun-asan.exe --revision` / `--help` | passes |
| `bun-asan.exe -p 42` / `-e 'code'` | passes |
| `require("./file")` (CJS from `-e`) | passes |
| `import("node:os")` / `import("bun")` | passes |
| `bun-asan.exe install` | passes (full registry fetch + extract) |
| `bun-asan.exe build file.js` | passes |
| `bun-asan.exe file.js` (ESM entry) | crashes, see below |
| `import("./file")` / `fetch()` / `Bun.file().text()` | crashes, see below |
| `bun-asan.exe test` | crashes loading the test file (same cause) |

### Build system

- `config.ts`: `--asan=on` permitted on Windows x64 (native and cross); still forced off on Windows arm64 (no LLVM runtime) and fails early on Windows+debug (no `bun-webkit-windows-amd64-debug-asan` prebuilt).
- `deps/webkit.ts`: the `-asan` prebuilt ships `lib/clang_rt.asan_dynamic-x86_64.{lib,dll}` and `lib/clang_rt.asan_static_runtime_thunk-x86_64.lib`; `provides.libs` now lists the two `.lib`s so they flow into `depLibs` in both full and link-only modes. `windowsAsanRuntime(cfg)` exported for the link step. WEBKIT_VERSION bumped to `365cb024` (oven-sh/WebKit#298: `ENABLE_ASSERTS=ON` and `/GF-` for the sanitizer leg).
- `bun.ts` / `ci.ts`: link emits `/WHOLEARCHIVE:<thunk>` (the `/MT` link recipe clang-cl's own driver uses for `-fsanitize=address`), `copy_asan_dll` places `clang_rt.asan_dynamic-x86_64.dll` next to `bun-asan.exe`, the cpp-only dep upload includes the DLL so link-only can copy it, and the packaged artifact zip includes it.
- `flags.ts`: global `-D_DISABLE_STRING_ANNOTATION -D_DISABLE_VECTOR_ANNOTATION` (the xwin splat has no `stl_asan.lib`); `/GF-` (otherwise `/O2` re-enables `/GF` and instrumented string literals COMDAT-merge with uninstrumented ICU ones); `/OPT:SAFEICF`/`/OPT:lldtailmerge` gated off for ASAN; `/clang:-fconstexpr-steps`/`-depth` for the assertions `ASCIILiteral` loop; link `/INFERASANLIBS:NO`.
- `deps/libuv.ts`: `-UNDEBUG` when `cfg.assertions` so libuv's own `assert()`s stay live (struct sizes verified identical).
- `.buildkite/ci.mjs`: `windows-x64-asan` build (cross-compiled on amazonlinux like the other Windows lanes) and test (Windows 2019, `Standard_E4ds_v6`) entries; rust build agent bumped to `r7i.4xlarge` for ASAN.
- `scripts/runner.node.mjs`: `detect_leaks=1` gated off on Windows (LSan unsupported there; the runtime rejects the flag).

### Runtime

- `bun_alloc::default_alloc`: Windows ASAN path for `malloc_aligned`/`usable_size`. There is no `posix_memalign`, and `_aligned_malloc` is not intercepted by the Windows runtime, so over-aligned requests go through an intercepted `libc::malloc(size + align - 1)` bumped into alignment; `free()`/`usable_size()` recover the chunk start via `__sanitizer_get_allocated_begin` so the single-entry `free(ptr)` contract is preserved. `#[global_allocator] = System` stays in place so the ASAN interceptor owns every allocation.
- `bun_bin`: `uv_replace_allocator(mi_*)` skipped under ASAN so libuv's allocations stay on the intercepted CRT heap. `__asan_default_options` on Windows adds `detect_odr_violation=0` (COMDAT folding of instrumented string literals otherwise trips it at startup).
- `bun_core::return_address`: the `[rbp+8]` load is now part of the inline asm instead of a Rust-level deref. The Rust deref is ASAN-instrumented and, when the function inlines beside a scope-ended local, landed in an `f8` region and tripped a `stack-use-after-scope` false positive (observed from `RefPtr::init_ref` on the DNS path). Applies to all ASAN targets, not just Windows.
- `bindings.cpp`: `Bun__CallFrame__describeFrame` defined unconditionally; the Rust caller is gated on `cfg(debug_assertions)`, the C++ side was `#if ASSERT_ENABLED`, and `CallFrame::describeFrame()` itself is always exported.

### Remaining blocker

Any `CreateThread` issued from the main thread after JS has finished evaluating and the event loop is about to tick crashes the new thread with `STATUS_ACCESS_VIOLATION` before `asan_thread_start` can print its `Tn: stack [...]` line. Bisected by inserting a trivial `CreateThread(NULL, 0, entry_that_just_InterlockedIncrements, NULL, 0, NULL)` probe at successive points in libuv:

| probe point | outcome |
|---|---|
| `uv_loop_init` (after `JSC::VM::VM`, before any JS) | T3 registers, entry runs |
| first `uv_timer_start` call (during JS, e.g. `setTimeout`) | T4 registers, entry runs |
| `uv_run` (after JS returned, first event-loop tick) | crash, no Tn, entry never runs |

The ASAN `CreateThread` hot-patch is intact at every point (first bytes of `kernel32!CreateThread` stay `eb f8` throughout, dumped from each probe). So the wrapper is called and allocates the `AsanThread`; the crash is on the new thread before `SetCurrentThread`/`ThreadStart` print, i.e. in a TLS callback or in `asan_thread_start` itself. Heisenbug: inserting a probe thread at any earlier `uv_timer_start` call makes the `uv_run` probe (and libuv's real worker threads) succeed.

Ruled out: `BUN_JSC_useJIT=0`, `_beginthreadex` vs `CreateThread`, `CREATE_SUSPENDED`, explicit `stack_size` vs 0, `windows_hook_rtl_allocators=0`, `-UNDEBUG` on libuv (struct sizes unchanged). `bun install` (bun's own threadpool, no VM) and `--hot` (file-watcher thread) both spawn threads fine; only threads spawned from the post-JS-eval main-thread context hit this.

Minimal repro with a native Windows build of this branch:

```
build\release-asan\bun-asan.exe -e "setTimeout(()=>console.log('tick'),5)"
```

prints the `uv_timer_start` calls then exits `0xC0000005` on the first `uv_run` thread create. Needs a debugger; I could not get cdb/procdump/WER to produce a dump on the CI image.
