### PR TITLE
dns(macOS): stop leaking a FilePoll hive slot per libinfo lookup

### DIFF
--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -1370,6 +1370,15 @@ mod _event_loop_draft {
                 uws_loop.inc();
                 uws_loop.tick();
                 uws_loop.dec();
+                // Run the deferred-free thunk (`Store::process_deferred_frees`)
+                // like `MiniEventLoop::tick_once` does after its raw tick; the
+                // FilePoll hive slots freed during this tick are reclaimed here.
+                // SAFETY: `loop_` was born `*mut` (`init_global`), so `cast_mut`
+                // keeps its provenance; it is HTTP-thread-only and disjoint from
+                // the C `us_loop_t` behind `uws_loop`, and no other `&`/`&mut`
+                // to this `MiniEventLoop` is live here (`uws_loop` re-derived
+                // per iteration, last used above).
+                unsafe { (*self.loop_.cast_mut()).on_after_event_loop() };
                 assert_abort_tracker_sockets_alive();
 
                 if cfg!(debug_assertions) {

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2941,6 +2941,14 @@ pub mod internal {
                 }
             }
         }
+        // Every path that reaches here has finished with the mach-port poll;
+        // return its hive slot (mirrors `get_addr_info_async_callback`).
+        // SAFETY: `req` is live; we are on the loop thread that owns the poll.
+        if let Some(poll) = unsafe { (*req).libinfo.file_poll.take() } {
+            // SAFETY: `poll` is the hive slot `lookup_libinfo` allocated; nothing
+            // else aliases it. `deinit` handles being called during dispatch.
+            unsafe { (*poll.as_ptr()).deinit() };
+        }
         after_result(req, addr_info, status_int);
     }
 


### PR DESCRIPTION
The internal DNS resolver's libinfo path (`fetch`, `Bun.connect`, WebSocket, QUIC) allocates a `FilePoll` hive slot to watch the `getaddrinfo_async` reply port and never returned it. Two independent gaps:

| where | before | after |
| --- | --- | --- |
| `libinfo_callback` (`dns.rs`) | slot never taken; `Request::deinit` doesn't own it → leaked | `file_poll.take()` + `deinit()` before `after_result`, mirroring `get_addr_info_async_callback` |
| `HttpThread::process_events` | drives raw `uws_loop.tick()`, never `on_after_event_loop` → deferred-free thunk never runs, freed polls park on `pending_free` forever | `on_after_event_loop()` after each tick, matching `MiniEventLoop::tick_once` |

## Verification

Slot-reuse oracle on a debug build (`BUN_DEBUG_SYS`, distinct `FilePoll.init` addresses across 5 sequential waves of 10 lookups; the hive is lowest-slot-first, so working reclaim ⇒ ~10 distinct):

| thread | before | after |
| --- | --- | --- |
| JS (`Bun.dns.prefetch`) | 50 inits / 50 distinct | 50 / 10 |
| HTTP (`fetch`) | 50 / 50 | 50 / 10 |

No automated test: the leak is one small hive slot per distinct-hostname lookup, not externally observable (RSS is dominated by allocator watermark; the debug `sys` log doesn't exist in release builds). macOS-only paths.