### PR TITLE
postgres: emit ones digit for zero first group in binary NUMERIC decode

### DIFF
--- a/src/sql_jsc/postgres/DataCell.rs
+++ b/src/sql_jsc/postgres/DataCell.rs
@@ -1027,6 +1027,9 @@ fn parse_binary_numeric<'a>(
     if ndigits == 0 {
         return Ok(PGNummericString::Static(b"0"));
     }
+    if ndigits < 0 {
+        return Err(crate::Error::InvalidBuffer);
+    }
 
     // Add negative sign if needed
     if sign == 0x4000 {
@@ -1045,7 +1048,6 @@ fn parse_binary_numeric<'a>(
         result.push(b'0');
     } else {
         let mut idx: usize = 0;
-        let mut first_non_zero = false;
 
         while idx <= weight as usize {
             // Compare in i32 to avoid usize→i16 truncation.
@@ -1056,22 +1058,17 @@ fn parse_binary_numeric<'a>(
             };
             bun_core::scoped_log!(PostgresDataCell, "digit: {}", digit);
             let digit_str: [u8; 4] = bun_core::fmt::itoa_padded::<4>(u64::from(digit));
-            let digit_len = 4usize;
-            if !first_non_zero {
-                // In the first digit, suppress extra leading decimal zeroes
+            if idx == 0 {
+                // First group: suppress leading zeroes but always emit the ones
+                // digit, matching Postgres get_str_from_var's unconditional final
+                // `*cp++ = dig + '0'`. Dropping it turns a zero group into "".
                 let mut start_idx: usize = 0;
-                while start_idx < digit_len && digit_str[start_idx] == b'0' {
+                while start_idx < 3 && digit_str[start_idx] == b'0' {
                     start_idx += 1;
                 }
-                if start_idx == digit_len {
-                    idx += 1;
-                    continue;
-                }
-                let digit_slice = &digit_str[start_idx..digit_len];
-                result.extend_from_slice(digit_slice);
-                first_non_zero = true;
+                result.extend_from_slice(&digit_str[start_idx..]);
             } else {
-                result.extend_from_slice(&digit_str[0..digit_len]);
+                result.extend_from_slice(&digit_str);
             }
             idx += 1;
         }

--- a/src/sql_jsc/postgres/DataCell.rs
+++ b/src/sql_jsc/postgres/DataCell.rs
@@ -1015,6 +1015,10 @@ fn parse_binary_numeric<'a>(
         dscale
     );
 
+    if ndigits < 0 {
+        return Err(crate::Error::InvalidBuffer);
+    }
+
     // Handle special cases
     match sign {
         0xC000 => return Ok(PGNummericString::Static(b"NaN")),
@@ -1026,9 +1030,6 @@ fn parse_binary_numeric<'a>(
 
     if ndigits == 0 {
         return Ok(PGNummericString::Static(b"0"));
-    }
-    if ndigits < 0 {
-        return Err(crate::Error::InvalidBuffer);
     }
 
     // Add negative sign if needed

--- a/test/js/sql/postgres-binary-numeric.test.ts
+++ b/test/js/sql/postgres-binary-numeric.test.ts
@@ -12,8 +12,16 @@
 // Bun's binary NUMERIC decoder is exercised.
 
 import { SQL } from "bun";
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { describeWithContainer } from "harness";
+import {
+  listeningServer,
+  pgAuthenticationOk,
+  pgCommandComplete,
+  pgDataRow,
+  pgReadyForQuery,
+  pgRowDescription,
+} from "./wire-frames";
 
 // Each literal is round-tripped through `'<literal>'::numeric`. The server
 // parses the text, encodes it as binary NUMERIC on the wire, and Bun's decoder
@@ -45,5 +53,85 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
     });
     const [row] = await sql`SELECT ${literal}::numeric AS n`;
     expect(row.n).toBe(literal);
+  });
+});
+
+// --- Wire-valid but non-normalised encodings -------------------------------
+// Postgres' numeric_recv accepts any digit word in [0, 10000), so a proxy or
+// hand-rolled encoder may legally send a NUMERIC whose only digit group is 0.
+// Postgres' get_str_from_var always emits the ones digit of the first group
+// (the final `*cp++ = dig + '0'` has no putit guard), so these decode to "0",
+// "0.00", "-0". A real server never emits them (it normalises to ndigits=0),
+// so a mock server is required. See test/js/sql/wire-frames.ts.
+
+const NUMERIC_OID = 1700;
+
+function numericCell(ndigits: number, weight: number, sign: number, dscale: number, digits: number[]): Buffer {
+  const b = Buffer.alloc(8 + 2 * digits.length);
+  b.writeInt16BE(ndigits, 0);
+  b.writeInt16BE(weight, 2);
+  b.writeUInt16BE(sign, 4);
+  b.writeInt16BE(dscale, 6);
+  for (let i = 0; i < digits.length; i++) b.writeUInt16BE(digits[i], 8 + 2 * i);
+  return b;
+}
+
+async function decodeNumeric(col: Buffer): Promise<unknown> {
+  const { port, server } = await listeningServer(socket => {
+    let startup = true;
+    socket.on("data", data => {
+      if (startup) {
+        startup = false;
+        socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+        return;
+      }
+      if (data[0] !== 0x51 /* 'Q' */) return;
+      socket.write(
+        Buffer.concat([
+          pgRowDescription([{ name: "n", typeOid: NUMERIC_OID, format: 1 }]),
+          pgDataRow([col]),
+          pgCommandComplete("SELECT 1"),
+          pgReadyForQuery(),
+        ]),
+      );
+    });
+    socket.on("error", () => {});
+  });
+  try {
+    await using sql = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1, idleTimeout: 5, connectionTimeout: 5 });
+    const [row]: any = await sql`select n`.simple();
+    return row.n;
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+}
+
+// Expected values are what Postgres' own get_str_from_var prints for the same
+// wire bytes (numeric.c), which is what every other binary-protocol client
+// produces.
+const zeroGroup: { name: string; col: Buffer; want: string }[] = [
+  { name: "ndigits=1 digits=[0]", col: numericCell(1, 0, 0x0000, 0, [0]), want: "0" },
+  { name: "ndigits=1 digits=[0] dscale=2", col: numericCell(1, 0, 0x0000, 2, [0]), want: "0.00" },
+  { name: "ndigits=1 digits=[0] negative", col: numericCell(1, 0, 0x4000, 0, [0]), want: "-0" },
+  { name: "ndigits=2 digits=[0,5] weight=1", col: numericCell(2, 1, 0x0000, 0, [0, 5]), want: "00005" },
+];
+
+describe("binary NUMERIC with a zero first digit group (non-normalised, wire-valid)", () => {
+  test.each(zeroGroup)("$name decodes to $want", async ({ col, want }) => {
+    expect(await decodeNumeric(col)).toBe(want);
+  });
+
+  test("negative ndigits is rejected", async () => {
+    // Postgres numeric_recv rejects this ("invalid length in external numeric").
+    let err: any;
+    try {
+      await decodeNumeric(numericCell(-1, 0, 0x0000, 0, []));
+    } catch (e) {
+      err = e;
+    }
+    expect({ code: err?.code, name: err?.name }).toEqual({
+      code: "ERR_POSTGRES_UNSUPPORTED_NUMERIC_FORMAT",
+      name: "PostgresError",
+    });
   });
 });

--- a/test/js/sql/postgres-binary-numeric.test.ts
+++ b/test/js/sql/postgres-binary-numeric.test.ts
@@ -126,11 +126,15 @@ describe("binary NUMERIC with a zero first digit group (non-normalised, wire-val
     expect(await decodeNumeric(col)).toBe(want);
   });
 
-  test("negative ndigits is rejected", async () => {
-    // Postgres numeric_recv rejects this ("invalid length in external numeric").
+  // Postgres numeric_recv reads ndigits as uint16 and always reads that many
+  // digit words, so 0xFFFF fails the buffer read regardless of sign.
+  test.each([
+    { sign: 0x0000, label: "positive" },
+    { sign: 0xc000, label: "NaN" },
+  ])("negative ndigits is rejected (sign=$label)", async ({ sign }) => {
     let err: any;
     try {
-      await decodeNumeric(numericCell(-1, 0, 0x0000, 0, []));
+      await decodeNumeric(numericCell(-1, 0, sign, 0, []));
     } catch (e) {
       err = e;
     }
@@ -138,5 +142,9 @@ describe("binary NUMERIC with a zero first digit group (non-normalised, wire-val
       code: "ERR_POSTGRES_UNSUPPORTED_NUMERIC_FORMAT",
       name: "PostgresError",
     });
+  });
+
+  test("well-formed NaN (ndigits=0, sign=0xC000) still decodes", async () => {
+    expect(await decodeNumeric(numericCell(0, 0, 0xc000, 0, []))).toBe("NaN");
   });
 });

--- a/test/js/sql/postgres-binary-numeric.test.ts
+++ b/test/js/sql/postgres-binary-numeric.test.ts
@@ -98,7 +98,12 @@ async function decodeNumeric(col: Buffer): Promise<unknown> {
     socket.on("error", () => {});
   });
   try {
-    await using sql = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1, idleTimeout: 5, connectionTimeout: 5 });
+    await using sql = new SQL({
+      url: `postgres://u@127.0.0.1:${port}/db`,
+      max: 1,
+      idleTimeout: 5,
+      connectionTimeout: 5,
+    });
     const [row]: any = await sql`select n`.simple();
     return row.n;
   } finally {


### PR DESCRIPTION
## Summary

`parse_binary_numeric` suppressed the entire first base-10000 digit group when it was `"0000"` and had no emitted-nothing fallback, so a wire-valid binary NUMERIC whose only digit word is zero decoded to the empty string. Postgres' `get_str_from_var` always emits the ones digit of the first group (the final `*cp++ = dig + '0'` has no `putit` guard), so the reference output for these encodings is `"0"`, `"0.00"`, `"-0"`.

A real server never sends these (zero is normalised to `ndigits=0`), but `numeric_recv` accepts any digit word in `[0, 10000)`, so a proxy or non-normalising encoder can legally produce them. Downstream, `Number("") === 0` but `Number(".00")` is `NaN`, and `"-"` / `""` silently break equality with every other binary-protocol client.

Separate arm from #34429 (which rejects digit words `>= 10000`); that fix does not touch the zero-group path.

## Reproduction

<details>
<summary>Mock-server repro</summary>

```
case 1 (ndigits=1 digits=[0]):           ""     (postgres: "0")
case 2 (ndigits=1 digits=[0] dscale=2):  ".00"  (postgres: "0.00")
case 3 (ndigits=1 digits=[0] negative):  "-"    (postgres: "-0")
case 4 (ndigits=-1):                     ""     (postgres: error)
```

</details>

## Fix

Match Postgres' `get_str_from_var`: leading-zero suppression applies only to the first group (`idx == 0`), stops at the third byte so the ones digit is always emitted, and subsequent groups emit all four bytes. Also reject `ndigits < 0`, which Postgres' `numeric_recv` refuses as "invalid length in external numeric" but previously fell through to `""`.

## Verification

`test/js/sql/postgres-binary-numeric.test.ts` gains a mock-server describe block with the four reported encodings plus `ndigits=2 weight=1 digits=[0,5]` (Postgres prints `"00005"`). All five fail on main and pass with this change; the existing 13 live-server round-trip cases are unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/postgres-binary-numeric.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b53ab50da)

test/js/sql/postgres-binary-numeric.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) postgres > binary NUMERIC decodes 0.000000001 [236.97ms]
(pass) postgres > binary NUMERIC decodes 0.000000000001 [38.09ms]
(pass) postgres > binary NUMERIC decodes 0.00000000123 [31.29ms]
(pass) postgres > binary NUMERIC decodes 0.0000000000001 [23.26ms]
(pass) postgres > binary NUMERIC decodes -0.000000001 [31.07ms]
(pass) postgres > binary NUMERIC decodes 0.00000000000000012345 [34.11ms]
(pass) postgres > binary NUMERIC decodes 0.00000001 [33.50ms]
(pass) postgres > binary NUMERIC decodes 0.0001 [26.62ms]
(pass) postgres > binary NUMERIC decodes 123.456 [30.78ms]
(pass) postgres > binary NU
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (735d0d307)

test/js/sql/postgres-binary-numeric.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) postgres > binary NUMERIC decodes 0.000000001 [7.71ms]
(pass) postgres > binary NUMERIC decodes 0.000000000001 [2.72ms]
(pass) postgres > binary NUMERIC decodes 0.00000000123 [3.77ms]
(pass) postgres > binary NUMERIC decodes 0.0000000000001 [2.62ms]
(pass) postgres > binary NUMERIC decodes -0.000000001 [2.11ms]
(pass) postgres > binary NUMERIC decodes 0.00000000000000012345 [1.99ms]
(pass) postgres > binary NUMERIC decodes 0.00000001 [2.09ms]
(pass) postgres > binary NUMERIC decodes 0.0001 [2.48ms]
(pass) postgres > binary NUMERIC decodes 123.456 [2.55ms]
(pass) postgres > binary NUMERIC decodes 1000000 [2.10ms]
(pass) postgres > binary NUMERIC decodes 0 [2.17ms]
(pass) postgres > binary NUMERIC decodes 0.123456789012345 [2.65ms]
(pass) postgres > binary NUMERIC decodes 12345678.000000009 [1.95ms]
(pass) binary NUMERIC with a zero first digit group (non-normalised, wire-valid) > ndigits=1 digits=[0] decodes to 0 [7.89ms]
(pass) binary NUMERIC with a zero first digit group (non-normalised, wire-valid) > ndigits
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/postgres-binary-numeric.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b53ab50da)

test/js/sql/postgres-binary-numeric.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) postgres > binary NUMERIC decodes 0.000000001 [245.43ms]
(pass) postgres > binary NUMERIC decodes 0.000000000001 [37.10ms]
(pass) postgres > binary NUMERIC decodes 0.00000000123 [36.12ms]
(pass) postgres > binary NUMERIC decodes 0.0000000000001 [30.56ms]
(pass) postgres > binary NUMERIC decodes -0.000000001 [23.44ms]
(pass) postgres > binary NUMERIC decodes 0.00000000000000012345 [30.46ms]
(pass) postgres > binary NUMERIC decodes 0.00000001 [26.12ms]
(pass) postgres > binary NUMERIC decodes 0.0001 [30.18ms]
(pass) postgres > binary NUMERIC decodes 123.456 [31.38ms]
(pass) postgres > binary NU
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 703ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   C
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/sql_jsc/postgres/DataCell.rs            |  24 +++----
 test/js/sql/postgres-binary-numeric.test.ts | 103 +++++++++++++++++++++++++++-
 2 files changed, 113 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/sql_jsc/postgres/DataCell.rs                 3      3      0
test/js/sql/postgres-binary-numeric.test.ts      2      5      0
```

</details>

<!-- robobun:evidence:end -->