### PR TITLE
ci: ship a single baseline x64 build per platform

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -138,12 +138,11 @@ const buildPlatforms = [
   { os: "darwin", arch: "aarch64", crossCompile: true, distro: "amazonlinux", release: "2023", features: ["docker"] },
   { os: "darwin", arch: "x64", crossCompile: true, distro: "amazonlinux", release: "2023", features: ["docker"] },
   { os: "linux", arch: "aarch64", distro: "amazonlinux", release: "2023", features: ["docker"] },
+  // x64 ships one baseline (Nehalem, SSE4.2) binary; SIMD is runtime-dispatched.
   { os: "linux", arch: "x64", distro: "amazonlinux", release: "2023", features: ["docker"] },
-  { os: "linux", arch: "x64", baseline: true, distro: "amazonlinux", release: "2023", features: ["docker"] },
   { os: "linux", arch: "x64", profile: "asan", distro: "amazonlinux", release: "2023", features: ["docker"] },
   { os: "linux", arch: "aarch64", abi: "musl", distro: "alpine", release: "3.23" },
   { os: "linux", arch: "x64", abi: "musl", distro: "alpine", release: "3.23" },
-  { os: "linux", arch: "x64", abi: "musl", baseline: true, distro: "alpine", release: "3.23" },
   // Android: cross-compiled from glibc amazonlinux via NDK sysroot. Host arch
   // matches target arch so only --abi/--target/--sysroot are cross.
   { os: "linux", arch: "aarch64", abi: "android", distro: "amazonlinux", release: "2023", features: ["docker"] },
@@ -163,15 +162,6 @@ const buildPlatforms = [
   // miscompile JSC on x86-64 at -O1+, so it is not the default — see the
   // ltoDefault comment in scripts/build/config.ts.
   { os: "windows", arch: "x64", crossCompile: true, distro: "amazonlinux", release: "2023", features: ["docker"] },
-  {
-    os: "windows",
-    arch: "x64",
-    baseline: true,
-    crossCompile: true,
-    distro: "amazonlinux",
-    release: "2023",
-    features: ["docker"],
-  },
   { os: "windows", arch: "aarch64", crossCompile: true, distro: "amazonlinux", release: "2023", features: ["docker"] },
 ];
 
@@ -193,16 +183,12 @@ const testPlatforms = [
   { os: "darwin", arch: "x64", release: "14", tier: "latest" },
   { os: "linux", arch: "aarch64", distro: "debian", release: "13", tier: "latest" },
   { os: "linux", arch: "x64", distro: "debian", release: "13", tier: "latest" },
-  { os: "linux", arch: "x64", baseline: true, distro: "debian", release: "13", tier: "latest" },
   { os: "linux", arch: "x64", profile: "asan", distro: "debian", release: "13", tier: "latest" },
   { os: "linux", arch: "aarch64", distro: "ubuntu", release: "25.04", tier: "latest" },
   { os: "linux", arch: "x64", distro: "ubuntu", release: "25.04", tier: "latest" },
-  { os: "linux", arch: "x64", baseline: true, distro: "ubuntu", release: "25.04", tier: "latest" },
   { os: "linux", arch: "aarch64", abi: "musl", distro: "alpine", release: "3.23", tier: "latest" },
   { os: "linux", arch: "x64", abi: "musl", distro: "alpine", release: "3.23", tier: "latest" },
-  { os: "linux", arch: "x64", abi: "musl", baseline: true, distro: "alpine", release: "3.23", tier: "latest" },
   { os: "windows", arch: "x64", release: "2019", tier: "oldest" },
-  { os: "windows", arch: "x64", release: "2019", baseline: true, tier: "oldest" },
   { os: "windows", arch: "aarch64", release: "11", tier: "latest" },
 ];
 
@@ -564,7 +550,11 @@ function getBuildArgs(target, options, mode) {
     // FreeBSD cross-compiles C++ from a Linux host: os/arch must be explicit.
     args.push(`--os=${os}`, `--arch=${arch}`);
   }
-  if (baseline) args.push("--baseline=on");
+  // linux/windows x64 (glibc, musl, msvc) always compile baseline (Nehalem):
+  // SIMD is runtime-dispatched, the artifact keeps its plain name, and the
+  // -baseline release names are copies made by the release script.
+  const shipsBaselineX64 = arch === "x64" && !profile && abi !== "android" && (os === "linux" || os === "windows");
+  if (baseline || shipsBaselineX64) args.push("--baseline=on");
   if (profile === "asan") args.push("--asan=on");
 
   // canary: options.canary can be number (revision count) or undefined
@@ -692,15 +682,16 @@ function getTargetTriplet(platform) {
 
 /**
  * Returns true if a platform needs QEMU-based baseline CPU verification.
- * x64 baseline builds verify no AVX/AVX2 instructions snuck in.
- * aarch64 builds verify no LSE/SVE instructions snuck in.
+ * linux/windows x64 builds (always Nehalem) verify no AVX/AVX2 snuck in.
+ * linux aarch64 builds verify no LSE/SVE instructions snuck in.
  * @param {Platform} platform
  * @returns {boolean}
  */
 function needsBaselineVerification(platform) {
-  const { os, arch, baseline } = platform;
-  if (os === "linux") return (arch === "x64" && baseline) || arch === "aarch64";
-  if (os === "windows") return arch === "x64" && baseline;
+  const { os, arch, abi, profile } = platform;
+  if (profile) return false;
+  if (os === "linux") return (arch === "x64" && abi !== "android") || arch === "aarch64";
+  if (os === "windows") return arch === "x64";
   return false;
 }
 
@@ -1548,7 +1539,7 @@ async function getPipeline(options = {}) {
         }
         // Windows builds are cross-compiled on Linux, but steps that end up in
         // this group still run on native Windows machines: the test shards
-        // (merged in below by group label) and x64-baseline's verify-baseline
+        // (merged in below by group label) and x64's verify-baseline
         // emulator phase. On [build images] runs they request the freshly
         // baked native Windows image, so wait for that bake too.
         if (target.os === "windows") {

--- a/.buildkite/scripts/upload-release.sh
+++ b/.buildkite/scripts/upload-release.sh
@@ -55,6 +55,11 @@ function assert_sentry() {
   done
 }
 
+function assert_zip() {
+  command -v zip &> /dev/null || package_manager_install zip
+  command -v unzip &> /dev/null || package_manager_install unzip
+}
+
 function run_command() {
   set -x
   "$@"
@@ -285,6 +290,7 @@ function create_release() {
   assert_github
   assert_aws
   assert_sentry
+  assert_zip
 
   local tag="$1" # 'canary' or 'x.y.z'
   local artifacts=(
@@ -296,14 +302,10 @@ function create_release() {
     bun-linux-aarch64-profile.zip
     bun-linux-x64.zip
     bun-linux-x64-profile.zip
-    bun-linux-x64-baseline.zip
-    bun-linux-x64-baseline-profile.zip
     bun-linux-aarch64-musl.zip
     bun-linux-aarch64-musl-profile.zip
     bun-linux-x64-musl.zip
     bun-linux-x64-musl-profile.zip
-    bun-linux-x64-musl-baseline.zip
-    bun-linux-x64-musl-baseline-profile.zip
     bun-linux-aarch64-android.zip
     bun-linux-aarch64-android-profile.zip
     bun-linux-x64-android.zip
@@ -314,23 +316,55 @@ function create_release() {
     bun-freebsd-x64-profile.zip
     bun-windows-x64.zip
     bun-windows-x64-profile.zip
-    bun-windows-x64-baseline.zip
-    bun-windows-x64-baseline-profile.zip
     bun-windows-aarch64.zip
     bun-windows-aarch64-profile.zip
   )
 
+  # x64 builds only baseline (Nehalem). The -baseline names are copies of
+  # the plain zip with the inner directory renamed to match, since bun upgrade
+  # and the install scripts require the folder name to equal the zip name.
+  local -A baseline_alias=(
+    [bun-linux-x64]=bun-linux-x64-baseline
+    [bun-linux-x64-profile]=bun-linux-x64-baseline-profile
+    [bun-linux-x64-musl]=bun-linux-x64-musl-baseline
+    [bun-linux-x64-musl-profile]=bun-linux-x64-musl-baseline-profile
+    [bun-windows-x64]=bun-windows-x64-baseline
+    [bun-windows-x64-profile]=bun-windows-x64-baseline-profile
+  )
+
+  function repackage_baseline() {
+    local src="$1" dst="$2"
+    rm -rf "$src" "$dst" "$dst.zip"
+    unzip -q "$src.zip"
+    mv "$src" "$dst"
+    zip -qry "$dst.zip" "$dst" # inner folder is $dst
+    rm -rf "$dst"
+  }
+
+  function upload_file() {
+    local file="$1"
+    if [ "$tag" == "canary" ]; then
+      upload_s3_file "releases/$BUILDKITE_COMMIT-canary" "$file" &
+    else
+      upload_s3_file "releases/$BUILDKITE_COMMIT" "$file" &
+    fi
+    upload_s3_file "releases/$tag" "$file" &
+    upload_github_asset "$tag" "$file" &
+    wait
+  }
+
   function upload_artifact() {
     local artifact="$1"
     download_buildkite_artifact "$artifact"
-    if [ "$tag" == "canary" ]; then
-      upload_s3_file "releases/$BUILDKITE_COMMIT-canary" "$artifact" &
+    local alias="${baseline_alias[${artifact%.zip}]}"
+    if [ -n "$alias" ]; then
+      # Build the alias before publishing either so the pair uploads together.
+      repackage_baseline "${artifact%.zip}" "$alias"
+      upload_file "$artifact"
+      upload_file "$alias.zip"
     else
-      upload_s3_file "releases/$BUILDKITE_COMMIT" "$artifact" &
+      upload_file "$artifact"
     fi
-    upload_s3_file "releases/$tag" "$artifact" &
-    upload_github_asset "$tag" "$artifact" &
-    wait
   }
 
   for artifact in "${artifacts[@]}"; do

--- a/scripts/build/ci.ts
+++ b/scripts/build/ci.ts
@@ -345,14 +345,18 @@ function upload(paths: string[], cwd: string): void {
 
 /**
  * Base triplet (bun-os-arch[-musl][-baseline]). Variant suffix (-profile,
- * -asan) is added by the caller. Matches ci.mjs getTargetTriplet() and
- * cmake's bunTriplet — any drift breaks test-step downloads.
+ * -asan) is added by the caller. Matches ci.mjs getTargetTriplet() — any
+ * drift breaks test-step downloads.
  */
 export function computeBunTriplet(cfg: Config): string {
   let t = `bun-${cfg.os}-${cfg.arch}`;
   if (cfg.abi === "musl") t += "-musl";
   if (cfg.abi === "android") t += "-android";
-  if (cfg.baseline) t += "-baseline";
+  // linux/windows x64 (not android) always compile baseline as the only x64
+  // build, so the artifact keeps its plain name; -baseline release names
+  // are copies made by the release script.
+  const shipsBaselineX64 = cfg.x64 && cfg.abi !== "android" && (cfg.linux || cfg.windows);
+  if (cfg.baseline && !shipsBaselineX64) t += "-baseline";
   return t;
 }
 

--- a/src/bun_core/string/immutable/unicode.rs
+++ b/src/bun_core/string/immutable/unicode.rs
@@ -523,7 +523,7 @@ pub fn copy_latin1_into_ascii(dest: &mut [u8], src: &[u8]) {
         }
     }
 
-    if to.len() >= 16 && crate::Environment::ENABLE_SIMD {
+    if to.len() >= 16 {
         const VECTOR_SIZE: usize = 16;
         let remain_in_u64_len = remain.len() - (remain.len() % VECTOR_SIZE);
         let to_in_u64_len = to.len() - (to.len() % VECTOR_SIZE);


### PR DESCRIPTION
### What does this PR do?

x64 currently ships two binaries per platform: a plain build compiled with `-march=haswell` and a separate `-baseline` build compiled with `-march=nehalem`. The SIMD-heavy paths — string search, JSON indexing, sourcemap VLQ decoding, xxhash3, and the image kernels — already use Highway dynamic dispatch (`HWY_DYNAMIC_DISPATCH`), and the vendored SIMD dependencies (simdutf, zlib-ng, zstd, libdeflate, BoringSSL, libwebp) do their own runtime CPU dispatch. Those paths pick the best available instruction set at runtime regardless of the build's `-march`, so a separate haswell build isn't buying the SIMD it appears to.

This collapses linux x64 (glibc and musl) and windows x64 to a single baseline build each:

- The plain x64 build lanes now compile as baseline (Nehalem); the separate `-baseline` build lanes and their test lanes are removed.
- The existing plain artifact and step names are unchanged (`bun-linux-x64.zip`, `bun-linux-x64-musl.zip`, `bun-windows-x64.zip`, plus `-profile`), so downstream steps keep resolving.
- `verify-baseline` (Intel SDE on Windows, pinned qemu on Linux) now runs against those lanes, so the no-AVX/AVX2 check is preserved.
- The `-baseline` release names are produced by the release script as copies of the plain zip with the inner directory renamed to match — `bun upgrade` and the install scripts require the folder name to equal the zip name — so every existing release asset name (plain, `-baseline`, and their `-profile` variants) still ships with identical contents.
- darwin, freebsd, android and asan lanes are unchanged, and `--baseline` remains an option for other targets.

Also drops the `ENABLE_SIMD` gate (`= !BASELINE`) on `copy_latin1_into_ascii`'s 16-byte fast path. The loop is plain `u64` arithmetic that vectorizes at SSE2, so it was being compiled out of the shipped x64 binary for no benefit.

Note: the shipped x64 binary now reports itself as baseline (version banner, `bun upgrade` zip selection, crash-report platform tag). All of those resolve against the `-baseline` names the release still produces.

### How did you verify your code works?

CI is the verification for the matrix and release changes. Locally: exercised the repackage step against a real zip round-trip to confirm the plain zip is preserved and the copy's top-level folder matches its name, and diffed the baseline-verification gating for every lane against the previous behavior so only the three collapsed lanes gain verification and no existing lane (e.g. linux-aarch64-android) loses it.