### PR TITLE
Bun.sliceAnsi: keep ANSI ordered with speculative-zone content under ellipsis

### DIFF
--- a/src/jsc/bindings/sliceAnsi.cpp
+++ b/src/jsc/bindings/sliceAnsi.cpp
@@ -907,11 +907,27 @@ static WTF::String emitSliceStreaming(
             return ellipsis.toString(); // degenerate: range too small
     }
     // Speculative zone: when cutEnd is unknown and we've budgeted for an
-    // ellipsis, content in cols [end, end+ellipsisEndBudget) goes here. If
-    // we later detect cutEnd (more input past the zone) → discard, emit
-    // ellipsis. If EOF reached first (no cut) → flush specZone, no ellipsis.
-    StringBuilder specZone;
+    // ellipsis, content in cols [end, end+ellipsisEndBudget) is written to
+    // `result` as normal and its starting offset is remembered here. If we
+    // later detect cutEnd (more input past the zone) → shrink result back to
+    // specZoneMark and restore style state from the snapshot. If EOF reached
+    // first (no cut) → keep it, cancel ellipsis. Writing straight to result
+    // keeps ANSI flushed via flushPending interleaved with the spec-zone chars
+    // in the correct order.
     bool inSpecZone = false;
+    unsigned specZoneMark = 0;
+    SgrStyleState specStyles;
+    bool specHyperlink = false;
+    String specHyperlinkClosePrefix, specHyperlinkTerminator;
+    auto enterSpecZone = [&]() {
+        if (inSpecZone) return;
+        inSpecZone = true;
+        specZoneMark = result.length();
+        specStyles = activeStyles;
+        specHyperlink = activeHyperlink;
+        specHyperlinkClosePrefix = activeHyperlinkClosePrefix;
+        specHyperlinkTerminator = activeHyperlinkTerminator;
+    };
     const size_t specEnd = (ellipsisEndBudget > 0) ? end + ellipsisEndBudget : end;
 
     // ------------------------------------------------------------------------
@@ -967,12 +983,9 @@ static WTF::String emitSliceStreaming(
             }
             if (include) {
                 flushPending(/*filterCloseOnly=*/false);
-                if (!endUnbounded && position >= end && ellipsisEndBudget > 0) {
-                    if (!inSpecZone) inSpecZone = true;
-                    specZone.append(std::span { p, charLen });
-                } else {
-                    result.append(std::span { p, charLen });
-                }
+                if (!endUnbounded && position >= end && ellipsisEndBudget > 0)
+                    enterSpecZone();
+                result.append(std::span { p, charLen });
             } else {
                 pending.clear();
                 pendingHl.clear();
@@ -982,10 +995,7 @@ static WTF::String emitSliceStreaming(
             // JOIN: continuation, position unchanged. Pending is inside cluster.
             if (include) {
                 flushPending(/*filterCloseOnly=*/false);
-                if (inSpecZone)
-                    specZone.append(std::span { p, charLen });
-                else
-                    result.append(std::span { p, charLen });
+                result.append(std::span { p, charLen });
             } else {
                 pending.clear();
                 pendingHl.clear();
@@ -1086,16 +1096,16 @@ static WTF::String emitSliceStreaming(
                                                 : std::min(static_cast<size_t>(specEnd > position ? specEnd - position : 0), bulkN);
                     if (emitN > 0) {
                         // Split at spec zone boundary [end, specEnd).
-                        if (ellipsisEndBudget > 0 && position < end && !endUnbounded) {
-                            size_t toMain = std::min(end - position, emitN);
-                            result.append(std::span { p, toMain });
-                            if (emitN > toMain) {
-                                inSpecZone = true;
-                                specZone.append(std::span { p + toMain, emitN - toMain });
+                        if (ellipsisEndBudget > 0 && !endUnbounded) {
+                            if (position < end) {
+                                size_t toMain = std::min(end - position, emitN);
+                                result.append(std::span { p, toMain });
+                                if (emitN > toMain) enterSpecZone();
+                                result.append(std::span { p + toMain, emitN - toMain });
+                            } else {
+                                enterSpecZone();
+                                result.append(std::span { p, emitN });
                             }
-                        } else if (inSpecZone || (!endUnbounded && position >= end)) {
-                            inSpecZone = true;
-                            specZone.append(std::span { p, emitN });
                         } else {
                             result.append(std::span { p, emitN });
                         }
@@ -1202,13 +1212,21 @@ walkDone:;
     if (!include) return emptyString();
 
     // Resolve lazy cutEnd: if we budgeted a spec zone and sawCutEnd → cut.
-    // Otherwise (EOF reached without exceeding specEnd) → no cut, flush zone.
+    // Otherwise (EOF reached without exceeding specEnd) → no cut, keep zone.
     if (ellipsisEndBudget > 0) {
         if (sawCutEnd) {
-            // Cut confirmed: discard spec zone, keep ellipsis budget (emit ellipsis).
+            // Cut confirmed: discard spec-zone content and restore style state
+            // to what it was at the zone boundary, so emitCloseCodes and the
+            // hyperlink close below reflect only what's actually in result.
+            if (inSpecZone) {
+                result.shrink(specZoneMark);
+                activeStyles = std::move(specStyles);
+                activeHyperlink = specHyperlink;
+                activeHyperlinkClosePrefix = std::move(specHyperlinkClosePrefix);
+                activeHyperlinkTerminator = std::move(specHyperlinkTerminator);
+            }
         } else {
-            // No cut: append spec zone content, cancel ellipsis.
-            result.append(specZone);
+            // No cut: spec-zone content is already in result. Cancel ellipsis.
             needEndEllipsis = false;
         }
     }

--- a/test/js/bun/util/sliceAnsi.test.ts
+++ b/test/js/bun/util/sliceAnsi.test.ts
@@ -1143,7 +1143,9 @@ describe("Bun.sliceAnsi", () => {
     test("SGR between speculative-zone chars is discarded with the zone when cut", () => {
       const red = "\u001B[31m";
       const green = "\u001B[32m";
+      const bold = "\u001B[1m";
       const reset = "\u001B[39m";
+      const resetAll = "\u001B[0m";
       // 'efg' fall in the speculative zone and are replaced by the ellipsis;
       // the \e[32m between them applies only to discarded chars and must not
       // leak into the output. The negative-index path already behaves this
@@ -1154,6 +1156,25 @@ describe("Bun.sliceAnsi", () => {
       const viaKnown = Bun.sliceAnsi(text, -11, -4, { ellipsis: "..." });
       expect(viaLazy).toBe(`${red}abcd...${reset}`);
       expect(viaLazy).toBe(viaKnown);
+      // SGR 0 (full reset) between zone chars: the snapshot restore must bring
+      // back every active slot so emitCloseCodes closes them individually.
+      const multi = `${red}${bold}abcde${resetAll}fghij`;
+      expect(Bun.sliceAnsi(multi, 0, 7, { ellipsis: "..." })).toBe(`${red}${bold}abcd...\u001B[22m${reset}`);
+      expect(Bun.sliceAnsi(multi, 0, 7, { ellipsis: "..." })).toBe(Bun.sliceAnsi(multi, -10, -3, { ellipsis: "..." }));
+    });
+
+    test("hyperlink state is restored when speculative zone is discarded", () => {
+      // OSC 8 open lands between two speculative-zone chars and every linked
+      // character is discarded: no OSC 8 bytes should appear in the output.
+      const inner = "abcde" + createHyperlink("fghij", "http://x");
+      expect(Bun.sliceAnsi(inner, 0, 7, { ellipsis: "..." })).toBe("abcd...");
+      expect(Bun.sliceAnsi(inner, 0, 7, { ellipsis: "..." })).toBe(Bun.sliceAnsi(inner, -10, -3, { ellipsis: "..." }));
+      // Link open before the zone and close between zone chars: restoring the
+      // snapshot keeps the link active so a close is still synthesized before
+      // the ellipsis.
+      const outer = createHyperlink("abcde", "http://x") + "fghij";
+      expect(Bun.sliceAnsi(outer, 0, 7, { ellipsis: "..." })).toBe(createHyperlink("abcd", "http://x") + "...");
+      expect(Bun.sliceAnsi(outer, 0, 7, { ellipsis: "..." })).toBe(Bun.sliceAnsi(outer, -10, -3, { ellipsis: "..." }));
     });
   });
 

--- a/test/js/bun/util/sliceAnsi.test.ts
+++ b/test/js/bun/util/sliceAnsi.test.ts
@@ -1120,6 +1120,41 @@ describe("Bun.sliceAnsi", () => {
       expect(Bun.sliceAnsi("unicorn", -4, undefined, E)).toBe(E + "orn");
       expect(Bun.sliceAnsi("unicorn", 0, 4, ".")).toBe("uni.");
     });
+
+    test("trailing ANSI stays after speculative-zone content when string fits exactly", () => {
+      const red = "\u001B[31m";
+      const green = "\u001B[32m";
+      const reset = "\u001B[39m";
+      // End budget lands exactly at EOF: speculative zone ("d") is kept. The
+      // trailing close code must come AFTER that content, not before it.
+      expect(Bun.sliceAnsi(`${red}abcd${reset}`, 0, 4, { ellipsis: E })).toBe(`${red}abcd${reset}`);
+      expect(Bun.sliceAnsi(`${red}abcd${reset}`, 0, 4, { ellipsis: "..." })).toBe(`${red}abcd${reset}`);
+      // SGR change between speculative-zone chars must stay interleaved.
+      expect(Bun.sliceAnsi(`${red}abcde${green}fg${reset}`, 0, 7, { ellipsis: "..." })).toBe(
+        `${red}abcde${green}fg${reset}`,
+      );
+      // Same for OSC 8 hyperlink close.
+      const hl = createHyperlink("abcd", "http://x");
+      expect(Bun.sliceAnsi(hl, 0, 4, { ellipsis: E })).toBe(hl);
+      // UTF-16 input path (force a non-ASCII char before the styled run).
+      expect(Bun.sliceAnsi(`\u5B89${red}bcd${reset}`, 0, 5, { ellipsis: E })).toBe(`\u5B89${red}bcd${reset}`);
+    });
+
+    test("SGR between speculative-zone chars is discarded with the zone when cut", () => {
+      const red = "\u001B[31m";
+      const green = "\u001B[32m";
+      const reset = "\u001B[39m";
+      // 'efg' fall in the speculative zone and are replaced by the ellipsis;
+      // the \e[32m between them applies only to discarded chars and must not
+      // leak into the output. The negative-index path already behaves this
+      // way; the lazy (positive-index) path should match.
+      const text = `${red}abcde${green}fghijk${reset}`;
+      expect(Bun.stringWidth(text)).toBe(11);
+      const viaLazy = Bun.sliceAnsi(text, 0, 7, { ellipsis: "..." });
+      const viaKnown = Bun.sliceAnsi(text, -11, -4, { ellipsis: "..." });
+      expect(viaLazy).toBe(`${red}abcd...${reset}`);
+      expect(viaLazy).toBe(viaKnown);
+    });
   });
 
   // ======================================================================


### PR DESCRIPTION
## Reproduction

```js
Bun.sliceAnsi("\x1b[31mabcd\x1b[39m", 0, 4, { ellipsis: "…" })
// => "\x1b[31mabc\x1b[39md"   ('d' is unstyled)
// expected "\x1b[31mabcd\x1b[39m"
```

When a styled string's width exactly matches `end` and an `ellipsis` is supplied, the close code is emitted before the final visible column instead of after it. The same ordering break applies to SGR changes between speculative-zone characters and to OSC 8 hyperlink closes.

## Cause

`emitSliceStreaming` resolves the end ellipsis lazily for positive indices: it shortens `end` by the ellipsis width and writes content in cols `[end, specEnd)` into a separate `specZone` buffer until it knows whether the end is actually cut. `flushPending`, which emits buffered ANSI between visible characters, always appends to `result`. When the speculative zone is kept (EOF reached without exceeding `specEnd`), the trailing `flushPending` at EOF writes the close code to `result` before `result.append(specZone)` copies the final column in, so the close lands ahead of the content it is supposed to follow. ANSI flushed between two speculative-zone characters is misplaced the same way.

## Fix

Write speculative-zone content directly into `result` and remember the offset plus SGR/hyperlink state at zone entry. On discard (cut confirmed), `result.shrink(mark)` drops the zone content along with any ANSI flushed inside it, and the style snapshot is restored so `emitCloseCodes` and the hyperlink close reflect only what remains. When the zone is kept, nothing extra happens: ANSI already landed in `result` interleaved with the characters in the right order.

A side effect is that SGR opens whose styled characters are entirely inside the discarded zone no longer leak onto the ellipsis, which makes the positive-index lazy path match the negative-index (`cutEndKnown`) path for the same slice.

## Verification

```sh
USE_SYSTEM_BUN=1 bun test test/js/bun/util/sliceAnsi.test.ts -t speculative-zone   # fails
bun bd test test/js/bun/util/sliceAnsi.test.ts                                     # 156 pass
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/sliceAnsi.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (953e575bc)

test/js/bun/util/sliceAnsi.test.ts:
(pass) Bun.sliceAnsi > plain strings > slices ASCII string like String.prototype.slice [3.83ms]
(pass) Bun.sliceAnsi > plain strings > returns empty string for empty input [1.87ms]
(pass) Bun.sliceAnsi > plain strings > returns full string with no arguments beyond first [2.62ms]
(pass) Bun.sliceAnsi > plain strings > start=0, end=0 returns empty [1.61ms]
(pass) Bun.sliceAnsi > plain strings > start > end returns empty [1.63ms]
(pass) Bun.sliceAnsi > plain strings > start beyond string length returns empty [1.48ms]
(pass) Bun.sliceAnsi > plain strings > end beyond string length returns remainder [1.64ms]
(pass) Bun.sliceAnsi > plain strings > negative start [2.34ms]
(pass) Bun.sliceAns
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/util/sliceAnsi.test.ts:
(pass) Bun.sliceAnsi > plain strings > slices ASCII string like String.prototype.slice [0.05ms]
(pass) Bun.sliceAnsi > plain strings > returns empty string for empty input [0.02ms]
(pass) Bun.sliceAnsi > plain strings > returns full string with no arguments beyond first [0.02ms]
(pass) Bun.sliceAnsi > plain strings > start=0, end=0 returns empty [0.01ms]
(pass) Bun.sliceAnsi > plain strings > start > end returns empty [0.01ms]
(pass) Bun.sliceAnsi > plain strings > start beyond string length returns empty
(pass) Bun.sliceAnsi > plain strings > end beyond string length returns remainder [0.01ms]
(pass) Bun.sliceAnsi > plain strings > negative start [0.02ms]
(pass) Bun.sliceAnsi > plain strings > negative end [0.02ms]
(pass) Bun.sliceAnsi > plain strings > both negative
(pass) Bun.sliceAnsi > plain strings > single character slice [0.01ms]
(pass) Bun.sliceAnsi > ANSI color codes > slices colored text, preserving ANSI codes at start [0.03ms]
(pass) Bun.sliceAnsi > ANSI color codes > preserves active styles at slice start [0.01ms]
(pass) Bun.sliceAnsi > ANSI color codes > multiple style codes [0.0
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/sliceAnsi.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (953e575bc)

test/js/bun/util/sliceAnsi.test.ts:
(pass) Bun.sliceAnsi > plain strings > slices ASCII string like String.prototype.slice [3.32ms]
(pass) Bun.sliceAnsi > plain strings > returns empty string for empty input [1.77ms]
(pass) Bun.sliceAnsi > plain strings > returns full string with no arguments beyond first [2.04ms]
(pass) Bun.sliceAnsi > plain strings > start=0, end=0 returns empty [1.57ms]
(pass) Bun.sliceAnsi > plain strings > start > end returns empty [1.34ms]
(pass) Bun.sliceAnsi > plain strings > start beyond string length returns empty [1.51ms]
(pass) Bun.sliceAnsi > plain strings > end beyond string length returns remainder [1.69ms]
(pass) Bun.sliceAnsi > plain strings > negative start [2.35ms]
(pass) Bun.sliceAns
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     953e575bcb
  features     (none)

22 deps, 106 codegen, 1168 objects in 873ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [42.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [9.00ms]
[3/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [8.00ms]
[4/1231] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1231] fetch picohttpparser
[picohttpparser] up to date
[6/1231] gen ErrorCode+*.h
[7/1231] fetch tinycc
[t
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/sliceAnsi.cpp     | 72 ++++++++++++++++++++++++--------------
 test/js/bun/util/sliceAnsi.test.ts | 56 +++++++++++++++++++++++++++++
 2 files changed, 101 insertions(+), 27 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/jsc/bindings/sliceAnsi.cpp          5      5      0
test/js/bun/util/sliceAnsi.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->