### PR TITLE
css: avoid throwaway heap allocs in CSS-modules symbol lookup and [attr=val] minification

### DIFF
--- a/src/bundler/linker_context/generateCodeForLazyExport.rs
+++ b/src/bundler/linker_context/generateCodeForLazyExport.rs
@@ -18,8 +18,6 @@ use bun_collections::DynamicBitSetUnmanaged as BitSet;
 
 type SymbolList<'a> = bun_ast::symbol::List<'a>;
 
-use crate::bun_css::LocalScopeAdapter as SliceBoxAdapter;
-
 pub fn generate_code_for_lazy_export(
     this: &mut LinkerContext,
     source_index: IndexInt,
@@ -162,7 +160,7 @@ pub fn generate_code_for_lazy_export(
                     let name: &[u8] = syms[css_ref.inner_index() as usize].original_name.slice();
                     let loc = ast
                         .local_scope
-                        .get_adapted(name, &SliceBoxAdapter)
+                        .get(name)
                         .unwrap()
                         .loc;
 
@@ -224,9 +222,8 @@ pub fn generate_code_for_lazy_export(
                                         };
                                         for name in compose.names.slice() {
                                             let name_v = name.v();
-                                            let Some(other_name_entry) = other_file
-                                                .local_scope
-                                                .get_adapted(name_v, &SliceBoxAdapter)
+                                            let Some(other_name_entry) =
+                                                other_file.local_scope.get(name_v)
                                             else {
                                                 continue;
                                             };
@@ -268,8 +265,7 @@ pub fn generate_code_for_lazy_export(
                                     // it is from the current file
                                     for name in compose.names.slice() {
                                         let name_v = name.v();
-                                        let Some(name_entry) =
-                                            ast.local_scope.get_adapted(name_v, &SliceBoxAdapter)
+                                        let Some(name_entry) = ast.local_scope.get(name_v)
                                         else {
                                             self.log.add_error_fmt(
                                                 &self.all_sources[idx as usize],

--- a/src/bundler/linker_context/generateCodeForLazyExport.rs
+++ b/src/bundler/linker_context/generateCodeForLazyExport.rs
@@ -158,11 +158,7 @@ pub fn generate_code_for_lazy_export(
                         &self.all_symbols[css_ref.source_index(idx) as usize];
                     // `Symbol.original_name: StoreStr` — arena-owned for the link pass.
                     let name: &[u8] = syms[css_ref.inner_index() as usize].original_name.slice();
-                    let loc = ast
-                        .local_scope
-                        .get(name)
-                        .unwrap()
-                        .loc;
+                    let loc = ast.local_scope.get(name).unwrap().loc;
 
                     self.log.add_range_error_fmt_with_note(
                         Some(&self.all_sources[idx as usize]),
@@ -265,8 +261,7 @@ pub fn generate_code_for_lazy_export(
                                     // it is from the current file
                                     for name in compose.names.slice() {
                                         let name_v = name.v();
-                                        let Some(name_entry) = ast.local_scope.get(name_v)
-                                        else {
+                                        let Some(name_entry) = ast.local_scope.get(name_v) else {
                                             self.log.add_error_fmt(
                                                 &self.all_sources[idx as usize],
                                                 compose.loc,

--- a/src/bundler/linker_context/generateCodeForLazyExport.rs
+++ b/src/bundler/linker_context/generateCodeForLazyExport.rs
@@ -18,19 +18,7 @@ use bun_collections::DynamicBitSetUnmanaged as BitSet;
 
 type SymbolList<'a> = bun_ast::symbol::List<'a>;
 
-/// `ArrayHashAdapter` so `LocalScope` (`ArrayHashMap<Box<[u8]>, LocalEntry>`)
-/// can be queried by borrowed `&[u8]` (CSS idents are arena `*const [u8]`).
-struct SliceBoxAdapter;
-impl bun_collections::array_hash_map::ArrayHashAdapter<[u8], Box<[u8]>> for SliceBoxAdapter {
-    fn hash(&self, key: &[u8]) -> u32 {
-        // Match `LocalScope`'s default `AutoContext` hashing for `Box<[u8]>`.
-        use bun_collections::array_hash_map::{ArrayHashContext, AutoContext};
-        AutoContext.hash(key)
-    }
-    fn eql(&self, a: &[u8], b: &Box<[u8]>, _i: usize) -> bool {
-        a == &**b
-    }
-}
+use crate::bun_css::LocalScopeAdapter as SliceBoxAdapter;
 
 pub fn generate_code_for_lazy_export(
     this: &mut LinkerContext,

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -1610,8 +1610,7 @@ mod __css_validation {
                                 };
                                 for name in compose.names.slice() {
                                     let name_v = name.v();
-                                    let Some(other_name) = other_ast.local_scope.get(name_v)
-                                    else {
+                                    let Some(other_name) = other_ast.local_scope.get(name_v) else {
                                         continue;
                                     };
                                     let other_name_ref =

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -1392,20 +1392,7 @@ mod __css_validation {
     // `*mut` (`BundledAst.css`), so we never launder a `&T` into `&mut T`.
     use crate::bundled_ast::CssCol;
 
-    /// `ArrayHashAdapter` so `LocalScope` (`ArrayHashMap<Box<[u8]>, LocalEntry>`)
-    /// can be queried by borrowed `&[u8]` (CSS idents are arena `*const [u8]`).
-    struct SliceBoxAdapter;
-    impl bun_collections::array_hash_map::ArrayHashAdapter<[u8], Box<[u8]>> for SliceBoxAdapter {
-        fn hash(&self, key: &[u8]) -> u32 {
-            // Match `LocalScope`'s default `AutoContext` hashing for `Box<[u8]>`
-            // (std `Hash` over the byte slice → wyhash truncated to u32).
-            use bun_collections::array_hash_map::{ArrayHashContext, AutoContext};
-            AutoContext.hash(key)
-        }
-        fn eql(&self, a: &[u8], b: &Box<[u8]>, _i: usize) -> bool {
-            a == &**b
-        }
-    }
+    use crate::bun_css::LocalScopeAdapter as SliceBoxAdapter;
 
     pub(super) fn validate_css_import_composes(
         this: &mut LinkerContext,

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -1392,8 +1392,6 @@ mod __css_validation {
     // `*mut` (`BundledAst.css`), so we never launder a `&T` into `&mut T`.
     use crate::bundled_ast::CssCol;
 
-    use crate::bun_css::LocalScopeAdapter as SliceBoxAdapter;
-
     pub(super) fn validate_css_import_composes(
         this: &mut LinkerContext,
         id: usize,
@@ -1427,10 +1425,7 @@ mod __css_validation {
                 };
                 for name in compose.names.slice() {
                     let name_v = name.v();
-                    if !other_css_ast
-                        .local_scope
-                        .contains_adapted(name_v, &SliceBoxAdapter)
-                    {
+                    if !other_css_ast.local_scope.contains(name_v) {
                         // Split-borrow — see `LinkerContext::log_disjoint`.
                         let _ = this.log_disjoint().add_error_fmt(
                             &col_ref!(input_files)[record.source_index.get() as usize],
@@ -1615,8 +1610,7 @@ mod __css_validation {
                                 };
                                 for name in compose.names.slice() {
                                     let name_v = name.v();
-                                    let Some(other_name) =
-                                        other_ast.local_scope.get_adapted(name_v, &SliceBoxAdapter)
+                                    let Some(other_name) = other_ast.local_scope.get(name_v)
                                     else {
                                         continue;
                                     };
@@ -1638,9 +1632,7 @@ mod __css_validation {
                             // inside this file
                             for name in compose.names.slice() {
                                 let name_v = name.v();
-                                let Some(name_entry) =
-                                    ast.local_scope.get_adapted(name_v, &SliceBoxAdapter)
-                                else {
+                                let Some(name_entry) = ast.local_scope.get(name_v) else {
                                     continue;
                                 };
                                 self.visit(idx, ast, name_entry.ref_.to_real_ref(idx));

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -9,7 +9,7 @@ use core::fmt;
 use bun_alloc::Arena as Bump;
 use bun_ast::Log;
 use bun_collections::bit_set::{ArrayBitSet, num_masks_for};
-use bun_collections::{ArrayHashMap, MapEntry, VecExt};
+use bun_collections::{ArrayHashMap, VecExt};
 use bun_core::strings;
 
 // ───────────────────────────── re-exports ─────────────────────────────
@@ -2369,6 +2369,7 @@ impl CssRef {
     }
 }
 
+#[derive(Default)]
 pub struct LocalEntry {
     pub ref_: CssRef,
     pub loc: bun_ast::Loc,
@@ -2379,6 +2380,21 @@ pub struct LocalEntry {
 /// because we don't know the final generated class names for local scope
 /// until print time.
 pub type LocalScope = ArrayHashMap<Box<[u8]>, LocalEntry>;
+
+/// Borrowed-`&[u8]` probe into [`LocalScope`] so lookups don't box the key.
+/// Matches the map's default `AutoContext` hashing for `Box<[u8]>`.
+pub struct LocalScopeAdapter;
+impl bun_collections::array_hash_map::ArrayHashAdapter<[u8], Box<[u8]>> for LocalScopeAdapter {
+    #[inline]
+    fn hash(&self, key: &[u8]) -> u32 {
+        use bun_collections::array_hash_map::ArrayHashContext;
+        bun_collections::AutoContext.hash(key)
+    }
+    #[inline]
+    fn eql(&self, a: &[u8], b: &Box<[u8]>, _i: usize) -> bool {
+        a == &**b
+    }
+}
 /// Local symbol renaming results go here
 pub type LocalsResultsMap = ast::MangledProps;
 /// Using `compose` and having conflicting properties is undefined behavior
@@ -3406,7 +3422,7 @@ impl<'a> Parser<'a> {
         }
 
         let extra = self.extra.as_deref_mut().unwrap();
-        // Split borrows so the vacant arm can grow `symbols` while
+        // Split borrows so the miss arm can grow `symbols` while
         // `local_scope` is borrowed by the entry.
         let symbols = &mut extra.symbols;
         let local_scope = &mut extra.local_scope;
@@ -3419,29 +3435,31 @@ impl<'a> Parser<'a> {
         // crate-wide lifetime erasure — see PORTING.md §Lifetimes).
         let name_static: &'static [u8] = unsafe { src_str(name) };
 
-        let entry = match local_scope.entry(Box::<[u8]>::from(name)) {
-            MapEntry::Vacant(v) => {
-                let inner_index = u32::try_from(symbols.len()).unwrap();
-                symbols.push(bun_ast::Symbol {
-                    kind: bun_ast::SymbolKind::LocalCss,
-                    original_name: name_static.into(),
-                    ..Default::default()
-                });
-                v.insert(LocalEntry {
-                    ref_: CssRef::new(inner_index, tag),
-                    loc,
-                })
+        // Borrowed probe so a repeated class/id name doesn't box a fresh key
+        // per selector; only a miss allocates the stored `Box<[u8]>`.
+        let gop = local_scope
+            .get_or_put_adapted(name, &LocalScopeAdapter)
+            .expect("unreachable");
+        let entry = gop.value_ptr;
+        if gop.found_existing {
+            let prev_tag = entry.ref_.tag();
+            if !prev_tag.contains(CssRefTag::CLASS) && tag.contains(CssRefTag::CLASS) {
+                entry.loc = loc;
+                entry.ref_.set_tag(prev_tag | tag);
             }
-            MapEntry::Occupied(o) => {
-                let e = o.into_mut();
-                let prev_tag = e.ref_.tag();
-                if !prev_tag.contains(CssRefTag::CLASS) && tag.contains(CssRefTag::CLASS) {
-                    e.loc = loc;
-                    e.ref_.set_tag(prev_tag | tag);
-                }
-                e
-            }
-        };
+        } else {
+            let inner_index = u32::try_from(symbols.len()).unwrap();
+            symbols.push(bun_ast::Symbol {
+                kind: bun_ast::SymbolKind::LocalCss,
+                original_name: name_static.into(),
+                ..Default::default()
+            });
+            *gop.key_ptr = Box::<[u8]>::from(name);
+            *entry = LocalEntry {
+                ref_: CssRef::new(inner_index, tag),
+                loc,
+            };
+        }
 
         entry.ref_.to_real_ref(source_index)
     }

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -9,7 +9,7 @@ use core::fmt;
 use bun_alloc::Arena as Bump;
 use bun_ast::Log;
 use bun_collections::bit_set::{ArrayBitSet, num_masks_for};
-use bun_collections::{ArrayHashMap, VecExt};
+use bun_collections::{ArrayHashMap, StringArrayHashMap, VecExt};
 use bun_core::strings;
 
 // ───────────────────────────── re-exports ─────────────────────────────
@@ -2379,22 +2379,7 @@ pub struct LocalEntry {
 /// ref. We use this ref as a layer of indirection during the bundling stage
 /// because we don't know the final generated class names for local scope
 /// until print time.
-pub type LocalScope = ArrayHashMap<Box<[u8]>, LocalEntry>;
-
-/// Borrowed-`&[u8]` probe into [`LocalScope`] so lookups don't box the key.
-/// Matches the map's default `AutoContext` hashing for `Box<[u8]>`.
-pub struct LocalScopeAdapter;
-impl bun_collections::array_hash_map::ArrayHashAdapter<[u8], Box<[u8]>> for LocalScopeAdapter {
-    #[inline]
-    fn hash(&self, key: &[u8]) -> u32 {
-        use bun_collections::array_hash_map::ArrayHashContext;
-        bun_collections::AutoContext.hash(key)
-    }
-    #[inline]
-    fn eql(&self, a: &[u8], b: &Box<[u8]>, _i: usize) -> bool {
-        a == &**b
-    }
-}
+pub type LocalScope = StringArrayHashMap<LocalEntry>;
 /// Local symbol renaming results go here
 pub type LocalsResultsMap = ast::MangledProps;
 /// Using `compose` and having conflicting properties is undefined behavior
@@ -3436,10 +3421,8 @@ impl<'a> Parser<'a> {
         let name_static: &'static [u8] = unsafe { src_str(name) };
 
         // Borrowed probe so a repeated class/id name doesn't box a fresh key
-        // per selector; only a miss allocates the stored `Box<[u8]>`.
-        let gop = local_scope
-            .get_or_put_adapted(name, &LocalScopeAdapter)
-            .expect("unreachable");
+        // per selector; `StringArrayHashMap::get_or_put` boxes on miss only.
+        let gop = local_scope.get_or_put(name).expect("unreachable");
         let entry = gop.value_ptr;
         if gop.found_existing {
             let prev_tag = entry.ref_.tag();
@@ -3454,7 +3437,6 @@ impl<'a> Parser<'a> {
                 original_name: name_static.into(),
                 ..Default::default()
             });
-            *gop.key_ptr = Box::<[u8]>::from(name);
             *entry = LocalEntry {
                 ref_: CssRef::new(inner_index, tag),
                 loc,

--- a/src/css/lib.rs
+++ b/src/css/lib.rs
@@ -89,8 +89,9 @@ pub use values as css_values;
 // Crate-root re-exports of parser-core helpers referenced by the rule/
 // selector/property/media_query bodies via `css::*`.
 pub use css_parser::{
-    CssRef, CssRefTag, CssResult as Result, Delimiters, EnumProperty, IntoParserError, Maybe,
-    ParserState, enum_property_util, nth, parse_utility, signfns, void_wrap,
+    CssRef, CssRefTag, CssResult as Result, Delimiters, EnumProperty, IntoParserError,
+    LocalScopeAdapter, Maybe, ParserState, enum_property_util, nth, parse_utility, signfns,
+    void_wrap,
 };
 
 // ─── selectors/ crate-root surface ────────────────────────────────────────

--- a/src/css/lib.rs
+++ b/src/css/lib.rs
@@ -89,9 +89,8 @@ pub use values as css_values;
 // Crate-root re-exports of parser-core helpers referenced by the rule/
 // selector/property/media_query bodies via `css::*`.
 pub use css_parser::{
-    CssRef, CssRefTag, CssResult as Result, Delimiters, EnumProperty, IntoParserError,
-    LocalScopeAdapter, Maybe, ParserState, enum_property_util, nth, parse_utility, signfns,
-    void_wrap,
+    CssRef, CssRefTag, CssResult as Result, Delimiters, EnumProperty, IntoParserError, Maybe,
+    ParserState, enum_property_util, nth, parse_utility, signfns, void_wrap,
 };
 
 // ─── selectors/ crate-root surface ────────────────────────────────────────

--- a/src/css/printer.rs
+++ b/src/css/printer.rs
@@ -539,6 +539,21 @@ impl<'a> Printer<'a> {
         Ok(())
     }
 
+    /// `write_str(&self.scratchbuf[range])` with the field borrows split so
+    /// callers can fill `scratchbuf` and flush it through the same `&mut self`.
+    pub(crate) fn write_scratchbuf(&mut self, range: core::ops::Range<usize>) -> PrintResult<()> {
+        let s = &self.scratchbuf[range];
+        #[cfg(debug_assertions)]
+        {
+            debug_assert!(!s.contains(&b'\n'));
+        }
+        self.col += u32::try_from(s.len()).expect("int cast");
+        if self.dest.write_all(s).is_err() {
+            return Err(self.add_fmt_error());
+        }
+        Ok(())
+    }
+
     /// Like `write_str`, but newline-containing byte content is permitted:
     /// `line`/`col` are tracked across newlines (matching `write_char` applied
     /// byte-by-byte), whereas `write_str` debug-asserts that no newlines are

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -845,7 +845,8 @@ pub mod serialize {
                     // buffer; the quoted-string length is counted in a null
                     // sink, so picking the shorter form allocates nothing.
                     dest.scratchbuf.clear();
-                    let _ = css::serializer::serialize_identifier(value_bytes, &mut dest.scratchbuf);
+                    let _ =
+                        css::serializer::serialize_identifier(value_bytes, &mut dest.scratchbuf);
                     let id_len = dest.scratchbuf.len();
 
                     let mut counter = bun_io::DiscardingWriter::new();

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -836,25 +836,27 @@ pub mod serialize {
                 operator.to_css(dest)?;
 
                 if dest.minify {
-                    // PERF: should we put a scratch buffer in the printer
                     // Serialize as both an identifier and a string and choose the shorter one.
                     // SAFETY: per the `CssString` invariant, the pointee borrows the parser
                     // arena which outlives the `Printer` it is being written to.
                     let value_bytes = unsafe { crate::arena_str(*value) };
-                    // `Vec<u8>: WriteAll<Error = Infallible>` — cannot fail.
-                    let mut id: Vec<u8> = Vec::new();
-                    let _ = css::serializer::serialize_identifier(value_bytes, &mut id);
 
-                    // `serialize_string` is called directly here since `CssString`
-                    // (`*const [u8]`) does not implement `generic::ToCss`.
-                    let mut s: Vec<u8> = Vec::new();
-                    let _ = css::serializer::serialize_string(value_bytes, &mut s);
+                    // Identifier form goes into the printer's reusable scratch
+                    // buffer; the quoted-string length is counted in a null
+                    // sink, so picking the shorter form allocates nothing.
+                    dest.scratchbuf.clear();
+                    let _ = css::serializer::serialize_identifier(value_bytes, &mut dest.scratchbuf);
+                    let id_len = dest.scratchbuf.len();
 
-                    let id_items = &id[..];
-                    if !id_items.is_empty() && id_items.len() < s.len() {
-                        dest.write_str(id_items)?;
+                    let mut counter = bun_io::DiscardingWriter::new();
+                    let _ = css::serializer::serialize_string(value_bytes, &mut counter);
+
+                    if id_len > 0 && id_len < counter.count {
+                        dest.write_scratchbuf(0..id_len)?;
                     } else {
-                        dest.write_str(&s)?;
+                        // `serialize_string` is called directly here since `CssString`
+                        // (`*const [u8]`) does not implement `generic::ToCss`.
+                        dest.serialize_string(value_bytes)?;
                     }
                 } else {
                     CSSStringFns::to_css(value, dest)?;

--- a/test/bundler/css/css-modules.test.ts
+++ b/test/bundler/css/css-modules.test.ts
@@ -181,36 +181,6 @@ describe("css", () => {
     },
   });
 
-  // Minified `[attr=value]` picks the shorter of identifier vs quoted-string
-  // serialization; this exercises the Printer's reusable scratch buffer.
-  itBundled("css-module/AttributeSelectorValueMinified", {
-    files: {
-      "/entry.css": `
-        [data-x="foo"] { color: red }
-        [data-x="a b"] { color: blue }
-        [data-x=""] { color: green }
-        [data-x="123"] { color: orange }
-        [data-x="\\\\"] { color: purple }
-      `,
-    },
-    entryPoints: ["/entry.css"],
-    outdir: "/out",
-    minifyWhitespace: true,
-    onAfterBundle(api) {
-      const css = api.readFile("/out/entry.css");
-      // identifier form is shorter: foo (3) < "foo" (5)
-      expect(css).toContain("[data-x=foo]");
-      // identifier form is shorter: a\ b (4) < "a b" (5)
-      expect(css).toContain("[data-x=a\\ b]");
-      // empty value has no identifier form
-      expect(css).toContain('[data-x=""]');
-      // leading digit: identifier (\31 23) is 6 bytes, "123" is 5 bytes
-      expect(css).toContain('[data-x="123"]');
-      // single backslash: identifier (\\) is 2 bytes, "\\" is 4 bytes
-      expect(css).toContain("[data-x=\\\\]");
-    },
-  });
-
   itBundled("css-module/ExportsMapMultipleClassesAndComposes", {
     files: {
       "/entry.js": `

--- a/test/bundler/css/css-modules.test.ts
+++ b/test/bundler/css/css-modules.test.ts
@@ -146,6 +146,71 @@ describe("css", () => {
     },
   });
 
+  // The parser dedupes repeated class/id names through a borrowed lookup
+  // (`add_symbol_for_name`); many references to the same names must all map
+  // to a single hashed symbol each.
+  itBundled("css-module/RepeatedClassAndIdReferences", {
+    files: {
+      "/entry.js": `
+        import styles from './styles.module.css';
+        console.log(JSON.stringify(styles));
+      `,
+      "/styles.module.css":
+        Array.from({ length: 64 }, (_, i) => `.btn { z-index: ${i} }`).join("\n") +
+        "\n#hero { color: red }\n" +
+        Array.from({ length: 32 }, () => `#hero .btn { color: blue }`).join("\n"),
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    onAfterBundle(api) {
+      const js = api.readFile("/out/entry.js");
+      const css = api.readFile("/out/entry.css");
+
+      const btn = js.match(/btn:\s*"(btn_[A-Za-z0-9_-]+)"/);
+      const hero = js.match(/hero:\s*"(hero_[A-Za-z0-9_-]+)"/);
+      expect(btn).not.toBeNull();
+      expect(hero).not.toBeNull();
+
+      // Every `.btn` / `#hero` occurrence shares the same hashed name.
+      const btnHashes = new Set([...css.matchAll(/\.btn_[A-Za-z0-9_-]+/g)].map(m => m[0]));
+      const heroHashes = new Set([...css.matchAll(/#hero_[A-Za-z0-9_-]+/g)].map(m => m[0]));
+      expect([...btnHashes]).toEqual([`.${btn![1]}`]);
+      expect([...heroHashes]).toEqual([`#${hero![1]}`]);
+      expect(css).not.toMatch(/\.btn\b[^_]/);
+      expect(css).not.toMatch(/#hero\b[^_]/);
+    },
+  });
+
+  // Minified `[attr=value]` picks the shorter of identifier vs quoted-string
+  // serialization; this exercises the Printer's reusable scratch buffer.
+  itBundled("css-module/AttributeSelectorValueMinified", {
+    files: {
+      "/entry.css": `
+        [data-x="foo"] { color: red }
+        [data-x="a b"] { color: blue }
+        [data-x=""] { color: green }
+        [data-x="123"] { color: orange }
+        [data-x="\\\\"] { color: purple }
+      `,
+    },
+    entryPoints: ["/entry.css"],
+    outdir: "/out",
+    minifyWhitespace: true,
+    onAfterBundle(api) {
+      const css = api.readFile("/out/entry.css");
+      // identifier form is shorter: foo (3) < "foo" (5)
+      expect(css).toContain("[data-x=foo]");
+      // identifier form is shorter: a\ b (4) < "a b" (5)
+      expect(css).toContain("[data-x=a\\ b]");
+      // empty value has no identifier form
+      expect(css).toContain('[data-x=""]');
+      // leading digit: identifier (\31 23) is 6 bytes, "123" is 5 bytes
+      expect(css).toContain('[data-x="123"]');
+      // single backslash: identifier (\\) is 2 bytes, "\\" is 4 bytes
+      expect(css).toContain("[data-x=\\\\]");
+    },
+  });
+
   itBundled("css-module/ExportsMapMultipleClassesAndComposes", {
     files: {
       "/entry.js": `

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -5253,6 +5253,8 @@ describe("css tests", () => {
     minify_test('[foo="foo bar"] {color:red}', "[foo=foo\\ bar]{color:red}");
     minify_test('[foo="foo bar baz"] {color:red}', '[foo="foo bar baz"]{color:red}');
     minify_test('[foo=""] {color:red}', '[foo=""]{color:red}');
+    minify_test('[foo="123"] {color:red}', '[foo="123"]{color:red}');
+    minify_test('[foo="\\\\"] {color:red}', "[foo=\\\\]{color:red}");
     minify_test('.test:not([foo="bar"]) {color:red}', ".test:not([foo=bar]){color:red}");
     minify_test(".test + .foo {color:red}", ".test+.foo{color:red}");
     minify_test(".test ~ .foo {color:red}", ".test~.foo{color:red}");


### PR DESCRIPTION
## What

Two small allocation sinks in the CSS pipeline:

### `add_symbol_for_name` boxed the lookup key on every call

`LocalScope` was `ArrayHashMap<Box<[u8]>, LocalEntry>`, and `entry()` takes the key by value, so

```rust
local_scope.entry(Box::<[u8]>::from(name))
```

heap-allocated a fresh `Box<[u8]>` for every `.class` / `#id` selector in CSS-modules mode. When the name was already present (the common case in any real stylesheet, where the same class is referenced many times) the box was dropped immediately on the `Occupied` arm.

Changed `LocalScope` to `StringArrayHashMap<LocalEntry>`, which already exposes borrowed `&[u8]` `get` / `contains` / `get_or_put` (boxing the stored key on miss only). `add_symbol_for_name` now calls `get_or_put(name)` directly, and the two private `SliceBoxAdapter` copies in the bundler (`generateCodeForLazyExport.rs`, `scanImportsAndExports.rs`) are gone in favor of plain `.get(name)` / `.contains(name)`. The map is per-parse and never serialized, so the hash-context change (`AutoContext` -> `StringContext`) is free.

### Minified `[attr=val]` allocated two `Vec<u8>` per selector

`serialize_component` serialized the value both as an identifier and as a quoted string into fresh `Vec<u8>`s to pick the shorter form. The `Printer` already carries a reusable `scratchbuf: BumpVec<'a, u8>` for exactly this, but nothing ever wrote to it (the original code even had a `PERF: should we put a scratch buffer in the printer` comment next to the allocations).

Now the identifier form goes into `scratchbuf` and the quoted-string length is counted with a `DiscardingWriter`, so choosing the shorter form allocates nothing. A small `Printer::write_scratchbuf(range)` helper splits the field borrows so callers can fill `scratchbuf` and flush it through the same `&mut self`.

## Why this is correct

Pure allocation refactor; output is unchanged.

- `StringArrayHashMap` wraps the same `ArrayHashMap<Box<[u8]>, _>` storage and `Deref`s to it, so `.count()` / `.values()` in `ParseTask.rs` / `LinkerContext.rs` keep working; its `get_or_put(&[u8])` boxes the key on miss and leaves it alone on hit, which is exactly what the old `entry(Box::from(name))` did minus the throwaway alloc.
- The minified-attribute branch preserves the `id_len > 0 && id_len < string_len` tie-break, and `dest.serialize_string` / `write_scratchbuf` route through `Printer::write_str` just like the old `dest.write_str(&vec)`, so column tracking is identical.

## Tests

- `test/bundler/css/css-modules.test.ts`: added `css-module/RepeatedClassAndIdReferences`, a CSS module that references the same `.btn` / `#hero` many times; asserts every occurrence hashes to a single symbol each (exercises the hit path of `add_symbol_for_name` heavily).
- `test/js/bun/css/css.test.ts`: added leading-digit and single-backslash cases to the existing `[foo=...]` minify block, covering both branches of the ident-vs-string tie-break.

Both tests pass before and after this change (there is no observable behavior difference to assert against), so the fail-before gate cannot distinguish them; they exist to guard the refactored paths against regressions.

Also ran: `test/bundler/esbuild/css.test.ts` (56 pass), `test/js/bun/css/css.test.ts` (1131 pass), `test/bundler/bundler_loader.test.ts -t module` (2 pass).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/css/css-modules.test.ts test/js/bun/css/css.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (3905ffd4a)

test/bundler/css/css-modules.test.ts:
(pass) css > css-module/GlobalPseudoFunction [650.41ms]
(pass) css > css-module/BundleTwoFilesWithoutCodeSplitting [144.89ms]
(pass) css > css-module/BundleTwoFilesWithCodeSplitting [137.82ms]
(pass) css > css-module/AnimationNameScopedToKeyframes [222.15ms]
(pass) css > css-module/RepeatedClassAndIdReferences [321.88ms]
(pass) css > css-module/ExportsMapMultipleClassesAndComposes [151.29ms]

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: colum
... (truncated)

release without fix: 13 failed, 67 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/css/css-modules.test.ts:
(pass) css > css-module/GlobalPseudoFunction [19.40ms]
(pass) css > css-module/BundleTwoFilesWithoutCodeSplitting [7.40ms]
(pass) css > css-module/BundleTwoFilesWithCodeSplitting [6.23ms]
130 |       expect(rotateKeyframes, "@keyframes rotate should be scoped").not.toBeNull();
131 | 
132 |       // The `animation` shorthand references the SAME scoped keyframes name.
133 |       const animShorthand = css.match(/animation:\s*([^;]+);/);
134 |       expect(animShorthand, "animation shorthand should be present").not.toBeNull();
135 |       expect(animShorthand![1]).toContain(animKeyframes![1]);
                                      ^
error: expect(received).toContain(expected)

Expected to contain: "anim_-MSaAA"
Received: "anim forwards ease-out .25s"

      at onAfterBundle (/workspace/bun/test/bundler/css/css-modules.test.ts:135:33)
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1591:7)
(fail) css > css-module/AnimationNameScopedToKeyframes [10.36ms]
(pass) css > css-module/RepeatedClassAndIdReferences [8.82ms]
(pass) css > css-module/ExportsMapMultipleClassesAndComposes [6
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/css/css-modules.test.ts test/js/bun/css/css.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (3905ffd4a)

test/bundler/css/css-modules.test.ts:
(pass) css > css-module/GlobalPseudoFunction [623.83ms]
(pass) css > css-module/BundleTwoFilesWithoutCodeSplitting [158.34ms]
(pass) css > css-module/BundleTwoFilesWithCodeSplitting [134.83ms]
(pass) css > css-module/AnimationNameScopedToKeyframes [153.80ms]
(pass) css > css-module/RepeatedClassAndIdReferences [260.92ms]
(pass) css > css-module/ExportsMapMultipleClassesAndComposes [151.13ms]

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: colum
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     3905ffd4a4
  features     (none)

22 deps, 106 codegen, 1169 objects in 1527ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1232] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [23.00ms]
[2/1232] gen bindgenv2
[3/1232] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [4.00ms]
[4/1232] fetch picohttpparser
[picohttpparser] up to date
[5/1232] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1232] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [10.00ms]
[7/1232] fetch zlib
[zlib]
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../linker_context/generateCodeForLazyExport.rs    | 29 ++-----------
 .../linker_context/scanImportsAndExports.rs        | 28 ++----------
 src/css/css_parser.rs                              | 50 +++++++++++-----------
 src/css/printer.rs                                 | 15 +++++++
 src/css/selectors/selector.rs                      | 31 ++++++++------
 test/bundler/css/css-modules.test.ts               | 35 +++++++++++++++
 test/js/bun/css/css.test.ts                        |  2 +
 7 files changed, 101 insertions(+), 89 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/bundler/linker_context/generateCodeForLazyExport.rs      3      5      0
src/bundler/linker_context/scanImportsAndExports.rs          3      5      0
src/css/css_parser.rs                                        4      7      0
src/css/printer.rs                                           2      1      0
src/css/selectors/selector.rs                                2      1      0
test/bundler/css/css-modules.test.ts                         3      2      0
test/js/bun/css/css.test.ts                                  1      1      0
```

</details>

<!-- robobun:evidence:end -->