### PR TITLE
bundler: convert per-edge-recursive JS-import-graph walks to explicit-stack DFS

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -819,13 +819,11 @@ impl<'a> LinkerContext<'a> {
                     continue;
                 }
 
-                let import_records = import_records_list[source_index as usize].as_slice();
                 let _ = self.validate_tla(
                     source_index,
                     tla_keywords,
                     tla_checks,
                     input_files,
-                    import_records,
                     flags,
                     import_records_list,
                 )?;
@@ -1888,11 +1886,9 @@ impl<'a> LinkerContext<'a> {
         tla_keywords: &[Range],
         tla_checks: &mut [TlaCheck],
         input_files: &[Source],
-        import_records: &[ImportRecord],
         meta_flags: &mut [crate::js_meta::Flags],
         ast_import_records: &[bun_ast::import_record::List<'a>],
     ) -> Result<TlaCheck, AllocError> {
-        let _ = import_records;
         // Explicit-stack postorder DFS (was per-edge recursive). `Enter`
         // seeds a file and queues each followed import paired with an
         // `AfterChild` resume point; that resume reads the child's completed

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -774,8 +774,8 @@ impl<'a> LinkerContext<'a> {
             // from `*self` (= `BundleV2.linker`). The SoA column slices below
             // are physically disjoint and the underlying slabs do not
             // reallocate inside `validate_tla`; we cache raw column pointers
-            // and reborrow per call to satisfy borrowck (`&mut self` is held
-            // across the recursion).
+            // and reborrow once for the loop to satisfy borrowck alongside
+            // `&mut self`.
             let parse_graph: *mut Graph<'a> = self.parse_graph;
             let import_records_list: *const [bun_ast::import_record::List<'a>] =
                 self.graph.ast.items_import_records();
@@ -783,9 +783,9 @@ impl<'a> LinkerContext<'a> {
             let css_asts: *const [crate::bundled_ast::CssCol] = self.graph.ast.items_css();
             let files_len = self.graph.files.len();
             // SAFETY: see block comment above — `parse_graph` backref disjoint
-            // from `*self`, stable SoA slabs; the recursive `validate_tla` body
-            // neither reallocates the slabs nor forms a competing `&mut` to
-            // any read-only column. All seven derefs share that invariant.
+            // from `*self`, stable SoA slabs; `validate_tla` neither
+            // reallocates the slabs nor forms a competing `&mut` to any
+            // read-only column. All seven derefs share that invariant.
             let (tla_keywords, tla_checks, input_files, import_records_list, css_asts, flags) = unsafe {
                 (
                     (*parse_graph).ast.items_top_level_await_keyword(),
@@ -819,14 +819,14 @@ impl<'a> LinkerContext<'a> {
                     continue;
                 }
 
-                let _ = self.validate_tla(
+                self.validate_tla(
                     source_index,
                     tla_keywords,
                     tla_checks,
                     input_files,
                     flags,
                     import_records_list,
-                )?;
+                );
 
                 source_index += 1;
             }
@@ -902,7 +902,8 @@ impl<'a> LinkerContext<'a> {
         // Note: these slices alias into self.graph.
         // The SoA columns are physically disjoint
         // and the underlying slabs don't reallocate during tree-shaking, so we
-        // cache raw column base pointers and reborrow at each recursive call.
+        // cache raw column base pointers and reborrow once for the
+        // worklist-driven passes below.
         let parts: *mut [bun_ast::PartList<'a>] = self.graph.ast.items_parts_mut();
         let parts_live: *mut [bun_collections::AutoBitSet] = self.graph.parts_live.as_mut_slice();
         let import_records: *const [bun_ast::import_record::List<'a>] =
@@ -918,9 +919,9 @@ impl<'a> LinkerContext<'a> {
 
         // SAFETY: see block comment above — disjoint SoA columns, stable slabs
         // (no reallocation during tree-shaking). All column derefs share that
-        // invariant; reborrowing once here (rather than per-call) is sound
-        // because the recursive `mark_file_*` bodies neither reallocate the
-        // slabs nor form a competing `&mut` to any read-only column.
+        // invariant; reborrowing once here is sound because the
+        // worklist-driven `mark_file_*` steps neither reallocate the slabs
+        // nor form a competing `&mut` to any read-only column.
         let (
             entry_points,
             side_effects,
@@ -1888,7 +1889,7 @@ impl<'a> LinkerContext<'a> {
         input_files: &[Source],
         meta_flags: &mut [crate::js_meta::Flags],
         ast_import_records: &[bun_ast::import_record::List<'a>],
-    ) -> Result<TlaCheck, AllocError> {
+    ) {
         // Explicit-stack postorder DFS (was per-edge recursive). `Enter`
         // seeds a file and queues each followed import paired with an
         // `AfterChild` resume point; that resume reads the child's completed
@@ -1906,7 +1907,7 @@ impl<'a> LinkerContext<'a> {
         }
 
         if tla_checks[source_index as usize].depth != 0 {
-            return Ok(tla_checks[source_index as usize]);
+            return;
         }
 
         let mut stack: Vec<Frame> = vec![Frame::Enter(source_index)];
@@ -2070,8 +2071,6 @@ impl<'a> LinkerContext<'a> {
                 }
             }
         }
-
-        Ok(tla_checks[source_index as usize])
     }
 
     pub fn should_remove_import_export_stmt(

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -958,6 +958,7 @@ impl<'a> LinkerContext<'a> {
                 import_records,
                 entry_point_kinds,
                 css_reprs,
+                worklist: Vec::new(),
             };
 
             // Tree shaking: Each entry point marks all files reachable from itself
@@ -2594,12 +2595,11 @@ impl<'a> js_printer::RequireOrImportMetaSource for LinkerContext<'a> {
 // accessors.
 // ══════════════════════════════════════════════════════════════════════════
 
-// The three `mark_*` functions below are mutually recursive and hot. Passing
-// the five SoA-column slices as separate arguments costs 10 words of fat
-// pointers per call; with `&mut self` + indices that overflows the 6 SysV
-// integer-arg registers and spills to the stack on every recursive step.
-// Packing the slices into a borrowed context struct keeps each call at 3-4
-// register-sized arguments.
+// The liveness pass visits every (file, part) at most once. Processing order is
+// irrelevant to the final bitset state, so the former mutual recursion is
+// driven off an explicit worklist (LIFO, so traversal order matches the old
+// DFS). Packing the slices into a borrowed context struct keeps each step at
+// 3-4 register-sized arguments.
 pub struct TreeShakeCtx<'a, 'r> {
     pub side_effects: &'r [SideEffects],
     pub parts: &'r [bun_ast::PartList<'a>],
@@ -2607,6 +2607,16 @@ pub struct TreeShakeCtx<'a, 'r> {
     pub import_records: &'r [bun_ast::import_record::List<'a>],
     pub entry_point_kinds: &'r [EntryPoint::Kind],
     pub css_reprs: &'r [crate::bundled_ast::CssCol],
+    pub worklist: Vec<TreeShakeWork>,
+}
+
+#[derive(Clone, Copy)]
+pub enum TreeShakeWork {
+    File(crate::IndexInt),
+    Part {
+        part_index: crate::IndexInt,
+        source_index: crate::IndexInt,
+    },
 }
 
 pub struct CodeSplitCtx<'a, 'r> {
@@ -2720,6 +2730,24 @@ impl<'a> LinkerContext<'a> {
         ctx: &mut TreeShakeCtx<'a, '_>,
         source_index: crate::IndexInt,
     ) {
+        debug_assert!(ctx.worklist.is_empty());
+        ctx.worklist.push(TreeShakeWork::File(source_index));
+        while let Some(work) = ctx.worklist.pop() {
+            match work {
+                TreeShakeWork::File(src) => self.mark_file_live_step(ctx, src),
+                TreeShakeWork::Part {
+                    part_index,
+                    source_index,
+                } => self.mark_part_live_step(ctx, part_index, source_index),
+            }
+        }
+    }
+
+    fn mark_file_live_step(
+        &mut self,
+        ctx: &mut TreeShakeCtx<'a, '_>,
+        source_index: crate::IndexInt,
+    ) {
         #[cfg(debug_assertions)]
         {
             let parse_graph = self.parse_graph();
@@ -2746,9 +2774,6 @@ impl<'a> LinkerContext<'a> {
             );
         }
 
-        #[cfg(debug_assertions)]
-        scopeguard::defer! { debug_tree_shake!("end()"); }
-
         if self.graph.files_live.is_set(source_index as usize) {
             return;
         }
@@ -2760,11 +2785,12 @@ impl<'a> LinkerContext<'a> {
         }
 
         if ctx.css_reprs[source_index as usize].is_some() {
-            for ri in 0..ctx.import_records[source_index as usize].len() {
-                let record = &ctx.import_records[source_index as usize][ri];
+            for record in ctx.import_records[source_index as usize].iter() {
                 if record.source_index.is_valid() {
-                    let other_source_index = record.source_index.get();
-                    self.mark_file_live_for_tree_shaking(ctx, other_source_index);
+                    let other = record.source_index.get();
+                    if !self.graph.files_live.is_set(other as usize) {
+                        ctx.worklist.push(TreeShakeWork::File(other));
+                    }
                 }
             }
             return;
@@ -2774,20 +2800,19 @@ impl<'a> LinkerContext<'a> {
         // via .url kind import records. Follow all import records for HTML files
         // so these assets are marked live and included in the manifest.
         if self.parse_graph().input_files.items_loader()[source_index as usize] == Loader::Html {
-            for ri in 0..ctx.import_records[source_index as usize].len() {
-                let record = &ctx.import_records[source_index as usize][ri];
+            for record in ctx.import_records[source_index as usize].iter() {
                 if record.source_index.is_valid() {
-                    let other_source_index = record.source_index.get();
-                    self.mark_file_live_for_tree_shaking(ctx, other_source_index);
+                    let other = record.source_index.get();
+                    if !self.graph.files_live.is_set(other as usize) {
+                        ctx.worklist.push(TreeShakeWork::File(other));
+                    }
                 }
             }
             return;
         }
 
-        let part_count = ctx.parts[source_index as usize].len();
-        for part_index in 0..part_count {
-            // Note: reshaped for borrowck — re-borrow part each iteration since recursion mutates `parts`
-            let part = &ctx.parts[source_index as usize].as_slice()[part_index];
+        let parts = ctx.parts[source_index as usize].as_slice();
+        for (part_index, part) in parts.iter().enumerate() {
             let mut can_be_removed_if_unused = part.can_be_removed_if_unused;
 
             if can_be_removed_if_unused && part.tag == bun_ast::PartTag::CommonjsNamedExport {
@@ -2796,14 +2821,8 @@ impl<'a> LinkerContext<'a> {
                 }
             }
 
-            // Also include any statement-level imports. Iterate by index so we
-            // don't hold a borrow of `part`/`parts` across the recursive call —
-            // the recursion never resizes this part's `import_record_indices`,
-            // so re-slicing each iteration is sound.
-            let import_indices_len = part.import_record_indices.len();
-            for ii in 0..import_indices_len {
-                let import_index = ctx.parts[source_index as usize].as_slice()[part_index]
-                    .import_record_indices[ii];
+            // Also include any statement-level imports
+            for &import_index in part.import_record_indices.iter() {
                 let record = &ctx.import_records[source_index as usize][import_index as usize];
                 if record.kind != ImportKind::Stmt {
                     continue;
@@ -2825,7 +2844,9 @@ impl<'a> LinkerContext<'a> {
                     }
 
                     // Otherwise, include this module for its side effects
-                    self.mark_file_live_for_tree_shaking(ctx, other_source_index);
+                    if !self.graph.files_live.is_set(other_source_index as usize) {
+                        ctx.worklist.push(TreeShakeWork::File(other_source_index));
+                    }
                 } else if is_external_without_side_effects {
                     // This can be removed if it's unused
                     continue;
@@ -2839,23 +2860,23 @@ impl<'a> LinkerContext<'a> {
             // Include all parts in this file with side effects, or just include
             // everything if tree-shaking is disabled. Note that we still want to
             // perform tree-shaking on the runtime even if tree-shaking is disabled.
-            let force_tree_shaking =
-                ctx.parts[source_index as usize].as_slice()[part_index].force_tree_shaking;
             if !can_be_removed_if_unused
-                || (!force_tree_shaking
+                || (!part.force_tree_shaking
                     && !self.options.tree_shaking
                     && ctx.entry_point_kinds[source_index as usize].is_entry_point())
             {
-                self.mark_part_live_for_tree_shaking(
-                    ctx,
-                    u32::try_from(part_index).expect("int cast"),
-                    source_index,
-                );
+                let part_index = u32::try_from(part_index).expect("int cast");
+                if !ctx.parts_live[source_index as usize].is_set(part_index as usize) {
+                    ctx.worklist.push(TreeShakeWork::Part {
+                        part_index,
+                        source_index,
+                    });
+                }
             }
         }
     }
 
-    pub fn mark_part_live_for_tree_shaking(
+    fn mark_part_live_step(
         &mut self,
         ctx: &mut TreeShakeCtx<'a, '_>,
         part_index: crate::IndexInt,
@@ -2901,22 +2922,16 @@ impl<'a> LinkerContext<'a> {
             );
         }
 
-        #[cfg(debug_assertions)]
-        scopeguard::defer! { debug_tree_shake!("end()"); }
-
         // Include the file containing this part
-        self.mark_file_live_for_tree_shaking(ctx, source_index);
+        if !self.graph.files_live.is_set(source_index as usize) {
+            ctx.worklist.push(TreeShakeWork::File(source_index));
+        }
 
-        // The recursion above/below only flips bits in `ctx.parts_live`; it never
-        // resizes any part's `dependencies`, so the slice's len/ptr are stable.
-        // Iterate by index and re-borrow per iteration to satisfy borrowck without
-        // the per-call `Vec` clone the original port did.
-        let dependencies_len = ctx.parts[source_index as usize].as_slice()[part_index as usize]
-            .dependencies
-            .len();
+        let dependencies =
+            &ctx.parts[source_index as usize].as_slice()[part_index as usize].dependencies;
 
         #[cfg(feature = "debug_logs")]
-        if dependencies_len == 0 {
+        if dependencies.is_empty() {
             log_part_dependency_tree!(
                 "markPartLiveForTreeShaking {}:{} | EMPTY",
                 source_index,
@@ -2924,9 +2939,7 @@ impl<'a> LinkerContext<'a> {
             );
         }
 
-        for di in 0..dependencies_len {
-            let dependency =
-                ctx.parts[source_index as usize].as_slice()[part_index as usize].dependencies[di];
+        for dependency in dependencies.iter() {
             #[cfg(feature = "debug_logs")]
             if source_index != 0 && dependency.source_index.get() != 0 {
                 log_part_dependency_tree!(
@@ -2938,11 +2951,14 @@ impl<'a> LinkerContext<'a> {
                 );
             }
 
-            self.mark_part_live_for_tree_shaking(
-                ctx,
-                dependency.part_index,
-                dependency.source_index.get(),
-            );
+            let dep_source = dependency.source_index.get();
+            let dep_part = dependency.part_index;
+            if !ctx.parts_live[dep_source as usize].is_set(dep_part as usize) {
+                ctx.worklist.push(TreeShakeWork::Part {
+                    part_index: dep_part,
+                    source_index: dep_source,
+                });
+            }
         }
     }
 } // end tree-shaking impl

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -987,6 +987,7 @@ impl<'a> LinkerContext<'a> {
                 import_records,
                 file_entry_bits,
                 css_reprs,
+                stack: Vec::new(),
             };
 
             // Code splitting: Determine which entry points can reach which files. This
@@ -1891,26 +1892,77 @@ impl<'a> LinkerContext<'a> {
         meta_flags: &mut [crate::js_meta::Flags],
         ast_import_records: &[bun_ast::import_record::List<'a>],
     ) -> Result<TlaCheck, AllocError> {
-        // Note: re-index `tla_checks` after each recursion — recursive calls also mutate it.
-        if tla_checks[source_index as usize].depth == 0 {
-            tla_checks[source_index as usize].depth = 1;
-            if tla_keywords[source_index as usize].len > 0 {
-                tla_checks[source_index as usize].parent = source_index;
-            }
+        let _ = import_records;
+        // Explicit-stack postorder DFS (was per-edge recursive). `Enter`
+        // seeds a file and queues each followed import paired with an
+        // `AfterChild` resume point; that resume reads the child's completed
+        // `tla_checks` entry. `Leave` sets the async flag once all children
+        // are settled. Successors are pushed in pop order then the tail is
+        // reversed so LIFO pop reproduces the original recursion order.
+        #[derive(Copy, Clone)]
+        enum Frame {
+            Enter(crate::IndexInt),
+            AfterChild {
+                source_index: crate::IndexInt,
+                import_record_index: u32,
+            },
+            Leave(crate::IndexInt),
+        }
 
-            for (import_record_index, record) in import_records.iter().enumerate() {
-                if Index::is_valid(record.source_index)
-                    && (record.kind == ImportKind::Require || record.kind == ImportKind::Stmt)
-                {
-                    let parent = self.validate_tla(
-                        record.source_index.get(),
-                        tla_keywords,
-                        tla_checks,
-                        input_files,
-                        ast_import_records[record.source_index.get() as usize].as_slice(),
-                        meta_flags,
-                        ast_import_records,
-                    )?;
+        if tla_checks[source_index as usize].depth != 0 {
+            return Ok(tla_checks[source_index as usize]);
+        }
+
+        let mut stack: Vec<Frame> = vec![Frame::Enter(source_index)];
+
+        while let Some(frame) = stack.pop() {
+            match frame {
+                Frame::Enter(source_index) => {
+                    if tla_checks[source_index as usize].depth != 0 {
+                        continue;
+                    }
+                    tla_checks[source_index as usize].depth = 1;
+                    if tla_keywords[source_index as usize].len > 0 {
+                        tla_checks[source_index as usize].parent = source_index;
+                    }
+
+                    let mark = stack.len();
+                    for (import_record_index, record) in
+                        ast_import_records[source_index as usize]
+                            .as_slice()
+                            .iter()
+                            .enumerate()
+                    {
+                        if Index::is_valid(record.source_index)
+                            && (record.kind == ImportKind::Require
+                                || record.kind == ImportKind::Stmt)
+                        {
+                            stack.push(Frame::Enter(record.source_index.get()));
+                            stack.push(Frame::AfterChild {
+                                source_index,
+                                import_record_index: u32::try_from(import_record_index)
+                                    .expect("int cast"),
+                            });
+                        }
+                    }
+                    stack.push(Frame::Leave(source_index));
+                    stack[mark..].reverse();
+                }
+                Frame::Leave(source_index) => {
+                    // Make sure that if we wrap this module in a closure, the closure is also
+                    // async. This happens when you call "import()" on this module and code
+                    // splitting is off.
+                    if Index::is_valid(Index::init(tla_checks[source_index as usize].parent)) {
+                        meta_flags[source_index as usize].is_async_or_has_async_dependency = true;
+                    }
+                }
+                Frame::AfterChild {
+                    source_index,
+                    import_record_index,
+                } => {
+                    let record = &ast_import_records[source_index as usize].as_slice()
+                        [import_record_index as usize];
+                    let parent = tla_checks[record.source_index.get() as usize];
                     if Index::is_invalid(Index::init(parent.parent)) {
                         continue;
                     }
@@ -1924,8 +1976,7 @@ impl<'a> LinkerContext<'a> {
                     {
                         result_tla_check.depth = parent.depth + 1;
                         result_tla_check.parent = record.source_index.get();
-                        result_tla_check.import_record_index =
-                            u32::try_from(import_record_index).expect("int cast");
+                        result_tla_check.import_record_index = import_record_index;
                         continue;
                     }
 
@@ -2022,13 +2073,6 @@ impl<'a> LinkerContext<'a> {
                         );
                     }
                 }
-            }
-
-            // Make sure that if we wrap this module in a closure, the closure is also
-            // async. This happens when you call "import()" on this module and code
-            // splitting is off.
-            if Index::is_valid(Index::init(tla_checks[source_index as usize].parent)) {
-                meta_flags[source_index as usize].is_async_or_has_async_dependency = true;
             }
         }
 
@@ -2625,6 +2669,7 @@ pub struct CodeSplitCtx<'a, 'r> {
     pub import_records: &'r [bun_ast::import_record::List<'a>],
     pub file_entry_bits: &'r mut [AutoBitSet],
     pub css_reprs: &'r [crate::bundled_ast::CssCol],
+    pub stack: Vec<(crate::IndexInt, u32)>,
 }
 
 impl<'a> LinkerContext<'a> {
@@ -2635,91 +2680,69 @@ impl<'a> LinkerContext<'a> {
         entry_points_count: usize,
         distance: u32,
     ) {
-        if !self.graph.files_live.is_set(source_index as usize) {
-            return;
-        }
+        // Explicit-stack DFS (was per-edge recursive). Only bit/distance
+        // state is produced, so traversal order within an entry point does
+        // not affect the result; successors are pushed without reordering.
+        debug_assert!(ctx.stack.is_empty());
+        ctx.stack.push((source_index, distance));
 
-        let cur_dist = ctx.distances[source_index as usize];
-        let traverse_again = distance < cur_dist;
-        if traverse_again {
-            ctx.distances[source_index as usize] = distance;
-        }
-        let out_dist = distance + 1;
-
-        let bits = &mut ctx.file_entry_bits[source_index as usize];
-
-        // Don't mark this file more than once
-        if bits.is_set(entry_points_count) && !traverse_again {
-            return;
-        }
-
-        bits.set(entry_points_count);
-
-        #[cfg(feature = "debug_logs")]
-        {
-            let parse_graph = self.parse_graph();
-            debug_tree_shake!(
-                "markFileReachableForCodeSplitting(entry: {}): {} {} ({})",
-                entry_points_count,
-                bstr::BStr::new(
-                    &parse_graph.input_files.items_source()[source_index as usize]
-                        .path
-                        .pretty
-                ),
-                <&'static str>::from(
-                    parse_graph.ast.items_target()[source_index as usize].bake_graph()
-                ),
-                out_dist,
-            );
-        }
-
-        if ctx.css_reprs[source_index as usize].is_some() {
-            for ri in 0..ctx.import_records[source_index as usize].len() {
-                let record = &ctx.import_records[source_index as usize][ri];
-                if record.source_index.is_valid()
-                    && !self.is_external_dynamic_import(record, source_index)
-                {
-                    let other = record.source_index.get();
-                    self.mark_file_reachable_for_code_splitting(
-                        ctx,
-                        other,
-                        entry_points_count,
-                        out_dist,
-                    );
-                }
+        while let Some((source_index, distance)) = ctx.stack.pop() {
+            if !self.graph.files_live.is_set(source_index as usize) {
+                continue;
             }
-            return;
-        }
 
-        for ri in 0..ctx.import_records[source_index as usize].len() {
-            let record = &ctx.import_records[source_index as usize][ri];
-            if record.source_index.is_valid()
-                && !self.is_external_dynamic_import(record, source_index)
+            let cur_dist = ctx.distances[source_index as usize];
+            let traverse_again = distance < cur_dist;
+            if traverse_again {
+                ctx.distances[source_index as usize] = distance;
+            }
+            let out_dist = distance + 1;
+
+            let bits = &mut ctx.file_entry_bits[source_index as usize];
+
+            // Don't mark this file more than once
+            if bits.is_set(entry_points_count) && !traverse_again {
+                continue;
+            }
+
+            bits.set(entry_points_count);
+
+            #[cfg(feature = "debug_logs")]
             {
-                let other = record.source_index.get();
-                self.mark_file_reachable_for_code_splitting(
-                    ctx,
-                    other,
+                let parse_graph = self.parse_graph();
+                debug_tree_shake!(
+                    "markFileReachableForCodeSplitting(entry: {}): {} {} ({})",
                     entry_points_count,
+                    bstr::BStr::new(
+                        &parse_graph.input_files.items_source()[source_index as usize]
+                            .path
+                            .pretty
+                    ),
+                    <&'static str>::from(
+                        parse_graph.ast.items_target()[source_index as usize].bake_graph()
+                    ),
                     out_dist,
                 );
             }
-        }
 
-        let part_count = ctx.parts[source_index as usize].len();
-        for pi in 0..part_count {
-            let deps_len = ctx.parts[source_index as usize].as_slice()[pi]
-                .dependencies
-                .len();
-            for di in 0..deps_len {
-                let dependency = ctx.parts[source_index as usize].as_slice()[pi].dependencies[di];
-                if dependency.source_index.get() != source_index {
-                    self.mark_file_reachable_for_code_splitting(
-                        ctx,
-                        dependency.source_index.get(),
-                        entry_points_count,
-                        out_dist,
-                    );
+            for record in ctx.import_records[source_index as usize].iter() {
+                if record.source_index.is_valid()
+                    && !self.is_external_dynamic_import(record, source_index)
+                {
+                    ctx.stack.push((record.source_index.get(), out_dist));
+                }
+            }
+
+            // CSS files only follow their import records.
+            if ctx.css_reprs[source_index as usize].is_some() {
+                continue;
+            }
+
+            for part in ctx.parts[source_index as usize].as_slice() {
+                for dependency in part.dependencies.iter() {
+                    if dependency.source_index.get() != source_index {
+                        ctx.stack.push((dependency.source_index.get(), out_dist));
+                    }
                 }
             }
         }

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1927,11 +1927,10 @@ impl<'a> LinkerContext<'a> {
                     }
 
                     let mark = stack.len();
-                    for (import_record_index, record) in
-                        ast_import_records[source_index as usize]
-                            .as_slice()
-                            .iter()
-                            .enumerate()
+                    for (import_record_index, record) in ast_import_records[source_index as usize]
+                        .as_slice()
+                        .iter()
+                        .enumerate()
                     {
                         if Index::is_valid(record.source_index)
                             && (record.kind == ImportKind::Require

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -917,75 +917,87 @@ impl<'a> LinkerGraph<'a> {
     }
 
     pub fn propagate_async_dependencies(&mut self) -> Result<(), crate::Error> {
-        struct State<'a> {
-            visited: AutoBitSet,
-            import_records: &'a [import_record::List<'a>],
-            flags: &'a mut [js_meta::Flags],
+        // Explicit-stack postorder DFS (was per-edge recursive). A parent's
+        // flag is read from each child after that child's subtree is fully
+        // processed; `AfterChild` is the resumption point for that read.
+        #[derive(Copy, Clone)]
+        enum Frame {
+            Enter(usize),
+            AfterChild { parent: usize, child: usize },
         }
 
-        impl<'a> State<'a> {
-            pub(crate) fn visit_all(&mut self) {
-                for i in 0..self.import_records.len() {
-                    self.visit(i);
-                }
+        let import_records = self.ast.items_import_records();
+        let flags = self.meta.items_flags_mut();
+        let len = import_records.len();
+        let mut visited = AutoBitSet::init_empty(self.ast.len())?;
+        let mut stack: Vec<Frame> = Vec::new();
+
+        for root in 0..len {
+            if visited.is_set(root) {
+                continue;
             }
+            stack.push(Frame::Enter(root));
 
-            fn visit(&mut self, index: usize) {
-                if self.visited.is_set(index) {
-                    return;
-                }
-                self.visited.set(index);
-                if self.flags[index].is_async_or_has_async_dependency {
-                    return;
-                }
-
-                for import_record in self.import_records[index].as_slice().iter() {
-                    match import_record.kind {
-                        ImportKind::Stmt => {}
-
-                        // Any use of `import()` that makes the parent async will necessarily use
-                        // top-level await, so this will have already been detected by `validateTLA`,
-                        // and `is_async_or_has_async_dependency` will already be true.
-                        //
-                        // We don't want to process these imports here because `import()` can appear in
-                        // non-top-level contexts (like inside an async function) or in contexts that
-                        // don't use `await`, which don't necessarily make the parent module async.
-                        ImportKind::Dynamic => continue,
-
-                        // `require()` cannot import async modules.
-                        ImportKind::Require | ImportKind::RequireResolve => continue,
-
-                        // Entry points; not imports from JS
-                        ImportKind::EntryPointRun | ImportKind::EntryPointBuild => continue,
-                        // CSS imports
-                        ImportKind::At
-                        | ImportKind::AtConditional
-                        | ImportKind::Url
-                        | ImportKind::Composes => continue,
-                        // Other non-JS imports
-                        ImportKind::HtmlManifest | ImportKind::Internal => continue,
+            while let Some(frame) = stack.pop() {
+                match frame {
+                    Frame::AfterChild { parent, child } => {
+                        if flags[child].is_async_or_has_async_dependency {
+                            flags[parent].is_async_or_has_async_dependency = true;
+                        }
                     }
+                    Frame::Enter(index) => {
+                        if visited.is_set(index) {
+                            continue;
+                        }
+                        visited.set(index);
+                        if flags[index].is_async_or_has_async_dependency {
+                            continue;
+                        }
 
-                    let import_index: usize = import_record.source_index.get() as usize;
-                    if import_index >= self.import_records.len() {
-                        continue;
-                    }
-                    self.visit(import_index);
+                        let mark = stack.len();
+                        for import_record in import_records[index].as_slice().iter() {
+                            match import_record.kind {
+                                ImportKind::Stmt => {}
 
-                    if self.flags[import_index].is_async_or_has_async_dependency {
-                        self.flags[index].is_async_or_has_async_dependency = true;
-                        break;
+                                // Any use of `import()` that makes the parent async will necessarily use
+                                // top-level await, so this will have already been detected by `validateTLA`,
+                                // and `is_async_or_has_async_dependency` will already be true.
+                                //
+                                // We don't want to process these imports here because `import()` can appear in
+                                // non-top-level contexts (like inside an async function) or in contexts that
+                                // don't use `await`, which don't necessarily make the parent module async.
+                                ImportKind::Dynamic => continue,
+
+                                // `require()` cannot import async modules.
+                                ImportKind::Require | ImportKind::RequireResolve => continue,
+
+                                // Entry points; not imports from JS
+                                ImportKind::EntryPointRun | ImportKind::EntryPointBuild => continue,
+                                // CSS imports
+                                ImportKind::At
+                                | ImportKind::AtConditional
+                                | ImportKind::Url
+                                | ImportKind::Composes => continue,
+                                // Other non-JS imports
+                                ImportKind::HtmlManifest | ImportKind::Internal => continue,
+                            }
+
+                            let import_index: usize =
+                                import_record.source_index.get() as usize;
+                            if import_index >= len {
+                                continue;
+                            }
+                            stack.push(Frame::Enter(import_index));
+                            stack.push(Frame::AfterChild {
+                                parent: index,
+                                child: import_index,
+                            });
+                        }
+                        stack[mark..].reverse();
                     }
                 }
             }
         }
-
-        let mut state = State {
-            visited: AutoBitSet::init_empty(self.ast.len())?,
-            import_records: self.ast.items_import_records(),
-            flags: self.meta.items_flags_mut(),
-        };
-        state.visit_all();
         Ok(())
     }
 }

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -982,8 +982,7 @@ impl<'a> LinkerGraph<'a> {
                                 ImportKind::HtmlManifest | ImportKind::Internal => continue,
                             }
 
-                            let import_index: usize =
-                                import_record.source_index.get() as usize;
+                            let import_index: usize = import_record.source_index.get() as usize;
                             if import_index >= len {
                                 continue;
                             }

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1811,9 +1811,9 @@ pub mod bv2_impl {
                 let mut has_redirect = false;
                 // when there are no import records, v index will be invalid
                 if (import_record_list_id.get() as usize) < self.all_import_records.len() {
-                    let import_records_len =
-                        self.all_import_records[import_record_list_id.get() as usize].len()
-                            as usize;
+                    let import_records_len = self.all_import_records
+                        [import_record_list_id.get() as usize]
+                        .len() as usize;
                     for ir_idx in 0..import_records_len {
                         let import_record = &mut self.all_import_records
                             [import_record_list_id.get() as usize]

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1707,6 +1707,20 @@ pub mod bv2_impl {
         pub additional_files_imported_by_js_and_inlined_in_css: &'a mut DynamicBitSetUnmanaged,
         /// Files which are imported by CSS and inlined in CSS
         pub additional_files_imported_by_css_and_inlined: &'a mut DynamicBitSetUnmanaged,
+
+        pub stack: Vec<ReachFrame>,
+    }
+
+    #[derive(Copy, Clone)]
+    pub enum ReachFrame {
+        Enter {
+            source_index: Index,
+            was_dynamic_import: bool,
+        },
+        Leave {
+            source_index: Index,
+            was_dynamic_import: bool,
+        },
     }
 
     impl<'a> ReachableFileVisitor<'a> {
@@ -1716,141 +1730,178 @@ pub mod bv2_impl {
         // deterministic given that the entry point order is deterministic, since the
         // returned order is the postorder of the graph traversal and import record
         // order within a given file is deterministic.
+        //
+        // Explicit-stack DFS (was per-edge recursive). `Enter` does the
+        // pre-order work and queues successors; `Leave` performs the
+        // post-order append. Successors are pushed in pop order then the tail
+        // is reversed so LIFO pop reproduces the original recursion order.
         pub fn visit<const CHECK_DYNAMIC_IMPORTS: bool>(
             &mut self,
             source_index: Index,
             was_dynamic_import: bool,
         ) {
-            if source_index.is_invalid() {
-                return;
-            }
+            debug_assert!(self.stack.is_empty());
+            self.stack.push(ReachFrame::Enter {
+                source_index,
+                was_dynamic_import,
+            });
 
-            if self.visited.is_set(source_index.get() as usize) {
-                if CHECK_DYNAMIC_IMPORTS {
-                    if was_dynamic_import {
+            while let Some(frame) = self.stack.pop() {
+                let (source_index, was_dynamic_import) = match frame {
+                    ReachFrame::Leave {
+                        source_index,
+                        was_dynamic_import,
+                    } => {
+                        // Each file must come after its dependencies
+                        self.reachable.push(source_index);
+                        if CHECK_DYNAMIC_IMPORTS && was_dynamic_import {
+                            self.dynamic_import_entry_points
+                                .put(source_index.get(), ())
+                                .expect("unreachable");
+                        }
+                        continue;
+                    }
+                    ReachFrame::Enter {
+                        source_index,
+                        was_dynamic_import,
+                    } => (source_index, was_dynamic_import),
+                };
+
+                if source_index.is_invalid() {
+                    continue;
+                }
+
+                if self.visited.is_set(source_index.get() as usize) {
+                    if CHECK_DYNAMIC_IMPORTS && was_dynamic_import {
                         self.dynamic_import_entry_points
                             .put(source_index.get(), ())
                             .expect("unreachable");
                     }
+                    continue;
                 }
-                return;
-            }
-            self.visited.set(source_index.get() as usize);
+                self.visited.set(source_index.get() as usize);
 
-            if let Some(scb_bitset) = &self.scb_bitset {
-                if scb_bitset.is_set(source_index.get() as usize) {
-                    let scb_index = self
-                        .scb_list
-                        .get_index(source_index.get())
-                        .expect("unreachable");
-                    self.visit::<CHECK_DYNAMIC_IMPORTS>(
-                        Index::init(self.scb_list.list.items_reference_source_index()[scb_index]),
-                        false,
-                    );
-                    self.visit::<CHECK_DYNAMIC_IMPORTS>(
-                        Index::init(self.scb_list.list.items_ssr_source_index()[scb_index]),
-                        false,
-                    );
-                }
-            }
+                let mark = self.stack.len();
 
-            let is_js = self.all_loaders[source_index.get() as usize].is_javascript_like();
-            let is_css = self.all_loaders[source_index.get() as usize].is_css();
-
-            let import_record_list_id = source_index;
-            // when there are no import records, v index will be invalid
-            if (import_record_list_id.get() as usize) < self.all_import_records.len() {
-                // reshaped for borrowck — split borrow of all_import_records
-                let import_records_len =
-                    self.all_import_records[import_record_list_id.get() as usize].len() as usize;
-                for ir_idx in 0..import_records_len {
-                    let import_record = &mut self.all_import_records
-                        [import_record_list_id.get() as usize]
-                        .as_mut_slice()[ir_idx];
-                    let mut other_source = import_record.source_index;
-                    if other_source.is_valid() {
-                        let mut redirect_count: usize = 0;
-                        while let Some(redirect_id) =
-                            get_redirect_id(self.redirects[other_source.get() as usize])
-                        {
-                            // reshaped for borrowck — copy out the redirect target's
-                            // (source_index, path) before re-borrowing `all_import_records` mutably.
-                            let (other_src_idx, other_path) = {
-                                let other_import_records =
-                                    self.all_import_records[other_source.get() as usize].as_slice();
-                                let other_import_record =
-                                    &other_import_records[redirect_id as usize];
-                                (other_import_record.source_index, other_import_record.path)
-                            };
-                            let import_record = &mut self.all_import_records
-                                [import_record_list_id.get() as usize]
-                                .as_mut_slice()[ir_idx];
-                            import_record.source_index = other_src_idx;
-                            import_record.path = other_path;
-                            other_source = other_src_idx;
-                            if redirect_count == Self::MAX_REDIRECTS {
-                                import_record.path.is_disabled = true;
-                                import_record.source_index = Index::INVALID;
-                                break;
-                            }
-
-                            // Handle redirects to a builtin or external module
-                            // https://github.com/oven-sh/bun/issues/3764
-                            if !other_source.is_valid() {
-                                break;
-                            }
-                            redirect_count += 1;
-                        }
-
-                        let import_record = &self.all_import_records
-                            [import_record_list_id.get() as usize]
-                            .as_slice()[ir_idx];
-                        // Mark if the file is imported by JS and its URL is inlined for CSS
-                        let is_inlined = import_record.source_index.is_valid()
-                            && !self.all_urls_for_css[import_record.source_index.get() as usize]
-                                .is_empty();
-                        if is_js && is_inlined {
-                            self.additional_files_imported_by_js_and_inlined_in_css
-                                .set(import_record.source_index.get() as usize);
-                        } else if is_css && is_inlined {
-                            self.additional_files_imported_by_css_and_inlined
-                                .set(import_record.source_index.get() as usize);
-                        }
-
-                        let next_source = import_record.source_index;
-                        let kind_is_dynamic = import_record.kind == ImportKind::Dynamic;
-                        self.visit::<CHECK_DYNAMIC_IMPORTS>(
-                            next_source,
-                            CHECK_DYNAMIC_IMPORTS && kind_is_dynamic,
-                        );
+                if let Some(scb_bitset) = &self.scb_bitset {
+                    if scb_bitset.is_set(source_index.get() as usize) {
+                        let scb_index = self
+                            .scb_list
+                            .get_index(source_index.get())
+                            .expect("unreachable");
+                        self.stack.push(ReachFrame::Enter {
+                            source_index: Index::init(
+                                self.scb_list.list.items_reference_source_index()[scb_index],
+                            ),
+                            was_dynamic_import: false,
+                        });
+                        self.stack.push(ReachFrame::Enter {
+                            source_index: Index::init(
+                                self.scb_list.list.items_ssr_source_index()[scb_index],
+                            ),
+                            was_dynamic_import: false,
+                        });
                     }
                 }
 
-                // Redirects replace the source file with another file
-                if let Some(redirect_id) =
-                    get_redirect_id(self.redirects[source_index.get() as usize])
-                {
-                    let redirect_source_index = self.all_import_records
-                        [source_index.get() as usize]
-                        .as_slice()[redirect_id as usize]
-                        .source_index
-                        .get();
-                    self.visit::<CHECK_DYNAMIC_IMPORTS>(
-                        Index::source(redirect_source_index),
-                        was_dynamic_import,
-                    );
-                    return;
-                }
-            }
+                let is_js = self.all_loaders[source_index.get() as usize].is_javascript_like();
+                let is_css = self.all_loaders[source_index.get() as usize].is_css();
 
-            // Each file must come after its dependencies
-            self.reachable.push(source_index);
-            if CHECK_DYNAMIC_IMPORTS {
-                if was_dynamic_import {
-                    self.dynamic_import_entry_points
-                        .put(source_index.get(), ())
-                        .expect("unreachable");
+                let import_record_list_id = source_index;
+                let mut has_redirect = false;
+                // when there are no import records, v index will be invalid
+                if (import_record_list_id.get() as usize) < self.all_import_records.len() {
+                    let import_records_len =
+                        self.all_import_records[import_record_list_id.get() as usize].len()
+                            as usize;
+                    for ir_idx in 0..import_records_len {
+                        let import_record = &mut self.all_import_records
+                            [import_record_list_id.get() as usize]
+                            .as_mut_slice()[ir_idx];
+                        let mut other_source = import_record.source_index;
+                        if other_source.is_valid() {
+                            let mut redirect_count: usize = 0;
+                            while let Some(redirect_id) =
+                                get_redirect_id(self.redirects[other_source.get() as usize])
+                            {
+                                let (other_src_idx, other_path) = {
+                                    let other_import_records = self.all_import_records
+                                        [other_source.get() as usize]
+                                        .as_slice();
+                                    let other_import_record =
+                                        &other_import_records[redirect_id as usize];
+                                    (other_import_record.source_index, other_import_record.path)
+                                };
+                                let import_record = &mut self.all_import_records
+                                    [import_record_list_id.get() as usize]
+                                    .as_mut_slice()[ir_idx];
+                                import_record.source_index = other_src_idx;
+                                import_record.path = other_path;
+                                other_source = other_src_idx;
+                                if redirect_count == Self::MAX_REDIRECTS {
+                                    import_record.path.is_disabled = true;
+                                    import_record.source_index = Index::INVALID;
+                                    break;
+                                }
+
+                                // Handle redirects to a builtin or external module
+                                // https://github.com/oven-sh/bun/issues/3764
+                                if !other_source.is_valid() {
+                                    break;
+                                }
+                                redirect_count += 1;
+                            }
+
+                            let import_record = &self.all_import_records
+                                [import_record_list_id.get() as usize]
+                                .as_slice()[ir_idx];
+                            // Mark if the file is imported by JS and its URL is inlined for CSS
+                            let is_inlined = import_record.source_index.is_valid()
+                                && !self.all_urls_for_css
+                                    [import_record.source_index.get() as usize]
+                                    .is_empty();
+                            if is_js && is_inlined {
+                                self.additional_files_imported_by_js_and_inlined_in_css
+                                    .set(import_record.source_index.get() as usize);
+                            } else if is_css && is_inlined {
+                                self.additional_files_imported_by_css_and_inlined
+                                    .set(import_record.source_index.get() as usize);
+                            }
+
+                            let next_source = import_record.source_index;
+                            let kind_is_dynamic = import_record.kind == ImportKind::Dynamic;
+                            self.stack.push(ReachFrame::Enter {
+                                source_index: next_source,
+                                was_dynamic_import: CHECK_DYNAMIC_IMPORTS && kind_is_dynamic,
+                            });
+                        }
+                    }
+
+                    // Redirects replace the source file with another file
+                    if let Some(redirect_id) =
+                        get_redirect_id(self.redirects[source_index.get() as usize])
+                    {
+                        let redirect_source_index = self.all_import_records
+                            [source_index.get() as usize]
+                            .as_slice()[redirect_id as usize]
+                            .source_index
+                            .get();
+                        self.stack.push(ReachFrame::Enter {
+                            source_index: Index::source(redirect_source_index),
+                            was_dynamic_import,
+                        });
+                        has_redirect = true;
+                    }
                 }
+
+                if !has_redirect {
+                    self.stack.push(ReachFrame::Leave {
+                        source_index,
+                        was_dynamic_import,
+                    });
+                }
+
+                self.stack[mark..].reverse();
             }
         }
     }
@@ -1933,6 +1984,7 @@ pub mod bv2_impl {
                     &mut additional_files_imported_by_js_and_inlined_in_css,
                 additional_files_imported_by_css_and_inlined:
                     &mut additional_files_imported_by_css_and_inlined,
+                stack: Vec::new(),
             };
 
             // If we don't include the runtime, __toESM or __toCommonJS will not get

--- a/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
+++ b/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
@@ -92,6 +92,7 @@ pub fn find_imported_parts_in_js_order(
             entry_point: chunk.entry_point,
             chunk_index,
             entry_point_chunk_indices,
+            stack: Vec::new(),
         };
 
         match (with_code_splitting, with_scb) {
@@ -153,6 +154,24 @@ pub struct FindImportedPartsVisitor<'a, 'ctx> {
     /// Raw column pointer into `c.graph.files` for the single mutable write in
     /// `visit` (see the raw-pointer note above).
     entry_point_chunk_indices: *mut [u32],
+    stack: Vec<PartsFrame>,
+}
+
+#[derive(Copy, Clone)]
+enum PartsFrame {
+    Enter(IndexInt),
+    /// Per-part post action: append this part's range after its imports.
+    Part {
+        source_index: IndexInt,
+        part_index: IndexInt,
+        can_be_split: bool,
+    },
+    /// Per-file post action: record the file after all of its parts.
+    File {
+        source_index: IndexInt,
+        is_file_in_chunk: bool,
+        can_be_split: bool,
+    },
 }
 
 impl<'a, 'ctx> FindImportedPartsVisitor<'a, 'ctx> {
@@ -179,106 +198,147 @@ impl<'a, 'ctx> FindImportedPartsVisitor<'a, 'ctx> {
 
     // Traverse the graph using this stable order and linearize the files with
     // dependencies before dependents
+    //
+    // Explicit-stack DFS (was per-edge recursive). `Enter` expands a file,
+    // queuing its imports interleaved with per-part `Part` markers and a
+    // trailing `File` marker, then reverses the tail so LIFO pop reproduces
+    // the original recursion order exactly.
     pub fn visit<const WITH_CODE_SPLITTING: bool, const WITH_SCB: bool>(
         &mut self,
         source_index: IndexInt,
     ) {
-        if source_index == Index::INVALID.value() {
-            return;
-        }
-        let visited_entry = bun_core::handle_oom(self.visited.get_or_put(source_index));
-        if visited_entry.found_existing {
-            return;
-        }
+        debug_assert!(self.stack.is_empty());
+        self.stack.push(PartsFrame::Enter(source_index));
 
-        let mut is_file_in_chunk = if WITH_CODE_SPLITTING
-            && self.c.graph.ast.items_css()[source_index as usize].is_none()
-        {
-            // when code splitting, include the file in the chunk if ALL of the entry points overlap
-            self.entry_bits
-                .eql(&self.c.graph.files.items_entry_bits()[source_index as usize])
-        } else {
-            // when NOT code splitting, include the file in the chunk if ANY of the entry points overlap
-            self.entry_bits
-                .has_intersection(&self.c.graph.files.items_entry_bits()[source_index as usize])
-        };
+        while let Some(frame) = self.stack.pop() {
+            match frame {
+                PartsFrame::Part {
+                    source_index,
+                    part_index,
+                    can_be_split,
+                } => {
+                    let part = &self.parts[source_index as usize].as_slice()[part_index as usize];
+                    if can_be_split
+                        && part_index != bun_ast::NAMESPACE_EXPORT_PART_INDEX
+                        && self.c.should_include_part(source_index, part)
+                    {
+                        let js_parts = if source_index == Index::RUNTIME.value() {
+                            &mut self.parts_prefix
+                        } else {
+                            &mut self.part_ranges
+                        };
+                        Self::append_or_extend_range(js_parts, source_index, part_index);
+                    }
+                    continue;
+                }
+                PartsFrame::File {
+                    source_index,
+                    is_file_in_chunk,
+                    can_be_split,
+                } => {
+                    if is_file_in_chunk {
+                        if WITH_SCB && self.c.graph.is_scb_bitset.is_set(source_index as usize) {
+                            // SAFETY: `entry_point_chunk_indices` is the raw column pointer
+                            // for `entry_point_chunk_index` (distinct from every
+                            // column read through `self.c` / `self.flags` / `self.parts`),
+                            // valid for `graph.files.len()` writes for the duration of the
+                            // link step. No `&` to this column is live here.
+                            unsafe {
+                                (*self.entry_point_chunk_indices)[source_index as usize] =
+                                    self.chunk_index;
+                            }
+                        }
 
-        // Wrapped files can't be split because they are all inside the wrapper
-        let can_be_split = self.flags[source_index as usize].wrap == Wrap::None;
+                        self.files.push(source_index);
 
-        let parts = self.parts[source_index as usize].as_slice();
-        let parts_live = &self.c.graph.parts_live[source_index as usize];
-        if can_be_split
-            && is_file_in_chunk
-            && parts_live.is_set(bun_ast::NAMESPACE_EXPORT_PART_INDEX as usize)
-        {
-            Self::append_or_extend_range(
-                &mut self.part_ranges,
-                source_index,
-                bun_ast::NAMESPACE_EXPORT_PART_INDEX,
-            );
-        }
-
-        let records = self.import_records[source_index as usize].as_slice();
-
-        for part_index_ in 0..parts.len() {
-            let part = &parts[part_index_];
-            let part_index = part_index_ as u32;
-            let is_part_in_this_chunk = is_file_in_chunk && parts_live.is_set(part_index_);
-            for &record_id in part.import_record_indices.slice() {
-                let record: &ImportRecord = &records[record_id as usize];
-                if record.source_index.is_valid()
-                    && (record.kind == ImportKind::Stmt || is_part_in_this_chunk)
-                {
-                    if self.c.is_external_dynamic_import(record, source_index) {
-                        // Don't follow import() dependencies
+                        // CommonJS files are all-or-nothing so all parts must be contiguous
+                        if !can_be_split {
+                            self.parts_prefix.push(PartRange {
+                                source_index: Index::init(source_index),
+                                part_index_begin: 0,
+                                part_index_end: self.parts[source_index as usize].len() as u32,
+                            });
+                        }
+                    }
+                    continue;
+                }
+                PartsFrame::Enter(source_index) => {
+                    if source_index == Index::INVALID.value() {
+                        continue;
+                    }
+                    let visited_entry =
+                        bun_core::handle_oom(self.visited.get_or_put(source_index));
+                    if visited_entry.found_existing {
                         continue;
                     }
 
-                    self.visit::<WITH_CODE_SPLITTING, WITH_SCB>(record.source_index.get());
-                }
-            }
-
-            // Then include this part after the files it imports
-            if is_part_in_this_chunk {
-                is_file_in_chunk = true;
-
-                if can_be_split
-                    && part_index != bun_ast::NAMESPACE_EXPORT_PART_INDEX
-                    && self.c.should_include_part(source_index, part)
-                {
-                    let js_parts = if source_index == Index::RUNTIME.value() {
-                        &mut self.parts_prefix
+                    let is_file_in_chunk = if WITH_CODE_SPLITTING
+                        && self.c.graph.ast.items_css()[source_index as usize].is_none()
+                    {
+                        // when code splitting, include the file in the chunk if ALL of the entry points overlap
+                        self.entry_bits
+                            .eql(&self.c.graph.files.items_entry_bits()[source_index as usize])
                     } else {
-                        &mut self.part_ranges
+                        // when NOT code splitting, include the file in the chunk if ANY of the entry points overlap
+                        self.entry_bits.has_intersection(
+                            &self.c.graph.files.items_entry_bits()[source_index as usize],
+                        )
                     };
 
-                    Self::append_or_extend_range(js_parts, source_index, part_index);
+                    // Wrapped files can't be split because they are all inside the wrapper
+                    let can_be_split = self.flags[source_index as usize].wrap == Wrap::None;
+
+                    let parts = self.parts[source_index as usize].as_slice();
+                    let parts_live = &self.c.graph.parts_live[source_index as usize];
+                    if can_be_split
+                        && is_file_in_chunk
+                        && parts_live.is_set(bun_ast::NAMESPACE_EXPORT_PART_INDEX as usize)
+                    {
+                        Self::append_or_extend_range(
+                            &mut self.part_ranges,
+                            source_index,
+                            bun_ast::NAMESPACE_EXPORT_PART_INDEX,
+                        );
+                    }
+
+                    let records = self.import_records[source_index as usize].as_slice();
+
+                    let mark = self.stack.len();
+                    for part_index_ in 0..parts.len() {
+                        let part = &parts[part_index_];
+                        let part_index = part_index_ as u32;
+                        let is_part_in_this_chunk =
+                            is_file_in_chunk && parts_live.is_set(part_index_);
+                        for &record_id in part.import_record_indices.slice() {
+                            let record: &ImportRecord = &records[record_id as usize];
+                            if record.source_index.is_valid()
+                                && (record.kind == ImportKind::Stmt || is_part_in_this_chunk)
+                            {
+                                if self.c.is_external_dynamic_import(record, source_index) {
+                                    // Don't follow import() dependencies
+                                    continue;
+                                }
+                                self.stack
+                                    .push(PartsFrame::Enter(record.source_index.get()));
+                            }
+                        }
+
+                        // Then include this part after the files it imports
+                        if is_part_in_this_chunk {
+                            self.stack.push(PartsFrame::Part {
+                                source_index,
+                                part_index,
+                                can_be_split,
+                            });
+                        }
+                    }
+                    self.stack.push(PartsFrame::File {
+                        source_index,
+                        is_file_in_chunk,
+                        can_be_split,
+                    });
+                    self.stack[mark..].reverse();
                 }
-            }
-        }
-
-        if is_file_in_chunk {
-            if WITH_SCB && self.c.graph.is_scb_bitset.is_set(source_index as usize) {
-                // SAFETY: `entry_point_chunk_indices` is the raw column pointer
-                // for `entry_point_chunk_index` (distinct from every
-                // column read through `self.c` / `self.flags` / `self.parts`),
-                // valid for `graph.files.len()` writes for the duration of the
-                // link step. No `&` to this column is live here.
-                unsafe {
-                    (*self.entry_point_chunk_indices)[source_index as usize] = self.chunk_index;
-                }
-            }
-
-            self.files.push(source_index);
-
-            // CommonJS files are all-or-nothing so all parts must be contiguous
-            if !can_be_split {
-                self.parts_prefix.push(PartRange {
-                    source_index: Index::init(source_index),
-                    part_index_begin: 0,
-                    part_index_end: parts.len() as u32,
-                });
             }
         }
     }

--- a/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
+++ b/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
@@ -266,8 +266,7 @@ impl<'a, 'ctx> FindImportedPartsVisitor<'a, 'ctx> {
                     if source_index == Index::INVALID.value() {
                         continue;
                     }
-                    let visited_entry =
-                        bun_core::handle_oom(self.visited.get_or_put(source_index));
+                    let visited_entry = bun_core::handle_oom(self.visited.get_or_put(source_index));
                     if visited_entry.found_existing {
                         continue;
                     }

--- a/src/bundler/linker_context/findImportedCSSFilesInJSOrder.rs
+++ b/src/bundler/linker_context/findImportedCSSFilesInJSOrder.rs
@@ -3,9 +3,7 @@ use bun_alloc::Arena;
 use bun_ast::ImportRecord;
 use bun_collections::VecExt;
 
-use crate::options::Loader;
 use crate::{Index, LinkerContext};
-use bun_ast::PartList;
 use bun_collections::DynamicBitSet as BitSet;
 
 /// JavaScript modules are traversed in depth-first postorder. This is the
@@ -37,26 +35,34 @@ pub fn find_imported_css_files_in_js_order(
     let all_loaders = this.parse_graph().input_files.items_loader();
     let all_parts = this.graph.ast.items_parts();
 
-    // Nested `fn` item so the visitor can recurse directly.
-    #[allow(clippy::too_many_arguments)]
-    fn visit(
-        c: &LinkerContext,
-        import_records: &[bun_ast::import_record::List<'_>],
-        parts: &[PartList<'_>],
-        loaders: &[Loader],
-        visits: &mut BitSet,
-        o: &mut Vec<Index>,
-        source_index: Index,
-        is_css: bool,
-    ) {
-        if visits.is_set(source_index.get() as usize) {
-            return;
+    // Explicit-stack DFS (was per-edge recursive). `Enter` pushes
+    // successors in discovery order then reverses the tail so `Leave`
+    // fires in the same depth-first postorder the recursion produced.
+    #[derive(Copy, Clone)]
+    enum Frame {
+        Enter(Index),
+        Leave(Index),
+    }
+    let mut stack: Vec<Frame> = vec![Frame::Enter(entry_point)];
+
+    while let Some(frame) = stack.pop() {
+        let source_index = match frame {
+            Frame::Leave(source_index) => {
+                order.push(source_index);
+                continue;
+            }
+            Frame::Enter(source_index) => source_index,
+        };
+
+        if visited.is_set(source_index.get() as usize) {
+            continue;
         }
-        visits.set(source_index.get() as usize);
+        visited.set(source_index.get() as usize);
 
-        let records: &[ImportRecord] = import_records[source_index.get() as usize].as_slice();
-        let p = &parts[source_index.get() as usize];
+        let records: &[ImportRecord] = all_import_records[source_index.get() as usize].as_slice();
+        let p = &all_parts[source_index.get() as usize];
 
+        let mark = stack.len();
         // Iterate over each part in the file in order
         for part in p.as_slice() {
             // Traverse any files imported by this part. Note that CommonJS calls
@@ -67,38 +73,21 @@ pub fn find_imported_css_files_in_js_order(
             // this is the only way to do it.
             for &import_record_index in part.import_record_indices.slice() {
                 let record = &records[import_record_index as usize];
-                if record.source_index.is_valid() {
-                    visit(
-                        c,
-                        import_records,
-                        parts,
-                        loaders,
-                        visits,
-                        o,
-                        record.source_index,
-                        loaders[record.source_index.get() as usize].is_css(),
-                    );
+                if record.source_index.is_valid()
+                    && !visited.is_set(record.source_index.get() as usize)
+                {
+                    stack.push(Frame::Enter(record.source_index));
                 }
             }
         }
-
-        if is_css && source_index.is_valid() {
-            // bun.handleOom(o.append(temp, source_index)) — Rust Vec uses global arena.
-            o.push(source_index);
+        // Only CSS files contribute to `order`; skip the `Leave` for
+        // everything else. The entry point was always visited with
+        // `is_css = false` in the recursive form.
+        if source_index != entry_point && all_loaders[source_index.get() as usize].is_css() {
+            stack.push(Frame::Leave(source_index));
         }
+        stack[mark..].reverse();
     }
-
-    // Include all files reachable from the entry point
-    visit(
-        this,
-        all_import_records,
-        all_parts,
-        all_loaders,
-        &mut visited,
-        &mut order,
-        entry_point,
-        false,
-    );
 
     order
 }

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -308,6 +308,7 @@ pub fn scan_imports_and_exports(
                     export_star_map: HashMap::default(),
                     export_star_records: &*export_star_import_records,
                     output_format,
+                    wrap_stack: Vec::new(),
                 }
             };
             for source_index_ in &reachable {
@@ -1171,6 +1172,7 @@ struct DependencyWrapper<'a> {
     entry_point_kinds: &'a [EntryPoint::Kind],
     export_star_records: &'a [bun_alloc::AstVec<u32>],
     output_format: options::Format,
+    wrap_stack: Vec<IndexInt>,
 }
 
 impl DependencyWrapper<'_> {
@@ -1213,35 +1215,40 @@ impl DependencyWrapper<'_> {
     }
 
     fn wrap(&mut self, source_index: IndexInt) {
-        let mut flag = self.flags[source_index as usize];
+        // Explicit worklist (was per-edge recursive). Only flag bits are
+        // written and never re-read to decide later iterations, so
+        // processing order is irrelevant.
+        debug_assert!(self.wrap_stack.is_empty());
+        self.wrap_stack.push(source_index);
 
-        if flag.did_wrap_dependencies {
-            return;
-        }
-        flag.did_wrap_dependencies = true;
+        while let Some(source_index) = self.wrap_stack.pop() {
+            let flag = &mut self.flags[source_index as usize];
 
-        // Never wrap the runtime file since it always comes first
-        if source_index == Index::RUNTIME.get() {
-            return;
-        }
-
-        // This module must be wrapped
-        if flag.wrap == WrapKind::None {
-            flag.wrap = match self.exports_kind[source_index as usize] {
-                ExportsKind::Cjs => WrapKind::Cjs,
-                _ => WrapKind::Esm,
-            };
-        }
-        self.flags[source_index as usize] = flag;
-
-        // `import_records` is a `&'a [_]` (Copy) field — copy it out so the
-        // recursive `&mut self` call does not overlap the iterator borrow.
-        let records = self.import_records;
-        for record in records[source_index as usize].as_slice() {
-            if !record.source_index.is_valid() {
+            if flag.did_wrap_dependencies {
                 continue;
             }
-            self.wrap(record.source_index.get());
+            flag.did_wrap_dependencies = true;
+
+            // Never wrap the runtime file since it always comes first
+            if source_index == Index::RUNTIME.get() {
+                continue;
+            }
+
+            // This module must be wrapped
+            if flag.wrap == WrapKind::None {
+                flag.wrap = match self.exports_kind[source_index as usize] {
+                    ExportsKind::Cjs => WrapKind::Cjs,
+                    _ => WrapKind::Esm,
+                };
+            }
+
+            for record in self.import_records[source_index as usize].as_slice() {
+                if record.source_index.is_valid()
+                    && !self.flags[record.source_index.get() as usize].did_wrap_dependencies
+                {
+                    self.wrap_stack.push(record.source_index.get());
+                }
+            }
         }
     }
 }

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2744,6 +2744,24 @@ describe("bundler", () => {
       expect(out).not.toContain("na_ve");
     },
   });
+  // The tree-shaking liveness pass used to recurse once per import-graph edge,
+  // overflowing the stack on long linear chains under debug+ASAN. 3000 modules
+  // reliably crashed the old recursive walk.
+  const deepChainDepth = 3000;
+  itBundled("edgecase/DeepImportChainTreeShaking", {
+    files: {
+      "/entry.js": `import { v0 } from "./m0.js"; console.log(v0);`,
+      [`/m${deepChainDepth - 1}.js`]: `export const v${deepChainDepth - 1} = 1;`,
+      ...Object.fromEntries(
+        Array.from({ length: deepChainDepth - 1 }, (_, i) => [
+          `/m${i}.js`,
+          `import { v${i + 1} } from "./m${i + 1}.js"; export const v${i} = v${i + 1} + 1;`,
+        ]),
+      ),
+    },
+    backend: "cli",
+    run: { stdout: String(deepChainDepth) },
+  });
   itBundled("edgecase/NonAsciiPathDerivedWrapperName", {
     files: {
       "/entry.ts": /* js */ `

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2747,41 +2747,41 @@ describe("bundler", () => {
   // The bundler's per-edge graph walks (reachable files, tree-shaking /
   // code-splitting liveness, chunk part ordering, CSS discovery, TLA
   // validation, async propagation, dependency wrapping) used to recurse once
-  // per import-graph edge, overflowing the stack on long linear chains.
+  // per import-graph edge, overflowing the stack on long linear chains. 7000
+  // reliably crashed the old recursive form under debug+ASAN.
   const deepChainDepth = 7000;
-  const deepChainLinks = Object.fromEntries(
-    Array.from({ length: deepChainDepth - 1 }, (_, i) => [
-      `/m${i}.js`,
-      `import { v${i + 1} } from "./m${i + 1}.js"; export const v${i} = v${i + 1} + 1;`,
-    ]),
-  );
+  const deepChainFiles = {
+    ...Object.fromEntries(
+      Array.from({ length: deepChainDepth - 1 }, (_, i) => [
+        `/m${i}.js`,
+        `import { v${i + 1} } from "./m${i + 1}.js"; export const v${i} = v${i + 1} + 1;`,
+      ]),
+    ),
+    [`/m${deepChainDepth - 1}.js`]: `export const v${deepChainDepth - 1} = 1;`,
+  };
   itBundled("edgecase/DeepImportChain", {
     files: {
       "/entry.js": `import { v0 } from "./m0.js"; console.log(v0);`,
-      ...deepChainLinks,
-      [`/m${deepChainDepth - 1}.js`]: `export const v${deepChainDepth - 1} = 1;`,
+      ...deepChainFiles,
     },
     backend: "cli",
     run: { stdout: String(deepChainDepth) },
   });
-  itBundled("edgecase/DeepImportChainTLA", {
+  // Top-level await in the entry makes `validate_tla` / `propagate_async` walk
+  // the chain; `await import()` of an ESM head without splitting wraps the
+  // whole chain, driving `DependencyWrapper::wrap` through it. The wrapped
+  // output initializes module N by calling module N+1's init, so running it
+  // would recurse at runtime; checking for the deepest wrapper is enough.
+  itBundled("edgecase/DeepImportChainWrappedTLA", {
     files: {
-      "/entry.js": `import { v0 } from "./m0.js"; console.log(v0);`,
-      ...deepChainLinks,
-      [`/m${deepChainDepth - 1}.js`]: `export const v${deepChainDepth - 1} = await Promise.resolve(1);`,
+      "/entry.js": `await 0; const { v0 } = await import("./m0.js"); console.log(v0);`,
+      ...deepChainFiles,
     },
     backend: "cli",
-    run: { stdout: String(deepChainDepth) },
-  });
-  itBundled("edgecase/DeepImportChainWrapped", {
-    files: {
-      "/entry.cjs": `const { v0 } = require("./m0.js"); console.log(v0);`,
-      ...deepChainLinks,
-      [`/m${deepChainDepth - 1}.js`]: `export const v${deepChainDepth - 1} = 1;`,
+    onAfterBundle(api) {
+      const out = api.readFile("out.js");
+      expect(out).toContain(`init_m${deepChainDepth - 2}`);
     },
-    entryPoints: ["/entry.cjs"],
-    backend: "cli",
-    run: { stdout: String(deepChainDepth) },
   });
   itBundled("edgecase/NonAsciiPathDerivedWrapperName", {
     files: {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2744,21 +2744,42 @@ describe("bundler", () => {
       expect(out).not.toContain("na_ve");
     },
   });
-  // The tree-shaking liveness pass used to recurse once per import-graph edge,
-  // overflowing the stack on long linear chains under debug+ASAN. 3000 modules
-  // reliably crashed the old recursive walk.
-  const deepChainDepth = 3000;
-  itBundled("edgecase/DeepImportChainTreeShaking", {
+  // The bundler's per-edge graph walks (reachable files, tree-shaking /
+  // code-splitting liveness, chunk part ordering, CSS discovery, TLA
+  // validation, async propagation, dependency wrapping) used to recurse once
+  // per import-graph edge, overflowing the stack on long linear chains.
+  const deepChainDepth = 7000;
+  const deepChainLinks = Object.fromEntries(
+    Array.from({ length: deepChainDepth - 1 }, (_, i) => [
+      `/m${i}.js`,
+      `import { v${i + 1} } from "./m${i + 1}.js"; export const v${i} = v${i + 1} + 1;`,
+    ]),
+  );
+  itBundled("edgecase/DeepImportChain", {
     files: {
       "/entry.js": `import { v0 } from "./m0.js"; console.log(v0);`,
+      ...deepChainLinks,
       [`/m${deepChainDepth - 1}.js`]: `export const v${deepChainDepth - 1} = 1;`,
-      ...Object.fromEntries(
-        Array.from({ length: deepChainDepth - 1 }, (_, i) => [
-          `/m${i}.js`,
-          `import { v${i + 1} } from "./m${i + 1}.js"; export const v${i} = v${i + 1} + 1;`,
-        ]),
-      ),
     },
+    backend: "cli",
+    run: { stdout: String(deepChainDepth) },
+  });
+  itBundled("edgecase/DeepImportChainTLA", {
+    files: {
+      "/entry.js": `import { v0 } from "./m0.js"; console.log(v0);`,
+      ...deepChainLinks,
+      [`/m${deepChainDepth - 1}.js`]: `export const v${deepChainDepth - 1} = await Promise.resolve(1);`,
+    },
+    backend: "cli",
+    run: { stdout: String(deepChainDepth) },
+  });
+  itBundled("edgecase/DeepImportChainWrapped", {
+    files: {
+      "/entry.cjs": `const { v0 } = require("./m0.js"); console.log(v0);`,
+      ...deepChainLinks,
+      [`/m${deepChainDepth - 1}.js`]: `export const v${deepChainDepth - 1} = 1;`,
+    },
+    entryPoints: ["/entry.cjs"],
     backend: "cli",
     run: { stdout: String(deepChainDepth) },
   });


### PR DESCRIPTION
### What does this PR do?

The linker walks the JS import graph with per-edge recursion in several independent passes. A linear chain of a few thousand modules is enough to overflow the stack:

```
AddressSanitizer: stack-overflow
  ReachableFileVisitor::visit src/bundler/bundle_v2.rs:1822 (x243)
```

Repro (debug build):

```sh
for i in $(seq 0 6998); do
  echo "import { v$((i+1)) } from './m$((i+1)).js'; export const v$i = v$((i+1)) + 1;" > m$i.js
done
echo 'export const v6999 = 1;' > m6999.js
echo 'import { v0 } from "./m0.js"; console.log(v0);' > entry.js
bun-debug build entry.js --outdir=dist
```

At 3000 modules `mark_file_live_for_tree_shaking` falls over first; at 7000 the earlier `ReachableFileVisitor::visit` does. Every pass below hits the same bound, so fixing them one at a time just moves the crash.

### Fix

Convert every per-edge-recursive walk over the JS import graph that this input reaches to an explicit stack:

| pass | shape | conversion |
| --- | --- | --- |
| `ReachableFileVisitor::visit` | postorder reachable list, mutates import records | Enter/Leave |
| `mark_file_live_for_tree_shaking` / `mark_part_live` | bit-set fixpoint | LIFO worklist |
| `mark_file_reachable_for_code_splitting` | bit-set + min-distance | LIFO worklist |
| `find_imported_css_files_in_js_order` | postorder CSS list | Enter/Leave |
| `FindImportedPartsVisitor::visit` | postorder part ranges, per-part action | Enter/Part/File |
| `validate_tla` | min-depth parent chain, reads child result | Enter/AfterChild/Leave |
| `propagate_async_dependencies` | postorder flag propagation | Enter/AfterChild |
| `DependencyWrapper::wrap` | bit-set fixpoint | LIFO worklist |

The order-independent bit-setting walks become a plain LIFO worklist. The postorder walks push successors in the desired pop order and then reverse the just-pushed tail, so LIFO pop reproduces the original recursion order exactly; `AfterChild` frames are the resumption point where a parent reads a child's completed state. `validate_tla` no longer threads per-call slices or returns the child's `TlaCheck` (both dead once the recursion is gone).

First commit is the tree-shaking worklist from #34541 (cherry-picked); this PR supersedes that one with the rest of the passes so a single deep-chain test can run end to end.

Not in scope here: the walks over the export-star graph, CSS `@import` graph, and chunk graph (`has_dynamic_exports_due_to_export_star`, `ExportStarContext::add_exports`, `find_imported_files_in_css_order`, `append_isolated_hashes_for_imported_chunks`, `StaticRouteVisitor`). Those recurse per edge too but need different inputs to trigger.

### Performance

Release build of this branch (`af93cab`) vs release build of the merge-base (`78f3a46`), both built with the same toolchain on the same machine. Each scenario is 2000 generated modules bundled in-process via `Bun.build()`, 5 interleaved process runs × 50 iterations each, reporting the minimum. Flag columns: `default` (no flags), `--format=cjs`, `--splitting --format=esm`, `--minify`, `--splitting --format=esm --minify`.

All 32 outputs are byte-identical between the two builds.

| fixture | flags | main (ms) | PR (ms) | Δ |
| --- | --- | ---: | ---: | ---: |
| esm-linear | default | 74.39 | 71.28 | -4.2% |
| esm-linear | cjs | 97.44 | 107.19 | +10.0% |
| esm-linear | split | 92.96 | 75.68 | -18.6% |
| esm-linear | minify | 88.66 | 85.76 | -3.3% |
| esm-linear | split+minify | 78.77 | 71.68 | -9.0% |
| esm-wide | default | 23.50 | 22.68 | -3.5% |
| esm-wide | cjs | 23.64 | 24.17 | +2.2% |
| esm-wide | split | 24.88 | 25.98 | +4.4% |
| esm-wide | minify | 24.09 | 24.75 | +2.7% |
| esm-wide | split+minify | 26.13 | 24.89 | -4.8% |
| esm-cyclical | default | 27.67 | 24.61 | -11.1% |
| esm-cyclical | cjs | 24.60 | 25.66 | +4.3% |
| esm-cyclical | split | 26.98 | 24.15 | -10.5% |
| esm-cyclical | minify | 22.69 | 25.26 | +11.3% |
| esm-cyclical | split+minify | 21.79 | 24.15 | +10.8% |
| cjs-esm-mixed | default | 89.00 | 98.76 | +11.0% |
| cjs-esm-mixed | cjs | 106.31 | 105.31 | -0.9% |
| cjs-esm-mixed | split | 94.39 | 91.84 | -2.7% |
| cjs-esm-mixed | minify | 99.55 | 90.07 | -9.5% |
| cjs-esm-mixed | split+minify | 92.62 | 90.57 | -2.2% |
| dynamic-cyclical | default | 101.81 | 96.72 | -5.0% |
| dynamic-cyclical | minify | 91.93 | 99.50 | +8.2% |
| require-linear | default | 89.06 | 78.41 | -12.0% |
| require-linear | cjs | 65.66 | 70.13 | +6.8% |
| require-linear | split | 71.27 | 77.82 | +9.2% |
| require-linear | minify | 77.96 | 83.01 | +6.5% |
| require-linear | split+minify | 84.37 | 77.32 | -8.4% |
| multi-entry | default | 40.24 | 39.57 | -1.7% |
| multi-entry | cjs | 42.72 | 38.55 | -9.8% |
| multi-entry | split | 26.87 | 22.72 | -15.4% |
| multi-entry | minify | 41.69 | 36.86 | -11.6% |
| multi-entry | split+minify | 24.72 | 22.12 | -10.5% |

Range -18.6% to +11.3%, mean -2.1%. The measurement noise floor on this host (same binary against itself, identical methodology) is -29.0% to +20.8%, mean -1.8%, so every delta above is inside the noise. The converted passes visit the same nodes with the same per-node work; the only difference is heap `Vec` vs call stack for the frame storage.

<details>
<summary>Fixture shapes</summary>

- `esm-linear`: each module `import`s the next and re-exports a derived value (the crash repro).
- `esm-wide`: one entry `import`s 2000 leaves directly.
- `esm-cyclical`: 400 rings of 5 ESM modules, each ring member `import`s the next (last back to first); entry `import`s every ring head.
- `cjs-esm-mixed`: alternating `.cjs`/`.mjs` chain with a back-edge every 10 modules (`require`/`import` mix with cycles).
- `dynamic-cyclical`: entry `await import()`s the head; each module statically `import`s the next and `() => import()`s a module 5 steps back.
- `require-linear`: plain `require()` chain.
- `multi-entry`: 20 entry points sharing a 4-ary ESM dependency tree; each entry `import`s a different branch head plus the shared root.

`--splitting` is skipped for `dynamic-cyclical` (it produces ~2000 chunks and dominates the run), and `--format=cjs` is skipped for `dynamic-cyclical` (top-level await in entry).
</details>

### How did you verify your code works?

- New `edgecase/DeepImportChain` bundles a 7000-deep linear chain and runs the output (prints `7000`). New `edgecase/DeepImportChainWrappedTLA` bundles the same chain from an `await 0; await import(...)` entry, which drives the TLA and wrap passes through the whole chain, and checks for the deepest generated init wrapper. Both crash with the stack-overflow trace above on main under debug+ASAN, pass with this change.
- All 32 scenarios in the performance matrix above produce byte-identical output vs the merge-base build.
- `bun bd test` on `bundler_edgecase`, `esbuild/default`, `esbuild/dce`, `esbuild/splitting`, `esbuild/importstar`, `esbuild/css`, `bundler_cjs`, `bundler_cjs2esm`, `bundler_splitting`, `bundler_html`, `bundler_barrel`, `bundler_minify`, `bundler_browser`, `bundler_loader`: 0 new failures.
- 20000-module chain bundles and runs correctly.
