### PR TITLE
node:crypto: secureHeapUsed() returns stats object instead of undefined

### DIFF
--- a/src/runtime/node/node_crypto_binding.rs
+++ b/src/runtime/node/node_crypto_binding.rs
@@ -1165,8 +1165,15 @@ mod _impl {
     }
 
     #[bun_jsc::host_fn]
-    pub(super) fn secure_heap_used(_: &JSGlobalObject, _: &CallFrame) -> JsResult<JSValue> {
-        Ok(JSValue::UNDEFINED)
+    pub(super) fn secure_heap_used(global: &JSGlobalObject, _: &CallFrame) -> JsResult<JSValue> {
+        // BoringSSL has no secure heap. Return Node's "unavailable" shape so
+        // `crypto.secureHeapUsed().used` etc. work instead of throwing on undefined.
+        let obj = JSValue::create_empty_object(global, 4);
+        obj.put(global, b"total", JSValue::js_number(0.0));
+        obj.put(global, b"used", JSValue::js_number(0.0));
+        obj.put(global, b"utilization", JSValue::js_number(0.0));
+        obj.put(global, b"min", JSValue::js_number(0.0));
+        Ok(obj)
     }
 
     #[bun_jsc::host_fn]

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -932,6 +932,13 @@ it("cipher.setAAD on a non-authenticated cipher throws ERR_CRYPTO_INVALID_STATE"
   });
 });
 
+it("crypto.secureHeapUsed() returns the zero-shaped stats object", () => {
+  expect(typeof crypto.secureHeapUsed).toBe("function");
+  const result = crypto.secureHeapUsed();
+  expect(result).toEqual({ total: 0, used: 0, utilization: 0, min: 0 });
+  expect(crypto.secureHeapUsed().used).toBe(0);
+});
+
 it("generatePrime(Sync) should return an ArrayBuffer", async () => {
   const prime = crypto.generatePrimeSync(512);
   expect(prime).toBeInstanceOf(ArrayBuffer);


### PR DESCRIPTION
## What does this PR do?

`crypto.secureHeapUsed()` was a silent stub that returned `undefined`. Node returns a stats object `{total, used, utilization, min}` even when no secure heap is configured, so portable code like `crypto.secureHeapUsed().used` works on Node but throws a `TypeError: undefined is not an object` on Bun.

Repro:
```js
import crypto from "node:crypto";
console.log(crypto.secureHeapUsed());
// node: { total: 0, used: 0, utilization: NaN, min: 2 }
// bun (before): undefined
console.log(crypto.secureHeapUsed().used);
// node: 0
// bun (before): TypeError: undefined is not an object
```

### Cause

`secure_heap_used` in `src/runtime/node/node_crypto_binding.rs` returned `JSValue::UNDEFINED`.

### Fix

Return Node's own "secure heap unavailable" shape, `{total: 0, used: 0, utilization: 0, min: 0}`. This is the exact object Node's JS wrapper produces when the native binding returns undefined (see [lib/internal/crypto/util.js](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/crypto/util.js)). BoringSSL has no secure heap and Bun does not accept `--secure-heap`, so the zero shape is accurate.

## How did you verify your code works?

Added a test in `test/js/node/crypto/node-crypto.test.js` that asserts the return value equals `{total:0, used:0, utilization:0, min:0}` and that `.used` is accessible.

Fails with `USE_SYSTEM_BUN=1 bun test` (received `undefined`), passes with `bun bd test`. Full `node-crypto.test.js` suite passes (193 tests).

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/crypto/node-crypto.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (d1be3aca4)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [7.29ms]
(pass) crypto.randomInt should return a number [3.89ms]
(pass) crypto.randomInt with no arguments [5.74ms]
(pass) crypto.randomInt with one argument [4.02ms]
(pass) crypto.randomInt with a callback [76.69ms]
(pass) createHash > rsa-md5 - "Hello World" [14.14ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [7.66ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [1.53ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [1.63ms]
(pass) createHash > rsa-sha1 - "Hello World" [14.90ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [2.19ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [2.01m
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (5b709c331)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [0.11ms]
(pass) crypto.randomInt should return a number [0.03ms]
(pass) crypto.randomInt with no arguments [0.06ms]
(pass) crypto.randomInt with one argument [0.03ms]
(pass) crypto.randomInt with a callback [0.70ms]
(pass) createHash > rsa-md5 - "Hello World" [0.14ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [0.05ms]
(pass) createHash > rsa-ripemd160 - "Hello World"
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [0.01ms]
(pass) createHash > rsa-sha1 - "Hello World" [0.11ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [0.02ms]
(pass) createHash > rsa-sha1-2 - "Hello World"
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary
(pass) createHash > rsa-sha224 - "Hello World" [0.02ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary
(pass) createHash > rsa-sha256 - "Hello World" [0.01ms]
(pass) createHash > rsa-sha256 - "Hello World" -> binary
(pass) createHash > rsa-sha3-224 - "Hello World"
(pass) createHash > rsa-sha3-224 - "Hello World" -> binary
(pass) createHash > rsa-sha3-256 - "Hello World"

... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/crypto/node-crypto.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (d1be3aca4)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [4.95ms]
(pass) crypto.randomInt should return a number [2.38ms]
(pass) crypto.randomInt with no arguments [3.72ms]
(pass) crypto.randomInt with one argument [2.44ms]
(pass) crypto.randomInt with a callback [50.13ms]
(pass) createHash > rsa-md5 - "Hello World" [11.68ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [7.50ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [1.47ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [1.61ms]
(pass) createHash > rsa-sha1 - "Hello World" [13.70ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [2.02ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [1.22m
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 913ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/node/node_crypto_binding.rs | 11 +++++++++--
 test/js/node/crypto/node-crypto.test.js |  7 +++++++
 2 files changed, 16 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/runtime/node/node_crypto_binding.rs      1      1      0
test/js/node/crypto/node-crypto.test.js      1      1      0
```

</details>

<!-- robobun:evidence:end -->