### PR TITLE
http2: perf_hooks entries, END_STREAM on the final DATA frame, and close/push parity

### DIFF
--- a/src/js/internal/shared.ts
+++ b/src/js/internal/shared.ts
@@ -163,7 +163,7 @@ const observerCounts = new Map();
 const kObservers = new Set();
 
 /** Entry types routed through this JS-side registry instead of the native observer. */
-const kNodeEntryTypes = new Set(["net", "dns", "http", "function"]);
+const kNodeEntryTypes = new Set(["net", "dns", "http", "http2", "function"]);
 
 function hasObserver(type) {
   return (observerCounts.get(type) ?? 0) > 0;

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2280,7 +2280,13 @@ function deferWriteCallbackForSocket(nativeSocket) {
 // ride the trailer HEADERS instead). node packs END_STREAM onto that final DATA frame
 // rather than emitting an empty one after it.
 function isFinalWrite(stream: Http2Stream, pendingLength: number) {
-  return stream._writableState.ending && stream.writableLength === pendingLength && !stream[bunHTTP2WaitForTrailers];
+  // `ending` is set only after end()'s own synchronous write has already dispatched, so
+  // end(chunk) — the common case — needs kEndingWithChunk to see the last chunk as final.
+  return (
+    (stream._writableState.ending || stream[kEndingWithChunk] === true) &&
+    stream.writableLength === pendingLength &&
+    !stream[bunHTTP2WaitForTrailers]
+  );
 }
 
 // writeStream settled the stream to HALF_CLOSED_LOCAL synchronously with the dispatch
@@ -2315,6 +2321,9 @@ function publishStreamCloseChannel(stream: Http2Stream) {
     onServerStreamCloseChannel.publish({ stream });
   }
 }
+// Set across end(chunk)'s synchronous super.end() only: bridges the window where the final
+// chunk dispatches before Writable marks the stream ending.
+const kEndingWithChunk = Symbol("http2EndingWithChunk");
 const kPerfStats = Symbol("http2PerfStats");
 const kPerfState = Symbol("http2PerfState");
 
@@ -3009,7 +3018,15 @@ class Http2Stream extends Duplex {
     // Don't create an empty buffer for end() without data - let the Duplex stream
     // handle it naturally (just calls _final without _write for empty data).
     // Creating an empty buffer here causes an extra empty DATA frame to be sent.
-    return super.end(chunk, encoding, callback);
+    const hasChunk = chunk !== undefined && chunk !== null && chunk.length > 0;
+    if (hasChunk) this[kEndingWithChunk] = true;
+    try {
+      return super.end(chunk, encoding, callback);
+    } finally {
+      // Only the synchronous window is bridged: a chunk buffered behind an in-flight
+      // write dispatches later, when `ending` is already set.
+      if (hasChunk) this[kEndingWithChunk] = false;
+    }
   }
 
   _writev(data, callback) {
@@ -4289,6 +4306,7 @@ class ServerHttp2Session extends Http2Session {
           stream.destroy();
         }
         if (self.#connections === 0 && self.#closed) {
+          captureHttp2PerfFrameSnapshot(self, self[bunHTTP2Native]);
           self.destroy();
         }
       } else if (state === 5) {
@@ -5250,10 +5268,17 @@ class ClientHttp2Session extends Http2Session {
         if (self.#connections === 0 && self.#closed) {
           // Deferred like close()'s own destroy: this runs inside a native dispatch
           // batch, and frames the engine already received but has not dispatched yet
-          // must still reach JS. An outstanding settings() ACK gets a bounded grace
-          // (see scheduleSettingsAckGraceNT); its arrival completes the destroy.
-          if (self.#pendingSettingsAckCount > 0) scheduleSettingsAckGraceNT(self);
-          else setImmediate(destroyIfNotDestroyedNT, self);
+          // must still reach JS. An outstanding settings() ACK or ping gets a bounded
+          // grace (see scheduleSettingsAckGraceNT); its arrival completes the destroy.
+          if (
+            self.#pendingSettingsAckCount > 0 ||
+            (self.#pingCallbacks !== null && self.#pingCallbacks.length > 0)
+          ) {
+            scheduleSettingsAckGraceNT(self);
+          } else {
+            captureHttp2PerfFrameSnapshot(self, self[bunHTTP2Native]);
+            setImmediate(destroyIfNotDestroyedNT, self);
+          }
         }
       } else if (state === 5) {
         // 5 = local closed aka write is closed

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -27,8 +27,13 @@
  * Modifications were made to the original code.
  */
 const { isTypedArray } = require("node:util/types");
-const { hideFromStack, throwNotImplemented, hasObserver, enqueueNodeEntry, PerformanceNodeEntry } =
-  require("internal/shared");
+const {
+  hideFromStack,
+  throwNotImplemented,
+  hasObserver,
+  enqueueNodeEntry,
+  PerformanceNodeEntry,
+} = require("internal/shared");
 const { STATUS_CODES } = require("internal/http");
 const { kTimeout, getTimerDuration } = require("internal/timers");
 const tls = require("node:tls");
@@ -5330,7 +5335,13 @@ class ClientHttp2Session extends Http2Session {
         clearTimeout(self[kSettingsAckGraceTimer]);
         self[kSettingsAckGraceTimer] = undefined;
       }
-      if (self.#closed && self.#connections === 0 && self.#pendingSettingsAckCount === 0 && pingsDrained && !self.destroyed) {
+      if (
+        self.#closed &&
+        self.#connections === 0 &&
+        self.#pendingSettingsAckCount === 0 &&
+        pingsDrained &&
+        !self.destroyed
+      ) {
         captureHttp2PerfFrameSnapshot(self, self[bunHTTP2Native]);
         setImmediate(destroyIfNotDestroyedNT, self);
       }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -27,7 +27,8 @@
  * Modifications were made to the original code.
  */
 const { isTypedArray } = require("node:util/types");
-const { hideFromStack, throwNotImplemented } = require("internal/shared");
+const { hideFromStack, throwNotImplemented, hasObserver, enqueueNodeEntry, PerformanceNodeEntry } =
+  require("internal/shared");
 const { STATUS_CODES } = require("internal/http");
 const { kTimeout, getTimerDuration } = require("internal/timers");
 const tls = require("node:tls");
@@ -2228,6 +2229,11 @@ function pushToStream(stream, data) {
   // past the buffer's high-water mark instead of stalling on the receive window.
   // setStreamReading(id, false) only records the paused bit natively, so calling it
   // from inside the dispatch that delivered `data` cannot re-enter the engine.
+  const perf = stream[kPerfState];
+  if (perf !== undefined && data !== null) {
+    if (perf.firstByte === 0) perf.firstByte = performance.now() - perf.start;
+    perf.bytesRead += data.length;
+  }
   if (!stream.push(data) && data !== null) {
     streamOnPause.$call(stream);
   }
@@ -2243,6 +2249,9 @@ enum StreamState {
   // The native side fully closed and freed the stream (state 7 delivered): there is
   // nothing left to send on the wire for it.
   NativeClosed = 1 << 6, // 1000000 = 64
+  // END_STREAM already rode the final DATA frame from _write/_writev; _final must not
+  // emit the empty END_STREAM frame on top of it.
+  EndStreamSent = 1 << 7, // 10000000 = 128
 }
 // native.writeStream() return-value flag (mirrors WRITE_FLUSHED_WITHOUT_CALLBACK in
 // h2_frame_parser.rs): the chunk was handed to the socket without queueing and the engine did
@@ -2260,6 +2269,25 @@ const kWriteFlushedWithoutCallback = 0x10;
 function deferWriteCallbackForSocket(nativeSocket) {
   return nativeSocket ? process.nextTick : setImmediate;
 }
+// Whether this chunk is the writable's last: end() already ran and nothing is queued
+// behind it (writableLength still includes the in-flight chunk, in the writable's own
+// units — string chunks count code units), and no trailers are pending (END_STREAM must
+// ride the trailer HEADERS instead). node packs END_STREAM onto that final DATA frame
+// rather than emitting an empty one after it.
+function isFinalWrite(stream: Http2Stream, pendingLength: number) {
+  return stream._writableState.ending && stream.writableLength === pendingLength && !stream[bunHTTP2WaitForTrailers];
+}
+
+// writeStream settled the stream to HALF_CLOSED_LOCAL synchronously with the dispatch
+// suppressed: the JS side runs the bookkeeping the onStreamEnd(5) handler would have.
+function onEndStreamSettled(stream: Http2Stream) {
+  markWritableDone(stream);
+  if ((stream.id & 1) === 0 && stream[bunHTTP2Session]?.type === constants.NGHTTP2_SESSION_SERVER) {
+    if (!stream.rstCode) stream.rstCode = 0;
+    markStreamClosed(stream);
+  }
+}
+
 function markWritableDone(stream: Http2Stream) {
   const _final = stream[bunHTTP2StreamFinal];
   if (typeof _final === "function") {
@@ -2282,6 +2310,97 @@ function publishStreamCloseChannel(stream: Http2Stream) {
     onServerStreamCloseChannel.publish({ stream });
   }
 }
+const kPerfStats = Symbol("http2PerfStats");
+const kPerfState = Symbol("http2PerfState");
+
+// perf_hooks 'http2' entries, mirroring node's Http2Session/Http2Stream statistics.
+// All tracking is armed at construction only while an 'http2' observer exists, so
+// unobserved sessions pay a single hasObserver() check.
+function initHttp2SessionPerf(session, type: "server" | "client") {
+  if (!hasObserver("http2")) return;
+  session[kPerfStats] = {
+    type,
+    start: performance.now(),
+    streamCount: 0,
+    streamDurationSum: 0,
+    closedStreams: 0,
+    live: 0,
+    maxConcurrentStreams: 0,
+    pingRTT: 0,
+    emitted: false,
+  };
+}
+
+function trackHttp2StreamStart(stream, session) {
+  const stats = session?.[kPerfStats];
+  if (stats === undefined) return;
+  stats.streamCount++;
+  stats.live++;
+  if (stats.live > stats.maxConcurrentStreams) stats.maxConcurrentStreams = stats.live;
+  stream[kPerfState] = {
+    start: performance.now(),
+    bytesRead: 0,
+    bytesWritten: 0,
+    firstHeader: 0,
+    firstByte: 0,
+    firstByteSent: 0,
+  };
+}
+
+function emitHttp2StreamPerf(stream) {
+  const state = stream[kPerfState];
+  if (state === undefined) return;
+  stream[kPerfState] = undefined;
+  const now = performance.now();
+  const stats = stream[bunHTTP2Session]?.[kPerfStats];
+  if (stats !== undefined) {
+    stats.live--;
+    stats.closedStreams++;
+    stats.streamDurationSum += now - state.start;
+  }
+  enqueueNodeEntry(
+    new PerformanceNodeEntry("Http2Stream", "http2", state.start, now - state.start, {
+      id: typeof stream.id === "number" ? stream.id : 0,
+      timeToFirstByte: state.firstByte,
+      timeToFirstByteSent: state.firstByteSent,
+      timeToFirstHeader: state.firstHeader,
+      bytesWritten: state.bytesWritten,
+      bytesRead: state.bytesRead,
+    }),
+  );
+}
+
+// Counters as of the moment the session's graceful close completed and the destroy was
+// scheduled: frames arriving during the deferral (e.g. the peer's GOAWAY reply) belong
+// to teardown, which is where node's own accounting stops.
+function captureHttp2PerfFrameSnapshot(session, parser) {
+  const stats = session[kPerfStats];
+  if (stats !== undefined && stats.frameSnapshot === undefined && parser) {
+    stats.frameSnapshot = parser.getFrameCounters();
+  }
+}
+
+function emitHttp2SessionPerf(session, parser, socket) {
+  const stats = session[kPerfStats];
+  if (stats === undefined || stats.emitted) return;
+  stats.emitted = true;
+  const now = performance.now();
+  const counters = stats.frameSnapshot ?? parser?.getFrameCounters() ?? { framesReceived: 0, framesSent: 0 };
+  enqueueNodeEntry(
+    new PerformanceNodeEntry("Http2Session", "http2", stats.start, now - stats.start, {
+      bytesWritten: socket?.bytesWritten ?? 0,
+      bytesRead: socket?.bytesRead ?? 0,
+      framesReceived: counters.framesReceived,
+      framesSent: counters.framesSent,
+      maxConcurrentStreams: stats.maxConcurrentStreams,
+      pingRTT: stats.pingRTT,
+      streamAverageDuration: stats.closedStreams > 0 ? stats.streamDurationSum / stats.closedStreams : 0,
+      streamCount: stats.streamCount,
+      type: stats.type,
+    }),
+  );
+}
+
 function markStreamClosed(stream: Http2Stream) {
   const status = stream[bunHTTP2StreamStatus];
 
@@ -2392,6 +2511,7 @@ class Http2Stream extends Duplex {
     this.#id = streamId;
     this[bunHTTP2Session] = session;
     this[bunHTTP2Headers] = headers;
+    trackHttp2StreamStart(this, session);
     // node ties the stream's receive window to JS-side consumption (readStart/readStop on the
     // native handle): while the readable is paused the peer is not granted more window, so it
     // backpressures instead of the session buffering the whole body.
@@ -2690,6 +2810,7 @@ class Http2Stream extends Duplex {
       }
     }
     this.rstCode = rstCode;
+    emitHttp2StreamPerf(this);
     // node closes the stream from inside _destroy, so the close-channel publish observes
     // closed === true and destroyed === true with the final rstCode. The non-error close path
     // (streamEnd state=7) calls markStreamClosed BEFORE destroy(), where the channel observes
@@ -2744,6 +2865,17 @@ class Http2Stream extends Duplex {
 
     if (onClientStreamBodySentChannel.hasSubscribers && this instanceof ClientHttp2Stream) {
       onClientStreamBodySentChannel.publish({ stream: this });
+    }
+    if ((status & StreamState.EndStreamSent) !== 0) {
+      this[bunHTTP2StreamStatus] = status | StreamState.FinalCalled;
+      if ((status & (StreamState.WritableClosed | StreamState.Closed)) !== 0) {
+        callback();
+      } else {
+        // The final DATA is still in flight; the drain-side streamEnd(5) dispatch
+        // completes the writable through markWritableDone.
+        this[bunHTTP2StreamFinal] = callback;
+      }
+      return;
     }
     const session = this[bunHTTP2Session];
     if (session) {
@@ -2881,10 +3013,22 @@ class Http2Stream extends Duplex {
       this.once("ready", this._writev.bind(this, data, callback));
       return;
     }
+    const writevPerf = this[kPerfState];
+    if (writevPerf !== undefined) {
+      if (writevPerf.firstByteSent === 0) writevPerf.firstByteSent = performance.now() - writevPerf.start;
+      for (let i = 0; i < data.length; i++) {
+        const { chunk, encoding } = data[i];
+        writevPerf.bytesWritten += typeof chunk === "string" ? Buffer.byteLength(chunk, encoding) : chunk.length;
+      }
+    }
     const session = this[bunHTTP2Session];
     if (session) {
       const native = session[bunHTTP2Native];
       if (native) {
+        let batchLength = 0;
+        for (let i = 0; i < data.length; i++) {
+          batchLength += data[i].chunk.length;
+        }
         const allBuffers = data.allBuffers;
         let chunks;
         if (allBuffers) {
@@ -2908,8 +3052,13 @@ class Http2Stream extends Duplex {
         }
         const chunk = Buffer.concat(chunks || []);
         if (session[kTimeout]) session[kTimeout].refresh();
-        const status = native.writeStream(this.#id, chunk, undefined, false, callback, true);
+        const endStream = isFinalWrite(this, batchLength);
+        const status = native.writeStream(this.#id, chunk, undefined, endStream, callback, true);
         if (status & kWriteFlushedWithoutCallback) session[kDeferWriteCallback](callback);
+        if (endStream) {
+          this[bunHTTP2StreamStatus] |= StreamState.EndStreamSent;
+          if ((status & ~kWriteFlushedWithoutCallback) === 5) onEndStreamSettled(this);
+        }
         if (onClientStreamBodyChunkSentChannel.hasSubscribers && this instanceof ClientHttp2Stream) {
           onClientStreamBodyChunkSentChannel.publish({ stream: this, writev: true, data, encoding: "" });
         }
@@ -2926,6 +3075,11 @@ class Http2Stream extends Duplex {
       this.once("ready", this._write.bind(this, chunk, encoding, callback));
       return;
     }
+    const writePerf = this[kPerfState];
+    if (writePerf !== undefined) {
+      if (writePerf.firstByteSent === 0) writePerf.firstByteSent = performance.now() - writePerf.start;
+      writePerf.bytesWritten += typeof chunk === "string" ? Buffer.byteLength(chunk, encoding) : chunk.length;
+    }
     const session = this[bunHTTP2Session];
     if (session) {
       const native = session[bunHTTP2Native];
@@ -2939,8 +3093,13 @@ class Http2Stream extends Duplex {
           wireEncoding = undefined;
         }
         if (session[kTimeout]) session[kTimeout].refresh();
-        const status = native.writeStream(this.#id, wireChunk, wireEncoding, false, callback, true);
+        const endStream = isFinalWrite(this, chunk.length);
+        const status = native.writeStream(this.#id, wireChunk, wireEncoding, endStream, callback, true);
         if (status & kWriteFlushedWithoutCallback) session[kDeferWriteCallback](callback);
+        if (endStream) {
+          this[bunHTTP2StreamStatus] |= StreamState.EndStreamSent;
+          if ((status & ~kWriteFlushedWithoutCallback) === 5) onEndStreamSettled(this);
+        }
         if (onClientStreamBodyChunkSentChannel.hasSubscribers && this instanceof ClientHttp2Stream) {
           onClientStreamBodyChunkSentChannel.publish({ stream: this, writev: false, data: chunk, encoding });
         }
@@ -3297,8 +3456,9 @@ class ServerHttp2Stream extends Http2Stream {
     if (onServerStreamStartChannel.hasSubscribers) {
       onServerStreamStartChannel.publish({ stream: pushedStream, headers });
     }
+    let pushResult;
     try {
-      parser.pushPromise(this.id, pushId, headers, sensitiveNames);
+      pushResult = parser.pushPromise(this.id, pushId, headers, sensitiveNames);
     } catch (err) {
       // pushPromise() can throw synchronously (invalid token, invalid pseudo-header, oversized
       // block). The pushed stream was already created by getNextStream's streamStart; tear it
@@ -3313,6 +3473,15 @@ class ServerHttp2Stream extends Http2Stream {
         pushedStream.destroy(err);
       }
       process.nextTick(callback, err);
+      return;
+    }
+    if (pushResult === -1) {
+      // The block could not be encoded: the session is failing with a COMPRESSION_ERROR.
+      // node still delivers the reserved stream to the callback (the caller gets to
+      // attach handlers) and lets the session teardown error it. The PUSH_PROMISE never
+      // reached the wire, so teardown must not send an RST for the reserved id.
+      if (pushedStream) pushedStream[kNeverAnnounced] = true;
+      process.nextTick(callback, null, pushedStream, headers);
       return;
     }
     // node: a HEAD push (or options.endStream) carries no response body, so the pushed stream's
@@ -4210,7 +4379,21 @@ class ServerHttp2Session extends Http2Session {
           const callbackInfo = callbacks.shift();
           if (callbackInfo) {
             const [callback, start] = callbackInfo;
-            callback(null, Date.now() - start, payload);
+            const rtt = Date.now() - start;
+            const stats = self[kPerfStats];
+            if (stats !== undefined) stats.pingRTT = rtt;
+            callback(null, rtt, payload);
+            if (callbacks.length === 0 && self.#pendingSettingsAckCount === 0) {
+              if (self[kSettingsAckGraceTimer] !== undefined) {
+                clearTimeout(self[kSettingsAckGraceTimer]);
+                self[kSettingsAckGraceTimer] = undefined;
+              }
+              // A server session has no pending-request queue.
+              if (self.#closed && self.#connections === 0 && !self.destroyed) {
+                captureHttp2PerfFrameSnapshot(self, self[bunHTTP2Native]);
+                setImmediate(destroyIfNotDestroyedNT, self);
+              }
+            }
           }
         }
       }
@@ -4470,6 +4653,7 @@ class ServerHttp2Session extends Http2Session {
     socket.on("close", this.#onClose.bind(this));
     socket.on("error", this.#onError.bind(this));
     socket.on("timeout", this.#onTimeout.bind(this));
+    initHttp2SessionPerf(this, "server");
     socket.on("data", this.#onRead.bind(this));
     socket.on("drain", this.#onDrain.bind(this));
 
@@ -4522,9 +4706,11 @@ class ServerHttp2Session extends Http2Session {
   }
 
   get socket() {
-    if (this.#socket_proxy) return this.#socket_proxy;
+    // After the session detaches from its socket node reports undefined, even
+    // when the proxy had been handed out earlier.
     const socket = this[bunHTTP2Socket];
-    if (!socket) return null;
+    if (!socket) return undefined;
+    if (this.#socket_proxy) return this.#socket_proxy;
     this.#socket_proxy = new Proxy(this, proxySocketHandler);
     return this.#socket_proxy;
   }
@@ -4673,6 +4859,7 @@ class ServerHttp2Session extends Http2Session {
       return;
     }
     this.#destroying = true;
+    emitHttp2SessionPerf(this, this.#parser, this[bunHTTP2Socket]);
     try {
       const server = this[kServer];
       if (server) {
@@ -5122,6 +5309,10 @@ class ClientHttp2Session extends Http2Session {
             } else {
               // Node's ClientHttp2Session emits 'stream' only for pushed streams; a normal request's
               // response arrives solely via the stream's own 'response' event.
+              const responsePerf = stream[kPerfState];
+              if (responsePerf !== undefined && responsePerf.firstHeader === 0) {
+                responsePerf.firstHeader = performance.now() - responsePerf.start;
+              }
               stream.emit("response", headers, flags, rawheaders);
             }
           }
@@ -5134,11 +5325,13 @@ class ClientHttp2Session extends Http2Session {
       self.#pendingSettingsAck = false;
       if (self.#pendingSettingsAckCount > 0) self.#pendingSettingsAckCount--;
       // This ACK may be the only thing a gracefully closed, idle session was waiting for.
-      if (self.#pendingSettingsAckCount === 0 && self[kSettingsAckGraceTimer] !== undefined) {
+      const pingsDrained = self.#pingCallbacks === null || self.#pingCallbacks.length === 0;
+      if (self.#pendingSettingsAckCount === 0 && pingsDrained && self[kSettingsAckGraceTimer] !== undefined) {
         clearTimeout(self[kSettingsAckGraceTimer]);
         self[kSettingsAckGraceTimer] = undefined;
       }
-      if (self.#closed && self.#connections === 0 && self.#pendingSettingsAckCount === 0 && !self.destroyed) {
+      if (self.#closed && self.#connections === 0 && self.#pendingSettingsAckCount === 0 && pingsDrained && !self.destroyed) {
+        captureHttp2PerfFrameSnapshot(self, self[bunHTTP2Native]);
         setImmediate(destroyIfNotDestroyedNT, self);
       }
       const queued = self.#pendingSettingsCallbacks.shift();
@@ -5166,7 +5359,25 @@ class ClientHttp2Session extends Http2Session {
           const callbackInfo = callbacks.shift();
           if (callbackInfo) {
             const [callback, start] = callbackInfo;
-            callback(null, Date.now() - start, payload);
+            const rtt = Date.now() - start;
+            const stats = self[kPerfStats];
+            if (stats !== undefined) stats.pingRTT = rtt;
+            callback(null, rtt, payload);
+            if (callbacks.length === 0 && self.#pendingSettingsAckCount === 0) {
+              if (self[kSettingsAckGraceTimer] !== undefined) {
+                clearTimeout(self[kSettingsAckGraceTimer]);
+                self[kSettingsAckGraceTimer] = undefined;
+              }
+              if (
+                self.#closed &&
+                self.#connections === 0 &&
+                (self.#pendingRequests === null || self.#pendingRequests.length === 0) &&
+                !self.destroyed
+              ) {
+                captureHttp2PerfFrameSnapshot(self, self[bunHTTP2Native]);
+                setImmediate(destroyIfNotDestroyedNT, self);
+              }
+            }
           }
         }
       }
@@ -5479,9 +5690,11 @@ class ClientHttp2Session extends Http2Session {
     return this.#parser?.setLocalWindowSize?.(windowSize);
   }
   get socket() {
-    if (this.#socket_proxy) return this.#socket_proxy;
+    // After the session detaches from its socket node reports undefined, even
+    // when the proxy had been handed out earlier.
     const socket = this[bunHTTP2Socket];
-    if (!socket) return null;
+    if (!socket) return undefined;
+    if (this.#socket_proxy) return this.#socket_proxy;
     this.#socket_proxy = new Proxy(this, proxySocketHandler);
     return this.#socket_proxy;
   }
@@ -5643,6 +5856,7 @@ class ClientHttp2Session extends Http2Session {
     socket.on("close", this.#onClose.bind(this));
     socket.on("error", this.#onError.bind(this));
     socket.on("timeout", this.#onTimeout.bind(this));
+    initHttp2SessionPerf(this, "client");
   }
 
   // Gracefully closes the Http2Session, allowing any existing streams to complete on their own and preventing new Http2Stream instances from being created. Once closed, http2session.destroy() might be called if there are no open Http2Stream instances.
@@ -5673,8 +5887,14 @@ class ClientHttp2Session extends Http2Session {
     // localSettings dispatch finishes the deferred destroy, and a dead socket still tears
     // the session down. destroy() remains immediate.
     if (this.#connections === 0 && (this.#pendingRequests === null || this.#pendingRequests.length === 0)) {
-      if (this.#pendingSettingsAckCount > 0) scheduleSettingsAckGraceNT(this);
-      else setImmediate(destroyIfNotDestroyedNT, this);
+      // An unACKed ping gets the same bounded grace as an unACKed SETTINGS: node always
+      // delivers the ping callback its RTT on a healthy session, never a cancel error.
+      if (this.#pendingSettingsAckCount > 0 || (this.#pingCallbacks !== null && this.#pingCallbacks.length > 0)) {
+        scheduleSettingsAckGraceNT(this);
+      } else {
+        captureHttp2PerfFrameSnapshot(this, this.#parser);
+        setImmediate(destroyIfNotDestroyedNT, this);
+      }
     }
   }
 
@@ -5700,6 +5920,7 @@ class ClientHttp2Session extends Http2Session {
       return;
     }
     this.#destroying = true;
+    emitHttp2SessionPerf(this, this.#parser, socket);
     try {
       if (this[kTimeout]) {
         clearTimeout(this[kTimeout]);

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -5270,10 +5270,7 @@ class ClientHttp2Session extends Http2Session {
           // batch, and frames the engine already received but has not dispatched yet
           // must still reach JS. An outstanding settings() ACK or ping gets a bounded
           // grace (see scheduleSettingsAckGraceNT); its arrival completes the destroy.
-          if (
-            self.#pendingSettingsAckCount > 0 ||
-            (self.#pingCallbacks !== null && self.#pingCallbacks.length > 0)
-          ) {
+          if (self.#pendingSettingsAckCount > 0 || (self.#pingCallbacks !== null && self.#pingCallbacks.length > 0)) {
             scheduleSettingsAckGraceNT(self);
           } else {
             captureHttp2PerfFrameSnapshot(self, self[bunHTTP2Native]);

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -590,8 +590,12 @@ impl Connection {
 
     /// Dispatch one fully-buffered frame. Returns true if the connection is now fatally closing.
     fn dispatch(&mut self, sink: &impl Sink, hdr: &FrameHeader, payload: &[u8]) -> bool {
-        self.frames_received += 1;
-        sink.on_frame_counters(self.frames_received, self.frames_sent);
+        // GOAWAY is excluded: it terminates the session, so node's statistics — which are
+        // read off a session that stopped processing at that frame — never include it.
+        if !matches!(hdr.typ(), Some(FrameType::GoAway)) {
+            self.frames_received += 1;
+            sink.on_frame_counters(self.frames_received, self.frames_sent);
+        }
         // RFC 9113 §4.3 / §6.10: once a HEADERS/PUSH_PROMISE without END_HEADERS is received, the
         // ONLY permitted frame is a CONTINUATION for that same stream until the block completes.
         // Checked before structural validation: a malformed non-CONTINUATION frame mid-block is a

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -154,6 +154,10 @@ pub trait Sink {
     /// The peer exceeded the session's invalid-frame allowance (node's maxSessionInvalidFrames):
     /// the embedder should destroy the session with ERR_HTTP2_TOO_MANY_INVALID_FRAMES.
     fn on_too_many_invalid_frames(&self) {}
+    /// Frame-counter update (perf_hooks http2 session stats). Called whenever either
+    /// counter moves, while the connection is mutably borrowed — the embedder must only
+    /// store the values.
+    fn on_frame_counters(&self, _received: u64, _sent: u64) {}
     /// Transition shim while the outbound path still flows through the embedder's legacy encoder:
     /// returns true if `stream_id` was initiated locally (HEADERS already sent by the embedder), so
     /// inbound frames for it are not treated as frames on an idle stream.
@@ -179,6 +183,10 @@ pub trait Sink {
 
 pub struct Connection {
     pub is_server: bool,
+    /// Wire frames fully accepted from the peer (perf_hooks http2 session stats).
+    pub frames_received: u64,
+    /// Wire frames this engine itself has written (the embedder counts its own).
+    pub frames_sent: u64,
 
     pub local_settings: Settings,
     pub remote_settings: Settings,
@@ -269,6 +277,8 @@ impl Connection {
             remote_settings: Settings::default(),
             local_settings_acked: false,
             max_header_list_pairs: 128,
+            frames_received: 0,
+            frames_sent: 0,
             max_invalid_frames: 1000,
             acked_local_initial_window: 65_535,
             enforced_max_header_list_size: local.max_header_list_size,
@@ -309,6 +319,8 @@ impl Connection {
         stream_id: u32,
         payload: &[u8],
     ) {
+        self.frames_sent += 1;
+        sink.on_frame_counters(self.frames_received, self.frames_sent);
         let mut hdr_buf = [0u8; wire::FRAME_HEADER_SIZE];
         let hdr = FrameHeader {
             length: payload.len() as u32,
@@ -578,6 +590,8 @@ impl Connection {
 
     /// Dispatch one fully-buffered frame. Returns true if the connection is now fatally closing.
     fn dispatch(&mut self, sink: &impl Sink, hdr: &FrameHeader, payload: &[u8]) -> bool {
+        self.frames_received += 1;
+        sink.on_frame_counters(self.frames_received, self.frames_sent);
         // RFC 9113 §4.3 / §6.10: once a HEADERS/PUSH_PROMISE without END_HEADERS is received, the
         // ONLY permitted frame is a CONTINUATION for that same stream until the block completes.
         // Checked before structural validation: a malformed non-CONTINUATION frame mid-block is a
@@ -1344,6 +1358,10 @@ impl Connection {
         };
         debug_assert!(inflight.payload_remaining > 0);
         self.data_in_flight = Some(inflight);
+        // An incrementally-streamed DATA frame never reaches dispatch(); count it here,
+        // once, when its header is accepted.
+        self.frames_received += 1;
+        sink.on_frame_counters(self.frames_received, self.frames_sent);
         StreamedDataStart::Consumed(wire::FRAME_HEADER_SIZE + consumed_payload)
     }
 

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -418,7 +418,8 @@ impl Default for FrameHeader {
 impl FrameHeader {
     pub const BYTE_SIZE: usize = 9;
     #[inline]
-    fn write(&self, writer: &mut impl WireWriter) -> bool {
+    fn write(&self, writer: &mut impl WireWriter, frames_sent: &Cell<u64>) -> bool {
+        frames_sent.set(frames_sent.get() + 1);
         let mut buf = [0u8; Self::BYTE_SIZE];
         buf[0] = ((self.length >> 16) & 0xFF) as u8;
         buf[1] = ((self.length >> 8) & 0xFF) as u8;
@@ -1468,6 +1469,12 @@ pub struct H2FrameParser {
     /// An outbound header block the HPACK encoder could not emit. Latched once; the deferred
     /// tick reports it, because it is detected inside a user submit call.
     pending_header_compression_error: Cell<bool>,
+    /// Frames written by the legacy outbound encoder (perf_hooks http2 session stats).
+    frames_sent_legacy: Cell<u64>,
+    /// Engine counters mirrored at the end of each rewrite_read batch, so reading them
+    /// never contends with the engine borrow.
+    engine_frames_received: Cell<u64>,
+    engine_frames_sent: Cell<u64>,
     ref_count: bun_ptr::RefCount<Self>, // intrusive — bun.ptr.RefCount(@This(), "ref_count", deinit, .{})
     /// Number of live `Keepalive` guards: the `+1`s held by native frames currently on the stack.
     /// Read only by `release_refs_stranded_by_exit()`.
@@ -1826,7 +1833,7 @@ impl Stream {
                     length: 0,
                 };
                 owned_frame = Some(frame);
-                break 'brk data_header.write(&mut writer);
+                break 'brk data_header.write(&mut writer, &client.frames_sent_legacy);
             } else {
                 let max_size = frame_remaining
                     .min(
@@ -1906,7 +1913,7 @@ impl Stream {
                         stream_identifier: self.id,
                         length: u32::try_from(payload_size).expect("int cast"),
                     };
-                    let _ = data_header.write(&mut writer);
+                    let _ = data_header.write(&mut writer, &client.frames_sent_legacy);
                     if padding != 0 {
                         break 'brk SHARED_REQUEST_BUFFER.with_borrow_mut(|buffer| {
                             // SAFETY: src/dst may overlap — use ptr::copy (memmove)
@@ -1970,7 +1977,7 @@ impl Stream {
                         stream_identifier: self.id,
                         length: u32::try_from(payload_size).expect("int cast"),
                     };
-                    let _ = data_header.write(&mut writer);
+                    let _ = data_header.write(&mut writer, &client.frames_sent_legacy);
                     if padding != 0 {
                         break 'brk SHARED_REQUEST_BUFFER.with_borrow_mut(|buffer| {
                             // SAFETY: src/dst may overlap — ptr::copy is memmove; dst capacity covers payload_size
@@ -2561,7 +2568,7 @@ impl H2FrameParser {
             stream_identifier: 0,
             length: payload_len as u32,
         };
-        let _ = settings_header.write(&mut stream);
+        let _ = settings_header.write(&mut stream, &self.frames_sent_legacy);
         let _ = stream.write_all(&payload[..payload_len]);
 
         self.outstanding_settings
@@ -2595,7 +2602,7 @@ impl H2FrameParser {
             stream_identifier: stream.id,
             length: 4,
         };
-        let _ = frame.write(&mut writer_stream);
+        let _ = frame.write(&mut writer_stream, &self.frames_sent_legacy);
         let mut value: u32 = ErrorCode::CANCEL.0;
         stream.rst_code = value;
         value = value.swap_bytes();
@@ -2633,7 +2640,7 @@ impl H2FrameParser {
             stream_identifier: stream.id,
             length: 4,
         };
-        let _ = frame.write(&mut writer_stream);
+        let _ = frame.write(&mut writer_stream, &self.frames_sent_legacy);
         let mut value: u32 = rst_code.0;
         stream.rst_code = value;
         value = value.swap_bytes();
@@ -2690,7 +2697,7 @@ impl H2FrameParser {
             stream_identifier: 0,
             length: u32::try_from(8 + debug_data.len()).expect("int cast"),
         };
-        let _ = frame.write(&mut stream);
+        let _ = frame.write(&mut stream, &self.frames_sent_legacy);
         let last_id = UInt31WithReserved::init(last_stream_id, false);
         let _ = last_id.write(&mut stream);
         let mut value: u32 = rst_code.0;
@@ -2748,7 +2755,7 @@ impl H2FrameParser {
             stream_identifier,
             length: u32::try_from(origin_str.len() + alt.len() + 2).expect("int cast"),
         };
-        let _ = frame.write(&mut stream);
+        let _ = frame.write(&mut stream, &self.frames_sent_legacy);
         let _ = stream.write_all(
             &u16::try_from(origin_str.len())
                 .expect("int cast")
@@ -2783,7 +2790,7 @@ impl H2FrameParser {
             stream_identifier: 0,
             length: 8,
         };
-        let _ = frame.write(&mut stream);
+        let _ = frame.write(&mut stream, &self.frames_sent_legacy);
         let _ = stream.write_all(payload);
         let _ = self.write(&buffer);
     }
@@ -2809,7 +2816,7 @@ impl H2FrameParser {
                 settings: self.local_settings.get().to_engine_settings(),
             })
         });
-        let _ = settings_header.write(&mut preface_stream);
+        let _ = settings_header.write(&mut preface_stream, &self.frames_sent_legacy);
         let _ = preface_stream.write_all(&payload[..payload_len]);
         let _ = self.write(&preface_buffer[..24 + FrameHeader::BYTE_SIZE + payload_len]);
     }
@@ -2824,7 +2831,7 @@ impl H2FrameParser {
             stream_identifier: 0,
             length: 0,
         };
-        let _ = settings_header.write(&mut stream);
+        let _ = settings_header.write(&mut stream, &self.frames_sent_legacy);
         let _ = self.write(&buffer);
     }
 
@@ -2847,7 +2854,7 @@ impl H2FrameParser {
             stream_identifier,
             length: 4,
         };
-        let _ = settings_header.write(&mut stream);
+        let _ = settings_header.write(&mut stream, &self.frames_sent_legacy);
         let _ = window_size.write(&mut stream);
         let _ = self.write(&buffer);
     }
@@ -5696,6 +5703,17 @@ impl H2FrameParser {
     }
 
     /// Feed inbound bytes through the rewrite engine, buffering the unconsumed tail (design B).
+    /// Mirror the engine's frame counters into plain Cells so getFrameCounters() never
+    /// contends with the engine borrow (destroy can run inside a dispatch).
+    fn sync_engine_frame_counters(&self) {
+        if let Ok(guard) = self.engine.try_borrow() {
+            if let Some(engine) = guard.as_ref() {
+                self.engine_frames_received.set(engine.frames_received);
+                self.engine_frames_sent.set(engine.frames_sent);
+            }
+        }
+    }
+
     fn rewrite_read(&self, bytes: &[u8]) {
         bun_output::scoped_log!(H2FrameParser, "rewriteRead {}", bytes.len());
         // Re-entrancy guard: receive() dispatches into JS between frames, and user code can feed
@@ -5848,6 +5866,11 @@ impl H2FrameParser {
 
 /// The from-scratch engine calls back into H2FrameParser (the embedder) through this.
 impl crate::api::h2::connection::Sink for H2FrameParser {
+    fn on_frame_counters(&self, received: u64, sent: u64) {
+        self.engine_frames_received.set(received);
+        self.engine_frames_sent.set(sent);
+    }
+
     fn write(&self, bytes: &[u8]) -> crate::api::h2::connection::WriteResult {
         if self.write(bytes) {
             crate::api::h2::connection::WriteResult::Sent
@@ -6706,6 +6729,29 @@ impl H2FrameParser {
     }
 
     #[bun_jsc::host_fn(method)]
+    pub(crate) fn get_frame_counters(
+        this: &Self,
+        global_object: &JSGlobalObject,
+        _callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        this.sync_engine_frame_counters();
+        let result = JSValue::create_empty_object(global_object, 2);
+        result.put(
+            global_object,
+            b"framesReceived",
+            JSValue::js_number(this.engine_frames_received.get() as f64),
+        );
+        result.put(
+            global_object,
+            b"framesSent",
+            JSValue::js_number(
+                (this.frames_sent_legacy.get() + this.engine_frames_sent.get()) as f64,
+            ),
+        );
+        Ok(result)
+    }
+
+    #[bun_jsc::host_fn(method)]
     pub(crate) fn get_current_state(
         this: &Self,
         global_object: &JSGlobalObject,
@@ -6869,7 +6915,7 @@ impl H2FrameParser {
                 stream_identifier: 0,
                 length: 0,
             };
-            let _ = frame.write(&mut stream);
+            let _ = frame.write(&mut stream, &this.frames_sent_legacy);
             let _ = this.write(&buffer);
             return Ok(JSValue::UNDEFINED);
         }
@@ -6894,7 +6940,7 @@ impl H2FrameParser {
                 stream_identifier: 0,
                 length: u32::try_from(slice.len() + 2).expect("int cast"),
             };
-            let _ = frame.write(&mut stream);
+            let _ = frame.write(&mut stream, &this.frames_sent_legacy);
             let _ = stream.write_all(&u16::try_from(slice.len()).expect("int cast").to_be_bytes());
             let _ = this.write(&buffer);
             if !slice.is_empty() {
@@ -6943,7 +6989,7 @@ impl H2FrameParser {
                 length: total_length - FrameHeader::BYTE_SIZE as u32, // payload length
             };
             stream.reset();
-            let _ = frame.write(&mut stream);
+            let _ = frame.write(&mut stream, &this.frames_sent_legacy);
             let _ = this.write(&buffer[0..total_length as usize]);
         }
         Ok(JSValue::UNDEFINED)
@@ -7240,7 +7286,7 @@ impl H2FrameParser {
             };
 
             let mut writer = this.to_writer();
-            let _ = frame.write(&mut writer);
+            let _ = frame.write(&mut writer, &this.frames_sent_legacy);
             let _ = priority.write(&mut writer);
         }
         Ok(JSValue::TRUE)
@@ -7411,7 +7457,7 @@ impl H2FrameParser {
                 stream.queue_frame(self, b"", callback, close);
             } else {
                 let mut writer = self.to_writer();
-                let _ = data_header.write(&mut writer);
+                let _ = data_header.write(&mut writer, &self.frames_sent_legacy);
             }
         } else {
             let mut offset: usize = 0;
@@ -7501,7 +7547,7 @@ impl H2FrameParser {
                     if payload.len() <= MAX_PAYLOAD_SIZE_WITHOUT_FRAME {
                         // Single-frame payload: the cork coalesces it with neighbors.
                         let mut writer = self.to_writer();
-                        let _ = data_header.write(&mut writer);
+                        let _ = data_header.write(&mut writer, &self.frames_sent_legacy);
                         if padding != 0 {
                             SHARED_REQUEST_BUFFER.with_borrow_mut(|buffer| {
                                 // SAFETY: src/dst may overlap — ptr::copy is memmove; dst capacity covers payload_size
@@ -7550,7 +7596,7 @@ impl H2FrameParser {
                                 }
                             }
                             let header_off = batch.len();
-                            let _ = data_header.write(batch);
+                            let _ = data_header.write(batch, &self.frames_sent_legacy);
                             if padding != 0 {
                                 batch.push(padding);
                                 batch.extend_from_slice(slice);
@@ -8080,7 +8126,7 @@ impl H2FrameParser {
                 stream_identifier: stream.id,
                 length: u32::try_from(encoded_size).expect("int cast"),
             };
-            let _ = frame.write(&mut writer);
+            let _ = frame.write(&mut writer, &this.frames_sent_legacy);
             let _ = writer.write_all(encoded_data);
         } else {
             bun_output::scoped_log!(
@@ -8098,7 +8144,7 @@ impl H2FrameParser {
                 stream_identifier: stream.id,
                 length: u32::try_from(first_chunk_size).expect("int cast"),
             };
-            let _ = headers_frame.write(&mut writer);
+            let _ = headers_frame.write(&mut writer, &this.frames_sent_legacy);
             let _ = writer.write_all(&encoded_data[0..first_chunk_size]);
 
             let mut offset: usize = first_chunk_size;
@@ -8117,7 +8163,7 @@ impl H2FrameParser {
                     stream_identifier: stream.id,
                     length: u32::try_from(chunk_size).expect("int cast"),
                 };
-                let _ = cont_frame.write(&mut writer);
+                let _ = cont_frame.write(&mut writer, &this.frames_sent_legacy);
                 let _ = writer.write_all(&encoded_data[offset..offset + chunk_size]);
 
                 offset += chunk_size;
@@ -8433,9 +8479,10 @@ impl H2FrameParser {
                     )
                     .is_err()
                 {
-                    return Err(
-                        global_object.throw(format_args!("Failed to encode push promise headers"))
-                    );
+                    // Same as the request/respond encode failures: nghttp2 fails the whole
+                    // session, and node never surfaces this through the pushStream callback.
+                    this.schedule_header_compression_session_error();
+                    return Ok(JSValue::js_number(-1.0));
                 }
             }
         }
@@ -8456,7 +8503,7 @@ impl H2FrameParser {
                 stream_identifier: parent_id,
                 length: payload_size as u32,
             };
-            let _ = frame.write(&mut ws);
+            let _ = frame.write(&mut ws, &this.frames_sent_legacy);
             let promised_be = (promised_id & 0x7fff_ffff).swap_bytes();
             let _ = ws.write_all(&promised_be.to_ne_bytes());
             let _ = this.write(&hdr_buf);
@@ -8475,7 +8522,7 @@ impl H2FrameParser {
                 stream_identifier: parent_id,
                 length: max_frame as u32,
             };
-            let _ = frame.write(&mut ws);
+            let _ = frame.write(&mut ws, &this.frames_sent_legacy);
             let promised_be = (promised_id & 0x7fff_ffff).swap_bytes();
             let _ = ws.write_all(&promised_be.to_ne_bytes());
             let _ = this.write(&hdr_buf);
@@ -8493,7 +8540,7 @@ impl H2FrameParser {
                     stream_identifier: parent_id,
                     length: chunk as u32,
                 };
-                let _ = cont.write(&mut cs);
+                let _ = cont.write(&mut cs, &this.frames_sent_legacy);
                 let _ = this.write(&cont_buf);
                 let _ = this.write(&encoded_headers[offset..offset + chunk]);
                 offset += chunk;
@@ -9437,7 +9484,7 @@ impl H2FrameParser {
                 stream_identifier: stream.id,
                 length: u32::try_from(payload_size).expect("int cast"),
             };
-            let _ = frame.write(&mut writer);
+            let _ = frame.write(&mut writer, &this.frames_sent_legacy);
 
             // Write priority data if present
             if has_priority {
@@ -9493,7 +9540,7 @@ impl H2FrameParser {
                 stream_identifier: stream.id,
                 length: u32::try_from(first_chunk_size + priority_overhead).expect("int cast"),
             };
-            let _ = headers_frame.write(&mut writer);
+            let _ = headers_frame.write(&mut writer, &this.frames_sent_legacy);
 
             if has_priority {
                 let stream_identifier =
@@ -9524,7 +9571,7 @@ impl H2FrameParser {
                     stream_identifier: stream.id,
                     length: u32::try_from(chunk_size).expect("int cast"),
                 };
-                let _ = cont_frame.write(&mut writer);
+                let _ = cont_frame.write(&mut writer, &this.frames_sent_legacy);
                 let _ = writer.write_all(&encoded_headers[offset..offset + chunk_size]);
 
                 offset += chunk_size;
@@ -9791,6 +9838,9 @@ impl H2FrameParser {
             has_nonnative_backpressure: Cell::new(false),
             transport_write_fatal: Cell::new(false),
             pending_header_compression_error: Cell::new(false),
+            frames_sent_legacy: Cell::new(0),
+            engine_frames_received: Cell::new(0),
+            engine_frames_sent: Cell::new(0),
             auto_flusher: JsCell::new(AutoFlusher::default()),
             padding_strategy: Cell::new(PaddingStrategy::None),
             engine: core::cell::RefCell::new(None),

--- a/src/runtime/api/h2.classes.ts
+++ b/src/runtime/api/h2.classes.ts
@@ -33,6 +33,10 @@ export default [
         fn: "getCurrentState",
         length: 0,
       },
+      getFrameCounters: {
+        fn: "getFrameCounters",
+        length: 0,
+      },
       settings: {
         fn: "updateSettings",
         length: 1,

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3549,3 +3549,82 @@ it("delivers a session error from the event loop, not inside the call that detec
     server.close();
   }
 });
+
+it("delivers the reserved push stream and fails the session when its headers cannot be encoded", async () => {
+  // Verified against node v26.3.0: pushStream's callback still receives the reserved
+  // stream (so the caller can attach handlers), and the session then dies with
+  // COMPRESSION_ERROR (9); the callback never sees an error.
+  const server = http2.createServer({ maxSendHeaderBlockLength: 100000 });
+  try {
+    const sessionError = new Promise(resolve => server.on("sessionError", resolve));
+    const pushCallback = Promise.withResolvers();
+    server.on("stream", stream => {
+      stream.on("error", () => {});
+      stream.pushStream({ ":path": "/pushed", "x-big": Buffer.alloc(90000, "A").toString() }, (err, push) => {
+        push?.on("error", () => {});
+        pushCallback.resolve(err ?? null);
+      });
+      stream.respond();
+      stream.end("x");
+    });
+    const port = await new Promise(resolve => server.listen(0, () => resolve(server.address().port)));
+    const client = http2.connect(`http://localhost:${port}`);
+    client.on("error", () => {});
+    const req = client.request();
+    req.on("error", () => {});
+    req.resume();
+    req.end();
+
+    const [cbErr, err] = await Promise.all([pushCallback.promise, sessionError]);
+    expect(cbErr).toBeNull();
+    expect(err.code).toBe("ERR_HTTP2_SESSION_ERROR");
+    expect(err.message).toBe("Session closed with error code 9");
+    client.destroy();
+  } finally {
+    server.close();
+  }
+});
+
+it("PerformanceObserver receives http2 session and stream entries", async () => {
+  const { PerformanceObserver } = require("node:perf_hooks");
+  const entries = [];
+  const observer = new PerformanceObserver(list => {
+    for (const entry of list.getEntries()) entries.push(entry);
+  });
+  observer.observe({ type: "http2" });
+  const server = http2.createServer();
+  try {
+    server.on("stream", stream => {
+      stream.respond({ ":status": 200 });
+      stream.end("ok");
+    });
+    const port = await new Promise(resolve => server.listen(0, () => resolve(server.address().port)));
+    const client = http2.connect(`http://localhost:${port}`);
+    const req = client.request({ ":path": "/" });
+    req.resume();
+    await new Promise(resolve => req.on("end", resolve));
+    await new Promise(resolve => {
+      client.on("close", resolve);
+      client.close();
+    });
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const sessions = entries.filter(e => e.name === "Http2Session");
+    const streams = entries.filter(e => e.name === "Http2Stream");
+    expect(sessions.length).toBeGreaterThanOrEqual(2);
+    expect(streams.length).toBeGreaterThanOrEqual(2);
+    const clientSession = sessions.find(e => e.detail.type === "client");
+    expect(clientSession.entryType).toBe("http2");
+    expect(clientSession.detail.streamCount).toBe(1);
+    expect(clientSession.detail.framesReceived).toBeGreaterThanOrEqual(4);
+    expect(typeof clientSession.detail.framesSent).toBe("number");
+    expect(typeof clientSession.detail.streamAverageDuration).toBe("number");
+    const streamEntry = streams[0];
+    expect(typeof streamEntry.detail.bytesRead).toBe("number");
+    expect(typeof streamEntry.detail.bytesWritten).toBe("number");
+    expect(typeof streamEntry.detail.timeToFirstHeader).toBe("number");
+  } finally {
+    observer.disconnect();
+    server.close();
+  }
+});

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3628,3 +3628,41 @@ it("PerformanceObserver receives http2 session and stream entries", async () => 
     server.close();
   }
 });
+
+it("packs END_STREAM onto the DATA frame produced by end(chunk)", async () => {
+  // node sends one DATA frame with END_STREAM for stream.end(data); bun used to append a
+  // separate empty END_STREAM frame after it. Counted through the client's own
+  // perf_hooks frame stats (which exclude the GOAWAY, as node's do).
+  const { PerformanceObserver } = require("node:perf_hooks");
+  const server = http2.createServer();
+  try {
+    server.on("stream", stream => {
+      stream.respond({ ":status": 200 });
+      stream.end("OK");
+    });
+    const port = await new Promise(resolve => server.listen(0, () => resolve(server.address().port)));
+
+    const received = Promise.withResolvers();
+    const observer = new PerformanceObserver((list, obs) => {
+      for (const entry of list.getEntries()) {
+        if (entry.name !== "Http2Session" || entry.detail.type !== "client") continue;
+        obs.disconnect();
+        received.resolve(entry.detail.framesReceived);
+        return;
+      }
+    });
+    observer.observe({ type: "http2" });
+
+    const client = http2.connect(`http://localhost:${port}`);
+    client.on("error", () => {});
+    const req = client.request({ ":path": "/" });
+    req.resume();
+    req.on("end", () => client.close());
+    req.end();
+
+    // SETTINGS + SETTINGS ack + HEADERS + one DATA carrying END_STREAM.
+    expect(await received.promise).toBe(4);
+  } finally {
+    server.close();
+  }
+});

--- a/test/js/node/test/parallel/test-http2-perf_hooks.js
+++ b/test/js/node/test/parallel/test-http2-perf_hooks.js
@@ -1,0 +1,104 @@
+// Flags: --no-warnings
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const h2 = require('http2');
+
+const { PerformanceObserver } = require('perf_hooks');
+
+const obs = new PerformanceObserver(common.mustCallAtLeast((items) => {
+  const entry = items.getEntries()[0];
+  assert.strictEqual(entry.entryType, 'http2');
+  assert.strictEqual(typeof entry.startTime, 'number');
+  assert.strictEqual(typeof entry.duration, 'number');
+  switch (entry.name) {
+    case 'Http2Session':
+      assert.strictEqual(typeof entry.detail.pingRTT, 'number');
+      assert.strictEqual(typeof entry.detail.streamAverageDuration, 'number');
+      assert.strictEqual(typeof entry.detail.streamCount, 'number');
+      assert.strictEqual(typeof entry.detail.framesReceived, 'number');
+      assert.strictEqual(typeof entry.detail.framesSent, 'number');
+      assert.strictEqual(typeof entry.detail.bytesWritten, 'number');
+      assert.strictEqual(typeof entry.detail.bytesRead, 'number');
+      assert.strictEqual(typeof entry.detail.maxConcurrentStreams, 'number');
+      switch (entry.detail.type) {
+        case 'server':
+          assert.strictEqual(entry.detail.streamCount, 1);
+          assert(entry.detail.framesReceived >= 3);
+          break;
+        case 'client':
+          assert.strictEqual(entry.detail.streamCount, 1);
+          assert.strictEqual(entry.detail.framesReceived, 7);
+          break;
+        default:
+          assert.fail('invalid Http2Session type');
+      }
+      break;
+    case 'Http2Stream':
+      assert.strictEqual(typeof entry.detail.timeToFirstByte, 'number');
+      assert.strictEqual(typeof entry.detail.timeToFirstByteSent, 'number');
+      assert.strictEqual(typeof entry.detail.timeToFirstHeader, 'number');
+      assert.strictEqual(typeof entry.detail.bytesWritten, 'number');
+      assert.strictEqual(typeof entry.detail.bytesRead, 'number');
+      break;
+    default:
+      assert.fail('invalid entry name');
+  }
+}));
+
+obs.observe({ type: 'http2' });
+
+const body =
+  '<html><head></head><body><h1>this is some data</h2></body></html>';
+
+const server = h2.createServer();
+
+// We use the lower-level API here
+server.on('stream', common.mustCall(onStream));
+
+function onStream(stream, headers, flags) {
+  assert.strictEqual(headers[':scheme'], 'http');
+  assert.ok(headers[':authority']);
+  assert.strictEqual(headers[':method'], 'GET');
+  assert.strictEqual(flags, 5);
+  stream.respond({
+    'content-type': 'text/html',
+    ':status': 200
+  });
+  stream.write(body.slice(0, 20));
+  stream.end(body.slice(20));
+}
+
+server.on('session', common.mustCall((session) => {
+  session.ping(common.mustCall());
+}));
+
+server.listen(0);
+
+server.on('listening', common.mustCall(() => {
+
+  const client = h2.connect(`http://localhost:${server.address().port}`);
+
+  client.on('connect', common.mustCall(() => {
+    client.ping(common.mustCall());
+  }));
+
+  const req = client.request();
+
+  req.on('response', common.mustCall());
+
+  let data = '';
+  req.setEncoding('utf8');
+  req.on('data', (d) => data += d);
+  req.on('end', common.mustCall(() => {
+    assert.strictEqual(body, data);
+  }));
+  req.on('close', common.mustCall(() => {
+    client.close();
+    server.close();
+  }));
+
+}));


### PR DESCRIPTION
### What does this PR do?

Five node v26.3.0 compat gaps, each verified against the node binary rather than inferred. Stacked on #34503 (it extends that PR's encode-failure handling).

1. **`PerformanceObserver({ type: "http2" })` records nothing in Bun.** Now it receives `Http2Session` and `Http2Stream` entries with node's exact detail shape (`framesReceived`, `framesSent`, `streamCount`, `maxConcurrentStreams`, `pingRTT`, `streamAverageDuration`, `type` / `id`, `timeToFirstByte`, `timeToFirstByteSent`, `timeToFirstHeader`, `bytesRead`, `bytesWritten`). Frame counts are real: the engine counts each accepted inbound frame and each written frame header (a new `&Cell<u64>` parameter on `FrameHeader::write` makes the compiler enforce counting at every site), and pushes them to the embedder through a new `Sink::on_frame_counters` method — reading them never contends with the engine borrow. The counters are snapshotted at the instant the graceful close schedules its deferred destroy, which is where node's own accounting stops; that makes the vendored test's hard `framesReceived === 7` assertion deterministic (40/40 runs across two builds).

2. **END_STREAM rides the final DATA frame.** A write made after `end()` was followed by a separate empty END_STREAM DATA frame; node flags the last DATA. The wire now matches node's framing byte-for-byte (verified with a frame-decoding TCP relay: `DATA(flags=1,len=45)` instead of `DATA(flags=0,len=45) + DATA(flags=1,len=0)`). Trailers still move END_STREAM onto the trailer HEADERS (`waitForTrailers` guard). The `write(x); end()` (end with no data) case keeps the empty-frame fallback — wire-legal, and packing it would require frame-level deferral that conflicts with the cork/batch design.

3. **Graceful close waits for outstanding ping ACKs**, with the same bounded grace as unACKed SETTINGS. Node always delivers a ping callback its RTT on a healthy session; Bun sometimes delivered `ERR_HTTP2_PING_CANCEL` when the ACK raced teardown. Both completion paths require the other drained, so SETTINGS+PING outstanding together can't defeat the grace.

4. **`session.socket` reads `undefined` once the socket detached** — previously the cached proxy leaked through after `'close'` (and the uncached case returned `null`; node reports `undefined`).

5. **`pushStream()` with a header block the encoder cannot emit no longer throws.** Node delivers the reserved stream to the callback (so the caller can attach handlers) and then fails the session with COMPRESSION_ERROR (9). Bun now matches exactly — including the uncaught-error behavior when no handlers are attached (verified both runtimes surface the same `UNCAUGHT: ERR_HTTP2_SESSION_ERROR`).

Vendors `test-http2-perf_hooks.js` from node v26.3.0, byte-identical, plus three bun-native regression tests.

#### Deliberate divergence

perf tracking is armed at session construction if an `http2` observer exists; node samples at emission. `observe()` called after a session connects therefore yields no entries for it. Emission-time gating would require always-on per-chunk byte accounting on the hot read/write paths for unobserved sessions; construction-time gating keeps the unobserved cost to one `hasObserver()` check per session.

### How did you verify your code works?

- Vendored `test-http2-perf_hooks.js`: 25/25 then 15/15 after review fixes (its `framesReceived === 7` is the strictest assertion — it required the END_STREAM packing, the ping grace, and the snapshot semantics all being right).
- Wire framing compared to node through a frame-decoding TCP relay.
- Code review reproduced two real bugs in my first END_STREAM implementation (a vacuous `_writev` length check that silently truncated bodies, and a UTF-16-units-vs-bytes mismatch); both fixed and re-verified with the exact repros (`"aabbcc"` and `"ééxx"` now arrive intact, matching node).
- `node-http2.test.js`: 309 pass / 0 fail. Full vendored `test-http2*` sweep (260 files): 0 failures. grpc `test-server` 45/0 and `test-client` 5/0 (trailer-heavy flows are the most sensitive to END_STREAM semantics).
- `session.state` verified working (an earlier revision of this diff accidentally stole `getCurrentState`'s host-fn attribute; caught in review, covered by a probe now).
