### PR TITLE
sourcemap: reserve capacity and batch ';' in InternalSourceMap append_vlq_to

### DIFF
--- a/bench/sourcemap/append-vlq-bench.ts
+++ b/bench/sourcemap/append-vlq-bench.ts
@@ -1,0 +1,76 @@
+// Microbench for InternalSourceMap.append_vlq_to() (re-encoding the internal
+// blob back to a standard VLQ "mappings" string). Compare against a baseline
+// build by running:
+//
+//   bun run build:release bench/sourcemap/append-vlq-bench.ts
+//
+// This path is hit by the inspector inline-sourcemap emit and by
+// ParsedSourceMap.write_vlqs / Chunk.print_source_map_contents_from_internal,
+// not by stack remapping (see internal-sourcemap-bench.ts for that).
+
+// @ts-expect-error bun:internal-for-testing has no .d.ts
+import { internalSourceMap } from "bun:internal-for-testing";
+
+const ITER = 50;
+const flag = process.argv[2] ?? "bench";
+
+const B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+function encodeVLQ(value: number): string {
+  let v = value < 0 ? (-value << 1) | 1 : value << 1;
+  let out = "";
+  do {
+    let digit = v & 31;
+    v >>>= 5;
+    if (v > 0) digit |= 32;
+    out += B64[digit];
+  } while (v > 0);
+  return out;
+}
+
+// ~200k mappings across 50k generated lines: exercises the per-mapping encode
+// and the upfront capacity reservation.
+function buildDense(): string {
+  const parts: string[] = [];
+  let prevGenCol = 0;
+  let prevOrigLine = 0;
+  let prevOrigCol = 0;
+  for (let line = 0; line < 50_000; line++) {
+    let col = 0;
+    for (let k = 0; k < 4; k++) {
+      col += 3 + k;
+      const ocol = prevOrigCol + 3 + k;
+      if (k > 0) parts.push(",");
+      parts.push(
+        encodeVLQ(col - prevGenCol) + encodeVLQ(0) + encodeVLQ(line - prevOrigLine) + encodeVLQ(ocol - prevOrigCol),
+      );
+      prevGenCol = col;
+      prevOrigLine = line;
+      prevOrigCol = ocol;
+    }
+    parts.push(";");
+    prevGenCol = 0;
+  }
+  return parts.join("");
+}
+
+// Two mappings separated by a 5M-line run of ';': exercises the batched
+// line-separator write.
+function buildGap(): string {
+  return "AAAA" + Buffer.alloc(5_000_000, ";").toString() + "AAAA";
+}
+
+function run(name: string, blob: Uint8Array) {
+  // Warm.
+  let out = internalSourceMap.toVLQ(blob);
+  for (let i = 0; i < 4; i++) out = internalSourceMap.toVLQ(blob);
+
+  const t0 = performance.now();
+  for (let i = 0; i < ITER; i++) out = internalSourceMap.toVLQ(blob);
+  const t1 = performance.now();
+  console.log(
+    `[${flag}] ${name.padEnd(30)} ${((t1 - t0) / ITER).toFixed(3)} ms/op  (${out.length} bytes, ${ITER} iters)`,
+  );
+}
+
+run("200k mappings, 50k lines:", internalSourceMap.fromVLQ(buildDense()));
+run("2 mappings, 5M-line gap:", internalSourceMap.fromVLQ(buildGap()));

--- a/src/sourcemap/InternalSourceMap.rs
+++ b/src/sourcemap/InternalSourceMap.rs
@@ -915,7 +915,7 @@ fn emit_vlq(
 ) {
     if *generated_line < state.generated_line {
         let gap = (state.generated_line - *generated_line) as usize;
-        let _ = out.append_char_n_times(b';', gap);
+        out.list.resize(out.list.len() + gap, b';');
         prev.generated_column = 0;
         *generated_line = state.generated_line;
     }

--- a/src/sourcemap/InternalSourceMap.rs
+++ b/src/sourcemap/InternalSourceMap.rs
@@ -883,6 +883,12 @@ impl InternalSourceMap {
     /// the inspector's inline-sourcemap path needs this.
     pub fn append_vlq_to(self, out: &mut MutableString) {
         let n_sync = self.sync_count();
+        // A 4-field VLQ segment averages ~5 bytes plus a separator. Cap by the
+        // structural bound so a crafted header can't force an unbounded reserve.
+        let count = self
+            .mapping_count()
+            .min((n_sync as usize).saturating_mul(SYNC_INTERVAL));
+        let _ = out.grow_if_needed(count.saturating_mul(6));
         let mut prev = SourceMapState::default();
         let mut generated_line: i32 = 0;
 
@@ -907,10 +913,11 @@ fn emit_vlq(
     generated_line: &mut i32,
     out: &mut MutableString,
 ) {
-    while *generated_line < state.generated_line {
-        out.list.push(b';');
+    if *generated_line < state.generated_line {
+        let gap = (state.generated_line - *generated_line) as usize;
+        let _ = out.append_char_n_times(b';', gap);
         prev.generated_column = 0;
-        *generated_line += 1;
+        *generated_line = state.generated_line;
     }
     let current = SourceMapState {
         generated_line: state.generated_line,

--- a/test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts
+++ b/test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts
@@ -294,6 +294,46 @@ describe("InternalSourceMap.toVLQ", () => {
 });
 
 describe("InternalSourceMap round-trip", () => {
+  test("large blank-line run and many mappings re-encode byte-identically", () => {
+    // append_vlq_to() reserves mapping_count * 6 bytes upfront and writes
+    // multi-line `;` gaps in one shot; this input exercises both with a
+    // 50 000-line gap and >2000 mappings (many sync windows).
+    let vlqIn = "";
+    let prevGenCol = 0;
+    let prevOrigLine = 0;
+    let prevOrigCol = 0;
+    const emit = (genCol: number, origLine: number, origCol: number) => {
+      if (vlqIn.length && !vlqIn.endsWith(";")) vlqIn += ",";
+      vlqIn += encodeVLQ(genCol - prevGenCol) + encodeVLQ(0) + encodeVLQ(origLine - prevOrigLine) + encodeVLQ(origCol - prevOrigCol);
+      prevGenCol = genCol;
+      prevOrigLine = origLine;
+      prevOrigCol = origCol;
+    };
+    const newline = (n: number) => {
+      vlqIn += Buffer.alloc(n, ";").toString();
+      prevGenCol = 0;
+    };
+    for (let line = 0; line < 500; line++) {
+      for (let k = 0; k < 4; k++) emit(k * 4, line, k * 3);
+      newline(1);
+    }
+    newline(50_000);
+    emit(0, 600, 0);
+    newline(1);
+    for (let k = 0; k < 100; k++) emit(k * 2, 601, k * 2);
+
+    const reference = decodeMappings(vlqIn);
+    expect(reference.length).toBe(2101);
+
+    const blob = internalSourceMap.fromVLQ(vlqIn);
+    const vlqOut = internalSourceMap.toVLQ(blob);
+
+    // The gap re-encodes as exactly 50 001 consecutive ';'.
+    expect(vlqOut.indexOf(Buffer.alloc(50_001, ";").toString())).toBeGreaterThan(0);
+    // Semantics preserved end to end.
+    expect(decodeMappings(vlqOut)).toEqual(reference);
+  });
+
   test("synthetic: fromVLQ → toVLQ preserves all 4-field positions; names dropped, 1-field skipped", () => {
     const vlqIn = buildSyntheticVLQ();
     const reference = decodeMappings(vlqIn);

--- a/test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts
+++ b/test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts
@@ -304,7 +304,11 @@ describe("InternalSourceMap round-trip", () => {
     let prevOrigCol = 0;
     const emit = (genCol: number, origLine: number, origCol: number) => {
       if (vlqIn.length && !vlqIn.endsWith(";")) vlqIn += ",";
-      vlqIn += encodeVLQ(genCol - prevGenCol) + encodeVLQ(0) + encodeVLQ(origLine - prevOrigLine) + encodeVLQ(origCol - prevOrigCol);
+      vlqIn +=
+        encodeVLQ(genCol - prevGenCol) +
+        encodeVLQ(0) +
+        encodeVLQ(origLine - prevOrigLine) +
+        encodeVLQ(origCol - prevOrigCol);
       prevGenCol = genCol;
       prevOrigLine = origLine;
       prevOrigCol = origCol;


### PR DESCRIPTION
`InternalSourceMap::append_vlq_to()` re-encodes the internal bit-packed blob back to a standard VLQ `mappings` string (used by the inspector inline-sourcemap path, `ParsedSourceMap::write_vlqs`, and `Chunk::print_source_map_contents_from_internal`). Two small inefficiencies:

1. Every caller starts from `MutableString::init_empty()` and the function reserves nothing, so a large map (typescript.js: ~843k mappings, ~3-5 MB of VLQ text) drives the output `Vec` through ~log2(N) doubling realloc+memcpy cycles.
2. `emit_vlq` writes line-separator `;` bytes with `push` in a per-byte `while` loop, so a multi-line gap of N generated lines is N separate bounds-checked writes plus the growth reallocs.

### Fix

- Reserve `mapping_count * 6` bytes once at the top. The estimate is capped by `sync_count * SYNC_INTERVAL` (the structural upper bound that `is_valid_blob` already constrains) so a crafted header reaching the `bun:internal-for-testing` entry point can't force an arbitrarily large reservation.
- Compute the line gap once and write all separators with `Vec::resize` (memset-specialised).

Output bytes are identical.

### Numbers

`bun run build:release bench/sourcemap/append-vlq-bench.ts` (new in this PR), release build, three runs each:

```
[before] 200k mappings, 50k lines:      6.025 ms/op  (999999 bytes, 50 iters)
[before] 2 mappings, 5M-line gap:       7.187 ms/op  (5000008 bytes, 50 iters)
[before] 200k mappings, 50k lines:      9.587 ms/op  (999999 bytes, 50 iters)
[before] 2 mappings, 5M-line gap:       7.942 ms/op  (5000008 bytes, 50 iters)
[before] 200k mappings, 50k lines:      7.371 ms/op  (999999 bytes, 50 iters)
[before] 2 mappings, 5M-line gap:       9.173 ms/op  (5000008 bytes, 50 iters)

[after]  200k mappings, 50k lines:      7.778 ms/op  (999999 bytes, 50 iters)
[after]  2 mappings, 5M-line gap:       2.639 ms/op  (5000008 bytes, 50 iters)
[after]  200k mappings, 50k lines:      6.562 ms/op  (999999 bytes, 50 iters)
[after]  2 mappings, 5M-line gap:       2.011 ms/op  (5000008 bytes, 50 iters)
[after]  200k mappings, 50k lines:      5.680 ms/op  (999999 bytes, 50 iters)
[after]  2 mappings, 5M-line gap:       1.948 ms/op  (5000008 bytes, 50 iters)
```

The line-gap case is ~3.5x faster. The dense case is unchanged within run-to-run noise (a 30-run interleaved A/B puts the mean delta at about -0.5 ms on a ~8 ms baseline with sd ~1.3 ms); the per-mapping VLQ encode dominates there and the avoided reallocs are a few hundred microseconds.

### Testing

Added a round-trip case to `test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts` that drives a 50 000-line gap plus >2000 mappings through `fromVLQ -> toVLQ` and checks the decoded positions match the reference and the re-encoded run of `;` is exactly the right length. The existing round-trip suite (synthetic + real bundler output) and `compile-sourcemap-internal.test.ts` pass unchanged.

This is a performance-only change: the new test passes on an unpatched build as well because the emitted bytes are the same before and after, so the before/after proof is the benchmark script above rather than a failing test.
