### PR TITLE
sliceAnsi: return the ellipsis when a start-cut range holds only zero-width clusters

### DIFF
--- a/src/jsc/bindings/sliceAnsi.cpp
+++ b/src/jsc/bindings/sliceAnsi.cpp
@@ -1305,7 +1305,7 @@ walkDone:;
     // all content; the `lastClusterCol` arm catches the case where only
     // zero-width clusters (tab/LF/ZWSP) reached the original start.
     if (ellipsisWidth > 0 && (!include || (!needStartEllipsis && !needEndEllipsis))
-        && (sawCutEnd || (cutStartForEllipsis && (position > startBeforeBudget || (!include && hasPrev && lastClusterCol >= startBeforeBudget)))))
+        && (sawCutEnd || (cutStartForEllipsis && (position > startBeforeBudget || (hasPrev && lastClusterCol >= startBeforeBudget)))))
         return ellipsis.toString();
 
     if (!include) return emptyString();

--- a/src/jsc/bindings/sliceAnsi.cpp
+++ b/src/jsc/bindings/sliceAnsi.cpp
@@ -1305,9 +1305,7 @@ walkDone:;
     // all content; the `lastClusterCol` arm catches the case where only
     // zero-width clusters (tab/LF/ZWSP) reached the original start.
     if (ellipsisWidth > 0 && (!include || (!needStartEllipsis && !needEndEllipsis))
-        && (sawCutEnd || (cutStartForEllipsis
-                && (position > startBeforeBudget
-                    || (!include && hasPrev && lastClusterCol >= startBeforeBudget)))))
+        && (sawCutEnd || (cutStartForEllipsis && (position > startBeforeBudget || (!include && hasPrev && lastClusterCol >= startBeforeBudget)))))
         return ellipsis.toString();
 
     if (!include) return emptyString();

--- a/src/jsc/bindings/sliceAnsi.cpp
+++ b/src/jsc/bindings/sliceAnsi.cpp
@@ -1289,6 +1289,9 @@ walkDone:;
     // Finalize the last cluster's width contribution. If we broke early via
     // sawCutEnd, pending was already flushed close-only at the break.
     const bool reachedEOF = !sawCutEnd;
+    // When reachedEOF && hasPrev, `position` here is the start column of the
+    // last cluster, i.e. the highest break column the walk reached.
+    const size_t lastClusterCol = position;
     if (reachedEOF) {
         if (hasPrev) position += gs.width();
         // The last cluster may have overflowed specEnd (wide char straddling
@@ -1299,9 +1302,12 @@ walkDone:;
     // Degenerate: something was cut but no ellipsis fit in the range →
     // bare ellipsis, mirroring the ASCII fast path's !doStart && !doEnd
     // branch. `!include` covers a start budget that pushed `start` past
-    // all content.
+    // all content; the `lastClusterCol` arm catches the case where only
+    // zero-width clusters (tab/LF/ZWSP) reached the original start.
     if (ellipsisWidth > 0 && (!include || (!needStartEllipsis && !needEndEllipsis))
-        && (sawCutEnd || (cutStartForEllipsis && position > startBeforeBudget)))
+        && (sawCutEnd || (cutStartForEllipsis
+                && (position > startBeforeBudget
+                    || (!include && hasPrev && lastClusterCol >= startBeforeBudget)))))
         return ellipsis.toString();
 
     if (!include) return emptyString();

--- a/test/js/bun/util/sliceAnsi.test.ts
+++ b/test/js/bun/util/sliceAnsi.test.ts
@@ -1383,7 +1383,7 @@ describe("Bun.sliceAnsi", () => {
       // original start): stays empty, no ellipsis.
       expect(Bun.sliceAnsi("Ж", 1, 3, { ellipsis: E })).toBe("");
       expect(Bun.sliceAnsi("Ж\x1b[31m", 1, 3, { ellipsis: E })).toBe("");
-      expect(Bun.sliceAnsi("Ж", 1, 2, e)).toBe("");
+      expect(Bun.sliceAnsi("Ж\x1b[31m", 1, 2, e)).toBe("");
       // No cut on either side: content returned, no ellipsis.
       expect(Bun.sliceAnsi("Ж", 0, 1, e)).toBe("Ж");
       expect(Bun.sliceAnsi("Ж\n", 0, 1, e)).toBe("Ж");

--- a/test/js/bun/util/sliceAnsi.test.ts
+++ b/test/js/bun/util/sliceAnsi.test.ts
@@ -1360,6 +1360,22 @@ describe("Bun.sliceAnsi", () => {
       // Start-cut with a trailing newline still returns the ellipsis
       // (the start cut is what makes it degenerate, not the end).
       expect(Bun.sliceAnsi("ЖЗ\n", 1, 2, e)).toBe(">>");
+      // Start budget consumed the whole range and only zero-width clusters
+      // (tab/LF/ZWSP) lie at the original start: still the bare ellipsis,
+      // same as the visible-content case above. Plain slice is non-empty.
+      expect(Bun.sliceAnsi("a\t", 1, 3)).toBe("\t");
+      expect(Bun.sliceAnsi("a\t", 1, 3, { ellipsis: E })).toBe(E);
+      expect(Bun.sliceAnsi("a\x1b[31m\t", 1, 3, { ellipsis: E })).toBe(E);
+      expect(Bun.sliceAnsi("Ж\t", 1, 3, { ellipsis: E })).toBe(E);
+      expect(Bun.sliceAnsi("a\n", 1, 3, { ellipsis: E })).toBe(E);
+      expect(Bun.sliceAnsi("a\u200b", 1, 3, { ellipsis: E })).toBe(E);
+      expect(Bun.sliceAnsi("ab\t", 2, 4, { ellipsis: E })).toBe(E);
+      expect(Bun.sliceAnsi("ЖЗ\t", 2, 4, { ellipsis: E })).toBe(E);
+      expect(Bun.sliceAnsi("a\t\t", 1, 3, { ellipsis: E })).toBe(E);
+      // Same zero-width range but the plain slice is empty (nothing at the
+      // original start): stays empty, no ellipsis.
+      expect(Bun.sliceAnsi("Ж", 1, 3, { ellipsis: E })).toBe("");
+      expect(Bun.sliceAnsi("Ж\x1b[31m", 1, 3, { ellipsis: E })).toBe("");
       // No cut on either side: content returned, no ellipsis.
       expect(Bun.sliceAnsi("Ж", 0, 1, e)).toBe("Ж");
       expect(Bun.sliceAnsi("Ж\n", 0, 1, e)).toBe("Ж");

--- a/test/js/bun/util/sliceAnsi.test.ts
+++ b/test/js/bun/util/sliceAnsi.test.ts
@@ -1372,10 +1372,18 @@ describe("Bun.sliceAnsi", () => {
       expect(Bun.sliceAnsi("ab\t", 2, 4, { ellipsis: E })).toBe(E);
       expect(Bun.sliceAnsi("ЖЗ\t", 2, 4, { ellipsis: E })).toBe(E);
       expect(Bun.sliceAnsi("a\t\t", 1, 3, { ellipsis: E })).toBe(E);
+      // Same, but ellipsisWidth >= range so no start budget was applied and
+      // `include` flipped true on the zero-width cluster: still the ellipsis.
+      expect(Bun.sliceAnsi("Ж\t", 1, 2, e)).toBe(">>");
+      expect(Bun.sliceAnsi("a\t", 1, 2, e)).toBe(">>");
+      expect(Bun.sliceAnsi("a\u200b", 1, 2, e)).toBe(">>");
+      expect(Bun.sliceAnsi("a\x1b[31m\t", 1, 3, e)).toBe(">>");
+      expect(Bun.sliceAnsi("a\t\t", 1, 2, e)).toBe(">>");
       // Same zero-width range but the plain slice is empty (nothing at the
       // original start): stays empty, no ellipsis.
       expect(Bun.sliceAnsi("Ж", 1, 3, { ellipsis: E })).toBe("");
       expect(Bun.sliceAnsi("Ж\x1b[31m", 1, 3, { ellipsis: E })).toBe("");
+      expect(Bun.sliceAnsi("Ж", 1, 2, e)).toBe("");
       // No cut on either side: content returned, no ellipsis.
       expect(Bun.sliceAnsi("Ж", 0, 1, e)).toBe("Ж");
       expect(Bun.sliceAnsi("Ж\n", 0, 1, e)).toBe("Ж");


### PR DESCRIPTION
Follow-up to #33488 (which fixed #2515 for visible content). The start-side degenerate fallback still missed ranges whose plain-slice content is entirely zero-width.

## Repro

```js
Bun.sliceAnsi("a\x1b[31m\t", 1, 3, {ellipsis: "…"});  // "" (expected "…")
Bun.sliceAnsi("a\x1b[31m\t", 1, 3);                   // "\x1b[31m\t\x1b[39m" (plain slice keeps the tab)
Bun.sliceAnsi("ЖЗИ", 1, 4, {ellipsis: ">>"});         // ">>" (already fixed by #33488)
```

## Cause

The bare-ellipsis fallback at `walkDone` tests `position > startBeforeBudget` to decide whether the requested range held content. `position` is the column *after* the last cluster, so a zero-width cluster (tab/LF/ZWSP) sitting exactly at `startBeforeBudget` leaves `position == startBeforeBudget` and the arm evaluates false. The start-ellipsis budget had pushed `start` past that cluster, so `include` never flipped, and the next line returns `emptyString()`.

## Fix

Capture `position` (the last cluster's start column) before the EOF width finalize, and extend the start-cut arm with `!include && hasPrev && lastClusterCol >= startBeforeBudget`. This catches "only zero-width clusters reached the original start" without touching the hot walk loop. The `!include` guard scopes the change to the reported case: ranges where the start budget consumed the whole range.

## Verification

`bun bd test test/js/bun/util/sliceAnsi.test.ts` → 166 pass; `sliceAnsi-fuzz.test.ts` → 48 pass. Fail-before verified by stashing `src/`.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/sliceAnsi.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (1ed30a6c8)

test/js/bun/util/sliceAnsi.test.ts:
(pass) Bun.sliceAnsi > plain strings > slices ASCII string like String.prototype.slice [3.13ms]
(pass) Bun.sliceAnsi > plain strings > returns empty string for empty input [2.02ms]
(pass) Bun.sliceAnsi > plain strings > returns full string with no arguments beyond first [1.62ms]
(pass) Bun.sliceAnsi > plain strings > start=0, end=0 returns empty [1.49ms]
(pass) Bun.sliceAnsi > plain strings > start > end returns empty [1.33ms]
(pass) Bun.sliceAnsi > plain strings > start beyond string length returns empty [1.50ms]
(pass) Bun.sliceAnsi > plain strings > end beyond string length returns remainder [1.67ms]
(pass) Bun.sliceAnsi > plain strings > negative start [2.36ms]
(pass) Bun.sliceAns
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (75dce269a)

test/js/bun/util/sliceAnsi.test.ts:
(pass) Bun.sliceAnsi > plain strings > slices ASCII string like String.prototype.slice [0.04ms]
(pass) Bun.sliceAnsi > plain strings > returns empty string for empty input [0.01ms]
(pass) Bun.sliceAnsi > plain strings > returns full string with no arguments beyond first [0.01ms]
(pass) Bun.sliceAnsi > plain strings > start=0, end=0 returns empty
(pass) Bun.sliceAnsi > plain strings > start > end returns empty [0.01ms]
(pass) Bun.sliceAnsi > plain strings > start beyond string length returns empty [0.03ms]
(pass) Bun.sliceAnsi > plain strings > end beyond string length returns remainder [0.01ms]
(pass) Bun.sliceAnsi > plain strings > negative start [0.02ms]
(pass) Bun.sliceAnsi > plain strings > negative end [0.03ms]
(pass) Bun.sliceAnsi > plain strings > both negative
(pass) Bun.sliceAnsi > plain strings > negative start keeps trailing zero-width and ANSI content [0.17ms]
(pass) Bun.sliceAnsi > plain strings > negative end strictly before total width still cuts [0.02ms]
(pass) Bun.sliceAnsi > plain strings > single character slice [0.02ms]
(pass) Bun.sliceAnsi > ANSI color codes > slices color
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/sliceAnsi.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (1ed30a6c8)

test/js/bun/util/sliceAnsi.test.ts:
(pass) Bun.sliceAnsi > plain strings > slices ASCII string like String.prototype.slice [3.21ms]
(pass) Bun.sliceAnsi > plain strings > returns empty string for empty input [2.00ms]
(pass) Bun.sliceAnsi > plain strings > returns full string with no arguments beyond first [1.61ms]
(pass) Bun.sliceAnsi > plain strings > start=0, end=0 returns empty [1.48ms]
(pass) Bun.sliceAnsi > plain strings > start > end returns empty [1.29ms]
(pass) Bun.sliceAnsi > plain strings > start beyond string length returns empty [1.57ms]
(pass) Bun.sliceAnsi > plain strings > end beyond string length returns remainder [1.72ms]
(pass) Bun.sliceAnsi > plain strings > negative start [2.35ms]
(pass) Bun.sliceAns
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 681ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[2/7] gen cpp.rs (cppbind)
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/sr
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/sliceAnsi.cpp     |  8 ++++++--
 test/js/bun/util/sliceAnsi.test.ts | 24 ++++++++++++++++++++++++
 2 files changed, 30 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/jsc/bindings/sliceAnsi.cpp          6      3      0
test/js/bun/util/sliceAnsi.test.ts      3      3      0
```

</details>

<!-- robobun:evidence:end -->