### PR TITLE
bun build: let NODE_ENV=production override tsconfig jsx setting

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -731,6 +731,20 @@ impl<'a> Transpiler<'a> {
                 let was_production = self.options.production;
                 env.load_process()?;
                 let has_production_env = env.is_production();
+
+                // Load the project root for .env file discovery. If the cwd
+                // (or a parent) is unreadable, readDirInfo may return null;
+                // bail out of .env file loading in that case, but process
+                // env vars were already loaded above.
+                let top_level_dir = self.fs().top_level_dir;
+                let dir_info = self.resolver.read_dir_info(top_level_dir).ok().flatten();
+
+                // Merge tsconfig JSX before applying env-derived production so
+                // NODE_ENV=production overrides the tsconfig `jsx` default.
+                if let Some(tsconfig) = dir_info.and_then(|d| d.tsconfig_json()) {
+                    merge_tsconfig_jsx_into(tsconfig, &mut self.options.jsx);
+                }
+
                 if !was_production && has_production_env {
                     self.options.set_production(true);
                     // The resolver's FORWARD_DECL `BundleOptions` now exposes
@@ -742,19 +756,9 @@ impl<'a> Transpiler<'a> {
                     self.resolver.opts.set_production(true);
                 }
 
-                // Load the project root for .env file discovery. If the cwd
-                // (or a parent) is unreadable, readDirInfo may return null;
-                // bail out of .env file loading in that case, but process
-                // env vars were already loaded above.
-                let top_level_dir = self.fs().top_level_dir;
-                let dir_info = match self.resolver.read_dir_info(top_level_dir) {
-                    Ok(Some(d)) => d,
-                    _ => return Ok(()),
+                let Some(dir_info) = dir_info else {
+                    return Ok(());
                 };
-
-                if let Some(tsconfig) = dir_info.tsconfig_json() {
-                    merge_tsconfig_jsx_into(tsconfig, &mut self.options.jsx);
-                }
 
                 let Some(dir) = dir_info.get_entries(self.resolver.generation) else {
                     return Ok(());

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -441,8 +441,11 @@ impl BuildCommand {
             unsafe { (*this_transpiler.env).map.put(b"NODE_ENV", b"production")? };
         }
 
-        this_transpiler.configure_defines()?;
+        // `configure_linker`'s auto-JSX step copies tsconfig `jsx` wholesale;
+        // run it before `configure_defines` so env/`--define` NODE_ENV=production
+        // overrides the tsconfig default, matching `Bun.build()` and `bun run`.
         this_transpiler.configure_linker();
+        this_transpiler.configure_defines()?;
 
         if !this_transpiler.options.production {
             this_transpiler

--- a/test/regression/issue/23959.test.ts
+++ b/test/regression/issue/23959.test.ts
@@ -44,7 +44,9 @@ async function buildAndGetRuntime(opts: {
   const matches = stdout.match(/react\/jsx[a-z-]*runtime/g) ?? [];
   const unique = [...new Set(matches)];
   if (exitCode !== 0 || unique.length !== 1) {
-    throw new Error(`bun build exited ${exitCode}; runtimes=${JSON.stringify(unique)}\nstderr:\n${stderr}\nstdout:\n${stdout}`);
+    throw new Error(
+      `bun build exited ${exitCode}; runtimes=${JSON.stringify(unique)}\nstderr:\n${stderr}\nstdout:\n${stdout}`,
+    );
   }
   return { runtime: unique[0], stdout, stderr };
 }

--- a/test/regression/issue/23959.test.ts
+++ b/test/regression/issue/23959.test.ts
@@ -6,7 +6,7 @@
 // `--production` survived. React's production `jsx-dev-runtime` exports
 // `jsxDEV = undefined`, so the resulting bundle TypeErrors at first render.
 
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 const entry = `const el = <div prop="1">x</div>;\nexport default el;\n`;
@@ -57,14 +57,17 @@ describe("bun build: tsconfig jsx vs NODE_ENV=production", () => {
     expect(stdout).not.toContain("jsxDEV");
   });
 
-  test.concurrent("tsconfig react-jsx + --define process.env.NODE_ENV=production uses production JSX runtime", async () => {
-    const { runtime, stdout } = await buildAndGetRuntime({
-      tsconfigJsx: "react-jsx",
-      extraArgs: ["--define", 'process.env.NODE_ENV="production"'],
-    });
-    expect(runtime).toBe("react/jsx-runtime");
-    expect(stdout).not.toContain("jsxDEV");
-  });
+  test.concurrent(
+    "tsconfig react-jsx + --define process.env.NODE_ENV=production uses production JSX runtime",
+    async () => {
+      const { runtime, stdout } = await buildAndGetRuntime({
+        tsconfigJsx: "react-jsx",
+        extraArgs: ["--define", 'process.env.NODE_ENV="production"'],
+      });
+      expect(runtime).toBe("react/jsx-runtime");
+      expect(stdout).not.toContain("jsxDEV");
+    },
+  );
 
   test.concurrent("tsconfig react-jsxdev + NODE_ENV=production env uses production JSX runtime", async () => {
     const { runtime } = await buildAndGetRuntime({

--- a/test/regression/issue/23959.test.ts
+++ b/test/regression/issue/23959.test.ts
@@ -43,7 +43,9 @@ async function buildAndGetRuntime(opts: {
 
   const matches = stdout.match(/react\/jsx[a-z-]*runtime/g) ?? [];
   const unique = [...new Set(matches)];
-  expect({ stderr, exitCode, runtimes: unique }).toEqual({ stderr: "", exitCode: 0, runtimes: [unique[0]] });
+  if (exitCode !== 0 || unique.length !== 1) {
+    throw new Error(`bun build exited ${exitCode}; runtimes=${JSON.stringify(unique)}\nstderr:\n${stderr}\nstdout:\n${stdout}`);
+  }
   return { runtime: unique[0], stdout, stderr };
 }
 

--- a/test/regression/issue/23959.test.ts
+++ b/test/regression/issue/23959.test.ts
@@ -1,0 +1,106 @@
+// https://github.com/oven-sh/bun/issues/23959
+//
+// A tsconfig.json with `"jsx": "react-jsx"` was clobbering both
+// `NODE_ENV=production` and `--define process.env.NODE_ENV="production"` in
+// `bun build`, forcing the dev JSX runtime (`react/jsx-dev-runtime`). Only
+// `--production` survived. React's production `jsx-dev-runtime` exports
+// `jsxDEV = undefined`, so the resulting bundle TypeErrors at first render.
+
+import { describe, test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+const entry = `const el = <div prop="1">x</div>;\nexport default el;\n`;
+
+async function buildAndGetRuntime(opts: {
+  tsconfigJsx?: string;
+  env?: Record<string, string | undefined>;
+  extraArgs?: string[];
+}): Promise<{ runtime: string; stdout: string; stderr: string }> {
+  const files: Record<string, string> = { "index.jsx": entry };
+  if (opts.tsconfigJsx) {
+    files["tsconfig.json"] = JSON.stringify({ compilerOptions: { jsx: opts.tsconfigJsx } });
+  }
+  using dir = tempDir("jsx-tsconfig-prod", files);
+
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "build",
+      "./index.jsx",
+      "--target=browser",
+      "--external",
+      "react",
+      "--external",
+      "react/*",
+      ...(opts.extraArgs ?? []),
+    ],
+    env: { ...bunEnv, NODE_ENV: undefined, ...opts.env },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const matches = stdout.match(/react\/jsx[a-z-]*runtime/g) ?? [];
+  const unique = [...new Set(matches)];
+  expect({ stderr, exitCode, runtimes: unique }).toEqual({ stderr: "", exitCode: 0, runtimes: [unique[0]] });
+  return { runtime: unique[0], stdout, stderr };
+}
+
+describe("bun build: tsconfig jsx vs NODE_ENV=production", () => {
+  test.concurrent("tsconfig react-jsx + NODE_ENV=production env uses production JSX runtime", async () => {
+    const { runtime, stdout } = await buildAndGetRuntime({
+      tsconfigJsx: "react-jsx",
+      env: { NODE_ENV: "production" },
+    });
+    expect(runtime).toBe("react/jsx-runtime");
+    expect(stdout).not.toContain("jsxDEV");
+  });
+
+  test.concurrent("tsconfig react-jsx + --define process.env.NODE_ENV=production uses production JSX runtime", async () => {
+    const { runtime, stdout } = await buildAndGetRuntime({
+      tsconfigJsx: "react-jsx",
+      extraArgs: ["--define", 'process.env.NODE_ENV="production"'],
+    });
+    expect(runtime).toBe("react/jsx-runtime");
+    expect(stdout).not.toContain("jsxDEV");
+  });
+
+  test.concurrent("tsconfig react-jsxdev + NODE_ENV=production env uses production JSX runtime", async () => {
+    const { runtime } = await buildAndGetRuntime({
+      tsconfigJsx: "react-jsxdev",
+      env: { NODE_ENV: "production" },
+    });
+    expect(runtime).toBe("react/jsx-runtime");
+  });
+
+  test.concurrent("tsconfig react-jsx + --production uses production JSX runtime", async () => {
+    const { runtime } = await buildAndGetRuntime({
+      tsconfigJsx: "react-jsx",
+      extraArgs: ["--production"],
+    });
+    expect(runtime).toBe("react/jsx-runtime");
+  });
+
+  test.concurrent("tsconfig react-jsx without NODE_ENV still uses dev JSX runtime", async () => {
+    const { runtime } = await buildAndGetRuntime({
+      tsconfigJsx: "react-jsx",
+    });
+    expect(runtime).toBe("react/jsx-dev-runtime");
+  });
+
+  test.concurrent("no tsconfig + NODE_ENV=production uses production JSX runtime", async () => {
+    const { runtime } = await buildAndGetRuntime({
+      env: { NODE_ENV: "production" },
+    });
+    expect(runtime).toBe("react/jsx-runtime");
+  });
+
+  test.concurrent("tsconfig react-jsx + NODE_ENV=development uses dev JSX runtime", async () => {
+    const { runtime } = await buildAndGetRuntime({
+      tsconfigJsx: "react-jsx",
+      env: { NODE_ENV: "development" },
+    });
+    expect(runtime).toBe("react/jsx-dev-runtime");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes #23959.

With a `tsconfig.json` setting `"jsx": "react-jsx"`, `bun build` emits the development JSX runtime (`react/jsx-dev-runtime`, `jsxDEV`) even when `NODE_ENV=production` is set in the environment or via `--define process.env.NODE_ENV="production"`. Only `--production` survived. React's production `react/jsx-dev-runtime` exports `jsxDEV = undefined`, so the resulting bundle throws `jsxDEV is not a function` at the first element construction.

### Reproduction

```sh
printf 'const a = <div p="1">x</div>;\nglobalThis.s = a;\n' > m.jsx
printf '{"compilerOptions":{"jsx":"react-jsx"}}' > tsconfig.json

NODE_ENV=production bun build m.jsx --external 'react*' | grep -o 'react/jsx[a-z-]*'
# before: react/jsx-dev-runtime
# after:  react/jsx-runtime

bun build m.jsx --external 'react*' --define 'process.env.NODE_ENV="production"' | grep -o 'react/jsx[a-z-]*'
# before: react/jsx-dev-runtime
# after:  react/jsx-runtime
```

### Root cause

`build_command.rs` called `configure_defines()` before `configure_linker()`. `configure_linker`'s auto-JSX step copies the tsconfig `jsx` pragma wholesale into `options.jsx`, wiping the `jsx.development = false` that `configure_defines` had just derived from `NODE_ENV`. Every other entry point (`Bun.build()`, `bun run`, bake, test scanner) already calls `configure_linker()` first, which is why the JS API was not affected.

### Fix

- Swap `configure_linker()` to run before `configure_defines()` in `build_command.rs`, matching all other call sites.
- Reorder `run_env_loader` so the tsconfig JSX merge happens before the env-derived `set_production`, so `NODE_ENV=production` consistently wins over the tsconfig default within that function as well.

### Tests

`test/regression/issue/23959.test.ts` covers:
- tsconfig `react-jsx` + `NODE_ENV=production` env (the bug)
- tsconfig `react-jsx` + `--define process.env.NODE_ENV="production"` (the bug)
- tsconfig `react-jsxdev` + `NODE_ENV=production` env (same root cause)
- tsconfig `react-jsx` + `--production` (already worked; regression guard)
- tsconfig `react-jsx` with no NODE_ENV (stays dev; guards against over-forcing)
- no tsconfig + `NODE_ENV=production` (control)
- tsconfig `react-jsx` + `NODE_ENV=development` (stays dev)

Verified `test/bundler/bundler_jsx.test.ts`, `test/bundler/esbuild/tsconfig.test.ts`, `test/cli/run/tsconfig-override.test.ts`, and `test/bundler/bundler_edgecase.test.ts` all pass.

Related: #31651 takes a different approach (setting `force_node_env = Production`); this PR fixes the ordering so the existing machinery works as intended.