### PR TITLE
ci(macos): move the nightly builds/ wipe to agent-startup; reboot-only cleanup daemon

### DIFF
--- a/scripts/agent.mjs
+++ b/scripts/agent.mjs
@@ -203,9 +203,13 @@ async function doBuildkiteAgent(action, cliOptions = {}) {
       // Matches the script already deployed on the fleet: covers both the
       // Homebrew-agent layout (older x64 boxes) and the Library layout (this
       // installer), fixes ownership, then reboots.
+      // The pgrep guard skips the cycle when a job is live (the agent runs
+      // each job under a `buildkite-agent bootstrap` child); wiping builds/
+      // from under a live job turns into spurious test failures.
       const cleanupPlistPath = "/Library/LaunchDaemons/com.buildkite.cleanup.plist";
       const cleanupScript =
         `PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin; ` +
+        `pgrep -qf "buildkite-agent bootstrap" && exit 0; ` +
         `BASE_PREFIX=$([ "$(uname -m)" = "arm64" ] && echo "/opt/homebrew" || echo "/usr/local"); ` +
         `{ rm -rf $BASE_PREFIX/{var,etc}/buildkite-agent/{builds,cache}/* ${homePath}/{builds,cache}/* /tmp/* /var/tmp/* || true; } && ` +
         `{ chown -R ${runAsUser}:admin $BASE_PREFIX/var/buildkite-agent $BASE_PREFIX/etc/buildkite-agent || true; } && ` +

--- a/scripts/agent.mjs
+++ b/scripts/agent.mjs
@@ -200,19 +200,27 @@ async function doBuildkiteAgent(action, cliOptions = {}) {
 `;
       writeFile(plistPath, plist, { mode: 0o644 });
 
-      // Matches the script already deployed on the fleet: covers both the
-      // Homebrew-agent layout (older x64 boxes) and the Library layout (this
-      // installer), fixes ownership, then reboots.
-      // The pgrep guard skips the cycle when a job is live (the agent runs
-      // each job under a `buildkite-agent bootstrap` child); wiping builds/
-      // from under a live job turns into spurious test failures. The [b]
-      // keeps the pattern from matching this sh -c's own argv.
+      // agent-startup fires before the agent registers with Buildkite, so no
+      // job is in flight: the only safe point to wipe builds/ and /tmp. The
+      // path is baked in because this hook sees only the agent process env.
+      const hooksPath = join(homePath, "hooks");
+      mkdir(hooksPath);
+      const agentStartupHook = [
+        `#!/bin/sh`,
+        `pgrep -qf '[b]uildkite-agent bootstrap' && exit 0`,
+        `rm -rf '${join(homePath, "builds")}'/* /tmp/* /var/tmp/* 2>/dev/null || true`,
+        ``,
+      ].join("\n");
+      writeFile(join(hooksPath, "agent-startup"), agentStartupHook, { mode: 0o755 });
+
+      // Daily reboot; deletion of live-job paths lives in agent-startup above.
+      // Rebooting an in-flight job is exit_status -1 (agent lost), which
+      // .buildkite/ci.mjs getRetry() auto-retries once.
       const cleanupPlistPath = "/Library/LaunchDaemons/com.buildkite.cleanup.plist";
       const cleanupScript =
         `PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin; ` +
-        `pgrep -qf '[b]uildkite-agent bootstrap' && exit 0; ` +
         `BASE_PREFIX=$([ "$(uname -m)" = "arm64" ] && echo "/opt/homebrew" || echo "/usr/local"); ` +
-        `{ rm -rf $BASE_PREFIX/{var,etc}/buildkite-agent/{builds,cache}/* ${homePath}/{builds,cache}/* /tmp/* /var/tmp/* || true; } && ` +
+        `{ rm -rf /System/Volumes/Data/System/Library/Caches/com.apple.coresymbolicationd/* || true; } && ` +
         `{ chown -R ${runAsUser}:admin $BASE_PREFIX/var/buildkite-agent $BASE_PREFIX/etc/buildkite-agent || true; } && ` +
         `{ chmod -R 755 $BASE_PREFIX/var/buildkite-agent $BASE_PREFIX/etc/buildkite-agent || true; } && ` +
         `{ shutdown -r now || reboot; }`;

--- a/scripts/agent.mjs
+++ b/scripts/agent.mjs
@@ -205,11 +205,12 @@ async function doBuildkiteAgent(action, cliOptions = {}) {
       // installer), fixes ownership, then reboots.
       // The pgrep guard skips the cycle when a job is live (the agent runs
       // each job under a `buildkite-agent bootstrap` child); wiping builds/
-      // from under a live job turns into spurious test failures.
+      // from under a live job turns into spurious test failures. The [b]
+      // keeps the pattern from matching this sh -c's own argv.
       const cleanupPlistPath = "/Library/LaunchDaemons/com.buildkite.cleanup.plist";
       const cleanupScript =
         `PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin; ` +
-        `pgrep -qf "buildkite-agent bootstrap" && exit 0; ` +
+        `pgrep -qf '[b]uildkite-agent bootstrap' && exit 0; ` +
         `BASE_PREFIX=$([ "$(uname -m)" = "arm64" ] && echo "/opt/homebrew" || echo "/usr/local"); ` +
         `{ rm -rf $BASE_PREFIX/{var,etc}/buildkite-agent/{builds,cache}/* ${homePath}/{builds,cache}/* /tmp/* /var/tmp/* || true; } && ` +
         `{ chown -R ${runAsUser}:admin $BASE_PREFIX/var/buildkite-agent $BASE_PREFIX/etc/buildkite-agent || true; } && ` +

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -634,6 +634,15 @@ async function runTests() {
         break;
       }
 
+      // If the binary has vanished (agent cleanup / disk wipe) every remaining
+      // spawn will ENOENT and be recorded as a test failure. Abort instead.
+      if (!existsSync(execPath)) {
+        throw new Error(
+          `${execPath} no longer exists; the checkout was removed mid-run ` +
+            `(agent cleanup or disk wipe). Aborting instead of marking the remaining tests failed.`,
+        );
+      }
+
       const color = attempt >= maxAttempts ? "red" : "yellow";
       const label = `${getAnsi(color)}[${index}/${total}] ${title} - ${error}${getAnsi("reset")}`;
       startGroup(label, () => {


### PR DESCRIPTION
## What happened

`test/regression/issue/26358.test.ts` went red on `:darwin: 14 x64` in [build 73894](https://buildkite.com/bun/bun/builds/73894) with:

```
error: Cannot find module '_util/numeric.ts' from '.../test/harness.ts'
```

The test itself is fine. Reading the job log past the annotation shows what actually happened on `darwin-naan-x64` at 13:36 UTC (06:36 PDT, the box's scheduled `com.buildkite.cleanup` minute):

1. `_util/numeric.ts` can't be resolved (file gone)
2. Retry: the test file itself is gone (`Test filter ... had no matches`)
3. Retry: `spawn bun-profile ENOENT` (the binary is gone)
4. `uv_os_get_passwd returned ENOENT` (box is rebooting)

The daemon does `rm -rf builds/* ... && shutdown -r now` with no check for an in-flight job, so it wiped the checkout out from under a live test shard. Buildkite saw the agent still connected while tests were "failing", so it recorded a real test failure instead of the agent-lost retry a plain reboot would have produced.

## Fix

Move the `rm -rf` to where no job can be running, and leave the scheduled daemon as a pure reboot.

**`scripts/agent.mjs`** (source of truth for `agent.mjs install`-provisioned boxes):

- Write a new `<hooks-path>/agent-startup` hook. Buildkite-agent runs `agent-startup` after loading config and **before registering with the scheduler** ([clicommand/agent_start.go:1231](https://github.com/buildkite/agent/blob/v3.87.0/clicommand/agent_start.go#L1231)), so no job can be assigned yet. The hook wipes `builds/*` and `/tmp/*`, with a `pgrep bootstrap` guard for the edge case where the agent restarts under an orphaned bootstrap child.
- Strip the `builds/cache/tmp` targets out of the `com.buildkite.cleanup` script so the scheduled daemon only clears the coresymbolicationd cache, fixes ownership, and reboots. Rebooting an in-flight job is `exit_status -1` (agent lost), which `.buildkite/ci.mjs` `getRetry()` already auto-retries once (line 317).

**`scripts/runner.node.mjs`**: after a failed attempt, if `execPath` no longer exists on disk, abort the whole run with a descriptive error instead of retrying and then moving on to mark every remaining test as failed. Defence in depth for any future wipe-under-live-job.

## Fleet rollout

The 15 live macOS boxes fall into three layouts. Surveyed all of them on 2026-07-16; every box's current `com.buildkite.cleanup` script matches the `agent.mjs` template (same `PATH=...; BASE_PREFIX=...; { rm -rf ... } && chown && chmod && shutdown -r now` shape) with only per-box differences in the scheduled minute and, on one box, the chown user.

| layout | boxes | hooks-path | build-path | change |
|---|---|---|---|---|
| A (homebrew x64) | bagel, cornbread, matzo, naan, pita, pretzel, rye | `/usr/local/etc/buildkite-agent/hooks` | `/usr/local/{etc,var}/buildkite-agent/builds` | both edits |
| B (`agent.mjs`) | flatbread (x64), breadstick, crouton (arm64) | `/Users/administrator/Library/Services/buildkite-agent/hooks` | `/Users/administrator/Library/Services/buildkite-agent/builds` | both edits |
| C (tart hosts) | baguette, challah, ciabatta, focaccia, sourdough (arm64) | `/Users/ciadmin/tart-hooks` | `/Users/ciadmin/tart-builds*` | **no change** |

Layout C is already immune: tests run inside ephemeral tart VMs, and the host daemon's `rm -rf` targets (`$BASE_PREFIX/.../buildkite-agent/builds`, `/Users/*/Library/Services/...`) don't match the actual host build paths (`/Users/ciadmin/tart-builds*`), so it has never wiped a live checkout there. Leaving those five alone.

### Per-box edits (A+B, 10 boxes)

For each box, two writes and no daemon signalled; the next scheduled reboot picks up the new plist, and the agent coming up after that reboot runs the new hook:

1. New file `<hooks-path>/agent-startup`, mode 0755, owned by the agent user:
   ```sh
   #!/bin/sh
   pgrep -qf '[b]uildkite-agent bootstrap' && exit 0
   rm -rf '<build-path>'/* /tmp/* /var/tmp/* 2>/dev/null || true
   ```
2. `plutil -replace ProgramArguments.2 -string` on `/Library/LaunchDaemons/com.buildkite.cleanup.plist` to:
   ```sh
   PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin; BASE_PREFIX=$([ "$(uname -m)" = "arm64" ] && echo "/opt/homebrew" || echo "/usr/local"); { rm -rf /System/Volumes/Data/System/Library/Caches/com.apple.coresymbolicationd/* || true; } && { chown -R <user>:admin $BASE_PREFIX/var/buildkite-agent $BASE_PREFIX/etc/buildkite-agent || true; } && { chmod -R 755 $BASE_PREFIX/var/buildkite-agent $BASE_PREFIX/etc/buildkite-agent || true; } && { shutdown -r now || reboot; }
   ```
   (preserves each box's existing `StartCalendarInterval`; a `.bak.<ts>` copy of the original plist is kept)

<details>
<summary>Exact values per box (from dry-run on each)</summary>

```
darwin-bagel-x64        hook@/usr/local/etc/buildkite-agent/hooks   rm '/usr/local/var/buildkite-agent/builds'/*   chown administrator
darwin-cornbread-x64    hook@/usr/local/etc/buildkite-agent/hooks   rm '/usr/local/etc/buildkite-agent/builds'/*   chown administrator
darwin-matzo-x64        hook@/usr/local/etc/buildkite-agent/hooks   rm '/usr/local/etc/buildkite-agent/builds'/*   chown administrator
darwin-naan-x64         hook@/usr/local/etc/buildkite-agent/hooks   rm '/usr/local/etc/buildkite-agent/builds'/*   chown administrator
darwin-pita-x64         hook@/usr/local/etc/buildkite-agent/hooks   rm '/usr/local/etc/buildkite-agent/builds'/*   chown administrator
darwin-pretzel-x64      hook@/usr/local/etc/buildkite-agent/hooks   rm '/usr/local/etc/buildkite-agent/builds'/*   chown administrator
darwin-rye-x64          hook@/usr/local/etc/buildkite-agent/hooks   rm '/usr/local/etc/buildkite-agent/builds'/*   chown administrator
darwin-flatbread-x64    hook@~/Library/Services/buildkite-agent/hooks  rm '~/Library/Services/buildkite-agent/builds'/*  chown administrator
darwin-breadstick-arm64 hook@~/Library/Services/buildkite-agent/hooks  rm '~/Library/Services/buildkite-agent/builds'/*  chown root
darwin-crouton-arm64    hook@~/Library/Services/buildkite-agent/hooks  rm '~/Library/Services/buildkite-agent/builds'/*  chown administrator
```

Dry-run on all ten validates the rewritten plist with `plutil -lint` before anything would be written.
</details>

The daemon was introduced in #29672.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->