### PR TITLE
create: report GitHub 5xx as a GitHub error; skip live-GitHub tests on it

### DIFF
--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -397,18 +397,23 @@ impl CreateCommand {
                     ) {
                         Ok(b) => b,
                         Err(err) => {
-                            if matches!(err, crate::Error::HTTPForbidden) {
+                            if matches!(
+                                err,
+                                crate::Error::HTTPForbidden | crate::Error::HTTPTooManyRequests
+                            ) {
                                 node.end();
                                 progress.refresh();
 
                                 pretty_error!(
-                                    "\n<r><red>error:<r> GitHub returned 403. This usually means GitHub is rate limiting your requests.\nTo fix this, either:<r>  <b>A) pass a <r><cyan>GITHUB_ACCESS_TOKEN<r> environment variable to bun<r>\n  <b>B)Wait a little and try again<r>\n",
+                                    "\n<r><red>error:<r> GitHub returned {}. This usually means GitHub is rate limiting your requests.\nTo fix this, either:<r>  <b>A) pass a <r><cyan>GITHUB_ACCESS_TOKEN<r> environment variable to bun<r>\n  <b>B)Wait a little and try again<r>\n",
+                                    if matches!(err, crate::Error::HTTPForbidden) {
+                                        "403"
+                                    } else {
+                                        "429"
+                                    },
                                 );
                                 Global::crash();
-                            } else if matches!(
-                                err,
-                                crate::Error::GitHubIsDown | crate::Error::HTTPTooManyRequests
-                            ) {
+                            } else if matches!(err, crate::Error::GitHubIsDown) {
                                 node.end();
                                 progress.refresh();
 

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -405,6 +405,18 @@ impl CreateCommand {
                                     "\n<r><red>error:<r> GitHub returned 403. This usually means GitHub is rate limiting your requests.\nTo fix this, either:<r>  <b>A) pass a <r><cyan>GITHUB_ACCESS_TOKEN<r> environment variable to bun<r>\n  <b>B)Wait a little and try again<r>\n",
                                 );
                                 Global::crash();
+                            } else if matches!(
+                                err,
+                                crate::Error::GitHubIsDown | crate::Error::HTTPTooManyRequests
+                            ) {
+                                node.end();
+                                progress.refresh();
+
+                                pretty_error!(
+                                    "\n<r><red>error:<r> GitHub returned a server error while fetching the tarball for <b>\"{}\"<r>. GitHub may be temporarily unavailable; wait a moment and try again.\n",
+                                    bstr::BStr::new(template),
+                                );
+                                Global::crash();
                             } else if matches!(err, crate::Error::GitHubRepositoryNotFound) {
                                 node.end();
                                 progress.refresh();
@@ -2322,7 +2334,7 @@ impl Example {
             404 => return Err(crate::Error::GitHubRepositoryNotFound),
             403 => return Err(crate::Error::HTTPForbidden),
             429 => return Err(crate::Error::HTTPTooManyRequests),
-            499..=599 => return Err(crate::Error::NPMIsDown),
+            499..=599 => return Err(crate::Error::GitHubIsDown),
             200 => {}
             _ => return Err(crate::Error::HTTPError),
         }

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -199,16 +199,15 @@ it("should create template from local folder", async () => {
 // `bun create <github-url>` hits https://api.github.com/repos/{owner}/{repo}/tarball.
 // CI exhausts the unauthenticated 60 req/hr limit (403) and the endpoint serves 5xx
 // during outages; skip rather than fail since these tests exercise `bun create`, not GitHub.
+function githubUnavailableReason(stderr: string): string | null {
+  if (stderr.includes("GitHub is rate limiting")) return "GitHub API rate limit reached. Set GITHUB_TOKEN to avoid this.";
+  if (stderr.includes("GitHub returned a server error")) return "GitHub API returned a 5xx server error.";
+  return null;
+}
 function isGithubUnavailable(stderr: string): boolean {
-  if (stderr.includes("GitHub is rate limiting")) {
-    console.warn("Skipping: GitHub API rate limit reached. Set GITHUB_TOKEN to avoid this.");
-    return true;
-  }
-  if (stderr.includes("GitHub returned a server error")) {
-    console.warn("Skipping: GitHub API returned a 5xx server error.");
-    return true;
-  }
-  return false;
+  const reason = githubUnavailableReason(stderr);
+  if (reason) console.warn(`Skipping: ${reason}`);
+  return reason !== null;
 }
 
 for (const [status, expected] of [
@@ -239,7 +238,7 @@ for (const [status, expected] of [
 
     const [, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(err).toContain(expected);
-    expect(isGithubUnavailable(err)).toBe(true);
+    expect(githubUnavailableReason(err)).not.toBeNull();
     expect(err).not.toContain("NPMIsDown");
     expect(err).not.toContain("An internal error occurred");
     expect(exitCode).toBe(1);

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -198,14 +198,50 @@ it("should create template from local folder", async () => {
 
 // `bun create <github-url>` hits https://api.github.com/repos/{owner}/{repo}/tarball.
 // Unauthenticated GitHub API is limited to 60 req/hr per IP; CI agents running many
-// parallel builds exhaust that quickly. When we detect the rate-limit error, skip the
-// test rather than fail — we are testing `bun create`, not GitHub's availability.
-function isGithubRateLimited(stderr: string): boolean {
+// parallel builds exhaust that quickly, and the endpoint can also return 5xx during a
+// GitHub outage. When we detect either, skip rather than fail: these tests exercise
+// `bun create`, not GitHub's availability.
+function isGithubUnavailable(stderr: string): boolean {
   if (stderr.includes("GitHub returned 403")) {
     console.warn("Skipping: GitHub API rate limit reached (403). Set GITHUB_TOKEN to avoid this.");
     return true;
   }
+  if (stderr.includes("GitHub returned a server error")) {
+    console.warn("Skipping: GitHub API returned a 5xx/429 server error.");
+    return true;
+  }
   return false;
+}
+
+for (const status of [503, 429]) {
+  it(`should report a GitHub server error (not NPMIsDown) when the tarball request gets ${status}`, async () => {
+    using server = Bun.serve({
+      tls,
+      port: 0,
+      fetch() {
+        return new Response("service unavailable", { status });
+      },
+    });
+
+    await using proc = spawn({
+      cmd: [bunExe(), "create", "github.com/dylan-conway/create-test"],
+      cwd: x_dir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...env,
+        NODE_TLS_REJECT_UNAUTHORIZED: "0",
+        GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
+      },
+    });
+
+    const [, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).toContain("error: GitHub returned a server error");
+    expect(err).toContain('"dylan-conway/create-test"');
+    expect(err).not.toContain("NPMIsDown");
+    expect(err).not.toContain("An internal error occurred");
+    expect(exitCode).toBe(1);
+  });
 }
 
 it("should not mention cd prompt when created in current directory", async () => {
@@ -219,7 +255,7 @@ it("should not mention cd prompt when created in current directory", async () =>
   });
 
   const [out, err] = await Promise.all([stdout.text(), stderr.text(), exited]);
-  if (isGithubRateLimited(err)) return;
+  if (isGithubUnavailable(err)) return;
 
   expect(err).not.toContain("error:");
   expect(out).toContain("bun dev");
@@ -237,7 +273,7 @@ for (const repo of ["https://github.com/dylan-conway/create-test", "github.com/d
     });
 
     const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
-    if (isGithubRateLimited(err)) return;
+    if (isGithubUnavailable(err)) return;
     expect(err).not.toContain("error:");
     expect(out).toContain("Success! dylan-conway/create-test loaded into create-test");
     expect(await exists(join(x_dir, "create-test", "node_modules", "jquery"))).toBe(true);

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -200,7 +200,8 @@ it("should create template from local folder", async () => {
 // CI exhausts the unauthenticated 60 req/hr limit (403) and the endpoint serves 5xx
 // during outages; skip rather than fail since these tests exercise `bun create`, not GitHub.
 function githubUnavailableReason(stderr: string): string | null {
-  if (stderr.includes("GitHub is rate limiting")) return "GitHub API rate limit reached. Set GITHUB_TOKEN to avoid this.";
+  if (stderr.includes("GitHub is rate limiting"))
+    return "GitHub API rate limit reached. Set GITHUB_TOKEN to avoid this.";
   if (stderr.includes("GitHub returned a server error")) return "GitHub API returned a 5xx server error.";
   return null;
 }

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -197,29 +197,31 @@ it("should create template from local folder", async () => {
 });
 
 // `bun create <github-url>` hits https://api.github.com/repos/{owner}/{repo}/tarball.
-// Unauthenticated GitHub API is limited to 60 req/hr per IP; CI agents running many
-// parallel builds exhaust that quickly, and the endpoint can also return 5xx during a
-// GitHub outage. When we detect either, skip rather than fail: these tests exercise
-// `bun create`, not GitHub's availability.
+// CI exhausts the unauthenticated 60 req/hr limit (403) and the endpoint serves 5xx
+// during outages; skip rather than fail since these tests exercise `bun create`, not GitHub.
 function isGithubUnavailable(stderr: string): boolean {
-  if (stderr.includes("GitHub returned 403")) {
-    console.warn("Skipping: GitHub API rate limit reached (403). Set GITHUB_TOKEN to avoid this.");
+  if (stderr.includes("GitHub is rate limiting")) {
+    console.warn("Skipping: GitHub API rate limit reached. Set GITHUB_TOKEN to avoid this.");
     return true;
   }
   if (stderr.includes("GitHub returned a server error")) {
-    console.warn("Skipping: GitHub API returned a 5xx/429 server error.");
+    console.warn("Skipping: GitHub API returned a 5xx server error.");
     return true;
   }
   return false;
 }
 
-for (const status of [503, 429]) {
-  it(`should report a GitHub server error (not NPMIsDown) when the tarball request gets ${status}`, async () => {
+for (const [status, expected] of [
+  [503, "error: GitHub returned a server error"],
+  [429, "error: GitHub returned 429. This usually means GitHub is rate limiting your requests"],
+  [403, "error: GitHub returned 403. This usually means GitHub is rate limiting your requests"],
+] as const) {
+  it(`should name GitHub in the error when the tarball request gets ${status}`, async () => {
     using server = Bun.serve({
       tls,
       port: 0,
       fetch() {
-        return new Response("service unavailable", { status });
+        return new Response("nope", { status });
       },
     });
 
@@ -236,8 +238,8 @@ for (const status of [503, 429]) {
     });
 
     const [, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(err).toContain("error: GitHub returned a server error");
-    expect(err).toContain('"dylan-conway/create-test"');
+    expect(err).toContain(expected);
+    expect(isGithubUnavailable(err)).toBe(true);
     expect(err).not.toContain("NPMIsDown");
     expect(err).not.toContain("An internal error occurred");
     expect(exitCode).toBe(1);


### PR DESCRIPTION
## Problem

`test/cli/install/bun-create.test.ts` went red in CI on every retry on multiple lanes (builds 74144, 74149, 74151, 74152, 74153, 74154) with:

```
error: An internal error occurred (NPMIsDown)
```

The three affected tests spawn `bun create https://github.com/dylan-conway/create-test`, which fetches `https://api.github.com/repos/dylan-conway/create-test/tarball`. During the api.github.com outage on 2026-07-16 that endpoint (and `/zen`, `/repos/...`, etc.) started serving 503 Unicorn pages for GET requests, and `fetch_from_github` maps every 5xx from GitHub to `crate::Error::NPMIsDown`. That variant has been there since the original Zig implementation (it was copy/pasted from the npm-registry fetch path just below it), so a GitHub outage surfaces to users as "NPMIsDown" and to CI as a hard failure. The 429 path falls through to the same generic "internal error" message.

#29956 previously made these tests skip on GitHub 403 (rate limit), but 5xx/429 still fell through.

## Fix

- `src/runtime/cli/create_command.rs`: in `fetch_from_github`, map 5xx to `GitHubIsDown` (the variant `bun upgrade` already uses for the same case) instead of `NPMIsDown`. At the `GithubRepository` call site:
  - fold `HTTPTooManyRequests` into the existing 403 arm so 429 gets the same rate-limit message with the `GITHUB_ACCESS_TOKEN` remedy (the status code is interpolated so the message still names which one was returned);
  - add a `GitHubIsDown` arm that prints a server-error message naming GitHub and the template instead of falling through to the generic "An internal error occurred (...)".
  The npm-registry `fetch` path below still uses `NPMIsDown`, which is correct there.
- `test/cli/install/bun-create.test.ts`: add three hermetic tests that point `GITHUB_API_DOMAIN` at a local TLS server returning 503/429/403 and assert the expected message for each (and that `NPMIsDown`/`An internal error occurred` is not printed). These fail on main for 503 and 429 and pass with the fix regardless of whether GitHub is up.
- Extend the existing skip helper (now `isGithubUnavailable`) so the three live-GitHub tests also skip on 5xx and 429, the same way they already skip on 403.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/cli/install/bun-create.test.ts -t "should name GitHub"
# 503 and 429 fail: "An internal error occurred (NPMIsDown)" / "(HTTPTooManyRequests)"
# 403 passes (pre-existing behavior, kept verbatim)

bun bd test test/cli/install/bun-create.test.ts
# 17 pass
```

There is no single culprit PR for the test break itself; the live-GitHub dependency predates #29956 and the `NPMIsDown` label predates the Rust port (#30412). The outage is the trigger.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-create.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (99aa78917)

test/cli/install/bun-create.test.ts:
(pass) should not crash > ["create"] [126.92ms]
(pass) should not crash > ["create",""] [114.76ms]
(pass) should not crash > ["create","--"] [106.43ms]
(pass) should not crash > ["create","--",""] [111.24ms]
(pass) should not crash > ["create","--help"] [106.53ms]
(pass) should create selected template with @ prefix [429.66ms]
(pass) should create selected template with @ prefix implicit `/create` [420.24ms]
(pass) should create selected template with @ prefix implicit `/create` with version [477.03ms]
Copying files... 

[17.00ms] git

[107.00ms] bun create /tmp/cr8-8przvA9/bun-create/test-template

Come hang out in bun's Discord: https://bun.com/discord

Created test-template proje
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (2d0d38384)

test/cli/install/bun-create.test.ts:
(pass) should not crash > ["create"] [2.23ms]
(pass) should not crash > ["create",""] [1.73ms]
(pass) should not crash > ["create","--"] [1.30ms]
(pass) should not crash > ["create","--",""] [1.56ms]
(pass) should not crash > ["create","--help"] [1.23ms]
(pass) should create selected template with @ prefix [45.09ms]
(pass) should create selected template with @ prefix implicit `/create` [47.80ms]
(pass) should create selected template with @ prefix implicit `/create` with version [43.63ms]
Copying files... 

[15.00ms] git

[15.00ms] bun create /tmp/cr8-8tLZMcv/bun-create/test-template

Come hang out in bun's Discord: https://bun.com/discord

Created test-template project successfully

# To get started, run:

  cd test-template
  bun dev

(pass) should create template from local folder [20.38ms]
(pass) should name GitHub in the error when the tarball request gets 503 [14.09ms]
(pass) should name GitHub in the error when the tarball request gets 429 [13.45ms]
(pass) should name GitHub in the error when the tarball request gets 403 [13.11ms]
(pass) should not mention cd prompt when created in cu
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-create.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (99aa78917)

test/cli/install/bun-create.test.ts:
(pass) should not crash > ["create"] [120.74ms]
(pass) should not crash > ["create",""] [104.70ms]
(pass) should not crash > ["create","--"] [111.53ms]
(pass) should not crash > ["create","--",""] [106.08ms]
(pass) should not crash > ["create","--help"] [104.13ms]
(pass) should create selected template with @ prefix [513.75ms]
(pass) should create selected template with @ prefix implicit `/create` [516.78ms]
(pass) should create selected template with @ prefix implicit `/create` with version [434.24ms]
Copying files... 

[16.00ms] git

[106.00ms] bun create /tmp/cr8-8sRs1GK/bun-create/test-template

Come hang out in bun's Discord: https://bun.com/discord

Created test-template proje
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 713ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/create_command.rs   | 23 ++++++++++++--
 test/cli/install/bun-create.test.ts | 62 ++++++++++++++++++++++++++++++-------
 2 files changed, 70 insertions(+), 15 deletions(-)
```

</details>

**gate history** · 1 passed · 2 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/runtime/cli/create_command.rs        2      4      0
test/cli/install/bun-create.test.ts      3      8      0
```

</details>

<!-- robobun:evidence:end -->