### PR TITLE
node:wasi: fix poll_oneoff TypeError on clock subscriptions

### DIFF
--- a/src/js/node/wasi.ts
+++ b/src/js/node/wasi.ts
@@ -1495,6 +1495,7 @@ var require_wasi = __commonJS({
             return constants_1.WASI_ESUCCESS;
           }),
           poll_oneoff: (sin, sout, nsubscriptions, neventsPtr) => {
+            const pollEntryNs = BigInt(Bun.nanoseconds());
             let nevents = 0;
             let waitTimeNs = BigInt(0);
             let fd = -1;
@@ -1584,18 +1585,21 @@ var require_wasi = __commonJS({
                 return r;
               }
             }
-            if (waitTimeNs >= 1e6) {
-              const sleep = this.sleep;
-              if (sleep == null && !warnedAboutSleep) {
-                warnedAboutSleep = true;
-                console.log("(100% cpu burning waiting for stdin: please define a way to sleep!) ");
-              }
-              if (sleep != null) {
-                const ms = nsToMs(waitTimeNs);
-                sleep.$call(this, ms);
-              } else {
-                const end = BigInt(bindings.hrtime()) + waitTimeNs;
-                while (BigInt(bindings.hrtime()) < end) {}
+            if (waitTimeNs > 0) {
+              waitTimeNs -= BigInt(Bun.nanoseconds()) - pollEntryNs;
+              if (waitTimeNs >= 1e6) {
+                const sleep = this.sleep;
+                if (sleep == null && !warnedAboutSleep) {
+                  warnedAboutSleep = true;
+                  console.log("(100% cpu burning waiting for stdin: please define a way to sleep!) ");
+                }
+                if (sleep != null) {
+                  const ms = nsToMs(waitTimeNs);
+                  sleep.$call(this, ms);
+                } else {
+                  const end = BigInt(bindings.hrtime()) + waitTimeNs;
+                  while (BigInt(bindings.hrtime()) < end) {}
+                }
               }
             }
             return constants_1.WASI_ESUCCESS;

--- a/src/js/node/wasi.ts
+++ b/src/js/node/wasi.ts
@@ -1584,21 +1584,18 @@ var require_wasi = __commonJS({
                 return r;
               }
             }
-            if (waitTimeNs > 0) {
-              waitTimeNs -= Bun.nanoseconds() - timeOrigin;
-              if (waitTimeNs >= 1e6) {
-                const sleep = this.sleep;
-                if (sleep == null && !warnedAboutSleep) {
-                  warnedAboutSleep = true;
-                  console.log("(100% cpu burning waiting for stdin: please define a way to sleep!) ");
-                }
-                if (sleep != null) {
-                  const ms = nsToMs(waitTimeNs);
-                  sleep.$call(this, ms);
-                } else {
-                  const end = BigInt(bindings.hrtime()) + waitTimeNs;
-                  while (BigInt(bindings.hrtime()) < end) {}
-                }
+            if (waitTimeNs >= 1e6) {
+              const sleep = this.sleep;
+              if (sleep == null && !warnedAboutSleep) {
+                warnedAboutSleep = true;
+                console.log("(100% cpu burning waiting for stdin: please define a way to sleep!) ");
+              }
+              if (sleep != null) {
+                const ms = nsToMs(waitTimeNs);
+                sleep.$call(this, ms);
+              } else {
+                const end = BigInt(bindings.hrtime()) + waitTimeNs;
+                while (BigInt(bindings.hrtime()) < end) {}
               }
             }
             return constants_1.WASI_ESUCCESS;

--- a/test/js/bun/wasm/wasi.test.js
+++ b/test/js/bun/wasm/wasi.test.js
@@ -26,7 +26,8 @@ it("Should support printing 'hello world'", () => {
 
 it("poll_oneoff with a relative clock subscription sleeps instead of throwing", () => {
   // This is the code path wasi-libc's sleep()/usleep()/nanosleep() takes.
-  const wasi = new WASI({ version: "preview1" });
+  let sleptMs;
+  const wasi = new WASI({ version: "preview1", sleep: ms => void (sleptMs = ms) });
   wasi.setMemory(new WebAssembly.Memory({ initial: 1 }));
   const view = new DataView(wasi.memory.buffer);
 
@@ -45,17 +46,14 @@ it("poll_oneoff with a relative clock subscription sleeps instead of throwing", 
   view.setBigUint64(sin + 32, 0n, true);
   view.setUint16(sin + 40, 0, true);
 
-  const before = process.hrtime.bigint();
   const errno = wasi.wasiImport.poll_oneoff(sin, sout, 1, neventsPtr);
-  const elapsedMs = Number((process.hrtime.bigint() - before) / 1_000_000n);
 
   expect(errno).toBe(WASI_ESUCCESS);
+  expect(sleptMs).toBe(20);
   expect(view.getUint32(neventsPtr, true)).toBe(1);
   expect(view.getBigUint64(sout + 0, true)).toBe(42n);
   expect(view.getUint16(sout + 8, true)).toBe(WASI_ESUCCESS);
   expect(view.getUint8(sout + 10)).toBe(WASI_EVENTTYPE_CLOCK);
-  expect(elapsedMs).toBeGreaterThanOrEqual(19);
-  expect(elapsedMs).toBeLessThan(10_000);
 });
 
 it("fd_fdstat_set_rights only narrows the rights of a descriptor", () => {

--- a/test/js/bun/wasm/wasi.test.js
+++ b/test/js/bun/wasm/wasi.test.js
@@ -24,6 +24,40 @@ it("Should support printing 'hello world'", () => {
   });
 });
 
+it("poll_oneoff with a relative clock subscription sleeps instead of throwing", () => {
+  // This is the code path wasi-libc's sleep()/usleep()/nanosleep() takes.
+  const wasi = new WASI({ version: "preview1" });
+  wasi.setMemory(new WebAssembly.Memory({ initial: 1 }));
+  const view = new DataView(wasi.memory.buffer);
+
+  const WASI_ESUCCESS = 0;
+  const WASI_EVENTTYPE_CLOCK = 0;
+  const WASI_CLOCK_MONOTONIC = 1;
+  const sin = 512;
+  const sout = 1024;
+  const neventsPtr = 128;
+
+  // one subscription: userdata=42, type=clock, clockid=monotonic, timeout=20ms relative
+  view.setBigUint64(sin + 0, 42n, true);
+  view.setUint8(sin + 8, WASI_EVENTTYPE_CLOCK);
+  view.setUint32(sin + 16, WASI_CLOCK_MONOTONIC, true);
+  view.setBigUint64(sin + 24, 20_000_000n, true);
+  view.setBigUint64(sin + 32, 0n, true);
+  view.setUint16(sin + 40, 0, true);
+
+  const before = process.hrtime.bigint();
+  const errno = wasi.wasiImport.poll_oneoff(sin, sout, 1, neventsPtr);
+  const elapsedMs = Number((process.hrtime.bigint() - before) / 1_000_000n);
+
+  expect(errno).toBe(WASI_ESUCCESS);
+  expect(view.getUint32(neventsPtr, true)).toBe(1);
+  expect(view.getBigUint64(sout + 0, true)).toBe(42n);
+  expect(view.getUint16(sout + 8, true)).toBe(WASI_ESUCCESS);
+  expect(view.getUint8(sout + 10)).toBe(WASI_EVENTTYPE_CLOCK);
+  expect(elapsedMs).toBeGreaterThanOrEqual(19);
+  expect(elapsedMs).toBeLessThan(10_000);
+});
+
 it("fd_fdstat_set_rights only narrows the rights of a descriptor", () => {
   using dir = tempDir("wasi-set-rights", {
     "inside.txt": "inside",

--- a/test/js/bun/wasm/wasi.test.js
+++ b/test/js/bun/wasm/wasi.test.js
@@ -1,5 +1,5 @@
 import { spawnSync } from "bun";
-import { expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import fs from "node:fs";
 import path from "node:path";
@@ -24,36 +24,99 @@ it("Should support printing 'hello world'", () => {
   });
 });
 
-it("poll_oneoff with a relative clock subscription sleeps instead of throwing", () => {
-  // This is the code path wasi-libc's sleep()/usleep()/nanosleep() takes.
-  let sleptMs;
-  const wasi = new WASI({ version: "preview1", sleep: ms => void (sleptMs = ms) });
-  wasi.setMemory(new WebAssembly.Memory({ initial: 1 }));
-  const view = new DataView(wasi.memory.buffer);
-
+describe("poll_oneoff clock subscriptions", () => {
   const WASI_ESUCCESS = 0;
   const WASI_EVENTTYPE_CLOCK = 0;
+  const WASI_EVENTTYPE_FD_READ = 1;
   const WASI_CLOCK_MONOTONIC = 1;
+  const WASI_SUBSCRIPTION_CLOCK_ABSTIME = 1;
+  const WASI_STDIN_FILENO = 0;
+  const SUBSCRIPTION_SIZE = 48;
+  const TEN_SECONDS_NS = 10_000_000_000n;
+  const TEN_SECONDS_MS = 10_000;
   const sin = 512;
   const sout = 1024;
   const neventsPtr = 128;
 
-  // one subscription: userdata=42, type=clock, clockid=monotonic, timeout=20ms relative
-  view.setBigUint64(sin + 0, 42n, true);
-  view.setUint8(sin + 8, WASI_EVENTTYPE_CLOCK);
-  view.setUint32(sin + 16, WASI_CLOCK_MONOTONIC, true);
-  view.setBigUint64(sin + 24, 20_000_000n, true);
-  view.setBigUint64(sin + 32, 0n, true);
-  view.setUint16(sin + 40, 0, true);
+  // `sleep` is the hook poll_oneoff uses to block (Bun.sleepSync by default). Recording
+  // its argument instead of sleeping keeps the tests fast and turns a wrong wait length
+  // into a wrong number instead of a hang.
+  function setup(sleep) {
+    const wasi = new WASI({ version: "preview1", sleep });
+    wasi.setMemory(new WebAssembly.Memory({ initial: 1 }));
+    return { wasi, view: new DataView(wasi.memory.buffer) };
+  }
 
-  const errno = wasi.wasiImport.poll_oneoff(sin, sout, 1, neventsPtr);
+  function writeClockSubscription(view, offset, { userdata, timeout, absolute = false }) {
+    view.setBigUint64(offset + 0, userdata, true);
+    view.setUint8(offset + 8, WASI_EVENTTYPE_CLOCK);
+    view.setUint32(offset + 16, WASI_CLOCK_MONOTONIC, true);
+    view.setBigUint64(offset + 24, timeout, true);
+    view.setBigUint64(offset + 32, 0n, true);
+    view.setUint16(offset + 40, absolute ? WASI_SUBSCRIPTION_CLOCK_ABSTIME : 0, true);
+  }
 
-  expect(errno).toBe(WASI_ESUCCESS);
-  expect(sleptMs).toBe(20);
-  expect(view.getUint32(neventsPtr, true)).toBe(1);
-  expect(view.getBigUint64(sout + 0, true)).toBe(42n);
-  expect(view.getUint16(sout + 8, true)).toBe(WASI_ESUCCESS);
-  expect(view.getUint8(sout + 10)).toBe(WASI_EVENTTYPE_CLOCK);
+  function writeStdinReadSubscription(view, offset, userdata) {
+    view.setBigUint64(offset + 0, userdata, true);
+    view.setUint8(offset + 8, WASI_EVENTTYPE_FD_READ);
+    view.setUint32(offset + 16, WASI_STDIN_FILENO, true);
+  }
+
+  it("a relative timeout sleeps for the timeout", () => {
+    // The hostcall wasi-libc makes for sleep()/usleep()/nanosleep().
+    const sleeps = [];
+    const { wasi, view } = setup(ms => void sleeps.push(ms));
+    writeClockSubscription(view, sin, { userdata: 42n, timeout: TEN_SECONDS_NS });
+
+    const errno = wasi.wasiImport.poll_oneoff(sin, sout, 1, neventsPtr);
+
+    expect(errno).toBe(WASI_ESUCCESS);
+    expect(view.getUint32(neventsPtr, true)).toBe(1);
+    expect(view.getBigUint64(sout + 0, true)).toBe(42n);
+    expect(view.getUint16(sout + 8, true)).toBe(WASI_ESUCCESS);
+    expect(view.getUint8(sout + 10)).toBe(WASI_EVENTTYPE_CLOCK);
+    // Less the time poll_oneoff itself took before it got around to sleeping.
+    expect(sleeps).toHaveLength(1);
+    expect(sleeps[0]).toBeLessThanOrEqual(TEN_SECONDS_MS);
+    expect(sleeps[0]).toBeGreaterThan(TEN_SECONDS_MS - 1000);
+  });
+
+  it("an absolute deadline sleeps until the deadline", () => {
+    const sleeps = [];
+    const { wasi, view } = setup(ms => void sleeps.push(ms));
+    const deadline = BigInt(Bun.nanoseconds()) + TEN_SECONDS_NS;
+    writeClockSubscription(view, sin, { userdata: 7n, timeout: deadline, absolute: true });
+
+    const errno = wasi.wasiImport.poll_oneoff(sin, sout, 1, neventsPtr);
+
+    expect(errno).toBe(WASI_ESUCCESS);
+    expect(view.getUint32(neventsPtr, true)).toBe(1);
+    expect(sleeps).toHaveLength(1);
+    expect(sleeps[0]).toBeLessThanOrEqual(TEN_SECONDS_MS);
+    expect(sleeps[0]).toBeGreaterThan(TEN_SECONDS_MS - 1000);
+  });
+
+  it("time already spent inside poll_oneoff is deducted from the wait", () => {
+    // The hostcall wasi-libc makes for poll() on stdin with a timeout. With no recent stdin
+    // activity, poll_oneoff pauses 50ms for the stdin subscription (shortPause) before it
+    // reaches the clock wait; the clock wait must be shortened by the time that took.
+    const sleeps = [];
+    const { wasi, view } = setup(ms => {
+      sleeps.push(ms);
+      if (sleeps.length === 1) Bun.sleepSync(ms);
+    });
+    writeStdinReadSubscription(view, sin, 1n);
+    writeClockSubscription(view, sin + SUBSCRIPTION_SIZE, { userdata: 2n, timeout: TEN_SECONDS_NS });
+
+    const errno = wasi.wasiImport.poll_oneoff(sin, sout, 2, neventsPtr);
+
+    expect(errno).toBe(WASI_ESUCCESS);
+    expect(view.getUint32(neventsPtr, true)).toBe(2);
+    expect(sleeps).toHaveLength(2);
+    expect(sleeps[0]).toBe(50);
+    expect(sleeps[1]).toBeLessThanOrEqual(TEN_SECONDS_MS - 50);
+    expect(sleeps[1]).toBeGreaterThan(TEN_SECONDS_MS - 1000);
+  });
 });
 
 it("fd_fdstat_set_rights only narrows the rights of a descriptor", () => {


### PR DESCRIPTION
### Problem

- Any `poll_oneoff` call with a clock subscription throws `TypeError: Invalid mix of BigInt and other type in subtraction.` This is the hostcall wasi-libc makes for `sleep()`, `usleep()`, `nanosleep()` and for `poll()` with a timeout, so a guest that sleeps dies with a raw TypeError (#20857).
- Cause: `src/js/node/wasi.ts:1588` does `waitTimeNs -= Bun.nanoseconds() - timeOrigin;` where `waitTimeNs` is a BigInt and the right-hand side is a Number.
- The right-hand side is also the wrong quantity. This code is a port of wasi-js, where the line reads `waitTimeNs -= BigInt(bindings.hrtime()) - startNs;` with `startNs` captured when `poll_oneoff` was entered, i.e. it deducts the time `poll_oneoff` itself has already spent (in particular the 50 ms `shortPause()` taken for an idle stdin subscription). Commit 3ddd8b2fa5 swapped `startNs` for `timeOrigin`, which is the wall-clock epoch at process start in nanoseconds (about 1.79e18). Fixing only the type, as #20858 does, turns a 20 ms sleep into a request for 1786779982751 ms (about 56 years); with the default `Bun.sleepSync` hook the call never returns, which matches what the author of #20858 saw when trying their build.

### Fix

- Capture `pollEntryNs` when `poll_oneoff` is entered and deduct `BigInt(Bun.nanoseconds()) - pollEntryNs` from the wait, restoring the reference implementation's arithmetic. The rest of the block is unchanged, so the diff against `src/js/node/wasi.ts` is two lines.
- This is correct because `waitTimeNs` holds the requested wait measured when each subscription was processed, so the remaining wait is that minus the time spent since entry; `nsToMs` then converts it for the sleep hook as before.
- The two changed lines are identical to the corresponding lines in #35709 (the larger node:wasi rework), so that branch rebases over this without conflict; the 32 byte event record layout that #35709 also fixes is a separate bug and is not touched here.
- Tests: `test/js/bun/wasm/wasi.test.js`, `poll_oneoff clock subscriptions`: a relative timeout, an absolute deadline, and a stdin + timeout poll that checks the 50 ms pause is deducted from the clock wait. The sleep hook records its argument instead of sleeping, so a wrong wait length shows up as a wrong number rather than a hang. All three throw the TypeError above on the released build and pass with this change.
- Also verified by building main with the #20858 cast applied instead: the 20 ms subscription asked the hook for 1786779982751 ms, and with the default hook a 10 s watchdog killed the process.
- The BigInt/Number mismatch was first identified by @jtenner in #20857 and #20858.

### Background

- `poll_oneoff` is the WASI preview1 syscall a guest uses to wait for events. Each subscription is 48 bytes; a clock subscription carries a timeout that is either relative or, with the `ABSTIME` flag, an absolute deadline. `src/js/node/wasi.ts` computes the longest wait across the clock subscriptions into `waitTimeNs` (a BigInt) and then blocks for it.
- Blocking goes through the instance's `sleep` option (`Bun.sleepSync` by default); tests can pass their own hook. A stdin read subscription additionally calls `shortPause()`, which sleeps 50 ms through the same hook before the clock wait is reached, which is what the deducted elapsed time is for.
- `timeOrigin` is still used by `now()` for `WASI_CLOCK_REALTIME`, so nothing becomes dead.

Fixes #20857
Closes #20858
Related to #43659

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/wasm/wasi.test.js

<!-- robobun:evidence:end -->

