### PR TITLE
Report module.children and module._compile in heap snapshots

### DIFF
--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -1303,6 +1303,10 @@ function allCachedValues(obj: ClassDefinition) {
     }
   }
 
+  for (const name in obj.callbacks ?? {}) {
+    values.push([name, `m_callback_${name}`]);
+  }
+
   return values;
 }
 
@@ -1538,8 +1542,9 @@ function generateClassImpl(typeName, obj: ClassDefinition) {
   } = obj;
   const name = className(typeName);
 
-  // analyzeHeap reports every cached value as a named property edge; appendHidden
-  // marks for GC without emitting a duplicate anonymous internal edge.
+  // analyzeHeap reports these as named property edges (see allCachedValues); appendHidden
+  // marks for GC without emitting a duplicate anonymous internal edge. klass caches are
+  // marked but never reported, which is moot: no setter is generated, so they stay empty.
   let DEFINE_VISIT_CHILDREN_LIST = [...Object.entries(fields), ...Object.entries(proto)]
     .filter(([name, { cache = false }]) => cache === true)
     .map(([name]) => `visitor.appendHidden(thisObject->m_${name});`)

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1239,6 +1239,22 @@ void JSCommonJSModule::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
             analyzer.analyzePropertyNameEdge(cell, overriddenParent.asCell(), overriddenParentIdentifier.impl());
         }
     }
+
+    if (thisObject->m_childrenValue) {
+        JSValue childrenValue = thisObject->m_childrenValue.get();
+        if (childrenValue.isCell()) {
+            const Identifier childrenIdentifier = Identifier::fromString(vm, "children"_s);
+            analyzer.analyzePropertyNameEdge(cell, childrenValue.asCell(), childrenIdentifier.impl());
+        }
+    }
+
+    if (thisObject->m_overriddenCompile) {
+        JSValue overriddenCompile = thisObject->m_overriddenCompile.get();
+        if (overriddenCompile.isCell()) {
+            const Identifier overriddenCompileIdentifier = Identifier::fromString(vm, "_compile"_s);
+            analyzer.analyzePropertyNameEdge(cell, overriddenCompile.asCell(), overriddenCompileIdentifier.impl());
+        }
+    }
 }
 
 const JSC::ClassInfo JSCommonJSModule::s_info = { "Module"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSCommonJSModule) };

--- a/test/js/bun/util/commonjs-module-heap-snapshot-fixture.cjs
+++ b/test/js/bun/util/commonjs-module-heap-snapshot-fixture.cjs
@@ -1,0 +1,31 @@
+// Prints the class names each "Property" edge out of a Module (CommonJS) node points at.
+// The property name alone is not meaningful: the prototype's accessor produces a
+// CustomGetterSetter edge under the same name whether or not the cached slot is reported.
+module._compile = function overriddenCompileFn() {};
+module.children; // materializes the lazily-built children array
+
+const snapshot = Bun.generateHeapSnapshot();
+const { nodes, edges, nodeClassNames, edgeNames, edgeTypes, type } = snapshot;
+
+const nodeStride = type === "GCDebugging" ? 7 : 4;
+const moduleClassIndex = nodeClassNames.indexOf("Module");
+if (moduleClassIndex === -1) throw new Error("no Module class in snapshot");
+
+// Edges reference node identifiers (nodes[i + 0]), not node indices.
+const classNameOfId = new Map();
+const moduleIds = new Set();
+for (let i = 0; i < nodes.length; i += nodeStride) {
+  classNameOfId.set(nodes[i], nodeClassNames[nodes[i + 2]]);
+  if (nodes[i + 2] === moduleClassIndex) moduleIds.add(nodes[i]);
+}
+
+const propertyEdgeType = edgeTypes.indexOf("Property");
+const targetsByName = {};
+for (let i = 0; i < edges.length; i += 4) {
+  if (edges[i + 2] !== propertyEdgeType) continue;
+  if (!moduleIds.has(edges[i])) continue;
+  const name = edgeNames[edges[i + 3]];
+  (targetsByName[name] ??= []).push(classNameOfId.get(edges[i + 1]));
+}
+
+console.log(JSON.stringify(targetsByName));

--- a/test/js/bun/util/heap-snapshot.test.ts
+++ b/test/js/bun/util/heap-snapshot.test.ts
@@ -1,5 +1,7 @@
 import { estimateShallowMemoryUsageOf, heapStats } from "bun:jsc";
 import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import path from "node:path";
 import { parseHeapSnapshot, summarizeByType } from "./heap";
 
 describe("Native types report their size correctly", () => {
@@ -197,5 +199,26 @@ describe("Native types report their size correctly", () => {
     expect(summariesMap.get("WebSocket")?.size).toBeGreaterThan(1024 * 128);
 
     delete globalThis.ws;
+  });
+});
+
+describe("CommonJS Module cached slots are visible in heap snapshots", () => {
+  it("reports children and _compile as property edges", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(__dirname, "commonjs-module-heap-snapshot-fixture.cjs")],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    // Every WriteBarrier slot appendHidden'd in visitChildren needs a matching
+    // analyzePropertyNameEdge, or it retains memory with no visible retainer path.
+    // Without it these names still appear, but only as CustomGetterSetter accessor edges.
+    const targetsByName = JSON.parse(stdout);
+    expect(targetsByName["_compile"]).toContain("Function");
+    expect(targetsByName["children"]).toContain("Array");
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
`visitor.appendHidden(x)` marks `x` for GC but reports no heap-snapshot edge — `SlotVisitor::appendSlow` calls `m_heapAnalyzer->analyzeEdge` and then delegates to `appendHiddenSlowImpl`, which `appendHiddenSlow` calls directly, skipping the analyzer. Snapshot visibility comes from the separate `analyzeHeap` override. Two of `JSCommonJSModule`'s `appendHidden`'d slots had no matching `analyzePropertyNameEdge`.

| Slot | Holds | Before | After |
| --- | --- | --- | --- |
| `m_overriddenCompile` | user-assigned `module._compile` (`:706`, invoked `:1423`) | no edge | `Module --_compile--> Function` |
| `m_childrenValue` | lazily-built children array, or any value via the public setter (`:555`, `:596`) | no edge | `Module --children--> Array` |

Both are user-reachable and retain memory, so a `module._compile` hook closing over a large capture (what `ts-node` and `pirates` install) was held with no visible retainer path. Matches how `id`/`filename`/`dirname` already report.

Driving the debug binary with a `_compile` hook capturing a 4MB buffer:

```
# before                              # after
Module --_compile--> CustomGetterSetter    Module --_compile--> Function
Module --children--> CustomGetterSetter    Module --children--> Array
                                           Module --_compile--> CustomGetterSetter
                                           Module --children--> CustomGetterSetter
```

The `CustomGetterSetter` edge is the prototype accessor and appears either way — which is why the test asserts on the edge *target*, not the property name. An earlier version asserting names passed against unpatched Bun.

Also folds `callbacks` into `allCachedValues` in the codegen, so a generated class's `m_callback_*` slots (appendHidden'd in `visitChildren`, never reported) don't repeat the same drift.

### Scope

- **Audited** every `appendHidden` call site: 27 files, matched slot-by-slot against each class's `analyzeHeap`. The 25 stream classes are clean; `JSCommonJSModule` was the only mismatch.
- **`callbacks` has no users today**, so that hunk emits nothing and no test covers it. Verified by temporarily wiring a callback into `sockets.classes.ts`, confirming it compiles and emits the right edge (`WriteBarrier<JSObject>::get()` → `JSValue` converts implicitly), then reverting.
- **`klass` caches** are `appendHidden`'d and never reported, but no setter is generated for them, so they are permanently empty and there is nothing to report. Left alone; the comment now says so.

### Test

`test/js/bun/util/heap-snapshot.test.ts` — fails on `USE_SYSTEM_BUN=1`, passes on the debug build.
