### PR TITLE
Bun.wrapAnsi: keep 8-bit C1 CSI sequences intact when wrapping

### DIFF
--- a/src/jsc/bindings/wrapAnsi.cpp
+++ b/src/jsc/bindings/wrapAnsi.cpp
@@ -334,15 +334,16 @@ static void trimRowTrailingSpaces(Row<Char>& row, bool ambiguousIsNarrow)
         bool inEscape = false;
         bool inOscEscape = false;
         for (size_t i = 0; i < size; ++i) {
-            if (data[i] == 0x1b || data[i] == 0x9b || inEscape) {
-                ansiOnly.append(data[i]);
-                if (data[i] == 0x1b) {
+            const Char c = data[i];
+            if (c == 0x1b || c == 0x9b || inEscape) {
+                ansiOnly.append(c);
+                if (c == 0x1b) {
                     inEscape = true;
                     inOscEscape = (i + 1 < size && data[i + 1] == ']');
-                } else if (data[i] == 0x9b) {
+                } else if (c == 0x9b) {
                     inEscape = true;
                     inOscEscape = false;
-                } else if (isAnsiEscapeTerminator(data[i], inOscEscape)) {
+                } else if (isAnsiEscapeTerminator(c, inOscEscape)) {
                     inEscape = false;
                     inOscEscape = false;
                 }
@@ -358,15 +359,16 @@ static void trimRowTrailingSpaces(Row<Char>& row, bool ambiguousIsNarrow)
         bool inEscape = false;
         bool inOscEscape = false;
         for (size_t i = lastVisibleEnd; i < size; ++i) {
-            if (data[i] == 0x1b || data[i] == 0x9b || inEscape) {
-                trailingAnsi.append(data[i]);
-                if (data[i] == 0x1b) {
+            const Char c = data[i];
+            if (c == 0x1b || c == 0x9b || inEscape) {
+                trailingAnsi.append(c);
+                if (c == 0x1b) {
                     inEscape = true;
                     inOscEscape = (i + 1 < size && data[i + 1] == ']');
-                } else if (data[i] == 0x9b) {
+                } else if (c == 0x9b) {
                     inEscape = true;
                     inOscEscape = false;
-                } else if (isAnsiEscapeTerminator(data[i], inOscEscape)) {
+                } else if (isAnsiEscapeTerminator(c, inOscEscape)) {
                     inEscape = false;
                     inOscEscape = false;
                 }

--- a/src/jsc/bindings/wrapAnsi.cpp
+++ b/src/jsc/bindings/wrapAnsi.cpp
@@ -149,7 +149,7 @@ public:
 
         while (read < size) {
             Char c = m_data[read];
-            if (c == 0x1b) {
+            if (c == 0x1b || c == 0x9b) {
                 inEscape = true;
             } else if (inEscape) {
                 if (c == 'm' || c == 0x07)
@@ -212,6 +212,10 @@ static void wrapWord(Vector<Row<Char>>& rows, const Char* wordStart, const Char*
             // Check for CSI escape (ESC [)
             if (wordEnd - it > 1 && it[1] == '[')
                 isInsideCsiEscape = true;
+        } else if (*it == 0x9b) {
+            // 8-bit C1 CSI: single-byte introducer, no '[' follows.
+            isInsideEscape = true;
+            isInsideCsiEscape = true;
         }
 
         size_t charLen = 0;
@@ -330,11 +334,14 @@ static void trimRowTrailingSpaces(Row<Char>& row, bool ambiguousIsNarrow)
         bool inEscape = false;
         bool inOscEscape = false;
         for (size_t i = 0; i < size; ++i) {
-            if (data[i] == 0x1b || inEscape) {
+            if (data[i] == 0x1b || data[i] == 0x9b || inEscape) {
                 ansiOnly.append(data[i]);
                 if (data[i] == 0x1b) {
                     inEscape = true;
                     inOscEscape = (i + 1 < size && data[i + 1] == ']');
+                } else if (data[i] == 0x9b) {
+                    inEscape = true;
+                    inOscEscape = false;
                 } else if (isAnsiEscapeTerminator(data[i], inOscEscape)) {
                     inEscape = false;
                     inOscEscape = false;
@@ -351,11 +358,14 @@ static void trimRowTrailingSpaces(Row<Char>& row, bool ambiguousIsNarrow)
         bool inEscape = false;
         bool inOscEscape = false;
         for (size_t i = lastVisibleEnd; i < size; ++i) {
-            if (data[i] == 0x1b || inEscape) {
+            if (data[i] == 0x1b || data[i] == 0x9b || inEscape) {
                 trailingAnsi.append(data[i]);
                 if (data[i] == 0x1b) {
                     inEscape = true;
                     inOscEscape = (i + 1 < size && data[i + 1] == ']');
+                } else if (data[i] == 0x9b) {
+                    inEscape = true;
+                    inOscEscape = false;
                 } else if (isAnsiEscapeTerminator(data[i], inOscEscape)) {
                     inEscape = false;
                     inOscEscape = false;
@@ -377,11 +387,16 @@ static constexpr uint32_t END_CODE = 39;
 template<typename Char>
 static std::optional<uint32_t> parseSgrCode(const Char* start, const Char* end)
 {
-    if (end - start < 3 || start[0] != 0x1b || start[1] != '[')
+    const Char* it;
+    if (end - start >= 3 && start[0] == 0x1b && start[1] == '[')
+        it = start + 2;
+    else if (end - start >= 2 && start[0] == 0x9b)
+        it = start + 1;
+    else
         return std::nullopt;
 
     uint32_t code = 0;
-    for (const Char* it = start + 2; it < end; ++it) {
+    for (; it < end; ++it) {
         Char c = *it;
         if (c >= '0' && c <= '9') {
             code = code * 10 + (c - '0');
@@ -475,10 +490,10 @@ static void joinRowsWithAnsiPreservation(const Vector<Row<Char>>& rows, StringBu
         Char c = joined[i];
         result.append(static_cast<UChar>(c));
 
-        if (c == 0x1b && i + 1 < joined.size()) {
+        if ((c == 0x1b || c == 0x9b) && i + 1 < joined.size()) {
             auto span = joined.span();
             // Parse ANSI sequence
-            if (joined[i + 1] == '[') {
+            if (c == 0x9b || joined[i + 1] == '[') {
                 if (auto code = parseSgrCode(span.data() + i, span.data() + span.size())) {
                     if (*code == END_CODE || *code == 0)
                         escapeCode = std::nullopt;

--- a/test/js/bun/util/wrapAnsi.test.ts
+++ b/test/js/bun/util/wrapAnsi.test.ts
@@ -97,6 +97,40 @@ describe("Bun.wrapAnsi", () => {
     });
   });
 
+  describe("8-bit C1 CSI sequences", () => {
+    // \x9B is the single-byte C1 CSI introducer, equivalent to ESC [. Its
+    // parameter bytes must never be treated as wrappable visible text, and the
+    // SGR code it carries must be tracked for close/reopen at line boundaries
+    // the same as the ESC [ form (matching npm wrap-ansi).
+    test("hard wrap never inserts a newline inside a C1 CSI sequence", () => {
+      const input = "\x9B31mabcdefghij\x9B39m";
+      expect(Bun.wrapAnsi(input, 3, { hard: true })).toBe(
+        "\x9B31mabc\x1b[39m\n\x1b[31mdef\x1b[39m\n\x1b[31mghi\x1b[39m\n\x1b[31mj\x9B39m",
+      );
+    });
+
+    test("hard wrap keeps C1 CSI intact on the UTF-16 path", () => {
+      const input = "\x9B31m日本語\x9B39m";
+      expect(Bun.wrapAnsi(input, 4, { hard: true })).toBe("\x9B31m日本\x1b[39m\n\x1b[31m語\x9B39m");
+    });
+
+    test("wordWrap:false keeps C1 CSI intact", () => {
+      const input = "\x9B31mabcdef\x9B39m";
+      expect(Bun.wrapAnsi(input, 3, { wordWrap: false })).toBe("\x9B31mabc\x1b[39m\n\x1b[31mdef\x9B39m");
+    });
+
+    test("C1 SGR is closed and reopened across a soft line break", () => {
+      const input = "\x9B31mhello world\x9B39m";
+      expect(Bun.wrapAnsi(input, 5)).toBe("\x9B31mhello\x1b[39m\n\x1b[31mworld\x9B39m");
+    });
+
+    test("stripANSI(wrapAnsi(s)) === wrapAnsi(stripANSI(s)) for C1 input", () => {
+      const input = "\x9B31mabcdefghij\x9B39m";
+      const wrapped = Bun.wrapAnsi(input, 3, { hard: true });
+      expect(Bun.stripANSI(wrapped)).toBe(Bun.wrapAnsi(Bun.stripANSI(input), 3, { hard: true }));
+    });
+  });
+
   describe("Unicode support", () => {
     test("handles full-width characters", () => {
       // 日本語 characters are 2 columns each

--- a/test/js/bun/util/wrapAnsi.test.ts
+++ b/test/js/bun/util/wrapAnsi.test.ts
@@ -98,10 +98,9 @@ describe("Bun.wrapAnsi", () => {
   });
 
   describe("8-bit C1 CSI sequences", () => {
-    // \x9B is the single-byte C1 CSI introducer, equivalent to ESC [. Its
-    // parameter bytes must never be treated as wrappable visible text, and the
-    // SGR code it carries must be tracked for close/reopen at line boundaries
-    // the same as the ESC [ form (matching npm wrap-ansi).
+    // \x9B is the single-byte C1 CSI introducer (== ESC [). Its parameter bytes
+    // must not be treated as wrappable visible text, and the SGR code it carries
+    // must be tracked for close/reopen at line boundaries (matching npm wrap-ansi).
     test("hard wrap never inserts a newline inside a C1 CSI sequence", () => {
       const input = "\x9B31mabcdefghij\x9B39m";
       expect(Bun.wrapAnsi(input, 3, { hard: true })).toBe(

--- a/test/js/bun/util/wrapAnsi.test.ts
+++ b/test/js/bun/util/wrapAnsi.test.ts
@@ -119,6 +119,15 @@ describe("Bun.wrapAnsi", () => {
       expect(Bun.wrapAnsi(input, 3, { wordWrap: false })).toBe("\x9B31mabc\x1b[39m\n\x1b[31mdef\x9B39m");
     });
 
+    test("hard wrap keeps a non-SGR C1 CSI (final byte != 'm') intact", () => {
+      // \x9B2K = erase-in-line; wrapWord must end the escape on 'K' (any CSI
+      // final byte in 0x40-0x7E), same as it already does for ESC [ 2 K.
+      expect(Bun.wrapAnsi("\x9B2Kabcdef", 3, { hard: true })).toBe("\x9B2Kabc\ndef");
+      expect(Bun.wrapAnsi("\x9B2Kabcdef", 3, { hard: true })).toBe(
+        Bun.wrapAnsi("\x1b[2Kabcdef", 3, { hard: true }).replace("\x1b[", "\x9B"),
+      );
+    });
+
     test("C1 SGR is closed and reopened across a soft line break", () => {
       const input = "\x9B31mhello world\x9B39m";
       expect(Bun.wrapAnsi(input, 5)).toBe("\x9B31mhello\x1b[39m\n\x1b[31mworld\x9B39m");


### PR DESCRIPTION
## Repro

```js
const s = "\x9B31mabcdefghij\x9B39m";   // C1 CSI form of a red span
Bun.wrapAnsi(s, 3, { hard: true });
// "\x9B31m\nabc\ndef\nghi\nj\x9B39\nm"
//                              ^^^^^^^ newline lands between "39" and "m"
```

The output is a corrupted escape stream: a terminal renders the split fragment as visible garbage and the color state leaks. npm `wrap-ansi@9` keeps both sequences intact and closes/reopens the style at each break:

```
"\x9B31mabc\x1b[39m\n\x1b[31mdef\x1b[39m\n\x1b[31mghi\x1b[39m\n\x1b[31mj\x9B39m"
```

The composition law also broke on any C1 input:

```js
Bun.stripANSI(Bun.wrapAnsi(s, 3, {hard: true}))
  === Bun.wrapAnsi(Bun.stripANSI(s), 3, {hard: true});   // false (before) -> true (after)
```

## Cause

`wrapWord`, `trimLeadingSpaces`, `trimRowTrailingSpaces`, `parseSgrCode` and `joinRowsWithAnsiPreservation` in `src/jsc/bindings/wrapAnsi.cpp` tested only `*it == 0x1b` for the escape introducer. `\x9B` (the single-byte C1 CSI, equivalent to `ESC [`) fell through to the visible-character path, so its parameter bytes were counted as width-1 text and wrapped, and the SGR code it introduced was never tracked for close/reopen. `Bun.stripANSI` and `Bun.sliceAnsi` already recognize `0x9B` via the shared `ANSI::isEscapeCharacter`/`consumeANSI` helpers; `wrapAnsi` was the odd one out.

## Fix

Each of those scanners now also enters escape state on `0x9b`, and `parseSgrCode` accepts the `\x9B<digits>m` form. The CSI terminator check (final byte in `[0x40, 0x7E]`) already applied, so no other logic changes. Close/reopen codes emitted at line boundaries stay in the `ESC [` form, matching npm `wrap-ansi`.

## Verification

New `8-bit C1 CSI sequences` block in `test/js/bun/util/wrapAnsi.test.ts` covers hard wrap (Latin-1 and UTF-16), `wordWrap:false`, soft wrap with close/reopen, and the `stripANSI`/`wrapAnsi` composition law. All five fail with `USE_SYSTEM_BUN=1`; all 154 tests in the file and all 23 npm-ported tests pass with the fix. Expected values match npm `wrap-ansi@9` byte-for-byte.

`Bun.stringWidth` still counts a C1 sequence's parameter bytes as visible columns (see #33488, which deliberately scopes C1 out of width accounting). That affects where soft wrap chooses to break but never splits a sequence; the tests here assert the post-fix output regardless.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/wrapAnsi.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (506f955dc)

test/js/bun/util/wrapAnsi.test.ts:
(pass) Bun.wrapAnsi > basic wrapping > wraps text at word boundaries [4.22ms]
(pass) Bun.wrapAnsi > basic wrapping > handles empty string [3.09ms]
(pass) Bun.wrapAnsi > basic wrapping > no wrapping needed [2.65ms]
(pass) Bun.wrapAnsi > basic wrapping > wraps multiple words [3.40ms]
(pass) Bun.wrapAnsi > basic wrapping > handles single long word [3.23ms]
(pass) Bun.wrapAnsi > basic wrapping > handles columns = 0 [2.59ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks long words in middle [3.79ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks very long word [3.75ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap false disables wrapping [3.44ms]
(pass) Bun.wrapAnsi > trim option > tri
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (811e13f0d)

test/js/bun/util/wrapAnsi.test.ts:
(pass) Bun.wrapAnsi > basic wrapping > wraps text at word boundaries [1.11ms]
(pass) Bun.wrapAnsi > basic wrapping > handles empty string [0.05ms]
(pass) Bun.wrapAnsi > basic wrapping > no wrapping needed [0.02ms]
(pass) Bun.wrapAnsi > basic wrapping > wraps multiple words [0.03ms]
(pass) Bun.wrapAnsi > basic wrapping > handles single long word [0.02ms]
(pass) Bun.wrapAnsi > basic wrapping > handles columns = 0 [0.02ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks long words in middle [0.05ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks very long word [0.02ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap false disables wrapping [0.04ms]
(pass) Bun.wrapAnsi > trim option > trims leading whitespace by default [0.02ms]
(pass) Bun.wrapAnsi > trim option > trim false preserves leading whitespace [0.02ms]
(pass) Bun.wrapAnsi > ANSI escape codes > preserves simple color code [0.03ms]
(pass) Bun.wrapAnsi > ANSI escape codes > preserves color across line break [0.03ms]
(pass) Bun.wrapAnsi > ANSI escape codes > handles multiple colors [0.03ms]
(pass) Bun.wrapAnsi > ANSI escape codes > handles 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/wrapAnsi.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (506f955dc)

test/js/bun/util/wrapAnsi.test.ts:
(pass) Bun.wrapAnsi > basic wrapping > wraps text at word boundaries [1.89ms]
(pass) Bun.wrapAnsi > basic wrapping > handles empty string [1.62ms]
(pass) Bun.wrapAnsi > basic wrapping > no wrapping needed [1.35ms]
(pass) Bun.wrapAnsi > basic wrapping > wraps multiple words [1.74ms]
(pass) Bun.wrapAnsi > basic wrapping > handles single long word [1.68ms]
(pass) Bun.wrapAnsi > basic wrapping > handles columns = 0 [1.27ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks long words in middle [2.12ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks very long word [1.98ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap false disables wrapping [1.84ms]
(pass) Bun.wrapAnsi > trim option > tri
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 772ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen cpp.rs (cppbind)
[1/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/wrapAnsi.cpp     | 43 +++++++++++++++++++++++++++------------
 test/js/bun/util/wrapAnsi.test.ts | 42 ++++++++++++++++++++++++++++++++++++++
 2 files changed, 72 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/jsc/bindings/wrapAnsi.cpp          2      6      0
test/js/bun/util/wrapAnsi.test.ts      3      4      0
```

</details>

<!-- robobun:evidence:end -->