### PR TITLE
formData(): reject malformed multipart bodies with TypeError on every path

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2968,7 +2968,14 @@ impl BlobExt for Blob {
         buf: *mut [u8],
     ) -> JSValue {
         let Some(encoder) = self.get_form_data_encoding() else {
-            return ZigString::init(b"Invalid encoding").to_error_instance(global);
+            return global
+                .err(
+                    jsc::ErrorCode::FORMDATA_PARSE_ERROR,
+                    format_args!(
+                        "Can't decode form data from body because of incorrect MIME type/boundary"
+                    ),
+                )
+                .to_js();
         };
 
         // `crate::webcore::form_data::Encoding` re-exports
@@ -2979,9 +2986,12 @@ impl BlobExt for Blob {
         let buf = unsafe { &*buf };
         match crate::webcore::form_data::FormData::to_js(global, buf, &encoder.encoding) {
             Ok(v) => v,
-            Err(err) => {
-                global.create_error_instance(format_args!("FormData encoding failed: {err}"))
-            }
+            Err(err) => global
+                .err(
+                    jsc::ErrorCode::FORMDATA_PARSE_ERROR,
+                    format_args!("FormData parse error {}", err.name()),
+                )
+                .to_js(),
         }
     }
 

--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -4,8 +4,8 @@ use bun_collections::ArrayHashMap;
 use bun_core::{self, declare_scope, scoped_log};
 use bun_core::{ZigString, ZigStringSlice, strings};
 use bun_jsc::{
-    AnyPromise, CallFrame, DOMFormData, JSGlobalObject, JSValue, JsError, JsResult, JsTerminated,
-    ZigStringJsc as _,
+    AnyPromise, CallFrame, DOMFormData, ErrorCode, JSGlobalObject, JSValue, JsError, JsResult,
+    JsTerminated,
 };
 use bun_semver::{self, SlicedString};
 use core::ffi::c_void;
@@ -57,7 +57,14 @@ impl AsyncFormDataExt for AsyncFormData {
                 );
                 promise.reject(
                     global,
-                    ZigString::init(b"FormData missing boundary").to_error_instance(global),
+                    global
+                        .err(
+                            ErrorCode::FORMDATA_PARSE_ERROR,
+                            format_args!(
+                                "Can't decode form data from body because of incorrect MIME type/boundary"
+                            ),
+                        )
+                        .to_js(),
                 )?;
                 return Ok(());
             }
@@ -69,7 +76,12 @@ impl AsyncFormDataExt for AsyncFormData {
                 scoped_log!(FormData, "AsnycFormData.toJS -> failed ");
                 promise.reject(
                     global,
-                    global.create_error_instance(format_args!("FormData {}", e.name())),
+                    global
+                        .err(
+                            ErrorCode::FORMDATA_PARSE_ERROR,
+                            format_args!("FormData parse error {}", e.name()),
+                        )
+                        .to_js(),
                 )?;
                 return Ok(());
             }
@@ -194,7 +206,12 @@ pub fn from_multipart_data(global: &JSGlobalObject, frame: &CallFrame) -> JsResu
         Ok(v) => Ok(v),
         Err(crate::Error::JSError) => Err(JsError::Thrown),
         Err(crate::Error::JSTerminated) => Err(JsError::Terminated),
-        Err(e) => Err(global.throw_error(e, "while parsing FormData")),
+        Err(e) => Err(global
+            .err(
+                ErrorCode::FORMDATA_PARSE_ERROR,
+                format_args!("FormData parse error {}", e.name()),
+            )
+            .throw()),
     }
 }
 

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -255,6 +255,92 @@ describe("FormData", () => {
     }
   });
 
+  // WHATWG Body mixin: formData() package-data failure must reject with TypeError.
+  // The serve path previously rejected with a plain Error.
+  it("malformed multipart body rejects with TypeError on every formData() path", async () => {
+    const boundary = "BX9";
+    const contentType = `multipart/form-data; boundary=${boundary}`;
+    const bad = `--${boundary}\r\nContent-Disposition: form-data; name="k"\r\n\r\nv`;
+
+    const classify = (e: any) => ({
+      name: e?.constructor?.name,
+      isTypeError: e instanceof TypeError,
+      code: e?.code,
+      message: e?.message,
+    });
+
+    let respErr: any;
+    await new Response(bad, { headers: { "content-type": contentType } })
+      .formData()
+      .then(() => {
+        throw new Error("Response.formData should have rejected");
+      })
+      .catch(e => (respErr = e));
+
+    let reqErr: any;
+    await new Request("http://x/", { method: "POST", body: bad, headers: { "content-type": contentType } })
+      .formData()
+      .then(() => {
+        throw new Error("Request.formData should have rejected");
+      })
+      .catch(e => (reqErr = e));
+
+    let streamErr: any;
+    await new Response(
+      new ReadableStream({
+        start(ctrl) {
+          ctrl.enqueue(new TextEncoder().encode(bad));
+          ctrl.close();
+        },
+      }),
+      { headers: { "content-type": contentType } },
+    )
+      .formData()
+      .then(() => {
+        throw new Error("Response(stream).formData should have rejected");
+      })
+      .catch(e => (streamErr = e));
+
+    let serveErr: any;
+    {
+      const { promise: handled, resolve: onHandled, reject: onHandleErr } = Promise.withResolvers<void>();
+      await using server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        async fetch(req) {
+          await req.formData().then(
+            () => onHandleErr(new Error("serve req.formData should have rejected")),
+            e => {
+              serveErr = e;
+              onHandled();
+            },
+          );
+          return new Response("done");
+        },
+      });
+      const res = await fetch(server.url, {
+        method: "POST",
+        body: bad,
+        headers: { "content-type": contentType },
+      });
+      await res.text();
+      await handled;
+    }
+
+    expect({
+      Response: classify(respErr),
+      Request: classify(reqErr),
+      stream: classify(streamErr),
+      serve: classify(serveErr),
+    }).toEqual({
+      Response: { name: "TypeError", isTypeError: true, code: "ERR_FORMDATA_PARSE_ERROR", message: respErr.message },
+      Request: { name: "TypeError", isTypeError: true, code: "ERR_FORMDATA_PARSE_ERROR", message: respErr.message },
+      stream: { name: "TypeError", isTypeError: true, code: "ERR_FORMDATA_PARSE_ERROR", message: respErr.message },
+      serve: { name: "TypeError", isTypeError: true, code: "ERR_FORMDATA_PARSE_ERROR", message: respErr.message },
+    });
+    expect(respErr.message).toContain("missing final boundary");
+  });
+
   // RFC 2045 §5.1 / RFC 7231 §3.1.1.1: media type/subtype and parameter
   // attribute names are case-insensitive; the boundary VALUE is byte-exact.
   describe("Content-Type case-insensitivity", () => {

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -256,7 +256,6 @@ describe("FormData", () => {
   });
 
   // WHATWG Body mixin: formData() package-data failure must reject with TypeError.
-  // The serve path previously rejected with a plain Error.
   it("malformed multipart body rejects with TypeError on every formData() path", async () => {
     const boundary = "BX9";
     const contentType = `multipart/form-data; boundary=${boundary}`;
@@ -284,6 +283,14 @@ describe("FormData", () => {
         throw new Error("Request.formData should have rejected");
       })
       .catch(e => (reqErr = e));
+
+    let blobErr: any;
+    await new Blob([bad], { type: contentType })
+      .formData()
+      .then(() => {
+        throw new Error("Blob.formData should have rejected");
+      })
+      .catch(e => (blobErr = e));
 
     let streamErr: any;
     await new Response(
@@ -330,11 +337,13 @@ describe("FormData", () => {
     expect({
       Response: classify(respErr),
       Request: classify(reqErr),
+      Blob: classify(blobErr),
       stream: classify(streamErr),
       serve: classify(serveErr),
     }).toEqual({
       Response: { name: "TypeError", isTypeError: true, code: "ERR_FORMDATA_PARSE_ERROR", message: respErr.message },
       Request: { name: "TypeError", isTypeError: true, code: "ERR_FORMDATA_PARSE_ERROR", message: respErr.message },
+      Blob: { name: "TypeError", isTypeError: true, code: "ERR_FORMDATA_PARSE_ERROR", message: respErr.message },
       stream: { name: "TypeError", isTypeError: true, code: "ERR_FORMDATA_PARSE_ERROR", message: respErr.message },
       serve: { name: "TypeError", isTypeError: true, code: "ERR_FORMDATA_PARSE_ERROR", message: respErr.message },
     });


### PR DESCRIPTION
## What does this PR do?

`req.formData()` inside `Bun.serve` rejected a malformed multipart body with a plain `Error`, while `new Response(sameBytes).formData()` in the same process rejected with a `TypeError` (code `ERR_FORMDATA_PARSE_ERROR`). The `new Response(readableStream).formData()` and `new Blob(...).formData()` paths had the same problem. This violates the WHATWG Body mixin's package-data algorithm (failure is a `TypeError`), disagrees with Node/undici, and breaks `e instanceof TypeError` classification that works everywhere else.

### Repro

```js
const B = "BX9", CT = `multipart/form-data; boundary=${B}`;
const BAD = `--${B}\r\nContent-Disposition: form-data; name="k"\r\n\r\nv`; // no final boundary
let serveErr;
const server = Bun.serve({ port: 0, async fetch(req) {
  try { await req.formData(); } catch (e) { serveErr = e; }
  return new Response("done");
}});
await fetch(server.url, { method: "POST", body: BAD, headers: { "content-type": CT } }).then(r => r.text());
server.stop(true);
let respErr; try { await new Response(BAD, { headers: { "content-type": CT } }).formData(); } catch (e) { respErr = e; }
console.log("serve:", serveErr.constructor.name, serveErr instanceof TypeError);
// before: Error false   after: TypeError true
console.log("Response:", respErr.constructor.name, respErr instanceof TypeError);
// TypeError true
```

### Cause

The Body mixin's `formData()` has several error-construction sites. Only the synchronous in-memory path in `Body.rs` used `ErrorCode::FORMDATA_PARSE_ERROR`; the others built a plain `Error`:

- `FormData.rs` `AsyncFormDataExt::to_js` (buffered body, the `Bun.serve` path): `create_error_instance` / `to_error_instance`
- `FormData.rs` `from_multipart_data` (`FormData.from`, the ReadableStream path): `throw_error`
- `Blob.rs` `to_form_data_with_bytes` (`Blob.prototype.formData()`): `create_error_instance` / `to_error_instance`

### Fix

Route all of them through `ErrorCode::FORMDATA_PARSE_ERROR` with the same `"FormData parse error <reason>"` message format as the `Body.rs` path.

### Verification

Added a test in `test/js/web/html/FormData.test.ts` that sends the same malformed body through all five entry points (`new Response(string)`, `new Request(string)`, `new Blob(...)`, `new Response(ReadableStream)`, `Bun.serve` request) and asserts every rejection is a `TypeError` with code `ERR_FORMDATA_PARSE_ERROR` and an identical message.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/html/FormData.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ae2304d4e)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [5.07ms]
(pass) FormData > should be able to append a Blob [11.67ms]
(pass) FormData > should be able to set a Blob [8.17ms]
(pass) FormData > should be able to set a string [2.88ms]
(pass) FormData > should get filename from file [3.85ms]
(pass) FormData > should use the correct filenames [5.41ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [14.46ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [60.83ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [4.88ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [9.77ms]
(pa
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (672c65541)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [0.07ms]
(pass) FormData > should be able to append a Blob [0.16ms]
(pass) FormData > should be able to set a Blob [0.08ms]
(pass) FormData > should be able to set a string [0.04ms]
(pass) FormData > should get filename from file [0.05ms]
(pass) FormData > should use the correct filenames [0.05ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [0.26ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [0.73ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [0.04ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [0.04ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [0.01ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [0.02ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Request [0.01ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Request [0.02ms]
(pass) F
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/html/FormData.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ae2304d4e)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [3.37ms]
(pass) FormData > should be able to append a Blob [8.22ms]
(pass) FormData > should be able to set a Blob [5.82ms]
(pass) FormData > should be able to set a string [2.73ms]
(pass) FormData > should get filename from file [3.93ms]
(pass) FormData > should use the correct filenames [8.30ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [22.91ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [38.90ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [3.10ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [5.57ms]
(pas
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 812ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/Blob.rs       | 18 ++++++--
 src/runtime/webcore/FormData.rs   | 27 ++++++++---
 test/js/web/html/FormData.test.ts | 95 +++++++++++++++++++++++++++++++++++++++
 3 files changed, 131 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/runtime/webcore/Blob.rs            3      1      0
src/runtime/webcore/FormData.rs        2      4      0
test/js/web/html/FormData.test.ts      2      6      0
```

</details>

<!-- robobun:evidence:end -->