### PR TITLE
Gate recvmsg_x / sendmsg_x to macOS 15.6 or later

### DIFF
--- a/src/analytics/lib.rs
+++ b/src/analytics/lib.rs
@@ -464,14 +464,19 @@ pub mod generate_header {
         // macOS sendmsg_x / recvmsg_x feature gate
         // ──────────────────────────────────────────────────────────────────
 
-        // On macOS 13, tests that use sendmsg_x or recvmsg_x hang.
+        // Before macOS 15.6 (xnu-11417.140.69), recvmsg_x's soreceive_m_list()
+        // leaks the socket lock: concurrent batch-receives on one shared UDP
+        // socket deadlock the kernel and black-hole all loopback until reboot.
         #[cfg(target_os = "macos")]
-        static USE_MSGX_ON_MACOS_14_OR_LATER: OnceLock<bool> = OnceLock::new();
+        static USE_MSGX_ON_MACOS_15_6_OR_LATER: OnceLock<bool> = OnceLock::new();
 
         #[cfg(target_os = "macos")]
-        fn detect_use_msgx_on_macos_14_or_later() -> bool {
-            let version = semver::Version::parse_utf8(for_os().version);
-            version.valid && version.version.max().major >= 14
+        fn detect_use_msgx_on_macos_15_6_or_later() -> bool {
+            let parsed = semver::Version::parse_utf8(for_os().version);
+            let minimum = semver::Version::parse_utf8(b"15.6.0").version.min();
+            parsed.valid
+                && semver::Version::order_without_tag(parsed.version.min(), minimum)
+                    != core::cmp::Ordering::Less
         }
 
         #[unsafe(no_mangle)]
@@ -483,7 +488,7 @@ pub mod generate_header {
             }
             #[cfg(target_os = "macos")]
             {
-                *USE_MSGX_ON_MACOS_14_OR_LATER.get_or_init(detect_use_msgx_on_macos_14_or_later)
+                *USE_MSGX_ON_MACOS_15_6_OR_LATER.get_or_init(detect_use_msgx_on_macos_15_6_or_later)
                     as i32
             }
         }

--- a/src/analytics/lib.rs
+++ b/src/analytics/lib.rs
@@ -473,10 +473,8 @@ pub mod generate_header {
         #[cfg(target_os = "macos")]
         fn detect_use_msgx_on_macos_15_6_or_later() -> bool {
             let parsed = semver::Version::parse_utf8(for_os().version);
-            let minimum = semver::Version::parse_utf8(b"15.6.0").version.min();
-            parsed.valid
-                && semver::Version::order_without_tag(parsed.version.min(), minimum)
-                    != core::cmp::Ordering::Less
+            let version = parsed.version.min();
+            parsed.valid && (version.major, version.minor) >= (15, 6)
         }
 
         #[unsafe(no_mangle)]


### PR DESCRIPTION
### What does this PR do?

Tightens the macOS version gate on `recvmsg_x` / `sendmsg_x` from "macOS 14 or later" to "macOS 15.6 or later."

On macOS older than 15.6, `recvmsg_x` — bun's batched UDP receive — is backed by xnu's `soreceive_m_list()`, which leaks the socket lock: two of its early-exit paths `goto out` past the function's only `socket_unlock`. When two or more processes call `recvmsg_x` concurrently on one shared UDP socket while datagrams are arriving (e.g. cluster workers sharing a dgram handle), one of them returns to userspace still owning the socket lock. Its next receive on that socket blocks on the lock it already holds — a self-deadlock — and the kernel's shared loopback input thread then blocks behind it, so every `127.0.0.1` / `::1` packet on the machine is black-holed until reboot. External networking keeps working, which is why an affected box looks like a test failure rather than a machine failure.

macOS 15.6 (`xnu-11417.140.69`) changed both early exits to `goto release`, which runs the unlock, so the batched calls are only safe there and newer. The previous gate ("14 or later," carrying a note that the calls "hang tests" on 13) was set too permissively: 14.x and 15.0–15.5 still leak. Older macOS now takes the per-message `recvmsg` / `sendmsg` loop already used on macOS 13.

### How did you verify your code works?

The wedge reproduces on demand from ~30 lines of plain C — a UDP socket shared by `fork`, two concurrent `recvmsg_x` callers, and a sender flooding it; a few dozen instances in parallel deadlock a macOS 15.0 / 14.3 box within a minute, and macOS's own `spindump` reports it as `Deadlock:` with the socket lock's waiter being its owner. With batched receive disabled, the same load ran healthy at several times the concurrency for the full test window. The leak site and its fix version were confirmed against the xnu source (both exits are `goto release` starting at `xnu-11417.140.69`).

There is no automated test: a real regression test would have to wedge the CI machine's kernel to prove the fix, which is the one thing CI can't be allowed to do.
