### PR TITLE
Bun.stringWidth: recognize C1 escape introducers and ST-terminated control strings

### DIFF
--- a/src/jsc/bindings/highway_strings.cpp
+++ b/src/jsc/bindings/highway_strings.cpp
@@ -863,8 +863,9 @@ size_t VisibleLatin1WidthImpl(const uint8_t* HWY_RESTRICT input, size_t len)
 //
 // Used by Bun.stringWidth's default mode (stringWidth.cpp). Escape sequences
 // contribute nothing to the width:
-//   CSI  ESC [ <params> <final in [0x40,0x7E]>
-//   OSC  ESC ] <payload> (BEL | 0x9C | ESC \)
+//   CSI  ESC [  or 0x9B            <params> <final in [0x40,0x7E]>
+//   OSC  ESC ]  or 0x9D            <payload> (BEL | 0x9C | ESC \)
+//   DCS/SOS/PM/APC  ESC P/X/^/_  or 0x90/0x98/0x9E/0x9F  <payload> (0x9C | ESC \)
 //   bare ESC followed by anything else: only the ESC itself is dropped.
 //
 // The whole input is processed in a single pass: every vector chunk is
@@ -873,13 +874,19 @@ size_t VisibleLatin1WidthImpl(const uint8_t* HWY_RESTRICT input, size_t len)
 // few scalar bit operations per escape. This keeps dense SGR input (an escape
 // every few bytes) from paying a separate scan per sequence, while chunks with
 // no escapes reduce to one popcount. Sequences may straddle chunk boundaries;
-// the state enum below carries "inside CSI/OSC" across chunks.
+// the state enum below carries "inside CSI/OSC/ST-string" across chunks.
 
 enum class AnsiExcludeState : uint8_t {
     None,
-    InCSI, // saw ESC [ — looking for the final byte in [0x40, 0x7E]
-    InOSC, // saw ESC ] — looking for BEL, 0x9C or ESC-backslash (ST)
+    InCSI, // saw ESC [ or 0x9B — looking for the final byte in [0x40, 0x7E]
+    InOSC, // saw ESC ] or 0x9D — looking for BEL, 0x9C or ESC-backslash (ST)
+    InST, // saw ESC P/X/^/_ or 0x90/0x98/0x9E/0x9F — looking for 0x9C or ESC-backslash (ST)
 };
+
+static HWY_INLINE bool IsC1StIntroducer(uint8_t c)
+{
+    return c == 0x90 || c == 0x98 || c == 0x9E || c == 0x9F;
+}
 
 // Zero-width Latin-1 bytes: C0 controls, DEL + C1 controls, soft hyphen.
 static HWY_INLINE bool IsVisibleLatin1Byte(uint8_t c)
@@ -902,7 +909,8 @@ static size_t VisibleLatin1WidthExcludeANSIScalar(const uint8_t* HWY_RESTRICT in
             i += 1;
             break;
         case AnsiExcludeState::InOSC:
-            if (c == 0x07 || c == 0x9C) {
+        case AnsiExcludeState::InST:
+            if (c == 0x9C || (c == 0x07 && state == AnsiExcludeState::InOSC)) {
                 state = AnsiExcludeState::None;
                 i += 1;
                 break;
@@ -932,7 +940,27 @@ static size_t VisibleLatin1WidthExcludeANSIScalar(const uint8_t* HWY_RESTRICT in
                     i += 2;
                     break;
                 }
+                if (next == 'P' || next == 'X' || next == '^' || next == '_') {
+                    state = AnsiExcludeState::InST;
+                    i += 2;
+                    break;
+                }
                 // ESC followed by anything else: only the ESC is dropped.
+                i += 1;
+                break;
+            }
+            if (c == 0x9B) {
+                state = AnsiExcludeState::InCSI;
+                i += 1;
+                break;
+            }
+            if (c == 0x9D) {
+                state = AnsiExcludeState::InOSC;
+                i += 1;
+                break;
+            }
+            if (IsC1StIntroducer(c)) {
+                state = AnsiExcludeState::InST;
                 i += 1;
                 break;
             }
@@ -982,6 +1010,10 @@ size_t VisibleLatin1WidthExcludeANSIImpl(const uint8_t* HWY_RESTRICT input, size
         const auto vec_0x3E = hn::Set(d, uint8_t { 0x3E }); // 0x7E - 0x40
         const auto vec_bel = hn::Set(d, uint8_t { 0x07 });
         const auto vec_c1_st = hn::Set(d, uint8_t { 0x9C });
+        const auto vec_0x90 = hn::Set(d, uint8_t { 0x90 });
+        const auto vec_0x0F = hn::Set(d, uint8_t { 0x0F });
+        const auto vec_c1_csi = hn::Set(d, uint8_t { 0x9B });
+        const auto vec_c1_osc = hn::Set(d, uint8_t { 0x9D });
 
         const uint64_t laneMask = MaskBitsBelow(N);
 
@@ -995,30 +1027,79 @@ size_t VisibleLatin1WidthExcludeANSIImpl(const uint8_t* HWY_RESTRICT input, size
             return bits;
         };
 
+        // Shared terminator scan for OSC/ST-string payloads. `termMask` is the
+        // one-byte terminator bitmask (BEL|0x9C for OSC, 0x9C for ST-strings).
+        // Returns true if a terminator was found in this chunk and updates
+        // `zero`/`consumed`/`pos`/`introRemaining`; false means the payload
+        // continues past the chunk.
+        const auto scanStringTerminator = [&](uint64_t termMask, uint64_t escMask, size_t p, size_t searchFrom,
+                                              uint64_t& zero, size_t& consumed, size_t& pos, uint64_t& introRemaining) -> bool {
+            uint64_t cand = (termMask | escMask) & ~MaskBitsBelow(searchFrom);
+            while (cand != 0) {
+                const size_t t = static_cast<size_t>(hwy::Num0BitsBelowLS1Bit_Nonzero64(cand));
+                if ((termMask >> t) & 1) {
+                    zero |= MaskBitsBelow(t + 1) & ~MaskBitsBelow(p);
+                    introRemaining &= ~MaskBitsBelow(t + 1);
+                    pos = t + 1;
+                    return true;
+                }
+                // ESC inside the payload: terminates only as ESC \.
+                if (i + t + 1 < len && input[i + t + 1] == '\\') {
+                    if (t + 2 <= N) {
+                        zero |= MaskBitsBelow(t + 2) & ~MaskBitsBelow(p);
+                        introRemaining &= ~MaskBitsBelow(t + 2);
+                        pos = t + 2;
+                    } else {
+                        zero |= laneMask & ~MaskBitsBelow(p);
+                        consumed = t + 2;
+                        introRemaining = 0;
+                        pos = N;
+                    }
+                    return true;
+                }
+                cand &= cand - 1;
+            }
+            return false;
+        };
+
         while (i + N <= len) {
             const auto chunk = hn::LoadU(d, input + i);
 
             const auto esc_m = hn::Eq(chunk, vec_esc);
+            // Bytes 0x90-0x9F: any C1 escape introducer (0x9B CSI, 0x9D OSC,
+            // 0x90/0x98/0x9E/0x9F ST-string) lives here, as does 0x9C ST. Used
+            // only to gate the fast path; the slow path re-checks the exact byte.
+            const auto c1_range_m = hn::Le(hn::Sub(chunk, vec_0x90), vec_0x0F);
             const auto printable_m = classifyPrintable(chunk);
 
             // Fast path: nothing escape-related in this chunk.
-            if (state == AnsiExcludeState::None && hn::AllFalse(d, esc_m)) {
+            if (state == AnsiExcludeState::None && hn::AllFalse(d, hn::Or(esc_m, c1_range_m))) {
                 count += hn::CountTrue(d, printable_m);
                 i += N;
                 continue;
             }
 
             const auto final_m = hn::Le(hn::Sub(chunk, vec_0x40), vec_0x3E); // 0x40..0x7E
-            const auto term_m = hn::Or(hn::Eq(chunk, vec_bel), hn::Eq(chunk, vec_c1_st));
+            const auto c1_st_m = hn::Eq(chunk, vec_c1_st);
+            const auto term_m = hn::Or(hn::Eq(chunk, vec_bel), c1_st_m);
+            // C1 introducers: 0x9B/0x9D plus 0x90/0x98/0x9E/0x9F. 0x9C is the
+            // ST terminator; 0x91-0x97/0x99/0x9A are plain zero-width controls.
+            const auto c1_stintro_m = hn::Or(
+                hn::Or(hn::Eq(chunk, vec_0x90), hn::Eq(chunk, hn::Set(d, uint8_t { 0x98 }))),
+                hn::Or(hn::Eq(chunk, hn::Set(d, uint8_t { 0x9E })), hn::Eq(chunk, hn::Set(d, uint8_t { 0x9F }))));
+            const auto c1_intro_m = hn::Or(hn::Or(hn::Eq(chunk, vec_c1_csi), hn::Eq(chunk, vec_c1_osc)), c1_stintro_m);
 
             const uint64_t esc = maskToBits(esc_m);
             const uint64_t prn = maskToBits(printable_m);
             const uint64_t fin = maskToBits(final_m);
             const uint64_t term = maskToBits(term_m);
+            const uint64_t stTerm = maskToBits(c1_st_m);
+            const uint64_t c1Intro = maskToBits(c1_intro_m);
 
             uint64_t zero = 0; // bits covered by escape sequences
             size_t consumed = N; // may exceed N when a sequence straddles the chunk end
             size_t pos = 0; // offset where escape processing resumes after carried state
+            uint64_t introRemaining = 0; // set after carried-state handling
 
             // Finish a sequence carried over from the previous chunk.
             if (state == AnsiExcludeState::InCSI) {
@@ -1030,59 +1111,64 @@ size_t VisibleLatin1WidthExcludeANSIImpl(const uint8_t* HWY_RESTRICT input, size
                 zero |= MaskBitsBelow(e + 1);
                 pos = e + 1;
                 state = AnsiExcludeState::None;
-            } else if (state == AnsiExcludeState::InOSC) {
-                uint64_t cand = term | esc;
-                bool ended = false;
-                while (cand != 0) {
-                    const size_t t = static_cast<size_t>(hwy::Num0BitsBelowLS1Bit_Nonzero64(cand));
-                    if ((term >> t) & 1) {
-                        zero |= MaskBitsBelow(t + 1);
-                        pos = t + 1;
-                        ended = true;
-                        break;
-                    }
-                    // ESC inside the OSC payload: terminates only as ESC \.
-                    if (i + t + 1 < len && input[i + t + 1] == '\\') {
-                        if (t + 2 <= N) {
-                            zero |= MaskBitsBelow(t + 2);
-                            pos = t + 2;
-                        } else {
-                            zero |= laneMask;
-                            consumed = t + 2;
-                            pos = N;
-                        }
-                        ended = true;
-                        break;
-                    }
-                    cand &= cand - 1;
-                }
-                if (!ended) {
-                    i += N; // whole chunk is OSC payload
+            } else if (state == AnsiExcludeState::InOSC || state == AnsiExcludeState::InST) {
+                const uint64_t tmask = (state == AnsiExcludeState::InOSC) ? term : stTerm;
+                uint64_t dummy = 0;
+                if (!scanStringTerminator(tmask, esc, 0, 0, zero, consumed, pos, dummy)) {
+                    i += N; // whole chunk is payload
                     continue;
                 }
                 state = AnsiExcludeState::None;
             }
 
             // Process escape sequences that start in this chunk.
-            uint64_t escRemaining = esc & ~MaskBitsBelow(pos);
-            while (escRemaining != 0) {
-                const size_t p = static_cast<size_t>(hwy::Num0BitsBelowLS1Bit_Nonzero64(escRemaining));
-                if (i + p + 1 >= len) {
-                    // Trailing ESC at the very end of the input: dropped.
-                    zero |= uint64_t { 1 } << p;
-                    escRemaining &= escRemaining - 1;
-                    continue;
-                }
-                const uint8_t next = input[i + p + 1];
-                if (next == '[') {
-                    const size_t searchFrom = p + 2;
-                    if (searchFrom >= N) {
-                        // Parameters start in the next chunk; consume the '[' too.
-                        zero |= laneMask & ~MaskBitsBelow(p);
-                        consumed = searchFrom;
-                        state = AnsiExcludeState::InCSI;
-                        break;
+            introRemaining = (esc | c1Intro) & ~MaskBitsBelow(pos);
+            while (introRemaining != 0) {
+                const size_t p = static_cast<size_t>(hwy::Num0BitsBelowLS1Bit_Nonzero64(introRemaining));
+                const uint8_t intro = input[i + p];
+
+                AnsiExcludeState seqKind;
+                size_t searchFrom;
+                if (intro == 0x1B) {
+                    if (i + p + 1 >= len) {
+                        // Trailing ESC at the very end of the input: dropped.
+                        zero |= uint64_t { 1 } << p;
+                        introRemaining &= introRemaining - 1;
+                        continue;
                     }
+                    const uint8_t next = input[i + p + 1];
+                    if (next == '[')
+                        seqKind = AnsiExcludeState::InCSI;
+                    else if (next == ']')
+                        seqKind = AnsiExcludeState::InOSC;
+                    else if (next == 'P' || next == 'X' || next == '^' || next == '_')
+                        seqKind = AnsiExcludeState::InST;
+                    else {
+                        // Bare ESC: only the ESC itself is zero-width.
+                        zero |= uint64_t { 1 } << p;
+                        introRemaining &= introRemaining - 1;
+                        continue;
+                    }
+                    searchFrom = p + 2;
+                } else if (intro == 0x9B) {
+                    seqKind = AnsiExcludeState::InCSI;
+                    searchFrom = p + 1;
+                } else if (intro == 0x9D) {
+                    seqKind = AnsiExcludeState::InOSC;
+                    searchFrom = p + 1;
+                } else {
+                    seqKind = AnsiExcludeState::InST;
+                    searchFrom = p + 1;
+                }
+
+                if (searchFrom >= N) {
+                    zero |= laneMask & ~MaskBitsBelow(p);
+                    consumed = searchFrom;
+                    state = seqKind;
+                    break;
+                }
+
+                if (seqKind == AnsiExcludeState::InCSI) {
                     const uint64_t f = fin & ~MaskBitsBelow(searchFrom);
                     if (f == 0) {
                         zero |= laneMask & ~MaskBitsBelow(p);
@@ -1091,52 +1177,16 @@ size_t VisibleLatin1WidthExcludeANSIImpl(const uint8_t* HWY_RESTRICT input, size
                     }
                     const size_t e = static_cast<size_t>(hwy::Num0BitsBelowLS1Bit_Nonzero64(f));
                     zero |= MaskBitsBelow(e + 1) & ~MaskBitsBelow(p);
-                    escRemaining &= ~MaskBitsBelow(e + 1);
+                    introRemaining &= ~MaskBitsBelow(e + 1);
                     continue;
                 }
-                if (next == ']') {
-                    const size_t searchFrom = p + 2;
-                    if (searchFrom >= N) {
-                        // Payload starts in the next chunk; consume the ']' too.
-                        zero |= laneMask & ~MaskBitsBelow(p);
-                        consumed = searchFrom;
-                        state = AnsiExcludeState::InOSC;
-                        break;
-                    }
-                    uint64_t cand = (term | esc) & ~MaskBitsBelow(searchFrom);
-                    bool ended = false;
-                    while (cand != 0) {
-                        const size_t t = static_cast<size_t>(hwy::Num0BitsBelowLS1Bit_Nonzero64(cand));
-                        if ((term >> t) & 1) {
-                            zero |= MaskBitsBelow(t + 1) & ~MaskBitsBelow(p);
-                            escRemaining &= ~MaskBitsBelow(t + 1);
-                            ended = true;
-                            break;
-                        }
-                        if (i + t + 1 < len && input[i + t + 1] == '\\') {
-                            if (t + 2 <= N) {
-                                zero |= MaskBitsBelow(t + 2) & ~MaskBitsBelow(p);
-                                escRemaining &= ~MaskBitsBelow(t + 2);
-                            } else {
-                                zero |= laneMask & ~MaskBitsBelow(p);
-                                consumed = t + 2;
-                                escRemaining = 0;
-                            }
-                            ended = true;
-                            break;
-                        }
-                        cand &= cand - 1;
-                    }
-                    if (!ended) {
-                        zero |= laneMask & ~MaskBitsBelow(p);
-                        state = AnsiExcludeState::InOSC;
-                        break;
-                    }
-                    continue;
+
+                const uint64_t tmask = (seqKind == AnsiExcludeState::InOSC) ? term : stTerm;
+                if (!scanStringTerminator(tmask, esc, p, searchFrom, zero, consumed, pos, introRemaining)) {
+                    zero |= laneMask & ~MaskBitsBelow(p);
+                    state = seqKind;
+                    break;
                 }
-                // Bare ESC: only the ESC itself is zero-width.
-                zero |= uint64_t { 1 } << p;
-                escRemaining &= escRemaining - 1;
             }
 
             count += static_cast<size_t>(hwy::PopCount(prn & ~zero & laneMask));
@@ -1145,12 +1195,13 @@ size_t VisibleLatin1WidthExcludeANSIImpl(const uint8_t* HWY_RESTRICT input, size
     }
 
     // Short inputs and the final partial chunk: one masked load. With no ESC
-    // byte (and no carried escape state) the printable count is the answer —
-    // lanes past the end load as zero, which is not printable. Otherwise fall
-    // back to the scalar state machine for the remaining < N bytes.
+    // or 0x90-0x9F byte (and no carried escape state) the printable count is
+    // the answer — lanes past the end load as zero, which is not printable.
+    // Otherwise fall back to the scalar state machine for the remaining bytes.
     if (i < len) {
         const auto chunk = hn::LoadN(d, input + i, len - i);
-        if (state == AnsiExcludeState::None && hn::AllFalse(d, hn::Eq(chunk, vec_esc))) {
+        const auto c1_range_m = hn::Le(hn::Sub(chunk, hn::Set(d, uint8_t { 0x90 })), hn::Set(d, uint8_t { 0x0F }));
+        if (state == AnsiExcludeState::None && hn::AllFalse(d, hn::Or(hn::Eq(chunk, vec_esc), c1_range_m))) {
             count += hn::CountTrue(d, classifyPrintable(chunk));
             return count;
         }

--- a/src/jsc/bindings/sliceAnsi.cpp
+++ b/src/jsc/bindings/sliceAnsi.cpp
@@ -627,10 +627,10 @@ static const Char* parseControlString(const Char* start, const Char* end)
         }
         // Unterminated control string — DO NOT consume to EOF. A single C1
         // byte (0x90, 0x98, 0x9E, 0x9F) or malformed ESC-sequence should not
-        // swallow the rest of the string (DoS vector; also inconsistent with
-        // Bun.stringWidth which treats these as standalone width-0 controls).
-        // Instead, return nullptr so the caller treats the introducer as a
-        // single visible char (which will be width 0 via codepointWidth).
+        // swallow the rest of the string when slicing. Instead, return nullptr
+        // so the caller treats the introducer as a single visible char (which
+        // will be width 0 via codepointWidth). Note: Bun.stringWidth and
+        // Bun.stripANSI do consume unterminated control strings to EOF.
         return nullptr;
     }
 

--- a/src/jsc/bindings/stringWidth.cpp
+++ b/src/jsc/bindings/stringWidth.cpp
@@ -685,10 +685,11 @@ size_t utf8IndexAtWidthExcludeANSI(std::span<const uint8_t> input, size_t maxWid
             return *stop;
         remaining = remaining.subspan(esc);
 
-        // Same CSI/OSC skip as visibleLatin1WidthExcludeANSI.
+        // Same CSI/OSC/ST-string skip as visibleLatin1WidthExcludeANSI.
         if (remaining.size() < 2)
             return input.size();
-        if (remaining[1] == '[') {
+        const uint8_t next = remaining[1];
+        if (next == '[') {
             if (remaining.size() < 3)
                 return input.size();
             remaining = remaining.subspan(2);
@@ -696,16 +697,19 @@ size_t utf8IndexAtWidthExcludeANSI(std::span<const uint8_t> input, size_t maxWid
             if (!term)
                 return input.size();
             remaining = remaining.subspan(static_cast<size_t>(term - remaining.data()) + 1);
-        } else if (remaining[1] == ']') {
+        } else if (next == ']' || next == 'P' || next == 'X' || next == '^' || next == '_') {
+            const bool osc = (next == ']');
             remaining = remaining.subspan(2);
             while (true) {
-                const uint8_t* term = ANSI::scanForAnyByte<0x07, 0x9c, 0x1b>(remaining.data(), remaining.data() + remaining.size());
+                const uint8_t* term = osc
+                    ? ANSI::scanForAnyByte<0x07, 0x9c, 0x1b>(remaining.data(), remaining.data() + remaining.size())
+                    : ANSI::scanForAnyByte<0x9c, 0x1b>(remaining.data(), remaining.data() + remaining.size());
                 if (!term) {
                     remaining = remaining.subspan(remaining.size());
                     break;
                 }
                 const size_t t = static_cast<size_t>(term - remaining.data());
-                if (*term == 0x07 || *term == 0x9c) {
+                if (*term == 0x9c || (osc && *term == 0x07)) {
                     remaining = remaining.subspan(t + 1);
                     break;
                 }
@@ -768,8 +772,10 @@ static UTF16Decoded decodeUTF16Codepoint(std::span<const char16_t> input)
 }
 
 // Grapheme-cluster-aware width of UTF-16 text. When `excludeAnsiColors` is
-// set, CSI (ESC [ ... final) and OSC (ESC ] ... BEL/ST) sequences contribute
-// nothing; otherwise escape bytes are counted like ordinary codepoints.
+// set, CSI (ESC [ or 0x9B ... final), OSC (ESC ] or 0x9D ... BEL/ST) and
+// ST-terminated control strings (ESC P/X/^/_ or 0x90/0x98/0x9E/0x9F ... ST)
+// contribute nothing; otherwise escape bytes are counted like ordinary
+// codepoints.
 size_t visibleUTF16Width(std::span<const char16_t> input, bool excludeAnsiColors, bool ambiguousAsWide)
 {
     size_t len = 0;
@@ -782,8 +788,9 @@ size_t visibleUTF16Width(std::span<const char16_t> input, bool excludeAnsiColors
     GraphemeBreakState breakState = GraphemeBreakState::Default;
     GraphemeState graphemeState;
     bool saw1b = false; // saw ESC, deciding what follows
-    bool sawCsi = false; // inside CSI: ESC [
-    bool sawOsc = false; // inside OSC: ESC ]
+    bool sawCsi = false; // inside CSI: ESC [ or 0x9B
+    bool sawOsc = false; // inside OSC: ESC ] or 0x9D
+    bool sawSt = false; // inside DCS/SOS/PM/APC: ESC P/X/^/_ or 0x90/0x98/0x9E/0x9F
 
     while (true) {
         // Bulk fast path: leading code units that are always their own
@@ -797,7 +804,7 @@ size_t visibleUTF16Width(std::span<const char16_t> input, bool excludeAnsiColors
         // East-Asian-Ambiguous) and while inside an escape sequence; the
         // first-unit check skips the call when the next codepoint (surrogate
         // pair, control, ESC) clearly needs the scalar path anyway.
-        if (!ambiguousAsWide && !saw1b && !sawCsi && !sawOsc && !input.empty()
+        if (!ambiguousAsWide && !saw1b && !sawCsi && !sawOsc && !sawSt && !input.empty()
             && input[0] >= 0x20 && !U16_IS_SURROGATE(input[0])) {
             size_t bulkWidth = 0;
             const size_t consumed = highway_visible_utf16_width(
@@ -830,7 +837,7 @@ size_t visibleUTF16Width(std::span<const char16_t> input, bool excludeAnsiColors
             // Fast path: bulk ASCII processing when not inside an escape
             // sequence. ASCII chars are always their own graphemes, so they
             // can be counted directly with SIMD.
-            if (idx > 0 && !saw1b && !sawCsi && !sawOsc) {
+            if (idx > 0 && !saw1b && !sawCsi && !sawOsc && !sawSt) {
                 // If stripping ANSI, stop at the first ESC; otherwise process
                 // the entire run.
                 size_t bulkEnd = idx;
@@ -887,9 +894,13 @@ size_t visibleUTF16Width(std::span<const char16_t> input, bool excludeAnsiColors
                     // non-ASCII codepoint handler below keeps parsing.
                     break;
                 }
-                if (sawOsc) {
-                    // OSC payload terminates at BEL (0x07) or ESC + '\' (ST).
-                    const char16_t* term = ANSI::scanForAnyByte<0x07, 0x1b>(input.data() + j, input.data() + idx);
+                if (sawOsc || sawSt) {
+                    // OSC payload terminates at BEL (0x07) or ESC + '\' (ST);
+                    // DCS/SOS/PM/APC terminate at ESC + '\' only (plus C1 ST
+                    // 0x9C, which is non-ASCII and handled below).
+                    const char16_t* term = sawOsc
+                        ? ANSI::scanForAnyByte<0x07, 0x1b>(input.data() + j, input.data() + idx)
+                        : ANSI::scanForAnyByte<0x1b>(input.data() + j, input.data() + idx);
                     if (term) {
                         const size_t t = static_cast<size_t>(term - input.data());
                         if (*term == 0x07) {
@@ -902,14 +913,15 @@ size_t visibleUTF16Width(std::span<const char16_t> input, bool excludeAnsiColors
                         if (t + 1 < idx && input[t + 1] == u'\\') {
                             saw1b = false;
                             sawOsc = false;
+                            sawSt = false;
                             j = t + 2;
                             continue;
                         }
-                        // Lone ESC inside OSC — skip it and keep scanning.
+                        // Lone ESC inside payload — skip it and keep scanning.
                         j = t + 1;
                         continue;
                     }
-                    // Terminator not in this ASCII run — stay in OSC state.
+                    // Terminator not in this ASCII run — stay in state.
                     break;
                 }
 
@@ -924,6 +936,10 @@ size_t visibleUTF16Width(std::span<const char16_t> input, bool excludeAnsiColors
                     }
                     if (cp == ']') {
                         sawOsc = true;
+                        continue;
+                    }
+                    if (cp == 'P' || cp == 'X' || cp == '^' || cp == '_') {
+                        sawSt = true;
                         continue;
                     }
                     if (cp == 0x1b) {
@@ -971,13 +987,15 @@ size_t visibleUTF16Width(std::span<const char16_t> input, bool excludeAnsiColors
         const char32_t cp = decoded.codePoint;
 
         // Handle non-ASCII characters inside escape sequences.
-        if (sawOsc) {
+        if (sawOsc || sawSt) {
             // In OSC, look for BEL (0x07) or C1 ST (0x9C); the 7-bit ST
-            // (ESC \) only uses ASCII and is handled above. Non-ASCII chars
-            // inside OSC do not contribute to width.
-            if (cp == 0x07 || cp == 0x9c) {
+            // (ESC \) only uses ASCII and is handled above. DCS/SOS/PM/APC
+            // terminate at C1 ST only. Non-ASCII chars inside the payload do
+            // not contribute to width.
+            if (cp == 0x9c || (cp == 0x07 && sawOsc)) {
                 saw1b = false;
                 sawOsc = false;
+                sawSt = false;
             }
             continue;
         }
@@ -992,6 +1010,24 @@ size_t visibleUTF16Width(std::span<const char16_t> input, bool excludeAnsiColors
             // ESC followed by non-ASCII — not a valid sequence start; treat
             // the char normally below.
             saw1b = false;
+        }
+        // C1 escape introducers (0x90-0x9F). These are the 8-bit equivalents
+        // of ESC [ / ESC ] / ESC P/X/^/_ and must not let their payload count
+        // as visible text — Bun.stripANSI and Bun.sliceAnsi already strip them.
+        if (excludeAnsiColors && cp >= 0x90 && cp <= 0x9f) {
+            if (cp == 0x9b) {
+                sawCsi = true;
+                continue;
+            }
+            if (cp == 0x9d) {
+                sawOsc = true;
+                continue;
+            }
+            if (cp == 0x90 || cp == 0x98 || cp == 0x9e || cp == 0x9f) {
+                sawSt = true;
+                continue;
+            }
+            // 0x91-0x97, 0x99, 0x9A, 0x9C: ordinary zero-width C1 controls.
         }
 
         const uint8_t packed = fusedClassify(cp);

--- a/test/js/bun/util/sliceAnsi-fuzz.test.ts
+++ b/test/js/bun/util/sliceAnsi-fuzz.test.ts
@@ -443,7 +443,8 @@ function randomString(rng: () => number, minLen: number, maxLen: number): string
       // stripANSI consume to EOF, and this generator is meant to produce
       // inputs the three width models agree on.
       const c1 = 0x80 + Math.floor(rng() * 0x20);
-      const safe = c1 === 0x90 || c1 === 0x98 || c1 === 0x9b || c1 === 0x9d || c1 === 0x9e || c1 === 0x9f ? c1 - 0x10 : c1;
+      const safe =
+        c1 === 0x90 || c1 === 0x98 || c1 === 0x9b || c1 === 0x9d || c1 === 0x9e || c1 === 0x9f ? c1 - 0x10 : c1;
       pieces.push(String.fromCharCode(safe));
     } else {
       // Truecolor SGR

--- a/test/js/bun/util/sliceAnsi-fuzz.test.ts
+++ b/test/js/bun/util/sliceAnsi-fuzz.test.ts
@@ -2,6 +2,7 @@
 // These complement sliceAnsi.test.ts with property-based and adversarial cases.
 
 import { describe, expect, test } from "bun:test";
+import { isDebug } from "harness";
 
 // Seeded PRNG for reproducibility. Change seed to explore different cases.
 function makeRng(seed: number) {
@@ -222,11 +223,14 @@ describe("sliceAnsi adversarial", () => {
     for (let i = 9; i >= 1; i--) s += `\x1b[39m`;
     const out = Bun.sliceAnsi(s, 0, 1);
     expect(Bun.stripANSI(out)).toBe("X");
-    // Time bound: should be O(n), not O(n²). Generous threshold for debug builds.
+    // Time bound: should be O(n), not O(n²). Debug+ASAN is ~300x slower than
+    // release so scale the workload down there; an O(n²) regression would
+    // still blow past the bound at either iteration count.
+    const iters = isDebug ? 50 : 1000;
     const start = Bun.nanoseconds();
-    for (let i = 0; i < 1000; i++) Bun.sliceAnsi(s, 0, 1);
+    for (let i = 0; i < iters; i++) Bun.sliceAnsi(s, 0, 1);
     const elapsed = (Bun.nanoseconds() - start) / 1e6;
-    expect(elapsed).toBeLessThan(5000); // < 5s for 1000 iters
+    expect(elapsed).toBeLessThan(5000);
   });
 
   // Huge SGR parameter values.

--- a/test/js/bun/util/sliceAnsi-fuzz.test.ts
+++ b/test/js/bun/util/sliceAnsi-fuzz.test.ts
@@ -436,8 +436,15 @@ function randomString(rng: () => number, minLen: number, maxLen: number): string
       // Control char
       pieces.push(String.fromCharCode(Math.floor(rng() * 0x20)));
     } else if (r < 0.96) {
-      // C1 control
-      pieces.push(String.fromCharCode(0x80 + Math.floor(rng() * 0x20)));
+      // C1 control. Remap the ANSI introducer bytes (0x90 DCS, 0x98 SOS,
+      // 0x9B CSI, 0x9D OSC, 0x9E PM, 0x9F APC) down by 0x10 so a lone
+      // introducer never opens an unterminated control string: sliceAnsi
+      // leaves the trailing bytes visible for those while stringWidth and
+      // stripANSI consume to EOF, and this generator is meant to produce
+      // inputs the three width models agree on.
+      const c1 = 0x80 + Math.floor(rng() * 0x20);
+      const safe = c1 === 0x90 || c1 === 0x98 || c1 === 0x9b || c1 === 0x9d || c1 === 0x9e || c1 === 0x9f ? c1 - 0x10 : c1;
+      pieces.push(String.fromCharCode(safe));
     } else {
       // Truecolor SGR
       pieces.push(`\x1b[38;2;${Math.floor(rng() * 256)};${Math.floor(rng() * 256)};${Math.floor(rng() * 256)}m`);
@@ -486,9 +493,10 @@ describe("sliceAnsi negative indices", () => {
   test("computeTotalWidth matches stringWidth for cluster-rich input", () => {
     // Negative indices with clustering (emoji, ZWJ, combining) stress the
     // pre-pass path. It should give the same totalWidth as stringWidth.
-    // Note: use stringWidth(s) directly (NOT stripANSI) — stripANSI's
-    // consumeANSI swallows unterminated OSC to EOF, but both stringWidth
-    // and sliceAnsi correctly treat malformed introducers as standalone.
+    // randomString() excludes bare C1 escape introducers so the input never
+    // contains an unterminated control string (the one case where sliceAnsi's
+    // width model deliberately keeps the trailing bytes visible while
+    // stringWidth/stripANSI consume to EOF).
     const rng = makeRng(0x70741);
     for (let i = 0; i < 100; i++) {
       const s = randomString(rng, 10, 80);
@@ -780,11 +788,10 @@ describe("sliceAnsi direct stringWidth invariant (post-fix)", () => {
     // Now stringWidth correctly preserves grapheme state across ANSI, so
     // we can test the direct invariant. Keep +1 for wide-at-boundary.
     //
-    // KNOWN LIMITATION: stringWidth doesn't recognize C1 (8-bit) escape
-    // sequences (0x9B CSI, 0x9D OSC, 0x90 DCS, etc.) — only 7-bit (ESC[).
-    // sliceAnsi DOES handle C1. So inputs with C1 sequences will show
-    // stringWidth > sliceAnsi's internal width. We exclude C1 from this
-    // test's generator; C1 coverage is in the adversarial tests above.
+    // Unterminated control strings are the one place sliceAnsi's width model
+    // and stringWidth deliberately diverge (sliceAnsi keeps the trailing
+    // bytes visible; stringWidth/stripANSI consume to EOF). This generator
+    // excludes C1 bytes entirely so a stray control byte can never open one.
     const rng = makeRng(0xd1ec7);
     for (let i = 0; i < 200; i++) {
       const s = randomStringNoC1(rng, 0, 100);
@@ -799,9 +806,8 @@ describe("sliceAnsi direct stringWidth invariant (post-fix)", () => {
   });
 });
 
-// Like randomString but excludes C1 control bytes (0x80-0x9F). Used for tests
-// that compare directly against Bun.stringWidth, which doesn't recognize C1
-// escape sequences (only 7-bit ESC-based).
+// Like randomString but excludes C1 control bytes (0x80-0x9F) entirely, so no
+// piece can combine with a neighbour into an unterminated control string.
 function randomStringNoC1(rng: () => number, minLen: number, maxLen: number): string {
   const len = minLen + Math.floor(rng() * (maxLen - minLen + 1));
   const pieces: string[] = [];

--- a/test/js/bun/util/stringWidth.test.ts
+++ b/test/js/bun/util/stringWidth.test.ts
@@ -399,6 +399,104 @@ describe("stringWidth extended", () => {
     });
   });
 
+  // Bun.stringWidth must agree with Bun.stripANSI / Bun.sliceAnsi on what an
+  // escape sequence is. These cover the 8-bit C1 introducers (ECMA-48 §5.3)
+  // and the ST-terminated control strings (DCS/SOS/PM/APC) that stripANSI and
+  // sliceAnsi already recognize.
+  describe("C1 escapes and ST-terminated control strings", () => {
+    test("C1 CSI (0x9B) is equivalent to ESC [", () => {
+      expect(Bun.stringWidth("\x9B31mhi\x9B39m")).toBe(2);
+      expect(Bun.stringWidth("a\x9B5Ab")).toBe(2);
+      expect(Bun.stringWidth("\x9B38;2;255;0;0mX\x9B39m")).toBe(1);
+      // UTF-16 path
+      expect(Bun.stringWidth("\x9B31m日本\x9B39m")).toBe(4);
+      expect(Bun.stringWidth("😀\x9B1mok\x9B22m😀")).toBe(6);
+    });
+
+    test("C1 OSC (0x9D) is equivalent to ESC ]", () => {
+      expect(Bun.stringWidth("\x9D8;;https://bun.com\x07link\x9D8;;\x07")).toBe(4);
+      expect(Bun.stringWidth("\x9D8;;url\x9Ctext\x9D8;;\x9C")).toBe(4);
+      expect(Bun.stringWidth("\x9D0;title\x1b\\text")).toBe(4);
+      // UTF-16 path
+      expect(Bun.stringWidth("\x9D8;;https://bun.com\x07文档\x9D8;;\x07")).toBe(4);
+    });
+
+    test("DCS/SOS/PM/APC payloads are zero-width", () => {
+      // 7-bit (ESC P/X/^/_) with ESC\ terminator
+      expect(Bun.stringWidth("a\x1bP+q544e\x1b\\b")).toBe(2);
+      expect(Bun.stringWidth("a\x1bXpayload\x1b\\b")).toBe(2);
+      expect(Bun.stringWidth("a\x1b^pm\x1b\\b")).toBe(2);
+      expect(Bun.stringWidth("a\x1b_apc data\x1b\\b")).toBe(2);
+      // 8-bit (0x90/0x98/0x9E/0x9F) with C1 ST terminator
+      expect(Bun.stringWidth("a\x90+q544e\x9Cb")).toBe(2);
+      expect(Bun.stringWidth("a\x98payload\x9Cb")).toBe(2);
+      expect(Bun.stringWidth("a\x9Epm\x9Cb")).toBe(2);
+      expect(Bun.stringWidth("a\x9Fapc\x9Cb")).toBe(2);
+      // UTF-16 path
+      expect(Bun.stringWidth("中\x1bP+q\x1b\\文")).toBe(4);
+      expect(Bun.stringWidth("中\x90+q\x9C文")).toBe(4);
+    });
+
+    test("BEL does not terminate DCS/SOS/PM/APC", () => {
+      // BEL terminates OSC only; inside a DCS payload it is just a byte.
+      expect(Bun.stringWidth("a\x1bPdata\x07still dcs\x1b\\b")).toBe(2);
+      expect(Bun.stringWidth("a\x90data\x07still\x9Cb")).toBe(2);
+    });
+
+    test("unterminated C1/ST sequences consume to end of string", () => {
+      // Same consume-to-EOF semantics as unterminated ESC[ / ESC].
+      expect(Bun.stringWidth("abc\x9B31;38;2;1;2;3")).toBe(3);
+      expect(Bun.stringWidth("abc\x9D0;title")).toBe(3);
+      expect(Bun.stringWidth("abc\x90payload")).toBe(3);
+      expect(Bun.stringWidth("abc\x1bPpayload")).toBe(3);
+      expect(Bun.stringWidth("中文\x9B31")).toBe(4);
+    });
+
+    test("non-introducer C1 bytes stay zero-width controls", () => {
+      // 0x91-0x97, 0x99, 0x9A, 0x9C alone do not open a sequence.
+      for (const cp of [0x91, 0x92, 0x97, 0x99, 0x9a, 0x9c]) {
+        expect(Bun.stringWidth("a" + String.fromCharCode(cp) + "b")).toBe(2);
+      }
+    });
+
+    test("C1 CSI still stripped with countAnsiEscapeCodes: false, counted with true", () => {
+      const s = "\x9B31mhi\x9B39m";
+      expect(Bun.stringWidth(s, { countAnsiEscapeCodes: false })).toBe(2);
+      // With counting enabled: 0x9B is a zero-width C1 control, '3','1','m'
+      // etc. count individually: 3+2+3 = 8.
+      expect(Bun.stringWidth(s, { countAnsiEscapeCodes: true })).toBe(8);
+    });
+
+    test("stringWidth agrees with stripANSI on C1/DCS input", () => {
+      const cases = [
+        "\x9B31mhi\x9B39m",
+        "\x9D8;;url\x9Clink\x9D8;;\x9C",
+        "\x1bP+q544e\x1b\\text",
+        "\x90dcs\x9Ctext",
+        "\x98sos\x9Ctext",
+        "\x9Epm\x9Ctext",
+        "\x9Fapc\x9Ctext",
+        "pre\x9B1mmid\x9B22m\x1bPdcs\x1b\\post",
+        // UTF-16
+        "日\x9B31m本\x9B39m語",
+        "中\x90+q\x9C文",
+      ];
+      for (const s of cases) {
+        expect({ input: s, width: Bun.stringWidth(s) }).toEqual({
+          input: s,
+          width: Bun.stringWidth(Bun.stripANSI(s)),
+        });
+      }
+    });
+
+    test("sliceAnsi negative index agrees with stringWidth offset on C1 input", () => {
+      const m = "\x9B32mabcdef";
+      expect(Bun.sliceAnsi(m, -3)).toBe(Bun.sliceAnsi(m, Bun.stringWidth(m) - 3));
+      const n = "\x9B31mhi\x9B39m world";
+      expect(Bun.sliceAnsi(n, -4)).toBe(Bun.sliceAnsi(n, Bun.stringWidth(n) - 4));
+    });
+  });
+
   describe("emoji handling", () => {
     test("basic emoji", () => {
       expect(Bun.stringWidth("😀")).toBe(2);
@@ -606,7 +704,9 @@ describe("stringWidth extended", () => {
     });
 
     test("bare ESC followed by non-sequence", () => {
-      expect(Bun.stringWidth("a\x1bXb")).toBe(3); // ESC + X is not a valid sequence
+      // ESC + Z is not a recognized sequence introducer: only ESC is dropped.
+      expect(Bun.stringWidth("a\x1bZb")).toBe(3);
+      expect(Bun.stringWidth("a\x1b!b")).toBe(3);
     });
   });
 
@@ -814,13 +914,19 @@ describe("stringWidth extended", () => {
     });
 
     test("C1 control characters", () => {
-      // C1 controls: 0x80-0x9F
+      // C1 controls 0x80-0x9F, excluding the ANSI escape introducers
+      // (0x90 DCS, 0x98 SOS, 0x9B CSI, 0x9D OSC, 0x9E PM, 0x9F APC) which
+      // would swallow the following bytes as payload.
+      const introducers = new Set([0x90, 0x98, 0x9b, 0x9d, 0x9e, 0x9f]);
       let input = "";
+      let visible = 0;
       for (let i = 0x80; i <= 0x9f; i++) {
+        if (introducers.has(i)) continue;
         input += "a" + String.fromCharCode(i);
+        visible++;
       }
       input = input.repeat(300);
-      expect(Bun.stringWidth(input)).toBe(9600); // 32 'a' chars per pattern * 300
+      expect(Bun.stringWidth(input)).toBe(visible * 300);
     });
 
     test("worst case: every character needs special handling", () => {
@@ -1034,13 +1140,15 @@ test("options lookup ignores Object.prototype pollution", () => {
 
 // The Latin-1 ANSI-excluding width is computed by a single-pass SIMD kernel
 // (highway_visible_latin1_width_exclude_ansi) that classifies 16-64 byte
-// chunks into bitmasks and carries in-CSI / in-OSC state across chunk
-// boundaries. These tests pin its behavior at and around those boundaries and
-// against a scalar reference implementation of the same escape semantics:
-//   CSI  ESC [ <params> <final byte in [0x40, 0x7E]>   -> zero width
-//   OSC  ESC ] <payload> (BEL | 0x9C | ESC \)           -> zero width
-//   bare ESC followed by anything else                  -> only the ESC is dropped
-//   C0 controls, DEL, C1 controls, soft hyphen (0xAD)   -> zero width
+// chunks into bitmasks and carries in-CSI / in-OSC / in-ST-string state across
+// chunk boundaries. These tests pin its behavior at and around those
+// boundaries and against a scalar reference implementation of the same escape
+// semantics:
+//   CSI  ESC [ or 0x9B  <params> <final byte in [0x40, 0x7E]>             -> zero width
+//   OSC  ESC ] or 0x9D  <payload> (BEL | 0x9C | ESC \)                    -> zero width
+//   DCS/SOS/PM/APC  ESC P/X/^/_  or 0x90/0x98/0x9E/0x9F  (0x9C | ESC \)   -> zero width
+//   bare ESC followed by anything else                                    -> only the ESC is dropped
+//   C0 controls, DEL, C1 controls, soft hyphen (0xAD)                     -> zero width
 describe("ANSI escapes across SIMD chunk boundaries", () => {
   const ESC = "\x1b";
   const rep = (fill: string, count: number) => Buffer.alloc(fill.length * count, fill, "latin1").toString("latin1");
@@ -1049,6 +1157,24 @@ describe("ANSI escapes across SIMD chunk boundaries", () => {
     let width = 0;
     let i = 0;
     const len = str.length;
+    const scanCsi = () => {
+      while (i < len && !(str.charCodeAt(i) >= 0x40 && str.charCodeAt(i) <= 0x7e)) i++;
+      i++;
+    };
+    const scanString = (bel: boolean) => {
+      while (i < len) {
+        const t = str.charCodeAt(i);
+        if (t === 0x9c || (bel && t === 0x07)) {
+          i++;
+          break;
+        }
+        if (t === 0x1b && i + 1 < len && str.charCodeAt(i + 1) === 0x5c /* \ */) {
+          i += 2;
+          break;
+        }
+        i++;
+      }
+    };
     while (i < len) {
       const c = str.charCodeAt(i);
       if (c === 0x1b) {
@@ -1059,27 +1185,35 @@ describe("ANSI escapes across SIMD chunk boundaries", () => {
         const next = str.charCodeAt(i + 1);
         if (next === 0x5b /* [ */) {
           i += 2;
-          while (i < len && !(str.charCodeAt(i) >= 0x40 && str.charCodeAt(i) <= 0x7e)) i++;
-          i++;
+          scanCsi();
           continue;
         }
         if (next === 0x5d /* ] */) {
           i += 2;
-          while (i < len) {
-            const t = str.charCodeAt(i);
-            if (t === 0x07 || t === 0x9c) {
-              i++;
-              break;
-            }
-            if (t === 0x1b && i + 1 < len && str.charCodeAt(i + 1) === 0x5c /* \ */) {
-              i += 2;
-              break;
-            }
-            i++;
-          }
+          scanString(true);
+          continue;
+        }
+        if (next === 0x50 /* P */ || next === 0x58 /* X */ || next === 0x5e /* ^ */ || next === 0x5f /* _ */) {
+          i += 2;
+          scanString(false);
           continue;
         }
         i++;
+        continue;
+      }
+      if (c === 0x9b) {
+        i++;
+        scanCsi();
+        continue;
+      }
+      if (c === 0x9d) {
+        i++;
+        scanString(true);
+        continue;
+      }
+      if (c === 0x90 || c === 0x98 || c === 0x9e || c === 0x9f) {
+        i++;
+        scanString(false);
         continue;
       }
       width += c >= 0x20 && !(c >= 0x7f && c <= 0x9f) && c !== 0xad ? 1 : 0;
@@ -1104,6 +1238,28 @@ describe("ANSI escapes across SIMD chunk boundaries", () => {
     for (let pad = 0; pad <= 192; pad++) {
       const str = rep("a", pad) + `${ESC}[31m` + "bcd" + `${ESC}[0m` + rep("e", 8);
       expect(Bun.stringWidth(str)).toBe(pad + 3 + 8);
+    }
+  });
+
+  test("C1 CSI and ST-terminated sequences at every offset across a chunk boundary", () => {
+    for (let pad = 0; pad <= 192; pad++) {
+      expect(Bun.stringWidth(rep("a", pad) + "\x9B31m" + "bcd" + "\x9B0m" + rep("e", 8))).toBe(pad + 3 + 8);
+      expect(Bun.stringWidth(rep("a", pad) + "\x9D0;t\x07" + rep("e", 8))).toBe(pad + 8);
+      expect(Bun.stringWidth(rep("a", pad) + `${ESC}P+q${ESC}\\` + rep("e", 8))).toBe(pad + 8);
+      expect(Bun.stringWidth(rep("a", pad) + "\x90+q\x9C" + rep("e", 8))).toBe(pad + 8);
+      expectMatchesReference(rep("a", pad) + "\x9B31mbcd\x9B0m" + rep("e", 8));
+    }
+  });
+
+  test("long ST-terminated payload spanning many chunks", () => {
+    const payload = rep("x", 300);
+    for (const [open, close] of [
+      [`${ESC}P`, `${ESC}\\`],
+      ["\x90", "\x9C"],
+      ["\x9F", `${ESC}\\`],
+    ] as const) {
+      const seq = open + payload + close;
+      expect(Bun.stringWidth(rep("a", 70) + seq + rep("b", 70))).toBe(140);
     }
   });
 
@@ -1188,7 +1344,7 @@ describe("ANSI escapes across SIMD chunk boundaries", () => {
       seed = (seed * 1103515245 + 12345) & 0x7fffffff;
       return seed;
     };
-    const alphabet = "\x1b[]m;19aZ \x07\x9c\\\xad\x01\x7f\x80\x9f\xa0\xe9\xff@~?K";
+    const alphabet = "\x1b[]m;19aZ \x07\x9c\\\xad\x01\x7f\x80\x9f\xa0\xe9\xff@~?K\x9b\x9d\x90\x98P^_";
     const mismatches: string[] = [];
     for (let iter = 0; iter < 500; iter++) {
       const len = next() % 300;


### PR DESCRIPTION
`Bun.stringWidth` counted the payload of 8-bit C1 escape sequences as visible columns, while `Bun.stripANSI` and `Bun.sliceAnsi` already exclude the same bytes. The public width arbiter disagreed with its own escape family.

## Repro

```js
const s = "\x9B31mhi\x9B39m";       // C1 CSI form of \x1b[31mhi\x1b[39m
Bun.stringWidth(s);                 // 8   <- "31m"/"39m" counted as text
Bun.stripANSI(s);                   // "hi" <- stripANSI excludes them
Bun.stringWidth(Bun.stripANSI(s));  // 2

// Same class: C1 OSC "\x9D8;;u\x9C" -> stringWidth 4; ESC-P DCS "\x1bP+q\x1b\\" -> 4.

// Downstream: sliceAnsi resolves negative indices against its own width model:
const m = "\x9B32mabcdef";                            // 6 visible cols
Bun.sliceAnsi(m, -3);                                 // "\x9B32mdef\x1b[39m"
Bun.sliceAnsi(m, Bun.stringWidth(m) - 3);             // ""  <- not equal
```

Every caller that measures with `stringWidth` and cuts with `sliceAnsi` (the documented pairing) mis-slices on C1/DCS input by the payload length of each sequence.

## Cause

`stringWidth.cpp`'s ANSI scanner handled only the two most common 7-bit forms (`ESC [` CSI and `ESC ]` OSC). The shared `ANSI::consumeANSI()` recognizer in `ANSIHelpers.h`, which `stripANSI` and `wrapAnsi` use, and `sliceAnsi.cpp`'s tokenizer (`parseCsi`/`parseControlString`) both additionally handle:
- C1 CSI `0x9B` (equivalent to `ESC [`)
- C1 OSC `0x9D` (equivalent to `ESC ]`)
- DCS/SOS/PM/APC: `ESC P/X/^/_` and `0x90/0x98/0x9E/0x9F`, all ST-terminated

The npm `ansi-regex` package (which backs `string-width`, the package `Bun.stringWidth` is documented as matching) matches `[\x1B\x9B]`, so the C1 CSI form was also a documented-compatibility gap.

## Fix

Teach the two width paths `Bun.stringWidth` actually dispatches to:

- `highway_strings.cpp` (Latin-1 single-pass SIMD kernel): add an `InST` state alongside `InCSI`/`InOSC`; gate the no-escape fast path on "no ESC and no `0x90-0x9F` byte"; extend the chunk bitmask dispatch to walk `ESC | C1-introducer` positions and factor the OSC/ST terminator scan into one helper so both in-chunk and carried-state paths share it.
- `stringWidth.cpp` (UTF-16 grapheme scanner): add a `sawSt` flag mirroring `sawOsc`; dispatch `0x9B`/`0x9D`/`0x90`/`0x98`/`0x9E`/`0x9F` in the non-ASCII codepoint section where C1 bytes land; recognize `P`/`X`/`^`/`_` after ESC.
- `utf8IndexAtWidthExcludeANSI` (Rust-caller truncation helper): add `ESC P/X/^/_` so it tracks the Latin-1 kernel it mirrors.

Unterminated C1/ST sequences consume to EOF, same as the existing `ESC [`/`ESC ]` handling and same as `stripANSI`. `sliceAnsi` deliberately keeps the trailing bytes visible when an introducer is unterminated (so a stray C1 byte does not swallow a whole string when slicing); its comment is updated to note that this is now the one place its width model differs from `stringWidth`.

## Verification

```
$ bun bd test stringWidth.test.ts
 158 pass  0 fail

$ git stash push -- src/ && bun bd test stringWidth.test.ts -t "C1 escapes"
 1 pass  8 fail
```

`stringWidth.test.ts` gains a describe block covering each form (Latin-1 and UTF-16), a chunk-boundary sweep sliding C1/DCS sequences across every 16/32/64-byte offset, and the property `stringWidth(s) === stringWidth(stripANSI(s))` for C1/DCS input. The existing pseudo-random SIMD cross-check gains the new introducer bytes in its alphabet.

`sliceAnsi-fuzz.test.ts`: `randomString()` no longer emits bare C1 introducer bytes (which would open an unterminated control string the three width models handle differently), and two stale comments describing the old `stringWidth` limitation are updated.

Related: #33488 covers the 7-bit Fe/Fs/nF escape grammar (`ESC 7`, `ESC ( B`, etc.) and explicitly scoped C1 out as a separate change; this PR is that change. Whichever lands second will need a small rebase in the Latin-1 kernel's escape dispatch.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 11 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/sliceAnsi-fuzz.test.ts test/js/bun/util/stringWidth.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (4ac5a16d1)

test/js/bun/util/sliceAnsi-fuzz.test.ts:
(pass) sliceAnsi invariants > output width never exceeds requested range [824.00ms]
(pass) sliceAnsi invariants > slice of stripped equals stripped slice (for 1-width chars) [569.43ms]
(pass) sliceAnsi invariants > adjacent slices cover full visible string [325.97ms]
(pass) sliceAnsi invariants > output is always well-formed UTF-16 [727.87ms]
(pass) sliceAnsi invariants > full slice preserves visible content [258.37ms]
(pass) sliceAnsi invariants > slicing a slice is idempotent on visible content [290.24ms]
(pass) sliceAnsi invariants > ellipsis output width respects budget [546.30ms]
(pass) sliceAnsi adversarial > inputs near SIMD stride
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (d8f5059ca)

test/js/bun/util/sliceAnsi-fuzz.test.ts:
(pass) sliceAnsi invariants > output width never exceeds requested range [5.43ms]
(pass) sliceAnsi invariants > slice of stripped equals stripped slice (for 1-width chars) [2.66ms]
(pass) sliceAnsi invariants > adjacent slices cover full visible string [1.53ms]
(pass) sliceAnsi invariants > output is always well-formed UTF-16 [3.98ms]
(pass) sliceAnsi invariants > full slice preserves visible content [2.08ms]
(pass) sliceAnsi invariants > slicing a slice is idempotent on visible content [1.54ms]
(pass) sliceAnsi invariants > ellipsis output width respects budget [3.20ms]
(pass) sliceAnsi adversarial > inputs near SIMD stride boundaries [0.18ms]
(pass) sliceAnsi adversarial > C1 ST at SIMD boundary positions [0.06ms]
(pass) sliceAnsi adversarial > unterminated CSI sequences don't hang or overread [0.07ms]
(pass) sliceAnsi adversarial > many SGR codes don't overflow or quadratic-slow [69.90ms]
(pass) sliceAnsi adversarial > huge SGR params don't overflow uint32 [0.11ms]
(pass) sliceAnsi adversarial > SGR with many parameters [0.07ms]
(pass) sliceAnsi adversarial > string of only zero-width 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/sliceAnsi-fuzz.test.ts test/js/bun/util/stringWidth.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (4ac5a16d1)

test/js/bun/util/sliceAnsi-fuzz.test.ts:
(pass) sliceAnsi invariants > output width never exceeds requested range [815.62ms]
(pass) sliceAnsi invariants > slice of stripped equals stripped slice (for 1-width chars) [568.63ms]
(pass) sliceAnsi invariants > adjacent slices cover full visible string [324.55ms]
(pass) sliceAnsi invariants > output is always well-formed UTF-16 [720.29ms]
(pass) sliceAnsi invariants > full slice preserves visible content [263.59ms]
(pass) sliceAnsi invariants > slicing a slice is idempotent on visible content [290.71ms]
(pass) sliceAnsi invariants > ellipsis output width respects budget [546.71ms]
(pass) sliceAnsi adversarial > inputs near SIMD stride
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 736ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[2/7] gen cpp.rs (cppbind)
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/highway_strings.cpp    | 253 +++++++++++++++++++-------------
 src/jsc/bindings/sliceAnsi.cpp          |   8 +-
 src/jsc/bindings/stringWidth.cpp        |  76 +++++++---
 test/js/bun/util/sliceAnsi-fuzz.test.ts |  43 ++++--
 test/js/bun/util/stringWidth.test.ts    | 206 ++++++++++++++++++++++----
 5 files changed, 420 insertions(+), 166 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/jsc/bindings/highway_strings.cpp         1      3      0
src/jsc/bindings/sliceAnsi.cpp               1      1      0
src/jsc/bindings/stringWidth.cpp             1      6      0
test/js/bun/util/sliceAnsi-fuzz.test.ts      2      7      0
test/js/bun/util/stringWidth.test.ts         1      6      0
```

</details>

<!-- robobun:evidence:end -->