### PR TITLE
node:http2: keep each session's corked frames on its own wire

### DIFF
--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -3441,6 +3441,15 @@ impl H2FrameParser {
     /// to the socket, so a multi-frame batch carries the already-corked bytes (e.g. the
     /// response HEADERS frame) in the same write.
     fn drain_cork_into(&self, out: &mut Vec<u8>) {
+        // CORK_BUFFER is thread-local across every session: only drain bytes we corked.
+        // send_data()'s multi-frame path reaches here without having called cork(), and
+        // prepending another session's corked frames to this one's batch sends them to
+        // the wrong peer. uncork() clears CORKED_H2 before calling this, so None passes.
+        if let Some(corked) = CORKED_H2.with(|c| c.get())
+            && !std::ptr::eq(corked, self.as_ctx_ptr())
+        {
+            return;
+        }
         let off = CORK_OFFSET.with(|c| c.get()) as usize;
         if off == 0 {
             return;

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3368,3 +3368,64 @@ it("Http2Stream pull-mode read() after pause() replenishes the receive window", 
     server.close();
   }
 });
+
+// The outbound cork buffer is thread-local across every Http2Session. Interleaving
+// respond()/write() across two sessions used to let the second session's corked
+// HEADERS be prepended to the first session's multi-frame DATA batch and sent to
+// the wrong peer: one client saw a foreign HEADERS frame, the other never saw its
+// own (test/js/web/fetch/fetch-backpressure.test.ts went intermittently red on
+// Windows CI once #32488 widened the interleaving window).
+it("http2 server sends each session's frames to its own peer under interleaved respond()/write()", async () => {
+  const BIG = Buffer.alloc(64 * 1024, 65);
+  const N = 10;
+  const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: false });
+  const streams = [];
+  const bothStreams = Promise.withResolvers();
+  server.on("stream", stream => {
+    stream.on("error", () => {});
+    streams.push(stream);
+    if (streams.length === 2) bothStreams.resolve();
+  });
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const results = Promise.all(
+      [0, 1].map(
+        i =>
+          new Promise(resolve => {
+            const client = http2.connect(`https://127.0.0.1:${server.address().port}`, TLS_OPTIONS);
+            client.on("error", e => resolve({ i, status: undefined, total: 0, err: String(e) }));
+            const req = client.request({ ":path": "/" });
+            let total = 0;
+            let status;
+            req.on("response", h => (status = h[":status"]));
+            req.on("data", c => (total += c.length));
+            req.on("end", () => {
+              client.close();
+              resolve({ i, status, total });
+            });
+            req.on("error", e => resolve({ i, status, total, err: String(e) }));
+            req.end();
+          }),
+      ),
+    );
+    await bothStreams.promise;
+    // A.respond() corks A's HEADERS; B.respond() force-uncorks A (to A's socket)
+    // then corks B's HEADERS. A.write(64KB) takes the multi-frame DATA path,
+    // which drains the thread-local cork: without the ownership check it pulls
+    // B's HEADERS into A's batch.
+    streams[0].respond({ ":status": 200 });
+    streams[1].respond({ ":status": 200 });
+    for (let k = 0; k < N; k++) {
+      streams[0].write(BIG);
+      streams[1].write(BIG);
+    }
+    streams[0].end();
+    streams[1].end();
+    expect(await results).toEqual([
+      { i: 0, status: 200, total: BIG.length * N },
+      { i: 1, status: 200, total: BIG.length * N },
+    ]);
+  } finally {
+    server.close();
+  }
+});

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3381,6 +3381,7 @@ it("http2 server sends each session's frames to its own peer under interleaved r
   const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: false });
   const streams = [];
   const bothStreams = Promise.withResolvers();
+  server.on("error", bothStreams.reject);
   server.on("stream", stream => {
     stream.on("error", () => {});
     streams.push(stream);
@@ -3392,18 +3393,22 @@ it("http2 server sends each session's frames to its own peer under interleaved r
       [0, 1].map(
         i =>
           new Promise(resolve => {
-            const client = http2.connect(`https://127.0.0.1:${server.address().port}`, TLS_OPTIONS);
-            client.on("error", e => resolve({ i, status: undefined, total: 0, err: String(e) }));
-            const req = client.request({ ":path": "/" });
             let total = 0;
             let status;
+            const fail = e => {
+              bothStreams.reject(e);
+              resolve({ i, status, total, err: String(e) });
+            };
+            const client = http2.connect(`https://127.0.0.1:${server.address().port}`, TLS_OPTIONS);
+            client.on("error", fail);
+            const req = client.request({ ":path": "/" });
             req.on("response", h => (status = h[":status"]));
             req.on("data", c => (total += c.length));
             req.on("end", () => {
               client.close();
               resolve({ i, status, total });
             });
-            req.on("error", e => resolve({ i, status, total, err: String(e) }));
+            req.on("error", fail);
             req.end();
           }),
       ),


### PR DESCRIPTION
Fixes `test/js/web/fetch/fetch-backpressure.test.ts` going red on Windows CI (first seen in build [74048](https://buildkite.com/bun/bun/builds/74048)).

## Repro

Connect two TLS clients to one `http2.createSecureServer`, then interleave:

```js
streams[0].respond({ ':status': 200 }); // A corks A's HEADERS
streams[1].respond({ ':status': 200 }); // B.cork() force-uncorks A, corks B's HEADERS
streams[0].write(Buffer.alloc(64 * 1024)); // A's multi-frame DATA path drains B's HEADERS onto A's socket
```

On main, client B never receives its `:status` (its HEADERS went to A instead). On Windows, client A additionally errors with `NGHTTP2_PROTOCOL_ERROR` / `HTTP2ProtocolError`. Reproduces deterministically on every platform.

## Cause

`CORK_BUFFER` is a thread-local shared by every `H2FrameParser` on the JS thread; `CORKED_H2` names the current owner. `cork()` takes the slot (force-uncorking any prior owner to that owner's socket) and `uncork()` / `flush_cork_buffer()` only drain it when the caller owns the slot.

`send_data()`'s multi-frame path (payload larger than one DATA frame) was the one `drain_cork_into()` caller that never checked `CORKED_H2`: it blindly pulled whatever was in `CORK_BUFFER` into its own batch and wrote it to its own socket. When that happened to be another session's corked HEADERS, the wrong peer received it.

The missing check was introduced together with the batched write path in #31584. #32488 is what surfaced it in `fetch-backpressure.test.ts`: once Http2Stream write callbacks defer to `process.nextTick`, one session's `'drain'` write can run while another session's inbound dispatch still owns the cork.

## Fix

`drain_cork_into()` now early-returns when `CORKED_H2` is set to a different parser, matching the existing guard in `uncork()`. `uncork()` clears `CORKED_H2` to `None` before calling `drain_cork_into()`, so the `None` case passes through unchanged. The foreign owner's bytes stay in place for its own `auto_flush` / next `cork()` handover to send.

## Verification

New test in `test/js/node/http2/node-http2.test.js` fails on main (client 1 has `status: undefined`) and passes with the fix, on both Linux and Windows. The Windows-only `fetch-backpressure.test.ts` h2 cases now pass 360/360 concurrent iterations where they previously failed ~25% of the time.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/fetch-backpressure.test.ts

<!-- robobun:evidence:end -->