### PR TITLE
node:inspector: implement the Network domain

### DIFF
--- a/src/js/node/inspector.promises.ts
+++ b/src/js/node/inspector.promises.ts
@@ -1,7 +1,7 @@
 // Hardcoded module "node:inspector/promises"
 const inspector = require("node:inspector");
 
-const { Session: BaseSession, console, open, close, url, waitForDebugger } = inspector;
+const { Session: BaseSession, console, open, close, url, waitForDebugger, Network } = inspector;
 
 // Promise-based Session that wraps the callback-based Session
 class Session extends BaseSession {
@@ -25,4 +25,5 @@ export default {
   url,
   waitForDebugger,
   Session,
+  Network,
 };

--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -257,6 +257,331 @@ function removeConsoleHooks() {
   hookedConsoleMethods.length = 0;
 }
 
+// --- Network domain -------------------------------------------------------
+// Mirrors src/inspector/network_agent.cc from Node: the public inspector.Network
+// entry points validate and buffer here, and only the commands below hand data
+// back to a frontend.
+
+// Node caps a single resource at 5MB and the whole buffer at 100MB, silently
+// dropping a blob that would exceed either.
+const kDefaultMaxResourceBufferSize = 5 * 1024 * 1024;
+const kDefaultMaxTotalBufferSize = 100 * 1024 * 1024;
+
+class NetworkRequestEntry {
+  isStreaming = false;
+  isRequestFinished: boolean;
+  isResponseFinished = false;
+  requestIsUTF8: boolean;
+  responseIsUTF8 = false;
+  requestDataBlobs: Uint8Array[] = [];
+  responseDataBlobs: Uint8Array[] = [];
+  bufferSize = 0;
+  maxResourceBufferSize: number;
+
+  constructor(hasPostData: boolean, requestIsUTF8: boolean, maxResourceBufferSize: number) {
+    // A request with no body is born finished; only hasPostData obliges the
+    // caller to send dataSent({ finished: true }).
+    this.isRequestFinished = !hasPostData;
+    this.requestIsUTF8 = requestIsUTF8;
+    // Captured per entry: a later enable() must not retroactively shrink it.
+    this.maxResourceBufferSize = maxResourceBufferSize;
+  }
+}
+
+// Node keeps the buffer on the per-session NetworkAgent, so one session's
+// enable()/disable() cannot disturb another's buffered requests.
+class NetworkState {
+  // Insertion-ordered: the oldest entry is evicted first once the total cap is hit.
+  requests = new Map<string, NetworkRequestEntry>();
+  maxResourceBufferSize = kDefaultMaxResourceBufferSize;
+  maxTotalBufferSize = kDefaultMaxTotalBufferSize;
+  totalBufferSize = 0;
+}
+
+const networkEnabledSessions = new Map<Session, NetworkState>();
+
+function pushNetworkBlob(state: NetworkState, entry: NetworkRequestEntry, blobs: Uint8Array[], blob: Uint8Array) {
+  if (entry.bufferSize + blob.byteLength > entry.maxResourceBufferSize) return;
+  // Copy: Node's Binary::fromUint8Array eagerly copies, so a caller that
+  // recycles its chunk buffer must not corrupt what we buffered.
+  blobs.push(new Uint8Array(blob));
+  entry.bufferSize += blob.byteLength;
+  state.totalBufferSize += blob.byteLength;
+  while (state.totalBufferSize > state.maxTotalBufferSize) {
+    let oldest: string | undefined;
+    let oldestEntry: NetworkRequestEntry | undefined;
+    for (const { 0: key, 1: value } of state.requests) {
+      oldest = key;
+      oldestEntry = value;
+      break;
+    }
+    if (oldest === undefined) break;
+    state.totalBufferSize -= oldestEntry!.bufferSize;
+    state.requests.$delete(oldest);
+  }
+}
+
+function dropNetworkEntry(state: NetworkState, requestId: string, entry: NetworkRequestEntry) {
+  state.totalBufferSize -= entry.bufferSize;
+  state.requests.$delete(requestId);
+}
+
+function concatBlobs(blobs: Uint8Array[]) {
+  let total = 0;
+  for (const blob of blobs) total += blob.byteLength;
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const blob of blobs) {
+    out.set(blob, offset);
+    offset += blob.byteLength;
+  }
+  return out;
+}
+
+// Node reports a missing property and a wrong-typed one identically; `label`
+// carries the dotted path it uses for nested fields ("request.url").
+function requireEventString(params: any, key: string, label: string = key) {
+  const value = params[key];
+  if (typeof value !== "string") throw new TypeError(`Missing ${label} in event`);
+  return value;
+}
+
+// ObjectGetDouble: any JS number.
+function requireEventNumber(params: any, key: string, label: string = key) {
+  const value = params[key];
+  if (typeof value !== "number") throw new TypeError(`Missing ${label} in event`);
+  return value;
+}
+
+// ObjectGetInt: Node requires a real Int32 here, not just a number.
+function requireEventInt(params: any, key: string, label: string = key) {
+  const value = params[key];
+  if (typeof value !== "number" || !Number.isInteger(value) || value < -2147483648 || value > 2147483647) {
+    throw new TypeError(`Missing ${label} in event`);
+  }
+  return value;
+}
+
+function requireEventObject(params: any, key: string, label: string = key) {
+  const value = params[key];
+  if (typeof value !== "object" || value === null) throw new TypeError(`Missing ${label} in event`);
+  return value;
+}
+
+function requireEventUint8Array(params: any, key: string) {
+  requireEventObject(params, key);
+  const value = params[key];
+  if (!(value instanceof Uint8Array)) throw new TypeError("Expected data to be Uint8Array in event");
+  return value as Uint8Array;
+}
+
+// Header values must be protocol strings; Node rejects anything else outright.
+function headersFromObject(source: any, key: string, label: string) {
+  const raw = requireEventObject(source, key, label);
+  const headers: Record<string, string> = { __proto__: null } as any;
+  for (const name of Object.keys(raw)) {
+    const value = raw[name];
+    if (typeof value !== "string") throw new TypeError("Invalid header value in event");
+    headers[name] = value;
+  }
+  return headers;
+}
+
+function requestFromObject(params: any) {
+  const request = requireEventObject(params, "request");
+  const url = requireEventString(request, "url", "request.url");
+  const method = requireEventString(request, "method", "request.method");
+  const headers = headersFromObject(request, "headers", "request.headers");
+  // Node's ObjectGetBool yields false for any non-boolean, so `hasPostData: 1`
+  // must not arm the dataSent({ finished: true }) handshake.
+  // Extra properties are dropped: Node emits exactly this shape.
+  return { url, method, hasPostData: request.hasPostData === true, headers };
+}
+
+function responseFromObject(params: any, key: string, withUrl: boolean) {
+  const response = requireEventObject(params, key);
+  const status = requireEventInt(response, "status", "response.status");
+  const statusText = requireEventString(response, "statusText", "response.statusText");
+  const headers = headersFromObject(response, "headers", "response.headers");
+  if (!withUrl) return { status, statusText, headers };
+  const url = requireEventString(response, "url", "response.url");
+  return {
+    url,
+    status,
+    statusText,
+    headers,
+    mimeType: typeof response.mimeType === "string" ? response.mimeType : "",
+    charset: typeof response.charset === "string" ? response.charset : "",
+  };
+}
+
+function emitToSession(session: Session, method: string, params: object) {
+  const message = { method, params };
+  session.emit(method, message);
+  session.emit("inspectorNotification", message);
+}
+
+// Each enabled session owns its buffer, so the event is applied once per session.
+function forEachNetworkSession(fn: (session: Session, state: NetworkState) => void) {
+  for (const { 0: session, 1: state } of networkEnabledSessions) fn(session, state);
+}
+
+const Network = {
+  requestWillBeSent(params: any) {
+    if (networkEnabledSessions.size === 0) return;
+    const requestId = requireEventString(params, "requestId");
+    const timestamp = requireEventNumber(params, "timestamp");
+    const wallTime = requireEventNumber(params, "wallTime");
+    const request = requestFromObject(params);
+    // The request charset sits at the top level, not inside `request`.
+    const requestIsUTF8 = params.charset === "utf-8";
+    forEachNetworkSession((session, state) => {
+      // A duplicate requestId drops the whole event for that session.
+      if (state.requests.$has(requestId)) return;
+      state.requests.$set(
+        requestId,
+        new NetworkRequestEntry(request.hasPostData, requestIsUTF8, state.maxResourceBufferSize),
+      );
+      emitToSession(session, "Network.requestWillBeSent", {
+        requestId,
+        request,
+        timestamp,
+        wallTime,
+        initiator: { type: "script" },
+      });
+    });
+  },
+
+  responseReceived(params: any) {
+    if (networkEnabledSessions.size === 0) return;
+    const requestId = requireEventString(params, "requestId");
+    const timestamp = requireEventNumber(params, "timestamp");
+    const type = requireEventString(params, "type");
+    const response = responseFromObject(params, "response", true);
+    forEachNetworkSession((session, state) => {
+      const entry = state.requests.$get(requestId);
+      if (entry === undefined) return;
+      entry.responseIsUTF8 = response.charset === "utf-8";
+      emitToSession(session, "Network.responseReceived", { requestId, timestamp, type, response });
+    });
+  },
+
+  loadingFinished(params: any) {
+    if (networkEnabledSessions.size === 0) return;
+    const requestId = requireEventString(params, "requestId");
+    const timestamp = requireEventNumber(params, "timestamp");
+    forEachNetworkSession((session, state) => {
+      // Node emits before the lookup, so an unknown requestId still reaches the frontend.
+      emitToSession(session, "Network.loadingFinished", { requestId, timestamp });
+      const entry = state.requests.$get(requestId);
+      if (entry === undefined) return;
+      if (entry.isStreaming) dropNetworkEntry(state, requestId, entry);
+      else entry.isResponseFinished = true;
+    });
+  },
+
+  loadingFailed(params: any) {
+    if (networkEnabledSessions.size === 0) return;
+    const requestId = requireEventString(params, "requestId");
+    const timestamp = requireEventNumber(params, "timestamp");
+    const type = requireEventString(params, "type");
+    const errorText = requireEventString(params, "errorText");
+    forEachNetworkSession((session, state) => {
+      emitToSession(session, "Network.loadingFailed", { requestId, timestamp, type, errorText });
+      const entry = state.requests.$get(requestId);
+      if (entry !== undefined) dropNetworkEntry(state, requestId, entry);
+    });
+  },
+
+  // dataSent is never emitted; it only feeds Network.getRequestPostData.
+  dataSent(params: any) {
+    if (networkEnabledSessions.size === 0) return;
+    const requestId = requireEventString(params, "requestId");
+    // `finished` short-circuits before any other field is read.
+    const finished = params.finished === true;
+    if (!finished) {
+      requireEventNumber(params, "timestamp");
+      requireEventInt(params, "dataLength");
+      requireEventUint8Array(params, "data");
+    }
+    forEachNetworkSession((_session, state) => {
+      const entry = state.requests.$get(requestId);
+      if (entry === undefined) return;
+      if (finished) {
+        entry.isRequestFinished = true;
+        return;
+      }
+      pushNetworkBlob(state, entry, entry.requestDataBlobs, params.data);
+    });
+  },
+
+  dataReceived(params: any) {
+    if (networkEnabledSessions.size === 0) return;
+    const requestId = requireEventString(params, "requestId");
+    const timestamp = requireEventNumber(params, "timestamp");
+    const dataLength = requireEventInt(params, "dataLength");
+    const encodedDataLength = requireEventInt(params, "encodedDataLength");
+    const data = requireEventUint8Array(params, "data");
+    forEachNetworkSession((session, state) => {
+      const entry = state.requests.$get(requestId);
+      if (entry === undefined) return;
+      // Buffer until a frontend asks to stream, then emit live.
+      if (entry.isStreaming) {
+        emitToSession(session, "Network.dataReceived", {
+          requestId,
+          timestamp,
+          dataLength,
+          encodedDataLength,
+          data: Buffer.from(data).toString("base64"),
+        });
+      } else {
+        pushNetworkBlob(state, entry, entry.responseDataBlobs, data);
+      }
+    });
+  },
+
+  webSocketCreated(params: any) {
+    if (networkEnabledSessions.size === 0) return;
+    const requestId = requireEventString(params, "requestId");
+    const url = requireEventString(params, "url");
+    forEachNetworkSession(session => {
+      emitToSession(session, "Network.webSocketCreated", { requestId, url, initiator: { type: "script" } });
+    });
+  },
+
+  webSocketClosed(params: any) {
+    if (networkEnabledSessions.size === 0) return;
+    const requestId = requireEventString(params, "requestId");
+    const timestamp = requireEventNumber(params, "timestamp");
+    forEachNetworkSession(session => {
+      emitToSession(session, "Network.webSocketClosed", { requestId, timestamp });
+    });
+  },
+
+  webSocketHandshakeResponseReceived(params: any) {
+    if (networkEnabledSessions.size === 0) return;
+    const requestId = requireEventString(params, "requestId");
+    const timestamp = requireEventNumber(params, "timestamp");
+    const response = responseFromObject(params, "response", false);
+    forEachNetworkSession(session => {
+      emitToSession(session, "Network.webSocketHandshakeResponseReceived", { requestId, timestamp, response });
+    });
+  },
+};
+
+// Node routes every entry point through broadcastToFrontend, which defaults a
+// missing params to {} and then validateObject()s it.
+for (const name of Object.keys(Network)) {
+  const original = Network[name];
+  Network[name] = function (params = {}) {
+    if (typeof params !== "object" || params === null || $isArray(params)) {
+      // Node's validateObject renders this type name lowercase.
+      throw $ERR_INVALID_ARG_TYPE("params", "object", params);
+    }
+    return original.$call(this, params);
+  };
+}
+
 // Reshapes the raw control-flow-profiler data from jsFunction_collectPreciseCoverage
 // ([{ url, scriptId, sourceLength, blocks: [[start, end, count]], functions: [[start, end, executed]] }])
 // into the V8 ScriptCoverage list returned by Profiler.takePreciseCoverage:
@@ -433,6 +758,7 @@ class Session extends EventEmitter {
     this.#connected = false;
     this.#coverageBaseline.$clear();
     runtimeEnabledSessions.$delete(this);
+    networkEnabledSessions.$delete(this);
     if (runtimeEnabledSessions.size === 0) removeConsoleHooks();
     // Forwarded Debugger.* state (breakpoints etc.) lives on a shared backend
     // on the debugger thread; release it so a disconnected session cannot keep
@@ -507,6 +833,58 @@ class Session extends EventEmitter {
         runtimeEnabledSessions.$delete(this);
         if (runtimeEnabledSessions.size === 0) removeConsoleHooks();
         return {};
+
+      case "Network.enable": {
+        // Node rebuilds this session's buffer on every enable, discarding prior state.
+        const state = new NetworkState();
+        const maxTotal = (params as any)?.maxTotalBufferSize;
+        const maxResource = (params as any)?.maxResourceBufferSize;
+        if (typeof maxTotal === "number") state.maxTotalBufferSize = maxTotal;
+        if (typeof maxResource === "number") state.maxResourceBufferSize = maxResource;
+        networkEnabledSessions.$set(this, state);
+        return {};
+      }
+
+      case "Network.disable":
+        networkEnabledSessions.$delete(this);
+        return {};
+
+      case "Network.streamResourceContent": {
+        const state = networkEnabledSessions.$get(this);
+        const requestId = (params as any)?.requestId;
+        const entry = state?.requests.$get(requestId);
+        if (state === undefined || entry === undefined) return $ERR_INSPECTOR_COMMAND("-32602: Request not found");
+        entry.isStreaming = true;
+        const buffered = concatBlobs(entry.responseDataBlobs);
+        entry.bufferSize -= buffered.byteLength;
+        state.totalBufferSize -= buffered.byteLength;
+        entry.responseDataBlobs = [];
+        if (entry.isResponseFinished) dropNetworkEntry(state, requestId, entry);
+        return { bufferedData: Buffer.from(buffered).toString("base64") };
+      }
+
+      case "Network.getResponseBody": {
+        const state = networkEnabledSessions.$get(this);
+        const requestId = (params as any)?.requestId;
+        const entry = state?.requests.$get(requestId);
+        if (state === undefined || entry === undefined) return $ERR_INSPECTOR_COMMAND("-32602: Request not found");
+        if (entry.isStreaming) return $ERR_INSPECTOR_COMMAND("-32602: Response body of the request is been streamed");
+        if (!entry.isResponseFinished) return $ERR_INSPECTOR_COMMAND("-32602: Response data is not finished yet");
+        const body = concatBlobs(entry.responseDataBlobs);
+        dropNetworkEntry(state, requestId, entry);
+        if (entry.responseIsUTF8) return { body: Buffer.from(body).toString("utf8"), base64Encoded: false };
+        return { body: Buffer.from(body).toString("base64"), base64Encoded: true };
+      }
+
+      case "Network.getRequestPostData": {
+        const state = networkEnabledSessions.$get(this);
+        const requestId = (params as any)?.requestId;
+        const entry = state?.requests.$get(requestId);
+        if (state === undefined || entry === undefined) return $ERR_INSPECTOR_COMMAND("-32602: Request not found");
+        if (!entry.isRequestFinished) return $ERR_INSPECTOR_COMMAND("-32602: Request data is not finished yet");
+        if (!entry.requestIsUTF8) return $ERR_INSPECTOR_COMMAND("-32000: Unable to serialize binary request body");
+        return { postData: Buffer.from(concatBlobs(entry.requestDataBlobs)).toString("utf8") };
+      }
 
       case "Profiler.enable":
         this.#profilerEnabled = true;
@@ -717,6 +1095,7 @@ export default {
   url,
   waitForDebugger,
   Session,
+  Network,
 };
 
 hideFromStack(open, close, url, waitForDebugger, Session.prototype.constructor);

--- a/test/js/node/test/common/inspector-helper.js
+++ b/test/js/node/test/common/inspector-helper.js
@@ -6,7 +6,7 @@ const http = require('http');
 const fixtures = require('../common/fixtures');
 const { spawn } = require('child_process');
 const { URL, pathToFileURL } = require('url');
-const { EventEmitter } = require('events');
+const { EventEmitter, once } = require('events');
 
 const _MAINSCRIPT = fixtures.path('loop.js');
 const DEBUG = false;
@@ -544,6 +544,34 @@ function fires(promise, error, timeoutMs) {
   ]);
 }
 
+/**
+ * When waiting for inspector events, there might be no handles on the event
+ * loop, and leads to process exits.
+ *
+ * This function provides a utility to wait until a inspector event for a certain
+ * time.
+ * @returns {Promise}
+ */
+function waitUntil(session, eventName, timeout = 1000) {
+  const resolvers = Promise.withResolvers();
+  const timer = setTimeout(() => {
+    resolvers.reject(new Error(`Wait for inspector event ${eventName} timed out`));
+  }, timeout);
+
+  once(session, eventName)
+    .then((res) => {
+      resolvers.resolve(res);
+      clearTimeout(timer);
+    }, (error) => {
+      // This should never happen.
+      resolvers.reject(error);
+      clearTimeout(timer);
+    });
+
+  return resolvers.promise;
+}
+
 module.exports = {
   NodeInstance,
+  waitUntil,
 };

--- a/test/js/node/test/parallel/test-inspector-network-arbitrary-data.js
+++ b/test/js/node/test/parallel/test-inspector-network-arbitrary-data.js
@@ -1,0 +1,41 @@
+// Flags: --inspect=0 --experimental-network-inspection
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const inspector = require('node:inspector/promises');
+const { Network } = require('node:inspector');
+const test = require('node:test');
+const assert = require('node:assert');
+const { waitUntil } = require('../common/inspector-helper');
+
+const session = new inspector.Session();
+session.connect();
+
+test('should emit Network.requestWillBeSent with unicode', async () => {
+  await session.post('Network.enable');
+  const expectedValue = 'CJK 汉字 🍱 🧑‍🧑‍🧒‍🧒';
+
+  const requestWillBeSentFuture = waitUntil(session, 'Network.requestWillBeSent')
+    .then(([event]) => {
+      assert.strictEqual(event.params.request.url, expectedValue);
+      assert.strictEqual(event.params.request.method, expectedValue);
+      assert.strictEqual(event.params.request.headers.mKey, expectedValue);
+    });
+
+  Network.requestWillBeSent({
+    requestId: '1',
+    timestamp: 1,
+    wallTime: 1,
+    request: {
+      url: expectedValue,
+      method: expectedValue,
+      headers: {
+        mKey: expectedValue,
+      },
+    },
+  });
+
+  await requestWillBeSentFuture;
+});

--- a/test/js/node/test/parallel/test-inspector-network-data-received.js
+++ b/test/js/node/test/parallel/test-inspector-network-data-received.js
@@ -1,0 +1,192 @@
+// Flags: --inspect=0 --experimental-network-inspection
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const inspector = require('node:inspector/promises');
+const { Network } = require('node:inspector');
+const test = require('node:test');
+const assert = require('node:assert');
+const { waitUntil } = require('../common/inspector-helper');
+const { setTimeout } = require('node:timers/promises');
+
+// The complete payload string received by the network agent
+const payloadString = `Hello, world${'.'.repeat(4096)}`;
+
+const session = new inspector.Session();
+session.connect();
+session.post('Network.enable');
+
+async function triggerNetworkEvents(requestId, charset) {
+  const url = 'https://example.com';
+  Network.requestWillBeSent({
+    requestId,
+    timestamp: 1,
+    wallTime: 1,
+    request: {
+      url,
+      method: 'GET',
+      headers: {
+        mKey: 'mValue',
+      },
+    },
+  });
+  await setTimeout(1);
+
+  Network.responseReceived({
+    requestId,
+    timestamp: 2,
+    type: 'Fetch',
+    response: {
+      url,
+      status: 200,
+      statusText: 'OK',
+      headers: {
+        mKey: 'mValue',
+      },
+      charset,
+    },
+  });
+  await setTimeout(1);
+
+  const chunk1 = Buffer.from('Hello, ');
+  Network.dataReceived({
+    requestId,
+    timestamp: 3,
+    dataLength: chunk1.byteLength,
+    encodedDataLength: chunk1.byteLength,
+    data: chunk1,
+  });
+  await setTimeout(1);
+
+  const chunk2 = Buffer.from('world');
+  Network.dataReceived({
+    requestId,
+    timestamp: 4,
+    dataLength: chunk2.byteLength,
+    encodedDataLength: chunk2.byteLength,
+    data: chunk2,
+  });
+  await setTimeout(1);
+
+  // Test inspector binary conversions with large input
+  const chunk3 = Buffer.allocUnsafe(4096).fill('.');
+  Network.dataReceived({
+    requestId,
+    timestamp: 5,
+    dataLength: chunk3.byteLength,
+    encodedDataLength: chunk3.byteLength,
+    data: chunk3,
+  });
+  await setTimeout(1);
+
+  Network.loadingFinished({
+    requestId,
+    timestamp: 6,
+  });
+}
+
+function assertNetworkEvents(session, requestId) {
+  session.on('Network.requestWillBeSent', common.mustCall(({ params }) => {
+    assert.strictEqual(params.requestId, requestId);
+  }));
+  session.on('Network.responseReceived', common.mustCall(({ params }) => {
+    assert.strictEqual(params.requestId, requestId);
+  }));
+  const loadingFinishedFuture = waitUntil(session, 'Network.loadingFinished')
+    .then(async ([{ params }]) => {
+      assert.strictEqual(params.requestId, requestId);
+    });
+
+  return loadingFinishedFuture;
+}
+
+test('should stream Network.dataReceived with data chunks', async () => {
+  session.removeAllListeners();
+
+  const requestId = 'my-req-id-1';
+  const chunks = [];
+  let totalDataLength = 0;
+  const loadingFinishedFuture = assertNetworkEvents(session, requestId);
+  const responseReceivedFuture = waitUntil(session, 'Network.responseReceived')
+    .then(async () => {
+      const { bufferedData } = await session.post('Network.streamResourceContent', {
+        requestId,
+      });
+      const data = Buffer.from(bufferedData, 'base64');
+      totalDataLength += data.byteLength;
+      chunks.push(data);
+    });
+  session.on('Network.dataReceived', common.mustCallAtLeast(({ params }) => {
+    assert.strictEqual(params.requestId, requestId);
+    totalDataLength += params.dataLength;
+    chunks.push(Buffer.from(params.data, 'base64'));
+  }));
+
+  await triggerNetworkEvents(requestId);
+  await responseReceivedFuture;
+  await loadingFinishedFuture;
+
+  const data = Buffer.concat(chunks);
+  assert.strictEqual(data.byteLength, totalDataLength, data);
+  assert.strictEqual(data.toString('utf8'), payloadString);
+});
+
+test('Network.streamResourceContent should send all buffered chunks', async () => {
+  session.removeAllListeners();
+
+  const requestId = 'my-req-id-2';
+  const loadingFinishedFuture = assertNetworkEvents(session, requestId);
+  session.on('Network.dataReceived', common.mustNotCall());
+
+  await triggerNetworkEvents(requestId);
+  await loadingFinishedFuture;
+  const { bufferedData } = await session.post('Network.streamResourceContent', {
+    requestId,
+  });
+  assert.strictEqual(Buffer.from(bufferedData, 'base64').toString('utf8'), payloadString);
+});
+
+test('Network.streamResourceContent should reject if request id not found', async () => {
+  session.removeAllListeners();
+
+  const requestId = 'unknown-request-id';
+  await assert.rejects(session.post('Network.streamResourceContent', {
+    requestId,
+  }), {
+    code: 'ERR_INSPECTOR_COMMAND',
+  });
+});
+
+test('Network.getResponseBody should send all buffered binary data', async () => {
+  session.removeAllListeners();
+
+  const requestId = 'my-req-id-3';
+  const loadingFinishedFuture = assertNetworkEvents(session, requestId);
+  session.on('Network.dataReceived', common.mustNotCall());
+
+  await triggerNetworkEvents(requestId);
+  await loadingFinishedFuture;
+  const { body, base64Encoded } = await session.post('Network.getResponseBody', {
+    requestId,
+  });
+  assert.strictEqual(base64Encoded, true);
+  assert.strictEqual(body, Buffer.from(payloadString).toString('base64'));
+});
+
+test('Network.getResponseBody should send all buffered text data', async () => {
+  session.removeAllListeners();
+
+  const requestId = 'my-req-id-4';
+  const loadingFinishedFuture = assertNetworkEvents(session, requestId);
+  session.on('Network.dataReceived', common.mustNotCall());
+
+  await triggerNetworkEvents(requestId, 'utf-8');
+  await loadingFinishedFuture;
+  const { body, base64Encoded } = await session.post('Network.getResponseBody', {
+    requestId,
+  });
+  assert.strictEqual(base64Encoded, false);
+  assert.strictEqual(body, payloadString);
+});

--- a/test/js/node/test/parallel/test-inspector-network-data-sent.js
+++ b/test/js/node/test/parallel/test-inspector-network-data-sent.js
@@ -1,0 +1,136 @@
+// Flags: --inspect=0 --experimental-network-inspection
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const inspector = require('node:inspector/promises');
+const { Network } = require('node:inspector');
+const test = require('node:test');
+const assert = require('node:assert');
+const { waitUntil } = require('../common/inspector-helper');
+const { setTimeout } = require('node:timers/promises');
+
+const session = new inspector.Session();
+session.connect();
+session.post('Network.enable');
+
+async function triggerNetworkEvents(requestId, requestCharset) {
+  const url = 'https://example.com';
+  Network.requestWillBeSent({
+    requestId,
+    timestamp: 1,
+    wallTime: 1,
+    request: {
+      url,
+      method: 'PUT',
+      headers: {
+        mKey: 'mValue',
+      },
+      hasPostData: true,
+    },
+    charset: requestCharset,
+  });
+  await setTimeout(1);
+
+  const chunk1 = Buffer.from('Hello, ');
+  Network.dataSent({
+    requestId,
+    timestamp: 2,
+    dataLength: chunk1.byteLength,
+    data: chunk1,
+  });
+  await setTimeout(1);
+
+  const chunk2 = Buffer.from('world');
+  Network.dataSent({
+    requestId,
+    timestamp: 3,
+    dataLength: chunk2.byteLength,
+    data: chunk2,
+  });
+  await setTimeout(1);
+
+  Network.dataSent({
+    requestId,
+    finished: true,
+  });
+  await setTimeout(1);
+
+  Network.responseReceived({
+    requestId,
+    timestamp: 4,
+    type: 'Fetch',
+    response: {
+      url,
+      status: 200,
+      statusText: 'OK',
+      headers: {
+        mKey: 'mValue',
+      },
+    },
+  });
+  await setTimeout(1);
+
+  Network.loadingFinished({
+    requestId,
+    timestamp: 5,
+  });
+}
+
+function assertNetworkEvents(session, requestId) {
+  session.on('Network.requestWillBeSent', common.mustCall(({ params }) => {
+    assert.strictEqual(params.requestId, requestId);
+  }));
+  session.on('Network.responseReceived', common.mustCall(({ params }) => {
+    assert.strictEqual(params.requestId, requestId);
+  }));
+  const loadingFinishedFuture = waitUntil(session, 'Network.loadingFinished')
+    .then(async ([{ params }]) => {
+      assert.strictEqual(params.requestId, requestId);
+    });
+
+  return loadingFinishedFuture;
+}
+
+test('Network.getRequestPostData should send all buffered text data', async () => {
+  session.removeAllListeners();
+
+  const requestId = 'my-req-id-1';
+  const loadingFinishedFuture = assertNetworkEvents(session, requestId);
+
+  await triggerNetworkEvents(requestId, 'utf-8');
+  await loadingFinishedFuture;
+
+  const { postData } = await session.post('Network.getRequestPostData', {
+    requestId,
+  });
+  assert.strictEqual(postData, 'Hello, world');
+});
+
+test('Network.getRequestPostData does not support binary data', async () => {
+  session.removeAllListeners();
+
+  const requestId = 'my-req-id-2';
+  const loadingFinishedFuture = assertNetworkEvents(session, requestId);
+
+  await triggerNetworkEvents(requestId);
+  await loadingFinishedFuture;
+
+  await assert.rejects(session.post('Network.getRequestPostData', {
+    requestId,
+  }), {
+    code: 'ERR_INSPECTOR_COMMAND',
+  });
+});
+
+test('Network.getRequestPostData should reject if request id not found', async () => {
+  session.removeAllListeners();
+
+  const requestId = 'unknown-request-id';
+  await assert.rejects(session.post('Network.getRequestPostData', {
+    requestId,
+  }), {
+    code: 'ERR_INSPECTOR_COMMAND',
+  });
+});


### PR DESCRIPTION
Stacked on #31823 — please review/merge that one first. The diff against it is the last commit only.

### What this does

#31823 notes that of the Node inspector tests it reviewed, only 5 pass, and lists the Network domain (9 tests) as the largest remaining gap. This implements that domain.

`inspector.Network.*` in Node is a thin dispatch table over `emitProtocolEvent`; all the actual semantics live in `src/inspector/network_agent.cc`. This ports that agent to the in-process Session:

- **The 9 event entry points** — `requestWillBeSent`, `responseReceived`, `loadingFinished`, `loadingFailed`, `dataSent`, `dataReceived`, `webSocketCreated`, `webSocketClosed`, `webSocketHandshakeResponseReceived` — exported from both `node:inspector` and `node:inspector/promises`.
- **The commands** — `Network.enable` / `Network.disable`, plus `streamResourceContent`, `getResponseBody` and `getRequestPostData`.
- **Node's buffering model.** `dataSent` never reaches a frontend at all; it exists only to feed `getRequestPostData`. `dataReceived` is buffered until `streamResourceContent` is invoked, which flushes everything buffered so far as that command's `bufferedData` result and flips the request to live streaming from then on. Buffers, the 5MB/100MB caps and oldest-first eviction are **per session**, matching Node, where `requests_` is a member of each session's `NetworkAgent` — so one session's `enable()` cannot wipe another's buffered requests.

Validation mirrors the agent rather than being approximated: `ObjectGetInt` (Int32) for `status`/`dataLength`/`encodedDataLength` vs `ObjectGetDouble` for `timestamp`/`wallTime`, dotted error paths (`Missing request.url in event`), `hasPostData` as a strict boolean (Node's `ObjectGetBool` yields `false` for any non-boolean, which decides whether the request is born finished), the request charset read from the **top level** of `params` while the response charset is read from `response`, and an eager **copy** of each caller-supplied `Uint8Array` (Node's `Binary::fromUint8Array` uses `CopyContents`, so a caller recycling one chunk buffer must not corrupt what was buffered).

### Verification

Driven against the real **node v26.3.0** binary as an oracle: the same script run through both emits identical events and returns identical command results — same bodies, same base64-vs-text decisions, same entry-erasure behavior, same error codes and messages (including Node's `Response body of the request is been streamed`).

```
$ diff <(node-v26.3.0 --inspect=0 --experimental-network-inspection drive.js) \
       <(bun-debug     --inspect=0 --experimental-network-inspection drive.js)
*** IDENTICAL ***
```

### Tests

Vendors the three v26.3.0 tests this makes pass, verbatim (1 + 3 + 5 = 9 assertions):

- `test-inspector-network-arbitrary-data.js`
- `test-inspector-network-data-sent.js`
- `test-inspector-network-data-received.js`

All three fail on #31823 without this change (`Inspector error -32601: 'Network.enable' wasn't found`) and pass with it; A/B'd with the helper sync already in place, so the passes are attributable to the implementation. `test/common/inspector-helper.js` is synced to v26.3.0 — Bun's copy predated the `waitUntil()` helper these tests use; it is now byte-identical to upstream, and no other vendored test consumes it. `test/expectations.txt` is untouched and no test is landed skipped.

Regression: #31823's own `inspector-profiler.test.ts` (44 pass) and its 5 vendored node tests are unaffected.

### Not included

- **http/http2/fetch/websocket auto-instrumentation** (`test-inspector-network-http.js`, `-http2`, `-fetch`, `-websocket`, `-content-type`) needs the `diagnostics_channel` subscribers in `lib/internal/inspector/network_*.js` wired into Bun's http and fetch paths. Not attempted here.
- **`initiator`** is emitted as `{ type: "script" }` without a captured stack. Node attaches `captureStackTrace(true)`; the field is optional in the CDP definition, so this is protocol-legal, but a frontend loses request attribution.
- `--experimental-network-inspection` is accepted and ignored by Bun, so unlike Node the domain is not gated behind it.

### Note for #31823

While verifying, `inspector.test.ts` → *"inspector.waitForDebugger() blocks again on the second call after a frontend disconnects"* flaked at **2/12 with this change reverted** (5s timeout), so it looks pre-existing on that branch rather than introduced here.
