### PR TITLE
node:wasi: honor returnOnExit so proc_exit does not kill the host process

### DIFF
--- a/src/js/node/wasi.ts
+++ b/src/js/node/wasi.ts
@@ -798,7 +798,7 @@ var require_wasi = __commonJS({
         this.env = wasiConfig.env ?? defaultConfig.env;
 
         const args = wasiConfig.args ?? defaultConfig.args;
-        const returnOnExit = wasiConfig.returnOnExit ?? true;
+        const { returnOnExit = true } = wasiConfig;
         validateBoolean(returnOnExit, "options.returnOnExit");
         this.returnOnExit = returnOnExit;
         this.memory = void 0;

--- a/src/js/node/wasi.ts
+++ b/src/js/node/wasi.ts
@@ -6,7 +6,10 @@
 //
 // Eventually we will implement this in native code, but this is just a quick hack to get WASI working.
 
+const { validateBoolean } = require("internal/validators");
+
 const nodeFsConstants = $processBindingConstants.fs;
+const kExitCode = Symbol("kExitCode");
 
 var __getOwnPropNames = Object.getOwnPropertyNames;
 
@@ -795,6 +798,9 @@ var require_wasi = __commonJS({
         this.env = wasiConfig.env ?? defaultConfig.env;
 
         const args = wasiConfig.args ?? defaultConfig.args;
+        const returnOnExit = wasiConfig.returnOnExit ?? true;
+        validateBoolean(returnOnExit, "options.returnOnExit");
+        this.returnOnExit = returnOnExit;
         this.memory = void 0;
         this.view = void 0;
         this.bindings = wasiConfig.bindings || defaultConfig.bindings;
@@ -1835,6 +1841,10 @@ var require_wasi = __commonJS({
             return constants_1.WASI_ESUCCESS;
           },
           proc_exit: rval => {
+            if (this.returnOnExit) {
+              this[kExitCode] = rval;
+              throw kExitCode;
+            }
             bindings.exit(rval);
             return constants_1.WASI_ESUCCESS;
           },
@@ -1961,9 +1971,15 @@ var require_wasi = __commonJS({
           }
         }
         this.setMemory(memory);
+        this[kExitCode] = 0;
         if (exports2._start) {
-          exports2._start();
+          try {
+            exports2._start();
+          } catch (err) {
+            if (err !== kExitCode) throw err;
+          }
         }
+        return this[kExitCode];
       }
       getImports(module2) {
         let namespace: string | null = null;

--- a/src/js/wasi-runner.js
+++ b/src/js/wasi-runner.js
@@ -46,6 +46,6 @@ const instance = !Number(WASM_USE_ASYNC_INIT)
   ? new WebAssembly.Instance(wasm, wasi.getImports(wasm))
   : await WebAssembly.instantiate(wasm, wasi.getImports(wasm));
 
-wasi.start(instance);
+const exitCode = wasi.start(instance);
 
-process.reallyExit(0);
+process.reallyExit(exitCode ?? 0);

--- a/test/js/bun/wasm/wasi.test.js
+++ b/test/js/bun/wasm/wasi.test.js
@@ -234,8 +234,8 @@ describe.concurrent("proc_exit / returnOnExit", () => {
     expect(() => wasi.start(instance)).toThrow(WebAssembly.RuntimeError);
   });
 
-  it("validates returnOnExit is a boolean", () => {
-    expect(() => new WASI({ version: "preview1", returnOnExit: "yes" })).toThrow(
+  it.each(["yes", null, 1])("validates returnOnExit is a boolean (%p)", value => {
+    expect(() => new WASI({ version: "preview1", returnOnExit: value })).toThrow(
       expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
     );
   });

--- a/test/js/bun/wasm/wasi.test.js
+++ b/test/js/bun/wasm/wasi.test.js
@@ -1,9 +1,49 @@
 import { spawnSync } from "bun";
-import { expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import fs from "node:fs";
 import path from "node:path";
 import { WASI } from "node:wasi";
+
+// Builds a minimal wasi_snapshot_preview1 module that imports proc_exit and exports
+// memory + _start. startBody is the raw body of _start (import 0 = proc_exit).
+function craftProcExitModule(startBody) {
+  const u = x => {
+    const a = [];
+    do {
+      let c = x & 127;
+      x >>>= 7;
+      if (x) c |= 128;
+      a.push(c);
+    } while (x);
+    return a;
+  };
+  const str = s => [...u(s.length), ...[...s].map(c => c.charCodeAt(0))];
+  const sec = (id, b) => [id, ...u(b.length), ...b];
+  const type = [2, 0x60, 1, 0x7f, 0, 0x60, 0, 0];
+  const imp = [1, ...str("wasi_snapshot_preview1"), ...str("proc_exit"), 0, 0];
+  const func = [1, 1];
+  const mem = [1, 0, 1];
+  const exp = [2, ...str("_start"), 0, 1, ...str("memory"), 2, 0];
+  const body = [0, ...startBody, 0x0b];
+  const code = [1, ...u(body.length), ...body];
+  return new Uint8Array([
+    0,
+    97,
+    115,
+    109,
+    1,
+    0,
+    0,
+    0,
+    ...sec(1, type),
+    ...sec(2, imp),
+    ...sec(3, func),
+    ...sec(5, mem),
+    ...sec(7, exp),
+    ...sec(10, code),
+  ]);
+}
 
 it("Should support printing 'hello world'", () => {
   const { stdout, stderr, exitCode } = spawnSync({
@@ -137,4 +177,66 @@ it("path_* syscalls cannot escape the preopened directory", () => {
     WASI_ESUCCESS,
   );
   expect(wasi.FD_MAP.has(4)).toBe(true);
+});
+
+describe.concurrent("proc_exit / returnOnExit", () => {
+  // _start body: i32.const 7; call 0 (proc_exit); drop-unreachable-padding not needed
+  const START_EXIT_7 = [0x41, 7, 0x10, 0];
+
+  async function run(opts, startBody) {
+    const bytes = craftProcExitModule(startBody);
+    const childSrc = /* js */ `
+      const { WASI } = require("node:wasi");
+      const wasi = new WASI(${JSON.stringify(opts)});
+      const bytes = Uint8Array.from(${JSON.stringify([...bytes])});
+      const instance = new WebAssembly.Instance(new WebAssembly.Module(bytes), {
+        wasi_snapshot_preview1: wasi.wasiImport,
+      });
+      const ret = wasi.start(instance);
+      console.log("AFTER-START ret=" + ret);
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", childSrc],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it("returnOnExit: true makes start() return the guest's exit code", async () => {
+    const { stdout, stderr, exitCode } = await run({ version: "preview1", returnOnExit: true }, START_EXIT_7);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "AFTER-START ret=7\n", stderr: "", exitCode: 0 });
+  });
+
+  it("returnOnExit defaults to true", async () => {
+    const { stdout, stderr, exitCode } = await run({ version: "preview1" }, START_EXIT_7);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "AFTER-START ret=7\n", stderr: "", exitCode: 0 });
+  });
+
+  it("returnOnExit: false terminates the host process with the guest's exit code", async () => {
+    const { stdout, exitCode } = await run({ version: "preview1", returnOnExit: false }, START_EXIT_7);
+    expect({ stdout, exitCode }).toEqual({ stdout: "", exitCode: 7 });
+  });
+
+  it("start() returns 0 when _start returns without calling proc_exit", async () => {
+    const { stdout, stderr, exitCode } = await run({ version: "preview1", returnOnExit: true }, []);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "AFTER-START ret=0\n", stderr: "", exitCode: 0 });
+  });
+
+  it("start() rethrows traps that are not proc_exit", () => {
+    const bytes = craftProcExitModule([0x00]); // unreachable
+    const wasi = new WASI({ version: "preview1", returnOnExit: true });
+    const instance = new WebAssembly.Instance(new WebAssembly.Module(bytes), {
+      wasi_snapshot_preview1: wasi.wasiImport,
+    });
+    expect(() => wasi.start(instance)).toThrow(WebAssembly.RuntimeError);
+  });
+
+  it("validates returnOnExit is a boolean", () => {
+    expect(() => new WASI({ version: "preview1", returnOnExit: "yes" })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
+  });
 });

--- a/test/js/bun/wasm/wasi.test.js
+++ b/test/js/bun/wasm/wasi.test.js
@@ -239,4 +239,19 @@ describe.concurrent("proc_exit / returnOnExit", () => {
       expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
     );
   });
+
+  it("`bun file.wasm` still exits with the guest's proc_exit code", async () => {
+    using dir = tempDir("wasi-runner-exit", {
+      "exit7.wasm": craftProcExitModule(START_EXIT_7),
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "exit7.wasm"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 7 });
+  });
 });


### PR DESCRIPTION
## What

`node:wasi`'s `proc_exit` import was wired directly to `process.exit()`, so any WASI guest calling `proc_exit` terminated the embedding Bun process with a guest-chosen exit code. Since every wasi-libc command module ends `_start` with `proc_exit`, you could not run a normal WASI binary and keep your process. The documented `returnOnExit` option (Node default `true`: `start()` returns the guest's exit code) was ignored entirely.

## Repro

```js
import { WASI } from "node:wasi";
// a minimal preview1 module whose _start calls proc_exit(7)
const BYTES = /* hand-crafted bytes, see test */;
const w = new WASI({ version: "preview1", returnOnExit: true });
const i = new WebAssembly.Instance(new WebAssembly.Module(BYTES), { wasi_snapshot_preview1: w.wasiImport });
console.log("AFTER-START ret=" + w.start(i));
```

| | output | exit code |
|-|-|-|
| Node v26.3.0 | `AFTER-START ret=7` | 0 |
| Bun (before) | *(nothing)* | 7 |
| Bun (after)  | `AFTER-START ret=7` | 0 |

## Cause

`src/js/node/wasi.ts` `defaultBindings.exit` is `code => process.exit(code)`, `wasiImport.proc_exit` calls it unconditionally, and `start()` had no catch around `_start()` and no return value. The `returnOnExit` constructor option was never read.

## Fix

Match Node's semantics:
- `returnOnExit` defaults to `true` and is validated as a boolean.
- When `true`, `proc_exit` stores the code and throws a private `Symbol` sentinel; `start()` catches exactly that sentinel and returns the stored code (0 if `_start` returned without calling `proc_exit`).
- When `false`, `proc_exit` calls `process.exit(code)` as before.
- Other errors raised from `_start` (e.g. `unreachable` traps) propagate unchanged.

## Verification

New tests in `test/js/bun/wasm/wasi.test.js` cover all four `returnOnExit` cases plus option validation and trap propagation. On unpatched Bun the `returnOnExit: true` / default / return-0 / validation cases fail; all pass with this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/wasm/wasi.test.js

<!-- robobun:evidence:end -->