### PR TITLE
FormData: terminate unquoted Content-Disposition parameter values at ';'

### DIFF
--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -334,7 +334,8 @@ pub(crate) fn for_each_multipart_entry<C>(
                 while let Some(eql_start) = strings::index_of(value, b"=") {
                     let eql_key = strings::trim(&value[..eql_start], b" \t;");
                     value = &value[eql_start + 1..];
-                    if value.starts_with(b"\"") {
+                    let quoted = value.starts_with(b"\"");
+                    if quoted {
                         value = &value[1..];
                     }
 
@@ -344,6 +345,12 @@ pub(crate) fn for_each_multipart_entry<C>(
                         while i < field_value.len() {
                             match field_value[i] {
                                 b'"' => {
+                                    field_value = &field_value[..i];
+                                    i += 1;
+                                    break;
+                                }
+                                // Unquoted value is an RFC 2045 token; leave `;` for the outer loop.
+                                b';' if !quoted => {
                                     field_value = &field_value[..i];
                                     break;
                                 }
@@ -356,7 +363,7 @@ pub(crate) fn for_each_multipart_entry<C>(
                             }
                             i += 1;
                         }
-                        value = &value[(i + 1).min(value.len())..];
+                        value = &value[i.min(value.len())..];
                     }
 
                     if strings::eql_case_insensitive_ascii(eql_key, b"name", true) {

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -339,6 +339,93 @@ describe("FormData", () => {
     }
   });
 
+  // RFC 2045 §5.1: an unquoted parameter value is a token and ends at `;`.
+  // Previously the unquoted-value scan only stopped at `"` or end of line, so
+  // `name=k; filename=x.txt` swallowed the whole tail into the name.
+  describe("Content-Disposition unquoted parameter values", () => {
+    const boundary = "BXa";
+    const parse = async (C: typeof Response | typeof Request, disposition: string) => {
+      const body = `--${boundary}\r\nContent-Disposition: ${disposition}\r\n\r\nv\r\n--${boundary}--\r\n`;
+      const headers = { "Content-Type": `multipart/form-data; boundary=${boundary}` };
+      const req =
+        C === Response ? new Response(body, { headers }) : new Request("http://x/", { method: "POST", body, headers });
+      const fd = await req.formData();
+      return Promise.all(
+        [...fd].map(async ([k, v]) =>
+          typeof v === "string" ? { key: k, string: v } : { key: k, file: v.name, text: await v.text() },
+        ),
+      );
+    };
+
+    for (const C of [Response, Request] as const) {
+      describe(C.name, () => {
+        it.each([
+          [`form-data; name=k; filename=x.txt`, [{ key: "k", file: "x.txt", text: "v" }]],
+          [`form-data; name=k; filename="x.txt"`, [{ key: "k", file: "x.txt", text: "v" }]],
+          [`form-data; name="k"; filename=x.txt`, [{ key: "k", file: "x.txt", text: "v" }]],
+          [`form-data; filename=x.txt; name=k`, [{ key: "k", file: "x.txt", text: "v" }]],
+          [`form-data; name=k; foo=bar; filename=x.txt`, [{ key: "k", file: "x.txt", text: "v" }]],
+          [`form-data; name="a;b"; filename=x.txt`, [{ key: "a;b", file: "x.txt", text: "v" }]],
+          [`form-data; name=k`, [{ key: "k", string: "v" }]],
+          // .NET 8 MultipartFormDataContent emits unquoted name/filename plus a
+          // trailing RFC 5987 filename*= parameter.
+          [
+            `form-data; name=image; filename=test.jpg; filename*=utf-8''test.jpg`,
+            [{ key: "image", file: "test.jpg", text: "v" }],
+          ],
+        ] as const)("%s", async (disposition, expected) => {
+          expect(await parse(C, disposition)).toEqual(expected);
+        });
+      });
+    }
+
+    // https://github.com/oven-sh/bun/issues/11779
+    // .NET 8 MultipartFormDataContent: quoted boundary in the request
+    // Content-Type, Content-Type header before Content-Disposition in the part,
+    // unquoted name/filename tokens, and a trailing filename*= parameter.
+    it("parses a .NET 8 MultipartFormDataContent upload via Bun.serve req.formData()", async () => {
+      const b = "9a63f0e1-8e4c-4dbf-8f11-cafefeedbeef";
+      const img = Buffer.alloc(102404, 0xab);
+      const body = Buffer.concat([
+        Buffer.from(
+          `--${b}\r\n` +
+            `Content-Type: image/jpeg\r\n` +
+            `Content-Disposition: form-data; name=image; filename=test.jpg; filename*=utf-8''test.jpg\r\n` +
+            `\r\n`,
+        ),
+        img,
+        Buffer.from(`\r\n--${b}--\r\n`),
+      ]);
+
+      let got: { keys: string[]; file: unknown } | undefined;
+      await using server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          const fd = await req.formData();
+          const file = fd.get("image");
+          got = {
+            keys: [...fd.keys()],
+            file:
+              file instanceof Blob
+                ? { name: (file as File).name, size: file.size, type: file.type, isFile: file instanceof File }
+                : file,
+          };
+          return new Response("ok");
+        },
+      });
+      const res = await fetch(server.url, {
+        method: "POST",
+        headers: { "Content-Type": `multipart/form-data; boundary="${b}"` },
+        body,
+      });
+      expect(await res.text()).toBe("ok");
+      expect(got).toEqual({
+        keys: ["image"],
+        file: { name: "test.jpg", size: 102404, type: "image/jpeg", isFile: true },
+      });
+    });
+  });
+
   test("FormData.from (URLSearchParams)", () => {
     expect(
       // @ts-expect-error


### PR DESCRIPTION
### What does this PR do?

Fixes the multipart/form-data parser so that an unquoted `Content-Disposition` parameter value ends at the next `;`, matching RFC 2045 §5.1 token grammar and the behaviour of busboy/multer.

Fixes #11779.

### Reproduction

.NET 8's `MultipartFormDataContent` emits unquoted parameter values:

```
Content-Disposition: form-data; name=image; filename=test.jpg; filename*=utf-8''test.jpg
```

```js
const b = "9a63f0e1-8e4c-4dbf-8f11-cafefeedbeef";
const img = Buffer.alloc(102404, 0xab);
const body = Buffer.concat([
  Buffer.from(`--${b}\r\nContent-Type: image/jpeg\r\nContent-Disposition: form-data; name=image; filename=test.jpg; filename*=utf-8''test.jpg\r\n\r\n`),
  img, Buffer.from(`\r\n--${b}--\r\n`),
]);
const fd = await new Response(body, {
  headers: { "Content-Type": `multipart/form-data; boundary="${b}"` },
}).formData();
console.log([...fd.keys()], fd.get("image"));
```

Before: `["image; filename=test.jpg; filename*=utf-8''test.jpg"]`, `null`.
After: `["image"]`, `File { name: "test.jpg", size: 102404, type: "image/jpeg" }`.

Node's undici also rejects the unquoted shape, so this is a leniency change (accept unquoted token values per RFC 7578, as busboy/multer do) rather than strict spec conformance.

### Cause

`for_each_multipart_entry` in `src/runtime/webcore/FormData.rs` scans the value after `=` looking for a terminating `"` (or `\"` escape) but treats every other byte, including `;`, as part of the value. When the value is unquoted and another parameter follows, the scan runs to end of line and the `; filename=...` suffix is swallowed into the field name. The part is then emitted as a string entry under that corrupted key, so the application sees the original field as missing.

Only an unquoted value that is not the last parameter is affected, which is why the quoted `name="k"; filename="x.txt"` shape Bun itself emits round-trips correctly.

### Fix

Track whether the current value opened with a `"`. When it did not, also terminate the scan at `;` and leave the separator in place for the outer attribute loop. Quoted values are unchanged, so `name="a;b"` still parses to `a;b`.

### Verification

`bun bd test test/js/web/html/FormData.test.ts`: all 166 tests pass, including 17 new cases covering both unquoted orderings, an unknown attribute in between, a quoted value containing `;`, the .NET `filename*=` shape, and the full .NET request body through `Bun.serve` `req.formData()`. The new cases fail with `USE_SYSTEM_BUN=1`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 11 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/html/FormData.test.ts
bun test v1.4.0 (624ba0575)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [5.53ms]
(pass) FormData > should be able to append a Blob [11.63ms]
(pass) FormData > should be able to set a Blob [10.33ms]
(pass) FormData > should be able to set a string [4.02ms]
(pass) FormData > should get filename from file [5.74ms]
(pass) FormData > should use the correct filenames [7.31ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [21.31ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [54.75ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [3.89ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [7.84ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [2.66ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [5.55ms]
(pass) FormData > should parse multipart/form-data (
... (truncated)

release without fix: 28 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [0.08ms]
(pass) FormData > should be able to append a Blob [0.83ms]
(pass) FormData > should be able to set a Blob [0.10ms]
(pass) FormData > should be able to set a string [0.05ms]
(pass) FormData > should get filename from file [0.62ms]
(pass) FormData > should use the correct filenames [0.07ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [0.39ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [1.06ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [1.01ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [0.06ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [0.02ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [0.03ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Request [0.02ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Request [0.02ms]
(pass) F
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/html/FormData.test.ts
bun test v1.4.0 (624ba0575)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [4.52ms]
(pass) FormData > should be able to append a Blob [8.99ms]
(pass) FormData > should be able to set a Blob [7.64ms]
(pass) FormData > should be able to set a string [3.01ms]
(pass) FormData > should get filename from file [4.13ms]
(pass) FormData > should use the correct filenames [5.27ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [17.89ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [40.12ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [3.26ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [5.44ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [1.93ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [4.00ms]
(pass) FormData > should parse multipart/form-data (si
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     624ba0575c
  features     baseline

22 deps, 108 codegen, 1171 objects in 2266ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] gen ErrorCode+*.h
[2/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[3/1234] fetch zlib
[zlib] up to date
[4/1234] fetch picohttpparser
[picohttpparser] up to date
[5/1234] subst deps/zlib/zlib.h
[6/1234] fetch tinycc
[tinycc] up to date
[7/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[8/1234] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[9/1234] subst deps/zlib/zconf.h
[10/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[11/1234] gen bindgenv2
[12/1234] fetch brotli
[brotli] up to date
[13/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/FormData.rs   | 11 ++++-
 test/js/web/html/FormData.test.ts | 87 +++++++++++++++++++++++++++++++++++++++
 2 files changed, 96 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/runtime/webcore/FormData.rs        1      1      0
test/js/web/html/FormData.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->