### PR TITLE
bundler: emit posix-relative paths in the HTML-import manifest on Windows

### DIFF
--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -662,7 +662,6 @@ impl IntermediateOutput {
         let unique_key_for_additional_files =
             graph.input_files.items_unique_key_for_additional_file();
         let mut relative_platform_buf = bun_paths::path_buffer_pool::get();
-        let mut file_path_buf = bun_paths::path_buffer_pool::get();
         match self {
             IntermediateOutput::Pieces(pieces) => {
                 let entry_point_chunks_for_scb = linker_graph.files.items_entry_point_chunk_index();
@@ -943,18 +942,6 @@ impl IntermediateOutput {
                                 _ => unreachable!(),
                             };
 
-                            // normalize windows paths to '/'
-                            // The source slices are reachable only
-                            // through `&Graph` / `&[Chunk]` here; materialising `&mut` from a
-                            // shared-provenance pointer is UB regardless of whether the write
-                            // happens. Copy into a pooled scratch buffer and normalise that.
-                            let file_path: &[u8] = {
-                                let n = file_path.len();
-                                let dst = &mut file_path_buf[..n];
-                                dst.copy_from_slice(file_path);
-                                bun_paths::resolve_path::platform_to_posix_in_place::<u8>(dst);
-                                dst
-                            };
                             let cheap_normalizer = cheap_prefix_normalizer(
                                 import_prefix,
                                 if use_outdir_relative_path {

--- a/src/bundler/HTMLImportManifest.rs
+++ b/src/bundler/HTMLImportManifest.rs
@@ -327,7 +327,8 @@ pub fn write<W: Write + ?Sized>(
 
                 // `dest_path` comes from `PathTemplate::print` (native separators);
                 // rewrite to `/` so it matches the posix `final_rel_path`s above.
-                let dest_path = platform_to_posix_buf::<u8>(&output_file.dest_path, &mut **dest_buf);
+                let dest_path =
+                    platform_to_posix_buf::<u8>(&output_file.dest_path, &mut **dest_buf);
                 let path: &[u8] = if inject_compiler_filesystem_prefix {
                     temp_buffer.clear();
                     temp_buffer.extend_from_slice(public_path);

--- a/src/bundler/HTMLImportManifest.rs
+++ b/src/bundler/HTMLImportManifest.rs
@@ -43,7 +43,7 @@ use bun_core::strings;
 use bun_io::{FmtAdapter, Write};
 use bun_js_printer::Encoding;
 use bun_paths::path_buffer_pool;
-use bun_paths::resolve_path::{platform, platform_to_posix_buf, platform_to_posix_in_place};
+use bun_paths::resolve_path::{platform, platform_to_posix_in_place};
 use bun_resolver::fs::FileSystem;
 
 use crate::Graph::Graph;
@@ -199,7 +199,6 @@ pub fn write<W: Write + ?Sized>(
     let public_path: &[u8] = &options.public_path;
     let mut temp_buffer: Vec<u8> = Vec::new();
     let mut input_buf = path_buffer_pool::get();
-    let mut dest_buf = path_buffer_pool::get();
 
     for ch in chunks.iter() {
         if ch.entry_point.source_index() == browser_source_index && ch.entry_point.is_entry_point()
@@ -325,17 +324,15 @@ pub fn write<W: Write + ?Sized>(
                 platform_to_posix_in_place::<u8>(&mut input_buf[..len]);
                 let path_for_key = strings::remove_leading_dot_slash(&input_buf[..len]);
 
-                // `dest_path` comes from `PathTemplate::print` (native separators);
-                // rewrite to `/` so it matches the posix `final_rel_path`s above.
-                let dest_path =
-                    platform_to_posix_buf::<u8>(&output_file.dest_path, &mut **dest_buf);
                 let path: &[u8] = if inject_compiler_filesystem_prefix {
                     temp_buffer.clear();
                     temp_buffer.extend_from_slice(public_path);
-                    temp_buffer.extend_from_slice(strings::remove_leading_dot_slash(dest_path));
+                    temp_buffer.extend_from_slice(strings::remove_leading_dot_slash(
+                        &output_file.dest_path,
+                    ));
                     &temp_buffer[..]
                 } else {
-                    dest_path
+                    &output_file.dest_path[..]
                 };
 
                 write_entry_item(

--- a/src/bundler/HTMLImportManifest.rs
+++ b/src/bundler/HTMLImportManifest.rs
@@ -42,7 +42,8 @@ use bun_collections::VecExt;
 use bun_core::strings;
 use bun_io::{FmtAdapter, Write};
 use bun_js_printer::Encoding;
-use bun_paths::resolve_path::relative_normalized;
+use bun_paths::path_buffer_pool;
+use bun_paths::resolve_path::{platform, platform_to_posix_buf, platform_to_posix_in_place};
 use bun_resolver::fs::FileSystem;
 
 use crate::Graph::Graph;
@@ -197,6 +198,8 @@ pub fn write<W: Write + ?Sized>(
     // Use the server-side public path here.
     let public_path: &[u8] = &options.public_path;
     let mut temp_buffer: Vec<u8> = Vec::new();
+    let mut input_buf = path_buffer_pool::get();
+    let mut dest_buf = path_buffer_pool::get();
 
     for ch in chunks.iter() {
         if ch.entry_point.source_index() == browser_source_index && ch.entry_point.is_entry_point()
@@ -253,11 +256,16 @@ pub fn write<W: Write + ?Sized>(
             let input: &[u8] = if !ch.entry_point.is_entry_point() {
                 b""
             } else {
-                let path_for_key = relative_normalized::<bun_paths::platform::Posix, false>(
+                // `root_dir` and `source.path.text` are native absolute paths, so
+                // compute the relative path with host semantics and emit it as posix.
+                let len = bun_paths::resolve_path::relative_platform_buf::<platform::Auto, true>(
+                    &mut **input_buf,
                     root_dir,
                     sources[ch.entry_point.source_index() as usize].path.text,
-                );
-                strings::remove_leading_dot_slash(path_for_key)
+                )
+                .len();
+                platform_to_posix_in_place::<u8>(&mut input_buf[..len]);
+                strings::remove_leading_dot_slash(&input_buf[..len])
             };
 
             let path: &[u8] = if inject_compiler_filesystem_prefix {
@@ -308,21 +316,25 @@ pub fn write<W: Write + ?Sized>(
                 }
                 first = false;
 
-                let path_for_key = relative_normalized::<bun_paths::platform::Posix, false>(
+                let len = bun_paths::resolve_path::relative_platform_buf::<platform::Auto, true>(
+                    &mut **input_buf,
                     root_dir,
                     sources[source_index.get() as usize].path.text,
-                );
-                let path_for_key = strings::remove_leading_dot_slash(path_for_key);
+                )
+                .len();
+                platform_to_posix_in_place::<u8>(&mut input_buf[..len]);
+                let path_for_key = strings::remove_leading_dot_slash(&input_buf[..len]);
 
+                // `dest_path` comes from `PathTemplate::print` (native separators);
+                // rewrite to `/` so it matches the posix `final_rel_path`s above.
+                let dest_path = platform_to_posix_buf::<u8>(&output_file.dest_path, &mut **dest_buf);
                 let path: &[u8] = if inject_compiler_filesystem_prefix {
                     temp_buffer.clear();
                     temp_buffer.extend_from_slice(public_path);
-                    temp_buffer.extend_from_slice(strings::remove_leading_dot_slash(
-                        &output_file.dest_path,
-                    ));
+                    temp_buffer.extend_from_slice(strings::remove_leading_dot_slash(dest_path));
                     &temp_buffer[..]
                 } else {
-                    &output_file.dest_path[..]
+                    dest_path
                 };
 
                 write_entry_item(

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4155,6 +4155,10 @@ pub mod bv2_impl {
                             template
                                 .print(&mut v, !self.transpiler.options.compile)
                                 .expect("oom");
+                            // Same invariant as `Chunk.final_rel_path`: every consumer
+                            // (chunk assembly, manifest JSON, standalone graph, HTTP
+                            // routes) wants `/`, and Windows openat normalises `/` itself.
+                            bun_paths::resolve_path::platform_to_posix_in_place::<u8>(&mut v);
                             v.into_boxed_slice()
                         };
 

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -270,13 +270,7 @@ pub(super) fn write_sourcemap_to_disk(
     let source_map_index = file.source_map_index;
     debug_assert!(bundled_outputs[source_map_index as usize].output_kind == OutputKind::Sourcemap);
 
-    let without_prefix = if strings::has_prefix(&file.dest_path, b"./")
-        || (cfg!(windows) && strings::has_prefix(&file.dest_path, b".\\"))
-    {
-        &file.dest_path[2..]
-    } else {
-        &file.dest_path[..]
-    };
+    let without_prefix = strings::remove_leading_dot_slash(&file.dest_path);
 
     let mut key = Vec::with_capacity(6 + without_prefix.len());
     write!(&mut key, "bake:/{}", BStr::new(without_prefix)).expect("infallible: in-memory write");
@@ -754,13 +748,7 @@ pub(super) fn build_with_vm(
 
                     match file.output_kind {
                         OutputKind::EntryPoint | OutputKind::Chunk => {
-                            let without_prefix = if strings::has_prefix(&file.dest_path, b"./")
-                                || (cfg!(windows) && strings::has_prefix(&file.dest_path, b".\\"))
-                            {
-                                &file.dest_path[2..]
-                            } else {
-                                &file.dest_path[..]
-                            };
+                            let without_prefix = strings::remove_leading_dot_slash(&file.dest_path);
 
                             if let Some(entry_point_index) = file.entry_point_index {
                                 if (entry_point_index as usize) < module_keys.len() {

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -775,16 +775,6 @@ pub(crate) fn to_bytes(
 
         let dest_path = bun_core::strings::remove_leading_dot_slash(&output_file.dest_path);
 
-        // Windows: store the key with `/`. The template printer emits native
-        // `\` into `dest_path`, but `find_assume_standalone_path` normalizes
-        // lookups to `/`, so a `\` key would miss (ENOENT). `src/bundler/Chunk.rs`
-        // only normalizes a scratch copy, so we re-normalize here.
-        #[cfg(windows)]
-        let mut dest_path_buf = PathBuffer::uninit();
-        #[cfg(windows)]
-        let dest_path: &[u8] =
-            path::resolve_path::platform_to_posix_buf::<u8>(dest_path, &mut dest_path_buf);
-
         let bytecode: StringPointer = 'brk: {
             if output_file.bytecode_index != u32::MAX {
                 // Bytecode alignment for JSC bytecode cache deserialization.

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -382,20 +382,26 @@ console.log("About manifest:", aboutHtml);
       files: Array<{ input?: string; path: string; loader: string }>;
     };
 
+    const absolute = /^(?:[A-Za-z]:|[\\/]|\.\.[\\/])/;
     expect(manifest.index).not.toContain("\\");
+    expect(manifest.index).not.toMatch(absolute);
 
-    const byLoader = Object.fromEntries(manifest.files.map(f => [f.loader, f]));
-    // Entry chunks are keyed by the entry HTML source, relative to `root`.
-    expect(byLoader.html.input).toBe("page/index.html");
-    expect(byLoader.js.input).toBe("page/index.html");
-    expect(byLoader.css.input).toBe("page/index.html");
-    // file-loader asset
-    expect(byLoader.file.input).toBe("page/icon.txt");
+    // Entry chunks are keyed by the entry HTML source, relative to `root`;
+    // the file-loader asset is keyed by its own source path.
+    expect(manifest.files.map(f => [f.loader, f.input])).toEqual([
+      ["js", "page/index.html"],
+      ["html", "page/index.html"],
+      ["css", "page/index.html"],
+      ["file", "page/icon.txt"],
+    ]);
     for (const f of manifest.files) {
       expect(f.path).not.toContain("\\");
-      if (f.input !== undefined) expect(f.input).not.toContain("\\");
+      expect(f.path).not.toMatch(absolute);
     }
-    expect(byLoader.file.path).toStartWith("./");
+    // file-loader asset path comes from `additional_output_files[].dest_path`,
+    // which was the one emitted with native `\` before the fix.
+    const asset = manifest.files.find(f => f.loader === "file")!;
+    expect(asset.path).toStartWith("./");
   });
 
   // The HTML chunk's etag must change when only a referenced JS/CSS chunk

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { tempDir, tempDirWithFiles } from "harness";
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { itBundled } from "./expectBundled";
@@ -364,13 +364,14 @@ console.log("About manifest:", aboutHtml);
   // `input` keys must be project-relative and every path must use `/` regardless
   // of the host (no leaked build-machine absolute paths, no backslashes).
   test("html-import/manifest-paths-are-posix-relative", async () => {
-    const dir = tempDirWithFiles("html-manifest-paths", {
+    using cwd = tempDir("html-manifest-paths", {
       "server.ts": `import m from "./page/index.html"; console.log(JSON.stringify(m));`,
       "page/index.html": `<!doctype html><link rel="stylesheet" href="./s.css"><script type="module" src="./a.ts"></script>`,
       "page/a.ts": `import icon from "./icon.txt" with { type: "file" }; console.log(icon);`,
       "page/s.css": `body { color: red }`,
       "page/icon.txt": `hi`,
     });
+    const dir = String(cwd);
 
     const out = join(dir, "out");
     const r = await Bun.build({ entrypoints: [join(dir, "server.ts")], outdir: out, target: "bun", root: dir });

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -360,6 +360,44 @@ console.log("About manifest:", aboutHtml);
     },
   });
 
+  // The manifest is meant to be passed straight to a static-file server, so its
+  // `input` keys must be project-relative and every path must use `/` regardless
+  // of the host (no leaked build-machine absolute paths, no backslashes).
+  test("html-import/manifest-paths-are-posix-relative", async () => {
+    const dir = tempDirWithFiles("html-manifest-paths", {
+      "server.ts": `import m from "./page/index.html"; console.log(JSON.stringify(m));`,
+      "page/index.html": `<!doctype html><link rel="stylesheet" href="./s.css"><script type="module" src="./a.ts"></script>`,
+      "page/a.ts": `import icon from "./icon.txt" with { type: "file" }; console.log(icon);`,
+      "page/s.css": `body { color: red }`,
+      "page/icon.txt": `hi`,
+    });
+
+    const out = join(dir, "out");
+    const r = await Bun.build({ entrypoints: [join(dir, "server.ts")], outdir: out, target: "bun", root: dir });
+    expect(r.success).toBe(true);
+    const js = readFileSync(join(out, "server.js"), "utf8");
+    const m = js.match(/__jsonParse\("(.+?)"\)/s)!;
+    const manifest = JSON.parse(JSON.parse('"' + m[1] + '"')) as {
+      index: string;
+      files: Array<{ input?: string; path: string; loader: string }>;
+    };
+
+    expect(manifest.index).not.toContain("\\");
+
+    const byLoader = Object.fromEntries(manifest.files.map(f => [f.loader, f]));
+    // Entry chunks are keyed by the entry HTML source, relative to `root`.
+    expect(byLoader.html.input).toBe("page/index.html");
+    expect(byLoader.js.input).toBe("page/index.html");
+    expect(byLoader.css.input).toBe("page/index.html");
+    // file-loader asset
+    expect(byLoader.file.input).toBe("page/icon.txt");
+    for (const f of manifest.files) {
+      expect(f.path).not.toContain("\\");
+      if (f.input !== undefined) expect(f.input).not.toContain("\\");
+    }
+    expect(byLoader.file.path).toStartWith("./");
+  });
+
   // The HTML chunk's etag must change when only a referenced JS/CSS chunk
   // changes; otherwise the browser 304s to a body that points at chunks the
   // server no longer has.


### PR DESCRIPTION
### Problem

On Windows, importing an HTML file from JS and bundling for `target: "bun"` emits a manifest whose `files[].input` and file-loader `files[].path` fields are wrong:

```jsonc
// Windows, before
{ "input": "../C:\\Users\\...\\Temp\\...\\client.html", "path": ".\\favicon-wjepk3hq.png", ... }
// Linux/macOS, and expected
{ "input": "client.html",                               "path": "./favicon-wjepk3hq.png", ... }
```

The manifest is meant to be handed to a static file server, so leaking a build-machine absolute path (and using `\` separators) makes it unusable on Windows builds. This is the path-format symptom reported in #21283.

### Cause

Two separate gaps.

**`input`:** `HTMLImportManifest::write` derives the key with

```rust
relative_normalized::<bun_paths::platform::Posix, false>(root_dir, source.path.text)
```

Both operands are native absolute paths (`C:\...` with backslashes on Windows). `relative_normalized` does not normalise its inputs, and under `Platform::Posix` `\` is not a separator and `C:\...` is not absolute, so each side is treated as a single path segment. The result is `"../" + source.path.text`.

**`path`:** `additional_output_files[].dest_path` is produced by `PathTemplate::print`, which emits native separators. `Chunk.final_rel_path` is posix-converted right after templating (`generateChunksInParallel.rs:372`), but the parallel code for additional output files at `bundle_v2.rs:4154-4158` skips that step. Three consumers had already independently re-normalised the same field to work around this:

- `Chunk.rs:946-956` copied into a scratch buffer and posix-converted before emitting an asset URL;
- `StandaloneModuleGraph.rs:778-786` carried a `#[cfg(windows)] platform_to_posix_buf` with a comment pointing back at the `Chunk.rs` workaround;
- `bake/production.rs:273-279,757-763` special-cased a `.\` prefix when building `bake:/` module keys.

Other readers (static-route registration in `HTMLBundle.rs`, asset URLs in `bake/production.rs`, the CLI summary in `build_command.rs:1059`) emitted the `\` form on Windows.

### Fix

* Compute the manifest `input` with `relative_platform_buf::<platform::Auto, true>` (host semantics, normalised inputs) into a pooled buffer and `platform_to_posix_in_place` the result, matching `final_rel_path` / sourcemap `sources`.
* Posix-convert `additional_output_files[].dest_path` once at the producer, immediately after `template.print(...)` in `bundle_v2.rs`, so it carries the same invariant as `Chunk.final_rel_path`. Every reader either already re-normalised, routes through `platform::Auto`/`Loose` path helpers whose separator test accepts `/`, or wants a URL/module key where `/` is required; Windows `openat`/`mkdirat` normalise `/` before the NT syscall.
* Drop the now-redundant consumer workarounds in `Chunk.rs`, `StandaloneModuleGraph.rs`, and `bake/production.rs`.

All path helpers touched are no-ops on POSIX, so Linux/macOS output is byte-identical.

### Verification

New `html-import/manifest-paths-are-posix-relative` in `test/bundler/html-import-manifest.test.ts` builds with `Bun.build` (so it runs on Windows today, independent of the `itBundled` harness) and asserts every `input`/`path` is `/`-separated and project-relative.

Windows x64:
```
# fail-before (canary)
Expected: "page/index.html"
Received: "../C:\Users\azureuser\AppData\Local\Temp\html-manifest-paths_...\page\index.html"
# pass-after (this branch)
(pass) bundler > html-import/manifest-paths-are-posix-relative
```

Also verified on Windows with this branch:
- `bun build entry.ts --outdir out --asset-naming "[dir]/[name]-[hash].[ext]"` emits `var icon_default = "./sub/icon-neqd1z7a.txt"` and prints `sub/icon-neqd1z7a.txt` in the CLI summary (was `.\sub\...`);
- `bun build --compile entry.ts` with a file-loader asset embeds and reads the asset correctly (exercises the `StandaloneModuleGraph` key).

Linux x64: all 6 tests in `test/bundler/html-import-manifest.test.ts` pass with the two inline snapshots unchanged; `bundler_loader.test.ts` and `bundler_naming.test.ts` pass.

The fix only affects Windows output, so the Linux-only fail-before gate will see the new test pass both ways; Windows CI is the direct proof.

### Note on the `itBundled` snapshot tests

#34552 re-enables `itBundled` on Windows and gates `html-import/manifest-with-metadata` and `html-import/multiple-manifests` as `todo: isWindows`. With this fix applied those tests still fail there, because the harness's temp root is an 8.3 short path (`C:\Users\AZUREU~1\...`) while `options.root_dir` is canonicalised to the long form via `GetFinalPathNameByHandleW`, so `relative(root_dir, source)` walks up and back down. That is the same `root_dir`-vs-source canonicalisation mismatch that breaks `naming/AssetNamingDir` and is tracked separately; once it is fixed the `todo: isWindows` gates on these two tests can be dropped.
