### PR TITLE
base64: remove stale calc_size doc warning

### DIFF
--- a/src/base64/lib.rs
+++ b/src/base64/lib.rs
@@ -507,7 +507,6 @@ pub mod zig_base64 {
         }
 
         /// Compute the encoded length
-        /// Note: this is wrong for base64url encoding. Do not use it for that.
         pub fn calc_size(&self, source_len: usize) -> usize {
             if self.pad_char.is_some() {
                 source_len.div_ceil(3) * 4


### PR DESCRIPTION
Fixes #34370

`Base64Encoder::calc_size` carried a doc note saying it is wrong for base64url and must not be used for that. The note dates back to the Zig std.base64 port, where calc_size was unconditionally `div_ceil(source_len, 3) * 4` and so overestimated the length of unpadded output.

The current implementation branches on `pad_char` and returns the exact unpadded length for `None` (leftover of 1 byte adds 2 chars, leftover of 2 adds 3), matching `url_safe_encode_len_from_size` in the same file. The warning no longer describes the code, so this removes it.

Comment-only change, no behavior difference; `cargo check -p bun_base64` passes.