### PR TITLE
collections: fix Stacked Borrows UB in LinearFifo intra-slice ptr::copy calls

### DIFF
--- a/src/collections/linear_fifo.rs
+++ b/src/collections/linear_fifo.rs
@@ -83,12 +83,15 @@ fn assume_init_slice_mut<T>(s: &mut [MaybeUninit<T>]) -> &mut [T] {
 /// subsequent `count -= 1`).
 #[inline(always)]
 fn shift_down_one<T>(slice: &mut [T]) {
-    if slice.len() <= 1 {
+    let len = slice.len();
+    if len <= 1 {
         return;
     }
+    let p = slice.as_mut_ptr();
     // SAFETY: src `[1..len)` and dst `[0..len-1)` are both in-bounds of
-    // `slice`; `ptr::copy` handles the overlap.
-    unsafe { ptr::copy(slice.as_ptr().add(1), slice.as_mut_ptr(), slice.len() - 1) };
+    // `slice`; `ptr::copy` handles the overlap. Both pointers derive from one
+    // `as_mut_ptr()` so the src tag is not invalidated by a later Unique retag.
+    unsafe { ptr::copy(p.add(1), p, len - 1) };
 }
 
 #[cfg(debug_assertions)]
@@ -276,9 +279,9 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
             // this copy overlaps
             let count = self.count;
             let head = self.head;
-            let buf = self.buf.as_mut_slice();
+            let buf = self.buf.as_mut_slice().as_mut_ptr();
             // SAFETY: src/dst within same allocation; ptr::copy is memmove.
-            unsafe { ptr::copy(buf.as_ptr().add(head), buf.as_mut_ptr(), count) };
+            unsafe { ptr::copy(buf.add(head), buf, count) };
             self.head = 0;
         } else {
             // Stable Rust cannot size a stack array by `size_of::<T>()`, so use
@@ -299,19 +302,15 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
             while self.head != 0 {
                 let n = self.head.min(tmp_len);
                 let m = buf_len - n;
-                let buf = self.buf.as_mut_slice();
+                let buf = self.buf.as_mut_slice().as_mut_ptr();
                 // SAFETY: `tmp` is disjoint from `buf`. The tmp↔buf copies move
                 // `n * size_of::<T>()` raw bytes (no `T` typed access through
                 // the 1-aligned scratch). The buf→buf shift overlaps, so use
                 // `ptr::copy` (memmove); it operates on properly-aligned `*T`.
                 unsafe {
-                    ptr::copy_nonoverlapping(buf.as_ptr().cast::<u8>(), tmp_ptr, n * t_size);
-                    ptr::copy(buf.as_ptr().add(n), buf.as_mut_ptr(), m);
-                    ptr::copy_nonoverlapping(
-                        tmp_ptr,
-                        buf.as_mut_ptr().add(m).cast::<u8>(),
-                        n * t_size,
-                    );
+                    ptr::copy_nonoverlapping(buf.cast::<u8>(), tmp_ptr, n * t_size);
+                    ptr::copy(buf.add(n), buf, m);
+                    ptr::copy_nonoverlapping(tmp_ptr, buf.add(m).cast::<u8>(), n * t_size);
                 }
                 self.head -= n;
             }
@@ -822,6 +821,29 @@ mod tests {
     use super::*;
 
     type DynFifoU8 = LinearFifo<u8, DynamicBuffer<u8>>;
+
+    // Drives `realign()` down its wrapped-rotation branch (the `else` arm with
+    // the tmp scratch loop). Growing a wrapped Dynamic fifo is the only path
+    // that reaches it: write 8, read 6, write 5 leaves head=6 count=7 in an
+    // 8-slot buffer, then a further write forces a grow → realign.
+    #[test]
+    fn realign_wrapped_rotation_preserves_contents() {
+        let mut fifo = DynFifoU8::init();
+        fifo.write(b"abcdefgh").unwrap();
+        for _ in 0..6 {
+            fifo.read_item().unwrap();
+        }
+        fifo.write(b"ijklm").unwrap();
+        assert_eq!(fifo.buf_len(), 8);
+        assert!(fifo.buf_len() - fifo.head < fifo.count, "must be wrapped");
+
+        fifo.write(b"nop").unwrap();
+
+        assert_eq!(fifo.head, 0);
+        let mut out = [0u8; 16];
+        let n = fifo.read(&mut out);
+        assert_eq!(&out[..n], b"ghijklmnop");
+    }
 
     #[test]
     fn discard_zero_from_empty_buffer_should_not_error_on_overflow() {

--- a/test/internal/linear-fifo.test.ts
+++ b/test/internal/linear-fifo.test.ts
@@ -18,6 +18,7 @@
  */
 import { linearFifoOrderedRemoveProbe } from "bun:internal-for-testing";
 import { expect, test } from "bun:test";
+import { existsSync } from "node:fs";
 import path from "node:path";
 
 test("ordered_remove_item preserves FIFO order in the wrapped tail sub-branch (head < count)", () => {
@@ -40,11 +41,15 @@ test("ordered_remove_item preserves FIFO order in the wrapped prefix sub-branch 
 // runtime-observable effect, so the discriminator is `cargo miri test` itself.
 // `bun run rust:miri` pins Tree Borrows (which accepts the old shape); this
 // test clears MIRIFLAGS to use miri's default Stacked Borrows model. Skipped
-// where miri is not installed (most Buildkite test lanes).
+// where miri is not installed, or where the cargo workspace is not resolvable
+// (test-only lanes run a prebuilt binary and lack vendor/lolhtml; see
+// scripts/rust-miri.ts for the same prerequisite check).
 const cargoBin = Bun.which("cargo");
 const repoRoot = path.resolve(import.meta.dir, "..", "..");
+const workspaceResolvable = existsSync(path.join(repoRoot, "vendor", "lolhtml", "Cargo.toml"));
 const miriAvailable =
   !!cargoBin &&
+  workspaceResolvable &&
   Bun.spawnSync({
     cmd: [cargoBin, "miri", "--version"],
     cwd: repoRoot,

--- a/test/internal/linear-fifo.test.ts
+++ b/test/internal/linear-fifo.test.ts
@@ -46,7 +46,9 @@ test("ordered_remove_item preserves FIFO order in the wrapped prefix sub-branch 
 // scripts/rust-miri.ts for the same prerequisite check).
 const cargoBin = Bun.which("cargo");
 const repoRoot = path.resolve(import.meta.dir, "..", "..");
-const workspaceResolvable = existsSync(path.join(repoRoot, "vendor", "lolhtml", "Cargo.toml"));
+const workspaceResolvable =
+  existsSync(path.join(repoRoot, "vendor", "lolhtml", "Cargo.toml")) &&
+  existsSync(path.join(repoRoot, "build", "debug", "codegen", "build_options.rs"));
 const miriAvailable =
   !!cargoBin &&
   workspaceResolvable &&

--- a/test/internal/linear-fifo.test.ts
+++ b/test/internal/linear-fifo.test.ts
@@ -57,7 +57,7 @@ test.skipIf(!miriAvailable)(
   "linear_fifo unit tests are clean under Stacked Borrows miri",
   async () => {
     await using proc = Bun.spawn({
-      cmd: [cargoBin!, "miri", "test", "-p", "bun_collections", "--", "linear_fifo"],
+      cmd: [cargoBin!, "miri", "test", "--locked", "-p", "bun_collections", "--", "linear_fifo"],
       cwd: repoRoot,
       env: { ...process.env, MIRIFLAGS: "" },
       stdout: "pipe",

--- a/test/internal/linear-fifo.test.ts
+++ b/test/internal/linear-fifo.test.ts
@@ -18,6 +18,7 @@
  */
 import { linearFifoOrderedRemoveProbe } from "bun:internal-for-testing";
 import { expect, test } from "bun:test";
+import path from "node:path";
 
 test("ordered_remove_item preserves FIFO order in the wrapped tail sub-branch (head < count)", () => {
   // write 12, read 8, write 10 -> head=8, count=14, buf_len=16 (wraps).
@@ -32,3 +33,43 @@ test("ordered_remove_item preserves FIFO order in the wrapped prefix sub-branch 
   // remove offset 5 -> index=(12+5)&15=1 < head -> wrapped-prefix sub-branch, drops 205.
   expect(linearFifoOrderedRemoveProbe(1)).toEqual([200, 201, 202, 203, 204, 206, 207]);
 });
+
+// The intra-slice `ptr::copy` calls in `shift_down_one` / `realign` used to
+// pass `slice.as_ptr()` as src and `slice.as_mut_ptr()` as dst in one call;
+// under Stacked Borrows the second retag invalidates the first. This has no
+// runtime-observable effect, so the discriminator is `cargo miri test` itself.
+// `bun run rust:miri` pins Tree Borrows (which accepts the old shape); this
+// test clears MIRIFLAGS to use miri's default Stacked Borrows model. Skipped
+// where miri is not installed (most Buildkite test lanes).
+const cargoBin = Bun.which("cargo");
+const repoRoot = path.resolve(import.meta.dir, "..", "..");
+const miriAvailable =
+  !!cargoBin &&
+  Bun.spawnSync({
+    cmd: [cargoBin, "miri", "--version"],
+    cwd: repoRoot,
+    stdout: "ignore",
+    stderr: "ignore",
+    timeout: 30_000,
+  }).exitCode === 0;
+
+test.skipIf(!miriAvailable)(
+  "linear_fifo unit tests are clean under Stacked Borrows miri",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [cargoBin!, "miri", "test", "-p", "bun_collections", "--", "linear_fifo"],
+      cwd: repoRoot,
+      env: { ...process.env, MIRIFLAGS: "" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) {
+      // Surface miri's diagnostic so the gate/CI log shows the actual UB.
+      console.error(stderr || stdout);
+    }
+    expect(stderr).not.toContain("Undefined Behavior");
+    expect(exitCode).toBe(0);
+  },
+  120_000,
+);


### PR DESCRIPTION
## What

`shift_down_one` and both branches of `realign` in `LinearFifo` call `ptr::copy` with `slice.as_ptr()` as the source and `slice.as_mut_ptr()` as the destination in the same expression:

```rust
unsafe { ptr::copy(slice.as_ptr().add(1), slice.as_mut_ptr(), slice.len() - 1) };
```

Under Stacked Borrows, `as_ptr()` creates a `SharedReadOnly` tag, then `as_mut_ptr()` (evaluated second) performs a `Unique` retag that invalidates the first pointer before `ptr::copy` reads through it:

```
error: Undefined Behavior: attempting a read access using <247765> at alloc66987[0x28], but that tag does not exist in the borrow stack for this location
  --> src/collections/linear_fifo.rs:91:14
help: <247765> was created by a SharedReadOnly retag at offsets [0x24..0x40]
help: <247765> was later invalidated at offsets [0x24..0x40] by a Unique function-entry retag inside this call
```

## Fix

Derive both pointers from a single `as_mut_ptr()` call, matching how `std`'s `slice::copy_within` does the same overlapping move:

```rust
let p = slice.as_mut_ptr();
unsafe { ptr::copy(p.add(1), p, len - 1) };
```

Applied at all three sites (the `shift_down_one` helper plus both `realign` copy paths). No change to runtime behaviour or codegen; this only affects pointer provenance.

## Why this is worth fixing

`bun run rust:miri` uses Tree Borrows, which accepts the old pattern, so CI was not red. But the pattern is rejected by Stacked Borrows (miri's default), is the shape `std` itself avoids in `copy_within`, and costs nothing to fix. Anyone running `cargo miri test -p bun_collections` without `MIRIFLAGS` currently hits UB here; after this change the `linear_fifo` suite is clean under both models.

#31107 independently reaches the same conclusion for the two `realign` sites as part of a broader Channel fix; this PR is the narrow `linear_fifo.rs` change so the file is clean on its own.

## Tests

- `src/collections/linear_fifo.rs`: new `realign_wrapped_rotation_preserves_contents` unit test for `realign`'s wrapped-rotation branch (the `else` arm with the tmp-scratch loop), which was previously unreached by the test suite.
- `test/internal/linear-fifo.test.ts`: new case that spawns `cargo miri test -p bun_collections -- linear_fifo` with `MIRIFLAGS=""` (Stacked Borrows). This is the discriminator for the fix: it fails on main with `Undefined Behavior` and passes here. Skipped on lanes where miri is not installed.

## Verification

```
# fail-before (Stacked Borrows, main):
$ cargo miri test -p bun_collections -- linear_fifo
test linear_fifo::tests::linear_fifo_u8_dynamic ... error: Undefined Behavior ...

# pass-after (Stacked Borrows, this branch):
$ cargo miri test -p bun_collections -- linear_fifo
test result: ok. 7 passed; 0 failed

# Tree Borrows (CI config) still green:
$ MIRIFLAGS=-Zmiri-tree-borrows cargo miri test -p bun_collections -- linear_fifo
test result: ok. 7 passed; 0 failed

$ cargo test -p bun_collections
test result: ok. 40 passed; 0 failed

$ bun bd test test/internal/linear-fifo.test.ts
3 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/linear-fifo.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (a3b917072)

test/internal/linear-fifo.test.ts:
(pass) ordered_remove_item preserves FIFO order in the wrapped tail sub-branch (head < count) [9.94ms]
(pass) ordered_remove_item preserves FIFO order in the wrapped prefix sub-branch (head > count) [2.09ms]
   Compiling bun_core v0.0.0 (/workspace/bun/src/bun_core)
   Compiling bun_ptr v0.0.0 (/workspace/bun/src/ptr)
   Compiling bun_collections v0.0.0 (/workspace/bun/src/collections)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.47s
     Running unittests lib.rs (target/miri/x86_64-unknown-linux-gnu/debug/deps/bun_collections-71cea161efba8e48)
error: Undefined Behavior: attempting a read access using <227200> at alloc77239[0x0], but that tag does not exist in th
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (cb0042dd8)

test/internal/linear-fifo.test.ts:
(pass) ordered_remove_item preserves FIFO order in the wrapped tail sub-branch (head < count) [0.47ms]
(pass) ordered_remove_item preserves FIFO order in the wrapped prefix sub-branch (head > count) [0.04ms]
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.10s
     Running unittests lib.rs (target/miri/x86_64-unknown-linux-gnu/debug/deps/bun_collections-71cea161efba8e48)
error: Undefined Behavior: attempting a read access using <227200> at alloc77239[0x0], but that tag does not exist in the borrow stack for this location
   --> src/collections/linear_fifo.rs:281:22
    |
281 |             unsafe { ptr::copy(buf.as_ptr().add(head), buf.as_mut_ptr(), count) };
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this error occurs as part of an access at alloc77239[0x0..0x8]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for fur
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/linear-fifo.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (a3b917072)

test/internal/linear-fifo.test.ts:
(pass) ordered_remove_item preserves FIFO order in the wrapped tail sub-branch (head < count) [7.77ms]
(pass) ordered_remove_item preserves FIFO order in the wrapped prefix sub-branch (head > count) [1.54ms]
(pass) linear_fifo unit tests are clean under Stacked Borrows miri [4637.86ms]

 3 pass
 0 fail
 4 expect() calls
Ran 3 tests across 1 file. [6.75s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 765ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/138] gen ErrorCode+*.h
[2/138] gen cpp.rs (cppbind)
[3/138] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[4/138] gen JS modules (bundle-modules)
Preprocess modules (8571ms)
Bundle modules (48ms)
Postprocesss modules (172ms)
Bundle Functions (830ms)
Generate Code (108ms)

[9.75s] Bundled "src/js" for production
  2035 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[4/138] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/collections/linear_fifo.rs    | 48 ++++++++++++++++++++++++++++-----------
 test/internal/linear-fifo.test.ts | 48 +++++++++++++++++++++++++++++++++++++++
 2 files changed, 83 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/collections/linear_fifo.rs         1      6      0
test/internal/linear-fifo.test.ts      2      7      0
```

</details>

<!-- robobun:evidence:end -->