### PR TITLE
test(valkey): allocate refused port instead of hardcoding 12345

### DIFF
--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -1,5 +1,5 @@
 import { RedisClient } from "bun";
-import { describe, expect, mock, test } from "bun:test";
+import { beforeAll, describe, expect, mock, test } from "bun:test";
 import net from "net";
 import { DEFAULT_REDIS_OPTIONS, DEFAULT_REDIS_URL, delay, isEnabled } from "../test-utils";
 
@@ -11,8 +11,17 @@ import { DEFAULT_REDIS_OPTIONS, DEFAULT_REDIS_URL, delay, isEnabled } from "../t
  * - Error propagation
  */
 describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
-  // Use invalid port to force connection failure
-  const BAD_CONNECTION_URL = "redis://localhost:12345";
+  // A port with nothing listening so the connect is refused. bind(0)->close
+  // instead of a fixed port so an unrelated process occupying 12345 can't turn
+  // this into a protocol-parse failure ("Failed to read data (stack path)").
+  let BAD_CONNECTION_URL!: string;
+  beforeAll(async () => {
+    const server = net.createServer();
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as net.AddressInfo).port;
+    await new Promise<void>(resolve => server.close(() => resolve()));
+    BAD_CONNECTION_URL = `redis://127.0.0.1:${port}`;
+  });
 
   describe("Connection Failure Handling", () => {
     test("should handle initial connection failure gracefully", async () => {


### PR DESCRIPTION
## What

`test/js/valkey/reliability/connection-failures.test.ts` went red in [build 74111](https://buildkite.com/bun/bun/builds/74111) on `:debian: 13 x64` (4/4 retries on the shard, the other 19 shards for the same lane passed):

```
error: expect(received).toMatch(expected)
Expected substring or pattern: /connection closed|socket closed|failed to connect/i
Received: "Failed to read data (stack path)"
```

## Cause

The suite hardcoded `redis://localhost:12345` as a "guaranteed bad" address and asserted connection-refused behaviour. On that runner something was listening on TCP 12345, so `RedisClient` connected, wrote `HELLO`, read non-RESP bytes back, and the reply parser failed with `Failed to read data (stack path)` (the `on_data` stack-path error in `src/runtime/valkey_jsc/valkey.rs`) instead of the expected connection error.

Reproduced locally by binding a junk-writing TCP server to 12345 before driving the same code path:

```
Got error: "Failed to read data (stack path)"
```

## Fix

Replace the fixed port with a `bind(0)` → read the port → `close()` sequence in `beforeAll`, the same pattern `test/js/sql/wire-frames.ts` exports as `closedPort()`. The connection-failure tests then target a freshly released ephemeral port on `127.0.0.1`, independent of what else is bound on the machine.

The code paths exercised are unchanged: every affected test still drives `RedisClient` into `on_connect_error`/`on_close` and asserts the same `/connection closed|socket closed|failed to connect/i` messages and `"Connection closed"` snapshot.

## Verification

With a garbage server deliberately bound to 12345:

```
[setup] evil server on 12345
[test] BAD_CONNECTION_URL = redis://127.0.0.1:46257
  PASS initial connection failure
  PASS offline queue enabled
  PASS clean up resources when disconnected
  PASS multiple clients not crash
4 pass, 0 fail
```

`bun bd test test/js/valkey/reliability/connection-failures.test.ts` passes (connection-failure cases are gated on Docker and skip in this container; the non-gated `Auto-Reconnect In-Flight Commands` case passes).