### PR TITLE
Bun.sliceAnsi: detect end cut when final wide cluster overflows on lazy path

### DIFF
--- a/src/jsc/bindings/sliceAnsi.cpp
+++ b/src/jsc/bindings/sliceAnsi.cpp
@@ -1190,6 +1190,9 @@ walkDone:;
     // with close-only filtering; we don't re-finalize.)
     if (!sawCutEnd) {
         if (hasPrev) position += gs.width();
+        // The final cluster may itself overflow specEnd (a wide cluster that
+        // started before specEnd with no following break to detect it in-walk).
+        if (!endUnbounded && position > specEnd) sawCutEnd = true;
         // Trailing ANSI: if position >= end, it's post-cut → filter. Use the
         // ORIGINAL end bound (specEnd includes the spec zone; for filtering,
         // what matters is whether position exceeds the USER'S requested end,

--- a/src/jsc/bindings/sliceAnsi.cpp
+++ b/src/jsc/bindings/sliceAnsi.cpp
@@ -1190,16 +1190,20 @@ walkDone:;
     // with close-only filtering; we don't re-finalize.)
     if (!sawCutEnd) {
         if (hasPrev) position += gs.width();
-        // The final cluster may itself overflow specEnd (a wide cluster that
-        // started before specEnd with no following break to detect it in-walk).
-        if (!endUnbounded && position > specEnd) sawCutEnd = true;
-        // Trailing ANSI: if position >= end, it's post-cut → filter. Use the
-        // ORIGINAL end bound (specEnd includes the spec zone; for filtering,
-        // what matters is whether position exceeds the USER'S requested end,
-        // which is `specEnd` when no ellipsis budget, or `end + budget` when
-        // there is one — same thing).
-        bool trailingPastEnd = !endUnbounded && position >= specEnd;
-        if (include) flushPending(/*filterCloseOnly=*/trailingPastEnd);
+        if (ellipsisEndBudget > 0 && position > specEnd) {
+            // Final cluster overflowed specEnd with no following break to catch
+            // it in-walk. Pending ANSI at EOF sits after discarded spec-zone
+            // content; emitCloseCodes re-closes so the ellipsis inherits style.
+            sawCutEnd = true;
+        } else {
+            // Trailing ANSI: if position >= end, it's post-cut → filter. Use
+            // the ORIGINAL end bound (specEnd includes the spec zone; for
+            // filtering, what matters is whether position exceeds the USER'S
+            // requested end, which is `specEnd` when no ellipsis budget, or
+            // `end + budget` when there is one — same thing).
+            bool trailingPastEnd = !endUnbounded && position >= specEnd;
+            if (include) flushPending(/*filterCloseOnly=*/trailingPastEnd);
+        }
     }
 
     if (!include) return emptyString();

--- a/test/js/bun/util/sliceAnsi.test.ts
+++ b/test/js/bun/util/sliceAnsi.test.ts
@@ -1116,7 +1116,8 @@ describe("Bun.sliceAnsi", () => {
       expect(Bun.sliceAnsi("abcd\u6F22", 0, 5, { ellipsis: ">>" })).toBe("abc>>");
       // With active SGR: ellipsis inherits it via emitCloseCodes, including
       // when the input carries its own explicit close after the wide char.
-      const red = "\u001B[31m", reset = "\u001B[39m";
+      const red = "\u001B[31m",
+        reset = "\u001B[39m";
       expect(Bun.sliceAnsi(red + "ab\u6F22", 0, 3, { ellipsis: E })).toBe(red + "ab" + E + reset);
       expect(Bun.sliceAnsi(red + "ab\u6F22" + reset, 0, 3, { ellipsis: E })).toBe(red + "ab" + E + reset);
       // start > 0: start ellipsis budgeted first, same EOF overflow detection.
@@ -1133,7 +1134,9 @@ describe("Bun.sliceAnsi", () => {
       // Equivalence with the paths that already got this right.
       expect(Bun.sliceAnsi("ab\u6F22", 0, 3, { ellipsis: E })).toBe(Bun.sliceAnsi("ab\u6F22", 0, -1, { ellipsis: E }));
       expect(Bun.sliceAnsi("ab\u6F22", 0, 3, { ellipsis: E })).toBe(Bun.sliceAnsi("ab\u6F22x", 0, 3, { ellipsis: E }));
-      expect(Bun.sliceAnsi("xyab\u6F22", 2, 5, { ellipsis: E })).toBe(Bun.sliceAnsi("xyab\u6F22", 2, -1, { ellipsis: E }));
+      expect(Bun.sliceAnsi("xyab\u6F22", 2, 5, { ellipsis: E })).toBe(
+        Bun.sliceAnsi("xyab\u6F22", 2, -1, { ellipsis: E }),
+      );
       expect(Bun.sliceAnsi(red + "ab\u6F22" + reset, 0, 3, { ellipsis: E })).toBe(
         Bun.sliceAnsi(red + "ab\u6F22" + reset, 0, -1, { ellipsis: E }),
       );

--- a/test/js/bun/util/sliceAnsi.test.ts
+++ b/test/js/bun/util/sliceAnsi.test.ts
@@ -1104,6 +1104,29 @@ describe("Bun.sliceAnsi", () => {
       expect(Bun.sliceAnsi("\u5B89\u5B81\u54C8\u4E16\u754C", 0, 5, { ellipsis: E })).toBe("\u5B89\u5B81" + E);
     });
 
+    test("wide char overflowing end at EOF is a cut (lazy path)", () => {
+      // 漢 is width 2. When it is the last cluster and its width extends past
+      // the requested end, the lazy-cutEnd path must emit the ellipsis just
+      // like the ASCII fast path and the negative-index path do.
+      expect(Bun.sliceAnsi("ab\u6F22", 0, 3, { ellipsis: E })).toBe("ab" + E);
+      expect(Bun.sliceAnsi("abc\u6F22", 0, 4, { ellipsis: E })).toBe("abc" + E);
+      expect(Bun.sliceAnsi("\u6F22\u6F22", 0, 3, { ellipsis: E })).toBe("\u6F22" + E);
+      expect(Bun.sliceAnsi("ab\u6F22\u6F22", 0, 5, { ellipsis: E })).toBe("ab\u6F22" + E);
+      // Multi-column ellipsis budget.
+      expect(Bun.sliceAnsi("abcd\u6F22", 0, 5, { ellipsis: ">>" })).toBe("abc>>");
+      // With active SGR: ellipsis inherits it, close is auto-emitted.
+      expect(Bun.sliceAnsi("\u001B[31mab\u6F22", 0, 3, { ellipsis: E })).toBe("\u001B[31mab" + E + "\u001B[39m");
+      // Exact fit (total width == end) is not a cut.
+      expect(Bun.sliceAnsi("ab\u6F22", 0, 4, { ellipsis: E })).toBe("ab\u6F22");
+      expect(Bun.sliceAnsi("a\u6F22", 0, 3, { ellipsis: E })).toBe("a\u6F22");
+      expect(Bun.sliceAnsi("a\u6F22b", 0, 4, { ellipsis: E })).toBe("a\u6F22b");
+      expect(Bun.sliceAnsi("abcd\u6F22", 0, 6, { ellipsis: ">>" })).toBe("abcd\u6F22");
+      // Equivalence with the paths that already got this right.
+      expect(Bun.sliceAnsi("ab\u6F22", 0, 3, { ellipsis: E })).toBe(Bun.sliceAnsi("ab\u6F22", 0, -1, { ellipsis: E }));
+      expect(Bun.sliceAnsi("ab\u6F22", 0, 3, { ellipsis: E })).toBe(Bun.sliceAnsi("ab\u6F22x", 0, 3, { ellipsis: E }));
+      expect(Bun.stringWidth(Bun.sliceAnsi("ab\u6F22", 0, 3, { ellipsis: E }))).toBe(3);
+    });
+
     test("empty ellipsis behaves like plain slice", () => {
       expect(Bun.sliceAnsi("unicorn", 0, 4, { ellipsis: "" })).toBe("unic");
     });

--- a/test/js/bun/util/sliceAnsi.test.ts
+++ b/test/js/bun/util/sliceAnsi.test.ts
@@ -1114,8 +1114,17 @@ describe("Bun.sliceAnsi", () => {
       expect(Bun.sliceAnsi("ab\u6F22\u6F22", 0, 5, { ellipsis: E })).toBe("ab\u6F22" + E);
       // Multi-column ellipsis budget.
       expect(Bun.sliceAnsi("abcd\u6F22", 0, 5, { ellipsis: ">>" })).toBe("abc>>");
-      // With active SGR: ellipsis inherits it, close is auto-emitted.
-      expect(Bun.sliceAnsi("\u001B[31mab\u6F22", 0, 3, { ellipsis: E })).toBe("\u001B[31mab" + E + "\u001B[39m");
+      // With active SGR: ellipsis inherits it via emitCloseCodes, including
+      // when the input carries its own explicit close after the wide char.
+      const red = "\u001B[31m", reset = "\u001B[39m";
+      expect(Bun.sliceAnsi(red + "ab\u6F22", 0, 3, { ellipsis: E })).toBe(red + "ab" + E + reset);
+      expect(Bun.sliceAnsi(red + "ab\u6F22" + reset, 0, 3, { ellipsis: E })).toBe(red + "ab" + E + reset);
+      // start > 0: start ellipsis budgeted first, same EOF overflow detection.
+      expect(Bun.sliceAnsi("xyab\u6F22", 2, 5, { ellipsis: E })).toBe(E + "b" + E);
+      expect(Bun.sliceAnsi("xyab\u6F22", 2, 6, { ellipsis: E })).toBe(E + "b\u6F22");
+      // 8-bit (LChar) instantiation: U+00A7 is width 2 under ambiguousIsNarrow:false.
+      expect(Bun.sliceAnsi("ab\u00A7", 0, 3, { ellipsis: ".", ambiguousIsNarrow: false })).toBe("ab.");
+      expect(Bun.sliceAnsi("ab\u00A7", 0, 4, { ellipsis: ".", ambiguousIsNarrow: false })).toBe("ab\u00A7");
       // Exact fit (total width == end) is not a cut.
       expect(Bun.sliceAnsi("ab\u6F22", 0, 4, { ellipsis: E })).toBe("ab\u6F22");
       expect(Bun.sliceAnsi("a\u6F22", 0, 3, { ellipsis: E })).toBe("a\u6F22");
@@ -1124,6 +1133,10 @@ describe("Bun.sliceAnsi", () => {
       // Equivalence with the paths that already got this right.
       expect(Bun.sliceAnsi("ab\u6F22", 0, 3, { ellipsis: E })).toBe(Bun.sliceAnsi("ab\u6F22", 0, -1, { ellipsis: E }));
       expect(Bun.sliceAnsi("ab\u6F22", 0, 3, { ellipsis: E })).toBe(Bun.sliceAnsi("ab\u6F22x", 0, 3, { ellipsis: E }));
+      expect(Bun.sliceAnsi("xyab\u6F22", 2, 5, { ellipsis: E })).toBe(Bun.sliceAnsi("xyab\u6F22", 2, -1, { ellipsis: E }));
+      expect(Bun.sliceAnsi(red + "ab\u6F22" + reset, 0, 3, { ellipsis: E })).toBe(
+        Bun.sliceAnsi(red + "ab\u6F22" + reset, 0, -1, { ellipsis: E }),
+      );
       expect(Bun.stringWidth(Bun.sliceAnsi("ab\u6F22", 0, 3, { ellipsis: E }))).toBe(3);
     });
 


### PR DESCRIPTION
## Repro

```js
Bun.sliceAnsi("ab\u6F22", 0, 3, { ellipsis: "\u2026" })   // "ab\u6F22"  (4 cols, no ellipsis)
Bun.sliceAnsi("abcd",     0, 3, { ellipsis: "\u2026" })   // "ab\u2026"  (ASCII fast path: correct)
Bun.sliceAnsi("ab\u6F22", 0, -1, { ellipsis: "\u2026" })  // "ab\u2026"  (cutEndKnown path: correct)
```

`\u6F22` is width 2 so `"ab\u6F22"` is 4 columns. Slicing `[0, 3)` with an ellipsis should produce `"ab\u2026"` (3 columns) on every path, but the lazy cutEnd path (positive finite indices, no pre-scan) returns the uncut 4-column string.

## Cause

`emitSliceStreaming` detects the end cut inside `processVisibleCp` when a grapheme break lands at `position >= specEnd`. When the wide cluster is the **last** visible thing in the input, EOF follows directly and there is no next break to observe the overflow. The post-walk finalization bumps `position` by the last cluster's width but never re-evaluates `sawCutEnd`, so the speculative zone is flushed as "no cut" and the ellipsis is dropped.

## Fix

After finalizing the last cluster's width in the post-walk block, when `ellipsisEndBudget > 0` and the final `position` strictly exceeds `specEnd`, set `sawCutEnd = true` and skip the trailing `flushPending`: the pending ANSI at EOF sits after spec-zone content that is being discarded, and `activeStyles.emitCloseCodes` already re-closes after the ellipsis so the ellipsis inherits the active style (the documented SGR-inheritance contract, matching the `cutEndKnown` path). Strictly `>` keeps exact-fit (`position == specEnd`) resolving as no cut, and the `ellipsisEndBudget > 0` gate leaves the no-ellipsis path byte-identical.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/util/sliceAnsi.test.ts -t "wide char overflowing end at EOF"
(fail) ... Expected: "ab\u2026"  Received: "ab\u6F22"

$ bun bd test test/js/bun/util/sliceAnsi.test.ts
 155 pass  0 fail
```

The new test covers the overflow case at several column offsets, a multi-column ellipsis budget, `start > 0` (both-ellipsis) and its exact-fit negative, the 8-bit `LChar` instantiation via an ambiguous-width Latin-1 codepoint, SGR inheritance with and without an explicit trailing close, the exact-fit negatives, and equivalence with the negative-index and not-EOF paths.

Related: #34391 addresses the zero-width **false positive** for `sawCutEnd` (trailing LF at the boundary is not a cut). This PR is the converse **false negative** (overflowing wide cluster at EOF is a cut). The two changes touch adjacent but non-overlapping lines.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/sliceAnsi.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (07d9603ac)

test/js/bun/util/sliceAnsi.test.ts:
(pass) Bun.sliceAnsi > plain strings > slices ASCII string like String.prototype.slice [3.06ms]
(pass) Bun.sliceAnsi > plain strings > returns empty string for empty input [2.21ms]
(pass) Bun.sliceAnsi > plain strings > returns full string with no arguments beyond first [2.14ms]
(pass) Bun.sliceAnsi > plain strings > start=0, end=0 returns empty [1.29ms]
(pass) Bun.sliceAnsi > plain strings > start > end returns empty [1.85ms]
(pass) Bun.sliceAnsi > plain strings > start beyond string length returns empty [1.31ms]
(pass) Bun.sliceAnsi > plain strings > end beyond string length returns remainder [2.08ms]
(pass) Bun.sliceAnsi > plain strings > negative start [2.46ms]
(pass) Bun.sliceAns
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/util/sliceAnsi.test.ts:
(pass) Bun.sliceAnsi > plain strings > slices ASCII string like String.prototype.slice [0.09ms]
(pass) Bun.sliceAnsi > plain strings > returns empty string for empty input [0.03ms]
(pass) Bun.sliceAnsi > plain strings > returns full string with no arguments beyond first [0.04ms]
(pass) Bun.sliceAnsi > plain strings > start=0, end=0 returns empty [0.02ms]
(pass) Bun.sliceAnsi > plain strings > start > end returns empty [0.02ms]
(pass) Bun.sliceAnsi > plain strings > start beyond string length returns empty [0.02ms]
(pass) Bun.sliceAnsi > plain strings > end beyond string length returns remainder [0.03ms]
(pass) Bun.sliceAnsi > plain strings > negative start [0.04ms]
(pass) Bun.sliceAnsi > plain strings > negative end [0.03ms]
(pass) Bun.sliceAnsi > plain strings > both negative [0.02ms]
(pass) Bun.sliceAnsi > plain strings > single character slice [0.03ms]
(pass) Bun.sliceAnsi > ANSI color codes > slices colored text, preserving ANSI codes at start [0.06ms]
(pass) Bun.sliceAnsi > ANSI color codes > preserves active styles at slice start [0.02ms]
(pass) Bun.sliceAnsi > ANSI color codes > multipl
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/sliceAnsi.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (07d9603ac)

test/js/bun/util/sliceAnsi.test.ts:
(pass) Bun.sliceAnsi > plain strings > slices ASCII string like String.prototype.slice [3.83ms]
(pass) Bun.sliceAnsi > plain strings > returns empty string for empty input [2.43ms]
(pass) Bun.sliceAnsi > plain strings > returns full string with no arguments beyond first [1.91ms]
(pass) Bun.sliceAnsi > plain strings > start=0, end=0 returns empty [1.78ms]
(pass) Bun.sliceAnsi > plain strings > start > end returns empty [1.89ms]
(pass) Bun.sliceAnsi > plain strings > start beyond string length returns empty [1.29ms]
(pass) Bun.sliceAnsi > plain strings > end beyond string length returns remainder [2.14ms]
(pass) Bun.sliceAnsi > plain strings > negative start [2.17ms]
(pass) Bun.sliceAns
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     07d9603acb
  features     (none)

22 deps, 106 codegen, 1168 objects in 1080ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [49.00ms]
[2/1231] fetch zlib
[zlib] up to date
[3/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1231] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1231] gen .bind.ts → GeneratedBindings.cpp
[6/1231] gen ErrorCode+*.h
[7/1231] gen bindgenv2
[8/1231] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/sliceAnsi.cpp     | 21 +++++++++++++-------
 test/js/bun/util/sliceAnsi.test.ts | 39 ++++++++++++++++++++++++++++++++++++++
 2 files changed, 53 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/jsc/bindings/sliceAnsi.cpp          6      2      0
test/js/bun/util/sliceAnsi.test.ts      3      3      0
```

</details>

<!-- robobun:evidence:end -->