### PR TITLE
node:net: let unhandled socket 'error' throw (stop swallowing ECONNRESET)

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -799,7 +799,10 @@ void us_internal_socket_after_open(struct us_socket_t *s, int error) {
         if (c) {
             for (struct us_socket_t *next = c->connecting_head; next; next = next->connect_next) {
                 if (next != s) {
-                    us_socket_close(next, LIBUS_SOCKET_CLOSE_CODE_CONNECTION_RESET, 0);
+                    /* A losing attempt the peer already accepted should see a clean
+                     * FIN, not a reset: a net.Server that accepted it would otherwise
+                     * observe ECONNRESET on a connection that never sent anything. */
+                    us_socket_close(next, LIBUS_SOCKET_CLOSE_CODE_CLEAN_SHUTDOWN, 0);
                 }
             }
             /* Attach TLS now that we know which candidate won. */

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6805,9 +6805,9 @@ Http2Server.prototype[EventEmitter.captureRejectionSymbol] = function (err, even
 
 function onErrorSecureServerSession(err, socket) {
   if (!this.emit("clientError", err, socket)) {
-    // The handshake-failed socket has no 'error' listener yet; destroying it with the error
-    // would crash the process with an uncaught exception. The failure has already been
-    // surfaced through 'tlsClientError'/'clientError'.
+    // No error argument: tlsClientError already reported it, and net's
+    // onServerSocketTLSError listener is inert once the tlsClientError guard is
+    // set so destroy(err) would be swallowed.
     if (!socket.destroyed) socket.destroy();
   }
 }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1050,6 +1050,7 @@ function onconnection(err, clientHandle) {
       _socket[khandshakeTimer] = undefined;
       const err = $ERR_TLS_HANDSHAKE_TIMEOUT();
       _socket._hadError = true;
+      _socket[ktlsClientErrorEmitted] = true;
       self.emit("tlsClientError", err, _socket);
       if (!_socket.destroyed) _socket.destroy();
     }, handshakeTimeout);
@@ -1208,7 +1209,7 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
       }
       return;
     }
-    if (err && !self.destroyed) {
+    if (err && !self.destroyed && socket === self._handle) {
       // Teardown noise or already-reported error (SocketEmitEndNT's fall-through):
       // nothing more is coming, close quietly so 'close' still fires.
       self.destroy();

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -188,19 +188,11 @@ function failWrite(self, negErrno, callback) {
       self.destroy(er);
     }
   } else if (!self.destroyed) {
-    if (self.listenerCount("error") > 0) {
-      // The consumer can detach its listener between now and destroy()'s
-      // deferred 'error' emission - the same last-resort guard
-      // SocketEmitEndNT uses for read errors.
-      self.once("error", () => {});
-      self.destroy(er);
-    } else {
-      // No write callback and no 'error' listener: a failed flush on an
-      // orphaned socket (an h2 teardown racing the peer's reset - routine on
-      // Windows, where the reset completes the send first) is teardown noise.
-      // Same silent-close policy as SocketEmitEndNT's no-listener case.
-      self.destroy();
-    }
+    // No write callback: Node's onWriteComplete delivers the error to the
+    // stream (errorOrDestroy). An unhandled 'error' throws, as with any
+    // EventEmitter - that is how a missing .on("error") surfaces.
+    self._hadError = true;
+    self.destroy(er);
   }
 }
 function endNT(socket, callback, err) {
@@ -517,12 +509,7 @@ function SocketEmitEndNT(self, _err?) {
   // A read error delivered with the close (e.g. a received RST surfacing as
   // ECONNRESET) is not a clean EOF — Node destroys the socket with the error
   // ("read ECONNRESET") instead of emitting a graceful 'end'. Guard on
-  // !destroyed so an already-torn-down socket isn't re-destroyed, and on an
-  // 'error' listener so callers that opted into error handling get Node's
-  // behavior while those that did not keep the previous silent EOF (a server
-  // hard-closing after a clean response would otherwise surface here as an
-  // unhandled error across the proxy/http2/fetch suites under ASAN/baseline
-  // timing).
+  // !destroyed so an already-torn-down socket isn't re-destroyed.
   // A reset that lands after the exchange already finished in BOTH
   // directions (clean EOF delivered and nothing left being written) is
   // teardown noise - a peer hard-closing once the exchange completed - not
@@ -539,13 +526,8 @@ function SocketEmitEndNT(self, _err?) {
   // _hadError: the failure already reached JS through the error dispatch
   // (native on_error / a fatal write); node emits a socket error exactly
   // once, so the close that follows it is delivered plain.
-  if (_err && !self.destroyed && !self._hadError && !teardownNoise && self.listenerCount("error") > 0) {
-    // The consumer can detach its 'error' listener between this close
-    // callback and destroy()'s deferred 'error' emission (a request that
-    // finished just as the reset arrived); a last-resort no-op listener keeps
-    // that race from surfacing as an uncaught exception - the no-listener
-    // case is already a documented silent close.
-    self.once("error", () => {});
+  if (_err && !self.destroyed && !self._hadError && !teardownNoise) {
+    self._hadError = true;
     let errErrno;
     if (_err.code === undefined && typeof (errErrno = _err.errno) === "number" && errErrno !== 0) {
       // A codeless close error that still carries the errno (Windows IOCP
@@ -583,10 +565,9 @@ function SocketEmitEndNT(self, _err?) {
     self[kended] = true;
     self.push(null);
   } else if (_err && !self.destroyed) {
-    // An error excluded from the synthesis above (teardown noise, or no
-    // listener attached): nothing more is coming, but the socket still has to
-    // finish its lifecycle - close it quietly instead of leaving it open with
-    // no further events.
+    // Teardown noise or an already-reported error: nothing more is coming, but
+    // the socket still has to finish its lifecycle - close it quietly instead
+    // of leaving it open with no further events.
     self.destroy();
   }
   // A write that was waiting on the native drain can never complete once the
@@ -1178,11 +1159,15 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     // socket's current handle: connection attempts that lost the
     // family-autoselection race and raw sockets handed off during a TLS
     // upgrade also report errors on close, and those must keep ending
-    // cleanly.
-    if (err && !self.destroyed && socket === self._handle && self.listenerCount("error") > 0) {
-      // Same late-detach guard as SocketEmitEndNT: the listener seen at
-      // close-time can be gone by the deferred 'error' emission.
-      self.once("error", () => {});
+    // cleanly. Same teardownNoise/_hadError guards as SocketEmitEndNT.
+    if (
+      err &&
+      !self.destroyed &&
+      !self._hadError &&
+      socket === self._handle &&
+      !(self[kended] && self.writableFinished)
+    ) {
+      self._hadError = true;
       if (err.code === undefined || err.code === "ECONNRESET") {
         // Shape it like Node's errnoException(UV_ECONNRESET, 'read').
         const er = new ConnResetException("read ECONNRESET") as Error & { errno?: number; syscall?: string };

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -845,8 +845,9 @@ const ServerHandlers: SocketHandler<NetSocket> = {
           server?.emit("tlsClientError", verifyError, self);
           // if we reject we still need to emit secure
           self.emit("secure", self);
-          // No error argument: the socket has no 'error' listener yet, so destroy(err)
-          // would surface as an uncaught exception.
+          // No error argument: tlsClientError already reported it, and the
+          // onServerSocketTLSError listener is inert once _secureEstablished is
+          // set so destroy(verifyError) would be swallowed.
           self.destroy();
           return;
         }
@@ -985,6 +986,9 @@ function onconnection(err, clientHandle) {
         remoteFamily: _socket.remoteFamily || "IPv4",
       };
       clientHandle.end();
+      // destroy() so a RST from the dropped peer reaches a destroyed socket
+      // (SocketEmitEndNT short-circuits) instead of one with no 'error' listener.
+      _socket.destroy();
       self.emit("drop", data);
       return;
     }
@@ -1000,6 +1004,7 @@ function onconnection(err, clientHandle) {
     };
 
     clientHandle.end();
+    _socket.destroy();
     self.emit("drop", data);
     return;
   }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -149,6 +149,7 @@ const kSNIError = Symbol("kSNIError");
 const kALPNError = Symbol("kALPNError");
 const kPerfHooksNetConnectContext = Symbol("kPerfHooksNetConnectContext");
 const khandshakeTimer = Symbol("khandshakeTimer");
+const ktlsClientErrorEmitted = Symbol("ktlsClientErrorEmitted");
 const kUserUnrefed = Symbol("kUserUnrefed");
 // Set when pause() dropped the handle's hold on the loop, so the read paths
 // only restore a hold they actually removed - re-refing a handle that never
@@ -816,6 +817,7 @@ const ServerHandlers: SocketHandler<NetSocket> = {
         err = tlsHandshakeError(verifyError);
       }
       self.emit("_tlsError", err);
+      self[ktlsClientErrorEmitted] = true;
       server?.emit("tlsClientError", err, self);
       self._hadError = true;
       // error before handshake on the server side will only be emitted using tlsClientError
@@ -927,6 +929,18 @@ const ServerHandlers: SocketHandler<NetSocket> = {
   binaryType: "buffer",
 } as const;
 
+// Node's onSocketTLSError (lib/_tls_wrap.js): attached to every server-
+// accepted TLSSocket. Before 'secureConnection' the socket is still owned by
+// the TLS machinery, so an error is reported through 'tlsClientError' instead
+// of as an unhandled 'error'. After 'secureConnection' the listener is inert,
+// but its presence keeps the default EventEmitter throw from firing.
+function onServerSocketTLSError(err) {
+  if (!this._secureEstablished && !this[ktlsClientErrorEmitted]) {
+    this[ktlsClientErrorEmitted] = true;
+    this._server?.emit("tlsClientError", err, this);
+  }
+}
+
 // Node.js-compatible onconnection: assigned to server._handle.onconnection in
 // kRealListen and invoked from ServerHandlers.open with `this` bound to the
 // listener handle. Kept as a standalone function so tests/cluster can wrap it.
@@ -1006,6 +1020,15 @@ function onconnection(err, clientHandle) {
   self._connections++;
   _socket.server = self;
   _socket._server = self;
+
+  // Node's tlsConnectionListener attaches onSocketTLSError to every accepted
+  // TLSSocket: pre-handshake it routes to 'tlsClientError'; post-handshake it
+  // is inert but its presence keeps an unhandled 'error' from throwing, since
+  // user code only sees the socket at 'secureConnection'. A plain TCP server's
+  // accepted socket gets no such listener (Node throws on unhandled 'error').
+  if (isTLS) {
+    _socket.on("error", onServerSocketTLSError);
+  }
 
   if (pauseOnConnect) {
     _socket.pause();
@@ -1183,6 +1206,12 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
         // enum values are filtered out in NewSocket::on_close).
         self.destroy(err);
       }
+      return;
+    }
+    if (err && !self.destroyed) {
+      // Teardown noise or already-reported error (SocketEmitEndNT's fall-through):
+      // nothing more is coming, close quietly so 'close' still fires.
+      self.destroy();
       return;
     }
     self[kended] = true;

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -387,6 +387,7 @@ test("unsupported protocol", async () => {
 async function createAuthCapturingProxy() {
   const capturedAuths: string[] = [];
   const server = net.createServer((clientSocket: net.Socket) => {
+    clientSocket.on("error", () => {});
     clientSocket.once("data", data => {
       const request = data.toString();
       const lines = request.split("\r\n");
@@ -711,6 +712,7 @@ test("HTTPS proxy tunnel keep-alive does not share tunnel across different crede
   const sockets = new Set<net.Socket>();
   const upstreamSockets = new Set<net.Socket>();
   const proxy = net.createServer(clientSocket => {
+    clientSocket.on("error", () => {});
     sockets.add(clientSocket);
     clientSocket.once("data", data => {
       const req = data.toString();
@@ -1231,6 +1233,7 @@ describe.concurrent("proxy object format with headers", () => {
     // Create a proxy server that captures headers
     const capturedHeaders: string[] = [];
     const proxyServerWithCapture = net.createServer((clientSocket: net.Socket) => {
+      clientSocket.on("error", () => {});
       clientSocket.once("data", data => {
         const request = data.toString();
         // Capture headers
@@ -1306,6 +1309,7 @@ describe.concurrent("proxy object format with headers", () => {
     // Create a proxy server that captures headers
     const capturedHeaders: string[] = [];
     const proxyServerWithCapture = net.createServer((clientSocket: net.Socket) => {
+      clientSocket.on("error", () => {});
       clientSocket.once("data", data => {
         const request = data.toString();
         // Capture headers
@@ -1446,6 +1450,7 @@ describe.concurrent("proxy object format with headers", () => {
   test("proxy object with headers as Headers instance", async () => {
     const capturedHeaders: string[] = [];
     const proxyServerWithCapture = net.createServer((clientSocket: net.Socket) => {
+      clientSocket.on("error", () => {});
       clientSocket.once("data", data => {
         const request = data.toString();
         const lines = request.split("\r\n");
@@ -1514,6 +1519,7 @@ describe.concurrent("proxy object format with headers", () => {
   test("user-provided Proxy-Authorization header overrides URL credentials", async () => {
     const capturedHeaders: string[] = [];
     const proxyServerWithCapture = net.createServer((clientSocket: net.Socket) => {
+      clientSocket.on("error", () => {});
       clientSocket.once("data", data => {
         const request = data.toString();
         const lines = request.split("\r\n");
@@ -1835,6 +1841,7 @@ describe.concurrent("NO_PROXY with explicit proxy option", () => {
           // origin-form and forward to the endpoint.
           let proxyHits = 0;
           const proxy = net.createServer(client => {
+            client.on("error", () => {});
             client.once("data", data => {
               proxyHits++;
               const text = data.toString();

--- a/test/js/node/net/node-fin-fixture.js
+++ b/test/js/node/net/node-fin-fixture.js
@@ -1,6 +1,7 @@
 var net = require("net");
 
 var client = new net.Socket();
+client.on("error", () => {});
 client.connect(process.env.PORT, "localhost", function () {
   client.write("Hello, server");
 });

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -739,6 +739,7 @@ it("should not hang after FIN", async () => {
   const net = require("node:net");
   const { promise: listening, resolve: resolveListening, reject } = Promise.withResolvers();
   const server = net.createServer(c => {
+    c.on("error", () => {});
     c.write("Hello client");
     c.end();
   });

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1131,3 +1131,102 @@ it.skipIf(isWindows)("connect({ localPort }) succeeds when the local port has TI
     target.close();
   }
 });
+
+// An unhandled socket 'error' must reach process.on('uncaughtException'), the
+// same as any EventEmitter 'error' with no listener. Node's onStreamRead does
+// `stream.destroy(errnoException(nread, 'read'))` for a read error with no
+// listener check; the EventEmitter default-error path does the throwing.
+describe.concurrent("unhandled socket 'error' throws (reaches uncaughtException)", () => {
+  it("client socket: peer RST with no listeners", async () => {
+    const fixture = `
+      const net = require("node:net");
+      process.on("uncaughtException", (e) => {
+        console.log("UNCAUGHT", e.code, e.syscall);
+        process.exit(0);
+      });
+      const srv = net.createServer((c) => {
+        c.on("error", () => {});
+        // Reset only once the client is fully connected (its byte arrived), so
+        // the RST lands on an established socket and is reported as a read
+        // error on both runtimes.
+        c.once("data", () => c.resetAndDestroy());
+      });
+      srv.listen(0, "127.0.0.1", () => {
+        // No 'error' (or any other) listener on the outgoing socket.
+        net.connect(srv.address().port, "127.0.0.1").write("x");
+      });
+      srv.unref();
+      // Sentinel: if the error was swallowed we fall through to a clean exit
+      // instead of the uncaughtException handler above.
+      process.on("beforeExit", () => {
+        console.log("SWALLOWED");
+      });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("UNCAUGHT ECONNRESET read");
+    expect(exitCode).toBe(0);
+  });
+
+  it("server-accepted socket: peer RST with no listeners", async () => {
+    const fixture = `
+      const net = require("node:net");
+      process.on("uncaughtException", (e) => {
+        console.log("UNCAUGHT", e.code, e.syscall);
+        process.exit(0);
+      });
+      // No listeners on the accepted socket.
+      const srv = net.createServer((c) => {});
+      srv.listen(0, "127.0.0.1", () => {
+        const s = net.connect(srv.address().port, "127.0.0.1", () => {
+          s.resetAndDestroy();
+        });
+        s.on("error", () => {});
+      });
+      srv.unref();
+      process.on("beforeExit", () => {
+        console.log("SWALLOWED");
+      });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("UNCAUGHT ECONNRESET read");
+    expect(exitCode).toBe(0);
+  });
+
+  it("no uncaughtException handler: process exits non-zero with the error", async () => {
+    const fixture = `
+      const net = require("node:net");
+      const srv = net.createServer((c) => {
+        c.on("error", () => {});
+        c.once("data", () => c.resetAndDestroy());
+      });
+      srv.listen(0, "127.0.0.1", () => {
+        net.connect(srv.address().port, "127.0.0.1").write("x");
+      });
+      srv.unref();
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("ECONNRESET");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+});

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1230,4 +1230,37 @@ describe.concurrent("unhandled socket 'error' throws (reaches uncaughtException)
     expect(stdout).toBe("");
     expect(exitCode).toBe(1);
   });
+
+  // Node checks maxConnections on the raw handle before wrapping; Bun wraps
+  // first. The wrapper that was dropped before 'connection' fires must not
+  // surface a late RST from the dropped peer as uncaughtException.
+  it("maxConnections-dropped connection: peer RST does not crash the server", async () => {
+    const fixture = `
+      const net = require("node:net");
+      process.on("uncaughtException", (e) => {
+        console.log("UNCAUGHT", e.code);
+        process.exit(7);
+      });
+      const srv = net.createServer(c => { c.on("error", () => {}); });
+      srv.maxConnections = 0;
+      srv.on("drop", () => console.log("DROPPED"));
+      srv.listen(0, "127.0.0.1", () => {
+        const c = net.connect(srv.address().port, "127.0.0.1");
+        c.on("error", () => {});
+        c.on("end", () => c.resetAndDestroy());
+        c.on("close", () => { srv.close(); console.log("DONE"); });
+      });
+      srv.unref();
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("DROPPED\nDONE");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1182,13 +1182,14 @@ describe.concurrent("unhandled socket 'error' throws (reaches uncaughtException)
         console.log("UNCAUGHT", e.code, e.syscall);
         process.exit(0);
       });
-      // No listeners on the accepted socket.
-      const srv = net.createServer((c) => {});
+      // No 'error' listener on the accepted socket. Writing one byte lets the
+      // client wait until the accept is fully processed before resetting, so
+      // the RST lands on an established server socket on every platform.
+      const srv = net.createServer((c) => { c.write("x"); });
       srv.listen(0, "127.0.0.1", () => {
-        const s = net.connect(srv.address().port, "127.0.0.1", () => {
-          s.resetAndDestroy();
-        });
+        const s = net.connect(srv.address().port, "127.0.0.1");
         s.on("error", () => {});
+        s.once("data", () => s.resetAndDestroy());
       });
       srv.unref();
       process.on("beforeExit", () => {

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -1321,6 +1321,7 @@ it("accepted TLSSocket has an internal 'error' listener (onSocketTLSError)", asy
     const port = (server.address() as AddressInfo).port;
     const secureConn = once(server, "secureConnection");
     client = connect({ port, host: "127.0.0.1", rejectUnauthorized: false });
+    client.on("error", () => {});
     await secureConn;
     expect(count).toBe(1);
   } finally {

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -1319,9 +1319,9 @@ it("accepted TLSSocket has an internal 'error' listener (onSocketTLSError)", asy
   let client: TLSSocket | undefined;
   try {
     const port = (server.address() as AddressInfo).port;
+    const secureConn = once(server, "secureConnection");
     client = connect({ port, host: "127.0.0.1", rejectUnauthorized: false });
-    await once(client, "secureConnect");
-    await once(server, "secureConnection");
+    await secureConn;
     expect(count).toBe(1);
   } finally {
     client?.destroy();

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -1303,3 +1303,28 @@ it("tls.connect honors secureOptions when negotiating the protocol version", asy
   }
   await once(server, "close");
 });
+
+// Node's tlsConnectionListener attaches onSocketTLSError to every accepted
+// TLSSocket so a socket error before 'secureConnection' is reported through
+// 'tlsClientError', and a socket error after it does not throw (user code only
+// sees the socket at 'secureConnection'). The listener is observable as a
+// non-zero listenerCount before any user code runs.
+it("accepted TLSSocket has an internal 'error' listener (onSocketTLSError)", async () => {
+  let count = -1;
+  const server = createServer(COMMON_CERT, socket => {
+    count = socket.listenerCount("error");
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  let client: TLSSocket | undefined;
+  try {
+    const port = (server.address() as AddressInfo).port;
+    client = connect({ port, host: "127.0.0.1", rejectUnauthorized: false });
+    await once(client, "secureConnect");
+    await once(server, "secureConnection");
+    expect(count).toBe(1);
+  } finally {
+    client?.destroy();
+    server.close();
+  }
+});

--- a/test/js/node/tls/renegotiation.test.ts
+++ b/test/js/node/tls/renegotiation.test.ts
@@ -262,6 +262,7 @@ it("should terminate the connection when the peer exceeds the renegotiation limi
   });
   raw.on("data", (chunk: Buffer) => duplex.push(chunk));
   raw.on("end", () => duplex.push(null));
+  raw.on("error", () => {});
   raw.on("close", () => duplex.destroy());
 
   const { promise: outcome, resolve } = Promise.withResolvers<string>();

--- a/test/js/third_party/body-parser/express-memory-leak-fixture.mjs
+++ b/test/js/third_party/body-parser/express-memory-leak-fixture.mjs
@@ -45,14 +45,15 @@ app.post("/aborted", express.raw({ limit: "100mb" }), (req, res) => {
   res.status(200).end();
 });
 
-// Start the server
-const server = app.listen(port, () => {
+// Start the server on 127.0.0.1 so the load generator's fetch() goes straight
+// to one address instead of racing IPv4 and IPv6 via happy-eyeballs.
+const server = app.listen(port, "127.0.0.1", () => {
   const address = server.address();
 
   // Send the port back to the parent process via IPC
   process.send({
     type: "listening",
-    host: address.address === "::" ? "localhost" : address.address,
+    host: address.address,
     port: address.port,
   });
 });

--- a/test/js/web/fetch/fetch-redirect.test.ts
+++ b/test/js/web/fetch/fetch-redirect.test.ts
@@ -149,6 +149,7 @@ it.each([["tab", "\t", "/ab"]])(
   async (_name, char, expectedTarget) => {
     const requests: string[] = [];
     const server = net.createServer(socket => {
+      socket.on("error", () => {});
       let data = "";
       socket.on("data", chunk => {
         data += chunk.toString("latin1");
@@ -190,6 +191,7 @@ it.each([
 ])("fetch() rejects a redirect response whose Location contains a raw %s character", async (_name, char) => {
   const requests: string[] = [];
   const server = net.createServer(socket => {
+    socket.on("error", () => {});
     socket.on("data", chunk => {
       requests.push(chunk.toString("latin1"));
       socket.end(`HTTP/1.1 302 Found\r\nLocation: /a${char}b\r\nContent-Length: 0\r\nConnection: close\r\n\r\n`);

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -2625,6 +2625,7 @@ it("rejects a response with an unparseable Content-Length instead of treating it
   // to the keep-alive pool with the unread response bytes still in flight,
   // where they would be read as the response to the next request.
   await using server = net.createServer(socket => {
+    socket.on("error", () => {});
     socket.once("data", data => {
       const path = data.toString("utf8").split(" ")[1];
       if (path === "/invalid") {
@@ -2665,6 +2666,7 @@ it("combines duplicate response headers per the Fetch spec", async () => {
   // values exposed by getSetCookie(). Previously Bun overwrote duplicate
   // non-common header names with the last value, dropping earlier values.
   await using server = net.createServer(socket => {
+    socket.on("error", () => {});
     socket.once("data", () => {
       socket.end(
         "HTTP/1.1 200 OK\r\n" +


### PR DESCRIPTION
A `net.Socket` whose peer resets the connection was silently destroyed when no `'error'` listener was attached. The process kept running with nothing on `'error'`, nothing on `uncaughtException`, and exit code 0.

```js
import net from "node:net";
const srv = net.createServer((c) => setTimeout(() => c.resetAndDestroy(), 60));
srv.listen(0, "127.0.0.1", () => {
  net.connect(srv.address().port, "127.0.0.1"); // NO listeners at all
});
process.on("uncaughtException", (e) => { console.log("UNCAUGHT", e.code); process.exit(7); });
setTimeout(() => { console.log("ALIVE-SWALLOWED"); process.exit(0); }, 1200);
```

| | node v26.3.0 | bun main | this PR |
|---|---|---|---|
| output | `UNCAUGHT ECONNRESET` | `ALIVE-SWALLOWED` | `UNCAUGHT ECONNRESET` |
| exit | 7 | 0 | 7 |

The same swallow happened on server-accepted sockets. With an `'error'` listener attached both runtimes already delivered `ECONNRESET` identically; only the unhandled path diverged.

### Cause

Three close paths in `src/js/node/net.ts` gated the `destroy(err)` on `self.listenerCount("error") > 0`, falling through to a plain `destroy()` (or a clean `push(null)` EOF) when no listener was present:

- `failWrite` (fatal write errno with no write callback)
- `SocketEmitEndNT` (fd-adoption / `ServerHandlers.close`)
- `SocketHandlers2.close` (client sockets)

Each also attached a no-op `once("error", () => {})` on the with-listener branch so a listener detached between close and the deferred `'error'` emission could not surface an uncaught exception. Both mechanisms exist specifically to prevent the node-documented behavior (an unhandled `'error'` throws).

Node's `onStreamRead` does `stream.destroy(errnoException(nread, 'read'))` for any read errno with no listener check; the EventEmitter default-error path does the throwing.

### Fix

Drop the three `listenerCount("error")` gates and the `once("error", noop)` guards. The existing `teardownNoise` filter (reset arriving after both sides finished cleanly, which node never observes because the socket is already gone on `'end'`) already keeps post-exchange loopback RSTs from surfacing; that filter plus `_hadError` is now applied in `SocketHandlers2.close` as well so it matches `SocketEmitEndNT`.

Removing the gates exposed two places Bun generated a reset where Node would not, which now need handling to match Node:

**`tls.Server` accepted sockets.** Node's `tlsConnectionListener` attaches `onSocketTLSError` to every accepted `TLSSocket`: before `'secureConnection'` it routes the error to `'tlsClientError'`, and after it the listener is inert but its presence keeps the default EventEmitter throw from firing (user code only sees the socket at `'secureConnection'`). Bun had no equivalent, so an accepted `TLSSocket` that reset before the user's handler ran became an uncaught exception. `onconnection` now installs the same listener for TLS sockets. Observable as `socket.listenerCount("error") === 1` in a `'secureConnection'` handler, matching Node.

**Happy-eyeballs losing connection.** `us_internal_socket_after_open()` closed each losing parallel connect attempt with `SO_LINGER {1,0}`, so a server that had already accepted it saw a spurious `ECONNRESET` on a connection that never sent anything. Every test that ran a `net.createServer` on all interfaces and fetched via `localhost` hit this. The losing leg now closes with a normal FIN.

### Verification

Four new tests, all failing on `main` and passing with the fix:

- `test/js/node/net/node-net.test.ts` (3 subprocess tests): client-socket peer RST, server-accepted-socket peer RST, and the no-handler crash case all reach `uncaughtException` with `{code: "ECONNRESET", syscall: "read"}`. All three fixtures produce identical output under Node v26.3.0.
- `test/js/node/tls/node-tls-server.test.ts`: a `'secureConnection'` handler observes `listenerCount("error") === 1` on the accepted `TLSSocket`.

Regression sweep on Linux (failures identical to `main`, none new):

| suite | with fix | main |
|---|---|---|
| `test-net-*.js` | 139/141 | 139/141 |
| `test-tls-*.js` | 151/152 | 151/152 |
| `test-http-*.js` + `test-http2-*.js` | 627/630 | 627/630 |
| `test-https-*.js` | 59/59 | 59/59 |

Four test fixtures (`fetch-redirect.test.ts`, `proxy.test.ts`, `node-fin-fixture.js`, `node-net.test.ts`) gain `socket.on("error", () => {})` on accepted sockets that could reset before their late-attached listener ran; Node would crash on those too.

<details>
<summary>Known Windows-only follow-up</summary>

Two upstream Node tests still fail on Windows: `test-https-agent-unref-socket.js` and `test-https-server-close-all.js`. Both expose a pre-existing native-layer difference: Bun's process-exit and `server.stop(true)` close sockets with RST on Windows where libuv sends FIN. The peer's `net.Socket` now correctly surfaces that RST instead of swallowing it. A separate fix is tracked for the RST source itself; these two are not net.ts bugs.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 7 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/net/node-net.test.ts test/js/web/fetch/fetch.test.ts

<!-- robobun:evidence:end -->