### PR TITLE
resolver: take Entry.mutex when filling Entry.abs_path in load_as_file and siblings

### DIFF
--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -1201,8 +1201,8 @@ where
                                                 let _entry_guard = ent.mutex.lock_guard();
                                                 ent.set_cache_fd(Fd::INVALID);
                                                 ent.need_stat.set(true);
+                                                path_string = ent.abs_path;
                                             }
-                                            path_string = ent.abs_path;
                                             file_hash = Watcher::get_hash(path_string.as_bytes());
                                             for (entry_id, hash) in hashes.iter().enumerate() {
                                                 if *hash == file_hash {

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -1201,7 +1201,7 @@ where
                                                 let _entry_guard = ent.mutex.lock_guard();
                                                 ent.set_cache_fd(Fd::INVALID);
                                                 ent.need_stat.set(true);
-                                                path_string = ent.abs_path;
+                                                path_string = ent.abs_path();
                                             }
                                             file_hash = Watcher::get_hash(path_string.as_bytes());
                                             for (entry_id, hash) in hashes.iter().enumerate() {

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -279,7 +279,7 @@ pub struct Entry {
     pub mutex: Mutex,
     pub need_stat: core::cell::Cell<bool>,
 
-    pub abs_path: Interned,
+    pub abs_path: core::cell::Cell<Interned>,
 }
 
 impl Entry {
@@ -336,15 +336,32 @@ impl Entry {
         self.dir
     }
 
-    /// `Interned` is `Copy`.
+    /// `Interned` is `Copy`. Caller must hold `self.mutex` when this entry is
+    /// reachable from another thread; see [`abs_path_or_fill`].
     #[inline]
     pub fn abs_path(&self) -> Interned {
-        self.abs_path
+        self.abs_path.get()
     }
 
     #[inline]
-    pub fn set_abs_path(&mut self, p: Interned) {
-        self.abs_path = p;
+    pub fn set_abs_path(&self, p: Interned) {
+        self.abs_path.set(p);
+    }
+
+    /// Double-checked lazy fill of `abs_path` under `self.mutex`, matching
+    /// [`kind`](Self::kind) / [`symlink`](Self::symlink). Returns the cached
+    /// value if already set, otherwise calls `fill`, stores the result, and
+    /// returns it. `abs_path` is a two-word slice, so unlocked access can
+    /// observe a torn `(ptr, len)` on weakly-ordered CPUs.
+    pub fn abs_path_or_fill(&self, fill: impl FnOnce() -> Interned) -> &'static [u8] {
+        let _g = self.mutex.lock_guard();
+        let cached = self.abs_path.get();
+        if !cached.is_empty() {
+            return cached.as_bytes();
+        }
+        let v = fill();
+        self.abs_path.set(v);
+        v.as_bytes()
     }
 
     /// Stat-on-first-use.
@@ -426,7 +443,7 @@ impl Clone for Entry {
             base_lowercase_: strings::StringOrTinyString::init(self.base_lowercase_.slice()),
             mutex: Mutex::default(),
             need_stat: core::cell::Cell::new(self.need_stat.get()),
-            abs_path: self.abs_path,
+            abs_path: core::cell::Cell::new(self.abs_path.get()),
         }
     }
 }
@@ -440,7 +457,7 @@ impl Default for Entry {
             base_lowercase_: strings::StringOrTinyString::init(b""),
             mutex: Mutex::default(),
             need_stat: core::cell::Cell::new(true),
-            abs_path: Interned::EMPTY,
+            abs_path: core::cell::Cell::new(Interned::EMPTY),
         }
     }
 }
@@ -731,7 +748,7 @@ impl DirEntry {
                     kind: found_kind.unwrap_or(EntryKind::File),
                     fd: Fd::INVALID,
                 }));
-                addr_of_mut!((*p).abs_path).write(Interned::EMPTY);
+                addr_of_mut!((*p).abs_path).write(core::cell::Cell::new(Interned::EMPTY));
                 p
             }
         };

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -3896,17 +3896,21 @@ impl<'a> Resolver<'a> {
                 }
 
                 let absolute_out_path: &[u8] = {
-                    if entry_query.entry().abs_path.is_empty() {
-                        // SAFETY: EntryStore-owned slot; resolver mutex held. RHS fully
-                        // evaluated before LHS `&mut Entry` is materialized.
-                        unsafe { &mut *entry_query.entry }.abs_path = Interned::from_static(
+                    let _entry_guard = entry_query.entry().mutex.lock_guard();
+                    let cached = entry_query.entry().abs_path;
+                    if !cached.is_empty() {
+                        cached.as_bytes()
+                    } else {
+                        let interned = Interned::from_static(
                             self.fs_ref()
                                 .dirname_store
                                 .append_slice(abs_esm_path)
                                 .expect("unreachable"),
                         );
+                        // SAFETY: EntryStore-owned slot; `Entry.mutex` held.
+                        unsafe { &mut *entry_query.entry }.abs_path = interned;
+                        interned.as_bytes()
                     }
-                    entry_query.entry().abs_path.as_bytes()
                 };
                 let module_type = if let Some(pkg) = resolved_dir_info.package_json() {
                     pkg.module_type
@@ -5271,19 +5275,23 @@ impl<'a> Resolver<'a> {
                     == Fs::file_system::EntryKind::File
                 {
                     let out_buf: &[u8] = {
-                        if lookup.entry().abs_path.is_empty() {
+                        let _entry_guard = lookup.entry().mutex.lock_guard();
+                        let cached = lookup.entry().abs_path;
+                        if !cached.is_empty() {
+                            cached.as_bytes()
+                        } else {
                             let parts = [dir_info.abs_path, &base[..]];
                             let out_buf_ = self.fs_ref().abs_buf(&parts, bufs!(index));
-                            // SAFETY: EntryStore-owned slot; resolver mutex held. RHS fully
-                            // evaluated before LHS `&mut Entry` is materialized.
-                            unsafe { &mut *lookup.entry }.abs_path = Interned::from_static(
+                            let interned = Interned::from_static(
                                 self.fs_ref()
                                     .dirname_store
                                     .append_slice(out_buf_)
                                     .expect("unreachable"),
                             );
+                            // SAFETY: EntryStore-owned slot; `Entry.mutex` held.
+                            unsafe { &mut *lookup.entry }.abs_path = interned;
+                            interned.as_bytes()
                         }
-                        lookup.entry().abs_path.as_bytes()
                     };
 
                     if let Some(debug) = self.debug_logs.as_mut() {
@@ -5768,19 +5776,26 @@ impl<'a> Resolver<'a> {
                 }
 
                 let abs_path: &'static [u8] = {
-                    if query.entry().abs_path.is_empty() {
+                    // `abs_path` is a two-word slice; serialize on the per-entry
+                    // mutex so the check/write/read is atomic relative to the
+                    // router's `Route::parse` doing the same fill.
+                    let _entry_guard = query.entry().mutex.lock_guard();
+                    let cached = query.entry().abs_path;
+                    if !cached.is_empty() {
+                        cached.as_bytes()
+                    } else {
                         let abs_path_parts = [query.entry().dir, query.entry().base()];
                         let joined = self.fs_ref().abs_buf(&abs_path_parts, bufs!(load_as_file));
-                        // SAFETY: EntryStore-owned slot; resolver mutex held. RHS fully
-                        // evaluated before LHS `&mut Entry` is materialized.
-                        unsafe { &mut *query.entry }.abs_path = Interned::from_static(
+                        let interned = Interned::from_static(
                             self.fs_ref()
                                 .dirname_store
                                 .append_slice(joined)
                                 .expect("unreachable"),
                         );
+                        // SAFETY: EntryStore-owned slot; `Entry.mutex` held.
+                        unsafe { &mut *query.entry }.abs_path = interned;
+                        interned.as_bytes()
                     }
-                    query.entry().abs_path.as_bytes()
                 };
 
                 dec_ret!(Some(LoadResult {
@@ -5874,7 +5889,11 @@ impl<'a> Resolver<'a> {
 
                             dec_ret!(Some(LoadResult {
                                 path: {
-                                    if query.entry().abs_path.is_empty() {
+                                    let _entry_guard = query.entry().mutex.lock_guard();
+                                    let cached = query.entry().abs_path;
+                                    if !cached.is_empty() {
+                                        cached.as_bytes()
+                                    } else {
                                         // SAFETY: `dir` is `&'static [u8]` (DirnameStore-interned),
                                         // copied out so no `&Entry` borrow survives into the
                                         // `&mut Entry` write below.
@@ -5900,11 +5919,10 @@ impl<'a> Resolver<'a> {
                                                     .expect("unreachable"),
                                             )
                                         };
-                                        // SAFETY: EntryStore-owned slot; resolver mutex held. RHS
-                                        // fully evaluated above — sole `&mut Entry` for this write.
+                                        // SAFETY: EntryStore-owned slot; `Entry.mutex` held.
                                         unsafe { &mut *query.entry }.abs_path = new_abs;
+                                        new_abs.as_bytes()
                                     }
-                                    query.entry().abs_path.as_bytes()
                                 },
                                 diff_case: query.diff_case,
                                 dirname_fd: entries!().fd,
@@ -5981,21 +5999,21 @@ impl<'a> Resolver<'a> {
                 // now that we've found it, we allocate it.
                 return Some(LoadResult {
                     path: {
-                        // SAFETY: EntryStore-owned slot; resolver mutex held. RHS is fully
-                        // evaluated (shared reads) before the LHS `&mut Entry` is
-                        // materialized for the write — no overlapping unique borrow.
-                        unsafe { &mut *query.entry }.abs_path = if query.entry().abs_path.is_empty()
-                        {
-                            Interned::from_static(
+                        let _entry_guard = query.entry().mutex.lock_guard();
+                        let cached = query.entry().abs_path;
+                        if !cached.is_empty() {
+                            cached.as_bytes()
+                        } else {
+                            let interned = Interned::from_static(
                                 self.fs_ref()
                                     .dirname_store
                                     .append_slice(&buffer[..])
                                     .expect("unreachable"),
-                            )
-                        } else {
-                            query.entry().abs_path
-                        };
-                        query.entry().abs_path.as_bytes()
+                            );
+                            // SAFETY: EntryStore-owned slot; `Entry.mutex` held.
+                            unsafe { &mut *query.entry }.abs_path = interned;
+                            interned.as_bytes()
+                        }
                     },
                     diff_case: query.diff_case,
                     dirname_fd: entries.fd,

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -3895,23 +3895,14 @@ impl<'a> Resolver<'a> {
                     return MatchStatus::NotFound;
                 }
 
-                let absolute_out_path: &[u8] = {
-                    let _entry_guard = entry_query.entry().mutex.lock_guard();
-                    let cached = entry_query.entry().abs_path;
-                    if !cached.is_empty() {
-                        cached.as_bytes()
-                    } else {
-                        let interned = Interned::from_static(
-                            self.fs_ref()
-                                .dirname_store
-                                .append_slice(abs_esm_path)
-                                .expect("unreachable"),
-                        );
-                        // SAFETY: EntryStore-owned slot; `Entry.mutex` held.
-                        unsafe { &mut *entry_query.entry }.abs_path = interned;
-                        interned.as_bytes()
-                    }
-                };
+                let absolute_out_path: &[u8] = entry_query.entry().abs_path_or_fill(|| {
+                    Interned::from_static(
+                        self.fs_ref()
+                            .dirname_store
+                            .append_slice(abs_esm_path)
+                            .expect("unreachable"),
+                    )
+                });
                 let module_type = if let Some(pkg) = resolved_dir_info.package_json() {
                     pkg.module_type
                 } else {
@@ -5274,25 +5265,16 @@ impl<'a> Resolver<'a> {
                 if unsafe { lookup.entry().kind(rfs, self.store_fd) }
                     == Fs::file_system::EntryKind::File
                 {
-                    let out_buf: &[u8] = {
-                        let _entry_guard = lookup.entry().mutex.lock_guard();
-                        let cached = lookup.entry().abs_path;
-                        if !cached.is_empty() {
-                            cached.as_bytes()
-                        } else {
-                            let parts = [dir_info.abs_path, &base[..]];
-                            let out_buf_ = self.fs_ref().abs_buf(&parts, bufs!(index));
-                            let interned = Interned::from_static(
-                                self.fs_ref()
-                                    .dirname_store
-                                    .append_slice(out_buf_)
-                                    .expect("unreachable"),
-                            );
-                            // SAFETY: EntryStore-owned slot; `Entry.mutex` held.
-                            unsafe { &mut *lookup.entry }.abs_path = interned;
-                            interned.as_bytes()
-                        }
-                    };
+                    let out_buf: &[u8] = lookup.entry().abs_path_or_fill(|| {
+                        let parts = [dir_info.abs_path, &base[..]];
+                        let out_buf_ = self.fs_ref().abs_buf(&parts, bufs!(index));
+                        Interned::from_static(
+                            self.fs_ref()
+                                .dirname_store
+                                .append_slice(out_buf_)
+                                .expect("unreachable"),
+                        )
+                    });
 
                     if let Some(debug) = self.debug_logs.as_mut() {
                         debug.add_note_fmt(format_args!(
@@ -5775,28 +5757,16 @@ impl<'a> Resolver<'a> {
                     debug.add_note_fmt(format_args!("Found file \"{}\" ", bstr::BStr::new(base)));
                 }
 
-                let abs_path: &'static [u8] = {
-                    // `abs_path` is a two-word slice; serialize on the per-entry
-                    // mutex so the check/write/read is atomic relative to the
-                    // router's `Route::parse` doing the same fill.
-                    let _entry_guard = query.entry().mutex.lock_guard();
-                    let cached = query.entry().abs_path;
-                    if !cached.is_empty() {
-                        cached.as_bytes()
-                    } else {
-                        let abs_path_parts = [query.entry().dir, query.entry().base()];
-                        let joined = self.fs_ref().abs_buf(&abs_path_parts, bufs!(load_as_file));
-                        let interned = Interned::from_static(
-                            self.fs_ref()
-                                .dirname_store
-                                .append_slice(joined)
-                                .expect("unreachable"),
-                        );
-                        // SAFETY: EntryStore-owned slot; `Entry.mutex` held.
-                        unsafe { &mut *query.entry }.abs_path = interned;
-                        interned.as_bytes()
-                    }
-                };
+                let abs_path: &'static [u8] = query.entry().abs_path_or_fill(|| {
+                    let abs_path_parts = [query.entry().dir, query.entry().base()];
+                    let joined = self.fs_ref().abs_buf(&abs_path_parts, bufs!(load_as_file));
+                    Interned::from_static(
+                        self.fs_ref()
+                            .dirname_store
+                            .append_slice(joined)
+                            .expect("unreachable"),
+                    )
+                });
 
                 dec_ret!(Some(LoadResult {
                     path: abs_path,
@@ -5888,42 +5858,30 @@ impl<'a> Resolver<'a> {
                             }
 
                             dec_ret!(Some(LoadResult {
-                                path: {
-                                    let _entry_guard = query.entry().mutex.lock_guard();
-                                    let cached = query.entry().abs_path;
-                                    if !cached.is_empty() {
-                                        cached.as_bytes()
+                                path: query.entry().abs_path_or_fill(|| {
+                                    let entry_dir = query.entry().dir;
+                                    if !entry_dir.is_empty()
+                                        && entry_dir[entry_dir.len() - 1] == SEP
+                                    {
+                                        let parts: [&[u8]; 2] = [entry_dir, &buffer[..]];
+                                        Interned::from_static(
+                                            self.fs_ref()
+                                                .filename_store
+                                                .append_parts(&parts)
+                                                .expect("unreachable"),
+                                        )
+                                        // the trailing path CAN be missing here
                                     } else {
-                                        // SAFETY: `dir` is `&'static [u8]` (DirnameStore-interned),
-                                        // copied out so no `&Entry` borrow survives into the
-                                        // `&mut Entry` write below.
-                                        let entry_dir = query.entry().dir;
-                                        let new_abs = if !entry_dir.is_empty()
-                                            && entry_dir[entry_dir.len() - 1] == SEP
-                                        {
-                                            let parts: [&[u8]; 2] = [entry_dir, &buffer[..]];
-                                            Interned::from_static(
-                                                self.fs_ref()
-                                                    .filename_store
-                                                    .append_parts(&parts)
-                                                    .expect("unreachable"),
-                                            )
-                                            // the trailing path CAN be missing here
-                                        } else {
-                                            let parts: [&[u8]; 3] =
-                                                [entry_dir, SEP_STR.as_bytes(), &buffer[..]];
-                                            Interned::from_static(
-                                                self.fs_ref()
-                                                    .filename_store
-                                                    .append_parts(&parts)
-                                                    .expect("unreachable"),
-                                            )
-                                        };
-                                        // SAFETY: EntryStore-owned slot; `Entry.mutex` held.
-                                        unsafe { &mut *query.entry }.abs_path = new_abs;
-                                        new_abs.as_bytes()
+                                        let parts: [&[u8]; 3] =
+                                            [entry_dir, SEP_STR.as_bytes(), &buffer[..]];
+                                        Interned::from_static(
+                                            self.fs_ref()
+                                                .filename_store
+                                                .append_parts(&parts)
+                                                .expect("unreachable"),
+                                        )
                                     }
-                                },
+                                }),
                                 diff_case: query.diff_case,
                                 dirname_fd: entries!().fd,
                                 file_fd: query.entry().cache().fd,
@@ -5998,23 +5956,14 @@ impl<'a> Resolver<'a> {
 
                 // now that we've found it, we allocate it.
                 return Some(LoadResult {
-                    path: {
-                        let _entry_guard = query.entry().mutex.lock_guard();
-                        let cached = query.entry().abs_path;
-                        if !cached.is_empty() {
-                            cached.as_bytes()
-                        } else {
-                            let interned = Interned::from_static(
-                                self.fs_ref()
-                                    .dirname_store
-                                    .append_slice(&buffer[..])
-                                    .expect("unreachable"),
-                            );
-                            // SAFETY: EntryStore-owned slot; `Entry.mutex` held.
-                            unsafe { &mut *query.entry }.abs_path = interned;
-                            interned.as_bytes()
-                        }
-                    },
+                    path: query.entry().abs_path_or_fill(|| {
+                        Interned::from_static(
+                            self.fs_ref()
+                                .dirname_store
+                                .append_slice(&buffer[..])
+                                .expect("unreachable"),
+                        )
+                    }),
                     diff_case: query.diff_case,
                     dirname_fd: entries.fd,
                     file_fd: query.entry().cache().fd,

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -1032,11 +1032,17 @@ impl Route {
         // `base_`/`extname` are no longer used.
         // SAFETY: caller passes an EntryStore-owned pointer valid for the
         // process lifetime; no other live `&mut` to it during this call.
-        let entry_abs_path = unsafe { &*entry }.abs_path().as_bytes();
+        // `abs_path` is a two-word slice that other threads (the bundler's
+        // resolver) fill under `Entry.mutex`; read it under the same lock so
+        // this thread can never observe a torn (ptr, len).
+        let entry_abs_path = {
+            let _entry_guard = unsafe { &*entry }.mutex.lock_guard();
+            unsafe { &*entry }.abs_path()
+        };
         let mut abs_path_str: &[u8] = if entry_abs_path.is_empty() {
             b""
         } else {
-            entry_abs_path
+            entry_abs_path.as_bytes()
         };
 
         let base = &base_[0..base_.len() - extname.len()];

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -1026,24 +1026,14 @@ impl Route {
     ) -> Option<Route> {
         // NOTE: `entry` is a raw `*mut Entry`
         // because `base_`/`extname` may borrow `(*entry).base_` (tiny inline
-        // string) and a `&mut Entry` parameter would alias them.
-        // Reads go through `unsafe { &*entry }`; the single mutation
-        // (`set_abs_path`) goes through `unsafe { &mut *entry }` after
-        // `base_`/`extname` are no longer used.
+        // string) and a `&mut Entry` parameter would alias them. Reads and the
+        // `abs_path` fill go through `unsafe { &*entry }`.
         // SAFETY: caller passes an EntryStore-owned pointer valid for the
         // process lifetime; no other live `&mut` to it during this call.
-        // `abs_path` is a two-word slice that other threads (the bundler's
-        // resolver) fill under `Entry.mutex`; read it under the same lock so
-        // this thread can never observe a torn (ptr, len).
-        let entry_abs_path = {
-            let _entry_guard = unsafe { &*entry }.mutex.lock_guard();
-            unsafe { &*entry }.abs_path()
-        };
-        let mut abs_path_str: &[u8] = if entry_abs_path.is_empty() {
-            b""
-        } else {
-            entry_abs_path.as_bytes()
-        };
+        // `abs_path` is lazily filled under `Entry.mutex` in the `'fill` block
+        // below (see `Entry::abs_path_or_fill`); start empty and let that
+        // locked check populate it so the hot path takes the lock once.
+        let mut abs_path_str: &[u8] = b"";
 
         let base = &base_[0..base_.len() - extname.len()];
 
@@ -1160,18 +1150,11 @@ impl Route {
                 };
 
             'fill: {
-                if !abs_path_str.is_empty() {
-                    break 'fill;
-                }
                 // The reads of `cache().fd` and the `set_abs_path` write below
                 // rewrite the cached `Entry`; serialize them on the per-entry
                 // mutex (the same lock every other `Entry` rewrite path takes).
                 // SAFETY: see fn-level NOTE — read-only reborrow.
                 let _entry_guard = unsafe { &*entry }.mutex.lock_guard();
-                // Re-check under the lock: the bundler's resolver may have
-                // filled `abs_path` between the initial locked read above and
-                // this acquire, in which case the open + get_fd_path + intern
-                // below would recompute an equivalent value.
                 let cached = unsafe { &*entry }.abs_path();
                 if !cached.is_empty() {
                     abs_path_str = cached.as_bytes();
@@ -1254,9 +1237,8 @@ impl Route {
                     .append(_abs)
                     .expect("unreachable");
 
-                // SAFETY: sole mutation; `base_`/`extname` (which may borrow
-                // `(*entry).base_.remainder_buf`) are not used after this.
-                unsafe { &mut *entry }.set_abs_path(Interned::from_static(abs_path_str));
+                // SAFETY: see fn-level NOTE — read-only reborrow; `Entry.mutex` held.
+                unsafe { &*entry }.set_abs_path(Interned::from_static(abs_path_str));
             }
 
             #[cfg(windows)]

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -1159,12 +1159,24 @@ impl Route {
                     )
                 };
 
-            if abs_path_str.is_empty() {
+            'fill: {
+                if !abs_path_str.is_empty() {
+                    break 'fill;
+                }
                 // The reads of `cache().fd` and the `set_abs_path` write below
                 // rewrite the cached `Entry`; serialize them on the per-entry
                 // mutex (the same lock every other `Entry` rewrite path takes).
                 // SAFETY: see fn-level NOTE — read-only reborrow.
                 let _entry_guard = unsafe { &*entry }.mutex.lock_guard();
+                // Re-check under the lock: the bundler's resolver may have
+                // filled `abs_path` between the initial locked read above and
+                // this acquire, in which case the open + get_fd_path + intern
+                // below would recompute an equivalent value.
+                let cached = unsafe { &*entry }.abs_path();
+                if !cached.is_empty() {
+                    abs_path_str = cached.as_bytes();
+                    break 'fill;
+                }
                 // NOTE: reshaped for borrowck — `defer if (needs_close) file.close()`
                 // becomes a scopeguard owning the Option<File>; `needs_close` is a
                 // Cell so the drop closure can read it while the body still mutates.

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -417,7 +417,7 @@ impl<'a> Scanner<'a> {
             }
             fs::EntryKind::File => {
                 // already seen it!
-                if !entry.abs_path.is_empty() {
+                if !entry.abs_path().is_empty() {
                     return;
                 }
 
@@ -450,8 +450,8 @@ impl<'a> Scanner<'a> {
                     Ok(s) => s,
                     Err(_) => bun_core::out_of_memory(),
                 };
-                entry.abs_path = Interned::from_static(stored);
-                self.test_files.push(entry.abs_path);
+                entry.set_abs_path(Interned::from_static(stored));
+                self.test_files.push(entry.abs_path());
             }
         }
     }

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -826,6 +826,7 @@ it("reload() while Bun.build() resolves the same directory", async () => {
     "fixture.ts": /* ts */ `
       import path from "path";
       const pagesDir = path.join(import.meta.dir, "pages");
+      const pagesDirPosix = pagesDir.replaceAll(path.sep, "/");
       const entrypoints: string[] = [];
       for (let i = 1; i <= 40; i++) {
         entrypoints.push(path.join(pagesDir, "p" + i + ".tsx"));
@@ -858,7 +859,7 @@ it("reload() while Bun.build() resolves the same directory", async () => {
         // Entry after every bust+reread; a torn value surfaces as a
         // filePath that isn't the absolute .tsx path.
         for (const fp of Object.values(router.routes)) {
-          pathsOk &&= typeof fp === "string" && fp.startsWith(pagesDir) && fp.endsWith(".tsx");
+          pathsOk &&= typeof fp === "string" && fp.startsWith(pagesDirPosix) && fp.endsWith(".tsx");
         }
         const results = await Promise.all(builds);
         buildsOk &&= results.every(r => r.success);

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -843,6 +843,7 @@ it("reload() while Bun.build() resolves the same directory", async () => {
       await Bun.build({ entrypoints, target: "bun", throw: false });
       let matches = 0;
       let buildsOk = true;
+      let pathsOk = true;
       for (let round = 0; round < 40; round++) {
         const builds = Array.from({ length: 4 }, () =>
           Bun.build({ entrypoints, target: "bun", throw: false }),
@@ -852,10 +853,17 @@ it("reload() while Bun.build() resolves the same directory", async () => {
           const m = router.match("/p7");
           if (m && m.filePath.endsWith("p7.tsx")) matches++;
         }
+        // Each route's abs-path is filled by both the router (under the
+        // per-entry mutex) and the bundler's resolver for the same fresh
+        // Entry after every bust+reread; a torn value surfaces as a
+        // filePath that isn't the absolute .tsx path.
+        for (const fp of Object.values(router.routes)) {
+          pathsOk &&= typeof fp === "string" && fp.startsWith(pagesDir) && fp.endsWith(".tsx");
+        }
         const results = await Promise.all(builds);
         buildsOk &&= results.every(r => r.success);
       }
-      console.log("matches", matches, "builds-ok", buildsOk);
+      console.log("matches", matches, "builds-ok", buildsOk, "paths-ok", pathsOk);
     `,
   };
   for (let i = 1; i <= 40; i++) {
@@ -877,7 +885,7 @@ it("reload() while Bun.build() resolves the same directory", async () => {
     stderr: normalizeBunSnapshot(stderr, String(dir)),
     exitCode,
     signalCode: proc.signalCode,
-  }).toEqual({ stdout: "matches 2000 builds-ok true", stderr: "", exitCode: 0, signalCode: null });
+  }).toEqual({ stdout: "matches 2000 builds-ok true paths-ok true", stderr: "", exitCode: 0, signalCode: null });
 }, 60_000);
 
 it("loads routes from a directory already cached by Bun.build()", async () => {


### PR DESCRIPTION
`test/js/bun/util/filesystem_router.test.ts` went red on Debian 13 aarch64 in build [74037](https://buildkite.com/bun/bun/builds/74037): the `reload() while Bun.build() resolves the same directory` subprocess segfaulted at address `0x31` after ~24ms.

## Cause

Symbolizing the crash trace against the build's own `bun-linux-aarch64-profile` binary gives the bundle thread at:

```
memchr::...::rfind                       twoway.rs:372
bun_core::strings::last_index_of         src/bun_core/string/immutable.rs:713
Resolver::load_as_file_or_directory      src/resolver/resolver.rs:5435
Resolver::resolve_without_symlinks       src/resolver/resolver.rs:1934
Resolver::resolve_and_auto_install       src/resolver/resolver.rs:1447
Transpiler::_resolve_entry_point         src/bundler/transpiler.rs:444
BundleV2::enqueue_entry_points_normal    src/bundler/bundle_v2.rs:2973
BundleThread::generate_in_new_thread     src/bundler/BundleThread.rs:276
```

`resolver.rs:5435` is `strings::last_index_of(file.path, "node_modules/")`, and `file.path` is what `load_as_file` returned from `query.entry().abs_path.as_bytes()`. That field was lazily filled at five sibling sites in the resolver (`load_as_file` plain path and js-to-ts rewrite, `load_extension`, `load_index_with_extension`, `handle_esm_resolution`), each with the shape

```rust
if query.entry().abs_path.is_empty() {
    unsafe { &mut *query.entry }.abs_path = Interned::from_static(...);
}
query.entry().abs_path.as_bytes()
```

None of them took the per-entry `Entry.mutex`, while `Route::parse` (`src/router/lib.rs`) filled the same field under that mutex; the accompanying SAFETY comments said "resolver mutex held", but `load_as_file`/`load_extension`/`load_as_file_or_directory` are reached from `resolve_without_symlinks` without ever taking `RESOLVER_MUTEX`.

Every `reload()` busts the directory out of both caches and `dir_info_cached_miss` re-reads it with `in_place = None`, so fresh `Entry` objects are appended with `abs_path = Interned::EMPTY`. The bundler's `read_directory` then rewrites that fresh `DirEntry` in place with `prev = &mut D.data` and reuses those same `Entry` objects. So the router (JS thread, under `Entry.mutex`) and the bundler's resolver (bundle thread, no lock) race to fill `abs_path` on the very same `Entry`.

`Interned` is a `#[repr(transparent)] &'static [u8]`, i.e. a two-word `(ptr, len)`. An unsynchronized two-word store/load pair is a data race; under aarch64's weak memory model the reader can observe the torn `(old_ptr, new_len)` combination that x86-TSO never produces, and `last_index_of` then indexes into a slice whose pointer and length do not belong together.

This race predates #34271; #34271's intensified test fixture (one priming build, then forty rounds of four concurrent `Bun.build()` calls against fifty `reload()`s) is what widened the window enough for CI to hit it.

## Fix

Add `Entry::abs_path_or_fill(&self, fill: impl FnOnce() -> Interned) -> &'static [u8]` in `src/resolver/fs.rs` next to the existing `Entry::kind` / `Entry::symlink` helpers, which already implement the same double-checked-lock lazy-fill for the sibling `cache` / `need_stat` fields. `Entry.abs_path` becomes `Cell<Interned>` (matching `cache: Cell<EntryCache>` and `need_stat: Cell<bool>` on the same struct) so the helper writes through `&self`.

All five resolver fill sites collapse to `query.entry().abs_path_or_fill(|| Interned::from_static(...))`, dropping the per-site `unsafe { &mut *query.entry }` writes and the now-incorrect SAFETY comments. `Route::parse` does the equivalent single-acquire check+fill inline (its fill body can `return None` on I/O error, which a closure cannot), and the hot reloader's `abs_path` read is moved inside the `Entry.mutex` guard it already holds for `set_cache_fd` / `need_stat`. The per-site drift that let these five sites miss the lock #33056 established for every other `Entry` rewrite is what this centralization removes.

Lock order is unchanged: the helper nests `Entry.mutex` over the `BSSStringList` mutex `dirname_store.append_slice` takes inside the closure, and nothing under that append touches `Entry.mutex`, matching the `entries_mutex` -> `Entry.mutex` order #33056 documented.

## Verification

- `bun bd test test/js/bun/util/filesystem_router.test.ts` (29/29), `resolve.test.ts` (43/43), `import-meta.test.js` (32/32), `framework-router.test.ts` (35/35), `hot.test.ts` (12/12) all green.
- `bun run rust:check-all` clean on all 10 targets.
- The existing concurrency test now also asserts every `router.routes` value is a valid absolute `.tsx` path after each round, so a torn `abs_path` on the router side is observable as a wrong `filePath` rather than only as a subprocess crash.

The torn state requires a weakly-ordered CPU (x86-TSO only surfaces `(new_ptr, old_len)`, which is the empty slice), so the fail-before half of the gate's probe cannot fire on the x64 gate host: 30 consecutive release runs and 15 debug+ASAN runs of the test pass there without this change. The aarch64 crash trace above is the direct evidence for the fail-before side.