### PR TITLE
node:sqlite: reset outstanding statements before deserialize() so it succeeds with an open iterate() cursor

### DIFF
--- a/src/jsc/bindings/sqlite/NodeSqlite.cpp
+++ b/src/jsc/bindings/sqlite/NodeSqlite.cpp
@@ -2076,17 +2076,21 @@ JSC_DEFINE_HOST_FUNCTION(jsDatabaseSyncDeserialize, (JSGlobalObject * globalObje
     memcpy(owned, span.data(), span.size());
 
     // Invalidate every existing statement first — after the schema
-    // swap they reference tables that no longer exist. Bumping the
-    // open-generation makes every live JSStatementSync report
-    // isFinalized() without us having to track them explicitly (same
-    // mechanism close()+open() relies on), and Node finalizes its
-    // statements before deserializing too, so the bump stays ahead of
-    // the fallible call. We leave the underlying sqlite3_stmt* alone:
-    // the JS wrappers still own those handles and will
-    // sqlite3_finalize() them on GC, so finalizing here would make the
-    // wrapper double-free a dangling pointer. sqlite3_deserialize
-    // tolerates the outstanding stmts — they simply fail if stepped,
-    // which the generation check prevents.
+    // swap they reference tables that no longer exist. Node
+    // sqlite3_finalize()s its tracked statements here; we can't
+    // (the JS wrappers still own those handles and finalize on GC, so
+    // a pre-emptive finalize would double-free), but an un-reset
+    // iterate() cursor holds a read transaction that makes
+    // sqlite3_deserialize()'s internal ATTACH return SQLITE_BUSY.
+    // Reset every outstanding stmt on the connection so the swap
+    // succeeds, then bump the open-generation so every JSStatementSync
+    // reports isFinalized() (same mechanism close()+open() uses). The
+    // bump stays ahead of the fallible call to match Node, which
+    // finalizes unconditionally before deserializing.
+    for (sqlite3_stmt* s = sqlite3_next_stmt(self->connection(), nullptr); s;
+        s = sqlite3_next_stmt(self->connection(), s)) {
+        sqlite3_reset(s);
+    }
     self->bumpOpenGeneration();
 
     int r = sqlite3_deserialize(self->connection(), dbNameUtf8.data(), owned,

--- a/src/jsc/bindings/sqlite/lazy_sqlite3.h
+++ b/src/jsc/bindings/sqlite/lazy_sqlite3.h
@@ -86,6 +86,7 @@ typedef unsigned char* (*lazy_sqlite3_serialize_type)(sqlite3* db, const char* z
 typedef int (*lazy_sqlite3_deserialize_type)(sqlite3* db, const char* zSchema, unsigned char* pData, sqlite3_int64 szDb, sqlite3_int64 szBuf, unsigned mFlags);
 typedef int (*lazy_sqlite3_stmt_readonly_type)(sqlite3_stmt* pStmt);
 typedef int (*lazy_sqlite3_stmt_busy_type)(sqlite3_stmt* pStmt);
+typedef sqlite3_stmt* (*lazy_sqlite3_next_stmt_type)(sqlite3* pDb, sqlite3_stmt* pStmt);
 typedef int (*lazy_sqlite3_compileoption_used_type)(const char* zOptName);
 typedef int64_t (*lazy_sqlite3_last_insert_rowid_type)(sqlite3* db);
 typedef int (*lazy_sqlite3_set_authorizer_type)(sqlite3*, int (*xAuth)(void*, int, const char*, const char*, const char*, const char*), void* pUserData);
@@ -183,6 +184,7 @@ inline lazy_sqlite3_serialize_type lazy_sqlite3_serialize;
 inline lazy_sqlite3_deserialize_type lazy_sqlite3_deserialize;
 inline lazy_sqlite3_stmt_readonly_type lazy_sqlite3_stmt_readonly;
 inline lazy_sqlite3_stmt_busy_type lazy_sqlite3_stmt_busy;
+inline lazy_sqlite3_next_stmt_type lazy_sqlite3_next_stmt;
 inline lazy_sqlite3_compileoption_used_type lazy_sqlite3_compileoption_used;
 inline lazy_sqlite3_config_type lazy_sqlite3_config;
 inline lazy_sqlite3_extended_result_codes_type lazy_sqlite3_extended_result_codes;
@@ -280,6 +282,7 @@ inline lazy_sqlite3changeset_apply_type lazy_sqlite3changeset_apply;
 #define sqlite3_deserialize lazy_sqlite3_deserialize
 #define sqlite3_stmt_readonly lazy_sqlite3_stmt_readonly
 #define sqlite3_stmt_busy lazy_sqlite3_stmt_busy
+#define sqlite3_next_stmt lazy_sqlite3_next_stmt
 #define sqlite3_column_int64 lazy_sqlite3_column_int64
 #define sqlite3_compileoption_used lazy_sqlite3_compileoption_used
 #define sqlite3_config lazy_sqlite3_config
@@ -419,6 +422,7 @@ inline int lazyLoadSQLite()
     lazy_sqlite3_malloc64 = (lazy_sqlite3_malloc64_type)dlsym(sqlite3_handle, "sqlite3_malloc64");
     lazy_sqlite3_stmt_readonly = (lazy_sqlite3_stmt_readonly_type)dlsym(sqlite3_handle, "sqlite3_stmt_readonly");
     lazy_sqlite3_stmt_busy = (lazy_sqlite3_stmt_busy_type)dlsym(sqlite3_handle, "sqlite3_stmt_busy");
+    lazy_sqlite3_next_stmt = (lazy_sqlite3_next_stmt_type)dlsym(sqlite3_handle, "sqlite3_next_stmt");
     lazy_sqlite3_compileoption_used = (lazy_sqlite3_compileoption_used_type)dlsym(sqlite3_handle, "sqlite3_compileoption_used");
     lazy_sqlite3_config = (lazy_sqlite3_config_type)dlsym(sqlite3_handle, "sqlite3_config");
     lazy_sqlite3_extended_result_codes = (lazy_sqlite3_extended_result_codes_type)dlsym(sqlite3_handle, "sqlite3_extended_result_codes");

--- a/test/js/node/sqlite/node-sqlite.test.ts
+++ b/test/js/node/sqlite/node-sqlite.test.ts
@@ -1491,6 +1491,31 @@ describe("serialize() / deserialize()", () => {
     dst.close();
     Bun.gc(true);
   });
+
+  test("succeeds while an iterate() cursor is open (resets outstanding statements like Node)", () => {
+    // Node calls FinalizeStatements() before sqlite3_deserialize(), so an
+    // un-reset cursor never holds a read transaction through the swap. Bun
+    // can't finalize (wrappers own the stmt*) but must reset, otherwise the
+    // internal ATTACH returns SQLITE_BUSY and the generation bump leaves
+    // every statement dead against the OLD database content.
+    const donor = new DatabaseSync(":memory:");
+    donor.exec("CREATE TABLE q(z); INSERT INTO q VALUES (9)");
+    const img = donor.serialize();
+    donor.close();
+
+    const db = new DatabaseSync(":memory:");
+    db.exec("CREATE TABLE t(a); INSERT INTO t VALUES (1),(2)");
+    const idle = db.prepare("SELECT a FROM t");
+    const it = db.prepare("SELECT a FROM t").iterate();
+    expect(it.next().value).toEqual({ a: 1 }); // cursor now mid-iteration: open read txn
+
+    db.deserialize(img);
+
+    expect(() => idle.get()).toThrow(expect.objectContaining({ code: "ERR_INVALID_STATE" }));
+    expect(db.prepare("SELECT z FROM q").get()).toEqual({ z: 9 });
+    expect(() => db.prepare("SELECT count(*) c FROM t").get()).toThrow(/no such table: t/);
+    db.close();
+  });
 });
 
 describe("createTagStore()", () => {


### PR DESCRIPTION
## What

`DatabaseSync#deserialize()` now resets every outstanding `sqlite3_stmt*` on the connection before calling `sqlite3_deserialize()`, matching Node's `FinalizeStatements()` step.

## Why

```js
import { DatabaseSync } from "node:sqlite";
const donor = new DatabaseSync(":memory:");
donor.exec("create table q(z); insert into q values (9)");
const img = donor.serialize(); donor.close();

const db = new DatabaseSync(":memory:");
db.exec("create table t(a); insert into t values (1),(2)");
const st = db.prepare("select a from t");
db.prepare("select a from t").iterate().next(); // open read txn

db.deserialize(img);        // Node: ok        Bun before: ERR_SQLITE_ERROR "database is locked"
st.get();                   // both:  ERR_INVALID_STATE "statement has been finalized"
db.prepare("select z from q").get();   // Node: {z:9}     Bun before: "no such table: q"
db.prepare("select * from t").get();   // Node: "no such table: t"   Bun before: {a:1}
```

Node finalizes its tracked statements before the swap. Bun only bumped the open-generation (so JS wrappers report "finalized") but left the underlying `sqlite3_stmt*` mid-step: its read transaction made `sqlite3_deserialize()`'s internal `ATTACH x AS main` fail with `SQLITE_BUSY`. Because the generation was already bumped, every statement on the connection then reported "finalized" against the untouched original content: the database was unchanged yet unusable without re-preparing everything.

## Fix

Walk `sqlite3_next_stmt()` and `sqlite3_reset()` each statement before the swap so the read transaction is released. We cannot `sqlite3_finalize()` them here (the JS wrappers still own those handles and would double-free on GC), but reset is enough to drop the lock. The generation bump stays ahead of the fallible call to match Node, which finalizes unconditionally before deserializing.

Also wired `sqlite3_next_stmt` into `lazy_sqlite3.h` for the macOS dlopen path.

## Verification

- New test in `test/js/node/sqlite/node-sqlite.test.ts` fails on current canary with `database is locked`, passes with this change.
- Full `node-sqlite.test.ts` suite: 111 pass / 0 fail.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/sqlite/node-sqlite.test.ts

<!-- robobun:evidence:end -->