### PR TITLE
Bun.serve(http3): send the Date header on HTTP/3 responses

### DIFF
--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -495,6 +495,9 @@ static lsquic_conn_ctx_t *us_quic_on_new_conn(void *if_ctx, lsquic_conn_t *conn)
     ctx->loop->num_polls++;
 #endif
     ctx->conn_count++;
+    /* Arm the sweep-timer refcount so DateHeaderTimer runs for h3-only
+     * servers; the TCP path does this per-socket in context.c. */
+    us_internal_enable_sweep_timer(ctx->loop);
     qs->next = ctx->conns;
     ctx->conns = qs;
     if (ctx->on_open) ctx->on_open(qs);
@@ -516,6 +519,7 @@ static void us_quic_on_conn_closed(lsquic_conn_t *conn) {
     ctx->loop->num_polls--;
 #endif
     ctx->conn_count--;
+    us_internal_disable_sweep_timer(ctx->loop);
     /* During graceful drain the UDP fd is the only thing left holding the
      * loop; release it when the last conn closes so the process can exit. */
     if (ctx->closing && ctx->conn_count == 0) {

--- a/packages/bun-uws/src/Http3Response.h
+++ b/packages/bun-uws/src/Http3Response.h
@@ -62,6 +62,7 @@ struct Http3Response {
         Http3ResponseData *d = getHttpResponseData();
         if (!(d->state & Http3ResponseData::HTTP_WRITE_CALLED)) {
             writeStatus("200 OK");
+            writeMark();
             sendBufferedHeaders(d, false);
             d->state |= Http3ResponseData::HTTP_WRITE_CALLED;
         }
@@ -107,6 +108,7 @@ struct Http3Response {
             us_quic_stream_shutdown((us_quic_stream_t *) this);
         } else {
             writeStatus("200 OK");
+            writeMark();
             sendBufferedHeaders(d, true);
         }
         markDone(d);
@@ -228,6 +230,7 @@ private:
 
         if (!(d->state & Http3ResponseData::HTTP_WRITE_CALLED)) {
             writeStatus("200 OK");
+            writeMark();
             if (!(d->state & Http3ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER) && totalSize) {
                 writeHeader("content-length", totalSize);
                 d->state |= Http3ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER;

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -1125,6 +1125,40 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
 });
 
 describe("Bun.serve HTTP/3 production", () => {
+  // RFC 9110 §6.6.1: an origin server with a clock MUST send Date.
+  // H1 writes it via HttpResponse::writeMark(); H3 must too.
+  test("Date header is sent on every response shape", async () => {
+    await withServer(async port => {
+      // Cover every Http3Response header-send path: internalEnd (string/buffer
+      // body, 404, static route), flushHeaders (ReadableStream, Bun.file,
+      // file route), endWithoutBody (204, HEAD).
+      const cases: Array<{ path: string; method?: string }> = [
+        { path: "/hello" },
+        { path: "/big" },
+        { path: "/status" },
+        { path: "/nope" },
+        { path: "/stream" },
+        { path: "/file" },
+        { path: "/static" },
+        { path: "/file-route" },
+        { path: "/big", method: "HEAD" },
+      ];
+      const httpDate = /^[A-Z][a-z]{2}, \d{2} [A-Z][a-z]{2} \d{4} \d{2}:\d{2}:\d{2} GMT$/;
+      const results: Array<{ req: string; date: string | null }> = [];
+      for (const c of cases) {
+        const res = await fetchH3(port, c.path, c.method ? { method: c.method } : {});
+        await res.arrayBuffer();
+        results.push({ req: `${c.method ?? "GET"} ${c.path}`, date: res.headers.get("date") });
+      }
+      expect(results).toEqual(
+        cases.map(c => ({
+          req: `${c.method ?? "GET"} ${c.path}`,
+          date: expect.stringMatching(httpDate),
+        })),
+      );
+    });
+  });
+
   // E: H1 responses advertise the H3 endpoint so browsers can discover it.
   test("Alt-Svc emitted on HTTP/1.1 responses when http3 is enabled", async () => {
     await withServer(async port => {


### PR DESCRIPTION
## Repro

```js
const server = Bun.serve({
  port: 0, http3: true, tls: { cert, key },
  fetch: () => new Response("hi"),
});
const url = `https://127.0.0.1:${server.port}/`;
const h1 = await fetch(url, { tls: { rejectUnauthorized: false } });
const h3 = await fetch(url, { protocol: "http3", tls: { rejectUnauthorized: false } });
console.log("h1 date:", h1.headers.get("date"));   // "Thu, 16 Jul 2026 17:08:28 GMT"
console.log("h3 date:", h3.headers.get("date"));   // null
```

Every H3 response shape is affected: 200/404/204/HEAD, string/buffer/stream/`Bun.file`/static-route bodies. RFC 9110 §6.6.1 makes `Date` a MUST for an origin server with a clock, and its absence breaks cache freshness arithmetic downstream of an H3 endpoint.

## Cause

`Http3Response::writeMark()` (which appends the cached per-loop `Date` header and guards on `HTTP_WROTE_DATE_HEADER`) has existed since the H3 server landed, and is exported through the FFI as `uws_h3_res_write_mark` / `h3::Response::write_mark()`. Nothing calls it.

The HTTP/1.1 `HttpResponse<SSL>` calls `writeMark()` from every header-to-body transition (`internalEnd`, `write`, `flushHeaders`, `sendTerminatingChunk`). `Http3Response`'s equivalents buffer headers and hand them to `sendBufferedHeaders()` without ever touching `writeMark()`, so the HEADERS frame never carries `date`.

## Fix

Call `writeMark()` from the three `Http3Response` paths that emit the HEADERS frame: `flushHeaders()`, `endWithoutBody()` and `internalEnd()`. Each call sits immediately after `writeStatus()` and before `sendBufferedHeaders()`, matching the H1 placement. `writeMark()` is idempotent, so the explicit `resp.write_mark()` `FileRoute` already issues composes unchanged.

### Keeping `LoopData::date` fresh on h3-only servers

`writeMark()` reads the 29-byte cached date from `LoopData`, which is refreshed by `DateHeaderTimer`. That timer is gated on `sweep_timer_count > 0`, and only the TCP socket-link paths in `context.c` bump that refcount; `quic.c` never did. So on an `http1: false` server the header would be present but frozen at process start. `quic.c` now calls `us_internal_enable_sweep_timer`/`disable` alongside `conn_count++`/`--`, at the same sites `num_polls` is already balanced, mirroring the TCP per-socket pattern. The sweep timer's TCP-socket-group walk is an empty no-op when only QUIC connections exist; the timer itself is `uv_unref`'d on libuv so it does not hold the loop.

## Verification

New test in `serve-http3.test.ts` asserts an RFC-1123 `Date` on nine response shapes chosen to cover all three entry points (string body / 512 KB buffer / 404 / 204 / `ReadableStream` / `Bun.file` / static route / file route / `HEAD`). Fails on main with `date: null` on eight of nine; passes with the fix. Full `serve-http3.test.ts` (47 tests, including the `http1: false` and `h3-only server exits naturally after stop() drains` lifecycle tests that exercise the new refcount), `fetch-http3-client.test.ts` (52) and `fetch-http3-adversarial.test.ts` + `serve-protocols.test.ts` (47) all green. Freshness on `http1: false` verified manually: two requests 1.5s apart return different `Date` values.

Related: #33427 fixes the H1-side bodiless-response `Date` gap and explicitly scopes out H3; this PR is the H3 half. The two changes do not touch the same lines.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/http/serve-http3.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (17b61e637)

test/js/bun/http/serve-http3.test.ts:
(pass) Bun.serve HTTP/3 > basic GET [1689.21ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [1645.66ms]
(pass) Bun.serve HTTP/3 > 204 with no body [1635.68ms]
(pass) Bun.serve HTTP/3 > query string is preserved [1654.50ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [1733.42ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [1657.63ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [1626.77ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [1663.25ms]
(pass) Bun.serve HTTP/3 > http1: false — url/address/stop see the QUIC listener [2672.4
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (913485ce1)

test/js/bun/http/serve-http3.test.ts:
(pass) Bun.serve HTTP/3 > basic GET [198.82ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [143.93ms]
(pass) Bun.serve HTTP/3 > 204 with no body [141.21ms]
(pass) Bun.serve HTTP/3 > query string is preserved [147.93ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [142.30ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [140.66ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [137.69ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [142.47ms]
(pass) Bun.serve HTTP/3 > http1: false — url/address/stop see the QUIC listener [1037.71ms]
(pass) Bun.serve HTTP/3 > maxRequestBodySize is enforced for H3 bodies without Content-Length [135.63ms]
(pass) Bun.serve HTTP/3 > unknown route returns 404 [141.86ms]
(pass) Bun.serve HTTP/3 > routes: handler with :params [141.01ms]
(pass) Bun.serve HTTP/3 > routes: per-method handler [142.04ms]
(pass) Bun.serve HTTP/3 > routes: method-specific '/*' falls through to fetch() on other methods [136.91ms]
(pass) Bun.serve H
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/http/serve-http3.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (17b61e637)

test/js/bun/http/serve-http3.test.ts:
(pass) Bun.serve HTTP/3 > basic GET [1677.18ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [1912.40ms]
(pass) Bun.serve HTTP/3 > 204 with no body [1626.81ms]
(pass) Bun.serve HTTP/3 > query string is preserved [1633.79ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [1690.18ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [1672.93ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [1642.26ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [1638.98ms]
(pass) Bun.serve HTTP/3 > http1: false — url/address/stop see the QUIC listener [2579.6
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 818ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/quic.c     |  4 ++++
 packages/bun-uws/src/Http3Response.h |  3 +++
 test/js/bun/http/serve-http3.test.ts | 34 ++++++++++++++++++++++++++++++++++
 3 files changed, 41 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
packages/bun-usockets/src/quic.c          3      2      0
packages/bun-uws/src/Http3Response.h      1      3      0
test/js/bun/http/serve-http3.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->