### PR TITLE
dns: destroy the per-VM c-ares channel before JSC/RareData teardown on worker terminate

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1595,6 +1595,13 @@ impl VirtualMachine {
                     .unwrap()
                     .close_all_socket_groups(vm_ref);
             }
+            // Destroy the per-VM c-ares channel while JSC / `RareData.file_polls`
+            // / `runtime_state` are all still live — `ares_destroy()` re-enters
+            // them from its EDESTRUCTION and socket-state callbacks. Mirrors
+            // `WebWorker::shutdown`.
+            if let Some(hooks) = runtime_hooks() {
+                (hooks.close_dns_for_terminate)();
+            }
 
             // The HTTP daemon thread holds a `Box<ThreadlocalAsyncHTTP>` per
             // in-flight request; with the JS thread exiting those never reach
@@ -1825,6 +1832,14 @@ pub struct RuntimeHooks {
     /// `vm` is the live per-thread VM; `runtime_state` must still be installed
     /// and the JSC heap must not have been swept yet.
     pub cancel_all_timers: unsafe fn(vm: *mut VirtualMachine),
+    /// Destroy the per-VM global DNS resolver's c-ares channel now, while JSC,
+    /// the event loop, `RareData.file_polls`, and `runtime_state` are all
+    /// live. `ares_destroy()` re-enters the resolver's socket-state and query
+    /// callbacks; deferring it to `deinit_runtime_state`'s `RuntimeState` drop
+    /// runs those callbacks against freed state. No-op when the resolver was
+    /// never lazily created. Called from `WebWorker::shutdown` / `global_exit`
+    /// right after `close_all_socket_groups`.
+    pub close_dns_for_terminate: fn(),
 }
 
 /// Canonical `EventLoopCtx` vtable for a `*mut VirtualMachine` owner — the JS

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1290,7 +1290,11 @@ impl WebWorker {
             // the socket-state callback for each fd it closes, both of which
             // dereference state (`JSGlobalObject`, `RareData.file_polls`,
             // `runtime_state().timer`) that step 3/5 below free. Deferring it
-            // to `destroy()`'s `deinit_runtime_state` is a UAF.
+            // to `destroy()`'s `deinit_runtime_state` is a UAF. Must FOLLOW
+            // `close_all_socket_groups`: its on_close JS can call
+            // `dns.resolve*()`, and `Resolver::get_channel()` lazily re-inits
+            // on `channel == None` — running this earlier lets a re-created
+            // channel survive to `GlobalData::drop` (the original UAF).
             if let Some(hooks) = runtime_hooks() {
                 (hooks.close_dns_for_terminate)();
             }

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1285,6 +1285,15 @@ impl WebWorker {
                 // is step 3 below).
                 rare.close_all_socket_groups(unsafe { &*vm_ptr });
             }
+            // Destroy the per-VM c-ares channel now: `ares_destroy()` fires
+            // every pending query callback with `ARES_EDESTRUCTION` and then
+            // the socket-state callback for each fd it closes, both of which
+            // dereference state (`JSGlobalObject`, `RareData.file_polls`,
+            // `runtime_state().timer`) that step 3/5 below free. Deferring it
+            // to `destroy()`'s `deinit_runtime_state` is a UAF.
+            if let Some(hooks) = runtime_hooks() {
+                (hooks.close_dns_for_terminate)();
+            }
             // Stop cross-thread posters first: markTerminating() serializes
             // with postTaskTo() on the contexts-map lock, so after this call
             // every task another thread has already enqueued is visible to the

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -718,6 +718,16 @@ impl ErrorDeferred {
             }
         }
 
+        let vm = global_this.bun_vm();
+        // Worker terminate's `close_dns_for_terminate` fires EDESTRUCTION with
+        // `is_shutting_down` already set; the task queue is about to be
+        // drained-without-run and ManagedTask has no cleanup here, so enqueuing
+        // would leak the `Context` and its `JSPromiseStrong` box. Drop now while
+        // JSC is still live so the Strong handle releases cleanly.
+        if vm.is_shutting_down() {
+            return;
+        }
+
         let context = bun_core::heap::into_raw(Box::new(Context {
             deferred: self,
             global_this: bun_ptr::BackRef::new(global_this),
@@ -725,9 +735,7 @@ impl ErrorDeferred {
         // TODO(@heimskr): new custom Task type
         // SAFETY: `bun_vm()` returns a non-null VM pointer (VM-owned for the lifetime of
         // the JSGlobalObject).
-        global_this
-            .bun_vm()
-            .as_mut()
+        vm.as_mut()
             .enqueue_task(bun_jsc::ManagedTask::ManagedTask::new(
                 context,
                 Context::callback,

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -4220,9 +4220,11 @@ impl Resolver {
         let this = self.as_ctx_ptr();
         scopeguard::defer! {
             // SAFETY: `this` is the heap allocation from `init`. This releases the
-            // ref taken by `add_timer`; all callers of `request_completed` (the only
-            // path here) hold an `IntrusiveRc<Resolver>`, so the timer ref is never
-            // the last and this `deref` cannot reach 0 while `&self` is live.
+            // ref taken by `add_timer`. Callers via `request_completed` hold an
+            // `IntrusiveRc<Resolver>`; the `close_channel_for_terminate` caller is
+            // the global resolver, which carries a permanent +1 pin from
+            // `global_resolver()`. Either way the timer ref is never the last and
+            // this `deref` cannot reach 0 while `&self` is live.
             unsafe {
                 let uws_loop = (*this).vm().uws_loop();
                 let state = crate::jsc_hooks::runtime_state();

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2138,6 +2138,27 @@ impl Drop for GlobalData {
     }
 }
 
+impl Resolver {
+    /// Worker-terminate / main-VM-destruct hook: tear down the c-ares channel
+    /// while the JSC VM, `RareData.file_polls`, event loop, and `runtime_state`
+    /// are all still live. `ares_destroy()` synchronously fires every pending
+    /// query callback with `ARES_EDESTRUCTION` and then the socket-state
+    /// callback for each fd it closes; those callback chains dereference
+    /// `DNSLookup::global_this` (to enqueue the rejection task) and the hive
+    /// `FilePoll` (to unregister it from the loop). Running this after either
+    /// is freed is a UAF (Node `test-worker-dns-terminate.js`).
+    pub fn close_channel_for_terminate(&self) {
+        if let Some(channel) = self.channel.take() {
+            // SAFETY: `channel` is the live handle from `ares_init_options`, owned by this resolver.
+            unsafe { c_ares::Channel::destroy(channel) };
+        }
+        // `GetAddrInfoRequest`'s EDESTRUCTION path does not call
+        // `request_completed()`, so the c-ares timeout timer (and its +1 ref on
+        // this resolver plus the uws active-handle bump) can still be linked.
+        self.remove_timer();
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // internal — process-wide DNS cache used by usockets connect path
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1486,6 +1486,7 @@ pub(crate) static __BUN_RUNTIME_HOOKS: RuntimeHooks = RuntimeHooks {
     terminate_all_workers_and_wait,
     retroactively_report_discovered_tests,
     cancel_all_timers,
+    close_dns_for_terminate,
 };
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -1616,6 +1617,22 @@ unsafe fn cancel_all_timers(vm: *mut VirtualMachine) {
     // contract. `addr_of_mut!` does not materialize a `&mut RuntimeState`.
     unsafe {
         crate::timer::All::cancel_all_timeout_objects(ptr::addr_of_mut!((*state).timer), vm);
+    }
+}
+
+/// `RuntimeHooks::close_dns_for_terminate` — destroy the per-VM global DNS
+/// resolver's c-ares channel now so its `ARES_EDESTRUCTION` and socket-state
+/// callbacks run while the JSC VM, `RareData.file_polls`, and `runtime_state`
+/// are all still live. See `Resolver::close_channel_for_terminate`.
+fn close_dns_for_terminate() {
+    let state = runtime_state();
+    if state.is_null() {
+        return;
+    }
+    // SAFETY: `state` is the live per-thread `RuntimeState` box; shared borrow
+    // of the `OnceCell` only (the resolver's own state is interior-mutable).
+    if let Some(gd) = unsafe { &(*state).global_dns_data }.get() {
+        gd.resolver.close_channel_for_terminate();
     }
 }
 

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+import { join } from "path";
 
 // Worker VM startup/teardown is much slower under debug and/or ASAN; these
 // tests spawn many workers, so scale iteration counts and timeouts down.
@@ -150,7 +151,11 @@ test.skipIf(!isASAN)(
         }
       `,
       ],
-      env: bunEnv,
+      env: {
+        ...bunEnv,
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+        LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+      },
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -142,14 +142,15 @@ test.skipIf(!isASAN)(
             // Hermetic: point the global resolver's c-ares channel at a local
             // UDP socket that never replies, so both queries are guaranteed
             // in-flight (socket registered, no completion) when terminate()
-            // lands. In bun, dns.lookup() uses the c-ares backend on Linux
-            // and so also respects setServers().
+            // lands. dns.lookup() only respects setServers() where the c-ares
+            // backend is the default (Linux); elsewhere resolve4 alone still
+            // covers the socket-state and EDESTRUCTION paths hermetically.
             'const dgram = require("dgram");' +
             'const dns = require("dns");' +
             'const s = dgram.createSocket("udp4");' +
             's.bind(0, "127.0.0.1", () => {' +
             '  dns.setServers(["127.0.0.1:" + s.address().port]);' +
-            '  dns.lookup("example.org", () => {});' +
+            '  if (process.platform === "linux") dns.lookup("example.org", () => {});' +
             '  dns.resolve4("example.org", () => {});' +
             '  require("worker_threads").parentPort.postMessage(0);' +
             '});',

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -139,10 +139,20 @@ test.skipIf(!isASAN)(
         let done = 0;
         for (let i = 0; i < 4; i++) {
           const w = new Worker(
+            // Hermetic: point the global resolver's c-ares channel at a local
+            // UDP socket that never replies, so both queries are guaranteed
+            // in-flight (socket registered, no completion) when terminate()
+            // lands. In bun, dns.lookup() uses the c-ares backend on Linux
+            // and so also respects setServers().
+            'const dgram = require("dgram");' +
             'const dns = require("dns");' +
-            'dns.lookup("nonexistent.org", () => {});' +
-            'dns.resolve4("nonexistent.org", () => {});' +
-            'require("worker_threads").parentPort.postMessage(0);',
+            'const s = dgram.createSocket("udp4");' +
+            's.bind(0, "127.0.0.1", () => {' +
+            '  dns.setServers(["127.0.0.1:" + s.address().port]);' +
+            '  dns.lookup("example.org", () => {});' +
+            '  dns.resolve4("example.org", () => {});' +
+            '  require("worker_threads").parentPort.postMessage(0);' +
+            '});',
             { eval: true },
           );
           w.on("message", () => w.terminate().then(() => {

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -119,3 +119,46 @@ test(
   },
   timeout,
 );
+
+// Regression: the per-VM c-ares channel was destroyed in deinit_runtime_state
+// (RuntimeState drop) AFTER JSC teardown and RareData.file_polls drop.
+// ares_destroy() synchronously fires EDESTRUCTION query callbacks and socket-
+// state callbacks, which then dereferenced the freed JSGlobalObject and the
+// freed FilePoll hive. ASAN-only: release builds read freed memory without
+// crashing. Upstream Node test-worker-dns-terminate.js.
+test.skipIf(!isASAN)(
+  "terminate() while dns.lookup() is in flight does not UAF on c-ares channel teardown",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { Worker } = require("worker_threads");
+        let done = 0;
+        for (let i = 0; i < 4; i++) {
+          const w = new Worker(
+            'const dns = require("dns");' +
+            'dns.lookup("nonexistent.org", () => {});' +
+            'dns.resolve4("nonexistent.org", () => {});' +
+            'require("worker_threads").parentPort.postMessage(0);',
+            { eval: true },
+          );
+          w.on("message", () => w.terminate().then(() => {
+            if (++done === 4) console.log("ok");
+          }));
+        }
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("ok\n");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -156,9 +156,7 @@ test.skipIf(!isASAN)(
     });
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout).toBe("ok\n");
-    expect(exitCode).toBe(0);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok\n", stderr: "", exitCode: 0 });
   },
   timeout,
 );


### PR DESCRIPTION
## What

Fixes a heap-use-after-free when a Worker with an in-flight `dns.lookup()` / `dns.resolve*()` is terminated.

Surfaced by Node's upstream `test/parallel/test-worker-dns-terminate.js` (being vendored in #34441), on the debian 13 x64-asan lane:

```
==11356==ERROR: AddressSanitizer: heap-use-after-free on address 0x12ce0a3af168
READ of size 4 at 0x12ce0a3af168 thread T6 (Worker)
    #0 FilePoll::unregister            src/io/posix_event_loop.rs:951
    #1 FilePoll::deinit_possibly_defer src/io/posix_event_loop.rs:428
    #2 FilePoll::deinit_with_vm        src/io/posix_event_loop.rs:448
    #3 Resolver::on_dns_socket_state   src/runtime/dns_jsc/dns.rs:4894
    #6 ares_conn_sock_state_cb_update  vendor/cares/src/lib/ares_conn.c:36

freed by thread T6 (Worker):
    drop_in_place<Box<posix_event_loop::Store>>   (RareData field drop)
    VirtualMachine::destroy                       src/jsc/VirtualMachine.rs:4453
    WebWorker::shutdown                           src/jsc/web_worker.rs:1299
```

## Repro

```js
const { Worker } = require('worker_threads');
const w = new Worker(`
  const dns = require('dns');
  dns.lookup('nonexistent.org', () => {});
  require('worker_threads').parentPort.postMessage('0');
`, { eval: true });
w.on('message', () => w.terminate());
```

## Cause

`WebWorker::shutdown()` runs, in order: `WebWorker__teardownJSCVM` (frees the `JSGlobalObject`), then `VirtualMachine::destroy()` which drops `rare_data` (frees the `FilePoll` hive `Store`) and finally calls `deinit_runtime_state` which drops `RuntimeState`. That last drop runs `GlobalData::drop` which calls `ares_destroy()` on the per-VM c-ares channel.

`ares_destroy()` synchronously fires every pending query callback with `ARES_EDESTRUCTION` and then the socket-state callback for each fd it closes. Those callback chains re-enter:

- `Resolver::on_dns_socket_state` -> `FilePoll::deinit_with_vm` on the already-freed hive slot (the ASAN trace above)
- `GetAddrInfoRequest::on_cares_complete` -> `DNSLookup::process_get_addr_info` -> `reject_later(global_this)` on the freed `JSGlobalObject` (bmalloc-backed so ASAN misses it)
- `ResolveInfoRequest::on_cares_complete` -> `request_completed()` -> `remove_timer()` -> `(*runtime_state()).timer` with the TLS already nulled (null deref)

## Fix

Add a `RuntimeHooks::close_dns_for_terminate` slot that runs `Resolver::close_channel_for_terminate()` from `WebWorker::shutdown()` (and the `BUN_DESTRUCT_VM_ON_EXIT` main-thread path) right after `close_all_socket_groups`, while JSC, `RareData.file_polls`, the event loop, and `runtime_state` are all still live. The method also removes the resolver's c-ares timeout timer, which `GetAddrInfoRequest`'s EDESTRUCTION path never unwinds. `GlobalData::drop` still handles the channel if the early hook never ran (it sees `channel == None` when it did).

This matches Node's model: `Worker::Exit` -> `CleanupHandles()` closes every handle wrap (including `ChannelWrap`) before disposing the Isolate.

## Verification

New ASAN-gated test in `test/js/web/workers/worker-terminate-lifetime.test.ts` spawns four workers that each start a `dns.lookup()` + `dns.resolve4()` and terminates them mid-flight.

- **fail-before** (`git stash -- src/ && bun bd test ...`): null-deref panic / ASAN heap-use-after-free
- **pass-after**: clean exit 0 across 10 consecutive runs

Also verified `test/js/node/dns/` and `test/js/bun/dns/` pass/fail counts are unchanged vs. main, and `bun run rust:check-all` is clean on all targets.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/workers/worker-terminate-lifetime.test.ts

<!-- robobun:evidence:end -->