### PR TITLE
usockets: re-arm readable in raw_shutdown after read_eof so the close is delivered on Windows

### DIFF
--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -314,7 +314,7 @@ struct us_socket_t {
    * the driver's epilogue via ssl_pending_detach. */
   unsigned char ssl_in_use : 1;
   unsigned char ssl_pending_detach : 1;
-  /* Peer FIN was dispatched as on_end on a half-open socket; readable interest is never re-added and on_end never re-fires. */
+  /* Peer FIN was dispatched as on_end on a half-open socket; on_end never re-fires (readable is only re-armed once shut down, to close). */
   unsigned char read_eof : 1;
   /* The close code passed to the deferred close (e.g. a reset requested from
    * inside a handshake callback must still RST, not FIN, when it is finally

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -724,12 +724,11 @@ int us_connecting_socket_is_shut_down(struct us_connecting_socket_t *c) {
 }
 
 void us_internal_socket_raw_shutdown(struct us_socket_t *s) {
-    /* Todo: should we emit on_close if calling shutdown on an already half-closed socket?
-     * We need more states in that case, we need to track RECEIVED_FIN
-     * so far, the app has to track this and call close as needed */
     if (!us_socket_is_closed(s) && us_internal_poll_type(&s->p) != POLL_TYPE_SOCKET_SHUT_DOWN) {
         us_internal_poll_set_type(&s->p, POLL_TYPE_SOCKET_SHUT_DOWN);
-        us_poll_change(&s->p, s->group->loop, us_poll_events(&s->p) & LIBUS_SOCKET_READABLE);
+        /* After read_eof the poll may be at 0 events; re-arm READABLE so the SHUT_DOWN eof branch closes us. */
+        us_poll_change(&s->p, s->group->loop,
+                       s->read_eof ? LIBUS_SOCKET_READABLE : (us_poll_events(&s->p) & LIBUS_SOCKET_READABLE));
         bsd_shutdown_socket(us_poll_fd((struct us_poll_t *) s));
 #ifdef LIBUS_USE_KQUEUE
         if (!(us_poll_events(&s->p) & LIBUS_SOCKET_READABLE)) {

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -3834,6 +3834,7 @@ describe("allowHalfOpen socket shut down after the peer's FIN", () => {
   // the fully-closed state is delivered; unfixed, the libuv backend stranded.
   it("closes when shutdown() runs after the poll has settled", async () => {
     const ended = Promise.withResolvers<Socket>();
+    const drained = Promise.withResolvers<void>();
     const closed = Promise.withResolvers<void>();
 
     using server = Bun.listen({
@@ -3844,13 +3845,20 @@ describe("allowHalfOpen socket shut down after the peer's FIN", () => {
         open() {},
         data() {},
         end: s => ended.resolve(s),
-        error() {},
+        // The EOF path arms one writable wakeup; this is the last event the
+        // socket emits before it goes idle.
+        drain: () => drained.resolve(),
+        error(_s, e) {
+          ended.reject(e);
+          drained.reject(e);
+          closed.reject(e);
+        },
         close: () => closed.resolve(),
       },
     });
 
     const peerClosed = Promise.withResolvers<void>();
-    const peer = await Bun.connect({
+    await Bun.connect({
       hostname: "127.0.0.1",
       port: server.port,
       allowHalfOpen: true,
@@ -3858,17 +3866,20 @@ describe("allowHalfOpen socket shut down after the peer's FIN", () => {
         open: s => s.shutdown(), // FIN
         data() {},
         end() {},
-        error() {},
+        error: (_s, e) => peerClosed.reject(e),
         close: () => peerClosed.resolve(),
       },
     });
 
     const victim = await ended.promise;
-    // Let the writable side drain and the poll settle before shutting down.
-    for (let i = 0; i < 5; i++) await new Promise<void>(r => setImmediate(r));
+    await drained.promise;
+    // Going idle is not observable from JS: after drain returns, usockets drops
+    // the poll's events, and the event loop's next poll phase then consumes the
+    // FIN's final re-report. Two loop turns get past that poll phase; shutting
+    // down any earlier still finds an armed wakeup and passes without the fix.
+    for (let i = 0; i < 2; i++) await new Promise<void>(r => setImmediate(r));
     victim.shutdown();
     await closed.promise;
     await peerClosed.promise;
-    peer.end();
   });
 });

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -3827,3 +3827,48 @@ describe("allowHalfOpen socket whose peer resets behind pending writes", () => {
     expect(endCount).toBe(1);
   });
 });
+
+describe("allowHalfOpen socket shut down after the peer's FIN", () => {
+  // Once end() has been delivered the poll drops readable interest and, with
+  // nothing queued, settles with no events armed. shutdown() must re-arm it so
+  // the fully-closed state is delivered; unfixed, the libuv backend stranded.
+  it("closes when shutdown() runs after the poll has settled", async () => {
+    const ended = Promise.withResolvers<Socket>();
+    const closed = Promise.withResolvers<void>();
+
+    using server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      allowHalfOpen: true,
+      socket: {
+        open() {},
+        data() {},
+        end: s => ended.resolve(s),
+        error() {},
+        close: () => closed.resolve(),
+      },
+    });
+
+    const peerClosed = Promise.withResolvers<void>();
+    const peer = await Bun.connect({
+      hostname: "127.0.0.1",
+      port: server.port,
+      allowHalfOpen: true,
+      socket: {
+        open: s => s.shutdown(), // FIN
+        data() {},
+        end() {},
+        error() {},
+        close: () => peerClosed.resolve(),
+      },
+    });
+
+    const victim = await ended.promise;
+    // Let the writable side drain and the poll settle before shutting down.
+    for (let i = 0; i < 5; i++) await new Promise<void>(r => setImmediate(r));
+    victim.shutdown();
+    await closed.promise;
+    await peerClosed.promise;
+    peer.end();
+  });
+});


### PR DESCRIPTION
### Problem

- An `allowHalfOpen` socket whose peer has sent FIN strands forever on Windows if we call `shutdown()` after the poll has gone idle. Repro: `Bun.listen({allowHalfOpen: true})`, peer `shutdown()`s, victim gets `end`, victim calls `shutdown()` a few ticks later, victim's `close` never fires.
- After #37077 latched `read_eof`, the half-open EOF path drops readable interest and, once pending writes drain, the poll settles with no events armed. `us_internal_socket_raw_shutdown` (`packages/bun-usockets/src/socket.c`) then masks the poll with `events & READABLE`, which is `0 & READABLE`: a no-op `us_poll_change`, so nothing is armed to report that both halves are now closed.
- epoll is unaffected (HUP is reported unmasked); kqueue is covered by the read sentinel #37077 added in the same function; the libuv backend has no equivalent, so only Windows strands.

### Fix

- In `raw_shutdown`, when `read_eof` is set, arm `READABLE` explicitly instead of masking. The next poll delivers the EOF against a `SHUT_DOWN` socket and the existing branch closes it.
- Correct because after `read_eof` a readable wakeup can only ever report EOF (there is no more data), and the `SHUT_DOWN` eof branch is exactly the "both halves closed" close path every backend already uses; this just guarantees it has an event to run on.
- Test: `test/js/bun/net/socket.test.ts` "closes when shutdown() runs after the poll has settled". On windows-x64 it times out against main and passes with this change; on Linux it passes both ways (HUP), as expected.
- Also ran on windows-x64 and linux-x64 with the change: `socket.test.ts`, `tcp-server.test.ts`, `node-net*.test.*`, `node-http-connect.test.ts`, and the vendored `test-net-*half*`, `test-http-*connect*`, `test-http-*upgrade*`, `test-net-half-open-peer-reset-*` suites. No changes versus main.

### Background

- A half-open socket is one where the peer has closed its write side (we saw EOF) but we may still write. usockets tracks "EOF was delivered" in `read_eof` and stops polling for reads so the EOF is not re-reported.
- A usockets poll is the set of readiness events (`READABLE`/`WRITABLE`) registered with the OS for a socket. On libuv this maps to `uv_poll_start`; registering zero events means the OS will not wake us for that socket at all.
- `raw_shutdown` marks the socket `SHUT_DOWN` and sends our FIN. The loop closes a `SHUT_DOWN` socket when it next observes EOF on it; that observation needs a readable wakeup.

History: this PR originally also fixed the Windows `drain` storm on these sockets; #37077 landed that part on main, so this is rebased onto it and reduced to the remaining `raw_shutdown` gap.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 19 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/net/socket.test.ts

<!-- robobun:evidence:end -->