### PR TITLE
Bun.serve(http3): send Content-Length: 0 on empty-body responses

### DIFF
--- a/packages/bun-uws/src/Http3Response.h
+++ b/packages/bun-uws/src/Http3Response.h
@@ -26,6 +26,12 @@ struct Http3Response {
         d->state |= Http3ResponseData::HTTP_STATUS_CALLED;
         /* Zig hands us "200 OK"; HTTP/3 wants only the 3-digit code. */
         std::string_view code = status.size() >= 3 ? status.substr(0, 3) : std::string_view{"200"};
+        /* RFC 9110 8.6: a 1xx/204 MUST NOT carry Content-Length. Mirrors
+         * HttpResponse<SSL>::writeStatus so internalEnd's auto content-length
+         * skips the same statuses HTTP/1 does. */
+        if (code[0] == '1' || (code[0] == '2' && code[1] == '0' && code[2] == '4')) {
+            d->state |= Http3ResponseData::HTTP_NO_BODY_STATUS;
+        }
         appendHeader(d, ":status", code);
         return this;
     }
@@ -99,8 +105,10 @@ struct Http3Response {
 
     void endWithoutBody(std::optional<size_t> reportedContentLength = std::nullopt, bool /*closeConnection*/ = false) {
         Http3ResponseData *d = getHttpResponseData();
+        writeStatus("200 OK");
         if (reportedContentLength.has_value() &&
-            !(d->state & Http3ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER)) {
+            !(d->state & (Http3ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER
+                          | Http3ResponseData::HTTP_NO_BODY_STATUS))) {
             writeHeader("content-length", (uint64_t) *reportedContentLength);
         }
         if (d->state & Http3ResponseData::HTTP_WRITE_CALLED) {
@@ -228,7 +236,8 @@ private:
 
         if (!(d->state & Http3ResponseData::HTTP_WRITE_CALLED)) {
             writeStatus("200 OK");
-            if (!(d->state & Http3ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER) && totalSize) {
+            if (!(d->state & (Http3ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER
+                              | Http3ResponseData::HTTP_NO_BODY_STATUS))) {
                 writeHeader("content-length", totalSize);
                 d->state |= Http3ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER;
             }

--- a/packages/bun-uws/src/Http3Response.h
+++ b/packages/bun-uws/src/Http3Response.h
@@ -114,7 +114,6 @@ struct Http3Response {
         if (d->state & Http3ResponseData::HTTP_WRITE_CALLED) {
             us_quic_stream_shutdown((us_quic_stream_t *) this);
         } else {
-            writeStatus("200 OK");
             sendBufferedHeaders(d, true);
         }
         markDone(d);

--- a/packages/bun-uws/src/Http3ResponseData.h
+++ b/packages/bun-uws/src/Http3ResponseData.h
@@ -21,7 +21,7 @@ struct Http3ResponseData {
 
     /* Same bit values as HttpResponseData so uws_res_state() consumers
      * (Zig's State enum) work unchanged. */
-    enum : uint8_t {
+    enum : uint16_t {
         HTTP_STATUS_CALLED = 1,
         HTTP_WRITE_CALLED = 2,
         HTTP_END_CALLED = 4,
@@ -29,6 +29,9 @@ struct Http3ResponseData {
         HTTP_CONNECTION_CLOSE = 16,
         HTTP_WROTE_CONTENT_LENGTH_HEADER = 32,
         HTTP_WROTE_DATE_HEADER = 64,
+        /* 1xx/204: no Content-Length (RFC 9110 8.6). Same bit as
+         * HttpResponseData<SSL>::HTTP_NO_BODY_STATUS. */
+        HTTP_NO_BODY_STATUS = 1 << 9,
     };
 
     void *userData = nullptr;
@@ -61,7 +64,7 @@ struct Http3ResponseData {
 
     uint64_t offset = 0;
     uint64_t totalSize = 0;
-    uint8_t state = 0;
+    uint16_t state = 0;
 
     void appendHeader(const char *name, unsigned nlen, const char *value, unsigned vlen) {
         size_t off = hdrBuf.size();

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -244,6 +244,48 @@ describe("Bun.serve HTTP/3", () => {
     });
   });
 
+  // Http3Response::internalEnd gated the auto content-length on `totalSize`,
+  // so a zero-length body lost the header while HTTP/1 sent `Content-Length: 0`.
+  test("content-length matches HTTP/1 at the zero-length boundary", async () => {
+    const script = `
+      const server = Bun.serve({
+        port: 0, tls: ${JSON.stringify(tls)}, http3: true,
+        fetch(req) {
+          const u = new URL(req.url);
+          if (u.pathname === "/204") return new Response(null, { status: 204 });
+          const n = Number(u.searchParams.get("n") ?? 0);
+          return new Response(Buffer.alloc(n, "x").toString(), { status: 404 });
+        },
+      });
+      console.error("PORT=" + server.port);
+      process.stdin.on("data", () => {});
+      ${STOP_ON_STDIN_END}
+    `;
+    await withCustomServer(script, async port => {
+      const cl = async (path: string, proto: "h1" | "h3") => {
+        const res = await fetch(`https://127.0.0.1:${port}${path}`, {
+          ...(proto === "h3" ? { protocol: "http3" } : {}),
+          tls: { rejectUnauthorized: false },
+        } as RequestInit);
+        await res.arrayBuffer();
+        return { status: res.status, cl: res.headers.get("content-length") };
+      };
+      expect({
+        "h1 n=0": await cl("/?n=0", "h1"),
+        "h3 n=0": await cl("/?n=0", "h3"),
+        "h1 n=1": await cl("/?n=1", "h1"),
+        "h3 n=1": await cl("/?n=1", "h3"),
+        "h3 204": await cl("/204", "h3"),
+      }).toEqual({
+        "h1 n=0": { status: 404, cl: "0" },
+        "h3 n=0": { status: 404, cl: "0" },
+        "h1 n=1": { status: 404, cl: "1" },
+        "h3 n=1": { status: 404, cl: "1" },
+        "h3 204": { status: 204, cl: null },
+      });
+    });
+  });
+
   test("query string is preserved", async () => {
     await withServer(async port => {
       const res = await fetchH3(port, "/query?q=hello%20world&x=1");


### PR DESCRIPTION
## Reproduction

```js
const server = Bun.serve({
  port: 0, http3: true, tls,
  fetch: req => new Response("", { status: 404 }),
});
const h1 = await fetch(server.url, { tls: { rejectUnauthorized: false } });
const h3 = await fetch(server.url, { tls: { rejectUnauthorized: false }, protocol: "h3" });
h1.headers.get("content-length");  // "0"
h3.headers.get("content-length");  // null   <- should be "0"
```

Any body length ≥ 1 gets `content-length` on both transports; only length 0 diverges.

## Cause

`Http3Response::internalEnd` (packages/bun-uws/src/Http3Response.h) gated the auto content-length header on `&& totalSize`, so a zero-length body skipped the header. The HTTP/1 path has no such guard (HttpResponse.h internalEnd: "Even zero is a valid content-length").

## Fix

Drop the `&& totalSize` gate so `content-length: 0` is emitted for zero-length bodies, matching HTTP/1.

Doing this alone would regress 204: RFC 9110 §8.6 says a 1xx/204 MUST NOT carry Content-Length, and Bun.serve routes a 204 through the same `try_end("", 0)` path. So also add `HTTP_NO_BODY_STATUS` to `Http3ResponseData` (same bit value as `HttpResponseData<SSL>`), set it in `writeStatus` for 1xx/204, and skip the auto content-length when it is set. This mirrors `HttpResponse<SSL>::writeStatus` exactly.

After:
| | h1 | h3 before | h3 after |
|---|---|---|---|
| 404, `""` | `"0"` | `null` | `"0"` |
| 404, `"x"` | `"1"` | `"1"` | `"1"` |
| 204 | `null` | `null` | `null` |
| 304 | `"0"` | `null` | `"0"` |
| HEAD on `"abc"` | `"3"` | `"3"` | `"3"` |

## Verification

- New test `content-length matches HTTP/1 at the zero-length boundary` in `test/js/bun/http/serve-http3.test.ts` fails with `USE_SYSTEM_BUN=1` (h3 n=0 returns `cl: null`), passes with this change.
- Full `serve-http3.test.ts` suite: 47 pass, 0 fail.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/http/serve-http3.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (1380a9894)

test/js/bun/http/serve-http3.test.ts:
(pass) Bun.serve HTTP/3 > basic GET [2436.21ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [2368.46ms]
(pass) Bun.serve HTTP/3 > 204 with no body [2561.83ms]
274 |         "h1 n=0": await cl("/?n=0", "h1"),
275 |         "h3 n=0": await cl("/?n=0", "h3"),
276 |         "h1 n=1": await cl("/?n=1", "h1"),
277 |         "h3 n=1": await cl("/?n=1", "h3"),
278 |         "h3 204": await cl("/204", "h3"),
279 |       }).toEqual({
               ^
error: expect(received).toEqual(expected)

  {
    "h1 n=0": {
      "cl": "0",
      "status": 404,
    },
    "h1 n=1": {
      "cl": "1",
      "status": 404,
    },
    "h3 204": {
      "cl": null,
      "status":
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (515a0ce70)

test/js/bun/http/serve-http3.test.ts:
(pass) Bun.serve HTTP/3 > basic GET [174.03ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [146.34ms]
(pass) Bun.serve HTTP/3 > 204 with no body [165.93ms]
(pass) Bun.serve HTTP/3 > content-length matches HTTP/1 at the zero-length boundary [168.76ms]
(pass) Bun.serve HTTP/3 > query string is preserved [162.64ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [166.78ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [145.24ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [139.89ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [149.02ms]
(pass) Bun.serve HTTP/3 > http1: false — url/address/stop see the QUIC listener [1042.80ms]
(pass) Bun.serve HTTP/3 > maxRequestBodySize is enforced for H3 bodies without Content-Length [139.73ms]
(pass) Bun.serve HTTP/3 > unknown route returns 404 [156.69ms]
(pass) Bun.serve HTTP/3 > routes: handler with :params [161.30ms]
(pass) Bun.serve HTTP/3 > routes: per-method handler [143.24ms]
(pass) Bun.serve HTTP/3 > route
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/http/serve-http3.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (1380a9894)

test/js/bun/http/serve-http3.test.ts:
(pass) Bun.serve HTTP/3 > basic GET [2802.54ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [2421.75ms]
(pass) Bun.serve HTTP/3 > 204 with no body [2085.20ms]
(pass) Bun.serve HTTP/3 > content-length matches HTTP/1 at the zero-length boundary [2242.65ms]
(pass) Bun.serve HTTP/3 > query string is preserved [2493.21ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [2309.93ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [2519.41ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [2433.45ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [2265
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 1049ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringss
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-uws/src/Http3Response.h     | 14 ++++++++---
 packages/bun-uws/src/Http3ResponseData.h |  7 ++++--
 test/js/bun/http/serve-http3.test.ts     | 42 ++++++++++++++++++++++++++++++++
 3 files changed, 58 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
packages/bun-uws/src/Http3Response.h          3      4      0
packages/bun-uws/src/Http3ResponseData.h      1      2      0
test/js/bun/http/serve-http3.test.ts          5      1      0
```

</details>

<!-- robobun:evidence:end -->