### PR TITLE
test(next-pages): run puppeteer browser download once, outside bun install

### DIFF
--- a/test/integration/next-pages/test/dev-server.test.ts
+++ b/test/integration/next-pages/test/dev-server.test.ts
@@ -100,9 +100,12 @@ async function getDevServerURL() {
 beforeAll(async () => {
   copyFileSync(join(root, "src/Counter1.txt"), join(root, "src/Counter.tsx"));
 
+  // Skip the browser download inside `bun i`: puppeteer is default-trusted so
+  // install.mjs would otherwise run twice against the same cache, and the first
+  // (silent) run has left a half-extracted chrome-headless-shell on macOS CI.
   const install = Bun.spawnSync([bunExe(), "i"], {
     cwd: root,
-    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(root, ".bun-install"), ...puppeteerInstallEnv },
+    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(root, ".bun-install"), PUPPETEER_SKIP_DOWNLOAD: "1" },
     stdout: "inherit",
     stderr: "inherit",
     stdin: "inherit",
@@ -110,6 +113,18 @@ beforeAll(async () => {
   if (!install.success) {
     const reason = install.signalCode || `code ${install.exitCode}`;
     throw new Error(`Failed to install dependencies: ${reason}`);
+  }
+
+  const browserInstall = Bun.spawnSync([bunExe(), join("node_modules", "puppeteer", "install.mjs")], {
+    cwd: root,
+    env: { ...bunEnv, ...puppeteerInstallEnv },
+    stdout: "inherit",
+    stderr: "inherit",
+    stdin: "inherit",
+  });
+  if (!browserInstall.success) {
+    const reason = browserInstall.signalCode || `code ${browserInstall.exitCode}`;
+    throw new Error(`Failed to install puppeteer browser: ${reason}`);
   }
 
   try {


### PR DESCRIPTION
## What

`dev-server.test.ts` went red on `:darwin: 14 aarch64` in builds [73894](https://buildkite.com/bun/bun/builds/73894), [73915](https://buildkite.com/bun/bun/builds/73915), and [73954](https://buildkite.com/bun/bun/builds/73954) (every retry), with:

```
$ cd node_modules/puppeteer && bun install.mjs
chrome (139.0.7258.66) downloaded to .../chrome/mac_arm-139.0.7258.66
error: The browser folder (.../chrome-headless-shell/mac_arm-139.0.7258.66) exists but the executable (.../chrome-headless-shell) is missing
      at installUrl (.../@puppeteer/browsers/lib/esm/install.js:154:27)
error: postinstall script from "default-create-template" exited with 1
```

## Why

Every failure was on `darwin-ciabatta-arm64-tart-15` (shard 1). On that one host `rebake.sh` ran twice; the second pass did `tart delete bun-ci-base && tart clone macos-runner bun-ci-base` and then hit `GUEST_NEVER_BOOTED`, leaving `bun-ci-base` as an unbaked `ghcr.io/cirruslabs/macos-runner:sequoia` clone with no `/usr/local/bin/{node,bun}`. The other tart hosts all finished their bake and have `/usr/local/bin/node` v24.3.0.

On the unbaked guest the only `node` in PATH is `/opt/homebrew/bin/node` (v24.16.0, shipped by the cirruslabs image). `bun install` resolves `node` for dependency lifecycle scripts via `get_node_path()` (PackageManager.rs:1163) and finds that one, so puppeteer's own `postinstall: "node install.mjs"` (puppeteer is default-trusted) runs under Node v24.16.0.

Node v24.16.0 has a regression: when `extract-zip` (yauzl under the hood) is kicked off from an un-awaited promise, the process exits 0 mid-extraction. Puppeteer's `install.mjs` does exactly that (`downloadBrowsers()` is called without `await`). Reproduced on a baked guest by pointing at each `node` directly, 3/3:

```
/usr/local/bin/node            v24.3.0     files=17  exe=OK       exit=0
/opt/homebrew/bin/node         v24.16.0    files=2   exe=missing  exit=0
nodejs.org official binary     v24.16.0    files=2   exe=missing  exit=0
```

So puppeteer's own postinstall exits 0 with chrome-headless-shell only partly written (ABOUT + a truncated LICENSE, zip still on disk). The fixture's root `postinstall: "cd node_modules/puppeteer && bun install.mjs"` then runs against the same `PUPPETEER_CACHE_DIR`, sees the folder but no executable, and throws.

Not a Bun bug and not stale machine state; it's a Node 24.16.0 event-loop-ref regression surfaced by a failed CI image bake.

## Fix

Pass `PUPPETEER_SKIP_DOWNLOAD=1` to `bun i` so both postinstalls are no-ops, then run `install.mjs` exactly once afterwards under `bunExe()` (not whatever `node` is in PATH). That step inherits stdio, so a download failure is visible and fails the test with a clear message. Same code paths (`bun install`, lockfile snapshot, `next dev` under `bun --bun`, puppeteer launch) as before; the browser download just isn't nested inside the install anymore.

The CI image on ciabatta should still be rebaked, but this change makes the test independent of which `node` happens to be in PATH on a given lane, so a future Node regression or image drift can't break it the same way. `dev-server-ssr-100.test.ts` hits the same double-install but never launches a browser; #34369 skips the download there entirely.

## Verification

In [build 73954 on darwin-ciabatta-arm64](https://buildkite.com/bun/bun/builds/73954#019f6be3-cf4f-4aeb-be26-bb273d1db9c8), the same job ran both tests: the patched `dev-server.test.ts` passed with a clean ~2.5s download, and the unpatched `dev-server-ssr-100.test.ts` failed with the exact "browser folder exists but executable is missing" error, confirming the mechanism.
