### PR TITLE
http2: fix silent client stall when the socket flows before connect completes

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -5592,6 +5592,12 @@ class ClientHttp2Session extends Http2Session {
     }
 
     function onConnect() {
+      // The parser's construction re-enters JS and can drain the tick queue, so a
+      // connect that fires from that drain arrives before the constructor finished.
+      if (this.#parser === undefined) {
+        process.nextTick(onConnect.bind(this));
+        return;
+      }
       try {
         this.#onConnect(arguments);
         listener?.$call(this, this);
@@ -5605,6 +5611,7 @@ class ClientHttp2Session extends Http2Session {
     if (typeof options?.maxOutstandingSettings === "number" && options.maxOutstandingSettings >= 1) {
       this.#maxOutstandingSettings = options.maxOutstandingSettings;
     }
+    let connectOnNextTick = false;
     if (typeof options?.createConnection === "function") {
       socket = options.createConnection(url, options);
       this[bunHTTP2Socket] = socket;
@@ -5613,7 +5620,7 @@ class ClientHttp2Session extends Http2Session {
         const connectEvent = socket instanceof tls.TLSSocket ? "secureConnect" : "connect";
         socket.once(connectEvent, onConnect.bind(this));
       } else {
-        process.nextTick(onConnect.bind(this));
+        connectOnNextTick = true;
       }
     } else {
       socket = connectWithProtocol(
@@ -5655,6 +5662,12 @@ class ClientHttp2Session extends Http2Session {
     socket.on("close", this.#onClose.bind(this));
     socket.on("error", this.#onError.bind(this));
     socket.on("timeout", this.#onTimeout.bind(this));
+    if (connectOnNextTick) {
+      // Queued only now that the session is fully built: the parser's construction
+      // re-enters JS, which can drain the tick queue, and an earlier-queued onConnect
+      // would then run against a session whose #parser is not assigned yet.
+      process.nextTick(onConnect.bind(this));
+    }
   }
 
   // Gracefully closes the Http2Session, allowing any existing streams to complete on their own and preventing new Http2Stream instances from being created. Once closed, http2session.destroy() might be called if there are no open Http2Stream instances.

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1462,6 +1462,8 @@ pub struct H2FrameParser {
     hpack: JsCell<Option<lshpack::HpackHandle>>,
 
     has_nonnative_backpressure: Cell<bool>,
+    /// True while flush() has bytes out in an onWrite dispatch to a JS-backed socket.
+    js_socket_flushing: Cell<bool>,
     /// A native write returned a terminal result (socket closed, shut down, or the kernel
     /// rejected the send). Latched once; the deferred tick closes the transport.
     transport_write_fatal: Cell<bool>,
@@ -3159,6 +3161,13 @@ impl H2FrameParser {
 
     pub(crate) fn flush(&self) -> usize {
         bun_output::scoped_log!(H2FrameParser, "flush");
+        // The onWrite dispatch below re-enters JS, and a synchronous transport
+        // (duplexPair) can re-enter flush() from inside it: bail so the in-flight
+        // bytes are not sent a second time (through any arm — a connect callback
+        // running inside the dispatch may have attached a native socket).
+        if self.js_socket_flushing.get() {
+            return 0;
+        }
         // Keep `self` alive across the re-entrant JS calls below.
         let _keepalive = self.keepalive();
 
@@ -3173,7 +3182,8 @@ impl H2FrameParser {
             BunSocket::None => {
                 // consider that backpressure is gone and flush data queue
                 self.has_nonnative_backpressure.set(false);
-                let bytes_len = self.write_buffer.get().slice().len();
+                let offset = self.write_buffer_offset.get();
+                let bytes_len = self.write_buffer.get().slice()[offset..].len();
                 if bytes_len > 0 {
                     let global = self.handlers.get().global();
                     // A failed conversion means the VM is terminating (or OOM): report
@@ -3182,22 +3192,42 @@ impl H2FrameParser {
                         .handlers
                         .get()
                         .binary_type
-                        .to_js(self.write_buffer.get().slice(), &global)
+                        .to_js(&self.write_buffer.get().slice()[offset..], &global)
                     else {
                         return 0;
                     };
+                    self.js_socket_flushing.set(true);
                     let result = self.call(JSH2FrameParser::Gc::onWrite, output_value);
+                    self.js_socket_flushing.set(false);
 
-                    // defer block
-                    self.write_buffer_offset.set(0);
-                    self.write_buffer.with_mut(|wb| {
-                        wb.clear();
-                        if wb.capacity() > MAX_BUFFER_SIZE as usize {
-                            wb.shrink_to(MAX_BUFFER_SIZE as usize);
-                        }
-                    });
+                    // Same contract as _write: -1 dropped, 0 queued by the socket, else sent.
+                    let code = if result.is_number() { result.to_int32() } else { -1 };
+                    if code == -1 {
+                        // JS did not take the bytes (e.g. the session's socket is not ready
+                        // yet). Keep them queued for the next flush — clearing here loses
+                        // the connection preface when the peer's first frames arrive before
+                        // the connect callback has run.
+                        self.has_nonnative_backpressure.set(true);
+                        return 0;
+                    }
 
-                    if result.is_boolean() && !result.to_boolean() {
+                    // Consume exactly what was handed to JS: writes made re-entrantly during
+                    // the dispatch sit after it in the buffer and wait for the next flush.
+                    // `>=` also covers the buffer having been cleared (detach) during the
+                    // dispatch, where advancing would strand the offset past the end.
+                    if offset + bytes_len >= self.write_buffer.get().slice().len() {
+                        self.write_buffer_offset.set(0);
+                        self.write_buffer.with_mut(|wb| {
+                            wb.clear();
+                            if wb.capacity() > MAX_BUFFER_SIZE as usize {
+                                wb.shrink_to(MAX_BUFFER_SIZE as usize);
+                            }
+                        });
+                    } else {
+                        self.write_buffer_offset.set(offset + bytes_len);
+                    }
+
+                    if code == 0 {
                         self.has_nonnative_backpressure.set(true);
                         return bytes_len;
                     }
@@ -9777,6 +9807,7 @@ impl H2FrameParser {
             streams: JsCell::new(BunHashMap::default()),
             hpack: JsCell::new(None),
             has_nonnative_backpressure: Cell::new(false),
+            js_socket_flushing: Cell::new(false),
             transport_write_fatal: Cell::new(false),
             auto_flusher: JsCell::new(AutoFlusher::default()),
             padding_strategy: Cell::new(PaddingStrategy::None),

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -3201,7 +3201,11 @@ impl H2FrameParser {
                     self.js_socket_flushing.set(false);
 
                     // Same contract as _write: -1 dropped, 0 queued by the socket, else sent.
-                    let code = if result.is_number() { result.to_int32() } else { -1 };
+                    let code = if result.is_number() {
+                        result.to_int32()
+                    } else {
+                        -1
+                    };
                     if code == -1 {
                         // JS did not take the bytes (e.g. the session's socket is not ready
                         // yet). Keep them queued for the next flush — clearing here loses

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3489,3 +3489,35 @@ it("http2 server sends each session's frames to its own peer under interleaved r
     server.close();
   }
 });
+
+it("client connects over a user Duplex that already has a 'data' listener", async () => {
+  // A 'data' listener attached before connect() puts the stream in flowing mode, so the
+  // peer's first frames can arrive before the connect callback has run. The preface must
+  // survive that: it used to be dropped, silently stalling the session.
+  const { duplexPair } = require("node:stream");
+  const [clientSide, serverSide] = duplexPair();
+  const server = http2.createServer();
+  server.on("stream", stream => {
+    stream.respond({ ":status": 200 });
+    stream.end("ok");
+  });
+  server.emit("connection", serverSide);
+
+  clientSide.on("data", () => {});
+  const client = http2.connect("http://localhost", { createConnection: () => clientSide });
+  client.on("error", () => {});
+
+  const req = client.request({ ":path": "/" });
+  let status = 0;
+  let body = "";
+  req.setEncoding("utf8");
+  req.on("response", headers => {
+    status = headers[":status"];
+  });
+  req.on("data", chunk => (body += chunk));
+  await new Promise(resolve => req.on("end", resolve));
+  expect(status).toBe(200);
+  expect(body).toBe("ok");
+  client.close();
+  server.close();
+});


### PR DESCRIPTION
### What does this PR do?

Fixes a silent hang: attaching a `'data'` listener to a user Duplex **before** `http2.connect()` made Bun's client never write its connection preface — the session stalled forever with no error. Node works in every ordering. Minimal repro:

```js
const [clientSide, serverSide] = duplexPair();
server.emit("connection", serverSide);
clientSide.on("data", () => {});                       // <- before connect(): hangs
const client = http2.connect("http://x", { createConnection: () => clientSide });
```

The listener puts the stream in flowing mode, so the peer's first frames arrive before the connect callback has run. Three distinct bugs compounded, each verified against node v26.3.0:

1. **`flush()`'s JS-backed-socket arm destroyed refused bytes.** It dispatched the queued `write_buffer` to the JS `onWrite` handler, then cleared the buffer unconditionally, re-latching backpressure only on a boolean `false` — but the handlers return `-1/0/1`, never booleans, so that check has been dead since it landed. A refusal (`-1`, the session's socket not ready yet) read as success and the preface was dropped; nothing ever retried because the socket never got bytes, so `'drain'` never fired. Now honors the same numeric contract `_write` uses, and consumes only the `[offset..offset+len]` prefix actually handed to JS, so writes made re-entrantly during the dispatch are preserved in order.

2. **Re-entrancy sent the retained bytes twice.** With a synchronous transport (duplexPair delivers inline), `flush()` re-enters from inside its own `onWrite` call — the first version of this fix produced a *duplicate preface* and the server answered with a GOAWAY protocol error. The whole function is now guarded while a dispatch is in flight; the guard covers the native arms too, in case a connect callback attaches a native socket mid-dispatch. The consume comparison is `>=` so a `detach()` clearing the buffer during the dispatch cannot strand the offset past the end.

3. **`onConnect` could run against a half-built session.** The client constructor queued `process.nextTick(onConnect)` before assigning `#parser`. The parser's construction re-enters JS, which can drain the tick queue (observed under `bun test`, where module-load depth differs from `bun run`), so `onConnect` hit `this.#parser.flush()` with `#parser` undefined → TypeError → caught → session destroyed with `ERR_HTTP2_INVALID_SESSION`. The tick is now queued after construction, and `onConnect` re-defers if a connect event still lands early (a user Duplex can emit `'connect'` from its own queued tick).

### How did you verify your code works?

Against the node v26.3.0 binary:

- All three listener orderings (`none` / `after` / `before`) complete the request round-trip under `bun run`; the `before` case previously timed out having written 0 bytes.
- The same scenario passes under `bun test`, which previously failed on bug 3 before even reaching the socket.
- Wire-integrity worst case: `before` ordering + a **1 MB** response over duplexPair → body byte-for-byte intact, framing overhead comparable to node (1049402B vs node's 1049213B server→client).
- `test-http2-client-proxy-over-http2` (h2-over-h2 tunneling — the other consumer of the JS-socket write path): 3/3.
- `node-http2.test.js`: 306 pass / 6 skip / 0 fail, including a new regression test covering both the flowing-mode delivery and the nextTick-onConnect path. Vendored `test-http2*` sweep: 0 failures (`test-http2-pipe.js` flaked once under 4-way parallel load and passes 3/3 standalone — known dual-stack flake).
- `test-http2-padding-aligned` (vendored upstream, not in-tree) now gets past the stall to its real assertions — those encode nghttp2's exact write granularity, which Bun's write coalescing intentionally does not match, so it is not added here.

Known accounting nit, deliberately not addressed: while a consumed prefix is retained (only during re-entrant append windows), `getBufferSize()`/session memory accounting counts the full buffer length rather than `len - offset`. The window is transient and the handlers make sustained growth unreachable (`-1` implies `socket.write` was never entered, hence no re-entry).
