### PR TITLE
build(darwin): asan-dyld-shim falls through to real iterate on older macOS

### DIFF
--- a/scripts/build/shims/asan-dyld-shim.c
+++ b/scripts/build/shims/asan-dyld-shim.c
@@ -50,16 +50,21 @@ struct dyld_shared_cache_dylib_text_info {
 typedef void (^dsc_callback)(const struct dyld_shared_cache_dylib_text_info*);
 
 // Forward-declare the real symbol so the interpose table can reference it.
+// Our own calls to it reach the system symbol: dyld does not interpose the
+// image that defines the __interpose tuple (see Apple's dyld-interposing.h).
 extern int dyld_shared_cache_iterate_text(const uuid_t, dsc_callback);
 
 static int shim_iterate(const uuid_t uuid, dsc_callback cb) {
-  (void)uuid;
   typedef const struct mach_header* (*get_hdr_fn)(void);
   get_hdr_fn get_hdr = (get_hdr_fn)dlsym(RTLD_DEFAULT, "_dyld_get_dyld_header");
   const struct mach_header* hdr = get_hdr ? get_hdr() : NULL;
   size_t len;
   const void* cacheStart = _dyld_get_shared_cache_range(&len);
-  if (!hdr || !cacheStart || !cb) return -1;
+  // _dyld_get_dyld_header only exists on newer macOS. On older releases the
+  // real iterate has no 26.4 deadlock, so delegate rather than return -1
+  // (ASAN CHECK_EQ(res, 0) aborts otherwise). Mirrors the upstream fix.
+  if (!hdr || !cacheStart) return dyld_shared_cache_iterate_text(uuid, cb);
+  if (!cb) return -1;
 
   struct dyld_shared_cache_dylib_text_info info;
   memset(&info, 0, sizeof(info));
@@ -72,7 +77,7 @@ static int shim_iterate(const uuid_t uuid, dsc_callback cb) {
 
 // DYLD_INTERPOSE: tells dyld to redirect calls to the original symbol (from
 // any image, including the ASAN runtime) to our replacement. The original
-// pointer here is linker-resolved to the system's symbol; we never call it.
+// pointer here is linker-resolved to the system's symbol.
 __attribute__((used, section("__DATA,__interpose")))
 static struct { const void* replacement; const void* original; } interpose_tbl[] = {
   { (const void*)(uintptr_t)&shim_iterate,


### PR DESCRIPTION
## Problem

`bun bd` aborts at startup on macOS releases older than 26.4 (seen on 15.6.1, Homebrew llvm@21):

```
AddressSanitizer: CHECK failed: sanitizer_procmaps_mac.cpp:214 "((res)) == ((0))" (0xffffffffffffffff, 0x0)
    <empty stack>
Abort trap: 6
```

The post-link `bun-debug --revision` smoke test dies with this, so the debug build never completes. Workaround has been `bun run build --asan=off`.

## Cause

`scripts/build/shims/asan-dyld-shim.c` interposes `dyld_shared_cache_iterate_text` to keep ASAN init from deadlocking on macOS 26.4 (llvm/llvm-project#182943). It looks up the private `_dyld_get_dyld_header` via `dlsym` to synthesize the one cache entry ASAN needs.

Apple's own `dyld_priv.h` marks that symbol ["Added in macOS/iOS 26.4"](https://github.com/apple-oss-distributions/dyld/blob/dyld-1376.6/include/mach-o/dyld_priv.h) (first appears in dyld-1376.6; absent from dyld-1340 and every earlier tag). On any macOS < 26.4, `dlsym` returns `NULL`, the shim returns `-1`, and compiler-rt's `CHECK_EQ(res, 0)` aborts.

The shim is linked into every `cfg.darwin && cfg.asan` build with no runtime check, so it breaks every debug build on macOS hosts that predate 26.4.

## Fix

When the shim can't synthesize the entry (`dlsym` returned `NULL`, or no shared cache), delegate to the real `dyld_shared_cache_iterate_text` instead of returning `-1`. The deadlock and the getter were introduced together in 26.4, so "getter absent" is exactly "real iterate is safe".

This is the same shape as the upstream compiler-rt fix (llvm/llvm-project#188913): weak-import `_dyld_get_dyld_header`, use it when present, otherwise fall through to the existing iterate path.

Calling the original by name from inside the interposer does not recurse. dyld explicitly adds an identity-mapping tuple for the defining image; from [DyldRuntimeState.cpp](https://github.com/apple-oss-distributions/dyld/blob/dyld-1378/dyld/DyldRuntimeState.cpp):

> `// now add specific interpose so that the generic is not applied to the interposing dylib, so it can call through to old impl`

(This is also how Apple's own `DYLD_INTERPOSE` wrapper example in [dyld-interposing.h](https://github.com/apple-oss-distributions/dyld/blob/main/include/mach-o/dyld-interposing.h) works.)

## Verification

Shim is only compiled for `darwin && asan` (no CI lane exists for that combination); verified the change compiles clean with `-Wall -Wextra -fblocks` against stubbed darwin headers. Behaviour on 26.4+ is unchanged: `dlsym` finds the symbol there and the same synthesize path runs as before.

## Why this is the right fix

The alternative is gating shim emission on host macOS version in `shims.ts`, but the runtime check is strictly better: one binary works on both, and it matches upstream exactly. The shim is temporary regardless (self-obsoletes via `workarounds.ts` once LLVM 22.1.4+ is the floor; #34299 deletes it as part of the LLVM 22 bump), so the goal here is just to stop breaking pre-26.4 macOS until that lands.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->