### PR TITLE
process.report: validate arguments and embed user error in getReport()

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -2108,14 +2108,18 @@ JSValue constructReportJavaScriptStack(VM& vm, Zig::GlobalObject* globalObject, 
     WTF::String stackString;
     bool haveErrorObject = errorValue.isObject();
     if (haveErrorObject) {
+        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         auto* errorObject = errorValue.getObject();
         JSValue stackValue = errorObject->get(globalObject, vm.propertyNames->stack);
-        RETURN_IF_EXCEPTION(scope, {});
-        if (stackValue.isString()) {
-            stackString = stackValue.toWTFString(globalObject);
-            RETURN_IF_EXCEPTION(scope, {});
+        if (!catchScope.clearExceptionExceptTermination()) [[unlikely]]
+            return {};
+        if (stackValue && stackValue.isString()) {
+            stackString = asString(stackValue)->value(globalObject);
+            if (!catchScope.clearExceptionExceptTermination()) [[unlikely]]
+                return {};
         }
     }
+    RETURN_IF_EXCEPTION(scope, {});
 
     if (haveErrorObject && stackString.isNull()) {
         javascriptStack->putDirect(vm, vm.propertyNames->message, JSC::jsString(vm, String("No stack."_s)), 0);
@@ -2163,19 +2167,30 @@ JSValue constructReportJavaScriptStack(VM& vm, Zig::GlobalObject* globalObject, 
     }
 
     if (haveErrorObject) {
+        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         auto* errorObject = errorValue.getObject();
         JSC::PropertyNameArrayBuilder names(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
         errorObject->methodTable()->getOwnPropertyNames(errorObject, globalObject, names, DontEnumPropertiesMode::Exclude);
-        RETURN_IF_EXCEPTION(scope, {});
+        if (!catchScope.clearExceptionExceptTermination()) [[unlikely]]
+            return {};
         for (const auto& name : names) {
             if (name == vm.propertyNames->stack || name == vm.propertyNames->message) continue;
             JSValue v = errorObject->get(globalObject, name);
-            RETURN_IF_EXCEPTION(scope, {});
+            if (catchScope.exception()) {
+                if (!catchScope.clearExceptionExceptTermination()) [[unlikely]]
+                    return {};
+                continue;
+            }
             JSString* str = v.toString(globalObject);
-            RETURN_IF_EXCEPTION(scope, {});
+            if (catchScope.exception()) {
+                if (!catchScope.clearExceptionExceptTermination()) [[unlikely]]
+                    return {};
+                continue;
+            }
             errorProperties->putDirect(vm, name, str, 0);
         }
     }
+    RETURN_IF_EXCEPTION(scope, {});
 
     javascriptStack->putDirect(vm, JSC::Identifier::fromString(vm, "errorProperties"_s), errorProperties, 0);
     return javascriptStack;
@@ -2642,6 +2657,7 @@ static JSValue constructProcessReportObject(VM& vm, JSObject* processObject)
 
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     auto* report = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 11);
+    RETURN_IF_EXCEPTION(scope, {});
 
     unsigned accessorAttrs = PropertyAttribute::CustomAccessor | 0;
     report->putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "compact"_s), JSC::CustomGetterSetter::create(vm, processReport_getCompact, processReport_setCompact), accessorAttrs);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -2175,6 +2175,7 @@ JSValue constructReportJavaScriptStack(VM& vm, Zig::GlobalObject* globalObject, 
             return {};
         for (const auto& name : names) {
             if (name == vm.propertyNames->stack || name == vm.propertyNames->message) continue;
+            if (parseIndex(name)) continue;
             JSValue v = errorObject->get(globalObject, name);
             if (catchScope.exception()) {
                 if (!catchScope.clearExceptionExceptTermination()) [[unlikely]]
@@ -2543,8 +2544,9 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionGetReport, (JSGlobalObject * globalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue err = callFrame->argument(0);
-    if (!err.isUndefined() && (err.isNull() || !err.isObject())) {
-        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "err"_s, "Object"_s, err);
+    if (!err.isUndefined()) {
+        Bun::V::validateObject(scope, globalObject, err, "err"_s);
+        RETURN_IF_EXCEPTION(scope, {});
     }
 
     RELEASE_AND_RETURN(scope, JSValue::encode(constructReportObjectComplete(vm, defaultGlobalObject(globalObject), String(), err)));
@@ -2558,7 +2560,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionWriteReport, (JSGlobalObject * globalOb
     JSValue file = callFrame->argument(0);
     JSValue err = callFrame->argument(1);
 
-    if (!file.isNull() && file.isObject()) {
+    if (!file.isNull() && file.isObject() && !file.isCallable()) {
         err = file;
         file = jsUndefined();
     } else if (!file.isUndefined()) {
@@ -2566,8 +2568,9 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionWriteReport, (JSGlobalObject * globalOb
         RETURN_IF_EXCEPTION(scope, {});
     }
 
-    if (!err.isUndefined() && (err.isNull() || !err.isObject())) {
-        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "err"_s, "Object"_s, err);
+    if (!err.isUndefined()) {
+        Bun::V::validateObject(scope, globalObject, err, "err"_s);
+        RETURN_IF_EXCEPTION(scope, {});
     }
 
     return JSValue::encode(file);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -2500,8 +2500,9 @@ static JSValue constructReportObjectComplete(VM& vm, Zig::GlobalObject* globalOb
 
         report->putDirect(vm, JSC::Identifier::fromString(vm, "header"_s), constructHeader(), 0);
         RETURN_IF_EXCEPTION(scope, {});
-        report->putDirect(vm, JSC::Identifier::fromString(vm, "javascriptStack"_s), constructReportJavaScriptStack(vm, globalObject, errorValue), 0);
+        JSValue javascriptStack = constructReportJavaScriptStack(vm, globalObject, errorValue);
         RETURN_IF_EXCEPTION(scope, {});
+        report->putDirect(vm, JSC::Identifier::fromString(vm, "javascriptStack"_s), javascriptStack, 0);
         report->putDirect(vm, JSC::Identifier::fromString(vm, "javascriptHeap"_s), constructJavaScriptHeap(), 0);
         RETURN_IF_EXCEPTION(scope, {});
         report->putDirect(vm, JSC::Identifier::fromString(vm, "nativeStack"_s), constructNativeStack(), 0);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1055,6 +1055,7 @@ static const NeverDestroyed<String>* getSignalNames()
 
     return signalNames;
 }
+static constexpr size_t numSignalNames = 32;
 
 static void loadSignalNumberMap()
 {
@@ -2642,9 +2643,19 @@ JSC_DEFINE_CUSTOM_SETTER(processReport_setSignal, (JSC::JSGlobalObject * globalO
     RETURN_IF_EXCEPTION(scope, false);
     WTF::String str = value.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, false);
-    if (!isSignalName(str)) {
+    // Validate against the full known-name table rather than signalNameToNumberMap; on
+    // Windows the latter only contains the seven libuv-registerable console signals, which
+    // would reject the "SIGUSR2" default that Node (via os.constants.signals) accepts.
+    auto isKnownName = [](const WTF::String& s) {
+        auto signalNames = getSignalNames();
+        for (size_t i = 0; i < numSignalNames; i++) {
+            if (s == signalNames[i]) return true;
+        }
+        return false;
+    };
+    if (!isKnownName(str)) {
         WTF::String upper = str.convertToUppercaseWithoutLocale();
-        if (isSignalName(upper)) {
+        if (isKnownName(upper)) {
             Bun::ERR::UNKNOWN_SIGNAL(scope, globalObject, value, true);
         } else {
             Bun::ERR::UNKNOWN_SIGNAL(scope, globalObject, value);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -2558,41 +2558,41 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionWriteReport, (JSGlobalObject * globalOb
     return JSValue::encode(file);
 }
 
-#define DEFINE_REPORT_BOOLEAN_ACCESSOR(fnName, field, argName)                                                                                                           \
-    JSC_DEFINE_CUSTOM_GETTER(processReport_get##fnName, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))                          \
-    {                                                                                                                                                                    \
-        auto* process = uncheckedDowncast<Zig::GlobalObject>(globalObject)->processObject();                                                                             \
-        return JSValue::encode(jsBoolean(process->field));                                                                                                               \
-    }                                                                                                                                                                    \
+#define DEFINE_REPORT_BOOLEAN_ACCESSOR(fnName, field, argName)                                                                                                                    \
+    JSC_DEFINE_CUSTOM_GETTER(processReport_get##fnName, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))                                   \
+    {                                                                                                                                                                             \
+        auto* process = uncheckedDowncast<Zig::GlobalObject>(globalObject)->processObject();                                                                                      \
+        return JSValue::encode(jsBoolean(process->field));                                                                                                                        \
+    }                                                                                                                                                                             \
     JSC_DEFINE_CUSTOM_SETTER(processReport_set##fnName, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, JSC::PropertyName)) \
-    {                                                                                                                                                                    \
-        auto& vm = JSC::getVM(globalObject);                                                                                                                             \
-        auto scope = DECLARE_THROW_SCOPE(vm);                                                                                                                            \
-        JSValue value = JSValue::decode(encodedValue);                                                                                                                   \
-        Bun::V::validateBoolean(scope, globalObject, value, argName);                                                                                                    \
-        RETURN_IF_EXCEPTION(scope, false);                                                                                                                               \
-        uncheckedDowncast<Zig::GlobalObject>(globalObject)->processObject()->field = value.asBoolean();                                                                  \
-        return true;                                                                                                                                                     \
+    {                                                                                                                                                                             \
+        auto& vm = JSC::getVM(globalObject);                                                                                                                                      \
+        auto scope = DECLARE_THROW_SCOPE(vm);                                                                                                                                     \
+        JSValue value = JSValue::decode(encodedValue);                                                                                                                            \
+        Bun::V::validateBoolean(scope, globalObject, value, argName);                                                                                                             \
+        RETURN_IF_EXCEPTION(scope, false);                                                                                                                                        \
+        uncheckedDowncast<Zig::GlobalObject>(globalObject)->processObject()->field = value.asBoolean();                                                                           \
+        return true;                                                                                                                                                              \
     }
 
-#define DEFINE_REPORT_STRING_ACCESSOR(fnName, field, argName)                                                                                                            \
-    JSC_DEFINE_CUSTOM_GETTER(processReport_get##fnName, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))                          \
-    {                                                                                                                                                                    \
-        auto& vm = JSC::getVM(globalObject);                                                                                                                             \
-        auto* process = uncheckedDowncast<Zig::GlobalObject>(globalObject)->processObject();                                                                             \
-        return JSValue::encode(jsString(vm, process->field));                                                                                                            \
-    }                                                                                                                                                                    \
+#define DEFINE_REPORT_STRING_ACCESSOR(fnName, field, argName)                                                                                                                     \
+    JSC_DEFINE_CUSTOM_GETTER(processReport_get##fnName, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))                                   \
+    {                                                                                                                                                                             \
+        auto& vm = JSC::getVM(globalObject);                                                                                                                                      \
+        auto* process = uncheckedDowncast<Zig::GlobalObject>(globalObject)->processObject();                                                                                      \
+        return JSValue::encode(jsString(vm, process->field));                                                                                                                     \
+    }                                                                                                                                                                             \
     JSC_DEFINE_CUSTOM_SETTER(processReport_set##fnName, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, JSC::PropertyName)) \
-    {                                                                                                                                                                    \
-        auto& vm = JSC::getVM(globalObject);                                                                                                                             \
-        auto scope = DECLARE_THROW_SCOPE(vm);                                                                                                                            \
-        JSValue value = JSValue::decode(encodedValue);                                                                                                                   \
-        Bun::V::validateString(scope, globalObject, value, argName);                                                                                                     \
-        RETURN_IF_EXCEPTION(scope, false);                                                                                                                               \
-        WTF::String str = value.toWTFString(globalObject);                                                                                                               \
-        RETURN_IF_EXCEPTION(scope, false);                                                                                                                               \
-        uncheckedDowncast<Zig::GlobalObject>(globalObject)->processObject()->field = str;                                                                                \
-        return true;                                                                                                                                                     \
+    {                                                                                                                                                                             \
+        auto& vm = JSC::getVM(globalObject);                                                                                                                                      \
+        auto scope = DECLARE_THROW_SCOPE(vm);                                                                                                                                     \
+        JSValue value = JSValue::decode(encodedValue);                                                                                                                            \
+        Bun::V::validateString(scope, globalObject, value, argName);                                                                                                              \
+        RETURN_IF_EXCEPTION(scope, false);                                                                                                                                        \
+        WTF::String str = value.toWTFString(globalObject);                                                                                                                        \
+        RETURN_IF_EXCEPTION(scope, false);                                                                                                                                        \
+        uncheckedDowncast<Zig::GlobalObject>(globalObject)->processObject()->field = str;                                                                                         \
+        return true;                                                                                                                                                              \
     }
 
 DEFINE_REPORT_BOOLEAN_ACCESSOR(Compact, m_reportCompact, "compact"_s)

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -2547,7 +2547,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionGetReport, (JSGlobalObject * globalObje
         return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "err"_s, "Object"_s, err);
     }
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(constructReportObjectComplete(vm, uncheckedDowncast<Zig::GlobalObject>(globalObject), String(), err)));
+    RELEASE_AND_RETURN(scope, JSValue::encode(constructReportObjectComplete(vm, defaultGlobalObject(globalObject), String(), err)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(Process_functionWriteReport, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
@@ -2576,7 +2576,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionWriteReport, (JSGlobalObject * globalOb
 #define DEFINE_REPORT_BOOLEAN_ACCESSOR(fnName, field, argName)                                                                                                                    \
     JSC_DEFINE_CUSTOM_GETTER(processReport_get##fnName, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))                                   \
     {                                                                                                                                                                             \
-        auto* process = uncheckedDowncast<Zig::GlobalObject>(globalObject)->processObject();                                                                                      \
+        auto* process = defaultGlobalObject(globalObject)->processObject();                                                                                                       \
         return JSValue::encode(jsBoolean(process->field));                                                                                                                        \
     }                                                                                                                                                                             \
     JSC_DEFINE_CUSTOM_SETTER(processReport_set##fnName, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, JSC::PropertyName)) \
@@ -2586,7 +2586,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionWriteReport, (JSGlobalObject * globalOb
         JSValue value = JSValue::decode(encodedValue);                                                                                                                            \
         Bun::V::validateBoolean(scope, globalObject, value, argName);                                                                                                             \
         RETURN_IF_EXCEPTION(scope, false);                                                                                                                                        \
-        uncheckedDowncast<Zig::GlobalObject>(globalObject)->processObject()->field = value.asBoolean();                                                                           \
+        defaultGlobalObject(globalObject)->processObject()->field = value.asBoolean();                                                                                            \
         return true;                                                                                                                                                              \
     }
 
@@ -2594,7 +2594,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionWriteReport, (JSGlobalObject * globalOb
     JSC_DEFINE_CUSTOM_GETTER(processReport_get##fnName, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))                                   \
     {                                                                                                                                                                             \
         auto& vm = JSC::getVM(globalObject);                                                                                                                                      \
-        auto* process = uncheckedDowncast<Zig::GlobalObject>(globalObject)->processObject();                                                                                      \
+        auto* process = defaultGlobalObject(globalObject)->processObject();                                                                                                       \
         return JSValue::encode(jsString(vm, process->field));                                                                                                                     \
     }                                                                                                                                                                             \
     JSC_DEFINE_CUSTOM_SETTER(processReport_set##fnName, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, JSC::PropertyName)) \
@@ -2606,7 +2606,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionWriteReport, (JSGlobalObject * globalOb
         RETURN_IF_EXCEPTION(scope, false);                                                                                                                                        \
         WTF::String str = value.toWTFString(globalObject);                                                                                                                        \
         RETURN_IF_EXCEPTION(scope, false);                                                                                                                                        \
-        uncheckedDowncast<Zig::GlobalObject>(globalObject)->processObject()->field = str;                                                                                         \
+        defaultGlobalObject(globalObject)->processObject()->field = str;                                                                                                          \
         return true;                                                                                                                                                              \
     }
 
@@ -2625,7 +2625,7 @@ DEFINE_REPORT_STRING_ACCESSOR(Filename, m_reportFilename, "filename"_s)
 JSC_DEFINE_CUSTOM_GETTER(processReport_getSignal, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
 {
     auto& vm = JSC::getVM(globalObject);
-    auto* process = uncheckedDowncast<Zig::GlobalObject>(globalObject)->processObject();
+    auto* process = defaultGlobalObject(globalObject)->processObject();
     return JSValue::encode(jsString(vm, process->m_reportSignal));
 }
 
@@ -2647,7 +2647,7 @@ JSC_DEFINE_CUSTOM_SETTER(processReport_setSignal, (JSC::JSGlobalObject * globalO
         }
         return false;
     }
-    uncheckedDowncast<Zig::GlobalObject>(globalObject)->processObject()->m_reportSignal = str;
+    defaultGlobalObject(globalObject)->processObject()->m_reportSignal = str;
     return true;
 }
 

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -42,6 +42,7 @@
 #include <sys/stat.h>
 #include "ConsoleObject.h"
 #include <JavaScriptCore/GetterSetter.h>
+#include <JavaScriptCore/CustomGetterSetter.h>
 #include <JavaScriptCore/JSSet.h>
 #include <JavaScriptCore/LazyProperty.h>
 #include <JavaScriptCore/LazyPropertyInlines.h>
@@ -2094,7 +2095,93 @@ JSC_DEFINE_CUSTOM_SETTER(setProcessConnected, (JSC::JSGlobalObject * lexicalGlob
     return false;
 }
 
-static JSValue constructReportObjectComplete(VM& vm, Zig::GlobalObject* globalObject, const String& fileName)
+JSValue constructReportJavaScriptStack(VM& vm, Zig::GlobalObject* globalObject, JSValue errorValue)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSC::JSObject* javascriptStack = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 3);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    JSC::JSObject* errorProperties = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 1);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    WTF::String stackString;
+    bool haveErrorObject = errorValue.isObject();
+    if (haveErrorObject) {
+        auto* errorObject = errorValue.getObject();
+        JSValue stackValue = errorObject->get(globalObject, vm.propertyNames->stack);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (stackValue.isString()) {
+            stackString = stackValue.toWTFString(globalObject);
+            RETURN_IF_EXCEPTION(scope, {});
+        }
+    }
+
+    if (haveErrorObject && stackString.isNull()) {
+        javascriptStack->putDirect(vm, vm.propertyNames->message, JSC::jsString(vm, String("No stack."_s)), 0);
+        JSC::JSArray* stackArray = JSC::constructEmptyArray(globalObject, nullptr);
+        RETURN_IF_EXCEPTION(scope, {});
+        stackArray->push(globalObject, JSC::jsString(vm, String("Unavailable."_s)));
+        RETURN_IF_EXCEPTION(scope, {});
+        javascriptStack->putDirect(vm, vm.propertyNames->stack, stackArray, 0);
+        javascriptStack->putDirect(vm, JSC::Identifier::fromString(vm, "errorProperties"_s), errorProperties, 0);
+        return javascriptStack;
+    }
+
+    if (!haveErrorObject) {
+        WTF::Vector<JSC::StackFrame> stackFrames;
+        vm.interpreter.getStackTrace(javascriptStack, stackFrames, 1);
+        String name = "Error"_s;
+        String msg = "JavaScript Callstack"_s;
+        OrdinalNumber line = OrdinalNumber::beforeFirst();
+        OrdinalNumber column = OrdinalNumber::beforeFirst();
+        WTF::String sourceURL;
+        stackString = Bun::formatStackTrace(
+            vm, globalObject, globalObject, name, msg,
+            line, column,
+            sourceURL, stackFrames, nullptr);
+        javascriptStack->putDirect(vm, vm.propertyNames->message, JSC::jsString(vm, String("Error [ERR_SYNTHETIC]: JavaScript Callstack"_s)), 0);
+        errorProperties->putDirect(vm, JSC::Identifier::fromString(vm, "code"_s), JSC::jsString(vm, String("ERR_SYNTHETIC"_s)), 0);
+    }
+
+    size_t firstNewline = stackString.find('\n');
+    if (haveErrorObject) {
+        WTF::String messageLine = firstNewline == WTF::notFound ? stackString : stackString.substring(0, firstNewline);
+        javascriptStack->putDirect(vm, vm.propertyNames->message, JSC::jsString(vm, messageLine), 0);
+    }
+
+    if (firstNewline != WTF::notFound) {
+        JSC::JSArray* stackArray = JSC::constructEmptyArray(globalObject, nullptr);
+        RETURN_IF_EXCEPTION(scope, {});
+        WTF::String rest = stackString.substring(firstNewline + 1);
+        rest.split('\n', [&](const WTF::StringView& line) {
+            stackArray->push(globalObject, JSC::jsString(vm, line.toString().trim(isASCIIWhitespace)));
+            RETURN_IF_EXCEPTION(scope, );
+        });
+        RETURN_IF_EXCEPTION(scope, {});
+        javascriptStack->putDirect(vm, vm.propertyNames->stack, stackArray, 0);
+    }
+
+    if (haveErrorObject) {
+        auto* errorObject = errorValue.getObject();
+        JSC::PropertyNameArrayBuilder names(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
+        errorObject->methodTable()->getOwnPropertyNames(errorObject, globalObject, names, DontEnumPropertiesMode::Exclude);
+        RETURN_IF_EXCEPTION(scope, {});
+        for (const auto& name : names) {
+            if (name == vm.propertyNames->stack || name == vm.propertyNames->message) continue;
+            JSValue v = errorObject->get(globalObject, name);
+            RETURN_IF_EXCEPTION(scope, {});
+            JSString* str = v.toString(globalObject);
+            RETURN_IF_EXCEPTION(scope, {});
+            errorProperties->putDirect(vm, name, str, 0);
+        }
+    }
+
+    javascriptStack->putDirect(vm, JSC::Identifier::fromString(vm, "errorProperties"_s), errorProperties, 0);
+    return javascriptStack;
+}
+
+static JSValue constructReportObjectComplete(VM& vm, Zig::GlobalObject* globalObject, const String& fileName, JSValue errorValue)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 #if !OS(WINDOWS)
@@ -2333,52 +2420,6 @@ static JSValue constructReportObjectComplete(VM& vm, Zig::GlobalObject* globalOb
         return uvthreadResourceUsage;
     };
 
-    auto constructJavaScriptStack = [&]() -> JSC::JSValue {
-        JSC::JSObject* javascriptStack = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 3);
-        RETURN_IF_EXCEPTION(scope, {});
-
-        javascriptStack->putDirect(vm, vm.propertyNames->message, JSC::jsString(vm, String("Error [ERR_SYNTHETIC]: JavaScript Callstack"_s)), 0);
-
-        // TODO: allow errors as an argument
-        {
-            WTF::Vector<JSC::StackFrame> stackFrames;
-            vm.interpreter.getStackTrace(javascriptStack, stackFrames, 1);
-            String name = "Error"_s;
-            String message = "JavaScript Callstack"_s;
-            OrdinalNumber line = OrdinalNumber::beforeFirst();
-            OrdinalNumber column = OrdinalNumber::beforeFirst();
-            WTF::String sourceURL;
-            WTF::String stackProperty = Bun::formatStackTrace(
-                vm, globalObject, globalObject, name, message,
-                line, column,
-                sourceURL, stackFrames, nullptr);
-
-            WTF::String stack;
-            // first line after "Error:"
-            size_t firstLine = stackProperty.find('\n');
-            if (firstLine != WTF::notFound) {
-                stack = stackProperty.substring(firstLine + 1);
-            }
-
-            JSC::JSArray* stackArray = JSC::constructEmptyArray(globalObject, nullptr);
-            RETURN_IF_EXCEPTION(scope, {});
-
-            stack.split('\n', [&](const WTF::StringView& line) {
-                stackArray->push(globalObject, JSC::jsString(vm, line.toString().trim(isASCIIWhitespace)));
-                RETURN_IF_EXCEPTION(scope, );
-            });
-            RETURN_IF_EXCEPTION(scope, {});
-
-            javascriptStack->putDirect(vm, vm.propertyNames->stack, stackArray, 0);
-        }
-
-        JSC::JSObject* errorProperties = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 1);
-        RETURN_IF_EXCEPTION(scope, {});
-        errorProperties->putDirect(vm, JSC::Identifier::fromString(vm, "code"_s), JSC::jsString(vm, String("ERR_SYNTHETIC"_s)), 0);
-        javascriptStack->putDirect(vm, JSC::Identifier::fromString(vm, "errorProperties"_s), errorProperties, 0);
-        return javascriptStack;
-    };
-
     auto constructSharedObjects = [&]() -> JSC::JSValue {
         JSC::JSObject* sharedObjects = JSC::constructEmptyArray(globalObject, nullptr);
         RETURN_IF_EXCEPTION(scope, {});
@@ -2443,7 +2484,7 @@ static JSValue constructReportObjectComplete(VM& vm, Zig::GlobalObject* globalOb
 
         report->putDirect(vm, JSC::Identifier::fromString(vm, "header"_s), constructHeader(), 0);
         RETURN_IF_EXCEPTION(scope, {});
-        report->putDirect(vm, JSC::Identifier::fromString(vm, "javascriptStack"_s), constructJavaScriptStack(), 0);
+        report->putDirect(vm, JSC::Identifier::fromString(vm, "javascriptStack"_s), constructReportJavaScriptStack(vm, globalObject, errorValue), 0);
         RETURN_IF_EXCEPTION(scope, {});
         report->putDirect(vm, JSC::Identifier::fromString(vm, "javascriptHeap"_s), constructJavaScriptHeap(), 0);
         RETURN_IF_EXCEPTION(scope, {});
@@ -2472,47 +2513,148 @@ static JSValue constructReportObjectComplete(VM& vm, Zig::GlobalObject* globalOb
     }
 #else // OS(WINDOWS)
     // Forward declaration - implemented in BunProcessReportObjectWindows.cpp
-    JSValue constructReportObjectWindows(VM & vm, Zig::GlobalObject * globalObject, Process * process);
+    JSValue constructReportObjectWindows(VM & vm, Zig::GlobalObject * globalObject, Process * process, JSValue errorValue);
 
     // Get the Process object - needed for accessing report settings
     Process* process = globalObject->processObject();
 
-    return constructReportObjectWindows(vm, globalObject, process);
+    return constructReportObjectWindows(vm, globalObject, process, errorValue);
 #endif
 }
 
 JSC_DEFINE_HOST_FUNCTION(Process_functionGetReport, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
-    // TODO: node:vm
-    return JSValue::encode(constructReportObjectComplete(vm, uncheckedDowncast<Zig::GlobalObject>(globalObject), String()));
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue err = callFrame->argument(0);
+    if (!err.isUndefined() && (err.isNull() || !err.isObject())) {
+        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "err"_s, "Object"_s, err);
+    }
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(constructReportObjectComplete(vm, uncheckedDowncast<Zig::GlobalObject>(globalObject), String(), err)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(Process_functionWriteReport, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    // TODO:
-    return JSValue::encode(callFrame->argument(0));
+
+    JSValue file = callFrame->argument(0);
+    JSValue err = callFrame->argument(1);
+
+    if (!file.isNull() && file.isObject()) {
+        err = file;
+        file = jsUndefined();
+    } else if (!file.isUndefined()) {
+        Bun::V::validateString(scope, globalObject, file, "file"_s);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+
+    if (!err.isUndefined() && (err.isNull() || !err.isObject())) {
+        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "err"_s, "Object"_s, err);
+    }
+
+    return JSValue::encode(file);
+}
+
+#define DEFINE_REPORT_BOOLEAN_ACCESSOR(fnName, field, argName)                                                                                                           \
+    JSC_DEFINE_CUSTOM_GETTER(processReport_get##fnName, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))                          \
+    {                                                                                                                                                                    \
+        auto* process = uncheckedDowncast<Zig::GlobalObject>(globalObject)->processObject();                                                                             \
+        return JSValue::encode(jsBoolean(process->field));                                                                                                               \
+    }                                                                                                                                                                    \
+    JSC_DEFINE_CUSTOM_SETTER(processReport_set##fnName, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, JSC::PropertyName)) \
+    {                                                                                                                                                                    \
+        auto& vm = JSC::getVM(globalObject);                                                                                                                             \
+        auto scope = DECLARE_THROW_SCOPE(vm);                                                                                                                            \
+        JSValue value = JSValue::decode(encodedValue);                                                                                                                   \
+        Bun::V::validateBoolean(scope, globalObject, value, argName);                                                                                                    \
+        RETURN_IF_EXCEPTION(scope, false);                                                                                                                               \
+        uncheckedDowncast<Zig::GlobalObject>(globalObject)->processObject()->field = value.asBoolean();                                                                  \
+        return true;                                                                                                                                                     \
+    }
+
+#define DEFINE_REPORT_STRING_ACCESSOR(fnName, field, argName)                                                                                                            \
+    JSC_DEFINE_CUSTOM_GETTER(processReport_get##fnName, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))                          \
+    {                                                                                                                                                                    \
+        auto& vm = JSC::getVM(globalObject);                                                                                                                             \
+        auto* process = uncheckedDowncast<Zig::GlobalObject>(globalObject)->processObject();                                                                             \
+        return JSValue::encode(jsString(vm, process->field));                                                                                                            \
+    }                                                                                                                                                                    \
+    JSC_DEFINE_CUSTOM_SETTER(processReport_set##fnName, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, JSC::PropertyName)) \
+    {                                                                                                                                                                    \
+        auto& vm = JSC::getVM(globalObject);                                                                                                                             \
+        auto scope = DECLARE_THROW_SCOPE(vm);                                                                                                                            \
+        JSValue value = JSValue::decode(encodedValue);                                                                                                                   \
+        Bun::V::validateString(scope, globalObject, value, argName);                                                                                                     \
+        RETURN_IF_EXCEPTION(scope, false);                                                                                                                               \
+        WTF::String str = value.toWTFString(globalObject);                                                                                                               \
+        RETURN_IF_EXCEPTION(scope, false);                                                                                                                               \
+        uncheckedDowncast<Zig::GlobalObject>(globalObject)->processObject()->field = str;                                                                                \
+        return true;                                                                                                                                                     \
+    }
+
+DEFINE_REPORT_BOOLEAN_ACCESSOR(Compact, m_reportCompact, "compact"_s)
+DEFINE_REPORT_BOOLEAN_ACCESSOR(ReportOnFatalError, m_reportOnFatalError, "trigger"_s)
+DEFINE_REPORT_BOOLEAN_ACCESSOR(ReportOnSignal, m_reportOnSignal, "trigger"_s)
+DEFINE_REPORT_BOOLEAN_ACCESSOR(ReportOnUncaughtException, m_reportReportOnUncaughtException, "trigger"_s)
+DEFINE_REPORT_BOOLEAN_ACCESSOR(ExcludeEnv, m_reportExcludeEnv, "excludeEnv"_s)
+DEFINE_REPORT_BOOLEAN_ACCESSOR(ExcludeNetwork, m_reportExcludeNetwork, "excludeNetwork"_s)
+DEFINE_REPORT_STRING_ACCESSOR(Directory, m_reportDirectory, "directory"_s)
+DEFINE_REPORT_STRING_ACCESSOR(Filename, m_reportFilename, "filename"_s)
+
+#undef DEFINE_REPORT_BOOLEAN_ACCESSOR
+#undef DEFINE_REPORT_STRING_ACCESSOR
+
+JSC_DEFINE_CUSTOM_GETTER(processReport_getSignal, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto* process = uncheckedDowncast<Zig::GlobalObject>(globalObject)->processObject();
+    return JSValue::encode(jsString(vm, process->m_reportSignal));
+}
+
+JSC_DEFINE_CUSTOM_SETTER(processReport_setSignal, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, JSC::PropertyName))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue value = JSValue::decode(encodedValue);
+    Bun::V::validateString(scope, globalObject, value, "signal"_s);
+    RETURN_IF_EXCEPTION(scope, false);
+    WTF::String str = value.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, false);
+    if (!isSignalName(str)) {
+        WTF::String upper = str.convertToUppercaseWithoutLocale();
+        if (isSignalName(upper)) {
+            Bun::ERR::UNKNOWN_SIGNAL(scope, globalObject, value, true);
+        } else {
+            Bun::ERR::UNKNOWN_SIGNAL(scope, globalObject, value);
+        }
+        return false;
+    }
+    uncheckedDowncast<Zig::GlobalObject>(globalObject)->processObject()->m_reportSignal = str;
+    return true;
 }
 
 static JSValue constructProcessReportObject(VM& vm, JSObject* processObject)
 {
     auto* globalObject = processObject->globalObject();
-    auto process = uncheckedDowncast<Process>(processObject);
 
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-    auto* report = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 10);
-    report->putDirect(vm, JSC::Identifier::fromString(vm, "compact"_s), JSC::jsBoolean(false), 0);
-    report->putDirect(vm, JSC::Identifier::fromString(vm, "directory"_s), JSC::jsEmptyString(vm), 0);
-    report->putDirect(vm, JSC::Identifier::fromString(vm, "filename"_s), JSC::jsEmptyString(vm), 0);
-    report->putDirect(vm, JSC::Identifier::fromString(vm, "getReport"_s), JSC::JSFunction::create(vm, globalObject, 0, String("getReport"_s), Process_functionGetReport, ImplementationVisibility::Public), 0);
-    report->putDirect(vm, JSC::Identifier::fromString(vm, "reportOnFatalError"_s), JSC::jsBoolean(false), 0);
-    report->putDirect(vm, JSC::Identifier::fromString(vm, "reportOnSignal"_s), JSC::jsBoolean(false), 0);
-    report->putDirect(vm, JSC::Identifier::fromString(vm, "reportOnUncaughtException"_s), JSC::jsBoolean(process->m_reportOnUncaughtException), 0);
-    report->putDirect(vm, JSC::Identifier::fromString(vm, "excludeEnv"_s), JSC::jsBoolean(false), 0);
-    report->putDirect(vm, JSC::Identifier::fromString(vm, "excludeEnv"_s), JSC::jsString(vm, String("SIGUSR2"_s)), 0);
-    report->putDirect(vm, JSC::Identifier::fromString(vm, "writeReport"_s), JSC::JSFunction::create(vm, globalObject, 1, String("writeReport"_s), Process_functionWriteReport, ImplementationVisibility::Public), 0);
+    auto* report = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 11);
+
+    unsigned accessorAttrs = PropertyAttribute::CustomAccessor | 0;
+    report->putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "compact"_s), JSC::CustomGetterSetter::create(vm, processReport_getCompact, processReport_setCompact), accessorAttrs);
+    report->putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "directory"_s), JSC::CustomGetterSetter::create(vm, processReport_getDirectory, processReport_setDirectory), accessorAttrs);
+    report->putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "excludeEnv"_s), JSC::CustomGetterSetter::create(vm, processReport_getExcludeEnv, processReport_setExcludeEnv), accessorAttrs);
+    report->putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "excludeNetwork"_s), JSC::CustomGetterSetter::create(vm, processReport_getExcludeNetwork, processReport_setExcludeNetwork), accessorAttrs);
+    report->putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "filename"_s), JSC::CustomGetterSetter::create(vm, processReport_getFilename, processReport_setFilename), accessorAttrs);
+    report->putDirect(vm, JSC::Identifier::fromString(vm, "getReport"_s), JSC::JSFunction::create(vm, globalObject, 1, String("getReport"_s), Process_functionGetReport, ImplementationVisibility::Public), 0);
+    report->putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "reportOnFatalError"_s), JSC::CustomGetterSetter::create(vm, processReport_getReportOnFatalError, processReport_setReportOnFatalError), accessorAttrs);
+    report->putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "reportOnSignal"_s), JSC::CustomGetterSetter::create(vm, processReport_getReportOnSignal, processReport_setReportOnSignal), accessorAttrs);
+    report->putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "reportOnUncaughtException"_s), JSC::CustomGetterSetter::create(vm, processReport_getReportOnUncaughtException, processReport_setReportOnUncaughtException), accessorAttrs);
+    report->putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "signal"_s), JSC::CustomGetterSetter::create(vm, processReport_getSignal, processReport_setSignal), accessorAttrs);
+    report->putDirect(vm, JSC::Identifier::fromString(vm, "writeReport"_s), JSC::JSFunction::create(vm, globalObject, 2, String("writeReport"_s), Process_functionWriteReport, ImplementationVisibility::Public), 0);
     RETURN_IF_EXCEPTION(scope, {});
     return report;
 }

--- a/src/jsc/bindings/BunProcess.h
+++ b/src/jsc/bindings/BunProcess.h
@@ -41,6 +41,15 @@ public:
 
     DECLARE_EXPORT_INFO;
     bool m_reportOnUncaughtException = false;
+    bool m_reportCompact = false;
+    bool m_reportOnFatalError = false;
+    bool m_reportOnSignal = false;
+    bool m_reportReportOnUncaughtException = false;
+    bool m_reportExcludeEnv = false;
+    bool m_reportExcludeNetwork = false;
+    WTF::String m_reportDirectory { emptyString() };
+    WTF::String m_reportFilename { emptyString() };
+    WTF::String m_reportSignal { "SIGUSR2"_s };
 
     static void destroy(JSC::JSCell* cell)
     {

--- a/src/jsc/bindings/BunProcessReportObjectWindows.cpp
+++ b/src/jsc/bindings/BunProcessReportObjectWindows.cpp
@@ -41,7 +41,9 @@ using namespace JSC;
 // External functions
 extern "C" EncodedJSValue Bun__Process__createExecArgv(JSGlobalObject*);
 
-JSValue constructReportObjectWindows(VM& vm, Zig::GlobalObject* globalObject, Process* process)
+JSValue constructReportJavaScriptStack(VM& vm, Zig::GlobalObject* globalObject, JSValue errorValue);
+
+JSValue constructReportObjectWindows(VM& vm, Zig::GlobalObject* globalObject, Process* process, JSValue errorValue)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -240,48 +242,7 @@ JSValue constructReportObjectWindows(VM& vm, Zig::GlobalObject* globalObject, Pr
 
     // JavaScript stack
     {
-        JSObject* javascriptStack = constructEmptyObject(globalObject, globalObject->objectPrototype());
-        RETURN_IF_EXCEPTION(scope, {});
-
-        javascriptStack->putDirect(vm, vm.propertyNames->message, jsString(vm, String("Error [ERR_SYNTHETIC]: JavaScript Callstack"_s)), 0);
-
-        WTF::Vector<StackFrame> stackFrames;
-        vm.interpreter.getStackTrace(javascriptStack, stackFrames, 1);
-
-        String name = "Error"_s;
-        String message = "JavaScript Callstack"_s;
-        OrdinalNumber line = OrdinalNumber::beforeFirst();
-        OrdinalNumber column = OrdinalNumber::beforeFirst();
-        WTF::String sourceURL;
-
-        WTF::String stackProperty = Bun::formatStackTrace(
-            vm, globalObject, globalObject, name, message,
-            line, column,
-            sourceURL, stackFrames, nullptr);
-
-        WTF::String stack;
-        size_t firstLine = stackProperty.find('\n');
-        if (firstLine != WTF::notFound) {
-            stack = stackProperty.substring(firstLine + 1);
-        }
-
-        JSArray* stackArray = constructEmptyArray(globalObject, nullptr);
-        RETURN_IF_EXCEPTION(scope, {});
-
-        stack.split('\n', [&](const WTF::StringView& line) {
-            stackArray->push(globalObject, jsString(vm, line.toString().trim(isASCIIWhitespace)));
-            RETURN_IF_EXCEPTION(scope, );
-        });
-        RETURN_IF_EXCEPTION(scope, {});
-
-        javascriptStack->putDirect(vm, vm.propertyNames->stack, stackArray, 0);
-
-        JSObject* errorProperties = constructEmptyObject(globalObject, globalObject->objectPrototype());
-        RETURN_IF_EXCEPTION(scope, {});
-        errorProperties->putDirect(vm, Identifier::fromString(vm, "code"_s), jsString(vm, String("ERR_SYNTHETIC"_s)), 0);
-        javascriptStack->putDirect(vm, Identifier::fromString(vm, "errorProperties"_s), errorProperties, 0);
-
-        report->putDirect(vm, Identifier::fromString(vm, "javascriptStack"_s), javascriptStack, 0);
+        report->putDirect(vm, Identifier::fromString(vm, "javascriptStack"_s), constructReportJavaScriptStack(vm, globalObject, errorValue), 0);
         RETURN_IF_EXCEPTION(scope, {});
     }
 

--- a/src/jsc/bindings/BunProcessReportObjectWindows.cpp
+++ b/src/jsc/bindings/BunProcessReportObjectWindows.cpp
@@ -242,8 +242,9 @@ JSValue constructReportObjectWindows(VM& vm, Zig::GlobalObject* globalObject, Pr
 
     // JavaScript stack
     {
-        report->putDirect(vm, Identifier::fromString(vm, "javascriptStack"_s), constructReportJavaScriptStack(vm, globalObject, errorValue), 0);
+        JSValue javascriptStack = constructReportJavaScriptStack(vm, globalObject, errorValue);
         RETURN_IF_EXCEPTION(scope, {});
+        report->putDirect(vm, Identifier::fromString(vm, "javascriptStack"_s), javascriptStack, 0);
     }
 
     // JavaScript heap

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1041,6 +1041,51 @@ describe.concurrent(() => {
       });
     });
 
+    it("getReport(err) swallows a throwing .stack getter", () => {
+      const o = {
+        get stack() {
+          throw new Error("boom");
+        },
+      };
+      expect(process.report.getReport(o).javascriptStack).toEqual({
+        message: "No stack.",
+        stack: ["Unavailable."],
+        errorProperties: {},
+      });
+    });
+
+    it("getReport(err) skips throwing property getters in errorProperties", () => {
+      const o = {
+        stack: "head\n  at frame\n",
+        a: 1,
+        get b() {
+          throw new Error("boom");
+        },
+        c: 3,
+      };
+      expect(process.report.getReport(o).javascriptStack).toEqual({
+        message: "head",
+        stack: ["at frame"],
+        errorProperties: { a: "1", c: "3" },
+      });
+    });
+
+    it("getReport(err) swallows a Proxy ownKeys trap that throws", () => {
+      const p = new Proxy(
+        { stack: "head\n  at frame\n" },
+        {
+          ownKeys() {
+            throw new Error("boom");
+          },
+        },
+      );
+      expect(process.report.getReport(p).javascriptStack).toEqual({
+        message: "head",
+        stack: ["at frame"],
+        errorProperties: {},
+      });
+    });
+
     it("getReport(err) validates the argument type", () => {
       for (const v of [42, "x", true, null]) {
         expect(() => process.report.getReport(v)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1128,19 +1128,21 @@ describe.concurrent(() => {
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(JSON.parse(stdout)).toEqual({
-        compact: false,
-        directory: "",
-        filename: "",
-        signal: "SIGUSR2",
-        reportOnFatalError: false,
-        reportOnSignal: false,
-        reportOnUncaughtException: false,
-        excludeEnv: false,
-        excludeNetwork: false,
+      expect({ stdout: JSON.parse(stdout), stderr, exitCode }).toEqual({
+        stdout: {
+          compact: false,
+          directory: "",
+          filename: "",
+          signal: "SIGUSR2",
+          reportOnFatalError: false,
+          reportOnSignal: false,
+          reportOnUncaughtException: false,
+          excludeEnv: false,
+          excludeNetwork: false,
+        },
+        stderr: "",
+        exitCode: 0,
       });
-      expect(stderr).toBe("");
-      expect(exitCode).toBe(0);
     });
 
     describe.each([
@@ -1172,9 +1174,11 @@ describe.concurrent(() => {
           stderr: "pipe",
         });
         const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-        expect(stdout).toBe(`bad-err ${code} true\ngood ${JSON.stringify(good)}\n`);
-        expect(stderr).toBe("");
-        expect(exitCode).toBe(0);
+        expect({ stdout, stderr, exitCode }).toEqual({
+          stdout: `bad-err ${code} true\ngood ${JSON.stringify(good)}\n`,
+          stderr: "",
+          exitCode: 0,
+        });
       });
     });
   });

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1043,18 +1043,14 @@ describe.concurrent(() => {
 
     it("getReport(err) validates the argument type", () => {
       for (const v of [42, "x", true, null]) {
-        expect(() => process.report.getReport(v)).toThrow(
-          expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
-        );
+        expect(() => process.report.getReport(v)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
       }
       expect(() => process.report.getReport(undefined)).not.toThrow();
       expect(() => process.report.getReport({})).not.toThrow();
     });
 
     it("writeReport validates its arguments", () => {
-      expect(() => process.report.writeReport(42)).toThrow(
-        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
-      );
+      expect(() => process.report.writeReport(42)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
       expect(() => process.report.writeReport("file", 42)).toThrow(
         expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
       );

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1070,6 +1070,15 @@ describe.concurrent(() => {
       });
     });
 
+    it("getReport(err) skips integer-index own properties in errorProperties", () => {
+      const o = { stack: "head\n  at frame\n", 0: "x", 1: "y", named: "z" };
+      expect(process.report.getReport(o).javascriptStack).toEqual({
+        message: "head",
+        stack: ["at frame"],
+        errorProperties: { named: "z" },
+      });
+    });
+
     it("getReport(err) swallows a Proxy ownKeys trap that throws", () => {
       const p = new Proxy(
         { stack: "head\n  at frame\n" },
@@ -1112,7 +1121,7 @@ describe.concurrent(() => {
     });
 
     it("getReport(err) validates the argument type", () => {
-      for (const v of [42, "x", true, null]) {
+      for (const v of [42, "x", true, null, [], () => {}]) {
         expect(() => process.report.getReport(v)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
       }
       expect(() => process.report.getReport(undefined)).not.toThrow();
@@ -1120,7 +1129,15 @@ describe.concurrent(() => {
     });
 
     it("writeReport validates its arguments", () => {
-      expect(() => process.report.writeReport(42)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
+      for (const [arg, argName] of [
+        [42, "file"],
+        [() => {}, "file"],
+        [[], "err"],
+      ]) {
+        expect(() => process.report.writeReport(arg)).toThrow(
+          expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE", message: expect.stringContaining(`"${argName}"`) }),
+        );
+      }
       expect(() => process.report.writeReport("file", 42)).toThrow(
         expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
       );

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1086,6 +1086,31 @@ describe.concurrent(() => {
       });
     });
 
+    it("accessors and getReport work when invoked from a node:vm context", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const vm = require("node:vm");
+           const r = process.report;
+           const ctx = vm.createContext({ r, Error });
+           vm.runInContext("r.compact = true", ctx);
+           const sig = vm.runInContext("r.signal", ctx);
+           const msg = vm.runInContext("r.getReport(new Error('vm-marker')).javascriptStack.message", ctx);
+           console.log(JSON.stringify({ compact: r.compact, sig, msg }));`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: JSON.parse(stdout), stderr, exitCode }).toEqual({
+        stdout: { compact: true, sig: "SIGUSR2", msg: "Error: vm-marker" },
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
     it("getReport(err) validates the argument type", () => {
       for (const v of [42, "x", true, null]) {
         expect(() => process.report.getReport(v)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1192,6 +1192,7 @@ describe.concurrent(() => {
       ["directory", 123, "ERR_INVALID_ARG_TYPE", "dir"],
       ["filename", 123, "ERR_INVALID_ARG_TYPE", "file"],
       ["signal", "NOTASIG", "ERR_UNKNOWN_SIGNAL", "SIGINT"],
+      ["signal", "NOTASIG", "ERR_UNKNOWN_SIGNAL", "SIGUSR2"],
       ["signal", 123, "ERR_INVALID_ARG_TYPE", "SIGINT"],
       ["reportOnFatalError", 1, "ERR_INVALID_ARG_TYPE", true],
       ["reportOnSignal", 1, "ERR_INVALID_ARG_TYPE", true],

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1003,6 +1003,141 @@ describe.concurrent(() => {
     JSON.stringify(process.report.getReport(), null, 2);
   });
 
+  describe("process.report", () => {
+    it("getReport() with no argument uses a synthetic error", () => {
+      const g = process.report.getReport();
+      expect(g.javascriptStack.message).toBe("Error [ERR_SYNTHETIC]: JavaScript Callstack");
+      expect(g.javascriptStack.errorProperties).toEqual({ code: "ERR_SYNTHETIC" });
+      expect(Array.isArray(g.javascriptStack.stack)).toBe(true);
+    });
+
+    it("getReport(err) embeds the error's message and stack", () => {
+      const err = new Error("marker-xyzzy");
+      err.code = "ECUSTOM";
+      err.num = 42;
+      const g = process.report.getReport(err);
+      expect(g.javascriptStack.message).toBe("Error: marker-xyzzy");
+      expect(Array.isArray(g.javascriptStack.stack)).toBe(true);
+      expect(g.javascriptStack.stack.length).toBeGreaterThan(0);
+      expect(g.javascriptStack.stack.some(l => l.includes("process.test.js"))).toBe(true);
+      expect(g.javascriptStack.errorProperties).toEqual({ code: "ECUSTOM", num: "42" });
+    });
+
+    it("getReport(err) uses the stack property verbatim when present", () => {
+      const g = process.report.getReport({ stack: "first\n  at frame1\n  at frame2\n", extra: "x" });
+      expect(g.javascriptStack).toEqual({
+        message: "first",
+        stack: ["at frame1", "at frame2"],
+        errorProperties: { extra: "x" },
+      });
+    });
+
+    it("getReport(err) handles an object without a stack", () => {
+      const g = process.report.getReport({ custom: "v" });
+      expect(g.javascriptStack).toEqual({
+        message: "No stack.",
+        stack: ["Unavailable."],
+        errorProperties: {},
+      });
+    });
+
+    it("getReport(err) validates the argument type", () => {
+      for (const v of [42, "x", true, null]) {
+        expect(() => process.report.getReport(v)).toThrow(
+          expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+        );
+      }
+      expect(() => process.report.getReport(undefined)).not.toThrow();
+      expect(() => process.report.getReport({})).not.toThrow();
+    });
+
+    it("writeReport validates its arguments", () => {
+      expect(() => process.report.writeReport(42)).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+      );
+      expect(() => process.report.writeReport("file", 42)).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+      );
+      expect(() => process.report.writeReport("file", null)).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+      );
+      expect(() => process.report.writeReport(new Error("e"))).not.toThrow();
+    });
+
+    it("has the expected defaults", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const r = process.report;
+           console.log(JSON.stringify({
+             compact: r.compact,
+             directory: r.directory,
+             filename: r.filename,
+             signal: r.signal,
+             reportOnFatalError: r.reportOnFatalError,
+             reportOnSignal: r.reportOnSignal,
+             reportOnUncaughtException: r.reportOnUncaughtException,
+             excludeEnv: r.excludeEnv,
+             excludeNetwork: r.excludeNetwork,
+           }));`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(JSON.parse(stdout)).toEqual({
+        compact: false,
+        directory: "",
+        filename: "",
+        signal: "SIGUSR2",
+        reportOnFatalError: false,
+        reportOnSignal: false,
+        reportOnUncaughtException: false,
+        excludeEnv: false,
+        excludeNetwork: false,
+      });
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    });
+
+    describe.each([
+      ["compact", 1, "ERR_INVALID_ARG_TYPE", true],
+      ["directory", 123, "ERR_INVALID_ARG_TYPE", "dir"],
+      ["filename", 123, "ERR_INVALID_ARG_TYPE", "file"],
+      ["signal", "NOTASIG", "ERR_UNKNOWN_SIGNAL", "SIGINT"],
+      ["signal", 123, "ERR_INVALID_ARG_TYPE", "SIGINT"],
+      ["reportOnFatalError", 1, "ERR_INVALID_ARG_TYPE", true],
+      ["reportOnSignal", 1, "ERR_INVALID_ARG_TYPE", true],
+      ["reportOnUncaughtException", 1, "ERR_INVALID_ARG_TYPE", true],
+      ["excludeEnv", 1, "ERR_INVALID_ARG_TYPE", true],
+      ["excludeNetwork", 1, "ERR_INVALID_ARG_TYPE", true],
+    ])("%s", (prop, bad, code, good) => {
+      it(`rejects ${JSON.stringify(bad)} with ${code} and accepts ${JSON.stringify(good)}`, async () => {
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            `const r = process.report;
+             const before = r[${JSON.stringify(prop)}];
+             try { r[${JSON.stringify(prop)}] = ${JSON.stringify(bad)}; console.log("bad-ok"); }
+             catch (e) { console.log("bad-err", e.code, r[${JSON.stringify(prop)}] === before); }
+             r[${JSON.stringify(prop)}] = ${JSON.stringify(good)};
+             console.log("good", JSON.stringify(r[${JSON.stringify(prop)}]));`,
+          ],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stdout).toBe(`bad-err ${code} true\ngood ${JSON.stringify(good)}\n`);
+        expect(stderr).toBe("");
+        expect(exitCode).toBe(0);
+      });
+    });
+  });
+
   it("process.exit with jsDoubleNumber that is an integer", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), join(import.meta.dir, "./process-exit-decimal-fixture.js")],


### PR DESCRIPTION
## What does this PR do?

Fixes `process.report` argument validation and error embedding to match Node.js.

### Repro

```js
const r = process.report;
const g = r.getReport(new Error("marker-xyzzy"));
console.log(JSON.stringify(g.javascriptStack).includes("marker-xyzzy")); // node: true; bun: false
console.log(g.javascriptStack.message); // node: "Error: marker-xyzzy"; bun: "Error [ERR_SYNTHETIC]: JavaScript Callstack"

for (const v of [42, "x", null]) {
  try { r.getReport(v); console.log("accepted", v); }  // bun: all accepted
  catch (e) { console.log(e.code, v); }                // node: ERR_INVALID_ARG_TYPE x3
}
for (const [p, v] of [["compact", 1], ["directory", 123], ["signal", "NOTASIG"]]) {
  try { r[p] = v; console.log(`set ${p}:`, r[p]); }    // bun: all stick
  catch (e) { console.log(`set ${p}:`, e.code); }      // node: ERR_INVALID_ARG_TYPE / ERR_UNKNOWN_SIGNAL
}
```

### Cause

`Process_functionGetReport` never read `callFrame` arguments, so the passed error was discarded and the synthetic current stack was substituted. The `process.report` configuration properties were plain `putDirect` data properties with no setter validation, so any value was accepted verbatim. The old constructor also wrote the `"SIGUSR2"` default onto the `"excludeEnv"` key instead of `"signal"`, and omitted `excludeNetwork` entirely.

### Fix

- `getReport(err)`: when `err` is provided it must be a non-null object (`ERR_INVALID_ARG_TYPE` otherwise). Its `.stack` is split into `javascriptStack.message` (first line) and `javascriptStack.stack` (remaining trimmed lines), and its own enumerable properties (other than `stack`/`message`) are stringified into `javascriptStack.errorProperties`. If `.stack` is not a string, Node's `"No stack." / ["Unavailable."]` shape is used. Omitting `err` keeps the existing synthetic behavior.
- `writeReport(file, err)`: validates the `(string?, object?)` / `(object)` overloads the same way Node does. The underlying write is still a no-op.
- The nine configuration properties (`compact`, `directory`, `filename`, `signal`, `reportOnFatalError`, `reportOnSignal`, `reportOnUncaughtException`, `excludeEnv`, `excludeNetwork`) are now native accessors backed by fields on `Process`. Setters run `validateBoolean` / `validateString` / `validateSignalName`, throwing `ERR_INVALID_ARG_TYPE` or `ERR_UNKNOWN_SIGNAL`. `reportOnUncaughtException` uses its own storage so it no longer aliases the `setUncaughtExceptionCaptureCallback` "already set" flag.
- The `javascriptStack` builder is factored into a single `constructReportJavaScriptStack` shared by the POSIX and Windows report paths.

### Verification

`bun bd test test/js/node/process/process.test.js -t "process.report"` passes (18 tests) on linux-x64 and windows-x64; the new cases fail under `USE_SYSTEM_BUN=1`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/process/process.test.js

<!-- robobun:evidence:end -->