### PR TITLE
Reserve "arguments", "eval" and "await" as binding names in bundle output

### DIFF
--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -1060,14 +1060,28 @@ pub fn compute_initial_reserved_names(
 
     const CJS_NAMES: [&[u8]; 2] = [b"exports", b"module"];
 
+    // "arguments" and "eval" are not reserved words, but strict mode forbids
+    // them as binding targets. ESM output is always strict, and dev server
+    // chunks are loaded as ES modules.
+    const STRICT_MODE_RESTRICTED_NAMES: [&[u8]; 2] = [b"arguments", b"eval"];
+
+    let is_strict = output_format == Format::Esm || output_format == Format::InternalBakeDev;
+
     let cjs_names_len: u32 = if output_format == Format::Cjs {
         CJS_NAMES.len() as u32
     } else {
         0
     };
 
+    let strict_names_len: usize = if is_strict {
+        STRICT_MODE_RESTRICTED_NAMES.len()
+    } else {
+        0
+    };
+
     names.ensure_total_capacity(
         cjs_names_len as usize
+            + strict_names_len
             + (Keywords.len() + StrictModeReservedWords.len() + 1 + EXTRAS.len()),
     )?;
 
@@ -1088,6 +1102,12 @@ pub fn compute_initial_reserved_names(
     // something in a nested scope as an top-level export.
     if output_format == Format::Cjs {
         for name in CJS_NAMES {
+            names.put_assume_capacity(name, 1);
+        }
+    }
+
+    if is_strict {
+        for name in STRICT_MODE_RESTRICTED_NAMES {
             names.put_assume_capacity(name, 1);
         }
     }

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -1060,12 +1060,13 @@ pub fn compute_initial_reserved_names(
 
     const CJS_NAMES: [&[u8]; 2] = [b"exports", b"module"];
 
-    // "arguments", "eval", and "await" are not reserved words, but module code
-    // (always strict) forbids them as binding targets. ESM output is loaded as
-    // a module, and so are dev server chunks (<script type="module">).
-    const MODULE_CODE_RESTRICTED_NAMES: [&[u8]; 3] = [b"arguments", b"eval", b"await"];
-
-    let is_module_code = output_format == Format::Esm || output_format == Format::InternalBakeDev;
+    // Not keywords, so `Keywords`/`StrictModeReservedWords` miss them, but none
+    // of them can be a binding name in strict code: `await` is reserved in
+    // modules and `eval`/`arguments` are rejected as binding identifiers. ESM
+    // output is always strict, and cjs/iife output is too whenever the entry
+    // point's "use strict" directive is hoisted into the bundle, so reserve
+    // them for every format like the keywords above.
+    const STRICT_MODE_BINDING_RESTRICTED_NAMES: [&[u8]; 3] = [b"arguments", b"eval", b"await"];
 
     let cjs_names_len: u32 = if output_format == Format::Cjs {
         CJS_NAMES.len() as u32
@@ -1073,16 +1074,13 @@ pub fn compute_initial_reserved_names(
         0
     };
 
-    let module_names_len: usize = if is_module_code {
-        MODULE_CODE_RESTRICTED_NAMES.len()
-    } else {
-        0
-    };
-
     names.ensure_total_capacity(
         cjs_names_len as usize
-            + module_names_len
-            + (Keywords.len() + StrictModeReservedWords.len() + 1 + EXTRAS.len()),
+            + (Keywords.len()
+                + StrictModeReservedWords.len()
+                + STRICT_MODE_BINDING_RESTRICTED_NAMES.len()
+                + 1
+                + EXTRAS.len()),
     )?;
 
     for keyword in Keywords.keys() {
@@ -1091,6 +1089,10 @@ pub fn compute_initial_reserved_names(
 
     for keyword in StrictModeReservedWords.iter() {
         names.put_assume_capacity(keyword, 1);
+    }
+
+    for name in STRICT_MODE_BINDING_RESTRICTED_NAMES {
+        names.put_assume_capacity(name, 1);
     }
 
     // Node contains code that scans CommonJS modules in an attempt to statically
@@ -1102,12 +1104,6 @@ pub fn compute_initial_reserved_names(
     // something in a nested scope as an top-level export.
     if output_format == Format::Cjs {
         for name in CJS_NAMES {
-            names.put_assume_capacity(name, 1);
-        }
-    }
-
-    if is_module_code {
-        for name in MODULE_CODE_RESTRICTED_NAMES {
             names.put_assume_capacity(name, 1);
         }
     }

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -1060,12 +1060,12 @@ pub fn compute_initial_reserved_names(
 
     const CJS_NAMES: [&[u8]; 2] = [b"exports", b"module"];
 
-    // "arguments" and "eval" are not reserved words, but strict mode forbids
-    // them as binding targets. ESM output is always strict, and dev server
-    // chunks are loaded as ES modules.
-    const STRICT_MODE_RESTRICTED_NAMES: [&[u8]; 2] = [b"arguments", b"eval"];
+    // "arguments", "eval", and "await" are not reserved words, but module code
+    // (always strict) forbids them as binding targets. ESM output is loaded as
+    // a module, and so are dev server chunks (<script type="module">).
+    const MODULE_CODE_RESTRICTED_NAMES: [&[u8]; 3] = [b"arguments", b"eval", b"await"];
 
-    let is_strict = output_format == Format::Esm || output_format == Format::InternalBakeDev;
+    let is_module_code = output_format == Format::Esm || output_format == Format::InternalBakeDev;
 
     let cjs_names_len: u32 = if output_format == Format::Cjs {
         CJS_NAMES.len() as u32
@@ -1073,15 +1073,15 @@ pub fn compute_initial_reserved_names(
         0
     };
 
-    let strict_names_len: usize = if is_strict {
-        STRICT_MODE_RESTRICTED_NAMES.len()
+    let module_names_len: usize = if is_module_code {
+        MODULE_CODE_RESTRICTED_NAMES.len()
     } else {
         0
     };
 
     names.ensure_total_capacity(
         cjs_names_len as usize
-            + strict_names_len
+            + module_names_len
             + (Keywords.len() + StrictModeReservedWords.len() + 1 + EXTRAS.len()),
     )?;
 
@@ -1106,8 +1106,8 @@ pub fn compute_initial_reserved_names(
         }
     }
 
-    if is_strict {
-        for name in STRICT_MODE_RESTRICTED_NAMES {
+    if is_module_code {
+        for name in MODULE_CODE_RESTRICTED_NAMES {
             names.put_assume_capacity(name, 1);
         }
     }

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -865,38 +865,47 @@ devTest("barrel optimization: namespace re-export cycle through a star-exported 
     await c.expectMessage("result: object Y KEEP DEEP OTHER");
   },
 });
-devTest("module with strict-mode restricted basename (#34357)", {
+devTest("module with restricted-identifier basename (#34357)", {
   // https://github.com/oven-sh/bun/issues/34357
-  // A module whose generated namespace symbol is named "arguments" or "eval"
-  // must not produce `var [arguments, eval] = hmr.imports;` in the chunk;
-  // those names are invalid binding targets in strict mode (browsers load the
-  // chunk with <script type="module">).
+  // A module whose generated namespace symbol is named "arguments", "eval",
+  // or "await" must not produce `var [arguments, eval, await] = hmr.imports;`
+  // in the chunk; those names are invalid binding targets in module code
+  // (browsers load the chunk with <script type="module">).
   files: {
     "index.html": emptyHtmlFile({
       scripts: ["index.ts"],
     }),
     "index.ts": `
-      import { Arguments, Eval } from './lib';
-      console.log('PASS ' + Arguments + ' ' + Eval);
+      import { Arguments, Eval, Await } from './lib';
+      console.log('PASS ' + Arguments + ' ' + Eval + ' ' + Await);
     `,
     "lib.ts": `
       export * from './arguments/index.mjs';
       export * from './eval/index.mjs';
+      export * from './await/index.mjs';
     `,
     "arguments/index.mjs": `export const Arguments = 1;`,
     "eval/index.mjs": `export const Eval = 2;`,
+    "await/index.mjs": `export const Await = 3;`,
   },
   async test(dev) {
     // The test client evaluates scripts with indirect eval (sloppy mode),
     // which accepts bindings browsers reject in module code, so additionally
-    // assert the chunk parses in strict mode.
+    // assert the chunk parses under the Module goal using node.
     const html = await dev.fetch("/").text();
     const src = html.match(/<script type="module" .*?src="(.*?)"/)?.[1];
     expect(src).toBeDefined();
     const chunk = await dev.fetch(src!).text();
-    expect(() => new Function(`"use strict";\n${chunk}`)).not.toThrow();
+    await using check = Bun.spawn({
+      cmd: [process.env.BUN_DEV_SERVER_CLIENT_EXECUTABLE ?? Bun.which("node")!, "--check", "--input-type=module"],
+      stdin: new Blob([chunk]),
+      stderr: "pipe",
+    });
+    const [checkStderr, checkExitCode] = await Promise.all([check.stderr.text(), check.exited]);
+    expect(checkStderr).toBe("");
+    expect(checkExitCode).toBe(0);
 
     await using c = await dev.client();
-    await c.expectMessage("PASS 1 2");
+    await c.expectMessage("PASS 1 2 3");
   },
 });

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -865,3 +865,38 @@ devTest("barrel optimization: namespace re-export cycle through a star-exported 
     await c.expectMessage("result: object Y KEEP DEEP OTHER");
   },
 });
+devTest("module with strict-mode restricted basename (#34357)", {
+  // https://github.com/oven-sh/bun/issues/34357
+  // A module whose generated namespace symbol is named "arguments" or "eval"
+  // must not produce `var [arguments, eval] = hmr.imports;` in the chunk;
+  // those names are invalid binding targets in strict mode (browsers load the
+  // chunk with <script type="module">).
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import { Arguments, Eval } from './lib';
+      console.log('PASS ' + Arguments + ' ' + Eval);
+    `,
+    "lib.ts": `
+      export * from './arguments/index.mjs';
+      export * from './eval/index.mjs';
+    `,
+    "arguments/index.mjs": `export const Arguments = 1;`,
+    "eval/index.mjs": `export const Eval = 2;`,
+  },
+  async test(dev) {
+    // The test client evaluates scripts with indirect eval (sloppy mode),
+    // which accepts bindings browsers reject in module code, so additionally
+    // assert the chunk parses in strict mode.
+    const html = await dev.fetch("/").text();
+    const src = html.match(/<script type="module" .*?src="(.*?)"/)?.[1];
+    expect(src).toBeDefined();
+    const chunk = await dev.fetch(src!).text();
+    expect(() => new Function(`"use strict";\n${chunk}`)).not.toThrow();
+
+    await using c = await dev.client();
+    await c.expectMessage("PASS 1 2");
+  },
+});

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -303,6 +303,67 @@ describe("bundler", async () => {
     },
   });
 
+  // Each local name of a CSS module and each top-level key of a JSON file that
+  // is imported by name (or through a namespace) becomes a top-level `var` in
+  // the bundle. `await`, `eval` and `arguments` are not keywords, but none of
+  // them can be declared in strict-mode code, so the bundle has to rename them
+  // the same way it already renames `class`.
+  itBundled("bun/loader-css-module-strict-mode-binding-names", {
+    target: "bun",
+    outdir: "/out",
+    files: {
+      "/entry.ts": /* js */ `
+    import styles, { await as a, eval as e, arguments as g, class as c } from './styles.module.css';
+    const out = [
+      Object.keys(styles),
+      a.startsWith("await_"),
+      e.startsWith("eval_"),
+      g.startsWith("arguments_"),
+      c.startsWith("class_"),
+      a === styles.await && e === styles.eval && g === styles.arguments && c === styles.class,
+    ];
+    console.write(JSON.stringify(out));
+  `,
+      "/styles.module.css": `
+    .await { color: red; }
+    .eval { color: green; }
+    .arguments { color: blue; }
+    .class { color: black; }
+  `,
+    },
+    run: { stdout: '[["await","eval","arguments","class"],true,true,true,true,true]' },
+  });
+
+  itBundled("bun/loader-json-strict-mode-binding-names", {
+    target: "bun",
+    files: {
+      "/entry.ts": /* js */ `
+    import * as ns from './data.json';
+    import { await as a, eval as e, arguments as g } from './data.json';
+    console.write(JSON.stringify([Object.keys(ns).sort(), a, e, g, ns.default]));
+  `,
+      "/data.json": `{"await": 1, "eval": 2, "arguments": 3}`,
+    },
+    run: { stdout: '[["arguments","await","default","eval"],1,2,3,{"await":1,"eval":2,"arguments":3}]' },
+  });
+
+  // A "use strict" directive on the entry point is hoisted to the top of cjs
+  // and iife bundles, so these names are invalid bindings there as well.
+  for (const format of ["cjs", "iife"] as const) {
+    itBundled(`bun/loader-json-strict-mode-binding-names-${format}`, {
+      format,
+      files: {
+        "/entry.ts": /* js */ `
+      "use strict";
+      import { await as a, eval as e, arguments as g } from './data.json';
+      console.write(JSON.stringify([a, e, g]));
+    `,
+        "/data.json": `{"await": 1, "eval": 2, "arguments": 3}`,
+      },
+      run: { stdout: "[1,2,3]" },
+    });
+  }
+
   // The CSS-modules lazy export builds its object through `E::Object::put`.
   itBundled("bun/loader-css-module-proto-class-is-own-property", {
     target: "bun",


### PR DESCRIPTION
Fixes #34357 (closed by the reporter, but the bug still reproduces on 1.4.0 canary). Also covers the `bun build` form of the same bug: a CSS module class named `.await`, `.eval` or `.arguments` (or a JSON key with one of those names) imported by name or through a namespace.

### Problem
- The bundler can print `var arguments = ...`, `var eval = ...`, `var await = ...` (or `var [arguments, eval] = hmr.imports;` in a dev server chunk) for symbols it generated itself. The build succeeds and the output fails to parse: `SyntaxError: Cannot use 'await' as a variable name in a module.`, `Unexpected eval or arguments in strict mode`, `Invalid destructuring assignment target`.
- Two ways such a symbol is generated:
  - the dev server names a module's namespace symbol after its path basename (typebox has `build/system/arguments/index.mjs`, reached through `export * from './arguments/index.mjs'`), so the chunk gets `var [arguments, eval] = hmr.imports;`
  - `generate_code_for_lazy_export` creates one top-level symbol per CSS module local name / JSON key when something imports it by name or via `import * as`, so `.await {}` becomes `var await = "await_yls9kw"`
- Cause: `compute_initial_reserved_names` (`src/js_printer/renamer.rs`) seeds the renamer with `Keywords` and `StrictModeReservedWords` only. `await`, `eval` and `arguments` are in neither table (the lexer treats them as identifiers), so unlike `class` (renamed to `class2`) they are emitted verbatim.

### Fix
- Add the three names to the initial reserved set, so colliding generated symbols get the usual numeric suffix: `var [arguments2, eval2] = hmr.imports;`, `var await2 = "await_yls9kw"`, and the export maps keep the original names (`await: () => await2`).
- Reserved for every output format, not only esm: a `"use strict"` directive on the entry point is hoisted to the top of cjs and iife bundles, and node rejects `var eval` / `var arguments` in those with `SyntaxError: Unexpected eval or arguments in strict mode` (checked with `--format cjs` and `--format iife` on 1.4.0). This matches how the keywords are reserved.
- Safe for user code: the implicit `arguments` of every function is `must_not_be_renamed` (`parse_fn.rs`), unbound references to `eval`/`arguments` are never renamed, and a sloppy-mode `var await = 1` becomes `var await2 = 1` with its references renamed along with it, the same thing that already happens to a sloppy-mode `var yield`.
- Tests:
  - `test/bake/dev/bundle.test.ts`: modules named `arguments/`, `eval/`, `await/` re-exported through a barrel; asserts the served chunk parses under the module goal (`node --check --input-type=module`) and that the exports resolve in the client. Fails on main with `SyntaxError: Cannot declare a variable named 'arguments' in strict mode.`
  - `test/bundler/bundler_loader.test.ts`, the four `*-strict-mode-binding-names*` tests: CSS module classes and JSON keys with these names, imported by name and through a namespace, in esm, cjs (`"use strict"`) and iife (`"use strict"`) output; the bundle is run. All four fail on 1.4.0 (`Cannot use 'await' as a variable name in a module.`, `Declarations with the name "eval" cannot be used in strict mode`) and pass with this change.
  - Also run with this change: `test/bundler/{bundler_loader,bundler_minify,bundler_cjs,bundler_edgecase,bundler_splitting,bundler_naming}.test.ts`, `test/bundler/css/css-modules.test.ts`, `test/bundler/esbuild/{loader,default}.test.ts` (covers the sloppy-mode `arguments` declaration cases), `test/bundler/transpiler/transpiler.test.js`; all passing.
- Related, not changed here: `import * as ns from "./x.module.css"` additionally needs #38286 (the runtime `__export` helper is missing from the output) before the namespace form of the CSS case loads; the named-import form works with this PR alone. #34617 attacks the same three names from the other side, by remapping them in `ensure_valid_identifier` (`_await`); the two changes are independent and either one fixes the cases above.

### Background
- Renamer: after linking, every top-level symbol in a chunk is assigned its printed name by `NumberRenamer`, which starts from a root set of reserved names (`compute_initial_reserved_names`: keywords, strict-mode reserved words, the unbound globals the chunk references) and appends `2`, `3`, ... to any symbol whose original name is already taken. `MinifyRenamer` uses the same set to decide which short names it may hand out.
- Keywords vs. these three names: `class`, `if`, ... are in the lexer's keyword table and `let`, `yield`, ... in its strict-mode table, so they were already reserved. `await` is only reserved in module code (and async bodies), and `eval`/`arguments` are ordinary identifiers that strict mode forbids as binding names, so neither lexer table lists them.
- Lazy export: JSON, TOML and CSS module files are turned into a JS stub by the linker; when one of their keys is imported by name, the stub gets a real top-level `var` per key so it can be tree shaken individually. The key is used as the symbol's original name, which is how arbitrary user strings reach the renamer.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/bundle.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (7e7ae00e2)

test/bake/dev/bundle.test.ts:
Dev server testing directory: /tmp/bun-dev-test-4EG31n
^[[0;30mdev|^[[0m Started development server: http://localhost:44135
^[[0;30mdev|^[[0m ^[[32mBundled page in 239ms^[[0m^[[2m:^[[0m routes/index.ts ^[[2m+ 1 more^[[0m
^[[0;30mdev|^[[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
^[[0;30mdev|^[[0m 
^[[0;30mdev|^[[0m Module "db.ts" is not accepted by routes/index.ts,
^[[0;30mdev|^[[0m ^[[32mReloaded in 96ms^[[0m^[[2m:^[[0m db.ts
^[[0;30mdev|^[[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To preven
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (7e7ae00e2)

test/bake/dev/bundle.test.ts:
Dev server testing directory: /tmp/bun-dev-test-WTKEw0
^[[0;30mdev|^[[0m Started development server: http://localhost:42543
^[[0;30mdev|^[[0m ^[[32mBundled page in 4ms^[[0m^[[2m:^[[0m routes/index.ts ^[[2m+ 1 more^[[0m
^[[0;30mdev|^[[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
^[[0;30mdev|^[[0m 
^[[0;30mdev|^[[0m Module "db.ts" is not accepted by routes/index.ts,
^[[0;30mdev|^[[0m ^[[32mReloaded in 2ms^[[0m^[[2m:^[[0m db.ts
^[[0;30mdev|^[[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
^[[0;30mdev|^[[0m 
^[[0;30mdev|^[[0m Module "routes/index.ts" is a root module that does not self-accept.
^[[0;30mdev|^[[0m ^[[36m[x2]^[[0m ^[[32mReloaded in 3ms^[[0m^[[2m:^[[0m routes/index.ts
(pass)  DEV:bundle-1: import identifier doesnt get renamed [1218.78ms]
^[[0;30mdev|^[[0m Started development server: http://localho
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/bundle.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (7e7ae00e2)

test/bake/dev/bundle.test.ts:
Dev server testing directory: /tmp/bun-dev-test-U0uirW
^[[0;30mdev|^[[0m Started development server: http://localhost:42497
^[[0;30mdev|^[[0m ^[[32mBundled page in 218ms^[[0m^[[2m:^[[0m routes/index.ts ^[[2m+ 1 more^[[0m
^[[0;30mdev|^[[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
^[[0;30mdev|^[[0m 
^[[0;30mdev|^[[0m Module "db.ts" is not accepted by routes/index.ts,
^[[0;30mdev|^[[0m ^[[32mReloaded in 86ms^[[0m^[[2m:^[[0m db.ts
^[[0;30mdev|^[[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To preven
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 973ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
^[[1m^[[92m   Compiling^[[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
^[[1m^[[92m   Compiling^[[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
^[[1m^[[92m   Compiling^[[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
^[[1m^[[92m   Compiling^[[0m bun_transpiler v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_printer/renamer.rs    | 20 ++++++++++++++++++++
 test/bake/dev/bundle.test.ts | 44 ++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 64 insertions(+)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                          reads  edits  tests
src/js_printer/renamer.rs         3      6      0
test/bake/dev/bundle.test.ts      1      2      0
```

</details>

**root cause** · written by the author bot

The dev server's HMR wrapper derives namespace binding names from module path basenames, and the renamer's reserved name set for module goal output did not include "arguments", "eval", or "await", so a dependency module named arguments produced `var [arguments, ...] = hmr.imports`, which is an invalid destructuring target in module code and fails at parse time. The fix adds those three identifiers to the renamer's initial reserved names when the output format is ESM or the internal dev server format, so any generated symbol with one of those names is renamed with a numeric suffix such as ar…

<!-- robobun:evidence:end -->
