### PR TITLE
JSC::Heap: count Fast/Oversize typed array vectors in arrayBufferSize()

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -7,7 +7,7 @@
 // -lto variants built with ThinLTO (per-module summaries for cross-language
 // importing), and the Windows ICU data table filtered + per-item zstd
 // compressed (lazily decompressed via bun_icu_decompress.cpp).
-export const WEBKIT_VERSION = "4895f45dfbd0d1226c4d41799887bc0ecb9f341b";
+export const WEBKIT_VERSION = "autobuild-preview-pr-303-f5b8ea7c";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3726,17 +3726,9 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionMemoryUsage, (JSC::JSGlobalObject * glo
 
     result->putDirectOffset(vm, 3, JSC::jsNumber(vm.heap.extraMemorySize() + vm.heap.externalMemorySize()));
 
-    // JSC won't count this number until vm.heap.addReference() is called.
-    // That will only happen in cases like:
-    // - new ArrayBuffer()
-    // - new Uint8Array(42).buffer
-    // - fs.readFile(path, "utf-8") (sometimes)
-    // - ...
-    //
-    // But it won't happen in cases like:
-    // - new Uint8Array(42)
-    // - Buffer.alloc(42)
-    // - new Uint8Array(42).slice()
+    // arrayBufferSize() includes ArrayBuffer-backed storage plus the backing
+    // vectors of FastTypedArray and OversizeTypedArray views, so Buffer.alloc()
+    // and new Uint8Array(n) are counted even without materializing .buffer.
     result->putDirectOffset(vm, 4, JSC::jsNumber(vm.heap.arrayBufferSize()));
 
     RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(result));

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1471,6 +1471,79 @@ it("process.memoryUsage.arrayBuffers", () => {
   expect(process.memoryUsage().arrayBuffers).toBeGreaterThanOrEqual(initial + 16 * 1024 * 1024);
 });
 
+it("process.memoryUsage.arrayBuffers counts typed arrays without a materialized ArrayBuffer", async () => {
+  const script = `
+    const MB = 1 << 20;
+    const held = [];
+
+    const baseline = process.memoryUsage().arrayBuffers;
+
+    for (let i = 0; i < 8; i++) held.push(Buffer.alloc(8 * MB));
+    const afterOversize = process.memoryUsage().arrayBuffers;
+
+    for (let i = 0; i < 8; i++) held.push(new ArrayBuffer(8 * MB));
+    const afterArrayBuffer = process.memoryUsage().arrayBuffers;
+
+    const beforePromote = process.memoryUsage().arrayBuffers;
+    for (let i = 0; i < 8; i++) held[i].buffer;
+    const afterPromote = process.memoryUsage().arrayBuffers;
+
+    // FastTypedArray: run hot so DFG/FTL inline-allocates, then full GC so the
+    // visit-based correction counts every live vector exactly.
+    for (let i = 0; i < 100000; i++) held.push(new Uint8Array(256));
+    for (let i = 0; i < 100000; i++) held.push(new Uint8Array(8));
+    Bun.gc(true);
+    const afterFastGC = process.memoryUsage().arrayBuffers;
+
+    held.length = 0;
+    Bun.gc(true);
+    Bun.gc(true);
+    const afterCollect = process.memoryUsage().arrayBuffers;
+
+    process.stdout.write(JSON.stringify({
+      oversize: afterOversize - baseline,
+      arrayBuffer: afterArrayBuffer - afterOversize,
+      promote: afterPromote - beforePromote,
+      fastAfterGC: afterFastGC - baseline,
+      afterCollect: afterCollect - baseline,
+    }));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const result = JSON.parse(stdout);
+
+  const OVERSIZE_TOTAL = 8 * 8 * (1 << 20);
+  const FAST_TOTAL = 100000 * 256 + 100000 * 8;
+
+  // OversizeTypedArray backing (Buffer.alloc with size > fastSizeLimit) is
+  // tracked exactly at allocation time.
+  expect(result.oversize).toBeGreaterThanOrEqual(OVERSIZE_TOTAL);
+  expect(result.oversize).toBeLessThan(OVERSIZE_TOTAL * 1.5);
+
+  // Explicit ArrayBuffer allocations were already counted and still are.
+  expect(result.arrayBuffer).toBeGreaterThanOrEqual(OVERSIZE_TOTAL);
+  expect(result.arrayBuffer).toBeLessThan(OVERSIZE_TOTAL * 1.5);
+
+  // Materializing .buffer must not double count the same bytes.
+  expect(result.promote).toBeLessThan(OVERSIZE_TOTAL * 0.25);
+
+  // After a full GC the counter reflects every live Fast/Oversize/ArrayBuffer
+  // vector including JIT inline-allocated FastTypedArrays.
+  expect(result.fastAfterGC).toBeGreaterThanOrEqual(2 * OVERSIZE_TOTAL + FAST_TOTAL);
+  expect(result.fastAfterGC).toBeLessThan((2 * OVERSIZE_TOTAL + FAST_TOTAL) * 1.25);
+
+  // After releasing everything the counter drops back.
+  expect(result.afterCollect).toBeLessThan(OVERSIZE_TOTAL * 0.5);
+
+  expect(exitCode).toBe(0);
+});
+
 it("should handle user assigned `default` properties", async () => {
   process.default = 1;
   process.hello = 2;


### PR DESCRIPTION
### What does this PR do?

Makes `JSC::Heap::arrayBufferSize()` (and therefore `process.memoryUsage().arrayBuffers`) include the backing storage of typed arrays that have no materialized `ArrayBuffer`.

Depends on oven-sh/WebKit#303. `WEBKIT_VERSION` currently points at the preview release for that PR and must be bumped to the merge commit's `autobuild-<sha>` before this lands.

Supersedes #33673 (which computed the same number via an O(live typed arrays) heap walk in `BunProcess.cpp`); this change keeps `arrayBufferSize()` O(1) by maintaining the counter inside JSC.

```js
const held = [];
const a0 = process.memoryUsage().arrayBuffers;
for (let i = 0; i < 8; i++) held.push(Buffer.alloc(8 << 20));
const a1 = process.memoryUsage().arrayBuffers;
console.log(a1 - a0);
```

Before: `0`. After: `67108864`.

### How

`Heap::arrayBufferSize()` returned only `m_arrayBuffers.size()`, which tracks `ArrayBuffer`-backed storage registered via `addReference()` (JSArrayBuffer, WastefulTypedArray, DataView). `FastTypedArray` (<= 1000 elements, vector in the primitive Gigacage auxiliary space) and `OversizeTypedArray` (vector from `Gigacage::tryMalloc` with a finalizer) have no `ArrayBuffer` until `.buffer` is accessed via `slowDownAndWasteMemory()`, so `new Uint8Array(n)` / `Buffer.alloc(n)` were invisible.

oven-sh/WebKit#303 adds, under `USE(BUN_JSC_ADDITIONS)`:

- `size_t Heap::m_typedArrayVectorBytes` (atomic CAS) included in `arrayBufferSize()`.
- `reportTypedArrayVectorBytesAllocated/Deallocated` called from `JSArrayBufferView::finishCreation` (Fast/Oversize), `finalize` (Oversize), and `slowDownAndWasteMemory` (both) so the counter moves immediately for the C++ paths and stays balanced across the Wasteful transition.
- `JSGenericTypedArrayView::visitChildrenImpl` reports Fast/Oversize `byteSize` into a per-`SlotVisitor` accumulator; on full GC `sweepArrayBuffers` overwrites `m_typedArrayVectorBytes` with the visited sum, matching `GCIncomingRefCountedSet::sweep`. This covers DFG/FTL inline-allocated `FastTypedArray`s (which bypass `finishCreation`) and reclaims bytes for collected `FastTypedArray`s that have no finalizer.

Accuracy: OversizeTypedArray and ArrayBuffer-backed storage are exact immediately. FastTypedArray bytes are exact after a full GC; DFG/FTL inline-allocated FastTypedArrays (<= 1000 elements) are undercounted until then. Allocation-sunk typed arrays correctly contribute nothing.

### How did you verify your code works?

`bun run build:local` against the WebKit branch, then:

```
8 x new Uint8Array(8MB)        delta: 67108864
8 x Buffer.alloc(8MB)          delta: 67108864
1024 x new Uint8Array(512)     delta: 524288
8 x new ArrayBuffer(8MB)       delta: 67109632
.buffer promote 8 views        delta: 768         (no double count)
held.length = 0; Bun.gc(true)  delta: 0
```

Hot JIT loop, 100k x Uint8Array(256) + 100k x Uint8Array(8), held: `862720+15080` before GC (LLInt/baseline iterations only), `26400000` after `Bun.gc(true)` (exact = 100000x256 + 100000x8). 3M non-escaping `new Uint8Array(8)`: `0` after GC. 50-iteration GC stress loop: no crash, counter stays bounded.

Added `process.memoryUsage.arrayBuffers counts typed arrays without a materialized ArrayBuffer` in `test/js/node/process/process.test.js` covering Oversize immediate tracking, ArrayBuffer, `.buffer` promotion (no double count), hot-loop FastTypedArray after full GC, and release after GC. Fails on the current release (`Received: 0`) and passes against the local WebKit build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/process/process.test.js

<!-- robobun:evidence:end -->