### PR TITLE
Atomics.waitAsync: break the DispatchTimer self-ref cycle when notify stops the timer before it fires

### DIFF
--- a/src/jsc/bindings/BunJSCEventLoop.cpp
+++ b/src/jsc/bindings/BunJSCEventLoop.cpp
@@ -106,7 +106,9 @@ extern "C" void Bun__JSC_onBeforeWait(JSC::VM* _Nonnull vm, uint64_t nowNs)
 // captures a Ref to the timer itself; the cycle only breaks when fired()
 // moves it out. WTFTimer__cancel calls this once it has removed the timer
 // from the wtf_timers heap (i.e. fired() is not and will never run), so the
-// m_function storage is not being executed and clearing it is safe.
+// m_function storage is not being executed and clearing it is safe. Remove
+// once oven-sh/WebKit makes Waiter::clearTimer (or dispatchAfter itself)
+// break the cycle; see oven-sh/bun#34456.
 extern "C" void Bun__breakDispatchTimerCycle(WTF::RunLoop::TimerBase* timer)
 {
     if (timer->description() != "DispatchTimer"_s) [[likely]]

--- a/src/jsc/bindings/BunJSCEventLoop.cpp
+++ b/src/jsc/bindings/BunJSCEventLoop.cpp
@@ -5,6 +5,7 @@
 
 #include <JavaScriptCore/VM.h>
 #include <JavaScriptCore/Heap.h>
+#include <wtf/RunLoop.h>
 
 #if USE(MIMALLOC)
 // Matches oven-sh/mimalloc's mi_attr_noexcept declaration; bmalloc's
@@ -99,4 +100,16 @@ extern "C" void Bun__JSC_onBeforeWait(JSC::VM* _Nonnull vm, uint64_t nowNs)
 #endif
         }
     }
+}
+
+// RunLoop::dispatchAfter stores a lambda in DispatchTimer::m_function that
+// captures a Ref to the timer itself; the cycle only breaks when fired()
+// moves it out. WTFTimer__cancel calls this once it has removed the timer
+// from the wtf_timers heap (i.e. fired() is not and will never run), so the
+// m_function storage is not being executed and clearing it is safe.
+extern "C" void Bun__breakDispatchTimerCycle(WTF::RunLoop::TimerBase* timer)
+{
+    if (timer->description() != "DispatchTimer"_s) [[likely]]
+        return;
+    static_cast<WTF::RunLoop::DispatchTimer*>(timer)->setFunction({});
 }

--- a/src/jsc/bindings/BunJSCEventLoop.cpp
+++ b/src/jsc/bindings/BunJSCEventLoop.cpp
@@ -102,13 +102,10 @@ extern "C" void Bun__JSC_onBeforeWait(JSC::VM* _Nonnull vm, uint64_t nowNs)
     }
 }
 
-// RunLoop::dispatchAfter stores a lambda in DispatchTimer::m_function that
-// captures a Ref to the timer itself; the cycle only breaks when fired()
-// moves it out. WTFTimer__cancel calls this once it has removed the timer
-// from the wtf_timers heap (i.e. fired() is not and will never run), so the
-// m_function storage is not being executed and clearing it is safe. Remove
-// once oven-sh/WebKit makes Waiter::clearTimer (or dispatchAfter itself)
-// break the cycle; see oven-sh/bun#34456.
+// Transitional shim: delete once WEBKIT_VERSION includes oven-sh/WebKit#305,
+// where RunLoopBun's TimerBase::stop() does this via didStopWhileActive().
+// WTFTimer__cancel calls this only after wtf_disarm removed a still-ACTIVE
+// node (fired() cannot be running), so clearing m_function is safe.
 extern "C" void Bun__breakDispatchTimerCycle(WTF::RunLoop::TimerBase* timer)
 {
     if (timer->description() != "DispatchTimer"_s) [[likely]]

--- a/src/runtime/timer/WTFTimer.rs
+++ b/src/runtime/timer/WTFTimer.rs
@@ -85,7 +85,7 @@ impl WTFTimer {
         // SAFETY: `vm` is the live VM that owns this timer's heap.
         unsafe {
             let state = crate::jsc_hooks::runtime_state_of(vm);
-            (*state)
+            let _ = (*state)
                 .timer
                 .wtf_disarm(ptr::addr_of_mut!((*this).event_loop_timer));
         }
@@ -181,9 +181,12 @@ impl WTFTimer {
         }
     }
 
+    /// Returns `true` if the timer was still armed in the `wtf_timers` heap
+    /// and has now been removed (see [`super::All::wtf_disarm`]).
+    ///
     /// # Safety
     /// `this` must point at a live heap-allocated `WTFTimer`.
-    pub unsafe fn cancel(this: *mut Self) {
+    pub unsafe fn cancel(this: *mut Self) -> bool {
         // SAFETY: per fn contract — `this` outlives this scope. `ThisPtr` vends
         // only fresh short-lived `&Self` per Deref.
         let t = unsafe { bun_ptr::ThisPtr::new(this) };
@@ -205,11 +208,12 @@ impl WTFTimer {
             // any thread and is a no-op for a node that is no longer linked.
             unsafe {
                 let state = crate::jsc_hooks::runtime_state_of(t.vm.as_ptr());
-                (*state)
+                return (*state)
                     .timer
                     .wtf_disarm(ptr::addr_of_mut!((*this).event_loop_timer));
             }
         }
+        false
     }
 
     /// `EventLoopTimer.fire` dispatch arm body for `Tag::WTFTimer`.
@@ -239,7 +243,7 @@ impl WTFTimer {
     /// `this` must be the unique owner of a `heap::alloc`-produced `WTFTimer`.
     pub unsafe fn deinit(this: *mut Self) {
         // SAFETY: per fn contract.
-        unsafe { Self::cancel(this) };
+        let _ = unsafe { Self::cancel(this) };
         // SAFETY: `bun.TrivialNew` ↔ `heap::alloc`, so `heap::take` is
         // the paired free.
         drop(unsafe { bun_core::heap::take(this) });
@@ -309,9 +313,22 @@ pub(crate) unsafe extern "C" fn WTFTimer__deinit(this: *mut WTFTimer) {
 #[unsafe(no_mangle)]
 pub(crate) unsafe extern "C" fn WTFTimer__cancel(this: *mut WTFTimer) {
     // SAFETY: per fn contract.
-    unsafe { WTFTimer::cancel(this) };
+    let was_armed = unsafe { WTFTimer::cancel(this) };
+    // `dispatchAfter` captures a self-`Ref` in `DispatchTimer::m_function` that
+    // only `fired()` moves out; stopping a still-armed timer (the
+    // `Atomics.waitAsync` notify/unregister path) would orphan the cycle and
+    // leak both the timer and this box. `was_armed` proves `drain_due_wtf_timers`
+    // has not popped it (ACTIVE → FIRED is set under the same lock), so
+    // `m_function` is not executing and is safe to clear. Not on `deinit`'s
+    // path: `~TimerBase` runs after `~DispatchTimer` already destroyed it.
+    if was_armed {
+        // SAFETY: `this` is live (the caller in `TimerBase::stop()` owns it).
+        unsafe { Bun__breakDispatchTimerCycle((*this).run_loop_timer) };
+    }
 }
 
 unsafe extern "C" {
     safe fn WTFTimer__fire(this: NonNull<RunLoopTimer>);
+    /// Defined in `src/jsc/bindings/BunJSCEventLoop.cpp`.
+    safe fn Bun__breakDispatchTimerCycle(timer: NonNull<RunLoopTimer>);
 }

--- a/src/runtime/timer/WTFTimer.rs
+++ b/src/runtime/timer/WTFTimer.rs
@@ -308,23 +308,30 @@ pub(crate) unsafe extern "C" fn WTFTimer__deinit(this: *mut WTFTimer) {
     unsafe { WTFTimer::deinit(this) };
 }
 
+/// Returns whether the timer was still armed in the `wtf_timers` heap, i.e.
+/// `drain_due_wtf_timers` has not popped it (ACTIVE → FIRED is serialised by
+/// the heap lock), so `fired()` is not running and will not run.
+/// `RunLoopBun.cpp`'s `TimerBase::stop()` forwards this to
+/// `didStopWhileActive()` (oven-sh/WebKit#305).
+///
 /// # Safety
 /// `this` must point at a live `WTFTimer` produced by [`WTFTimer__create`].
 #[unsafe(no_mangle)]
-pub(crate) unsafe extern "C" fn WTFTimer__cancel(this: *mut WTFTimer) {
+pub(crate) unsafe extern "C" fn WTFTimer__cancel(this: *mut WTFTimer) -> bool {
     // SAFETY: per fn contract.
     let was_armed = unsafe { WTFTimer::cancel(this) };
     // `dispatchAfter` captures a self-`Ref` in `DispatchTimer::m_function` that
     // only `fired()` moves out; stopping a still-armed timer (the
-    // `Atomics.waitAsync` notify/unregister path) would orphan the cycle and
-    // leak both the timer and this box. `was_armed` proves `drain_due_wtf_timers`
-    // has not popped it (ACTIVE → FIRED is set under the same lock), so
-    // `m_function` is not executing and is safe to clear. Not on `deinit`'s
-    // path: `~TimerBase` runs after `~DispatchTimer` already destroyed it.
+    // `Atomics.waitAsync` notify/unregister path) orphans the cycle and leaks
+    // both the timer and this box. Delete this call (and the C++ helper) once
+    // WEBKIT_VERSION includes oven-sh/WebKit#305, where `TimerBase::stop()`
+    // does the same via `didStopWhileActive()`; until then the prebuilt WTF
+    // still declares this function `void` and ignores the return.
     if was_armed {
         // SAFETY: `this` is live (the caller in `TimerBase::stop()` owns it).
         unsafe { Bun__breakDispatchTimerCycle((*this).run_loop_timer) };
     }
+    was_armed
 }
 
 unsafe extern "C" {

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -866,8 +866,11 @@ impl All {
         }
     }
 
+    /// Returns `true` when the timer was still in the heap (i.e. not yet popped
+    /// by [`Self::drain_due_wtf_timers`]); `false` means it has already been
+    /// popped for firing or was never armed.
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn wtf_disarm(&mut self, timer: *mut EventLoopTimer) {
+    pub(crate) fn wtf_disarm(&mut self, timer: *mut EventLoopTimer) -> bool {
         // SAFETY: caller guarantees `timer` is a valid live EventLoopTimer.
         debug_assert!(unsafe { (*timer).tag } == EventLoopTimerTag::WTFTimer);
         let mut wtf = self.wtf_timers.lock();
@@ -876,8 +879,10 @@ impl All {
             if (*timer).state == EventLoopTimerState::ACTIVE {
                 wtf.remove(timer);
                 (*timer).state = EventLoopTimerState::CANCELLED;
+                return true;
             }
         }
+        false
     }
 
     unsafe fn drain_due_wtf_timers(

--- a/test/js/web/atomics.test.ts
+++ b/test/js/web/atomics.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN } from "harness";
 
 describe("Atomics", () => {
   describe("basic operations", () => {
@@ -159,6 +160,53 @@ describe("Atomics", () => {
         expect(typeof result.value).toBe("string");
       }
     });
+
+    test("waitAsync timeout stopped by notify does not leak the DispatchTimer", async () => {
+      // RunLoop::dispatchAfter stores a self-Ref in DispatchTimer::m_function; before
+      // the fix, Waiter::clearTimer's stop() left that cycle intact and every notified
+      // waiter leaked a DispatchTimer + Bun-side WTFTimer box.
+      const perBatch = isASAN ? 10_000 : 40_000;
+      const src = `
+        const i32 = new Int32Array(new SharedArrayBuffer(4));
+        async function batch(n) {
+          const ps = new Array(n);
+          for (let i = 0; i < n; i++) {
+            ps[i] = Atomics.waitAsync(i32, 0, 0, 300_000).value;
+            Atomics.notify(i32, 0, 1);
+          }
+          // Drain the deferred-work tickets so the promise reactions and the
+          // Waiter refs they hold aren't still queued when rss is sampled.
+          for (const v of await Promise.all(ps)) {
+            if (v !== "ok") throw new Error("expected ok, got " + v);
+          }
+          Bun.gc(true);
+        }
+        await batch(${perBatch});
+        await batch(${perBatch});
+        const rss0 = process.memoryUsage().rss;
+        for (let i = 0; i < 4; i++) await batch(${perBatch});
+        const rss1 = process.memoryUsage().rss;
+        console.log(JSON.stringify({ delta: rss1 - rss0 }));
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", src],
+        env: {
+          ...bunEnv,
+          // ASAN's freed-allocation quarantine keeps freed DispatchTimer/Waiter
+          // memory resident, which hides the fix's effect on rss. The gate runs
+          // debug+ASAN; disable the quarantine so rss reflects what's live.
+          ASAN_OPTIONS: `${bunEnv.ASAN_OPTIONS ?? "allow_user_segv_handler=1"}:quarantine_size_mb=0`,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+      const { delta } = JSON.parse(stdout);
+      // Without the fix the four measured batches leak ~15 MB under ASAN and
+      // well over 30 MB in release; with the fix rss is flat after warm-up.
+      expect(delta).toBeLessThan(6 * 1024 * 1024);
+    }, 30_000);
   });
 
   describe("different TypedArray types", () => {

--- a/test/js/web/atomics.test.ts
+++ b/test/js/web/atomics.test.ts
@@ -201,11 +201,13 @@ describe("Atomics", () => {
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
-      const { delta } = JSON.parse(stdout);
+      expect({ stdout, stderr, exitCode }).toMatchObject({
+        stdout: expect.stringMatching(/"delta":/),
+        exitCode: 0,
+      });
       // Without the fix the four measured batches leak ~15 MB under ASAN and
       // well over 30 MB in release; with the fix rss is flat after warm-up.
-      expect(delta).toBeLessThan(6 * 1024 * 1024);
+      expect(JSON.parse(stdout).delta).toBeLessThan(6 * 1024 * 1024);
     }, 30_000);
   });
 

--- a/test/leaksan.supp
+++ b/test/leaksan.supp
@@ -114,11 +114,6 @@ leak:create_ssl_context_from_bun_options
 leak:jsc.Debugger.startJSDebuggerThread
 # test/js/sql/sqlite-sql.test.ts
 leak:WebCore::jsSQLStatementOpenStatementFunction
-# test/js/web/atomics.test.ts — RunLoop::dispatchAfter's DispatchTimer captures
-# a Ref to itself in m_function; the cycle only breaks when fired(). If stop()
-# is called before firing (WaiterListManager::clearTimer on notify/unregister),
-# the DispatchTimer and its Bun-side WTFTimer Box leak. JSC-owned ref-cycle.
-leak:WTF::RunLoop::dispatchAfter
 # test/cli/run/workspaces.test.ts, test/regression/issue/26207.test.ts —
 # run_scripts_with_filter ends with Global::exit() so pre_script_name /
 # post_script_name / script_name_owned locals never Drop (intentional per the


### PR DESCRIPTION
Every `Atomics.waitAsync(buf, i, v, timeout)` that is woken by `Atomics.notify` (or by `WaiterListManager::unregister` on VM/global teardown) before its timeout fires leaks a `WTF::RunLoop::DispatchTimer` and the Bun-side `WTFTimer` box it owns. This is a runtime leak, not just a shutdown reporting gap; it was hidden on the ASAN lane by a `leak:WTF::RunLoop::dispatchAfter` suppression in `test/leaksan.supp`.

### Repro

```js
const i32 = new Int32Array(new SharedArrayBuffer(4));
async function batch(n) {
  const ps = new Array(n);
  for (let i = 0; i < n; i++) {
    ps[i] = Atomics.waitAsync(i32, 0, 0, 300_000).value;
    Atomics.notify(i32, 0, 1);
  }
  await Promise.all(ps);
  Bun.gc(true);
}
for (let r = 0; r < 8; r++) {
  await batch(10_000);
  console.log("round", r, "rss:", (process.memoryUsage().rss / 1024 / 1024).toFixed(1), "MB");
}
```

| round | release before | release after | ASAN (quarantine=0) before | ASAN after |
|---|---|---|---|---|
| 1 | 42.4 MB | 43.4 MB | 354.0 MB | 348.7 MB |
| 7 | 81.7 MB | 43.3 MB | 376.1 MB | 348.6 MB |

### Cause

`RunLoop::dispatchAfter` (`wtf/RunLoop.cpp`) stores its fire lambda in `DispatchTimer::m_function`, and the lambda captures `timer.copyRef()` to the timer itself. That self-ref is only moved out into `protectedTimer` when `fired()` actually runs:

```cpp
timer->setFunction([timer = timer.copyRef(), function = WTF::move(function)]() mutable {
    Ref<DispatchTimer> protectedTimer { WTF::move(timer) };
    function();
    protectedTimer->stop();
});
```

`Waiter::clearTimer` (reached from `notifyWaiterImpl` / `cancelAndClear`) does `m_timer->stop(); m_timer = nullptr;`, which drops the waiter's ref but leaves `m_function` (and thus the self-ref and the captured `Ref<Waiter>`) intact, orphaning the cycle.

### Fix

`dispatchAfter` and `Waiter::clearTimer` are in the prebuilt WebKit, so the fix hooks in at the one point where Bun's own code runs in this path: `WTFTimer__cancel`, called from `RunLoop::TimerBase::stop()`.

- `All::wtf_disarm` now returns whether it removed a still-`ACTIVE` node from the `wtf_timers` heap.
- `WTFTimer__cancel` forwards that to a new C++ helper `Bun__breakDispatchTimerCycle(TimerBase*)` which, for timers whose `description()` is `"DispatchTimer"`, clears `m_function` via the public `setFunction({})`. That releases the self-ref, after which `clearTimer`'s `m_timer = nullptr` drops the refcount to zero and `~TimerBase` frees the `WTFTimer` box.

The `was_armed` gate is what makes this safe across threads. `drain_due_wtf_timers` pops a node and sets `state = FIRED` under the `wtf_timers` lock before releasing it and calling `fired()`; `wtf_disarm` checks `state == ACTIVE` under the same lock. So `was_armed == true` implies the node was never popped and `fired()` is not and will never execute, so `m_function` is not on any stack. When `was_armed == false` (already popped, or stopped from inside the fire lambda's own `protectedTimer->stop()`), we leave `m_function` alone; `fired()` breaks the cycle itself. `WTFTimer::deinit` still calls `cancel()` but not the helper, since `~TimerBase` runs after `~DispatchTimer` has already destroyed `m_function`.

On a Bun run loop the only `DispatchTimer` producer is `WaiterListManager::waitAsyncImpl`; `WorkQueue::dispatchAfter` callers (Watchdog, VMTraps SignalSender, ExecutableAllocator) run on generic-kind run loops and never reach `WTFTimer__create`. Other `TimerBase` subclasses on the Bun run loop (the `RunLoop::Timer`-based `JSRunLoopTimer` etc.) keep a different `description()` and are skipped.

### Verification

New test in `test/js/web/atomics.test.ts` runs six batches of `waitAsync` + `notify` in a subprocess and asserts RSS is flat across the last four; it sets `ASAN_OPTIONS=...:quarantine_size_mb=0` so ASAN's freed-allocation quarantine does not mask the difference.

```
git stash push -- src/ && bun bd test test/js/web/atomics.test.ts -t 'does not leak'
  expect(received).toBeLessThan(expected)
  Expected: < 6291456
  Received: 16990208
git stash pop && bun bd test test/js/web/atomics.test.ts -t 'does not leak'
  29 pass / 0 fail
```

LSan with the `dispatchAfter` suppression removed:

- before: `Direct leak of 8000 byte(s) in 100 object(s) ... #9 WTFTimer__create ... #12 WTF::RunLoop::dispatchAfter`
- after: clean

The cross-thread stress fixture `test/js/web/timers/timer-heap-race.test.ts` (four threads arming short `waitAsync` timeouts while the others `Atomics.notify` them) and `test/regression/issue/atomics-waitasync-wtftimer-uaf.test.ts` still pass, as does the worker teardown LSan fixture in the same file now that the suppression is gone.

### Why not in `Waiter::clearTimer`

The obvious one-liner is `m_timer->setFunction({});` between `stop()` and `m_timer = nullptr;` in `WaiterListManager.h`. On the Bun run loop that is not safe: `clearTimer` runs under the list lock from the notifying thread, while the owning thread's `fired()` may already be executing and blocked inside `timeoutAsyncWaiter` waiting for that same lock. `stop()` is a no-op once `drain_due_wtf_timers` has popped the node, so the lock does not cover `m_function`'s storage and clearing it there would free a `Function<>` whose `CallableWrapper::call()` is on another thread's stack. The `was_armed` gate in this PR is the thing that distinguishes "never popped, safe to clear" from "already popped, leave it to `fired()`", and `RunLoop::TimerBase::stop()` (where `WTFTimer__cancel` is the sole caller on a Bun run loop) is the earliest point where that information is available without changing the prebuilt WTF API. A follow-up in oven-sh/WebKit can move the same gate into `RunLoopBun`'s `stop()` and drop this helper; until then this is the minimal correct change on the bun side.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/atomics.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (abb3f38f2)

test/js/web/atomics.test.ts:
(pass) Atomics > basic operations > store and load [4.75ms]
(pass) Atomics > basic operations > add [3.11ms]
(pass) Atomics > basic operations > sub [3.34ms]
(pass) Atomics > basic operations > exchange [2.72ms]
(pass) Atomics > basic operations > compareExchange [3.10ms]
(pass) Atomics > bitwise operations > and [2.46ms]
(pass) Atomics > bitwise operations > or [2.54ms]
(pass) Atomics > bitwise operations > xor [2.17ms]
(pass) Atomics > utility functions > isLockFree [3.11ms]
(pass) Atomics > utility functions > pause [2.42ms]
(pass) Atomics > synchronization > wait with timeout [12.50ms]
(pass) Atomics > synchronization > wait with non-matching value [1.87ms]
(pass) Atomics > synchronization > no
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (d3e62047c)

test/js/web/atomics.test.ts:
(pass) Atomics > basic operations > store and load [0.08ms]
(pass) Atomics > basic operations > add [0.04ms]
(pass) Atomics > basic operations > sub [0.03ms]
(pass) Atomics > basic operations > exchange [0.02ms]
(pass) Atomics > basic operations > compareExchange [0.03ms]
(pass) Atomics > bitwise operations > and [0.02ms]
(pass) Atomics > bitwise operations > or [0.02ms]
(pass) Atomics > bitwise operations > xor [0.02ms]
(pass) Atomics > utility functions > isLockFree [0.03ms]
(pass) Atomics > utility functions > pause [0.03ms]
(pass) Atomics > synchronization > wait with timeout [10.12ms]
(pass) Atomics > synchronization > wait with non-matching value [0.07ms]
(pass) Atomics > synchronization > notify [0.02ms]
(pass) Atomics > synchronization > waitAsync with timeout [0.04ms]
(pass) Atomics > synchronization > waitAsync timeout stopped by notify does not leak the DispatchTimer [342.05ms]
(pass) Atomics > different TypedArray types > Int8Array [0.14ms]
(pass) Atomics > different TypedArray types > Int16Array [0.04ms]
(pass) Atomics > different TypedArray types > Int32Array [0.04ms]
(pass) Atomics > d
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/atomics.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (abb3f38f2)

test/js/web/atomics.test.ts:
(pass) Atomics > basic operations > store and load [4.56ms]
(pass) Atomics > basic operations > add [3.01ms]
(pass) Atomics > basic operations > sub [3.32ms]
(pass) Atomics > basic operations > exchange [2.43ms]
(pass) Atomics > basic operations > compareExchange [2.96ms]
(pass) Atomics > bitwise operations > and [2.42ms]
(pass) Atomics > bitwise operations > or [2.39ms]
(pass) Atomics > bitwise operations > xor [2.11ms]
(pass) Atomics > utility functions > isLockFree [3.10ms]
(pass) Atomics > utility functions > pause [2.33ms]
(pass) Atomics > synchronization > wait with timeout [12.36ms]
(pass) Atomics > synchronization > wait with non-matching value [2.22ms]
(pass) Atomics > synchronization > no
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 690ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[2/8] gen cpp.rs (cppbind)
[2/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/wor
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/BunJSCEventLoop.cpp | 12 +++++++++
 src/runtime/timer/WTFTimer.rs        | 36 +++++++++++++++++++++-----
 src/runtime/timer/mod.rs             |  7 ++++-
 test/js/web/atomics.test.ts          | 50 ++++++++++++++++++++++++++++++++++++
 test/leaksan.supp                    |  5 ----
 5 files changed, 98 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/jsc/bindings/BunJSCEventLoop.cpp      5      8      0
src/runtime/timer/WTFTimer.rs             5      9      0
src/runtime/timer/mod.rs                  2      1      0
test/js/web/atomics.test.ts               2      7      0
test/leaksan.supp                         1      1      0
```

</details>

<!-- robobun:evidence:end -->

### oven-sh/WebKit#305

The proper home for this is `RunLoopBun.cpp`'s `TimerBase::stop()`. oven-sh/WebKit#305 adds a virtual `TimerBase::didStopWhileActive()` (default no-op, `DispatchTimer` overrides it to clear `m_function`) and has `stop()` call it when `WTFTimer__cancel` returns true, removing the `description()` string match and the bun-side `static_cast`. This PR now also makes the Rust-side `WTFTimer__cancel` return `bool` so that change can land; until `WEBKIT_VERSION` is bumped to include it, the prebuilt WTF's `void` declaration ignores the return and `Bun__breakDispatchTimerCycle` carries the fix. Once bumped, delete `Bun__breakDispatchTimerCycle` and its call site.
