### PR TITLE
usockets(tls): FIN the TCP write side after SSL_shutdown completes on a half-open socket

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -2234,8 +2234,11 @@ void us_internal_ssl_shutdown(struct us_socket_t *s) {
       ERR_clear_error();
       s->ssl_fatal_error = 1;
     }
-    us_internal_socket_raw_shutdown(s);
   }
+  /* RECEIVED_SHUTDOWN brought us here, so the TLS shutdown is complete; FIN the
+   * TCP write side so the poll type becomes SHUT_DOWN and the loop's
+   * is_shut_down eof branch can close once both halves are done. */
+  us_internal_socket_raw_shutdown(s);
 }
 
 /* Resume a handshake suspended by an async SNICallback. `ctx` (may be NULL =

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, nodeExe } from "harness";
+import { bunEnv, bunExe, isLinux, nodeExe, tls as tlsCert } from "harness";
 import http from "http";
 
 import { once } from "node:events";
@@ -553,6 +553,68 @@ describe("HTTP server CONNECT", () => {
       // Should either get an error response or timeout/connection error
       expect(response).not.toContain("200 Connection established");
     }
+  });
+
+  // https CONNECT: server socket.end() after peer FIN must also FIN at the TCP
+  // layer. us_internal_ssl_shutdown with SSL_RECEIVED_SHUTDOWN already set
+  // (peer's half-close) reaches SSL_shutdown() == 1 and previously returned
+  // without the raw TCP shutdown, so the poll type never moved to SHUT_DOWN
+  // and (on epoll, with autoDestroy disabled) nothing ever closed the socket.
+  // Linux-only: the close is reported via EPOLLHUP once both halves have FIN'd;
+  // kqueue/libuv need the readable_ended re-arm to re-derive it.
+  test.skipIf(!isLinux)("https CONNECT socket.end() after peer FIN half-closes TCP so the socket can close", async () => {
+    // The client uses tls.connect({ socket: rawNetSocket }) so end() routes
+    // through the raw FIN path (not a TLS close_notify first), which is the
+    // ordering that leaves the server's eof already consumed by the
+    // allow_half_open branch before the deferred socket.end() runs.
+    const fixture = /* js */ `
+      const https = require("node:https");
+      const net = require("node:net");
+      const tls = require("node:tls");
+
+      const server = https.createServer({ cert: process.env.CERT, key: process.env.KEY }, () => {});
+      server.on("connect", (req, socket) => {
+        // Disable autoDestroy so the only thing that can close this socket is
+        // the transport reporting both directions shut (EPOLLHUP once our FIN
+        // answers the peer's). With the missing raw_shutdown, that never fires.
+        socket._readableState.autoDestroy = false;
+        socket._writableState.autoDestroy = false;
+        socket.write("HTTP/1.1 200 Connection Established\\r\\n\\r\\n");
+        socket.on("end", () => {
+          console.log("server:end");
+          socket.end();
+        });
+        socket.on("finish", () => console.log("server:finish"));
+        socket.on("close", () => {
+          console.log("server:close");
+          server.close();
+        });
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const raw = net.connect({ port: server.address().port, host: "127.0.0.1", allowHalfOpen: true });
+        const client = tls.connect({ socket: raw, rejectUnauthorized: false });
+        client.on("secureConnect", () => {
+          client.write("CONNECT example.com:443 HTTP/1.1\\r\\nHost: example.com:443\\r\\n\\r\\n");
+        });
+        client.on("data", () => client.end());
+        client.on("close", () => console.log("client:close"));
+      });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: { ...bunEnv, CERT: tlsCert.cert, KEY: tlsCert.key },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    // Before the fix the server socket never closes: stdout stops at
+    // server:finish and the process hangs until the test timeout. client:close
+    // and server:close may interleave, so assert presence + server ordering.
+    const lines = stdout.split("\n").filter(Boolean);
+    expect(lines.filter(l => l.startsWith("server:"))).toEqual(["server:end", "server:finish", "server:close"]);
+    expect(lines).toContain("client:close");
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -555,20 +555,15 @@ describe("HTTP server CONNECT", () => {
     }
   });
 
-  // https CONNECT: server socket.end() after peer FIN must also FIN at the TCP
-  // layer. us_internal_ssl_shutdown with SSL_RECEIVED_SHUTDOWN already set
-  // (peer's half-close) reaches SSL_shutdown() == 1 and previously returned
-  // without the raw TCP shutdown, so the poll type never moved to SHUT_DOWN
-  // and (on epoll, with autoDestroy disabled) nothing ever closed the socket.
-  // Linux-only: the close is reported via EPOLLHUP once both halves have FIN'd;
-  // kqueue/libuv need the readable_ended re-arm to re-derive it.
+  // https CONNECT: server socket.end() after peer FIN must also FIN the TCP
+  // write side. Linux-only: the close is observed via EPOLLHUP once both halves
+  // have FIN'd; kqueue/libuv need the readable_ended re-arm to re-derive it.
   test.skipIf(!isLinux)(
     "https CONNECT socket.end() after peer FIN half-closes TCP so the socket can close",
     async () => {
-      // The client uses tls.connect({ socket: rawNetSocket }) so end() routes
-      // through the raw FIN path (not a TLS close_notify first), which is the
-      // ordering that leaves the server's eof already consumed by the
-      // allow_half_open branch before the deferred socket.end() runs.
+      // tls.connect wraps a raw net.Socket so end() sends a raw FIN (not
+      // close_notify first): that ordering has the server's eof already
+      // consumed by allow_half_open before the deferred socket.end() runs.
       const fixture = /* js */ `
       const https = require("node:https");
       const net = require("node:net");
@@ -576,9 +571,8 @@ describe("HTTP server CONNECT", () => {
 
       const server = https.createServer({ cert: process.env.CERT, key: process.env.KEY }, () => {});
       server.on("connect", (req, socket) => {
-        // Disable autoDestroy so the only thing that can close this socket is
-        // the transport reporting both directions shut (EPOLLHUP once our FIN
-        // answers the peer's). With the missing raw_shutdown, that never fires.
+        // autoDestroy off: only the transport (EPOLLHUP once our FIN answers
+        // the peer's) can close this socket.
         socket._readableState.autoDestroy = false;
         socket._writableState.autoDestroy = false;
         socket.write("HTTP/1.1 200 Connection Established\\r\\n\\r\\n");

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -562,12 +562,14 @@ describe("HTTP server CONNECT", () => {
   // and (on epoll, with autoDestroy disabled) nothing ever closed the socket.
   // Linux-only: the close is reported via EPOLLHUP once both halves have FIN'd;
   // kqueue/libuv need the readable_ended re-arm to re-derive it.
-  test.skipIf(!isLinux)("https CONNECT socket.end() after peer FIN half-closes TCP so the socket can close", async () => {
-    // The client uses tls.connect({ socket: rawNetSocket }) so end() routes
-    // through the raw FIN path (not a TLS close_notify first), which is the
-    // ordering that leaves the server's eof already consumed by the
-    // allow_half_open branch before the deferred socket.end() runs.
-    const fixture = /* js */ `
+  test.skipIf(!isLinux)(
+    "https CONNECT socket.end() after peer FIN half-closes TCP so the socket can close",
+    async () => {
+      // The client uses tls.connect({ socket: rawNetSocket }) so end() routes
+      // through the raw FIN path (not a TLS close_notify first), which is the
+      // ordering that leaves the server's eof already consumed by the
+      // allow_half_open branch before the deferred socket.end() runs.
+      const fixture = /* js */ `
       const https = require("node:https");
       const net = require("node:net");
       const tls = require("node:tls");
@@ -600,22 +602,23 @@ describe("HTTP server CONNECT", () => {
         client.on("close", () => console.log("client:close"));
       });
     `;
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", fixture],
-      env: { ...bunEnv, CERT: tlsCert.cert, KEY: tlsCert.key },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    // Before the fix the server socket never closes: stdout stops at
-    // server:finish and the process hangs until the test timeout. client:close
-    // and server:close may interleave, so assert presence + server ordering.
-    const lines = stdout.split("\n").filter(Boolean);
-    expect(lines.filter(l => l.startsWith("server:"))).toEqual(["server:end", "server:finish", "server:close"]);
-    expect(lines).toContain("client:close");
-    expect(exitCode).toBe(0);
-  });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: { ...bunEnv, CERT: tlsCert.cert, KEY: tlsCert.key },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      // Before the fix the server socket never closes: stdout stops at
+      // server:finish and the process hangs until the test timeout. client:close
+      // and server:close may interleave, so assert presence + server ordering.
+      const lines = stdout.split("\n").filter(Boolean);
+      expect(lines.filter(l => l.startsWith("server:"))).toEqual(["server:end", "server:finish", "server:close"]);
+      expect(lines).toContain("client:close");
+      expect(exitCode).toBe(0);
+    },
+  );
 });
 
 /**

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -609,14 +609,21 @@ describe("HTTP server CONNECT", () => {
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
       // Before the fix the server socket never closes: stdout stops at
       // server:finish and the process hangs until the test timeout. client:close
       // and server:close may interleave, so assert presence + server ordering.
       const lines = stdout.split("\n").filter(Boolean);
-      expect(lines.filter(l => l.startsWith("server:"))).toEqual(["server:end", "server:finish", "server:close"]);
-      expect(lines).toContain("client:close");
-      expect(exitCode).toBe(0);
+      expect({
+        server: lines.filter(l => l.startsWith("server:")),
+        hasClientClose: lines.includes("client:close"),
+        stderr,
+        exitCode,
+      }).toEqual({
+        server: ["server:end", "server:finish", "server:close"],
+        hasClientClose: true,
+        stderr: "",
+        exitCode: 0,
+      });
     },
   );
 });


### PR DESCRIPTION
### What does this PR do?

#### Problem

`us_internal_ssl_shutdown` only takes the `SSL_shutdown()` path when `SSL_RECEIVED_SHUTDOWN` is already set (the `!SSL_in_init && !RECEIVED_SHUTDOWN` branch at the top handles the common case with a raw TCP half-close instead). That precondition is met for an `allow_half_open` TLS server socket whose peer has already half-closed: `ssl_on_end` sets `SSL_RECEIVED_SHUTDOWN` before dispatching `'end'`, and the ZERO_RETURN path sets it by receiving the peer's close_notify.

With `RECEIVED_SHUTDOWN` already set, `SSL_shutdown()` sends our close_notify and returns 1. The function then returned without calling `us_internal_socket_raw_shutdown`, so:

- no TCP FIN was ever sent to the peer (only the close_notify TLS record);
- the poll type stayed `SOCKET`, not `SHUT_DOWN`;
- on epoll, the half-open poll had already been changed to `WRITABLE` when the peer's FIN was handled, the writable dispatch drops it to 0 once drained, and `EPOLLHUP` (the only thing reported at events=0) needs both halves FIN'd, so the loop's `is_shut_down` close path never ran.

Every other exit from `us_internal_ssl_shutdown` already calls `us_internal_socket_raw_shutdown`; only the `ret >= 0` path did not.

#### Reachable path

The only sockets that reach the `SSL_shutdown()` path after a peer half-close are `UWS_HTTP_TLS` sockets with `allow_half_open` set: `node:https` server CONNECT/Upgrade tunnels (`upgradeToTunnelMode` sets `allow_half_open`), where the JS `'end'` handler's `socket.end()` routes through `handle.end()` → `us_socket_shutdown`. `net.Socket`'s Duplex `autoDestroy: true` normally follows with `handle.close()`, which hid this; with `autoDestroy` disabled the socket never closes.

#### Fix

Call `us_internal_socket_raw_shutdown(s)` after the `SSL_shutdown` branch regardless of `ret`, matching the other exit paths. This sends the TCP FIN and moves the poll type to `SHUT_DOWN`.

#### Relation to #34487

Once the FIN is sent, epoll reports `EPOLLHUP` (both halves down) and the socket closes via the `is_shut_down` eof branch. kqueue and libuv still need the `readable_ended` re-arm from #34487 for the poll to re-derive eof at events=0; this PR is the TLS-side prerequisite that gets the FIN on the wire at all.

### How did you verify your code works?

New test in `test/js/node/http/node-http-connect.test.ts` spawns an https CONNECT server with `autoDestroy` disabled, a TLS client that half-closes first (raw FIN, no close_notify first), and waits for the server socket's `'close'`:

```
# before
(fail) … https CONNECT socket.end() after peer FIN half-closes TCP so the socket can close
  ^ this test timed out after 5000ms.
# after
(pass) … https CONNECT socket.end() after peer FIN half-closes TCP so the socket can close
```

Gated to Linux because the close is observed via `EPOLLHUP`; kqueue/libuv coverage comes with #34487.

Also ran with no new failures vs main: `test/js/node/tls/` (159/161), `test/js/bun/net/socket.test.ts` + `test/js/node/net/` (249/268), and `test/js/node/test/parallel/test-{tls,https}-*.js` (207/210).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/http/node-http-connect.test.ts

<!-- robobun:evidence:end -->