### PR TITLE
destructOnExit: release nested JSLockHolder VM refs so ~VM runs

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -4132,8 +4132,15 @@ extern "C" void Zig__GlobalObject__destructOnExit(Zig::GlobalObject* globalObjec
     gcUnprotect(globalObject);
     globalObject = nullptr;
     vm.heap.collectNow(JSC::Sync, JSC::CollectionScope::Full);
-    vm.derefSuppressingSaferCPPChecking();
-    vm.derefSuppressingSaferCPPChecking();
+    // Drop every remaining VM ref so ~VM -> Heap::lastChanceToFinalize()
+    // destroys cells collectNow left conservatively reachable (whose native
+    // m_ctx would otherwise leak). Two refs are the creation pair; any beyond
+    // that are RefPtr<VM> in JSLockHolders still on the stack (e.g.
+    // JSEventListener::handleEvent when process.exit() came from
+    // worker.onmessage). global_exit is noreturn so their dtors never run,
+    // and workers were already joined, so no other thread holds the VM.
+    for (unsigned refs = vm.refCount(); refs > 0; --refs)
+        vm.derefSuppressingSaferCPPChecking();
     runLoop->threadWillExit();
 }
 

--- a/test/js/web/timers/timer-heap-exit-onmessage-fixture.ts
+++ b/test/js/web/timers/timer-heap-exit-onmessage-fixture.ts
@@ -1,0 +1,25 @@
+// process.exit() from inside worker.onmessage: JSEventListener::handleEvent
+// has a JSLockHolder (RefPtr<VM>) on the stack, so the VM refcount is one
+// higher than the two creation refs destructOnExit used to release. ~VM() and
+// therefore Heap::lastChanceToFinalize() never ran, and any wrapper collectNow
+// left conservatively reachable leaked its native m_ctx. Keep a Timeout
+// wrapper live via globalThis so conservative reachability is deterministic.
+declare var self: Worker;
+
+if (!Bun.isMainThread) {
+  self.onmessage = () => postMessage("ready");
+} else {
+  const worker = new Worker(import.meta.url);
+  worker.onerror = (e: ErrorEvent) => {
+    console.error("worker error:", e.message);
+    process.exit(1);
+  };
+  worker.onmessage = () => {
+    // Rooted via globalThis so collectNow()'s mark phase keeps the JSTimeout
+    // alive regardless of stack layout; only lastChanceToFinalize frees it.
+    (globalThis as any).__pin = setTimeout(() => {}, 1 << 30);
+    console.log("OK");
+    process.exit(0);
+  };
+  worker.postMessage({});
+}

--- a/test/js/web/timers/timer-heap-race.test.ts
+++ b/test/js/web/timers/timer-heap-race.test.ts
@@ -62,3 +62,24 @@ it.skipIf(!isASAN)(
   },
   20_000,
 );
+
+it.skipIf(!isASAN)(
+  "process.exit() from worker.onmessage finalizes the JSC heap",
+  async () => {
+    // handleEvent's JSLockHolder leaves an extra RefPtr<VM> on the stack at
+    // destructOnExit, so dropping only the two creation refs left ~VM (and
+    // lastChanceToFinalize) unreached and conservatively-live m_ctx leaked.
+    const { stdout, stderr, signal, exitCode } = await runFixture("timer-heap-exit-onmessage-fixture.ts", {
+      BUN_DESTRUCT_VM_ON_EXIT: "1",
+      ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=1:abort_on_error=1",
+      LSAN_OPTIONS: `malloc_context_size=30:print_suppressions=0:suppressions=${path.join(import.meta.dir, "..", "..", "..", "leaksan.supp")}`,
+    });
+    expect({ stdout, stderr, signal, exitCode }).toEqual({
+      stdout: "OK\n",
+      stderr: expect.not.stringContaining("LeakSanitizer"),
+      signal: null,
+      exitCode: 0,
+    });
+  },
+  20_000,
+);


### PR DESCRIPTION
## What

`test/js/web/timers/timer-heap-race.test.ts` went flakily red on the x64-asan lane (seen in #34422's build 74213 and reported against build 74295):

```
==6590==ERROR: LeakSanitizer: detected memory leaks
Direct leak of 480 byte(s) in 1 object(s) allocated from:
    ...
    <bun_runtime::timer::timeout_object::TimeoutObject>::init_with src/runtime/timer/mod.rs:142
    <bun_runtime::timer::All>::set_timeout src/runtime/timer/Timer.rs:271
    ...
    WebCore::JSEventListener::handleEvent JSEventListener.cpp:239
    WebCore::EventTarget::dispatchEvent EventTarget.cpp:248
```

The test itself (added in #33131) is a crash-freedom stress of the timer heap under cross-thread `Atomics.waitAsync` cancellation; the leak it is tripping over is a pre-existing main-thread VM teardown gap that the fixture happens to reach.

## Cause

The fixture calls `process.exit(0)` from `worker.onmessage`. That handler runs inside `JSEventListener::handleEvent`, which takes its own `JSLockHolder` (holding a `RefPtr<VM>`). When `global_exit` reaches `Zig__GlobalObject__destructOnExit`, the VM refcount is therefore at least 3 (two creation refs plus the handler's lock holder), but `destructOnExit` only released the two creation refs. `~VM()` never ran, so `Heap::lastChanceToFinalize()` was skipped.

`collectNow()` still runs first, so most `JSTimeout` wrappers are swept and their `TimeoutObject` boxes freed via `finalize()`. The flaky single leak is whichever wrapper the conservative stack scan happened to keep reachable (a stale encoded pointer from an earlier `fire()` frame): without `lastChanceToFinalize()`, that wrapper's destructor never runs and its `m_ctx` box (one 480-byte `TimeoutObject`) is reported by LSan.

## Fix

Release every remaining VM ref in `destructOnExit` so `~VM()` always runs. The two creation refs are constant; anything beyond that is a `RefPtr<VM>` in a `JSLockHolder` still on the stack. `global_exit` is noreturn so those holders' destructors never run, and `terminate_all_workers_and_wait` has already joined every worker thread, so no other thread can observe the freed VM.

The same observation and a closely related fix already exist on the unmerged `ciro/repl-node-tests` branch (commit 19d8c87295, for the REPL's mid-eval `process.exit()`). This PR takes the simpler `refCount()` loop so the full `~VM()` teardown path runs rather than calling `lastChanceToFinalize()` directly.

## Verification

- New asan-only test `process.exit() from worker.onmessage finalizes the JSC heap` reproduces the leak deterministically by pinning a `Timeout` on `globalThis` before exiting from `onmessage`: fails on main (480-byte `TimeoutObject`), passes with the fix.
- Original flaky fixture: 0/50 failures with the fix (was ~20/30 on main) under the CI LSan settings.
- `bun bd test test/js/web/timers/timer-heap-race.test.ts`: 4 pass.
- `bun bd test test/js/web/workers/`: 369 pass.

`destructOnExit` only runs under `BUN_DESTRUCT_VM_ON_EXIT=1` (the asan/leak lane), so release builds are unaffected.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/timers/timer-heap-race.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (fafaab4b0)

test/js/web/timers/timer-heap-race.test.ts:
(pass) timer heap survives cross-thread Atomics.waitAsync timeout cancellation [3787.02ms]
(pass) timer heap stays consistent while GC re-arms the RunLoop timer [2407.83ms]
(pass) terminating a worker with pending Atomics.waitAsync tickets does not leak deferred-work tasks [6996.69ms]
72 |     const { stdout, stderr, signal, exitCode } = await runFixture("timer-heap-exit-onmessage-fixture.ts", {
73 |       BUN_DESTRUCT_VM_ON_EXIT: "1",
74 |       ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=1:abort_on_error=1",
75 |       LSAN_OPTIONS: `malloc_context_size=30:print_suppressions=0:suppressions=${path.join(import.meta.dir, "..", "..", "..", "l
... (truncated)

release without fix: 3 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/timers/timer-heap-race.test.ts:
(pass) timer heap survives cross-thread Atomics.waitAsync timeout cancellation [3035.50ms]
(skip) timer heap stays consistent while GC re-arms the RunLoop timer
(skip) terminating a worker with pending Atomics.waitAsync tickets does not leak deferred-work tasks
(skip) process.exit() from worker.onmessage finalizes the JSC heap

 1 pass
 3 skip
 0 fail
 1 expect() calls
Ran 4 tests across 1 file. [3.20s]
__F:0:S:3
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/timers/timer-heap-race.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (fafaab4b0)

test/js/web/timers/timer-heap-race.test.ts:
(pass) timer heap survives cross-thread Atomics.waitAsync timeout cancellation [3804.35ms]
(pass) timer heap stays consistent while GC re-arms the RunLoop timer [2506.79ms]
(pass) terminating a worker with pending Atomics.waitAsync tickets does not leak deferred-work tasks [7028.21ms]
(pass) process.exit() from worker.onmessage finalizes the JSC heap [7245.33ms]

 4 pass
 0 fail
 4 expect() calls
Ran 4 tests across 1 file. [22.62s]
__F:0:S:0

release with fix: 3 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     fafaab4b07
  features     (none)

22 deps, 106 codegen, 1169 objects in 851ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1232] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [15.00ms]
[2/1232] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [2.00ms]
[3/1232] gen ErrorCode+*.h
[4/1232] gen bindgenv2
[5/1232] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [9.00ms]
[6/1232] fetch zlib
[zlib] up to date
[7/1232] fetch picohttpparser
[picohttpparser] up to date
[8/1232] gen .bind.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ZigGlobalObject.cpp               | 11 ++++++++--
 .../timers/timer-heap-exit-onmessage-fixture.ts    | 25 ++++++++++++++++++++++
 test/js/web/timers/timer-heap-race.test.ts         | 21 ++++++++++++++++++
 3 files changed, 55 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/jsc/bindings/ZigGlobalObject.cpp                         4      7      0
test/js/web/timers/timer-heap-exit-onmessage-fixture.ts      0      1      0
test/js/web/timers/timer-heap-race.test.ts                   2      3      0
```

</details>

**self-review** · no surviving concerns

29 concerns were raised and did not survive verification.

<!-- robobun:evidence:end -->