### PR TITLE
usockets(win): FIN open sockets at process exit and on close_all force-drain

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -120,9 +120,11 @@ void us_socket_group_close_all_ex(struct us_socket_group_t *group, int also_list
      * open in head_sockets waiting for the peer's reply. Callers of close_all
      * (e.g. Listener.deinit) free the embedding storage immediately after, so
      * any survivor's s->group becomes a dangling pointer. The graceful walk
-     * already flushed close_notify; force-drain the rest synchronously now. */
+     * already flushed close_notify; force-drain the rest synchronously now.
+     * FAST_SHUTDOWN (not RESET): node's closeAllConnections() is destroy(),
+     * not resetAndDestroy(); SO_LINGER{1,0} here RSTs the peer on Windows. */
     while (group->head_sockets) {
-        us_internal_socket_close_raw(group->head_sockets, LIBUS_SOCKET_CLOSE_CODE_CONNECTION_RESET, 0);
+        us_internal_socket_close_raw(group->head_sockets, LIBUS_SOCKET_CLOSE_CODE_FAST_SHUTDOWN, 0);
     }
 
     /* Sockets parked in the loop-wide low-prio queue aren't in head_sockets

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -352,6 +352,10 @@ void us_socket_group_close_all_ex(us_socket_group_r group, int also_listeners) n
  * (see close_all_ex). */
 int us_loop_close_all_groups(us_loop_r loop) nonnull_fn_decl;
 
+/* Windows process-exit: closesocket() every still-open fd so ExitProcess
+ * doesn't RST the peer. No dispatch, no free. No-op on POSIX. */
+void us_loop_close_fds_for_exit(us_loop_r loop) nonnull_fn_decl;
+
 unsigned short us_socket_group_timestamp(us_socket_group_r group) nonnull_fn_decl;
 struct us_loop_t *us_socket_group_loop(us_socket_group_r group) nonnull_fn_decl __attribute((returns_nonnull));
 void *us_socket_group_ext(us_socket_group_r group) nonnull_fn_decl;

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -225,6 +225,28 @@ int us_loop_close_all_groups(struct us_loop_t *loop) {
     return any;
 }
 
+/* Windows RSTs a socket abandoned at ExitProcess; closesocket() with default
+ * linger hands it to the kernel for a graceful close that survives process
+ * teardown (what node's RunCleanup → uv_close does). No dispatch, no free. */
+void us_loop_close_fds_for_exit(struct us_loop_t *loop) {
+#ifdef _WIN32
+    for (struct us_socket_group_t *g = loop->data.head; g; g = g->next) {
+        for (struct us_socket_t *s = g->head_sockets; s; s = s->next) {
+            if (!s->flags.is_closed) {
+                bsd_close_socket(us_poll_fd(&s->p));
+            }
+        }
+    }
+    for (struct us_socket_t *s = loop->data.low_prio_head; s; s = s->next) {
+        if (!s->flags.is_closed) {
+            bsd_close_socket(us_poll_fd(&s->p));
+        }
+    }
+#else
+    (void) loop;
+#endif
+}
+
 /* This functions should never run recursively */
 void us_internal_timer_sweep(struct us_loop_t *loop) {
     struct us_internal_loop_data_t *loop_data = &loop->data;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1621,6 +1621,12 @@ impl VirtualMachine {
             unsafe { (*uws::Loop::get()).drain_closed_sockets() };
 
             self.destroy();
+        } else {
+            // Windows RSTs sockets abandoned at ExitProcess (POSIX FINs on fd
+            // reap). closesocket() each open fd so the kernel graceful-close
+            // survives ExitProcess, matching node's RunCleanup → uv_close.
+            #[cfg(windows)]
+            self.uws_loop_mut().close_fds_for_exit();
         }
         bun_core::Global::exit(u32::from(self.exit_handler.exit_code))
     }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1622,9 +1622,9 @@ impl VirtualMachine {
 
             self.destroy();
         } else {
-            // Windows RSTs sockets abandoned at ExitProcess (POSIX FINs on fd
-            // reap). closesocket() each open fd so the kernel graceful-close
-            // survives ExitProcess, matching node's RunCleanup → uv_close.
+            // Windows RSTs sockets abandoned at ExitProcess; POSIX kernels FIN
+            // on fd reap. closesocket() each open fd so Windows matches POSIX
+            // (and node's natural-exit RunCleanup → uv_close).
             #[cfg(windows)]
             self.uws_loop_mut().close_fds_for_exit();
         }

--- a/src/uws_sys/Loop.rs
+++ b/src/uws_sys/Loop.rs
@@ -549,6 +549,13 @@ impl WindowsLoop {
         unsafe { c::us_loop_close_all_groups(self) != 0 }
     }
 
+    /// `closesocket()` every still-open fd so `ExitProcess` doesn't RST the
+    /// peer. No JS dispatch, no free. Called once, immediately before exit.
+    pub fn close_fds_for_exit(&mut self) {
+        // SAFETY: self is a valid loop pointer
+        unsafe { c::us_loop_close_fds_for_exit(self) };
+    }
+
     // See PosixLoop::next_tick — same trampoline-synthesis limitation.
     pub fn next_tick(
         &mut self,
@@ -660,6 +667,8 @@ mod c {
         );
         pub(super) fn us_internal_free_closed_sockets(loop_: *mut Loop);
         pub(super) fn us_loop_close_all_groups(loop_: *mut Loop) -> c_int;
+        #[cfg(windows)]
+        pub(super) fn us_loop_close_fds_for_exit(loop_: *mut Loop);
         #[cfg(not(windows))]
         pub(super) safe fn uws_get_loop() -> *mut Loop;
         #[cfg(windows)]

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1,7 +1,7 @@
 import { Socket as _BunSocket, TCPSocketListener } from "bun";
 import { heapStats } from "bun:jsc";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, expectMaxObjectTypeCount, isASAN, isDebug, isWindows, tmpdirSync } from "harness";
+import { bunEnv, bunExe, expectMaxObjectTypeCount, isASAN, isDebug, isWindows, tls as tlsCert, tmpdirSync } from "harness";
 import { randomUUID } from "node:crypto";
 import { once } from "node:events";
 import fs from "node:fs";
@@ -1130,4 +1130,119 @@ it.skipIf(isWindows)("connect({ localPort }) succeeds when the local port has TI
   } finally {
     target.close();
   }
+});
+
+// Windows RSTs sockets abandoned at ExitProcess; bun must closesocket() them
+// first so the peer sees FIN (node does this via RunCleanup → uv_close). On
+// POSIX the kernel FINs on fd reap, so this is a Windows-only observable.
+it.skipIf(!isWindows)("natural process exit with an open unref'd socket FINs the peer (no RST)", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const net = require("net");
+const { spawn } = require("child_process");
+const srv = net.createServer(c => {
+  let data = "";
+  c.on("data", d => { data += d; });
+  c.on("end", () => console.log("END " + data));
+  c.on("error", e => console.log("ERROR " + e.code));
+  c.on("close", hadError => { console.log("CLOSE hadError=" + hadError); srv.close(); });
+});
+srv.listen(0, "127.0.0.1", () => {
+  const child = spawn(process.execPath, ["-e", \`
+    const s = require("net").connect(\${srv.address().port}, "127.0.0.1");
+    s.on("connect", () => { s.write("hello"); s.unref(); });
+    s.on("error", () => {});
+  \`], { stdio: "inherit" });
+  child.on("close", code => console.log("CHILD_EXIT " + code));
+});
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  // Peer must observe a graceful close: END with the data, then CLOSE without error.
+  expect(stdout).toContain("END hello");
+  expect(stdout).toContain("CLOSE hadError=false");
+  expect(stdout).not.toContain("ERROR");
+  expect(exitCode).toBe(0);
+});
+
+it.skipIf(!isWindows)("process.exit() with an open socket FINs the peer (no RST)", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const net = require("net");
+const { spawn } = require("child_process");
+const srv = net.createServer(c => {
+  c.on("end", () => console.log("END"));
+  c.on("error", e => console.log("ERROR " + e.code));
+  c.on("close", hadError => { console.log("CLOSE hadError=" + hadError); srv.close(); });
+});
+srv.listen(0, "127.0.0.1", () => {
+  const child = spawn(process.execPath, ["-e", \`
+    const s = require("net").connect(\${srv.address().port}, "127.0.0.1");
+    s.on("connect", () => { s.write("bye"); process.exit(0); });
+    s.on("error", () => {});
+  \`], { stdio: "inherit" });
+  child.on("close", code => console.log("CHILD_EXIT " + code));
+});
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toContain("CLOSE hadError=false");
+  expect(stdout).not.toContain("ERROR");
+  expect(exitCode).toBe(0);
+});
+
+// https.Server.closeAllConnections() → server.stop(true) must FIN the client,
+// not RST. Node's closeAllConnections is socket.destroy() (uv_close → FIN),
+// not resetAndDestroy(). Only observable on Windows: Linux delivers the
+// already-sent close_notify before an RST, Windows drops it.
+it.skipIf(!isWindows)("https.Server.closeAllConnections() FINs the client (no RST)", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const https = require("https");
+const tls = require("tls");
+const srv = https.createServer(${JSON.stringify({ key: tlsCert.key, cert: tlsCert.cert })},
+  (req, res) => { res.writeHead(200, { Connection: "keep-alive" }); res.end(); });
+srv.listen(0, "127.0.0.1", () => {
+  const c = tls.connect({ port: srv.address().port, host: "127.0.0.1", rejectUnauthorized: false });
+  let got = "";
+  c.setEncoding("utf8");
+  c.on("data", d => {
+    got += d;
+    if (got.endsWith("0\\r\\n\\r\\n")) { srv.closeAllConnections(); srv.close(); }
+  });
+  c.on("end", () => console.log("CLIENT_END"));
+  c.on("error", e => console.log("CLIENT_ERROR " + e.code));
+  c.on("close", hadError => console.log("CLIENT_CLOSE hadError=" + hadError));
+  c.on("secureConnect", () => c.write("GET / HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n"));
+});
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toContain("CLIENT_CLOSE hadError=false");
+  expect(stdout).not.toContain("CLIENT_ERROR");
+  expect(exitCode).toBe(0);
 });

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1,7 +1,16 @@
 import { Socket as _BunSocket, TCPSocketListener } from "bun";
 import { heapStats } from "bun:jsc";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, expectMaxObjectTypeCount, isASAN, isDebug, isWindows, tls as tlsCert, tmpdirSync } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  expectMaxObjectTypeCount,
+  isASAN,
+  isDebug,
+  isWindows,
+  tls as tlsCert,
+  tmpdirSync,
+} from "harness";
 import { randomUUID } from "node:crypto";
 import { once } from "node:events";
 import fs from "node:fs";

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1141,9 +1141,9 @@ it.skipIf(isWindows)("connect({ localPort }) succeeds when the local port has TI
   }
 });
 
-// Windows RSTs sockets abandoned at ExitProcess; bun must closesocket() them
-// first so the peer sees FIN (node does this via RunCleanup → uv_close). On
-// POSIX the kernel FINs on fd reap, so this is a Windows-only observable.
+// Windows RSTs sockets abandoned at ExitProcess; a POSIX kernel FINs on fd
+// reap. Node's natural-exit path (loop drained, unref'd handle) uv_close()s
+// each open handle before exiting, so this is a Windows-only node-compat gap.
 it.skipIf(!isWindows)("natural process exit with an open unref'd socket FINs the peer (no RST)", async () => {
   await using proc = Bun.spawn({
     cmd: [
@@ -1174,46 +1174,16 @@ srv.listen(0, "127.0.0.1", () => {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  // Peer must observe a graceful close: END with the data, then CLOSE without error.
-  expect(stdout).toContain("END hello");
-  expect(stdout).toContain("CLOSE hadError=false");
-  expect(stdout).not.toContain("ERROR");
-  expect(exitCode).toBe(0);
-});
-
-it.skipIf(!isWindows)("process.exit() with an open socket FINs the peer (no RST)", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
-const net = require("net");
-const { spawn } = require("child_process");
-const srv = net.createServer(c => {
-  c.on("end", () => console.log("END"));
-  c.on("error", e => console.log("ERROR " + e.code));
-  c.on("close", hadError => { console.log("CLOSE hadError=" + hadError); srv.close(); });
-});
-srv.listen(0, "127.0.0.1", () => {
-  const child = spawn(process.execPath, ["-e", \`
-    const s = require("net").connect(\${srv.address().port}, "127.0.0.1");
-    s.on("connect", () => { s.write("bye"); process.exit(0); });
-    s.on("error", () => {});
-  \`], { stdio: "inherit" });
-  child.on("close", code => console.log("CHILD_EXIT " + code));
-});
-      `,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
+  // CHILD_EXIT may interleave with END/CLOSE; pick out the peer-observed lines.
+  const seen = stdout
+    .split(/\r?\n/)
+    .filter(l => l.startsWith("END") || l.startsWith("ERROR") || l.startsWith("CLOSE"))
+    .join("\n");
+  expect({ seen, stderr, exitCode }).toEqual({
+    seen: "END hello\nCLOSE hadError=false",
+    stderr: "",
+    exitCode: 0,
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(stdout).toContain("CLOSE hadError=false");
-  expect(stdout).not.toContain("ERROR");
-  expect(exitCode).toBe(0);
 });
 
 // https.Server.closeAllConnections() → server.stop(true) must FIN the client,
@@ -1250,8 +1220,13 @@ srv.listen(0, "127.0.0.1", () => {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(stdout).toContain("CLIENT_CLOSE hadError=false");
-  expect(stdout).not.toContain("CLIENT_ERROR");
-  expect(exitCode).toBe(0);
+  const seen = stdout
+    .split(/\r?\n/)
+    .filter(l => l.startsWith("CLIENT_"))
+    .join("\n");
+  expect({ seen, stderr, exitCode }).toEqual({
+    seen: "CLIENT_END\nCLIENT_CLOSE hadError=false",
+    stderr: "",
+    exitCode: 0,
+  });
 });


### PR DESCRIPTION
On Windows, bun sent RST where Node/libuv sends a graceful FIN in two paths:

### 1. Natural process exit with open sockets

A bun child process whose loop drains (unref'd `net.Socket`) abandons the handle at `ExitProcess`. Windows resets an abandoned socket; a POSIX kernel FINs on fd reap. Node's natural-exit path (`NodeMainInstance::Run` → `FreeEnvironment` → `RunCleanup`) `uv_close()`s every open handle before exit, so the peer always sees FIN.

Observed with a `net.Server` parent and a child that does `net.connect` + `socket.unref()` and lets the loop drain:

| child | Linux | Windows |
|---|---|---|
| node | FIN (`end`, `hadError:false`) | FIN |
| bun  | FIN | **RST (`ECONNRESET`, `hadError:true`)** |

(Node's explicit `process.exit()` path does *not* walk open handles and RSTs the peer on Windows; this PR makes bun FIN there too, which matches what the POSIX kernel already gives bun on Linux, but it is not Node-Windows parity for that specific path.)

### 2. `https.Server.closeAllConnections()`

`server.stop(true)` → `us_socket_group_close_all_ex`. The first pass closes TLS sockets gracefully (sends `close_notify`, defers on `WANT_READ`); the force-drain that follows used `CONNECTION_RESET`, arming `SO_LINGER{1,0}` before `closesocket`. On Linux loopback the already-sent `close_notify` reaches the peer before the RST so the client sees a clean TLS EOF. On Windows the RST wins and the client gets `ECONNRESET`. Node's `closeAllConnections()` is `socket.destroy()` (`uv_close` → FIN), not `resetAndDestroy()`.

Both are what makes `test-https-agent-unref-socket.js` and `test-https-server-close-all.js` fail on Windows once `net.ts` stops swallowing unhandled socket errors (#34513).

### Fix

- New `us_loop_close_fds_for_exit()`: walk every linked group and `closesocket()` each open fd, no dispatch, no free. Called from `VirtualMachine::global_exit()` on Windows only, just before `ExitProcess`. With default linger the kernel completes the graceful close across process teardown.
- `close_all_ex` force-drain: `FAST_SHUTDOWN` instead of `CONNECTION_RESET`. The graceful pass already flushed `close_notify`; the drain only needs to close the fd synchronously so the embedding storage can be freed. No caller of `close_all` wants RST.

### Verification

Two Windows-only tests in `test/js/node/net/node-net.test.ts` spawn subprocesses and assert the peer observes `hadError:false` with no `ECONNRESET`:

- unref'd socket + natural exit
- `https.Server.closeAllConnections()`

| | main (Windows) | this PR (Windows) | node (Windows) |
|---|---|---|---|
| unref + natural exit | `ECONNRESET` | `end`, `hadError:false` | `end`, `hadError:false` |
| `closeAllConnections` | `ECONNRESET` | `end`, `hadError:false` | `end`, `hadError:false` |

`test/js/node/net/node-net.test.ts` on Windows: 48 pass / 3 skip / 0 fail. `test-https-agent-unref-socket.js`, `test-https-server-close-all.js`, `test-http-server-close-all.js`, `test-http{,s}-server-close-idle.js` all exit 0 on Windows. Same suite unchanged on Linux.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/net/node-net.test.ts

<!-- robobun:evidence:end -->