### PR TITLE
Bun.stringWidth: honor ambiguousIsNarrow on the Latin-1 fast path

### DIFF
--- a/src/bun_core/string/immutable/visible.rs
+++ b/src/bun_core/string/immutable/visible.rs
@@ -10,7 +10,11 @@ pub mod visible {
     pub mod width {
         pub mod exclude_ansi_colors {
             unsafe extern "C" {
-                fn Bun__visibleWidthExcludeANSI_latin1(ptr: *const u8, len: usize) -> usize;
+                fn Bun__visibleWidthExcludeANSI_latin1(
+                    ptr: *const u8,
+                    len: usize,
+                    ambiguous_as_wide: bool,
+                ) -> usize;
                 fn Bun__visibleWidthExcludeANSI_utf8(ptr: *const u8, len: usize) -> usize;
                 fn Bun__visibleWidthExcludeANSI_utf16(
                     ptr: *const u16,
@@ -26,9 +30,15 @@ pub mod visible {
 
             /// Visible terminal width of Latin-1 bytes, treating ANSI escape
             /// sequences as zero-width.
-            pub(crate) fn latin1(input: &[u8]) -> usize {
+            pub(crate) fn latin1(input: &[u8], ambiguous_as_wide: bool) -> usize {
                 // SAFETY: `input` is a live slice for the duration of the call.
-                unsafe { Bun__visibleWidthExcludeANSI_latin1(input.as_ptr(), input.len()) }
+                unsafe {
+                    Bun__visibleWidthExcludeANSI_latin1(
+                        input.as_ptr(),
+                        input.len(),
+                        ambiguous_as_wide,
+                    )
+                }
             }
 
             /// Visible terminal width of a UTF-8 string, treating ANSI escape

--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -905,7 +905,7 @@ impl String {
             // the UTF-8 byte view.
             return w::utf8(self.as_zig().slice());
         }
-        w::latin1(self.latin1())
+        w::latin1(self.latin1(), ambiguous_as_wide)
     }
 
     /// `bun.String.isGlobal` — true iff this is a `ZigString`

--- a/src/jsc/bindings/sliceAnsi.cpp
+++ b/src/jsc/bindings/sliceAnsi.cpp
@@ -10,7 +10,7 @@
 extern "C" uint8_t Bun__codepointWidth(uint32_t cp, bool ambiguous_as_wide);
 extern "C" bool Bun__graphemeBreak(uint32_t cp1, uint32_t cp2, uint8_t* state);
 extern "C" bool Bun__isEmojiPresentation(uint32_t cp);
-extern "C" size_t Bun__visibleWidthExcludeANSI_latin1(const uint8_t* ptr, size_t len);
+extern "C" size_t Bun__visibleWidthExcludeANSI_latin1(const uint8_t* ptr, size_t len, bool ambiguous_as_wide);
 extern "C" size_t Bun__visibleWidthExcludeANSI_utf16(const uint16_t* ptr, size_t len, bool ambiguous_as_wide);
 
 namespace Bun {
@@ -1412,7 +1412,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionBunSliceAnsi, (JSC::JSGlobalObject * globalOb
     size_t ellipsisWidth = 0;
     if (!ellipsis.isEmpty()) {
         ellipsisWidth = ellipsis.is8Bit()
-            ? Bun__visibleWidthExcludeANSI_latin1(reinterpret_cast<const uint8_t*>(ellipsis.span8().data()), ellipsis.length())
+            ? Bun__visibleWidthExcludeANSI_latin1(reinterpret_cast<const uint8_t*>(ellipsis.span8().data()), ellipsis.length(), ambiguousIsWide)
             : Bun__visibleWidthExcludeANSI_utf16(reinterpret_cast<const uint16_t*>(ellipsis.span16().data()), ellipsis.length(), ambiguousIsWide);
     }
 

--- a/src/jsc/bindings/stringWidth.cpp
+++ b/src/jsc/bindings/stringWidth.cpp
@@ -495,23 +495,123 @@ struct GraphemeState {
 // ============================================================================
 
 // Zero-width Latin-1 bytes: C0 controls, DEL + C1 controls, soft hyphen.
-static uint8_t visibleLatin1WidthScalar(uint8_t c)
+static constexpr uint8_t visibleLatin1WidthScalar(uint8_t c)
 {
     return ((c >= 0x7F && c <= 0x9F) || c < 0x20 || c == 0xAD) ? 0 : 1;
 }
 
-size_t visibleLatin1Width(std::span<const uint8_t> input)
+// Per-byte Latin-1 width with East-Asian-Ambiguous treated as wide. Derived
+// from the same fused classification table the UTF-16 path uses so the two
+// encodings cannot disagree. 43 Latin-1 bytes in U+00A1..U+00FE are Ambiguous
+// (§, °, ±, ×, ÷, é, ...); the rest match visibleLatin1WidthScalar.
+static constexpr auto kLatin1WidthAmbiguousWide = []() constexpr {
+    std::array<uint8_t, 256> result {};
+    for (size_t c = 0; c < 256; c++)
+        result[c] = widthFromFused(fusedClassify(static_cast<char32_t>(c)), true);
+    return result;
+}();
+static_assert(kLatin1WidthAmbiguousWide['A'] == 1);
+static_assert(kLatin1WidthAmbiguousWide[0xE9] == 2); // é
+static_assert(kLatin1WidthAmbiguousWide[0xA7] == 2); // §
+static_assert(kLatin1WidthAmbiguousWide[0xB1] == 2); // ±
+static_assert(kLatin1WidthAmbiguousWide[0xE2] == 1); // â (not ambiguous)
+static_assert(kLatin1WidthAmbiguousWide[0xAD] == 0); // soft hyphen
+static_assert(kLatin1WidthAmbiguousWide[0x1B] == 0); // ESC
+
+// The fused table's narrow Latin-1 widths must match visibleLatin1WidthScalar
+// exactly, so `wide = narrow + (ambiguous ? 1 : 0)` is an equivalence, not an
+// approximation.
+static_assert([]() constexpr {
+    for (size_t c = 0; c < 256; c++) {
+        if (widthFromFused(fusedClassify(static_cast<char32_t>(c)), false) != visibleLatin1WidthScalar(static_cast<uint8_t>(c)))
+            return false;
+    }
+    return true;
+}());
+
+static size_t countLatin1Ambiguous(std::span<const uint8_t> input)
+{
+    size_t count = 0;
+    for (const uint8_t c : input)
+        count += kLatin1WidthAmbiguousWide[c] >> 1;
+    return count;
+}
+
+size_t visibleLatin1Width(std::span<const uint8_t> input, bool ambiguousAsWide)
 {
     // For inputs smaller than one SIMD vector the dynamic-dispatch call costs
     // more than the count itself — ANSI-heavy strings hit this constantly with
     // the short visible runs between escape sequences.
+    size_t count;
     if (input.size() < 16) {
-        size_t count = 0;
+        count = 0;
         for (const uint8_t c : input)
             count += visibleLatin1WidthScalar(c);
-        return count;
+    } else {
+        count = highway_visible_latin1_width(input.data(), input.size());
     }
-    return highway_visible_latin1_width(input.data(), input.size());
+    if (ambiguousAsWide)
+        count += countLatin1Ambiguous(input);
+    return count;
+}
+
+// Scalar escape-aware width for the ambiguous-as-wide case. Mirrors
+// VisibleLatin1WidthExcludeANSIScalar (highway_strings.cpp) byte for byte so
+// OSC payload bytes (which can be >= 0xA1) are excluded from the count.
+static size_t visibleLatin1WidthExcludeANSIAmbiguousWide(std::span<const uint8_t> input)
+{
+    enum class State : uint8_t { None, InCSI, InOSC };
+    State state = State::None;
+    size_t width = 0;
+    size_t i = 0;
+    const size_t len = input.size();
+    while (i < len) {
+        const uint8_t c = input[i];
+        switch (state) {
+        case State::InCSI:
+            if (c >= 0x40 && c <= 0x7E)
+                state = State::None;
+            i++;
+            break;
+        case State::InOSC:
+            if (c == 0x07 || c == 0x9C) {
+                state = State::None;
+                i++;
+                break;
+            }
+            if (c == 0x1B && i + 1 < len && input[i + 1] == '\\') {
+                state = State::None;
+                i += 2;
+                break;
+            }
+            i++;
+            break;
+        case State::None:
+            if (c == 0x1B) {
+                if (i + 1 >= len) {
+                    i++;
+                    break;
+                }
+                const uint8_t next = input[i + 1];
+                if (next == '[') {
+                    state = State::InCSI;
+                    i += 2;
+                    break;
+                }
+                if (next == ']') {
+                    state = State::InOSC;
+                    i += 2;
+                    break;
+                }
+                i++;
+                break;
+            }
+            width += kLatin1WidthAmbiguousWide[c];
+            i++;
+            break;
+        }
+    }
+    return width;
 }
 
 // Visible width treating ANSI escape sequences (ESC[...<final>, ESC]...BEL/ST)
@@ -520,11 +620,18 @@ size_t visibleLatin1Width(std::span<const uint8_t> input)
 // Implemented as a single-pass SIMD kernel (highway_strings.cpp): each chunk
 // is classified once into printable/escape bitmasks, so dense SGR input does
 // not pay a separate scan per escape sequence.
-size_t visibleLatin1WidthExcludeANSI(std::span<const uint8_t> input)
+size_t visibleLatin1WidthExcludeANSI(std::span<const uint8_t> input, bool ambiguousAsWide)
 {
     if (input.empty())
         return 0;
-    return highway_visible_latin1_width_exclude_ansi(input.data(), input.size());
+    if (!ambiguousAsWide)
+        return highway_visible_latin1_width_exclude_ansi(input.data(), input.size());
+    // Ambiguous Latin-1 bytes are all >= 0xA1, so they cannot appear inside a
+    // CSI (pure ASCII) but can appear inside an OSC payload. When no ESC is
+    // present the SIMD narrow result plus a per-byte correction is exact.
+    if (highway_index_of_char(input.data(), input.size(), 0x1B) == input.size())
+        return highway_visible_latin1_width_exclude_ansi(input.data(), input.size()) + countLatin1Ambiguous(input);
+    return visibleLatin1WidthExcludeANSIAmbiguousWide(input);
 }
 
 // ============================================================================
@@ -618,7 +725,7 @@ static size_t visibleUTF8WidthImpl(std::span<const uint8_t> input, AsciiWidthFn 
 size_t visibleUTF8WidthExcludeANSI(std::span<const uint8_t> input)
 {
     return visibleUTF8WidthImpl(input, [](std::span<const uint8_t> ascii) {
-        return visibleLatin1WidthExcludeANSI(ascii);
+        return visibleLatin1WidthExcludeANSI(ascii, false);
     });
 }
 
@@ -1022,9 +1129,9 @@ size_t visibleUTF16Width(std::span<const char16_t> input, bool excludeAnsiColors
 // console.table column sizing and the markdown ANSI renderer)
 // ============================================================================
 
-extern "C" size_t Bun__visibleWidthExcludeANSI_latin1(const uint8_t* ptr, size_t len)
+extern "C" size_t Bun__visibleWidthExcludeANSI_latin1(const uint8_t* ptr, size_t len, bool ambiguous_as_wide)
 {
-    return StringWidth::visibleLatin1WidthExcludeANSI({ ptr, len });
+    return StringWidth::visibleLatin1WidthExcludeANSI({ ptr, len }, ambiguous_as_wide);
 }
 
 extern "C" size_t Bun__visibleWidthExcludeANSI_utf16(const uint16_t* ptr, size_t len, bool ambiguous_as_wide)
@@ -1122,14 +1229,11 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionBunStringWidth, (JSC::JSGlobalObject * global
     const bool ambiguousAsWide = !ambiguousIsNarrow;
     size_t width;
     if (view->is8Bit()) {
-        // 8-bit JSC strings are Latin-1. The Latin-1 path has never honored
-        // ambiguousIsNarrow (parity with the previous implementation), even
-        // though some Latin-1 codepoints are East-Asian-Ambiguous (§, ×, ÷, ...).
         const auto span = view->span8();
         const std::span<const uint8_t> bytes { reinterpret_cast<const uint8_t*>(span.data()), span.size() };
         width = countAnsiEscapeCodes
-            ? StringWidth::visibleLatin1Width(bytes)
-            : StringWidth::visibleLatin1WidthExcludeANSI(bytes);
+            ? StringWidth::visibleLatin1Width(bytes, ambiguousAsWide)
+            : StringWidth::visibleLatin1WidthExcludeANSI(bytes, ambiguousAsWide);
     } else {
         const auto span = view->span16();
         width = StringWidth::visibleUTF16Width({ span.data(), span.size() }, !countAnsiEscapeCodes, ambiguousAsWide);

--- a/src/jsc/bindings/stringWidth.cpp
+++ b/src/jsc/bindings/stringWidth.cpp
@@ -560,7 +560,9 @@ size_t visibleLatin1Width(std::span<const uint8_t> input, bool ambiguousAsWide)
 // OSC payload bytes (which can be >= 0xA1) are excluded from the count.
 static size_t visibleLatin1WidthExcludeANSIAmbiguousWide(std::span<const uint8_t> input)
 {
-    enum class State : uint8_t { None, InCSI, InOSC };
+    enum class State : uint8_t { None,
+        InCSI,
+        InOSC };
     State state = State::None;
     size_t width = 0;
     size_t i = 0;

--- a/src/jsc/bindings/stringWidth.h
+++ b/src/jsc/bindings/stringWidth.h
@@ -22,10 +22,10 @@ bool graphemeBreak(char32_t cp1, char32_t cp2, uint8_t& state);
 bool isEmojiPresentation(char32_t cp);
 
 // Visible width of Latin-1 text, counting ANSI escape sequences as visible.
-size_t visibleLatin1Width(std::span<const uint8_t> input);
+size_t visibleLatin1Width(std::span<const uint8_t> input, bool ambiguousAsWide);
 
 // Visible width of Latin-1 text, treating ANSI escape sequences as zero-width.
-size_t visibleLatin1WidthExcludeANSI(std::span<const uint8_t> input);
+size_t visibleLatin1WidthExcludeANSI(std::span<const uint8_t> input, bool ambiguousAsWide);
 
 // Visible width of UTF-16 text (grapheme-cluster aware). `excludeAnsiColors`
 // treats ANSI escape sequences as zero-width.

--- a/src/jsc/bindings/wrapAnsi.cpp
+++ b/src/jsc/bindings/wrapAnsi.cpp
@@ -10,7 +10,7 @@
 
 // Native exports (implemented in stringWidth.cpp) for visible width calculation
 extern "C" size_t Bun__visibleWidthExcludeANSI_utf16(const uint16_t* ptr, size_t len, bool ambiguous_as_wide);
-extern "C" size_t Bun__visibleWidthExcludeANSI_latin1(const uint8_t* ptr, size_t len);
+extern "C" size_t Bun__visibleWidthExcludeANSI_latin1(const uint8_t* ptr, size_t len, bool ambiguous_as_wide);
 extern "C" uint8_t Bun__codepointWidth(uint32_t cp, bool ambiguous_as_wide);
 extern "C" bool Bun__graphemeBreak(uint32_t cp1, uint32_t cp2, uint8_t* state);
 
@@ -51,9 +51,7 @@ static size_t stringWidth(const Char* start, const Char* end, bool ambiguousIsNa
 
     if constexpr (sizeof(Char) == 1) {
         // 8-bit JSC strings are Latin1, not UTF-8
-        // Note: Latin1 doesn't have ambiguous width characters (all are in U+0000-U+00FF)
-        (void)ambiguousIsNarrow;
-        return Bun__visibleWidthExcludeANSI_latin1(reinterpret_cast<const uint8_t*>(start), len);
+        return Bun__visibleWidthExcludeANSI_latin1(reinterpret_cast<const uint8_t*>(start), len, !ambiguousIsNarrow);
     } else {
         return Bun__visibleWidthExcludeANSI_utf16(reinterpret_cast<const uint16_t*>(start), len, !ambiguousIsNarrow);
     }

--- a/test/js/bun/util/stringWidth.test.ts
+++ b/test/js/bun/util/stringWidth.test.ts
@@ -123,6 +123,112 @@ test("ambiguousIsNarrow=false", () => {
   }
 });
 
+// Bun.stringWidth must be a function of the string's codepoints only, never of
+// JSC's internal 8-bit/16-bit representation. 43 bytes in U+00A1..U+00FE are
+// East Asian Ambiguous (§, °, ±, ×, ÷, é, ...); the Latin-1 fast path used to
+// drop ambiguousIsNarrow and measure them as width 1 regardless.
+describe("ambiguousIsNarrow is encoding-independent on Latin-1 text", () => {
+  // Force a 16-bit backing store: build one flat string via a single
+  // String.fromCharCode call that includes a non-Latin-1 unit, then slice the
+  // interior. Concatenation would leave a rope whose Latin-1 leaf JSC can
+  // return directly from .slice().
+  const asUtf16 = (s: string) => {
+    const units = [0x4e00];
+    for (let i = 0; i < s.length; i++) units.push(s.charCodeAt(i));
+    units.push(0x4e00);
+    return String.fromCharCode.apply(null, units).slice(1, 1 + s.length);
+  };
+
+  test("same codepoints, same width, regardless of backing encoding", () => {
+    const l1 = "ééééé";
+    const u16 = asUtf16(l1);
+    expect(u16).toBe(l1);
+    for (const countAnsiEscapeCodes of [false, true]) {
+      expect(Bun.stringWidth(l1, { countAnsiEscapeCodes, ambiguousIsNarrow: false })).toBe(10);
+      expect(Bun.stringWidth(u16, { countAnsiEscapeCodes, ambiguousIsNarrow: false })).toBe(10);
+      expect(Bun.stringWidth(l1, { countAnsiEscapeCodes, ambiguousIsNarrow: true })).toBe(5);
+      expect(Bun.stringWidth(u16, { countAnsiEscapeCodes, ambiguousIsNarrow: true })).toBe(5);
+    }
+  });
+
+  test("every Latin-1 byte agrees between encodings, for every option combination", () => {
+    const mismatches: string[] = [];
+    for (let cp = 0x00; cp <= 0xff; cp++) {
+      // Use length 4 so JSC keeps the 16-bit backing store for the slice.
+      const l1 = String.fromCharCode(cp, cp, cp, cp);
+      const u16 = asUtf16(l1);
+      for (const ambiguousIsNarrow of [true, false]) {
+        for (const countAnsiEscapeCodes of [true, false]) {
+          const a = Bun.stringWidth(l1, { ambiguousIsNarrow, countAnsiEscapeCodes });
+          const b = Bun.stringWidth(u16, { ambiguousIsNarrow, countAnsiEscapeCodes });
+          if (a !== b) {
+            mismatches.push(
+              `U+${cp.toString(16).padStart(4, "0")} ambiguousIsNarrow=${ambiguousIsNarrow} countAnsi=${countAnsiEscapeCodes}: latin1=${a} utf16=${b}`,
+            );
+          }
+        }
+      }
+    }
+    expect(mismatches).toEqual([]);
+  });
+
+  test("long Latin-1 runs (past every SIMD chunk boundary)", () => {
+    for (const n of [1, 15, 16, 17, 63, 64, 65, 200]) {
+      const s = Buffer.alloc(n, "\xe9", "latin1").toString("latin1");
+      expect(Bun.stringWidth(s, { ambiguousIsNarrow: false })).toBe(2 * n);
+      expect(Bun.stringWidth(s, { ambiguousIsNarrow: false, countAnsiEscapeCodes: true })).toBe(2 * n);
+      expect(Bun.stringWidth(asUtf16(s), { ambiguousIsNarrow: false })).toBe(2 * n);
+    }
+    // Mixed: ambiguous + non-ambiguous + zero-width, no escapes.
+    const mixed = Buffer.alloc(40 * 5, "a\xe9b\xe2\xad", "latin1").toString("latin1");
+    expect(Bun.stringWidth(mixed, { ambiguousIsNarrow: false })).toBe(40 * 5);
+    expect(Bun.stringWidth(mixed, { ambiguousIsNarrow: true })).toBe(40 * 4);
+  });
+
+  test("CSI escapes interleaved with ambiguous Latin-1 bytes", () => {
+    const s = "\x1b[31mé§±\x1b[0m";
+    expect(Bun.stringWidth(s, { ambiguousIsNarrow: false })).toBe(6);
+    expect(Bun.stringWidth(s, { ambiguousIsNarrow: true })).toBe(3);
+    expect(Bun.stringWidth(asUtf16(s), { ambiguousIsNarrow: false })).toBe(6);
+    // Sliding an SGR across chunk boundaries in a long ambiguous run.
+    for (const pad of [0, 15, 16, 60, 64, 65, 120]) {
+      const body = Buffer.alloc(pad, "\xe9", "latin1").toString("latin1");
+      const str = body + "\x1b[38;2;1;2;3m" + body + "\x1b[0m";
+      expect(Bun.stringWidth(str, { ambiguousIsNarrow: false })).toBe(4 * pad);
+      expect(Bun.stringWidth(asUtf16(str), { ambiguousIsNarrow: false })).toBe(4 * pad);
+    }
+  });
+
+  test("OSC payload containing ambiguous Latin-1 bytes contributes nothing", () => {
+    // é inside the OSC URL must not be counted; é outside is width 2.
+    for (const term of ["\x07", "\x1b\\", "\x9c"]) {
+      const s = `é\x1b]8;;http://é§°.example/éé${term}link\x1b]8;;${term}é`;
+      expect(Bun.stringWidth(s, { ambiguousIsNarrow: false })).toBe(2 + 4 + 2);
+      expect(Bun.stringWidth(asUtf16(s), { ambiguousIsNarrow: false })).toBe(2 + 4 + 2);
+      expect(Bun.stringWidth(s, { ambiguousIsNarrow: true })).toBe(1 + 4 + 1);
+    }
+  });
+
+  test("stringWidth and sliceAnsi agree on Latin-1 ambiguous text", () => {
+    const l1 = "é§°±×÷";
+    const wide = Bun.stringWidth(l1, { ambiguousIsNarrow: false });
+    expect(wide).toBe(12);
+    expect(Bun.sliceAnsi(l1, 0, wide, { ambiguousIsNarrow: false })).toBe(l1);
+    expect(Bun.sliceAnsi(l1, 0, 4, { ambiguousIsNarrow: false })).toBe("é§");
+    expect(Bun.stringWidth(Bun.sliceAnsi(l1, 0, 4, false), { ambiguousIsNarrow: false })).toBe(4);
+  });
+
+  test("matches npm string-width for Latin-1 ambiguous characters", () => {
+    for (const s of ["§", "±", "×÷", "ééééé", "àáâãäå", "naïve façade"]) {
+      for (const countAnsiEscapeCodes of [false, true]) {
+        expect(Bun.stringWidth(s, { countAnsiEscapeCodes, ambiguousIsNarrow: false })).toBe(
+          npmStringWidth(s, { countAnsiEscapeCodes, ambiguousIsNarrow: false }),
+        );
+      }
+    }
+  });
+});
+
 for (let matcher of ["toMatchNPMStringWidth", "toMatchNPMStringWidthExcludeANSI"]) {
   test("ignores control characters", () => {
     expect(String.fromCodePoint(0))[matcher]();


### PR DESCRIPTION
## Reproduction

```js
const l1  = "ééééé";                 // Latin-1-backed
const u16 = ("ééééé一").slice(0, 5); // UTF-16-backed, === l1
console.log(l1 === u16);                                         // true
console.log(Bun.stringWidth(l1,  { ambiguousIsNarrow: false }));  // 5   (option ignored)
console.log(Bun.stringWidth(u16, { ambiguousIsNarrow: false }));  // 10  (option honored)
```

`Bun.stringWidth` returned different widths for identical text depending on whether JSC stored it as Latin-1 or UTF-16. `Bun.sliceAnsi` honored the option on Latin-1 input via `Bun__codepointWidth`, so the documented measure-then-cut pairing disagreed with itself.

## Cause

43 bytes in U+00A1..U+00FE are East Asian Ambiguous (§, °, ±, ×, ÷, é, è, ê, Þ, ß, ...), but `visibleLatin1Width` / `visibleLatin1WidthExcludeANSI` had no `ambiguousAsWide` parameter. Every caller of `Bun__visibleWidthExcludeANSI_latin1` (the `Bun.stringWidth` 8-bit branch, `wrapAnsi`'s `stringWidth<Latin1>`, `sliceAnsi`'s ellipsis sizing, the Rust `String::visible_width_exclude_ansi_colors` wrapper) silently dropped the flag, under a comment claiming Latin-1 has no ambiguous-width characters.

## Fix

Thread `ambiguousAsWide` through both Latin-1 width functions and the C export, and pass it from all four call sites. The per-byte wide-mode widths are a compile-time `std::array<uint8_t, 256>` derived from the same `fusedClassify` table the UTF-16 path uses, with a `static_assert` that the table's narrow Latin-1 widths match the existing scalar exactly, so the two encodings cannot drift apart.

Performance: the default (`ambiguousIsNarrow: true`) keeps the SIMD fast paths byte-for-byte unchanged. The opt-in wide mode on `countAnsiEscapeCodes: true` adds a scalar per-byte correction to the SIMD narrow result. The wide + exclude-ANSI mode uses SIMD + correction when no `ESC` is present, and a scalar ANSI state machine (mirroring `VisibleLatin1WidthExcludeANSIScalar`) otherwise so ambiguous bytes inside OSC payloads are not over-counted.

## Verification

New tests in `test/js/bun/util/stringWidth.test.ts` (`ambiguousIsNarrow is encoding-independent on Latin-1 text`) cover:
- the reported repro (Latin-1 vs UTF-16 backing for the same codepoints)
- a full sweep of all 256 Latin-1 bytes in both encodings under every option combination
- long runs across SIMD chunk boundaries
- CSI interleaved with ambiguous bytes
- OSC payloads containing ambiguous bytes (must not contribute)
- `stringWidth` / `sliceAnsi` agreement on Latin-1 ambiguous text
- parity with npm `string-width` for Latin-1 ambiguous characters

All 7 fail on `main`, all pass with this change. Existing `stringWidth` (154), `wrapAnsi`, and `sliceAnsi` (303) tests pass unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/stringWidth.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (655db2c4d)

test/js/bun/util/stringWidth.test.ts:
(pass) stringWidth [203.36ms]
(pass) toMatchNPMStringWidth > ansi colors [81.86ms]
(pass) toMatchNPMStringWidthExcludeANSI > ansi colors [61.59ms]
(pass) leading non-ansi characters in UTF-16 string seems to fail [5.96ms]
(pass) leading non-ansi characters in UTF-16 string seems to fail [2.64ms]
(pass) upstream [17.63ms]
(pass) upstream [11.63ms]
(pass) ambiguousIsNarrow=false [15.27ms]
142 |   test("same codepoints, same width, regardless of backing encoding", () => {
143 |     const l1 = "ééééé";
144 |     const u16 = asUtf16(l1);
145 |     expect(u16).toBe(l1);
146 |     for (const countAnsiEscapeCodes of [false, true]) {
147 |       expect(Bun.stringWidth(l1, { countAnsiE
... (truncated)

release without fix: 7 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/util/stringWidth.test.ts:
(pass) stringWidth [5.68ms]
(pass) toMatchNPMStringWidth > ansi colors [1.76ms]
(pass) toMatchNPMStringWidthExcludeANSI > ansi colors [0.84ms]
(pass) leading non-ansi characters in UTF-16 string seems to fail [0.10ms]
(pass) leading non-ansi characters in UTF-16 string seems to fail [0.06ms]
(pass) upstream [0.50ms]
(pass) upstream [0.36ms]
(pass) ambiguousIsNarrow=false [0.63ms]
142 |   test("same codepoints, same width, regardless of backing encoding", () => {
143 |     const l1 = "ééééé";
144 |     const u16 = asUtf16(l1);
145 |     expect(u16).toBe(l1);
146 |     for (const countAnsiEscapeCodes of [false, true]) {
147 |       expect(Bun.stringWidth(l1, { countAnsiEscapeCodes, ambiguousIsNarrow: false })).toBe(10);
                                                                                            ^
error: expect(received).toBe(expected)

Expected: 10
Received: 5

      at <anonymous> (/workspace/bun/test/js/bun/util/stringWidth.test.ts:147:87)
(fail) ambiguousIsNarrow is encoding-independent on Latin-1 text > same codepoints, same width, regardless of backing encoding [0.66m
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/stringWidth.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (655db2c4d)

test/js/bun/util/stringWidth.test.ts:
(pass) stringWidth [226.11ms]
(pass) toMatchNPMStringWidth > ansi colors [57.47ms]
(pass) toMatchNPMStringWidthExcludeANSI > ansi colors [42.67ms]
(pass) leading non-ansi characters in UTF-16 string seems to fail [8.14ms]
(pass) leading non-ansi characters in UTF-16 string seems to fail [3.74ms]
(pass) upstream [28.78ms]
(pass) upstream [18.73ms]
(pass) ambiguousIsNarrow=false [25.27ms]
(pass) ambiguousIsNarrow is encoding-independent on Latin-1 text > same codepoints, same width, regardless of backing encoding [14.78ms]
(pass) ambiguousIsNarrow is encoding-independent on Latin-1 text > every Latin-1 byte agrees between encodings, for every option combination [159.34ms]
(pass) amb
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     655db2c4d1
  features     (none)

22 deps, 106 codegen, 1168 objects in 1079ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [15.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [2.00ms]
[3/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [13.00ms]
[4/1231] gen ErrorCode+*.h
[5/1231] fetch zlib
[zlib] up to date
[6/1231] fetch tinycc
[tinycc] up to date
[7/1230] gen bindgenv2
[8/1230] fetch picohttpparser
[pi
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/string/immutable/visible.rs |  16 +++-
 src/bun_core/string/mod.rs               |   2 +-
 src/jsc/bindings/sliceAnsi.cpp           |   4 +-
 src/jsc/bindings/stringWidth.cpp         | 136 +++++++++++++++++++++++++++----
 src/jsc/bindings/stringWidth.h           |   4 +-
 src/jsc/bindings/wrapAnsi.cpp            |   6 +-
 test/js/bun/util/stringWidth.test.ts     | 106 ++++++++++++++++++++++++
 7 files changed, 247 insertions(+), 27 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/bun_core/string/immutable/visible.rs      1      1      0
src/bun_core/string/mod.rs                    1      1      0
src/jsc/bindings/sliceAnsi.cpp                2      1      0
src/jsc/bindings/stringWidth.cpp              1      2      0
src/jsc/bindings/stringWidth.h                1      1      0
src/jsc/bindings/wrapAnsi.cpp                 1      1      0
test/js/bun/util/stringWidth.test.ts          1      2      0
```

</details>

<!-- robobun:evidence:end -->