### PR TITLE
glob: drop redundant intermediate allocations in the per-path join/dedupe helpers

### DIFF
--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -698,10 +698,10 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                 // `close_disallowing_cwd(fd)` is covered explicitly on
                 // both exit paths below (Err arm and post-Ok); no `?` between here
                 // and those calls, so a scopeguard is unnecessary.
-                let pat_slice = self.walker.pattern_components[idx as usize]
-                    .pattern_slice(&self.walker.pattern)
-                    .to_vec();
-                let pathz = dupe_z(&pat_slice);
+                let pathz = dupe_z(
+                    self.walker.pattern_components[idx as usize]
+                        .pattern_slice(&self.walker.pattern),
+                );
                 // SAFETY: dupe_z NUL-terminates
                 let pathz_ref = ZStr::from_slice_with_nul(&pathz[..]);
                 let stat_result: Stat = match A::statat(fd, pathz_ref) {
@@ -1987,15 +1987,13 @@ impl<A: Accessor, const SENTINEL: bool> GlobWalker<A, SENTINEL> {
     ) -> Result<Option<MatchedPath>, AllocError> {
         let subdir_parts: &[&[u8]] = &[&dir_name[0..dir_name.len()], entry_name];
         let name_matched_path = self.join(subdir_parts)?;
-        // PERF: two lookups here (contains_key + insert); profile if hot.
-        if self.matched_paths.contains_key(&name_matched_path) {
+        if self.matched_paths.insert(&name_matched_path, ()).is_some() {
             log!(
                 "(dupe) prepared match: {}",
                 bstr::BStr::new(&name_matched_path)
             );
             return Ok(None);
         }
-        self.matched_paths.insert(&name_matched_path, ());
         // if SENTINEL { return name[0..name.len()-1 :0]; }
         log!("prepared match: {}", bstr::BStr::new(&name_matched_path));
         Ok(Some(name_matched_path))
@@ -2405,9 +2403,7 @@ fn bun_join<const SENTINEL: bool>(parts: &[&[u8]]) -> Box<[u8]> {
     if SENTINEL {
         let s = resolve_path::join_z_spill::<platform::Auto>(&mut spill, parts);
         // include trailing NUL in the owned box
-        let mut v = s.as_bytes().to_vec();
-        v.push(0);
-        v.into_boxed_slice()
+        Box::from(s.as_bytes_with_nul())
     } else {
         Box::from(resolve_path::join_spill::<platform::Auto>(
             &mut spill, parts,

--- a/src/paths/lib.rs
+++ b/src/paths/lib.rs
@@ -235,7 +235,10 @@ pub fn is_absolute_loose(p: &[u8]) -> bool {
 // seam side already has one, and stripping exactly one leading sep when both
 // sides have one. Byte-level / ASCII-sep only — never normalizes.
 fn join_sep_vec(parts: &[&[u8]]) -> Vec<u8> {
-    let mut out: Vec<u8> = Vec::new();
+    // Upper bound (bytes + one sep per part) also covers the NUL the SENTINEL
+    // caller appends, so push(0)/into_boxed_slice() don't reallocate.
+    let cap = parts.iter().map(|p| p.len()).sum::<usize>() + parts.len();
+    let mut out: Vec<u8> = Vec::with_capacity(cap);
     let mut prev_last: Option<u8> = None;
     for p in parts {
         if p.is_empty() {

--- a/src/paths/lib.rs
+++ b/src/paths/lib.rs
@@ -235,8 +235,8 @@ pub fn is_absolute_loose(p: &[u8]) -> bool {
 // seam side already has one, and stripping exactly one leading sep when both
 // sides have one. Byte-level / ASCII-sep only — never normalizes.
 fn join_sep_vec(parts: &[&[u8]]) -> Vec<u8> {
-    // Upper bound (bytes + one sep per part) also covers the NUL the SENTINEL
-    // caller appends, so push(0)/into_boxed_slice() don't reallocate.
+    // Upper bound (bytes + one sep per part) also leaves room for the NUL the
+    // SENTINEL caller appends, so we stay inside the initial allocation.
     let cap = parts.iter().map(|p| p.len()).sum::<usize>() + parts.len();
     let mut out: Vec<u8> = Vec::with_capacity(cap);
     let mut prev_last: Option<u8> = None;

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -877,24 +877,6 @@ test.skipIf(process.platform === "win32")("patterns with many components", () =>
   expect([...new Bun.Glob(sandwich).scanSync({ cwd: dir })].length).toBe(1);
 });
 
-// Brace alternatives that all reach the same file must yield it once: the
-// dedupe map in prepare_matched_path suppresses the repeat hits.
-test("overlapping brace alternatives dedupe to one result per file", () => {
-  const files: Record<string, string> = {};
-  const expected: string[] = [];
-  for (const top of ["a", "b", "c"]) {
-    for (const mid of ["d", "e", "f"]) {
-      files[`${top}/${mid}/target.txt`] = "";
-      files[`${top}/${mid}/other.log`] = "";
-      expected.push(`${top}/${mid}/target.txt`);
-    }
-  }
-  using dir = tempDir("glob-scan-brace-dedupe", files);
-  const norm = (a: string[]) => a.map(p => p.replaceAll("\\", "/")).sort();
-  const out = norm(Array.from(new Bun.Glob("{*,a,b,c}/*/*.txt").scanSync({ cwd: String(dir) })));
-  expect(out).toEqual(expected.sort());
-});
-
 // scan() keeps the cwd string it is given verbatim, but child paths pushed for
 // symlink work items are joined and normalized. The entry-name offset stored on
 // those work items must be derived from the normalized joined path, not from the

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -877,6 +877,49 @@ test.skipIf(process.platform === "win32")("patterns with many components", () =>
   expect([...new Bun.Glob(sandwich).scanSync({ cwd: dir })].length).toBe(1);
 });
 
+// Coverage for the per-path allocation hot spots: the subdir/match join (both
+// the absolute-normalizing and the non-normalizing branch), the literal-tail
+// statat() shortcut, and the matched-path dedupe map.
+describe("deep tree walk path joining", () => {
+  const norm = (a: string[]) => a.map(p => p.replaceAll("\\", "/")).sort();
+  const files: Record<string, string> = {};
+  const relExpected: string[] = [];
+  for (const top of ["a", "b", "c"]) {
+    for (const mid of ["d", "e", "f"]) {
+      for (const leaf of ["g", "h", "i"]) {
+        const dirRel = `${top}/${mid}/${leaf}`;
+        files[`${dirRel}/target.txt`] = "";
+        files[`${dirRel}/other.log`] = "";
+        relExpected.push(`${dirRel}/target.txt`);
+      }
+    }
+  }
+  relExpected.sort();
+
+  test.each([false, true])("wildcard walk (absolute: %p)", absolute => {
+    using dir = tempDir("glob-scan-join-walk", files);
+    const cwd = String(dir);
+    const out = norm(Array.from(new Bun.Glob("*/*/*/*.txt").scanSync({ cwd, absolute })));
+    const expected = absolute ? relExpected.map(p => norm([path.join(cwd, p)])[0]) : relExpected;
+    expect(out).toEqual(expected);
+  });
+
+  test.each([false, true])("literal-tail walk (absolute: %p)", absolute => {
+    using dir = tempDir("glob-scan-join-literal", files);
+    const cwd = String(dir);
+    const out = norm(Array.from(new Bun.Glob("*/*/*/target.txt").scanSync({ cwd, absolute })));
+    const expected = absolute ? relExpected.map(p => norm([path.join(cwd, p)])[0]) : relExpected;
+    expect(out).toEqual(expected);
+  });
+
+  test("overlapping brace alternatives dedupe to one result per file", () => {
+    using dir = tempDir("glob-scan-join-dedupe", files);
+    const cwd = String(dir);
+    const out = norm(Array.from(new Bun.Glob("{*,a,b,c}/*/*/*.txt").scanSync({ cwd })));
+    expect(out).toEqual(relExpected);
+  });
+});
+
 // scan() keeps the cwd string it is given verbatim, but child paths pushed for
 // symlink work items are joined and normalized. The entry-name offset stored on
 // those work items must be derived from the normalized joined path, not from the

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -877,47 +877,22 @@ test.skipIf(process.platform === "win32")("patterns with many components", () =>
   expect([...new Bun.Glob(sandwich).scanSync({ cwd: dir })].length).toBe(1);
 });
 
-// Coverage for the per-path allocation hot spots: the subdir/match join (both
-// the absolute-normalizing and the non-normalizing branch), the literal-tail
-// statat() shortcut, and the matched-path dedupe map.
-describe("deep tree walk path joining", () => {
-  const norm = (a: string[]) => a.map(p => p.replaceAll("\\", "/")).sort();
+// Brace alternatives that all reach the same file must yield it once: the
+// dedupe map in prepare_matched_path suppresses the repeat hits.
+test("overlapping brace alternatives dedupe to one result per file", () => {
   const files: Record<string, string> = {};
-  const relExpected: string[] = [];
+  const expected: string[] = [];
   for (const top of ["a", "b", "c"]) {
     for (const mid of ["d", "e", "f"]) {
-      for (const leaf of ["g", "h", "i"]) {
-        const dirRel = `${top}/${mid}/${leaf}`;
-        files[`${dirRel}/target.txt`] = "";
-        files[`${dirRel}/other.log`] = "";
-        relExpected.push(`${dirRel}/target.txt`);
-      }
+      files[`${top}/${mid}/target.txt`] = "";
+      files[`${top}/${mid}/other.log`] = "";
+      expected.push(`${top}/${mid}/target.txt`);
     }
   }
-  relExpected.sort();
-
-  test.each([false, true])("wildcard walk (absolute: %p)", absolute => {
-    using dir = tempDir("glob-scan-join-walk", files);
-    const cwd = String(dir);
-    const out = norm(Array.from(new Bun.Glob("*/*/*/*.txt").scanSync({ cwd, absolute })));
-    const expected = absolute ? relExpected.map(p => norm([path.join(cwd, p)])[0]) : relExpected;
-    expect(out).toEqual(expected);
-  });
-
-  test.each([false, true])("literal-tail walk (absolute: %p)", absolute => {
-    using dir = tempDir("glob-scan-join-literal", files);
-    const cwd = String(dir);
-    const out = norm(Array.from(new Bun.Glob("*/*/*/target.txt").scanSync({ cwd, absolute })));
-    const expected = absolute ? relExpected.map(p => norm([path.join(cwd, p)])[0]) : relExpected;
-    expect(out).toEqual(expected);
-  });
-
-  test("overlapping brace alternatives dedupe to one result per file", () => {
-    using dir = tempDir("glob-scan-join-dedupe", files);
-    const cwd = String(dir);
-    const out = norm(Array.from(new Bun.Glob("{*,a,b,c}/*/*/*.txt").scanSync({ cwd })));
-    expect(out).toEqual(relExpected);
-  });
+  using dir = tempDir("glob-scan-brace-dedupe", files);
+  const norm = (a: string[]) => a.map(p => p.replaceAll("\\", "/")).sort();
+  const out = norm(Array.from(new Bun.Glob("{*,a,b,c}/*/*.txt").scanSync({ cwd: String(dir) })));
+  expect(out).toEqual(expected.sort());
 });
 
 // scan() keeps the cwd string it is given verbatim, but child paths pushed for


### PR DESCRIPTION
## What

Four per-match / per-subdirectory allocation sites in the glob walker where the code allocated more than once to produce a single `Box<[u8]>`. Each is rewritten to the minimum calls, and in three of the four cases the result is also fewer lines. No observable output changes.

`Bun.Glob` instantiates the walker with `SENTINEL == false` (`BunGlobWalker`); the shell's pathname expansion uses `SENTINEL == true` (`BunGlobWalkerZ`). Each change below notes which consumer it reaches.

### `bun_join::<true>` (src/glob/GlobWalker.rs, shell absolute-path join)

```rust
let mut v = s.as_bytes().to_vec(); // alloc len, cap == len
v.push(0);                         // grow (realloc)
v.into_boxed_slice()               // cap > len, so shrink (realloc)
```
Three allocator calls: `to_vec()` sizes the `Vec` exactly, so `push(0)` forces a grow, and the grow leaves `cap > len` so `into_boxed_slice()` shrinks again. Replaced with
```rust
Box::from(s.as_bytes_with_nul())
```
`ZStr` already carries the trailing NUL at `len()`; copy it along with the bytes in one allocation.

### `join_sep_vec` (src/paths/lib.rs, both consumers' relative-path join)

The non-normalizing join used by the `absolute: false` branch started from `Vec::new()` and grew by doubling as each part was appended, then `join_sep_maybe_z` pushed a NUL and boxed it. Pre-size the `Vec` to `sum(part lengths) + part count`, an upper bound that also leaves room for the NUL, so appending the parts and the sentinel stays inside the first allocation.

### Literal-tail `statat()` path (src/glob/GlobWalker.rs, both consumers)

```rust
let pat_slice = pattern_slice(&self.walker.pattern).to_vec();
let pathz = dupe_z(&pat_slice);
```
`dupe_z` already copies into a fresh NUL-terminated box, so the `.to_vec()` before it was a second copy of the same bytes. Pass the borrowed slice straight to `dupe_z`.

### `prepare_matched_path` dedupe (src/glob/GlobWalker.rs, both consumers)

`contains_key(&k)` followed by `insert(&k, ())` hashed and probed the map twice. `StringArrayHashMap::insert` already reports whether the key existed (std `HashMap::insert` semantics), so `insert(&k, ()).is_some()` is one probe with identical semantics (the stored `()` is unchanged on a hit).

`prepare_matched_path_symlink` is left as-is: its probe key deliberately differs from its stored key under `SENTINEL == true` (see the `MatchedMap` doc comment), and collapsing the two calls there would change observable output.

## Why

These sit inside per-directory and per-match loops, and each rewrite is strictly fewer allocator round-trips with equal-or-simpler code. No wall-clock speedup is claimed: the scan loop is dominated by `getdents`/`fstatat`, so allocation savings here are not expected to move `bench/glob/scan.mjs`. The `bun_join::<true>` branch in particular is only reachable from shell globbing on absolute patterns, which has no dedicated benchmark.

## Out of scope

The per-directory `Box::new(PathBuffer::uninit())` in `transition_to_dir_iter_state` and the heap `dupe_z` before `lstatat` in the `FileKind::Unknown` arm are also avoidable, but pooling the `Directory.path` buffer changes struct layout and has thread-locality considerations for async scans, and the `lstatat` case is a rare-filesystem path. Left for a separate change.

## Testing

No new test: every touched path is already exercised by `test/js/bun/glob/scan.test.ts` (the `testWithOpts("absolute", ...)` block and fast-glob e2e suite for `bun_join`, every default-option scan for `join_sep_vec`, the `literal fast path` describe and the 130-component test for the `.to_vec()` site, and the `**` patterns throughout for `prepare_matched_path` dedupe), and an allocation-count reduction has no output-observable fail-before. A test that passes unchanged on the current release would only add noise. `test/js/bun/glob/scan.test.ts` and `test/js/node/fs/glob.test.ts` pass under `bun bd`; `rust:check-all` is clean on every target.
