### PR TITLE
semver: parse_version_number calls parse_ascii directly on the already-all-digit slice

### DIFF
--- a/src/semver/Version.rs
+++ b/src/semver/Version.rs
@@ -664,49 +664,10 @@ impl<T: VersionInt> VersionType<T> {
     }
 
     fn parse_version_number(input: &[u8]) -> Option<T> {
-        // max decimal u64 is 18446744073709551615
-        let mut bytes = [0u8; 20];
-        let mut byte_i: u8 = 0;
-
-        debug_assert!(input[0] != b'.');
-
-        for &char in input {
-            match char {
-                b'X' | b'x' | b'*' => return None,
-                b'0'..=b'9' => {
-                    // out of bounds
-                    if (byte_i as usize) + 1 > bytes.len() {
-                        return None;
-                    }
-                    bytes[byte_i as usize] = char;
-                    byte_i += 1;
-                }
-                b' ' | b'.' => break,
-                // ignore invalid characters
-                _ => {}
-            }
-        }
-
-        // If there are no numbers
-        if byte_i == 0 {
-            return None;
-        }
-
-        if bun_core::env::IS_DEBUG {
-            return match T::parse_ascii(&bytes[0..byte_i as usize]) {
-                Some(v) => Some(v),
-                None => {
-                    bun_core::pretty_errorln!(
-                        "ERROR parsing version: \"{}\", bytes: {}",
-                        bstr::BStr::new(input),
-                        bstr::BStr::new(&bytes[0..byte_i as usize]),
-                    );
-                    Some(T::ZERO)
-                }
-            };
-        }
-
-        Some(T::parse_ascii(&bytes[0..byte_i as usize]).unwrap_or(T::ZERO))
+        // Callers slice `input` from the first digit to the first non-digit,
+        // so every byte is already `b'0'..=b'9'` and the slice is non-empty.
+        debug_assert!(!input.is_empty() && input.iter().all(u8::is_ascii_digit));
+        Some(T::parse_ascii(input).unwrap_or(T::ZERO))
     }
 }
 

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -241,6 +241,22 @@ describe("Bun.semver.satisfies()", () => {
     testSatisfiesExact("5.0.0-beta.1", "5.0.0", false);
   });
 
+  test("overflow-length version components are not treated as wildcards", () => {
+    // A major/minor/patch component longer than 20 digits must behave the same
+    // as one that is exactly 20 digits and overflows u64. Previously the 21+
+    // digit case fell through to `None` (a wildcard) so any version matched.
+    // node-semver returns false for all of these.
+    const twenty = Buffer.alloc(20, "9").toString();
+    const twentyOne = Buffer.alloc(21, "9").toString();
+    for (const big of [twenty, twentyOne]) {
+      testSatisfies("^" + big, "1.0.0", false);
+      testSatisfies("^" + big, "5.0.0", false);
+      testSatisfies("~" + big, "1.0.0", false);
+      testSatisfies("~" + big, "5.0.0", false);
+      testSatisfies("~1." + big, "2.0.0", false);
+    }
+  });
+
   test("ranges", () => {
     testSatisfies("~1.2.3", "1.2.3", true);
     testSatisfies("~1.2", "1.2.0", true);

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -241,11 +241,9 @@ describe("Bun.semver.satisfies()", () => {
     testSatisfiesExact("5.0.0-beta.1", "5.0.0", false);
   });
 
-  test("overflow-length version components are not treated as wildcards", () => {
-    // A major/minor/patch component longer than 20 digits must behave the same
-    // as one that is exactly 20 digits and overflows u64. Previously the 21+
-    // digit case fell through to `None` (a wildcard) so any version matched.
-    // node-semver returns false for all of these.
+  test("long version components are not treated as wildcards", () => {
+    // A component >20 bytes must parse to its numeric value (or clamp on overflow),
+    // not fall through to a wildcard. node-semver loose mode agrees with all of these.
     const twenty = Buffer.alloc(20, "9").toString();
     const twentyOne = Buffer.alloc(21, "9").toString();
     for (const big of [twenty, twentyOne]) {
@@ -255,6 +253,11 @@ describe("Bun.semver.satisfies()", () => {
       testSatisfies("~" + big, "5.0.0", false);
       testSatisfies("~1." + big, "2.0.0", false);
     }
+    // 31 bytes but value 5: must be Some(5), not wildcard and not Some(0).
+    const padded = Buffer.alloc(30, "0").toString() + "5";
+    testSatisfies("^" + padded, "5.2.0", true);
+    testSatisfies("^" + padded, "0.5.0", false);
+    testSatisfies("^" + padded, "6.0.0", false);
   });
 
   test("ranges", () => {


### PR DESCRIPTION
## What

`parse_version_number` looped over its input byte by byte, matching on `X`/`x`/`*`, digits, whitespace and `.`, copying the digits into a 20-byte stack buffer before calling `T::parse_ascii` on the copy.

All three call sites pass `&input[part_start_i..last_char_i]`, where the bounds come from the parser's own digit scan:

```rust
b'0'..=b'9' => {
    part_start_i = i;
    i += 1;
    while i < input.len() && input[i].is_ascii_digit() { i += 1; }
    last_char_i = i;
```

So the slice is already non-empty and 100% ASCII digits. The match arms for non-digit bytes are unreachable and the buffer copy is redundant work done three times per `Version::parse`, which runs for every version key in every npm manifest.

## Observable bug

The 20-byte buffer guard was length-based, not value-based, so it created an inconsistency at 21 bytes regardless of the numeric value. Two cases:

**Overflow.** A 20-digit component that overflows `u64` went through `parse_ascii(...).unwrap_or(T::ZERO)` and became `Some(0)`, but a 21+ digit component hit the length guard and returned `None`, which downstream treats as a wildcard. So adding one more digit flipped a caret/tilde range from matching almost nothing to matching everything:

```js
Bun.semver.satisfies("1.0.0", "^" + "9".repeat(20))  // false
Bun.semver.satisfies("1.0.0", "^" + "9".repeat(21))  // true  (node-semver: false)
```

**Leading zeros.** A 21+ byte component whose value fits in `u64` (for example thirty leading zeros followed by `5`) also hit the length guard and became a wildcard, even though the value is just `5`:

```js
Bun.semver.satisfies("6.0.0", "^" + "0".repeat(30) + "5")  // true  (node-semver loose: false)
```

## Fix

Call `T::parse_ascii(input)` directly and keep the existing `unwrap_or(T::ZERO)` for overflow. A `debug_assert!` documents the all-digit invariant. Long components now parse to their numeric value when it fits and clamp to zero when it overflows, with no length cliff at 21 bytes. The caret/tilde cases in the new test agree with node-semver loose mode.

## Verification

- New test `long version components are not treated as wildcards` fails on current release, passes with the fix.
- Full `test/cli/install/semver.test.ts` (27 tests, 1822 expect calls) passes.
- `test/regression/issue/{08040,26657}.test.ts` pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/semver.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (1994a7750)

test/cli/install/semver.test.ts:
(pass) Bun.semver.order() > whitespace bug fix [4.17ms]
(pass) Bun.semver.order() > comparisons [36.17ms]
(pass) Bun.semver.order() > loose compare("0", "0.0") [3.89ms]
(pass) Bun.semver.order() > loose compare("1", "1.0") [1.67ms]
(pass) Bun.semver.order() > loose compare("1.2", "1.2.0") [0.86ms]
(pass) Bun.semver.order() > loose compare("1.x", "1.0.x") [0.75ms]
(pass) Bun.semver.order() > loose compare("1.x.x", "1.0.x") [0.78ms]
(pass) Bun.semver.order() > loose compare("2.x", "1.x") [0.79ms]
(pass) Bun.semver.order() > loose compare("2.x", "2.1") [0.77ms]
(pass) Bun.semver.order() > loose compare("2", "1") [0.77ms]
(pass) Bun.semver.order() > loose compare("3.*", "3.1") [0.76ms]
(pass) B
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/cli/install/semver.test.ts:
(pass) Bun.semver.order() > whitespace bug fix [0.08ms]
(pass) Bun.semver.order() > comparisons [0.30ms]
(pass) Bun.semver.order() > loose compare("0", "0.0") [0.04ms]
(pass) Bun.semver.order() > loose compare("1", "1.0")
(pass) Bun.semver.order() > loose compare("1.2", "1.2.0")
(pass) Bun.semver.order() > loose compare("1.x", "1.0.x")
(pass) Bun.semver.order() > loose compare("1.x.x", "1.0.x")
(pass) Bun.semver.order() > loose compare("2.x", "1.x")
(pass) Bun.semver.order() > loose compare("2.x", "2.1")
(pass) Bun.semver.order() > loose compare("2", "1")
(pass) Bun.semver.order() > loose compare("3.*", "3.1")
(pass) Bun.semver.order() > loose compare("3.2.*", "3.2.0")
(pass) Bun.semver.order() > loose compare("4294967295.4294967295.x", "4294967295.4294967295.4294967294")
(pass) Bun.semver.order() > loose compare("*", "4294967295.4294967295.4294967294")
(pass) Bun.semver.order() > equality [0.19ms]
(pass) Bun.semver.satisfies() > expected errors [0.26ms]
(pass) Bun.semver.satisfies() > failures does not cause weird memory issues [86.91ms]
(pass) Bun.semver.satisfies() > exact versions [0.48ms]
30
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/semver.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (1994a7750)

test/cli/install/semver.test.ts:
(pass) Bun.semver.order() > whitespace bug fix [3.89ms]
(pass) Bun.semver.order() > comparisons [35.35ms]
(pass) Bun.semver.order() > loose compare("0", "0.0") [3.08ms]
(pass) Bun.semver.order() > loose compare("1", "1.0") [1.23ms]
(pass) Bun.semver.order() > loose compare("1.2", "1.2.0") [0.78ms]
(pass) Bun.semver.order() > loose compare("1.x", "1.0.x") [0.76ms]
(pass) Bun.semver.order() > loose compare("1.x.x", "1.0.x") [0.78ms]
(pass) Bun.semver.order() > loose compare("2.x", "1.x") [0.78ms]
(pass) Bun.semver.order() > loose compare("2.x", "2.1") [1.14ms]
(pass) Bun.semver.order() > loose compare("2", "1") [0.94ms]
(pass) Bun.semver.order() > loose compare("3.*", "3.1") [0.81ms]
(pass) B
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 1132ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/76] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[1/76] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_semver v0.0.0 (/workspace/bun/src/semver)
[1m[92m   Compiling[0m bun_ast v0.0.0 (/workspace/bun/src/ast)
[1m[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/semver/Version.rs           | 47 ++++-------------------------------------
 test/cli/install/semver.test.ts | 19 +++++++++++++++++
 2 files changed, 23 insertions(+), 43 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                             reads  edits  tests
src/semver/Version.rs                4      1      0
test/cli/install/semver.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->