### PR TITLE
collections: MultiArrayList stable sort is O(n log n), not insertion sort

### DIFF
--- a/src/collections/multi_array_list.rs
+++ b/src/collections/multi_array_list.rs
@@ -1347,6 +1347,11 @@ fn aligned_alloc<T, A: Allocator>(
 
 // Index-based context sorts — port of `mem.sortContext` / `mem.sortUnstableContext`.
 
+const SMALL_SORT_THRESHOLD: usize = 32;
+
+/// Stable O(n log n) sort of `[a, b)` via an index-based comparator and swap.
+/// Sorts a permutation vector with `slice::sort_by`, then applies it in place
+/// with cycle-following (≤ n-1 `swap` calls).
 fn bun_collections_sort_context(
     a: usize,
     b: usize,
@@ -1354,17 +1359,51 @@ fn bun_collections_sort_context(
     mut swap: impl FnMut(usize, usize),
 ) {
     debug_assert!(a <= b);
-    if a >= b {
+    let n = b - a;
+    if n < 2 {
         return;
     }
-    let mut i = a + 1;
-    while i < b {
-        let mut j = i;
-        while j > a && less(j, j - 1) {
-            swap(j, j - 1);
-            j -= 1;
+    if n <= SMALL_SORT_THRESHOLD {
+        let mut i = a + 1;
+        while i < b {
+            let mut j = i;
+            while j > a && less(j, j - 1) {
+                swap(j, j - 1);
+                j -= 1;
+            }
+            i += 1;
         }
-        i += 1;
+        return;
+    }
+
+    let mut perm: Vec<usize> = (a..b).collect();
+    perm.sort_by(|&i, &j| {
+        if less(i, j) {
+            core::cmp::Ordering::Less
+        } else if less(j, i) {
+            core::cmp::Ordering::Greater
+        } else {
+            core::cmp::Ordering::Equal
+        }
+    });
+    // `perm[k]` is the absolute source index for target `a + k`. Walk each
+    // cycle once; mark visited positions by writing the identity back.
+    for k in 0..n {
+        if perm[k] == a + k {
+            continue;
+        }
+        let mut j = k;
+        loop {
+            let src = perm[j];
+            debug_assert!((a..b).contains(&src));
+            if src == a + k {
+                perm[j] = a + j;
+                break;
+            }
+            swap(a + j, src);
+            perm[j] = a + j;
+            j = src - a;
+        }
     }
 }
 
@@ -1533,6 +1572,19 @@ mod tests {
         assert_eq!(list.items::<"a", u32>(), &[0, 5, 2, 3, 4]);
     }
 
+    struct ByA {
+        a: *const u32,
+        len: usize,
+    }
+    impl SortContext for ByA {
+        fn less_than(&self, ai: usize, bi: usize) -> bool {
+            debug_assert!(ai < self.len && bi < self.len);
+            // SAFETY: `a` is the live `"a"` column base and `ai`/`bi` < `len`;
+            // the column is not reallocated during sort.
+            unsafe { *self.a.add(ai) < *self.a.add(bi) }
+        }
+    }
+
     #[test]
     fn sort_swaps_all_columns() {
         let mut list = MultiArrayList::<Foo>::default();
@@ -1544,20 +1596,117 @@ mod tests {
             })
             .unwrap();
         }
-        let raw = list.items_raw::<"a", u32>();
+        let a = list.items_raw::<"a", u32>();
         let len = list.len();
-        struct Ctx {
-            a: *const u32,
-            len: usize,
-        }
-        impl SortContext for Ctx {
-            fn less_than(&self, ai: usize, bi: usize) -> bool {
-                debug_assert!(ai < self.len && bi < self.len);
-                unsafe { *self.a.add(ai) < *self.a.add(bi) }
-            }
-        }
-        list.sort(&Ctx { a: raw, len });
+        list.sort(&ByA { a, len });
         assert_eq!(list.items::<"a", u32>(), &[0, 1, 2, 3, 4]);
         assert_eq!(list.items::<"c", u64>(), &[0, 10, 20, 30, 40]);
+    }
+
+    fn sort_via_context<T: Copy + Ord>(data: &mut Vec<T>, a: usize, b: usize) -> usize {
+        let cells = core::cell::Cell::from_mut(data.as_mut_slice()).as_slice_of_cells();
+        let swaps = core::cell::Cell::new(0usize);
+        bun_collections_sort_context(
+            a,
+            b,
+            |i, j| cells[i].get() < cells[j].get(),
+            |i, j| {
+                swaps.set(swaps.get() + 1);
+                cells[i].swap(&cells[j]);
+            },
+        );
+        swaps.get()
+    }
+
+    #[test]
+    fn sort_context_orders_correctly() {
+        for &n in &[0usize, 1, 2, 31, 32, 33, 200] {
+            let n32 = n as u32;
+            let mut v: Vec<u32> = (0..n32).rev().collect();
+            sort_via_context(&mut v, 0, n);
+            assert!(v.windows(2).all(|w| w[0] <= w[1]), "reverse n={n}");
+
+            let mut v: Vec<u32> = (0..n32).collect();
+            sort_via_context(&mut v, 0, n);
+            assert_eq!(v, (0..n32).collect::<Vec<_>>(), "sorted n={n}");
+
+            let mut v: Vec<u32> = (0..n32)
+                .map(|i| if i % 2 == 0 { i / 2 } else { n32 - 1 - i / 2 })
+                .collect();
+            sort_via_context(&mut v, 0, n);
+            assert!(v.windows(2).all(|w| w[0] <= w[1]), "interleaved n={n}");
+        }
+    }
+
+    #[test]
+    fn sort_context_linear_swaps() {
+        // Cycle-following does ≤ n-1 swaps; insertion sort would do n(n-1)/2.
+        let n = 400usize;
+        let mut v: Vec<u32> = (0..n as u32).rev().collect();
+        let swaps = sort_via_context(&mut v, 0, n);
+        assert!(v.windows(2).all(|w| w[0] <= w[1]));
+        assert!(swaps < n, "expected <{n} swaps, got {swaps}");
+    }
+
+    #[test]
+    fn sort_context_stable() {
+        // (key, original_index); sort by key, equal keys must keep index order.
+        let n = 300usize;
+        let mut v: Vec<(u32, u32)> = (0..n as u32).map(|i| (i % 7, i)).collect();
+        let cells = core::cell::Cell::from_mut(v.as_mut_slice()).as_slice_of_cells();
+        bun_collections_sort_context(
+            0,
+            n,
+            |i, j| cells[i].get().0 < cells[j].get().0,
+            |i, j| cells[i].swap(&cells[j]),
+        );
+        for w in v.windows(2) {
+            assert!(w[0].0 <= w[1].0);
+            if w[0].0 == w[1].0 {
+                assert!(
+                    w[0].1 < w[1].1,
+                    "stability broken: {:?} before {:?}",
+                    w[0],
+                    w[1]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn sort_context_span_offset() {
+        // Sort only [10, 90) of a 100-element array; ends must stay put.
+        let mut v: Vec<u32> = (0..100u32).map(|i| (i * 37) % 100).collect();
+        let head = v[..10].to_vec();
+        let tail = v[90..].to_vec();
+        let mut mid: Vec<u32> = v[10..90].to_vec();
+        mid.sort();
+        sort_via_context(&mut v, 10, 90);
+        assert_eq!(&v[..10], &head[..]);
+        assert_eq!(&v[90..], &tail[..]);
+        assert_eq!(&v[10..90], &mid[..]);
+    }
+
+    #[test]
+    fn sort_large_list_all_columns() {
+        let n = 500u32;
+        let mut list = MultiArrayList::<Foo>::default();
+        for i in (0..n).rev() {
+            list.push(Foo {
+                a: i,
+                b: (i % 256) as u8,
+                c: i as u64 * 10,
+            })
+            .unwrap();
+        }
+        let a = list.items_raw::<"a", u32>();
+        let len = list.len();
+        list.sort(&ByA { a, len });
+        let a_col = list.items::<"a", u32>();
+        let c_col = list.items::<"c", u64>();
+        for i in 0..n as usize {
+            assert_eq!(a_col[i], i as u32);
+            assert_eq!(c_col[i], i as u64 * 10);
+        }
     }
 }

--- a/src/collections/multi_array_list.rs
+++ b/src/collections/multi_array_list.rs
@@ -1345,7 +1345,8 @@ fn aligned_alloc<T, A: Allocator>(
         .map_err(|_| AllocError)
 }
 
-// Index-based context sorts — port of `mem.sortContext` / `mem.sortUnstableContext`.
+// Index-based context sorts — same `less`/`swap` callback API as Zig's
+// `mem.sortContext` / `mem.sortUnstableContext`, not the same algorithms.
 
 const SMALL_SORT_THRESHOLD: usize = 32;
 

--- a/test/js/node/module/sourcemap.test.js
+++ b/test/js/node/module/sourcemap.test.js
@@ -239,9 +239,7 @@ test("SourceMap with many out-of-order mappings sorts in O(n log n)", async () =
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(stdout).toBe("[0,1,40000,79999,80000]");
-  expect(exitCode).toBe(0);
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "[0,1,40000,79999,80000]", stderr: "", exitCode: 0 });
 });
 
 test("error.stack of // @bun code with a truncated VLQ in sourceMappingURL warns and degrades gracefully", async () => {

--- a/test/js/node/module/sourcemap.test.js
+++ b/test/js/node/module/sourcemap.test.js
@@ -215,6 +215,35 @@ console.log("done");`,
   expect(exitCode).toBe(0);
 });
 
+test("SourceMap with many out-of-order mappings sorts in O(n log n)", async () => {
+  // 80000 segments on one line in descending column order: every segment
+  // after the second has a negative generated-column delta, which forces a
+  // stable sort of the entire mapping list. The sort backing
+  // `MultiArrayList::sort` used to be plain insertion sort, so this input
+  // took ~20s on a release build and minutes under debug; with an
+  // O(n log n) sort it finishes in well under a second.
+  const script = `
+    const { SourceMap } = require("node:module");
+    const N = 80000;
+    // VLQ: 0 -> "A", 80000 -> "go8E", -1 -> "D". Segments are 4-field.
+    // Columns visited: 0, 80000, 79999, ..., 1.
+    const mappings = "AAAA,go8EAAA" + Buffer.alloc((N - 1) * 5, ",DAAA").toString();
+    const map = new SourceMap({ version: 3, sources: ["s.js"], names: [], mappings });
+    const probes = [0, 1, 40000, 79999, 80000].map(c => map.findEntry(0, c).generatedColumn);
+    process.stdout.write(JSON.stringify(probes));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("[0,1,40000,79999,80000]");
+  expect(exitCode).toBe(0);
+});
+
 test("error.stack of // @bun code with a truncated VLQ in sourceMappingURL warns and degrades gracefully", async () => {
   // 'g' is a single base64 byte with the VLQ continuation bit set, so the
   // mappings string ends mid-value. The generated-column field is truncated,


### PR DESCRIPTION
## What

`bun_collections_sort_context` (the stable sort used by `MultiArrayList::sort`/`sort_span`) was plain nested-while insertion sort: O(n²) comparisons and O(n²) `swap_rows` calls, each `swap_rows` touching every SoA column. The comment claimed it ports Zig's `std.mem.sortContext`, but Zig's is block sort.

The primary production caller is `src/sourcemap/Mapping.rs`, which sorts the entire parsed mapping list whenever any segment has a negative generated-column delta. Real bundles easily produce tens of thousands of such entries.

## Fix

Index-permutation sort: collect `(a..b)` into a `Vec<usize>`, sort it with `slice::sort_by` (stable, O(n log n)), then apply the permutation in place via cycle-following (≤ n-1 `swap` calls). Inputs of ≤ 32 elements keep the allocation-free insertion sort. This is the same pattern already used by `ArrayHashMap::sort`.

Stability is preserved: `slice::sort_by` is stable, and the comparator returns `Equal` for tied keys so equal elements keep their original relative order in the permutation.

## Verification

80000 reverse-ordered sourcemap segments on one line, `new SourceMap(...)` from `node:module`:

| build | before | after |
|---|---|---|
| release | 20.8 s | < 20 ms |
| debug+ASAN | minutes | 128 ms |

Scaling on release before the fix (confirming quadratic):

```
n=1000   3.7ms
n=2000  14.4ms
n=4000  54.2ms
n=8000 222.5ms
```

Rust unit tests cover correctness at the threshold boundary (31/32/33), reverse/sorted/interleaved inputs, stability, sub-range sort with a non-zero start, swap-count bound (< n for n=400 reverse), and a 500-row `MultiArrayList` where every column moves together.

The JS test (`test/js/node/module/sourcemap.test.js`) constructs the 80000-segment map in a child process and checks `findEntry` results; before this change the child does not complete within the default test timeout.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/module/sourcemap.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (4cc99867b)

test/js/node/module/sourcemap.test.js:
(pass) SourceMap class exists [14.81ms]
(pass) SourceMap constructor requires payload [8.06ms]
(pass) SourceMap payload must be an object [5.22ms]
(pass) SourceMap instance has expected methods [6.18ms]
(pass) SourceMap payload getter [3.60ms]
(pass) SourceMap lineLengths getter [3.32ms]
(pass) SourceMap lineLengths undefined when not provided [4.62ms]
(pass) SourceMap findEntry returns mapping data [5.44ms]
(pass) SourceMap findOrigin returns origin data [4.62ms]
(pass) SourceMap with names returns name property correctly [7.37ms]
(pass) SourceMap without names has undefined name property [4.97ms]
(pass) SourceMap with invalid name index has undefined name property [4.49ms]
(pa
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/module/sourcemap.test.js:
(pass) SourceMap class exists [0.05ms]
(pass) SourceMap constructor requires payload [0.78ms]
(pass) SourceMap payload must be an object [0.06ms]
(pass) SourceMap instance has expected methods [0.09ms]
(pass) SourceMap payload getter [0.03ms]
(pass) SourceMap lineLengths getter [0.03ms]
(pass) SourceMap lineLengths undefined when not provided [0.03ms]
(pass) SourceMap findEntry returns mapping data [0.07ms]
(pass) SourceMap findOrigin returns origin data [0.04ms]
(pass) SourceMap with names returns name property correctly [0.06ms]
(pass) SourceMap without names has undefined name property [0.03ms]
(pass) SourceMap with invalid name index has undefined name property [0.05ms]
(pass) SourceMap handles mappings with truncated VLQ segments without crashing [17.86ms]
killed 1 dangling process
(fail) SourceMap with many out-of-order mappings sorts in O(n log n) [5000.13ms]
  ^ this test timed out after 5000ms.

# Unhandled error between tests
-------------------------------
237 |     env: bunEnv,
238 |     stdout: "pipe",
239 |     stderr: "pipe",
240 |   });
241 |   const [stdout, stderr, exitCod
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/module/sourcemap.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (4cc99867b)

test/js/node/module/sourcemap.test.js:
(pass) SourceMap class exists [14.26ms]
(pass) SourceMap constructor requires payload [7.68ms]
(pass) SourceMap payload must be an object [5.44ms]
(pass) SourceMap instance has expected methods [5.94ms]
(pass) SourceMap payload getter [3.31ms]
(pass) SourceMap lineLengths getter [3.35ms]
(pass) SourceMap lineLengths undefined when not provided [3.34ms]
(pass) SourceMap findEntry returns mapping data [5.22ms]
(pass) SourceMap findOrigin returns origin data [4.61ms]
(pass) SourceMap with names returns name property correctly [7.97ms]
(pass) SourceMap without names has undefined name property [4.83ms]
(pass) SourceMap with invalid name index has undefined name property [4.47ms]
(pa
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4cc99867be
  features     (none)

22 deps, 106 codegen, 1169 objects in 1223ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1232] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [36.00ms]
[2/1232] gen bindgenv2
[3/1232] gen ErrorCode+*.h
[4/1232] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [8.00ms]
[5/1232] fetch zlib
[zlib] up to date
[6/1232] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1232] fetch tinycc
[tinycc] up to date
[8/1231] fetch picohttpparser
[picohttpparser] up to date
[9/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canar
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/collections/multi_array_list.rs   | 187 ++++++++++++++++++++++++++++++----
 test/js/node/module/sourcemap.test.js |  27 +++++
 2 files changed, 195 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/collections/multi_array_list.rs        4      6      0
test/js/node/module/sourcemap.test.js      2      4      0
```

</details>

<!-- robobun:evidence:end -->