### PR TITLE
node:sqlite: omit errstr on applyChangeset errors to match Node

### DIFF
--- a/src/jsc/bindings/sqlite/NodeSqlite.cpp
+++ b/src/jsc/bindings/sqlite/NodeSqlite.cpp
@@ -199,6 +199,18 @@ static void throwSqliteMessage(JSGlobalObject* globalObject, ThrowScope& scope, 
     scope.throwException(globalObject, createNodeSqliteError(globalObject, errcode, message));
 }
 
+// Node's THROW_ERR_SQLITE_ERROR(isolate, int) overload: message is the
+// canonical text and `errcode` is attached, but unlike the db-handle
+// overload no `errstr` property is set. applyChangeset is its only caller.
+static void throwSqliteResultCode(JSGlobalObject* globalObject, ThrowScope& scope, int errcode)
+{
+    auto& vm = getVM(globalObject);
+    auto* zigGlobal = defaultGlobalObject(globalObject);
+    JSObject* error = createError(zigGlobal, ErrorCode::ERR_SQLITE_ERROR, WTF::String::fromUTF8(sqlite3_errstr(errcode)));
+    error->putDirect(vm, Identifier::fromString(vm, "errcode"_s), jsNumber(errcode), 0);
+    scope.throwException(globalObject, error);
+}
+
 // The session extension, sqlite3_deserialize, sqlite3_db_config, and friends
 // report failure only in their RETURN code, so `r` is truth. Use the handle's
 // richer extended code/message only when its primary code AGREES with `r`.
@@ -1833,7 +1845,7 @@ JSC_DEFINE_HOST_FUNCTION(jsDatabaseSyncApplyChangeset, (JSGlobalObject * globalO
     if (r != SQLITE_OK) {
         // An invalid conflict-handler return is SQLITE_MISUSE and a malformed
         // changeset is SQLITE_CORRUPT; the vendored tests assert both exactly.
-        throwSqliteReturnCodeError(globalObject, scope, self->connection(), r);
+        throwSqliteResultCode(globalObject, scope, r);
         return {};
     }
     return JSValue::encode(jsBoolean(true));

--- a/src/jsc/bindings/sqlite/NodeSqlite.cpp
+++ b/src/jsc/bindings/sqlite/NodeSqlite.cpp
@@ -176,8 +176,9 @@ static JSC::JSUint8Array* adoptSqliteBuffer(JSGlobalObject* globalObject, void* 
 // Error helpers (match Node.js node_sqlite.cc shapes)
 // ─────────────────────────────────────────────────────────────────────────────
 
-// Every ERR_SQLITE_ERROR carries `errcode` (the extended result code) and
-// `errstr` (its canonical English text), matching node_sqlite.cc.
+// Node's CreateSQLiteError(isolate, sqlite3*) / (isolate, int) shape: sets
+// both `errcode` and `errstr`. (throwSqliteResultCode below mirrors the
+// THROW_ERR_SQLITE_ERROR(isolate, int) overload, which omits errstr.)
 static JSObject* createNodeSqliteError(JSGlobalObject* globalObject, int errcode, const WTF::String& message)
 {
     auto& vm = getVM(globalObject);

--- a/test/js/node/sqlite/node-sqlite.test.ts
+++ b/test/js/node/sqlite/node-sqlite.test.ts
@@ -1102,10 +1102,16 @@ describe.skipIf(!sqliteHasSession)("Session / changeset", () => {
     } catch (e) {
       ctrl = e;
     }
-    expect({ code: ctrl.code, errcode: ctrl.errcode, errstr: ctrl.errstr }).toEqual({
+    expect({
+      code: ctrl.code,
+      errcode: ctrl.errcode,
+      errstr: ctrl.errstr,
+      hasErrstr: Object.prototype.hasOwnProperty.call(ctrl, "errstr"),
+    }).toEqual({
       code: "ERR_SQLITE_ERROR",
       errcode: 1,
       errstr: "SQL logic error",
+      hasErrstr: true,
     });
     db.close();
   });

--- a/test/js/node/sqlite/node-sqlite.test.ts
+++ b/test/js/node/sqlite/node-sqlite.test.ts
@@ -1072,6 +1072,44 @@ describe.skipIf(!sqliteHasSession)("Session / changeset", () => {
     dst.close();
   });
 
+  test("applyChangeset error has errcode but no errstr own property", () => {
+    // Node's THROW_ERR_SQLITE_ERROR(isolate, int) overload attaches errcode
+    // but not errstr, unlike the db-handle overload exec()/prepare() use.
+    const db = new DatabaseSync(":memory:");
+    db.exec("CREATE TABLE t (a INTEGER PRIMARY KEY, b)");
+    let err: any;
+    try {
+      db.applyChangeset(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]));
+    } catch (e) {
+      err = e;
+    }
+    expect({
+      code: err.code,
+      errcode: err.errcode,
+      message: err.message,
+      hasErrstr: Object.prototype.hasOwnProperty.call(err, "errstr"),
+    }).toEqual({
+      code: "ERR_SQLITE_ERROR",
+      errcode: 11,
+      message: "database disk image is malformed",
+      hasErrstr: false,
+    });
+
+    // Control: exec() goes through the db-handle path and DOES carry errstr.
+    let ctrl: any;
+    try {
+      db.exec("selecx 1");
+    } catch (e) {
+      ctrl = e;
+    }
+    expect({ code: ctrl.code, errcode: ctrl.errcode, errstr: ctrl.errstr }).toEqual({
+      code: "ERR_SQLITE_ERROR",
+      errcode: 1,
+      errstr: "SQL logic error",
+    });
+    db.close();
+  });
+
   test("applyChangeset rejects a changeset detached by an options getter", () => {
     // The option getters run before the owned-buffer copy is made; a getter
     // that detaches the input must produce an error, not a silent no-op


### PR DESCRIPTION
## What

`DatabaseSync#applyChangeset` errors were carrying an `errstr` own property that Node.js omits on that path. The `code`, `errcode`, and `message` already matched; only the error-object shape diverged.

## Repro

```js
import { DatabaseSync } from "node:sqlite";
const db = new DatabaseSync(":memory:");
db.exec("create table t(a integer primary key, b)");
try { db.applyChangeset(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])); }
catch (e) { console.log(e.code, e.errcode, JSON.stringify(e.errstr)); }
```

| | changeset error | exec error (control) |
|--|--|--|
| node v26.3.0 | `ERR_SQLITE_ERROR 11 undefined` | `ERR_SQLITE_ERROR 1 "SQL logic error"` |
| bun before | `ERR_SQLITE_ERROR 11 "database disk image is malformed"` | `ERR_SQLITE_ERROR 1 "SQL logic error"` |
| bun after | `ERR_SQLITE_ERROR 11 undefined` | `ERR_SQLITE_ERROR 1 "SQL logic error"` |

## Cause

Node has three `THROW_ERR_SQLITE_ERROR` overloads. The `(isolate, sqlite3*)` overload (used by `exec`/`prepare` via `CHECK_ERROR_OR_THROW`) sets both `errcode` and `errstr`. The `(isolate, int)` overload sets only `errcode`:

```cpp
// node_sqlite.cc
inline void THROW_ERR_SQLITE_ERROR(Isolate* isolate, int errcode) {
  const char* errstr = sqlite3_errstr(errcode);
  ...
  if (CreateSQLiteError(isolate, errstr).ToLocal(&error) &&
      error->Set(..., env->errcode_string(), Integer::New(isolate, errcode)).IsJust()) {
    isolate->ThrowException(error);
  }
}
```

`applyChangeset` is the only caller of the `int` overload in Node. Bun routed every path through `createNodeSqliteError`, which always attached both.

## Fix

Add `throwSqliteResultCode` mirroring Node's `int` overload (message = `sqlite3_errstr(r)`, `errcode` set, no `errstr`) and call it from the `applyChangeset` error path.

## Verification

- New test in `test/js/node/sqlite/node-sqlite.test.ts` asserts `hasOwnProperty(err, "errstr") === false` for a malformed changeset and `errstr === "SQL logic error"` for the exec control; fails before, passes after.
- Full `node-sqlite.test.ts` (111 pass) and vendored `test-sqlite-session.js` (25 pass) green.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/sqlite/node-sqlite.test.ts

<!-- robobun:evidence:end -->