### PR TITLE
Bun.wrapAnsi: wrap OSC 8 hyperlinks with ST terminator or id= params

### DIFF
--- a/src/jsc/bindings/wrapAnsi.cpp
+++ b/src/jsc/bindings/wrapAnsi.cpp
@@ -145,15 +145,26 @@ public:
         size_t read = m_trimScanOffset;
         size_t write = m_trimScanOffset;
         bool inEscape = m_trimInEscape;
+        bool inOscEscape = m_trimInOscEscape;
         size_t removedWidth = 0;
 
         while (read < size) {
             Char c = m_data[read];
             if (c == 0x1b) {
-                inEscape = true;
-            } else if (inEscape) {
-                if (c == 'm' || c == 0x07)
+                if (inOscEscape && read + 1 < size && m_data[read + 1] == '\\') {
+                    m_data[write++] = c;
+                    m_data[write++] = m_data[read + 1];
+                    read += 2;
                     inEscape = false;
+                    inOscEscape = false;
+                    continue;
+                }
+                inEscape = true;
+                if (read + 1 < size && m_data[read + 1] == ']')
+                    inOscEscape = true;
+            } else if (inEscape) {
+                if (inOscEscape ? (c == 0x07 || c == 0x9c) : (c == 'm'))
+                    inEscape = false, inOscEscape = false;
             } else if (c == ' ' || c == '\t') {
                 if (c == ' ')
                     removedWidth++;
@@ -179,11 +190,13 @@ public:
 
         m_trimScanOffset = write;
         m_trimInEscape = inEscape;
+        m_trimInOscEscape = inOscEscape;
         return removedWidth;
     }
 
     size_t m_trimScanOffset = 0;
     bool m_trimInEscape = false;
+    bool m_trimInOscEscape = false;
     bool m_leadingTrimComplete = false;
 };
 
@@ -202,13 +215,18 @@ static void wrapWord(Vector<Row<Char>>& rows, const Char* wordStart, const Char*
     const Char* it = wordStart;
     while (it < wordEnd) {
         if (*it == 0x1b) {
+            // ST (ESC \) terminates an in-progress OSC sequence
+            if (isInsideLinkEscape && wordEnd - it > 1 && it[1] == '\\') {
+                rows.last().append(it, it + 2);
+                it += 2;
+                isInsideEscape = false;
+                isInsideLinkEscape = false;
+                continue;
+            }
             isInsideEscape = true;
             isInsideCsiEscape = false;
-            // Check for hyperlink escape (OSC 8)
-            if (wordEnd - it > 4) {
-                if (it[1] == ']' && it[2] == '8' && it[3] == ';' && it[4] == ';')
-                    isInsideLinkEscape = true;
-            }
+            if (wordEnd - it > 1 && it[1] == ']')
+                isInsideLinkEscape = true;
             // Check for CSI escape (ESC [)
             if (wordEnd - it > 1 && it[1] == '[')
                 isInsideCsiEscape = true;
@@ -246,7 +264,7 @@ static void wrapWord(Vector<Row<Char>>& rows, const Char* wordStart, const Char*
 
         if (isInsideEscape) {
             if (isInsideLinkEscape) {
-                if (*it == 0x07) {
+                if (*it == 0x07 || *it == 0x9c) {
                     isInsideEscape = false;
                     isInsideLinkEscape = false;
                 }
@@ -294,7 +312,7 @@ template<typename Char>
 static bool isAnsiEscapeTerminator(Char c, bool isOscSequence)
 {
     if (isOscSequence)
-        return c == 0x07; // BEL terminates OSC sequences
+        return c == 0x07 || c == 0x9c; // BEL or C1 ST terminate OSC sequences
     return isCsiTerminator(c); // CSI terminator
 }
 
@@ -395,25 +413,33 @@ static std::optional<uint32_t> parseSgrCode(const Char* start, const Char* end)
     return std::nullopt;
 }
 
+// Parse an OSC 8 hyperlink: ESC ] 8 ; params ; uri TERMINATOR
+// where TERMINATOR is BEL (0x07), ST (ESC \) or C1 ST (0x9c).
+// Returns the [params;uri) body span, and whether the URI is non-empty (open).
 template<typename Char>
-static std::pair<const Char*, const Char*> parseOsc8Url(const Char* start, const Char* end)
+static std::pair<const Char*, const Char*> parseOsc8Body(const Char* start, const Char* end, bool& isOpen)
 {
-    // Format: ESC ] 8 ; ; url BEL
-    if (end - start < 6)
-        return { nullptr, nullptr };
-    if (start[0] != 0x1b || start[1] != ']' || start[2] != '8' || start[3] != ';' || start[4] != ';')
+    isOpen = false;
+    if (end - start < 4 || start[0] != 0x1b || start[1] != ']' || start[2] != '8' || start[3] != ';')
         return { nullptr, nullptr };
 
-    const Char* urlStart = start + 5;
-    const Char* urlEnd = urlStart;
-
-    while (urlEnd < end && *urlEnd != 0x07 && *urlEnd != 0x1b)
-        urlEnd++;
-
-    if (urlEnd == urlStart)
+    const Char* bodyStart = start + 4;
+    const Char* sep = bodyStart;
+    while (sep < end && *sep != ';' && *sep != 0x07 && *sep != 0x9c && *sep != 0x1b)
+        sep++;
+    if (sep >= end || *sep != ';')
         return { nullptr, nullptr };
+    const Char* uriStart = sep + 1;
 
-    return { urlStart, urlEnd };
+    const Char* p = uriStart;
+    while (p < end) {
+        if (*p == 0x07 || *p == 0x9c || (*p == 0x1b && p + 1 < end && p[1] == '\\')) {
+            isOpen = p > uriStart;
+            return { bodyStart, p };
+        }
+        p++;
+    }
+    return { nullptr, nullptr };
 }
 
 static std::optional<uint32_t> getCloseCode(uint32_t code)
@@ -468,8 +494,8 @@ static void joinRowsWithAnsiPreservation(const Vector<Row<Char>>& rows, StringBu
 
     // Process for ANSI style preservation
     std::optional<uint32_t> escapeCode;
-    const Char* escapeUrl = nullptr;
-    size_t escapeUrlLen = 0;
+    const Char* escapeLink = nullptr;
+    size_t escapeLinkLen = 0;
 
     for (size_t i = 0; i < joined.size(); ++i) {
         Char c = joined[i];
@@ -485,14 +511,17 @@ static void joinRowsWithAnsiPreservation(const Vector<Row<Char>>& rows, StringBu
                     else
                         escapeCode = *code;
                 }
-            } else if (i + 4 < joined.size() && joined[i + 1] == ']' && joined[i + 2] == '8' && joined[i + 3] == ';' && joined[i + 4] == ';') {
-                auto [urlStart, urlEnd] = parseOsc8Url(span.data() + i, span.data() + span.size());
-                if (urlStart && urlEnd != urlStart) {
-                    escapeUrl = urlStart;
-                    escapeUrlLen = urlEnd - urlStart;
-                } else {
-                    escapeUrl = nullptr;
-                    escapeUrlLen = 0;
+            } else if (i + 3 < joined.size() && joined[i + 1] == ']' && joined[i + 2] == '8' && joined[i + 3] == ';') {
+                bool isOpen;
+                auto [bodyStart, bodyEnd] = parseOsc8Body(span.data() + i, span.data() + span.size(), isOpen);
+                if (bodyStart) {
+                    if (isOpen) {
+                        escapeLink = bodyStart;
+                        escapeLinkLen = bodyEnd - bodyStart;
+                    } else {
+                        escapeLink = nullptr;
+                        escapeLinkLen = 0;
+                    }
                 }
             }
         }
@@ -500,7 +529,7 @@ static void joinRowsWithAnsiPreservation(const Vector<Row<Char>>& rows, StringBu
         // Check if next character is newline
         if (i + 1 < joined.size() && joined[i + 1] == '\n') {
             // Close styles before newline
-            if (escapeUrl) {
+            if (escapeLink) {
                 result.append("\x1b]8;;\x07"_s);
             }
             if (escapeCode) {
@@ -517,10 +546,10 @@ static void joinRowsWithAnsiPreservation(const Vector<Row<Char>>& rows, StringBu
                 result.append(String::number(*escapeCode));
                 result.append('m');
             }
-            if (escapeUrl) {
-                result.append("\x1b]8;;"_s);
-                for (size_t j = 0; j < escapeUrlLen; ++j)
-                    result.append(static_cast<UChar>(escapeUrl[j]));
+            if (escapeLink) {
+                result.append("\x1b]8;"_s);
+                for (size_t j = 0; j < escapeLinkLen; ++j)
+                    result.append(static_cast<UChar>(escapeLink[j]));
                 result.append(static_cast<UChar>(0x07));
             }
         }

--- a/test/js/bun/util/wrapAnsi.test.ts
+++ b/test/js/bun/util/wrapAnsi.test.ts
@@ -653,6 +653,98 @@ describe("Bun.wrapAnsi", () => {
     });
   });
 
+  describe("OSC 8 hyperlinks", () => {
+    const lineWidths = (s: string) => s.split("\n").map(l => Bun.stringWidth(l));
+
+    // OSC 8 may be terminated by BEL (0x07), ST (ESC \) or C1 ST (0x9c), and may
+    // carry parameters (e.g. id=) between the first and second ';'. Every form must
+    // uphold the wrap contract: each output line's visible width <= columns.
+    const open = {
+      bel: "\x1b]8;;http://x\x07",
+      st: "\x1b]8;;http://x\x1b\\",
+      c1st: "\x1b]8;;http://x\x9c",
+      idBel: "\x1b]8;id=9;http://e.co\x07",
+      idSt: "\x1b]8;id=9;http://e.co\x1b\\",
+    };
+    const close = {
+      bel: "\x1b]8;;\x07",
+      st: "\x1b]8;;\x1b\\",
+      c1st: "\x1b]8;;\x9c",
+      idBel: "\x1b]8;;\x07",
+      idSt: "\x1b]8;;\x1b\\",
+    };
+    const variants = Object.keys(open) as (keyof typeof open)[];
+
+    describe.each(variants)("%s-terminated", v => {
+      test("hard wrap respects columns", () => {
+        const input = `${open[v]}longlonglongword${close[v]}`;
+        expect(lineWidths(Bun.wrapAnsi(input, 5, { hard: true }))).toEqual([5, 5, 5, 1]);
+      });
+
+      test("wordWrap:false respects columns", () => {
+        const input = `${open[v]}longlonglongword${close[v]}`;
+        expect(lineWidths(Bun.wrapAnsi(input, 5, { wordWrap: false }))).toEqual([5, 5, 5, 1]);
+      });
+
+      test("hard wrap with trailing text respects columns", () => {
+        const input = `${open[v]}idlink${close[v]} more`;
+        for (const w of lineWidths(Bun.wrapAnsi(input, 3, { hard: true }))) {
+          expect(w).toBeLessThanOrEqual(3);
+        }
+      });
+
+      test("hard wrap respects columns (UTF-16 input)", () => {
+        const input = `${open[v]}longlonglongword${close[v]}\u00e9`;
+        for (const w of lineWidths(Bun.wrapAnsi(input, 5, { hard: true }))) {
+          expect(w).toBeLessThanOrEqual(5);
+        }
+      });
+
+      test("soft wrap closes and reopens the link at each newline", () => {
+        const input = `${open[v]}aa bb cc${close[v]}`;
+        const out = Bun.wrapAnsi(input, 2);
+        expect(lineWidths(out)).toEqual([2, 2, 2]);
+        // Every wrapped line carries its own open (ESC ] 8 ; ... ; non-empty URI)
+        // and close (ESC ] 8 ; ; <terminator>) so it remains independently clickable.
+        const linkOpen = /\x1b]8;[^;]*;[^\x07\x1b\x9c]+(?:\x07|\x1b\\|\x9c)/;
+        const linkClose = /\x1b]8;;(?:\x07|\x1b\\|\x9c)/;
+        for (const line of out.split("\n")) {
+          expect(line).toMatch(linkOpen);
+          expect(line).toMatch(linkClose);
+        }
+      });
+    });
+
+    test("hard-wrapped ST-terminated link: exact output", () => {
+      const input = `${open.st}longlonglongword${close.st}`;
+      expect(Bun.wrapAnsi(input, 5, { hard: true })).toBe(
+        "\x1b]8;;http://x\x1b\\longl\x1b]8;;\x07\n" +
+          "\x1b]8;;http://x\x07onglo\x1b]8;;\x07\n" +
+          "\x1b]8;;http://x\x07ngwor\x1b]8;;\x07\n" +
+          "\x1b]8;;http://x\x07d\x1b]8;;\x1b\\",
+      );
+    });
+
+    test("soft-wrapped id= link preserves params when reopening", () => {
+      const input = `${open.idBel}aa bb cc${close.idBel}`;
+      expect(Bun.wrapAnsi(input, 2)).toBe(
+        "\x1b]8;id=9;http://e.co\x07aa\x1b]8;;\x07\n" +
+          "\x1b]8;id=9;http://e.co\x07bb\x1b]8;;\x07\n" +
+          "\x1b]8;id=9;http://e.co\x07cc\x1b]8;;\x07",
+      );
+    });
+
+    test("BEL form is unchanged", () => {
+      const input = `${open.bel}longlonglongword${close.bel}`;
+      expect(Bun.wrapAnsi(input, 5, { hard: true })).toBe(
+        "\x1b]8;;http://x\x07longl\x1b]8;;\x07\n" +
+          "\x1b]8;;http://x\x07onglo\x1b]8;;\x07\n" +
+          "\x1b]8;;http://x\x07ngwor\x1b]8;;\x07\n" +
+          "\x1b]8;;http://x\x07d\x1b]8;;\x07",
+      );
+    });
+  });
+
   describe("long inputs", () => {
     test("wraps a long run of color escape sequences on one line", async () => {
       await using proc = Bun.spawn({

--- a/test/js/bun/util/wrapAnsi.test.ts
+++ b/test/js/bun/util/wrapAnsi.test.ts
@@ -694,7 +694,8 @@ describe("Bun.wrapAnsi", () => {
       });
 
       test("hard wrap respects columns (UTF-16 input)", () => {
-        const input = `${open[v]}longlonglongword${close[v]}\u00e9`;
+        // U+0100 > 0xFF forces a 16-bit backing string so wrapAnsiImpl<UChar> runs.
+        const input = `${open[v]}longlonglongword${close[v]}\u0100`;
         for (const w of lineWidths(Bun.wrapAnsi(input, 5, { hard: true }))) {
           expect(w).toBeLessThanOrEqual(5);
         }


### PR DESCRIPTION
## Problem

`Bun.wrapAnsi` treats an entire OSC 8 hyperlink word as zero-width escape bytes (so it never wraps and output lines exceed `columns` by the full link text) when the link is either:

- terminated by ST (`ESC \`, the ECMA-48 standard terminator) or C1 ST (`0x9c`), or
- carries the documented `id=` parameter field (anything between the two `;`).

Only the exact `ESC ] 8 ; ; ... BEL` form wrapped correctly.

```js
const wid = (o) => o.split("\n").map((l) => Bun.stringWidth(l));
const st  = "\x1b]8;;http://x\x1b\\longlonglongword\x1b]8;;\x1b\\";
wid(Bun.wrapAnsi(st, 5, { hard: true }));   // [16]   (one line, width 16 at columns=5)
const idl = "\x1b]8;id=9;http://e.co\x07idlink\x1b]8;;\x07 more";
wid(Bun.wrapAnsi(idl, 3, { hard: true }));  // [6,3,1] (width 6 at columns=3)
const bel = "\x1b]8;;http://x\x07longlonglongword\x1b]8;;\x07";
wid(Bun.wrapAnsi(bel, 5, { hard: true }));  // [5,5,5,1] ok
```

`Bun.stringWidth` already measures the ST form correctly, so the documented wrap contract (every line width <= columns per `stringWidth`) is broken.

## Cause

In `src/jsc/bindings/wrapAnsi.cpp`:

- `wrapWord` detects OSC 8 only via the literal `it[1..4] == "]8;;"` check, so `id=` (or any params) falls into the `m`-terminated fallback and swallows the visible text; and it leaves OSC state only on BEL, so an ST-terminated link never ends and swallows the rest of the word.
- `parseOsc8Url` / `joinRowsWithAnsiPreservation` have the same `;;`-only introducer check and BEL-only terminator, so `id=` links are not closed/reopened at wrapped line boundaries.
- `trimLeadingSpaces` and `isAnsiEscapeTerminator` share the BEL-only OSC terminator assumption.

`Bun.sliceAnsi`'s `parseHyperlink` already handles ST, C1 ST and arbitrary params; this change brings `wrapAnsi` to parity.

## Fix

- `wrapWord`: recognize any `ESC ]` OSC introducer; terminate on BEL, ST (`ESC \`) or C1 ST.
- `trimLeadingSpaces`: track OSC vs CSI escapes; terminate OSC on BEL / ST / C1 ST.
- `isAnsiEscapeTerminator`: accept C1 ST for OSC sequences.
- `parseOsc8Url` -> `parseOsc8Body`: accept `ESC ] 8 ; params ; uri` with BEL / ST / C1 ST terminators and report whether the URI is non-empty (open vs close).
- `joinRowsWithAnsiPreservation`: store the full `params;uri` body so the reopened link on the next line preserves `id=`.

## Verification

New `OSC 8 hyperlinks` describe block in `test/js/bun/util/wrapAnsi.test.ts` exercises BEL, ST, C1 ST, `id=`+BEL and `id=`+ST across `hard`, `wordWrap:false`, UTF-16 input, and soft-wrap close/reopen. 21 of the 28 new tests fail on main; all 200 wrapAnsi tests (including the npm-ported suite) pass with the fix.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 21 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/wrapAnsi.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (5ca49d804)

test/js/bun/util/wrapAnsi.test.ts:
(pass) Bun.wrapAnsi > basic wrapping > wraps text at word boundaries [1.71ms]
(pass) Bun.wrapAnsi > basic wrapping > handles empty string [1.48ms]
(pass) Bun.wrapAnsi > basic wrapping > no wrapping needed [1.24ms]
(pass) Bun.wrapAnsi > basic wrapping > wraps multiple words [1.59ms]
(pass) Bun.wrapAnsi > basic wrapping > handles single long word [1.52ms]
(pass) Bun.wrapAnsi > basic wrapping > handles columns = 0 [1.17ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks long words in middle [1.87ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks very long word [1.76ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap false disables wrapping [1.62ms]
(pass) Bun.wrapAnsi > trim option > tri
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (0e8883c03)

test/js/bun/util/wrapAnsi.test.ts:
(pass) Bun.wrapAnsi > basic wrapping > wraps text at word boundaries [0.03ms]
(pass) Bun.wrapAnsi > basic wrapping > handles empty string [0.01ms]
(pass) Bun.wrapAnsi > basic wrapping > no wrapping needed
(pass) Bun.wrapAnsi > basic wrapping > wraps multiple words [0.01ms]
(pass) Bun.wrapAnsi > basic wrapping > handles single long word
(pass) Bun.wrapAnsi > basic wrapping > handles columns = 0 [0.01ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks long words in middle [0.02ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks very long word [0.01ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap false disables wrapping [0.02ms]
(pass) Bun.wrapAnsi > trim option > trims leading whitespace by default [0.01ms]
(pass) Bun.wrapAnsi > trim option > trim false preserves leading whitespace [0.01ms]
(pass) Bun.wrapAnsi > ANSI escape codes > preserves simple color code [0.02ms]
(pass) Bun.wrapAnsi > ANSI escape codes > preserves color across line break [0.02ms]
(pass) Bun.wrapAnsi > ANSI escape codes > handles multiple colors [0.01ms]
(pass) Bun.wrapAnsi > ANSI escape codes > handles bold and styles [0
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/wrapAnsi.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (5ca49d804)

test/js/bun/util/wrapAnsi.test.ts:
(pass) Bun.wrapAnsi > basic wrapping > wraps text at word boundaries [1.71ms]
(pass) Bun.wrapAnsi > basic wrapping > handles empty string [1.48ms]
(pass) Bun.wrapAnsi > basic wrapping > no wrapping needed [1.22ms]
(pass) Bun.wrapAnsi > basic wrapping > wraps multiple words [1.57ms]
(pass) Bun.wrapAnsi > basic wrapping > handles single long word [1.55ms]
(pass) Bun.wrapAnsi > basic wrapping > handles columns = 0 [1.16ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks long words in middle [1.85ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks very long word [1.76ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap false disables wrapping [1.63ms]
(pass) Bun.wrapAnsi > trim option > tri
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 818ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[2/7] gen cpp.rs (cppbind)
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/wrapAnsi.cpp     | 103 ++++++++++++++++++++++++--------------
 test/js/bun/util/wrapAnsi.test.ts |  93 ++++++++++++++++++++++++++++++++++
 2 files changed, 159 insertions(+), 37 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/jsc/bindings/wrapAnsi.cpp          2      7      0
test/js/bun/util/wrapAnsi.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->