### PR TITLE
http(h2/h3): O(1) async_http_id -> stream lookup on the fetch client

### DIFF
--- a/src/http/h2_client/ClientSession.rs
+++ b/src/http/h2_client/ClientSession.rs
@@ -63,6 +63,12 @@ pub struct ClientSession {
     pub read_buffer: Vec<u8>,
 
     pub streams: ArrayHashMap<u31, *mut Stream>,
+    /// Secondary index over `streams` keyed by the owning client's
+    /// `async_http_id`, so the per-chunk wakeups from the JS thread
+    /// (`stream_body_by_http_id` / `resume_receive_by_http_id` /
+    /// `drain_response_body_by_http_id` / `abort_by_http_id`) resolve in O(1)
+    /// instead of scanning every live stream on the session.
+    pub by_http_id: ArrayHashMap<u32, *mut Stream>,
     pub next_stream_id: u31,
     /// Stream id whose CONTINUATION sequence is in progress; 0 = none.
     pub expecting_continuation: u31,
@@ -243,6 +249,7 @@ impl ClientSession {
             write_buffer: bun_io::StreamBuffer::default(),
             read_buffer: Vec::new(),
             streams: ArrayHashMap::default(),
+            by_http_id: ArrayHashMap::default(),
             next_stream_id: 1,
             expecting_continuation: 0,
             pending_attach: Vec::new(),
@@ -400,8 +407,17 @@ impl ClientSession {
 
         let send_window = i32::try_from(self.remote_initial_window_size.min(wire::MAX_WINDOW_SIZE))
             .expect("int cast");
+        // Only clients with an abort-signal store are ever looked up by id
+        // (the HTTP-thread wake paths key off `abort_tracker()`); mirror that
+        // gate so unsignaled callers sharing the `0` sentinel never collide.
+        let async_http_id = client
+            .signals
+            .aborted
+            .is_some()
+            .then_some(client.async_http_id);
         let stream = bun_core::heap::into_raw(Stream::new(
             self.next_stream_id,
+            async_http_id,
             std::ptr::from_mut(self),
             Some(client.as_erased_ptr()),
             send_window,
@@ -410,6 +426,9 @@ impl ClientSession {
         self.next_stream_id = self.next_stream_id.saturating_add(2);
         let stream_ref = stream_mut(stream);
         let _ = self.streams.put(stream_ref.id, stream);
+        if let Some(id) = async_http_id {
+            let _ = self.by_http_id.put(id, stream);
+        }
         client.h2 = NonNull::new(stream);
         client.flags.protocol = Protocol::Http2;
         client.allow_retry = false;
@@ -422,8 +441,7 @@ impl ClientSession {
         // DATA-frame encoding may yield mid-body — compress into the Vec so the
         // cursor stays valid across event-loop ticks.
         if let Err(e) = client.compress_body_for_send(false) {
-            self.streams.swap_remove(&stream_ref.id);
-            drop_stream(stream);
+            self.remove_stream(stream);
             client.h2 = None;
             client.fail(e);
             return;
@@ -437,8 +455,7 @@ impl ClientSession {
             // never opened (RST on an idle stream is a connection error per
             // RFC 9113 §5.1).
             self.encoder_poisoned = true;
-            self.streams.swap_remove(&stream_ref.id);
-            drop_stream(stream);
+            self.remove_stream(stream);
             client.h2 = None;
             client.h2_fail(err);
             // The poisoned session is dead for new work; bounce any waiters
@@ -492,6 +509,9 @@ impl ClientSession {
             self.orphan_header_block = core::mem::take(&mut s.header_block);
         }
         self.streams.swap_remove(&s.id);
+        if let Some(id) = s.async_http_id {
+            self.by_http_id.swap_remove(&id);
+        }
         drop_stream(stream);
     }
 
@@ -549,31 +569,30 @@ impl ClientSession {
         self.socket.set_timeout(want);
     }
 
+    /// O(1) lookup in the `by_http_id` secondary index. Returns the raw
+    /// stream pointer (owned by `self.streams`) so callers can re-borrow
+    /// `&mut self` afterwards without an outstanding shared borrow.
+    #[inline]
+    fn stream_for_http_id(&self, async_http_id: u32) -> Option<*mut Stream> {
+        self.by_http_id.get(&async_http_id).copied()
+    }
+
     /// HTTP-thread wake-up from `scheduleResponseBodyDrain`: JS just enabled
     /// `response_body_streaming`, so flush any body bytes that arrived between
     /// metadata delivery and `getReader()`.
     pub fn drain_response_body_by_http_id(&mut self, async_http_id: u32) {
         let _guard = self.ref_scope();
-        for &stream in self.streams.values() {
-            let Some(client) = stream_mut(stream).client_mut() else {
-                continue;
-            };
-            if client.async_http_id != async_http_id {
-                continue;
-            }
-            client.h2_drain_response_body(self.socket);
+        let Some(stream) = self.stream_for_http_id(async_http_id) else {
             return;
+        };
+        if let Some(client) = stream_mut(stream).client_mut() {
+            client.h2_drain_response_body(self.socket);
         }
     }
 
     pub fn resume_receive_by_http_id(&mut self, async_http_id: u32) {
         let _guard = self.ref_scope();
-        let found = self.streams.values().iter().any(|&s| {
-            stream_mut(s)
-                .client_ref()
-                .is_some_and(|c| c.async_http_id == async_http_id)
-        });
-        if !found {
+        if self.stream_for_http_id(async_http_id).is_none() {
             return;
         }
         self.replenish_window();
@@ -588,34 +607,22 @@ impl ClientSession {
     /// end-of-body) are available in the ThreadSafeStreamBuffer.
     pub fn stream_body_by_http_id(&mut self, async_http_id: u32, ended: bool) {
         let _guard = self.ref_scope();
-        // Collect the target stream ptr first so no borrow of `self.streams`
-        // is held while mutating `self` below.
-        let mut target: Option<*mut Stream> = None;
-        for &stream in self.streams.values() {
+        let Some(stream) = self.stream_for_http_id(async_http_id) else {
+            return;
+        };
+        {
             let Some(client) = stream_mut(stream).client_mut() else {
-                continue;
-            };
-            if client.async_http_id != async_http_id {
-                continue;
-            }
-            if !matches!(
-                client.state.original_request_body,
-                HTTPRequestBody::Stream(_)
-            ) {
                 return;
-            }
-            if let HTTPRequestBody::Stream(ref mut st) = client.state.original_request_body {
-                st.ended = ended;
-            }
-            target = Some(stream);
-            break;
+            };
+            let HTTPRequestBody::Stream(ref mut st) = client.state.original_request_body else {
+                return;
+            };
+            st.ended = ended;
         }
-        if let Some(stream) = target {
-            self.rearm_timeout();
-            encode::drain_send_body(self, stream_mut(stream), usize::MAX);
-            if let Err(err) = self.flush() {
-                self.fail_all(err);
-            }
+        self.rearm_timeout();
+        encode::drain_send_body(self, stream_mut(stream), usize::MAX);
+        if let Err(err) = self.flush() {
+            self.fail_all(err);
         }
     }
 
@@ -837,6 +844,7 @@ impl ClientSession {
             }
         }
         self.streams.clear_retaining_capacity();
+        self.by_http_id.clear_retaining_capacity();
         // SAFETY: `self: &mut Self` carries write provenance to the Box alloc.
         unsafe { ClientSession::deref(self) };
     }
@@ -876,19 +884,7 @@ impl ClientSession {
             self.maybe_release();
             return;
         }
-        // Find the target before detaching so no borrow of `self.streams` is
-        // held across the mutation.
-        let mut target: Option<*mut Stream> = None;
-        for &e in self.streams.values() {
-            if stream_ref(e)
-                .client_ref()
-                .is_some_and(|c| c.async_http_id == async_http_id)
-            {
-                target = Some(e);
-                break;
-            }
-        }
-        if let Some(stream) = target {
+        if let Some(stream) = self.stream_for_http_id(async_http_id) {
             self.detach_with_failure(stream, crate::Error::Aborted);
         }
         self.rearm_timeout();

--- a/src/http/h2_client/Stream.rs
+++ b/src/http/h2_client/Stream.rs
@@ -20,6 +20,11 @@ use crate::HTTPClient;
 pub struct Stream {
     // HTTP/2 stream IDs are 31-bit; the top bit must stay clear.
     pub id: u32,
+    /// Snapshot of `client.async_http_id` at attach time. Stored so the
+    /// session's `by_http_id` index can be maintained after `client` has been
+    /// cleared (terminal delivery nulls `client` before `remove_stream`).
+    /// `None` for clients without an abort-signal store (not indexed).
+    pub async_http_id: Option<u32>,
     // BACKREF: this Stream is owned by `session.streams`; raw ptr per LIFETIMES class BACKREF.
     pub session: *mut ClientSession,
     // BACKREF: weak back-pointer, cleared before terminal callbacks.
@@ -122,12 +127,14 @@ impl Stream {
     /// fields get their defaults.
     pub fn new(
         id: u32,
+        async_http_id: Option<u32>,
         session: *mut ClientSession,
         client: Option<NonNull<HTTPClient<'static>>>,
         send_window: i32,
     ) -> Box<Self> {
         Box::new(Self {
             id,
+            async_http_id,
             session,
             client,
             header_block: Vec::new(),

--- a/src/http/h2_client/Stream.rs
+++ b/src/http/h2_client/Stream.rs
@@ -123,8 +123,6 @@ impl Drop for Stream {
 }
 
 impl Stream {
-    /// Callers pass `id`, `session`, `client`, `send_window`; the rest of the
-    /// fields get their defaults.
     pub fn new(
         id: u32,
         async_http_id: Option<u32>,

--- a/src/http/h3_client/ClientContext.rs
+++ b/src/http/h3_client/ClientContext.rs
@@ -221,7 +221,9 @@ impl ClientContext {
         let ctx = bun_ptr::BackRef::from(this);
         for &s in ctx.sessions.iter() {
             // Registry only holds live sessions — `session_mut` upgrade.
-            session_mut(s).stream_body_by_http_id(async_http_id, ended);
+            if session_mut(s).stream_body_by_http_id(async_http_id, ended) {
+                return;
+            }
         }
     }
 

--- a/src/http/h3_client/ClientSession.rs
+++ b/src/http/h3_client/ClientSession.rs
@@ -119,7 +119,7 @@ impl ClientSession {
         }
     }
 
-    pub fn stream_body_by_http_id(&mut self, async_http_id: u32, ended: bool) {
+    pub fn stream_body_by_http_id(&mut self, async_http_id: u32, ended: bool) -> bool {
         for &stream_ptr in self.pending.iter() {
             let stream = stream_mut(stream_ptr);
             let Some(client) = stream.client else {
@@ -129,17 +129,15 @@ impl ClientSession {
             if client.async_http_id != async_http_id {
                 continue;
             }
-            if !client.state.original_request_body.is_stream() {
-                return;
-            }
             if let crate::HTTPRequestBody::Stream(s) = &mut client.state.original_request_body {
                 s.ended = ended;
+                if let Some(qs) = stream.qstream_mut() {
+                    encode::drain_send_body(stream, qs);
+                }
             }
-            if let Some(qs) = stream.qstream_mut() {
-                encode::drain_send_body(stream, qs);
-            }
-            return;
+            return true;
         }
+        false
     }
 
     pub fn resume_receive_by_http_id(&mut self, async_http_id: u32) -> bool {

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -385,6 +385,66 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
     );
   });
 
+  test("concurrent ReadableStream uploads route each chunk to its own stream", async () => {
+    // Exercises the async_http_id -> stream index on the client session: each
+    // JS-side body chunk wakes the HTTP thread which must resolve the target
+    // stream without crossing the other 23 in-flight uploads.
+    let sessions = 0;
+    const server = makeH2Server();
+    server.on("session", () => sessions++);
+    server.on("stream", stream => {
+      const chunks: Buffer[] = [];
+      stream.on("data", c => chunks.push(c));
+      stream.on("end", () => {
+        stream.respond({ ":status": 200 });
+        stream.end(Buffer.concat(chunks));
+      });
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as import("node:net").AddressInfo;
+    try {
+      await using proc = await spawnFetch(`
+        const url = "https://localhost:${port}/";
+        const opts = { tls: { rejectUnauthorized: false } };
+        const N = 24, M = 24;
+        // Warmup so the h2 session exists and SETTINGS have been exchanged
+        // before the concurrent burst; otherwise requests can fan out to
+        // additional connections while the first is still handshaking.
+        await fetch(url, { ...opts, method: "POST", body: "warmup" }).then(r => r.text());
+        const results = await Promise.all(
+          Array.from({ length: N }, (_, i) => {
+            let k = 0;
+            const body = new ReadableStream({
+              pull(ctrl) {
+                if (k < M) {
+                  ctrl.enqueue(new TextEncoder().encode(i + ":" + k + ","));
+                  k++;
+                } else ctrl.close();
+              },
+            });
+            return fetch(url, { ...opts, method: "POST", body, duplex: "half" }).then(r => r.text());
+          }),
+        );
+        const bad = results
+          .map((got, i) => {
+            const want = Array.from({ length: M }, (_, k) => i + ":" + k + ",").join("");
+            return got === want ? null : i + " got=" + JSON.stringify(got);
+          })
+          .filter(Boolean);
+        if (bad.length) throw new Error("mismatch: " + bad.join(" | "));
+        console.log("ok", results.length);
+      `);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("ok 24");
+      expect(exitCode).toBe(0);
+      expect(sessions).toBe(1);
+    } finally {
+      server.close();
+    }
+  });
+
   test("POST with ReadableStream body larger than initial send window", async () => {
     await withH2Server(
       (req, res) => {


### PR DESCRIPTION
## What

The HTTP/2 `fetch()` client session keeps its active streams in a map keyed by the wire `stream_id`. The JS-thread wakeups that drive streaming request bodies and receive-side backpressure are keyed by `async_http_id` instead, so `stream_body_by_http_id` / `resume_receive_by_http_id` / `drain_response_body_by_http_id` / `abort_by_http_id` each walked `self.streams.values()` comparing `client.async_http_id` linearly:

https://github.com/oven-sh/bun/blob/91460bcfb8173e6707e36850d88d5b9f4b238dd7/src/http/h2_client/ClientSession.rs#L589-L612

These run once per JS-side body chunk (`drain_queued_writes`) and twice back-to-back per receive-resume (`drain_queued_receive_resumes`), so with N concurrent streams on a session every chunk pays O(N). A streaming upload burst of N requests with M chunks each does O(N * N * M) scan work in aggregate. Servers routinely advertise `MAX_CONCURRENT_STREAMS` of 100 or more.

The HTTP/3 context had the same shape at the outer level: `ClientContext::stream_body_by_http_id` visited every registered h3 session even after one reported a match (the per-session function returned `()`).

## Fix

* Add a secondary `ArrayHashMap<u32, *mut Stream>` on the h2 `ClientSession` keyed by `async_http_id`, populated in `attach()` and removed alongside the primary `streams` map in `remove_stream` / `on_close` / the two `attach` error paths. The four `*_by_http_id` functions now do one hash lookup.
* Snapshot `async_http_id` on the `Stream` itself so the index can be maintained after `stream.client` is nulled ahead of `remove_stream`. Only clients with an abort-signal store are indexed (the same gate as `register_abort_tracker`), so any future unsignaled caller sharing the `0` sentinel cannot collide.
* h3: make `ClientSession::stream_body_by_http_id` return whether it matched, and have `ClientContext::stream_body_by_http_id` stop on success (matching its siblings `abort_by_http_id` and `resume_receive_by_http_id`).

Observable behaviour is unchanged. The gate cannot fail-before/pass-after a pure performance change; the new test keeps 24 concurrent `ReadableStream` uploads on one h2 session and verifies every echoed body is routed to the correct request, covering the index maintenance end-to-end. All of `fetch-http2-client.test.ts` (62 tests), `fetch-http2-adversarial.test.ts`, `fetch-http2-leak.test.ts`, `fetch-http3-client.test.ts` and `fetch-backpressure.test.ts` pass under the debug+ASAN build.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/web/fetch/fetch-http2-client.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (241fe0336)

test/js/web/fetch/fetch-http2-client.test.ts:
(pass) fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT) > response body larger than one DATA frame [2534.77ms]
(pass) fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT) > GET: status, headers and body round-trip [3049.07ms]
(pass) fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT) > gzip content-encoding is decompressed [3300.98ms]
(pass) fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT) > POST with ReadableStream body streams as raw DATA frames [1558.02ms]
(pass) fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT) > POST: request body is delivered as DATA frames [4254.86ms]
(pass) fetch() ov
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/fetch/fetch-http2-client.test.ts:
(pass) fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT) > connection-specific request headers are stripped before HPACK [261.59ms]
(pass) fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT) > GET: status, headers and body round-trip [286.81ms]
(pass) fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT) > response trailers are consumed without breaking the body [265.33ms]
(pass) fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT) > response body larger than initial window triggers WINDOW_UPDATE [313.37ms]
(pass) fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT) > POST with ReadableStream body streams as raw DATA frames [319.20ms]
(pass) fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT) > gzip content-encoding is decompressed [322.19ms]
(pass) fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT) > raw frame server > REFUSED_STREAM is transparently retried on the same connection [322.35ms]
(pass) fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT) > multiple Set-Cookie response h
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/web/fetch/fetch-http2-client.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (241fe0336)

test/js/web/fetch/fetch-http2-client.test.ts:
(pass) fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT) > GET: status, headers and body round-trip [1984.84ms]
(pass) fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT) > response body larger than one DATA frame [1756.46ms]
(pass) fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT) > POST with ReadableStream body streams as raw DATA frames [916.35ms]
(pass) fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT) > POST: request body is delivered as DATA frames [2772.97ms]
(pass) fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT) > concurrent requests multiplex on one h2 session [2639.98ms]
(pass) f
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 841ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/123] gen ErrorCode+*.h
[2/123] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[3/123] gen cpp.rs (cppbind)
[4/123] gen JS modules (bundle-modules)
Preprocess modules (8593ms)
Bundle modules (38ms)
Postprocesss modules (131ms)
Bundle Functions (1015ms)
Generate Code (118ms)

[9.91s] Bundled "src/js" for production
  2035 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[5/122] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[6/122] pch pch/root-pch.h.hxx.pch
[7/122] cxx obj/unified/UnifiedSource-packages_bun_usockets_src_crypto-0.cpp.o
[8/122] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[9/122] cxx obj/unifie
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/h2_client/ClientSession.rs          | 106 +++++++++++++--------------
 src/http/h2_client/Stream.rs                 |   9 ++-
 src/http/h3_client/ClientContext.rs          |   4 +-
 src/http/h3_client/ClientSession.rs          |  14 ++--
 test/js/web/fetch/fetch-http2-client.test.ts |  60 +++++++++++++++
 5 files changed, 127 insertions(+), 66 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/http/h2_client/ClientSession.rs               1     13      0
src/http/h2_client/Stream.rs                      3      8      0
src/http/h3_client/ClientContext.rs               1      1      0
src/http/h3_client/ClientSession.rs               1      1      0
test/js/web/fetch/fetch-http2-client.test.ts      3      1      0
```

</details>

<!-- robobun:evidence:end -->