### PR TITLE
node:tls: destroy the wrapped net.Socket when tls.connect({ socket }) is destroyed

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1968,20 +1968,15 @@ Socket.prototype._destroy = function _destroy(err, callback) {
   $debug("Socket.prototype._destroy");
 
   this.connecting = false;
-  // Tear down the wrapped transport (tls.connect({ socket })) with this socket:
-  // the 'end'-listener release path only covers a graceful close, so a failed
-  // handshake or mid-stream destroy would otherwise leave the caller's socket
-  // with destroyed=false and its 'close' handlers never firing.
+  // Tear down the wrapped transport (tls.connect({ socket })) with this socket
+  // so the caller's 'close' fires on a failed handshake or mid-stream destroy
+  // too, not only on the graceful 'end' path kCloseRawConnection covers.
   const upgraded = this[kupgraded];
   if (upgraded && !upgraded.destroyed) {
-    if (upgraded instanceof Socket) {
-      // The raw half shares this._handle's fd (released via closeSocketHandle
-      // below); drop it so the wrapped Socket's own _destroy doesn't re-close.
-      upgraded._handle = null;
-      upgraded.destroy();
-    } else {
-      upgraded.destroy?.();
-    }
+    // On the upgradeTLS path upgraded._handle is the raw twin of this._handle
+    // (same us_socket_t; its close() is a no-op once this closes). For a
+    // duplex-wrapped net.Socket (named pipe) _handle owns its own fd.
+    upgraded.destroy?.();
   }
 
   // Close an fd adopted for synchronous writes (node closes the wrapping

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1968,16 +1968,7 @@ Socket.prototype._destroy = function _destroy(err, callback) {
   $debug("Socket.prototype._destroy");
 
   this.connecting = false;
-  // Tear down the wrapped transport (tls.connect({ socket })) with this socket
-  // so the caller's 'close' fires on a failed handshake or mid-stream destroy
-  // too, not only on the graceful 'end' path kCloseRawConnection covers.
   const upgraded = this[kupgraded];
-  if (upgraded && !upgraded.destroyed) {
-    // On the upgradeTLS path upgraded._handle is the raw twin of this._handle
-    // (same us_socket_t; its close() is a no-op once this closes). For a
-    // duplex-wrapped net.Socket (named pipe) _handle owns its own fd.
-    upgraded.destroy?.();
-  }
 
   // Close an fd adopted for synchronous writes (node closes the wrapping
   // libuv handle here). Leave stdio fds 0-2 open: process.stdout/stderr and
@@ -2040,6 +2031,13 @@ Socket.prototype._destroy = function _destroy(err, callback) {
   } else {
     callback(err);
     process.nextTick(emitCloseNT, this, !!err);
+  }
+
+  // Tear down the wrapped transport (tls.connect({ socket })) so its 'close'
+  // fires on a failed handshake too. After this._handle's close so terminate()
+  // stays first-close on the shared us_socket_t; the raw twin's close no-ops.
+  if (upgraded && !upgraded.destroyed) {
+    upgraded.destroy?.();
   }
 
   const server = this.server;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1968,13 +1968,20 @@ Socket.prototype._destroy = function _destroy(err, callback) {
   $debug("Socket.prototype._destroy");
 
   this.connecting = false;
-  // Tear down a wrapped generic duplex with this socket: the native handle's
-  // close only flushes close_notify and lets the wrapper drain; without an
-  // explicit destroy here a late RST on the underlying transport can surface
-  // as an unhandled error after this socket is gone.
+  // Tear down the wrapped transport (tls.connect({ socket })) with this socket:
+  // the 'end'-listener release path only covers a graceful close, so a failed
+  // handshake or mid-stream destroy would otherwise leave the caller's socket
+  // with destroyed=false and its 'close' handlers never firing.
   const upgraded = this[kupgraded];
-  if (upgraded && !(upgraded instanceof Socket) && !upgraded.destroyed) {
-    upgraded.destroy?.();
+  if (upgraded && !upgraded.destroyed) {
+    if (upgraded instanceof Socket) {
+      // The raw half shares this._handle's fd (released via closeSocketHandle
+      // below); drop it so the wrapped Socket's own _destroy doesn't re-close.
+      upgraded._handle = null;
+      upgraded.destroy();
+    } else {
+      upgraded.destroy?.();
+    }
   }
 
   // Close an fd adopted for synchronous writes (node closes the wrapping

--- a/test/js/node/tls/node-tls-upgrade.test.ts
+++ b/test/js/node/tls/node-tls-upgrade.test.ts
@@ -33,6 +33,33 @@ describe.each([
   });
 });
 
+// resetAndDestroy() on a tls.connect({ socket }) wrapper: the wrapped socket
+// must still be destroyed. The wrapped-socket teardown in _destroy runs after
+// this._handle's close so terminate() stays the first close on the shared
+// us_socket_t (first-close-wins).
+test("tls.connect({ socket }).resetAndDestroy() destroys the wrapped net.Socket", async () => {
+  const { promise: peerDone, resolve: peerResolve } = Promise.withResolvers<void>();
+  await using server = net.createServer(c => {
+    c.on("error", () => {});
+    c.on("close", () => peerResolve());
+    c.resume();
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+
+  const netSock = net.connect({ host: "127.0.0.1", port: (server.address() as net.AddressInfo).port });
+  netSock.on("error", () => {});
+  await once(netSock, "connect");
+
+  const netClose = once(netSock, "close");
+  const tlsSock = tls.connect({ socket: netSock, servername: "localhost" });
+  tlsSock.on("error", () => {});
+  tlsSock.resetAndDestroy();
+
+  await netClose;
+  expect(netSock.destroyed).toBe(true);
+  await peerDone;
+});
+
 test("should be able to upgrade a paused socket and also have backpressure on it #15438", async () => {
   // enought to trigger backpressure
   const payload = Buffer.alloc(16 * 1024 * 4, "b").toString("utf8");

--- a/test/js/node/tls/node-tls-upgrade.test.ts
+++ b/test/js/node/tls/node-tls-upgrade.test.ts
@@ -24,15 +24,12 @@ describe.each([
 
     const netClose = once(netSock, "close");
     const tlsSock = tls.connect({ socket: netSock, servername: "localhost" });
+
     const [tlsErr] = await once(tlsSock, "error");
     expect((tlsErr as NodeJS.ErrnoException).code).toBe("ERR_SSL_WRONG_VERSION_NUMBER");
 
     const [hadError] = await netClose;
-    expect(netSock.destroyed).toBe(true);
-    expect(hadError).toBe(false);
-
-    await once(tlsSock, "close");
-    expect(tlsSock.destroyed).toBe(true);
+    expect({ destroyed: netSock.destroyed, hadError }).toEqual({ destroyed: true, hadError: false });
   });
 });
 

--- a/test/js/node/tls/node-tls-upgrade.test.ts
+++ b/test/js/node/tls/node-tls-upgrade.test.ts
@@ -1,8 +1,40 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { once } from "events";
 import { tls as certs } from "harness";
 import net from "net";
 import tls from "tls";
+
+// A net.Socket handed to tls.connect({ socket }) must be destroyed (and emit
+// 'close') when the handshake fails. The 'end'-listener release path only
+// covers a graceful close; _destroy must tear down the wrapped socket too.
+describe.each([
+  ["connecting", false],
+  ["already connected", true],
+])("tls.connect({ socket }) with a failing handshake destroys the wrapped net.Socket (%s)", (_, waitForConnect) => {
+  test.concurrent("destroys the wrapped socket and fires its 'close'", async () => {
+    await using server = net.createServer(c => {
+      c.on("error", () => {});
+      c.on("data", () => c.write("NOT TLS AT ALL\r\n"));
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+
+    const netSock = net.connect({ host: "127.0.0.1", port: (server.address() as net.AddressInfo).port });
+    netSock.on("error", () => {});
+    if (waitForConnect) await once(netSock, "connect");
+
+    const netClose = once(netSock, "close");
+    const tlsSock = tls.connect({ socket: netSock, servername: "localhost" });
+    const [tlsErr] = await once(tlsSock, "error");
+    expect((tlsErr as NodeJS.ErrnoException).code).toBe("ERR_SSL_WRONG_VERSION_NUMBER");
+
+    const [hadError] = await netClose;
+    expect(netSock.destroyed).toBe(true);
+    expect(hadError).toBe(false);
+
+    await once(tlsSock, "close");
+    expect(tlsSock.destroyed).toBe(true);
+  });
+});
 
 test("should be able to upgrade a paused socket and also have backpressure on it #15438", async () => {
   // enought to trigger backpressure


### PR DESCRIPTION
### Reproduction

```js
import net from "node:net"; import tls from "node:tls";
const srv = net.createServer(c => { c.on("error", () => {}); c.on("data", () => c.write("NOT TLS AT ALL\r\n")); });
srv.listen(0, "127.0.0.1", () => {
  const ns = net.connect({ host: "127.0.0.1", port: srv.address().port });
  ns.on("error", () => {});
  const k = tls.connect({ socket: ns, servername: "localhost" }); // peer speaks non-TLS -> handshake fails
  k.on("error", e => console.log("tlsSock error:", e.code));
  ns.on("close", () => console.log("netSock close event"));
  setTimeout(() => { console.log("after 700ms: netSock.destroyed =", ns.destroyed); process.exit(0); }, 700);
});
```

Node v26.3.0 and pre-rewrite Bun:
```
tlsSock error: ERR_SSL_WRONG_VERSION_NUMBER
netSock close event
after 700ms: netSock.destroyed = true
```

Bun on main (a215285):
```
tlsSock error: ERR_SSL_WRONG_VERSION_NUMBER
after 700ms: netSock.destroyed = false
```

The kernel fd is released (no fd leak), but the JS `net.Socket` is stranded with `destroyed === false` and its `'close'` handlers never run. The `socket:` option exists for STARTTLS-style upgrades where callers own that socket and key their cleanup on its `'close'`, so every failed upgrade leaked one zombie Socket.

### Cause

After `tls.connect({ socket: ns })`, the wrapped `ns` has exactly two release paths in `net.ts`:

- `this.once("end", this[kCloseRawConnection])`: only fires on a graceful close; a handshake failure is `error` -> `close` with no `end`.
- `Socket.prototype._destroy`'s `this[kupgraded]` teardown: gated on `!(upgraded instanceof Socket)`, so it only ever tore down generic duplexes.

Neither fires on the error path for a real `net.Socket`, so it is never destroyed.

### Fix

`_destroy` drops the `!(upgraded instanceof Socket)` guard and calls `upgraded.destroy?.()` for any wrapped transport. The teardown runs after `this._handle` is closed so `resetAndDestroy()`'s `terminate()` stays the first close on the shared `us_socket_t` (`us_socket_close` is first-close-wins, socket.c:280); the raw twin's own `close()` then no-ops on `is_closed`. On the `upgradeDuplexToTLS` path (Windows named pipe) `upgraded._handle` owns its own fd and its `_destroy` closes it.

This also covers `tlsSock.destroy()` mid-stream and the server-side `new TLSSocket(socket, { isServer: true })` wrap.

### Verification

```
$ bun bd test test/js/node/tls/node-tls-upgrade.test.ts
(pass) tls.connect({ socket }) with a failing handshake destroys the wrapped net.Socket (connecting)
(pass) tls.connect({ socket }) with a failing handshake destroys the wrapped net.Socket (already connected)
(pass) tls.connect({ socket }).resetAndDestroy() destroys the wrapped net.Socket
(pass) should be able to upgrade a paused socket and also have backpressure on it #15438
```

The failing-handshake tests time out without the fix (waiting on the wrapped socket's `'close'`). Vendored Node tests `test-tls-connect-given-socket`, `test-tls-destroy-whilst-write`, `test-tls-inception`, `test-tls-on-empty-socket`, `test-tls-net-socket-keepalive`, `test-tls-js-stream` all pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-upgrade.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (0e4cd7da1)

test/js/node/tls/node-tls-upgrade.test.ts:
(fail) tls.connect({ socket }) with a failing handshake destroys the wrapped net.Socket (connecting) > destroys the wrapped socket and fires its 'close' [5005.66ms]
  ^ this test timed out after 5000ms.
(fail) tls.connect({ socket }) with a failing handshake destroys the wrapped net.Socket (already connected) > destroys the wrapped socket and fires its 'close' [5007.02ms]
  ^ this test timed out after 5000ms.
(pass) tls.connect({ socket }).resetAndDestroy() destroys the wrapped net.Socket [258.33ms]
(pass) should be able to upgrade a paused socket and also have backpressure on it #15438 [3785.04ms]

 2 pass
 2 fail
 4 expect() calls
Ran 4 tests across 1 file. [14.36s]
er
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (44ca65fc9)

test/js/node/tls/node-tls-upgrade.test.ts:
(pass) tls.connect({ socket }) with a failing handshake destroys the wrapped net.Socket (connecting) > destroys the wrapped socket and fires its 'close' [91.53ms]
(pass) tls.connect({ socket }) with a failing handshake destroys the wrapped net.Socket (already connected) > destroys the wrapped socket and fires its 'close' [82.36ms]
(pass) tls.connect({ socket }).resetAndDestroy() destroys the wrapped net.Socket [5.64ms]
(pass) should be able to upgrade a paused socket and also have backpressure on it #15438 [104.36ms]

 4 pass
 0 fail
 6 expect() calls
Ran 4 tests across 1 file. [661.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-upgrade.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (0e4cd7da1)

test/js/node/tls/node-tls-upgrade.test.ts:
(pass) tls.connect({ socket }) with a failing handshake destroys the wrapped net.Socket (connecting) > destroys the wrapped socket and fires its 'close' [1193.87ms]
(pass) tls.connect({ socket }) with a failing handshake destroys the wrapped net.Socket (already connected) > destroys the wrapped socket and fires its 'close' [1022.60ms]
(pass) tls.connect({ socket }).resetAndDestroy() destroys the wrapped net.Socket [307.54ms]
(pass) should be able to upgrade a paused socket and also have backpressure on it #15438 [3576.15ms]

 4 pass
 0 fail
 6 expect() calls
Ran 4 tests across 1 file. [9.06s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 1872ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/137] gen cpp.rs (cppbind)
[2/137] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[3/137] gen JS modules (bundle-modules)
Preprocess modules (11079ms)
Bundle modules (111ms)
Postprocesss modules (162ms)
Bundle Functions (1151ms)
Generate Code (147ms)

[12.71s] Bundled "src/js" for production
  2035 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[3/137] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: com
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/net.ts                        | 14 ++++----
 test/js/node/tls/node-tls-upgrade.test.ts | 58 ++++++++++++++++++++++++++++++-
 2 files changed, 64 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/node/net.ts                            18     21      0
test/js/node/tls/node-tls-upgrade.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->