### PR TITLE
Bun.wrapAnsi: end CSI scan on any 0x40-0x7E final byte in leading-whitespace trim

### DIFF
--- a/src/jsc/bindings/wrapAnsi.cpp
+++ b/src/jsc/bindings/wrapAnsi.cpp
@@ -104,6 +104,23 @@ static inline bool wordSeamIsAscii(Char rowTail, const Char* wordStart, const Ch
     return static_cast<char32_t>(rowTail) < 0x80 && static_cast<char32_t>(*wordStart) < 0x80;
 }
 
+// Helper to check if a character ends a CSI escape sequence
+// CSI sequences end with bytes in 0x40-0x7E range (excluding '[' which is the introducer)
+template<typename Char>
+static bool isCsiTerminator(Char c)
+{
+    return c >= 0x40 && c <= 0x7E && c != '[';
+}
+
+// Helper to check if a character ends an ANSI escape sequence
+template<typename Char>
+static bool isAnsiEscapeTerminator(Char c, bool isOscSequence)
+{
+    if (isOscSequence)
+        return c == 0x07; // BEL terminates OSC sequences
+    return isCsiTerminator(c); // CSI terminator
+}
+
 // ============================================================================
 // Row Management (using WTF::Vector)
 // ============================================================================
@@ -145,15 +162,19 @@ public:
         size_t read = m_trimScanOffset;
         size_t write = m_trimScanOffset;
         bool inEscape = m_trimInEscape;
+        bool inOscEscape = m_trimInOscEscape;
         size_t removedWidth = 0;
 
         while (read < size) {
             Char c = m_data[read];
             if (c == 0x1b) {
                 inEscape = true;
+                inOscEscape = (read + 1 < size && m_data[read + 1] == ']');
             } else if (inEscape) {
-                if (c == 'm' || c == 0x07)
+                if (isAnsiEscapeTerminator(c, inOscEscape)) {
                     inEscape = false;
+                    inOscEscape = false;
+                }
             } else if (c == ' ' || c == '\t') {
                 if (c == ' ')
                     removedWidth++;
@@ -179,11 +200,13 @@ public:
 
         m_trimScanOffset = write;
         m_trimInEscape = inEscape;
+        m_trimInOscEscape = inOscEscape;
         return removedWidth;
     }
 
     size_t m_trimScanOffset = 0;
     bool m_trimInEscape = false;
+    bool m_trimInOscEscape = false;
     bool m_leadingTrimComplete = false;
 };
 
@@ -279,23 +302,6 @@ static void wrapWord(Vector<Row<Char>>& rows, const Char* wordStart, const Char*
         rows.removeLast();
         rows.last().append(lastRow);
     }
-}
-
-// Helper to check if a character ends a CSI escape sequence
-// CSI sequences end with bytes in 0x40-0x7E range (excluding '[' which is the introducer)
-template<typename Char>
-static bool isCsiTerminator(Char c)
-{
-    return c >= 0x40 && c <= 0x7E && c != '[';
-}
-
-// Helper to check if a character ends an ANSI escape sequence
-template<typename Char>
-static bool isAnsiEscapeTerminator(Char c, bool isOscSequence)
-{
-    if (isOscSequence)
-        return c == 0x07; // BEL terminates OSC sequences
-    return isCsiTerminator(c); // CSI terminator
 }
 
 template<typename Char>

--- a/test/js/bun/util/wrapAnsi.test.ts
+++ b/test/js/bun/util/wrapAnsi.test.ts
@@ -57,6 +57,35 @@ describe("Bun.wrapAnsi", () => {
     test("trim false preserves leading whitespace", () => {
       expect(Bun.wrapAnsi("  hello", 10, { trim: false })).toBe("  hello");
     });
+
+    // Leading-whitespace trim must not depend on which escape sequence precedes
+    // it: the CSI scanner ends on any final byte in 0x40-0x7E (ECMA-48 §5.4),
+    // not just SGR's 'm'. With the escape stripped the result is identical.
+    describe("leading trim after non-SGR escape prefixes", () => {
+      const trimCases: [label: string, input: string, columns: number, expected: string][] = [
+        ["SGR red", "\x1b[31m\tab cd", 2, "\x1b[31mab\x1b[39m\n\x1b[31mcd"],
+        ["clear screen", "\x1b[2J\tab cd", 2, "\x1b[2Jab\ncd"],
+        ["erase line", "\x1b[0K\tab cd", 2, "\x1b[0Kab\ncd"],
+        ["cursor home", "\x1b[H\tab cd", 2, "\x1b[Hab\ncd"],
+        ["cursor up", "\x1b[1A\tab cd", 2, "\x1b[1Aab\ncd"],
+        ["cursor position", "\x1b[1;1H\tab cd", 2, "\x1b[1;1Hab\ncd"],
+        ["DEC private mode", "\x1b[?25l\tab cd", 2, "\x1b[?25lab\ncd"],
+        ["OSC 8 hyperlink", "\x1b]8;;http://x\x07\tab cd", 2, "\x1b]8;;http://x\x07ab\x1b]8;;\x07\n\x1b]8;;http://x\x07cd"],
+        ["CSI then SGR", "\x1b[2J\x1b[31m\tab cd", 2, "\x1b[2J\x1b[31mab\x1b[39m\n\x1b[31mcd"],
+      ];
+
+      test.each(trimCases)("trims leading tab after %s", (_, input, columns, expected) => {
+        expect(Bun.wrapAnsi(input, columns)).toBe(expected);
+      });
+
+      test.each(trimCases)("stripANSI composes with wrapAnsi after %s", (_, input, columns) => {
+        expect(Bun.stripANSI(Bun.wrapAnsi(input, columns))).toBe(Bun.wrapAnsi(Bun.stripANSI(input), columns));
+      });
+
+      test.each(trimCases)("trim:false preserves leading tab after %s", (_, input, columns) => {
+        expect(Bun.wrapAnsi(input, columns, { trim: false })).toContain("\t");
+      });
+    });
   });
 
   describe("ANSI escape codes", () => {

--- a/test/js/bun/util/wrapAnsi.test.ts
+++ b/test/js/bun/util/wrapAnsi.test.ts
@@ -70,7 +70,12 @@ describe("Bun.wrapAnsi", () => {
         ["cursor up", "\x1b[1A\tab cd", 2, "\x1b[1Aab\ncd"],
         ["cursor position", "\x1b[1;1H\tab cd", 2, "\x1b[1;1Hab\ncd"],
         ["DEC private mode", "\x1b[?25l\tab cd", 2, "\x1b[?25lab\ncd"],
-        ["OSC 8 hyperlink", "\x1b]8;;http://x\x07\tab cd", 2, "\x1b]8;;http://x\x07ab\x1b]8;;\x07\n\x1b]8;;http://x\x07cd"],
+        [
+          "OSC 8 hyperlink",
+          "\x1b]8;;http://x\x07\tab cd",
+          2,
+          "\x1b]8;;http://x\x07ab\x1b]8;;\x07\n\x1b]8;;http://x\x07cd",
+        ],
         ["CSI then SGR", "\x1b[2J\x1b[31m\tab cd", 2, "\x1b[2J\x1b[31mab\x1b[39m\n\x1b[31mcd"],
       ];
 

--- a/test/js/bun/util/wrapAnsi.test.ts
+++ b/test/js/bun/util/wrapAnsi.test.ts
@@ -79,16 +79,16 @@ describe("Bun.wrapAnsi", () => {
         ["CSI then SGR", "\x1b[2J\x1b[31m\tab cd", 2, "\x1b[2J\x1b[31mab\x1b[39m\n\x1b[31mcd"],
       ];
 
-      test.each(trimCases)("trims leading tab after %s", (_, input, columns, expected) => {
-        expect(Bun.wrapAnsi(input, columns)).toBe(expected);
-      });
-
-      test.each(trimCases)("stripANSI composes with wrapAnsi after %s", (_, input, columns) => {
-        expect(Bun.stripANSI(Bun.wrapAnsi(input, columns))).toBe(Bun.wrapAnsi(Bun.stripANSI(input), columns));
-      });
-
-      test.each(trimCases)("trim:false preserves leading tab after %s", (_, input, columns) => {
-        expect(Bun.wrapAnsi(input, columns, { trim: false })).toContain("\t");
+      describe.each(trimCases)("%s", (_, input, columns, expected) => {
+        test("trims leading tab", () => {
+          expect(Bun.wrapAnsi(input, columns)).toBe(expected);
+        });
+        test("stripANSI composes with wrapAnsi", () => {
+          expect(Bun.stripANSI(Bun.wrapAnsi(input, columns))).toBe(Bun.wrapAnsi(Bun.stripANSI(input), columns));
+        });
+        test("trim:false preserves leading tab", () => {
+          expect(Bun.wrapAnsi(input, columns, { trim: false })).toContain("\t");
+        });
       });
     });
   });


### PR DESCRIPTION
## What

`Bun.wrapAnsi`'s leading-whitespace trim was state-dependent on the escape bytes before it: a non-SGR CSI prefix (`\x1b[2J`, `\x1b[0K`, cursor moves) left the trim scanner stuck in "inside escape" because it only recognized `'m'` and BEL as terminators. The following whitespace was then classified as escape interior and preserved, while identical plain text (or text after an SGR prefix) had it trimmed.

## Repro

```js
const comp = (x, c) => [Bun.stripANSI(Bun.wrapAnsi(x, c)), Bun.wrapAnsi(Bun.stripANSI(x), c)];
comp("\x1b[2J\tab cd", 2);   // before: ["\tab\ncd", "ab\ncd"]   after: ["ab\ncd", "ab\ncd"]
comp("\x1b[0K\tab ", 2);     // before: ["\tab", "ab"]           after: ["ab", "ab"]
comp("\x1b[31m\tab cd", 2);  // ["ab\ncd", "ab\ncd"]  (SGR was already correct, unchanged)
```

Non-SGR CSI prefixes are exactly what real CLI output starts with (clear-screen, erase-line, cursor-home before a redraw), so renderers wrapping redraw buffers got different indentation than the same text wrapped standalone, and `stripANSI(wrapAnsi(x)) == wrapAnsi(stripANSI(x))` was broken.

## Cause

`Row::trimLeadingSpaces` in `src/jsc/bindings/wrapAnsi.cpp` treated every byte after ESC as escape interior until it saw `'m'` or BEL. CSI final bytes `J`/`K`/`H`/`A`/`l`/... never matched, so the scanner never left escape state.

## Fix

Track whether the escape is CSI (`ESC [`) or OSC (`ESC ]`) by peeking the byte after ESC, and end CSI on any final byte in 0x40-0x7E (ECMA-48 §5.4). This is the same approach `trimRowTrailingSpaces` and `wrapWord` in the same file already use; the two `isCsiTerminator`/`isAnsiEscapeTerminator` helpers are moved above `Row` so `trimLeadingSpaces` can share them.

## Verification

New `test.each` block in `test/js/bun/util/wrapAnsi.test.ts` covers clear-screen, erase-line, cursor-home/up/position, DEC private mode, OSC 8 hyperlink, and CSI+SGR combinations. 12 cases fail on 1.4.0 and all 176 pass with the fix; `wrapAnsi.npm.test.ts` and `sliceAnsi.test.ts` are unchanged.

## Not in this PR

The report also notes that plain `"\tab "` trims the leading tab but `"\tab\t"` keeps it. That is a separate control-flow quirk (trim is called before each space-delimited word, so a single-word line never sees the row after it has content) and matches npm `wrap-ansi@9` behavior; left as-is here.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/wrapAnsi.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (7dbf47de3)

test/js/bun/util/wrapAnsi.test.ts:
(pass) Bun.wrapAnsi > basic wrapping > wraps text at word boundaries [2.75ms]
(pass) Bun.wrapAnsi > basic wrapping > handles empty string [1.33ms]
(pass) Bun.wrapAnsi > basic wrapping > no wrapping needed [1.86ms]
(pass) Bun.wrapAnsi > basic wrapping > wraps multiple words [1.80ms]
(pass) Bun.wrapAnsi > basic wrapping > handles single long word [1.73ms]
(pass) Bun.wrapAnsi > basic wrapping > handles columns = 0 [2.33ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks long words in middle [2.20ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks very long word [1.78ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap false disables wrapping [2.38ms]
(pass) Bun.wrapAnsi > trim option > tri
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (b4c385b43)

test/js/bun/util/wrapAnsi.test.ts:
(pass) Bun.wrapAnsi > basic wrapping > wraps text at word boundaries [0.04ms]
(pass) Bun.wrapAnsi > basic wrapping > handles empty string [0.01ms]
(pass) Bun.wrapAnsi > basic wrapping > no wrapping needed
(pass) Bun.wrapAnsi > basic wrapping > wraps multiple words [0.01ms]
(pass) Bun.wrapAnsi > basic wrapping > handles single long word [0.01ms]
(pass) Bun.wrapAnsi > basic wrapping > handles columns = 0 [0.01ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks long words in middle [0.02ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks very long word [0.02ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap false disables wrapping [0.02ms]
(pass) Bun.wrapAnsi > trim option > trims leading whitespace by default [0.01ms]
(pass) Bun.wrapAnsi > trim option > trim false preserves leading whitespace [0.01ms]
(pass) Bun.wrapAnsi > trim option > leading trim after non-SGR escape prefixes > SGR red > trims leading tab [0.01ms]
(pass) Bun.wrapAnsi > trim option > leading trim after non-SGR escape prefixes > SGR red > stripANSI composes with wrapAnsi [0.02ms]
(pass) Bun.wrapAnsi > trim option > leading tri
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/wrapAnsi.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (7dbf47de3)

test/js/bun/util/wrapAnsi.test.ts:
(pass) Bun.wrapAnsi > basic wrapping > wraps text at word boundaries [2.23ms]
(pass) Bun.wrapAnsi > basic wrapping > handles empty string [1.24ms]
(pass) Bun.wrapAnsi > basic wrapping > no wrapping needed [1.61ms]
(pass) Bun.wrapAnsi > basic wrapping > wraps multiple words [1.62ms]
(pass) Bun.wrapAnsi > basic wrapping > handles single long word [1.19ms]
(pass) Bun.wrapAnsi > basic wrapping > handles columns = 0 [1.49ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks long words in middle [2.08ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks very long word [1.50ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap false disables wrapping [2.05ms]
(pass) Bun.wrapAnsi > trim option > tri
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 753ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[2/7] gen cpp.rs (cppbind)
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/wrapAnsi.cpp     | 42 ++++++++++++++++++++++-----------------
 test/js/bun/util/wrapAnsi.test.ts | 34 +++++++++++++++++++++++++++++++
 2 files changed, 58 insertions(+), 18 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/jsc/bindings/wrapAnsi.cpp          1      3      0
test/js/bun/util/wrapAnsi.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->