### PR TITLE
test(dgram): skip cluster shared-fd fixture on Intel macOS (wedges loopback)

### DIFF
--- a/test/js/bun/udp/dgram.test.ts
+++ b/test/js/bun/udp/dgram.test.ts
@@ -252,10 +252,9 @@ describe.skipIf(isWindows)("cluster", () => {
   // machine and SharedHandle teardown. A regression removing the double-close
   // guard would EBADF an IPC pipe and hang this fixture.
   //
-  // Skipped on Intel macOS: on macOS 14 x64 the four workers wedge in kernel
-  // exit (?E) with all four in recvmsg_x on the same SCM_RIGHTS-shared
-  // descriptor, which takes loopback down for the whole machine until reboot.
-  // Observed on every macOS 14 x64 CI agent; 13 and 15 not reproduced.
+  // Skipped on Intel macOS: on the macOS 14/15 x64 CI agents the four workers
+  // wedge in kernel exit (?E) with all four in recvmsg_x on the same
+  // SCM_RIGHTS-shared descriptor, and loopback stays dead until reboot.
   test.skipIf(isIntelMacOS)(
     "multi-worker shared socket adopts and tears down cleanly",
     async () => {

--- a/test/js/bun/udp/dgram.test.ts
+++ b/test/js/bun/udp/dgram.test.ts
@@ -256,17 +256,21 @@ describe.skipIf(isWindows)("cluster", () => {
   // exit (?E) with all four in recvmsg_x on the same SCM_RIGHTS-shared
   // descriptor, which takes loopback down for the whole machine until reboot.
   // Observed on every macOS 14 x64 CI agent; 13 and 15 not reproduced.
-  test.skipIf(isIntelMacOS)("multi-worker shared socket adopts and tears down cleanly", async () => {
-    // Assert the success line, not just exit 0: the fixture has bail-out paths
-    // that also exit 0. 25s deadline sits between the fixture's 20s watchdog
-    // and this test's own timeout so the watchdog's diagnostic reaches stderr.
-    const { stdout, stderr, exitCode } = await runClusterFixture("dgram-cluster-shared-fd-fixture.ts", 25_000);
-    expect(stderr).toBe("");
-    // Traffic receipt is best-effort (kernel-arbitrated), teardown is the
-    // contract: the success line carries received/sent for diagnostics.
-    expect(stdout).toStartWith("ok: all 4 workers adopted and released the shared descriptor ");
-    expect(exitCode).toBe(0);
-  }, 40_000);
+  test.skipIf(isIntelMacOS)(
+    "multi-worker shared socket adopts and tears down cleanly",
+    async () => {
+      // Assert the success line, not just exit 0: the fixture has bail-out paths
+      // that also exit 0. 25s deadline sits between the fixture's 20s watchdog
+      // and this test's own timeout so the watchdog's diagnostic reaches stderr.
+      const { stdout, stderr, exitCode } = await runClusterFixture("dgram-cluster-shared-fd-fixture.ts", 25_000);
+      expect(stderr).toBe("");
+      // Traffic receipt is best-effort (kernel-arbitrated), teardown is the
+      // contract: the success line carries received/sent for diagnostics.
+      expect(stdout).toStartWith("ok: all 4 workers adopted and released the shared descriptor ");
+      expect(exitCode).toBe(0);
+    },
+    40_000,
+  );
 });
 
 describe("after close()", () => {

--- a/test/js/bun/udp/dgram.test.ts
+++ b/test/js/bun/udp/dgram.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, jest, test } from "bun:test";
 import { createSocket } from "dgram";
 import { Worker } from "node:worker_threads";
 
-import { bunEnv, bunExe, disableAggressiveGCScope, isWindows } from "harness";
+import { bunEnv, bunExe, disableAggressiveGCScope, isIntelMacOS, isWindows } from "harness";
 import path from "path";
 import { nodeDataCases } from "./testdata";
 
@@ -251,7 +251,12 @@ describe.skipIf(isWindows)("cluster", () => {
   // Multi-worker traffic + close: exercises the DGRAM_FDS Owned/Adopted state
   // machine and SharedHandle teardown. A regression removing the double-close
   // guard would EBADF an IPC pipe and hang this fixture.
-  test("multi-worker shared socket adopts and tears down cleanly", async () => {
+  //
+  // Skipped on Intel macOS: on macOS 14 x64 the four workers wedge in kernel
+  // exit (?E) with all four in recvmsg_x on the same SCM_RIGHTS-shared
+  // descriptor, which takes loopback down for the whole machine until reboot.
+  // Observed on every macOS 14 x64 CI agent; 13 and 15 not reproduced.
+  test.skipIf(isIntelMacOS)("multi-worker shared socket adopts and tears down cleanly", async () => {
     // Assert the success line, not just exit 0: the fixture has bail-out paths
     // that also exit 0. 25s deadline sits between the fixture's 20s watchdog
     // and this test's own timeout so the watchdog's diagnostic reaches stderr.


### PR DESCRIPTION
## Reproduction

`test/bake/dev/ecosystem.test.ts` (and every other `test/bake/dev/*` test, plus `bun-create.test.ts`, `quic-*.test.ts`, etc.) went red on the `:darwin: 14 x64` lane starting with build [74206](https://buildkite.com/bun/bun/builds/74206) and stayed red on every subsequent job scheduled to the same agent. The tests themselves are fine; they time out because `connect("127.0.0.1", port)` never completes.

On each affected agent:

```
$ ping -c 1 127.0.0.1
1 packets transmitted, 0 packets received, 100.0% packet loss

$ ps -eo pid,lstart,stat,comm | grep '?E'
47986 Thu Jul 16 17:25:00 2026     ?E   (bun-profile)
47987 Thu Jul 16 17:25:00 2026     ?E   (bun-profile)
47988 Thu Jul 16 17:25:00 2026     ?E   (bun-profile)
47989 Thu Jul 16 17:25:00 2026     ?E   (bun-profile)
```

`kill -9` on the four zombies and `ifconfig lo0 down/up` do not recover it; only a reboot does.

## Cause

Commit 57e30a5c70 (#32625, merged 2026-07-16 15:53 PDT) added `test/js/bun/udp/dgram-cluster-shared-fd-fixture.ts`, which forks four cluster workers that each adopt the primary's bound UDP descriptor via `SCM_RIGHTS` and sit in the readable loop (`recvmsg_x` on macOS) while the primary floods `sendto` at ~500/s. On macOS 14/15 x64 the four workers get stuck in kernel exit (`?E`) during teardown and the lo0 DLIL input thread stops draining (see the `dlil_input_async lo0 burst limit 8192 exceeded` kernel log captured in #34445). Loopback then drops 100% of packets until reboot.

Every macOS 14/15 x64 agent in the fleet wedged this way within a few hours of #32625 landing, each with exactly four consecutive-PID `?E` bun-profile zombies timestamped at a run of `dgram.test.ts`:

| agent | macOS | wedge time (PDT) | first timed-out job | confirmed test |
|---|---|---|---|---|
| darwin-matzo-x64 | 14.4 | 17:25:00 | 74206 | multi-worker shared socket ([74184](https://buildkite.com/bun/bun/builds/74184)) |
| darwin-cornbread-x64 | 14.5 | 18:44:20 | 74263 | (4 zombies, same signature) |
| darwin-pretzel-x64 | 14.3 | 20:26:48 | 74295 | (4 zombies, same signature) |
| darwin-bagel-x64 | 14.3 | 21:13:07 | 74318 | multi-worker shared socket ([74318](https://buildkite.com/bun/bun/builds/74318)) |
| darwin-flatbread-x64 | 15.0 | (per #34445) | 74298 | (since rebooted, uptime 32 min at time of check) |

The macOS 13 x64 agents (pita, naan, rye) were unaffected, though sharding meant they had not yet been handed this test. The x64 agents are bare-metal and carry state across jobs, so one wedge burns the box until the nightly 06:30 reboot. The arm64 lanes run in tart VMs that reset between jobs.

## Fix

Skip `multi-worker shared socket adopts and tears down cleanly` on Intel macOS. The single-worker `worker.disconnect()` test in the same block is kept: it exercises the basic close-callback contract with one worker and has not wedged any box. Multi-worker coverage remains on Linux and the arm64 macOS tart lanes.

This is the prevention half; #34445 adds a loopback health-check to the runner so a job that lands on an already-wedged box fails fast with a clear annotation instead of 45 minutes of unrelated timeouts.

## Verification

`bun bd test test/js/bun/udp/dgram.test.ts` passes all 61 tests on Linux (skip does not apply there). `bun bd test test/bake/dev/ecosystem.test.ts` passes on Linux. The four still-wedged agents need a reboot, which will happen at the nightly cleanup if not sooner; until then this PR's own darwin x64 lane will time out if it lands on one of them.

## Follow-up

Whether the wedge is a macOS kernel bug alone or is specifically triggered by the private `recvmsg_x` syscall bun uses on the shared descriptor (Node/libuv uses plain `recvmsg` on darwin) is worth checking once a healthy Intel macOS box is available; if disabling `recvmsg_x` for adopted fds avoids it, this skip can be narrowed or removed.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->