### PR TITLE
internal: release once() callback after it fires so http.ClientRequest is collectable

### DIFF
--- a/src/js/internal/shared.ts
+++ b/src/js/internal/shared.ts
@@ -132,7 +132,11 @@ function once(callback, { preserveReturnValue = false } = kEmptyObject) {
   return function (...args) {
     if (called) return returnValue;
     called = true;
-    const result = callback.$apply(this, args);
+    const fn = callback;
+    // Drop the reference so the wrapper cannot keep the callback's
+    // closure (and everything it captured) alive once it has run.
+    callback = undefined;
+    const result = fn.$apply(this, args);
     returnValue = preserveReturnValue ? result : undefined;
     return result;
   };

--- a/test/js/node/http/node-http-client-request-gc-fixture.js
+++ b/test/js/node/http/node-http-client-request-gc-fixture.js
@@ -12,6 +12,7 @@ const server = http
 
 const heldWrappers = [];
 const total = 4;
+let done = 0;
 let collected = 0;
 const registry = new FinalizationRegistry(() => {
   collected++;
@@ -28,12 +29,16 @@ function run() {
   };
 
   for (let i = 0; i < total; i++) {
-    const req = http.get({ hostname: "127.0.0.1", port, agent }, res => res.resume());
+    const req = http.get({ hostname: "127.0.0.1", port, agent }, res => {
+      res.resume();
+      res.on("end", () => done++);
+    });
     registry.register(req);
   }
 
   let iters = 0;
   setImmediate(function status() {
+    if (done < total) return setImmediate(status);
     global.gc();
     iters++;
     if (collected === total) {

--- a/test/js/node/http/node-http-client-request-gc-fixture.js
+++ b/test/js/node/http/node-http-client-request-gc-fixture.js
@@ -1,13 +1,6 @@
 "use strict";
-// When an http.Agent creates a new socket it wraps the connect callback in
-// the internal once() helper and hands that wrapper to createConnection().
-// The wrapped callback closes over `cb`, which is onSocketCreated bound to
-// the ClientRequest. JSC is a conservative collector, so a stale stack word
-// that happens to look like the wrapper keeps it (and the request it was
-// created for) alive for as long as the keep-alive socket sits in the free
-// pool. This fixture makes that retention deterministic by holding the
-// wrapper explicitly and then asserting every ClientRequest is still
-// collectable once the wrapper has fired.
+// Hold the once() wrapper that _http_agent.createSocket passes to
+// createConnection and assert every ClientRequest is still collectable.
 const http = require("http");
 
 const server = http
@@ -15,7 +8,7 @@ const server = http
     res.writeHead(200);
     res.end("ok");
   })
-  .listen(0, run);
+  .listen(0, "127.0.0.1", run);
 
 const heldWrappers = [];
 const total = 4;
@@ -30,12 +23,12 @@ function run() {
 
   const originalCreateConnection = agent.createConnection;
   agent.createConnection = function (options, oncreate) {
-    heldWrappers.push(oncreate);
+    if (typeof oncreate === "function") heldWrappers.push(oncreate);
     return originalCreateConnection.call(this, options, oncreate);
   };
 
   for (let i = 0; i < total; i++) {
-    const req = http.get({ hostname: "localhost", port, agent }, res => res.resume());
+    const req = http.get({ hostname: "127.0.0.1", port, agent }, res => res.resume());
     registry.register(req);
   }
 
@@ -44,13 +37,13 @@ function run() {
     global.gc();
     iters++;
     if (collected === total) {
-      console.log("collected " + collected + "/" + total);
+      console.log("collected " + collected + "/" + total + " holding " + heldWrappers.length + " wrappers");
       server.close();
       agent.destroy();
       return;
     }
     if (iters > 50) {
-      console.log("stuck " + collected + "/" + total + " (holding " + heldWrappers.length + " wrappers)");
+      console.log("stuck " + collected + "/" + total + " holding " + heldWrappers.length + " wrappers");
       process.exit(1);
     }
     setImmediate(status);

--- a/test/js/node/http/node-http-client-request-gc-fixture.js
+++ b/test/js/node/http/node-http-client-request-gc-fixture.js
@@ -1,0 +1,58 @@
+"use strict";
+// When an http.Agent creates a new socket it wraps the connect callback in
+// the internal once() helper and hands that wrapper to createConnection().
+// The wrapped callback closes over `cb`, which is onSocketCreated bound to
+// the ClientRequest. JSC is a conservative collector, so a stale stack word
+// that happens to look like the wrapper keeps it (and the request it was
+// created for) alive for as long as the keep-alive socket sits in the free
+// pool. This fixture makes that retention deterministic by holding the
+// wrapper explicitly and then asserting every ClientRequest is still
+// collectable once the wrapper has fired.
+const http = require("http");
+
+const server = http
+  .createServer((req, res) => {
+    res.writeHead(200);
+    res.end("ok");
+  })
+  .listen(0, run);
+
+const heldWrappers = [];
+const total = 4;
+let collected = 0;
+const registry = new FinalizationRegistry(() => {
+  collected++;
+});
+
+function run() {
+  const port = server.address().port;
+  const agent = new http.Agent({ keepAlive: true });
+
+  const originalCreateConnection = agent.createConnection;
+  agent.createConnection = function (options, oncreate) {
+    heldWrappers.push(oncreate);
+    return originalCreateConnection.call(this, options, oncreate);
+  };
+
+  for (let i = 0; i < total; i++) {
+    const req = http.get({ hostname: "localhost", port, agent }, res => res.resume());
+    registry.register(req);
+  }
+
+  let iters = 0;
+  setImmediate(function status() {
+    global.gc();
+    iters++;
+    if (collected === total) {
+      console.log("collected " + collected + "/" + total);
+      server.close();
+      agent.destroy();
+      return;
+    }
+    if (iters > 50) {
+      console.log("stuck " + collected + "/" + total + " (holding " + heldWrappers.length + " wrappers)");
+      process.exit(1);
+    }
+    setImmediate(status);
+  });
+}

--- a/test/js/node/http/node-http-client-request-gc-fixture.js
+++ b/test/js/node/http/node-http-client-request-gc-fixture.js
@@ -31,7 +31,11 @@ function run() {
   for (let i = 0; i < total; i++) {
     const req = http.get({ hostname: "127.0.0.1", port, agent }, res => {
       res.resume();
-      res.on("end", () => done++);
+      res.on("close", () => done++);
+    });
+    req.on("error", err => {
+      console.error(err);
+      process.exit(1);
     });
     registry.register(req);
   }

--- a/test/js/node/http/node-http-client-request-gc.test.ts
+++ b/test/js/node/http/node-http-client-request-gc.test.ts
@@ -2,13 +2,8 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import path from "node:path";
 
-// _http_agent.createSocket wraps its connect callback with the internal once()
-// helper. Before this fix once() never cleared its `callback` slot, so a
-// reference to the wrapper transitively pinned onSocketCreated.bind(this, req)
-// and the ClientRequest with it. JSC's conservative root scan occasionally
-// kept that wrapper alive via a stale stack word, which made Node's upstream
-// test-gc-http-client* tests hang on some CI lanes. The fixture holds the
-// wrapper explicitly so the retention is deterministic.
+// once() must drop its callback after firing so a held wrapper cannot pin
+// onSocketCreated.bind(this, req) and the ClientRequest with it.
 test("http.ClientRequest is collectable while the agent's once() connect wrapper is still reachable", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "--expose-gc", path.join(import.meta.dir, "node-http-client-request-gc-fixture.js")],
@@ -19,7 +14,9 @@ test("http.ClientRequest is collectable while the agent's once() connect wrapper
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toBe("");
-  expect(stdout.trim()).toBe("collected 4/4");
-  expect(exitCode).toBe(0);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: "collected 4/4 holding 4 wrappers",
+    stderr: "",
+    exitCode: 0,
+  });
 });

--- a/test/js/node/http/node-http-client-request-gc.test.ts
+++ b/test/js/node/http/node-http-client-request-gc.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import path from "node:path";
+
+// _http_agent.createSocket wraps its connect callback with the internal once()
+// helper. Before this fix once() never cleared its `callback` slot, so a
+// reference to the wrapper transitively pinned onSocketCreated.bind(this, req)
+// and the ClientRequest with it. JSC's conservative root scan occasionally
+// kept that wrapper alive via a stale stack word, which made Node's upstream
+// test-gc-http-client* tests hang on some CI lanes. The fixture holds the
+// wrapper explicitly so the retention is deterministic.
+test("http.ClientRequest is collectable while the agent's once() connect wrapper is still reachable", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--expose-gc", path.join(import.meta.dir, "node-http-client-request-gc-fixture.js")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("collected 4/4");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

`test/js/node/test/sequential/test-gc-http-client-onerror.js` and `test-gc-http-client.js` were added in #34441 and immediately started timing out on alpine x64-baseline (build 74665), stuck forever at `done/collected/total: 8/7/8`: one `http.ClientRequest` is never collected.

## Cause

`_http_agent.createSocket` does:

```js
this.createSocket(req, options, onSocketCreated.bind(this, req));  // cb

const oncreate = once((err, s) => { ... cb(null, s); });
const newSocket = this.createConnection(options, oncreate);
```

The internal `once()` helper (`src/js/internal/shared.ts`) keeps `callback` in the returned wrapper's closure for the life of the wrapper, so `oncreate -> callback -> scope.cb -> onSocketCreated.bind(this, req) -> req` stays reachable as long as anything can reach `oncreate`.

Under V8 (Node.js) the wrapper becomes unreachable once `Socket.prototype.connect` returns and the precise GC collects it. JavaScriptCore is a conservative collector: a stale word on the native stack that happens to match the wrapper's address keeps it alive. A heap snapshot taken when the test is stuck shows exactly this chain rooted only from conservative stack state:

```
(conservative) -> once() wrapper -> callback -> createSocket scope
                  -> cb = onSocketCreated.bind(this, req) -> ClientRequest
```

Which request gets pinned depends on stack layout, so the test passes on most lanes and hangs on x64-baseline/musl.

## Fix

Null `callback` in `once()` before invoking it. The wrapper can then outlive the callback without retaining anything the callback captured. Behaviour is otherwise identical to Node's `internal/util` `once()` (same `called` flag, same `preserveReturnValue` semantics, same throw-on-first-call behaviour).

## Test

`test/js/node/http/node-http-client-request-gc.test.ts` makes the retention deterministic by overriding `agent.createConnection` to hold every `oncreate` wrapper it sees and then asserting all four `ClientRequest` objects are still collected.

Without the fix: `stuck 0/4 (holding 4 wrappers)`.
With the fix: `collected 4/4`.

All four upstream `test-gc-http-client*` tests and the existing `test-http-agent-*` / `test-stream-finished*` / `test-stream-pipeline*` suites still pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/test/sequential/test-gc-http-client-onerror.js test/js/node/http/node-http-client-request-gc.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (1b37d8f49)

test/js/node/http/node-http-client-request-gc.test.ts:
12 |     stderr: "pipe",
13 |   });
14 | 
15 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
16 | 
17 |   expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
                                                           ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
+   "exitCode": 1,
    "stderr": "",
-   "stdout": "collected 4/4 holding 4 wrappers",
+   "stdout": "stuck 0/4 holding 4 wrappers",
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/node/http/node-http
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (49e53790a)

test/js/node/http/node-http-client-request-gc.test.ts:
(pass) http.ClientRequest is collectable while the agent's once() connect wrapper is still reachable [53.55ms]

 1 pass
 0 fail
 1 expect() calls
Ran 1 test across 1 file. [220.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/test/sequential/test-gc-http-client-onerror.js test/js/node/http/node-http-client-request-gc.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (1b37d8f49)

test/js/node/http/node-http-client-request-gc.test.ts:
(pass) http.ClientRequest is collectable while the agent's once() connect wrapper is still reachable [2995.81ms]

 1 pass
 0 fail
 1 expect() calls
Ran 1 test across 1 file. [4.99s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 689ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/20] gen JS modules (bundle-modules)
Preprocess modules (7293ms)
Bundle modules (38ms)
Postprocesss modules (23ms)
Bundle Functions (666ms)
Generate Code (79ms)

[8.11s] Bundled "src/js" for production
  2035 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version:
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/shared.ts                          |  6 ++-
 .../http/node-http-client-request-gc-fixture.js    | 60 ++++++++++++++++++++++
 .../node/http/node-http-client-request-gc.test.ts  | 22 ++++++++
 3 files changed, 87 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/internal/shared.ts                                     1      1      0
test/js/node/http/node-http-client-request-gc-fixture.js      1      8      0
test/js/node/http/node-http-client-request-gc.test.ts         0      3      0
```

</details>

<!-- robobun:evidence:end -->