### PR TITLE
Bun.wrapAnsi: don't re-open SGR close codes after line breaks

### DIFF
--- a/src/jsc/bindings/wrapAnsi.cpp
+++ b/src/jsc/bindings/wrapAnsi.cpp
@@ -435,6 +435,8 @@ static std::optional<uint32_t> getCloseCode(uint32_t code)
         return 28;
     case 9:
         return 29;
+    case 53:
+        return 55;
     }
 
     if (code >= 30 && code <= 37)

--- a/src/jsc/bindings/wrapAnsi.cpp
+++ b/src/jsc/bindings/wrapAnsi.cpp
@@ -511,8 +511,9 @@ static void joinRowsWithAnsiPreservation(const Vector<Row<Char>>& rows, StringBu
                 }
             }
         } else if (c == '\n') {
-            // Restore styles after newline
-            if (escapeCode) {
+            // Restore styles after newline (only open codes; close/unknown codes
+            // have no close mapping and are not re-emitted, matching npm wrap-ansi)
+            if (escapeCode && getCloseCode(*escapeCode)) {
                 result.append("\x1b["_s);
                 result.append(String::number(*escapeCode));
                 result.append('m');

--- a/test/js/bun/util/wrapAnsi.test.ts
+++ b/test/js/bun/util/wrapAnsi.test.ts
@@ -95,6 +95,30 @@ describe("Bun.wrapAnsi", () => {
       // "ab" is 2 chars, should fit in width 2
       expect(Bun.wrapAnsi(input, 2)).toBe(input);
     });
+
+    // SGR close codes (22-29, 49) and unknown codes have no close mapping in
+    // ansi-styles' codes map, so npm wrap-ansi never re-emits them after a line
+    // break. Only open codes with a known close code are closed-then-reopened.
+    test.each([22, 23, 24, 25, 27, 28, 29, 49, 39, 0, 200])(
+      "does not re-open SGR close/unknown code %p after line break",
+      code => {
+        expect(Bun.wrapAnsi(`\x1b[${code}mabc def`, 3)).toBe(`\x1b[${code}mabc\ndef`);
+      },
+    );
+
+    test.each([
+      [1, 22],
+      [4, 24],
+      [31, 39],
+      [42, 49],
+      [100, 49],
+    ])("re-opens SGR open code %p after line break", (open, close) => {
+      expect(Bun.wrapAnsi(`\x1b[${open}mabc def`, 3)).toBe(`\x1b[${open}mabc\x1b[${close}m\n\x1b[${open}mdef`);
+    });
+
+    test("close code following an open code is not carried across line break", () => {
+      expect(Bun.wrapAnsi("\x1b[42mab\x1b[49mcd ef", 4)).toBe("\x1b[42mab\x1b[49mcd\nef");
+    });
   });
 
   describe("Unicode support", () => {

--- a/test/js/bun/util/wrapAnsi.test.ts
+++ b/test/js/bun/util/wrapAnsi.test.ts
@@ -96,10 +96,10 @@ describe("Bun.wrapAnsi", () => {
       expect(Bun.wrapAnsi(input, 2)).toBe(input);
     });
 
-    // SGR close codes (22-29, 49) and unknown codes have no close mapping in
-    // ansi-styles' codes map, so npm wrap-ansi never re-emits them after a line
-    // break. Only open codes with a known close code are closed-then-reopened.
-    test.each([22, 23, 24, 25, 27, 28, 29, 49, 39, 0, 200])(
+    // SGR close codes (22-29, 49, 55) and unknown codes have no close mapping
+    // in ansi-styles' codes map, so npm wrap-ansi never re-emits them after a
+    // line break. Only open codes with a known close code are closed-then-reopened.
+    test.each([22, 23, 24, 25, 27, 28, 29, 49, 55, 39, 0, 200])(
       "does not re-open SGR close/unknown code %p after line break",
       code => {
         expect(Bun.wrapAnsi(`\x1b[${code}mabc def`, 3)).toBe(`\x1b[${code}mabc\ndef`);
@@ -111,6 +111,7 @@ describe("Bun.wrapAnsi", () => {
       [4, 24],
       [31, 39],
       [42, 49],
+      [53, 55],
       [100, 49],
     ])("re-opens SGR open code %p after line break", (open, close) => {
       expect(Bun.wrapAnsi(`\x1b[${open}mabc def`, 3)).toBe(`\x1b[${open}mabc\x1b[${close}m\n\x1b[${open}mdef`);


### PR DESCRIPTION
## Repro

```js
for (const code of [49, 22, 24, 27]) {
  console.log(code, JSON.stringify(Bun.wrapAnsi(`\x1b[${code}mabc def`, 3)));
}
```

Before:
```
49 "\^[[49mabc\n\^[[49mdef"
22 "\^[[22mabc\n\^[[22mdef"
24 "\^[[24mabc\n\^[[24mdef"
27 "\^[[27mabc\n\^[[27mdef"
```

npm `wrap-ansi@9`:
```
49 "\^[[49mabc\ndef"
22 "\^[[22mabc\ndef"
24 "\^[[24mabc\ndef"
27 "\^[[27mabc\ndef"
```

## Cause

`joinRowsWithAnsiPreservation` tracks the most recent single-number SGR code and closes/reopens it around each inserted newline. The close-before-newline block already gates on `getCloseCode(*escapeCode)` (only emit a close if the stored code is a known open code), but the reopen-after-newline block only checked `if (escapeCode)`, so a close code like 49 or 22 (stored because it is neither 39 nor 0) was re-emitted at the start of every subsequent wrapped line. npm `wrap-ansi` gates both sides on `ansiStyles.codes.get(escapeCode)`, which is `undefined` for close and unknown codes.

## Fix

Gate the reopen on the same `getCloseCode()` check as the close block. Close codes (22-29, 49) and unknown codes now pass through once without being carried as an active style; open codes (1-9, 30-37, 40-47, 90-97, 100-107) continue to be closed and reopened across line breaks as before.

## Verification

New `test.each` cases in `test/js/bun/util/wrapAnsi.test.ts` cover every close code, an unknown code, the existing 39/0 controls, and the open-code set. 10 of the new cases fail with `USE_SYSTEM_BUN=1` and all 166 tests in the file plus the 23 ported npm tests pass with the fix.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/wrapAnsi.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (005c007ee)

test/js/bun/util/wrapAnsi.test.ts:
(pass) Bun.wrapAnsi > basic wrapping > wraps text at word boundaries [2.80ms]
(pass) Bun.wrapAnsi > basic wrapping > handles empty string [1.18ms]
(pass) Bun.wrapAnsi > basic wrapping > no wrapping needed [1.54ms]
(pass) Bun.wrapAnsi > basic wrapping > wraps multiple words [1.63ms]
(pass) Bun.wrapAnsi > basic wrapping > handles single long word [1.18ms]
(pass) Bun.wrapAnsi > basic wrapping > handles columns = 0 [1.49ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks long words in middle [1.97ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks very long word [1.62ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap false disables wrapping [2.04ms]
(pass) Bun.wrapAnsi > trim option > tri
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (5ee704809)

test/js/bun/util/wrapAnsi.test.ts:
(pass) Bun.wrapAnsi > basic wrapping > wraps text at word boundaries [0.04ms]
(pass) Bun.wrapAnsi > basic wrapping > handles empty string [0.01ms]
(pass) Bun.wrapAnsi > basic wrapping > no wrapping needed [0.01ms]
(pass) Bun.wrapAnsi > basic wrapping > wraps multiple words [0.01ms]
(pass) Bun.wrapAnsi > basic wrapping > handles single long word
(pass) Bun.wrapAnsi > basic wrapping > handles columns = 0 [0.01ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks long words in middle [0.02ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks very long word [0.02ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap false disables wrapping [0.02ms]
(pass) Bun.wrapAnsi > trim option > trims leading whitespace by default [0.01ms]
(pass) Bun.wrapAnsi > trim option > trim false preserves leading whitespace [0.01ms]
(pass) Bun.wrapAnsi > ANSI escape codes > preserves simple color code [0.02ms]
(pass) Bun.wrapAnsi > ANSI escape codes > preserves color across line break [0.02ms]
(pass) Bun.wrapAnsi > ANSI escape codes > handles multiple colors [0.01ms]
(pass) Bun.wrapAnsi > ANSI escape codes > handles bold and 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/wrapAnsi.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (005c007ee)

test/js/bun/util/wrapAnsi.test.ts:
(pass) Bun.wrapAnsi > basic wrapping > wraps text at word boundaries [2.33ms]
(pass) Bun.wrapAnsi > basic wrapping > handles empty string [1.22ms]
(pass) Bun.wrapAnsi > basic wrapping > no wrapping needed [1.58ms]
(pass) Bun.wrapAnsi > basic wrapping > wraps multiple words [1.63ms]
(pass) Bun.wrapAnsi > basic wrapping > handles single long word [1.18ms]
(pass) Bun.wrapAnsi > basic wrapping > handles columns = 0 [1.50ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks long words in middle [2.01ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks very long word [1.44ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap false disables wrapping [1.98ms]
(pass) Bun.wrapAnsi > trim option > tri
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 719ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[2/6] gen cpp.rs (cppbind)
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 28.97s
[3/6] link bun-profile
[4/6] bun-profile --re
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/wrapAnsi.cpp     |  7 +++++--
 test/js/bun/util/wrapAnsi.test.ts | 25 +++++++++++++++++++++++++
 2 files changed, 30 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/jsc/bindings/wrapAnsi.cpp          2      2      0
test/js/bun/util/wrapAnsi.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->