### PR TITLE
node:http client: report req.destroy() mid EOF-delimited body as aborted, not a clean 'end'

### DIFF
--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -599,9 +599,9 @@ function socketOnEnd() {
   const req = this._httpMessage;
   const parser = this.parser;
 
-  // An 'end' after req.destroy() is our own teardown, not a server FIN;
-  // finishing the parser here would mark an EOF-delimited body complete and
-  // let socketCloseListener deliver a clean 'end' for a locally aborted body.
+  // An 'end' after req.destroy() is our own teardown, not a server FIN.
+  // Finishing the parser here would mark an EOF-delimited body complete, so
+  // socketCloseListener would skip its abort check and emit a clean 'end'.
   if (req.destroyed) {
     socket.destroy();
     return;

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -599,6 +599,14 @@ function socketOnEnd() {
   const req = this._httpMessage;
   const parser = this.parser;
 
+  // An 'end' after req.destroy() is our own teardown, not a server FIN;
+  // finishing the parser here would mark an EOF-delimited body complete and
+  // let socketCloseListener deliver a clean 'end' for a locally aborted body.
+  if (req.destroyed) {
+    socket.destroy();
+    return;
+  }
+
   if (!req.res && !req.socket._hadError) {
     // If we don't have a response then we know that the socket
     // ended prematurely and we need to emit an error on the request.

--- a/test/js/node/http/node-http-client-destroy.test.ts
+++ b/test/js/node/http/node-http-client-destroy.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+import { once } from "node:events";
+import { request } from "node:http";
+import type { AddressInfo } from "node:net";
+import { createServer as createNetServer } from "node:net";
+
+describe("req.destroy() mid-body reports the response as aborted", () => {
+  // RFC 9112 6.3: without Content-Length or Transfer-Encoding the body is
+  // framed by connection close. Destroying the request locally must surface as
+  // 'aborted' + ECONNRESET (the download is truncated), never a clean 'end'.
+  it.each([
+    ["EOF-delimited", "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\npart1-", true],
+    ["chunked", "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n6\r\npart1-\r\n", false],
+  ] as const)("%s", async (_name, responseBytes, expectedComplete) => {
+    const server = createNetServer(s => {
+      s.on("error", () => {});
+      s.on("data", () => {
+        try {
+          s.write(responseBytes);
+        } catch {}
+      });
+    });
+    try {
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const { port } = server.address() as AddressInfo;
+
+      const { promise, resolve, reject } = Promise.withResolvers<{ events: string[]; complete: boolean }>();
+      const req = request({ host: "127.0.0.1", port }, res => {
+        const events: string[] = [];
+        res.on("data", () => {
+          events.push("data");
+          req.destroy();
+        });
+        res.on("end", () => events.push("end"));
+        res.on("aborted", () => events.push("aborted"));
+        res.on("error", (e: NodeJS.ErrnoException) => events.push(`error:${e.code}`));
+        res.on("close", () => resolve({ events, complete: res.complete }));
+      });
+      req.on("error", reject);
+      req.end();
+
+      const { events, complete } = await promise;
+      expect({ events, complete }).toEqual({
+        events: ["data", "aborted", "error:ECONNRESET"],
+        complete: expectedComplete,
+      });
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -3898,6 +3898,53 @@ it("http.Agent with proxyEnv does not write to a literal 'undefined' property", 
   }
 });
 
+describe("req.destroy() mid-body reports the response as aborted", () => {
+  // RFC 9112 6.3: without Content-Length or Transfer-Encoding the body is
+  // framed by connection close. Destroying the request locally must surface as
+  // 'aborted' + ECONNRESET (the download is truncated), never a clean 'end'.
+  it.each([
+    ["EOF-delimited", "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\npart1-", true],
+    ["chunked", "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n6\r\npart1-\r\n", false],
+  ])("%s", async (_name, responseBytes, expectedComplete) => {
+    const server = createNetServer(s => {
+      s.on("error", () => {});
+      s.on("data", () => {
+        try {
+          s.write(responseBytes);
+        } catch {}
+      });
+    });
+    try {
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const { port } = server.address() as AddressInfo;
+
+      const { promise, resolve, reject } = Promise.withResolvers<{ events: string[]; complete: boolean }>();
+      const req = request({ host: "127.0.0.1", port }, res => {
+        const events: string[] = [];
+        res.on("data", () => {
+          events.push("data");
+          req.destroy();
+        });
+        res.on("end", () => events.push("end"));
+        res.on("aborted", () => events.push("aborted"));
+        res.on("error", (e: NodeJS.ErrnoException) => events.push(`error:${e.code}`));
+        res.on("close", () => resolve({ events, complete: res.complete }));
+      });
+      req.on("error", reject);
+      req.end();
+
+      const { events, complete } = await promise;
+      expect({ events, complete }).toEqual({
+        events: ["data", "aborted", "error:ECONNRESET"],
+        complete: expectedComplete,
+      });
+    } finally {
+      server.close();
+    }
+  });
+});
+
 it("OutgoingMessage outputData is per-instance and _flushOutput is defined", () => {
   expect(typeof OutgoingMessage.prototype._flushOutput).toBe("function");
 

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -3898,53 +3898,6 @@ it("http.Agent with proxyEnv does not write to a literal 'undefined' property", 
   }
 });
 
-describe("req.destroy() mid-body reports the response as aborted", () => {
-  // RFC 9112 6.3: without Content-Length or Transfer-Encoding the body is
-  // framed by connection close. Destroying the request locally must surface as
-  // 'aborted' + ECONNRESET (the download is truncated), never a clean 'end'.
-  it.each([
-    ["EOF-delimited", "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\npart1-", true],
-    ["chunked", "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n6\r\npart1-\r\n", false],
-  ])("%s", async (_name, responseBytes, expectedComplete) => {
-    const server = createNetServer(s => {
-      s.on("error", () => {});
-      s.on("data", () => {
-        try {
-          s.write(responseBytes);
-        } catch {}
-      });
-    });
-    try {
-      server.listen(0, "127.0.0.1");
-      await once(server, "listening");
-      const { port } = server.address() as AddressInfo;
-
-      const { promise, resolve, reject } = Promise.withResolvers<{ events: string[]; complete: boolean }>();
-      const req = request({ host: "127.0.0.1", port }, res => {
-        const events: string[] = [];
-        res.on("data", () => {
-          events.push("data");
-          req.destroy();
-        });
-        res.on("end", () => events.push("end"));
-        res.on("aborted", () => events.push("aborted"));
-        res.on("error", (e: NodeJS.ErrnoException) => events.push(`error:${e.code}`));
-        res.on("close", () => resolve({ events, complete: res.complete }));
-      });
-      req.on("error", reject);
-      req.end();
-
-      const { events, complete } = await promise;
-      expect({ events, complete }).toEqual({
-        events: ["data", "aborted", "error:ECONNRESET"],
-        complete: expectedComplete,
-      });
-    } finally {
-      server.close();
-    }
-  });
-});
-
 it("OutgoingMessage outputData is per-instance and _flushOutput is defined", () => {
   expect(typeof OutgoingMessage.prototype._flushOutput).toBe("function");
 


### PR DESCRIPTION
### What

Calling `req.destroy()` while an EOF-delimited response body (no `Content-Length`, no `Transfer-Encoding`; RFC 9112 6.3 rule 8) is streaming delivers a clean `'end'` on the response and never `'aborted'` / `ECONNRESET`. A locally aborted, truncated download is indistinguishable from a complete one. The same destroy on a chunked body is already Node-identical.

```js
import http from "node:http";
import net from "node:net";
const HEAD = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\npart1-";
const srv = net.createServer(s => { s.on("error", () => {}); s.on("data", () => s.write(HEAD)); });
srv.listen(0, "127.0.0.1", () => {
  const req = http.request({ port: srv.address().port, host: "127.0.0.1" }, res => {
    const ev = [];
    res.on("data", () => { ev.push("data"); req.destroy(); });
    res.on("end", () => ev.push("end"));
    res.on("aborted", () => ev.push("aborted"));
    res.on("error", e => ev.push(`error:${e.code}`));
    res.on("close", () => { console.log(ev.join(",")); srv.close(); });
  });
  req.end();
});
// node:  data,aborted,error:ECONNRESET
// bun:   data,end
```

This matters for abort/cancel plumbing (timeouts, `AbortSignal`-driven destroys, user cancellation) on EOF-delimited origins: caches store the truncated prefix as the full body, retry logic never retries, metrics count the abort as a completed transfer.

### Why

`req.destroy()` destroys the socket, and the socket's `'end'` reaches `socketOnEnd` before `'close'` reaches `socketCloseListener`. `socketOnEnd` calls `parser.finish()`, which for an EOF-delimited body runs `parserOnMessageComplete` (sets `res.complete = true` and pushes EOF). By the time `socketCloseListener` checks `if (!res.complete)` the response already looks complete, so the `res.destroy(ConnResetException("aborted"))` path is skipped and `res.push(null)` delivers `'end'`.

Node never reaches `socketOnEnd` after `req.destroy()` because its `socket.destroy()` emits only `'close'`, so `parser.finish()` runs at the bottom of `socketCloseListener`, after the abort check. (#33256 fixes the underlying `net.Socket` spurious `'end'`; this change is independent of it.)

### Fix

Guard `socketOnEnd` on `!req.destroyed`: an `'end'` that arrives after the request was already destroyed is our own teardown, not a server FIN, so defer parser finalisation to `socketCloseListener`. `req.destroyed` is only set ahead of `socketOnEnd` by `ClientRequest.prototype.destroy` (the other setters remove the listener first or run after `'close'`).

### Verification

New parametrised test in `test/js/node/http/node-http.test.ts` covers both EOF-delimited and chunked framing and asserts the full event sequence plus `res.complete` against Node v26.3.0. Fails on bun 1.4.0 (`["data","end"]`), passes with this change. All 67 `test/js/node/test/parallel/test-http-client-*.js` and the abort/keep-alive/response-close tests pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-client-destroy.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (83ef4755d)

test/js/node/http/node-http-client-destroy.test.ts:
39 |       });
40 |       req.on("error", reject);
41 |       req.end();
42 | 
43 |       const { events, complete } = await promise;
44 |       expect({ events, complete }).toEqual({
                                        ^
error: expect(received).toEqual(expected)

  {
    "complete": true,
    "events": [
      "data",
-     "aborted",
-     "error:ECONNRESET",
+     "end",
    ],
  }

- Expected  - 2
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/node/http/node-http-client-destroy.test.ts:44:36)
(fail) req.destroy() mid-body reports the response as aborted > EOF-delimited [701.01ms]
(pass) req.destroy() mid-body reports the response 
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (10cf6aa06)

test/js/node/http/node-http-client-destroy.test.ts:
(pass) req.destroy() mid-body reports the response as aborted > EOF-delimited [12.31ms]
(pass) req.destroy() mid-body reports the response as aborted > chunked [2.29ms]

 2 pass
 0 fail
 2 expect() calls
Ran 2 tests across 1 file. [161.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-client-destroy.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (83ef4755d)

test/js/node/http/node-http-client-destroy.test.ts:
(pass) req.destroy() mid-body reports the response as aborted > EOF-delimited [771.82ms]
(pass) req.destroy() mid-body reports the response as aborted > chunked [129.31ms]

 2 pass
 0 fail
 2 expect() calls
Ran 2 tests across 1 file. [3.73s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 715ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/20] gen JS modules (bundle-modules)
Preprocess modules (6956ms)
Bundle modules (50ms)
Postprocesss modules (28ms)
Bundle Functions (760ms)
Generate Code (80ms)

[7.89s] Bundled "src/js" for production
  1968 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version:
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/_http_client.ts                        |  8 ++++
 test/js/node/http/node-http-client-destroy.test.ts | 52 ++++++++++++++++++++++
 2 files changed, 60 insertions(+)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/js/node/_http_client.ts                             3      4      0
test/js/node/http/node-http-client-destroy.test.ts      0      1      0
```

</details>

<!-- robobun:evidence:end -->