### PR TITLE
resolver: resolve tsconfig extends package specifiers and TS5 array form

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6696,6 +6696,8 @@ impl<'a> Resolver<'a> {
                         if parent_configs.append(current_ptr).is_err() {
                             // Degenerate >64-config extends tree (or a cycle):
                             // drop this config and merge what was collected.
+                            // SAFETY: `current_ptr` came from `heap::into_raw` and the
+                            // failed append left this scope its sole owner.
                             TSConfigJSON::destroy(unsafe { bun_core::heap::take(current_ptr) });
                             break 'walk;
                         }
@@ -6727,6 +6729,8 @@ impl<'a> Resolver<'a> {
                                     if worklist.append(raw).is_err() {
                                         // Degenerate >64-config extends tree (or a
                                         // cycle): drop this base and stop walking.
+                                        // SAFETY: `raw` came from `heap::into_raw` just
+                                        // above and was never stored anywhere.
                                         TSConfigJSON::destroy(unsafe { bun_core::heap::take(raw) });
                                         break 'walk;
                                     }
@@ -6754,6 +6758,8 @@ impl<'a> Resolver<'a> {
                     // is still merged (and freed) rather than leaked.
                     while let Some(pending) = worklist.pop() {
                         if parent_configs.append(pending).is_err() {
+                            // SAFETY: `pending` came from `heap::into_raw`; popped off
+                            // the worklist, this scope is its sole owner.
                             TSConfigJSON::destroy(unsafe { bun_core::heap::take(pending) });
                         }
                     }

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6635,53 +6635,63 @@ impl<'a> Resolver<'a> {
                 if let Some(tsconfig_json) = parsed_tsconfig {
                     let mut parent_configs: BoundedArray<*mut TSConfigJSON, 64> =
                         BoundedArray::default();
-                    parent_configs.append(tsconfig_json)?;
-                    // `current`/`parent_config_ptr`/`merged_config` are heap TSConfigJSON
+                    // `parent_config_ptr`/`merged_config` are heap TSConfigJSON
                     // allocations from `parse_tsconfig` (heap::alloc); uniquely owned by
-                    // this extends-chain walk and freed via heap::take below. Hold as
-                    // `BackRef` (pointee outlives holder) so the loop body reads via safe
-                    // `Deref` instead of three open-coded raw-ptr derefs.
-                    let mut current = bun_ptr::BackRef::from(
-                        core::ptr::NonNull::new(tsconfig_json).expect("heap alloc"),
-                    );
-                    while !current.extends.is_empty() {
+                    // this extends-chain walk and freed via heap::take below.
+                    //
+                    // `extends` may be an array (TS 5). Flatten the extends tree so
+                    // the merge pop order is: first entry's deepest base, ..., first
+                    // entry, ..., last entry's deepest base, ..., last entry, leaf.
+                    // A worklist DFS (pop, record, push children forward) yields that
+                    // order in `parent_configs` and matches the prior behaviour for a
+                    // single-string extends.
+                    let mut worklist: BoundedArray<*mut TSConfigJSON, 64> =
+                        BoundedArray::default();
+                    worklist.append(tsconfig_json)?;
+                    'walk: while let Some(current_ptr) = worklist.pop() {
+                        parent_configs.append(current_ptr)?;
+                        let current = bun_ptr::BackRef::from(
+                            core::ptr::NonNull::new(current_ptr).expect("heap alloc"),
+                        );
                         let ts_dir_name = Dirname::dirname(&current.abs_path);
-                        // tsc resolves non-relative `extends` specifiers
-                        // (e.g. "@tsconfig/node20") against node_modules.
-                        let parse_result = if is_package_path(&current.extends) {
-                            self.parse_tsconfig_extends_package(ts_dir_name, &current.extends)
-                        } else {
-                            let abs_path = ResolvePath::join_abs_string_buf(
-                                ts_dir_name,
-                                bufs!(tsconfig_path_abs),
-                                &[ts_dir_name, &current.extends],
-                                bun_paths::Platform::AUTO,
-                            );
-                            self.parse_tsconfig(abs_path, FD::INVALID, true)
-                        };
-                        let parent_config_maybe: Option<*mut TSConfigJSON> = match parse_result {
-                            Ok(v) => v.map(bun_core::heap::into_raw),
-                            Err(err) => {
-                                let _ = self.log_mut().add_debug_fmt(
-                                    None,
-                                    bun_ast::Loc::EMPTY,
-                                    format_args!(
-                                        "{} loading tsconfig.json extends {}",
-                                        bstr::BStr::new(err.name()),
-                                        bun_core::fmt::quote(&current.extends[..])
-                                    ),
+                        for entry in current.extends.iter() {
+                            // tsc resolves non-relative `extends` specifiers
+                            // (e.g. "@tsconfig/node20") against node_modules.
+                            let parse_result = if is_package_path(entry) {
+                                self.parse_tsconfig_extends_package(ts_dir_name, entry)
+                            } else {
+                                let abs_path = ResolvePath::join_abs_string_buf(
+                                    ts_dir_name,
+                                    bufs!(tsconfig_path_abs),
+                                    &[ts_dir_name, entry],
+                                    bun_paths::Platform::AUTO,
                                 );
-                                break;
+                                self.parse_tsconfig(abs_path, FD::INVALID, true)
+                            };
+                            match parse_result {
+                                Ok(Some(parent)) => {
+                                    worklist.append(bun_core::heap::into_raw(parent))?;
+                                }
+                                Ok(None) => break 'walk,
+                                Err(err) => {
+                                    let _ = self.log_mut().add_debug_fmt(
+                                        None,
+                                        bun_ast::Loc::EMPTY,
+                                        format_args!(
+                                            "{} loading tsconfig.json extends {}",
+                                            bstr::BStr::new(err.name()),
+                                            bun_core::fmt::quote(&entry[..])
+                                        ),
+                                    );
+                                    break 'walk;
+                                }
                             }
-                        };
-                        if let Some(parent_config) = parent_config_maybe {
-                            parent_configs.append(parent_config)?;
-                            current = bun_ptr::BackRef::from(
-                                core::ptr::NonNull::new(parent_config).expect("heap alloc"),
-                            );
-                        } else {
-                            break;
                         }
+                    }
+                    // Drain anything the 'walk break left on the worklist so it is
+                    // still merged (and freed) rather than leaked.
+                    while let Some(pending) = worklist.pop() {
+                        parent_configs.append(pending)?;
                     }
 
                     let merged_config = parent_configs.pop().unwrap();

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6678,9 +6678,7 @@ impl<'a> Resolver<'a> {
                                     if worklist.append(raw).is_err() {
                                         // Degenerate >64-config extends tree (or a
                                         // cycle): drop this base and stop walking.
-                                        TSConfigJSON::destroy(unsafe {
-                                            bun_core::heap::take(raw)
-                                        });
+                                        TSConfigJSON::destroy(unsafe { bun_core::heap::take(raw) });
                                         break 'walk;
                                     }
                                 }

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4182,13 +4182,23 @@ impl<'a> Resolver<'a> {
                     &[dir, node_modules, &specifier_json],
                 ];
                 for parts in candidates {
-                    let abs_path = ResolvePath::join_abs_string_buf(
-                        dir,
-                        bufs!(tsconfig_path_abs),
-                        parts,
-                        bun_paths::Platform::AUTO,
-                    );
-                    match self.parse_tsconfig(abs_path, FD::INVALID, true) {
+                    // NUL-terminated join so a hit can be realpath'd in place.
+                    let abs_path = ::bun_paths::resolve_path::join_abs_string_buf_z::<
+                        ::bun_paths::resolve_path::platform::Auto,
+                    >(dir, bufs!(tsconfig_path_abs), parts);
+                    // Workspace config packages are installed as symlinks;
+                    // resolve them so the base config's relative baseUrl/paths
+                    // are interpreted from the real location (tsc, esbuild).
+                    let parse_result = if self.opts.preserve_symlinks {
+                        self.parse_tsconfig(abs_path.as_bytes(), FD::INVALID, true)
+                    } else {
+                        let mut real_buf = bun_paths::path_buffer_pool::get();
+                        match bun_sys::realpath(abs_path, &mut real_buf) {
+                            Ok(real) => self.parse_tsconfig(real, FD::INVALID, true),
+                            Err(err) => Err(err.into()),
+                        }
+                    };
+                    match parse_result {
                         // Candidate is missing or not a regular file: keep looking.
                         Err(crate::Error::Sys(
                             bun_errno::SystemErrno::ENOENT
@@ -4204,6 +4214,41 @@ impl<'a> Resolver<'a> {
                 return Err(crate::Error::Sys(bun_errno::SystemErrno::ENOENT));
             }
             dir = parent;
+        }
+    }
+
+    /// Resolve a relative or absolute tsconfig `extends` value against the
+    /// tsconfig's directory, retrying with ".json" appended like tsc does for
+    /// extension-less targets.
+    fn parse_tsconfig_extends_relative(
+        &mut self,
+        ts_dir_name: &[u8],
+        entry: &[u8],
+    ) -> crate::CrateResult<Option<Box<TSConfigJSON>>> {
+        let abs_path = ResolvePath::join_abs_string_buf(
+            ts_dir_name,
+            bufs!(tsconfig_path_abs),
+            &[ts_dir_name, entry],
+            bun_paths::Platform::AUTO,
+        );
+        match self.parse_tsconfig(abs_path, FD::INVALID, true) {
+            Err(crate::Error::Sys(
+                bun_errno::SystemErrno::ENOENT
+                | bun_errno::SystemErrno::ENOTDIR
+                | bun_errno::SystemErrno::EISDIR,
+            )) if !entry.ends_with(b".json") => {
+                let mut entry_json = Vec::with_capacity(entry.len() + b".json".len());
+                entry_json.extend_from_slice(entry);
+                entry_json.extend_from_slice(b".json");
+                let abs_path = ResolvePath::join_abs_string_buf(
+                    ts_dir_name,
+                    bufs!(tsconfig_path_abs),
+                    &[ts_dir_name, &entry_json],
+                    bun_paths::Platform::AUTO,
+                );
+                self.parse_tsconfig(abs_path, FD::INVALID, true)
+            }
+            result => result,
         }
     }
 
@@ -6662,15 +6707,19 @@ impl<'a> Resolver<'a> {
                             // tsc resolves non-relative `extends` specifiers
                             // (e.g. "@tsconfig/node20") against node_modules.
                             let parse_result = if is_package_path(entry) {
-                                self.parse_tsconfig_extends_package(ts_dir_name, entry)
+                                match self.parse_tsconfig_extends_package(ts_dir_name, entry) {
+                                    // Bun historically resolved bare values like
+                                    // "base.json" relative to the tsconfig, so fall
+                                    // back when the node_modules walk misses.
+                                    Err(crate::Error::Sys(
+                                        bun_errno::SystemErrno::ENOENT
+                                        | bun_errno::SystemErrno::ENOTDIR
+                                        | bun_errno::SystemErrno::EISDIR,
+                                    )) => self.parse_tsconfig_extends_relative(ts_dir_name, entry),
+                                    result => result,
+                                }
                             } else {
-                                let abs_path = ResolvePath::join_abs_string_buf(
-                                    ts_dir_name,
-                                    bufs!(tsconfig_path_abs),
-                                    &[ts_dir_name, entry],
-                                    bun_paths::Platform::AUTO,
-                                );
-                                self.parse_tsconfig(abs_path, FD::INVALID, true)
+                                self.parse_tsconfig_extends_relative(ts_dir_name, entry)
                             };
                             match parse_result {
                                 Ok(Some(parent)) => {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4156,6 +4156,53 @@ impl<'a> Resolver<'a> {
         Ok(Some(result))
     }
 
+    /// Resolve a tsconfig `extends` package specifier (e.g. `@tsconfig/node20`
+    /// or `pkg/tsconfig.base.json`) by walking up parent `node_modules`
+    /// directories like tsc: try `<path>/tsconfig.json`, `<path>`, `<path>.json`.
+    fn parse_tsconfig_extends_package(
+        &mut self,
+        start_dir: &[u8],
+        specifier: &[u8],
+    ) -> crate::CrateResult<Option<Box<TSConfigJSON>>> {
+        let mut specifier_json = Vec::with_capacity(specifier.len() + b".json".len());
+        specifier_json.extend_from_slice(specifier);
+        specifier_json.extend_from_slice(b".json");
+
+        let mut dir = start_dir;
+        loop {
+            if !strings::eql(ResolvePath::basename(dir), b"node_modules") {
+                let node_modules: &[u8] = b"node_modules";
+                let candidates: [&[&[u8]]; 3] = [
+                    &[dir, node_modules, specifier, b"tsconfig.json"],
+                    &[dir, node_modules, specifier],
+                    &[dir, node_modules, &specifier_json],
+                ];
+                for parts in candidates {
+                    let abs_path = ResolvePath::join_abs_string_buf(
+                        dir,
+                        bufs!(tsconfig_path_abs),
+                        parts,
+                        bun_paths::Platform::AUTO,
+                    );
+                    match self.parse_tsconfig(abs_path, FD::INVALID) {
+                        // Candidate is missing or not a regular file: keep looking.
+                        Err(crate::Error::Sys(
+                            bun_errno::SystemErrno::ENOENT
+                            | bun_errno::SystemErrno::ENOTDIR
+                            | bun_errno::SystemErrno::EISDIR,
+                        )) => {}
+                        result => return result,
+                    }
+                }
+            }
+            let parent = Dirname::dirname(dir);
+            if parent.len() >= dir.len() {
+                return Err(crate::Error::Sys(bun_errno::SystemErrno::ENOENT));
+            }
+            dir = parent;
+        }
+    }
+
     pub fn bin_dirs(&self) -> &[&'static [u8]] {
         if !BIN_FOLDERS_LOADED.load(core::sync::atomic::Ordering::Acquire) {
             return &[];
@@ -6594,28 +6641,34 @@ impl<'a> Resolver<'a> {
                     );
                     while !current.extends.is_empty() {
                         let ts_dir_name = Dirname::dirname(&current.abs_path);
-                        let abs_path = ResolvePath::join_abs_string_buf(
-                            ts_dir_name,
-                            bufs!(tsconfig_path_abs),
-                            &[ts_dir_name, &current.extends],
-                            bun_paths::Platform::AUTO,
-                        );
-                        let parent_config_maybe: Option<*mut TSConfigJSON> =
-                            match self.parse_tsconfig(abs_path, FD::INVALID) {
-                                Ok(v) => v.map(bun_core::heap::into_raw),
-                                Err(err) => {
-                                    let _ = self.log_mut().add_debug_fmt(
-                                        None,
-                                        bun_ast::Loc::EMPTY,
-                                        format_args!(
-                                            "{} loading tsconfig.json extends {}",
-                                            bstr::BStr::new(err.name()),
-                                            bun_core::fmt::quote(abs_path)
-                                        ),
-                                    );
-                                    break;
-                                }
-                            };
+                        // tsc resolves non-relative `extends` specifiers
+                        // (e.g. "@tsconfig/node20") against node_modules.
+                        let parse_result = if is_package_path(&current.extends) {
+                            self.parse_tsconfig_extends_package(ts_dir_name, &current.extends)
+                        } else {
+                            let abs_path = ResolvePath::join_abs_string_buf(
+                                ts_dir_name,
+                                bufs!(tsconfig_path_abs),
+                                &[ts_dir_name, &current.extends],
+                                bun_paths::Platform::AUTO,
+                            );
+                            self.parse_tsconfig(abs_path, FD::INVALID)
+                        };
+                        let parent_config_maybe: Option<*mut TSConfigJSON> = match parse_result {
+                            Ok(v) => v.map(bun_core::heap::into_raw),
+                            Err(err) => {
+                                let _ = self.log_mut().add_debug_fmt(
+                                    None,
+                                    bun_ast::Loc::EMPTY,
+                                    format_args!(
+                                        "{} loading tsconfig.json extends {}",
+                                        bstr::BStr::new(err.name()),
+                                        bun_core::fmt::quote(&current.extends[..])
+                                    ),
+                                );
+                                break;
+                            }
+                        };
                         if let Some(parent_config) = parent_config_maybe {
                             parent_configs.append(parent_config)?;
                             current = bun_ptr::BackRef::from(

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6648,7 +6648,12 @@ impl<'a> Resolver<'a> {
                     let mut worklist: BoundedArray<*mut TSConfigJSON, 64> = BoundedArray::default();
                     worklist.append(tsconfig_json)?;
                     'walk: while let Some(current_ptr) = worklist.pop() {
-                        parent_configs.append(current_ptr)?;
+                        if parent_configs.append(current_ptr).is_err() {
+                            // Degenerate >64-config extends tree (or a cycle):
+                            // drop this config and merge what was collected.
+                            TSConfigJSON::destroy(unsafe { bun_core::heap::take(current_ptr) });
+                            break 'walk;
+                        }
                         let current = bun_ptr::BackRef::from(
                             core::ptr::NonNull::new(current_ptr).expect("heap alloc"),
                         );
@@ -6669,9 +6674,21 @@ impl<'a> Resolver<'a> {
                             };
                             match parse_result {
                                 Ok(Some(parent)) => {
-                                    worklist.append(bun_core::heap::into_raw(parent))?;
+                                    let raw = bun_core::heap::into_raw(parent);
+                                    if worklist.append(raw).is_err() {
+                                        // Degenerate >64-config extends tree (or a
+                                        // cycle): drop this base and stop walking.
+                                        TSConfigJSON::destroy(unsafe {
+                                            bun_core::heap::take(raw)
+                                        });
+                                        break 'walk;
+                                    }
                                 }
-                                Ok(None) => break 'walk,
+                                // Found but unparseable; the JSON parser already
+                                // logged it. Skip so sibling entries still apply.
+                                Ok(None) => {}
+                                // Missing entry: skip it, keep sibling entries
+                                // (tsc errors here, esbuild warns and continues).
                                 Err(err) => {
                                     let _ = self.log_mut().add_debug_fmt(
                                         None,
@@ -6682,15 +6699,16 @@ impl<'a> Resolver<'a> {
                                             bun_core::fmt::quote(&entry[..])
                                         ),
                                     );
-                                    break 'walk;
                                 }
                             }
                         }
                     }
-                    // Drain anything the 'walk break left on the worklist so it is
-                    // still merged (and freed) rather than leaked.
+                    // Drain anything an overflow break left on the worklist so it
+                    // is still merged (and freed) rather than leaked.
                     while let Some(pending) = worklist.pop() {
-                        parent_configs.append(pending)?;
+                        if parent_configs.append(pending).is_err() {
+                            TSConfigJSON::destroy(unsafe { bun_core::heap::take(pending) });
+                        }
                     }
 
                     let merged_config = parent_configs.pop().unwrap();
@@ -6703,6 +6721,8 @@ impl<'a> Resolver<'a> {
                         let mc = unsafe { &mut *merged_config };
                         mc.emit_decorator_metadata =
                             mc.emit_decorator_metadata || parent_config.emit_decorator_metadata;
+                        mc.experimental_decorators =
+                            mc.experimental_decorators || parent_config.experimental_decorators;
                         if let Some(v) = parent_config.use_define_for_class_fields {
                             mc.use_define_for_class_fields = Some(v);
                         }

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6645,8 +6645,7 @@ impl<'a> Resolver<'a> {
                     // A worklist DFS (pop, record, push children forward) yields that
                     // order in `parent_configs` and matches the prior behaviour for a
                     // single-string extends.
-                    let mut worklist: BoundedArray<*mut TSConfigJSON, 64> =
-                        BoundedArray::default();
+                    let mut worklist: BoundedArray<*mut TSConfigJSON, 64> = BoundedArray::default();
                     worklist.append(tsconfig_json)?;
                     'walk: while let Some(current_ptr) = worklist.pop() {
                         parent_configs.append(current_ptr)?;

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4075,6 +4075,7 @@ impl<'a> Resolver<'a> {
         &mut self,
         file: &[u8],
         dirname_fd: FD,
+        from_extends: bool,
     ) -> crate::CrateResult<Option<Box<TSConfigJSON>>> {
         // Since tsconfig.json is cached permanently, in our DirEntries cache
         // we must use the global allocator
@@ -4119,12 +4120,15 @@ impl<'a> Resolver<'a> {
 
         // SAFETY: BACKREF — `self.log` (see `log()` NOTE); disjoint from `self.caches`,
         // narrow `&mut` for this call only.
-        let mut result =
-            match TSConfigJSON::parse(unsafe { &mut *self.log() }, &source, &mut self.caches.json)?
-            {
-                Some(r) => r,
-                None => return Ok(None),
-            };
+        let mut result = match TSConfigJSON::parse(
+            unsafe { &mut *self.log() },
+            &source,
+            &mut self.caches.json,
+            from_extends,
+        )? {
+            Some(r) => r,
+            None => return Ok(None),
+        };
 
         if result.has_base_url() {
             // this might leak
@@ -4184,7 +4188,7 @@ impl<'a> Resolver<'a> {
                         parts,
                         bun_paths::Platform::AUTO,
                     );
-                    match self.parse_tsconfig(abs_path, FD::INVALID) {
+                    match self.parse_tsconfig(abs_path, FD::INVALID, true) {
                         // Candidate is missing or not a regular file: keep looking.
                         Err(crate::Error::Sys(
                             bun_errno::SystemErrno::ENOENT
@@ -6591,6 +6595,7 @@ impl<'a> Resolver<'a> {
                     } else {
                         FD::ZERO
                     },
+                    false,
                 ) {
                     Ok(v) => v.map(bun_core::heap::into_raw),
                     Err(err) => {
@@ -6652,7 +6657,7 @@ impl<'a> Resolver<'a> {
                                 &[ts_dir_name, &current.extends],
                                 bun_paths::Platform::AUTO,
                             );
-                            self.parse_tsconfig(abs_path, FD::INVALID)
+                            self.parse_tsconfig(abs_path, FD::INVALID, true)
                         };
                         let parent_config_maybe: Option<*mut TSConfigJSON> = match parse_result {
                             Ok(v) => v.map(bun_core::heap::into_raw),

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -311,6 +311,7 @@ impl TSConfigJSON {
         log: &mut bun_ast::Log,
         source: &bun_ast::Source,
         json_cache: &mut JsonCache,
+        from_extends: bool,
     ) -> Result<Option<Box<TSConfigJSON>>, crate::Error> {
         // Unfortunately "tsconfig.json" isn't actually JSON. It's some other
         // format that appears to be defined by the implementation details of the
@@ -359,7 +360,10 @@ impl TSConfigJSON {
         }
 
         if let Some(extends_value) = extends_value {
-            if !source.path.is_node_module() {
+            // Configs merely discovered inside node_modules during directory
+            // walks keep `extends` suppressed, but a config reached through an
+            // explicit extends reference follows the full chain like tsc.
+            if from_extends || !source.path.is_node_module() {
                 if let Some(str) = extends_value.as_str() {
                     result.extends = Box::from(str);
                 }

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -144,7 +144,9 @@ pub struct TSConfigJSON {
     /// More info: https://github.com/microsoft/TypeScript/issues/31869
     pub(crate) base_url_for_paths: Box<[u8]>,
 
-    pub(crate) extends: Box<[u8]>,
+    /// TypeScript 5 allows `extends` to be an array; a single string is the
+    /// one-element case. Later entries override earlier ones.
+    pub(crate) extends: Vec<Box<[u8]>>,
     /// The verbatim values of "compilerOptions.paths". The keys are patterns to
     /// match and the values are arrays of fallback paths to search. Each key and
     /// each fallback path can optionally have a single "*" wildcard character.
@@ -171,7 +173,7 @@ impl Default for TSConfigJSON {
             abs_path: Box::default(),
             base_url: Box::default(),
             base_url_for_paths: Box::default(),
-            extends: Box::default(),
+            extends: Vec::new(),
             paths: PathsMap::default(),
             jsx: options::jsx::Pragma::default(),
             jsx_flags: JsxFieldSet::empty(),
@@ -365,7 +367,17 @@ impl TSConfigJSON {
             // explicit extends reference follows the full chain like tsc.
             if from_extends || !source.path.is_node_module() {
                 if let Some(str) = extends_value.as_str() {
-                    result.extends = Box::from(str);
+                    if !str.is_empty() {
+                        result.extends.push(Box::from(str));
+                    }
+                } else if let Some(array) = extends_value.as_array() {
+                    for item in array.items() {
+                        if let Some(str) = item.as_str() {
+                            if !str.is_empty() {
+                                result.extends.push(Box::from(str));
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -329,6 +329,7 @@ impl Config {
                     &mut self.log,
                     &bun_ast::Source::init_path_string(b"tsconfig.json", &self.tsconfig_buf[..]),
                     &mut vm.transpiler.resolver.caches.json,
+                    false,
                 ) {
                     self.tsconfig = Some(parsed_tsconfig);
                 }

--- a/test/bundler/esbuild/tsconfig.test.ts
+++ b/test/bundler/esbuild/tsconfig.test.ts
@@ -787,6 +787,72 @@ describe("bundler", () => {
       api.expectFile("/Users/user/project/out.js").toContain(`React.createElement`);
     },
   });
+  itBundled("tsconfig/ExtendsPackageExactFile", {
+    files: {
+      "/Users/user/project/src/app/entry.tsx": `console.log(<div/>)`,
+      "/Users/user/project/src/tsconfig.json": /* json */ `
+        {
+          "extends": "@scope/configs/tsconfig.base.json"
+        }
+      `,
+      "/Users/user/project/node_modules/@scope/configs/tsconfig.base.json": /* json */ `
+        {
+          "compilerOptions": {
+            "jsx": "react",
+            "jsxFactory": "worked"
+          }
+        }
+      `,
+    },
+    outfile: "/Users/user/project/out.js",
+    onAfterBundle(api) {
+      api.expectFile("/Users/user/project/out.js").toContain(`worked("div", null)`);
+    },
+  });
+  itBundled("tsconfig/ExtendsPackageDirectory", {
+    files: {
+      "/Users/user/project/src/app/entry.tsx": `console.log(<div/>)`,
+      "/Users/user/project/src/tsconfig.json": /* json */ `
+        {
+          "extends": "my-configs"
+        }
+      `,
+      "/Users/user/project/node_modules/my-configs/tsconfig.json": /* json */ `
+        {
+          "compilerOptions": {
+            "jsx": "react",
+            "jsxFactory": "worked"
+          }
+        }
+      `,
+    },
+    outfile: "/Users/user/project/out.js",
+    onAfterBundle(api) {
+      api.expectFile("/Users/user/project/out.js").toContain(`worked("div", null)`);
+    },
+  });
+  itBundled("tsconfig/ExtendsPackageImplicitJson", {
+    files: {
+      "/Users/user/project/src/app/entry.tsx": `console.log(<div/>)`,
+      "/Users/user/project/src/tsconfig.json": /* json */ `
+        {
+          "extends": "my-configs/base"
+        }
+      `,
+      "/Users/user/project/node_modules/my-configs/base.json": /* json */ `
+        {
+          "compilerOptions": {
+            "jsx": "react",
+            "jsxFactory": "worked"
+          }
+        }
+      `,
+    },
+    outfile: "/Users/user/project/out.js",
+    onAfterBundle(api) {
+      api.expectFile("/Users/user/project/out.js").toContain(`worked("div", null)`);
+    },
+  });
   return;
   itBundled("tsconfig/PathsTypeOnly", {
     // GENERATED

--- a/test/bundler/esbuild/tsconfig.test.ts
+++ b/test/bundler/esbuild/tsconfig.test.ts
@@ -883,6 +883,67 @@ describe("bundler", () => {
       api.expectFile("/Users/user/project/out.js").toContain(`worked("div", null)`);
     },
   });
+  // TypeScript 5 array extends: later entries override earlier ones, and the
+  // leaf config overrides all of them.
+  itBundled("tsconfig/ExtendsArrayOverrideOrder", {
+    files: {
+      "/Users/user/project/src/app/entry.tsx": `console.log(<div/>)`,
+      "/Users/user/project/src/tsconfig.json": /* json */ `
+        {
+          "extends": ["./a.json", "./b.json"]
+        }
+      `,
+      "/Users/user/project/src/a.json": /* json */ `
+        {
+          "compilerOptions": {
+            "jsx": "react",
+            "jsxFactory": "fromA"
+          }
+        }
+      `,
+      "/Users/user/project/src/b.json": /* json */ `
+        {
+          "compilerOptions": {
+            "jsxFactory": "fromB"
+          }
+        }
+      `,
+    },
+    outfile: "/Users/user/project/out.js",
+    onAfterBundle(api) {
+      api.expectFile("/Users/user/project/out.js").toContain(`fromB("div", null)`);
+      api.expectFile("/Users/user/project/out.js").not.toContain(`fromA`);
+    },
+  });
+  itBundled("tsconfig/ExtendsArrayNested", {
+    files: {
+      "/Users/user/project/src/app/entry.tsx": `console.log(<div/>)`,
+      "/Users/user/project/src/tsconfig.json": /* json */ `
+        {
+          "extends": ["./a.json", "./b.json"]
+        }
+      `,
+      "/Users/user/project/src/a.json": /* json */ `
+        {
+          "compilerOptions": { "jsxFactory": "fromA" }
+        }
+      `,
+      "/Users/user/project/src/b.json": /* json */ `
+        {
+          "extends": "./b-base.json"
+        }
+      `,
+      "/Users/user/project/src/b-base.json": /* json */ `
+        {
+          "compilerOptions": { "jsx": "react", "jsxFactory": "fromBBase" }
+        }
+      `,
+    },
+    outfile: "/Users/user/project/out.js",
+    onAfterBundle(api) {
+      api.expectFile("/Users/user/project/out.js").toContain(`fromBBase("div", null)`);
+    },
+  });
   return;
   itBundled("tsconfig/PathsTypeOnly", {
     // GENERATED

--- a/test/bundler/esbuild/tsconfig.test.ts
+++ b/test/bundler/esbuild/tsconfig.test.ts
@@ -853,6 +853,36 @@ describe("bundler", () => {
       api.expectFile("/Users/user/project/out.js").toContain(`worked("div", null)`);
     },
   });
+  // The package config itself extends a sibling file, and the effective
+  // options live only in the base (the @adonisjs/tsconfig layout). The chain
+  // must keep going even though the config sits inside node_modules.
+  itBundled("tsconfig/ExtendsPackageLayered", {
+    files: {
+      "/Users/user/project/src/app/entry.tsx": `console.log(<div/>)`,
+      "/Users/user/project/src/tsconfig.json": /* json */ `
+        {
+          "extends": "my-configs/tsconfig.app.json"
+        }
+      `,
+      "/Users/user/project/node_modules/my-configs/tsconfig.app.json": /* json */ `
+        {
+          "extends": "./tsconfig.base.json"
+        }
+      `,
+      "/Users/user/project/node_modules/my-configs/tsconfig.base.json": /* json */ `
+        {
+          "compilerOptions": {
+            "jsx": "react",
+            "jsxFactory": "worked"
+          }
+        }
+      `,
+    },
+    outfile: "/Users/user/project/out.js",
+    onAfterBundle(api) {
+      api.expectFile("/Users/user/project/out.js").toContain(`worked("div", null)`);
+    },
+  });
   return;
   itBundled("tsconfig/PathsTypeOnly", {
     // GENERATED

--- a/test/js/bun/resolve/tsconfig-extends-leak.test.ts
+++ b/test/js/bun/resolve/tsconfig-extends-leak.test.ts
@@ -220,3 +220,63 @@ test("tsconfig 'extends' array entries may be package specifiers", async () => {
 
   expect({ stdout, stderr, exitCode }).toEqual({ stdout: "LIB\n", stderr: "", exitCode: 0 });
 });
+
+// The merge loop must carry experimentalDecorators from every config in the
+// chain, not just the one the merge starts from. With array extends, the
+// second entry is merged (not used as the starting config), so a flag set
+// only there exercises the merge path. No emitDecoratorMetadata here: that
+// flag alone already implies legacy semantics and would mask the bug.
+test("tsconfig 'extends' array merges experimentalDecorators from a non-first entry", async () => {
+  using dir = tempDir("tsconfig-extends-array-decorators", {
+    "paths.json": JSON.stringify({ compilerOptions: { paths: { "@lib/*": ["./lib/*"] } } }),
+    "decorators.json": JSON.stringify({ compilerOptions: { experimentalDecorators: true } }),
+    "tsconfig.json": JSON.stringify({ extends: ["./paths.json", "./decorators.json"] }),
+    "index.ts": `
+      function dec(target: unknown, key?: unknown) {
+        console.log("decorator args:", typeof target, typeof key);
+      }
+      class Foo {
+        @dec name!: string;
+      }
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Legacy decorators receive (prototype, key); TC39 would be (undefined, context).
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: "decorator args: object string\n",
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+// One unresolvable array entry must not drop the entries next to it.
+test("tsconfig 'extends' array keeps siblings when one entry is missing", async () => {
+  using dir = tempDir("tsconfig-extends-array-missing", {
+    "lib/mod.ts": `export default "OK";`,
+    "real.json": JSON.stringify({ compilerOptions: { paths: { "@lib/*": ["./lib/*"] } } }),
+    "tsconfig.json": JSON.stringify({ extends: ["./missing.json", "./real.json"] }),
+    "index.ts": `import x from "@lib/mod"; console.log(x);`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "OK\n", stderr: "", exitCode: 0 });
+});

--- a/test/js/bun/resolve/tsconfig-extends-leak.test.ts
+++ b/test/js/bun/resolve/tsconfig-extends-leak.test.ts
@@ -168,3 +168,55 @@ test("tsconfig 'extends' resolves package specifiers from node_modules", async (
     exitCode: 0,
   });
 });
+
+// TypeScript 5 allows "extends" to be an array. Each entry is resolved like a
+// single-string extends (relative or package specifier), and later entries
+// override earlier ones. The leaf config overrides all of them.
+test("tsconfig 'extends' accepts an array of base configs", async () => {
+  using dir = tempDir("tsconfig-extends-array", {
+    "lib/a/mod.ts": `export default "A";`,
+    "lib/b/mod.ts": `export default "B";`,
+    "a.json": JSON.stringify({ compilerOptions: { paths: { "@lib/*": ["./lib/a/*"] } } }),
+    "b.json": JSON.stringify({ compilerOptions: { paths: { "@lib/*": ["./lib/b/*"] } } }),
+    // paths is defined in both entries; the later one wins.
+    "tsconfig.json": JSON.stringify({ extends: ["./a.json", "./b.json"] }),
+    "index.ts": `import x from "@lib/mod"; console.log(x);`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "B\n", stderr: "", exitCode: 0 });
+});
+
+test("tsconfig 'extends' array entries may be package specifiers", async () => {
+  using dir = tempDir("tsconfig-extends-array-pkg", {
+    "lib/mod.ts": `export default "LIB";`,
+    "node_modules/@tsc/base/package.json": JSON.stringify({ name: "@tsc/base", version: "1.0.0" }),
+    "node_modules/@tsc/base/tsconfig.json": JSON.stringify({
+      compilerOptions: { paths: { "@lib/*": ["../../../lib/*"] } },
+    }),
+    "local.json": JSON.stringify({ compilerOptions: { jsx: "react" } }),
+    "tsconfig.json": JSON.stringify({ extends: ["@tsc/base", "./local.json"] }),
+    "index.ts": `import x from "@lib/mod"; console.log(x);`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "LIB\n", stderr: "", exitCode: 0 });
+});

--- a/test/js/bun/resolve/tsconfig-extends-leak.test.ts
+++ b/test/js/bun/resolve/tsconfig-extends-leak.test.ts
@@ -81,46 +81,6 @@ test.skipIf(!isDebug)("tsconfig 'extends' chain frees every intermediate TSConfi
 
 // Correctness: after freeing the intermediate structs, the merged config must
 // still resolve paths defined in the leaf and keep the merge semantics intact.
-// tsconfig "extends" accepts package specifiers (tsc resolves them against
-// node_modules, walking up parent directories). The extended config's
-// compilerOptions must apply: here experimentalDecorators (legacy decorator
-// call signature) and emitDecoratorMetadata (design:* metadata emission).
-test("tsconfig 'extends' resolves package specifiers from node_modules", async () => {
-  using dir = tempDir("tsconfig-extends-package", {
-    "node_modules/fake-tsconfig/package.json": JSON.stringify({ name: "fake-tsconfig", version: "1.0.0" }),
-    "node_modules/fake-tsconfig/flags.json": JSON.stringify({
-      compilerOptions: { experimentalDecorators: true, emitDecoratorMetadata: true },
-    }),
-    "tsconfig.json": JSON.stringify({ extends: "fake-tsconfig/flags.json" }),
-    "index.ts": `
-      (Reflect as any).metadata = (key: string, value: any) => (target: any, prop: any) => {
-        if (key === "design:type") console.log("design:type:", value.name);
-      };
-      function dec(target: unknown, key?: unknown) {
-        console.log("decorator args:", typeof target, typeof key);
-      }
-      class Foo {
-        @dec name!: string;
-      }
-    `,
-  });
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "index.ts"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect(stderr).toBe("");
-  // Legacy decorators receive (prototype, key); TC39 would be (undefined, context).
-  expect(stdout).toBe("design:type: String\ndecorator args: object string\n");
-  expect(exitCode).toBe(0);
-});
-
 // Guards against accidentally freeing data the merged config still references
 // (the merged struct borrows string slices from the intermediates' source
 // buffers, which outlive the struct).
@@ -161,4 +121,50 @@ test("tsconfig 'extends' merge still works after freeing intermediates", async (
   expect(stderr).toBe("");
   expect(stdout.trim()).toBe("leaf");
   expect(exitCode).toBe(0);
+});
+
+// tsconfig "extends" accepts package specifiers (tsc resolves them against
+// node_modules, walking up parent directories), and the package config may
+// itself extend another file. The chained compilerOptions must apply: here
+// experimentalDecorators (legacy decorator call signature) and
+// emitDecoratorMetadata (design:* metadata emission) live in the base config.
+test("tsconfig 'extends' resolves package specifiers from node_modules", async () => {
+  using dir = tempDir("tsconfig-extends-package", {
+    "node_modules/fake-tsconfig/package.json": JSON.stringify({ name: "fake-tsconfig", version: "1.0.0" }),
+    // Layered like @adonisjs/tsconfig: the entry config extends a sibling
+    // base config inside the package, and the flags live only in the base.
+    "node_modules/fake-tsconfig/tsconfig.app.json": JSON.stringify({ extends: "./flags.json" }),
+    "node_modules/fake-tsconfig/flags.json": JSON.stringify({
+      compilerOptions: { experimentalDecorators: true, emitDecoratorMetadata: true },
+    }),
+    "tsconfig.json": JSON.stringify({ extends: "fake-tsconfig/tsconfig.app.json" }),
+    "index.ts": `
+      (Reflect as any).metadata = (key: string, value: any) => (target: any, prop: any) => {
+        if (key === "design:type") console.log("design:type:", value.name);
+      };
+      function dec(target: unknown, key?: unknown) {
+        console.log("decorator args:", typeof target, typeof key);
+      }
+      class Foo {
+        @dec name!: string;
+      }
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Legacy decorators receive (prototype, key); TC39 would be (undefined, context).
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: "design:type: String\ndecorator args: object string\n",
+    stderr: "",
+    exitCode: 0,
+  });
 });

--- a/test/js/bun/resolve/tsconfig-extends-leak.test.ts
+++ b/test/js/bun/resolve/tsconfig-extends-leak.test.ts
@@ -81,6 +81,46 @@ test.skipIf(!isDebug)("tsconfig 'extends' chain frees every intermediate TSConfi
 
 // Correctness: after freeing the intermediate structs, the merged config must
 // still resolve paths defined in the leaf and keep the merge semantics intact.
+// tsconfig "extends" accepts package specifiers (tsc resolves them against
+// node_modules, walking up parent directories). The extended config's
+// compilerOptions must apply: here experimentalDecorators (legacy decorator
+// call signature) and emitDecoratorMetadata (design:* metadata emission).
+test("tsconfig 'extends' resolves package specifiers from node_modules", async () => {
+  using dir = tempDir("tsconfig-extends-package", {
+    "node_modules/fake-tsconfig/package.json": JSON.stringify({ name: "fake-tsconfig", version: "1.0.0" }),
+    "node_modules/fake-tsconfig/flags.json": JSON.stringify({
+      compilerOptions: { experimentalDecorators: true, emitDecoratorMetadata: true },
+    }),
+    "tsconfig.json": JSON.stringify({ extends: "fake-tsconfig/flags.json" }),
+    "index.ts": `
+      (Reflect as any).metadata = (key: string, value: any) => (target: any, prop: any) => {
+        if (key === "design:type") console.log("design:type:", value.name);
+      };
+      function dec(target: unknown, key?: unknown) {
+        console.log("decorator args:", typeof target, typeof key);
+      }
+      class Foo {
+        @dec name!: string;
+      }
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  // Legacy decorators receive (prototype, key); TC39 would be (undefined, context).
+  expect(stdout).toBe("design:type: String\ndecorator args: object string\n");
+  expect(exitCode).toBe(0);
+});
+
 // Guards against accidentally freeing data the merged config still references
 // (the merged struct borrows string slices from the intermediates' source
 // buffers, which outlive the struct).

--- a/test/js/bun/resolve/tsconfig-extends-leak.test.ts
+++ b/test/js/bun/resolve/tsconfig-extends-leak.test.ts
@@ -14,6 +14,7 @@
 
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+import fs from "node:fs";
 import path from "path";
 
 // The allocation log is only emitted in builds with Environment.allow_assert
@@ -279,4 +280,156 @@ test("tsconfig 'extends' array keeps siblings when one entry is missing", async 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect({ stdout, stderr, exitCode }).toEqual({ stdout: "OK\n", stderr: "", exitCode: 0 });
+});
+
+// The common NestJS/TypeORM shape: the leaf sets experimentalDecorators and
+// extends a base. The merge starts from the base, so the leaf's flag must be
+// carried over by the merge loop, not just flags from the starting config.
+test("tsconfig 'extends' keeps experimentalDecorators set in the extending config", async () => {
+  using dir = tempDir("tsconfig-extends-leaf-decorators", {
+    "base.json": JSON.stringify({ compilerOptions: { paths: { "@lib/*": ["./lib/*"] } } }),
+    "tsconfig.json": JSON.stringify({
+      extends: "./base.json",
+      compilerOptions: { experimentalDecorators: true },
+    }),
+    "index.ts": `
+      function dec(target: unknown, key?: unknown) {
+        console.log("decorator args:", typeof target, typeof key);
+      }
+      class Foo {
+        @dec name!: string;
+      }
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Legacy decorators receive (prototype, key); TC39 would be (undefined, context).
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: "decorator args: object string\n",
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+// A relative extends that points into node_modules follows the target's own
+// extends chain, same as a package specifier would (tsc behavior).
+test("tsconfig 'extends' via relative path into node_modules follows the chain", async () => {
+  using dir = tempDir("tsconfig-extends-relative-nm", {
+    "node_modules/pkg/app.json": JSON.stringify({ extends: "./flags.json" }),
+    "node_modules/pkg/flags.json": JSON.stringify({
+      compilerOptions: { experimentalDecorators: true },
+    }),
+    "tsconfig.json": JSON.stringify({ extends: "./node_modules/pkg/app.json" }),
+    "index.ts": `
+      function dec(target: unknown, key?: unknown) {
+        console.log("decorator args:", typeof target, typeof key);
+      }
+      class Foo {
+        @dec name!: string;
+      }
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: "decorator args: object string\n",
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+// "extends": "base.json" without "./" resolved relative to the tsconfig
+// before the node_modules walk existed; the walk misses and the relative
+// fallback must keep that shape working.
+test("tsconfig 'extends' bare sibling file name still resolves relative", async () => {
+  using dir = tempDir("tsconfig-extends-bare-relative", {
+    "lib/mod.ts": `export default "BARE";`,
+    "base.json": JSON.stringify({ compilerOptions: { paths: { "@lib/*": ["./lib/*"] } } }),
+    "tsconfig.json": JSON.stringify({ extends: "base.json" }),
+    "index.ts": `import x from "@lib/mod"; console.log(x);`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "BARE\n", stderr: "", exitCode: 0 });
+});
+
+// tsc appends ".json" to extension-less extends targets.
+test("tsconfig 'extends' appends .json to an extension-less relative target", async () => {
+  using dir = tempDir("tsconfig-extends-json-retry", {
+    "lib/mod.ts": `export default "RETRY";`,
+    "tsconfig.base.json": JSON.stringify({ compilerOptions: { paths: { "@lib/*": ["./lib/*"] } } }),
+    "tsconfig.json": JSON.stringify({ extends: "./tsconfig.base" }),
+    "index.ts": `import x from "@lib/mod"; console.log(x);`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "RETRY\n", stderr: "", exitCode: 0 });
+});
+
+// Workspace config packages are installed as symlinks. The resolved config
+// must be realpath'd so its relative paths entries are interpreted from the
+// package's real location, matching tsc and esbuild.
+test("tsconfig 'extends' package specifier resolves through a symlink", async () => {
+  using dir = tempDir("tsconfig-extends-symlink", {
+    "packages/cfg/tsconfig.json": JSON.stringify({
+      compilerOptions: { paths: { "@shared/*": ["../shared/*"] } },
+    }),
+    "packages/shared/mod.ts": `export default "SHARED";`,
+    "app/tsconfig.json": JSON.stringify({ extends: "@repo/cfg/tsconfig.json" }),
+    "app/index.ts": `import x from "@shared/mod"; console.log(x);`,
+  });
+  fs.mkdirSync(path.join(String(dir), "app/node_modules/@repo"), { recursive: true });
+  fs.symlinkSync(
+    path.join(String(dir), "packages/cfg"),
+    path.join(String(dir), "app/node_modules/@repo/cfg"),
+    "junction",
+  );
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: path.join(String(dir), "app"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "SHARED\n", stderr: "", exitCode: 0 });
 });

--- a/test/js/bun/resolve/tsconfig-extends-leak.test.ts
+++ b/test/js/bun/resolve/tsconfig-extends-leak.test.ts
@@ -85,7 +85,7 @@ test.skipIf(!isDebug)("tsconfig 'extends' chain frees every intermediate TSConfi
 // Guards against accidentally freeing data the merged config still references
 // (the merged struct borrows string slices from the intermediates' source
 // buffers, which outlive the struct).
-test("tsconfig 'extends' merge still works after freeing intermediates", async () => {
+test.concurrent("tsconfig 'extends' merge still works after freeing intermediates", async () => {
   using dir = tempDir("tsconfig-extends-merge", {
     "tsconfig.base2.json": JSON.stringify({
       compilerOptions: {
@@ -129,7 +129,7 @@ test("tsconfig 'extends' merge still works after freeing intermediates", async (
 // itself extend another file. The chained compilerOptions must apply: here
 // experimentalDecorators (legacy decorator call signature) and
 // emitDecoratorMetadata (design:* metadata emission) live in the base config.
-test("tsconfig 'extends' resolves package specifiers from node_modules", async () => {
+test.concurrent("tsconfig 'extends' resolves package specifiers from node_modules", async () => {
   using dir = tempDir("tsconfig-extends-package", {
     "node_modules/fake-tsconfig/package.json": JSON.stringify({ name: "fake-tsconfig", version: "1.0.0" }),
     // Layered like @adonisjs/tsconfig: the entry config extends a sibling
@@ -173,7 +173,7 @@ test("tsconfig 'extends' resolves package specifiers from node_modules", async (
 // TypeScript 5 allows "extends" to be an array. Each entry is resolved like a
 // single-string extends (relative or package specifier), and later entries
 // override earlier ones. The leaf config overrides all of them.
-test("tsconfig 'extends' accepts an array of base configs", async () => {
+test.concurrent("tsconfig 'extends' accepts an array of base configs", async () => {
   using dir = tempDir("tsconfig-extends-array", {
     "lib/a/mod.ts": `export default "A";`,
     "lib/b/mod.ts": `export default "B";`,
@@ -197,7 +197,7 @@ test("tsconfig 'extends' accepts an array of base configs", async () => {
   expect({ stdout, stderr, exitCode }).toEqual({ stdout: "B\n", stderr: "", exitCode: 0 });
 });
 
-test("tsconfig 'extends' array entries may be package specifiers", async () => {
+test.concurrent("tsconfig 'extends' array entries may be package specifiers", async () => {
   using dir = tempDir("tsconfig-extends-array-pkg", {
     "lib/mod.ts": `export default "LIB";`,
     "node_modules/@tsc/base/package.json": JSON.stringify({ name: "@tsc/base", version: "1.0.0" }),
@@ -227,7 +227,7 @@ test("tsconfig 'extends' array entries may be package specifiers", async () => {
 // second entry is merged (not used as the starting config), so a flag set
 // only there exercises the merge path. No emitDecoratorMetadata here: that
 // flag alone already implies legacy semantics and would mask the bug.
-test("tsconfig 'extends' array merges experimentalDecorators from a non-first entry", async () => {
+test.concurrent("tsconfig 'extends' array merges experimentalDecorators from a non-first entry", async () => {
   using dir = tempDir("tsconfig-extends-array-decorators", {
     "paths.json": JSON.stringify({ compilerOptions: { paths: { "@lib/*": ["./lib/*"] } } }),
     "decorators.json": JSON.stringify({ compilerOptions: { experimentalDecorators: true } }),
@@ -261,7 +261,7 @@ test("tsconfig 'extends' array merges experimentalDecorators from a non-first en
 });
 
 // One unresolvable array entry must not drop the entries next to it.
-test("tsconfig 'extends' array keeps siblings when one entry is missing", async () => {
+test.concurrent("tsconfig 'extends' array keeps siblings when one entry is missing", async () => {
   using dir = tempDir("tsconfig-extends-array-missing", {
     "lib/mod.ts": `export default "OK";`,
     "real.json": JSON.stringify({ compilerOptions: { paths: { "@lib/*": ["./lib/*"] } } }),
@@ -285,7 +285,7 @@ test("tsconfig 'extends' array keeps siblings when one entry is missing", async 
 // The common NestJS/TypeORM shape: the leaf sets experimentalDecorators and
 // extends a base. The merge starts from the base, so the leaf's flag must be
 // carried over by the merge loop, not just flags from the starting config.
-test("tsconfig 'extends' keeps experimentalDecorators set in the extending config", async () => {
+test.concurrent("tsconfig 'extends' keeps experimentalDecorators set in the extending config", async () => {
   using dir = tempDir("tsconfig-extends-leaf-decorators", {
     "base.json": JSON.stringify({ compilerOptions: { paths: { "@lib/*": ["./lib/*"] } } }),
     "tsconfig.json": JSON.stringify({
@@ -322,7 +322,7 @@ test("tsconfig 'extends' keeps experimentalDecorators set in the extending confi
 
 // A relative extends that points into node_modules follows the target's own
 // extends chain, same as a package specifier would (tsc behavior).
-test("tsconfig 'extends' via relative path into node_modules follows the chain", async () => {
+test.concurrent("tsconfig 'extends' via relative path into node_modules follows the chain", async () => {
   using dir = tempDir("tsconfig-extends-relative-nm", {
     "node_modules/pkg/app.json": JSON.stringify({ extends: "./flags.json" }),
     "node_modules/pkg/flags.json": JSON.stringify({
@@ -359,7 +359,7 @@ test("tsconfig 'extends' via relative path into node_modules follows the chain",
 // "extends": "base.json" without "./" resolved relative to the tsconfig
 // before the node_modules walk existed; the walk misses and the relative
 // fallback must keep that shape working.
-test("tsconfig 'extends' bare sibling file name still resolves relative", async () => {
+test.concurrent("tsconfig 'extends' bare sibling file name still resolves relative", async () => {
   using dir = tempDir("tsconfig-extends-bare-relative", {
     "lib/mod.ts": `export default "BARE";`,
     "base.json": JSON.stringify({ compilerOptions: { paths: { "@lib/*": ["./lib/*"] } } }),
@@ -381,7 +381,7 @@ test("tsconfig 'extends' bare sibling file name still resolves relative", async 
 });
 
 // tsc appends ".json" to extension-less extends targets.
-test("tsconfig 'extends' appends .json to an extension-less relative target", async () => {
+test.concurrent("tsconfig 'extends' appends .json to an extension-less relative target", async () => {
   using dir = tempDir("tsconfig-extends-json-retry", {
     "lib/mod.ts": `export default "RETRY";`,
     "tsconfig.base.json": JSON.stringify({ compilerOptions: { paths: { "@lib/*": ["./lib/*"] } } }),
@@ -405,7 +405,7 @@ test("tsconfig 'extends' appends .json to an extension-less relative target", as
 // Workspace config packages are installed as symlinks. The resolved config
 // must be realpath'd so its relative paths entries are interpreted from the
 // package's real location, matching tsc and esbuild.
-test("tsconfig 'extends' package specifier resolves through a symlink", async () => {
+test.concurrent("tsconfig 'extends' package specifier resolves through a symlink", async () => {
   using dir = tempDir("tsconfig-extends-symlink", {
     "packages/cfg/tsconfig.json": JSON.stringify({
       compilerOptions: { paths: { "@shared/*": ["../shared/*"] } },


### PR DESCRIPTION
Fixes #34494
Fixes #23695
Fixes #5277
Fixes #6326

### Problem

Two `tsconfig.json` `extends` shapes were silently dropped with no diagnostic, so the base config's `paths` / `jsx*` / decorator flags never applied and imports through a path alias failed with a plain `Cannot find module` that never mentions tsconfig:

1. A package specifier (`"@tsconfig/node20"`, `"@vue/tsconfig"`, `"@scope/pkg/tsconfig.json"`). The walk unconditionally path-joined the value against the tsconfig's directory, got a nonexistent path like `<project>/@tsconfig/node20`, and bailed with only a debug log. tsc resolves these against `node_modules`.
2. The TypeScript 5 array form (`"extends": ["./a.json", "./b.json"]`). The parser matched `extends` against a string only, so an array value fell through and the field stayed empty.

The same base file via a relative single-string `extends` worked in both cases.

```sh
d=$(mktemp -d); cd $d; mkdir -p lib node_modules/@tsc/base
printf 'export default "LIB";\n' > lib/mod.ts
printf 'import x from "@lib/mod"; console.log(x)\n' > app.ts
printf '{"name":"@tsc/base","version":"1.0.0"}\n' > node_modules/@tsc/base/package.json
printf '{"compilerOptions":{"paths":{"@lib/*":["../../../lib/*"]}}}\n' > node_modules/@tsc/base/tsconfig.json
printf '{"extends":"@tsc/base"}\n' > tsconfig.json
bun app.ts        # error: Cannot find module '@lib/mod'   (tsc resolves it)
printf '{"compilerOptions":{"paths":{"@lib/*":["./lib/*"]}}}\n' > a.json
printf '{"compilerOptions":{"jsx":"react"}}\n' > b.json
printf '{"extends":["./a.json","./b.json"]}\n' > tsconfig.json
bun app.ts        # error: Cannot find module '@lib/mod'   (array dropped)
```

### Fix

**Package specifiers.** In the extends walk in `dir_info_uncached`, branch on `is_package_path`: non-relative specifiers resolve by walking up parent `node_modules` directories from the tsconfig's dir, trying `<path>/tsconfig.json`, `<path>`, then `<path>.json` (esbuild's candidate order, matching tsc). ENOENT/ENOTDIR/EISDIR on a candidate moves to the next; any other error stops the search. Hits are realpath'd (unless `--preserve-symlinks`) so a symlinked workspace config package interprets its relative `baseUrl`/`paths` from its real location, matching tsc and esbuild. If the walk misses entirely, the value falls back to relative resolution, preserving the previously working bare `"base.json"` shape. A `from_extends` flag threaded through `parse_tsconfig` lifts the `is_node_module()` gate that suppressed `extends` for configs found inside `node_modules`, so a package config that itself extends a sibling (the `@adonisjs/tsconfig` layout) follows the full chain. This also changes relative values that point into `node_modules` (`"./node_modules/pkg/app.json"`): their own extends chain is followed now, where it was silently dropped before. Relative targets additionally retry with `.json` appended (tsc's behavior for `"./tsconfig.base"`).

**Array form.** `TSConfigJSON.extends` is now `Vec<Box<[u8]>>` and the parser accepts a string (one element) or an array of strings. The extends walk is a worklist DFS that flattens the tree into `parent_configs` so the existing merge pop order becomes `first entry's deepest base ... first entry ... last entry ... leaf`: later array entries override earlier ones and the leaf overrides all, matching tsc. A single-string extends walks exactly as before. A missing or unparseable entry skips just that entry (esbuild behavior), so sibling array entries still apply; a degenerate >64-config tree (or cycle) stops the walk and merges what was collected, freeing the rest.

**Merge loop.** The merge copied `emitDecoratorMetadata` but never `experimentalDecorators`, so the flag was dropped from any config that isn't the one the merge starts from. That includes the common single-string shape where the leaf sets `experimentalDecorators` and extends a base (NestJS/TypeORM layout), which reproduces on main today. Merged with the same OR semantics as `emitDecoratorMetadata`.

### Tests

- `test/js/bun/resolve/tsconfig-extends-leak.test.ts`: package-specifier extends (layered, flags in the base), array extends with override order via `paths`, array entries that are package specifiers, `experimentalDecorators` set only in a non-first array entry, and a missing array entry not dropping its siblings.
- `test/bundler/esbuild/tsconfig.test.ts`: package-specifier extends (exact file / bare directory / implicit `.json` / layered) and array extends (override order via `jsxFactory`, nested chain through an array entry).

```
USE_SYSTEM_BUN=1 bun test test/js/bun/resolve/tsconfig-extends-leak.test.ts   # 3 fail
USE_SYSTEM_BUN=1 bun test test/bundler/esbuild/tsconfig.test.ts               # 5 fail (ExtendsPackage*, ExtendsArray*)
bun bd test <both>                                                            # all pass
```

Also green: `test/cli/run/tsconfig-override.test.ts`, `test/bundler/bundler_decorator_metadata.test.ts`, `test/regression/issue/27526.test.ts`, `test/js/bun/transpiler/transpiler-tsconfig-uaf.test.ts`. The existing `alloc` leak test passes with the worklist walk (4 configs for a 2-entry array with one nested extends: 4 new / 3 destroy / 1 interned).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 7 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/esbuild/tsconfig.test.ts test/js/bun/resolve/tsconfig-extends-leak.test.ts
error: bindgenv2 emitted unexpected output type: /workspace/bun/build/debug/codegen/GeneratedSocketConfigBinaryType.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfigHandlers.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfig.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfigTLS.h, /workspace/bun/build/debug/codegen/GeneratedALPNProtocols.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfig.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfigFile.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfigSingleFile.h, /workspace/bun/build/debug/codegen/GeneratedFakeTimersConfig.h
error: script "bd" exited with code 1
__F:-1:S:0

release without fix: 15 failed, 4 skipped
bun test v1.4.0-canary.1 (da3851e57)

test/bundler/esbuild/tsconfig.test.ts:
(todo) bundler > tsconfig/Paths
(todo) bundler > tsconfig/PathsNoBaseURL
(todo) bundler > tsconfig/BadPathsNoBaseURL
(pass) bundler > tsconfig/PathsOverriddenBaseURL [38.91ms]
(pass) bundler > tsconfig/PathsOverriddenBaseURLDifferentDir [25.50ms]
(pass) bundler > tsconfig/PathsMissingBaseURL [14.38ms]
(pass) bundler > tsconfig/PathsInChildNoBaseURL [26.62ms]
(pass) bundler > tsconfig/PathsInGrandchildNoBaseURL [20.64ms]
(pass) bundler > tsconfig/PathsReplacedAcrossExtends [24.11ms]
(pass) bundler > tsconfig/EmptyPathsClearsParent [4.62ms]
(pass) bundler > tsconfig/JSX [20.81ms]
(pass) bundler > tsconfig/ReactJSXNotReact [41.43ms]
(pass) bundler > tsconfig/ReactJSXNotReactScoped [11.55ms]
(pass) bundler > tsconfig/ReactJSXDevNotReact [10.46ms]
(pass) bundler > tsconfig/ReactJSXDev [21.10ms]
(pass) bundler > tsconfig/ReactJSXDevTSConfigProduction [15.56ms]
(pass) bundler > tsconfig/ReactJSX [37.86ms]
(pass) bundler > tsconfig/ReactJSXClassic [6.67ms]
(pass) bundler > tsconfig/ReactJSXClassicWithNODE_ENV=Production [24.26ms]
(pass) bundler > tsconfig/ReactJSXClassicWithNODE_ENV=Development [23
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 3 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/esbuild/tsconfig.test.ts test/js/bun/resolve/tsconfig-extends-leak.test.ts
bun test v1.4.0 (33c462a4a)

test/bundler/esbuild/tsconfig.test.ts:
(todo) bundler > tsconfig/Paths
(todo) bundler > tsconfig/PathsNoBaseURL
(todo) bundler > tsconfig/BadPathsNoBaseURL
(pass) bundler > tsconfig/PathsOverriddenBaseURL [1654.61ms]
(pass) bundler > tsconfig/PathsOverriddenBaseURLDifferentDir [716.93ms]
(pass) bundler > tsconfig/PathsMissingBaseURL [200.68ms]
(pass) bundler > tsconfig/PathsInChildNoBaseURL [761.74ms]
(pass) bundler > tsconfig/PathsInGrandchildNoBaseURL [648.90ms]
(pass) bundler > tsconfig/PathsReplacedAcrossExtends [199.16ms]
(pass) bundler > tsconfig/EmptyPathsClearsParent [161.31ms]
(pass) bundler > tsconfig/JSX [276.06ms]
(pass) bundler > tsconfig/ReactJSXNotReact [1170.55ms]
(pass) bundler > tsconfig/ReactJSXNotReactScoped [484.25ms]
(pass) bundler > tsconfig/ReactJSXDevNotReact [238.60ms]
(pass) bundler > tsconfig/ReactJSXDev [805.95ms]
(pass) bundler > tsconfig/ReactJSXDevTSConfigProduction [540.15ms]
(pass) bundl
... (truncated)

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     33c462a4a9
  features     baseline

22 deps, 107 codegen, 1176 objects in 1620ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] gen bindgenv2
[3/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[4/1238] gen .bind.ts → GeneratedBindings.cpp
[5/1238] fetch tinycc
[tinycc] up to date
[6/1237] fetch zlib
[zlib] up to date
[7/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[8/1237] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[9/1237] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingHTTPParser.cpp
[10/1237] gen JSEvent.lut.h
Generating /workspace/bun/build/release/codegen/JSEvent.lut.h from /workspace/bun/sr
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/resolver/resolver.rs                          | 208 ++++++++++++---
 src/resolver/tsconfig_json.rs                     |  24 +-
 src/runtime/api/JSTranspiler.rs                   |   1 +
 test/bundler/esbuild/tsconfig.test.ts             | 157 +++++++++++
 test/js/bun/resolve/tsconfig-extends-leak.test.ts | 311 ++++++++++++++++++++++
 5 files changed, 663 insertions(+), 38 deletions(-)
```

</details>

**gate history** · 6 passed · 0 rejected · iteration 7

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/resolver/resolver.rs                              14     14      0
src/resolver/tsconfig_json.rs                          4      4      0
src/runtime/api/JSTranspiler.rs                        1      2      0
test/bundler/esbuild/tsconfig.test.ts                  3      3      0
test/js/bun/resolve/tsconfig-extends-leak.test.ts      5      7      0
```

</details>

**root cause** · written by the author bot

The resolver only handled relative paths in tsconfig `extends`, so a package specifier like `@adonisjs/tsconfig/tsconfig.app.json` was silently skipped and the inherited `compilerOptions`, including `experimentalDecorators` and `emitDecoratorMetadata`, never applied, leaving decorators compiled with TC39 semantics and no `design:*` metadata. The fix teaches the resolver to resolve non-relative `extends` specifiers against node_modules the way tsc does, walking the full extends chain (including arrays and nested configs with bounded traversal) and merging the inherited options into the effec…

<!-- robobun:evidence:end -->

