### PR TITLE
node:http2: don't override the engine's connection-error GOAWAY with INTERNAL_ERROR

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4210,8 +4210,20 @@ class ServerHttp2Session extends Http2Session {
         }
       }
     },
-    error(self: ServerHttp2Session, errorCode: number | string, lastStreamId: number, opaqueData: Buffer) {
+    error(
+      self: ServerHttp2Session,
+      errorCode: number | string,
+      lastStreamId: number,
+      opaqueData: Buffer,
+      sentGoawayCode?: number,
+    ) {
       if (!self) return;
+      // When the native layer already put a GOAWAY on the wire it tells us the code it sent;
+      // record it so destroy() does not re-announce the error with a different code (RFC 9113
+      // 6.8: receivers act on the most recently received GOAWAY).
+      if (typeof sentGoawayCode === "number") {
+        self[kGoawaySent] = sentGoawayCode;
+      }
       if (errorCode === "ERR_HTTP2_TOO_MANY_INVALID_FRAMES") {
         self.destroy($ERR_HTTP2_TOO_MANY_INVALID_FRAMES());
         return;
@@ -4220,7 +4232,7 @@ class ServerHttp2Session extends Http2Session {
       // detected; node surfaces those as NghttpError (code ERR_HTTP2_ERROR) via
       // onSessionInternalError.
       if (typeof errorCode === "number" && errorCode < 0) {
-        self.destroy(new NghttpError(errorCode));
+        self.destroy(new NghttpError(errorCode), sentGoawayCode);
         return;
       }
       self.destroy(errorCode as number);
@@ -4647,7 +4659,7 @@ class ServerHttp2Session extends Http2Session {
     // ('goaway' event) while in-flight streams are still allowed to finish. The session is only
     // destroyed once there is nothing in flight, and never before the GOAWAY had a chance to leave.
     this.goaway(constants.NGHTTP2_NO_ERROR, 0, Buffer.alloc(0));
-    this[kGoawaySent] = true;
+    this[kGoawaySent] = constants.NGHTTP2_NO_ERROR;
     this.#parser?.flush?.();
     if (this.#connections === 0) {
       setImmediate(destroyIfNotDestroyedNT, this);
@@ -4696,11 +4708,17 @@ class ServerHttp2Session extends Http2Session {
       this.#closed = true;
       this.#connected = false;
       if (socket) {
-        if (!this[kGoawaySent] || code) {
-          // close() already announced a graceful shutdown - re-sending NO_ERROR would be redundant
-          // and double-fires the peer's 'goaway' event. An error code is new information, though:
-          // a destroy(err) after close() must still put the error GOAWAY on the wire.
-          this.goaway(code || constants.NGHTTP2_NO_ERROR, 0, Buffer.alloc(0));
+        const prevSent = this[kGoawaySent];
+        const goawayCode = code || constants.NGHTTP2_NO_ERROR;
+        if (
+          prevSent === undefined ||
+          (prevSent === constants.NGHTTP2_NO_ERROR && goawayCode !== constants.NGHTTP2_NO_ERROR)
+        ) {
+          // Send when none sent yet, or to escalate close()'s NO_ERROR to an error code. Never
+          // re-announce once an error GOAWAY is on the wire: node's nghttp2_session_terminate_session
+          // is a no-op once terminated, so the peer observes exactly the engine's specific code.
+          this.goaway(goawayCode, 0, Buffer.alloc(0));
+          this[kGoawaySent] = goawayCode;
         }
         if (error) {
           // node's finishSessionClose destroys the socket when the session dies
@@ -5173,8 +5191,20 @@ class ClientHttp2Session extends Http2Session {
         }
       }
     },
-    error(self: ClientHttp2Session, errorCode: number | string, lastStreamId: number, opaqueData: Buffer) {
+    error(
+      self: ClientHttp2Session,
+      errorCode: number | string,
+      lastStreamId: number,
+      opaqueData: Buffer,
+      sentGoawayCode?: number,
+    ) {
       if (!self) return;
+      // When the native layer already put a GOAWAY on the wire it tells us the code it sent;
+      // record it so destroy() does not re-announce the error with a different code (RFC 9113
+      // 6.8: receivers act on the most recently received GOAWAY).
+      if (typeof sentGoawayCode === "number") {
+        self[kGoawaySent] = sentGoawayCode;
+      }
       // The native parser reports the maxSessionInvalidFrames violation with a string code
       // (it is a JS-level error, not an HTTP/2 error code). A negative numeric code is an
       // nghttp2-style library error for a violation our own engine detected; node surfaces
@@ -5185,7 +5215,7 @@ class ClientHttp2Session extends Http2Session {
           : typeof errorCode === "number" && errorCode < 0
             ? new NghttpError(errorCode)
             : sessionErrorFromCodeNamed(errorCode as number);
-      self.destroy(error_instance);
+      self.destroy(error_instance, sentGoawayCode);
     },
 
     wantTrailers(self: ClientHttp2Session, stream: ClientHttp2Stream) {
@@ -5661,7 +5691,7 @@ class ClientHttp2Session extends Http2Session {
     // ('goaway' event) while in-flight streams are still allowed to finish. The session is only
     // destroyed once there is nothing in flight, and never before the GOAWAY had a chance to leave.
     this.goaway(constants.NGHTTP2_NO_ERROR, 0, Buffer.alloc(0));
-    this[kGoawaySent] = true;
+    this[kGoawaySent] = constants.NGHTTP2_NO_ERROR;
     this.#parser?.flush?.();
     // Requests queued while the socket is still connecting count as in-flight too: they are
     // rejected with ERR_HTTP2_GOAWAY_SESSION from #onConnect (node's requestOnConnect), not
@@ -5740,11 +5770,17 @@ class ClientHttp2Session extends Http2Session {
         }
       }
       if (socket) {
-        if (!this[kGoawaySent] || code) {
-          // close() already announced a graceful shutdown - re-sending NO_ERROR would be redundant
-          // and double-fires the peer's 'goaway' event. An error code is new information, though:
-          // a destroy(err) after close() must still put the error GOAWAY on the wire.
-          this.goaway(code || constants.NGHTTP2_NO_ERROR, 0, Buffer.alloc(0));
+        const prevSent = this[kGoawaySent];
+        const goawayCode = code || constants.NGHTTP2_NO_ERROR;
+        if (
+          prevSent === undefined ||
+          (prevSent === constants.NGHTTP2_NO_ERROR && goawayCode !== constants.NGHTTP2_NO_ERROR)
+        ) {
+          // Send when none sent yet, or to escalate close()'s NO_ERROR to an error code. Never
+          // re-announce once an error GOAWAY is on the wire: node's nghttp2_session_terminate_session
+          // is a no-op once terminated, so the peer observes exactly the engine's specific code.
+          this.goaway(goawayCode, 0, Buffer.alloc(0));
+          this[kGoawaySent] = goawayCode;
         }
         if (error) {
           // See the client session: end first, destroy a tick later (node's

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -104,10 +104,11 @@ const MAX_OUTBOUND_ACK_QUEUE: u32 = 1000;
 /// ownership cycle.
 pub trait Sink {
     fn write(&self, bytes: &[u8]) -> WriteResult;
-    /// A locally-detected connection error: the GOAWAY (when one applies) is already on the wire.
-    /// `lib_error_code` is the negative nghttp2-style library error code (`wire::lib_error`) the
-    /// embedder maps to node's NghttpError.
-    fn on_error(&self, lib_error_code: i32, last_stream_id: u32, debug: &[u8]);
+    /// A locally-detected connection error: the GOAWAY is already on the wire. `lib_error_code` is
+    /// the negative nghttp2-style library error code (`wire::lib_error`) the embedder maps to
+    /// node's NghttpError; `sent_code` is the HTTP/2 error code carried by that GOAWAY, so the
+    /// embedder can record it and not re-announce the error with a different code.
+    fn on_error(&self, lib_error_code: i32, sent_code: u32, last_stream_id: u32, debug: &[u8]);
     fn on_local_settings(&self, settings: &Settings);
     fn on_remote_settings(&self, settings: &Settings);
     fn on_ping(&self, payload: &[u8], is_ack: bool);
@@ -368,7 +369,7 @@ impl Connection {
         payload.extend_from_slice(debug);
         self.write_frame(sink, FrameType::GoAway, 0, 0, &payload);
         let last = self.last_stream_id;
-        sink.on_error(lib_code, last, debug);
+        sink.on_error(lib_code, code.as_u32(), last, debug);
     }
 
     /// Connection error with the generic NGHTTP2_ERR_PROTO library code — the same thing node
@@ -1948,7 +1949,7 @@ mod tests {
             self.out.borrow_mut().extend_from_slice(bytes);
             WriteResult::Sent
         }
-        fn on_error(&self, lib_code: i32, _l: u32, _d: &[u8]) {
+        fn on_error(&self, lib_code: i32, _sent: u32, _l: u32, _d: &[u8]) {
             // send_go_away() reports through on_error; record it so the _is_goaway tests can assert.
             self.local_error.set(Some(lib_code));
         }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -2712,11 +2712,12 @@ impl H2FrameParser {
 
         if emit_error {
             if rst_code != ErrorCode::NO_ERROR {
-                self.dispatch_with_2_extra(
+                self.dispatch_with_3_extra(
                     JSH2FrameParser::Gc::onError,
                     JSValue::js_number(rst_code.0 as f64),
                     JSValue::js_number(self.last_stream_id.get() as f64),
                     chunk,
+                    JSValue::js_number(rst_code.0 as f64),
                 );
             }
             self.dispatch_with_extra(
@@ -5817,7 +5818,7 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
         }
     }
 
-    fn on_error(&self, lib_error_code: i32, _last: u32, debug: &[u8]) {
+    fn on_error(&self, lib_error_code: i32, sent_code: u32, _last: u32, debug: &[u8]) {
         // The engine detected a connection error and already wrote the GOAWAY: surface it to JS
         // as the negative nghttp2-style library error code (the JS handler builds node's
         // NghttpError from it: code ERR_HTTP2_ERROR, message nghttp2_strerror), then the end
@@ -5830,11 +5831,12 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
             .to_js(debug, &g)
             .unwrap_or(JSValue::UNDEFINED);
         if lib_error_code != 0 {
-            self.dispatch_with_2_extra(
+            self.dispatch_with_3_extra(
                 JSH2FrameParser::Gc::onError,
                 JSValue::js_number(lib_error_code as f64),
                 JSValue::js_number(self.last_stream_id.get() as f64),
                 chunk,
+                JSValue::js_number(sent_code as f64),
             );
         }
         self.dispatch_with_extra(

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -452,22 +452,23 @@ describe("connection-error GOAWAY is sent once with the specific code (RFC 9113 
       ErrorCode.FRAME_SIZE_ERROR,
       (c: RawH2) => c.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(5)),
     ],
-    [
-      "INITIAL_WINDOW_SIZE overflow -> FLOW_CONTROL_ERROR",
-      ErrorCode.FLOW_CONTROL_ERROR,
-      (c: RawH2) => {
-        const b = Buffer.alloc(6);
-        b.writeUInt16BE(0x4, 0);
-        b.writeUInt32BE(0x80000000, 2);
-        c.sendFrame(FrameType.SETTINGS, 0, 0, b);
-      },
-    ],
-  ] as const)("%s", async (_name, expected, send) => {
-    const codes = await collectGoawayCodes(send);
-    // Node sends exactly one GOAWAY here (nghttp2_session_terminate_session is a no-op once
-    // terminated). A second GOAWAY with a different code (e.g. destroy()'s INTERNAL_ERROR
-    // default) is what conforming peers would act on, misclassifying the failure.
-    expect(codes).toEqual([expected]);
+  ] as const)("%s (matches node)", async (_name, expected, send) => {
+    // Node parity: nghttp2 writes the specific GOAWAY and enters terminated state, so the
+    // destroy()->terminate_session that follows is a no-op and exactly this one frame is sent.
+    expect(await collectGoawayCodes(send)).toEqual([expected]);
+  });
+
+  test("INITIAL_WINDOW_SIZE overflow -> FLOW_CONTROL_ERROR (RFC-correct; node sends INTERNAL_ERROR)", async () => {
+    // Deliberate node divergence: nghttp2 returns fatal NGHTTP2_ERR_FLOW_CONTROL (-524) here
+    // without terminating, so node's destroy() writes only INTERNAL_ERROR. Bun's engine writes
+    // the RFC 9113 6.5.2 FLOW_CONTROL_ERROR itself and destroy() does not override it.
+    const codes = await collectGoawayCodes(c => {
+      const b = Buffer.alloc(6);
+      b.writeUInt16BE(0x4, 0);
+      b.writeUInt32BE(0x80000000, 2);
+      c.sendFrame(FrameType.SETTINGS, 0, 0, b);
+    });
+    expect(codes).toEqual([ErrorCode.FLOW_CONTROL_ERROR]);
   });
 });
 

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -422,6 +422,55 @@ describe("frame size limit (checklist §4.2)", () => {
   });
 });
 
+// RFC 9113 §6.8: receivers act on the most recently received GOAWAY, so a second GOAWAY carrying a
+// different error code overrides what the peer observes. Node sends exactly one on a connection
+// error (nghttp2_session_terminate_session is a no-op once terminated).
+describe("connection-error GOAWAY is sent once with the specific code (RFC 9113 §5.4.1, §6.8)", () => {
+  async function collectGoawayCodes(send: (c: RawH2) => void): Promise<number[]> {
+    const c = await RawH2.connect(port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      c.sendSettingsAck();
+      send(c);
+      await c.waitForGoaway();
+      await c.waitClosed();
+      return c.frames.filter(f => f.type === FrameType.GOAWAY).map(goawayErrorCode);
+    } finally {
+      c.destroy();
+    }
+  }
+
+  test.each([
+    [
+      "DATA on stream 0 -> PROTOCOL_ERROR",
+      ErrorCode.PROTOCOL_ERROR,
+      (c: RawH2) => c.sendFrame(FrameType.DATA, 0, 0, Buffer.from("x")),
+    ],
+    [
+      "PING with length != 8 -> FRAME_SIZE_ERROR",
+      ErrorCode.FRAME_SIZE_ERROR,
+      (c: RawH2) => c.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(5)),
+    ],
+    [
+      "INITIAL_WINDOW_SIZE overflow -> FLOW_CONTROL_ERROR",
+      ErrorCode.FLOW_CONTROL_ERROR,
+      (c: RawH2) => {
+        const b = Buffer.alloc(6);
+        b.writeUInt16BE(0x4, 0);
+        b.writeUInt32BE(0x80000000, 2);
+        c.sendFrame(FrameType.SETTINGS, 0, 0, b);
+      },
+    ],
+  ] as const)("%s", async (_name, expected, send) => {
+    const codes = await collectGoawayCodes(send);
+    // Node sends exactly one GOAWAY here (nghttp2_session_terminate_session is a no-op once
+    // terminated). A second GOAWAY with a different code (e.g. destroy()'s INTERNAL_ERROR
+    // default) is what conforming peers would act on, misclassifying the failure.
+    expect(codes).toEqual([expected]);
+  });
+});
+
 // ── Client-side conformance: a raw byte-level HTTP/2 *server* drives a Bun `node:http2`
 // client and asserts the client's wire behavior (push stream states, SETTINGS ack ordering).
 


### PR DESCRIPTION
### What

On a locally-detected connection error the inbound HTTP/2 engine writes a GOAWAY with the RFC 9113 §5.4.1 code (PROTOCOL_ERROR / FRAME_SIZE_ERROR / COMPRESSION_ERROR / FLOW_CONTROL_ERROR) and then dispatches a negative nghttp2-style library code to the JS session `error` handler. Since #32488 that handler wraps the code as an `NghttpError` and calls `session.destroy(error)` with no numeric code, so `destroy()` defaults the code to `NGHTTP2_INTERNAL_ERROR` and writes a **second** GOAWAY.

RFC 9113 §6.8 has receivers act on the most recently received GOAWAY, so conforming peers (nghttp2, grpc, curl) observe `INTERNAL_ERROR` instead of the specific code and misclassify a peer protocol violation as a server fault, flipping retry/abuse handling.

### Repro

```js
import http2 from "node:http2"; import net from "node:net";
const fr = (t,f,sid,pl=Buffer.alloc(0)) => { const b=Buffer.alloc(9+pl.length); b.writeUIntBE(pl.length,0,3); b[3]=t; b[4]=f; b.writeUInt32BE(sid,5); pl.copy(b,9); return b; };
const PRE = Buffer.concat([Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n","binary"), fr(4,0,0), fr(4,1,0)]);
const srv = http2.createServer(); srv.on("sessionError", () => {});
await new Promise(r => srv.listen(0, "127.0.0.1", r));
const s = net.connect(srv.address().port, "127.0.0.1", () => s.write(Buffer.concat([PRE, fr(6,0,0,Buffer.alloc(5))])));
// Collect every GOAWAY until close; node: [FRAME_SIZE], bun 1.4.0: [FRAME_SIZE,FRAME_SIZE], main: [FRAME_SIZE,INTERNAL]
```

| | DATA on stream 0 | PING len≠8 | bad HPACK | INITIAL_WINDOW_SIZE > 2^31-1 |
|---|---|---|---|---|
| node 26 | `PROTOCOL` | `FRAME_SIZE` | `COMPRESSION` | `INTERNAL` |
| bun 1.4.0 | `PROTOCOL,PROTOCOL` | `FRAME_SIZE,FRAME_SIZE` | `COMPRESSION,COMPRESSION` | `FLOW_CONTROL,FLOW_CONTROL` |
| bun main (before) | `PROTOCOL,INTERNAL` | `FRAME_SIZE,INTERNAL` | `COMPRESSION,INTERNAL` | `FLOW_CONTROL,INTERNAL` |
| this PR | `PROTOCOL` | `FRAME_SIZE` | `COMPRESSION` | `FLOW_CONTROL` |

The first three columns match node. The fourth is a deliberate RFC-conformance improvement over node: nghttp2 returns fatal `NGHTTP2_ERR_FLOW_CONTROL` (-524) for an out-of-range `INITIAL_WINDOW_SIZE` without having terminated the session, so node's `destroy()` is the only writer and puts `INTERNAL_ERROR` on the wire. Bun's engine writes the RFC 9113 §6.5.2 `FLOW_CONTROL_ERROR` itself, and `destroy()` now leaves that alone instead of overriding it.

### Fix

- `Sink::on_error` now carries the HTTP/2 error code the engine wrote in its GOAWAY and forwards it to the JS `error` handler as a fourth argument. The legacy `send_go_away(emit_error=true)` path does the same.
- The JS `error` handler records that code in `kGoawaySent` before calling `destroy()`.
- `kGoawaySent` now stores the sent error code rather than a boolean. `destroy()` only writes a GOAWAY when none has been sent yet, or to escalate `close()`'s `NO_ERROR` to an error code. Once an error GOAWAY is on the wire it never re-announces, matching Node where `nghttp2_session_terminate_session` is a no-op once the session is terminated.

Paths that dispatch `onError` without the engine having sent a GOAWAY (unsolicited PING ACK, `maxSessionInvalidFrames`) pass no fourth argument and are unchanged: `destroy()` still writes the GOAWAY there.

### Verification

New cases in `test/js/node/http2/h2-conformance.test.ts` drive a raw byte-level client against an h2c server, trigger PROTOCOL_ERROR / FRAME_SIZE_ERROR / FLOW_CONTROL_ERROR, wait for the connection to close, and assert exactly one GOAWAY carrying the specific code was observed. The flow-control case is labelled as an intentional RFC-conformance divergence from node. Fails on main with `[code, 2]`; passes with this change.
