### PR TITLE
sql(postgres): bound DataRow/RowDescription/ParameterDescription reads by the message length

### DIFF
--- a/src/sql/postgres/protocol/DataRow.rs
+++ b/src/sql/postgres/protocol/DataRow.rs
@@ -9,13 +9,23 @@ pub fn decode<C: Copy, R: ReaderContext>(
     reader: &mut NewReader<R>,
     mut for_each: impl FnMut(C, u32, Option<&mut Data>) -> Result<bool, AnyPostgresError>,
 ) -> Result<(), AnyPostgresError> {
-    let mut _remaining_bytes = reader.length()?;
-    _remaining_bytes = _remaining_bytes.saturating_sub(4);
+    // The Int32 message length bounds every read below; a field count or cell
+    // length that overruns it is a malformed DataRow (libpq: "insufficient
+    // data left in message"), not a ShortRead to wait on.
+    let mut remaining_bytes = reader.length()?.saturating_sub(4);
 
+    if remaining_bytes < 2 {
+        return Err(AnyPostgresError::InvalidMessage);
+    }
     let remaining_fields: usize = usize::from(reader.short()?);
+    remaining_bytes -= 2;
 
     for index in 0..remaining_fields {
+        if remaining_bytes < 4 {
+            return Err(AnyPostgresError::InvalidMessage);
+        }
         let byte_length = reader.int4()?;
+        remaining_bytes -= 4;
         match byte_length {
             0 => {
                 let mut empty = Data::EMPTY;
@@ -33,6 +43,10 @@ pub fn decode<C: Copy, R: ReaderContext>(
                 }
             }
             _ => {
+                if byte_length > remaining_bytes {
+                    return Err(AnyPostgresError::InvalidMessage);
+                }
+                remaining_bytes -= byte_length;
                 let mut bytes = reader.bytes(usize::try_from(byte_length).expect("int cast"))?;
                 if !for_each(
                     context,

--- a/src/sql/postgres/protocol/ParameterDescription.rs
+++ b/src/sql/postgres/protocol/ParameterDescription.rs
@@ -11,12 +11,18 @@ impl ParameterDescription {
     pub fn decode_internal<Container: super::new_reader::ReaderContext>(
         mut reader: NewReader<Container>,
     ) -> Result<Self, AnyPostgresError> {
-        let mut remaining_bytes = reader.length()?;
-        remaining_bytes = remaining_bytes.saturating_sub(4);
-        let _ = remaining_bytes;
+        // The Int32 message length bounds the Int16 count and the Int32[n]
+        // body; an overrun is a malformed message, not a ShortRead.
+        let remaining_bytes = reader.length()?.saturating_sub(4) as usize;
 
+        if remaining_bytes < 2 {
+            return Err(AnyPostgresError::InvalidMessage);
+        }
         let count = reader.short()?;
         let n = usize::from(count);
+        if n * core::mem::size_of::<Int4>() > remaining_bytes - 2 {
+            return Err(AnyPostgresError::InvalidMessage);
+        }
         let mut parameters: Box<[Int4]> = vec![Int4::default(); n].into_boxed_slice();
 
         let data = reader.read(n * core::mem::size_of::<Int4>())?;

--- a/src/sql/postgres/protocol/RowDescription.rs
+++ b/src/sql/postgres/protocol/RowDescription.rs
@@ -14,16 +14,31 @@ impl RowDescription {
     pub fn decode_internal<Container: super::new_reader::ReaderContext>(
         mut reader: NewReader<Container>,
     ) -> Result<Self, AnyPostgresError> {
-        let mut remaining_bytes = reader.length()?;
-        remaining_bytes = remaining_bytes.saturating_sub(4);
-        let _ = remaining_bytes;
+        // The Int32 message length bounds the field-count and every per-field
+        // read; an overrun is a malformed RowDescription, not a ShortRead.
+        let mut remaining_bytes = reader.length()?.saturating_sub(4) as usize;
 
+        if remaining_bytes < 2 {
+            return Err(AnyPostgresError::InvalidMessage);
+        }
         let field_count: usize = usize::from(reader.short()?);
+        remaining_bytes -= 2;
 
         // `Vec::push` so `?` drops already-decoded elements automatically.
         let mut fields: Vec<FieldDescription> = Vec::with_capacity(field_count);
         for _ in 0..field_count {
-            fields.push(FieldDescription::decode_internal::<Container>(&mut reader)?);
+            let before = reader.peek().len();
+            let field = match FieldDescription::decode_internal::<Container>(&mut reader) {
+                Ok(f) => f,
+                Err(AnyPostgresError::ShortRead) => return Err(AnyPostgresError::InvalidMessage),
+                Err(e) => return Err(e),
+            };
+            let consumed = before.saturating_sub(reader.peek().len());
+            if consumed > remaining_bytes {
+                return Err(AnyPostgresError::InvalidMessage);
+            }
+            remaining_bytes -= consumed;
+            fields.push(field);
         }
 
         Ok(Self {

--- a/test/js/sql/postgres-datarow-overrun.test.ts
+++ b/test/js/sql/postgres-datarow-overrun.test.ts
@@ -4,60 +4,98 @@
 // All wire-protocol bytes come from test/js/sql/wire-frames.ts; do not inline
 // Buffer.alloc frame construction here.
 //
-// A DataRow's Int32 message length frames the field count and every per-column
-// Int32 cell length inside it. A cell length (or field count) that overruns the
-// enclosing message is a protocol error (libpq: "insufficient data left in
-// message"); a decoder that trusts the inner lengths over the outer one reads
-// the following CommandComplete/ReadyForQuery bytes as cell payload, still
-// comes up short, and waits for socket data that never arrives. The query must
-// reject with ERR_POSTGRES_INVALID_MESSAGE, not hang.
+// DataRow, RowDescription and ParameterDescription each carry an Int32 message
+// length that frames an Int16 count and a variable-length body driven by that
+// count. A count (or per-column Int32 cell length) that overruns the enclosing
+// message is a protocol error (libpq: "insufficient data left in message"); a
+// decoder that trusts the inner counts over the outer length reads the
+// following CommandComplete / ReadyForQuery bytes as payload, still comes up
+// short, and returns ShortRead. The dispatch loop treats ShortRead as "wait
+// for more socket data", so the query never settles and every later query
+// queues behind it forever. All three must reject with
+// ERR_POSTGRES_INVALID_MESSAGE instead.
 import { SQL } from "bun";
-import { afterAll, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 import {
   listeningServer,
   pgAuthenticationOk,
+  pgBindComplete,
   pgCommandComplete,
   pgDataRow,
   pgInt32,
+  pgParameterDescription,
+  pgParseComplete,
   pgRaw,
+  pgReadFrontendMessages,
   pgReadyForQuery,
   pgRowDescription,
 } from "./wire-frames";
 
-const rowDesc = pgRowDescription([{ name: "n", typeOid: 25 /* text */ }]);
+// --- DataRow / RowDescription (simple-query path) --------------------------
 
-// Each case is a DataRow body whose declared message length is truthful but
-// whose inner field/cell accounting cannot fit inside it. A valid
-// CommandComplete + ReadyForQuery follows so an unbounded reader wedges.
-const malformed: { name: string; row: Buffer }[] = [
+const oneField = pgRowDescription([{ name: "n", typeOid: 25 /* text */ }]).subarray(7);
+
+const simpleCases: { name: string; reply: Buffer[]; code: string }[] = [
   {
-    // Int16 field_count=1, Int32 cell_len=100, then 2 bytes of payload.
-    name: "cell length exceeds the enclosing message",
-    row: pgRaw("D", Buffer.concat([Buffer.from([0, 1]), pgInt32(100), Buffer.from("ab")])),
+    // DataRow: Int16 field_count=1, Int32 cell_len=100, then 2 bytes of payload.
+    name: "DataRow cell length exceeds the enclosing message",
+    reply: [
+      pgRowDescription([{ name: "n", typeOid: 25 }]),
+      pgRaw("D", Buffer.concat([Buffer.from([0, 1]), pgInt32(100), Buffer.from("ab")])),
+      pgCommandComplete("SELECT 1"),
+      pgReadyForQuery(),
+    ],
+    code: "ERR_POSTGRES_INVALID_MESSAGE",
   },
   {
-    // Int16 field_count=3 but only one cell's worth of bytes follows.
-    name: "field count exceeds the enclosing message",
-    row: pgRaw("D", Buffer.concat([Buffer.from([0, 3]), pgInt32(2), Buffer.from("ab")])),
+    // DataRow: Int16 field_count=3 but only one cell's worth of bytes follows.
+    name: "DataRow field count exceeds the enclosing message",
+    reply: [
+      pgRowDescription([{ name: "n", typeOid: 25 }]),
+      pgRaw("D", Buffer.concat([Buffer.from([0, 3]), pgInt32(2), Buffer.from("ab")])),
+      pgCommandComplete("SELECT 1"),
+      pgReadyForQuery(),
+    ],
+    code: "ERR_POSTGRES_INVALID_MESSAGE",
   },
   {
-    // A negative cell length other than -1 (NULL) would read ~4 GiB.
-    name: "negative cell length other than -1",
-    row: pgRaw("D", Buffer.concat([Buffer.from([0, 1]), pgInt32(-2), Buffer.from("ab")])),
+    // DataRow: a negative cell length other than -1 (NULL) would read ~4 GiB.
+    name: "DataRow negative cell length other than -1",
+    reply: [
+      pgRowDescription([{ name: "n", typeOid: 25 }]),
+      pgRaw("D", Buffer.concat([Buffer.from([0, 1]), pgInt32(-2), Buffer.from("ab")])),
+      pgCommandComplete("SELECT 1"),
+      pgReadyForQuery(),
+    ],
+    code: "ERR_POSTGRES_INVALID_MESSAGE",
   },
   {
-    // Declared message length 5: room for the Int32 length + one stray byte,
-    // not even the Int16 field count.
-    name: "message too short for the field count",
-    row: pgRaw("D", Buffer.from([0]), 5),
+    // DataRow: declared message length 5, room for the Int32 length + one
+    // stray byte, not even the Int16 field count.
+    name: "DataRow message too short for the field count",
+    reply: [
+      pgRowDescription([{ name: "n", typeOid: 25 }]),
+      pgRaw("D", Buffer.from([0]), 5),
+      pgCommandComplete("SELECT 1"),
+      pgReadyForQuery(),
+    ],
+    code: "ERR_POSTGRES_INVALID_MESSAGE",
+  },
+  {
+    // RowDescription: Int16 field_count=2, body carries exactly one field.
+    // Only ReadyForQuery follows so the second field's reads exhaust the
+    // buffer instead of tripping the format-code check on garbage bytes.
+    name: "RowDescription field count exceeds the enclosing message",
+    reply: [pgRaw("T", Buffer.concat([Buffer.from([0, 2]), oneField])), pgReadyForQuery()],
+    code: "ERR_POSTGRES_INVALID_MESSAGE",
   },
 ];
 
-// One mock server for the file; each test sets `current` before connecting and
-// the accept handler latches it per connection.
-let current!: Buffer;
-const { port, server } = await listeningServer(socket => {
-  const row = current;
+// One mock server for the file; each test sets `simpleReply` before connecting
+// and the accept handler latches it per connection.
+let simpleReply!: Buffer[];
+const simple = await listeningServer(socket => {
+  const frames = simpleReply;
   let startup = true;
   socket.on("data", data => {
     if (startup) {
@@ -66,15 +104,15 @@ const { port, server } = await listeningServer(socket => {
       return;
     }
     if (data[0] !== 0x51 /* 'Q' */) return;
-    socket.write(Buffer.concat([rowDesc, row, pgCommandComplete("SELECT 1"), pgReadyForQuery()]));
+    socket.write(Buffer.concat(frames));
   });
   socket.on("error", () => {});
 });
-afterAll(() => new Promise<void>(r => server.close(() => r())));
+afterAll(() => new Promise<void>(r => simple.server.close(() => r())));
 
-test.each(malformed)("postgres: DataRow with $name fails the query", async ({ row }) => {
-  current = row;
-  const db = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1, connectionTimeout: 1 });
+test.each(simpleCases)("postgres: $name fails the query", async ({ reply, code }) => {
+  simpleReply = reply;
+  const db = new SQL({ url: `postgres://u@127.0.0.1:${simple.port}/db`, max: 1, connectionTimeout: 1 });
   let err: any;
   try {
     await db`select n`.simple();
@@ -84,20 +122,113 @@ test.each(malformed)("postgres: DataRow with $name fails the query", async ({ ro
   } finally {
     await db.close({ timeout: 0 }).catch(() => {});
   }
-  expect({ code: err.code, name: err.name }).toEqual({
-    code: "ERR_POSTGRES_INVALID_MESSAGE",
-    name: "PostgresError",
-  });
+  expect({ code: err.code, name: err.name }).toEqual({ code, name: "PostgresError" });
 });
 
 // Boundary: a cell that exactly fills the declared message length still decodes.
 test("postgres: DataRow whose cell exactly fills the message still decodes", async () => {
-  current = pgDataRow([Buffer.from("ab")]);
-  const db = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1, connectionTimeout: 1 });
+  simpleReply = [
+    pgRowDescription([{ name: "n", typeOid: 25 }]),
+    pgDataRow([Buffer.from("ab")]),
+    pgCommandComplete("SELECT 1"),
+    pgReadyForQuery(),
+  ];
+  const db = new SQL({ url: `postgres://u@127.0.0.1:${simple.port}/db`, max: 1, connectionTimeout: 1 });
   try {
     const rows: any = await db`select n`.simple();
     expect(rows[0]).toEqual({ n: "ab" });
   } finally {
     await db.close({ timeout: 0 }).catch(() => {});
   }
+});
+
+// --- ParameterDescription (extended-protocol path) -------------------------
+
+describe("postgres: ParameterDescription body overrun", () => {
+  // Mock backend that answers Parse with the four-message prepare response,
+  // replacing ParameterDescription with `pd`, and answers Bind with one row.
+  let pd!: Buffer;
+  let extended: { port: number; server: import("node:net").Server };
+  const makeExtended = async () =>
+    listeningServer(socket => {
+      const frame = pd;
+      let pending = Buffer.alloc(0);
+      let sawStartup = false;
+      socket.on("data", chunk => {
+        pending = Buffer.concat([pending, chunk]);
+        if (!sawStartup) {
+          if (pending.length < 4) return;
+          const len = pending.readInt32BE(0);
+          if (pending.length < len) return;
+          pending = pending.subarray(len);
+          sawStartup = true;
+          socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+        }
+        pending = pgReadFrontendMessages(pending, type => {
+          if (type === 0x50 /* Parse */) {
+            socket.write(
+              Buffer.concat([
+                pgParseComplete(),
+                frame,
+                pgRowDescription([{ name: "v", typeOid: 25 }]),
+                pgReadyForQuery(),
+              ]),
+            );
+          } else if (type === 0x42 /* Bind */) {
+            socket.write(
+              Buffer.concat([
+                pgBindComplete(),
+                pgDataRow([Buffer.from("x")]),
+                pgCommandComplete("SELECT 1"),
+                pgReadyForQuery(),
+              ]),
+            );
+          }
+        });
+      });
+      socket.on("error", () => {});
+    });
+
+  async function prepared(): Promise<any> {
+    extended = await makeExtended();
+    const db = new SQL({
+      adapter: "postgres",
+      hostname: "127.0.0.1",
+      port: extended.port,
+      username: "u",
+      database: "db",
+      tls: false,
+      max: 1,
+      prepare: true,
+      connectionTimeout: 1,
+    });
+    try {
+      return await db`select ${"x"} as v`;
+    } finally {
+      await db.close({ timeout: 0 }).catch(() => {});
+      await new Promise<void>(r => extended.server.close(() => r()));
+    }
+  }
+
+  test("parameter count exceeding the message fails the query", async () => {
+    // Int16 count=1000 but no Int32[n] body follows.
+    pd = pgRaw("t", Buffer.from([0x03, 0xe8]));
+    let err: any;
+    try {
+      await prepared();
+      err = new Error("expected the query to reject");
+    } catch (e) {
+      err = e;
+    }
+    expect({ code: err.code, name: err.name }).toEqual({
+      code: "ERR_POSTGRES_INVALID_MESSAGE",
+      name: "PostgresError",
+    });
+  });
+
+  test("well-formed ParameterDescription still decodes", async () => {
+    pd = pgParameterDescription([25]);
+    const rows: any = await prepared();
+    expect(rows[0]).toEqual({ v: "x" });
+  });
 });

--- a/test/js/sql/postgres-datarow-overrun.test.ts
+++ b/test/js/sql/postgres-datarow-overrun.test.ts
@@ -1,0 +1,103 @@
+// Fault-injection test: requires a server that refuses / drops / sends malformed
+// frames, which a healthy container will not do on demand. DO NOT COPY THIS
+// PATTERN — anything a real server can produce belongs in describeWithContainer.
+// All wire-protocol bytes come from test/js/sql/wire-frames.ts; do not inline
+// Buffer.alloc frame construction here.
+//
+// A DataRow's Int32 message length frames the field count and every per-column
+// Int32 cell length inside it. A cell length (or field count) that overruns the
+// enclosing message is a protocol error (libpq: "insufficient data left in
+// message"); a decoder that trusts the inner lengths over the outer one reads
+// the following CommandComplete/ReadyForQuery bytes as cell payload, still
+// comes up short, and waits for socket data that never arrives. The query must
+// reject with ERR_POSTGRES_INVALID_MESSAGE, not hang.
+import { SQL } from "bun";
+import { afterAll, expect, test } from "bun:test";
+import {
+  listeningServer,
+  pgAuthenticationOk,
+  pgCommandComplete,
+  pgDataRow,
+  pgInt32,
+  pgRaw,
+  pgReadyForQuery,
+  pgRowDescription,
+} from "./wire-frames";
+
+const rowDesc = pgRowDescription([{ name: "n", typeOid: 25 /* text */ }]);
+
+// Each case is a DataRow body whose declared message length is truthful but
+// whose inner field/cell accounting cannot fit inside it. A valid
+// CommandComplete + ReadyForQuery follows so an unbounded reader wedges.
+const malformed: { name: string; row: Buffer }[] = [
+  {
+    // Int16 field_count=1, Int32 cell_len=100, then 2 bytes of payload.
+    name: "cell length exceeds the enclosing message",
+    row: pgRaw("D", Buffer.concat([Buffer.from([0, 1]), pgInt32(100), Buffer.from("ab")])),
+  },
+  {
+    // Int16 field_count=3 but only one cell's worth of bytes follows.
+    name: "field count exceeds the enclosing message",
+    row: pgRaw("D", Buffer.concat([Buffer.from([0, 3]), pgInt32(2), Buffer.from("ab")])),
+  },
+  {
+    // A negative cell length other than -1 (NULL) would read ~4 GiB.
+    name: "negative cell length other than -1",
+    row: pgRaw("D", Buffer.concat([Buffer.from([0, 1]), pgInt32(-2), Buffer.from("ab")])),
+  },
+  {
+    // Declared message length 5: room for the Int32 length + one stray byte,
+    // not even the Int16 field count.
+    name: "message too short for the field count",
+    row: pgRaw("D", Buffer.from([0]), 5),
+  },
+];
+
+// One mock server for the file; each test sets `current` before connecting and
+// the accept handler latches it per connection.
+let current!: Buffer;
+const { port, server } = await listeningServer(socket => {
+  const row = current;
+  let startup = true;
+  socket.on("data", data => {
+    if (startup) {
+      startup = false;
+      socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+      return;
+    }
+    if (data[0] !== 0x51 /* 'Q' */) return;
+    socket.write(Buffer.concat([rowDesc, row, pgCommandComplete("SELECT 1"), pgReadyForQuery()]));
+  });
+  socket.on("error", () => {});
+});
+afterAll(() => new Promise<void>(r => server.close(() => r())));
+
+test.each(malformed)("postgres: DataRow with $name fails the query", async ({ row }) => {
+  current = row;
+  const db = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1, connectionTimeout: 1 });
+  let err: any;
+  try {
+    await db`select n`.simple();
+    err = new Error("expected the query to reject");
+  } catch (e) {
+    err = e;
+  } finally {
+    await db.close({ timeout: 0 }).catch(() => {});
+  }
+  expect({ code: err.code, name: err.name }).toEqual({
+    code: "ERR_POSTGRES_INVALID_MESSAGE",
+    name: "PostgresError",
+  });
+});
+
+// Boundary: a cell that exactly fills the declared message length still decodes.
+test("postgres: DataRow whose cell exactly fills the message still decodes", async () => {
+  current = pgDataRow([Buffer.from("ab")]);
+  const db = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1, connectionTimeout: 1 });
+  try {
+    const rows: any = await db`select n`.simple();
+    expect(rows[0]).toEqual({ n: "ab" });
+  } finally {
+    await db.close({ timeout: 0 }).catch(() => {});
+  }
+});


### PR DESCRIPTION
## Problem

`Bun.SQL`'s Postgres `DataRow` decoder trusts each column's Int32 byte length (and the Int16 field count) over the enclosing message's Int32 length. When a cell claims more bytes than the message carries, the reader consumes the following `CommandComplete` / `ReadyForQuery` bytes as cell payload, still comes up short, and returns `ShortRead`. The dispatch loop treats `ShortRead` as "wait for more socket data", so the query never settles (no error, no timeout) and every later query queues behind it forever. libpq raises `insufficient data left in message` for the same frame.

`RowDescription` and `ParameterDescription` share the pattern: both computed `remaining_bytes = reader.length()? - 4` and discarded it via `let _ = remaining_bytes;`, then trusted their Int16 count.

Repro (mock server, deterministic):

```js
// DataRow: Int16 field_count=1, Int32 cell_len=100, then 2 bytes of payload.
// Followed by a valid CommandComplete + ReadyForQuery.
const sql = new Bun.SQL(`postgres://u:p@127.0.0.1:${server.port}/db?sslmode=disable`);
const got = await Promise.race([
  sql`select n`.then(r => `decoded ${JSON.stringify(r[0]?.n)}`, e => `clean error: ${e?.code ?? e}`),
  new Promise(r => setTimeout(() => r("WEDGED"), 3000)),
]);
// Before: WEDGED (query still pending while a valid ReadyForQuery sat in the buffer)
// After:  clean error: ERR_POSTGRES_INVALID_MESSAGE
```

A truncating proxy/middlebox or a buggy pooler can produce this shape on the wire; every other client errors loudly and recovers while Bun's DB layer hangs silently.

## Fix

Track `remaining_bytes` across the field-count read and each per-field / per-cell read in all three decoders, returning `AnyPostgresError::InvalidMessage` (surfaces as `ERR_POSTGRES_INVALID_MESSAGE`) when the inner accounting overruns the message body:

- `DataRow` decrements `remaining_bytes` by 2 for the field count, 4 for each cell header, and the cell length for each payload.
- `ParameterDescription` checks `n * 4` against the remaining body length before the bulk read.
- `RowDescription` tracks bytes consumed per field via `reader.peek().len()` and maps `ShortRead` during field decode to `InvalidMessage` (the full message body is already buffered once `length()` succeeds, so running out of bytes during field decode means the field overran the message).

## Verification

`test/js/sql/postgres-datarow-overrun.test.ts` drives all three decoders with internally inconsistent bodies plus well-formed controls. Before the fix the DataRow / RowDescription / ParameterDescription overrun cases time out; after the fix they reject with `ERR_POSTGRES_INVALID_MESSAGE` and the controls still decode.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/postgres-datarow-overrun.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (5180ce362)

test/js/sql/postgres-datarow-overrun.test.ts:
(fail) postgres: DataRow cell length exceeds the enclosing message fails the query [5006.39ms]
  ^ this test timed out after 5000ms.
(fail) postgres: DataRow field count exceeds the enclosing message fails the query [5007.25ms]
  ^ this test timed out after 5000ms.
(fail) postgres: DataRow negative cell length other than -1 fails the query [5004.95ms]
  ^ this test timed out after 5000ms.
(fail) postgres: DataRow message too short for the field count fails the query [5008.78ms]
  ^ this test timed out after 5000ms.
(fail) postgres: RowDescription field count exceeds the enclosing message fails the query [5005.46ms]
  ^ this test timed out after 5000ms.
(pass) postg
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (748ed033b)

test/js/sql/postgres-datarow-overrun.test.ts:
(pass) postgres: DataRow cell length exceeds the enclosing message fails the query [6.46ms]
(pass) postgres: DataRow field count exceeds the enclosing message fails the query [2.05ms]
(pass) postgres: DataRow negative cell length other than -1 fails the query [0.66ms]
(pass) postgres: DataRow message too short for the field count fails the query [0.53ms]
(fail) postgres: RowDescription field count exceeds the enclosing message fails the query [5000.08ms]
  ^ this test timed out after 5000ms.
(pass) postgres: DataRow whose cell exactly fills the message still decodes [1.54ms]
(fail) postgres: ParameterDescription body overrun > parameter count exceeding the message fails the query [5000.02ms]
  ^ this test timed out after 5000ms.
(pass) postgres: ParameterDescription body overrun > well-formed ParameterDescription still decodes [2.83ms]
(fail) (unnamed) [5000.20ms]
  ^ a beforeEach/afterEach hook timed out for this test.

 6 pass
 3 fail
 6 expect() calls
Ran 9 tests across 1 file. [15.20s]
__F:3:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/postgres-datarow-overrun.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (5180ce362)

test/js/sql/postgres-datarow-overrun.test.ts:
(pass) postgres: DataRow cell length exceeds the enclosing message fails the query [443.69ms]
(pass) postgres: DataRow field count exceeds the enclosing message fails the query [145.92ms]
(pass) postgres: DataRow negative cell length other than -1 fails the query [68.84ms]
(pass) postgres: DataRow message too short for the field count fails the query [62.22ms]
(pass) postgres: RowDescription field count exceeds the enclosing message fails the query [58.00ms]
(pass) postgres: DataRow whose cell exactly fills the message still decodes [85.73ms]
(pass) postgres: ParameterDescription body overrun > parameter count exceeding the message fails the query [177.07ms]
(pass)
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 784ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/sql/postgres/protocol/DataRow.rs              |  18 +-
 src/sql/postgres/protocol/ParameterDescription.rs |  12 +-
 src/sql/postgres/protocol/RowDescription.rs       |  23 ++-
 test/js/sql/postgres-datarow-overrun.test.ts      | 234 ++++++++++++++++++++++
 4 files changed, 278 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/sql/postgres/protocol/DataRow.rs                   2      1      0
src/sql/postgres/protocol/ParameterDescription.rs      1      1      0
src/sql/postgres/protocol/RowDescription.rs            1      1      0
test/js/sql/postgres-datarow-overrun.test.ts           0      2      0
```

</details>

<!-- robobun:evidence:end -->