### PR TITLE
Bun.sliceAnsi: return ellipsis for start-cut degenerate on non-ASCII input

### DIFF
--- a/src/jsc/bindings/sliceAnsi.cpp
+++ b/src/jsc/bindings/sliceAnsi.cpp
@@ -886,6 +886,7 @@ static WTF::String emitSliceStreaming(
     bool needStartEllipsis = false;
     bool needEndEllipsis = false;
     size_t ellipsisEndBudget = 0; // how much we shrank `end` by for end ellipsis
+    const size_t startBeforeBudget = start;
     if (ellipsisWidth > 0) {
         if (cutStartForEllipsis && ellipsisWidth < (endUnbounded ? SIZE_MAX - start : end - start)) {
             needStartEllipsis = true;
@@ -1199,7 +1200,14 @@ walkDone:;
         if (include) flushPending(/*filterCloseOnly=*/trailingPastEnd);
     }
 
-    if (!include) return emptyString();
+    if (!include) {
+        // Start-side degenerate: the ellipsis budget pushed `start` past all
+        // content but the original range was non-empty. Match the cutEndKnown
+        // fallback above and the ASCII fast path: return the ellipsis.
+        if (ellipsisWidth > 0 && cutStartForEllipsis && position > startBeforeBudget)
+            return ellipsis.toString();
+        return emptyString();
+    }
 
     // Resolve lazy cutEnd: if we budgeted a spec zone and sawCutEnd → cut.
     // Otherwise (EOF reached without exceeding specEnd) → no cut, flush zone.

--- a/src/jsc/bindings/sliceAnsi.cpp
+++ b/src/jsc/bindings/sliceAnsi.cpp
@@ -1200,10 +1200,18 @@ walkDone:;
         if (include) flushPending(/*filterCloseOnly=*/trailingPastEnd);
     }
 
+    // Lazy-path degenerate: a cut happened but neither ellipsis was budgeted
+    // (range too small for the ellipsis). Match the cutEndKnown fallback above
+    // and the ASCII fast path: return the bare ellipsis.
+    if (ellipsisWidth > 0 && !needStartEllipsis && !needEndEllipsis) {
+        bool startActuallyCut = cutStartForEllipsis && position > startBeforeBudget;
+        if (startActuallyCut || sawCutEnd)
+            return ellipsis.toString();
+    }
+
     if (!include) {
-        // Start-side degenerate: the ellipsis budget pushed `start` past all
-        // content but the original range was non-empty. Match the cutEndKnown
-        // fallback above and the ASCII fast path: return the ellipsis.
+        // Start-ellipsis budget pushed `start` past all content but the
+        // original range was non-empty: return the budgeted ellipsis.
         if (ellipsisWidth > 0 && cutStartForEllipsis && position > startBeforeBudget)
             return ellipsis.toString();
         return emptyString();

--- a/src/jsc/bindings/sliceAnsi.cpp
+++ b/src/jsc/bindings/sliceAnsi.cpp
@@ -1200,22 +1200,14 @@ walkDone:;
         if (include) flushPending(/*filterCloseOnly=*/trailingPastEnd);
     }
 
-    // Lazy-path degenerate: a cut happened but neither ellipsis was budgeted
-    // (range too small for the ellipsis). Match the cutEndKnown fallback above
-    // and the ASCII fast path: return the bare ellipsis.
-    if (ellipsisWidth > 0 && !needStartEllipsis && !needEndEllipsis) {
-        bool startActuallyCut = cutStartForEllipsis && position > startBeforeBudget;
-        if (startActuallyCut || sawCutEnd)
-            return ellipsis.toString();
-    }
+    // Start-cut degenerate: start was cut and the original range had content,
+    // but the ellipsis left no room (budget pushed start past all content, or
+    // range too small to budget at all). Match the cutEndKnown/ASCII fallback.
+    if (ellipsisWidth > 0 && cutStartForEllipsis && position > startBeforeBudget
+        && (!include || (!needStartEllipsis && !needEndEllipsis)))
+        return ellipsis.toString();
 
-    if (!include) {
-        // Start-ellipsis budget pushed `start` past all content but the
-        // original range was non-empty: return the budgeted ellipsis.
-        if (ellipsisWidth > 0 && cutStartForEllipsis && position > startBeforeBudget)
-            return ellipsis.toString();
-        return emptyString();
-    }
+    if (!include) return emptyString();
 
     // Resolve lazy cutEnd: if we budgeted a spec zone and sawCutEnd → cut.
     // Otherwise (EOF reached without exceeding specEnd) → no cut, flush zone.

--- a/test/js/bun/util/sliceAnsi.test.ts
+++ b/test/js/bun/util/sliceAnsi.test.ts
@@ -1122,6 +1122,27 @@ describe("Bun.sliceAnsi", () => {
       expect(Bun.sliceAnsi("Ж", 1, 2, { ellipsis: ">>" })).toBe("");
     });
 
+    test("lazy-path degenerate (ellipsis wider than range) matches ASCII fast path", () => {
+      // Ellipsis wider than the requested range, on the lazy-cutEnd streaming
+      // path: neither ellipsis budget applies. If a cut occurs, return the
+      // bare ellipsis (parity with the ASCII fast path).
+      const e = { ellipsis: ">>" };
+      // End-cut only.
+      expect(Bun.sliceAnsi("ЖЗИ", 0, 1, e)).toBe(">>");
+      expect(Bun.sliceAnsi("abc", 0, 1, e)).toBe(">>");
+      expect(Bun.sliceAnsi("ЖЗИ", 0, 2, e)).toBe(">>");
+      expect(Bun.sliceAnsi("abc", 0, 2, e)).toBe(">>");
+      // Both sides cut.
+      expect(Bun.sliceAnsi("ЖЗИ", 1, 2, e)).toBe(">>");
+      expect(Bun.sliceAnsi("abc", 1, 2, e)).toBe(">>");
+      // Start-cut only (no end cut: string ends at the range end).
+      expect(Bun.sliceAnsi("ЖЗ", 1, 2, e)).toBe(">>");
+      expect(Bun.sliceAnsi("ab", 1, 2, e)).toBe(">>");
+      // No cut on either side: content returned, no ellipsis.
+      expect(Bun.sliceAnsi("Ж", 0, 1, e)).toBe("Ж");
+      expect(Bun.sliceAnsi("ЖЗ", 0, 2, e)).toBe("ЖЗ");
+    });
+
     test("no ellipsis when not cut", () => {
       // short string, large range: no cut, no ellipsis
       expect(Bun.sliceAnsi("hi", 0, 100, { ellipsis: E })).toBe("hi");

--- a/test/js/bun/util/sliceAnsi.test.ts
+++ b/test/js/bun/util/sliceAnsi.test.ts
@@ -1122,25 +1122,33 @@ describe("Bun.sliceAnsi", () => {
       expect(Bun.sliceAnsi("Ж", 1, 2, { ellipsis: ">>" })).toBe("");
     });
 
-    test("lazy-path degenerate (ellipsis wider than range) matches ASCII fast path", () => {
-      // Ellipsis wider than the requested range, on the lazy-cutEnd streaming
-      // path: neither ellipsis budget applies. If a cut occurs, return the
-      // bare ellipsis (parity with the ASCII fast path).
+    test("start-cut degenerate (ellipsis wider than range) matches ASCII fast path", () => {
+      // Ellipsis wider than the requested range and start is cut: neither
+      // ellipsis budget applies, but the degenerate fallback must still fire.
       const e = { ellipsis: ">>" };
-      // End-cut only.
-      expect(Bun.sliceAnsi("ЖЗИ", 0, 1, e)).toBe(">>");
-      expect(Bun.sliceAnsi("abc", 0, 1, e)).toBe(">>");
-      expect(Bun.sliceAnsi("ЖЗИ", 0, 2, e)).toBe(">>");
-      expect(Bun.sliceAnsi("abc", 0, 2, e)).toBe(">>");
-      // Both sides cut.
+      // Start cut, end also cut.
       expect(Bun.sliceAnsi("ЖЗИ", 1, 2, e)).toBe(">>");
       expect(Bun.sliceAnsi("abc", 1, 2, e)).toBe(">>");
-      // Start-cut only (no end cut: string ends at the range end).
+      // Start cut, end not cut (string ends at the range end).
       expect(Bun.sliceAnsi("ЖЗ", 1, 2, e)).toBe(">>");
       expect(Bun.sliceAnsi("ab", 1, 2, e)).toBe(">>");
       // No cut on either side: content returned, no ellipsis.
       expect(Bun.sliceAnsi("Ж", 0, 1, e)).toBe("Ж");
       expect(Bun.sliceAnsi("ЖЗ", 0, 2, e)).toBe("ЖЗ");
+    });
+
+    test("trailing zero-width content past end is not a cut", () => {
+      // A zero-width cluster (LF, CR, ZWSP) exactly at the end boundary must
+      // not trigger the degenerate-ellipsis fallback: nothing visible was cut.
+      const e = { ellipsis: ">>" };
+      expect(Bun.sliceAnsi("hi\n", 0, 2, e)).toBe("hi");
+      expect(Bun.sliceAnsi("ЖЗ\n", 0, 2, e)).toBe("ЖЗ");
+      expect(Bun.sliceAnsi("h\n", 0, 1, { ellipsis: "…" })).toBe("h");
+      expect(Bun.sliceAnsi("a\u200b", 0, 1, e)).toBe("a");
+      expect(Bun.sliceAnsi("a\n", -1, undefined, e)).toBe("a");
+      // Start-cut with a trailing newline still returns the ellipsis
+      // (the start cut is what makes it degenerate, not the end).
+      expect(Bun.sliceAnsi("ЖЗ\n", 1, 2, e)).toBe(">>");
     });
 
     test("no ellipsis when not cut", () => {

--- a/test/js/bun/util/sliceAnsi.test.ts
+++ b/test/js/bun/util/sliceAnsi.test.ts
@@ -1108,6 +1108,20 @@ describe("Bun.sliceAnsi", () => {
       expect(Bun.sliceAnsi("unicorn", 0, 4, { ellipsis: "" })).toBe("unic");
     });
 
+    test("start-cut degenerate on non-ASCII returns ellipsis, not empty", () => {
+      // Streaming path (non-ASCII input, positive indices): start ellipsis
+      // budget pushes `start` past the string's width. The ellipsis must still
+      // be returned, matching the ASCII fast path and the end-cut degenerate.
+      expect(Bun.sliceAnsi("ЖЗИ", 1, 4)).toBe("ЗИ");
+      expect(Bun.sliceAnsi("ЖЗИ", 1, 4, { ellipsis: ">>" })).toBe(">>");
+      expect(Bun.sliceAnsi("ЖЗИ", 2, 5, { ellipsis: ">>" })).toBe(">>");
+      // Same shape via the ASCII fast path, for parity.
+      expect(Bun.sliceAnsi("abc", 1, 4, { ellipsis: ">>" })).toBe(">>");
+      // Original range empty (start >= totalW): still empty, no ellipsis.
+      expect(Bun.sliceAnsi("ЖЗИ", 3, 6, { ellipsis: ">>" })).toBe("");
+      expect(Bun.sliceAnsi("Ж", 1, 2, { ellipsis: ">>" })).toBe("");
+    });
+
     test("no ellipsis when not cut", () => {
       // short string, large range: no cut, no ellipsis
       expect(Bun.sliceAnsi("hi", 0, 100, { ellipsis: E })).toBe("hi");


### PR DESCRIPTION
## Repro

```js
Bun.sliceAnsi("ЖЗИ", 1, 4)                        // "ЗИ"   (content exists)
Bun.sliceAnsi("ЖЗИ", 1, 4, { ellipsis: ">>" })    // ""     ← bug: both content and ellipsis dropped
Bun.sliceAnsi("abc", 1, 4, { ellipsis: ">>" })    // ">>"   (ASCII fast path: correct)
Bun.sliceAnsi("hello world", 0, 1, { ellipsis: "…" }) // "…" (end-cut degenerate: correct)
```

## Cause

`emitSliceStreaming` budgets for the start ellipsis by bumping `start += ellipsisWidth`. When that pushes `start` past the string width, no cluster boundary ever satisfies `position >= start`, so `include` never flips on and the function hits the `if (!include) return emptyString()` early return. The degenerate-ellipsis fallback (`return ellipsis.toString()`) only exists on the `cutEndKnown` path, so the lazy-cutEnd streaming path drops both the budgeted ellipsis and the content.

## Fix

At the `!include` exit, return the ellipsis when the start was cut and the original (pre-budget) range actually had content (`position > startBeforeBudget`, where `position` is the total visible width at that point). This matches both the `cutEndKnown` degenerate fallback and the ASCII fast path, and preserves the empty-string result when the requested range was empty to begin with (e.g. `[3,6)` of a 3-column string).

## Verification

```
$ bun-debug -e 'console.log(JSON.stringify(Bun.sliceAnsi("ЖЗИ", 1, 4, { ellipsis: ">>" })))'
">>"
```

New test in `test/js/bun/util/sliceAnsi.test.ts` covers the degenerate case and the empty-range negatives; all 155 existing sliceAnsi tests pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/sliceAnsi.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (607215591)

test/js/bun/util/sliceAnsi.test.ts:
(pass) Bun.sliceAnsi > plain strings > slices ASCII string like String.prototype.slice [3.15ms]
(pass) Bun.sliceAnsi > plain strings > returns empty string for empty input [1.65ms]
(pass) Bun.sliceAnsi > plain strings > returns full string with no arguments beyond first [1.93ms]
(pass) Bun.sliceAnsi > plain strings > start=0, end=0 returns empty [1.17ms]
(pass) Bun.sliceAnsi > plain strings > start > end returns empty [1.61ms]
(pass) Bun.sliceAnsi > plain strings > start beyond string length returns empty [1.52ms]
(pass) Bun.sliceAnsi > plain strings > end beyond string length returns remainder [1.66ms]
(pass) Bun.sliceAnsi > plain strings > negative start [2.28ms]
(pass) Bun.sliceAns
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (17fe0fe50)

test/js/bun/util/sliceAnsi.test.ts:
(pass) Bun.sliceAnsi > plain strings > slices ASCII string like String.prototype.slice [0.05ms]
(pass) Bun.sliceAnsi > plain strings > returns empty string for empty input [0.02ms]
(pass) Bun.sliceAnsi > plain strings > returns full string with no arguments beyond first [0.03ms]
(pass) Bun.sliceAnsi > plain strings > start=0, end=0 returns empty
(pass) Bun.sliceAnsi > plain strings > start > end returns empty [0.01ms]
(pass) Bun.sliceAnsi > plain strings > start beyond string length returns empty [0.01ms]
(pass) Bun.sliceAnsi > plain strings > end beyond string length returns remainder [0.01ms]
(pass) Bun.sliceAnsi > plain strings > negative start [0.02ms]
(pass) Bun.sliceAnsi > plain strings > negative end [0.02ms]
(pass) Bun.sliceAnsi > plain strings > both negative [0.01ms]
(pass) Bun.sliceAnsi > plain strings > single character slice [0.01ms]
(pass) Bun.sliceAnsi > ANSI color codes > slices colored text, preserving ANSI codes at start [0.03ms]
(pass) Bun.sliceAnsi > ANSI color codes > preserves active styles at slice start [0.01ms]
(pass) Bun.sliceAnsi > ANSI color codes > multiple style c
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/sliceAnsi.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (607215591)

test/js/bun/util/sliceAnsi.test.ts:
(pass) Bun.sliceAnsi > plain strings > slices ASCII string like String.prototype.slice [3.61ms]
(pass) Bun.sliceAnsi > plain strings > returns empty string for empty input [1.93ms]
(pass) Bun.sliceAnsi > plain strings > returns full string with no arguments beyond first [2.11ms]
(pass) Bun.sliceAnsi > plain strings > start=0, end=0 returns empty [1.30ms]
(pass) Bun.sliceAnsi > plain strings > start > end returns empty [1.69ms]
(pass) Bun.sliceAnsi > plain strings > start beyond string length returns empty [1.50ms]
(pass) Bun.sliceAnsi > plain strings > end beyond string length returns remainder [1.68ms]
(pass) Bun.sliceAnsi > plain strings > negative start [2.36ms]
(pass) Bun.sliceAns
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 786ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen cpp.rs (cppbind)
[1/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/sliceAnsi.cpp     |  8 +++++++
 test/js/bun/util/sliceAnsi.test.ts | 43 ++++++++++++++++++++++++++++++++++++++
 2 files changed, 51 insertions(+)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/jsc/bindings/sliceAnsi.cpp          7      5      0
test/js/bun/util/sliceAnsi.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->