### PR TITLE
node:http2: remoteSettings/localSettings return {} while connecting, not null

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -125,39 +125,16 @@ const kDefaultSettings = {
   enableConnectProtocol: false,
 };
 
-const kLocalSettingsKeys = [
-  "headerTableSize",
-  "enablePush",
-  "maxConcurrentStreams",
-  "initialWindowSize",
-  "maxFrameSize",
-  "maxHeaderListSize",
-  "maxHeaderSize",
-  "enableConnectProtocol",
-];
-
-// node's session.localSettings reflects the settings this side submitted (including
-// customSettings) from the moment they go out with the connection preface — it does not wait for
-// the peer's SETTINGS ACK. Overlay the user-submitted values on top of the pre-ACK defaults; the
-// native localSettings dispatch replaces the object with the engine's confirmed view once the ACK
-// arrives.
-function applySubmittedLocalSettings(target: Record<string, any>, submitted: any) {
-  if (submitted == null || typeof submitted !== "object") return target;
-  for (let i = 0; i < kLocalSettingsKeys.length; i++) {
-    const key = kLocalSettingsKeys[i];
-    const value = submitted[key];
-    if (value !== undefined) target[key] = value;
+// Pre-ACK localSettings view: node's getSettings() reads nghttp2's effective local settings
+// (protocol defaults until the first ACK) but carries submitted customSettings forward from
+// the SETTINGS frame buffer, so only customSettings is visible pre-ACK.
+function initialLocalSettings(submitted: any) {
+  const settings: any = { ...kDefaultSettings };
+  const custom = submitted?.customSettings;
+  if (custom != null && typeof custom === "object") {
+    settings.customSettings = { ...custom };
   }
-  // maxHeaderListSize and maxHeaderSize alias the same SETTINGS entry.
-  if (submitted.maxHeaderListSize !== undefined && submitted.maxHeaderSize === undefined) {
-    target.maxHeaderSize = submitted.maxHeaderListSize;
-  } else if (submitted.maxHeaderSize !== undefined && submitted.maxHeaderListSize === undefined) {
-    target.maxHeaderListSize = submitted.maxHeaderSize;
-  }
-  if (submitted.customSettings != null && typeof submitted.customSettings === "object") {
-    target.customSettings = { ...submitted.customSettings };
-  }
-  return target;
+  return settings;
 }
 
 function throwSettingRangeError(name: string, value: any) {
@@ -4005,19 +3982,7 @@ class ServerHttp2Session extends Http2Session {
   #url: URL;
   #isServer: boolean = false;
   #alpnProtocol: string | undefined = undefined;
-  #localSettings: Settings | null = {
-    headerTableSize: 4096,
-    // RFC 9113 §6.5.2: servers MUST NOT advertise ENABLE_PUSH != 0. The
-    // initial SETTINGS frame forces this to 0 in the constructor — keep the
-    // default here in sync so `session.localSettings.enablePush` agrees with
-    // the wire before the peer's SETTINGS ACK arrives.
-    enablePush: false,
-    maxConcurrentStreams: 100,
-    initialWindowSize: 65535,
-    maxFrameSize: 16384,
-    maxHeaderListSize: 65535,
-    maxHeaderSize: 65535,
-  };
+  #localSettings: Settings | null = null;
   #encrypted: boolean = false;
   #pendingSettingsAck: boolean = true;
   // Count of SETTINGS frames sent that the peer has not yet ACKed (the initial connection
@@ -4464,8 +4429,7 @@ class ServerHttp2Session extends Http2Session {
       validateSettings(options.settings);
     }
     const nativeSettings = serverNativeSettings(options);
-    // localSettings reads the submitted values (incl. customSettings) before the peer ACKs.
-    this.#localSettings = applySubmittedLocalSettings({ ...this.#localSettings }, nativeSettings);
+    this.#localSettings = initialLocalSettings(nativeSettings);
     this.#parser = new H2FrameParser({
       native: nativeSocket,
       context: this,
@@ -4518,11 +4482,13 @@ class ServerHttp2Session extends Http2Session {
   }
 
   get remoteSettings() {
-    return this.#remoteSettings;
+    if (this.destroyed || this.connecting) return {};
+    return (this.#remoteSettings ??= getDefaultSettings());
   }
 
   get localSettings() {
-    return this.#localSettings;
+    if (this.destroyed || this.connecting) return {};
+    return (this.#localSettings ??= getDefaultSettings());
   }
 
   get pendingSettingsAck() {
@@ -4919,15 +4885,7 @@ class ClientHttp2Session extends Http2Session {
   #url: URL;
   #authority: string;
   #alpnProtocol: string | undefined = undefined;
-  #localSettings: Settings | null = {
-    headerTableSize: 4096,
-    enablePush: true,
-    maxConcurrentStreams: 100,
-    initialWindowSize: 65535,
-    maxFrameSize: 16384,
-    maxHeaderListSize: 65535,
-    maxHeaderSize: 65535,
-  };
+  #localSettings: Settings | null = null;
   #encrypted: boolean = false;
   #pendingSettingsAck: boolean = true;
   // Count of SETTINGS frames sent that the peer has not yet ACKed (the initial connection
@@ -5415,11 +5373,13 @@ class ClientHttp2Session extends Http2Session {
   }
 
   get remoteSettings() {
-    return this.#remoteSettings;
+    if (this.destroyed || this.connecting) return {};
+    return (this.#remoteSettings ??= getDefaultSettings());
   }
 
   get localSettings() {
-    return this.#localSettings;
+    if (this.destroyed || this.connecting) return {};
+    return (this.#localSettings ??= getDefaultSettings());
   }
 
   get pendingSettingsAck() {
@@ -5642,8 +5602,7 @@ class ClientHttp2Session extends Http2Session {
       validateSettings(options.settings);
     }
     const nativeSettings = { ...options, ...options?.settings };
-    // localSettings reads the submitted values (incl. customSettings) before the peer ACKs.
-    this.#localSettings = applySubmittedLocalSettings({ ...this.#localSettings }, nativeSettings);
+    this.#localSettings = initialLocalSettings(nativeSettings);
     this.#parser = new H2FrameParser({
       native: nativeSocket,
       context: this,

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -857,8 +857,11 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
             expect(client.destroyed).toBeFalse();
             expect(client.originSet.length).toBe(1);
             expect(client.pendingSettingsAck).toBeTrue();
-            assertSettings(client.localSettings);
-            expect(client.remoteSettings).toBeNull();
+            // node: while `connecting || destroyed` both getters return a fresh empty object; the
+            // first SETTINGS ACK populates localSettings, the peer's first SETTINGS frame populates
+            // remoteSettings.
+            expect(client.localSettings).toEqual({});
+            expect(client.remoteSettings).toEqual({});
             const headers = { ":path": "/" };
             const req = client.request(headers);
             expect(req.closed).toBeFalse();
@@ -3485,6 +3488,70 @@ it("http2 server sends each session's frames to its own peer under interleaved r
       { i: 0, status: 200, total: BIG.length * N },
       { i: 1, status: 200, total: BIG.length * N },
     ]);
+  } finally {
+    server.close();
+  }
+});
+
+// node's Http2Session.remoteSettings/localSettings getters return `{}` while the session is
+// connecting or destroyed and a cached Settings object once the handle is live, so
+// `session.remoteSettings.maxConcurrentStreams` is always a safe read. Bun previously returned
+// `null` in the connect()-to-first-SETTINGS window, throwing TypeError on property access.
+it("remoteSettings/localSettings are never null before the peer's SETTINGS arrives", async () => {
+  const server = http2.createServer();
+  server.on("stream", stream => {
+    stream.respond({ ":status": 200 });
+    stream.end("ok");
+  });
+  const { promise: serverSessionPromise, resolve: resolveServerSession } = Promise.withResolvers();
+  server.on("session", resolveServerSession);
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+
+  try {
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`, {
+      settings: { enablePush: false, initialWindowSize: 99999 },
+    });
+    const { promise: donePromise, resolve: resolveDone, reject: rejectDone } = Promise.withResolvers();
+    client.on("error", rejectDone);
+
+    // Synchronously after connect(): node returns a fresh {} each read; bun used to return null.
+    expect(client.remoteSettings).toEqual({});
+    expect(client.localSettings).toEqual({});
+    // The documented use (deciding how many requests to pipeline) must not throw.
+    expect(client.remoteSettings.maxConcurrentStreams).toBeUndefined();
+
+    const { promise: remotePromise, resolve: resolveRemote } = Promise.withResolvers();
+    const { promise: localPromise, resolve: resolveLocal } = Promise.withResolvers();
+    client.once("remoteSettings", resolveRemote);
+    client.once("localSettings", resolveLocal);
+
+    const remote = await remotePromise;
+    expect(typeof remote.maxConcurrentStreams).toBe("number");
+    // After the peer's SETTINGS arrives the getter reports it and caches the object identity.
+    expect(client.remoteSettings).toBe(remote);
+    expect(client.remoteSettings).toBe(client.remoteSettings);
+
+    const local = await localPromise;
+    // localSettings reflects the ACKed values (the constructor's submitted settings), not pre-ACK.
+    expect(local.enablePush).toBe(false);
+    expect(local.initialWindowSize).toBe(99999);
+    expect(client.localSettings).toBe(local);
+
+    // Server side: the incoming socket is already connected, so the getter falls through to the
+    // protocol defaults immediately (never `{}` on the server path).
+    const serverSession = await serverSessionPromise;
+    expect(typeof serverSession.remoteSettings).toBe("object");
+    expect(serverSession.remoteSettings).not.toBeNull();
+    expect(typeof serverSession.remoteSettings.maxConcurrentStreams).toBe("number");
+    expect(typeof serverSession.localSettings).toBe("object");
+    expect(serverSession.localSettings).not.toBeNull();
+
+    client.on("close", resolveDone);
+    client.destroy();
+    await donePromise;
+    // After destroy both getters go back to {}.
+    expect(client.remoteSettings).toEqual({});
+    expect(client.localSettings).toEqual({});
   } finally {
     server.close();
   }

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3507,23 +3507,27 @@ it("remoteSettings/localSettings are never null before the peer's SETTINGS arriv
   server.on("session", resolveServerSession);
   await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
 
+  let client;
   try {
-    const client = http2.connect(`http://127.0.0.1:${server.address().port}`, {
+    client = http2.connect(`http://127.0.0.1:${server.address().port}`, {
       settings: { enablePush: false, initialWindowSize: 99999 },
     });
     const { promise: donePromise, resolve: resolveDone, reject: rejectDone } = Promise.withResolvers();
-    client.on("error", rejectDone);
+    const { promise: remotePromise, resolve: resolveRemote, reject: rejectRemote } = Promise.withResolvers();
+    const { promise: localPromise, resolve: resolveLocal, reject: rejectLocal } = Promise.withResolvers();
+    client.on("error", err => {
+      rejectRemote(err);
+      rejectLocal(err);
+      rejectDone(err);
+    });
+    client.once("remoteSettings", resolveRemote);
+    client.once("localSettings", resolveLocal);
 
     // Synchronously after connect(): node returns a fresh {} each read; bun used to return null.
     expect(client.remoteSettings).toEqual({});
     expect(client.localSettings).toEqual({});
     // The documented use (deciding how many requests to pipeline) must not throw.
     expect(client.remoteSettings.maxConcurrentStreams).toBeUndefined();
-
-    const { promise: remotePromise, resolve: resolveRemote } = Promise.withResolvers();
-    const { promise: localPromise, resolve: resolveLocal } = Promise.withResolvers();
-    client.once("remoteSettings", resolveRemote);
-    client.once("localSettings", resolveLocal);
 
     const remote = await remotePromise;
     expect(typeof remote.maxConcurrentStreams).toBe("number");
@@ -3553,6 +3557,7 @@ it("remoteSettings/localSettings are never null before the peer's SETTINGS arriv
     expect(client.remoteSettings).toEqual({});
     expect(client.localSettings).toEqual({});
   } finally {
+    client?.destroy();
     server.close();
   }
 });


### PR DESCRIPTION
## Reproduction

```js
import http2 from "node:http2";
const srv = http2.createServer();
srv.on("stream", st => { st.respond({ ":status": 200 }); st.end("ok"); });
srv.listen(0, "127.0.0.1", () => {
  const c = http2.connect(`http://127.0.0.1:${srv.address().port}`);
  // Throws in bun, works in node:
  console.log(c.remoteSettings.maxConcurrentStreams);
  c.on("remoteSettings", () => { c.close(); srv.close(); });
});
```

```
TypeError: null is not an object (evaluating 'c.remoteSettings.maxConcurrentStreams')
```

## Cause

`#remoteSettings` was seeded as `null` and the getter returned it verbatim until the native `remoteSettings` dispatch fired on the peer's first SETTINGS frame. Node's getter (`lib/internal/http2/core.js` `Http2Session#remoteSettings`) returns `{}` while `destroyed || connecting` and otherwise queries/caches the handle's view, so property access is always safe.

`localSettings` had a related divergence: the previous rewrite overlaid every submitted constructor setting onto the pre-ACK defaults (`applySubmittedLocalSettings`), but node only surfaces submitted `customSettings` pre-ACK; standard settings stay at nghttp2's effective (default) values until the peer's SETTINGS ACK arrives. Verified against Node v26.3.0.

## Fix

Both getters on `ClientHttp2Session` and `ServerHttp2Session` now return `{}` while `destroyed || connecting` and fall back to `getDefaultSettings()` once the handle is live but no SETTINGS have been received. `#localSettings` is seeded with protocol defaults plus only the submitted `customSettings` (the one field node surfaces pre-ACK), replacing `applySubmittedLocalSettings`.

## Verification

- New test `remoteSettings/localSettings are never null before the peer's SETTINGS arrives` fails on main (`expect(client.remoteSettings).toEqual({})` receives `null`), passes with the fix.
- Updated `settings and properties should work` to assert `{}` pre-connect instead of `null`.
- `test/js/node/test/parallel/test-http2-session-settings.js` and the other `test-http2-*settings*` upstream tests still pass.
- Full `node-http2.test.js` suite: 304 pass, 6 skip, 0 fail.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (64263d395)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [828.89ms]
(pass) node none > Client Basics > should be able to send a POST request [575.04ms]
(pass) node none > Client Basics > constants [18.51ms]
(pass) node none > Client Basics > getDefaultSettings [7.42ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [22.87ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.05ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.68ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.29ms
... (truncated)

release without fix: 6 skipped
bun test v1.4.0-canary.1 (64263d395)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [3.02ms]
(pass) node none > Client Basics > getDefaultSettings [0.17ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [1.01ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.77ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.07ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.09ms]
(pass) node none > Client Basics > is possible to abort request [4.56ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.69ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.64ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.92ms]
(pass) node none > Client Basics > should be able to send a GET request [112.82ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > should be able to send
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (64263d395)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [801.45ms]
(pass) node none > Client Basics > should be able to send a POST request [566.42ms]
(pass) node none > Client Basics > constants [18.70ms]
(pass) node none > Client Basics > getDefaultSettings [7.27ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [22.86ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [4.87ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.60ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.13ms
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 731ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/20] gen JS modules (bundle-modules)
Preprocess modules (7276ms)
Bundle modules (29ms)
Postprocesss modules (137ms)
Bundle Functions (722ms)
Generate Code (108ms)

[8.29s] Bundled "src/js" for production
  1991 kb
  164 internal modules
  13 native modules
  90 internal functions across 19 files
[build] done
bun test v1.4.0-canary.1 (64263d395)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.84ms]
(pass) node none > Client Basics > getDefaultSettings [0.15ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.35ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.09ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buff
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                  | 83 +++++++++--------------------------
 test/js/node/http2/node-http2.test.js | 76 +++++++++++++++++++++++++++++++-
 2 files changed, 95 insertions(+), 64 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/js/node/http2.ts                       6      6      0
test/js/node/http2/node-http2.test.js      5      5      0
```

</details>

<!-- robobun:evidence:end -->