### PR TITLE
sql(mysql): fix truncated Time::to_binary when microseconds != 0

### DIFF
--- a/src/sql_jsc/mysql/MySQLValue.rs
+++ b/src/sql_jsc/mysql/MySQLValue.rs
@@ -806,7 +806,7 @@ impl Time {
                 } else {
                     buffer[0] = 12; // length
                     buffer[9..13].copy_from_slice(&self.microseconds.to_le_bytes());
-                    12
+                    13
                 }
             }
             _ => unreachable!(),


### PR DESCRIPTION
## What

`Time::to_binary` (the MySQL TIME binary-parameter encoder) writes 13 bytes when `microseconds != 0` but returned 12, so `Value::to_data` copied `buffer[0..12]` and dropped `buffer[12]` (the high byte of the little-endian `u32` microseconds). The length prefix in `buffer[0]` is 12, so the packet would advertise 12 payload bytes but carry only 11, desynchronizing the COM_STMT_EXECUTE stream the moment this encoder runs.

```rust
} else {
    buffer[0] = 12; // length
    buffer[9..13].copy_from_slice(&self.microseconds.to_le_bytes());
    12   // ← writes buffer[0..=12] but returns 12; should be 13
}
```

The `microseconds == 0` branch (writes 9, returns 9) and `DateTime::to_binary`'s DATETIME-with-microseconds branch (writes 12, returns 12) are already consistent; only this branch is off by one. The same bug was present in the pre-Rust Zig implementation.

## Why this has no JS test

This encode path is currently unreachable from JS. `Value::Time` is only constructed when `Value::from_js` is called with `FieldType::MYSQL_TYPE_TIME`, and the only source of that field type is `Signature::generate` → `field_type_from_js`, which maps a JS `Date` to `MYSQL_TYPE_DATETIME` (never `TIME`). The server-reported param types (`statement.params`, filled from the StmtPrepareOK column definitions) are decoded but only used for count checks; they never feed back into encoding. So today a `Date` bound to a `TIME(6)` column is sent as a DATETIME and coerced server-side, and `Time::to_binary` never executes.

A fail-before JS test is therefore not constructible, and `cargo test -p bun_sql_jsc` cannot link standalone (the crate transitively pulls in Windows link stubs on Linux), so a Rust unit test would not run either. The fix is applied so whoever later wires up TIME parameter binding (for example by honouring the server-reported param type) does not inherit a latent protocol desync.

Spotted during code review on #34452.