### PR TITLE
css: print background-clip in shorthand when it differs from origin

### DIFF
--- a/src/css/properties/background.rs
+++ b/src/css/properties/background.rs
@@ -191,7 +191,7 @@ impl Background {
             has_output = true;
         }
 
-        if (output_padding_box && !self.clip.eql_origin(BackgroundOrigin::BorderBox))
+        if (output_padding_box && !self.clip.eql_origin(self.origin))
             || !self.clip.eql_origin(BackgroundOrigin::BorderBox)
         {
             if has_output {

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -2923,26 +2923,11 @@ describe("css tests", () => {
     // The shorthand prints <box> twice when origin != clip. A single <box>
     // token sets both origin and clip, so dropping a border-box clip after a
     // non-default origin would change the declared clip value.
-    minify_test(
-      ".foo { background: red content-box border-box }",
-      ".foo{background:red content-box border-box}",
-    );
-    minify_test(
-      ".foo { background: red border-box content-box }",
-      ".foo{background:red border-box content-box}",
-    );
-    minify_test(
-      ".foo { background: red border-box padding-box }",
-      ".foo{background:red border-box padding-box}",
-    );
-    minify_test(
-      ".foo { background: red padding-box border-box }",
-      ".foo{background:red}",
-    );
-    minify_test(
-      ".foo { background: red border-box border-box }",
-      ".foo{background:red border-box}",
-    );
+    minify_test(".foo { background: red content-box border-box }", ".foo{background:red content-box border-box}");
+    minify_test(".foo { background: red border-box content-box }", ".foo{background:red border-box content-box}");
+    minify_test(".foo { background: red border-box padding-box }", ".foo{background:red border-box padding-box}");
+    minify_test(".foo { background: red padding-box border-box }", ".foo{background:red}");
+    minify_test(".foo { background: red border-box border-box }", ".foo{background:red border-box}");
     cssTest(
       `
       .foo {

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -2920,6 +2920,49 @@ describe("css tests", () => {
     );
     minify_test(".foo { background: transparent }", ".foo{background:0 0}");
 
+    // The shorthand prints <box> twice when origin != clip. A single <box>
+    // token sets both origin and clip, so dropping a border-box clip after a
+    // non-default origin would change the declared clip value.
+    minify_test(
+      ".foo { background: red content-box border-box }",
+      ".foo{background:red content-box border-box}",
+    );
+    minify_test(
+      ".foo { background: red border-box content-box }",
+      ".foo{background:red border-box content-box}",
+    );
+    minify_test(
+      ".foo { background: red border-box padding-box }",
+      ".foo{background:red border-box padding-box}",
+    );
+    minify_test(
+      ".foo { background: red padding-box border-box }",
+      ".foo{background:red}",
+    );
+    minify_test(
+      ".foo { background: red border-box border-box }",
+      ".foo{background:red border-box}",
+    );
+    cssTest(
+      `
+      .foo {
+        background-color: red;
+        background-position: 0% 0%;
+        background-size: auto;
+        background-repeat: repeat;
+        background-clip: border-box;
+        background-origin: content-box;
+        background-attachment: scroll;
+        background-image: none
+      }
+    `,
+      indoc`
+      .foo {
+        background: red content-box border-box;
+      }
+    `,
+    );
+
     minify_test(
       ".foo { background: url(\"data:image/svg+xml,%3Csvg width='168' height='24' xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E\") }",
       ".foo{background:url(\"data:image/svg+xml,%3Csvg width='168' height='24' xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E\")}",


### PR DESCRIPTION
## What does this PR do?

`Bun.build` on CSS was dropping an explicit `border-box` clip from the `background` shorthand whenever the origin was non-default, silently changing the declared `background-clip` value.

### Repro

```css
.a { background: red content-box border-box }
```

Before:
```css
.a { background: red content-box; }
```

Per [css-backgrounds-3 §3.11](https://www.w3.org/TR/css-backgrounds-3/#background), a single `<box>` token in the shorthand sets both `background-origin` and `background-clip`, so `red content-box` means clip=`content-box`, not the declared `border-box`.

After (matches lightningcss 1.32.0):
```css
.a { background: red content-box border-box; }
```

### Cause

`Background::to_css` gated the clip token on:

```rust
(output_padding_box && !clip.eql_origin(BorderBox)) || !clip.eql_origin(BorderBox)
```

which is `(A && B) || B`, i.e. just `!clip.eql_origin(BorderBox)`, so a `border-box` clip was never printed regardless of the origin that preceded it. The port dropped the upstream lightningcss `clip != origin` comparison ([upstream source](https://github.com/parcel-bundler/lightningcss/blob/v1.32.0/src/properties/background.rs#L507)).

### Fix

Compare the clip against `self.origin` in the first arm so the clip is printed whenever it differs from the printed origin (or whenever it is a non-default value on its own).

### Tests

Added the full origin/clip `<box>` matrix to the `background` suite in `test/js/bun/css/css.test.ts`, including the longhand-merge path. `.foo { background: red content-box border-box }` and the longhand variant fail on the current release and pass with this change; the remaining cases guard existing correct behavior.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/css.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (05c527140)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [2.99ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.12ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.19ms]
Output :root {
  --my-c
... (truncated)

release without fix: 14 failed, 67 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [0.19ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [0.03ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [0.04ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: white;
        --my-font-size: 16px;
      }
      .element {
        color: var(--my-color);
        background-color: var(--my-bg);
        font-size: 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/css.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (05c527140)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [3.69ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.30ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.21ms]
Output :root {
  --my-c
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 835ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   C
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/properties/background.rs |  2 +-
 test/js/bun/css/css.test.ts      | 28 ++++++++++++++++++++++++++++
 2 files changed, 29 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
src/css/properties/background.rs      1      1      0
test/js/bun/css/css.test.ts           2      1      0
```

</details>

**root cause** · written by the author bot

The serializer's condition for emitting the background-clip token in the background shorthand collapsed to checking only that clip was not border-box, so whenever origin was a non-default value and clip was border-box the clip token was dropped and the shorthand round-tripped with clip incorrectly equal to origin. The fix restores the intended comparison so the clip token is written whenever it differs from the origin value being serialized, matching the upstream lightningcss behavior. Regression tests cover the origin and clip combinations that previously lost the clip token.

<!-- robobun:evidence:end -->