### PR TITLE
usockets(quic): defer H3 server shutdown when lsquic's process_conns is on the stack

### DIFF
--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -55,6 +55,9 @@ struct us_quic_socket_context_s {
     unsigned int sni_count, sni_cap;
     int processing;
     int closing;
+    /* shutdown() was called from inside an on_stream_* callback; complete
+     * it right after the driving process_conns returns. */
+    int cooldown_pending;
     int is_client;
     unsigned int conn_count;
     unsigned int conn_ext_size;
@@ -147,6 +150,8 @@ static void us_quic_on_timer(struct us_timer_t *t) {
 }
 #endif
 
+static void us_quic_finish_deferred_shutdown(us_quic_socket_context_t *ctx);
+
 void us_quic_loop_process(struct us_loop_t *loop) {
     int min_diff = 0, have_tick = 0;
     for (us_quic_socket_context_t *ctx = loop->data.quic_head; ctx; ctx = ctx->next) {
@@ -155,6 +160,7 @@ void us_quic_loop_process(struct us_loop_t *loop) {
         ctx->pending_write_bytes = 0;
         lsquic_engine_process_conns(ctx->engine);
         ctx->processing = 0;
+        us_quic_finish_deferred_shutdown(ctx);
         int diff;
         if (lsquic_engine_earliest_adv_tick(ctx->engine, &diff)) {
             if (!have_tick || diff < min_diff) min_diff = diff;
@@ -193,6 +199,7 @@ static void us_quic_process(us_quic_socket_context_t *ctx) {
     ctx->processing = 1;
     lsquic_engine_process_conns(ctx->engine);
     ctx->processing = 0;
+    us_quic_finish_deferred_shutdown(ctx);
 }
 
 /* ───── packets out ───── */
@@ -751,10 +758,36 @@ void us_quic_socket_context_shutdown(us_quic_socket_context_t *ctx) {
     ctx->closing = 1;
     /* GOAWAY every conn and flush; loop_post keeps ticking so in-flight
      * streams drain. New conns are rejected in on_new_conn while closing. */
+    if (ctx->processing) {
+        /* server.stop() from inside an on_stream_* callback: process_conns
+         * is on the stack with ENPUB_PROC set, so cooldown/send_unsent
+         * re-enter the engine. Latch; the driver finishes the shutdown
+         * right after process_conns returns. */
+        ctx->cooldown_pending = 1;
+        return;
+    }
     lsquic_engine_cooldown(ctx->engine);
     lsquic_engine_send_unsent_packets(ctx->engine);
     us_quic_process(ctx);
     /* Nothing to drain — release the UDP fd now so the loop can exit. */
+    if (ctx->conn_count == 0) {
+        while (ctx->listeners) us_udp_socket_close(ctx->listeners->udp);
+    }
+}
+
+/* Finish a graceful shutdown that was latched while process_conns was on the
+ * stack. Called right after the driving process_conns returns with ENPUB_PROC
+ * clear. ctx->closing is already set, so a nested shutdown() is a no-op. */
+static void us_quic_finish_deferred_shutdown(us_quic_socket_context_t *ctx) {
+    if (!ctx->cooldown_pending || !ctx->engine) return;
+    ctx->cooldown_pending = 0;
+    lsquic_engine_cooldown(ctx->engine);
+    /* cooldown wrote GOAWAY into each conn's control stream and added them
+     * to tickable; tick once so the frame is packetized, then flush. */
+    ctx->processing = 1;
+    lsquic_engine_process_conns(ctx->engine);
+    ctx->processing = 0;
+    lsquic_engine_send_unsent_packets(ctx->engine);
     if (ctx->conn_count == 0) {
         while (ctx->listeners) us_udp_socket_close(ctx->listeners->udp);
     }
@@ -868,9 +901,14 @@ void us_quic_listen_socket_close(us_quic_listen_socket_t *ls) {
         for (us_quic_socket_t *qs = ls->ctx->conns; qs; qs = qs->next) {
             if (qs->conn) lsquic_conn_abort(qs->conn);
         }
-        lsquic_engine_cooldown(ls->ctx->engine);
-        us_quic_process(ls->ctx);
-        lsquic_engine_send_unsent_packets(ls->ctx->engine);
+        /* Abrupt stop from inside a request handler: process_conns is on the
+         * stack and will see IFC_ABORTED when it resumes. cooldown /
+         * send_unsent_packets must not run with ENPUB_PROC set. */
+        if (!ls->ctx->processing) {
+            lsquic_engine_cooldown(ls->ctx->engine);
+            us_quic_process(ls->ctx);
+            lsquic_engine_send_unsent_packets(ls->ctx->engine);
+        }
     }
     us_udp_socket_close(ls->udp);
 }

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -1041,6 +1041,88 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
     });
   });
 
+  // server.stop() called while lsquic_engine_process_conns is on the stack
+  // (i.e. from the request handler, or from a microtask the handler resolved)
+  // used to re-enter the engine via lsquic_engine_send_unsent_packets and
+  // trip `assert(!ENPUB_PROC)` in lsquic_engine.c. The shutdown is now
+  // deferred until process_conns returns; graceful stop still lets the
+  // in-flight request finish, which is what this test asserts.
+  for (const http1 of [false, true]) {
+    test(`server.stop() from inside an H3 handler drains the in-flight request (http1: ${http1})`, async () => {
+      // Client and server share one process: the handler runs from inside
+      // the server engine's process_conns, and the microtask drain that
+      // follows it reaches the top-level `server.stop()` with that frame
+      // still on the stack.
+      const script = `
+        const tls = ${JSON.stringify(tls)};
+        const { promise: inHandler, resolve: handlerStarted } = Promise.withResolvers();
+        const { promise: proceed, resolve: letGo } = Promise.withResolvers();
+        const server = Bun.serve({
+          port: 0, hostname: "127.0.0.1", tls, http3: true, http1: ${http1},
+          async fetch(req) {
+            handlerStarted();
+            await proceed;
+            return new Response("late");
+          },
+        });
+        const res = fetch("https://127.0.0.1:" + server.port + "/", {
+          protocol: "http3", tls: { rejectUnauthorized: false },
+        }).then(r => r.text());
+        await inHandler;
+        server.stop();
+        letGo();
+        process.stdout.write("got:" + await res);
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr }).toEqual({ stdout: "got:late", stderr: "" });
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  test("server.stop(true) from inside an H3 handler does not re-enter the engine", async () => {
+    // Abrupt stop closes the UDP fd with the server conn's CONNECTION_CLOSE
+    // still unsent, so the in-process client hangs on the dead session; an
+    // AbortController drops it once the second listener has answered.
+    const script = `
+      const tls = ${JSON.stringify(tls)};
+      const opts = { port: 0, hostname: "127.0.0.1", tls, http3: true, http1: false };
+      const server = Bun.serve({
+        ...opts,
+        async fetch(req) {
+          server.stop(true);
+          return new Response("unreachable");
+        },
+      });
+      const ac = new AbortController();
+      const dead = fetch("https://127.0.0.1:" + server.port + "/", {
+        protocol: "http3", tls: { rejectUnauthorized: false }, signal: ac.signal,
+      }).then(r => r.text(), () => "rejected");
+      const second = Bun.serve({ ...opts, fetch: () => new Response("second") });
+      const body = await fetch("https://127.0.0.1:" + second.port + "/", {
+        protocol: "http3", tls: { rejectUnauthorized: false },
+      }).then(r => r.text());
+      ac.abort();
+      await dead;
+      await second.stop(true);
+      process.stdout.write("got:" + body);
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr }).toEqual({ stdout: "got:second", stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+
   // Each QUIC connection counts as a virtual poll (loop->num_polls); after
   // server.stop() drains, the last conn close releases the UDP fd and the
   // loop has no polls left — the process exits without process.exit().

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -1043,10 +1043,11 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
 
   // server.stop() called while lsquic_engine_process_conns is on the stack
   // (i.e. from the request handler, or from a microtask the handler resolved)
-  // used to re-enter the engine via lsquic_engine_send_unsent_packets and
-  // trip `assert(!ENPUB_PROC)` in lsquic_engine.c. The shutdown is now
-  // deferred until process_conns returns; graceful stop still lets the
-  // in-flight request finish, which is what this test asserts.
+  // re-entered the engine via lsquic_engine_send_unsent_packets and tripped
+  // lsquic's `assert(!ENPUB_PROC)` re-entrancy guard. The assert is compiled
+  // out in release (NDEBUG) and the nested ENGINE_IN/OUT is benign for a
+  // single conn, so fail-before is debug-only; the positive contract asserted
+  // here (the in-flight request drains after stop()) holds on every build.
   for (const http1 of [false, true]) {
     test(`server.stop() from inside an H3 handler drains the in-flight request (http1: ${http1})`, async () => {
       // Client and server share one process: the handler runs from inside


### PR DESCRIPTION
Calling `server.stop()` on a `Bun.serve({tls, http3: true})` server while an HTTP/3 request is being dispatched aborts the process in debug builds:

```
lsquic_engine.c:3002: void lsquic_engine_send_unsent_packets(lsquic_engine_t *):
Assertion `!((engine)->pub.enp_flags & ENPUB_PROC)' failed.
```

#### Reproduction

```js
const { promise: inHandler, resolve: started } = Promise.withResolvers();
const server = Bun.serve({
  port: 0, hostname: "127.0.0.1", tls, http3: true, http1: false,
  async fetch(req) { started(); await new Promise(() => {}); },
});
fetch(`https://127.0.0.1:${server.port}/`,
  { protocol: "http3", tls: { rejectUnauthorized: false } }).catch(() => {});
await inHandler;
server.stop();   // abort()s with the assertion above
```

Reproduces whether `stop()` is called directly from the handler or from the top level after the handler parks: the microtask drain that follows the handler runs while `lsquic_engine_process_conns` is still on the stack. The same assertion fires for `stop(true)` from inside the handler. 5/5 on linux-x64 debug.

Release builds compile lsquic with `NDEBUG`, so the `ENGINE_IN` assert is gone and the nested call just sets-then-clears `ENPUB_PROC`. For the single-conn case that is benign (`send_packets_out` uses its own local iterator and `process_connections` is still inside `ci_tick`, not walking `conns_hash`), but it violates lsquic's documented "functions that iterate over connections cannot be nested" contract and is the scenario `ENPUB_PROC` exists to catch.

#### Cause

The H3 request handler is dispatched from `on_stream_headers` inside `lsquic_engine_process_conns`, which brackets itself with `ENGINE_IN`/`ENGINE_OUT`. `server.stop()` reaches `us_quic_socket_context_shutdown()` which calls `lsquic_engine_cooldown()` and `lsquic_engine_send_unsent_packets()` unconditionally; the latter opens with its own `ENGINE_IN`. `us_quic_listen_socket_close()` (the abrupt path) has the same unguarded call.

quic.c already tracks this state in `ctx->processing` and uses it to make `us_quic_process()` a no-op when nested, but the two shutdown paths didn't consult it before the explicit flush.

#### Fix

When `shutdown()` is called with `ctx->processing` set, latch `closing` (so `on_new_conn` rejects new connections immediately) and a `cooldown_pending` flag, and return. Both process-conns drivers (`us_quic_loop_process` and `us_quic_process`) run `us_quic_finish_deferred_shutdown()` right after `processing = 0`: cooldown writes GOAWAY, one extra tick packetizes it, `send_unsent_packets` flushes, and the listener fd is released if no conns remain. `listen_socket_close()` keeps the `lsquic_conn_abort` loop (just sets `IFC_ABORTED`, safe from inside a tick) and skips the cooldown/flush block when `processing` is set; the running `process_conns` sees the aborted flag when it resumes.

#### Verification

New tests in the `Bun.serve HTTP/3 lifecycle` group spawn a subprocess with client and server in the same process and assert the in-flight request drains for graceful `stop()` (both `http1: false` and `http1: true`), and that a second listener can bind and answer after `stop(true)` from inside the handler.

Fail-before is debug-only by construction: the contract violation is lsquic's own `assert()` and the re-entrancy has no release-observable symptom for a single connection. The tests still exercise a real contract on every build (graceful `stop()` from inside a handler lets the in-flight request finish); on a debug build without the fix all three abort with the assertion above.

<details><summary>fail-before (<code>bun bd</code> on main)</summary>

```
(fail) server.stop() from inside an H3 handler drains the in-flight request (http1: false)
(fail) server.stop() from inside an H3 handler drains the in-flight request (http1: true)
(fail) server.stop(true) from inside an H3 handler does not re-enter the engine
  stderr: "lsquic_engine.c:3002: ... Assertion `!((engine)->pub.enp_flags & ENPUB_PROC)' failed."
```
</details>

<details><summary>pass-after</summary>

```
(pass) server.stop() from inside an H3 handler drains the in-flight request (http1: false)
(pass) server.stop() from inside an H3 handler drains the in-flight request (http1: true)
(pass) server.stop(true) from inside an H3 handler does not re-enter the engine
serve-http3.test.ts: 49 pass / 0 fail
```
</details>

Found while investigating #34158; the sibling H3-only `unref()` guard is tracked in #34161 and becomes testable once this lands.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/http/serve-http3.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (e08198966)

test/js/bun/http/serve-http3.test.ts:
(pass) Bun.serve HTTP/3 > basic GET [1748.16ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [1725.98ms]
(pass) Bun.serve HTTP/3 > 204 with no body [2156.86ms]
(pass) Bun.serve HTTP/3 > query string is preserved [2305.63ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [1693.70ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [1689.93ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [1703.46ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [1723.45ms]
(pass) Bun.serve HTTP/3 > http1: false — url/address/stop see the QUIC listener [2653.6
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/http/serve-http3.test.ts:
(pass) Bun.serve HTTP/3 > basic GET [161.91ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [142.98ms]
(pass) Bun.serve HTTP/3 > 204 with no body [143.51ms]
(pass) Bun.serve HTTP/3 > query string is preserved [146.08ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [149.14ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [149.06ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [158.79ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [147.18ms]
(pass) Bun.serve HTTP/3 > http1: false — url/address/stop see the QUIC listener [1043.93ms]
(pass) Bun.serve HTTP/3 > maxRequestBodySize is enforced for H3 bodies without Content-Length [139.47ms]
(pass) Bun.serve HTTP/3 > unknown route returns 404 [144.80ms]
(pass) Bun.serve HTTP/3 > routes: handler with :params [144.80ms]
(pass) Bun.serve HTTP/3 > routes: per-method handler [143.78ms]
(pass) Bun.serve HTTP/3 > routes: method-specific '/*' falls through to fetch() on other methods [141.00ms]
(pass) Bun.serve H
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/http/serve-http3.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (e08198966)

test/js/bun/http/serve-http3.test.ts:
(pass) Bun.serve HTTP/3 > basic GET [1717.42ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [1654.82ms]
(pass) Bun.serve HTTP/3 > 204 with no body [1694.57ms]
(pass) Bun.serve HTTP/3 > query string is preserved [1921.20ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [1924.30ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [1938.18ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [1826.86ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [2209.32ms]
(pass) Bun.serve HTTP/3 > http1: false — url/address/stop see the QUIC listener [2678.6
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     e08198966a
  features     (none)

22 deps, 106 codegen, 1169 objects in 890ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1232] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [10.00ms]
[2/1232] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [4.00ms]
[3/1232] gen bindgenv2
[4/1232] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [4.00ms]
[5/1232] gen ErrorCode+*.h
[6/1232] fetch tinycc
[tinycc] up to date
[7/1231] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1231] fetch pi
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/quic.c     | 44 +++++++++++++++++--
 test/js/bun/http/serve-http3.test.ts | 83 ++++++++++++++++++++++++++++++++++++
 2 files changed, 124 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
packages/bun-usockets/src/quic.c          1      5      0
test/js/bun/http/serve-http3.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->