### PR TITLE
node:crypto: align DiffieHellman modulus-size bounds with Node

### DIFF
--- a/patches/boringssl/dh-max-modulus-10000.patch
+++ b/patches/boringssl/dh-max-modulus-10000.patch
@@ -1,0 +1,15 @@
+--- a/include/openssl/dh.h
++++ b/include/openssl/dh.h
+@@ -53,8 +53,10 @@
+ // Properties.
+ 
+ // OPENSSL_DH_MAX_MODULUS_BITS is the maximum supported Diffie-Hellman group
+-// modulus, in bits.
+-#define OPENSSL_DH_MAX_MODULUS_BITS 8192
++// modulus, in bits. BoringSSL uses 8192 here; raised to OpenSSL's 10000 so
++// Node.js user code with 8193..10000-bit custom DH primes keeps working.
++// Still within BN_MONTGOMERY_MAX_WORDS * BN_BITS2 (16384).
++#define OPENSSL_DH_MAX_MODULUS_BITS 10000
+ 
+ // DH_bits returns the size of `dh`'s group modulus, in bits.
+ OPENSSL_EXPORT unsigned DH_bits(const DH *dh);

--- a/scripts/build/deps/boringssl.ts
+++ b/scripts/build/deps/boringssl.ts
@@ -36,6 +36,8 @@ export const boringssl: Dependency = {
     commit: BORINGSSL_COMMIT,
   }),
 
+  patches: ["patches/boringssl/dh-max-modulus-10000.patch"],
+
   build: cfg => {
     // win-x64 uses NASM-syntax .asm; everything else (including win-aarch64)
     // uses gas .S that clang assembles.

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -1435,6 +1435,16 @@ DHPointer::CheckResult DHPointer::check()
 {
     ClearErrorOnReturn clearErrorOnReturn;
     if (!dh_) return DHPointer::CheckResult::NONE;
+
+    // Same size handling as OpenSSL's DH_check(), which BoringSSL's lacks.
+    const BIGNUM* p = DH_get0_p(dh_.get());
+    if (p == nullptr) return DHPointer::CheckResult::CHECK_FAILED;
+    int bits = BignumPointer::GetBitCount(p);
+    if (bits > kCheckMaxModulusBits)
+        return DHPointer::CheckResult::CHECK_FAILED;
+    if (bits > OPENSSL_DH_MAX_MODULUS_BITS)
+        return DHPointer::CheckResult::MODULUS_TOO_LARGE;
+
     int codes = 0;
     if (DH_check(dh_.get(), &codes) != 1)
         return DHPointer::CheckResult::CHECK_FAILED;

--- a/src/jsc/bindings/ncrypto.h
+++ b/src/jsc/bindings/ncrypto.h
@@ -888,6 +888,9 @@ public:
     static DHPointer FromGroup(const WTF::StringView name,
         FindGroupOption option = FindGroupOption::NONE);
 
+    // OpenSSL's OPENSSL_DH_CHECK_MAX_MODULUS_BITS, which BoringSSL does not define.
+    static constexpr int kCheckMaxModulusBits = 32768;
+
     static DHPointer New(BignumPointer&& p, BignumPointer&& g);
     static DHPointer New(size_t bits, unsigned int generator);
 
@@ -915,6 +918,10 @@ public:
         // Boringssl does not define the DH_CHECK_INVALID_[Q or J]_VALUE
         INVALID_Q = DH_CHECK_INVALID_Q_VALUE,
         INVALID_J = DH_CHECK_INVALID_J_VALUE,
+        MODULUS_TOO_LARGE = DH_MODULUS_TOO_LARGE,
+#else
+        // Boringssl does not define DH_MODULUS_TOO_LARGE; this is OpenSSL's value.
+        MODULUS_TOO_LARGE = 0x100,
 #endif
         CHECK_FAILED = 512,
     };

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -689,6 +689,80 @@ describe("DiffieHellman", () => {
       value: expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }),
     });
   });
+
+  describe("modulus size bounds", () => {
+    // Odd modulus of exactly `bits` bits. Composite is fine: the bounds under test
+    // are SIZE checks, and Miller-Rabin rejects a composite in one round so the
+    // eager DH_check stays fast at every width exercised here.
+    const oddModulus = bits => {
+      const n = Math.ceil(bits / 8);
+      const b = Buffer.alloc(n, 0xff);
+      b[0] = 0xff >> (n * 8 - bits);
+      b[n - 1] = 0xfb;
+      return b;
+    };
+
+    const checkingFailed = expect.objectContaining({
+      code: "ERR_CRYPTO_OPERATION_FAILED",
+      message: "Checking DH parameters failed",
+    });
+
+    // The constructor evaluates verifyError eagerly, like Node. OpenSSL's DH_check()
+    // refuses to run past OPENSSL_DH_CHECK_MAX_MODULUS_BITS (32768) and that refusal
+    // is the construction-time throw. BoringSSL's DH_check() instead refuses past its
+    // own 8192-bit OPENSSL_DH_MAX_MODULUS_BITS, which rejected every wider modulus
+    // that Node accepts, including the 32768-bit boundary value itself.
+    it.each([8193, 16384, 32767, 32768])("accepts a %i-bit prime at construction", bits => {
+      const dh = crypto.createDiffieHellman(oddModulus(bits), 2);
+      expect(dh.getPrime().length).toBe(Math.ceil(bits / 8));
+    });
+
+    it.each([32769, 32776, 65536, 8 << 20])("rejects a %i-bit prime at construction", bits => {
+      let err;
+      try {
+        crypto.createDiffieHellman(oddModulus(bits), 2);
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toEqual(checkingFailed);
+    });
+
+    it("rejects a prime above the bound passed as a hex string", () => {
+      expect(() => crypto.createDiffieHellman(oddModulus(32776).toString("hex"), "hex", 2)).toThrow(checkingFailed);
+    });
+
+    // BoringSSL sets OPENSSL_DH_MAX_MODULUS_BITS to 8192; OpenSSL uses 10000.
+    // Node user code with custom primes in the 8193..10000-bit range depends on
+    // the latter, so DH_generate_key / DH_compute_key have to accept it.
+    it.each([8192, 8193, 10000])("generateKeys and computeSecret work for a %i-bit prime", bits => {
+      const p = oddModulus(bits);
+      const a = crypto.createDiffieHellman(p, 2);
+      const b = crypto.createDiffieHellman(p, 2);
+      a.generateKeys();
+      b.generateKeys();
+      const secret = a.computeSecret(b.getPublicKey());
+      expect({ secret, length: secret.length }).toEqual({
+        secret: b.computeSecret(a.getPublicKey()),
+        length: Math.ceil(bits / 8),
+      });
+    });
+
+    it("generateKeys fails above the 10000-bit bound", () => {
+      const dh = crypto.createDiffieHellman(oddModulus(10001), 2);
+      expect(() => dh.generateKeys()).toThrow(
+        expect.objectContaining({ code: "ERR_CRYPTO_OPERATION_FAILED", message: "Key generation failed" }),
+      );
+    });
+
+    // OpenSSL's DH_check_params() reports DH_MODULUS_TOO_LARGE (0x100) as a flag
+    // for widths in (10000, 32768]; BoringSSL's would instead fail outright. The
+    // modulus is unusable for DH either way, so the flag alone is returned here
+    // rather than the full OpenSSL result that also carries the primality bits.
+    it("verifyError reports a too-large modulus for widths in (10000, 32768]", () => {
+      expect(crypto.createDiffieHellman(oddModulus(10001), 2).verifyError).toBe(0x100);
+      expect(crypto.createDiffieHellman(oddModulus(32768), 2).verifyError).toBe(0x100);
+    });
+  });
 });
 
 // An integer-valued Number is not always an int32 JSValue. An element of an array that


### PR DESCRIPTION
### Problem
- `createDiffieHellman(prime)` evaluates `verifyError` eagerly since #32623, like Node. That runs BoringSSL's `DH_check()`, which hard-fails past its 8192-bit `OPENSSL_DH_MAX_MODULUS_BITS` (`vendor/boringssl/crypto/fipsmodule/dh/check.cc.inc:34`). So every modulus wider than 8192 bits throws `ERR_CRYPTO_OPERATION_FAILED: Checking DH parameters failed` at construction. Node accepts up to 32768 bits there, including the 32768-bit boundary itself. Bun 1.3.14 accepted them too. This is a 1.4.0 regression.
- Before #32623 the same constant broke the other way: `generateKeys()` failed with `Key generation failed` for custom primes in the 8193..10000-bit range that Node (OpenSSL, cap 10000) handles.

### Fix
- Patch the vendored BoringSSL constant from 8192 to 10000 (`patches/boringssl/dh-max-modulus-10000.patch`). 10000 is still within `BN_MONTGOMERY_MAX_WORDS * BN_BITS2` = 16384, which the `static_assert` in `check.cc.inc` guards. Primes up to 10000 bits now construct, generate keys and compute secrets.
- `DHPointer::check()` applies OpenSSL's size handling before `DH_check()`: wider than `OPENSSL_DH_CHECK_MAX_MODULUS_BITS` (32768) is `CHECK_FAILED`, so the constructor throws the same error as Node. Widths in (10000, 32768] return `DH_MODULUS_TOO_LARGE` (0x100) as a flag, so the object constructs and `verifyError` is non-zero, as in Node. The primality bits OpenSSL also sets in that range are not computed: the modulus is unusable for DH either way, and BoringSSL's Montgomery code cannot handle more than 16384 bits.
- Verified: `test/js/node/crypto/node-crypto.test.js` (`modulus size bounds` block, 8 of 14 fail on 1.4.1). Also all of `test/js/node/crypto/` (1062 pass) and the 13 vendored `test-crypto-dh*.js`.

### Background
- `DH_check()` validates DH parameters (p, g) and returns a bitmask of problems. Node exposes that bitmask as `verifyError`, computed once in the constructor. A `DH_check()` that refuses to run (returns 0) becomes a constructor throw.
- OpenSSL has two size constants: `OPENSSL_DH_MAX_MODULUS_BITS` (10000) bounds key generation, and `OPENSSL_DH_CHECK_MAX_MODULUS_BITS` (32768) bounds what `DH_check()` will even look at. BoringSSL has one constant (8192) and uses it for both.
- The well-known RFC 3526 groups (`modp14`..`modp18`) are 2048 to 8192 bits, so they are not affected by either bound.

<details><summary>Notes</summary>

Differential run against node v26.3.0, after the fix every row matches:

```
  bits   bun 1.4.1                          fixed / node
  8192   constructed                        constructed
  8193   ERR_CRYPTO_OPERATION_FAILED        constructed
 10000   ERR_CRYPTO_OPERATION_FAILED        constructed, generateKeys OK (publen=1250)
 10001   ERR_CRYPTO_OPERATION_FAILED        constructed, verifyError=0x100, generateKeys fails
 16384   ERR_CRYPTO_OPERATION_FAILED        constructed, verifyError=0x100
 32767   ERR_CRYPTO_OPERATION_FAILED        constructed
 32768   ERR_CRYPTO_OPERATION_FAILED        constructed
 32769   ERR_CRYPTO_OPERATION_FAILED        ERR_CRYPTO_OPERATION_FAILED
```

In the 10001..32768 range Node reports `verifyError = 257` (`DH_MODULUS_TOO_LARGE | DH_CHECK_P_NOT_PRIME`) for the composite test modulus, Bun reports 256. Code that tests `verifyError !== 0` or `verifyError & DH_MODULUS_TOO_LARGE` agrees on both.

Related: #33522 changes the generator heuristics in the same `check()` function. The two changes are orthogonal and need a small merge in `check()` and the `CheckResult` enum.

Separate issue, not fixed here: the eager `DH_check()` from #32623 has no shortcut for the well-known groups, so `getDiffieHellman("modp18")` now takes about 26 s (modp16: 3.4 s, modp14: 0.5 s) where 1.3.14 and Node take 0 ms. OpenSSL returns early from `DH_check()` when `DH_get_nid()` recognizes the group. That is tracked separately.

The first version of this PR predates #32623 and added its own size check in the constructor. The eager `check()` on main makes that redundant, so it is gone.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/crypto/node-crypto.test.js
bun test v1.4.1 (861e9ae04)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [4.60ms]
(pass) crypto.randomInt should return a number [2.34ms]
(pass) crypto.randomInt with no arguments [3.96ms]
(pass) crypto.randomInt with one argument [2.87ms]
(pass) crypto.randomInt with a callback [41.61ms]
(pass) createHash > rsa-md5 - "Hello World" [8.48ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [4.93ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [0.82ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [0.86ms]
(pass) createHash > rsa-sha1 - "Hello World" [8.33ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [1.19ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.65ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary [0.72ms]
(pass) createHash > rsa-sha224 - "Hello World" [2.44ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [0.89ms]
(pass) createHash > rsa-sha256 - "Hello World" [1.84ms]
(pass) create
... (truncated)

release without fix: 8 FAILED
bun test v1.4.1-canary.1 (861e9ae04)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [0.11ms]
(pass) crypto.randomInt should return a number [0.03ms]
(pass) crypto.randomInt with no arguments [0.07ms]
(pass) crypto.randomInt with one argument [0.02ms]
(pass) crypto.randomInt with a callback [0.61ms]
(pass) createHash > rsa-md5 - "Hello World" [0.15ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [0.05ms]
(pass) createHash > rsa-ripemd160 - "Hello World"
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary
(pass) createHash > rsa-sha1 - "Hello World" [0.14ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [0.04ms]
(pass) createHash > rsa-sha1-2 - "Hello World"
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary
(pass) createHash > rsa-sha224 - "Hello World" [0.03ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary
(pass) createHash > rsa-sha256 - "Hello World" [0.01ms]
(pass) createHash > rsa-sha256 - "Hello World" -> binary
(pass) createHash > rsa-sha3-224 - "Hello World"
(pass) createHash > rsa-sha3-224 - "Hello World" -> binary
(pass) createHash > rsa-sha3-256 - "Hello World"
(pass) cr
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/crypto/node-crypto.test.js
bun test v1.4.1 (861e9ae04)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [4.53ms]
(pass) crypto.randomInt should return a number [2.28ms]
(pass) crypto.randomInt with no arguments [4.37ms]
(pass) crypto.randomInt with one argument [2.73ms]
(pass) crypto.randomInt with a callback [42.64ms]
(pass) createHash > rsa-md5 - "Hello World" [8.54ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [5.53ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [0.93ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [0.89ms]
(pass) createHash > rsa-sha1 - "Hello World" [8.95ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [1.30ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.68ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary [0.73ms]
(pass) createHash > rsa-sha224 - "Hello World" [2.50ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [0.91ms]
(pass) createHash > rsa-sha256 - "Hello World" [1.68ms]
(pass) create
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     8007bce477
  features     baseline

23 deps, 129 codegen, 1172 objects in 839ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (861e9ae04)

Checked 26 installs across 63 packages (no changes) [13.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (861e9ae04)

Checked 1 install across 2 packages (no changes) [7.00ms]
[5/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1217] fetch zlib
[zlib] up to date
[7/1217] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (861e9ae04)

Checked 111 installs across 104 packages (no changes) [11.00ms]
[8/1217] fetch tinycc
[tinycc] up to date
[9/1216] gen .bind.ts → GeneratedBindings.cpp
[10/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 6ms

  react-refresh.js  4.81
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
patches/boringssl/dh-max-modulus-10000.patch | 15 ++++++
 scripts/build/deps/boringssl.ts              |  2 +
 src/jsc/bindings/ncrypto.cpp                 | 10 ++++
 src/jsc/bindings/ncrypto.h                   |  7 +++
 test/js/node/crypto/node-crypto.test.js      | 74 ++++++++++++++++++++++++++++
 5 files changed, 108 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
patches/boringssl/dh-max-modulus-10000.patch      0      2      0
scripts/build/deps/boringssl.ts                   1      1      0
src/jsc/bindings/ncrypto.cpp                      3      3      0
src/jsc/bindings/ncrypto.h                        2      3      0
test/js/node/crypto/node-crypto.test.js           4      4      0
```

</details>

<!-- robobun:evidence:end -->