### PR TITLE
multipart/form-data: match `form-data` disposition type case-insensitively and accept HTAB as OWS

### DIFF
--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -354,14 +354,16 @@ pub fn for_each_multipart_entry<C>(
                 b""
             };
             if strings::eql_case_insensitive_ascii(key, b"content-disposition", true) {
-                value = strings::trim(value, b" ");
-                if value.starts_with(b"form-data;") {
+                // OWS after the colon is SP or HTAB (RFC 9112 §5.6.3); the
+                // disposition type is a case-insensitive token (RFC 2183 §2).
+                value = strings::trim(value, b" \t");
+                if strings::starts_with_case_insensitive_ascii(value, b"form-data;") {
                     value = &value[b"form-data;".len()..];
-                    value = strings::trim(value, b" ");
+                    value = strings::trim(value, b" \t");
                 }
 
                 while let Some(eql_start) = strings::index_of(value, b"=") {
-                    let eql_key = strings::trim(&value[..eql_start], b" ;");
+                    let eql_key = strings::trim(&value[..eql_start], b" \t;");
                     value = &value[eql_start + 1..];
                     if value.starts_with(b"\"") {
                         value = &value[1..];

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -300,6 +300,45 @@ describe("FormData", () => {
     }
   });
 
+  // RFC 2183 §2: the disposition type is a case-insensitive token.
+  // RFC 9112 §5.6.3: OWS = *( SP / HTAB ), so HTAB is valid after the colon.
+  describe("Content-Disposition: form-data token + OWS", () => {
+    const boundary = "BX7";
+    const mk = (hdr: string) => `--${boundary}\r\n${hdr}\r\n\r\nv\r\n--${boundary}--\r\n`;
+    const headers = { "Content-Type": `multipart/form-data; boundary=${boundary}` };
+
+    for (const C of [Response, Request] as const) {
+      const make = (body: string) =>
+        C === Response ? new Response(body, { headers }) : new Request("http://x/", { method: "POST", body, headers });
+
+      it.each([
+        ["lowercase", `Content-Disposition: form-data; name="k"`],
+        ["Form-Data", `Content-Disposition: Form-Data; name="k"`],
+        ["FORM-DATA", `Content-Disposition: FORM-DATA; name="k"`],
+        ["mixed case header + token", `CONTENT-DISPOSITION: Form-Data; NAME="k"`],
+        ["HTAB after colon", `Content-Disposition:\tform-data; name="k"`],
+        ["SP + HTAB after colon", `Content-Disposition: \t form-data; name="k"`],
+        ["HTAB after semicolon", `Content-Disposition: form-data;\tname="k"`],
+      ])(`${C.name}: %s`, async (_label, hdr) => {
+        const fd = await make(mk(hdr)).formData();
+        expect([...fd.entries()]).toEqual([["k", "v"]]);
+      });
+
+      it(`${C.name}: file part with Form-Data + HTAB OWS`, async () => {
+        const body =
+          `--${boundary}\r\n` +
+          `Content-Disposition:\tForm-Data; name="f"; filename="a.txt"\r\n` +
+          `Content-Type: text/plain\r\n\r\n` +
+          `hello\r\n--${boundary}--\r\n`;
+        const fd = await make(body).formData();
+        const file = fd.get("f") as File;
+        expect(file).toBeInstanceOf(File);
+        expect(file.name).toBe("a.txt");
+        expect(await file.text()).toBe("hello");
+      });
+    }
+  });
+
   test("FormData.from (URLSearchParams)", () => {
     expect(
       // @ts-expect-error


### PR DESCRIPTION
### What

The multipart/form-data parser silently dropped any part whose `Content-Disposition` header used a non-lowercase `form-data` token or had a HTAB (instead of SP) after the colon. No error was raised; the field simply never appeared in the resulting `FormData`.

```js
const B = "BX7";
const mk = hdr => `--${B}\r\n${hdr}\r\n\r\nv\r\n--${B}--\r\n`;
for (const hdr of [
  `Content-Disposition: form-data; name="k"`,   // ok
  `Content-Disposition: Form-Data; name="k"`,   // dropped
  `Content-Disposition: FORM-DATA; name="k"`,   // dropped
  `Content-Disposition:\tform-data; name="k"`,  // dropped
]) {
  const fd = await new Response(mk(hdr), {
    headers: { "content-type": `multipart/form-data; boundary=${B}` },
  }).formData();
  console.log(fd.get("k")); // "v" on Node 26; null on Bun for the last three
}
```

### Why

`for_each_multipart_entry` in `src/runtime/webcore/FormData.rs` trimmed only `b" "` after the colon and then compared with `value.starts_with(b"form-data;")`, which is a byte-exact, case-sensitive match. When that match failed the attribute loop still ran, but the first `=` split yielded a key like `Form-Data; name`, which never equals `name`, so the part fell through to the `name.len() == 0 -> continue` drop.

RFC 2183 §2 defines the disposition type as a case-insensitive token, and RFC 9112 §5.6.3 defines OWS as `*( SP / HTAB )`. The parser already matches the header name (`Content-Disposition`) and the `name=`/`filename=` attribute names case-insensitively; this was the one byte-exact comparison in the path. Node/undici accept all of the inputs above.

### Fix

Match the `form-data` token with `strings::starts_with_case_insensitive_ascii` and trim `b" \t"` at the three trim sites in the `Content-Disposition` branch.

### Verification

New `describe("Content-Disposition: form-data token + OWS")` block in `test/js/web/html/FormData.test.ts` covers `Form-Data`, `FORM-DATA`, HTAB after the colon, mixed SP+HTAB, HTAB after the semicolon, and a file part combining both, for `Response` and `Request`. 14 of the 16 cases fail on the released binary and all 16 pass with this change; the full `FormData.test.ts` suite (149 tests) passes.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 14 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/html/FormData.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (5fe9d7302)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [3.75ms]
(pass) FormData > should be able to append a Blob [7.97ms]
(pass) FormData > should be able to set a Blob [6.60ms]
(pass) FormData > should be able to set a string [2.87ms]
(pass) FormData > should get filename from file [3.96ms]
(pass) FormData > should use the correct filenames [5.74ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [15.45ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [36.86ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [3.10ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [6.01ms]
(pas
... (truncated)

release without fix: 17 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [0.06ms]
(pass) FormData > should be able to append a Blob [1.41ms]
(pass) FormData > should be able to set a Blob [0.12ms]
(pass) FormData > should be able to set a string [0.04ms]
(pass) FormData > should get filename from file [1.02ms]
(pass) FormData > should use the correct filenames [0.12ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [0.33ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [0.81ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [0.04ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [0.04ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [0.02ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [0.02ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Request [0.01ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Request [0.02ms]
(pass) F
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/html/FormData.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (5fe9d7302)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [3.73ms]
(pass) FormData > should be able to append a Blob [8.12ms]
(pass) FormData > should be able to set a Blob [6.46ms]
(pass) FormData > should be able to set a string [2.92ms]
(pass) FormData > should get filename from file [3.96ms]
(pass) FormData > should use the correct filenames [5.42ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [15.99ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [36.54ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [2.87ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [5.70ms]
(pas
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     5fe9d73026
  features     (none)

22 deps, 106 codegen, 1168 objects in 944ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [11.00ms]
[2/1231] gen bindgenv2
[3/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [2.00ms]
[4/1231] gen ErrorCode+*.h
[5/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [10.00ms]
[6/1231] fetch tinycc
[tinycc] up to date
[7/1230] fetch picohttpparser
[picohttpparser] up to date
[8/1230] gen .
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/FormData.rs   | 10 ++++++----
 test/js/web/html/FormData.test.ts | 39 +++++++++++++++++++++++++++++++++++++++
 2 files changed, 45 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/runtime/webcore/FormData.rs        1      1      0
test/js/web/html/FormData.test.ts      3      1      0
```

</details>

<!-- robobun:evidence:end -->