### PR TITLE
bundler: O(1) lookup for CommonJS export refs in printer

### DIFF
--- a/src/bundler/linker_context/doStep5.rs
+++ b/src/bundler/linker_context/doStep5.rs
@@ -314,16 +314,8 @@ impl LinkerContext<'_> {
             // form re-loaded `keys.len()` and bounds-checked each access).
             let part_index_u32 = part_index as u32;
             let dependencies = &mut part.dependencies;
-            for &ref_ in part.symbol_uses.keys() {
-                debug_assert!({
-                    let j = part
-                        .symbol_uses
-                        .keys()
-                        .iter()
-                        .position(|k| *k == ref_)
-                        .unwrap();
-                    part.symbol_uses.values()[j].count_estimate > 0
-                });
+            for (j, &ref_) in part.symbol_uses.keys().iter().enumerate() {
+                debug_assert!(part.symbol_uses.values()[j].count_estimate > 0);
 
                 // Inlined `c.top_level_symbols_to_parts(id, ref_)` against the
                 // hoisted per-file maps so the column pointer math (and the

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -3384,8 +3384,6 @@ pub mod __gated_printer {
                     self.print_space_before_identifier();
                     self.add_source_mapping(expr.loc);
 
-                    // reshaped for borrowck — find the matching index first,
-                    // then drop the immutable iter borrow before printing.
                     let mut found: Option<usize> = None;
                     if let Some(exports) = self.options.commonjs_named_exports {
                         let values = exports.values();

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1650,6 +1650,11 @@ pub mod __gated_printer {
         // Always carried; gated at call sites with MAY_HAVE_MODULE_INFO.
         pub module_info: Option<&'a mut analyze_transpiled_module::ModuleInfo>,
 
+        /// Lazy reverse index of `options.commonjs_named_exports`:
+        /// `values()[i].loc_ref.ref_` → `i`. Built on the first
+        /// `ECommonjsExportIdentifier` so the per-reference lookup is O(1).
+        commonjs_export_ref_to_index: bun_collections::HashMap<Ref, u32>,
+
         /// Arena for transient allocations during printing (rope flattening,
         /// UTF-16→UTF-8 transcoding).
         pub bump: &'a bun_alloc::Arena,
@@ -3383,12 +3388,18 @@ pub mod __gated_printer {
                     // then drop the immutable iter borrow before printing.
                     let mut found: Option<usize> = None;
                     if let Some(exports) = self.options.commonjs_named_exports {
-                        for (idx, value) in exports.values().iter().enumerate() {
-                            if value.loc_ref.ref_.eql(id.ref_) {
-                                found = Some(idx);
-                                break;
+                        let values = exports.values();
+                        if self.commonjs_export_ref_to_index.is_empty() && !values.is_empty() {
+                            self.commonjs_export_ref_to_index.reserve(values.len());
+                            for (idx, value) in values.iter().enumerate() {
+                                self.commonjs_export_ref_to_index
+                                    .insert(value.loc_ref.ref_, idx as u32);
                             }
                         }
+                        found = self
+                            .commonjs_export_ref_to_index
+                            .get(&id.ref_)
+                            .map(|&i| i as usize);
                     }
                     if let Some(idx) = found {
                         let exports = self.options.commonjs_named_exports.unwrap();
@@ -7040,6 +7051,7 @@ pub mod __gated_printer {
                 stack_overflowed: false,
                 was_lazy_export: false,
                 module_info: None,
+                commonjs_export_ref_to_index: bun_collections::HashMap::default(),
             };
             // The `Builder` field is `&'static [u32]` pending lifetime threading,
             // so instead of caching a self-borrow here,

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { itBundled } from "./expectBundled";
+import { bunEnv, bunExe, tempDir } from "harness";
+import path from "node:path";
 
 const fakeReactNodeModules = {
   "/node_modules/react/index.js": /* js */ `
@@ -392,4 +394,51 @@ describe("bundler", () => {
       stdout: '[[{"xyz":456},456],[{"xyz":123},123],[{"xyz":456},456],[{"xyz":123},123]]',
     },
   });
+
+  // Printing each `exports.<name>` reference used to linear-scan the named
+  // exports map, making a file with N distinct exports referenced N times
+  // take O(N^2). This also covers an O(N^2) debug_assert over part.symbol_uses.
+  test(
+    "cjs2esm/ManyNamedExportsPerf",
+    async () => {
+      const N = 25000;
+      const parts: string[] = [];
+      for (let i = 0; i < N; i++) parts.push(`exports.x${i} = ${i};\n`);
+      parts.push("function use() { return [");
+      for (let i = 0; i < N; i++) parts.push(`exports.x${i},`);
+      parts.push("]; }\nexports.use = use;\n");
+
+      using dir = tempDir("cjs2esm-many-exports", {
+        "lib.cjs": parts.join(""),
+        "entry.js": `import * as lib from './lib.cjs';\nconsole.log(Object.keys(lib).length);\n`,
+      });
+
+      await using build = Bun.spawn({
+        cmd: [bunExe(), "build", "./entry.js", "--outfile=out.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: 45_000,
+      });
+      const [buildOut, buildErr, buildExit] = await Promise.all([
+        build.stdout.text(),
+        build.stderr.text(),
+        build.exited,
+      ]);
+      if (build.signalCode) {
+        throw new Error(`bun build killed by ${build.signalCode} (took >45s); stderr: ${buildErr.slice(0, 500)}`);
+      }
+      expect(buildErr).not.toContain("error");
+      expect(buildOut).toContain("out.js");
+      expect(buildExit).toBe(0);
+
+      const out = await Bun.file(path.join(String(dir), "out.js")).text();
+      expect(out).toContain(`var $x0 = 0;`);
+      expect(out).toContain(`var $x${N - 1} = ${N - 1};`);
+      expect(out).toContain(`$x0, $x1, $x2,`);
+      expect(out).toContain(`$x${N - 2}, $x${N - 1}`);
+    },
+    60_000,
+  );
 });

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { itBundled } from "./expectBundled";
 import { bunEnv, bunExe, tempDir } from "harness";
 import path from "node:path";
+import { itBundled } from "./expectBundled";
 
 const fakeReactNodeModules = {
   "/node_modules/react/index.js": /* js */ `
@@ -398,47 +398,39 @@ describe("bundler", () => {
   // Printing each `exports.<name>` reference used to linear-scan the named
   // exports map, making a file with N distinct exports referenced N times
   // take O(N^2). This also covers an O(N^2) debug_assert over part.symbol_uses.
-  test(
-    "cjs2esm/ManyNamedExportsPerf",
-    async () => {
-      const N = 25000;
-      const parts: string[] = [];
-      for (let i = 0; i < N; i++) parts.push(`exports.x${i} = ${i};\n`);
-      parts.push("function use() { return [");
-      for (let i = 0; i < N; i++) parts.push(`exports.x${i},`);
-      parts.push("]; }\nexports.use = use;\n");
+  test("cjs2esm/ManyNamedExportsPerf", async () => {
+    const N = 25000;
+    const parts: string[] = [];
+    for (let i = 0; i < N; i++) parts.push(`exports.x${i} = ${i};\n`);
+    parts.push("function use() { return [");
+    for (let i = 0; i < N; i++) parts.push(`exports.x${i},`);
+    parts.push("]; }\nexports.use = use;\n");
 
-      using dir = tempDir("cjs2esm-many-exports", {
-        "lib.cjs": parts.join(""),
-        "entry.js": `import * as lib from './lib.cjs';\nconsole.log(Object.keys(lib).length);\n`,
-      });
+    using dir = tempDir("cjs2esm-many-exports", {
+      "lib.cjs": parts.join(""),
+      "entry.js": `import * as lib from './lib.cjs';\nconsole.log(Object.keys(lib).length);\n`,
+    });
 
-      await using build = Bun.spawn({
-        cmd: [bunExe(), "build", "./entry.js", "--outfile=out.js"],
-        env: bunEnv,
-        cwd: String(dir),
-        stdout: "pipe",
-        stderr: "pipe",
-        timeout: 45_000,
-      });
-      const [buildOut, buildErr, buildExit] = await Promise.all([
-        build.stdout.text(),
-        build.stderr.text(),
-        build.exited,
-      ]);
-      if (build.signalCode) {
-        throw new Error(`bun build killed by ${build.signalCode} (took >45s); stderr: ${buildErr.slice(0, 500)}`);
-      }
-      expect(buildErr).not.toContain("error");
-      expect(buildOut).toContain("out.js");
-      expect(buildExit).toBe(0);
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "./entry.js", "--outfile=out.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 45_000,
+    });
+    const [buildOut, buildErr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    if (build.signalCode) {
+      throw new Error(`bun build killed by ${build.signalCode} (took >45s); stderr: ${buildErr.slice(0, 500)}`);
+    }
+    expect(buildErr).not.toContain("error");
+    expect(buildOut).toContain("out.js");
+    expect(buildExit).toBe(0);
 
-      const out = await Bun.file(path.join(String(dir), "out.js")).text();
-      expect(out).toContain(`var $x0 = 0;`);
-      expect(out).toContain(`var $x${N - 1} = ${N - 1};`);
-      expect(out).toContain(`$x0, $x1, $x2,`);
-      expect(out).toContain(`$x${N - 2}, $x${N - 1}`);
-    },
-    60_000,
-  );
+    const out = await Bun.file(path.join(String(dir), "out.js")).text();
+    expect(out).toContain(`var $x0 = 0;`);
+    expect(out).toContain(`var $x${N - 1} = ${N - 1};`);
+    expect(out).toContain(`$x0, $x1, $x2,`);
+    expect(out).toContain(`$x${N - 2}, $x${N - 1}`);
+  }, 60_000);
 });

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -398,61 +398,53 @@ describe("bundler", () => {
   // Printing each `exports.<name>` reference used to linear-scan the named
   // exports map, making a file with N distinct exports referenced N times
   // take O(N^2). This also covers an O(N^2) debug_assert over part.symbol_uses.
-  test(
-    "cjs2esm/ManyNamedExportsPerf",
-    async () => {
-      const N = isDebug ? 25000 : 300000;
-      const buildTimeoutMs = isDebug ? 45_000 : 20_000;
-      // Rope-style `+=` so debug JSC stays fast.
-      let lib = "";
-      for (let i = 0; i < N; i++) {
-        lib += "exports.x";
-        lib += i;
-        lib += " = ";
-        lib += i;
-        lib += ";\n";
-      }
-      lib += "function use() { return [";
-      for (let i = 0; i < N; i++) {
-        lib += "exports.x";
-        lib += i;
-        lib += ",";
-      }
-      lib += "]; }\nexports.use = use;\n";
+  test("cjs2esm/ManyNamedExportsPerf", async () => {
+    const N = isDebug ? 25000 : 300000;
+    const buildTimeoutMs = isDebug ? 45_000 : 20_000;
+    // Rope-style `+=` so debug JSC stays fast.
+    let lib = "";
+    for (let i = 0; i < N; i++) {
+      lib += "exports.x";
+      lib += i;
+      lib += " = ";
+      lib += i;
+      lib += ";\n";
+    }
+    lib += "function use() { return [";
+    for (let i = 0; i < N; i++) {
+      lib += "exports.x";
+      lib += i;
+      lib += ",";
+    }
+    lib += "]; }\nexports.use = use;\n";
 
-      using dir = tempDir("cjs2esm-many-exports", {
-        "lib.cjs": lib,
-        "entry.js": `import * as lib from './lib.cjs';\nconsole.log(Object.keys(lib).length);\n`,
-      });
+    using dir = tempDir("cjs2esm-many-exports", {
+      "lib.cjs": lib,
+      "entry.js": `import * as lib from './lib.cjs';\nconsole.log(Object.keys(lib).length);\n`,
+    });
 
-      await using build = Bun.spawn({
-        cmd: [bunExe(), "build", "./entry.js", "--outfile=out.js"],
-        env: bunEnv,
-        cwd: String(dir),
-        stdout: "pipe",
-        stderr: "pipe",
-        timeout: buildTimeoutMs,
-      });
-      const [buildOut, buildErr, buildExit] = await Promise.all([
-        build.stdout.text(),
-        build.stderr.text(),
-        build.exited,
-      ]);
-      if (build.signalCode) {
-        throw new Error(
-          `bun build killed by ${build.signalCode} (took >${buildTimeoutMs}ms); stderr: ${buildErr.slice(0, 500)}`,
-        );
-      }
-      expect(buildErr).not.toContain("error");
-      expect(buildOut).toContain("out.js");
-      expect(buildExit).toBe(0);
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "./entry.js", "--outfile=out.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: buildTimeoutMs,
+    });
+    const [buildOut, buildErr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    if (build.signalCode) {
+      throw new Error(
+        `bun build killed by ${build.signalCode} (took >${buildTimeoutMs}ms); stderr: ${buildErr.slice(0, 500)}`,
+      );
+    }
+    expect(buildErr).not.toContain("error");
+    expect(buildOut).toContain("out.js");
+    expect(buildExit).toBe(0);
 
-      const out = await Bun.file(path.join(String(dir), "out.js")).text();
-      expect(out).toContain("var $x0 = 0;");
-      expect(out).toContain("var $x" + (N - 1) + " = " + (N - 1) + ";");
-      expect(out).toContain("$x0, $x1, $x2,");
-      expect(out).toContain("$x" + (N - 2) + ", $x" + (N - 1));
-    },
-    60_000,
-  );
+    const out = await Bun.file(path.join(String(dir), "out.js")).text();
+    expect(out).toContain("var $x0 = 0;");
+    expect(out).toContain("var $x" + (N - 1) + " = " + (N - 1) + ";");
+    expect(out).toContain("$x0, $x1, $x2,");
+    expect(out).toContain("$x" + (N - 2) + ", $x" + (N - 1));
+  }, 60_000);
 });

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -1,6 +1,4 @@
-import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, tempDir } from "harness";
-import path from "node:path";
+import { describe, expect } from "bun:test";
 import { itBundled } from "./expectBundled";
 
 const fakeReactNodeModules = {
@@ -394,57 +392,4 @@ describe("bundler", () => {
       stdout: '[[{"xyz":456},456],[{"xyz":123},123],[{"xyz":456},456],[{"xyz":123},123]]',
     },
   });
-
-  // Printing each `exports.<name>` reference used to linear-scan the named
-  // exports map, making a file with N distinct exports referenced N times
-  // take O(N^2). This also covers an O(N^2) debug_assert over part.symbol_uses.
-  test("cjs2esm/ManyNamedExportsPerf", async () => {
-    const N = isDebug ? 25000 : 300000;
-    const buildTimeoutMs = isDebug ? 45_000 : 20_000;
-    // Rope-style `+=` so debug JSC stays fast.
-    let lib = "";
-    for (let i = 0; i < N; i++) {
-      lib += "exports.x";
-      lib += i;
-      lib += " = ";
-      lib += i;
-      lib += ";\n";
-    }
-    lib += "function use() { return [";
-    for (let i = 0; i < N; i++) {
-      lib += "exports.x";
-      lib += i;
-      lib += ",";
-    }
-    lib += "]; }\nexports.use = use;\n";
-
-    using dir = tempDir("cjs2esm-many-exports", {
-      "lib.cjs": lib,
-      "entry.js": `import * as lib from './lib.cjs';\nconsole.log(Object.keys(lib).length);\n`,
-    });
-
-    await using build = Bun.spawn({
-      cmd: [bunExe(), "build", "./entry.js", "--outfile=out.js"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-      timeout: buildTimeoutMs,
-    });
-    const [buildOut, buildErr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
-    if (build.signalCode) {
-      throw new Error(
-        `bun build killed by ${build.signalCode} (took >${buildTimeoutMs}ms); stderr: ${buildErr.slice(0, 500)}`,
-      );
-    }
-    expect(buildErr).not.toContain("error");
-    expect(buildOut).toContain("out.js");
-    expect(buildExit).toBe(0);
-
-    const out = await Bun.file(path.join(String(dir), "out.js")).text();
-    expect(out).toContain("var $x0 = 0;");
-    expect(out).toContain("var $x" + (N - 1) + " = " + (N - 1) + ";");
-    expect(out).toContain("$x0, $x1, $x2,");
-    expect(out).toContain("$x" + (N - 2) + ", $x" + (N - 1));
-  }, 60_000);
 });

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, tempDir } from "harness";
 import path from "node:path";
 import { itBundled } from "./expectBundled";
 
@@ -398,39 +398,61 @@ describe("bundler", () => {
   // Printing each `exports.<name>` reference used to linear-scan the named
   // exports map, making a file with N distinct exports referenced N times
   // take O(N^2). This also covers an O(N^2) debug_assert over part.symbol_uses.
-  test("cjs2esm/ManyNamedExportsPerf", async () => {
-    const N = 25000;
-    const parts: string[] = [];
-    for (let i = 0; i < N; i++) parts.push(`exports.x${i} = ${i};\n`);
-    parts.push("function use() { return [");
-    for (let i = 0; i < N; i++) parts.push(`exports.x${i},`);
-    parts.push("]; }\nexports.use = use;\n");
+  test(
+    "cjs2esm/ManyNamedExportsPerf",
+    async () => {
+      const N = isDebug ? 25000 : 300000;
+      const buildTimeoutMs = isDebug ? 45_000 : 20_000;
+      // Rope-style `+=` so debug JSC stays fast.
+      let lib = "";
+      for (let i = 0; i < N; i++) {
+        lib += "exports.x";
+        lib += i;
+        lib += " = ";
+        lib += i;
+        lib += ";\n";
+      }
+      lib += "function use() { return [";
+      for (let i = 0; i < N; i++) {
+        lib += "exports.x";
+        lib += i;
+        lib += ",";
+      }
+      lib += "]; }\nexports.use = use;\n";
 
-    using dir = tempDir("cjs2esm-many-exports", {
-      "lib.cjs": parts.join(""),
-      "entry.js": `import * as lib from './lib.cjs';\nconsole.log(Object.keys(lib).length);\n`,
-    });
+      using dir = tempDir("cjs2esm-many-exports", {
+        "lib.cjs": lib,
+        "entry.js": `import * as lib from './lib.cjs';\nconsole.log(Object.keys(lib).length);\n`,
+      });
 
-    await using build = Bun.spawn({
-      cmd: [bunExe(), "build", "./entry.js", "--outfile=out.js"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-      timeout: 45_000,
-    });
-    const [buildOut, buildErr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
-    if (build.signalCode) {
-      throw new Error(`bun build killed by ${build.signalCode} (took >45s); stderr: ${buildErr.slice(0, 500)}`);
-    }
-    expect(buildErr).not.toContain("error");
-    expect(buildOut).toContain("out.js");
-    expect(buildExit).toBe(0);
+      await using build = Bun.spawn({
+        cmd: [bunExe(), "build", "./entry.js", "--outfile=out.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: buildTimeoutMs,
+      });
+      const [buildOut, buildErr, buildExit] = await Promise.all([
+        build.stdout.text(),
+        build.stderr.text(),
+        build.exited,
+      ]);
+      if (build.signalCode) {
+        throw new Error(
+          `bun build killed by ${build.signalCode} (took >${buildTimeoutMs}ms); stderr: ${buildErr.slice(0, 500)}`,
+        );
+      }
+      expect(buildErr).not.toContain("error");
+      expect(buildOut).toContain("out.js");
+      expect(buildExit).toBe(0);
 
-    const out = await Bun.file(path.join(String(dir), "out.js")).text();
-    expect(out).toContain(`var $x0 = 0;`);
-    expect(out).toContain(`var $x${N - 1} = ${N - 1};`);
-    expect(out).toContain(`$x0, $x1, $x2,`);
-    expect(out).toContain(`$x${N - 2}, $x${N - 1}`);
-  }, 60_000);
+      const out = await Bun.file(path.join(String(dir), "out.js")).text();
+      expect(out).toContain("var $x0 = 0;");
+      expect(out).toContain("var $x" + (N - 1) + " = " + (N - 1) + ";");
+      expect(out).toContain("$x0, $x1, $x2,");
+      expect(out).toContain("$x" + (N - 2) + ", $x" + (N - 1));
+    },
+    60_000,
+  );
 });


### PR DESCRIPTION
## Problem

When the CJS-to-ESM unwrapping produces `ECommonjsExportIdentifier` nodes (one per `exports.foo` / `module.exports.foo` reference that survives to the printer), `js_printer` linearly scanned `commonjs_named_exports.values()` comparing `.loc_ref.ref_` to the identifier's ref to recover the export name and `needs_decl` flag:

```rust
for (idx, value) in exports.values().iter().enumerate() {
    if value.loc_ref.ref_.eql(id.ref_) {
        found = Some(idx);
        break;
    }
}
```

For a file with N distinct named exports referenced N times (for example inside a function body), that is N scans of N entries, so printing is O(N^2) in the export count.

While investigating I also found a second quadratic loop, debug-only, in `doStep5.rs`: the `for &ref_ in part.symbol_uses.keys()` body re-derives the current key's index via `.iter().position(|k| *k == ref_)` inside a `debug_assert!`, which made the cross-part dependency step O(K^2) in the per-part symbol-use count under `debug_assertions`.

## Fix

- Printer: add a lazy `HashMap<Ref, u32>` reverse index on the `Printer` struct. It is built the first time an `ECommonjsExportIdentifier` is printed (one pass over `values()`) and then every subsequent lookup is O(1). `Ref`'s `Hash`/`Eq` already mask the user-bit lane, so the map resolves correctly even though `ECommonjsExportIdentifier` stores its `base` flag in that lane. Output is byte-identical.
- `doStep5`: switch the loop to `keys().iter().enumerate()` so the assert indexes `values()[j]` directly.

## Numbers

`lib.cjs` with N lines of `exports.xN = N;` plus `function use() { return [exports.x0, ..., exports.xN-1]; }`, bundled via `bun build entry.js`:

| build | N | before | after |
|-|-|-|-|
| release | 160000 | 8.9s | linear with decls-only baseline (~0.6s) |
| debug+ASAN | 25000 | 77.4s | 4.8s |
| debug+ASAN | 20000 | 55.3s | 4.2s |
| debug+ASAN | 5000 | 5.15s | 1.29s |

Output bytes are identical before and after at every N.

## Not changed

The handoff that flagged this also mentioned the `Vec<&ClauseItem>` allocation in `SExportClause` (`js_printer/lib.rs:5665`). I evaluated it: the filter loop has print side effects (it emits `var x = ns.alias;` for namespace-property-access clauses) and `swap_remove` reorders the remaining items, so avoiding the allocation in the common no-filter case would require either duplicating the ~25-line print loop or adding an enum-iterator adapter. It allocates one small `Vec` of pointers per `export { ... }` statement, which is negligible next to the per-reference quadratic scan, so I left it alone to keep this change focused.

## Test

Correctness is covered by the existing `cjs2esm` cases in `test/bundler/bundler_cjs2esm.test.ts` (in particular `ModuleExportsRenamingNoDeopt` and friends exercise the `ECommonjsExportIdentifier` print path). A large-N hang-guard test was tried in an earlier revision but dropped because it added ~10s to the bundler suite per run; the numbers above can be reproduced with the snippet in the Problem section.
