### PR TITLE
test/bundler: destructure timeoutScale so tests that set it aren't silently dropped

### DIFF
--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -554,8 +554,7 @@ function expectBundled(
     onAfterApiBundle,
     throw: _throw = false,
     // Consumed by itBundled for test-registration timeout, not here. Destructured so it
-    // doesn't land in unknownProps (whose throw the dry-run swallows, silently dropping
-    // the test). edgecase/AwsCdkLib and plugin/ResolveManySegfault were both hit by this.
+    // doesn't land in unknownProps (whose throw the dry-run swallows, silently dropping the test).
     timeoutScale: _timeoutScale,
     ...unknownProps
   } = opts;

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -553,6 +553,10 @@ function expectBundled(
     generateOutput = true,
     onAfterApiBundle,
     throw: _throw = false,
+    // Consumed by itBundled for test-registration timeout, not here. Destructured so it
+    // doesn't land in unknownProps (whose throw the dry-run swallows, silently dropping
+    // the test). edgecase/AwsCdkLib and plugin/ResolveManySegfault were both hit by this.
+    timeoutScale: _timeoutScale,
     ...unknownProps
   } = opts;
 

--- a/test/bundler/itBundled-options.test.ts
+++ b/test/bundler/itBundled-options.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { itBundled } from "./expectBundled";
+
+// expectBundled throws on any BundlerTestInput field it doesn't destructure. itBundled
+// swallows that throw in its registration-time dry-run, so an undestructured option
+// silently drops the test instead of failing it. This file guards harness-only options.
+describe("bundler", () => {
+  itBundled("options/AcceptsTimeoutScale", {
+    files: {
+      "/entry.js": `console.log("timeoutScale ok");`,
+    },
+    run: { stdout: "timeoutScale ok" },
+    timeoutScale: 1,
+  });
+});
+
+test("itBundled registers tests that set timeoutScale (not silently skipped)", async () => {
+  // Without the fix this reports "matched 0 tests": timeoutScale fell into unknownProps,
+  // the dry-run threw, and itBundled swallowed it. Same path dropped edgecase/AwsCdkLib
+  // and plugin/ResolveManySegfault on main.
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", import.meta.path, "-t", "AcceptsTimeoutScale"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const output = stdout + stderr;
+  expect(output).toContain("options/AcceptsTimeoutScale");
+  expect(output).not.toContain("matched 0 tests");
+  expect(exitCode).toBe(0);
+});

--- a/test/bundler/itBundled-options.test.ts
+++ b/test/bundler/itBundled-options.test.ts
@@ -7,10 +7,7 @@ import { itBundled } from "./expectBundled";
 // silently drops the test instead of failing it. This file guards harness-only options.
 describe("bundler", () => {
   itBundled("options/AcceptsTimeoutScale", {
-    files: {
-      "/entry.js": `console.log("timeoutScale ok");`,
-    },
-    run: { stdout: "timeoutScale ok" },
+    files: { "/entry.js": `console.log("timeoutScale ok");` },
     timeoutScale: 1,
   });
 });
@@ -24,13 +21,18 @@ test.skipIf(isWindows)("itBundled registers tests that set timeoutScale (not sil
   // and plugin/ResolveManySegfault on main.
   await using proc = Bun.spawn({
     cmd: [bunExe(), "test", import.meta.path, "-t", "AcceptsTimeoutScale"],
-    env: bunEnv,
+    env: {
+      ...bunEnv,
+      BUN_BUNDLER_TEST_USE_ESBUILD: undefined,
+      BUN_BUNDLER_TEST_FILTER: undefined,
+      BUN_BUNDLER_TEST_DEBUG: undefined,
+    },
     stdout: "pipe",
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   const output = stdout + stderr;
   expect(output).toContain("options/AcceptsTimeoutScale");
-  expect(output).not.toContain("matched 0 tests");
+  expect(output).toContain("1 pass");
   expect(exitCode).toBe(0);
 });

--- a/test/bundler/itBundled-options.test.ts
+++ b/test/bundler/itBundled-options.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 import { itBundled } from "./expectBundled";
 
 // expectBundled throws on any BundlerTestInput field it doesn't destructure. itBundled
@@ -15,7 +15,10 @@ describe("bundler", () => {
   });
 });
 
-test("itBundled registers tests that set timeoutScale (not silently skipped)", async () => {
+// On Windows the `new Error().stack!.includes("test/bundler/")` check at the top of
+// expectBundled sees backslashes and throws, which itBundled swallows, so every itBundled
+// test is silently dropped there regardless of timeoutScale. Tracked separately.
+test.skipIf(isWindows)("itBundled registers tests that set timeoutScale (not silently skipped)", async () => {
   // Without the fix this reports "matched 0 tests": timeoutScale fell into unknownProps,
   // the dry-run threw, and itBundled swallowed it. Same path dropped edgecase/AwsCdkLib
   // and plugin/ResolveManySegfault on main.


### PR DESCRIPTION
### Problem

`expectBundled` destructures every known `BundlerTestInput` field and throws on anything left in `...unknownProps`:

```ts
if (Object.keys(unknownProps).length > 0) {
  throw new Error("expectBundled received unexpected options: " + Object.keys(unknownProps).join(", "));
}
```

`itBundled` wraps its registration-time dry-run in a `try`/`catch` that returns without calling `it()` when that throws:

```ts
try {
  expectBundled(id, opts, true);
} catch (error) {
  return ref;
}
```

`timeoutScale` is declared in `BundlerTestInput` and consumed by `itBundled` for the per-test timeout, but was never added to `expectBundled`'s destructure block. So any test that sets `timeoutScale` throws on the dry-run, the `catch` swallows it, and the test is never registered with `bun:test`.

On `main` this silently drops two tests:

```console
$ bun test test/bundler/bundler_edgecase.test.ts -t AwsCdkLib
error: regex "AwsCdkLib" matched 0 tests. Searched 1 file (skipping 127 tests)

$ bun test test/bundler/bundler_plugin.test.ts -t ResolveManySegfault
error: regex "ResolveManySegfault" matched 0 tests. Searched 1 file (skipping 55 tests)
```

### Fix

Destructure `timeoutScale` in `expectBundled` so it doesn't land in `unknownProps`. It's unused in the body (itBundled reads it from `opts` directly).

With the fix both tests register and pass:

```console
$ bun test test/bundler/bundler_edgecase.test.ts -t AwsCdkLib
(pass) bundler > edgecase/AwsCdkLib [1222.19ms]

$ bun test test/bundler/bundler_plugin.test.ts -t ResolveManySegfault
(pass) bundler > plugin/ResolveManySegfault [99.45ms]
```

`bundler_edgecase.test.ts` goes from 127 registered tests to 128, `bundler_plugin.test.ts` from 55 to 56.

### Test

`test/bundler/itBundled-options.test.ts` adds a trivial `itBundled` with `timeoutScale: 1` and a spawn-based assertion that the test was actually registered (before the fix the spawned `bun test -t AcceptsTimeoutScale` reports `matched 0 tests` and the assertion fails). This fails loudly if a future harness-only option falls into `unknownProps` the same way.

The spawn assertion is skipped on Windows: `expectBundled`'s `new Error().stack!.includes("test/bundler/")` check sees backslashes there and throws, which `itBundled` swallows, so every `itBundled` test is already silently dropped on Windows regardless of `timeoutScale`. That's a separate pre-existing bug with much larger blast radius (it re-enables the entire bundler suite on Windows) and is tracked separately.

### Note

The fix is entirely under `test/` (test-harness code). The automated fail-before check stashes `src/` and `packages/` only, so it will not observe the bug with the diff reverted; the before/after evidence above is the direct equivalent. Other `BundlerTestInput` fields for unimplemented bundler options (`mangleProps`, `alias`, `nodePaths`, `extensionOrder`, `targetFromAPI`, `skipIfWeDidNotImplementWildcardSideEffects`) take the same path, which appears to be the intended skip mechanism for those, so they are left alone; `timeoutScale` is different in that it is already implemented in `itBundled` and was only missing from the destructure.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->