### PR TITLE
test(node-net): measure mimalloc page plateau, not single-round delta

### DIFF
--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -946,17 +946,21 @@ it.skipIf(isWindows || isASAN)(
         return heapStats().mimalloc.page_bins.reduce((a, b) => a + b.current, 0);
       }
 
-      // JSC shares mimalloc since #34009, so its heap growth is in this
-      // count too. It steps up for the first few rounds (one equal-sized
-      // warmup is not enough) and then sits flat; a real leak grows every
-      // round by the same ~38 pages. Sample five equal rounds and compare
-      // the last two: a plateau proves bounded, linear growth proves leak.
+      // JSC allocates through mimalloc too, so its heap growth is in this
+      // count. It steps up for the first few rounds and then sits flat; a
+      // real leak grows every round by the same ~38 pages. Run equal rounds
+      // until two in a row match (plateau = bounded), giving up after eight
+      // (linear growth = leak).
       const samples = [];
-      for (let round = 0; round < 5; round++) {
+      let delta = Infinity;
+      for (let round = 0; round < 8; round++) {
         await run(8000);
         samples.push(pageCount());
+        if (round > 0) {
+          delta = samples.at(-1) - samples.at(-2);
+          if (delta < 10) break;
+        }
       }
-      const delta = samples.at(-1) - samples.at(-2);
       console.log(JSON.stringify({ samples, delta }));
     `;
     await using proc = Bun.spawn({
@@ -968,8 +972,9 @@ it.skipIf(isWindows || isASAN)(
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     const { samples, delta } = JSON.parse(stdout.trim().split("\n").pop()!);
-    // Without the balancing deref: every round adds ~38 pages. With it: the
-    // last two rounds are byte-identical (delta 0, observed across 20 runs).
+    // Without the balancing deref every round adds ~38 pages and the loop
+    // runs to its cap. With it the count plateaus within four rounds (delta
+    // 0 between the last two, 60/60 linux + 15/15 darwin runs).
     expect(delta, `mimalloc page count per round: ${samples}`).toBeLessThan(10);
     expect(exitCode).toBe(0);
   },

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -899,8 +899,10 @@ it.if(isWindows)(
 
 // On Windows, unix paths route through the named-pipe codepath which reports
 // failure asynchronously; this test targets the synchronous-failure branch in
-// Listener.connectInner.
-it.skipIf(isWindows)(
+// Listener.connectInner. Under ASAN the global allocator is the system one,
+// so leaked Box<NewSocket> structs never show up in mimalloc's page bins and
+// the metric below is a no-op there.
+it.skipIf(isWindows || isASAN)(
   "should not leak when connect({path}) fails synchronously on a reused handle",
   async () => {
     // node:net creates a detached native socket (`_handle`) and passes it as
@@ -937,22 +939,25 @@ it.skipIf(isWindows)(
       }
 
       // Count live mimalloc pages across all size bins. Each leaked
-      // TCPSocket struct is ~300-400 bytes; 8k of them fill ~25 pages
-      // (release) / ~160 pages (debug+ASAN). Unlike RSS this is the
-      // allocator's own bookkeeping, so it's independent of OS page
-      // reclamation.
+      // TCPSocket struct is ~300-400 bytes; 8k of them fill ~38 pages.
+      // Unlike RSS this is the allocator's own bookkeeping, so it's
+      // independent of OS page reclamation.
       function pageCount() {
         return heapStats().mimalloc.page_bins.reduce((a, b) => a + b.current, 0);
       }
 
-      // Warm up with the SAME workload as the measured run: on builds where
-      // JSC shares mimalloc, its heap keeps growing until the first full-size
-      // batch, so equal batches make the delta isolate the per-run leak.
-      await run(8000);
-      const before = pageCount();
-      await run(8000);
-      const after = pageCount();
-      console.log(JSON.stringify({ before, after, delta: after - before }));
+      // JSC shares mimalloc since #34009, so its heap growth is in this
+      // count too. It steps up for the first few rounds (one equal-sized
+      // warmup is not enough) and then sits flat; a real leak grows every
+      // round by the same ~38 pages. Sample five equal rounds and compare
+      // the last two: a plateau proves bounded, linear growth proves leak.
+      const samples = [];
+      for (let round = 0; round < 5; round++) {
+        await run(8000);
+        samples.push(pageCount());
+      }
+      const delta = samples.at(-1) - samples.at(-2);
+      console.log(JSON.stringify({ samples, delta }));
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", script],
@@ -962,10 +967,10 @@ it.skipIf(isWindows)(
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    const { before, after, delta } = JSON.parse(stdout.trim().split("\n").pop()!);
-    // Without the balancing deref: +25 pages (release) / +163 pages
-    // (debug+ASAN). With it: 0 ± 2. The threshold sits well clear of both.
-    expect(delta, `mimalloc page count: ${before} -> ${after}`).toBeLessThan(10);
+    const { samples, delta } = JSON.parse(stdout.trim().split("\n").pop()!);
+    // Without the balancing deref: every round adds ~38 pages. With it: the
+    // last two rounds are byte-identical (delta 0, observed across 20 runs).
+    expect(delta, `mimalloc page count per round: ${samples}`).toBeLessThan(10);
     expect(exitCode).toBe(0);
   },
   60_000,


### PR DESCRIPTION
Fixes `test/js/node/net/node-net.test.ts` going red on `:debian: 13 x64` (build 73897, reported from #32623).

### Failure

```
error: mimalloc page count: 134 -> 144
Expected: < 10
Received: 10
✗ should not leak when connect({path}) fails synchronously on a reused handle
```

### Cause

The test reads `heapStats().mimalloc.page_bins` after one warmup `run(8000)` and one measured `run(8000)`, asserting `delta < 10`. Since #34009 JSC allocates through mimalloc, so its heap growth is in that count; #34181 then moved the page sweep to a background thread, so how many pages the post-round `pageCount()` sees depends on how far the scavenger got during the 20 ms `Bun.sleep`.

The warmup round now ends at either ~83 or ~140 pages (scavenger finished vs not) while the measured round ends at ~140, so the observed delta is ~0 or ~55 depending on timing. No actual leak: scaling the workload 4x does not grow the delta, and repeated equal rounds always plateau by round 3.

<details>
<summary>measurements (release build at aca54d5c2)</summary>

```
current test (2 rounds), 20 runs:
  delta 56,59,59,0,57,0,0,1,1,1,55,1,2,60,58,2,59,0,1,1   (bimodal)

self-adjusting loop (with the fix), linux x64:
  {samples:[137,138],delta:1}
  {samples:[83,142,160,160],delta:0}
  ... 70/70 pass, breaks after 2-4 rounds

self-adjusting loop (with the fix), darwin arm64:
  {samples:[140,142,182,182,182],delta:0}
  ... 15/15 pass

with the balancing deref in Listener.rs removed (the #30168 bug):
  {samples:[117,209,269,306,344,381,419,456],delta:37}
  ... 35/35 fail, runs to the 8-round cap, +37/round

scale (current main), 8 runs each:
  N=4000:  delta 1,58,2,1,2,60,1,1
  N=8000:  delta 65,56,1,57,61,60,2,53
  N=16000: delta 24,17,13,44,47,27,16,45
  N=32000: delta 1,1,2,11,2,1,2,1
```
</details>

### Fix

Run equal rounds until two in a row match (plateau = bounded), giving up after eight. A real leak never plateaus (+38 per round) and fails; without the leak the loop breaks after 2-4 rounds. Decoupled from the allocator's current heap-growth shape so the next allocator change does not need another adjustment.

Also skip under ASAN: the global allocator is the system one there, so leaked `Box<NewSocket>` structs never reach mimalloc's page bins. The previous test was burning ~50 s of ASAN lane time on a metric that cannot fire.

### Verification

- linux x64 release at HEAD: 70/70 pass, ~0.8 s each
- darwin arm64 release at HEAD: 15/15 pass
- linux x64 release with the `NewSocket::deref` at `Listener.rs:1531` removed: 35/35 fail, `mimalloc page count per round: 208,236,273,310,347,384,422,459`

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->