### PR TITLE
ci: wait for dockerd before launching the test-service coordinator on Linux agents

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -310,12 +310,15 @@ function getRetry() {
     // human notices and clicks retry:
     //   -1  = agent lost / process killed (box died, agent restarted)
     //   255 = step timeout kill (timeout_in_minutes SIGTERM cascade)
+    //   75  = EX_TEMPFAIL from runner.node.mjs (required host service, e.g.
+    //         dockerd, never became reachable on this ephemeral VM)
     // User-canceled jobs are state=canceled, which never triggers automatic
     // retry, so this cannot resurrect deliberately canceled builds. limit: 1
     // caps the cost when a suite genuinely crashes with these statuses.
     automatic: [
       { exit_status: -1, limit: 1 },
       { exit_status: 255, limit: 1 },
+      { exit_status: 75, limit: 1 },
     ],
   };
 }

--- a/scripts/agent.mjs
+++ b/scripts/agent.mjs
@@ -113,7 +113,8 @@ async function doBuildkiteAgent(action, cliOptions = {}) {
 
         depend() {
           need net
-          use dns logger
+          use dns logger docker
+          after docker
         }
       `;
       writeFile(servicePath, service, { mode: 0o755 });
@@ -251,6 +252,7 @@ async function doBuildkiteAgent(action, cliOptions = {}) {
         Description=Buildkite Agent
         After=syslog.target
         After=network-online.target
+        After=docker.service
 
         [Service]
         Type=simple

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -507,6 +507,25 @@ async function runTests() {
   // don't run docker tests. Lifetime is tied to this process via the stdin
   // pipe.
   if (isCI && isLinux && spawnSync("docker", ["compose", "version"], { stdio: "ignore" }).status === 0) {
+    // On openrc hosts (alpine) the buildkite-agent service historically did
+    // not depend on docker, so on a cold boot the agent can accept a job
+    // before dockerd is listening: the `--- Docker` section above routinely
+    // prints "failed to connect to /var/run/docker.sock" on every alpine
+    // shard, and the coordinator's one-shot `docker version` then races it by
+    // a handful of seconds. Poll for the daemon briefly so the coordinator's
+    // prestart does not fire before the socket exists. If the daemon never
+    // comes up (bad VM boot) we fall through after the budget and
+    // container-backed tests fail loudly, which is the intended signal from
+    // isDockerEnabled().
+    const dockerDaemonUp = () => spawnSync("docker", ["version"], { stdio: "ignore" }).status === 0;
+    if (!dockerDaemonUp()) {
+      console.log("Docker daemon not reachable yet; waiting up to 30s for it...");
+      for (let i = 0; i < 30 && !dockerDaemonUp(); i++) {
+        await setTimeoutPromise(1000);
+      }
+      console.log("Docker daemon:", dockerDaemonUp() ? "ready" : "still unreachable after 30s");
+    }
+
     const coordinatorSocket = join(tmpdir(), `bun-docker-${process.pid}.sock`);
     const coordinator = spawn(execPath, [join(cwd, "test", "docker", "coordinator.ts"), ...tests], {
       stdio: ["pipe", "pipe", "inherit"],

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -513,17 +513,32 @@ async function runTests() {
     // prints "failed to connect to /var/run/docker.sock" on every alpine
     // shard, and the coordinator's one-shot `docker version` then races it by
     // a handful of seconds. Poll for the daemon briefly so the coordinator's
-    // prestart does not fire before the socket exists. If the daemon never
-    // comes up (bad VM boot) we fall through after the budget and
-    // container-backed tests fail loudly, which is the intended signal from
-    // isDockerEnabled().
+    // prestart does not fire before the socket exists.
     const dockerDaemonUp = () => spawnSync("docker", ["version"], { stdio: "ignore" }).status === 0;
     if (!dockerDaemonUp()) {
       console.log("Docker daemon not reachable yet; waiting up to 30s for it...");
       for (let i = 0; i < 30 && !dockerDaemonUp(); i++) {
         await setTimeoutPromise(1000);
       }
-      console.log("Docker daemon:", dockerDaemonUp() ? "ready" : "still unreachable after 30s");
+      if (dockerDaemonUp()) {
+        console.log("Docker daemon: ready");
+      } else {
+        // Still unreachable after the budget: the daemon failed to start on
+        // this boot. Running on would burn 4x retries of every docker-backed
+        // test on a dead host and paint an unrelated PR red; the Linux test
+        // agents are ephemeral, so bounce to Buildkite's automatic-retry hook
+        // (EX_TEMPFAIL, see getRetry() in .buildkite/ci.mjs) for a fresh VM.
+        // limit:1 there means a fleet-wide docker regression still surfaces
+        // on the second attempt.
+        const msg = `Docker daemon never became reachable on this agent (\`${getHostname()}\`); exiting for automatic retry on a fresh VM.`;
+        console.error(msg);
+        reportAnnotationToBuildKite({
+          label: "docker-daemon-unreachable",
+          content: msg,
+          style: "warning",
+        });
+        process.exit(75);
+      }
     }
 
     const coordinatorSocket = join(tmpdir(), `bun-docker-${process.pid}.sock`);


### PR DESCRIPTION
## What

`test/js/sql/sql-mysql-query-string-leak.test.ts` and `test/regression/issue/26030.test.ts` went red on `:alpine: 3.23 x64` shard 0 in [build 74556](https://buildkite.com/bun/bun/builds/74556#019f6f93-d118-4f13-946c-5e4c391bdc51) (PR #34477, unrelated to its diff):

```
failed to connect to the docker API at unix:///var/run/docker.sock; ... dial unix /var/run/docker.sock: connect: no such file or directory
error: A functional `docker` is required in CI for some tests.
      at isDockerEnabled (test/harness.ts:1056:17)
```
```
error: Failed to start service mysql_plain (via coordinator): Docker is not available. Please ensure Docker is installed and running.
```

All four in-shard retries hit the same state because the docker daemon on that VM never came up for the life of the job.

## Why

`scripts/agent.mjs` installs the buildkite-agent service with no ordering against docker:

```
# openrc                      # systemd
depend() {                    After=syslog.target
  need net                    After=network-online.target
  use dns logger
}
```

so on a cold ephemeral boot the agent can accept a job before `dockerd` is listening. Grepping the shard logs for that build: on **every** Alpine shard the runner's `--- Docker` section (`docker ps`) prints "failed to connect to /var/run/docker.sock", and the coordinator's one-shot `docker version` a few seconds later normally wins the race (shards 1-19 and the x64-baseline twin of shard 0 all went on to `coordinator: mysql_plain ready`). On this one VM it lost, and `docker version` was still failing 3+ minutes later when the test file ran, so the daemon never came up at all on that boot.

On Debian/Ubuntu the same `--- Docker` section already shows a healthy `CONTAINER ID ...` header at runner start, so this is specific to the openrc boot ordering.

## Fix

- `scripts/runner.node.mjs`: on CI Linux, if the docker CLI is present but `docker version` can't reach the daemon, poll it for up to 30s before spawning the test-service coordinator. This closes the cold-boot race for the current images at zero cost on hosts where the daemon is already up. If the daemon is still unreachable after 30s the shard is on a VM where dockerd failed to start; the runner annotates and exits `75` (`EX_TEMPFAIL`) so Buildkite's automatic-retry (`limit: 1`, Linux test agents are ephemeral `acquire-job`/`disconnect-after-job`) re-runs the shard on a fresh VM instead of burning 4x retries of every container-backed test against a dead host. A fleet-wide docker regression still surfaces on the second attempt.
- `.buildkite/ci.mjs`: add `exit_status: 75` to `getRetry()`'s automatic list alongside the existing `-1`/`255` infra-retry codes.
- `scripts/agent.mjs`: declare `after docker` / `use ... docker` in the openrc service and `After=docker.service` in the systemd unit so newly baked images boot with the correct ordering and the wait loop above is not doing load-bearing work.

## Verification

This is CI machinery with no `src/` or test changes; the reported test already passes on main HEAD whenever docker is reachable (299/300 recent builds). The fix cannot be demonstrated as fail-before/pass-after locally: without a reachable docker daemon the test is skipped (`isDockerEnabled()` returns false outside CI), and with one it already passed.

What I did verify:
- `node --check` passes on all three modified files.
- The new branch runs inside the existing `isCI && isLinux && docker compose version` guard, so non-Linux / dockerless hosts are untouched and a healthy daemon takes the fast path (one extra `spawnSync docker version`).
- Sampled five Alpine shard logs from build 74556: all show `docker ps` failing at runner start and docker becoming ready within the 30s budget, so the poll is sized against real numbers rather than guessed.
- openrc `use`/`after` and systemd `After=` are ordering-only (not `need`/`Requires=`), so images without docker still boot the agent.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->