### PR TITLE
postgres: reject out-of-range base-10000 digit words in binary NUMERIC decode

### DIFF
--- a/src/sql_jsc/postgres/DataCell.rs
+++ b/src/sql_jsc/postgres/DataCell.rs
@@ -1055,6 +1055,10 @@ fn parse_binary_numeric<'a>(
                 0
             };
             bun_core::scoped_log!(PostgresDataCell, "digit: {}", digit);
+            // Postgres numeric_recv rejects `d < 0 || d >= NBASE` (NBASE = 10000).
+            if digit >= 10000 {
+                return Err(crate::Error::InvalidBuffer);
+            }
             let digit_str: [u8; 4] = bun_core::fmt::itoa_padded::<4>(u64::from(digit));
             let digit_len = 4usize;
             if !first_non_zero {
@@ -1098,6 +1102,9 @@ fn parse_binary_numeric<'a>(
                 0
             };
             bun_core::scoped_log!(PostgresDataCell, "dscale digit: {}", digit);
+            if digit >= 10000 {
+                return Err(crate::Error::InvalidBuffer);
+            }
             let digit_str: [u8; 4] = bun_core::fmt::itoa_padded::<4>(u64::from(digit));
             result.extend_from_slice(&digit_str);
             d += 1;

--- a/test/js/sql/postgres-binary-numeric-digit-range.test.ts
+++ b/test/js/sql/postgres-binary-numeric-digit-range.test.ts
@@ -1,0 +1,100 @@
+// Postgres binary NUMERIC encodes the mantissa as base-10000 digit words
+// (Int16, valid range 0..=9999). numeric_recv in Postgres rejects anything
+// outside that range with `invalid digit in external "numeric" value`. Bun's
+// decoder fed the raw u16 straight into a 4-wide zero-padded formatter, so a
+// hostile server sending digit=10000 panicked debug_assert builds and silently
+// dropped high digits on release (10000 -> "", 10001 -> "1").
+
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import {
+  listeningServer,
+  pgAuthenticationOk,
+  pgCommandComplete,
+  pgDataRow,
+  pgReadyForQuery,
+  pgRowDescription,
+} from "./wire-frames";
+
+const NUMERIC_OID = 1700;
+
+function be16(n: number): Buffer {
+  const b = Buffer.alloc(2);
+  b.writeUInt16BE(n & 0xffff, 0);
+  return b;
+}
+
+// Postgres numeric_send(): Int16 ndigits, Int16 weight, uint16 sign, uint16 dscale, then ndigits Int16 digits.
+function numericDatum(ndigits: number, weight: number, sign: number, dscale: number, digits: number[]): Buffer {
+  return Buffer.concat([be16(ndigits), be16(weight), be16(sign), be16(dscale), ...digits.map(be16)]);
+}
+
+async function selectNumeric(datum: Buffer): Promise<{ value?: unknown; error?: any }> {
+  const { port, server } = await listeningServer(socket => {
+    let startup = true;
+    socket.on("data", () => {
+      if (startup) {
+        startup = false;
+        socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+        return;
+      }
+      socket.write(
+        Buffer.concat([
+          pgRowDescription([{ name: "n", typeOid: NUMERIC_OID, format: 1 }]),
+          pgDataRow([datum]),
+          pgCommandComplete("SELECT 1"),
+          pgReadyForQuery(),
+        ]),
+      );
+    });
+    socket.on("error", () => {});
+  });
+
+  try {
+    await using sql = new SQL({
+      url: `postgres://u@127.0.0.1:${port}/db`,
+      max: 1,
+      idleTimeout: 5,
+      connectionTimeout: 5,
+    });
+    try {
+      const [row]: any = await sql`select x`.simple();
+      return { value: row.n };
+    } catch (error) {
+      return { error };
+    }
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+}
+
+// Out-of-range digit words a hostile server/proxy can author. 10000 is the
+// smallest invalid value (NBASE itself); 65535 is the u16 maximum.
+const badIntegerDigits = [10000, 10001, 32768, 65535];
+
+test.each(badIntegerDigits)("binary NUMERIC rejects out-of-range digit word %p in the integer part", async d => {
+  // ndigits=1 weight=0 sign=+ dscale=0 digit=d : the integer-part decode loop.
+  const { value, error } = await selectNumeric(numericDatum(1, 0, 0x0000, 0, [d]));
+  expect(value).toBeUndefined();
+  expect({ code: error?.code, name: error?.name }).toEqual({
+    code: "ERR_POSTGRES_UNSUPPORTED_NUMERIC_FORMAT",
+    name: "PostgresError",
+  });
+});
+
+test("binary NUMERIC rejects out-of-range digit word in the fractional part", async () => {
+  // ndigits=1 weight=-1 sign=+ dscale=4 digit=10000 : the dscale decode loop.
+  const { value, error } = await selectNumeric(numericDatum(1, -1, 0x0000, 4, [10000]));
+  expect(value).toBeUndefined();
+  expect({ code: error?.code, name: error?.name }).toEqual({
+    code: "ERR_POSTGRES_UNSUPPORTED_NUMERIC_FORMAT",
+    name: "PostgresError",
+  });
+});
+
+test("binary NUMERIC still decodes in-range digit words", async () => {
+  // digit=9999 is the maximum valid digit.
+  expect(await selectNumeric(numericDatum(1, 0, 0x0000, 0, [9999]))).toEqual({ value: "9999" });
+  // ndigits=2 weight=1 digits=[1,2345] -> "1" + "2345" -> "12345"
+  expect(await selectNumeric(numericDatum(2, 1, 0x0000, 0, [1, 2345]))).toEqual({ value: "12345" });
+});


### PR DESCRIPTION
## Repro

A mock Postgres server sends a binary NUMERIC column (OID 1700, format=1) whose base-10000 digit word is `10000` (wire allows any u16; valid range is 0..9999):

```
panic: assertion failed: N == 0 || val < 10u64.saturating_pow(N as u32)
  itoa_padded<4>                     src/bun_core/fmt.rs:3047
  parse_binary_numeric               src/sql_jsc/postgres/DataCell.rs
```

On release builds the debug_assert is stripped and the high digits are silently dropped: digit `10000` decodes to `""`, `32768` decodes to `"2768"`, `65535` decodes to `"5535"`. The query succeeds and the app receives a wrong numeric value.

## Cause

`parse_binary_numeric` reads each u16 digit word from the wire and passes it straight to `itoa_padded::<4>`, which requires `val < 10^4`. The integer-part loop (line 1058) and the fractional-part loop (line 1101) both do this. Postgres' own `numeric_recv` checks `d < 0 || d >= NBASE` on every received digit and errors with `invalid digit in external "numeric" value`.

## Fix

Range-check `digit >= 10000` at both read sites and return `InvalidBuffer`, same posture as the existing sign check a few lines up. The caller already maps every error from this function to `ERR_POSTGRES_UNSUPPORTED_NUMERIC_FORMAT`.

## Verification

`test/js/sql/postgres-binary-numeric-digit-range.test.ts` drives a scripted wire server (via `test/js/sql/wire-frames.ts`, no Postgres needed) that sends digit words 10000/10001/32768/65535 in the integer part and 10000 in the fractional part. All reject with `ERR_POSTGRES_UNSUPPORTED_NUMERIC_FORMAT`; digit 9999 and a two-word valid value still decode. Fail-before on stock 1.4.0 shows the silent corruption (`32768` -> `"2768"`). The real-Postgres `postgres-binary-numeric.test.ts` suite (13 cases) still passes.

Related: #33576 validates numeric header fields but not the digit words.