### PR TITLE
Fix EEXIST from recursive mkdir on Windows ReadOnly directories

### DIFF
--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -7434,22 +7434,16 @@ fn exists_at_type_nt(dir: Fd, mut path: &[u16]) -> Maybe<ExistsAtType> {
             Tag::access,
         ));
     }
-    let attrs = basic_info.FileAttributes;
-    // From libuv: directories cannot be read-only.
-    // https://github.com/libuv/libuv/blob/eb5af8e3/src/win/fs.c#L2144-L2146
-    let is_dir = attrs != windows::INVALID_FILE_ATTRIBUTES
-        && (attrs & w::FILE_ATTRIBUTE_DIRECTORY) != 0
-        && (attrs & w::FILE_ATTRIBUTE_READONLY) == 0;
-    let is_regular = attrs != windows::INVALID_FILE_ATTRIBUTES
-        && ((attrs & w::FILE_ATTRIBUTE_DIRECTORY) == 0
-            || (attrs & w::FILE_ATTRIBUTE_READONLY) == 0);
-    if is_dir {
-        Ok(ExistsAtType::Directory)
-    } else if is_regular {
-        Ok(ExistsAtType::File)
-    } else {
-        Err(Error::from_code(E::EUNKNOWN, Tag::access))
-    }
+    // `FILE_ATTRIBUTE_READONLY` on a directory is a folder-customization
+    // marker (OneDrive sets it) and does not affect directory-ness; only
+    // `FILE_ATTRIBUTE_DIRECTORY` decides the type.
+    Ok(
+        if (basic_info.FileAttributes & w::FILE_ATTRIBUTE_DIRECTORY) != 0 {
+            ExistsAtType::Directory
+        } else {
+            ExistsAtType::File
+        },
+    )
 }
 /// `fstatat` then `S_ISDIR`.
 pub fn exists_at_type(dir: Fd, sub: &ZStr) -> Maybe<ExistsAtType> {

--- a/test/js/node/fs/fs-mkdir.test.ts
+++ b/test/js/node/fs/fs-mkdir.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { isLinux, isWindows, tmpdirSync } from "harness";
+import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -301,6 +302,45 @@ describe("fs.mkdir - return values", () => {
     expect(fs.existsSync(pathname)).toBe(true);
     expect(fs.statSync(pathname).isDirectory()).toBe(true);
     expect(result).toBeUndefined();
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/34413
+describe.skipIf(!isWindows)("fs.mkdir - recursive with ReadOnly attribute (Windows)", () => {
+  let tmpdir: string;
+  let readonlyDir: string;
+
+  beforeEach(() => {
+    tmpdir = getTmpDir();
+    readonlyDir = path.join(tmpdir, nextdir());
+    fs.mkdirSync(readonlyDir);
+    execSync(`attrib +R "${readonlyDir}"`);
+  });
+
+  afterEach(() => {
+    try {
+      execSync(`attrib -R "${readonlyDir}"`);
+      fs.rmSync(tmpdir, { recursive: true, force: true });
+    } catch (err) {
+      // Ignore cleanup errors
+    }
+  });
+
+  it("mkdirSync does not throw when the directory exists and is ReadOnly", () => {
+    expect(fs.mkdirSync(readonlyDir, { recursive: true })).toBeUndefined();
+    expect(fs.statSync(readonlyDir).isDirectory()).toBe(true);
+  });
+
+  it("promises.mkdir does not throw when the directory exists and is ReadOnly", async () => {
+    expect(await fs.promises.mkdir(readonlyDir, { recursive: true })).toBeUndefined();
+    expect(fs.statSync(readonlyDir).isDirectory()).toBe(true);
+  });
+
+  it("creates nested directories under a ReadOnly ancestor", () => {
+    const pathname = path.join(readonlyDir, nextdir(), nextdir());
+
+    fs.mkdirSync(pathname, { recursive: true });
+    expect(fs.statSync(pathname).isDirectory()).toBe(true);
   });
 });
 


### PR DESCRIPTION
Fixes #34413

### Problem

On Windows, `fs.mkdirSync(dir, { recursive: true })` (and `fs.promises.mkdir`) throws `EEXIST: file already exists, mkdir 'testdir'` when the existing directory has the ReadOnly attribute set. Node succeeds. OneDrive marks synced folders ReadOnly, so idempotent mkdir calls fail for anything installed under OneDrive.

```js
fs.mkdirSync(dir, { recursive: true });
execSync(`attrib +R ${dir}`);
fs.mkdirSync(dir, { recursive: true }); // throws EEXIST on Bun, fine on Node
```

### Cause

`exists_at_type_nt` in `src/sys/lib.rs` treated `FILE_ATTRIBUTE_READONLY` as disqualifying directory-ness, so a ReadOnly directory was neither a directory nor a file and the function returned `EUNKNOWN`. The recursive-mkdir EEXIST handler calls `directory_exists_at` to decide whether the existing path is a directory; the error made it re-raise the original `EEXIST`. The deleted logic cited libuv's "directories cannot be read-only" note, but in libuv that note is about synthesizing the write-permission bit in `st_mode`, not about classifying the entry type: on Windows the ReadOnly attribute on a directory is a folder-customization marker (OneDrive sets it) and does not make it less of a directory.

### Fix

Classify by `FILE_ATTRIBUTE_DIRECTORY` alone. This also fixes the junction + ReadOnly case from the issue, and any other caller of `directory_exists_at` / `exists_at_type` probing a ReadOnly directory.

### Verification

New Windows-gated tests in `test/js/node/fs/fs-mkdir.test.ts` (mkdirSync and promises.mkdir on an existing ReadOnly directory, plus nested creation under a ReadOnly ancestor). On windows-x64 the two EEXIST tests fail on bun 1.4.0 canary and pass with this change; the junction + ReadOnly repro from the issue also passes.