### PR TITLE
node:http: fix malformed chunked responses to HTTP/1.0 clients when Content-Length is removed

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -2323,7 +2323,17 @@ function renderNativeHeaders(res) {
         closeDelimited = true;
         res[kMustCloseConnection] = true;
       } else if (res._removedContLen) {
-        forceChunked = true;
+        // Node's _storeHeader only falls through to chunked when
+        // useChunkedEncodingByDefault is set (false for HTTP/1.0 requests),
+        // and the native writer never chunk-frames an HTTP/1.0 response, so
+        // everything else is close-delimited like the _removedTE case.
+        const req = res.req;
+        if (res.useChunkedEncodingByDefault && req.httpVersionMajor >= 1 && req.httpVersionMinor >= 1) {
+          forceChunked = true;
+        } else {
+          closeDelimited = true;
+          res[kMustCloseConnection] = true;
+        }
       }
     }
 

--- a/test/regression/issue/34415.test.ts
+++ b/test/regression/issue/34415.test.ts
@@ -1,0 +1,137 @@
+// https://github.com/oven-sh/bun/issues/34415
+// Removing Content-Length (what the npm `compression` middleware does) made the
+// server advertise `Transfer-Encoding: chunked` to HTTP/1.0 clients while the
+// body went out unframed, so nginx (proxy_http_version 1.0) returned 502.
+import { test, expect } from "bun:test";
+import http from "node:http";
+import net from "node:net";
+import { once } from "node:events";
+
+async function serve(handler: http.RequestListener): Promise<{ server: http.Server; port: number }> {
+  const server = http.createServer(handler);
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  return { server, port: (server.address() as net.AddressInfo).port };
+}
+
+async function rawRequest(port: number, request: string): Promise<string> {
+  const sock = net.connect(port, "127.0.0.1");
+  await once(sock, "connect");
+  sock.write(request);
+  const chunks: Buffer[] = [];
+  sock.on("data", c => chunks.push(c));
+  await once(sock, "close");
+  return Buffer.concat(chunks).toString("latin1");
+}
+
+function parseResponse(raw: string) {
+  const idx = raw.indexOf("\r\n\r\n");
+  expect(idx).toBeGreaterThan(0);
+  const [statusLine, ...headerLines] = raw.slice(0, idx).split("\r\n");
+  const headers: Record<string, string> = {};
+  for (const line of headerLines) {
+    const sep = line.indexOf(": ");
+    headers[line.slice(0, sep).toLowerCase()] = line.slice(sep + 2);
+  }
+  return { statusLine, headers, body: raw.slice(idx + 4) };
+}
+
+// Strict chunked-framing decoder: throws on anything nginx would reject.
+function decodeChunked(body: string): string {
+  let out = "";
+  let i = 0;
+  while (true) {
+    const lineEnd = body.indexOf("\r\n", i);
+    if (lineEnd === -1) throw new Error(`missing chunk size line at ${i}: ${JSON.stringify(body.slice(i, i + 32))}`);
+    const sizeHex = body.slice(i, lineEnd).split(";")[0];
+    if (!/^[0-9a-fA-F]+$/.test(sizeHex)) throw new Error(`invalid chunk size ${JSON.stringify(sizeHex)}`);
+    const size = parseInt(sizeHex, 16);
+    i = lineEnd + 2;
+    if (size === 0) {
+      if (body.slice(i) !== "\r\n") throw new Error(`bad chunked trailer ${JSON.stringify(body.slice(i))}`);
+      return out;
+    }
+    out += body.slice(i, i + size);
+    i += size;
+    if (body.slice(i, i + 2) !== "\r\n") throw new Error(`missing CRLF after chunk data at ${i}`);
+    i += 2;
+  }
+}
+
+function removeContentLengthHandler(req: http.IncomingMessage, res: http.ServerResponse) {
+  res.removeHeader("Content-Length");
+  res.write("hello world");
+  res.end();
+}
+
+test("HTTP/1.0 response with removed Content-Length is close-delimited, not chunked", async () => {
+  const { server, port } = await serve(removeContentLengthHandler);
+  try {
+    const res = parseResponse(await rawRequest(port, "GET / HTTP/1.0\r\nHost: localhost\r\n\r\n"));
+    expect({
+      status: res.statusLine,
+      transferEncoding: res.headers["transfer-encoding"],
+      connection: res.headers.connection,
+      body: res.body,
+    }).toEqual({
+      status: "HTTP/1.1 200 OK",
+      transferEncoding: undefined,
+      connection: "close",
+      body: "hello world",
+    });
+  } finally {
+    server.close();
+  }
+});
+
+test("HTTP/1.0 request with TE: chunked still gets a well-formed response", async () => {
+  const { server, port } = await serve(removeContentLengthHandler);
+  try {
+    const res = parseResponse(await rawRequest(port, "GET / HTTP/1.0\r\nHost: localhost\r\nTE: chunked\r\n\r\n"));
+    // The native writer never chunk-frames HTTP/1.0 responses, so the header
+    // must not be advertised and the body goes out close-delimited.
+    expect({
+      transferEncoding: res.headers["transfer-encoding"],
+      connection: res.headers.connection,
+      body: res.body,
+    }).toEqual({
+      transferEncoding: undefined,
+      connection: "close",
+      body: "hello world",
+    });
+  } finally {
+    server.close();
+  }
+});
+
+test("HTTP/1.0 response with removed Content-Length, end(data) only", async () => {
+  const { server, port } = await serve((req, res) => {
+    res.removeHeader("Content-Length");
+    res.end("hello world");
+  });
+  try {
+    const res = parseResponse(await rawRequest(port, "GET / HTTP/1.0\r\nHost: localhost\r\n\r\n"));
+    expect({
+      transferEncoding: res.headers["transfer-encoding"],
+      body: res.body,
+    }).toEqual({
+      transferEncoding: undefined,
+      body: "hello world",
+    });
+  } finally {
+    server.close();
+  }
+});
+
+test("HTTP/1.1 response with removed Content-Length stays chunked with valid framing", async () => {
+  const { server, port } = await serve(removeContentLengthHandler);
+  try {
+    const res = parseResponse(
+      await rawRequest(port, "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"),
+    );
+    expect(res.headers["transfer-encoding"]).toBe("chunked");
+    expect(decodeChunked(res.body)).toBe("hello world");
+  } finally {
+    server.close();
+  }
+});

--- a/test/regression/issue/34415.test.ts
+++ b/test/regression/issue/34415.test.ts
@@ -2,10 +2,10 @@
 // Removing Content-Length (what the npm `compression` middleware does) made the
 // server advertise `Transfer-Encoding: chunked` to HTTP/1.0 clients while the
 // body went out unframed, so nginx (proxy_http_version 1.0) returned 502.
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
+import { once } from "node:events";
 import http from "node:http";
 import net from "node:net";
-import { once } from "node:events";
 
 async function serve(handler: http.RequestListener): Promise<{ server: http.Server; port: number }> {
   const server = http.createServer(handler);
@@ -126,9 +126,7 @@ test("HTTP/1.0 response with removed Content-Length, end(data) only", async () =
 test("HTTP/1.1 response with removed Content-Length stays chunked with valid framing", async () => {
   const { server, port } = await serve(removeContentLengthHandler);
   try {
-    const res = parseResponse(
-      await rawRequest(port, "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"),
-    );
+    const res = parseResponse(await rawRequest(port, "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"));
     expect(res.headers["transfer-encoding"]).toBe("chunked");
     expect(decodeChunked(res.body)).toBe("hello world");
   } finally {


### PR DESCRIPTION
Fixes #34415

### Repro

```js
import http from "node:http";
const server = http.createServer((req, res) => {
  res.removeHeader("Content-Length"); // what the compression middleware does
  res.write("hello world");
  res.end();
});
// GET / HTTP/1.0 over a raw socket returns:
// HTTP/1.1 200 OK\r\n...\r\nTransfer-Encoding: chunked\r\n\r\nhello world
```

The response advertises `Transfer-Encoding: chunked` but the body is not chunk-framed. nginx (whose `proxy_http_version` defaults to 1.0) rejects it with `upstream sent invalid chunked response` and returns 502 for every proxied request. This is how NestJS/Express apps behind nginx broke on canary: the npm `compression` middleware always removes Content-Length.

### Cause

A regression from the node:http rewrite. In `_http_server.ts`, when the user removed Content-Length and no framing headers remain, the header renderer set `forceChunked` unconditionally, pushing a literal `Transfer-Encoding: chunked` header. The native writer never chunk-frames a response to an HTTP/1.0 request (`HTTP_ANCIENT_REQUEST` gates every chunk path in uWS), so the wire carried the chunked header with a raw body.

### Fix

Only fall through to chunked when `useChunkedEncodingByDefault` is set (Node clears it for HTTP/1.0 requests) and the request is HTTP/1.1, since the native writer cannot chunk-frame HTTP/1.0 regardless. Otherwise take the close-delimited path, like the removed-Transfer-Encoding case and Node's `_storeHeader`.

### Verification

- New `test/regression/issue/34415.test.ts` covers HTTP/1.0 (write+end and end-only), HTTP/1.0 with a `TE: chunked` request header, and HTTP/1.1 (must stay chunked with valid framing). 3 of 4 fail before the fix, all pass after.
- Reproduced the reporter's stack (express + `compression({threshold: 0})`): before, HTTP/1.0 gzip responses advertised chunked with raw gzip bytes where a chunk-size line should be; after, they are close-delimited with no `Transfer-Encoding` header and gunzip cleanly, while HTTP/1.1 responses remain well-formed chunked.
- `test/js/node/http/node-http.test.ts` passes (one pre-existing network-dependent proxy failure, identical on unmodified main).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/34415.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (1155f4e9c)

test/regression/issue/34415.test.ts:
71 |     expect({
72 |       status: res.statusLine,
73 |       transferEncoding: res.headers["transfer-encoding"],
74 |       connection: res.headers.connection,
75 |       body: res.body,
76 |     }).toEqual({
            ^
error: expect(received).toEqual(expected)

  {
    "body": "hello world",
    "connection": "close",
    "status": "HTTP/1.1 200 OK",
-   "transferEncoding": undefined,
+   "transferEncoding": "chunked",
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/regression/issue/34415.test.ts:76:8)
(fail) HTTP/1.0 response with removed Content-Length is close-delimited, not chunked [719.28ms]
92 |     // must not be advertised and the bod
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (225a94064)

test/regression/issue/34415.test.ts:
(pass) HTTP/1.0 response with removed Content-Length is close-delimited, not chunked [12.54ms]
(pass) HTTP/1.0 request with TE: chunked still gets a well-formed response [4.78ms]
(pass) HTTP/1.0 response with removed Content-Length, end(data) only [2.66ms]
(pass) HTTP/1.1 response with removed Content-Length stays chunked with valid framing [3.80ms]

 4 pass
 0 fail
 9 expect() calls
Ran 4 tests across 1 file. [196.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/34415.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (1155f4e9c)

test/regression/issue/34415.test.ts:
(pass) HTTP/1.0 response with removed Content-Length is close-delimited, not chunked [694.94ms]
(pass) HTTP/1.0 request with TE: chunked still gets a well-formed response [119.63ms]
(pass) HTTP/1.0 response with removed Content-Length, end(data) only [114.17ms]
(pass) HTTP/1.1 response with removed Content-Length stays chunked with valid framing [106.38ms]

 4 pass
 0 fail
 9 expect() calls
Ran 4 tests across 1 file. [3.84s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 693ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[2/23] gen cpp.rs (cppbind)
[3/23] gen JS modules (bundle-modules)
Preprocess modules (7239ms)
Bundle modules (49ms)
Postprocesss modules (162ms)
Bundle Functions (769ms)
Generate Code (80ms)

[8.32s] Bundled "src/js" for production
  1985 kb
  164 internal modules
  12 native modules
  90 internal functions across 19 files
[3/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/_http_server.ts         |  12 +++-
 test/regression/issue/34415.test.ts | 135 ++++++++++++++++++++++++++++++++++++
 2 files changed, 146 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/js/node/_http_server.ts              1      4      0
test/regression/issue/34415.test.ts      0      1      0
```

</details>

**root cause** · written by the author bot

When user code removed the Content-Length header, as the compression middleware does, Bun's node:http server unconditionally advertised Transfer-Encoding: chunked, but for HTTP/1.0 requests the native writer never actually chunk-framed the body, producing a response whose framing did not match its headers and causing nginx to reject it with a 502. The fix gates the chunked path on the request supporting chunked encoding, checking useChunkedEncodingByDefault along with an HTTP version of 1.1 or later, matching Node's behavior in _storeHeader. When that condition fails, the response falls bac…

<!-- robobun:evidence:end -->