### PR TITLE
Bun.sliceAnsi: keep trailing zero-width/ANSI content with negative start

### DIFF
--- a/src/jsc/bindings/sliceAnsi.cpp
+++ b/src/jsc/bindings/sliceAnsi.cpp
@@ -1318,7 +1318,10 @@ static WTF::String sliceAnsiImpl(std::span<const Char> input, double startD, dou
         SliceBounds b = resolveSliceBounds(startD, endD, totalW);
         if (b.empty) return emptyString();
         start = b.start;
-        end = b.end;
+        // !cutEnd ⇔ resolved end == totalW. Emit unbounded so trailing
+        // zero-width clusters and ANSI at column totalW are kept, matching
+        // the non-negative path's endD == +Inf behaviour.
+        end = b.cutEnd ? b.end : SIZE_MAX;
         cutEndKnown = true;
         cutEndHint = b.cutEnd;
     }

--- a/test/js/bun/util/sliceAnsi.test.ts
+++ b/test/js/bun/util/sliceAnsi.test.ts
@@ -160,6 +160,43 @@ describe("Bun.sliceAnsi", () => {
       expect(Bun.sliceAnsi("hello", -3, -1)).toBe("ll");
     });
 
+    test("negative start keeps trailing zero-width and ANSI content", () => {
+      expect(Bun.sliceAnsi("ab\t", -1)).toBe("b\t");
+      expect(Bun.sliceAnsi("ab\u200b", -1)).toBe("b\u200b");
+      expect(Bun.sliceAnsi("ab\x1b[31m", -1)).toBe("b\x1b[31m\x1b[39m");
+      expect(Bun.sliceAnsi("abc\x1b[1m\x1b[31m", -1)).toBe("c\x1b[1m\x1b[31m\x1b[39m\x1b[22m");
+      expect(Bun.sliceAnsi("ab\x1b[0m", -1)).toBe("b\x1b[0m");
+      expect(Bun.sliceAnsi("ab\t", -1, 1000)).toBe("b\t");
+
+      // sliceAnsi(s, -k) must match sliceAnsi(s, totalW - k) byte-for-byte
+      // whenever the positive form goes through the emit walk (start > 0).
+      const cases = [
+        "ab\t",
+        "ab\u200b",
+        "ab\u200b\u200b",
+        "ab\x1b[31m",
+        "abc\x1b[1m\x1b[31m",
+        "\x1b[31mab\x1b[39m\t",
+        "ab\x1b[0m",
+        "ab\t\u200b\x1b[31m",
+      ];
+      for (const s of cases) {
+        const totalW = Bun.stringWidth(s);
+        for (let k = 1; k < totalW; k++) {
+          const pos = Bun.sliceAnsi(s, totalW - k);
+          expect({ s, k, out: Bun.sliceAnsi(s, -k) }).toEqual({ s, k, out: pos });
+          expect({ s, k, out: Bun.sliceAnsi(s, -k, 1000) }).toEqual({ s, k, out: pos });
+        }
+        // -k clamped to 0: visible content must still include the trailing bytes.
+        expect(Bun.stripANSI(Bun.sliceAnsi(s, -1000))).toBe(Bun.stripANSI(s));
+      }
+    });
+
+    test("negative end strictly before total width still cuts", () => {
+      expect(Bun.sliceAnsi("ab\t", 0, -1)).toBe("a");
+      expect(Bun.sliceAnsi("ab\x1b[31m", 0, -1)).toBe("a");
+    });
+
     test("single character slice", () => {
       expect(Bun.sliceAnsi("hello", 0, 1)).toBe("h");
       expect(Bun.sliceAnsi("hello", 4, 5)).toBe("o");


### PR DESCRIPTION
## Reproduction

```js
Bun.sliceAnsi("ab\t", -1)        // "b"    (TAB dropped)
Bun.sliceAnsi("ab\t",  1)        // "b\t"  (equivalent positive slice)
Bun.sliceAnsi("ab\x1b[31m", -1)  // "b"    (SGR dropped entirely)
Bun.sliceAnsi("ab\x1b[31m",  1)  // "b\x1b[31m\x1b[39m"
```

`sliceAnsi(s, -k)` is documented to match `sliceAnsi(s, width(s) - k)`, but any string ending in a TAB, ZWSP, or SGR sequence loses that trailing content in the negative-index spelling only. Truncate-from-end (`sliceAnsi(s, -max)`, the cli-truncate replacement) silently eats trailing SGR resets, so the truncated string leaks its style state into whatever is printed after it.

## Cause

The negative-index path in `sliceAnsiImpl` resolves `[start, end)` against `computeTotalWidth` and passes a finite `end == totalW` into `emitSliceStreaming`. The emit walk hard-stops at `position >= specEnd`, so every trailing zero-width cluster and ANSI sequence sitting at column `totalW` is cut. The positive form with omitted end runs with `end == SIZE_MAX` (unbounded) and emits to EOF.

## Fix

When `resolveSliceBounds` reports `cutEnd == false` (resolved end equals `totalW`), pass `SIZE_MAX` as `end` so the emit walk runs unbounded, matching the non-negative path.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/util/sliceAnsi.test.ts -t "negative start keeps"
(fail) negative start keeps trailing zero-width and ANSI content
  Expected: "b\t"
  Received: "b"

$ bun bd test test/js/bun/util/sliceAnsi.test.ts
 156 pass
 0 fail
```

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/sliceAnsi.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (c9eb1ad55)

test/js/bun/util/sliceAnsi.test.ts:
(pass) Bun.sliceAnsi > plain strings > slices ASCII string like String.prototype.slice [4.16ms]
(pass) Bun.sliceAnsi > plain strings > returns empty string for empty input [1.86ms]
(pass) Bun.sliceAnsi > plain strings > returns full string with no arguments beyond first [2.08ms]
(pass) Bun.sliceAnsi > plain strings > start=0, end=0 returns empty [1.22ms]
(pass) Bun.sliceAnsi > plain strings > start > end returns empty [1.75ms]
(pass) Bun.sliceAnsi > plain strings > start beyond string length returns empty [1.19ms]
(pass) Bun.sliceAnsi > plain strings > end beyond string length returns remainder [2.01ms]
(pass) Bun.sliceAnsi > plain strings > negative start [2.33ms]
(pass) Bun.sliceAns
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (1d99c58d2)

test/js/bun/util/sliceAnsi.test.ts:
(pass) Bun.sliceAnsi > plain strings > slices ASCII string like String.prototype.slice [1.83ms]
(pass) Bun.sliceAnsi > plain strings > returns empty string for empty input [0.04ms]
(pass) Bun.sliceAnsi > plain strings > returns full string with no arguments beyond first [0.02ms]
(pass) Bun.sliceAnsi > plain strings > start=0, end=0 returns empty [0.01ms]
(pass) Bun.sliceAnsi > plain strings > start > end returns empty [0.01ms]
(pass) Bun.sliceAnsi > plain strings > start beyond string length returns empty [0.01ms]
(pass) Bun.sliceAnsi > plain strings > end beyond string length returns remainder [0.01ms]
(pass) Bun.sliceAnsi > plain strings > negative start [0.02ms]
(pass) Bun.sliceAnsi > plain strings > negative end [0.02ms]
(pass) Bun.sliceAnsi > plain strings > both negative
(pass) Bun.sliceAnsi > plain strings > negative start keeps trailing zero-width and ANSI content [0.19ms]
(pass) Bun.sliceAnsi > plain strings > negative end strictly before total width still cuts [0.02ms]
(pass) Bun.sliceAnsi > plain strings > single character slice [0.01ms]
(pass) Bun.sliceAnsi > ANSI color codes > sli
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/sliceAnsi.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (c9eb1ad55)

test/js/bun/util/sliceAnsi.test.ts:
(pass) Bun.sliceAnsi > plain strings > slices ASCII string like String.prototype.slice [3.26ms]
(pass) Bun.sliceAnsi > plain strings > returns empty string for empty input [1.63ms]
(pass) Bun.sliceAnsi > plain strings > returns full string with no arguments beyond first [2.04ms]
(pass) Bun.sliceAnsi > plain strings > start=0, end=0 returns empty [1.18ms]
(pass) Bun.sliceAnsi > plain strings > start > end returns empty [1.66ms]
(pass) Bun.sliceAnsi > plain strings > start beyond string length returns empty [1.17ms]
(pass) Bun.sliceAnsi > plain strings > end beyond string length returns remainder [1.99ms]
(pass) Bun.sliceAnsi > plain strings > negative start [2.42ms]
(pass) Bun.sliceAns
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 781ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen cpp.rs (cppbind)
[1/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/sliceAnsi.cpp     |  5 ++++-
 test/js/bun/util/sliceAnsi.test.ts | 37 +++++++++++++++++++++++++++++++++++++
 2 files changed, 41 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/jsc/bindings/sliceAnsi.cpp          3      1      0
test/js/bun/util/sliceAnsi.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->