### PR TITLE
resolver: hash-lookup tsconfig paths exact match, cache '*' position at parse

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4735,32 +4735,21 @@ impl<'a> Resolver<'a> {
         }
 
         // Check for exact matches first
-        {
-            // NOTE: ArrayHashMap has no `&self` (key,value) iterator; zip the
-            // parallel `keys()`/`values()` slices (insertion order).
-            for (key, value) in tsconfig
-                .paths
-                .keys()
-                .iter()
-                .zip(tsconfig.paths.values().iter())
-            {
-                if strings::eql_long(key, path, true) {
-                    for original_path in value.iter() {
-                        let mut absolute_original_path: &[u8] = original_path;
+        if let Some(entry) = tsconfig.paths.get(path) {
+            for original_path in entry.original_paths.iter() {
+                let mut absolute_original_path: &[u8] = original_path;
 
-                        if !bun_paths::is_absolute(absolute_original_path) {
-                            let parts: [&[u8]; 2] = [abs_base_url, original_path.as_ref()];
-                            absolute_original_path =
-                                self.fs_ref().abs_buf(&parts, bufs!(tsconfig_path_abs));
-                        }
+                if !bun_paths::is_absolute(absolute_original_path) {
+                    let parts: [&[u8]; 2] = [abs_base_url, original_path.as_ref()];
+                    absolute_original_path =
+                        self.fs_ref().abs_buf(&parts, bufs!(tsconfig_path_abs));
+                }
 
-                        if self
-                            .load_as_file_or_directory(absolute_original_path, kind, out)
-                            .is_success()
-                        {
-                            return MatchStatus::Success;
-                        }
-                    }
+                if self
+                    .load_as_file_or_directory(absolute_original_path, kind, out)
+                    .is_success()
+                {
+                    return MatchStatus::Success;
                 }
             }
         }
@@ -4775,13 +4764,13 @@ impl<'a> Resolver<'a> {
         let mut longest_match_prefix_length: i32 = -1;
         let mut longest_match_suffix_length: i32 = -1;
 
-        for (key, original_paths) in tsconfig
+        for (key, entry) in tsconfig
             .paths
             .keys()
             .iter()
             .zip(tsconfig.paths.values().iter())
         {
-            if let Some(star) = strings::index_of_char(key, b'*') {
+            if let Some(star) = entry.star {
                 let star = star as usize;
                 let prefix: &[u8] = if star == 0 { b"" } else { &key[0..star] };
                 let suffix: &[u8] = if star == key.len() - 1 {
@@ -4807,7 +4796,7 @@ impl<'a> Resolver<'a> {
                     longest_match = Some(TSConfigMatch {
                         prefix,
                         suffix,
-                        original_paths,
+                        original_paths: &entry.original_paths,
                     });
                 }
             }

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -1,4 +1,4 @@
-use bun_collections::ArrayHashMap;
+use bun_collections::StringArrayHashMap;
 use bun_core::strings;
 use bun_js_parser::lexer as js_lexer;
 use bun_parsers::json_parser;
@@ -114,11 +114,19 @@ impl JsonCache {
     }
 }
 
-// Heuristic: you probably don't have 100 of these
-// Probably like 5-10
-// Array iteration is faster and deterministically ordered in that case.
+/// One `compilerOptions.paths` entry. `star` is the `*` position in the key
+/// (cached at parse time; `None` for exact-match keys) so
+/// `match_tsconfig_paths` can skip the per-import `index_of_char` scan.
+#[derive(Default)]
+pub struct PathsEntry {
+    pub star: Option<u32>,
+    pub original_paths: Vec<Box<[u8]>>,
+}
+
+// `StringArrayHashMap` so `match_tsconfig_paths` can `get(&[u8])` without
+// boxing. Insertion order is preserved for deterministic wildcard iteration.
 // Both keys and values are owned (`Box`/`Vec`) and freed when the map drops.
-pub(crate) type PathsMap = ArrayHashMap<Box<[u8]>, Vec<Box<[u8]>>>;
+pub(crate) type PathsMap = StringArrayHashMap<PathsEntry>;
 
 // Hand-listed Pragma fields actually used below.
 #[derive(EnumSetType, Debug)]
@@ -641,7 +649,13 @@ impl TSConfigJSON {
                                         // (the extends-merge in the resolver) pass the stored slice
                                         // to the allocator, which requires the original length.
                                         values.shrink_to_fit();
-                                        let _ = result.paths.put(Box::from(key), values);
+                                        let _ = result.paths.put(
+                                            key,
+                                            PathsEntry {
+                                                star: strings::index_of_char(key, b'*'),
+                                                original_paths: values,
+                                            },
+                                        );
                                     }
                                     // else: Every entry was invalid; nothing to store. `values` drops here.
                                 }

--- a/test/js/bun/resolve/tsconfig-paths.test.ts
+++ b/test/js/bun/resolve/tsconfig-paths.test.ts
@@ -1,119 +1,136 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
 // match_tsconfig_paths used to do a linear key scan with eql_long for the
 // exact-match pass and re-scan every key for '*' on every call. With a hash
 // lookup for exact matches and the '*' position cached at parse time, the
-// per-import cost is O(1) for the exact pass plus one cheap branch per key
-// for the wildcard pass. Sizes below are chosen so the old per-import scan
-// cannot finish within the spawn timeout on a debug build while the fixed
-// path finishes in about a second.
+// per-import cost for the exact pass is O(1) independent of the key count.
 
-test("tsconfig paths: exact-match resolution is hash-lookup, not a key scan", async () => {
-  // 8000 exact-match keys (no '*'), all sharing a long common prefix so a
-  // bytewise compare cannot short-circuit on the first word, plus one
-  // wildcard entry at the end so the wildcard pass still runs.
-  const N_KEYS = 8000;
-  const N_RESOLVES = 6000;
-  const PREFIX = "monorepo-internal-workspace-package-alias-name-slot";
-  const keyAt = (i: number) => PREFIX + String(i).padStart(60 - PREFIX.length, "0");
+describe.concurrent("tsconfig compilerOptions.paths", () => {
+  test("exact-match resolution is O(1), not a scan over keys", async () => {
+    // Self-calibrating complexity check: with 8000 exact-match keys (all the
+    // same length, sharing a long prefix so a bytewise compare cannot exit on
+    // the first word), resolving the last inserted key must not be materially
+    // slower than resolving the first. On the linear scan the measured ratio
+    // is ~45x (release) / ~140x (debug); on a hash lookup it is ~1x.
+    const N_KEYS = 8000;
+    const PREFIX = "monorepo-internal-workspace-package-alias-name-slot";
+    const keyAt = (i: number) => PREFIX + String(i).padStart(60 - PREFIX.length, "0");
 
-  const paths: Record<string, string[]> = {};
-  for (let i = 0; i < N_KEYS; i++) paths[keyAt(i)] = ["./impl/target.ts"];
-  paths["@wild/*"] = ["./impl/*"];
+    const paths: Record<string, string[]> = {};
+    for (let i = 0; i < N_KEYS; i++) paths[keyAt(i)] = ["./impl/target.ts"];
+    paths["@wild/*"] = ["./impl/*"];
 
-  using dir = tempDir("tsconfig-paths-scan", {
-    "tsconfig.json": JSON.stringify({ compilerOptions: { baseUrl: ".", paths } }),
-    "impl/target.ts": "export const x = 1;\n",
-    "impl/wild.ts": "export const y = 2;\n",
-    "bench.ts":
-      `const dir = import.meta.dir;\n` +
-      `const PREFIX = ${JSON.stringify(PREFIX)};\n` +
-      `const keyAt = i => PREFIX + String(i).padStart(${60 - PREFIX.length}, "0");\n` +
-      `const target = Bun.resolveSync("./impl/target.ts", dir);\n` +
-      `for (let i = 0; i < ${N_RESOLVES}; i++) {\n` +
-      `  const r = Bun.resolveSync(keyAt(i % ${N_KEYS}), dir);\n` +
-      `  if (r !== target) throw new Error("exact-match resolved to " + r);\n` +
-      `}\n` +
-      `const wild = Bun.resolveSync("@wild/wild", dir);\n` +
-      `if (wild !== Bun.resolveSync("./impl/wild.ts", dir)) throw new Error("wildcard resolved to " + wild);\n` +
-      `console.log("ok");\n`,
+    using dir = tempDir("tsconfig-paths-scan", {
+      "tsconfig.json": JSON.stringify({ compilerOptions: { baseUrl: ".", paths } }),
+      "impl/target.ts": "export const x = 1;\n",
+      "impl/wild.ts": "export const y = 2;\n",
+      "bench.ts":
+        `const dir = import.meta.dir;\n` +
+        `const PREFIX = ${JSON.stringify(PREFIX)};\n` +
+        `const keyAt = i => PREFIX + String(i).padStart(${60 - PREFIX.length}, "0");\n` +
+        `const target = Bun.resolveSync("./impl/target.ts", dir);\n` +
+        `const ITERS = 1000;\n` +
+        `const bench = k => {\n` +
+        `  const t0 = Bun.nanoseconds();\n` +
+        `  for (let i = 0; i < ITERS; i++)\n` +
+        `    if (Bun.resolveSync(k, dir) !== target) throw new Error("resolved to wrong target: " + k);\n` +
+        `  return Bun.nanoseconds() - t0;\n` +
+        `};\n` +
+        `for (let i = 0; i < 20; i++) Bun.resolveSync(keyAt(0), dir);\n` +
+        `for (let i = 0; i < 20; i++) Bun.resolveSync(keyAt(${N_KEYS - 1}), dir);\n` +
+        `let first = Infinity, last = Infinity;\n` +
+        `for (let r = 0; r < 3; r++) {\n` +
+        `  first = Math.min(first, bench(keyAt(0)));\n` +
+        `  last = Math.min(last, bench(keyAt(${N_KEYS - 1})));\n` +
+        `}\n` +
+        `const wild = Bun.resolveSync("@wild/wild", dir);\n` +
+        `if (wild !== Bun.resolveSync("./impl/wild.ts", dir)) throw new Error("wildcard resolved to " + wild);\n` +
+        `console.log(JSON.stringify({ first, last, ratio: last / first }));\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(String(dir), "bench.ts")],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 15_000,
+      killSignal: "SIGKILL",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // A linear-scan debug build is killed by the spawn timeout above before
+    // it can print; a release build prints with a ratio well over the bound.
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    const { first, last, ratio } = JSON.parse(stdout);
+    expect({ first, last, ratio }).toEqual({
+      first: expect.any(Number),
+      last: expect.any(Number),
+      ratio: expect.any(Number),
+    });
+    // Linear scan gives >=45x here; hash lookup gives ~1x. 5x leaves >8x
+    // headroom on both sides across release, debug, and ASAN.
+    expect(ratio).toBeLessThan(5);
+  }, 30_000);
+
+  test("many entries resolve correctly (exact, wildcard, longest-prefix)", async () => {
+    const paths: Record<string, string[]> = {};
+    // Interleave exact and wildcard entries so iteration order is mixed.
+    for (let i = 0; i < 150; i++) {
+      paths[`exact-key-${i}`] = [`./exact/${i}.ts`];
+      paths[`wild${i}/*`] = [`./w/${i}/*`];
+    }
+    // Overlapping wildcards: longest prefix must win.
+    paths["@scope/*"] = ["./scope-short/*"];
+    paths["@scope/pkg/*"] = ["./scope-long/*"];
+
+    const files: Record<string, string> = {
+      "tsconfig.json": JSON.stringify({ compilerOptions: { baseUrl: ".", paths } }),
+      "scope-short/fallback.ts": "export {};\n",
+      "scope-long/main.ts": "export {};\n",
+      "main.ts":
+        `const dir = import.meta.dir;\n` +
+        `const out: string[] = [];\n` +
+        `const rel = p => p.slice(dir.length + 1).replace(/\\\\/g, "/");\n` +
+        `out.push(rel(Bun.resolveSync("exact-key-0", dir)));\n` +
+        `out.push(rel(Bun.resolveSync("exact-key-149", dir)));\n` +
+        `out.push(rel(Bun.resolveSync("wild7/hit", dir)));\n` +
+        `out.push(rel(Bun.resolveSync("wild149/hit", dir)));\n` +
+        `out.push(rel(Bun.resolveSync("@scope/pkg/main", dir)));\n` +
+        `out.push(rel(Bun.resolveSync("@scope/fallback", dir)));\n` +
+        `try { Bun.resolveSync("no-such-key", dir); out.push("BAD"); }\n` +
+        `catch (e) { out.push("notfound:" + e.code); }\n` +
+        `console.log(out.join("\\n"));\n`,
+    };
+    files["exact/0.ts"] = "export {};\n";
+    files["exact/149.ts"] = "export {};\n";
+    files["w/7/hit.ts"] = "export {};\n";
+    files["w/149/hit.ts"] = "export {};\n";
+
+    using dir = tempDir("tsconfig-paths-many", files);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(String(dir), "main.ts")],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.trim().split("\n")).toEqual([
+      "exact/0.ts",
+      "exact/149.ts",
+      "w/7/hit.ts",
+      "w/149/hit.ts",
+      "scope-long/main.ts",
+      "scope-short/fallback.ts",
+      "notfound:ERR_MODULE_NOT_FOUND",
+    ]);
+    expect(exitCode).toBe(0);
   });
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), join(String(dir), "bench.ts")],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-    timeout: 15_000,
-    killSignal: "SIGKILL",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect({ stdout, stderr: /error|panic|assert|crash|abort/i.test(stderr) ? stderr : "", exitCode }).toEqual({
-    stdout: "ok\n",
-    stderr: "",
-    exitCode: 0,
-  });
-}, 30_000);
-
-test("tsconfig paths: many entries resolve correctly (exact, wildcard, longest-prefix)", async () => {
-  const paths: Record<string, string[]> = {};
-  // Interleave exact and wildcard entries so iteration order is mixed.
-  for (let i = 0; i < 150; i++) {
-    paths[`exact-key-${i}`] = [`./exact/${i}.ts`];
-    paths[`wild${i}/*`] = [`./w/${i}/*`];
-  }
-  // Overlapping wildcards: longest prefix must win.
-  paths["@scope/*"] = ["./scope-short/*"];
-  paths["@scope/pkg/*"] = ["./scope-long/*"];
-
-  const files: Record<string, string> = {
-    "tsconfig.json": JSON.stringify({ compilerOptions: { baseUrl: ".", paths } }),
-    "scope-short/fallback.ts": "export {};\n",
-    "scope-long/main.ts": "export {};\n",
-    "main.ts":
-      `const dir = import.meta.dir;\n` +
-      `const out: string[] = [];\n` +
-      `const rel = p => p.slice(dir.length + 1).replace(/\\\\/g, "/");\n` +
-      `out.push(rel(Bun.resolveSync("exact-key-0", dir)));\n` +
-      `out.push(rel(Bun.resolveSync("exact-key-149", dir)));\n` +
-      `out.push(rel(Bun.resolveSync("wild7/hit", dir)));\n` +
-      `out.push(rel(Bun.resolveSync("wild149/hit", dir)));\n` +
-      `out.push(rel(Bun.resolveSync("@scope/pkg/main", dir)));\n` +
-      `out.push(rel(Bun.resolveSync("@scope/fallback", dir)));\n` +
-      `try { Bun.resolveSync("no-such-key", dir); out.push("BAD"); }\n` +
-      `catch (e) { out.push("notfound:" + e.code); }\n` +
-      `console.log(out.join("\\n"));\n`,
-  };
-  files["exact/0.ts"] = "export {};\n";
-  files["exact/149.ts"] = "export {};\n";
-  files["w/7/hit.ts"] = "export {};\n";
-  files["w/149/hit.ts"] = "export {};\n";
-
-  using dir = tempDir("tsconfig-paths-many", files);
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), join(String(dir), "main.ts")],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect(stdout.trim().split("\n")).toEqual([
-    "exact/0.ts",
-    "exact/149.ts",
-    "w/7/hit.ts",
-    "w/149/hit.ts",
-    "scope-long/main.ts",
-    "scope-short/fallback.ts",
-    "notfound:ERR_MODULE_NOT_FOUND",
-  ]);
-  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/resolve/tsconfig-paths.test.ts
+++ b/test/js/bun/resolve/tsconfig-paths.test.ts
@@ -7,7 +7,7 @@ import { join } from "path";
 // lookup for exact matches and the '*' position cached at parse time, the
 // per-import cost for the exact pass is O(1) independent of the key count.
 
-describe.concurrent("tsconfig compilerOptions.paths", () => {
+describe("tsconfig compilerOptions.paths", () => {
   test("exact-match resolution is O(1), not a scan over keys", async () => {
     // Self-calibrating complexity check: with 3000 exact-match keys (all the
     // same length, sharing a long prefix so a bytewise compare cannot exit on
@@ -72,7 +72,7 @@ describe.concurrent("tsconfig compilerOptions.paths", () => {
     expect(ratio).toBeLessThan(5);
   });
 
-  test("many entries resolve correctly (exact, wildcard, longest-prefix)", async () => {
+  test("many entries resolve correctly (exact, wildcard, longest-prefix, longest-suffix)", async () => {
     const paths: Record<string, string[]> = {};
     // Interleave exact and wildcard entries so iteration order is mixed.
     for (let i = 0; i < 150; i++) {
@@ -82,11 +82,19 @@ describe.concurrent("tsconfig compilerOptions.paths", () => {
     // Overlapping wildcards: longest prefix must win.
     paths["@scope/*"] = ["./scope-short/*"];
     paths["@scope/pkg/*"] = ["./scope-long/*"];
+    // Equal prefix, different suffix: longest suffix must win the tie.
+    // Both targets below exist; resolving to tie-long/* proves the longer
+    // suffix was selected over tie-short/*.
+    paths["tie/*"] = ["./tie-short/*"];
+    paths["tie/*end"] = ["./tie-long/*"];
 
     const files: Record<string, string> = {
       "tsconfig.json": JSON.stringify({ compilerOptions: { baseUrl: ".", paths } }),
       "scope-short/fallback.ts": "export {};\n",
       "scope-long/main.ts": "export {};\n",
+      "tie-long/x/end.ts": "export {};\n",
+      "tie-short/xend.ts": "export {};\n",
+      "tie-short/y.ts": "export {};\n",
       "main.ts":
         `const dir = import.meta.dir;\n` +
         `const out: string[] = [];\n` +
@@ -97,6 +105,8 @@ describe.concurrent("tsconfig compilerOptions.paths", () => {
         `out.push(rel(Bun.resolveSync("wild149/hit", dir)));\n` +
         `out.push(rel(Bun.resolveSync("@scope/pkg/main", dir)));\n` +
         `out.push(rel(Bun.resolveSync("@scope/fallback", dir)));\n` +
+        `out.push(rel(Bun.resolveSync("tie/xend", dir)));\n` +
+        `out.push(rel(Bun.resolveSync("tie/y", dir)));\n` +
         `try { Bun.resolveSync("no-such-key", dir); out.push("BAD"); }\n` +
         `catch (e) { out.push("notfound:" + e.code); }\n` +
         `console.log(out.join("\\n"));\n`,
@@ -125,6 +135,8 @@ describe.concurrent("tsconfig compilerOptions.paths", () => {
       "w/149/hit.ts",
       "scope-long/main.ts",
       "scope-short/fallback.ts",
+      "tie-long/x/end.ts",
+      "tie-short/y.ts",
       "notfound:ERR_MODULE_NOT_FOUND",
     ]);
     expect(exitCode).toBe(0);

--- a/test/js/bun/resolve/tsconfig-paths.test.ts
+++ b/test/js/bun/resolve/tsconfig-paths.test.ts
@@ -1,0 +1,119 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+// match_tsconfig_paths used to do a linear key scan with eql_long for the
+// exact-match pass and re-scan every key for '*' on every call. With a hash
+// lookup for exact matches and the '*' position cached at parse time, the
+// per-import cost is O(1) for the exact pass plus one cheap branch per key
+// for the wildcard pass. Sizes below are chosen so the old per-import scan
+// cannot finish within the spawn timeout on a debug build while the fixed
+// path finishes in about a second.
+
+test("tsconfig paths: exact-match resolution is hash-lookup, not a key scan", async () => {
+  // 8000 exact-match keys (no '*'), all sharing a long common prefix so a
+  // bytewise compare cannot short-circuit on the first word, plus one
+  // wildcard entry at the end so the wildcard pass still runs.
+  const N_KEYS = 8000;
+  const N_RESOLVES = 6000;
+  const PREFIX = "monorepo-internal-workspace-package-alias-name-slot";
+  const keyAt = (i: number) => PREFIX + String(i).padStart(60 - PREFIX.length, "0");
+
+  const paths: Record<string, string[]> = {};
+  for (let i = 0; i < N_KEYS; i++) paths[keyAt(i)] = ["./impl/target.ts"];
+  paths["@wild/*"] = ["./impl/*"];
+
+  using dir = tempDir("tsconfig-paths-scan", {
+    "tsconfig.json": JSON.stringify({ compilerOptions: { baseUrl: ".", paths } }),
+    "impl/target.ts": "export const x = 1;\n",
+    "impl/wild.ts": "export const y = 2;\n",
+    "bench.ts":
+      `const dir = import.meta.dir;\n` +
+      `const PREFIX = ${JSON.stringify(PREFIX)};\n` +
+      `const keyAt = i => PREFIX + String(i).padStart(${60 - PREFIX.length}, "0");\n` +
+      `const target = Bun.resolveSync("./impl/target.ts", dir);\n` +
+      `for (let i = 0; i < ${N_RESOLVES}; i++) {\n` +
+      `  const r = Bun.resolveSync(keyAt(i % ${N_KEYS}), dir);\n` +
+      `  if (r !== target) throw new Error("exact-match resolved to " + r);\n` +
+      `}\n` +
+      `const wild = Bun.resolveSync("@wild/wild", dir);\n` +
+      `if (wild !== Bun.resolveSync("./impl/wild.ts", dir)) throw new Error("wildcard resolved to " + wild);\n` +
+      `console.log("ok");\n`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(String(dir), "bench.ts")],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 15_000,
+    killSignal: "SIGKILL",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, stderr: /error|panic|assert|crash|abort/i.test(stderr) ? stderr : "", exitCode }).toEqual({
+    stdout: "ok\n",
+    stderr: "",
+    exitCode: 0,
+  });
+}, 30_000);
+
+test("tsconfig paths: many entries resolve correctly (exact, wildcard, longest-prefix)", async () => {
+  const paths: Record<string, string[]> = {};
+  // Interleave exact and wildcard entries so iteration order is mixed.
+  for (let i = 0; i < 150; i++) {
+    paths[`exact-key-${i}`] = [`./exact/${i}.ts`];
+    paths[`wild${i}/*`] = [`./w/${i}/*`];
+  }
+  // Overlapping wildcards: longest prefix must win.
+  paths["@scope/*"] = ["./scope-short/*"];
+  paths["@scope/pkg/*"] = ["./scope-long/*"];
+
+  const files: Record<string, string> = {
+    "tsconfig.json": JSON.stringify({ compilerOptions: { baseUrl: ".", paths } }),
+    "scope-short/fallback.ts": "export {};\n",
+    "scope-long/main.ts": "export {};\n",
+    "main.ts":
+      `const dir = import.meta.dir;\n` +
+      `const out: string[] = [];\n` +
+      `const rel = p => p.slice(dir.length + 1).replace(/\\\\/g, "/");\n` +
+      `out.push(rel(Bun.resolveSync("exact-key-0", dir)));\n` +
+      `out.push(rel(Bun.resolveSync("exact-key-149", dir)));\n` +
+      `out.push(rel(Bun.resolveSync("wild7/hit", dir)));\n` +
+      `out.push(rel(Bun.resolveSync("wild149/hit", dir)));\n` +
+      `out.push(rel(Bun.resolveSync("@scope/pkg/main", dir)));\n` +
+      `out.push(rel(Bun.resolveSync("@scope/fallback", dir)));\n` +
+      `try { Bun.resolveSync("no-such-key", dir); out.push("BAD"); }\n` +
+      `catch (e) { out.push("notfound:" + e.code); }\n` +
+      `console.log(out.join("\\n"));\n`,
+  };
+  files["exact/0.ts"] = "export {};\n";
+  files["exact/149.ts"] = "export {};\n";
+  files["w/7/hit.ts"] = "export {};\n";
+  files["w/149/hit.ts"] = "export {};\n";
+
+  using dir = tempDir("tsconfig-paths-many", files);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(String(dir), "main.ts")],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim().split("\n")).toEqual([
+    "exact/0.ts",
+    "exact/149.ts",
+    "w/7/hit.ts",
+    "w/149/hit.ts",
+    "scope-long/main.ts",
+    "scope-short/fallback.ts",
+    "notfound:ERR_MODULE_NOT_FOUND",
+  ]);
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/resolve/tsconfig-paths.test.ts
+++ b/test/js/bun/resolve/tsconfig-paths.test.ts
@@ -9,12 +9,12 @@ import { join } from "path";
 
 describe.concurrent("tsconfig compilerOptions.paths", () => {
   test("exact-match resolution is O(1), not a scan over keys", async () => {
-    // Self-calibrating complexity check: with 8000 exact-match keys (all the
+    // Self-calibrating complexity check: with 3000 exact-match keys (all the
     // same length, sharing a long prefix so a bytewise compare cannot exit on
     // the first word), resolving the last inserted key must not be materially
     // slower than resolving the first. On the linear scan the measured ratio
-    // is ~45x (release) / ~140x (debug); on a hash lookup it is ~1x.
-    const N_KEYS = 8000;
+    // is ~27x (release) / ~53x (debug); on a hash lookup it is ~1x.
+    const N_KEYS = 3000;
     const PREFIX = "monorepo-internal-workspace-package-alias-name-slot";
     const keyAt = (i: number) => PREFIX + String(i).padStart(60 - PREFIX.length, "0");
 
@@ -31,7 +31,7 @@ describe.concurrent("tsconfig compilerOptions.paths", () => {
         `const PREFIX = ${JSON.stringify(PREFIX)};\n` +
         `const keyAt = i => PREFIX + String(i).padStart(${60 - PREFIX.length}, "0");\n` +
         `const target = Bun.resolveSync("./impl/target.ts", dir);\n` +
-        `const ITERS = 1000;\n` +
+        `const ITERS = 400;\n` +
         `const bench = k => {\n` +
         `  const t0 = Bun.nanoseconds();\n` +
         `  for (let i = 0; i < ITERS; i++)\n` +
@@ -56,14 +56,10 @@ describe.concurrent("tsconfig compilerOptions.paths", () => {
       cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",
-      timeout: 15_000,
-      killSignal: "SIGKILL",
     });
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    // A linear-scan debug build is killed by the spawn timeout above before
-    // it can print; a release build prints with a ratio well over the bound.
     expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
     const { first, last, ratio } = JSON.parse(stdout);
     expect({ first, last, ratio }).toEqual({
@@ -71,10 +67,10 @@ describe.concurrent("tsconfig compilerOptions.paths", () => {
       last: expect.any(Number),
       ratio: expect.any(Number),
     });
-    // Linear scan gives >=45x here; hash lookup gives ~1x. 5x leaves >8x
+    // Linear scan gives >=27x here; hash lookup gives ~1x. 5x leaves >5x
     // headroom on both sides across release, debug, and ASAN.
     expect(ratio).toBeLessThan(5);
-  }, 30_000);
+  });
 
   test("many entries resolve correctly (exact, wildcard, longest-prefix)", async () => {
     const paths: Record<string, string[]> = {};


### PR DESCRIPTION
## What does this PR do?

`match_tsconfig_paths` runs for every bare-specifier import resolved under a tsconfig that defines `compilerOptions.paths`. It did two linear passes over the paths map per call:

- the exact-match pass iterated every key comparing with `strings::eql_long`
- the wildcard pass re-ran `strings::index_of_char(key, b'*')` on every key

so the per-import cost scaled linearly with the number of `paths` entries. Monorepos commonly have hundreds of entries.

### Fix

- `PathsMap` is now `StringArrayHashMap<PathsEntry>` so the exact-match pass is a single `tsconfig.paths.get(path)` hash lookup (which falls back to the same hash-prefiltered linear scan below 8 entries, so small configs are no slower).
- The `*` position is recorded once at tsconfig parse time in `PathsEntry.star`, so the wildcard pass does a branch per key instead of a byte scan per key. Insertion order is preserved, so wildcard selection (longest prefix, then longest suffix) is unchanged.

### Numbers

`Bun.resolveSync(key, dir)` against a tsconfig with N exact-match entries sharing a long common prefix, release build:

| entries | before (ns/resolve) | after |
| --- | --- | --- |
| 10 | ~2 100 | flat at baseline |
| 200 | ~3 400 | flat at baseline |
| 1 000 | ~6 900 | flat at baseline |
| 5 000 | ~27 500 | flat at baseline |

More directly, the ratio `resolve(key[N-1]) / resolve(key[0])` with 3 000 entries:

|  | before | after |
| --- | --- | --- |
| release | ~27x | ~1.0x |
| debug+ASAN | ~53x | ~1.0x |

### How did you verify your code works?

`test/js/bun/resolve/tsconfig-paths.test.ts`:

- "exact-match resolution is O(1), not a scan over keys": a child with 3 000 exact-match entries measures `resolve(key[2999]) / resolve(key[0])` over three rounds and asserts the ratio is under 5x. On an unfixed release build the ratio is ~27x; on an unfixed debug build the child cannot finish within the default test timeout. Both pass with the fix at ~1x in ~1.2 s on debug+ASAN.
- "many entries resolve correctly": 300 interleaved exact and wildcard entries plus two overlapping wildcards, checking exact hits, wildcard hits, longest-prefix selection between `@scope/*` and `@scope/pkg/*`, and the not-found path.

Also passing: `test/bundler/esbuild/tsconfig.test.ts`, `test/js/bun/resolve/tsconfig-extends-leak.test.ts`, `test/cli/run/tsconfig-override.test.ts`, `test/js/bun/resolve/resolve.test.ts`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/tsconfig-paths.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (d19d2350e)

test/js/bun/resolve/tsconfig-paths.test.ts:
killed 1 dangling process
(fail) tsconfig compilerOptions.paths > exact-match resolution is O(1), not a scan over keys [5005.46ms]
  ^ this test timed out after 5000ms.

# Unhandled error between tests
-------------------------------
58 |       stderr: "pipe",
59 |     });
60 | 
61 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
62 | 
63 |     expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
                                      ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
+   "exitCode": 143,
    "stderr": "",
  }

- Expected  - 1
+ Received  + 1

      at <anon
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (4cffc1a78)

test/js/bun/resolve/tsconfig-paths.test.ts:
(pass) tsconfig compilerOptions.paths > exact-match resolution is O(1), not a scan over keys [21.48ms]
(pass) tsconfig compilerOptions.paths > many entries resolve correctly (exact, wildcard, longest-prefix, longest-suffix) [52.72ms]

 2 pass
 0 fail
 5 expect() calls
Ran 2 tests across 1 file. [237.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/tsconfig-paths.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (d19d2350e)

test/js/bun/resolve/tsconfig-paths.test.ts:
(pass) tsconfig compilerOptions.paths > exact-match resolution is O(1), not a scan over keys [1142.38ms]
(pass) tsconfig compilerOptions.paths > many entries resolve correctly (exact, wildcard, longest-prefix, longest-suffix) [728.29ms]

 2 pass
 0 fail
 5 expect() calls
Ran 2 tests across 1 file. [3.98s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 755ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/138] gen ErrorCode+*.h
[2/138] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[3/138] gen cpp.rs (cppbind)
[4/138] gen JS modules (bundle-modules)
Preprocess modules (7540ms)
Bundle modules (32ms)
Postprocesss modules (199ms)
Bundle Functions (821ms)
Generate Code (112ms)

[8.73s] Bundled "src/js" for production
  2035 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[4/138] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/resolver/resolver.rs                   |  45 ++++-----
 src/resolver/tsconfig_json.rs              |  26 ++++--
 test/js/bun/resolve/tsconfig-paths.test.ts | 144 +++++++++++++++++++++++++++++
 3 files changed, 181 insertions(+), 34 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/resolver/resolver.rs                        3      2      0
src/resolver/tsconfig_json.rs                   4      5      0
test/js/bun/resolve/tsconfig-paths.test.ts      1     13      0
```

</details>

<!-- robobun:evidence:end -->