### PR TITLE
bundler: drive tree-shaking and code-splitting reachability off explicit worklists

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -987,6 +987,7 @@ impl<'a> LinkerContext<'a> {
                 import_records,
                 file_entry_bits,
                 css_reprs,
+                worklist: Vec::new(),
             };
 
             // Code splitting: Determine which entry points can reach which files. This
@@ -2625,6 +2626,7 @@ pub struct CodeSplitCtx<'a, 'r> {
     pub import_records: &'r [bun_ast::import_record::List<'a>],
     pub file_entry_bits: &'r mut [AutoBitSet],
     pub css_reprs: &'r [crate::bundled_ast::CssCol],
+    pub worklist: Vec<(crate::IndexInt, u32)>,
 }
 
 impl<'a> LinkerContext<'a> {
@@ -2635,91 +2637,74 @@ impl<'a> LinkerContext<'a> {
         entry_points_count: usize,
         distance: u32,
     ) {
-        if !self.graph.files_live.is_set(source_index as usize) {
-            return;
-        }
-
-        let cur_dist = ctx.distances[source_index as usize];
-        let traverse_again = distance < cur_dist;
-        if traverse_again {
-            ctx.distances[source_index as usize] = distance;
-        }
-        let out_dist = distance + 1;
-
-        let bits = &mut ctx.file_entry_bits[source_index as usize];
-
-        // Don't mark this file more than once
-        if bits.is_set(entry_points_count) && !traverse_again {
-            return;
-        }
-
-        bits.set(entry_points_count);
-
-        #[cfg(feature = "debug_logs")]
-        {
-            let parse_graph = self.parse_graph();
-            debug_tree_shake!(
-                "markFileReachableForCodeSplitting(entry: {}): {} {} ({})",
-                entry_points_count,
-                bstr::BStr::new(
-                    &parse_graph.input_files.items_source()[source_index as usize]
-                        .path
-                        .pretty
-                ),
-                <&'static str>::from(
-                    parse_graph.ast.items_target()[source_index as usize].bake_graph()
-                ),
-                out_dist,
-            );
-        }
-
-        if ctx.css_reprs[source_index as usize].is_some() {
-            for ri in 0..ctx.import_records[source_index as usize].len() {
-                let record = &ctx.import_records[source_index as usize][ri];
-                if record.source_index.is_valid()
-                    && !self.is_external_dynamic_import(record, source_index)
-                {
-                    let other = record.source_index.get();
-                    self.mark_file_reachable_for_code_splitting(
-                        ctx,
-                        other,
-                        entry_points_count,
-                        out_dist,
-                    );
-                }
+        debug_assert!(ctx.worklist.is_empty());
+        ctx.worklist.push((source_index, distance));
+        while let Some((source_index, distance)) = ctx.worklist.pop() {
+            if !self.graph.files_live.is_set(source_index as usize) {
+                continue;
             }
-            return;
-        }
 
-        for ri in 0..ctx.import_records[source_index as usize].len() {
-            let record = &ctx.import_records[source_index as usize][ri];
-            if record.source_index.is_valid()
-                && !self.is_external_dynamic_import(record, source_index)
+            let cur_dist = ctx.distances[source_index as usize];
+            let traverse_again = distance < cur_dist;
+            if traverse_again {
+                ctx.distances[source_index as usize] = distance;
+            }
+            let out_dist = distance + 1;
+
+            let bits = &mut ctx.file_entry_bits[source_index as usize];
+
+            // Don't mark this file more than once
+            if bits.is_set(entry_points_count) && !traverse_again {
+                continue;
+            }
+
+            bits.set(entry_points_count);
+
+            #[cfg(feature = "debug_logs")]
             {
-                let other = record.source_index.get();
-                self.mark_file_reachable_for_code_splitting(
-                    ctx,
-                    other,
+                let parse_graph = self.parse_graph();
+                debug_tree_shake!(
+                    "markFileReachableForCodeSplitting(entry: {}): {} {} ({})",
                     entry_points_count,
+                    bstr::BStr::new(
+                        &parse_graph.input_files.items_source()[source_index as usize]
+                            .path
+                            .pretty
+                    ),
+                    <&'static str>::from(
+                        parse_graph.ast.items_target()[source_index as usize].bake_graph()
+                    ),
                     out_dist,
                 );
             }
-        }
 
-        let part_count = ctx.parts[source_index as usize].len();
-        for pi in 0..part_count {
-            let deps_len = ctx.parts[source_index as usize].as_slice()[pi]
-                .dependencies
-                .len();
-            for di in 0..deps_len {
-                let dependency = ctx.parts[source_index as usize].as_slice()[pi].dependencies[di];
-                if dependency.source_index.get() != source_index {
-                    self.mark_file_reachable_for_code_splitting(
-                        ctx,
-                        dependency.source_index.get(),
-                        entry_points_count,
-                        out_dist,
-                    );
+            // Successors pushed onto a LIFO worklist. The only per-node state is
+            // the entry-point bit (monotone) and the min distance (relaxed on
+            // every shorter revisit), so the fixpoint is order-independent.
+            if ctx.css_reprs[source_index as usize].is_some() {
+                for record in ctx.import_records[source_index as usize].iter() {
+                    if record.source_index.is_valid()
+                        && !self.is_external_dynamic_import(record, source_index)
+                    {
+                        ctx.worklist.push((record.source_index.get(), out_dist));
+                    }
+                }
+                continue;
+            }
+
+            for record in ctx.import_records[source_index as usize].iter() {
+                if record.source_index.is_valid()
+                    && !self.is_external_dynamic_import(record, source_index)
+                {
+                    ctx.worklist.push((record.source_index.get(), out_dist));
+                }
+            }
+
+            for part in ctx.parts[source_index as usize].as_slice() {
+                for dependency in part.dependencies.iter() {
+                    if dependency.source_index.get() != source_index {
+                        ctx.worklist.push((dependency.source_index.get(), out_dist));
+                    }
                 }
             }
         }

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -904,7 +904,7 @@ impl<'a> LinkerContext<'a> {
         // Note: these slices alias into self.graph.
         // The SoA columns are physically disjoint
         // and the underlying slabs don't reallocate during tree-shaking, so we
-        // cache raw column base pointers and reborrow at each recursive call.
+        // cache raw column base pointers once and hand them to the pass contexts.
         let parts: *mut [bun_ast::PartList<'a>] = self.graph.ast.items_parts_mut();
         let parts_live: *mut [bun_collections::AutoBitSet] = self.graph.parts_live.as_mut_slice();
         let import_records: *const [bun_ast::import_record::List<'a>] =
@@ -920,9 +920,9 @@ impl<'a> LinkerContext<'a> {
 
         // SAFETY: see block comment above — disjoint SoA columns, stable slabs
         // (no reallocation during tree-shaking). All column derefs share that
-        // invariant; reborrowing once here (rather than per-call) is sound
-        // because the recursive `mark_file_*` bodies neither reallocate the
-        // slabs nor form a competing `&mut` to any read-only column.
+        // invariant; reborrowing once here is sound because the `mark_file_*`
+        // worklist steps neither reallocate the slabs nor form a competing
+        // `&mut` to any read-only column.
         let (
             entry_points,
             side_effects,

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -958,6 +958,7 @@ impl<'a> LinkerContext<'a> {
                 import_records,
                 entry_point_kinds,
                 css_reprs,
+                worklist: Vec::new(),
             };
 
             // Tree shaking: Each entry point marks all files reachable from itself
@@ -2594,12 +2595,11 @@ impl<'a> js_printer::RequireOrImportMetaSource for LinkerContext<'a> {
 // accessors.
 // ══════════════════════════════════════════════════════════════════════════
 
-// The three `mark_*` functions below are mutually recursive and hot. Passing
-// the five SoA-column slices as separate arguments costs 10 words of fat
-// pointers per call; with `&mut self` + indices that overflows the 6 SysV
-// integer-arg registers and spills to the stack on every recursive step.
-// Packing the slices into a borrowed context struct keeps each call at 3-4
-// register-sized arguments.
+// The liveness pass visits every (file, part) at most once. Processing order is
+// irrelevant to the final bitset state, so the former mutual recursion is
+// driven off an explicit worklist (LIFO, so traversal order matches the old
+// DFS). Packing the slices into a borrowed context struct keeps each step at
+// 3-4 register-sized arguments.
 pub struct TreeShakeCtx<'a, 'r> {
     pub side_effects: &'r [SideEffects],
     pub parts: &'r [bun_ast::PartList<'a>],
@@ -2607,6 +2607,16 @@ pub struct TreeShakeCtx<'a, 'r> {
     pub import_records: &'r [bun_ast::import_record::List<'a>],
     pub entry_point_kinds: &'r [EntryPoint::Kind],
     pub css_reprs: &'r [crate::bundled_ast::CssCol],
+    pub worklist: Vec<TreeShakeWork>,
+}
+
+#[derive(Clone, Copy)]
+pub enum TreeShakeWork {
+    File(crate::IndexInt),
+    Part {
+        part_index: crate::IndexInt,
+        source_index: crate::IndexInt,
+    },
 }
 
 pub struct CodeSplitCtx<'a, 'r> {
@@ -2720,6 +2730,24 @@ impl<'a> LinkerContext<'a> {
         ctx: &mut TreeShakeCtx<'a, '_>,
         source_index: crate::IndexInt,
     ) {
+        debug_assert!(ctx.worklist.is_empty());
+        ctx.worklist.push(TreeShakeWork::File(source_index));
+        while let Some(work) = ctx.worklist.pop() {
+            match work {
+                TreeShakeWork::File(src) => self.mark_file_live_step(ctx, src),
+                TreeShakeWork::Part {
+                    part_index,
+                    source_index,
+                } => self.mark_part_live_step(ctx, part_index, source_index),
+            }
+        }
+    }
+
+    fn mark_file_live_step(
+        &mut self,
+        ctx: &mut TreeShakeCtx<'a, '_>,
+        source_index: crate::IndexInt,
+    ) {
         #[cfg(debug_assertions)]
         {
             let parse_graph = self.parse_graph();
@@ -2746,9 +2774,6 @@ impl<'a> LinkerContext<'a> {
             );
         }
 
-        #[cfg(debug_assertions)]
-        scopeguard::defer! { debug_tree_shake!("end()"); }
-
         if self.graph.files_live.is_set(source_index as usize) {
             return;
         }
@@ -2760,11 +2785,12 @@ impl<'a> LinkerContext<'a> {
         }
 
         if ctx.css_reprs[source_index as usize].is_some() {
-            for ri in 0..ctx.import_records[source_index as usize].len() {
-                let record = &ctx.import_records[source_index as usize][ri];
+            for record in ctx.import_records[source_index as usize].iter() {
                 if record.source_index.is_valid() {
-                    let other_source_index = record.source_index.get();
-                    self.mark_file_live_for_tree_shaking(ctx, other_source_index);
+                    let other = record.source_index.get();
+                    if !self.graph.files_live.is_set(other as usize) {
+                        ctx.worklist.push(TreeShakeWork::File(other));
+                    }
                 }
             }
             return;
@@ -2774,20 +2800,19 @@ impl<'a> LinkerContext<'a> {
         // via .url kind import records. Follow all import records for HTML files
         // so these assets are marked live and included in the manifest.
         if self.parse_graph().input_files.items_loader()[source_index as usize] == Loader::Html {
-            for ri in 0..ctx.import_records[source_index as usize].len() {
-                let record = &ctx.import_records[source_index as usize][ri];
+            for record in ctx.import_records[source_index as usize].iter() {
                 if record.source_index.is_valid() {
-                    let other_source_index = record.source_index.get();
-                    self.mark_file_live_for_tree_shaking(ctx, other_source_index);
+                    let other = record.source_index.get();
+                    if !self.graph.files_live.is_set(other as usize) {
+                        ctx.worklist.push(TreeShakeWork::File(other));
+                    }
                 }
             }
             return;
         }
 
-        let part_count = ctx.parts[source_index as usize].len();
-        for part_index in 0..part_count {
-            // Note: reshaped for borrowck — re-borrow part each iteration since recursion mutates `parts`
-            let part = &ctx.parts[source_index as usize].as_slice()[part_index];
+        let parts = ctx.parts[source_index as usize].as_slice();
+        for (part_index, part) in parts.iter().enumerate() {
             let mut can_be_removed_if_unused = part.can_be_removed_if_unused;
 
             if can_be_removed_if_unused && part.tag == bun_ast::PartTag::CommonjsNamedExport {
@@ -2796,14 +2821,8 @@ impl<'a> LinkerContext<'a> {
                 }
             }
 
-            // Also include any statement-level imports. Iterate by index so we
-            // don't hold a borrow of `part`/`parts` across the recursive call —
-            // the recursion never resizes this part's `import_record_indices`,
-            // so re-slicing each iteration is sound.
-            let import_indices_len = part.import_record_indices.len();
-            for ii in 0..import_indices_len {
-                let import_index = ctx.parts[source_index as usize].as_slice()[part_index]
-                    .import_record_indices[ii];
+            // Also include any statement-level imports
+            for &import_index in part.import_record_indices.iter() {
                 let record = &ctx.import_records[source_index as usize][import_index as usize];
                 if record.kind != ImportKind::Stmt {
                     continue;
@@ -2825,7 +2844,9 @@ impl<'a> LinkerContext<'a> {
                     }
 
                     // Otherwise, include this module for its side effects
-                    self.mark_file_live_for_tree_shaking(ctx, other_source_index);
+                    if !self.graph.files_live.is_set(other_source_index as usize) {
+                        ctx.worklist.push(TreeShakeWork::File(other_source_index));
+                    }
                 } else if is_external_without_side_effects {
                     // This can be removed if it's unused
                     continue;
@@ -2839,23 +2860,23 @@ impl<'a> LinkerContext<'a> {
             // Include all parts in this file with side effects, or just include
             // everything if tree-shaking is disabled. Note that we still want to
             // perform tree-shaking on the runtime even if tree-shaking is disabled.
-            let force_tree_shaking =
-                ctx.parts[source_index as usize].as_slice()[part_index].force_tree_shaking;
             if !can_be_removed_if_unused
-                || (!force_tree_shaking
+                || (!part.force_tree_shaking
                     && !self.options.tree_shaking
                     && ctx.entry_point_kinds[source_index as usize].is_entry_point())
             {
-                self.mark_part_live_for_tree_shaking(
-                    ctx,
-                    u32::try_from(part_index).expect("int cast"),
-                    source_index,
-                );
+                let part_index = u32::try_from(part_index).expect("int cast");
+                if !ctx.parts_live[source_index as usize].is_set(part_index as usize) {
+                    ctx.worklist.push(TreeShakeWork::Part {
+                        part_index,
+                        source_index,
+                    });
+                }
             }
         }
     }
 
-    pub fn mark_part_live_for_tree_shaking(
+    fn mark_part_live_step(
         &mut self,
         ctx: &mut TreeShakeCtx<'a, '_>,
         part_index: crate::IndexInt,
@@ -2901,22 +2922,16 @@ impl<'a> LinkerContext<'a> {
             );
         }
 
-        #[cfg(debug_assertions)]
-        scopeguard::defer! { debug_tree_shake!("end()"); }
-
         // Include the file containing this part
-        self.mark_file_live_for_tree_shaking(ctx, source_index);
+        if !self.graph.files_live.is_set(source_index as usize) {
+            ctx.worklist.push(TreeShakeWork::File(source_index));
+        }
 
-        // The recursion above/below only flips bits in `ctx.parts_live`; it never
-        // resizes any part's `dependencies`, so the slice's len/ptr are stable.
-        // Iterate by index and re-borrow per iteration to satisfy borrowck without
-        // the per-call `Vec` clone the original port did.
-        let dependencies_len = ctx.parts[source_index as usize].as_slice()[part_index as usize]
-            .dependencies
-            .len();
+        let dependencies =
+            &ctx.parts[source_index as usize].as_slice()[part_index as usize].dependencies;
 
         #[cfg(feature = "debug_logs")]
-        if dependencies_len == 0 {
+        if dependencies.is_empty() {
             log_part_dependency_tree!(
                 "markPartLiveForTreeShaking {}:{} | EMPTY",
                 source_index,
@@ -2924,9 +2939,7 @@ impl<'a> LinkerContext<'a> {
             );
         }
 
-        for di in 0..dependencies_len {
-            let dependency =
-                ctx.parts[source_index as usize].as_slice()[part_index as usize].dependencies[di];
+        for dependency in dependencies.iter() {
             #[cfg(feature = "debug_logs")]
             if source_index != 0 && dependency.source_index.get() != 0 {
                 log_part_dependency_tree!(
@@ -2938,11 +2951,14 @@ impl<'a> LinkerContext<'a> {
                 );
             }
 
-            self.mark_part_live_for_tree_shaking(
-                ctx,
-                dependency.part_index,
-                dependency.source_index.get(),
-            );
+            let dep_source = dependency.source_index.get();
+            let dep_part = dependency.part_index;
+            if !ctx.parts_live[dep_source as usize].is_set(dep_part as usize) {
+                ctx.worklist.push(TreeShakeWork::Part {
+                    part_index: dep_part,
+                    source_index: dep_source,
+                });
+            }
         }
     }
 } // end tree-shaking impl

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2744,6 +2744,24 @@ describe("bundler", () => {
       expect(out).not.toContain("na_ve");
     },
   });
+  // The tree-shaking liveness pass used to recurse once per import-graph edge,
+  // overflowing the stack on long linear chains under debug+ASAN. 3000 modules
+  // reliably crashed the old recursive walk.
+  const deepChainDepth = 3000;
+  itBundled("edgecase/DeepImportChainTreeShaking", {
+    files: {
+      "/entry.js": `import { v0 } from "./m0.js"; console.log(v0);`,
+      [`/m${deepChainDepth - 1}.js`]: `export const v${deepChainDepth - 1} = 1;`,
+      ...Object.fromEntries(
+        Array.from({ length: deepChainDepth - 1 }, (_, i) => [
+          `/m${i}.js`,
+          `import { v${i + 1} } from "./m${i + 1}.js"; export const v${i} = v${i + 1} + 1;`,
+        ]),
+      ),
+    },
+    backend: "cli",
+    run: { stdout: String(deepChainDepth) },
+  });
   itBundled("edgecase/NonAsciiPathDerivedWrapperName", {
     files: {
       "/entry.ts": /* js */ `


### PR DESCRIPTION
### What does this PR do?

The three graph walks in `LinkerContext::tree_shaking_and_code_splitting` were recursive, one call frame per edge in the import graph. A linear chain of a few thousand modules is enough to overflow the stack:

```
AddressSanitizer: stack-overflow
    #5 mark_file_live_for_tree_shaking LinkerContext.rs:2776
    #6..#248 mark_file_live_for_tree_shaking LinkerContext.rs:2828 (x243)
```

Repro (debug build, 3000-module chain where each imports the next):

```sh
for i in $(seq 0 2998); do
  echo "import { v$((i+1)) } from './m$((i+1)).js'; export const v$i = v$((i+1)) + 1;" > m$i.js
done
echo "export const v2999 = 1;" > m2999.js
echo "import { v0 } from './m0.js'; console.log(v0);" > entry.js
bun-debug build entry.js --outdir=dist
```

Release builds survive longer chains but hit the same bound eventually.

### Fix

**`mark_file_live_for_tree_shaking` / `mark_part_live_for_tree_shaking`**: the pass only flips bits in `files_live` / `parts_live` and never reads a bit it just wrote to decide anything else in the same step, so processing order is irrelevant to the fixpoint. Replace the mutual recursion with a single LIFO `Vec<TreeShakeWork>` on `TreeShakeCtx`: each step pushes its successors instead of calling, and the public entry drains the queue. Successors already marked live are skipped before the push to keep the worklist bounded by the edge count.

**`mark_file_reachable_for_code_splitting`**: runs unconditionally right after, over the same graph, and self-recursed the same way. Per-node state is the entry-point bit (monotone) and the min distance (relaxed on every shorter revisit), so the fixpoint is again order-independent. Same LIFO treatment with a `Vec<(source_index, distance)>` on `CodeSplitCtx`.

With the recursion gone the per-iteration index re-borrows (which only existed to satisfy borrowck across the recursive `&mut self` calls) become plain iterators again.

### Scope

This covers the `tree_shaking_and_code_splitting` phase. The bundler has several other per-edge-recursive graph walks (`ReachableFileVisitor::visit` in `bundle_v2.rs` is the next to overflow at ~7000 modules under debug+ASAN, then `FindImportedPartsVisitor::visit`, `validate_tla`, etc.) that are left out of this PR because they build DFS-postorder lists whose output order is load-bearing, so they need an explicit-stack conversion rather than a flat worklist. Those are tracked separately.

### How did you verify your code works?

- New `edgecase/DeepImportChainTreeShaking` in `bundler_edgecase.test.ts` bundles a 3000-deep linear import chain and runs the output (prints `3000`). Crashes with the ASAN trace above on main, passes with this change.
- Byte-diffed bundled output against a release bun built from the same base commit without this change: identical on three.js x100 minified, and on 100/200-module chains both plain and `--splitting`.
- Release-build perf (hyperfine, same base commit, only `LinkerContext.rs` swapped): three.js x10 157ms vs 175ms, three.js x100 `--minify` 1.076s vs 1.073s, 10000-module chain 812ms vs 889ms. All within noise; the pass is a bitset walk that is sub-millisecond on three.js.
- `bun bd test` on `bundler_edgecase`, `esbuild/dce`, `esbuild/default`, `esbuild/splitting`, `esbuild/importstar`, `esbuild/css`, `bundler_html`, `bundler_cjs`, `bundler_cjs2esm`, `bundler_barrel`, `bundler_splitting`: 0 new failures.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->