### PR TITLE
jsx: honor tsconfig "react-jsx" vs "react-jsxdev" for the automatic runtime

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -561,6 +561,21 @@ impl<'a> Transpiler<'a> {
         let env_loader = self.env_mut();
         let mut is_production = env_loader.is_production();
 
+        // `load_defines` injects a default `process.env.NODE_ENV`; sample the
+        // explicit sources first so that default isn't mistaken for user intent
+        // and `force_node_env` stays `Unspecified` (tsconfig jsx stays in control).
+        let had_explicit_node_env = env_loader.get_node_env().is_some()
+            || self
+                .options
+                .transform_options
+                .define
+                .as_ref()
+                .is_some_and(|m| {
+                    m.keys
+                        .iter()
+                        .any(|k| &**k == options::default_user_defines::node_env::KEY)
+                });
+
         // `parse_env_json` needs a thread-local AST store to build
         // `E::String` nodes in. That work
         // is now done lazily inside `DefineData::parse`, only on the JSON-parse
@@ -576,13 +591,15 @@ impl<'a> Transpiler<'a> {
         self.options.load_defines(self.arena, Some(env_loader))?;
 
         let mut is_development = false;
-        if let Some(node_env) = self.options.define.dots.get(b"NODE_ENV".as_slice()) {
-            if !node_env.is_empty() {
-                if let Some(s) = node_env[0].data.value.e_string() {
-                    if s.eql_comptime(b"production") {
-                        is_production = true;
-                    } else if s.eql_comptime(b"development") {
-                        is_development = true;
+        if had_explicit_node_env {
+            if let Some(node_env) = self.options.define.dots.get(b"NODE_ENV".as_slice()) {
+                if !node_env.is_empty() {
+                    if let Some(s) = node_env[0].data.value.e_string() {
+                        if s.eql_comptime(b"production") {
+                            is_production = true;
+                        } else if s.eql_comptime(b"development") {
+                            is_development = true;
+                        }
                     }
                 }
             }

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -41,7 +41,9 @@ bun_core::declare_scope!(cache, visible);
 /// Version 22: Serialize `has_tla` in the cached ESM record flags byte. Entries
 /// written before #30888 carried `has_tla=false` for every module; the cache-HIT
 /// path reinstates the bug for any previously-cached TLA module (#30887).
-const EXPECTED_VERSION: u32 = 22;
+/// Version 23: `jsx.runtime`/`jsx.development` participate in the features hash,
+/// and tsconfig `"jsx": "react-jsx"` now emits the production runtime (#4227).
+const EXPECTED_VERSION: u32 = 23;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/options_types/jsx.rs
+++ b/src/options_types/jsx.rs
@@ -219,6 +219,9 @@ impl Pragma {
         hasher.update(&self.import_source.production);
         hasher.update(&self.classic_import_source);
         hasher.update(&self.package_name);
+        // `runtime` selects classic vs automatic emission; `development`
+        // selects `jsx` vs `jsxDEV`. Both shape transpiled output.
+        hasher.update(&[self.runtime as u8, self.development as u8]);
     }
 
     pub fn import_source(&self) -> &[u8] {

--- a/src/options_types/jsx.rs
+++ b/src/options_types/jsx.rs
@@ -46,9 +46,10 @@ pub struct RuntimeDevelopmentPair {
 bun_core::comptime_string_map! {
     pub static RUNTIME_MAP: RuntimeDevelopmentPair = {
         b"classic" => RuntimeDevelopmentPair { runtime: Runtime::Classic, development: None },
-        b"automatic" => RuntimeDevelopmentPair { runtime: Runtime::Automatic, development: Some(true) },
+        b"automatic" => RuntimeDevelopmentPair { runtime: Runtime::Automatic, development: None },
         b"react" => RuntimeDevelopmentPair { runtime: Runtime::Classic, development: None },
-        b"react-jsx" => RuntimeDevelopmentPair { runtime: Runtime::Automatic, development: Some(true) },
+        // TypeScript: "react-jsx" selects jsx/jsxs (production), "react-jsxdev" selects jsxDEV.
+        b"react-jsx" => RuntimeDevelopmentPair { runtime: Runtime::Automatic, development: Some(false) },
         b"react-jsxdev" => RuntimeDevelopmentPair { runtime: Runtime::Automatic, development: Some(true) },
     };
 }

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// tsconfig "jsx": "react-jsx" must select the production automatic runtime
+// (jsx/jsxs from <pkg>/jsx-runtime), and "react-jsxdev" must select the
+// development runtime (jsxDEV from <pkg>/jsx-dev-runtime). These mirror
+// TypeScript/esbuild semantics; previously both values mapped to the dev
+// runtime, so the production transform was unreachable via tsconfig.
+
+const shimFiles = {
+  "node_modules/shim/package.json": JSON.stringify({
+    name: "shim",
+    version: "1.0.0",
+    type: "module",
+    exports: {
+      ".": "./rt.js",
+      "./jsx-runtime": "./rt.js",
+      "./jsx-dev-runtime": "./dev.js",
+    },
+  }),
+  "node_modules/shim/rt.js": `
+    export const Fragment = Symbol.for("F");
+    export const jsx = () => (console.log("prod jsx"), {});
+    export const jsxs = jsx;
+  `,
+  "node_modules/shim/dev.js": `
+    export const Fragment = Symbol.for("F");
+    export const jsxDEV = () => (console.log("dev jsxDEV"), {});
+  `,
+  "m.jsx": `const a = <div p="1">x</div>;\nglobalThis.s = a;\n`,
+};
+
+describe("tsconfig compilerOptions.jsx", () => {
+  test.each([
+    ["react-jsx", "prod jsx", "shim/jsx-runtime"],
+    ["react-jsxdev", "dev jsxDEV", "shim/jsx-dev-runtime"],
+  ] as const)('"%s" selects the matching automatic runtime', async (jsx, runStdout, importSource) => {
+    using dir = tempDir("jsx-tsconfig", {
+      ...shimFiles,
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: { jsx, jsxImportSource: "shim" },
+      }),
+    });
+
+    // bun run
+    {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "m.jsx"],
+        env: { ...bunEnv, NODE_ENV: undefined },
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+        stdout: runStdout,
+        stderr: "",
+        exitCode: 0,
+      });
+    }
+
+    // bun build
+    {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "m.jsx", "--external", "shim*"],
+        env: { ...bunEnv, NODE_ENV: undefined },
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect(stderr).toBe("");
+      expect(stdout).toContain(`"${importSource}"`);
+      expect(stdout).not.toContain(
+        importSource === "shim/jsx-runtime" ? "jsx-dev-runtime" : '"shim/jsx-runtime"',
+      );
+      expect(exitCode).toBe(0);
+    }
+  });
+
+});

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
-// tsconfig "jsx": "react-jsx" must select the production automatic runtime
-// (jsx/jsxs from <pkg>/jsx-runtime), and "react-jsxdev" must select the
-// development runtime (jsxDEV from <pkg>/jsx-dev-runtime). These mirror
-// TypeScript/esbuild semantics; previously both values mapped to the dev
-// runtime, so the production transform was unreachable via tsconfig.
+// tsconfig "jsx": "react-jsx" selects the production automatic runtime (jsx/jsxs),
+// "react-jsxdev" selects the development runtime (jsxDEV), matching TypeScript/esbuild.
+// https://github.com/oven-sh/bun/issues/4227
 
 const shimFiles = {
   "node_modules/shim/package.json": JSON.stringify({
@@ -46,7 +44,7 @@ describe("tsconfig compilerOptions.jsx", () => {
     {
       await using proc = Bun.spawn({
         cmd: [bunExe(), "run", "m.jsx"],
-        env: { ...bunEnv, NODE_ENV: undefined },
+        env: { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined },
         cwd: String(dir),
         stdout: "pipe",
         stderr: "inherit",
@@ -59,7 +57,7 @@ describe("tsconfig compilerOptions.jsx", () => {
     {
       await using proc = Bun.spawn({
         cmd: [bunExe(), "build", "m.jsx", "--external", "shim*"],
-        env: { ...bunEnv, NODE_ENV: undefined },
+        env: { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined },
         cwd: String(dir),
         stdout: "pipe",
         stderr: "inherit",

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -51,11 +51,7 @@ describe("tsconfig compilerOptions.jsx", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
         stdout: runStdout,
         stderr: "",
@@ -72,18 +68,11 @@ describe("tsconfig compilerOptions.jsx", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toBe("");
       expect(stdout).toContain(`"${importSource}"`);
-      expect(stdout).not.toContain(
-        importSource === "shim/jsx-runtime" ? "jsx-dev-runtime" : '"shim/jsx-runtime"',
-      );
+      expect(stdout).not.toContain(importSource === "shim/jsx-runtime" ? "jsx-dev-runtime" : '"shim/jsx-runtime"');
       expect(exitCode).toBe(0);
     }
   });
-
 });

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -49,14 +49,10 @@ describe("tsconfig compilerOptions.jsx", () => {
         env: { ...bunEnv, NODE_ENV: undefined },
         cwd: String(dir),
         stdout: "pipe",
-        stderr: "pipe",
+        stderr: "inherit",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
-        stdout: runStdout,
-        stderr: "",
-        exitCode: 0,
-      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: runStdout, exitCode: 0 });
     }
 
     // bun build
@@ -66,10 +62,9 @@ describe("tsconfig compilerOptions.jsx", () => {
         env: { ...bunEnv, NODE_ENV: undefined },
         cwd: String(dir),
         stdout: "pipe",
-        stderr: "pipe",
+        stderr: "inherit",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
       expect(stdout).toContain(`"${importSource}"`);
       expect(stdout).not.toContain(importSource === "shim/jsx-runtime" ? "jsx-dev-runtime" : '"shim/jsx-runtime"');
       expect(exitCode).toBe(0);


### PR DESCRIPTION
### What does this PR do?

`compilerOptions.jsx: "react-jsx"` in tsconfig was indistinguishable from `"react-jsxdev"`: both selected the development automatic runtime (`jsxDEV` from `<pkg>/jsx-dev-runtime`), so the production transform (`jsx`/`jsxs` from `<pkg>/jsx-runtime`) was unreachable via tsconfig. TypeScript, Babel and esbuild all treat `"react-jsx"` as the production transform and `"react-jsxdev"` as the development one, and Bun's own docs (`docs/bundler/esbuild.mdx`, `--jsx-dev` row) document the same.

This breaks custom `jsxImportSource` libraries that only ship a production runtime (e.g. `nano-jsx`), and silently ships dev-runtime call sites for every `react-jsx` project that does not set `NODE_ENV=production`.

Fixes #4227.

#### Repro

```sh
mkdir -p /tmp/j/node_modules/shim && cd /tmp/j
cat > node_modules/shim/package.json <<'EOF'
{"name":"shim","type":"module","exports":{"./jsx-runtime":"./rt.js","./jsx-dev-runtime":"./dev.js"}}
EOF
echo 'export const jsx=()=>console.log("prod jsx");export const jsxs=jsx;export const Fragment=0;' > node_modules/shim/rt.js
echo 'export const jsxDEV=()=>console.log("dev jsxDEV");export const Fragment=0;' > node_modules/shim/dev.js
printf 'const a = <div/>;\n' > m.jsx
printf '{"compilerOptions":{"jsx":"react-jsx","jsxImportSource":"shim"}}' > tsconfig.json

bun run m.jsx
# before: dev jsxDEV
# after:  prod jsx

bun build m.jsx --external 'shim*' | grep -o 'shim/jsx[a-z-]*'
# before: shim/jsx-dev-runtime
# after:  shim/jsx-runtime
```

#### Root cause

Two layers:

1. `src/options_types/jsx.rs` `RUNTIME_MAP` mapped `"react-jsx"`, `"react-jsxdev"`, and `"automatic"` all to `development: Some(true)`, so the tsconfig value could not carry the dev/prod bit at all.
2. In `bun build`, `load_defines()` always injects a default `process.env.NODE_ENV = "development"` when none is set. `configure_defines()` then read that default back from `define.dots` as if it were user-supplied and set `force_node_env = Development`, which `bundle_v2` uses to override the per-file `jsx.development` from the resolver. So even with (1) fixed, `bun build` still forced the dev runtime.

#### Fix

- `RUNTIME_MAP`: `"react-jsx"` → `development: Some(false)`, `"react-jsxdev"` → `Some(true)`, `"automatic"` → `None` (carries no dev/prod opinion; matches esbuild/babel's `@jsxRuntime automatic` pragma semantics).
- `configure_defines()`: sample the explicit `NODE_ENV` sources (env var / user `--define`) before `load_defines()` injects its default, so `force_node_env` stays `Unspecified` when the user never set `NODE_ENV`. An explicit `NODE_ENV` still overrides tsconfig as before.

#### How did you verify your code works?

New `test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts` exercises both `bun run` and `bun build` for each tsconfig value with `NODE_ENV` unset. It fails on `USE_SYSTEM_BUN=1` (react-jsx case emits `dev jsxDEV`) and passes with the debug build.

Existing suites pass unchanged: `test/bundler/bundler_jsx.test.ts`, `test/bundler/esbuild/tsconfig.test.ts`, `test/bundler/transpiler/jsx-production.test.ts`, `test/bundler/bundler_env.test.ts`, `test/bundler/bun-build-api.test.ts`.

Defaults are preserved: no tsconfig → dev runtime; `--production` / `NODE_ENV=production` → prod runtime.

#### Related

#31651 patches the `NODE_ENV=production` override path in `configure_defines()`; this PR fixes the underlying mapping so `react-jsx` works without `NODE_ENV` at all.