### PR TITLE
bundler: make cross-chunk export alias renaming O(N) instead of O(N^2)

### DIFF
--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -1061,41 +1061,38 @@ impl ExportRenamer {
 
     pub fn next_renamed_name(&mut self, input: &[u8]) -> &[u8] {
         let entry = self.used.get_or_put(input).expect("unreachable");
-        let mut tries: u32 = 1;
-        if entry.found_existing {
-            loop {
-                self.string_buffer.reset();
-                write!(
-                    self.string_buffer.writer(),
-                    "{}{}",
-                    bstr::BStr::new(input),
-                    tries
-                )
-                .expect("unreachable");
-                tries += 1;
-                let attempt: &[u8] = self.string_buffer.slice();
-                // Reshaped for borrowck — `get_or_put` borrows `self.used`
-                // mutably, so allocate the arena copy first.
-                let to_use: &[u8] = self.arena.alloc_slice_copy(attempt);
-                let entry = self.used.get_or_put(to_use).expect("unreachable");
-                if !entry.found_existing {
-                    // `StringHashMap` owns a boxed copy of the key on insert.
-                    *entry.value_ptr = tries;
-
-                    let entry = self.used.get_or_put(input).expect("unreachable");
-                    *entry.value_ptr = tries;
-                    // `to_use` borrows `self.arena` (disjoint from `self.used`
-                    // above); returnable directly under split-borrow rules.
-                    return to_use;
-                }
-            }
-        } else {
-            *entry.value_ptr = tries;
+        if !entry.found_existing {
+            *entry.value_ptr = 1;
+            // `StringHashMap` does not expose a key pointer; allocate a copy in
+            // `self.arena` so the returned slice is tied to `&self`.
+            return self.arena.alloc_slice_copy(input);
         }
 
-        // `StringHashMap` does not expose a key pointer; allocate a copy in `self.arena`
-        // so the returned slice is tied to `&self` (sub-borrow of `&mut self`).
-        self.arena.alloc_slice_copy(input)
+        // Resume from the last suffix handed out for this prefix so N collisions
+        // on the same name stay O(N) total (see `NumberScope::find_unused_name`).
+        let mut tries: u32 = *entry.value_ptr;
+        loop {
+            self.string_buffer.reset();
+            write!(
+                self.string_buffer.writer(),
+                "{}{}",
+                bstr::BStr::new(input),
+                tries
+            )
+            .expect("unreachable");
+            tries += 1;
+            let attempt: &[u8] = self.string_buffer.slice();
+            if self.used.contains_key(attempt) {
+                continue;
+            }
+            // `StringHashMap::put` boxes the key itself; the arena copy below is
+            // only for the caller's returned slice (`string_buffer` is reused).
+            self.used.put(attempt, 1).expect("unreachable");
+            if let Some(v) = self.used.get_mut(input) {
+                *v = tries;
+            }
+            return self.arena.alloc_slice_copy(attempt);
+        }
     }
 
     pub fn next_minified_name(&mut self) -> Result<Vec<u8>, crate::Error> {

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -1088,9 +1088,7 @@ impl ExportRenamer {
             // `StringHashMap::put` boxes the key itself; the arena copy below is
             // only for the caller's returned slice (`string_buffer` is reused).
             self.used.put(attempt, 1).expect("unreachable");
-            if let Some(v) = self.used.get_mut(input) {
-                *v = tries;
-            }
+            *self.used.get_mut(input).expect("unreachable") = tries;
             return self.arena.alloc_slice_copy(attempt);
         }
     }

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -362,8 +362,9 @@ describe("bundler", () => {
     });
     const [buildOut, buildErr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
     if (buildExit !== 0) {
+      const why = build.killed ? `did not finish within ${THRESHOLD_MS}ms` : `exited ${buildExit}`;
       throw new Error(
-        `bun build did not finish within ${THRESHOLD_MS}ms for ${N} colliding cross-chunk export names ` +
+        `bun build ${why} for ${N} colliding cross-chunk export names ` +
           `(exit ${buildExit}, killed=${build.killed})\nstdout:\n${buildOut}\nstderr:\n${buildErr}`,
       );
     }

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -328,11 +328,9 @@ describe("bundler", () => {
     },
   });
 
-  // ExportRenamer::next_renamed_name used to re-scan every previously handed
-  // out suffix on each collision, making N same-named cross-chunk exports cost
-  // O(N^2). Debug builds need far fewer files to blow past the threshold than
-  // release, so scale N accordingly; both settings used to take >30s and now
-  // finish in a couple of seconds.
+  // N same-named cross-chunk exports must get unique aliases in O(N) total
+  // (ExportRenamer::next_renamed_name). Debug builds blow past the 15s cap
+  // with far fewer files than release, hence the isDebug-scaled N.
   test("splitting/ManyCrossChunkExportAliasCollisions", async () => {
     const N = isDebug ? 2500 : 20000;
     const THRESHOLD_MS = 15000;
@@ -396,8 +394,9 @@ describe("bundler", () => {
       stderr: "pipe",
     });
     const [runOut, runErr, runExit] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
-    expect(runErr).toBe("");
+    if (runExit !== 0) {
+      throw new Error(`running e1.js exited ${runExit}\nstdout:\n${runOut}\nstderr:\n${runErr}`);
+    }
     expect(runOut.trim()).toBe(`${(N * (N - 1)) / 2} 0 ${N - 1}`);
-    expect(runExit).toBe(0);
   }, 60_000);
 });

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir } from "harness";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { itBundled } from "./expectBundled";
@@ -329,10 +329,10 @@ describe("bundler", () => {
   });
 
   // N same-named cross-chunk exports must get unique aliases in O(N) total
-  // (ExportRenamer::next_renamed_name). Debug builds blow past the 15s cap
-  // with far fewer files than release, hence the isDebug-scaled N.
+  // (ExportRenamer::next_renamed_name). Debug/ASAN builds blow past the 15s
+  // cap with far fewer files than release, hence the scaled N.
   test("splitting/ManyCrossChunkExportAliasCollisions", async () => {
-    const N = isDebug ? 2500 : 20000;
+    const N = isDebug || isASAN ? 2500 : 20000;
     const THRESHOLD_MS = 15000;
 
     const files: Record<string, string> = {};
@@ -361,12 +361,14 @@ describe("bundler", () => {
       killSignal: "SIGKILL",
     });
     const [buildOut, buildErr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
-    if (buildExit !== 0) {
-      const why = build.killed ? `did not finish within ${THRESHOLD_MS}ms` : `exited ${buildExit}`;
+    if (build.signalCode !== null) {
       throw new Error(
-        `bun build ${why} for ${N} colliding cross-chunk export names ` +
-          `(exit ${buildExit}, killed=${build.killed})\nstdout:\n${buildOut}\nstderr:\n${buildErr}`,
+        `bun build did not finish within ${THRESHOLD_MS}ms for ${N} colliding cross-chunk export names ` +
+          `(signal ${build.signalCode})\nstdout:\n${buildOut}\nstderr:\n${buildErr}`,
       );
+    }
+    if (buildExit !== 0) {
+      throw new Error(`bun build exited ${buildExit}\nstdout:\n${buildOut}\nstderr:\n${buildErr}`);
     }
 
     // The shared chunk's export clause must hand out a unique alias for every

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -1,5 +1,7 @@
-import { describe } from "bun:test";
-import { bunEnv } from "harness";
+import { describe, test, expect } from "bun:test";
+import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { itBundled } from "./expectBundled";
 
 const env = {
@@ -325,4 +327,85 @@ describe("bundler", () => {
       stdout: "a.js executed\na loaded from entry\nb.js executed\nb.js imports a {}\nb loaded from entry, value: B",
     },
   });
+
+  // ExportRenamer::next_renamed_name used to re-scan every previously handed
+  // out suffix on each collision, making N same-named cross-chunk exports cost
+  // O(N^2). Debug builds need far fewer files to blow past the threshold than
+  // release, so scale N accordingly; both settings used to take >30s and now
+  // finish in a couple of seconds.
+  test(
+    "splitting/ManyCrossChunkExportAliasCollisions",
+    async () => {
+      const N = isDebug ? 2500 : 20000;
+      const THRESHOLD_MS = 15000;
+
+      const files: Record<string, string> = {};
+      let imports = "";
+      let uses = "";
+      for (let i = 0; i < N; i++) {
+        files[`s${i}.js`] = `export const shared = ${i};\n`;
+        imports += `import { shared as s${i} } from "./s${i}.js";\n`;
+        uses += `t += s${i};\n`;
+      }
+      // Flat statement list keeps every import live without building a deep AST.
+      const entryBody = imports + "let t = 0;\n" + uses + `console.log(t, s0, s${N - 1});\n`;
+      files["e1.js"] = entryBody;
+      files["e2.js"] = entryBody;
+
+      using dir = tempDir("splitting-export-alias-collisions", files);
+      const root = String(dir);
+
+      await using build = Bun.spawn({
+        cmd: [bunExe(), "build", "--splitting", "--format=esm", "--outdir", "out", "./e1.js", "./e2.js"],
+        env: bunEnv,
+        cwd: root,
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: THRESHOLD_MS,
+        killSignal: "SIGKILL",
+      });
+      const [buildOut, buildErr, buildExit] = await Promise.all([
+        build.stdout.text(),
+        build.stderr.text(),
+        build.exited,
+      ]);
+      if (buildExit !== 0) {
+        throw new Error(
+          `bun build did not finish within ${THRESHOLD_MS}ms for ${N} colliding cross-chunk export names ` +
+            `(exit ${buildExit}, killed=${build.killed})\nstdout:\n${buildOut}\nstderr:\n${buildErr}`,
+        );
+      }
+
+      // The shared chunk's export clause must hand out a unique alias for every
+      // `shared` symbol; verify by inspecting the generated chunk and by running
+      // the output.
+      const outDir = join(root, "out");
+      const chunkName = readdirSync(outDir).find(f => f !== "e1.js" && f !== "e2.js" && f.endsWith(".js"));
+      expect(chunkName).toBeDefined();
+      const chunk = readFileSync(join(outDir, chunkName!), "utf8");
+      const clause = chunk.match(/export\s*\{([^}]*)\}/)?.[1] ?? "";
+      const aliases = clause
+        .split(",")
+        .map(part => {
+          const bits = part.trim().split(/\s+as\s+/);
+          return bits[bits.length - 1];
+        })
+        .filter(Boolean);
+      expect(aliases.length).toBe(N);
+      expect(new Set(aliases).size).toBe(N);
+      for (const a of aliases) expect(a).toMatch(/^shared\d*$/);
+
+      await using run = Bun.spawn({
+        cmd: [bunExe(), join(outDir, "e1.js")],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [runOut, runErr, runExit] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+      expect(runErr).toBe("");
+      expect(runOut.trim()).toBe(`${(N * (N - 1)) / 2} 0 ${N - 1}`);
+      expect(runExit).toBe(0);
+    },
+    60_000,
+  );
 });

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isDebug, tempDir } from "harness";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -333,79 +333,71 @@ describe("bundler", () => {
   // O(N^2). Debug builds need far fewer files to blow past the threshold than
   // release, so scale N accordingly; both settings used to take >30s and now
   // finish in a couple of seconds.
-  test(
-    "splitting/ManyCrossChunkExportAliasCollisions",
-    async () => {
-      const N = isDebug ? 2500 : 20000;
-      const THRESHOLD_MS = 15000;
+  test("splitting/ManyCrossChunkExportAliasCollisions", async () => {
+    const N = isDebug ? 2500 : 20000;
+    const THRESHOLD_MS = 15000;
 
-      const files: Record<string, string> = {};
-      let imports = "";
-      let uses = "";
-      for (let i = 0; i < N; i++) {
-        files[`s${i}.js`] = `export const shared = ${i};\n`;
-        imports += `import { shared as s${i} } from "./s${i}.js";\n`;
-        uses += `t += s${i};\n`;
-      }
-      // Flat statement list keeps every import live without building a deep AST.
-      const entryBody = imports + "let t = 0;\n" + uses + `console.log(t, s0, s${N - 1});\n`;
-      files["e1.js"] = entryBody;
-      files["e2.js"] = entryBody;
+    const files: Record<string, string> = {};
+    let imports = "";
+    let uses = "";
+    for (let i = 0; i < N; i++) {
+      files[`s${i}.js`] = `export const shared = ${i};\n`;
+      imports += `import { shared as s${i} } from "./s${i}.js";\n`;
+      uses += `t += s${i};\n`;
+    }
+    // Flat statement list keeps every import live without building a deep AST.
+    const entryBody = imports + "let t = 0;\n" + uses + `console.log(t, s0, s${N - 1});\n`;
+    files["e1.js"] = entryBody;
+    files["e2.js"] = entryBody;
 
-      using dir = tempDir("splitting-export-alias-collisions", files);
-      const root = String(dir);
+    using dir = tempDir("splitting-export-alias-collisions", files);
+    const root = String(dir);
 
-      await using build = Bun.spawn({
-        cmd: [bunExe(), "build", "--splitting", "--format=esm", "--outdir", "out", "./e1.js", "./e2.js"],
-        env: bunEnv,
-        cwd: root,
-        stdout: "pipe",
-        stderr: "pipe",
-        timeout: THRESHOLD_MS,
-        killSignal: "SIGKILL",
-      });
-      const [buildOut, buildErr, buildExit] = await Promise.all([
-        build.stdout.text(),
-        build.stderr.text(),
-        build.exited,
-      ]);
-      if (buildExit !== 0) {
-        throw new Error(
-          `bun build did not finish within ${THRESHOLD_MS}ms for ${N} colliding cross-chunk export names ` +
-            `(exit ${buildExit}, killed=${build.killed})\nstdout:\n${buildOut}\nstderr:\n${buildErr}`,
-        );
-      }
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "--splitting", "--format=esm", "--outdir", "out", "./e1.js", "./e2.js"],
+      env: bunEnv,
+      cwd: root,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: THRESHOLD_MS,
+      killSignal: "SIGKILL",
+    });
+    const [buildOut, buildErr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    if (buildExit !== 0) {
+      throw new Error(
+        `bun build did not finish within ${THRESHOLD_MS}ms for ${N} colliding cross-chunk export names ` +
+          `(exit ${buildExit}, killed=${build.killed})\nstdout:\n${buildOut}\nstderr:\n${buildErr}`,
+      );
+    }
 
-      // The shared chunk's export clause must hand out a unique alias for every
-      // `shared` symbol; verify by inspecting the generated chunk and by running
-      // the output.
-      const outDir = join(root, "out");
-      const chunkName = readdirSync(outDir).find(f => f !== "e1.js" && f !== "e2.js" && f.endsWith(".js"));
-      expect(chunkName).toBeDefined();
-      const chunk = readFileSync(join(outDir, chunkName!), "utf8");
-      const clause = chunk.match(/export\s*\{([^}]*)\}/)?.[1] ?? "";
-      const aliases = clause
-        .split(",")
-        .map(part => {
-          const bits = part.trim().split(/\s+as\s+/);
-          return bits[bits.length - 1];
-        })
-        .filter(Boolean);
-      expect(aliases.length).toBe(N);
-      expect(new Set(aliases).size).toBe(N);
-      for (const a of aliases) expect(a).toMatch(/^shared\d*$/);
+    // The shared chunk's export clause must hand out a unique alias for every
+    // `shared` symbol; verify by inspecting the generated chunk and by running
+    // the output.
+    const outDir = join(root, "out");
+    const chunkName = readdirSync(outDir).find(f => f !== "e1.js" && f !== "e2.js" && f.endsWith(".js"));
+    expect(chunkName).toBeDefined();
+    const chunk = readFileSync(join(outDir, chunkName!), "utf8");
+    const clause = chunk.match(/export\s*\{([^}]*)\}/)?.[1] ?? "";
+    const aliases = clause
+      .split(",")
+      .map(part => {
+        const bits = part.trim().split(/\s+as\s+/);
+        return bits[bits.length - 1];
+      })
+      .filter(Boolean);
+    expect(aliases.length).toBe(N);
+    expect(new Set(aliases).size).toBe(N);
+    for (const a of aliases) expect(a).toMatch(/^shared\d*$/);
 
-      await using run = Bun.spawn({
-        cmd: [bunExe(), join(outDir, "e1.js")],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [runOut, runErr, runExit] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
-      expect(runErr).toBe("");
-      expect(runOut.trim()).toBe(`${(N * (N - 1)) / 2} 0 ${N - 1}`);
-      expect(runExit).toBe(0);
-    },
-    60_000,
-  );
+    await using run = Bun.spawn({
+      cmd: [bunExe(), join(outDir, "e1.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [runOut, runErr, runExit] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+    expect(runErr).toBe("");
+    expect(runOut.trim()).toBe(`${(N * (N - 1)) / 2} 0 ${N - 1}`);
+    expect(runExit).toBe(0);
+  }, 60_000);
 });


### PR DESCRIPTION
## What

`ExportRenamer::next_renamed_name` (in `src/js_printer/renamer.rs`) hands out unique export aliases for a shared chunk when code splitting produces many cross-chunk exports with the same original name. For N collisions on the same name it used to cost N*(N-1)/2 probes, and every failed probe left an unused copy in the renamer arena.

## Repro

Two entry points that each import `shared` from N tiny modules. With splitting, all N modules land in one shared chunk and `next_renamed_name("shared")` runs N times. Release build, total `Bun.build()` time:

| N | before | after |
| --- | --- | --- |
| 4000 | 707 ms | 72 ms |
| 8000 | 2577 ms | 184 ms |
| 16000 | 11457 ms | 369 ms |
| 20000 | 17276 ms | 424 ms |

## Cause

```rust
let entry = self.used.get_or_put(input).expect("unreachable");
let mut tries: u32 = 1;                               // ignores *entry.value_ptr
if entry.found_existing {
    loop {
        ...
        let to_use: &[u8] = self.arena.alloc_slice_copy(attempt);   // alloc before check
        let entry = self.used.get_or_put(to_use).expect("unreachable");
        if !entry.found_existing { ... return to_use; }
    }
}
```

The stored counter under `input` is written on every success but never read back, so each call restarts from suffix 1. `arena.alloc_slice_copy` runs before the existence check, and `get_or_put` heap-boxes the key even on an occupied entry, so each failed probe costs one bump alloc and one box alloc/free.

## Fix

Resume `tries` from `*entry.value_ptr` (matching `NumberScope::find_unused_name`), probe with `contains_key` first, and only arena-alloc + insert once a free name is found. The new name is stored with counter 1 so a later collision on that exact string starts from the same place the old loop did; output is byte-identical.

## Verification

New `splitting/ManyCrossChunkExportAliasCollisions` test in `test/bundler/bundler_splitting.test.ts` builds the repro, asserts the shared chunk has N unique `shared*` aliases, runs the output, and caps the build subprocess at 15s. Fails on main (killed at 15s), passes with this change. `test/bundler/esbuild/splitting.test.ts` still passes.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_splitting.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (e85b57cf8)

test/bundler/bundler_splitting.test.ts:
(pass) bundler > splitting/DynamicImportCSSFile [1150.74ms]
(pass) bundler > splitting/DynamicImportMultipleCSSImports [827.64ms]
(pass) bundler > splitting/StaticAndDynamicCSSImports [806.16ms]
(pass) bundler > splitting/NestedDynamicImportWithCSS [813.45ms]
(pass) bundler > splitting/SharedCSSBetweenChunks [781.28ms]
(pass) bundler > splitting/DynamicImportChainWithCSS [825.83ms]
(pass) bundler > splitting/ConditionalDynamicImportWithCSS [790.26ms]
(pass) bundler > splitting/MultipleEntryPointsWithSharedCSS [1210.15ms]
(pass) bundler > splitting/DynamicImportWithOnlyCSSNoJS [806.57ms]
(pass) bundler > splitting/CircularDynamicImportsWithCSS [801.58ms]
360 |       timeout: TH
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (97d3fae97)

test/bundler/bundler_splitting.test.ts:
(pass) bundler > splitting/DynamicImportCSSFile [52.59ms]
(pass) bundler > splitting/DynamicImportMultipleCSSImports [20.96ms]
(pass) bundler > splitting/StaticAndDynamicCSSImports [24.98ms]
(pass) bundler > splitting/NestedDynamicImportWithCSS [21.78ms]
(pass) bundler > splitting/SharedCSSBetweenChunks [21.38ms]
(pass) bundler > splitting/DynamicImportChainWithCSS [21.25ms]
(pass) bundler > splitting/ConditionalDynamicImportWithCSS [21.56ms]
(pass) bundler > splitting/MultipleEntryPointsWithSharedCSS [35.14ms]
(pass) bundler > splitting/DynamicImportWithOnlyCSSNoJS [19.24ms]
(pass) bundler > splitting/CircularDynamicImportsWithCSS [21.62ms]
(pass) bundler > splitting/ManyCrossChunkExportAliasCollisions [1771.01ms]

 11 pass
 0 fail
 20015 expect() calls
Ran 11 tests across 1 file. [2.42s]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_splitting.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (e85b57cf8)

test/bundler/bundler_splitting.test.ts:
(pass) bundler > splitting/DynamicImportCSSFile [1140.18ms]
(pass) bundler > splitting/DynamicImportMultipleCSSImports [797.62ms]
(pass) bundler > splitting/StaticAndDynamicCSSImports [907.63ms]
(pass) bundler > splitting/NestedDynamicImportWithCSS [1026.47ms]
(pass) bundler > splitting/SharedCSSBetweenChunks [947.23ms]
(pass) bundler > splitting/DynamicImportChainWithCSS [783.69ms]
(pass) bundler > splitting/ConditionalDynamicImportWithCSS [775.17ms]
(pass) bundler > splitting/MultipleEntryPointsWithSharedCSS [1123.43ms]
(pass) bundler > splitting/DynamicImportWithOnlyCSSNoJS [757.19ms]
(pass) bundler > splitting/CircularDynamicImportsWithCSS [800.75ms]
(pass) bundler > split
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 965ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/138] gen ErrorCode+*.h
[2/138] gen cpp.rs (cppbind)
[3/138] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[4/138] gen JS modules (bundle-modules)
Preprocess modules (8325ms)
Bundle modules (39ms)
Postprocesss modules (179ms)
Bundle Functions (846ms)
Generate Code (123ms)

[9.54s] Bundled "src/js" for production
  2035 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[4/138] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_printer/renamer.rs              | 61 ++++++++++++-------------
 test/bundler/bundler_splitting.test.ts | 81 +++++++++++++++++++++++++++++++++-
 2 files changed, 107 insertions(+), 35 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/js_printer/renamer.rs                   2      3      0
test/bundler/bundler_splitting.test.ts      3     15      0
```

</details>

<!-- robobun:evidence:end -->