### PR TITLE
Bun.serve: cap chunk-extension bytes at 16 KiB per chunk

### DIFF
--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -328,18 +328,16 @@ private:
 
         /* The return value is entirely up to us to interpret. The HttpParser cares only for whether the returned value is DIFFERENT from passed user */
 
-        /* node:http compat: the parser's per-connection node state lives in the
-         * IsNodeHttp=true ext block; the Bun.serve instantiation passes nullptr
-         * (and its parser instantiation contains no use of them). */
+        /* node:http compat: the trailer capture lives in the IsNodeHttp=true ext
+         * block; the Bun.serve instantiation passes nullptr (and its parser
+         * instantiation contains no use of it). */
         std::string *nodeHttpRequestTrailers = nullptr;
-        uint64_t *nodeHttpChunkedExtensionsByteCount = nullptr;
         if constexpr (IsNodeHttp) {
             auto *nodeHttpResponseData = (HttpResponseData<SSL, true> *) httpResponseData;
             nodeHttpRequestTrailers = &nodeHttpResponseData->nodeHttpRequestTrailers;
-            nodeHttpChunkedExtensionsByteCount = &nodeHttpResponseData->chunkedExtensionsByteCount;
         }
 
-        auto result = httpResponseData->template consumePostPadded<IsNodeHttp>(httpContextData->maxHeaderSize, httpResponseData->isConnectRequest, httpContextData->flags.requireHostHeader,httpContextData->flags.useStrictMethodValidation, httpContextData->flags.useInsecureHTTPParser, nodeHttpRequestTrailers, nodeHttpChunkedExtensionsByteCount, data, (unsigned int) length, s, proxyParser, [httpContextData](void *s, HttpRequest *httpRequest) -> void * {
+        auto result = httpResponseData->template consumePostPadded<IsNodeHttp>(httpContextData->maxHeaderSize, httpResponseData->isConnectRequest, httpContextData->flags.requireHostHeader,httpContextData->flags.useStrictMethodValidation, httpContextData->flags.useInsecureHTTPParser, nodeHttpRequestTrailers, &httpResponseData->chunkedExtensionsByteCount, data, (unsigned int) length, s, proxyParser, [httpContextData](void *s, HttpRequest *httpRequest) -> void * {
 
 
             /* For every request we reset the timeout and hang until user makes action */

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -86,8 +86,8 @@ struct HttpResponseData;
         /* A bare CR (not followed by LF) terminated a header value (llhttp's
          * HPE_LF_EXPECTED). */
         HTTP_PARSER_ERROR_LF_EXPECTED = 11,
-        /* node:http compat only: the chunk extensions of a single chunk exceeded
-         * the 16 KiB limit enforced by Node (HPE_CHUNK_EXTENSIONS_OVERFLOW). */
+        /* The chunk extensions of a single chunk exceeded the 16 KiB limit
+         * (Node/llhttp's HPE_CHUNK_EXTENSIONS_OVERFLOW). */
         HTTP_PARSER_ERROR_CHUNK_EXTENSIONS_OVERFLOW = 12,
         /* An HTTP/2 client connection preface was received on an HTTP/1 server
          * (llhttp's HPE_PAUSED_H2_UPGRADE). */

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -573,9 +573,9 @@ struct HttpResponseData;
 
         const size_t MAX_FALLBACK_SIZE = BUN_DEFAULT_MAX_HTTP_HEADER_SIZE;
 
-        /* Maximum size of the chunk extensions of a single chunk, matching Node's
-         * kMaxChunkExtensionsSize in src/node_http_parser.cc (16 KiB). Enforced
-         * only for node:http compat servers. */
+        /* Maximum chunk-extension bytes per chunk, matching Node/llhttp's
+         * kMaxChunkExtensionsSize (16 KiB). Enforced for every server
+         * personality so a client cannot stream unbounded extension bytes. */
         static const uint64_t MAX_CHUNK_EXTENSION_SIZE = 16 * 1024;
 
         /* Returns UINT64_MAX on error. Maximum 999999999 is allowed. */
@@ -1261,9 +1261,7 @@ struct HttpResponseData;
             } else if (transferEncoding.has) {
                 /* We already validated that chunked is last if present, before calling the handler */
                 remainingStreamingBytes = STATE_IS_CHUNKED;
-                if constexpr (IsNodeHttp) {
-                    *chunkedExtensionsByteCount = 0;
-                }
+                *chunkedExtensionsByteCount = 0;
                 /* If consume minimally, we do not want to consume anything but we want to mark this as being chunked */
                 if constexpr (!ConsumeMinimally) {
                     /* Go ahead and parse it (todo: better heuristics for emitting FIN to the app level) */
@@ -1271,7 +1269,7 @@ struct HttpResponseData;
                     for (auto chunk : uWS::ChunkIterator(&dataToConsume, &remainingStreamingBytes, false, chunkedExtensionsByteCount, nodeHttpRequestTrailers, maxBufferedHeaderSize)) {
                         /* llhttp errors at the offending extension byte, before any body bytes from
                          * that chunk reach the application; check before every dispatch. */
-                        if (IsNodeHttp && *chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
+                        if (*chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
                             return HttpParserResult::error(HTTP_ERROR_413_PAYLOAD_TOO_LARGE, HTTP_PARSER_ERROR_CHUNK_EXTENSIONS_OVERFLOW);
                         }
                         /* The fin dispatch completes the message: a malformed trailer field
@@ -1286,7 +1284,7 @@ struct HttpResponseData;
                             return HttpParserResult::success(consumedTotal, returnedUser);
                         }
                     }
-                    if (IsNodeHttp && *chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
+                    if (*chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
                         return HttpParserResult::error(HTTP_ERROR_413_PAYLOAD_TOO_LARGE, HTTP_PARSER_ERROR_CHUNK_EXTENSIONS_OVERFLOW);
                     }
                     if (isParsingInvalidChunkedEncoding(remainingStreamingBytes)) [[unlikely]] {
@@ -1352,7 +1350,7 @@ public:
                  /* It's either chunked or with a content-length */
                 std::string_view dataToConsume(data, length);
                 for (auto chunk : uWS::ChunkIterator(&dataToConsume, &remainingStreamingBytes, false, chunkedExtensionsByteCount, nodeHttpRequestTrailers, maxFallbackSize)) {
-                    if (IsNodeHttp && *chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
+                    if (*chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
                         return HttpParserResult::error(HTTP_ERROR_413_PAYLOAD_TOO_LARGE, HTTP_PARSER_ERROR_CHUNK_EXTENSIONS_OVERFLOW);
                     }
                     /* The fin dispatch completes the message: a malformed trailer field
@@ -1365,7 +1363,7 @@ public:
                         return HttpParserResult::success(0, returnedUser);
                     }
                 }
-                if (IsNodeHttp && *chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
+                if (*chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
                     return HttpParserResult::error(HTTP_ERROR_413_PAYLOAD_TOO_LARGE, HTTP_PARSER_ERROR_CHUNK_EXTENSIONS_OVERFLOW);
                 }
                 if (isParsingInvalidChunkedEncoding(remainingStreamingBytes)) {
@@ -1435,7 +1433,7 @@ public:
                         /* It's either chunked or with a content-length */
                         std::string_view dataToConsume(data, length);
                         for (auto chunk : uWS::ChunkIterator(&dataToConsume, &remainingStreamingBytes, false, chunkedExtensionsByteCount, nodeHttpRequestTrailers, maxFallbackSize)) {
-                            if (IsNodeHttp && *chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
+                            if (*chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
                                 return HttpParserResult::error(HTTP_ERROR_413_PAYLOAD_TOO_LARGE, HTTP_PARSER_ERROR_CHUNK_EXTENSIONS_OVERFLOW);
                             }
                             /* The fin dispatch completes the message: a malformed trailer field
@@ -1448,7 +1446,7 @@ public:
                                 return HttpParserResult::success(0, returnedUser);
                             }
                         }
-                        if (IsNodeHttp && *chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
+                        if (*chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
                             return HttpParserResult::error(HTTP_ERROR_413_PAYLOAD_TOO_LARGE, HTTP_PARSER_ERROR_CHUNK_EXTENSIONS_OVERFLOW);
                         }
                         if (isParsingInvalidChunkedEncoding(remainingStreamingBytes)) {

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -195,6 +195,11 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
      * so it cannot live in `state`. */
     bool isConnectRequest = false;
 
+    /* Chunk-extension bytes consumed on the current chunk-size line, reset per
+     * chunk (llhttp's on_chunk_header); capped at MAX_CHUNK_EXTENSION_SIZE for
+     * both Bun.serve and node:http servers. */
+    uint64_t chunkedExtensionsByteCount = 0;
+
     /* node:http server compat: number of pipelined responses dispatched to JS
      * that have not yet become this connection's current response. While
      * non-zero, newly parsed requests keep being queued (preserving response
@@ -234,11 +239,6 @@ struct HttpResponseData<SSL, true> : HttpResponseData<SSL, false> {
      * Mirrors last_message_start_/headers_completed_ in Node's http parser
      * ConnectionsList, which back server.headersTimeout/requestTimeout. */
     uint64_t lastMessageStartMs = 0;
-    /* Bytes of chunk extensions consumed on the current chunk-size line of the
-     * request body, matching llhttp/Node which resets the counter in
-     * on_chunk_header (per chunk, not per message). The parser gets it as a
-     * nullable pointer (see HttpParser::consumePostPadded). */
-    uint64_t chunkedExtensionsByteCount = 0;
     /* Trailer fields set via response.addTrailers(), pre-rendered as
      * "name: value\r\n" lines. Written between the terminating 0 chunk and the
      * final CRLF of a chunked response (RFC 9112 7.1.2); non-empty also forces

--- a/test/js/bun/http/http-server-chunking.test.ts
+++ b/test/js/bun/http/http-server-chunking.test.ts
@@ -250,9 +250,9 @@ describe.if(isPosix)("HTTP server handles split chunk-size CRLF", () => {
         socket: {
           data(s, d) { received += d.toString(); },
           open(s) {
-            // 64 KiB of extension bytes on one chunk-size line (cap is 16 KiB).
+            // 20 KiB of extension bytes on one chunk-size line (cap is 16 KiB).
             // Body is 2 bytes, well under maxRequestBodySize.
-            const ext = Buffer.alloc(64 * 1024, "e").toString();
+            const ext = Buffer.alloc(20 * 1024, "e").toString();
             s.write("POST / HTTP/1.1\\r\\nHost: x\\r\\nConnection: close\\r\\nTransfer-Encoding: chunked\\r\\n\\r\\n2;" + ext + "\\r\\nhi\\r\\n0\\r\\n\\r\\n");
             s.flush();
           },

--- a/test/js/bun/http/http-server-chunking.test.ts
+++ b/test/js/bun/http/http-server-chunking.test.ts
@@ -277,10 +277,12 @@ describe.if(isPosix)("HTTP server handles split chunk-size CRLF", () => {
     expect(exitCode).toBe(0);
   });
 
-  test.concurrentIf(!isASAN)("accepts small chunk extensions on every chunk (cap is per chunk, not per message)", async () => {
-    // 10 chunks x 8 KiB extension each = 80 KiB total extension bytes, but each
-    // chunk-size line is under the 16 KiB cap so the request must succeed.
-    const script = `
+  test.concurrentIf(!isASAN)(
+    "accepts small chunk extensions on every chunk (cap is per chunk, not per message)",
+    async () => {
+      // 10 chunks x 8 KiB extension each = 80 KiB total extension bytes, but each
+      // chunk-size line is under the 16 KiB cap so the request must succeed.
+      const script = `
       const server = Bun.serve({
         port: 0,
         async fetch(req) { return new Response("Got: " + (await req.text())); },
@@ -308,14 +310,15 @@ describe.if(isPosix)("HTTP server handles split chunk-size CRLF", () => {
       server.stop();
     `;
 
-    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stdout: "pipe", stderr: "pipe" });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr).toBe("");
-    expect(stdout).toContain("200 OK");
-    expect(stdout).toContain("Got: AAAAAAAAAA");
-    expect(exitCode).toBe(0);
-  });
+      expect(stderr).toBe("");
+      expect(stdout).toContain("200 OK");
+      expect(stdout).toContain("Got: AAAAAAAAAA");
+      expect(exitCode).toBe(0);
+    },
+  );
 
   test.concurrentIf(!isASAN)("rejects bare LF in chunk-size position (invalid byte not stranded)", async () => {
     // A byte <=32 that isn't \r in chunk-size position must error immediately.

--- a/test/js/bun/http/http-server-chunking.test.ts
+++ b/test/js/bun/http/http-server-chunking.test.ts
@@ -229,6 +229,94 @@ describe.if(isPosix)("HTTP server handles split chunk-size CRLF", () => {
     expect(exitCode).toBe(0);
   });
 
+  test.concurrentIf(!isASAN)("rejects chunk extensions that exceed the 16 KiB per-chunk cap", async () => {
+    // A hostile client can hold a connection and unmetered inbound bandwidth by
+    // streaming arbitrarily large chunk-extension bytes, which maxRequestBodySize
+    // never sees. llhttp (Node) caps this at 16 KiB per chunk; Bun.serve must too.
+    const script = `
+      const server = Bun.serve({
+        port: 0,
+        maxRequestBodySize: 1024 * 1024,
+        async fetch(req) {
+          const n = (await req.arrayBuffer()).byteLength;
+          return new Response("n=" + n);
+        },
+      });
+      const { promise, resolve } = Promise.withResolvers();
+      let received = "";
+      const socket = await Bun.connect({
+        hostname: "localhost",
+        port: server.port,
+        socket: {
+          data(s, d) { received += d.toString(); },
+          open(s) {
+            // 64 KiB of extension bytes on one chunk-size line (cap is 16 KiB).
+            // Body is 2 bytes, well under maxRequestBodySize.
+            const ext = Buffer.alloc(64 * 1024, "e").toString();
+            s.write("POST / HTTP/1.1\\r\\nHost: x\\r\\nConnection: close\\r\\nTransfer-Encoding: chunked\\r\\n\\r\\n2;" + ext + "\\r\\nhi\\r\\n0\\r\\n\\r\\n");
+            s.flush();
+          },
+          error() {},
+          close() { console.log(JSON.stringify({ received })); resolve(); },
+        },
+      });
+      await promise;
+      server.stop();
+    `;
+
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    const { received } = JSON.parse(stdout);
+    // Server must reject (413) and close the connection; it must not hand the
+    // request to fetch() (which would answer 200 "n=2").
+    expect(received).not.toContain("200");
+    expect(received).not.toContain("n=2");
+    expect(received).toContain("413");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrentIf(!isASAN)("accepts small chunk extensions on every chunk (cap is per chunk, not per message)", async () => {
+    // 10 chunks x 8 KiB extension each = 80 KiB total extension bytes, but each
+    // chunk-size line is under the 16 KiB cap so the request must succeed.
+    const script = `
+      const server = Bun.serve({
+        port: 0,
+        async fetch(req) { return new Response("Got: " + (await req.text())); },
+      });
+      const { promise, resolve } = Promise.withResolvers();
+      let received = "";
+      const socket = await Bun.connect({
+        hostname: "localhost",
+        port: server.port,
+        socket: {
+          data(s, d) { received += d.toString(); },
+          open(s) {
+            const ext = Buffer.alloc(8 * 1024, "e").toString();
+            let wire = "POST / HTTP/1.1\\r\\nHost: x\\r\\nConnection: close\\r\\nTransfer-Encoding: chunked\\r\\n\\r\\n";
+            for (let i = 0; i < 10; i++) wire += "1;" + ext + "\\r\\nA\\r\\n";
+            wire += "0\\r\\n\\r\\n";
+            s.write(wire);
+            s.flush();
+          },
+          error() {},
+          close() { console.log(received); resolve(); },
+        },
+      });
+      await promise;
+      server.stop();
+    `;
+
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toContain("200 OK");
+    expect(stdout).toContain("Got: AAAAAAAAAA");
+    expect(exitCode).toBe(0);
+  });
+
   test.concurrentIf(!isASAN)("rejects bare LF in chunk-size position (invalid byte not stranded)", async () => {
     // A byte <=32 that isn't \r in chunk-size position must error immediately.
     // Previously this could strand the byte in HttpParser's fallback buffer,

--- a/test/js/bun/http/http-server-chunking.test.ts
+++ b/test/js/bun/http/http-server-chunking.test.ts
@@ -533,7 +533,7 @@ describe.if(isPosix)("HTTP server handles split chunk-size CRLF", () => {
 describe.if(isPosix)("HTTP server handles fragmented requests", () => {
   test.concurrentIf(!isASAN)("handles requests with tiny send buffer (regression test)", async () => {
     using server = Bun.serve({
-      hostname: "localhost",
+      hostname: "127.0.0.1",
 
       port: 0,
       async fetch(req) {


### PR DESCRIPTION
## Repro

```js
// POST with Transfer-Encoding: chunked whose chunk-size line carries 32 MiB
// of extension bytes. Body is 2 bytes; maxRequestBodySize is 1 MiB.
const S = Bun.serve({
  port: 0, hostname: "127.0.0.1", maxRequestBodySize: 1024 * 1024,
  async fetch(req) { const n = (await req.arrayBuffer()).byteLength; return new Response(`n=${n}`); },
});
// raw socket client writes: headers, then "2;" + 32 MiB of 'e', then "\r\nhi\r\n0\r\n\r\n"
// before:  ext-bytes-accepted=33554432 status=200
// after:   status=413, connection closed
```

A hostile client can hold a connection, a parser, and unmetered inbound bandwidth with bytes that `maxRequestBodySize` never sees: the body is 2 bytes, the limit is 1 MiB, yet 32 MiB+ of chunk-extension garbage flows and the request completes 200. `idleTimeout` never fires while extension bytes trickle. Node (llhttp) and Bun's own `node:http` server reject the same request with 413/400 at ~16 KiB.

## Cause

`HttpParser::MAX_CHUNK_EXTENSION_SIZE` (16 KiB, matching Node's `kMaxChunkExtensionsSize`) already existed and the parser already counted extension bytes, but every overflow check was gated on the `IsNodeHttp` template parameter and the per-connection counter lived only in the `HttpResponseData<SSL, true>` (node:http) specialization; the `Bun.serve` instantiation passed `nullptr` and its template contained no use of the counter.

## Fix

Move `chunkedExtensionsByteCount` into the base `HttpResponseData<SSL, false>` so it exists for both server personalities, pass it unconditionally from `HttpContext`, and drop the `IsNodeHttp &&` gate on the six overflow checks and the per-request reset in `HttpParser.h`. `Bun.serve` now answers `413 Payload Too Large` and closes the connection when a single chunk's extension bytes exceed 16 KiB, matching `node:http` and llhttp.

The cap is per chunk (reset in `consumeHexNumber` at the start of each chunk-size line, same as llhttp's `on_chunk_header`), not per message; a second test covers 10 chunks x 8 KiB extension = 80 KiB total still being accepted.

## Verification

```
# without the fix (src/ + packages/ stashed):
(fail) rejects chunk extensions that exceed the 16 KiB per-chunk cap
  Expected to not contain: "200"
  Received: "HTTP/1.1 200 OK ... n=2"

# with the fix:
(pass) rejects chunk extensions that exceed the 16 KiB per-chunk cap
(pass) accepts small chunk extensions on every chunk (cap is per chunk, not per message)
```

Also green: `test/js/bun/http/request-smuggling.test.ts` (75 pass), `test/js/node/test/parallel/test-http-chunked-smuggling.js`, `test/js/node/http/node-http-server-timeouts.test.ts`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/http-server-chunking.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (2fc4246ac)

test/js/bun/http/http-server-chunking.test.ts:
(pass) HTTP server handles chunked transfer encoding > handles fragmented chunk terminators [585.66ms]
(pass) HTTP server handles chunked transfer encoding > rejects invalid terminator in fragmented reads [517.84ms]
(pass) HTTP server handles split chunk-size CRLF > handles lone CR at end of chunk-size line across TCP segments [640.62ms]
(pass) HTTP server handles split chunk-size CRLF > handles lone CR in chunk-size with extensions [665.61ms]
269 | 
270 |     expect(stderr).toBe("");
271 |     const { received } = JSON.parse(stdout);
272 |     // Server must reject (413) and close the connection; it must not hand the
273 |     // request to fetch() (which would 
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (8342a4e5f)

test/js/bun/http/http-server-chunking.test.ts:
(pass) HTTP server handles split chunk-size CRLF > rejects chunk extensions that exceed the 16 KiB per-chunk cap [19.39ms]
(pass) HTTP server handles split chunk-size CRLF > accepts small chunk extensions on every chunk (cap is per chunk, not per message) [18.34ms]
(pass) HTTP server handles split chunk-size CRLF > rejects bare LF in chunk-size position (invalid byte not stranded) [17.29ms]
(pass) HTTP server handles split chunk-size CRLF > rejects chunk-size with zero hex digits (bare CRLF) > rejects and does not process trailing pipelined request [15.31ms]
(pass) HTTP server handles split chunk-size CRLF > rejects chunk-size with zero hex digits (extension only) > rejects and does not process trailing pipelined request [14.23ms]
(pass) HTTP server handles split chunk-size CRLF > rejects Content-Length values that would alias chunked-encoding state bits [32.01ms]
(pass) HTTP server handles split chunk-size CRLF > rejects chunk-size with zero hex digits (bare CRLF) > rejects when chunk-size line is split across packets [52.65ms]
(pass) HTTP server handles chunked transfer encoding >
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/http-server-chunking.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (2fc4246ac)

test/js/bun/http/http-server-chunking.test.ts:
(pass) HTTP server handles chunked transfer encoding > handles fragmented chunk terminators [563.52ms]
(pass) HTTP server handles chunked transfer encoding > rejects invalid terminator in fragmented reads [567.56ms]
(pass) HTTP server handles split chunk-size CRLF > handles lone CR at end of chunk-size line across TCP segments [620.06ms]
(pass) HTTP server handles split chunk-size CRLF > handles lone CR in chunk-size with extensions [678.40ms]
(pass) HTTP server handles split chunk-size CRLF > rejects chunk extensions that exceed the 16 KiB per-chunk cap [529.28ms]
(pass) HTTP server handles split chunk-size CRLF > accepts small chunk extensions on every chunk (c
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 734ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen JS modules (bundle-modules)
Preprocess modules (7463ms)
Bundle modules (36ms)
Postprocesss modules (161ms)
Bundle Functions (779ms)
Generate Code (81ms)

[8.54s] Bundled "src/js" for production
  2035 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[1/12] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current versio
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-uws/src/HttpContext.h            | 10 ++-
 packages/bun-uws/src/HttpParser.h             | 26 ++++----
 packages/bun-uws/src/HttpResponseData.h       | 10 +--
 test/js/bun/http/http-server-chunking.test.ts | 93 ++++++++++++++++++++++++++-
 4 files changed, 113 insertions(+), 26 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
packages/bun-uws/src/HttpContext.h                 1      1      0
packages/bun-uws/src/HttpParser.h                  2      7      0
packages/bun-uws/src/HttpResponseData.h            3      2      0
test/js/bun/http/http-server-chunking.test.ts      4      5      0
```

</details>

<!-- robobun:evidence:end -->