### PR TITLE
node:sqlite: backup() to the same file rejects promptly instead of wedging the process

### DIFF
--- a/docs/runtime/nodejs-compat.mdx
+++ b/docs/runtime/nodejs-compat.mdx
@@ -173,7 +173,7 @@ This page is updated regularly and reflects the latest version of Bun's compatib
 
 ### [`node:sqlite`](https://nodejs.org/api/sqlite.html)
 
-🟢 Fully implemented. `backup()` runs synchronously and blocks the event loop for the duration of the copy (Node runs it on a worker thread) — throw from the `progress` callback to abort a backup that keeps hitting `SQLITE_BUSY`. A `Buffer`/`Uint8Array` database path must be valid UTF-8 (Node passes the raw bytes through; Bun rejects non-UTF-8 with `ERR_INVALID_ARG_VALUE`). On macOS, Bun uses the system `libsqlite3.dylib`; `loadExtension()` (and, on older macOS releases, `createSession()`/`applyChangeset()`) require a full SQLite build — call `require("bun:sqlite").Database.setCustomSQLite(path)` before opening a database.
+🟢 Fully implemented. `backup()` runs synchronously and blocks the event loop for the duration of the copy (Node runs it on a worker thread). A `Buffer`/`Uint8Array` database path must be valid UTF-8 (Node passes the raw bytes through; Bun rejects non-UTF-8 with `ERR_INVALID_ARG_VALUE`). On macOS, Bun uses the system `libsqlite3.dylib`; `loadExtension()` (and, on older macOS releases, `createSession()`/`applyChangeset()`) require a full SQLite build — call `require("bun:sqlite").Database.setCustomSQLite(path)` before opening a database.
 
 ### [`node:test`](https://nodejs.org/api/test.html)
 

--- a/src/jsc/bindings/sqlite/NodeSqlite.cpp
+++ b/src/jsc/bindings/sqlite/NodeSqlite.cpp
@@ -3987,66 +3987,68 @@ JSC_DEFINE_HOST_FUNCTION(jsNodeSqliteBackup, (JSGlobalObject * globalObject, Cal
         return rejectWithPending();
     }
 
-    // Node retries SQLITE_BUSY/LOCKED indefinitely (BackupJob just calls
-    // ScheduleWork() again with no timeout), so match that: no invented
-    // busy budget. Back off between retries so a contended destination
-    // doesn't busy-spin at 100% CPU. Unlike Node this loop runs on the JS
-    // thread, so a permanently-locked destination would be an unrecoverable
-    // hang; the progress callback fires on BUSY/LOCKED too so a caller can
-    // throw from it to abort. (Node fires progress between retries too, but
-    // gated on remaining_pages != 0 — Bun fires unconditionally so the
-    // escape hatch works even before the first successful step.)
+    // Node's BackupJob::AfterThreadPoolWork only reschedules when
+    // sqlite3_backup_remaining() != 0. A step that never reaches the page
+    // copy (destination locked, source == destination file, source in a
+    // write txn) returns BUSY with remaining still 0, so Node rejects on
+    // the first iteration instead of spinning. Match that gate exactly —
+    // this loop is synchronous on the JS thread, so an unconditional BUSY
+    // retry would be an unrecoverable process hang.
     constexpr int kBusyRetrySleepMs = 25;
 
     int totalPages = 0;
     while (true) {
         r = sqlite3_backup_step(backup, rate);
+
+        if (r != SQLITE_OK && r != SQLITE_DONE && r != SQLITE_BUSY && r != SQLITE_LOCKED) {
+            // Hard error. Node's HandleBackupError(resolver, backup_status_)
+            // builds the rejection from the step return code itself.
+            throwSqliteMessage(globalObject, scope, r, WTF::String::fromUTF8(sqlite3_errstr(r)));
+            sqlite3_backup_finish(backup);
+            sqlite3_close_v2(dest);
+            return rejectWithPending();
+        }
+
         totalPages = sqlite3_backup_pagecount(backup);
         int remaining = sqlite3_backup_remaining(backup);
 
-        if (progressFn && (r == SQLITE_OK || r == SQLITE_BUSY || r == SQLITE_LOCKED)) {
-            JSObject* payload = constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
-            payload->putDirect(vm, Identifier::fromString(vm, "totalPages"_s), jsNumber(totalPages), 0);
-            payload->putDirect(vm, Identifier::fromString(vm, "remainingPages"_s), jsNumber(remaining), 0);
-            MarkedArgumentBuffer args;
-            args.append(payload);
-            auto callData = JSC::getCallData(progressFn);
-            JSC::call(globalObject, progressFn, callData, jsNull(), args);
-            if (scope.exception()) [[unlikely]] {
+        if (remaining != 0) {
+            if (progressFn) {
+                JSObject* payload = constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
+                payload->putDirect(vm, Identifier::fromString(vm, "totalPages"_s), jsNumber(totalPages), 0);
+                payload->putDirect(vm, Identifier::fromString(vm, "remainingPages"_s), jsNumber(remaining), 0);
+                MarkedArgumentBuffer args;
+                args.append(payload);
+                auto callData = JSC::getCallData(progressFn);
+                JSC::call(globalObject, progressFn, callData, jsNull(), args);
+                if (scope.exception()) [[unlikely]] {
+                    sqlite3_backup_finish(backup);
+                    sqlite3_close_v2(dest);
+                    return rejectWithPending();
+                }
+            }
+            // Poll the termination trap so Worker.terminate() / the watchdog
+            // can break a very large copy; the VM is being torn down so
+            // clean up and unwind without allocating JS.
+            if (vm.traps().needHandling(VMTraps::NeedTermination) || vm.hasPendingTerminationException()) [[unlikely]] {
                 sqlite3_backup_finish(backup);
                 sqlite3_close_v2(dest);
-                return rejectWithPending();
+                scope.release();
+                return JSValue::encode(jsUndefined());
             }
-        }
-
-        if (r == SQLITE_DONE) break;
-        // Without a progress callback the loop never re-enters JS, so
-        // Worker.terminate() / the watchdog cannot land at a safepoint and
-        // hasTerminationRequest() is never set. Poll the trap bit directly
-        // (written atomically by notifyNeedTermination from the parent
-        // thread) so termination breaks a BUSY spin or a very large copy;
-        // Node's retry-forever semantics are preserved otherwise. The VM is
-        // being torn down, so just clean up and let the unwind happen — no
-        // JS allocation on a terminating VM.
-        if (vm.traps().needHandling(VMTraps::NeedTermination) || vm.hasPendingTerminationException()) [[unlikely]] {
-            sqlite3_backup_finish(backup);
-            sqlite3_close_v2(dest);
-            scope.release();
-            return JSValue::encode(jsUndefined());
-        }
-        if (r == SQLITE_OK) continue;
-        if (r == SQLITE_BUSY || r == SQLITE_LOCKED) {
-            sqlite3_sleep(kBusyRetrySleepMs);
+            if (r == SQLITE_BUSY || r == SQLITE_LOCKED) {
+                sqlite3_sleep(kBusyRetrySleepMs);
+            }
             continue;
         }
 
-        // sqlite3_backup_step()'s *return value* is the authoritative
-        // error here. It isn't reliably mirrored onto `dest`'s
-        // sqlite3_errcode() until sqlite3_backup_finish() runs (and
-        // that also clears some codes), so asking `dest` can yield
-        // "not an error"/errcode 0. Node's BackupJob uses the step
-        // return code directly for the rejected error — do the same.
-        throwSqliteMessage(globalObject, scope, r, WTF::String::fromUTF8(sqlite3_errstr(r)));
+        if (r == SQLITE_DONE) break;
+
+        // remaining == 0 with OK/BUSY/LOCKED: the step never advanced.
+        // Node's HandleBackupError(resolver) reads sqlite3_errcode(dest)
+        // here — which backup_step leaves untouched — so the observed
+        // error is errcode 0 / "not an error". Match that verbatim.
+        throwSqliteError(globalObject, scope, dest);
         sqlite3_backup_finish(backup);
         sqlite3_close_v2(dest);
         return rejectWithPending();

--- a/test/js/node/sqlite/node-sqlite.test.ts
+++ b/test/js/node/sqlite/node-sqlite.test.ts
@@ -6,7 +6,6 @@ import { builtinModules, isBuiltin } from "node:module";
 import path from "node:path";
 import { DatabaseSync, Session, StatementSync, backup, constants } from "node:sqlite";
 import { pathToFileURL } from "node:url";
-import { Worker } from "node:worker_threads";
 
 // On macOS bun dlopens the system libsqlite3.dylib, which Apple builds
 // without SQLITE_ENABLE_SESSION. createSession()/applyChangeset() throw

--- a/test/js/node/sqlite/node-sqlite.test.ts
+++ b/test/js/node/sqlite/node-sqlite.test.ts
@@ -1197,40 +1197,84 @@ describe.skipIf(!sqliteHasSession)("Session / changeset", () => {
 // Each backup_step with rate=1 fsyncs the destination once per page; keep
 // the page count tiny so the test stays fast on slow-fsync CI filesystems.
 describe("backup()", () => {
-  test("Worker.terminate() interrupts a backup() spinning on a locked destination", async () => {
-    // With no progress callback the BUSY loop never re-enters JS, so
-    // terminate() can only land if the loop polls vm.hasTerminationRequest().
-    using dir = tempDir("node-sqlite-backup-terminate", {
-      "worker.mjs": `
-        import { DatabaseSync, backup } from "node:sqlite";
-        import { parentPort, workerData } from "node:worker_threads";
-        const src = new DatabaseSync(":memory:");
-        src.exec("CREATE TABLE t (x); INSERT INTO t VALUES (1)");
-        parentPort.postMessage("spinning");
-        // destination is held write-locked by the parent: this spins on
-        // SQLITE_BUSY until terminated.
-        await backup(src, workerData.dest);
-        parentPort.postMessage("done");
-      `,
+  test("backing up a database to its own file rejects promptly", async () => {
+    // sqlite3_backup_init only compares sqlite3* pointers, so opening the
+    // source path a second time as the destination succeeds — but the
+    // source's SHARED lock blocks the destination's EXCLUSIVE upgrade and
+    // every sqlite3_backup_step() returns SQLITE_BUSY with remaining == 0.
+    // Node only reschedules when remaining != 0, so it rejects on the first
+    // step. A regression (unconditional BUSY retry on the JS thread) wedges
+    // the process, so run in a subprocess under a bounded timeout.
+    using dir = tempDir("node-sqlite-backup-self", {});
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { DatabaseSync, backup } = require("node:sqlite");
+         const db = new DatabaseSync(process.argv[1]);
+         db.exec("CREATE TABLE t (a); INSERT INTO t VALUES (1)");
+         backup(db, String(db.location())).then(
+           v => { console.log("resolved:" + v); process.exit(1); },
+           e => { console.log("rejected:" + e.code + ":" + e.errcode); process.exit(0); },
+         );`,
+        path.join(String(dir), "self.db"),
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
     });
-    const destPath = path.join(String(dir), "locked.db");
-    using holder = new DatabaseSync(destPath);
-    // BEGIN IMMEDIATE takes a RESERVED lock so a writer from another
-    // connection sees SQLITE_BUSY.
-    holder.exec("BEGIN IMMEDIATE");
-
-    const worker = new Worker(path.join(String(dir), "worker.mjs"), { workerData: { dest: destPath } });
-    const spinning = new Promise<void>((resolve, reject) => {
-      worker.on("message", m => (m === "spinning" ? resolve() : reject(new Error(`unexpected: ${m}`))));
-      worker.on("error", reject);
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      Promise.race([proc.exited, Bun.sleep(4_000).then(() => (proc.kill(), "timeout"))]),
+    ]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: "rejected:ERR_SQLITE_ERROR:0",
+      stderr: "",
+      exitCode: 0,
     });
-    await spinning;
+  });
 
-    const exitCode = await worker.terminate();
-    // The observable invariant is that terminate() returns at all — without
-    // the poll the worker's JS thread is stuck in sqlite3_sleep and the
-    // await never resolves (the test times out).
-    expect(typeof exitCode).toBe("number");
+  test("rejects promptly when the destination is write-locked", async () => {
+    // Same remaining == 0 gate as the self-backup case: the destination
+    // connection can't take its write lock, so the first step returns BUSY
+    // without ever advancing and Node rejects rather than retrying. Run in
+    // a subprocess so a regression is a bounded kill, not a wedged test.
+    using dir = tempDir("node-sqlite-backup-locked", {});
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { DatabaseSync, backup } = require("node:sqlite");
+         const path = require("node:path");
+         const dest = path.join(process.argv[1], "locked.db");
+         const holder = new DatabaseSync(dest);
+         holder.exec("BEGIN IMMEDIATE");
+         const src = new DatabaseSync(":memory:");
+         src.exec("CREATE TABLE t (x); INSERT INTO t VALUES (1)");
+         let calls = 0;
+         backup(src, dest, { progress: () => calls++ }).then(
+           v => { console.log("resolved:" + v); process.exit(1); },
+           e => { console.log("rejected:" + e.code + ":" + calls); process.exit(0); },
+         );`,
+        String(dir),
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      Promise.race([proc.exited, Bun.sleep(4_000).then(() => (proc.kill(), "timeout"))]),
+    ]);
+    // Node gates progress on remaining != 0, which is never true here, so
+    // calls stays 0.
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: "rejected:ERR_SQLITE_ERROR:0",
+      stderr: "",
+      exitCode: 0,
+    });
   });
 
   test("re-checks the source is open after reading options", () => {
@@ -1315,66 +1359,21 @@ describe("backup()", () => {
     src.close();
   });
 
-  test("progress fires on SQLITE_BUSY so a throw can abort a locked backup", async () => {
-    // Bun runs the whole backup on the JS thread, so a permanently-locked
-    // destination would otherwise be an unrecoverable hang. Run the whole
-    // scenario in a subprocess so a regression (progress never fires →
-    // sync loop) is a bounded timeout kill, not a wedged test process.
-    using dir = tempDir("node-sqlite-backup-busy", {});
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `const { DatabaseSync, backup } = require("node:sqlite");
-         const path = require("node:path");
-         const dst = path.join(process.argv[1], "dst.db");
-         // Child holds a RESERVED lock on the destination so
-         // sqlite3_backup_step returns SQLITE_BUSY. It self-exits so a
-         // regression that never fires progress still terminates.
-         const locker = Bun.spawn({
-           cmd: [process.execPath, "-e",
-             "const {DatabaseSync}=require('node:sqlite');" +
-             "const db=new DatabaseSync(process.argv[1]);" +
-             "db.exec('PRAGMA locking_mode=EXCLUSIVE');" +
-             "db.exec('BEGIN IMMEDIATE');" +
-             "db.exec('CREATE TABLE lock_t(x)');" +
-             "console.log('locked');" +
-             "setTimeout(()=>{},1<<30);",
-             dst],
-           stdout: "pipe", stderr: "inherit",
-         });
-         let ready = "";
-         for await (const c of locker.stdout) {
-           ready += Buffer.from(c).toString();
-           if (ready.includes("locked")) break;
-         }
-         if (!ready.includes("locked")) throw new Error("locker never ready");
-         const src = new DatabaseSync(":memory:");
-         src.exec("CREATE TABLE t (x)");
-         let calls = 0;
-         const p = backup(src, dst, {
-           progress: () => { if (++calls >= 2) throw new Error("busy-abort"); },
-         });
-         p.then(
-           () => { console.log("resolved"); process.exit(1); },
-           e => { console.log("rejected:" + e.message + ":" + calls); locker.kill(); process.exit(0); },
-         );`,
-        String(dir),
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
+  test("progress does not fire on the final step (SQLITE_DONE)", async () => {
+    // Node fires progress only while sqlite3_backup_remaining() != 0, which
+    // is never true on the step that returns SQLITE_DONE. With rate: -1 the
+    // whole database copies in one step, so progress never fires at all.
+    using dir = tempDir("node-sqlite-backup-done", {});
+    const src = new DatabaseSync(":memory:");
+    src.exec("CREATE TABLE t (x); INSERT INTO t VALUES (1), (2), (3)");
+    let progressCalls = 0;
+    const pages = await backup(src, path.join(String(dir), "dst.db"), {
+      rate: -1,
+      progress: () => progressCalls++,
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      Promise.race([proc.exited, Bun.sleep(15_000).then(() => (proc.kill(), "timeout"))]),
-    ]);
-    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
-      stdout: "rejected:busy-abort:2",
-      stderr: expect.any(String),
-      exitCode: 0,
-    });
+    expect(typeof pages).toBe("number");
+    expect(progressCalls).toBe(0);
+    src.close();
   });
 });
 

--- a/test/js/node/sqlite/node-sqlite.test.ts
+++ b/test/js/node/sqlite/node-sqlite.test.ts
@@ -1229,7 +1229,7 @@ describe("backup()", () => {
     ]);
     expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
       stdout: "rejected:ERR_SQLITE_ERROR:0",
-      stderr: "",
+      stderr: expect.any(String),
       exitCode: 0,
     });
   });
@@ -1271,7 +1271,7 @@ describe("backup()", () => {
     // calls stays 0.
     expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
       stdout: "rejected:ERR_SQLITE_ERROR:0",
-      stderr: "",
+      stderr: expect.any(String),
       exitCode: 0,
     });
   });


### PR DESCRIPTION
## What

`backup(db, db.location())` (destination path == source path) wedged the bun process forever in a synchronous `SQLITE_BUSY` retry loop on the JS thread. Node v26.3.0 rejects the promise on the first step.

## Repro

```js
import { DatabaseSync, backup } from "node:sqlite";
const db = new DatabaseSync("/tmp/selfbk.db");
db.exec("create table t(a); insert into t values (1)");
await backup(db, String(db.location()));
// node v26.3.0:  rejects: ERR_SQLITE_ERROR "not an error", errcode 0
// bun (before):  never returns; gdb shows unixSleep under jsNodeSqliteBackup
```

## Cause

`sqlite3_backup_init` only checks `pSrcDb == pDestDb` (handle pointer identity), so opening the source path a second time as the destination succeeds. On the first `sqlite3_backup_step`:

1. a read transaction on the source takes a SHARED lock on the file
2. `sqlite3BtreeBeginTrans(p->pDest, 2, ...)` tries to escalate to EXCLUSIVE on the same file and gets `SQLITE_BUSY`
3. the page-copy block that assigns `p->nRemaining` is skipped, so `sqlite3_backup_remaining()` stays 0
4. `p->rc = SQLITE_BUSY` is stored but `sqlite3_errcode(dest)` is never written

Node's `BackupJob::AfterThreadPoolWork` only reschedules when `sqlite3_backup_remaining() != 0`. With `remaining == 0` and `backup_status_ != SQLITE_DONE` it falls through to `HandleBackupError(resolver)`, which builds the rejection from `sqlite3_errcode(dest_)` (still 0, "not an error").

Bun retried `BUSY`/`LOCKED` unconditionally, on the JS thread, so the loop never exits.

## Fix

Match Node's control flow in `jsNodeSqliteBackup`:

- step result not in {OK, DONE, BUSY, LOCKED}: reject with the step return code (unchanged)
- `remaining != 0`: fire `progress`, poll VM termination, back off 25ms on BUSY/LOCKED, continue
- `remaining == 0` and result != DONE: reject with `sqlite3_errcode(dest)` (Node's `errcode 0` / "not an error")
- DONE: resolve

This also fixes the related case where another connection holds a write lock on the destination file, which has the same `remaining == 0` shape and now rejects promptly like Node instead of spinning.

## Tests

Two subprocess-bounded tests replace the two tests that asserted the old spin-forever behaviour:

- `backing up a database to its own file rejects promptly`: the exact repro above, subprocess killed at 4s if it hangs
- `rejects promptly when the destination is write-locked`: a RESERVED lock on the destination, same gate, also asserts `progress` does not fire (Node gates it on `remaining != 0`)

Plus `progress does not fire on the final step (SQLITE_DONE)` to pin the Node-matching progress gate.

<details><summary>fail-before / pass-after</summary>

Without the `src/` change:
```
(fail) backup() > backing up a database to its own file rejects promptly [5004.73ms]
(fail) backup() > rejects promptly when the destination is write-locked [5005.24ms]
```

With the change:
```
(pass) backup() > backing up a database to its own file rejects promptly [502.11ms]
(pass) backup() > rejects promptly when the destination is write-locked [568.50ms]
 111 pass / 4 skip / 0 fail
```
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/sqlite/node-sqlite.test.ts

<!-- robobun:evidence:end -->