### PR TITLE
test(node): add test-gc-http-client* from Node.js test suite

### DIFF
--- a/test/js/node/test/parallel/test-gc-http-client-connaborted.js
+++ b/test/js/node/test/parallel/test-gc-http-client-connaborted.js
@@ -1,0 +1,65 @@
+'use strict';
+// Flags: --expose-gc
+// just like test-gc-http-client.js,
+// but aborting every connection that comes in.
+
+const common = require('../common');
+const { onGC } = require('../common/gc');
+const http = require('http');
+const os = require('os');
+
+const cpus = os.availableParallelism();
+let createClients = true;
+let done = 0;
+let count = 0;
+let countGC = 0;
+
+function serverHandler(req, res) {
+  res.connection.destroy();
+}
+
+const server = http.createServer(serverHandler);
+server.listen(0, common.mustCall(() => {
+  for (let i = 0; i < cpus; i++)
+    getAll();
+}));
+
+function getAll() {
+  if (!createClients)
+    return;
+
+  const req = http.get({
+    hostname: 'localhost',
+    pathname: '/',
+    port: server.address().port
+  }, cb).on('error', cb);
+
+  count++;
+  onGC(req, { ongc });
+
+  setImmediate(getAll);
+}
+
+function cb(res) {
+  done += 1;
+}
+
+function ongc() {
+  countGC++;
+}
+
+setImmediate(status);
+
+function status() {
+  if (done > 0) {
+    createClients = false;
+    globalThis.gc();
+    console.log(`done/collected/total: ${done}/${countGC}/${count}`);
+    if (countGC === count) {
+      server.close();
+      return;
+    }
+  }
+
+  setImmediate(status);
+}

--- a/test/js/node/test/sequential/test-gc-http-client-onerror.js
+++ b/test/js/node/test/sequential/test-gc-http-client-onerror.js
@@ -1,0 +1,77 @@
+'use strict';
+// Flags: --expose-gc
+// just like test-gc-http-client.js,
+// but with an on('error') handler that does nothing.
+
+const common = require('../common');
+const { onGC } = require('../common/gc');
+
+const cpus = require('os').availableParallelism();
+
+function serverHandler(req, res) {
+  req.resume();
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('Hello World\n');
+}
+
+const http = require('http');
+const numRequests = 36;
+let createClients = true;
+let done = 0;
+let count = 0;
+let countGC = 0;
+
+const server = http.createServer(serverHandler);
+server.listen(0, common.mustCall(() => {
+  for (let i = 0; i < cpus; i++)
+    getAll(numRequests);
+}));
+
+function getAll(requestsRemaining) {
+  if (!createClients)
+    return;
+
+  if (requestsRemaining <= 0)
+    return;
+
+  const req = http.get({
+    hostname: 'localhost',
+    pathname: '/',
+    port: server.address().port,
+  }, cb).on('error', onerror);
+
+  count++;
+  onGC(req, { ongc });
+
+  setImmediate(getAll, requestsRemaining - 1);
+}
+
+function cb(res) {
+  res.resume();
+  done++;
+}
+
+function onerror(err) {
+  throw err;
+}
+
+function ongc() {
+  countGC++;
+}
+
+setImmediate(status);
+
+function status() {
+  if (done > 0) {
+    createClients = false;
+    global.gc();
+    console.log(`done/collected/total: ${done}/${countGC}/${count}`);
+    if (countGC === count) {
+      server.close();
+    } else {
+      setImmediate(status);
+    }
+  } else {
+    setImmediate(status);
+  }
+}

--- a/test/js/node/test/sequential/test-gc-http-client-timeout.js
+++ b/test/js/node/test/sequential/test-gc-http-client-timeout.js
@@ -1,0 +1,65 @@
+'use strict';
+// Flags: --expose-gc
+// Like test-gc-http-client.js, but with a timeout set.
+
+const common = require('../common');
+const { onGC } = require('../common/gc');
+const http = require('http');
+
+function serverHandler(req, res) {
+  setTimeout(function() {
+    req.resume();
+    res.writeHead(200);
+    res.end('hello\n');
+  }, 100);
+}
+
+const numRequests = 128;
+let done = 0;
+let countGC = 0;
+
+const server = http.createServer(serverHandler);
+server.listen(0, common.mustCall(() => {
+  getAll(numRequests);
+}));
+
+function getAll(requestsRemaining) {
+  if (requestsRemaining <= 0)
+    return;
+
+  const req = http.get({
+    hostname: 'localhost',
+    pathname: '/',
+    port: server.address().port,
+  }, cb);
+
+  req.setTimeout(10, common.mustCall());
+
+  onGC(req, { ongc });
+
+  setImmediate(getAll, requestsRemaining - 1);
+}
+
+function cb(res) {
+  res.resume();
+  done += 1;
+}
+
+function ongc() {
+  countGC++;
+}
+
+setImmediate(status);
+
+function status() {
+  if (done > 0) {
+    global.gc();
+    console.log(`done/collected/total: ${done}/${countGC}/${numRequests}`);
+    if (countGC === numRequests) {
+      server.close();
+      return;
+    }
+  }
+
+  setImmediate(status);
+}

--- a/test/js/node/test/sequential/test-gc-http-client.js
+++ b/test/js/node/test/sequential/test-gc-http-client.js
@@ -1,0 +1,71 @@
+'use strict';
+// Flags: --expose-gc
+// just a simple http server and client.
+
+const common = require('../common');
+const { onGC } = require('../common/gc');
+
+const cpus = require('os').availableParallelism();
+
+function serverHandler(req, res) {
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('Hello World\n');
+}
+
+const http = require('http');
+const numRequests = 36;
+let createClients = true;
+let done = 0;
+let count = 0;
+let countGC = 0;
+
+const server = http.createServer(serverHandler);
+server.listen(0, common.mustCall(() => {
+  for (let i = 0; i < cpus; i++)
+    getAll(numRequests);
+}));
+
+function getAll(requestsRemaining) {
+  if (!createClients)
+    return;
+
+  if (requestsRemaining <= 0)
+    return;
+
+  const req = http.get({
+    hostname: 'localhost',
+    pathname: '/',
+    port: server.address().port,
+  }, cb);
+
+  count++;
+  onGC(req, { ongc });
+
+  setImmediate(getAll, requestsRemaining - 1);
+}
+
+function cb(res) {
+  res.resume();
+  done += 1;
+}
+
+function ongc() {
+  countGC++;
+}
+
+setImmediate(status);
+
+function status() {
+  if (done > 0) {
+    createClients = false;
+    global.gc();
+    console.log(`done/collected/total: ${done}/${countGC}/${count}`);
+    if (countGC === count) {
+      server.close();
+    } else {
+      setImmediate(status);
+    }
+  } else {
+    setImmediate(status);
+  }
+}


### PR DESCRIPTION
Adds four Node.js GC tests that verify `http.ClientRequest` objects are collectable after the request completes:

- `parallel/test-gc-http-client-connaborted.js`
- `sequential/test-gc-http-client.js`
- `sequential/test-gc-http-client-onerror.js`
- `sequential/test-gc-http-client-timeout.js`

These are copied unmodified from the Node.js repository via `bun node:test:cp`. All four already pass against both release and debug builds with no runtime changes required.

<details>
<summary>Local verification (debug build, 5 iterations each)</summary>

```
run 1 test-gc-http-client.js -> exit 0 (5819ms)
run 1 test-gc-http-client-onerror.js -> exit 0 (5793ms)
run 1 test-gc-http-client-timeout.js -> exit 0 (15837ms)
run 1 test-gc-http-client-connaborted.js -> exit 0 (5199ms)
run 2 test-gc-http-client.js -> exit 0 (7266ms)
run 2 test-gc-http-client-onerror.js -> exit 0 (5863ms)
run 2 test-gc-http-client-timeout.js -> exit 0 (15698ms)
run 2 test-gc-http-client-connaborted.js -> exit 0 (5143ms)
run 3 test-gc-http-client.js -> exit 0 (5834ms)
run 3 test-gc-http-client-onerror.js -> exit 0 (5744ms)
run 3 test-gc-http-client-timeout.js -> exit 0 (15514ms)
run 3 test-gc-http-client-connaborted.js -> exit 0 (5254ms)
run 4 test-gc-http-client.js -> exit 0 (5749ms)
run 4 test-gc-http-client-onerror.js -> exit 0 (5797ms)
run 4 test-gc-http-client-timeout.js -> exit 0 (15509ms)
run 4 test-gc-http-client-connaborted.js -> exit 0 (5176ms)
run 5 test-gc-http-client.js -> exit 0 (5915ms)
run 5 test-gc-http-client-onerror.js -> exit 0 (5820ms)
run 5 test-gc-http-client-timeout.js -> exit 0 (15689ms)
run 5 test-gc-http-client-connaborted.js -> exit 0 (5280ms)
```

Release build runs each in 100-350ms.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->