### PR TITLE
bun:ffi: throw validation errors from viewSource and JSCallback instead of returning them

### DIFF
--- a/src/js/bun/ffi.ts
+++ b/src/js/bun/ffi.ts
@@ -69,7 +69,7 @@ var ffi = globalThis.Bun.FFI;
 const ptr = (arg1, arg2) => (typeof arg2 === "undefined" ? ffi.ptr(arg1) : ffi.ptr(arg1, arg2));
 const toBuffer = ffi.toBuffer;
 const toArrayBuffer = ffi.toArrayBuffer;
-const viewSource = ffi.viewSource;
+const nativeViewSource = ffi.viewSource;
 
 const BunCString = ffi.CString;
 const nativeLinkSymbols = ffi.linkSymbols;
@@ -518,6 +518,12 @@ function cc(options) {
   // Previously, it didn't need to be bound
   result.close = result.close.bind(result);
 
+  return result;
+}
+
+function viewSource(symbols, isCallback?) {
+  const result = nativeViewSource(symbols, isCallback);
+  if (Error.isError(result)) throw result;
   return result;
 }
 

--- a/src/js/bun/ffi.ts
+++ b/src/js/bun/ffi.ts
@@ -81,7 +81,9 @@ delete ffi.closeCallback;
 
 class JSCallback {
   constructor(cb, options) {
-    const { ctx, ptr } = nativeCallback(options, cb);
+    const result = nativeCallback(options, cb);
+    if (Error.isError(result)) throw result;
+    const { ctx, ptr } = result;
     this.#ctx = ctx;
     this.ptr = ptr;
     this.#threadsafe = !!options?.threadsafe;

--- a/test/js/bun/ffi/ffi-viewSource-non-object.test.ts
+++ b/test/js/bun/ffi/ffi-viewSource-non-object.test.ts
@@ -17,16 +17,14 @@ function thrown(fn: () => unknown): unknown {
 }
 
 describe.skipIf(isFFIUnavailable)("FFI viewSource", () => {
-  test("throws on non-object symbol descriptor values", () => {
-    // Each symbol descriptor must be an object like { args: [...], returns: "void" }.
-    // Previously, non-object values like numbers or strings would cause a debug
-    // assertion failure (crash) in generateSymbolForFunction; after that crash
-    // was fixed, viewSource returned the TypeError instead of throwing it.
-    for (const value of [42, "not_an_object", true] as const) {
-      const err = thrown(() => viewSource({ myFunc: value as any }));
-      expect(err).toBeInstanceOf(TypeError);
-      expect((err as TypeError).message).toContain("Expected an object");
-    }
+  // Each symbol descriptor must be an object like { args: [...], returns: "void" }.
+  // Previously, non-object values like numbers or strings would cause a debug
+  // assertion failure (crash) in generateSymbolForFunction; after that crash
+  // was fixed, viewSource returned the TypeError instead of throwing it.
+  test.each([42, "not_an_object", true])("throws on non-object symbol descriptor value %p", value => {
+    const err = thrown(() => viewSource({ myFunc: value as any }));
+    expect(err).toBeInstanceOf(TypeError);
+    expect((err as TypeError).message).toContain("Expected an object");
   });
 
   test("throws on an unknown FFI type", () => {
@@ -35,19 +33,15 @@ describe.skipIf(isFFIUnavailable)("FFI viewSource", () => {
     expect((err as TypeError).message).toContain("bogus_type");
   });
 
-  test("throws on a non-object options argument", () => {
-    for (const value of [null, undefined, 42] as const) {
-      const err = thrown(() => viewSource(value as any));
-      expect(err).toBeInstanceOf(TypeError);
-    }
+  test.each([null, undefined, 42])("throws on non-object options argument %p", value => {
+    const err = thrown(() => viewSource(value as any));
+    expect(err).toBeInstanceOf(TypeError);
   });
 
-  test("throws on a non-object callback descriptor", () => {
-    for (const value of [null, undefined, 42, "str"] as const) {
-      const err = thrown(() => viewSource(value as any, true));
-      expect(err).toBeInstanceOf(TypeError);
-      expect((err as TypeError).message).toContain("Expected an object");
-    }
+  test.each([null, undefined, 42, "str"])("throws on non-object callback descriptor %p", value => {
+    const err = thrown(() => viewSource(value as any, true));
+    expect(err).toBeInstanceOf(TypeError);
+    expect((err as TypeError).message).toContain("Expected an object");
   });
 
   test("returns the generated source for a valid descriptor", () => {

--- a/test/js/bun/ffi/ffi-viewSource-non-object.test.ts
+++ b/test/js/bun/ffi/ffi-viewSource-non-object.test.ts
@@ -1,16 +1,63 @@
+import { viewSource } from "bun:ffi";
 import { describe, expect, test } from "bun:test";
 import { isArm64, isWindows } from "harness";
 
 const isFFIUnavailable = isWindows && isArm64;
 
+// Captures what a call throws, or undefined if it returned normally. Written
+// explicitly so the assertions below distinguish a thrown Error from a
+// returned one regardless of toThrow()'s handling of returned Errors.
+function thrown(fn: () => unknown): unknown {
+  try {
+    fn();
+  } catch (e) {
+    return e;
+  }
+  return undefined;
+}
+
 describe.skipIf(isFFIUnavailable)("FFI viewSource", () => {
-  test("rejects non-object symbol descriptor values", () => {
-    // These should throw a TypeError because each symbol descriptor
-    // must be an object like { args: [...], returns: "void" }.
-    // Previously, non-object values like numbers or strings would
-    // cause a debug assertion failure (crash) in generateSymbolForFunction.
-    expect(() => Bun.FFI.viewSource({ myFunc: 42 })).toThrow("Expected an object");
-    expect(() => Bun.FFI.viewSource({ myFunc: "not_an_object" })).toThrow("Expected an object");
-    expect(() => Bun.FFI.viewSource({ myFunc: true })).toThrow("Expected an object");
+  test("throws on non-object symbol descriptor values", () => {
+    // Each symbol descriptor must be an object like { args: [...], returns: "void" }.
+    // Previously, non-object values like numbers or strings would cause a debug
+    // assertion failure (crash) in generateSymbolForFunction; after that crash
+    // was fixed, viewSource returned the TypeError instead of throwing it.
+    for (const value of [42, "not_an_object", true] as const) {
+      const err = thrown(() => viewSource({ myFunc: value as any }));
+      expect(err).toBeInstanceOf(TypeError);
+      expect((err as TypeError).message).toContain("Expected an object");
+    }
+  });
+
+  test("throws on an unknown FFI type", () => {
+    const err = thrown(() => viewSource({ foo: { args: ["bogus_type" as any], returns: "void" } }));
+    expect(err).toBeInstanceOf(TypeError);
+    expect((err as TypeError).message).toContain("bogus_type");
+  });
+
+  test("throws on a non-object options argument", () => {
+    for (const value of [null, undefined, 42] as const) {
+      const err = thrown(() => viewSource(value as any));
+      expect(err).toBeInstanceOf(TypeError);
+    }
+  });
+
+  test("throws on a non-object callback descriptor", () => {
+    for (const value of [null, undefined, 42, "str"] as const) {
+      const err = thrown(() => viewSource(value as any, true));
+      expect(err).toBeInstanceOf(TypeError);
+      expect((err as TypeError).message).toContain("Expected an object");
+    }
+  });
+
+  test("returns the generated source for a valid descriptor", () => {
+    const src = viewSource({ foo: { args: ["i32"], returns: "i32" } });
+    expect(src).toBeArray();
+    expect(src).toHaveLength(1);
+    expect(src[0]).toContain("JSFunctionCall");
+
+    const cbSrc = viewSource({ args: ["i32"], returns: "i32" }, true);
+    expect(typeof cbSrc).toBe("string");
+    expect(cbSrc).toContain("my_callback_function");
   });
 });

--- a/test/js/bun/ffi/ffi-viewSource-non-object.test.ts
+++ b/test/js/bun/ffi/ffi-viewSource-non-object.test.ts
@@ -1,4 +1,4 @@
-import { viewSource } from "bun:ffi";
+import { JSCallback, viewSource } from "bun:ffi";
 import { describe, expect, test } from "bun:test";
 import { isArm64, isWindows } from "harness";
 
@@ -17,10 +17,8 @@ function thrown(fn: () => unknown): unknown {
 }
 
 describe.skipIf(isFFIUnavailable)("FFI viewSource", () => {
-  // Each symbol descriptor must be an object like { args: [...], returns: "void" }.
-  // Previously, non-object values like numbers or strings would cause a debug
-  // assertion failure (crash) in generateSymbolForFunction; after that crash
-  // was fixed, viewSource returned the TypeError instead of throwing it.
+  // Descriptor values must be objects like { args: [...], returns: "void" }.
+  // https://github.com/oven-sh/bun/pull/28361, https://github.com/oven-sh/bun/pull/34396
   test.each([42, "not_an_object", true])("throws on non-object symbol descriptor value %p", value => {
     const err = thrown(() => viewSource({ myFunc: value as any }));
     expect(err).toBeInstanceOf(TypeError);
@@ -53,5 +51,31 @@ describe.skipIf(isFFIUnavailable)("FFI viewSource", () => {
     const cbSrc = viewSource({ args: ["i32"], returns: "i32" }, true);
     expect(typeof cbSrc).toBe("string");
     expect(cbSrc).toContain("my_callback_function");
+  });
+});
+
+describe.skipIf(isFFIUnavailable)("FFI JSCallback", () => {
+  test.each([null, undefined, 42, "str", true])("throws on non-object options %p", value => {
+    const err = thrown(() => new JSCallback(() => {}, value as any));
+    expect(err).toBeInstanceOf(TypeError);
+    expect((err as TypeError).message).toContain("Expected object");
+  });
+
+  test.each([null, undefined, 42, "str", {}])("throws on non-callable callback %p", value => {
+    const err = thrown(() => new JSCallback(value as any, { returns: "void" }));
+    expect(err).toBeInstanceOf(TypeError);
+    expect((err as TypeError).message).toContain("Expected callback function");
+  });
+
+  test("throws on an unknown FFI type", () => {
+    const err = thrown(() => new JSCallback(() => {}, { args: ["bogus_type" as any], returns: "void" }));
+    expect(err).toBeInstanceOf(TypeError);
+    expect((err as TypeError).message).toContain("bogus_type");
+  });
+
+  test("constructs with a valid descriptor", () => {
+    using cb = new JSCallback(() => {}, { args: ["i32"], returns: "void" });
+    expect(typeof cb.ptr).toBe("number");
+    expect(cb.ptr).not.toBe(0);
   });
 });


### PR DESCRIPTION
## What does this PR do?

`viewSource` from `bun:ffi` returned a `TypeError` instead of throwing it when the descriptor was invalid:

```js
import { viewSource } from "bun:ffi";

const result = viewSource({ myFunc: 42 });
result instanceof TypeError;  // true, returned not thrown
result.message;               // 'Expected an object for key "myFunc"'
```

`JSCallback` has the same bug: its constructor destructured the returned error, so validation failures produced a useless instance instead of throwing:

```js
import { JSCallback } from "bun:ffi";

const cb = new JSCallback(() => {}, 42);   // options must be an object
cb.ptr;                                    // undefined, no error surfaced
```

Both happen for every validation failure the native implementation reports: non-object descriptors, unknown FFI type names, a non-object options argument, and (for `JSCallback`) a non-callable callback.

### Cause

The native host functions on `Bun.FFI` return an `Error` instance as their value when validation fails; the `bun:ffi` module is expected to turn that into a throw. `dlopen`, `cc` and `linkSymbols` already do this with `if (Error.isError(result)) throw result;`, but `viewSource` was exported as a direct alias of the native function and `JSCallback` destructured the native result without checking it.

### Fix

Wrap `viewSource` and guard the `JSCallback` constructor the same way as the three existing siblings. The declared return type of `viewSource` in `packages/bun-types/ffi.d.ts` is `string[] | string`, which this now matches.

### Why this is correct

Matching `dlopen`/`cc`/`linkSymbols` keeps the `bun:ffi` module internally consistent, and it matches the typed contract. The low-level `Bun.FFI` object is left unchanged (it is not part of the typed public surface and `Bun.FFI.dlopen`/`Bun.FFI.linkSymbols` also return errors).

### How did you verify your code works?

Rewrote `test/js/bun/ffi/ffi-viewSource-non-object.test.ts` to assert the error is actually thrown (the old assertions only passed because `expect().toThrow()` currently accepts a returned Error, which #34392 tightens). Added `test.each` cases for `viewSource` (non-object descriptor, unknown type, non-object options, callback descriptor, valid input) and `JSCallback` (non-object options, non-callable callback, unknown type, valid input).

```
$ bun bd test test/js/bun/ffi/ffi-viewSource-non-object.test.ts
 24 pass  0 fail
```

22 of the 24 cases fail on an unfixed build (the two valid-input cases pass as expected). The full `test/js/bun/ffi/` suite is green and clean under `BUN_JSC_validateExceptionChecks=1`.

### Related

#34392 changes `toThrow()` to stop accepting a returned Error and rewrites this test to assert on the returned value as a stopgap. This PR is the actual fix; whichever lands second will need the test file reconciled.

#33200 touches `FFI::print`/`FFI::callback` for a different bug (propagating exceptions from descriptor getters) and still returns the validation error as a value, so the wrappers here cover both before and after that change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/ffi/ffi-viewSource-non-object.test.ts

<!-- robobun:evidence:end -->