### PR TITLE
Bun.sliceAnsi: don't treat trailing zero-width clusters as an end cut

### DIFF
--- a/src/jsc/bindings/sliceAnsi.cpp
+++ b/src/jsc/bindings/sliceAnsi.cpp
@@ -933,7 +933,8 @@ static WTF::String emitSliceStreaming(
     }
 
     const Char* p = data + position;
-    bool sawCutEnd = false; // set true if we break due to position >= specEnd
+    bool sawCutEnd = false; // visible content exists at/past specEnd
+    bool pastSpecEnd = false; // scanning zero-width tail at position == specEnd
 
     // Visible-codepoint processing, extracted so it can be called from both
     // the SIMD-skipped tight loop and the false-positive fallback. Returns
@@ -954,9 +955,20 @@ static WTF::String emitSliceStreaming(
             if (hasPrev) position += gs.width();
 
             if (!endUnbounded && position >= specEnd) {
-                sawCutEnd = true;
-                flushPending(/*filterCloseOnly=*/true);
-                return false; // signal break
+                // A visible cut needs width past specEnd: the prior cluster
+                // overflowed, or this cp is visible. A zero-width cp at exactly
+                // specEnd (LF/CR/ZWSP) is not a cut; keep scanning, don't emit.
+                if (position > specEnd || Bun__codepointWidth(cp, ambiguousIsWide) > 0) {
+                    sawCutEnd = true;
+                    flushPending(/*filterCloseOnly=*/true);
+                    return false; // signal break
+                }
+                pastSpecEnd = true;
+                gs.reset(cp, ambiguousIsWide);
+                prevVisCp = cp;
+                hasPrev = true;
+                p += charLen;
+                return true;
             }
 
             if (!include && position >= start) {
@@ -980,13 +992,13 @@ static WTF::String emitSliceStreaming(
             gs.reset(cp, ambiguousIsWide);
         } else {
             // JOIN: continuation, position unchanged. Pending is inside cluster.
-            if (include) {
+            if (include && !pastSpecEnd) {
                 flushPending(/*filterCloseOnly=*/false);
                 if (inSpecZone)
                     specZone.append(std::span { p, charLen });
                 else
                     result.append(std::span { p, charLen });
-            } else {
+            } else if (!include) {
                 pending.clear();
                 pendingHl.clear();
             }
@@ -1200,6 +1212,13 @@ walkDone:;
     }
 
     if (!include) return emptyString();
+
+    // End-cut degenerate on the lazy path: the ellipsis was too wide to
+    // budget (neither needStart nor needEnd set) but the walk found visible
+    // content past end. Match the cutEndKnown/ASCII fast-path fallback.
+    if (ellipsisWidth > 0 && !cutEndKnown && sawCutEnd
+        && !needStartEllipsis && !needEndEllipsis)
+        return ellipsis.toString();
 
     // Resolve lazy cutEnd: if we budgeted a spec zone and sawCutEnd → cut.
     // Otherwise (EOF reached without exceeding specEnd) → no cut, flush zone.

--- a/src/jsc/bindings/sliceAnsi.cpp
+++ b/src/jsc/bindings/sliceAnsi.cpp
@@ -1198,23 +1198,14 @@ static WTF::String emitSliceStreaming(
 walkDone:;
 
     // Natural EOF (loop completed without breaking early at past-end).
-    // Finalize the last cluster's width contribution, then flush trailing
-    // pending ANSI. Match old Step 5 semantics: isPastEnd for trailing ANSI
-    // is `position >= end` where position reflects the LAST visible char.
-    // (If we broke early via sawCutEnd, pending was already flushed there
-    // with close-only filtering; we don't re-finalize.)
-    if (!sawCutEnd) {
+    // Finalize the last cluster's width contribution. If we broke early via
+    // sawCutEnd, pending was already flushed close-only at the break.
+    const bool reachedEOF = !sawCutEnd;
+    if (reachedEOF) {
         if (hasPrev) position += gs.width();
         // The last cluster may have overflowed specEnd (wide char straddling
         // the boundary, or a Prepend-led cluster that started zero-width).
         if (!endUnbounded && position > specEnd) sawCutEnd = true;
-        // Trailing ANSI: if position >= end, it's post-cut → filter. Use the
-        // ORIGINAL end bound (specEnd includes the spec zone; for filtering,
-        // what matters is whether position exceeds the USER'S requested end,
-        // which is `specEnd` when no ellipsis budget, or `end + budget` when
-        // there is one — same thing).
-        bool trailingPastEnd = !endUnbounded && position >= specEnd;
-        if (include) flushPending(/*filterCloseOnly=*/trailingPastEnd);
     }
 
     if (!include) return emptyString();
@@ -1228,6 +1219,8 @@ walkDone:;
 
     // Resolve lazy cutEnd: if we budgeted a spec zone and sawCutEnd → cut.
     // Otherwise (EOF reached without exceeding specEnd) → no cut, flush zone.
+    // Resolve BEFORE trailing pending ANSI so close codes land after the
+    // last specZone column, not before it.
     if (ellipsisEndBudget > 0) {
         if (sawCutEnd) {
             // Cut confirmed: discard spec zone, keep ellipsis budget (emit ellipsis).
@@ -1236,6 +1229,13 @@ walkDone:;
             result.append(specZone);
             needEndEllipsis = false;
         }
+    }
+
+    if (reachedEOF) {
+        // Trailing ANSI: close-only when the last column reached the user's
+        // end bound (specEnd), unfiltered when the whole string fit inside.
+        bool trailingPastEnd = !endUnbounded && position >= specEnd;
+        flushPending(/*filterCloseOnly=*/trailingPastEnd);
     }
 
     if (activeHyperlink) {

--- a/src/jsc/bindings/sliceAnsi.cpp
+++ b/src/jsc/bindings/sliceAnsi.cpp
@@ -958,7 +958,10 @@ static WTF::String emitSliceStreaming(
                 // A visible cut needs width past specEnd: the prior cluster
                 // overflowed, or this cp is visible. A zero-width cp at exactly
                 // specEnd (LF/CR/ZWSP) is not a cut; keep scanning, don't emit.
-                if (position > specEnd || Bun__codepointWidth(cp, ambiguousIsWide) > 0) {
+                // Without an ellipsis the distinction is unobservable, so break
+                // immediately and keep the O(slice-length) scan bound.
+                if (ellipsisWidth == 0 || position > specEnd
+                    || Bun__codepointWidth(cp, ambiguousIsWide) > 0) {
                     sawCutEnd = true;
                     flushPending(/*filterCloseOnly=*/true);
                     return false; // signal break
@@ -1202,6 +1205,9 @@ walkDone:;
     // with close-only filtering; we don't re-finalize.)
     if (!sawCutEnd) {
         if (hasPrev) position += gs.width();
+        // The last cluster may have overflowed specEnd (wide char straddling
+        // the boundary, or a Prepend-led cluster that started zero-width).
+        if (!endUnbounded && position > specEnd) sawCutEnd = true;
         // Trailing ANSI: if position >= end, it's post-cut → filter. Use the
         // ORIGINAL end bound (specEnd includes the spec zone; for filtering,
         // what matters is whether position exceeds the USER'S requested end,
@@ -1213,10 +1219,10 @@ walkDone:;
 
     if (!include) return emptyString();
 
-    // End-cut degenerate on the lazy path: the ellipsis was too wide to
-    // budget (neither needStart nor needEnd set) but the walk found visible
-    // content past end. Match the cutEndKnown/ASCII fast-path fallback.
-    if (ellipsisWidth > 0 && !cutEndKnown && sawCutEnd
+    // Lazy-path degenerate: the ellipsis was too wide to budget (neither
+    // needStart nor needEnd set) but something was cut. Mirrors the
+    // cutEndKnown/ASCII fast-path (cutStartForEllipsis || cutEndHint) branch.
+    if (ellipsisWidth > 0 && !cutEndKnown && (cutStartForEllipsis || sawCutEnd)
         && !needStartEllipsis && !needEndEllipsis)
         return ellipsis.toString();
 

--- a/test/js/bun/util/sliceAnsi.test.ts
+++ b/test/js/bun/util/sliceAnsi.test.ts
@@ -1135,16 +1135,32 @@ describe("Bun.sliceAnsi", () => {
       expect(Bun.sliceAnsi("abcX\n\nY", 0, 4, { ellipsis: E })).toBe("abc" + E);
       expect(Bun.sliceAnsi("ЖЗИК\nЛ", 0, 4, { ellipsis: E })).toBe("ЖЗИ" + E);
       expect(Bun.sliceAnsi("\x1b[0mabcX\nY", 0, 4, { ellipsis: E })).toBe("abc" + E);
-      // A GCB=Prepend codepoint (U+0600) has width 0 but leads a visible
-      // cluster via GB9b: the cluster past end is a cut.
+      // A zero-width codepoint at end that leads a visible cluster (GB9b
+      // Prepend, keycap via Extend, SpacingMark) is a cut once the cluster
+      // width resolves at EOF.
       expect(Bun.sliceAnsi("abcX\u0600Y", 0, 4, { ellipsis: E })).toBe("abc" + E);
       expect(Bun.sliceAnsi("abcX\u0600YZ", 0, 4, { ellipsis: E })).toBe("abc" + E);
+      expect(Bun.sliceAnsi("ЖЗИК\u0600\u0661", 0, 4, { ellipsis: E })).toBe("ЖЗИ" + E);
+      expect(Bun.sliceAnsi("ЖЗИК\u200b\u20E3", 0, 4, { ellipsis: E })).toBe("ЖЗИ" + E);
+      expect(Bun.sliceAnsi("ЖЗИК\n\u20E3", 0, 4, { ellipsis: E })).toBe("ЖЗИ" + E);
+      expect(Bun.sliceAnsi("ЖЗИК\u200b\u0903", 0, 4, { ellipsis: E })).toBe("ЖЗИ" + E);
       expect(Bun.sliceAnsi("abcX\u0600", 0, 4, { ellipsis: E })).toBe("abcX");
       // Wide char straddling specEnd is a cut (its tail column is past end),
       // with or without a trailing break to re-enter the boundary check.
       expect(Bun.sliceAnsi("ab\u6F22\n", 0, 3, { ellipsis: E })).toBe("ab" + E);
       expect(Bun.sliceAnsi("ab\u6F22", 0, 3, { ellipsis: E })).toBe("ab" + E);
       expect(Bun.sliceAnsi("abcd", 0, 3, { ellipsis: E })).toBe("ab" + E);
+      // start > 0 (start ellipsis budgeted) with a zero-width tail: spec
+      // zone flushes, no end ellipsis.
+      expect(Bun.sliceAnsi("ЖЗИКЛ\n", 1, 5, { ellipsis: E })).toBe(E + "ИКЛ");
+      expect(Bun.sliceAnsi("abcde\n", 1, 5, { ellipsis: E })).toBe(E + "cde");
+      expect(Bun.sliceAnsi("\x1b[0mabcde\n", 1, 5, { ellipsis: E })).toBe(E + "cde");
+      expect(Bun.sliceAnsi("ЖЗИКЛ\nМ", 1, 5, { ellipsis: E })).toBe(E + "ИК" + E);
+      // Trailing close SGR after spec-zone content keeps input order when
+      // the zone is flushed.
+      expect(Bun.sliceAnsi("\x1b[31mЖЗИК\x1b[0m", 0, 4, { ellipsis: E })).toBe("\x1b[31mЖЗИК\x1b[0m");
+      expect(Bun.sliceAnsi("\x1b[31mЖЗИК\n\x1b[0m", 0, 4, { ellipsis: E })).toBe("\x1b[31mЖЗИК\x1b[0m");
+      expect(Bun.sliceAnsi("\x1b[31mЖЗИК\x1b[39m\n", 0, 4, { ellipsis: E })).toBe("\x1b[31mЖЗИК\x1b[39m");
     });
 
     test("lazy-path degenerate (ellipsis wider than range) matches ASCII fast path", () => {

--- a/test/js/bun/util/sliceAnsi.test.ts
+++ b/test/js/bun/util/sliceAnsi.test.ts
@@ -1114,6 +1114,52 @@ describe("Bun.sliceAnsi", () => {
       expect(Bun.sliceAnsi("hi", -100, undefined, { ellipsis: E })).toBe("hi");
     });
 
+    test("trailing zero-width clusters do not trigger the end ellipsis", () => {
+      // A zero-width cluster (LF/CR/ZWSP/tab) landing exactly at the end
+      // boundary must not count as a cut: nothing visible was discarded.
+      // Each non-ASCII case is paired with its ASCII fast-path equivalent
+      // (same column shape) which was already correct.
+      expect(Bun.sliceAnsi("abcX", 0, 4, { ellipsis: E })).toBe("abcX");
+      expect(Bun.sliceAnsi("abcX\n", 0, 4, { ellipsis: E })).toBe("abcX");
+      expect(Bun.sliceAnsi("abcX\r\n", 0, 4, { ellipsis: E })).toBe("abcX");
+      expect(Bun.sliceAnsi("abcX\u200b", 0, 4, { ellipsis: E })).toBe("abcX");
+      expect(Bun.sliceAnsi("abcX\t", 0, 4, { ellipsis: E })).toBe("abcX");
+      expect(Bun.sliceAnsi("abcX\n\n\n", 0, 4, { ellipsis: E })).toBe("abcX");
+      expect(Bun.sliceAnsi("ЖЗИК\n", 0, 4, { ellipsis: E })).toBe("ЖЗИК");
+      expect(Bun.sliceAnsi("ЖЗИ\n", 0, 3, { ellipsis: ">>" })).toBe("ЖЗИ");
+      expect(Bun.sliceAnsi("ab\u6F22\n", 0, 4, { ellipsis: E })).toBe("ab\u6F22");
+      // Leading ANSI forces the streaming walk even for ASCII visible chars.
+      expect(Bun.sliceAnsi("\x1b[0mabcX\n", 0, 4, { ellipsis: E })).toBe("abcX");
+      // Visible content after the zero-width tail IS a cut.
+      expect(Bun.sliceAnsi("abcX\nY", 0, 4, { ellipsis: E })).toBe("abc" + E);
+      expect(Bun.sliceAnsi("abcX\n\nY", 0, 4, { ellipsis: E })).toBe("abc" + E);
+      expect(Bun.sliceAnsi("ЖЗИК\nЛ", 0, 4, { ellipsis: E })).toBe("ЖЗИ" + E);
+      expect(Bun.sliceAnsi("\x1b[0mabcX\nY", 0, 4, { ellipsis: E })).toBe("abc" + E);
+      // Wide char straddling specEnd is a cut (its tail column is past end).
+      expect(Bun.sliceAnsi("ab\u6F22\n", 0, 3, { ellipsis: E })).toBe("ab" + E);
+    });
+
+    test("end-cut degenerate on the lazy path matches the ASCII fast path", () => {
+      // Ellipsis wider than the requested range, start=0, end is cut: the
+      // streaming walk must fall back to the bare ellipsis, same as the
+      // ASCII fast path does via its !doStart && !doEnd branch.
+      const e = { ellipsis: ">>" };
+      expect(Bun.sliceAnsi("abc", 0, 1, e)).toBe(">>");
+      expect(Bun.sliceAnsi("ЖЗИ", 0, 1, e)).toBe(">>");
+      expect(Bun.sliceAnsi("abc", 0, 2, e)).toBe(">>");
+      expect(Bun.sliceAnsi("ЖЗИ", 0, 2, e)).toBe(">>");
+      expect(Bun.sliceAnsi("\x1b[0mabc", 0, 1, e)).toBe(">>");
+      // No cut at end (string fits exactly, or only zero-width past it):
+      // content is returned, not the ellipsis.
+      expect(Bun.sliceAnsi("Ж", 0, 1, e)).toBe("Ж");
+      expect(Bun.sliceAnsi("Ж\n", 0, 1, e)).toBe("Ж");
+      expect(Bun.sliceAnsi("Ж\r\n", 0, 1, e)).toBe("Ж");
+      expect(Bun.sliceAnsi("a", 0, 1, e)).toBe("a");
+      expect(Bun.sliceAnsi("a\n", 0, 1, e)).toBe("a");
+      expect(Bun.sliceAnsi("ЖЗ", 0, 2, e)).toBe("ЖЗ");
+      expect(Bun.sliceAnsi("ЖЗ\n", 0, 2, e)).toBe("ЖЗ");
+    });
+
     test("string shorthand for ellipsis", () => {
       // 4th arg as bare string is equivalent to { ellipsis: string }
       expect(Bun.sliceAnsi("unicorn", 0, 4, E)).toBe("uni" + E);

--- a/test/js/bun/util/sliceAnsi.test.ts
+++ b/test/js/bun/util/sliceAnsi.test.ts
@@ -1135,22 +1135,38 @@ describe("Bun.sliceAnsi", () => {
       expect(Bun.sliceAnsi("abcX\n\nY", 0, 4, { ellipsis: E })).toBe("abc" + E);
       expect(Bun.sliceAnsi("ЖЗИК\nЛ", 0, 4, { ellipsis: E })).toBe("ЖЗИ" + E);
       expect(Bun.sliceAnsi("\x1b[0mabcX\nY", 0, 4, { ellipsis: E })).toBe("abc" + E);
-      // Wide char straddling specEnd is a cut (its tail column is past end).
+      // A GCB=Prepend codepoint (U+0600) has width 0 but leads a visible
+      // cluster via GB9b: the cluster past end is a cut.
+      expect(Bun.sliceAnsi("abcX\u0600Y", 0, 4, { ellipsis: E })).toBe("abc" + E);
+      expect(Bun.sliceAnsi("abcX\u0600YZ", 0, 4, { ellipsis: E })).toBe("abc" + E);
+      expect(Bun.sliceAnsi("abcX\u0600", 0, 4, { ellipsis: E })).toBe("abcX");
+      // Wide char straddling specEnd is a cut (its tail column is past end),
+      // with or without a trailing break to re-enter the boundary check.
       expect(Bun.sliceAnsi("ab\u6F22\n", 0, 3, { ellipsis: E })).toBe("ab" + E);
+      expect(Bun.sliceAnsi("ab\u6F22", 0, 3, { ellipsis: E })).toBe("ab" + E);
+      expect(Bun.sliceAnsi("abcd", 0, 3, { ellipsis: E })).toBe("ab" + E);
     });
 
-    test("end-cut degenerate on the lazy path matches the ASCII fast path", () => {
-      // Ellipsis wider than the requested range, start=0, end is cut: the
-      // streaming walk must fall back to the bare ellipsis, same as the
-      // ASCII fast path does via its !doStart && !doEnd branch.
+    test("lazy-path degenerate (ellipsis wider than range) matches ASCII fast path", () => {
+      // Ellipsis wider than the requested range: the streaming walk must fall
+      // back to the bare ellipsis when either side is cut, same as the ASCII
+      // fast path's !doStart && !doEnd branch.
       const e = { ellipsis: ">>" };
+      // End cut only.
       expect(Bun.sliceAnsi("abc", 0, 1, e)).toBe(">>");
       expect(Bun.sliceAnsi("ЖЗИ", 0, 1, e)).toBe(">>");
       expect(Bun.sliceAnsi("abc", 0, 2, e)).toBe(">>");
       expect(Bun.sliceAnsi("ЖЗИ", 0, 2, e)).toBe(">>");
       expect(Bun.sliceAnsi("\x1b[0mabc", 0, 1, e)).toBe(">>");
-      // No cut at end (string fits exactly, or only zero-width past it):
-      // content is returned, not the ellipsis.
+      expect(Bun.sliceAnsi("Ж\u0600Y", 0, 1, e)).toBe(">>");
+      // Start cut only (string ends exactly at the range end).
+      expect(Bun.sliceAnsi("abc", 1, 3, e)).toBe(">>");
+      expect(Bun.sliceAnsi("ЖЗИ", 1, 3, e)).toBe(">>");
+      expect(Bun.sliceAnsi("ЖЗ", 1, 2, e)).toBe(">>");
+      // Both sides cut.
+      expect(Bun.sliceAnsi("abc", 1, 2, e)).toBe(">>");
+      expect(Bun.sliceAnsi("ЖЗИ", 1, 2, e)).toBe(">>");
+      // No cut on either side: content returned, no ellipsis.
       expect(Bun.sliceAnsi("Ж", 0, 1, e)).toBe("Ж");
       expect(Bun.sliceAnsi("Ж\n", 0, 1, e)).toBe("Ж");
       expect(Bun.sliceAnsi("Ж\r\n", 0, 1, e)).toBe("Ж");


### PR DESCRIPTION
## Repro

```js
// trailing LF at the end boundary is not a visible cut
Bun.sliceAnsi("abcX\n", 0, 4, { ellipsis: "…" });  // "abc…", expected "abcX"
Bun.sliceAnsi("abcX",   0, 4, { ellipsis: "…" });  // "abcX" (ASCII fast path)

// degenerate ellipsis on the lazy path diverges from the ASCII fast path
Bun.sliceAnsi("ЖЗИ", 0, 1, { ellipsis: ">>" });    // "Ж",  expected ">>"
Bun.sliceAnsi("abc", 0, 1, { ellipsis: ">>" });    // ">>" (ASCII fast path)
```

## Cause

`emitSliceStreaming` set `sawCutEnd` whenever a grapheme break landed at `position >= specEnd`, including when the cluster starting there was zero-width (LF, CR, ZWSP, tab). That discarded the speculative zone and emitted the end ellipsis even though nothing visible exists past the boundary. The lazy path also had no degenerate fallback at all when the ellipsis was wider than the range, because the existing one is gated on `cutEndKnown`.

## Fix

`sawCutEnd` now means "visible width exists past `specEnd`", matching what the ASCII fast path and the negative-index path compute from `totalW`:

- At a break with `position >= specEnd`, fire only when the prior cluster overflowed (`position > specEnd`) or the codepoint at `specEnd` has visible width. A zero-width codepoint there enters a skip-and-continue scan until visible content appears or EOF. The scan is skipped when there is no ellipsis, preserving the O(slice-length) bound for that path.
- At EOF, if the finalized `position > specEnd` (wide char straddling the boundary, or a GCB=Prepend-led cluster whose first codepoint was zero-width), `sawCutEnd` is set. This also fixes the existing divergence where `Bun.sliceAnsi("ab漢", 0, 3, {ellipsis:"…"})` returned `"ab漢"` while `"abcd"` returned `"ab…"`.
- A post-walk degenerate check mirrors the `cutEndKnown`/ASCII fast-path `(cutStartForEllipsis || cutEndHint)` fallback using `(cutStartForEllipsis || sawCutEnd)`.

This is the end-cut counterpart to #34382; that PR additionally covers the start-cut degenerate when `include` never became true.

## Verification

- New tests fail on main and pass with this change.
- Full `sliceAnsi.test.ts` suite: 156 pass.
- `sliceAnsi-fuzz.test.ts`: 47 pass, 1 pre-existing timeout (`many SGR codes`, also times out on main under debug+ASAN).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/sliceAnsi.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (a182a90ac)

test/js/bun/util/sliceAnsi.test.ts:
(pass) Bun.sliceAnsi > plain strings > slices ASCII string like String.prototype.slice [3.11ms]
(pass) Bun.sliceAnsi > plain strings > returns empty string for empty input [1.66ms]
(pass) Bun.sliceAnsi > plain strings > returns full string with no arguments beyond first [1.97ms]
(pass) Bun.sliceAnsi > plain strings > start=0, end=0 returns empty [1.18ms]
(pass) Bun.sliceAnsi > plain strings > start > end returns empty [1.59ms]
(pass) Bun.sliceAnsi > plain strings > start beyond string length returns empty [1.46ms]
(pass) Bun.sliceAnsi > plain strings > end beyond string length returns remainder [1.63ms]
(pass) Bun.sliceAnsi > plain strings > negative start [2.35ms]
(pass) Bun.sliceAns
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/util/sliceAnsi.test.ts:
(pass) Bun.sliceAnsi > plain strings > slices ASCII string like String.prototype.slice [0.05ms]
(pass) Bun.sliceAnsi > plain strings > returns empty string for empty input [0.02ms]
(pass) Bun.sliceAnsi > plain strings > returns full string with no arguments beyond first [0.02ms]
(pass) Bun.sliceAnsi > plain strings > start=0, end=0 returns empty
(pass) Bun.sliceAnsi > plain strings > start > end returns empty [0.01ms]
(pass) Bun.sliceAnsi > plain strings > start beyond string length returns empty
(pass) Bun.sliceAnsi > plain strings > end beyond string length returns remainder [0.01ms]
(pass) Bun.sliceAnsi > plain strings > negative start [0.02ms]
(pass) Bun.sliceAnsi > plain strings > negative end [0.02ms]
(pass) Bun.sliceAnsi > plain strings > both negative
(pass) Bun.sliceAnsi > plain strings > single character slice [0.03ms]
(pass) Bun.sliceAnsi > ANSI color codes > slices colored text, preserving ANSI codes at start [0.03ms]
(pass) Bun.sliceAnsi > ANSI color codes > preserves active styles at slice start [0.01ms]
(pass) Bun.sliceAnsi > ANSI color codes > multiple style codes [0.02ms]
(pas
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/sliceAnsi.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (a182a90ac)

test/js/bun/util/sliceAnsi.test.ts:
(pass) Bun.sliceAnsi > plain strings > slices ASCII string like String.prototype.slice [3.46ms]
(pass) Bun.sliceAnsi > plain strings > returns empty string for empty input [1.65ms]
(pass) Bun.sliceAnsi > plain strings > returns full string with no arguments beyond first [1.99ms]
(pass) Bun.sliceAnsi > plain strings > start=0, end=0 returns empty [1.16ms]
(pass) Bun.sliceAnsi > plain strings > start > end returns empty [1.67ms]
(pass) Bun.sliceAnsi > plain strings > start beyond string length returns empty [1.74ms]
(pass) Bun.sliceAnsi > plain strings > end beyond string length returns remainder [1.72ms]
(pass) Bun.sliceAnsi > plain strings > negative start [2.47ms]
(pass) Bun.sliceAns
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     a182a90ac4
  features     (none)

22 deps, 106 codegen, 1168 objects in 838ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [17.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1231] gen ErrorCode+*.h
[4/1231] gen bindgenv2
[5/1231] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [16.00ms]
[7/1231] fetch tinycc
[tinycc] up to date
[8/1230] fetch p
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/sliceAnsi.cpp     | 63 ++++++++++++++++++++----------
 test/js/bun/util/sliceAnsi.test.ts | 78 ++++++++++++++++++++++++++++++++++++++
 2 files changed, 122 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/jsc/bindings/sliceAnsi.cpp          8     10      0
test/js/bun/util/sliceAnsi.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->