### PR TITLE
install: avoid quadratic scans in yarn.lock printer and bun.lock workspace parse

### DIFF
--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -2149,8 +2149,8 @@ pub fn parse_into_binary_lockfile(
             row_by_path.insert(row.key.slice(), idx);
         }
         for workspace_path in &workspace_path_snapshot {
-            let Some(&row_idx) = row_by_path
-                .get(workspace_path.slice(lockfile.buffers.string_bytes.as_slice()))
+            let Some(&row_idx) =
+                row_by_path.get(workspace_path.slice(lockfile.buffers.string_bytes.as_slice()))
             else {
                 continue;
             };
@@ -2195,8 +2195,7 @@ pub fn parse_into_binary_lockfile(
                     &mut lockfile.buffers.extern_strings,
                 )?;
             } else if let Some(bin_dir_expr) = value.get(b"binDir") {
-                pkg.bin =
-                    Bin::parse_append_from_directories(&bin_dir_expr, &mut sbuf!(lockfile))?;
+                pkg.bin = Bin::parse_append_from_directories(&bin_dir_expr, &mut sbuf!(lockfile))?;
             }
 
             // there should be no duplicates
@@ -3372,8 +3371,8 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
             row_by_path.insert(row.key.slice(), idx);
         }
         for workspace_path in lockfile.workspace_paths.values() {
-            let Some(&row_idx) = row_by_path
-                .get(workspace_path.slice(lockfile.buffers.string_bytes.as_slice()))
+            let Some(&row_idx) =
+                row_by_path.get(workspace_path.slice(lockfile.buffers.string_bytes.as_slice()))
             else {
                 continue;
             };

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -1594,6 +1594,17 @@ fn object_rows(expr: &Expr) -> &[JSON::E::PropertyJSON] {
     }
 }
 
+/// Map each row's key bytes to its index. Reverse insert so duplicate keys
+/// resolve to the first row, matching a linear-scan-and-break lookup.
+fn index_rows_by_key<'a>(rows: &'a [JSON::E::PropertyJSON]) -> HashMap<&'a [u8], usize> {
+    let mut m: HashMap<&'a [u8], usize> = HashMap::default();
+    m.reserve(rows.len());
+    for (idx, row) in rows.iter().enumerate().rev() {
+        m.insert(row.key.slice(), idx);
+    }
+    m
+}
+
 fn array_items(expr: &Expr) -> &[JSON::E::JsonValue] {
     match &expr.data {
         ExprData::EArrayJSON(a) => a.get().items(),
@@ -2143,11 +2154,7 @@ pub fn parse_into_binary_lockfile(
         // `workspace_paths.values()` iterator borrow. `String` is `Copy`.
         let workspace_path_snapshot: Vec<String> = lockfile.workspace_paths.values().to_vec();
         let workspace_rows = object_rows(&workspaces_obj);
-        let mut row_by_path: HashMap<&[u8], usize> = HashMap::default();
-        row_by_path.reserve(workspace_rows.len());
-        for (idx, row) in workspace_rows.iter().enumerate().rev() {
-            row_by_path.insert(row.key.slice(), idx);
-        }
+        let row_by_path = index_rows_by_key(workspace_rows);
         for workspace_path in &workspace_path_snapshot {
             let Some(&row_idx) =
                 row_by_path.get(workspace_path.slice(lockfile.buffers.string_bytes.as_slice()))
@@ -3365,11 +3372,7 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
     if IS_ROOT {
         let workspaces_obj = workspaces_obj.expect("workspaces_obj required when IS_ROOT");
         let workspace_rows = object_rows(workspaces_obj);
-        let mut row_by_path: HashMap<&[u8], usize> = HashMap::default();
-        row_by_path.reserve(workspace_rows.len());
-        for (idx, row) in workspace_rows.iter().enumerate().rev() {
-            row_by_path.insert(row.key.slice(), idx);
-        }
+        let row_by_path = index_rows_by_key(workspace_rows);
         for workspace_path in lockfile.workspace_paths.values() {
             let Some(&row_idx) =
                 row_by_path.get(workspace_path.slice(lockfile.buffers.string_bytes.as_slice()))

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -2142,77 +2142,79 @@ pub fn parse_into_binary_lockfile(
         // `append_package_dedupe`) without conflicting with the
         // `workspace_paths.values()` iterator borrow. `String` is `Copy`.
         let workspace_path_snapshot: Vec<String> = lockfile.workspace_paths.values().to_vec();
-        'workspaces: for workspace_path in &workspace_path_snapshot {
-            for row in object_rows(&workspaces_obj) {
-                let path = row.key.slice();
-                if !strings::eql_long(
-                    path,
-                    workspace_path.slice(lockfile.buffers.string_bytes.as_slice()),
-                    true,
-                ) {
-                    continue;
-                }
-                let value = Expr::from_json_value(&row.value, row.key_loc);
+        let workspace_rows = object_rows(&workspaces_obj);
+        let mut row_by_path: HashMap<&[u8], usize> = HashMap::default();
+        row_by_path.reserve(workspace_rows.len());
+        for (idx, row) in workspace_rows.iter().enumerate().rev() {
+            row_by_path.insert(row.key.slice(), idx);
+        }
+        for workspace_path in &workspace_path_snapshot {
+            let Some(&row_idx) = row_by_path
+                .get(workspace_path.slice(lockfile.buffers.string_bytes.as_slice()))
+            else {
+                continue;
+            };
+            let row = &workspace_rows[row_idx];
+            let path = row.key.slice();
+            let value = Expr::from_json_value(&row.value, row.key_loc);
 
-                let mut pkg = Package {
-                    resolution: Resolution::init(crate::resolution::TaggedValue::Workspace(
-                        sbuf!(lockfile).append(path)?,
-                    )),
-                    ..Default::default()
-                };
+            let mut pkg = Package {
+                resolution: Resolution::init(crate::resolution::TaggedValue::Workspace(
+                    sbuf!(lockfile).append(path)?,
+                )),
+                ..Default::default()
+            };
 
-                let name_expr = value.get(b"name").unwrap();
-                let name = name_expr
-                    .as_utf8_string_literal()
-                    .expect("infallible: is_string checked");
-                let name_hash = StringBuilder::string_hash(name);
+            let name_expr = value.get(b"name").unwrap();
+            let name = name_expr
+                .as_utf8_string_literal()
+                .expect("infallible: is_string checked");
+            let name_hash = StringBuilder::string_hash(name);
 
-                pkg.name = sbuf!(lockfile).append_with_hash(name, name_hash)?;
-                pkg.name_hash = name_hash;
+            pkg.name = sbuf!(lockfile).append_with_hash(name, name_hash)?;
+            pkg.name_hash = name_hash;
 
-                let (off, len) = parse_append_dependencies::<false, false>(
-                    lockfile,
-                    &value,
-                    &mut *log,
-                    source,
-                    &mut optional_peers_buf,
-                    None,
-                    None,
-                    None,
+            let (off, len) = parse_append_dependencies::<false, false>(
+                lockfile,
+                &value,
+                &mut *log,
+                source,
+                &mut optional_peers_buf,
+                None,
+                None,
+                None,
+            )?;
+
+            pkg.dependencies = DependencySlice::new(off, len);
+            pkg.resolutions = PackageIDSlice::new(off, len);
+
+            if let Some(bin_expr) = value.get(b"bin") {
+                pkg.bin = Bin::parse_append(
+                    &bin_expr,
+                    &mut sbuf!(lockfile),
+                    &mut lockfile.buffers.extern_strings,
                 )?;
-
-                pkg.dependencies = DependencySlice::new(off, len);
-                pkg.resolutions = PackageIDSlice::new(off, len);
-
-                if let Some(bin_expr) = value.get(b"bin") {
-                    pkg.bin = Bin::parse_append(
-                        &bin_expr,
-                        &mut sbuf!(lockfile),
-                        &mut lockfile.buffers.extern_strings,
-                    )?;
-                } else if let Some(bin_dir_expr) = value.get(b"binDir") {
-                    pkg.bin =
-                        Bin::parse_append_from_directories(&bin_dir_expr, &mut sbuf!(lockfile))?;
-                }
-
-                // there should be no duplicates
-                let pkg_id = lockfile.append_package_dedupe(&mut pkg)?;
-
-                let entry = pkg_map.get_or_put(name)?;
-                if entry.found_existing {
-                    log.add_error_fmt(
-                        source,
-                        row.key_loc,
-                        format_args!("Duplicate workspace name: '{}'", bstr::BStr::new(name)),
-                    );
-                    return Err(ParseError::InvalidWorkspaceObject);
-                }
-
-                *entry.value_ptr = pkg_id;
-
-                workspace_pkgs_len += 1;
-                continue 'workspaces;
+            } else if let Some(bin_dir_expr) = value.get(b"binDir") {
+                pkg.bin =
+                    Bin::parse_append_from_directories(&bin_dir_expr, &mut sbuf!(lockfile))?;
             }
+
+            // there should be no duplicates
+            let pkg_id = lockfile.append_package_dedupe(&mut pkg)?;
+
+            let entry = pkg_map.get_or_put(name)?;
+            if entry.found_existing {
+                log.add_error_fmt(
+                    source,
+                    row.key_loc,
+                    format_args!("Duplicate workspace name: '{}'", bstr::BStr::new(name)),
+                );
+                return Err(ParseError::InvalidWorkspaceObject);
+            }
+
+            *entry.value_ptr = pkg_id;
+
+            workspace_pkgs_len += 1;
         }
     }
 
@@ -3363,43 +3365,45 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
 
     if IS_ROOT {
         let workspaces_obj = workspaces_obj.expect("workspaces_obj required when IS_ROOT");
-        'workspaces: for workspace_path in lockfile.workspace_paths.values() {
-            for row in object_rows(workspaces_obj) {
-                let path = row.key.slice();
-                if !strings::eql_long(
-                    path,
-                    workspace_path.slice(lockfile.buffers.string_bytes.as_slice()),
-                    true,
-                ) {
-                    continue;
-                }
-                let value = Expr::from_json_value(&row.value, row.key_loc);
+        let workspace_rows = object_rows(workspaces_obj);
+        let mut row_by_path: HashMap<&[u8], usize> = HashMap::default();
+        row_by_path.reserve(workspace_rows.len());
+        for (idx, row) in workspace_rows.iter().enumerate().rev() {
+            row_by_path.insert(row.key.slice(), idx);
+        }
+        for workspace_path in lockfile.workspace_paths.values() {
+            let Some(&row_idx) = row_by_path
+                .get(workspace_path.slice(lockfile.buffers.string_bytes.as_slice()))
+            else {
+                continue;
+            };
+            let row = &workspace_rows[row_idx];
+            let path = row.key.slice();
+            let value = Expr::from_json_value(&row.value, row.key_loc);
 
-                let name_expr = value.get(b"name").unwrap();
-                let name = name_expr
-                    .as_utf8_string_literal()
-                    .expect("infallible: is_string checked");
-                let name_hash = StringBuilder::string_hash(name);
+            let name_expr = value.get(b"name").unwrap();
+            let name = name_expr
+                .as_utf8_string_literal()
+                .expect("infallible: is_string checked");
+            let name_hash = StringBuilder::string_hash(name);
 
-                let dep = Dependency {
-                    name: sbuf!(lockfile).append_with_hash(name, name_hash)?,
-                    name_hash,
-                    behavior: Behavior::WORKSPACE,
-                    version: DependencyVersion {
-                        tag: DependencyVersionTag::Workspace,
-                        value: DependencyVersionValue {
-                            workspace: sbuf!(lockfile).append(path)?,
-                        },
-                        literal: String::default(),
+            let dep = Dependency {
+                name: sbuf!(lockfile).append_with_hash(name, name_hash)?,
+                name_hash,
+                behavior: Behavior::WORKSPACE,
+                version: DependencyVersion {
+                    tag: DependencyVersionTag::Workspace,
+                    value: DependencyVersionValue {
+                        workspace: sbuf!(lockfile).append(path)?,
                     },
-                };
+                    literal: String::default(),
+                },
+            };
 
-                // after parseAppendDependencies has been called for each package the
-                // size of lockfile.buffers.resolutions is set to the length of dependencies
-                // and values set to invalid_package_id before mapping.
-                lockfile.buffers.dependencies.push(dep);
-                continue 'workspaces;
-            }
+            // after parseAppendDependencies has been called for each package the
+            // size of lockfile.buffers.resolutions is set to the length of dependencies
+            // and values set to invalid_package_id before mapping.
+            lockfile.buffers.dependencies.push(dep);
         }
     }
 

--- a/src/install/lockfile/printer/Yarn.rs
+++ b/src/install/lockfile/printer/Yarn.rs
@@ -62,38 +62,48 @@ fn packages(this: &mut Printer, writer: &mut impl bun_io::Write) -> Result<(), c
     // overlapping &mut [Version] slices.
     let mut requested_versions: HashMap<PackageID, (usize, usize)> = HashMap::default();
 
-    // We push into a pre-reserved Vec — set_len would drop uninit tail elements
-    // (and index-assign would drop uninit old values). Profile if hot.
-    let mut all_requested_versions_buf: Vec<dependency::Version> =
-        Vec::with_capacity(resolutions_buffer.len());
-
     let package_count = names.len() as PackageID;
     let mut alphabetized_names: Vec<PackageID> = vec![0; (package_count - 1) as usize];
 
     let string_buf: &[u8] = this.lockfile.buffers.string_bytes.as_slice();
 
     // First, we need to build a map of all requested versions
-    // This is so we can print requested versions
+    // This is so we can print requested versions.
+    // Bucket the resolution buffer by package id in one pass instead of
+    // rescanning it once per package.
+    let mut starts: Vec<usize> = vec![0; package_count as usize + 1];
+    for &r in resolutions_buffer {
+        if r > 0 && r < package_count {
+            starts[r as usize + 1] += 1;
+        }
+    }
+    for i in 2..=package_count as usize {
+        starts[i] += starts[i - 1];
+    }
+    let total = starts[package_count as usize];
+
+    let mut all_requested_versions_buf: Vec<dependency::Version> = Vec::with_capacity(total);
+    all_requested_versions_buf.resize_with(total, dependency::Version::default);
+
+    {
+        let mut cursors = starts.clone();
+        for (dep, &r) in dependencies_buffer.iter().zip(resolutions_buffer.iter()) {
+            if r > 0 && r < package_count {
+                let slot = cursors[r as usize];
+                cursors[r as usize] = slot + 1;
+                all_requested_versions_buf[slot] = dep.version.clone();
+            }
+        }
+    }
+
     {
         let mut i: PackageID = 1;
         while i < package_count {
             alphabetized_names[(i - 1) as usize] = i;
 
-            let mut resolutions = resolutions_buffer;
-            let mut dependencies = dependencies_buffer;
-
-            let mut j: usize = 0;
-            let requested_version_start = all_requested_versions_buf.len();
-            while let Some(k) = resolutions.iter().position(|&r| r == i) {
-                j += 1;
-
-                all_requested_versions_buf.push(dependencies[k].version.clone());
-
-                dependencies = &dependencies[k + 1..];
-                resolutions = &resolutions[k + 1..];
-            }
-
-            let dependency_versions = &mut all_requested_versions_buf[requested_version_start..];
+            let start = starts[i as usize];
+            let end = starts[i as usize + 1];
+            let dependency_versions = &mut all_requested_versions_buf[start..end];
             if dependency_versions.len() > 1 {
                 dependency_versions.sort_by(|a, b| {
                     if dependency::Version::is_less_than_with_tag(string_buf, a, b) {
@@ -105,7 +115,7 @@ fn packages(this: &mut Printer, writer: &mut impl bun_io::Write) -> Result<(), c
                     }
                 });
             }
-            requested_versions.insert(i, (requested_version_start, j));
+            requested_versions.insert(i, (start, end - start));
 
             i += 1;
         }

--- a/src/install/lockfile/printer/Yarn.rs
+++ b/src/install/lockfile/printer/Yarn.rs
@@ -1,7 +1,6 @@
 use crate::lockfile::package::PackageColumns as _;
 use core::cmp::Ordering;
 
-use bun_collections::HashMap;
 use bun_core::strings;
 use bun_semver::String as SemverString;
 
@@ -58,10 +57,6 @@ fn packages(this: &mut Printer, writer: &mut impl bun_io::Write) -> Result<(), c
     let resolutions_buffer: &[PackageID] = this.lockfile.buffers.resolutions.as_slice();
     let dependencies_buffer: &[Dependency] = this.lockfile.buffers.dependencies.as_slice();
 
-    // Store (start, len) into `all_requested_versions_buf` instead of
-    // overlapping &mut [Version] slices.
-    let mut requested_versions: HashMap<PackageID, (usize, usize)> = HashMap::default();
-
     let package_count = names.len() as PackageID;
     let mut alphabetized_names: Vec<PackageID> = vec![0; (package_count - 1) as usize];
 
@@ -115,7 +110,6 @@ fn packages(this: &mut Printer, writer: &mut impl bun_io::Write) -> Result<(), c
                     }
                 });
             }
-            requested_versions.insert(i, (start, end - start));
 
             i += 1;
         }
@@ -142,8 +136,9 @@ fn packages(this: &mut Printer, writer: &mut impl bun_io::Write) -> Result<(), c
         // "@babel/core@7.9.0":
         {
             writer.write_all(b"\n")?;
-            let (rv_start, rv_len) = *requested_versions.get(&i).unwrap();
-            let dependency_versions = &all_requested_versions_buf[rv_start..rv_start + rv_len];
+            let rv_start = starts[i as usize];
+            let rv_end = starts[i as usize + 1];
+            let dependency_versions = &all_requested_versions_buf[rv_start..rv_end];
 
             // https://github.com/yarnpkg/yarn/blob/158d96dce95313d9a00218302631cd263877d164/src/lockfile/stringify.js#L9
             let always_needs_quote = strings::must_escape_yaml_string(name);

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -2158,18 +2158,22 @@ test.concurrent("bun.lock and yarn.lock round-trip a large workspace set", async
     ),
   ];
   for (let i = 0; i < N; i++) {
+    // Each package depends on the next three (wrapping) with a distinct
+    // request literal per edge, so every target's requested-version bucket
+    // holds literals that name that target.
     const deps: Record<string, string> = {};
-    // Each package depends on the next three (wrapping), so every package
-    // is requested from several others.
-    for (let j = 1; j <= 3; j++) {
-      deps[`pkg-${pad((i + j) % N)}`] = "workspace:*";
-    }
+    const t1 = (i + 1) % N;
+    const t2 = (i + 2) % N;
+    const t3 = (i + 3) % N;
+    deps[`pkg-${pad(t1)}`] = "workspace:*";
+    deps[`pkg-${pad(t2)}`] = `workspace:^1.0.${t2}`;
+    deps[`pkg-${pad(t3)}`] = `workspace:~1.0.${t3}`;
     writes.push(
       write(
         join(packageDir, "packages", `pkg-${pad(i)}`, "package.json"),
         JSON.stringify({
           name: `pkg-${pad(i)}`,
-          version: "1.0.0",
+          version: `1.0.${i}`,
           dependencies: deps,
         }),
       ),
@@ -2192,15 +2196,18 @@ test.concurrent("bun.lock and yarn.lock round-trip a large workspace set", async
   const bunLock = await file(join(packageDir, "bun.lock")).text();
   const yarnLock = await file(join(packageDir, "yarn.lock")).text();
 
-  // yarn.lock should list every workspace package once, each with three
-  // requesters collapsed to a single "workspace:*" key and three deps.
+  // Each package's key line lists exactly its own four requesters (root's
+  // workspace path plus the three literals that reference its index). A
+  // bucketing bug would surface as a literal carrying the wrong index here.
+  const keyLines = yarnLock.split("\n").filter(l => l.endsWith(":") && l.startsWith('"pkg-'));
+  expect(keyLines.length).toBe(N);
   for (let i = 0; i < N; i++) {
     const name = `pkg-${pad(i)}`;
-    expect(yarnLock).toContain(`"${name}@workspace:*":\n`);
+    expect(keyLines).toContain(
+      `"${name}@packages/${name}", "${name}@workspace:*", "${name}@workspace:^1.0.${i}", "${name}@workspace:~1.0.${i}":`,
+    );
     expect(yarnLock).toContain(`  version "workspace:packages/${name}"\n`);
   }
-  const depLines = yarnLock.split("\n").filter(l => /^ {4}pkg-\d{3} "workspace:\*"$/.test(l));
-  expect(depLines.length).toBe(N * 3);
 
   // Second install reparses bun.lock with N workspace rows and should see
   // no diff.

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -2138,3 +2138,82 @@ test("matching workspace devDependency and npm peerDependency", async () => {
   expect(err).not.toContain("updated");
   expect(out).toContain("no changes");
 });
+
+test.concurrent("bun.lock and yarn.lock round-trip a large workspace set", async () => {
+  // Exercise the per-workspace bun.lock parse loops and the yarn printer's
+  // requested-versions map with a non-trivial number of workspace packages.
+  using ctx = await setupTest();
+  const { packageDir, env } = ctx;
+
+  const N = 60;
+  const pad = (i: number) => String(i).padStart(3, "0");
+
+  const writes: Promise<number>[] = [
+    write(
+      join(packageDir, "package.json"),
+      JSON.stringify({
+        name: "many-workspaces-root",
+        workspaces: ["packages/*"],
+      }),
+    ),
+  ];
+  for (let i = 0; i < N; i++) {
+    const deps: Record<string, string> = {};
+    // Each package depends on the next three (wrapping), so every package
+    // is requested from several others.
+    for (let j = 1; j <= 3; j++) {
+      deps[`pkg-${pad((i + j) % N)}`] = "workspace:*";
+    }
+    writes.push(
+      write(
+        join(packageDir, "packages", `pkg-${pad(i)}`, "package.json"),
+        JSON.stringify({
+          name: `pkg-${pad(i)}`,
+          version: "1.0.0",
+          dependencies: deps,
+        }),
+      ),
+    );
+  }
+  await Promise.all(writes);
+
+  let { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "install", "--yarn"],
+    cwd: packageDir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  let [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+  expect(err).toContain("Saved lockfile");
+  expect(err).toContain("Saved yarn.lock");
+  expect(exitCode).toBe(0);
+
+  const bunLock = await file(join(packageDir, "bun.lock")).text();
+  const yarnLock = await file(join(packageDir, "yarn.lock")).text();
+
+  // yarn.lock should list every workspace package once, each with three
+  // requesters collapsed to a single "workspace:*" key and three deps.
+  for (let i = 0; i < N; i++) {
+    const name = `pkg-${pad(i)}`;
+    expect(yarnLock).toContain(`"${name}@workspace:*":\n`);
+    expect(yarnLock).toContain(`  version "workspace:packages/${name}"\n`);
+  }
+  const depLines = yarnLock.split("\n").filter(l => /^ {4}pkg-\d{3} "workspace:\*"$/.test(l));
+  expect(depLines.length).toBe(N * 3);
+
+  // Second install reparses bun.lock with N workspace rows and should see
+  // no diff.
+  ({ stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "install", "--frozen-lockfile"],
+    cwd: packageDir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  }));
+  [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+  expect(err).not.toContain("error:");
+  expect(err).not.toContain("Saved lockfile");
+  expect(exitCode).toBe(0);
+  expect(await file(join(packageDir, "bun.lock")).text()).toBe(bunLock);
+});


### PR DESCRIPTION
## What

Two lockfile code paths did per-item linear scans inside an outer per-item loop:

- **yarn.lock printer** (`src/install/lockfile/printer/Yarn.rs`): for each package `i` in `1..P`, repeatedly called `resolutions.iter().position(|&r| r == i)` across the full resolutions buffer, giving `O(P*D)` comparisons where `D` is the dependency count.
- **bun.lock workspace parse** (`src/install/lockfile/bun.lock.rs`, two sites): for each workspace path in `lockfile.workspace_paths`, linearly scanned every row of the `workspaces` JSON object to find the matching path, giving `O(W^2)` byte compares.

## Fix

- Yarn printer: bucket the resolutions buffer by package id with one counting pass, then fill a contiguous `Vec<Version>` in one placement pass. `O(P + D)` plus the unchanged per-bucket sort. The prefix-sum table also replaces the old `requested_versions: HashMap<PackageID, (usize, usize)>`, so the print loop now indexes `starts[i]..starts[i+1]` directly (one less allocation, no `.unwrap()`).
- bun.lock parse: index the `workspaces` object rows by path once (`HashMap<&[u8], usize>`) and look each workspace path up directly. The index is built in reverse so duplicate paths still resolve to the first row, matching the previous inner-loop-and-break behaviour. Iteration order over `workspace_paths` is unchanged, so package ids are assigned identically.

## Why

Large monorepos are the target for workspaces. With `W` and `P` in the thousands both scans become visible in `bun install --frozen-lockfile` and `bun install --yarn` timings. On a 6000-workspace / 30000-dep fixture (debug+asan build, same machine):

| operation | before | after |
| --- | --- | --- |
| `install --frozen-lockfile` | 54.1 s | 35.2 s |
| `install --yarn` (bun.lock present) | 56.9 s | 35.9 s |

Release-build `--frozen-lockfile` on the same fixture grows superlinearly on main (328 ms at W=2000, 738 ms at W=4000, 1660 ms at W=6000); the linear path flattens that curve.

`yarn.lock` and `bun.lock` output are byte-identical to the previous implementation on both a 60-workspace and a 6000-workspace fixture.

## Tests

This is a performance-only change with no behavioural difference, and there is no user-observable counter to assert against (unlike e.g. `heapStats().Promise` for allocation fixes). A wall-clock threshold at an `N` large enough to separate the two curves on a debug+asan build would put the passing case above a minute, which isn't acceptable for CI. Correctness is covered by the existing yarn.lock and bun.lock round-trip tests (`test/regression/issue/3192.test.ts`, the `--yarn` snapshot in `test/cli/install/__snapshots__/bun-install-registry.test.ts.snap`, and the `--frozen-lockfile` cases across `test/cli/install/bun-workspaces.test.ts` and `test/cli/install/bun-lock.test.ts`) plus the byte-identical diff above.

The new `bun.lock and yarn.lock round-trip a large workspace set` test in `bun-workspaces.test.ts` is independent coverage: no existing test ran `--yarn` followed by `--frozen-lockfile` on more than a handful of workspaces, so a future regression in either the bucketing or the path-index logic at scale would have slipped through. It passes against current main as well; it is not the fail-before proof for this change.

Related: #34524 touches the `sort_by` comparator inside the same yarn printer loop; that change and this one are independent.
