### PR TITLE
install: return Ordering directly from lockfile sort comparators

### DIFF
--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -657,10 +657,7 @@ impl VersionExt for Version {
 
     fn cmp_with_tag(string_buf: &[u8], lhs: &Version, rhs: &Version) -> Ordering {
         lhs.tag.cmp(rhs.tag).then_with(|| {
-            strings::order(
-                lhs.literal.slice(string_buf),
-                rhs.literal.slice(string_buf),
-            )
+            strings::order(lhs.literal.slice(string_buf), rhs.literal.slice(string_buf))
         })
     }
 

--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -72,7 +72,6 @@ pub trait DependencyExt {
         log: impl Into<Option<&'a mut bun_ast::Log>>,
         package_manager: impl Into<Option<&'b mut PackageManager>>,
     ) -> Option<Version>;
-    fn is_less_than(string_buf: &[u8], lhs: &Dependency, rhs: &Dependency) -> bool;
     fn cmp(string_buf: &[u8], lhs: &Dependency, rhs: &Dependency) -> Ordering;
     fn count_with_different_buffers<SB: StringBuilderLike>(
         &self,
@@ -164,19 +163,6 @@ impl DependencyExt for Dependency {
     /// 2. name ASC
     /// "name" must be ASC so that later, when we rebuild the lockfile
     /// we insert it back in reverse order without an extra sorting pass
-    fn is_less_than(string_buf: &[u8], lhs: &Dependency, rhs: &Dependency) -> bool {
-        let behavior = lhs.behavior.cmp(rhs.behavior);
-        if behavior != Ordering::Equal {
-            return behavior == Ordering::Less;
-        }
-
-        let lhs_name = lhs.name.slice(string_buf);
-        let rhs_name = rhs.name.slice(string_buf);
-        strings::cmp_strings_asc((), lhs_name, rhs_name)
-    }
-
-    /// Total-order comparator for `slice::sort_by`. Same key as
-    /// `is_less_than`: behavior group, then name ASC.
     fn cmp(string_buf: &[u8], lhs: &Dependency, rhs: &Dependency) -> Ordering {
         let behavior = lhs.behavior.cmp(rhs.behavior);
         if behavior != Ordering::Equal {
@@ -610,8 +596,6 @@ pub trait VersionExt {
         buf: &[u8],
         builder: &mut SB,
     ) -> Result<Version, crate::Error>;
-    fn is_less_than(string_buf: &[u8], lhs: &Version, rhs: &Version) -> bool;
-    fn is_less_than_with_tag(string_buf: &[u8], lhs: &Version, rhs: &Version) -> bool;
     fn cmp_with_tag(string_buf: &[u8], lhs: &Version, rhs: &Version) -> Ordering;
     fn to_version(
         alias: String,
@@ -640,19 +624,6 @@ impl VersionExt for Version {
             literal: builder.append_string(self.literal.slice(buf)),
             value: self.value.clone_in(self.tag, buf, builder)?,
         })
-    }
-
-    fn is_less_than(string_buf: &[u8], lhs: &Version, rhs: &Version) -> bool {
-        debug_assert!(lhs.tag == rhs.tag);
-        strings::cmp_strings_asc(
-            (),
-            lhs.literal.slice(string_buf),
-            rhs.literal.slice(string_buf),
-        )
-    }
-
-    fn is_less_than_with_tag(string_buf: &[u8], lhs: &Version, rhs: &Version) -> bool {
-        Self::cmp_with_tag(string_buf, lhs, rhs) == Ordering::Less
     }
 
     fn cmp_with_tag(string_buf: &[u8], lhs: &Version, rhs: &Version) -> Ordering {

--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -612,6 +612,7 @@ pub trait VersionExt {
     ) -> Result<Version, crate::Error>;
     fn is_less_than(string_buf: &[u8], lhs: &Version, rhs: &Version) -> bool;
     fn is_less_than_with_tag(string_buf: &[u8], lhs: &Version, rhs: &Version) -> bool;
+    fn cmp_with_tag(string_buf: &[u8], lhs: &Version, rhs: &Version) -> Ordering;
     fn to_version(
         alias: String,
         alias_hash: PackageNameHash,
@@ -651,16 +652,16 @@ impl VersionExt for Version {
     }
 
     fn is_less_than_with_tag(string_buf: &[u8], lhs: &Version, rhs: &Version) -> bool {
-        let tag_order = lhs.tag.cmp(rhs.tag);
-        if tag_order != Ordering::Equal {
-            return tag_order == Ordering::Less;
-        }
+        Self::cmp_with_tag(string_buf, lhs, rhs) == Ordering::Less
+    }
 
-        strings::cmp_strings_asc(
-            (),
-            lhs.literal.slice(string_buf),
-            rhs.literal.slice(string_buf),
-        )
+    fn cmp_with_tag(string_buf: &[u8], lhs: &Version, rhs: &Version) -> Ordering {
+        lhs.tag.cmp(rhs.tag).then_with(|| {
+            strings::order(
+                lhs.literal.slice(string_buf),
+                rhs.literal.slice(string_buf),
+            )
+        })
     }
 
     fn to_version(

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -662,7 +662,7 @@ pub(crate) fn install_isolated_packages(
             // and devDependency handling to match `hoistDependency`
             {
                 let sorter = lockfile::DepSorter { lockfile };
-                dep_ids_sort_buf.sort_by(|a, b| sorter.cmp(*a, *b));
+                dep_ids_sort_buf.sort_by(|a, b| sorter.order(*a, *b));
             }
 
             peer_dep_ids.clear();

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -662,15 +662,7 @@ pub(crate) fn install_isolated_packages(
             // and devDependency handling to match `hoistDependency`
             {
                 let sorter = lockfile::DepSorter { lockfile };
-                dep_ids_sort_buf.sort_by(|a, b| {
-                    if sorter.is_less_than(*a, *b) {
-                        core::cmp::Ordering::Less
-                    } else if sorter.is_less_than(*b, *a) {
-                        core::cmp::Ordering::Greater
-                    } else {
-                        core::cmp::Ordering::Equal
-                    }
-                });
+                dep_ids_sort_buf.sort_by(|a, b| sorter.cmp(*a, *b));
             }
 
             peer_dep_ids.clear();

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -227,21 +227,16 @@ pub(crate) struct DepSorter<'a> {
 }
 
 impl<'a> DepSorter<'a> {
-    pub(crate) fn is_less_than(&self, l: DependencyID, r: DependencyID) -> bool {
+    pub(crate) fn cmp(&self, l: DependencyID, r: DependencyID) -> Ordering {
         let deps_buf = self.lockfile.buffers.dependencies.as_slice();
         let string_buf = self.lockfile.buffers.string_bytes.as_slice();
 
         let l_dep = &deps_buf[l as usize];
         let r_dep = &deps_buf[r as usize];
 
-        match l_dep.behavior.cmp(r_dep.behavior) {
-            Ordering::Less => true,
-            Ordering::Greater => false,
-            Ordering::Equal => {
-                strings::order(l_dep.name.slice(string_buf), r_dep.name.slice(string_buf))
-                    == Ordering::Less
-            }
-        }
+        l_dep.behavior.cmp(r_dep.behavior).then_with(|| {
+            strings::order(l_dep.name.slice(string_buf), r_dep.name.slice(string_buf))
+        })
     }
 }
 

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -227,7 +227,7 @@ pub(crate) struct DepSorter<'a> {
 }
 
 impl<'a> DepSorter<'a> {
-    pub(crate) fn cmp(&self, l: DependencyID, r: DependencyID) -> Ordering {
+    pub(crate) fn order(&self, l: DependencyID, r: DependencyID) -> Ordering {
         let deps_buf = self.lockfile.buffers.dependencies.as_slice();
         let string_buf = self.lockfile.buffers.string_bytes.as_slice();
 

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -339,16 +339,7 @@ impl<R: ResolverContext> ResolverContextDyn for R {
 /// once instead of per-`R`).
 #[inline]
 fn dep_sort_cmp(buf: &[u8], a: &Dependency, b: &Dependency) -> core::cmp::Ordering {
-    // `slice::sort_by` requires
-    // a total order (and panics since 1.81 when violated), so derive
-    // `Ordering::Equal` from the predicate symmetrically.
-    if Dependency::is_less_than(buf, a, b) {
-        core::cmp::Ordering::Less
-    } else if Dependency::is_less_than(buf, b, a) {
-        core::cmp::Ordering::Greater
-    } else {
-        core::cmp::Ordering::Equal
-    }
+    Dependency::cmp(buf, a, b)
 }
 
 /// Field tags for the binary lockfile serializer (`bun.lockb`). The

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -731,7 +731,7 @@ impl Tree {
 
         {
             let sorter = DepSorter { lockfile };
-            builder.sort_buf.sort_unstable_by(|a, b| sorter.cmp(*a, *b));
+            builder.sort_buf.sort_unstable_by(|a, b| sorter.order(*a, *b));
         }
 
         // reshaped for borrowck — iterate over a snapshot of sort_buf indices since

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -731,7 +731,9 @@ impl Tree {
 
         {
             let sorter = DepSorter { lockfile };
-            builder.sort_buf.sort_unstable_by(|a, b| sorter.order(*a, *b));
+            builder
+                .sort_buf
+                .sort_unstable_by(|a, b| sorter.order(*a, *b));
         }
 
         // reshaped for borrowck — iterate over a snapshot of sort_buf indices since

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -731,15 +731,7 @@ impl Tree {
 
         {
             let sorter = DepSorter { lockfile };
-            builder.sort_buf.sort_unstable_by(|a, b| {
-                if DepSorter::is_less_than(&sorter, *a, *b) {
-                    core::cmp::Ordering::Less
-                } else if DepSorter::is_less_than(&sorter, *b, *a) {
-                    core::cmp::Ordering::Greater
-                } else {
-                    core::cmp::Ordering::Equal
-                }
-            });
+            builder.sort_buf.sort_unstable_by(|a, b| sorter.cmp(*a, *b));
         }
 
         // reshaped for borrowck — iterate over a snapshot of sort_buf indices since

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -149,11 +149,10 @@ struct TreeDepsSortCtx<'a> {
 }
 
 impl<'a> TreeDepsSortCtx<'a> {
-    pub(crate) fn is_less_than(&self, lhs: DependencyID, rhs: DependencyID) -> bool {
+    pub(crate) fn cmp(&self, lhs: DependencyID, rhs: DependencyID) -> core::cmp::Ordering {
         let l = &self.deps_buf[lhs as usize];
         let r = &self.deps_buf[rhs as usize];
-        strings::cmp_strings_asc(
-            (),
+        strings::order(
             l.name.slice(self.string_buf),
             r.name.slice(self.string_buf),
         )
@@ -668,15 +667,7 @@ impl Stringifier {
                         string_buf: buf,
                         deps_buf,
                     };
-                    tree_deps_sort_buf.sort_by(|&a, &b| {
-                        if ctx.is_less_than(a, b) {
-                            core::cmp::Ordering::Less
-                        } else if ctx.is_less_than(b, a) {
-                            core::cmp::Ordering::Greater
-                        } else {
-                            core::cmp::Ordering::Equal
-                        }
-                    });
+                    tree_deps_sort_buf.sort_by(|&a, &b| ctx.cmp(a, b));
                 }
 
                 for &dep_id in &tree_deps_sort_buf {
@@ -757,15 +748,7 @@ impl Stringifier {
                             string_buf: buf,
                             deps_buf,
                         };
-                        pkg_deps_sort_buf.sort_by(|&a, &b| {
-                            if ctx.is_less_than(a, b) {
-                                core::cmp::Ordering::Less
-                            } else if ctx.is_less_than(b, a) {
-                                core::cmp::Ordering::Greater
-                            } else {
-                                core::cmp::Ordering::Equal
-                            }
-                        });
+                        pkg_deps_sort_buf.sort_by(|&a, &b| ctx.cmp(a, b));
                     }
 
                     // INFO = { prod/dev/optional/peer dependencies, os, cpu, libc (TODO), bin, binDir }

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -149,7 +149,7 @@ struct TreeDepsSortCtx<'a> {
 }
 
 impl<'a> TreeDepsSortCtx<'a> {
-    pub(crate) fn cmp(&self, lhs: DependencyID, rhs: DependencyID) -> core::cmp::Ordering {
+    pub(crate) fn order(&self, lhs: DependencyID, rhs: DependencyID) -> core::cmp::Ordering {
         let l = &self.deps_buf[lhs as usize];
         let r = &self.deps_buf[rhs as usize];
         strings::order(l.name.slice(self.string_buf), r.name.slice(self.string_buf))
@@ -664,7 +664,7 @@ impl Stringifier {
                         string_buf: buf,
                         deps_buf,
                     };
-                    tree_deps_sort_buf.sort_by(|&a, &b| ctx.cmp(a, b));
+                    tree_deps_sort_buf.sort_by(|&a, &b| ctx.order(a, b));
                 }
 
                 for &dep_id in &tree_deps_sort_buf {
@@ -745,7 +745,7 @@ impl Stringifier {
                             string_buf: buf,
                             deps_buf,
                         };
-                        pkg_deps_sort_buf.sort_by(|&a, &b| ctx.cmp(a, b));
+                        pkg_deps_sort_buf.sort_by(|&a, &b| ctx.order(a, b));
                     }
 
                     // INFO = { prod/dev/optional/peer dependencies, os, cpu, libc (TODO), bin, binDir }

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -152,10 +152,7 @@ impl<'a> TreeDepsSortCtx<'a> {
     pub(crate) fn cmp(&self, lhs: DependencyID, rhs: DependencyID) -> core::cmp::Ordering {
         let l = &self.deps_buf[lhs as usize];
         let r = &self.deps_buf[rhs as usize];
-        strings::order(
-            l.name.slice(self.string_buf),
-            r.name.slice(self.string_buf),
-        )
+        strings::order(l.name.slice(self.string_buf), r.name.slice(self.string_buf))
     }
 }
 

--- a/src/install/lockfile/printer/Yarn.rs
+++ b/src/install/lockfile/printer/Yarn.rs
@@ -1,5 +1,4 @@
 use crate::lockfile::package::PackageColumns as _;
-use core::cmp::Ordering;
 
 use bun_collections::HashMap;
 use bun_core::strings;
@@ -95,15 +94,8 @@ fn packages(this: &mut Printer, writer: &mut impl bun_io::Write) -> Result<(), c
 
             let dependency_versions = &mut all_requested_versions_buf[requested_version_start..];
             if dependency_versions.len() > 1 {
-                dependency_versions.sort_by(|a, b| {
-                    if dependency::Version::is_less_than_with_tag(string_buf, a, b) {
-                        Ordering::Less
-                    } else if dependency::Version::is_less_than_with_tag(string_buf, b, a) {
-                        Ordering::Greater
-                    } else {
-                        Ordering::Equal
-                    }
-                });
+                dependency_versions
+                    .sort_by(|a, b| dependency::Version::cmp_with_tag(string_buf, a, b));
             }
             requested_versions.insert(i, (requested_version_start, j));
 

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -556,18 +556,6 @@ impl Dependency {
     /// Lives here so the lockfile
     /// stringifier (`bun.lock.rs`) can sort `&[Dependency]` without an upward
     /// `bun_install` edge or an extension trait.
-    pub fn is_less_than(string_buf: &[u8], lhs: &Dependency, rhs: &Dependency) -> bool {
-        let behavior = lhs.behavior.cmp(rhs.behavior);
-        if behavior != Ordering::Equal {
-            return behavior == Ordering::Less;
-        }
-        let lhs_name = lhs.name.slice(string_buf);
-        let rhs_name = rhs.name.slice(string_buf);
-        bun_core::strings::cmp_strings_asc((), lhs_name, rhs_name)
-    }
-
-    /// Total-order comparator for `slice::sort_by`. Same key as
-    /// [`is_less_than`](Self::is_less_than).
     pub fn cmp(string_buf: &[u8], lhs: &Dependency, rhs: &Dependency) -> Ordering {
         let behavior = lhs.behavior.cmp(rhs.behavior);
         if behavior != Ordering::Equal {


### PR DESCRIPTION
## What

Six `sort_by` call sites in `bun_install` derived `Ordering` by calling a boolean `is_less_than(a, b)` and, when that returned `false`, calling `is_less_than(b, a)`:

- `lockfile/Tree.rs` hoist builder (`DepSorter`)
- `isolated_install.rs` dep-id sort (`DepSorter`)
- `lockfile/bun.lock.rs` tree-deps and per-package deps (`TreeDepsSortCtx`, two sites)
- `lockfile/Package.rs` `dep_sort_cmp` (`Dependency::is_less_than`)
- `lockfile/printer/Yarn.rs` requested-version sort (`Version::is_less_than_with_tag`)

Each `is_less_than` slices both dependency names out of the string buffer and runs `strings::order` (memcmp). When `a >= b` under the key, the closure immediately re-runs the same comparison with the arguments swapped, so roughly half of all comparator invocations during a sort do the byte compare twice. These sorts run once per hoisted package while building the tree and again for every `"packages"` entry written to `bun.lock`.

## Fix

Give `DepSorter` / `TreeDepsSortCtx` a `cmp(&self, a, b) -> Ordering` and pass it straight to `sort_by`. Add `Version::cmp_with_tag`. `dep_sort_cmp` now forwards to the already-existing `Dependency::cmp`. One string comparison per comparator call; the key is unchanged (`behavior.cmp().then_with(|| strings::order(name_l, name_r))`).

The boolean predicates this replaces (`Dependency::is_less_than` inherent and trait, `Version::is_less_than`, `Version::is_less_than_with_tag`) have no remaining callers and are deleted.

Net: +18 / -119 across 8 files.

## Why this is correct

For a total order `cmp`, `is_less_than(a,b) <=> cmp(a,b) == Less`, and the old derivation
```
is_less_than(a,b)        -> Less
else is_less_than(b,a)   -> Greater
else                     -> Equal
```
is exactly `cmp(a,b)`. `behavior.cmp` and `strings::order` (i.e. `<[u8]>::cmp`) are both total, so `then_with` composes to the same total order. No observable output change.

## Verification

- `cargo check -p bun_install -p bun_install_types` and `bun run rust:check` clean
- `bun bd test test/cli/install/migrate-bun-lockb-v2.test.ts`: 2/2 pass. Its snapshot is a 2083-line `bun.lock` with ~1458 entries; a changed sort order would mismatch here.
- `bun-install.test.ts`, `bun-workspaces.test.ts`, `bun-lock.test.ts`, `isolated-install.test.ts`: identical pass/fail counts to the installed bun (pre-existing failures are verdaccio connectivity in the dev container).

This is a perf-only refactor; there is no fail-before test for "the comparator ran once instead of twice" without instrumenting `src/`. Correctness is covered by the existing lockfile snapshot tests above.