### PR TITLE
test(websocket): connect the GC-finalization loop via 127.0.0.1 instead of localhost

### DIFF
--- a/test/js/web/websocket/websocket.test.js
+++ b/test/js/web/websocket/websocket.test.js
@@ -837,18 +837,21 @@ it.serial("instances should be finalized when GC'd", async () => {
       sock.close();
     }
 
-    function openAndCloseWS() {
-      const { promise, resolve } = Promise.withResolvers();
-      const sock = new WebSocket(server.url.href.replace("http", "ws"));
-      sock.addEventListener("open", onOpen.bind(undefined, sock, resolve), {
-        once: true,
-      });
+    // IP literal so the loop never waits on getaddrinfo: on one darwin CI host
+    // the libinfo async reply for `localhost` has been seen to never arrive,
+    // wedging the DNS cache entry and every iteration with it.
+    const wsURL = `ws://127.0.0.1:${server.port}/`;
 
+    function openAndCloseWS(i) {
+      const { promise, resolve, reject } = Promise.withResolvers();
+      const sock = new WebSocket(wsURL);
+      sock.addEventListener("open", onOpen.bind(undefined, sock, resolve), { once: true });
+      sock.addEventListener("error", e => reject(new Error(`iteration ${i}: ${e?.message ?? e}`)), { once: true });
       return promise;
     }
 
     for (let i = 0; i < 1000; i++) {
-      await openAndCloseWS();
+      await openAndCloseWS(i);
       if (i % 100 === 0) {
         if (initial_websocket_count === 0) {
           initial_websocket_count = getWebSocketCount();


### PR DESCRIPTION
`test/js/web/websocket/websocket.test.js` has been going red on one darwin x64 CI host (reported from build [#73908](https://buildkite.com/bun/bun/builds/73908)):

```
✗ instances should be finalized when GC'd [90001.52ms]
  ^ this test timed out after 90000ms.
```

## What's happening

Every failure of this test in BuildKite history is on the same physical machine (darwin-bagel-x64 / formerly darwin-x64-mini-1, IP `207.254.55.55`) and only in the few hours after that box's scheduled 06:05 PDT nightly reboot. On every other darwin x64 agent the whole file finishes in ~1.6 s; on that box it hits the 90 s timeout on most or all of the four retries. The same binary run standalone on the same box passes in ~2 s.

The test opens 1000 WebSockets to `ws://localhost:PORT` and only awaits `open`, so one stuck connect hangs it forever with no diagnostic.

The macOS unified log from the failing run (build #73893 attempt 1) shows exactly what that one stuck connect is. The test process's last activity before the 90 s silence is libinfo's RFC 6724 destination sorter failing:

```
06:30:25.344506 bun-profile: (libsystem_info.dylib) [si_destination_compare] send failed: Invalid argument
06:30:25.344509 bun-profile: (libsystem_info.dylib) [si_destination_compare] send failed: Invalid argument
... 90 s of nothing ...
06:31:55.519091 mDNSResponder: [R8255] DNSServiceCreateConnection STOP PID[24420](bun-profile)
```

i.e. the `getaddrinfo_async_start` worker resolved `localhost` to `[::1, 127.0.0.1]`, ran `si_destination_compare` to sort them, that failed with `EINVAL`, and the mach-port reply never reached Bun's `FilePoll`. Bun's DNS cache entry for `(localhost, port)` stays in-flight, so all 1000 iterations coalesce onto it (`internal::getaddrinfo` cache-hit-inflight path in `src/runtime/dns_jsc/dns.rs`) and the test sits until the 90 s timeout.

Why only that box and only in that window is a macOS libinfo/network-state question I don't have a crisp answer to; the box uses DNS-over-HTTPS to 8.8.8.8 where most of the fleet has the MacStadium resolvers first, but `localhost` is served from `/etc/hosts` regardless.

## Fix

Connect via `ws://127.0.0.1:${server.port}/` instead of `ws://localhost:.../`. An IP literal short-circuits in `us_socket_group_connect` (`try_parse_ip` succeeds) and never calls `getaddrinfo`, so the libinfo path is out of the picture. The test still exercises the exact WebSocket lifecycle it is checking (connect -> open -> close -> finalize); the `localhost` DNS path is already covered by the concurrent tests in the same file.

Also wire the `error` event to reject the awaited promise so any future connect failure surfaces with a message instead of hanging for 90 s x 4 retries.

No `src/` change and the failure only reproduces on one CI host in a specific time window, so there is no local fail-before for this one.

<details>
<summary>Affected builds (all on 207.254.55.55)</summary>

| build | websocket.test.js started | result |
| --- | --- | --- |
| 72208 | 2026-07-12 12:36 UTC | ok |
| 72232 | 2026-07-12 13:48 UTC | timeout |
| 72248 | 2026-07-12 15:05 UTC | ok |
| 72444 | 2026-07-13 15:09 UTC | timeout |
| 72935 | 2026-07-14 13:55 UTC | ok |
| 72938 | 2026-07-14 14:26 UTC | timeout |
| 72945 | 2026-07-14 15:12 UTC | ok |
| 73260 | 2026-07-15 14:15 UTC | timeout |
| 73261 | 2026-07-15 15:06 UTC | ok |
| 73893 | 2026-07-16 13:30 UTC | timeout |
| 73908 | 2026-07-16 14:01 UTC | timeout |
| 73924 | 2026-07-16 14:34 UTC | timeout |
| 73944 | 2026-07-16 15:41 UTC | ok |

The box's `com.buildkite.cleanup` daemon reboots it at 06:05 PDT = 13:05 UTC.
</details>
