### PR TITLE
runner: give the parallel-safe test phase its own log group

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -636,11 +636,16 @@ async function runTests() {
 
       const color = attempt >= maxAttempts ? "red" : "yellow";
       const label = `${getAnsi(color)}[${index}/${total}] ${title} - ${error}${getAnsi("reset")}`;
-      startGroup(label, () => {
-        if (concurrent) return;
-        if (!isCI) return;
-        process.stderr.write(stdoutPreview);
-      });
+      if (concurrent) {
+        // Don't open a group mid-phase: it would re-anchor the log viewer's
+        // folding for every concurrent title printed after it.
+        console.log(label);
+      } else {
+        startGroup(label, () => {
+          if (!isCI) return;
+          process.stderr.write(stdoutPreview);
+        });
+      }
 
       failure ||= result;
       flaky ||= true;
@@ -831,6 +836,12 @@ async function runTests() {
     const serialTests = tests.filter(t => !isParallelSafeTest(t));
     const parallelSafeTests = tests.filter(t => isParallelSafeTest(t));
     await Promise.all(serialTests.map(t => limit(() => runOneTest(t, parallelism > 1))));
+    // Concurrent tests log their title without opening a group (interleaved
+    // output can't nest), so give the phase its own group instead of letting
+    // the log viewer fold every line under the last serial test's group.
+    if (parallelSafeTests.length && parallelSafeWidth > 1) {
+      startGroup(`Running ${parallelSafeTests.length} parallel-safe tests (${parallelSafeWidth}-wide)`);
+    }
     await Promise.all(parallelSafeTests.map(t => parallelSafeLimit(() => runOneTest(t, parallelSafeWidth > 1))));
   }
 


### PR DESCRIPTION
### What does this PR do?

In BuildKite the test runner's log showed the last serial test group (e.g. `[966/2476]`) followed immediately by `End`, which read as if the shard had silently stopped hundreds of files early. It hadn't — the parallel-safe phase (`js/node/test/parallel/`, `js/bun/test/parallel/`) runs concurrently and prints titles with a plain `console.log` (interleaved output can't nest in groups), so all ~1500 of those lines were folded under the last serial test's group.

- Open a `--- Running N parallel-safe tests (W-wide)` group before the phase so it appears as its own row in the log viewer.
- Print a concurrent test's failure label without opening a group, so a mid-phase failure doesn't re-anchor the folding for every title printed after it. Serial failures are unchanged.

### How did you verify your code works?

Read the raw job log for a green darwin shard: all 2476 file indices were present, with `[967/2476]` through `[2476/2476]` nested inside the `[966/2476]` group. This change only moves group markers; the fix is visible in the next BuildKite log.