### PR TITLE
node: duplexPair peer teardown, NODE_NO_WARNINGS exact match, non-holey FixedQueue (+3 tests)

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -137,6 +137,9 @@ new!(pub JENKINS_URL: string, "JENKINS_URL", {});
 new!(pub MI_VERBOSE: boolean, "MI_VERBOSE", { default: false });
 new!(pub NO_COLOR: boolean, "NO_COLOR", { default: false });
 new!(pub NODE_CHANNEL_FD: string, "NODE_CHANNEL_FD", {});
+// A string, not a boolean: node suppresses warnings only when the value is
+// exactly "1" (lib/internal/process/pre_execution.js).
+new!(pub NODE_NO_WARNINGS: string, "NODE_NO_WARNINGS", {});
 // Set by HostProcess.rs when spawning the WebView host subprocess. The
 // child's CLI entrypoint checks this before anything else and hands off to
 // C++ Bun__WebView__hostMain. Never returns — no JSC, no VM.
@@ -243,7 +246,6 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_FEATURE_FLAG_LAST_MODIFIED_PRETEND_304, "BUN_FEATURE_FLAG_LAST_MODIFIED_PRETEND_304", {});
     new_feature_flag!(pub BUN_NO_CODESIGN_MACHO_BINARY, "BUN_NO_CODESIGN_MACHO_BINARY", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_NO_LIBDEFLATE, "BUN_FEATURE_FLAG_NO_LIBDEFLATE", {});
-    new_feature_flag!(pub NODE_NO_WARNINGS, "NODE_NO_WARNINGS", {});
     new_feature_flag!(pub BUN_TRACE, "BUN_TRACE", {});
 }
 

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -233,6 +233,8 @@ export const exposedInternals = {
   "internal/async_context_frame": require("internal/async_context_frame"),
   "internal/async_hooks": require("internal/async_hooks"),
   "internal/dgram": require("internal/dgram"),
+  // Node's internal/fixed_queue module IS the FixedQueue class.
+  "internal/fixed_queue": require("internal/fixed_queue").FixedQueue,
   "internal/freelist": require("internal/freelist"),
   "internal/validators": require("internal/validators"),
   // internalBinding() is served by the registered "internal/test/binding"

--- a/src/js/internal/fixed_queue.ts
+++ b/src/js/internal/fixed_queue.ts
@@ -61,7 +61,9 @@ class FixedCircularBuffer<T> {
   constructor() {
     this.bottom = 0;
     this.top = 0;
-    this.list = $newArrayWithSize(kSize);
+    // Filled rather than left holey: a holey array deoptimizes element access
+    // and is observable through the queue's backing list.
+    this.list = $newArrayWithSize<T | undefined>(kSize).fill(undefined);
     this.next = null;
   }
 

--- a/src/js/internal/streams/duplexpair.ts
+++ b/src/js/internal/streams/duplexpair.ts
@@ -46,6 +46,25 @@ class DuplexSide extends Duplex {
     this.#otherSide.on("end", callback);
     this.#otherSide.push(null);
   }
+
+  _destroy(err, callback) {
+    const otherSide = this.#otherSide;
+
+    if (otherSide !== null && !otherSide.destroyed) {
+      // nextTick so the current execution stack (an HTTP parser, say) is not
+      // torn down underneath itself.
+      process.nextTick(() => {
+        if (otherSide.destroyed) return;
+
+        // Destroy without the error: closes the peer so it cannot hang, while
+        // avoiding an "Unhandled error" crash on that side.
+        if (err) otherSide.destroy();
+        else otherSide.push(null);
+      });
+    }
+
+    callback(err);
+  }
 }
 
 function duplexPair(options) {

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -2,6 +2,7 @@
 
 use core::ffi::c_char;
 
+use bun_core::env_var;
 use bun_core::env_var::feature_flag;
 use bun_core::{self, Environment, Global};
 use bun_jsc::zig_string::ZigString;
@@ -66,7 +67,7 @@ pub extern "C" fn exit(global_object: &JSGlobalObject, code: u8) {
 
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn Bun__NODE_NO_WARNINGS() -> bool {
-    feature_flag::NODE_NO_WARNINGS.get().unwrap_or(false)
+    env_var::NODE_NO_WARNINGS.get() == Some(b"1")
 }
 
 #[unsafe(no_mangle)]

--- a/test/js/node/test/parallel/test-duplex-error.js
+++ b/test/js/node/test/parallel/test-duplex-error.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { duplexPair } = require('stream');
+
+const [sideA, sideB] = duplexPair();
+
+// Side A should receive the error because we called .destroy(err) on it.
+sideA.on('error', common.mustCall((err) => {
+  assert.strictEqual(err.message, 'Simulated error');
+}));
+
+// Side B should NOT necessarily emit an error (to avoid crashing
+// existing code), but it MUST be destroyed.
+sideB.on('error', common.mustNotCall('Side B should not emit an error event'));
+
+sideB.on('close', common.mustCall(() => {
+  assert.strictEqual(sideB.destroyed, true);
+}));
+
+sideA.resume();
+sideB.resume();
+
+// Trigger the destruction
+sideA.destroy(new Error('Simulated error'));
+
+// Check the state in the next tick to allow nextTick/microtasks to run
+setImmediate(common.mustCall(() => {
+  assert.strictEqual(sideA.destroyed, true);
+  assert.strictEqual(sideB.destroyed, true);
+}));

--- a/test/js/node/test/parallel/test-env-var-no-warnings.js
+++ b/test/js/node/test/parallel/test-env-var-no-warnings.js
@@ -1,0 +1,41 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+
+if (process.argv[2] === 'child') {
+  process.emitWarning('foo');
+} else {
+  function test(newEnv) {
+    const [cmd, opts] = common.escapePOSIXShell`"${process.execPath}" "${__filename}" child`;
+
+    cp.exec(cmd, { ...opts, env: { ...opts?.env, ...newEnv } }, common.mustCall((err, stdout, stderr) => {
+      assert.strictEqual(err, null);
+      assert.strictEqual(stdout, '');
+
+      if (newEnv.NODE_NO_WARNINGS === '1')
+        assert.strictEqual(stderr, '');
+      else
+        assert.match(stderr.trim(), /Warning: foo\n/);
+    }));
+  }
+
+  test({});
+  test(process.env);
+  test({ NODE_NO_WARNINGS: undefined });
+  test({ NODE_NO_WARNINGS: null });
+  test({ NODE_NO_WARNINGS: 'foo' });
+  test({ NODE_NO_WARNINGS: true });
+  test({ NODE_NO_WARNINGS: false });
+  test({ NODE_NO_WARNINGS: {} });
+  test({ NODE_NO_WARNINGS: [] });
+  test({ NODE_NO_WARNINGS: function() {} });
+  test({ NODE_NO_WARNINGS: 0 });
+  test({ NODE_NO_WARNINGS: -1 });
+  test({ NODE_NO_WARNINGS: '0' });
+  test({ NODE_NO_WARNINGS: '01' });
+  test({ NODE_NO_WARNINGS: '2' });
+  // Don't test the number 1 because it will come through as a string in the
+  // child process environment.
+  test({ NODE_NO_WARNINGS: '1' });
+}

--- a/test/js/node/test/parallel/test-fixed-queue.js
+++ b/test/js/node/test/parallel/test-fixed-queue.js
@@ -1,0 +1,46 @@
+// Flags: --expose-internals
+'use strict';
+
+require('../common');
+
+const assert = require('assert');
+const FixedQueue = require('internal/fixed_queue');
+
+{
+  const queue = new FixedQueue();
+  assert.strictEqual(queue.head, queue.tail);
+  assert(queue.isEmpty());
+  queue.push('a');
+  assert(!queue.isEmpty());
+  assert.strictEqual(queue.shift(), 'a');
+  assert.strictEqual(queue.shift(), null);
+}
+
+{
+  const queue = new FixedQueue();
+  for (let i = 0; i < 2047; i++)
+    queue.push('a');
+  assert(queue.head.isFull());
+  queue.push('a');
+  assert(!queue.head.isFull());
+
+  assert.notStrictEqual(queue.head, queue.tail);
+  for (let i = 0; i < 2047; i++)
+    assert.strictEqual(queue.shift(), 'a');
+  assert.strictEqual(queue.head, queue.tail);
+  assert(!queue.isEmpty());
+  assert.strictEqual(queue.shift(), 'a');
+  assert(queue.isEmpty());
+}
+
+{
+  // FixedQueue must not be holey array
+  // Refs: https://github.com/nodejs/node/issues/54472
+  const queue = new FixedQueue();
+  for (let i = 0; i < queue.head.list.length; i++) {
+    assert(i in queue.head.list);
+  }
+  for (let i = 0; i < queue.tail.list.length; i++) {
+    assert(i in queue.tail.list);
+  }
+}


### PR DESCRIPTION
Three Node v26.3.0 compatibility gaps, each shipped with the upstream test that covers it, copied verbatim. Two are real runtime bugs rather than test plumbing. None touch `perf_hooks`.

Stacked on #34517 (which adds the `exposedInternals` entries this builds on).

## `duplexPair` had no `_destroy` — destroying one side left the peer alive forever

`src/js/internal/streams/duplexpair.ts` was missing node's `_destroy` entirely (`lib/internal/streams/duplexpair.js`), so tearing down one side never ended or destroyed the other. Ported verbatim: the peer is closed on a `nextTick` so the current execution stack (an HTTP parser, say) isn't torn down underneath itself, and an errored destroy closes the peer *without* propagating the error, which is what prevents an "Unhandled error" crash on that side.

Confirmed against a build without the fix — `peer ended after destroy = false` before, `true` after, matching node.

Test: `test-duplex-error`

## `NODE_NO_WARNINGS` suppressed warnings for any truthy string

Node suppresses only when the value is exactly `"1"` (`lib/internal/process/pre_execution.js:339`); Bun routed it through a generic boolean env parse, so `"true"`, `"0"`, `"foo"` and `"01"` all suppressed. Read as a string and compare exactly.

Verified against the node binary for `1` / `true` / `0` / `foo` — all four now agree.

Note this is a **behavior change**: `NODE_NO_WARNINGS=true` no longer suppresses warnings, because it doesn't in node either.

Scope: the value is read from the OS environment, so one supplied only through an auto-loaded `.env` file is still not honoured. That gap is pre-existing (the old boolean flag had it too) and is not addressed here.

Test: `test-env-var-no-warnings`

## `FixedQueue`'s backing array was holey

`$newArrayWithSize(kSize)` leaves 2048 holes where node does `ArrayPrototypeFill(new Array(kSize), undefined)`. Holey arrays deoptimize element access, and the difference is observable through the queue's backing list.

Test: `test-fixed-queue` (also needs `internal/fixed_queue` mapped through `exposedInternals` — node's module *is* the FixedQueue class)

## Verification

- the 3 new tests: 3/3 green each under the runner's exact invocation
- `duplexPair` driven against the real node v26.3.0 binary across four scenarios — destroy-ends-peer, destroy-with-error, double destroy, and normal data flow — output **byte-identical**
- no regressions: `test/js/node/http2` + `test/js/node/stream` + `test/js/node/process` (711 tests) produce an **identical failure list** when run with this build and with a build without these changes, so nothing here regressed http2, which is `duplexPair`'s main consumer

## Investigated and deliberately excluded

- **`util.diff`** — implemented, then reverted. Bun's native `myersDiff` binding accepts only strings, so node's array form needs the Rust binding extended, which reaches into how `assert` renders diffs. Worth doing separately, not as a rider here.
- **`test-compression-decompression-stream`** — needs a shim for node's `internal/util` grab-bag module. Adding one would make future tests that require `internal/util` fail confusingly instead of cleanly.
- **`AbortSignal.timeout` reason message** — genuinely wrong (`"The operation timed out."` vs node's `"The operation was aborted due to timeout"`), but correcting it changes a user-visible string and requires updating three Bun-owned tests that assert the current wording. That belongs in its own PR.
- **`test-global-customevent`** — would pass on a 3-line `internal/event_target` shim with zero behavioral gain. Skipped as vacuous.
