### PR TITLE
bundler: canonicalize the asset source directory for [dir] only when string relativization falls outside root

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4122,23 +4122,55 @@ pub mod bv2_impl {
                         let source = &mut sources[index];
 
                         let output_path: Box<[u8]> = {
-                            // TODO: outbase
-                            let pathname =
-                                Fs::PathName::init(bun_paths::resolve_path::relative_platform::<
-                                    bun_paths::resolve_path::platform::Loose,
-                                    false,
-                                >(
-                                    &self.transpiler.options.root_dir,
-                                    source.path.text,
-                                ));
+                            let pathname = Fs::PathName::init(source.path.text);
 
                             template.placeholder.name = pathname.base.to_vec().into_boxed_slice();
-                            template.placeholder.dir = pathname.dir.to_vec().into_boxed_slice();
                             let mut ext: &[u8] = pathname.ext;
                             if !ext.is_empty() && ext[0] == b'.' {
                                 ext = &ext[1..];
                             }
                             template.placeholder.ext = ext.to_vec().into_boxed_slice();
+
+                            if template.needs(options::PlaceholderField::Dir) {
+                                // `root_dir` was canonicalized via `get_fd_path`
+                                // when the bundler was configured; resolve the
+                                // asset's directory the same way so the relative
+                                // path lines up on Windows even when the cwd
+                                // (and thus `source.path.text`) carries 8.3
+                                // short names. Mirrors `compute_chunks`.
+                                let source_dir: &[u8] = if pathname.dir.is_empty() {
+                                    b"."
+                                } else {
+                                    pathname.dir
+                                };
+                                let mut real_path_buf = bun_paths::path_buffer_pool::get();
+                                let dir: &[u8] = 'dir: {
+                                    let Ok(dir_file) = bun_sys::File::openat(
+                                        bun_sys::Fd::cwd(),
+                                        source_dir,
+                                        bun_sys::O::PATH | bun_sys::O::DIRECTORY,
+                                        0,
+                                    ) else {
+                                        break 'dir &*bun_paths::resolve_path::normalize_buf::<
+                                            bun_paths::platform::Auto,
+                                        >(
+                                            source_dir, &mut real_path_buf.0
+                                        );
+                                    };
+                                    match dir_file.get_path(&mut real_path_buf) {
+                                        Ok(p) => p,
+                                        Err(_) => &*bun_paths::resolve_path::normalize_buf::<
+                                            bun_paths::platform::Auto,
+                                        >(
+                                            source_dir, &mut real_path_buf.0
+                                        ),
+                                    }
+                                };
+                                template.placeholder.dir = bun_paths::resolve_path::relative_alloc(
+                                    &self.transpiler.options.root_dir,
+                                    dir,
+                                )?;
+                            }
 
                             if template.needs(options::PlaceholderField::Hash) {
                                 template.placeholder.hash =

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4132,12 +4132,9 @@ pub mod bv2_impl {
                             template.placeholder.ext = ext.to_vec().into_boxed_slice();
 
                             if template.needs(options::PlaceholderField::Dir) {
-                                // `root_dir` was canonicalized via `get_fd_path`
-                                // when the bundler was configured; resolve the
-                                // asset's directory the same way so the relative
-                                // path lines up on Windows even when the cwd
-                                // (and thus `source.path.text`) carries 8.3
-                                // short names. Mirrors `compute_chunks`.
+                                // `root_dir` is already canonical (`get_fd_path`);
+                                // canonicalize the source dir the same way so
+                                // Windows 8.3 short names relativize correctly.
                                 let source_dir: &[u8] = if pathname.dir.is_empty() {
                                     b"."
                                 } else {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4132,40 +4132,9 @@ pub mod bv2_impl {
                             template.placeholder.ext = ext.to_vec().into_boxed_slice();
 
                             if template.needs(options::PlaceholderField::Dir) {
-                                // `root_dir` is already canonical (`get_fd_path`);
-                                // canonicalize the source dir the same way so
-                                // Windows 8.3 short names relativize correctly.
-                                let source_dir: &[u8] = if pathname.dir.is_empty() {
-                                    b"."
-                                } else {
-                                    pathname.dir
-                                };
-                                let mut real_path_buf = bun_paths::path_buffer_pool::get();
-                                let dir: &[u8] = 'dir: {
-                                    let Ok(dir_file) = bun_sys::File::openat(
-                                        bun_sys::Fd::cwd(),
-                                        source_dir,
-                                        bun_sys::O::PATH | bun_sys::O::DIRECTORY,
-                                        0,
-                                    ) else {
-                                        break 'dir &*bun_paths::resolve_path::normalize_buf::<
-                                            bun_paths::platform::Auto,
-                                        >(
-                                            source_dir, &mut real_path_buf.0
-                                        );
-                                    };
-                                    match dir_file.get_path(&mut real_path_buf) {
-                                        Ok(p) => p,
-                                        Err(_) => &*bun_paths::resolve_path::normalize_buf::<
-                                            bun_paths::platform::Auto,
-                                        >(
-                                            source_dir, &mut real_path_buf.0
-                                        ),
-                                    }
-                                };
-                                template.placeholder.dir = bun_paths::resolve_path::relative_alloc(
+                                template.placeholder.dir = options::source_dir_relative_to_root(
+                                    pathname.dir,
                                     &self.transpiler.options.root_dir,
-                                    dir,
                                 )?;
                             }
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4135,6 +4135,7 @@ pub mod bv2_impl {
                                 template.placeholder.dir = options::source_dir_relative_to_root(
                                     pathname.dir,
                                     &self.transpiler.options.root_dir,
+                                    source.path.is_file(),
                                 )?;
                             }
 

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -5,7 +5,6 @@ use core::sync::atomic::AtomicUsize;
 use bun_alloc::Arena; // bumpalo::Bump re-export
 use bun_collections::{ArrayHashMap, AutoBitSet, VecExt};
 use bun_core::strings;
-use bun_paths::{PathBuffer, resolve_path};
 use bun_sourcemap::SourceMapPieces;
 use bun_wyhash::{self, Wyhash};
 
@@ -634,46 +633,10 @@ pub fn compute_chunks(this: &mut LinkerContext, unique_key: u64) -> crate::Resul
         }
 
         if chunk.template.needs(PlaceholderField::Dir) {
-            // this if check is a specific fix for `bun build hi.ts --external '*'`, without leading `./`
-            let dir_path: &[u8] = if !pathname.dir.is_empty() {
-                pathname.dir
-            } else {
-                b"."
-            };
-            let mut real_path_buf = PathBuffer::uninit();
-            let dir: &[u8] = 'dir: {
-                let Ok(dir_file) = bun_sys::File::openat(
-                    bun_sys::Fd::cwd(),
-                    dir_path,
-                    bun_sys::O::PATH | bun_sys::O::DIRECTORY,
-                    0,
-                ) else {
-                    break 'dir &*resolve_path::normalize_buf::<bun_paths::platform::Auto>(
-                        dir_path,
-                        &mut real_path_buf.0,
-                    );
-                };
-
-                match dir_file.get_path(&mut real_path_buf) {
-                    Ok(p) => break 'dir p,
-                    Err(err) => {
-                        // Split-borrow — see `LinkerContext::log_disjoint`.
-                        this.log_disjoint().add_error_fmt(
-                            None,
-                            bun_ast::Loc::EMPTY,
-                            format_args!(
-                                "{}: Failed to get full path for directory '{}'",
-                                bstr::BStr::new(err.name()),
-                                bstr::BStr::new(dir_path)
-                            ),
-                        );
-                        return Err(crate::Error::BuildFailed);
-                    }
-                }
-            };
-
-            let root_dir = &this.resolver().opts.root_dir;
-            chunk.template.placeholder.dir = resolve_path::relative_alloc(root_dir, dir)?;
+            chunk.template.placeholder.dir = crate::options::source_dir_relative_to_root(
+                pathname.dir,
+                &this.resolver().opts.root_dir,
+            )?;
         }
     }
 

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -636,6 +636,7 @@ pub fn compute_chunks(this: &mut LinkerContext, unique_key: u64) -> crate::Resul
             chunk.template.placeholder.dir = crate::options::source_dir_relative_to_root(
                 pathname.dir,
                 &this.resolver().opts.root_dir,
+                true,
             )?;
         }
     }

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2480,14 +2480,15 @@ pub enum PlaceholderField {
     Target,
 }
 
-/// `[dir]` placeholder value: when `on_disk`, canonicalize `source_dir` via
-/// `get_fd_path` (so Windows 8.3 short names / symlinked prefixes match a
-/// canonical `root_dir`); otherwise string-normalize. Then relativize.
+/// `[dir]` placeholder value: relativize `source_dir` against `root_dir`.
+/// Canonicalizes `source_dir` via `get_fd_path` only when the plain string
+/// relativization falls outside `root_dir` and `on_disk` is set.
 pub(crate) fn source_dir_relative_to_root(
     source_dir: &[u8],
     root_dir: &[u8],
     on_disk: bool,
 ) -> Result<Box<[u8]>, bun_alloc::AllocError> {
+    use bun_paths::resolve_path;
     // Empty for a bare-filename entry (`bun build hi.ts --external '*'`
     // with no leading `./`); openat needs "." not "".
     let source_dir: &[u8] = if source_dir.is_empty() {
@@ -2495,25 +2496,23 @@ pub(crate) fn source_dir_relative_to_root(
     } else {
         source_dir
     };
-    let mut buf = bun_paths::path_buffer_pool::get();
-    let dir: &[u8] = 'dir: {
-        if on_disk {
-            if let Ok(f) = bun_sys::File::openat(
-                bun_sys::Fd::cwd(),
-                source_dir,
-                bun_sys::O::PATH | bun_sys::O::DIRECTORY,
-                0,
-            ) {
-                if let Ok(p) = f.get_path(&mut buf) {
-                    break 'dir p;
-                }
+    let rel = resolve_path::relative_platform::<resolve_path::platform::Auto, false>(
+        root_dir, source_dir,
+    );
+    if on_disk && rel.starts_with(b"..") {
+        let mut buf = bun_paths::path_buffer_pool::get();
+        if let Ok(f) = bun_sys::File::openat(
+            bun_sys::Fd::cwd(),
+            source_dir,
+            bun_sys::O::PATH | bun_sys::O::DIRECTORY,
+            0,
+        ) {
+            if let Ok(p) = f.get_path(&mut buf) {
+                return resolve_path::relative_alloc(root_dir, p);
             }
         }
-        &*bun_paths::resolve_path::normalize_buf::<bun_paths::platform::Auto>(
-            source_dir, &mut buf.0,
-        )
-    };
-    bun_paths::resolve_path::relative_alloc(root_dir, dir)
+    }
+    Ok(Box::<[u8]>::from(rel))
 }
 
 // Shared body for PathTemplate::needs / PathTemplateConst::needs (D064).

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2507,7 +2507,9 @@ pub(crate) fn source_dir_relative_to_root(
                 }
             }
         }
-        &*bun_paths::resolve_path::normalize_buf::<bun_paths::platform::Auto>(source_dir, &mut buf.0)
+        &*bun_paths::resolve_path::normalize_buf::<bun_paths::platform::Auto>(
+            source_dir, &mut buf.0,
+        )
     };
     bun_paths::resolve_path::relative_alloc(root_dir, dir)
 }

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2488,6 +2488,8 @@ pub(crate) fn source_dir_relative_to_root(
     root_dir: &[u8],
     on_disk: bool,
 ) -> Result<Box<[u8]>, bun_alloc::AllocError> {
+    // Empty for a bare-filename entry (`bun build hi.ts --external '*'`
+    // with no leading `./`); openat needs "." not "".
     let source_dir: &[u8] = if source_dir.is_empty() {
         b"."
     } else {

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2480,6 +2480,36 @@ pub enum PlaceholderField {
     Target,
 }
 
+/// `[dir]` placeholder value: canonicalize `source_dir` via `get_fd_path`
+/// (so Windows 8.3 short names / symlinked prefixes match a canonical
+/// `root_dir`), fall back to string normalization, then relativize.
+pub(crate) fn source_dir_relative_to_root(
+    source_dir: &[u8],
+    root_dir: &[u8],
+) -> Result<Box<[u8]>, bun_alloc::AllocError> {
+    let source_dir: &[u8] = if source_dir.is_empty() { b"." } else { source_dir };
+    let mut buf = bun_paths::path_buffer_pool::get();
+    let dir: &[u8] = 'dir: {
+        let Ok(f) = bun_sys::File::openat(
+            bun_sys::Fd::cwd(),
+            source_dir,
+            bun_sys::O::PATH | bun_sys::O::DIRECTORY,
+            0,
+        ) else {
+            break 'dir &*bun_paths::resolve_path::normalize_buf::<bun_paths::platform::Auto>(
+                source_dir, &mut buf.0,
+            );
+        };
+        match f.get_path(&mut buf) {
+            Ok(p) => p,
+            Err(_) => &*bun_paths::resolve_path::normalize_buf::<bun_paths::platform::Auto>(
+                source_dir, &mut buf.0,
+            ),
+        }
+    };
+    bun_paths::resolve_path::relative_alloc(root_dir, dir)
+}
+
 // Shared body for PathTemplate::needs / PathTemplateConst::needs (D064).
 #[inline]
 pub(crate) fn path_template_needs(data: &[u8], field: PlaceholderField) -> bool {

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2480,12 +2480,13 @@ pub enum PlaceholderField {
     Target,
 }
 
-/// `[dir]` placeholder value: canonicalize `source_dir` via `get_fd_path`
-/// (so Windows 8.3 short names / symlinked prefixes match a canonical
-/// `root_dir`), fall back to string normalization, then relativize.
+/// `[dir]` placeholder value: when `on_disk`, canonicalize `source_dir` via
+/// `get_fd_path` (so Windows 8.3 short names / symlinked prefixes match a
+/// canonical `root_dir`); otherwise string-normalize. Then relativize.
 pub(crate) fn source_dir_relative_to_root(
     source_dir: &[u8],
     root_dir: &[u8],
+    on_disk: bool,
 ) -> Result<Box<[u8]>, bun_alloc::AllocError> {
     let source_dir: &[u8] = if source_dir.is_empty() {
         b"."
@@ -2494,22 +2495,19 @@ pub(crate) fn source_dir_relative_to_root(
     };
     let mut buf = bun_paths::path_buffer_pool::get();
     let dir: &[u8] = 'dir: {
-        let Ok(f) = bun_sys::File::openat(
-            bun_sys::Fd::cwd(),
-            source_dir,
-            bun_sys::O::PATH | bun_sys::O::DIRECTORY,
-            0,
-        ) else {
-            break 'dir &*bun_paths::resolve_path::normalize_buf::<bun_paths::platform::Auto>(
-                source_dir, &mut buf.0,
-            );
-        };
-        match f.get_path(&mut buf) {
-            Ok(p) => p,
-            Err(_) => &*bun_paths::resolve_path::normalize_buf::<bun_paths::platform::Auto>(
-                source_dir, &mut buf.0,
-            ),
+        if on_disk {
+            if let Ok(f) = bun_sys::File::openat(
+                bun_sys::Fd::cwd(),
+                source_dir,
+                bun_sys::O::PATH | bun_sys::O::DIRECTORY,
+                0,
+            ) {
+                if let Ok(p) = f.get_path(&mut buf) {
+                    break 'dir p;
+                }
+            }
         }
+        &*bun_paths::resolve_path::normalize_buf::<bun_paths::platform::Auto>(source_dir, &mut buf.0)
     };
     bun_paths::resolve_path::relative_alloc(root_dir, dir)
 }

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2487,7 +2487,11 @@ pub(crate) fn source_dir_relative_to_root(
     source_dir: &[u8],
     root_dir: &[u8],
 ) -> Result<Box<[u8]>, bun_alloc::AllocError> {
-    let source_dir: &[u8] = if source_dir.is_empty() { b"." } else { source_dir };
+    let source_dir: &[u8] = if source_dir.is_empty() {
+        b"."
+    } else {
+        source_dir
+    };
     let mut buf = bun_paths::path_buffer_pool::get();
     let dir: &[u8] = 'dir: {
         let Ok(f) = bun_sys::File::openat(

--- a/test/bundler/bundler_naming.test.ts
+++ b/test/bundler/bundler_naming.test.ts
@@ -1,8 +1,8 @@
-import { describe, test, expect } from "bun:test";
-import { ESBUILD, itBundled } from "./expectBundled";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { symlinkSync } from "node:fs";
 import { join } from "node:path";
+import { ESBUILD, itBundled } from "./expectBundled";
 
 describe("bundler", () => {
   itBundled("naming/EntryNamingCollission", {

--- a/test/bundler/bundler_naming.test.ts
+++ b/test/bundler/bundler_naming.test.ts
@@ -249,6 +249,53 @@ describe("bundler", () => {
     });
     expect(out).not.toContain("_.._");
   });
+  // The on-disk canonicalization above must not apply to a plugin asset whose
+  // virtual path happens to collide with a real cwd subdirectory: `[dir]` for
+  // a non-file namespace stays a pure string computation.
+  test("naming/AssetNamingDirVirtualNamespace", async () => {
+    using base = tempDir("asset-naming-dir-virt", {
+      "src/.keep": "",
+      "unrelated-target/.keep": "",
+    });
+    symlinkSync(join(String(base), "unrelated-target"), join(String(base), "assets"), isWindows ? "junction" : "dir");
+
+    const entry = join(String(base), "src/entry.js").replaceAll("\\", "/");
+    const script = `
+      const result = await Bun.build({
+        entrypoints: [${JSON.stringify(entry)}],
+        files: { ${JSON.stringify(entry)}: 'import f from "virt:assets/icon.bin"; console.log(f);' },
+        root: ${JSON.stringify(join(String(base), "src"))},
+        naming: { entry: "hello.[ext]", asset: "[dir]/[name].[ext]" },
+        plugins: [{
+          name: "virt",
+          setup(b) {
+            b.onResolve({ filter: /^virt:/ }, a => ({ path: a.path.slice(5), namespace: "virt" }));
+            b.onLoad({ filter: /.*/, namespace: "virt" }, () => ({ contents: "hi", loader: "file" }));
+          },
+        }],
+      });
+      if (!result.success) { for (const m of result.logs) console.error(String(m)); process.exit(1); }
+      for (const out of result.outputs) console.log(out.kind + " " + out.path);
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      cwd: String(base),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const out = stdout.replaceAll("\\", "/");
+    const assetLine = out.split("\n").find(l => l.startsWith("asset "));
+    expect({ assetLine, stderr, exitCode }).toEqual({
+      assetLine: "asset ./_.._/assets/icon.bin",
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(out).not.toContain("unrelated-target");
+  });
   itBundled("naming/AssetNoOverwrite", {
     todo: true,
     files: {

--- a/test/bundler/bundler_naming.test.ts
+++ b/test/bundler/bundler_naming.test.ts
@@ -248,9 +248,10 @@ describe("bundler", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).toBe("");
-    const assetLine = stdout.split("\n").find(l => l.startsWith("asset "));
+    const out = stdout.replaceAll("\\", "/");
+    const assetLine = out.split("\n").find(l => l.startsWith("asset "));
     expect(assetLine).toBe("asset ./lib/second/test.file");
-    expect(stdout).not.toContain("_.._");
+    expect(out).not.toContain("_.._");
     expect(exitCode).toBe(0);
   });
   itBundled("naming/AssetNoOverwrite", {

--- a/test/bundler/bundler_naming.test.ts
+++ b/test/bundler/bundler_naming.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "bun:test";
 import { ESBUILD, itBundled } from "./expectBundled";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
-import { mkdirSync, symlinkSync } from "node:fs";
+import { symlinkSync } from "node:fs";
 import { join } from "node:path";
 
 describe("bundler", () => {

--- a/test/bundler/bundler_naming.test.ts
+++ b/test/bundler/bundler_naming.test.ts
@@ -1,5 +1,8 @@
-import { describe } from "bun:test";
+import { describe, test, expect } from "bun:test";
 import { ESBUILD, itBundled } from "./expectBundled";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { mkdirSync, symlinkSync } from "node:fs";
+import { join } from "node:path";
 
 describe("bundler", () => {
   itBundled("naming/EntryNamingCollission", {
@@ -190,6 +193,65 @@ describe("bundler", () => {
         stdout: "./lib/second/test.file",
       },
     ],
+  });
+  // assetNaming `[dir]` must be relative to the configured root even when
+  // the root directory and the asset's source path spell the same on-disk
+  // location differently. Bun canonicalizes `root` via the file descriptor
+  // (`GetFinalPathNameByHandle` on Windows, /proc/self/fd on Linux) but
+  // `Bun.build({ files })` source paths are the literal map keys; previously
+  // the uncanonicalized source path was relativized against the canonical
+  // root, so no common prefix was found and `[dir]` expanded to a long
+  // `_.._/_.._/...` traversal back into the source tree. On Windows this
+  // surfaced whenever the cwd contained an 8.3 short path component such as
+  // `C:\Users\RUNNER~1\...` (the default TEMP directory in CI).
+  test("naming/AssetNamingDirCanonicalRoot", async () => {
+    using base = tempDir("asset-naming-dir-canon", {
+      "real/src/lib/first/.keep": "",
+      "real/src/lib/second/.keep": "",
+    });
+    const real = join(String(base), "real");
+    const link = join(String(base), "project-link");
+    // A junction needs no elevation on Windows; on POSIX this is a plain
+    // directory symlink. Either way `root` below canonicalizes to `real/src`
+    // while the `files` map keys keep the `project-link` spelling.
+    symlinkSync(real, link, isWindows ? "junction" : "dir");
+
+    const entry = join(link, "src/lib/first/file.js").replaceAll("\\", "/");
+    const asset = join(link, "src/lib/second/data.file").replaceAll("\\", "/");
+    const root = join(link, "src");
+
+    const script = `
+      const result = await Bun.build({
+        entrypoints: [${JSON.stringify(entry)}],
+        files: {
+          ${JSON.stringify(entry)}: 'import f from "../second/data.file"; console.log(f);',
+          ${JSON.stringify(asset)}: "this is a file",
+        },
+        root: ${JSON.stringify(root)},
+        naming: { entry: "hello.[ext]", asset: "[dir]/test.[ext]" },
+        loader: { ".file": "file" },
+      });
+      if (!result.success) {
+        for (const m of result.logs) console.error(String(m));
+        process.exit(1);
+      }
+      for (const out of result.outputs) console.log(out.kind + " " + out.path);
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      cwd: String(base),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    const assetLine = stdout.split("\n").find(l => l.startsWith("asset "));
+    expect(assetLine).toBe("asset ./lib/second/test.file");
+    expect(stdout).not.toContain("_.._");
+    expect(exitCode).toBe(0);
   });
   itBundled("naming/AssetNoOverwrite", {
     todo: true,

--- a/test/bundler/bundler_naming.test.ts
+++ b/test/bundler/bundler_naming.test.ts
@@ -194,16 +194,9 @@ describe("bundler", () => {
       },
     ],
   });
-  // assetNaming `[dir]` must be relative to the configured root even when
-  // the root directory and the asset's source path spell the same on-disk
-  // location differently. Bun canonicalizes `root` via the file descriptor
-  // (`GetFinalPathNameByHandle` on Windows, /proc/self/fd on Linux) but
-  // `Bun.build({ files })` source paths are the literal map keys; previously
-  // the uncanonicalized source path was relativized against the canonical
-  // root, so no common prefix was found and `[dir]` expanded to a long
-  // `_.._/_.._/...` traversal back into the source tree. On Windows this
-  // surfaced whenever the cwd contained an 8.3 short path component such as
-  // `C:\Users\RUNNER~1\...` (the default TEMP directory in CI).
+  // `[dir]` must resolve relative to the configured root even when root and
+  // the asset source path spell the same directory differently (Windows 8.3
+  // short names in the cwd, or a symlinked `Bun.build({ files })` key).
   test("naming/AssetNamingDirCanonicalRoot", async () => {
     using base = tempDir("asset-naming-dir-canon", {
       "real/src/lib/first/.keep": "",
@@ -247,12 +240,14 @@ describe("bundler", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr).toBe("");
     const out = stdout.replaceAll("\\", "/");
     const assetLine = out.split("\n").find(l => l.startsWith("asset "));
-    expect(assetLine).toBe("asset ./lib/second/test.file");
+    expect({ assetLine, stderr, exitCode }).toEqual({
+      assetLine: "asset ./lib/second/test.file",
+      stderr: "",
+      exitCode: 0,
+    });
     expect(out).not.toContain("_.._");
-    expect(exitCode).toBe(0);
   });
   itBundled("naming/AssetNoOverwrite", {
     todo: true,


### PR DESCRIPTION
### Problem

`assetNaming: "[dir]/..."` produces a path like `./_.._/_.._/.../AZUREU~1/AppData/Local/Temp/.../src/lib/second/test.file` instead of `./lib/second/test.file` on Windows whenever the working directory contains an 8.3 short path component (the default for `%TEMP%` on GitHub/Azure runners is `C:\Users\RUNNER~1\...`):

```console
> bun build ./src/lib/first/file.js --root=.\src --asset-naming "[dir]/test.[ext]" --outdir out
  hello.js                                                                                                            219 bytes  (entry point)
  .\_.._\_.._\_.._\_.._\_.._\_.._\AZUREU~1\AppData\Local\Temp\asset-naming-dir\src\lib\second\test.file  15 bytes   (asset)
```

The same failure mode also appears on POSIX with `Bun.build({ files })` when the map keys and `root` reference the same directory through a symlink.

### Cause

`options.root_dir` is `get_fd_path`-canonical (`GetFinalPathNameByHandle` on Windows, `/proc/self/fd` on Linux), so it always carries the long/resolved spelling. `source.path.text` for an asset handled by `process_files_to_copy` may not be: it is the resolver-joined path derived from the process cwd (which on Windows still carries 8.3 short components), or a literal `Bun.build({ files })` key. `relative_platform` finds no common prefix, emits a run of `..` segments, and the `[dir]` sanitizer rewrites them to `_.._`.

Entry/chunk `[dir]` substitution in `compute_chunks` already compensated by opening each chunk's directory and reading back its canonical path before relativizing.

### Fix

Extract a shared `options::source_dir_relative_to_root` helper and route both `process_files_to_copy` and `compute_chunks` through it. The helper first relativizes with plain string math; only when that result walks above `root_dir` (the spelling-mismatch case this PR targets) and the source is in the `file` namespace does it `openat`+`get_fd_path` the source directory and relativize again. In the common case where the resolver's path already sits under the canonical root there is no filesystem access at all, and `compute_chunks` no longer pays the unconditional per-chunk `openat` it carried on `main`.

`[name]`/`[ext]` are basename-only and now come straight from `source.path.text` without the relativization round-trip. A plugin asset in a non-`file` namespace keeps the pure-string result so its virtual dirname is never opened against an unrelated cwd directory.

### Test

`naming/AssetNamingDirCanonicalRoot` creates `real/src/lib/{first,second}` on disk, a `project-link` symlink (a junction on Windows) pointing at `real`, and runs `Bun.build` with `files` keys and `root` spelled through the link. Before this change the asset path is `./_.._/_.._/project-link/src/lib/second/test.file`; after, `./lib/second/test.file`.

`naming/AssetNamingDirVirtualNamespace` covers the non-`file` namespace guard: a plugin resolves `virt:assets/icon.bin` with `loader: "file"` while an `assets` symlink exists in cwd, and the asset `[dir]` stays `_.._/assets` (unchanged from `main`) rather than following the symlink.

Verified on Linux and Windows; the original Windows short-name CLI repro, `bundler/cli.test.ts` log cases, and `bundler_naming`/`bundler_loader`/`bundler_files`/`bundler_plugin`/`bundler_edgecase`/`esbuild/loader` all pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_naming.test.ts

<!-- robobun:evidence:end -->