### PR TITLE
http2: fail the session when an outbound header block cannot be encoded

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2186,18 +2186,6 @@ function sessionErrorFromCode(code: number) {
   return $ERR_HTTP2_SESSION_ERROR(code);
 }
 hideFromStack(sessionErrorFromCode);
-// Used for the legacy native error dispatches that still carry a positive HTTP/2 error code
-// (e.g. MAX_PENDING_SETTINGS_ACK, ENHANCE_YOUR_CALM from the outbound paths): the message carries
-// the NGHTTP2_* constant name. Violations detected by the inbound engine arrive as negative
-// nghttp2 library codes and are surfaced as NghttpError (ERR_HTTP2_ERROR), exactly like node.
-// GOAWAY-received errors stay numeric (sessionErrorFromCode) to match node's message exactly.
-function sessionErrorFromCodeNamed(code: number) {
-  if (code === 0xe) {
-    return $ERR_HTTP2_MAX_PENDING_SETTINGS_ACK();
-  }
-  return $ERR_HTTP2_SESSION_ERROR(nameForErrorCode[code] || code);
-}
-hideFromStack(sessionErrorFromCodeNamed);
 
 function assertSession(session) {
   if (!session) {
@@ -5194,7 +5182,7 @@ class ClientHttp2Session extends Http2Session {
           ? $ERR_HTTP2_TOO_MANY_INVALID_FRAMES()
           : typeof errorCode === "number" && errorCode < 0
             ? new NghttpError(errorCode)
-            : sessionErrorFromCodeNamed(errorCode as number);
+            : sessionErrorFromCode(errorCode as number);
       self.destroy(error_instance);
     },
 

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1465,6 +1465,9 @@ pub struct H2FrameParser {
     /// A native write returned a terminal result (socket closed, shut down, or the kernel
     /// rejected the send). Latched once; the deferred tick closes the transport.
     transport_write_fatal: Cell<bool>,
+    /// An outbound header block the HPACK encoder could not emit. Latched once; the deferred
+    /// tick reports it, because it is detected inside a user submit call.
+    pending_header_compression_error: Cell<bool>,
     ref_count: bun_ptr::RefCount<Self>, // intrusive — bun.ptr.RefCount(@This(), "ref_count", deinit, .{})
     /// Number of live `Keepalive` guards: the `+1`s held by native frames currently on the stack.
     /// Read only by `release_refs_stranded_by_exit()`.
@@ -2982,6 +2985,19 @@ impl H2FrameParser {
         );
     }
 
+    /// A header block the HPACK encoder cannot emit fails the whole session in nghttp2, so node
+    /// reports ERR_HTTP2_SESSION_ERROR (COMPRESSION_ERROR) rather than resetting the stream.
+    /// The stream is left open for the session teardown to error, matching node's request error.
+    fn schedule_header_compression_session_error(&self) {
+        if self.pending_header_compression_error.get() {
+            return;
+        }
+        // Detected inside the caller's own submit(): node delivers session errors from the
+        // event loop, so that call still returns with its stream usable for the rest of the tick.
+        self.pending_header_compression_error.set(true);
+        self.register_auto_flush();
+    }
+
     fn cork(&self) {
         if let Some(corked) = CORKED_H2.with(|c| c.get()) {
             if std::ptr::eq(corked, self.as_ctx_ptr()) {
@@ -3336,6 +3352,11 @@ impl H2FrameParser {
         if !self.auto_flusher.get().registered.get() {
             return;
         }
+        // A write that drains the buffer must not cancel the deferred tick a pending session
+        // error is waiting on; on_auto_flush unregisters once it has reported it.
+        if self.pending_header_compression_error.get() {
+            return;
+        }
         debug_assert!(self.auto_flusher.get().registered.get());
         let ctx = NonNull::new(self.as_ctx_ptr().cast::<c_void>());
         let removed = self
@@ -3431,6 +3452,15 @@ impl H2FrameParser {
                 self.transport_write_fatal.set(false);
             }
             return false;
+        }
+        if self.pending_header_compression_error.get() {
+            self.pending_header_compression_error.set(false);
+            self.dispatch_with_2_extra(
+                JSH2FrameParser::Gc::onError,
+                JSValue::js_number(ErrorCode::COMPRESSION_ERROR.0 as f64),
+                JSValue::js_number(self.last_stream_id.get() as f64),
+                JSValue::UNDEFINED,
+            );
         }
         let _ = self.flush();
         // we will unregister ourselves when the buffer is empty
@@ -8846,18 +8876,12 @@ impl H2FrameParser {
                         };
                         // SAFETY: stream is a *mut Stream from self.streams (heap::alloc); valid while the map entry exists
                         let stream = unsafe { &mut *stream };
-                        stream.state = StreamState::CLOSED;
                         if !stream_ctx_arg.is_empty_or_undefined_or_null()
                             && stream_ctx_arg.is_object()
                         {
                             stream.set_context(stream_ctx_arg, global_object);
                         }
-                        stream.rst_code = ErrorCode::COMPRESSION_ERROR.0;
-                        this.dispatch_with_extra(
-                            JSH2FrameParser::Gc::onStreamError,
-                            stream.get_identifier(),
-                            JSValue::js_number(stream.rst_code as f64),
-                        );
+                        this.schedule_header_compression_session_error();
                         return Ok(JSValue::js_number(stream_id as f64));
                     }
                 }
@@ -9038,13 +9062,7 @@ impl H2FrameParser {
                             {
                                 stream.set_context(stream_ctx_arg, global_object);
                             }
-                            stream.state = StreamState::CLOSED;
-                            stream.rst_code = ErrorCode::COMPRESSION_ERROR.0;
-                            this.dispatch_with_extra(
-                                JSH2FrameParser::Gc::onStreamError,
-                                stream.get_identifier(),
-                                JSValue::js_number(stream.rst_code as f64),
-                            );
+                            this.schedule_header_compression_session_error();
                             return Ok(JSValue::UNDEFINED);
                         }
                     }
@@ -9123,18 +9141,12 @@ impl H2FrameParser {
                         };
                         // SAFETY: stream is a *mut Stream from self.streams (heap::alloc); valid while the map entry exists
                         let stream = unsafe { &mut *stream };
-                        stream.state = StreamState::CLOSED;
                         if !stream_ctx_arg.is_empty_or_undefined_or_null()
                             && stream_ctx_arg.is_object()
                         {
                             stream.set_context(stream_ctx_arg, global_object);
                         }
-                        stream.rst_code = ErrorCode::COMPRESSION_ERROR.0;
-                        this.dispatch_with_extra(
-                            JSH2FrameParser::Gc::onStreamError,
-                            stream.get_identifier(),
-                            JSValue::js_number(stream.rst_code as f64),
-                        );
+                        this.schedule_header_compression_session_error();
                         return Ok(JSValue::js_number(stream_id as f64));
                     }
                 }
@@ -9778,6 +9790,7 @@ impl H2FrameParser {
             hpack: JsCell::new(None),
             has_nonnative_backpressure: Cell::new(false),
             transport_write_fatal: Cell::new(false),
+            pending_header_compression_error: Cell::new(false),
             auto_flusher: JsCell::new(AutoFlusher::default()),
             padding_strategy: Cell::new(PaddingStrategy::None),
             engine: core::cell::RefCell::new(None),

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -578,8 +578,10 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
             await doHttp2Request(HTTPS_SERVER, HTTPS_SERVER, { ":path": "/", "test-header": "A".repeat(90000) });
             expect("unreachable").toBe(true);
           } catch (err) {
-            expect(err.code).toBe("ERR_HTTP2_STREAM_ERROR");
-            expect(err.message).toBe("Stream closed with error code NGHTTP2_COMPRESSION_ERROR");
+            // Verified against node v26.3.0: a header block the encoder cannot emit fails the
+            // session with COMPRESSION_ERROR (9), it does not just reset the stream.
+            expect(err.code).toBe("ERR_HTTP2_SESSION_ERROR");
+            expect(err.message).toBe("Session closed with error code 9");
           }
         });
         it("should be destroyed after close", async () => {
@@ -3485,6 +3487,64 @@ it("http2 server sends each session's frames to its own peer under interleaved r
       { i: 0, status: 200, total: BIG.length * N },
       { i: 1, status: 200, total: BIG.length * N },
     ]);
+  } finally {
+    server.close();
+  }
+});
+
+it("fails the whole session when an outbound header block cannot be encoded", async () => {
+  // A header block the HPACK encoder cannot emit is a COMPRESSION_ERROR (9) against the
+  // session in node, so the session and the in-flight request both see
+  // ERR_HTTP2_SESSION_ERROR rather than a per-stream error.
+  const server = http2.createServer();
+  try {
+    const port = await new Promise(resolve => server.listen(0, () => resolve(server.address().port)));
+    const client = http2.connect(`http://localhost:${port}`, { maxSendHeaderBlockLength: 100000 });
+    const sessionError = new Promise(resolve => client.on("error", resolve));
+    const requestError = new Promise(resolve => {
+      const req = client.request({ "test-header": "A".repeat(90000) });
+      req.on("error", resolve);
+      req.end();
+    });
+
+    const [sessionErr, reqErr] = await Promise.all([sessionError, requestError]);
+    expect(sessionErr.code).toBe("ERR_HTTP2_SESSION_ERROR");
+    expect(sessionErr.message).toBe("Session closed with error code 9");
+    expect(reqErr.code).toBe("ERR_HTTP2_SESSION_ERROR");
+  } finally {
+    server.close();
+  }
+});
+
+it("delivers a session error from the event loop, not inside the call that detected it", async () => {
+  // node surfaces session errors from the event loop, so the submit call that tripped one
+  // still returns and its stream stays usable for the rest of the tick.
+  const server = http2.createServer({ maxSendHeaderBlockLength: 100000 });
+  try {
+    const observed = {};
+    const sessionError = new Promise(resolve => server.on("sessionError", resolve));
+    server.on("stream", stream => {
+      stream.on("error", () => {});
+      stream.additionalHeaders({ "test-header": "A".repeat(90000) });
+      observed.destroyedAfterSubmit = stream.destroyed;
+      stream.respond();
+      stream.end();
+      observed.submitsReturned = true;
+    });
+
+    const port = await new Promise(resolve => server.listen(0, () => resolve(server.address().port)));
+    const client = http2.connect(`http://localhost:${port}`);
+    client.on("error", () => {});
+    const req = client.request();
+    req.on("error", () => {});
+    req.end();
+
+    const err = await sessionError;
+    expect(err.code).toBe("ERR_HTTP2_SESSION_ERROR");
+    expect(err.message).toBe("Session closed with error code 9");
+    expect(observed.destroyedAfterSubmit).toBe(false);
+    expect(observed.submitsReturned).toBe(true);
+    client.destroy();
   } finally {
     server.close();
   }


### PR DESCRIPTION
### What does this PR do?

A header block Bun's HPACK encoder cannot emit was reported as a **per-stream** error (`ERR_HTTP2_STREAM_ERROR` / "Stream closed with error code NGHTTP2_COMPRESSION_ERROR"). nghttp2 fails the **whole session** with `COMPRESSION_ERROR` (9), so Node surfaces `ERR_HTTP2_SESSION_ERROR` / "Session closed with error code 9" on the session *and* on the in-flight request.

Three changes, each checked against the node v26.3.0 binary rather than inferred:

1. **Error scope.** The three encode-failure paths in `h2_frame_parser.rs` now schedule a session `COMPRESSION_ERROR` instead of resetting the stream. The stream is deliberately left open so the session teardown is what errors it — that is what produces Node's session error *on the request*, which Bun previously never emitted at all.

2. **Message format.** `ERR_HTTP2_SESSION_ERROR` carries the numeric code again. Node passes the raw `code` at both call sites in `lib/internal/http2/core.js` and uses `nameForErrorCode` **only** for `ERR_HTTP2_STREAM_ERROR`; every existing assertion in this repo already expected a number, so `sessionErrorFromCodeNamed` was a pure deviation and is removed. `nameForErrorCode` is still used for stream errors, and the `0xe` → `ERR_HTTP2_MAX_PENDING_SETTINGS_ACK` special case is preserved.

3. **Delivery timing.** The dispatch waits for the deferred tick. The failure is detected inside the caller's own `submit()`, and Node delivers session errors from the event loop — so `additionalHeaders()` still returns with its stream usable for the rest of the tick. Previously the session died re-entrantly and the following `respond()` threw `ERR_HTTP2_INVALID_STREAM`. A write that drains the buffer must not cancel the tick the pending error is waiting on, hence the guard in `unregister_auto_flush`.

The deferral lives at the Rust origin rather than in the shared JS `error` handler on purpose: `send_go_away(..., emit_error: true)` dispatches `onError` and then `onEnd` synchronously, and the `end` handler destroys error-free, so deferring in the shared handler could let an error-free destroy latch first and swallow the error. Keeping it at the origin bounds the change to the 3 paths that are actually re-entrant into user code.

### How did you verify your code works?

Side-by-side against `node v26.3.0` for every claim:

- **Server submit path** — identical step-for-step to Node: `additionalHeaders` returns → `destroyed? false / session.destroyed? false` → `respond returned` → `end returned` → then `[sessionError] ERR_HTTP2_SESSION_ERROR Session closed with error code 9`.
- **Client path** — both `client error` and `req error` fire with `ERR_HTTP2_SESSION_ERROR / Session closed with error code 9`, matching Node.
- **Boundary** — a large-but-encodable 60000-byte header still returns `status 200` on both.
- **Repeat** — three oversized requests on one session produce exactly **one** client error event on both.
- **Adjacent paths unchanged** — a raw DATA frame on stream 0 gives `ERR_HTTP2_ERROR / Protocol error` (identical to Node), and a rejected-stream flood still reports `Session closed with error code 11`.

Suites: `node-http2.test.js` **307 pass / 6 skip / 0 fail**, and a sweep of all **259** vendored `test-http2*` files with **0 failures**.

Note that suite is flaky under load — across five full runs a *different* test failed each time (concurrent-requests, URL-formats, statusMessage, both GOAWAY tests); each passed 3/3 in isolation, and the final run was clean.

#### Known remaining divergence (not addressed here)

`pushStream()` with an oversized header block still throws `Failed to encode push promise headers` and reports via callback, where Node fails the session with code 9. Converting that fourth site does match Node, but it leaves a stray uncaught `ERR_HTTP2_GOAWAY_SESSION` on the reserved push stream, because the JS `catch` that performs the `kNeverAnnounced` / `kReleaseUnannouncedStream` cleanup no longer runs. That divergence is pre-existing; fixing it properly means moving the push bookkeeping out of the catch, which belongs in its own change.

Separately, node's server emits **zero bytes** after a failed encode (measured), so its peer sees a protocol error; Bun's session dies a tick later and can still put the already-submitted response on the wire. Closing that window needs a session-dead latch gating every outbound frame path.
