### PR TITLE
Bun.wrapAnsi: keep zero-width characters when trimming trailing spaces

### DIFF
--- a/src/jsc/bindings/wrapAnsi.cpp
+++ b/src/jsc/bindings/wrapAnsi.cpp
@@ -326,10 +326,9 @@ static void trimRowTrailingSpaces(Row<Char>& row, bool ambiguousIsNarrow)
     if (lastVisibleEnd == size)
         return;
 
-    // Mirror npm wrap-ansi's stringVisibleTrimSpacesRight: zero-width tail words
-    // (ANSI escapes, ZWSP/ZWJ, combining marks) are kept; only the separator
-    // spaces between them are removed. Dropping non-space content here would
-    // delete ZWJ sequences and change rendered grapheme clusters.
+    // Mirror npm wrap-ansi's stringVisibleTrimSpacesRight: keep zero-width tail
+    // words (ANSI escapes, ZWSP/ZWJ, combining marks); remove only the separator
+    // spaces between them.
     Vector<Char> tail;
     tail.reserveCapacity(size - lastVisibleEnd);
     for (size_t i = lastVisibleEnd; i < size; ++i) {

--- a/src/jsc/bindings/wrapAnsi.cpp
+++ b/src/jsc/bindings/wrapAnsi.cpp
@@ -307,71 +307,38 @@ static void wrapWord(Vector<Row<Char>>& rows, const Char* wordStart, const Char*
 template<typename Char>
 static void trimRowTrailingSpaces(Row<Char>& row, bool ambiguousIsNarrow)
 {
-    // Find last visible word
     auto span = row.m_data.span();
     const Char* data = span.data();
     size_t size = span.size();
 
-    // Split by spaces and find last word with visible content
+    // Find the end of the last space-delimited word with nonzero visible width.
     size_t lastVisibleEnd = 0;
     size_t wordStart = 0;
-    bool hasVisibleContent = false;
 
     for (size_t i = 0; i <= size; ++i) {
         if (i == size || data[i] == ' ') {
-            if (wordStart < i) {
-                size_t wordWidth = stringWidth(data + wordStart, data + i, ambiguousIsNarrow);
-                if (wordWidth > 0) {
-                    hasVisibleContent = true;
-                    lastVisibleEnd = i;
-                }
-            }
+            if (wordStart < i && stringWidth(data + wordStart, data + i, ambiguousIsNarrow) > 0)
+                lastVisibleEnd = i;
             wordStart = i + 1;
         }
     }
 
-    if (!hasVisibleContent) {
-        // Keep only ANSI codes
-        Vector<Char> ansiOnly;
-        bool inEscape = false;
-        bool inOscEscape = false;
-        for (size_t i = 0; i < size; ++i) {
-            if (data[i] == 0x1b || inEscape) {
-                ansiOnly.append(data[i]);
-                if (data[i] == 0x1b) {
-                    inEscape = true;
-                    inOscEscape = (i + 1 < size && data[i + 1] == ']');
-                } else if (isAnsiEscapeTerminator(data[i], inOscEscape)) {
-                    inEscape = false;
-                    inOscEscape = false;
-                }
-            }
-        }
-        row.m_data = std::move(ansiOnly);
+    if (lastVisibleEnd == size)
         return;
+
+    // Mirror npm wrap-ansi's stringVisibleTrimSpacesRight: zero-width tail words
+    // (ANSI escapes, ZWSP/ZWJ, combining marks) are kept; only the separator
+    // spaces between them are removed. Dropping non-space content here would
+    // delete ZWJ sequences and change rendered grapheme clusters.
+    Vector<Char> tail;
+    tail.reserveCapacity(size - lastVisibleEnd);
+    for (size_t i = lastVisibleEnd; i < size; ++i) {
+        if (data[i] != ' ')
+            tail.append(data[i]);
     }
 
-    if (lastVisibleEnd < size) {
-        // Collect trailing ANSI codes
-        Vector<Char> trailingAnsi;
-        bool inEscape = false;
-        bool inOscEscape = false;
-        for (size_t i = lastVisibleEnd; i < size; ++i) {
-            if (data[i] == 0x1b || inEscape) {
-                trailingAnsi.append(data[i]);
-                if (data[i] == 0x1b) {
-                    inEscape = true;
-                    inOscEscape = (i + 1 < size && data[i + 1] == ']');
-                } else if (isAnsiEscapeTerminator(data[i], inOscEscape)) {
-                    inEscape = false;
-                    inOscEscape = false;
-                }
-            }
-        }
-
-        row.m_data.shrink(lastVisibleEnd);
-        row.m_data.appendVector(trailingAnsi);
-    }
+    row.m_data.shrink(lastVisibleEnd);
+    row.m_data.appendVector(tail);
 }
 
 // ============================================================================

--- a/test/js/bun/util/wrapAnsi.test.ts
+++ b/test/js/bun/util/wrapAnsi.test.ts
@@ -91,6 +91,66 @@ describe("Bun.wrapAnsi", () => {
         });
       });
     });
+
+    describe("trim preserves zero-width non-whitespace characters", () => {
+      // trim may only remove U+0020 (and insert newlines); zero-width characters
+      // like ZWSP/ZWJ/combining marks are content and must survive the default
+      // trim. Expected values match npm wrap-ansi's stringVisibleTrimSpacesRight.
+      const content = (s: string) => Bun.stripANSI(s).replace(/[ \t\n\r]/g, "");
+
+      test("ZWSP as its own word is kept when wrapped", () => {
+        expect(Bun.wrapAnsi("ab \u200B cd", 2)).toBe("ab\u200B\ncd");
+      });
+
+      test("ZWSP as trailing word is kept on a fitting line", () => {
+        expect(Bun.wrapAnsi("ab \u200B", 5)).toBe("ab\u200B");
+        expect(Bun.wrapAnsi("ab \u200B", 2)).toBe("ab\u200B");
+      });
+
+      test("ZWSP-only input is kept", () => {
+        expect(Bun.wrapAnsi("\u200B", 5)).toBe("\u200B");
+        expect(Bun.wrapAnsi(" \u200B ", 5)).toBe("\u200B");
+      });
+
+      test("ZWSP wrapped in ANSI is kept with its escapes", () => {
+        expect(Bun.wrapAnsi("ab \x1b[31m\u200B\x1b[39m cd", 2)).toBe("ab\x1b[31m\u200B\x1b[39m\ncd");
+        expect(Bun.wrapAnsi("\x1b[31m\u200B\x1b[39m", 5)).toBe("\x1b[31m\u200B\x1b[39m");
+      });
+
+      test("ZWJ as its own word is kept", () => {
+        expect(Bun.wrapAnsi("a \u200D b", 1)).toBe("a\u200D\nb");
+      });
+
+      test("combining mark as its own word is kept", () => {
+        expect(Bun.wrapAnsi("ab \u0301 cd", 2)).toBe("ab\u0301\ncd");
+      });
+
+      test("trailing space after a zero-width word is still trimmed", () => {
+        expect(Bun.wrapAnsi("ab \u200B ", 10)).toBe("ab\u200B");
+      });
+
+      test("zero-width tail with following ANSI keeps both in order", () => {
+        expect(Bun.wrapAnsi("ab \u200B \x1b[31m", 2)).toBe("ab\u200B\x1b[31m");
+      });
+
+      test("family emoji hard-wrapped at columns=1 preserves every ZWJ", () => {
+        const fam = "\u{1F469}\u200D\u{1F469}\u200D\u{1F467}\u200D\u{1F466}";
+        const out = Bun.wrapAnsi(fam, 1, { hard: true });
+        expect({
+          content: content(out),
+          codepoints: [...out.replaceAll("\n", "")].length,
+          raw: out,
+        }).toEqual({
+          content: content(fam),
+          codepoints: [...fam].length,
+          raw: "\n\u{1F469}\n\u200D\n\u{1F469}\n\u200D\n\u{1F467}\n\u200D\n\u{1F466}",
+        });
+      });
+
+      test("trim:false control still preserves zero-width content", () => {
+        expect(content(Bun.wrapAnsi("ab \u200B cd", 2, { trim: false }))).toBe(content("ab \u200B cd"));
+      });
+    });
   });
 
   describe("ANSI escape codes", () => {


### PR DESCRIPTION
## Repro

```js
// ZWSP forming a word of its own
Bun.wrapAnsi("ab \u200B cd", 2);  // "ab\ncd"  (ZWSP gone; npm: "ab\u200B\ncd")
Bun.wrapAnsi("ab \u200B", 5);     // "ab"       (ZWSP gone; npm: "ab\u200B")

// family emoji (WOMAN ZWJ WOMAN ZWJ GIRL ZWJ BOY) at columns=1, hard
const fam = "\u{1F469}\u200D\u{1F469}\u200D\u{1F467}\u200D\u{1F466}";
const out = Bun.wrapAnsi(fam, 1, { hard: true });
[...out.replaceAll("\n", "")].length;  // 4 (all three ZWJs deleted; npm: 7)
```

`trim` is documented as whitespace removal; ZWSP and ZWJ are not whitespace. Deleting ZWJs changes rendered emoji identity (one family becomes four people), and dropping ZWSP changes downstream re-wrap/copy behavior under the default options.

## Cause

`trimRowTrailingSpaces` splits the row on spaces, finds the last word with `stringWidth > 0`, and then for everything past it (or the whole row when no word has visible width) keeps **only the ANSI escape bytes**, discarding any other content. Zero-width non-whitespace characters (ZWSP U+200B, ZWJ U+200D, combining marks) have `stringWidth == 0` but are not ANSI, so they were dropped.

## Fix

Match npm `wrap-ansi`'s `stringVisibleTrimSpacesRight`: after the last word with nonzero visible width, keep every non-space byte and remove only the separator U+0020 spaces. ANSI escapes are non-space so they are still kept; zero-width characters are now kept too. The two escape-scanning branches collapse into a single non-space copy, and the now-unused `isCsiTerminator` / `isAnsiEscapeTerminator` helpers are removed.

## Verification

New tests in `test/js/bun/util/wrapAnsi.test.ts` cover ZWSP/ZWJ/combining-mark words, ZWSP wrapped in ANSI, ZWSP-only input, and the family-emoji hard-wrap case. Expected values match npm `wrap-ansi@9` byte-for-byte. 9 of the new assertions fail with `USE_SYSTEM_BUN=1`; all 159 tests in the file and all 23 ported npm tests pass with the fix.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/wrapAnsi.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (9bfc0f95b)

test/js/bun/util/wrapAnsi.test.ts:
(pass) Bun.wrapAnsi > basic wrapping > wraps text at word boundaries [2.14ms]
(pass) Bun.wrapAnsi > basic wrapping > handles empty string [1.21ms]
(pass) Bun.wrapAnsi > basic wrapping > no wrapping needed [1.55ms]
(pass) Bun.wrapAnsi > basic wrapping > wraps multiple words [1.61ms]
(pass) Bun.wrapAnsi > basic wrapping > handles single long word [1.20ms]
(pass) Bun.wrapAnsi > basic wrapping > handles columns = 0 [1.50ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks long words in middle [1.96ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks very long word [1.50ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap false disables wrapping [2.03ms]
(pass) Bun.wrapAnsi > trim option > tri
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (9bfc0f95b)

test/js/bun/util/wrapAnsi.test.ts:
(pass) Bun.wrapAnsi > basic wrapping > wraps text at word boundaries [0.03ms]
(pass) Bun.wrapAnsi > basic wrapping > handles empty string [0.01ms]
(pass) Bun.wrapAnsi > basic wrapping > no wrapping needed
(pass) Bun.wrapAnsi > basic wrapping > wraps multiple words [0.01ms]
(pass) Bun.wrapAnsi > basic wrapping > handles single long word
(pass) Bun.wrapAnsi > basic wrapping > handles columns = 0 [0.01ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks long words in middle [0.02ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks very long word [0.01ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap false disables wrapping [0.02ms]
(pass) Bun.wrapAnsi > trim option > trims leading whitespace by default [0.01ms]
(pass) Bun.wrapAnsi > trim option > trim false preserves leading whitespace [0.01ms]
(pass) Bun.wrapAnsi > trim option > leading trim after non-SGR escape prefixes > SGR red > trims leading tab [0.01ms]
(pass) Bun.wrapAnsi > trim option > leading trim after non-SGR escape prefixes > SGR red > stripANSI composes with wrapAnsi [0.02ms]
(pass) Bun.wrapAnsi > trim option > leading trim after n
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/wrapAnsi.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (9bfc0f95b)

test/js/bun/util/wrapAnsi.test.ts:
(pass) Bun.wrapAnsi > basic wrapping > wraps text at word boundaries [2.36ms]
(pass) Bun.wrapAnsi > basic wrapping > handles empty string [1.20ms]
(pass) Bun.wrapAnsi > basic wrapping > no wrapping needed [1.65ms]
(pass) Bun.wrapAnsi > basic wrapping > wraps multiple words [1.59ms]
(pass) Bun.wrapAnsi > basic wrapping > handles single long word [1.21ms]
(pass) Bun.wrapAnsi > basic wrapping > handles columns = 0 [1.49ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks long words in middle [1.98ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks very long word [1.50ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap false disables wrapping [2.03ms]
(pass) Bun.wrapAnsi > trim option > tri
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 751ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[2/6] gen cpp.rs (cppbind)
[2/5] link bun-profile
[3/5] bun-profile --revision
1.4.0-canary.1+9bfc0f95b
[5/5] strip bun
[build] done
bun test v1.4.0-canary.1 (9bfc0f95b)

test/js/bun/util/wrapAnsi.test.ts:
(pass) Bun.wrapAnsi > basic wrapping > wraps text at word boundaries [0.03ms]
(pass) Bun.wrapAnsi > basic wrapping > handles empty string [0.02ms]
(pass) Bun.wrapAnsi > basic wrapping > no wrapping needed [0.01ms]
(pass) Bun.wrapAnsi > basic wrapping > wraps multiple words [0.01ms]
(pass) Bun.wrapAnsi > basic wrapping > handles single long word [0.02ms]
(pass) Bun.wrapAnsi > basic wrapping > handles columns = 0 [0.02ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks long words in middle [0.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/wrapAnsi.cpp     | 64 +++++++++------------------------------
 test/js/bun/util/wrapAnsi.test.ts | 60 ++++++++++++++++++++++++++++++++++++
 2 files changed, 75 insertions(+), 49 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/jsc/bindings/wrapAnsi.cpp          3      4      0
test/js/bun/util/wrapAnsi.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->