### PR TITLE
http: gate close-delimited body progress on streaming signals

### DIFF
--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -603,30 +603,45 @@ impl<'a> AsyncHTTP<'a> {
 // Note: `bun_threading::Channel` requires `T: Copy`, which
 // `HTTPClientResult` is not. `send_sync` is a one-shot blocking handoff, so a
 // Guarded<Option<T>>+Condvar is the exact semantics needed.
+#[derive(Default)]
+struct SingleHTTPChannelSlot {
+    result: Option<HTTPClientResult<'static>>,
+    // `to_result()` moves `cloned_metadata` out on the first progress
+    // callback; stash it so the terminal result (and the `Response` that
+    // borrows its `owned_buf`) can carry it back to `send_sync`.
+    metadata: Option<crate::HTTPResponseMetadata>,
+}
+
 pub struct SingleHTTPChannel {
-    slot: bun_threading::Guarded<Option<HTTPClientResult<'static>>>,
+    slot: bun_threading::Guarded<SingleHTTPChannelSlot>,
     cv: bun_threading::Condvar,
 }
 
 impl SingleHTTPChannel {
     pub fn init() -> SingleHTTPChannel {
         SingleHTTPChannel {
-            slot: bun_threading::Guarded::new(None),
+            slot: bun_threading::Guarded::new(SingleHTTPChannelSlot::default()),
             cv: bun_threading::Condvar::new(),
         }
     }
     pub fn reset(&mut self) {
-        *self.slot.lock() = None;
+        *self.slot.lock() = SingleHTTPChannelSlot::default();
     }
-    fn write_item(&self, item: HTTPClientResult<'static>) {
+    fn stash_metadata(&self, m: crate::HTTPResponseMetadata) {
+        self.slot.lock().metadata = Some(m);
+    }
+    fn write_item(&self, mut item: HTTPClientResult<'static>) {
         let mut g = self.slot.lock();
-        *g = Some(item);
+        if item.metadata.is_none() {
+            item.metadata = g.metadata.take();
+        }
+        g.result = Some(item);
         self.cv.notify_one();
     }
     fn read_item(&self) -> HTTPClientResult<'static> {
         let mut g = self.slot.lock();
         loop {
-            if let Some(item) = g.take() {
+            if let Some(item) = g.result.take() {
                 return item;
             }
             self.cv.wait_guarded(&mut g);
@@ -637,8 +652,20 @@ impl SingleHTTPChannel {
 fn send_sync_callback(
     this: *mut SingleHTTPChannel,
     async_http: *mut AsyncHTTP<'static>,
-    result: HTTPClientResult<'_>,
+    mut result: HTTPClientResult<'_>,
 ) {
+    // SAFETY: `this` is the heap `SingleHTTPChannel` allocated in `send_sync`
+    // and kept alive until `read_item` returns the terminal result below.
+    let channel = unsafe { &*this };
+    // A close-delimited body reports progress once per packet; stash the
+    // metadata (only present on the first such callback) and otherwise
+    // ignore intermediate progress so `send_sync` sees the full body.
+    if result.has_more {
+        if let Some(m) = result.metadata.take() {
+            channel.stash_metadata(m);
+        }
+        return;
+    }
     // SAFETY: `async_http` is the HTTP-thread copy (inside ThreadlocalAsyncHTTP)
     // and `real` was set to the caller's stack/heap AsyncHTTP before scheduling.
     let async_http = unsafe { &mut *async_http };
@@ -662,13 +689,9 @@ fn send_sync_callback(
             .store(async_http.state.load(Ordering::Relaxed), Ordering::Relaxed);
         real.response_buffer = async_http.response_buffer;
     }
-    // SAFETY: `this` is the leaked `SingleHTTPChannel` from `send_sync` and is
-    // alive for the process lifetime; `result` borrows the HTTP-thread copy's
-    // response buffer, which is the caller's buffer — outlives the read in
-    // `send_sync`.
-    unsafe {
-        (*this).write_item(result.detach_lifetime());
-    }
+    // SAFETY: `result.body` borrows the HTTP-thread copy's response buffer,
+    // which is the caller's buffer and outlives the read in `send_sync`.
+    channel.write_item(unsafe { result.detach_lifetime() });
 }
 
 impl<'a> AsyncHTTP<'a> {
@@ -686,22 +709,24 @@ impl<'a> AsyncHTTP<'a> {
         self.schedule(&mut batch);
         crate::HTTPThread::schedule(batch);
 
-        // `ctx` is a live heap allocation we own; the HTTP thread only touches
-        // it inside `send_sync_callback`, whose final action is `write_item`,
-        // so by the time `read_item` returns the callback has finished and no
-        // other reference remains. `read_item` takes `&self` (channel internals
-        // are interior-mutable), so a `ParentRef` shared deref is sufficient.
+        // `ctx` is a live heap allocation we own; `send_sync_callback` writes
+        // exactly once (on the terminal `!has_more` result), after which no
+        // reference to `ctx` remains on the HTTP thread.
         let result = bun_ptr::ParentRef::from(ctx).read_item();
-        // SAFETY: see above — sole owner, callback completed.
+        // SAFETY: see above — sole owner, terminal callback completed.
         drop(unsafe { bun_core::heap::take(ctx.as_ptr()) });
         if let Some(err) = result.fail {
             return Err(err);
         }
-        debug_assert!(result.metadata.is_some());
+        let Some(metadata) = result.metadata else {
+            // Terminal result with neither error nor response head; treat as a
+            // closed connection rather than panicking on network-driven state.
+            return Err(crate::Error::ConnectionClosed);
+        };
         // The returned `Response` borrows `metadata.owned_buf` (status text +
         // header slices); suppress Drop so the borrowed buffer outlives the
         // call. `send_sync` is one-shot CLI.
-        let metadata = core::mem::ManuallyDrop::new(result.metadata.unwrap());
+        let metadata = core::mem::ManuallyDrop::new(metadata);
         Ok(metadata.response)
     }
 

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -603,45 +603,30 @@ impl<'a> AsyncHTTP<'a> {
 // Note: `bun_threading::Channel` requires `T: Copy`, which
 // `HTTPClientResult` is not. `send_sync` is a one-shot blocking handoff, so a
 // Guarded<Option<T>>+Condvar is the exact semantics needed.
-#[derive(Default)]
-struct SingleHTTPChannelSlot {
-    result: Option<HTTPClientResult<'static>>,
-    // `to_result()` moves `cloned_metadata` out on the first progress
-    // callback; stash it so the terminal result (and the `Response` that
-    // borrows its `owned_buf`) can carry it back to `send_sync`.
-    metadata: Option<crate::HTTPResponseMetadata>,
-}
-
 pub struct SingleHTTPChannel {
-    slot: bun_threading::Guarded<SingleHTTPChannelSlot>,
+    slot: bun_threading::Guarded<Option<HTTPClientResult<'static>>>,
     cv: bun_threading::Condvar,
 }
 
 impl SingleHTTPChannel {
     pub fn init() -> SingleHTTPChannel {
         SingleHTTPChannel {
-            slot: bun_threading::Guarded::new(SingleHTTPChannelSlot::default()),
+            slot: bun_threading::Guarded::new(None),
             cv: bun_threading::Condvar::new(),
         }
     }
     pub fn reset(&mut self) {
-        *self.slot.lock() = SingleHTTPChannelSlot::default();
+        *self.slot.lock() = None;
     }
-    fn stash_metadata(&self, m: crate::HTTPResponseMetadata) {
-        self.slot.lock().metadata = Some(m);
-    }
-    fn write_item(&self, mut item: HTTPClientResult<'static>) {
+    fn write_item(&self, item: HTTPClientResult<'static>) {
         let mut g = self.slot.lock();
-        if item.metadata.is_none() {
-            item.metadata = g.metadata.take();
-        }
-        g.result = Some(item);
+        *g = Some(item);
         self.cv.notify_one();
     }
     fn read_item(&self) -> HTTPClientResult<'static> {
         let mut g = self.slot.lock();
         loop {
-            if let Some(item) = g.result.take() {
+            if let Some(item) = g.take() {
                 return item;
             }
             self.cv.wait_guarded(&mut g);
@@ -652,20 +637,12 @@ impl SingleHTTPChannel {
 fn send_sync_callback(
     this: *mut SingleHTTPChannel,
     async_http: *mut AsyncHTTP<'static>,
-    mut result: HTTPClientResult<'_>,
+    result: HTTPClientResult<'_>,
 ) {
-    // SAFETY: `this` is the heap `SingleHTTPChannel` allocated in `send_sync`
-    // and kept alive until `read_item` returns the terminal result below.
-    let channel = unsafe { &*this };
-    // A close-delimited body reports progress once per packet; stash the
-    // metadata (only present on the first such callback) and otherwise
-    // ignore intermediate progress so `send_sync` sees the full body.
-    if result.has_more {
-        if let Some(m) = result.metadata.take() {
-            channel.stash_metadata(m);
-        }
-        return;
-    }
+    // `init_sync` leaves every streaming/progress signal unset, so the only
+    // callback is the terminal one; writing on `has_more` would hand
+    // `send_sync` a partial body and then write to a freed channel.
+    debug_assert!(!result.has_more);
     // SAFETY: `async_http` is the HTTP-thread copy (inside ThreadlocalAsyncHTTP)
     // and `real` was set to the caller's stack/heap AsyncHTTP before scheduling.
     let async_http = unsafe { &mut *async_http };
@@ -689,9 +666,13 @@ fn send_sync_callback(
             .store(async_http.state.load(Ordering::Relaxed), Ordering::Relaxed);
         real.response_buffer = async_http.response_buffer;
     }
-    // SAFETY: `result.body` borrows the HTTP-thread copy's response buffer,
-    // which is the caller's buffer and outlives the read in `send_sync`.
-    channel.write_item(unsafe { result.detach_lifetime() });
+    // SAFETY: `this` is the leaked `SingleHTTPChannel` from `send_sync` and is
+    // alive for the process lifetime; `result` borrows the HTTP-thread copy's
+    // response buffer, which is the caller's buffer — outlives the read in
+    // `send_sync`.
+    unsafe {
+        (*this).write_item(result.detach_lifetime());
+    }
 }
 
 impl<'a> AsyncHTTP<'a> {
@@ -709,18 +690,20 @@ impl<'a> AsyncHTTP<'a> {
         self.schedule(&mut batch);
         crate::HTTPThread::schedule(batch);
 
-        // `ctx` is a live heap allocation we own; `send_sync_callback` writes
-        // exactly once (on the terminal `!has_more` result), after which no
-        // reference to `ctx` remains on the HTTP thread.
+        // `ctx` is a live heap allocation we own; the HTTP thread only touches
+        // it inside `send_sync_callback`, whose final action is `write_item`,
+        // so by the time `read_item` returns the callback has finished and no
+        // other reference remains. `read_item` takes `&self` (channel internals
+        // are interior-mutable), so a `ParentRef` shared deref is sufficient.
         let result = bun_ptr::ParentRef::from(ctx).read_item();
-        // SAFETY: see above — sole owner, terminal callback completed.
+        // SAFETY: see above — sole owner, callback completed.
         drop(unsafe { bun_core::heap::take(ctx.as_ptr()) });
         if let Some(err) = result.fail {
             return Err(err);
         }
         let Some(metadata) = result.metadata else {
-            // Terminal result with neither error nor response head; treat as a
-            // closed connection rather than panicking on network-driven state.
+            // Terminal result with neither error nor response head; surface as
+            // a network error rather than panicking on network-driven state.
             return Err(crate::Error::ConnectionClosed);
         };
         // The returned `Response` borrows `metadata.owned_buf` (status text +

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4767,11 +4767,9 @@ impl<'a> HTTPClient<'a> {
         // done or streaming
         let is_done =
             content_length.is_some() && self.state.total_body_received >= content_length.unwrap();
-        if is_done
-            || self.signals.get(signals::Field::ResponseBodyStreaming)
-            || content_length.is_none()
-            || self.signals.body_receive_mode.is_some()
-        {
+        let is_streaming = self.signals.get(signals::Field::ResponseBodyStreaming)
+            || self.signals.body_receive_mode.is_some();
+        if is_done || is_streaming || content_length.is_none() {
             let is_final_chunk = is_done;
             // Move the body buffer's bytes out — process_body_buffer takes `&mut self.state`
             // and may mutate `compressed_body` (via decompress_bytes' reset) or `body_out_str`,
@@ -4787,7 +4785,10 @@ impl<'a> HTTPClient<'a> {
 
             let total_received = self.state.total_body_received;
             self.report_progress(total_received);
-            return Ok(is_done || processed);
+            // Close-delimited bodies still need per-packet decompression, but
+            // a non-streaming consumer must not see per-packet progress: the
+            // terminal callback (on close) is the first to carry metadata.
+            return Ok(is_done || (processed && is_streaming));
         }
         Ok(false)
     }

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -2644,6 +2644,14 @@ impl Example {
                         .expect("infallible: variant checked")
                         .data
                         .slice();
+                    let string_prop = |key: &[u8]| -> &'static [u8] {
+                        property
+                            .value
+                            .and_then(|v| v.as_property(key))
+                            .and_then(|q| q.expr.data.e_string())
+                            .map(|s| s.data.slice())
+                            .unwrap_or(b"")
+                    };
                     list[i] = Example {
                         name: if let Some(slash) =
                             bun_core::strings::index_of_char_usize(name, b'/')
@@ -2652,28 +2660,8 @@ impl Example {
                         } else {
                             name
                         },
-                        version: property
-                            .value
-                            .unwrap()
-                            .as_property(b"version")
-                            .unwrap()
-                            .expr
-                            .data
-                            .e_string()
-                            .unwrap()
-                            .data
-                            .slice(),
-                        description: property
-                            .value
-                            .unwrap()
-                            .as_property(b"description")
-                            .unwrap()
-                            .expr
-                            .data
-                            .e_string()
-                            .unwrap()
-                            .data
-                            .slice(),
+                        version: string_prop(b"version"),
+                        description: string_prop(b"description"),
                         local: false,
                     };
                 }

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -1,8 +1,11 @@
 import { spawn, spawnSync } from "bun";
 import { beforeEach, describe, expect, it } from "bun:test";
 import { exists, stat } from "fs/promises";
-import { bunExe, bunEnv as env, tmpdirSync } from "harness";
+import { bunExe, bunEnv as env, tls, tmpdirSync } from "harness";
+import * as nodetls from "node:tls";
+import { once } from "node:events";
 import { join } from "path";
+import { gzipSync } from "zlib";
 
 let x_dir: string;
 
@@ -81,6 +84,100 @@ it("should create selected template with @ prefix implicit `/create` with versio
   expect(err.split(/\r?\n/)).toContain(`error: GET https://registry.npmjs.org/@second-quick-start%2fcreate - 404`);
 
   await exited;
+});
+
+// The GitHub tarball endpoint can respond without Content-Length and without
+// Transfer-Encoding: chunked (close-delimited body). When such a body arrives
+// in more than one TCP packet the HTTP client reports intermediate progress,
+// and `AsyncHTTP::send_sync` (used by `bun create`, `bun upgrade`, `bun pm view`)
+// previously treated the first progress callback as the final result: it either
+// returned with an incomplete body or panicked on an `Option::unwrap()` of the
+// absent response metadata (observed in CI build 74166 during api.github.com
+// flapping).
+it("handles a close-delimited GitHub tarball body split across packets", async () => {
+  // Valid gzip of a single-member tar archive ("package.json" at depth 1 so
+  // extraction succeeds once the body is fully received).
+  const pkg = Buffer.from(
+    JSON.stringify({
+      name: "split-body-template",
+      "bun-create": { start: "bun run ok" },
+    }),
+  );
+  const tar = Buffer.alloc(512 + ((pkg.length + 511) & ~511) + 1024);
+  const header = tar.subarray(0, 512);
+  header.write("pkg/package.json");
+  header.write("0000644", 100);
+  header.write("0000000", 108);
+  header.write("0000000", 116);
+  header.write(pkg.length.toString(8).padStart(11, "0"), 124);
+  header.write("00000000000", 136);
+  header.write("        ", 148);
+  header.write("0", 156);
+  header.write("ustar\0", 257);
+  header.write("00", 263);
+  let sum = 0;
+  for (const b of header) sum += b;
+  header.write(sum.toString(8).padStart(6, "0") + "\0 ", 148);
+  pkg.copy(tar, 512);
+  const gz = gzipSync(tar);
+
+  // Raw TLS server so we control the exact HTTP framing: no Content-Length
+  // header, no chunked encoding, body ends when the socket closes.
+  const sockets = new Set<nodetls.TLSSocket>();
+  const server = nodetls.createServer({ cert: tls.cert, key: tls.key }, socket => {
+    sockets.add(socket);
+    socket.on("error", () => {});
+    socket.on("close", () => sockets.delete(socket));
+    socket.once("data", () => {
+      socket.write(
+        "HTTP/1.1 200 OK\r\n" +
+          "content-type: application/x-gzip\r\n" +
+          "connection: close\r\n" +
+          "\r\n",
+      );
+      // First body packet.
+      socket.write(gz.subarray(0, Math.floor(gz.length / 2)));
+      // Second body packet on a later tick so it arrives as a separate TLS
+      // record and triggers a second on_data() in the HTTP client.
+      setImmediate(() => {
+        socket.write(gz.subarray(Math.floor(gz.length / 2)));
+        socket.end();
+      });
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const port = (server.address() as import("node:net").AddressInfo).port;
+
+  try {
+    await using proc = spawn({
+      cmd: [bunExe(), "create", "github.com/owner/split-body-template", "--no-install", "--no-git"],
+      cwd: x_dir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...env,
+        NODE_TLS_REJECT_UNAUTHORIZED: "0",
+        GITHUB_API_DOMAIN: `127.0.0.1:${port}`,
+      },
+    });
+
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ out, err, exitCode, signalCode: proc.signalCode }).toEqual({
+      out: expect.stringContaining("Success! owner/split-body-template loaded into split-body-template"),
+      err: expect.not.stringContaining("error:"),
+      exitCode: 0,
+      signalCode: null,
+    });
+    expect(out).toContain("bun run ok");
+    expect(await Bun.file(join(x_dir, "split-body-template", "package.json")).json()).toEqual({
+      name: "split-body-template",
+    });
+  } finally {
+    for (const s of sockets) s.destroy();
+    await new Promise<void>(r => server.close(() => r()));
+  }
 });
 
 it("should create template from local folder", async () => {

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -2,8 +2,8 @@ import { spawn, spawnSync } from "bun";
 import { beforeEach, describe, expect, it } from "bun:test";
 import { exists, stat } from "fs/promises";
 import { bunExe, bunEnv as env, tls, tmpdirSync } from "harness";
-import * as nodetls from "node:tls";
 import { once } from "node:events";
+import * as nodetls from "node:tls";
 import { join } from "path";
 import { gzipSync } from "zlib";
 
@@ -129,12 +129,7 @@ it("handles a close-delimited GitHub tarball body split across packets", async (
     socket.on("error", () => {});
     socket.on("close", () => sockets.delete(socket));
     socket.once("data", () => {
-      socket.write(
-        "HTTP/1.1 200 OK\r\n" +
-          "content-type: application/x-gzip\r\n" +
-          "connection: close\r\n" +
-          "\r\n",
-      );
+      socket.write("HTTP/1.1 200 OK\r\n" + "content-type: application/x-gzip\r\n" + "connection: close\r\n" + "\r\n");
       // First body packet.
       socket.write(gz.subarray(0, Math.floor(gz.length / 2)));
       // Second body packet on a later tick so it arrives as a separate TLS

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -86,17 +86,11 @@ it("should create selected template with @ prefix implicit `/create` with versio
   await exited;
 });
 
-// The GitHub tarball endpoint can respond without Content-Length and without
-// Transfer-Encoding: chunked (close-delimited body). When such a body arrives
-// in more than one TCP packet the HTTP client reports intermediate progress,
-// and `AsyncHTTP::send_sync` (used by `bun create`, `bun upgrade`, `bun pm view`)
-// previously treated the first progress callback as the final result: it either
-// returned with an incomplete body or panicked on an `Option::unwrap()` of the
-// absent response metadata (observed in CI build 74166 during api.github.com
-// flapping).
+// Close-delimited body (no Content-Length, no chunked) split across packets:
+// send_sync must wait for the terminal callback, not return on the first
+// progress update. https://github.com/oven-sh/bun/pull/34425
 it("handles a close-delimited GitHub tarball body split across packets", async () => {
-  // Valid gzip of a single-member tar archive ("package.json" at depth 1 so
-  // extraction succeeds once the body is fully received).
+  // Single-member tar (package.json at depth 1) gzipped into the body.
   const pkg = Buffer.from(
     JSON.stringify({
       name: "split-body-template",
@@ -121,23 +115,26 @@ it("handles a close-delimited GitHub tarball body split across packets", async (
   pkg.copy(tar, 512);
   const gz = gzipSync(tar);
 
-  // Raw TLS server so we control the exact HTTP framing: no Content-Length
-  // header, no chunked encoding, body ends when the socket closes.
+  // Raw TLS server: no Content-Length, no chunked; body ends at FIN.
   const sockets = new Set<nodetls.TLSSocket>();
   const server = nodetls.createServer({ cert: tls.cert, key: tls.key }, socket => {
     sockets.add(socket);
+    socket.setNoDelay(true);
     socket.on("error", () => {});
     socket.on("close", () => sockets.delete(socket));
     socket.once("data", () => {
-      socket.write("HTTP/1.1 200 OK\r\n" + "content-type: application/x-gzip\r\n" + "connection: close\r\n" + "\r\n");
-      // First body packet.
-      socket.write(gz.subarray(0, Math.floor(gz.length / 2)));
-      // Second body packet on a later tick so it arrives as a separate TLS
-      // record and triggers a second on_data() in the HTTP client.
-      setImmediate(() => {
-        socket.write(gz.subarray(Math.floor(gz.length / 2)));
-        socket.end();
-      });
+      socket.write("HTTP/1.1 200 OK\r\ncontent-type: application/x-gzip\r\nconnection: close\r\n\r\n");
+      // Drip the body in many fragments, each on its own tick, so the client
+      // cannot coalesce them all into a single on_data() before the first one
+      // reaches its poll loop.
+      const step = Math.max(1, Math.floor(gz.length / 12));
+      let i = 0;
+      const push = () => {
+        if (i >= gz.length) return socket.end();
+        socket.write(gz.subarray(i, (i += step)));
+        setImmediate(push);
+      };
+      push();
     });
   });
   server.listen(0, "127.0.0.1");


### PR DESCRIPTION
## Problem

`test/cli/install/bun-create.test.ts` crashed in CI (build 74166, Ubuntu 25.04 aarch64) during the api.github.com outage on 2026-07-16:

```
panic: called `Option::unwrap()` on a `None` value
```

The trigger is a close-delimited HTTP/1.1 body (no `Content-Length`, no `Transfer-Encoding: chunked`, body ends at FIN). `handle_response_body_from_multiple_packets` enters its processing block on every packet for such a body (the `content_length.is_none()` term) and returns `true` whenever the output buffer is non-empty, so `progress_update` fires once per packet regardless of whether the consumer asked for streaming. `to_result()` attaches the response metadata only to the first of those callbacks.

Every non-streaming `HTTPClientResultCallback` consumer then has to be taught the same stash-and-reassemble dance. #33501 did it for `S3HttpSimpleTask`; `NetworkTask::notify` already does it; `send_sync` and `RemoteImageDownload::on_done` do not, so a close-delimited body split across packets either hands them a truncated body, panics `send_sync` on the missing metadata, or writes to state they have already freed.

## Fix

Gate the per-packet progress return on the same streaming signals that already select per-packet delivery everywhere else:

```rust
return Ok(is_done || (processed && is_streaming));
```

where `is_streaming` is `ResponseBodyStreaming || body_receive_mode.is_some()`. The block is still entered per packet so incremental decompression keeps running; only the `progress_update` trigger is suppressed. Non-streaming consumers now receive exactly one terminal callback with `metadata: Some` (because `cloned_metadata` is still held when `on_close` drives the terminal `progress_update`). Streaming consumers are unchanged: `fetch` wires `body_receive_mode` via `to_with_backpressure()`, `NetworkTask` sets `response_body_streaming`, and the S3 download stream calls `enable_response_body_streaming()`.

In `send_sync` the invariant is now asserted (`debug_assert!(!result.has_more)`), and the `metadata.unwrap()` becomes a `ConnectionClosed` error so a future regression surfaces as a catchable CLI error rather than a process abort. `RemoteImageDownload::on_done` is covered by the same change with no edits needed.

`create_command::fetch_all` replaces its chained `.unwrap()`s on registry-supplied `version`/`description` with optional lookups that default to empty (display-only values).

## Test

A hermetic test in `bun-create.test.ts` points `GITHUB_API_DOMAIN` at a local TLS server that serves a valid gzip tar with `content-type: application/x-gzip`, no `Content-Length`, and the body dripped across twelve `setImmediate`-separated writes with Nagle disabled. On main this fails with a truncated-body `ZlibError` (or the unwrap panic depending on scheduling); with the fix the full tarball is received and extracted.

```
# 30 iterations on the unfixed build: 0 pass / 30 fail
USE_SYSTEM_BUN=1 bun test test/cli/install/bun-create.test.ts -t close-delimited

bun bd test test/cli/install/bun-create.test.ts            # 15 pass
bun bd test test/cli/install/bun-upgrade.test.ts           # 8 pass
bun bd test test/cli/install/bun-audit.test.ts             # 16 pass
bun bd test test/js/bun/s3/s3-connection-close.test.ts     # 4 pass

# close-delimited fetch() smoke: buffered body intact, stream still per-chunk
status: 200 body: "Hello, close-delimited World!"
stream chunks: 10 body: "Hello, close-delimited World!"
```
