### PR TITLE
stdio: surface fast-path write completion as uncaughtException, not unhandledRejection

### DIFF
--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -603,14 +603,8 @@ function underscoreWriteFast(this: FSStream, data: any, encoding: any, cb: any) 
     const maybePromise = fileSink.write(data);
     if ($isPromise(maybePromise)) {
       maybePromise.then(
-        () => {
-          if (cb) cb(null);
-          this.emit("drain");
-        },
-        err => {
-          if (cb) cb(err);
-          require("internal/streams/destroy").errorOrDestroy(this, err);
-        },
+        () => process.nextTick(underscoreWriteFastDrained, this, cb),
+        err => process.nextTick(writeFastOnError, this, cb, err),
       );
       return false;
     } else {
@@ -622,6 +616,21 @@ function underscoreWriteFast(this: FSStream, data: any, encoding: any, cb: any) 
     require("internal/streams/destroy").errorOrDestroy(this, e, true);
     return false;
   }
+}
+
+function underscoreWriteFastDrained(stream, cb) {
+  if (cb) cb(null);
+  stream.emit("drain");
+}
+
+// Node's stdio write completion runs from a libuv callback, so a throw from the
+// user callback or emit('error') with no listener is an uncaughtException. The
+// nextTick hop keeps it that way instead of unhandledRejection from the sink's promise.
+function writeFastOnError(stream, cb, err) {
+  if (cb) cb(err);
+  // Node.js onwriteError: callback AND errorOrDestroy are both invoked; the
+  // callback is additive, not a replacement for the 'error' event.
+  require("internal/streams/destroy").errorOrDestroy(stream, err);
 }
 
 // This function implementation is not correct.
@@ -652,16 +661,8 @@ function writeFast(this: FSStream, data: any, encoding: any, cb: any) {
       // Two-arg then(): a throw from the fulfillment handler must not be
       // mistaken for a write failure.
       maybePromise.then(
-        () => {
-          this.emit("drain"); // Emit drain event
-          cb(null);
-        },
-        err => {
-          cb(err);
-          // Node.js onwriteError: callback AND destroy are both invoked; the
-          // callback is additive, not a replacement for the 'error' event.
-          require("internal/streams/destroy").errorOrDestroy(this, err);
-        },
+        () => process.nextTick(writeFastDrained, this, cb),
+        err => process.nextTick(writeFastOnError, this, cb, err),
       );
       return false; // Indicate backpressure
     } else {
@@ -677,6 +678,11 @@ function writeFast(this: FSStream, data: any, encoding: any, cb: any) {
     }
     return result;
   }
+}
+
+function writeFastDrained(stream, cb) {
+  stream.emit("drain");
+  cb(null);
 }
 
 writeStreamPrototype._writev = function (data, cb) {

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -216,7 +216,8 @@ describe.concurrent("process-stdio", () => {
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       // The bulk writes all land on stdout; the result line is on stderr.
       expect(stdout.length).toBeGreaterThan(0);
-      const line = stderr.trim().split("\n").pop()!;
+      const line = stderr.split("\n").find(l => l.startsWith("["));
+      if (!line) throw new Error("no result line on stderr: " + JSON.stringify(stderr));
       expect(JSON.parse(line)).toEqual(["cb:null", "uncaught:boom"]);
       expect(exitCode).toBe(7);
     },

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -1,6 +1,6 @@
 import { spawn, spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 import path from "path";
 import { isatty } from "tty";
 describe.concurrent("process-stdio", () => {
@@ -158,4 +158,67 @@ describe.concurrent("process-stdio", () => {
       `hello worldhello again|😋 Get Emoji — All Emojis to ✂️ Copy and 📋 Paste 👌`.repeat(9999),
     );
   });
+
+  // Node's uv write callback runs the user callback from a libuv frame, so a
+  // throw from it is an uncaughtException. Bun's FileSink reports completion via
+  // a promise, so a throw from the callback inside the promise reaction surfaced
+  // as unhandledRejection. Same class as the tty write-error case in tty.test.ts
+  // but on the success arm.
+  test.skipIf(isWindows)(
+    "process.stdout write callback that throws on a drained write surfaces as uncaughtException",
+    async () => {
+      await using proc = spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const events = [];
+            const done = code => {
+              process.stderr.write(JSON.stringify(events) + "\\n");
+              process.exit(code);
+            };
+            process.on("uncaughtException", err => {
+              events.push("uncaught:" + err.message);
+              done(7);
+            });
+            process.on("unhandledRejection", err => {
+              events.push("unhandledRejection:" + (err && err.message));
+              done(8);
+            });
+            // Fill the pipe until the sink buffers and returns a promise (write()
+            // reports that as false), then issue one more write whose callback
+            // throws. That callback runs from the sink's promise resolution once
+            // the parent has drained the pipe.
+            const chunk = Buffer.alloc(64 * 1024, 65);
+            let writes = 0;
+            while (process.stdout.write(chunk)) {
+              if (++writes > 256) {
+                events.push("no-backpressure");
+                done(9);
+              }
+            }
+            const buffered = process.stdout.write(chunk, err => {
+              events.push("cb:" + (err ? err.code : "null"));
+              throw new Error("boom");
+            });
+            if (buffered !== false) {
+              events.push("expected-backpressure");
+              done(9);
+            }
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+        stdin: "ignore",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      // The bulk writes all land on stdout; the result line is on stderr.
+      expect(stdout.length).toBeGreaterThan(0);
+      const line = stderr.trim().split("\n").pop()!;
+      expect(JSON.parse(line)).toEqual(["cb:null", "uncaught:boom"]);
+      expect(exitCode).toBe(7);
+    },
+  );
 });

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -240,7 +240,9 @@ describe.concurrent.skipIf(isWindows)("process.stdout on a hung-up tty", () => {
         writeSync(1, ".");
         if (++ticks > 100000) { events.push("no-hangup"); process.exit(99); }
         return setImmediate(probe);
-      } catch {}
+      } catch (e) {
+        if (!e || e.code !== "EIO") { events.push("probe:" + (e && e.code)); process.exit(99); }
+      }
       if (process.env.USE_END) {
         // Writable.prototype.end(chunk) routes through _write (underscoreWriteFast)
         // with state.onwrite as the callback, rather than the writeFast override.

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { join } from "node:path";
 import { WriteStream } from "node:tty";
 
 describe("ReadStream.prototype.setRawMode", () => {
@@ -189,6 +190,107 @@ describe("ReadStream.prototype.setRawMode", () => {
       afterStdinCooked: false,
     });
     expect(await proc.exited).toBe(0);
+  });
+});
+
+// When a stdout/stderr/child.stdin write fails (EIO on a hung-up tty, EPIPE on
+// a closed pipe) Node's uv write callback runs the cb + errorOrDestroy pair
+// from a libuv callback frame, so a throw from emit('error') with no listener
+// is an uncaughtException. Bun's FileSink reports the failure as a rejected
+// promise, so running the same pair from the promise reaction surfaced the
+// throw as unhandledRejection instead.
+describe.concurrent.skipIf(isWindows)("process.stdout on a hung-up tty", () => {
+  const fixture = `
+    const { writeFileSync } = require("node:fs");
+    const events = [];
+    process.on("exit", code => {
+      events.push("exit:" + code);
+      writeFileSync(process.env.RESULT_FILE, JSON.stringify(events));
+    });
+
+    // Outlive the SIGHUP the kernel sends when the master closes, like a
+    // nohup'd daemon, so the failing write is actually reached.
+    process.on("SIGHUP", () => {});
+
+    process.on("uncaughtException", err => {
+      events.push("uncaught:" + (err && err.code));
+      process.exit(7);
+    });
+    process.on("unhandledRejection", err => {
+      events.push("unhandledRejection:" + (err && err.code));
+      process.exit(8);
+    });
+
+    if (!process.env.NO_ERROR_LISTENER) {
+      process.stdout.on("error", err => {
+        events.push("error:" + err.code);
+        process.exit(0);
+      });
+    }
+
+    // stdin EOF means the pty master is closed, so the next stdout write is
+    // guaranteed to fail with EIO. No polling, no timers.
+    process.stdin.on("end", () => {
+      process.stdout.write("after hangup\\n", err => {
+        if (err) events.push("cb:" + err.code);
+      });
+    });
+    process.stdin.resume();
+
+    process.stdout.write("READY\\n");
+  `;
+
+  async function runUntilHangup(env: Record<string, string>) {
+    using dir = tempDir("stdout-hangup", { "fixture.js": fixture });
+    const resultFile = join(String(dir), "result.json");
+
+    let output = "";
+    const decoder = new TextDecoder();
+    const { promise: ready, resolve } = Promise.withResolvers<void>();
+    await using terminal = new Bun.Terminal({
+      data(_terminal, chunk: Uint8Array) {
+        output += decoder.decode(chunk, { stream: true });
+        if (output.includes("READY")) resolve();
+      },
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(String(dir), "fixture.js")],
+      env: { ...bunEnv, ...env, RESULT_FILE: resultFile },
+      terminal,
+    });
+
+    await Promise.race([
+      ready,
+      proc.exited.then(code => {
+        throw new Error(`child exited (${code}) before READY; terminal: ${JSON.stringify(output)}`);
+      }),
+    ]);
+    terminal.close();
+
+    const exitCode = await proc.exited;
+    const events = await Bun.file(resultFile)
+      .json()
+      .catch(() => null);
+    return { events, exitCode, signalCode: proc.signalCode };
+  }
+
+  // node v26.3.0: ["cb:EIO","uncaught:EIO","exit:7"]
+  test("unhandled write error surfaces as uncaughtException, not unhandledRejection", async () => {
+    expect(await runUntilHangup({ NO_ERROR_LISTENER: "1" })).toEqual({
+      events: ["cb:EIO", "uncaught:EIO", "exit:7"],
+      exitCode: 7,
+      signalCode: null,
+    });
+  });
+
+  // node v26.3.0: ["cb:EIO","error:EIO","exit:0"]
+  test("with an 'error' listener, both the write callback and the listener fire", async () => {
+    expect(await runUntilHangup({})).toEqual({
+      events: ["cb:EIO", "error:EIO", "exit:0"],
+      exitCode: 0,
+      signalCode: null,
+    });
   });
 });
 

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -228,9 +228,13 @@ describe.concurrent.skipIf(isWindows)("process.stdout on a hung-up tty", () => {
       });
     }
 
-    // stdin EOF means the pty master is closed, so the next stdout write is
-    // guaranteed to fail with EIO. No polling, no timers.
-    process.stdin.on("end", () => {
+    // stdin EOF (or EIO, which a hung-up pty slave can report for read()
+    // depending on platform/timing) means the master is closed, so the next
+    // stdout write is guaranteed to fail with EIO. No polling, no timers.
+    let fired = false;
+    const afterHangup = () => {
+      if (fired) return;
+      fired = true;
       if (process.env.USE_END) {
         // Writable.prototype.end(chunk) routes through _write (underscoreWriteFast)
         // with state.onwrite as the callback, rather than the writeFast override.
@@ -240,7 +244,9 @@ describe.concurrent.skipIf(isWindows)("process.stdout on a hung-up tty", () => {
           if (err) events.push("cb:" + err.code);
         });
       }
-    });
+    };
+    process.stdin.on("end", afterHangup);
+    process.stdin.on("error", afterHangup);
     process.stdin.resume();
 
     process.stdout.write("READY\\n");

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -231,9 +231,15 @@ describe.concurrent.skipIf(isWindows)("process.stdout on a hung-up tty", () => {
     // stdin EOF means the pty master is closed, so the next stdout write is
     // guaranteed to fail with EIO. No polling, no timers.
     process.stdin.on("end", () => {
-      process.stdout.write("after hangup\\n", err => {
-        if (err) events.push("cb:" + err.code);
-      });
+      if (process.env.USE_END) {
+        // Writable.prototype.end(chunk) routes through _write (underscoreWriteFast)
+        // with state.onwrite as the callback, rather than the writeFast override.
+        process.stdout.end("after hangup\\n");
+      } else {
+        process.stdout.write("after hangup\\n", err => {
+          if (err) events.push("cb:" + err.code);
+        });
+      }
     });
     process.stdin.resume();
 
@@ -289,6 +295,15 @@ describe.concurrent.skipIf(isWindows)("process.stdout on a hung-up tty", () => {
     expect(await runUntilHangup({})).toEqual({
       events: ["cb:EIO", "error:EIO", "exit:0"],
       exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  // node v26.3.0: ["uncaught:EIO","exit:7"]
+  test("unhandled end(chunk) error via _write surfaces as uncaughtException", async () => {
+    expect(await runUntilHangup({ NO_ERROR_LISTENER: "1", USE_END: "1" })).toEqual({
+      events: ["uncaught:EIO", "exit:7"],
+      exitCode: 7,
       signalCode: null,
     });
   });

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -201,7 +201,7 @@ describe("ReadStream.prototype.setRawMode", () => {
 // throw as unhandledRejection instead.
 describe.concurrent.skipIf(isWindows)("process.stdout on a hung-up tty", () => {
   const fixture = `
-    const { writeFileSync } = require("node:fs");
+    const { writeFileSync, writeSync } = require("node:fs");
     const events = [];
     process.on("exit", code => {
       events.push("exit:" + code);
@@ -228,13 +228,19 @@ describe.concurrent.skipIf(isWindows)("process.stdout on a hung-up tty", () => {
       });
     }
 
-    // stdin EOF (or EIO, which a hung-up pty slave can report for read()
-    // depending on platform/timing) means the master is closed, so the next
-    // stdout write is guaranteed to fail with EIO. No polling, no timers.
-    let fired = false;
-    const afterHangup = () => {
-      if (fired) return;
-      fired = true;
+    process.stdout.write("READY\\n");
+
+    // Probe fd 1 with a raw writeSync (bypassing the stream, so errorOrDestroy
+    // is not primed) until the master close is visible as EIO, then issue the
+    // stream write under test as the first failing stream write. Also keeps the
+    // loop alive without relying on stdin, which raced on CI.
+    let ticks = 0;
+    const probe = () => {
+      try {
+        writeSync(1, ".");
+        if (++ticks > 100000) { events.push("no-hangup"); process.exit(99); }
+        return setImmediate(probe);
+      } catch {}
       if (process.env.USE_END) {
         // Writable.prototype.end(chunk) routes through _write (underscoreWriteFast)
         // with state.onwrite as the callback, rather than the writeFast override.
@@ -245,11 +251,7 @@ describe.concurrent.skipIf(isWindows)("process.stdout on a hung-up tty", () => {
         });
       }
     };
-    process.stdin.on("end", afterHangup);
-    process.stdin.on("error", afterHangup);
-    process.stdin.resume();
-
-    process.stdout.write("READY\\n");
+    setImmediate(probe);
   `;
 
   async function runUntilHangup(env: Record<string, string>) {


### PR DESCRIPTION
## Repro

When a `process.stdout` / `process.stderr` / `child.stdin` write fails (EIO on a hung-up tty, EPIPE on a closed pipe) and no `'error'` listener is attached, the throw from `emit('error')` surfaces as `unhandledRejection` in Bun but `uncaughtException` in Node.

```js
const { writeFileSync } = require("node:fs");
const seen = [];
process.on("exit", c => { seen.push("exit:" + c); writeFileSync("/tmp/out.json", JSON.stringify(seen)); });
process.on("uncaughtException", e => { seen.push("uncaught:" + e.code); process.exit(7); });
process.on("unhandledRejection", e => { seen.push("unhandledRejection:" + e.code); process.exit(8); });
process.on("SIGHUP", () => {});
process.stdin.on("end", () => process.stdout.write("x\n", e => e && seen.push("cb:" + e.code)));
process.stdin.resume();
```

Run under a pty whose master is closed after the child is ready; the write to the slave then fails with EIO:

| | result |
|---|---|
| node v26.3.0 | `["cb:EIO","uncaught:EIO","exit:7"]` |
| bun main | `["cb:EIO","unhandledRejection:EIO","exit:8"]` |
| bun this PR | `["cb:EIO","uncaught:EIO","exit:7"]` |

Both channels terminate the process by default, so this only bites code that handles one of the two (e.g. an `uncaughtException` handler that logs and shuts down gracefully would not fire).

## Cause

`writeFast` / `underscoreWriteFast` in `src/js/internal/fs/streams.ts` run the write completion (`cb(err); errorOrDestroy(this, err)` on failure, `emit('drain'); cb(null)` on success) inside the sink's `.then()` reaction. For stdio `autoDestroy` is `false`, so `errorOrDestroy` calls `emitErrorNT` synchronously, and with no `'error'` listener `emit` throws. A throw from a promise reaction is reported as `unhandledRejection`.

Node's equivalent path runs from `state.onwrite`, invoked by the uv write callback, i.e. a libuv frame rather than a promise reaction, so the throw is an `uncaughtException`.

## Fix

Defer the reaction bodies to `process.nextTick`, so the throw escapes the promise context. The same is applied to the success arm so a throwing write callback or `'drain'` listener on a buffered write also surfaces as `uncaughtException` (Node's behavior).

## Verification

Four tests, three of which fail on `main`'s `src/`:

| test | node v26.3.0 | bun main | bun this PR |
|---|---|---|---|
| `write()` fails, no `'error'` listener | `uncaught:EIO` exit 7 | `unhandledRejection:EIO` exit 8 | `uncaught:EIO` exit 7 |
| `end(chunk)` fails, no `'error'` listener (reaches `_write`) | `uncaught:EIO` exit 7 | `unhandledRejection:EIO` exit 8 | `uncaught:EIO` exit 7 |
| write succeeds after backpressure, cb throws | `uncaught:boom` exit 7 | `unhandledRejection:boom` exit 8 | `uncaught:boom` exit 7 |
| `write()` fails, with `'error'` listener | `cb:EIO` + `error:EIO` | `cb:EIO` + `error:EIO` | `cb:EIO` + `error:EIO` |

The fourth is a regression guard: with a listener, nothing throws and both the callback and the `'error'` event fire. The first two exercise `writeFast` and `underscoreWriteFast` respectively (the latter via `Writable.prototype.end(chunk)` → `_write`). The tty tests use `Bun.Terminal` to reproduce the hangup deterministically (stdin EOF = master closed = next stdout write fails EIO). The backpressure test fills a piped stdout until `write()` returns `false`, then issues one more write whose callback throws.

Also re-run against the debug build with no new failures: `test/regression/issue/1632.test.ts`, `test/js/node/child_process/child-process-stdio.test.js`, `test/js/node/fs/fs.test.ts -t WriteStream`, `test/js/node/stream/node-stream.test.js`, and node's `test-console-log-stdio-broken-dest` / `test-process-external-stdio-close{,-spawn}` / `test-stdio-{closed,undestroy}` / `test-child-process-stdout-flush{,-exit}` / `test-child-process-can-write-to-stdout` / `test-child-process-stdio-big-write-end`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/process/process-stdio.test.ts test/js/node/tty.test.ts

<!-- robobun:evidence:end -->