### PR TITLE
resolver: substitute tsconfig paths '*' textually instead of path-joining

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4847,18 +4847,16 @@ impl<'a> Resolver<'a> {
                         original_path
                     };
 
-                // Load the original path relative to the "baseUrl" from tsconfig.json
-                let mut absolute_original_path: &[u8] = substituted;
-                if !bun_paths::is_absolute(substituted) {
-                    let parts: [&[u8]; 2] = [abs_base_url, substituted];
-                    let Some(joined) = self
-                        .fs_ref()
-                        .abs_buf_checked(&parts, bufs!(tsconfig_match_full_buf))
-                    else {
-                        continue;
-                    };
-                    absolute_original_path = joined;
-                }
+                // Resolve against "baseUrl" and normalize. The captured text
+                // may carry `..`, so normalize unconditionally; an absolute
+                // `substituted` replaces the base inside abs_buf_checked.
+                let parts: [&[u8]; 2] = [abs_base_url, substituted];
+                let Some(absolute_original_path) = self
+                    .fs_ref()
+                    .abs_buf_checked(&parts, bufs!(tsconfig_match_full_buf))
+                else {
+                    continue;
+                };
 
                 if self
                     .load_as_file_or_directory(absolute_original_path, kind, out)

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -351,7 +351,6 @@ pub struct Bufs {
     pub extension_path: PathBuffer,
     pub tsconfig_match_full_buf: PathBuffer,
     pub tsconfig_match_full_buf2: PathBuffer,
-    pub tsconfig_match_full_buf3: PathBuffer,
 
     pub esm_subpath: [u8; 512],
     pub esm_absolute_package_path: PathBuffer,
@@ -4830,53 +4829,36 @@ impl<'a> Resolver<'a> {
                 let matched_text =
                     &path[longest_match.prefix.len()..path.len() - longest_match.suffix.len()];
 
-                let total_length: Option<u32> = strings::index_of_char(original_path, b'*');
-                let prefix_end = total_length
-                    .map(|v| v as usize)
-                    .unwrap_or(original_path.len());
-                let prefix_parts: [&[u8]; 2] = [abs_base_url, &original_path[0..prefix_end]];
-
-                // Concatenate the matched text with the suffix from the wildcard path
-                let matched_text_with_suffix = bufs!(tsconfig_match_full_buf3);
-                let mut matched_text_with_suffix_len: usize = 0;
-                if total_length.is_some() {
-                    let suffix = strings::trim_left(&original_path[prefix_end..], b"*");
-                    matched_text_with_suffix_len = matched_text.len() + suffix.len();
-                    if matched_text_with_suffix_len > matched_text_with_suffix.len() {
-                        continue;
-                    }
-                    ::bun_core::concat_into(matched_text_with_suffix, &[matched_text, suffix]);
-                }
-
-                // 1. Normalize the base path
-                // so that "/Users/foo/project/", "../components/*" => "/Users/foo/components/""
-                let Some(prefix) = self
-                    .fs_ref()
-                    .abs_buf_checked(&prefix_parts, bufs!(tsconfig_match_full_buf2))
-                else {
-                    continue;
-                };
-
-                // 2. Join the new base path with the matched result
-                // so that "/Users/foo/components/", "/foo/bar" => /Users/foo/components/foo/bar
-                let parts: [&[u8]; 3] = [
-                    prefix,
-                    if matched_text_with_suffix_len > 0 {
-                        strings::trim_left(
-                            &matched_text_with_suffix[0..matched_text_with_suffix_len],
-                            b"/",
-                        )
+                // Substitute textually (TypeScript's replaceFirstStar), not via
+                // path-join: the '*' need not sit on a segment boundary.
+                let substituted_buf = bufs!(tsconfig_match_full_buf2);
+                let substituted: &[u8] =
+                    if let Some(star) = strings::index_of_char(original_path, b'*') {
+                        let star = star as usize;
+                        let before = &original_path[..star];
+                        let after = &original_path[star + 1..];
+                        let total = before.len() + matched_text.len() + after.len();
+                        if total > substituted_buf.len() {
+                            continue;
+                        }
+                        ::bun_core::concat_into(substituted_buf, &[before, matched_text, after]);
+                        &substituted_buf[..total]
                     } else {
-                        b""
-                    },
-                    strings::trim_left(longest_match.suffix, b"/"),
-                ];
-                let Some(absolute_original_path) = self
-                    .fs_ref()
-                    .abs_buf_checked(&parts, bufs!(tsconfig_match_full_buf))
-                else {
-                    continue;
-                };
+                        original_path
+                    };
+
+                // Load the original path relative to the "baseUrl" from tsconfig.json
+                let mut absolute_original_path: &[u8] = substituted;
+                if !bun_paths::is_absolute(substituted) {
+                    let parts: [&[u8]; 2] = [abs_base_url, substituted];
+                    let Some(joined) = self
+                        .fs_ref()
+                        .abs_buf_checked(&parts, bufs!(tsconfig_match_full_buf))
+                    else {
+                        continue;
+                    };
+                    absolute_original_path = joined;
+                }
 
                 if self
                     .load_as_file_or_directory(absolute_original_path, kind, out)

--- a/test/bundler/esbuild/tsconfig.test.ts
+++ b/test/bundler/esbuild/tsconfig.test.ts
@@ -7,7 +7,7 @@ import { itBundled } from "../expectBundled";
 // For debug, all files are written to $TEMP/bun-bundle-tests/tsconfig
 
 describe("bundler", () => {
-  itBundled("tsconfig/Paths", ({ root }) => ({
+  itBundled("tsconfig/Paths", {
     files: {
       "/entry.ts": /* ts */ `
         import baseurl_dot from './baseurl_dot'
@@ -51,8 +51,8 @@ describe("bundler", () => {
               "test5/*": ["./test5-first/*", "./test5-second/*"],
               "/virtual-in/test": ["./actual/test"],
               "/virtual-in-star/*": ["./actual/*"],
-              "/virtual-out/test": ["${root}/baseurl_dot/actual/test"],
-              "/virtual-out-star/*": ["${root}/baseurl_dot/actual/*"],
+              "/virtual-out/test": ["{{root}}/baseurl_dot/actual/test"],
+              "/virtual-out-star/*": ["{{root}}/baseurl_dot/actual/*"],
             }
           }
         }
@@ -105,8 +105,8 @@ describe("bundler", () => {
               "test5/*": ["./test5-first/*", "./test5-second/*"],
               "/virtual-in/test": ["./actual/test"],
               "/virtual-in-star/*": ["./actual/*"],
-              "/virtual-out/test": ["${root}/baseurl_nested/nested/actual/test"],
-              "/virtual-out-star/*": ["${root}/baseurl_nested/nested/actual/*"],
+              "/virtual-out/test": ["{{root}}/baseurl_nested/nested/actual/test"],
+              "/virtual-out-star/*": ["{{root}}/baseurl_nested/nested/actual/*"],
             }
           }
         }
@@ -127,7 +127,7 @@ describe("bundler", () => {
       stdout:
         '{"baseurl_dot":{"test0":"test0-success","test1":"test1-success","test2":"test2-success","test3":"test3-success","test4":"test4-success","test5":"test5-success","absoluteIn":"absolute-success","absoluteInStar":"absolute-success","absoluteOut":"absolute-success","absoluteOutStar":"absolute-success"},"baseurl_nested":{"test0":"test0-success","test1":"test1-success","test2":"test2-success","test3":"test3-success","test4":"test4-success","test5":"test5-success","absoluteIn":"absolute-success","absoluteInStar":"absolute-success","absoluteOut":"absolute-success","absoluteOutStar":"absolute-success"}}',
     },
-  }));
+  });
   itBundled("tsconfig/PathsNoBaseURL", {
     files: {
       "/entry.ts": /* ts */ `

--- a/test/bundler/esbuild/tsconfig.test.ts
+++ b/test/bundler/esbuild/tsconfig.test.ts
@@ -230,6 +230,35 @@ describe("bundler", () => {
         '{"simple":{"test0":"test0-success","test1":"test1-success","test2":"test2-success","test3":"test3-success","test4":"test4-success","test5":"test5-success","absolute":"absolute-success"},"extended":{"test0":"test0-success","test1":"test1-success","test2":"test2-success","test3":"test3-success","test4":"test4-success","test5":"test5-success","absolute":"absolute-success"}}',
     },
   });
+  itBundled("tsconfig/PathsWildcardSuffix", {
+    // https://github.com/oven-sh/bun/issues/26193
+    files: {
+      "/entry.ts": /* ts */ `
+        import a from '@src/lib.js'
+        import b from 'tie/xend'
+        import c from 'test3/foo'
+        console.log(JSON.stringify([a, b, c]))
+      `,
+      "/tsconfig.json": /* json */ `
+        {
+          "compilerOptions": {
+            "baseUrl": ".",
+            "paths": {
+              "@src/*.js": ["./src/*.ts"],
+              "tie/*end": ["./tie-long/*"],
+              "t*t3/foo": ["./test3-succ*s.ts"]
+            }
+          }
+        }
+      `,
+      "/src/lib.ts": `export default 'src-lib'`,
+      "/tie-long/x.ts": `export default 'tie-long-x'`,
+      "/test3-success.ts": `export default 'test3-success'`,
+    },
+    run: {
+      stdout: '["src-lib","tie-long-x","test3-success"]',
+    },
+  });
   // TODO: warnings shouldnt stop build?
   itBundled("tsconfig/BadPathsNoBaseURL", {
     // GENERATED

--- a/test/bundler/esbuild/tsconfig.test.ts
+++ b/test/bundler/esbuild/tsconfig.test.ts
@@ -8,7 +8,6 @@ import { itBundled } from "../expectBundled";
 
 describe("bundler", () => {
   itBundled("tsconfig/Paths", ({ root }) => ({
-    todo: true,
     files: {
       "/entry.ts": /* ts */ `
         import baseurl_dot from './baseurl_dot'
@@ -130,7 +129,6 @@ describe("bundler", () => {
     },
   }));
   itBundled("tsconfig/PathsNoBaseURL", {
-    todo: true,
     files: {
       "/entry.ts": /* ts */ `
         import simple from './simple'
@@ -230,14 +228,15 @@ describe("bundler", () => {
         '{"simple":{"test0":"test0-success","test1":"test1-success","test2":"test2-success","test3":"test3-success","test4":"test4-success","test5":"test5-success","absolute":"absolute-success"},"extended":{"test0":"test0-success","test1":"test1-success","test2":"test2-success","test3":"test3-success","test4":"test4-success","test5":"test5-success","absolute":"absolute-success"}}',
     },
   });
-  itBundled("tsconfig/PathsWildcardSuffix", {
+  itBundled("tsconfig/PathsWildcardKeySuffix", {
     // https://github.com/oven-sh/bun/issues/26193
+    // The '*'-not-on-a-segment-boundary shape lives in tsconfig/Paths above;
+    // this covers the two key-suffix shapes that test lacks.
     files: {
       "/entry.ts": /* ts */ `
         import a from '@src/lib.js'
         import b from 'tie/xend'
-        import c from 'test3/foo'
-        console.log(JSON.stringify([a, b, c]))
+        console.log(JSON.stringify([a, b]))
       `,
       "/tsconfig.json": /* json */ `
         {
@@ -245,18 +244,16 @@ describe("bundler", () => {
             "baseUrl": ".",
             "paths": {
               "@src/*.js": ["./src/*.ts"],
-              "tie/*end": ["./tie-long/*"],
-              "t*t3/foo": ["./test3-succ*s.ts"]
+              "tie/*end": ["./tie-long/*"]
             }
           }
         }
       `,
       "/src/lib.ts": `export default 'src-lib'`,
       "/tie-long/x.ts": `export default 'tie-long-x'`,
-      "/test3-success.ts": `export default 'test3-success'`,
     },
     run: {
-      stdout: '["src-lib","tie-long-x","test3-success"]',
+      stdout: '["src-lib","tie-long-x"]',
     },
   });
   // TODO: warnings shouldnt stop build?

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -154,7 +154,7 @@ describe.concurrent("long import path overflow", () => {
 
   it("tsconfig paths wildcard (matched text captured from import path)", async () => {
     using dir = makeDir();
-    // matchTSConfigPaths: bun.concat into fixed tsconfig_match_full_buf3
+    // matchTSConfigPaths: concat_into the fixed substitution buffer
     await run(String(dir), `\`@x/${long}\``);
   });
 

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1029,11 +1029,11 @@ describe("tsconfig paths wildcard substitution", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return { stdout, stderr, exitCode };
+    return { dir: String(dir), stdout, stderr, exitCode };
   }
 
-  it("maps a .js key suffix to a .ts target suffix (issue #26193)", async () => {
-    const { stdout, stderr, exitCode } = await run(
+  it.concurrent("maps a .js key suffix to a .ts target suffix (issue #26193)", async () => {
+    const { stdout, exitCode } = await run(
       {
         "tsconfig.json": JSON.stringify({
           compilerOptions: { baseUrl: ".", paths: { "@src/*.js": ["./src/*.ts"] } },
@@ -1042,13 +1042,13 @@ describe("tsconfig paths wildcard substitution", () => {
       },
       `import { greeting } from "@src/lib.js"; console.log(greeting);`,
     );
-    expect(stderr).toBe("");
-    expect(stdout).toBe("hi\n");
-    expect(exitCode).toBe(0);
+    expect({ stdout, exitCode }).toEqual({ stdout: "hi\n", exitCode: 0 });
   });
 
-  it("drops the key suffix when the target has no suffix", async () => {
-    const { stdout, stderr, exitCode } = await run(
+  it.concurrent("drops the key suffix when the target has no suffix", async () => {
+    // Longest prefix is equal ("tie/"), longest suffix "end" wins over "", so
+    // "tie/xend" matches "tie/*end" with * = "x" and resolves to ./tie-long/x.
+    const { stdout, exitCode } = await run(
       {
         "tsconfig.json": JSON.stringify({
           compilerOptions: { baseUrl: ".", paths: { "tie/*end": ["./tie-long/*"], "tie/*": ["./tie-short/*"] } },
@@ -1058,15 +1058,11 @@ describe("tsconfig paths wildcard substitution", () => {
       },
       `import { v } from "tie/xend"; console.log(v);`,
     );
-    expect(stderr).toBe("");
-    // Longest prefix is equal ("tie/"), longest suffix "end" wins over "", so
-    // "tie/xend" matches "tie/*end" with * = "x" and resolves to ./tie-long/x.
-    expect(stdout).toBe("long-x\n");
-    expect(exitCode).toBe(0);
+    expect({ stdout, exitCode }).toEqual({ stdout: "long-x\n", exitCode: 0 });
   });
 
-  it("substitutes into a '*' not on a segment boundary", async () => {
-    const { stdout, stderr, exitCode } = await run(
+  it.concurrent("substitutes into a '*' not on a segment boundary", async () => {
+    const { stdout, exitCode } = await run(
       {
         "tsconfig.json": JSON.stringify({
           compilerOptions: { baseUrl: ".", paths: { "t*t3/foo": ["./test3-succ*s.ts"] } },
@@ -1075,13 +1071,11 @@ describe("tsconfig paths wildcard substitution", () => {
       },
       `import v from "test3/foo"; console.log(v);`,
     );
-    expect(stderr).toBe("");
-    expect(stdout).toBe("test3-success\n");
-    expect(exitCode).toBe(0);
+    expect({ stdout, exitCode }).toEqual({ stdout: "test3-success\n", exitCode: 0 });
   });
 
-  it("still resolves plain prefix-only wildcards", async () => {
-    const { stdout, stderr, exitCode } = await run(
+  it.concurrent("still resolves plain prefix-only wildcards", async () => {
+    const { stdout, exitCode } = await run(
       {
         "tsconfig.json": JSON.stringify({
           compilerOptions: { baseUrl: ".", paths: { "@/*": ["./src/*"] } },
@@ -1090,13 +1084,11 @@ describe("tsconfig paths wildcard substitution", () => {
       },
       `import { ok } from "@/a/b"; console.log(ok);`,
     );
-    expect(stderr).toBe("");
-    expect(stdout).toBe("1\n");
-    expect(exitCode).toBe(0);
+    expect({ stdout, exitCode }).toEqual({ stdout: "1\n", exitCode: 0 });
   });
 
-  it("falls through to the next target when the first does not exist", async () => {
-    const { stdout, stderr, exitCode } = await run(
+  it.concurrent("falls through to the next target when the first does not exist", async () => {
+    const { stdout, exitCode } = await run(
       {
         "tsconfig.json": JSON.stringify({
           compilerOptions: { baseUrl: ".", paths: { "lib/*.js": ["./first/*.ts", "./second/*.ts"] } },
@@ -1105,9 +1097,25 @@ describe("tsconfig paths wildcard substitution", () => {
       },
       `import { where } from "lib/thing.js"; console.log(where);`,
     );
-    expect(stderr).toBe("");
-    expect(stdout).toBe("second\n");
-    expect(exitCode).toBe(0);
+    expect({ stdout, exitCode }).toEqual({ stdout: "second\n", exitCode: 0 });
+  });
+
+  it.concurrent("normalizes '..' from the captured text through an absolute target", async () => {
+    using base = tempDir("tsconfig-paths-abs-target", {
+      "src/lib.ts": `export const v = "hi";`,
+    });
+    const abs = String(base).replaceAll("\\", "/");
+    const { dir, stdout, exitCode } = await run(
+      {
+        "tsconfig.json": JSON.stringify({
+          compilerOptions: { baseUrl: ".", paths: { "@pkg/*": [`${abs}/src/*`] } },
+        }),
+      },
+      `console.log(Bun.resolveSync("@pkg/sub/../lib", import.meta.dir));`,
+    );
+    void dir;
+    expect({ stdout, exitCode }).toEqual({ stdout: join(String(base), "src", "lib.ts") + "\n", exitCode: 0 });
+    expect(stdout).not.toContain("..");
   });
 });
 

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1013,6 +1013,104 @@ describe("resolving external URL specifiers with non-ASCII characters", () => {
   });
 });
 
+// tsconfig "paths" wildcard substitution: the captured text replaces the first
+// '*' in the target textually (TypeScript's replaceFirstStar). The key
+// pattern's suffix is consumed by the match and must not be re-appended, and
+// a '*' that is not on a segment boundary must not get a '/' inserted.
+// https://github.com/oven-sh/bun/issues/26193
+describe("tsconfig paths wildcard substitution", () => {
+  async function run(files: Record<string, string>, script: string) {
+    using dir = tempDir("tsconfig-paths-wildcard", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it("maps a .js key suffix to a .ts target suffix (issue #26193)", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      {
+        "tsconfig.json": JSON.stringify({
+          compilerOptions: { baseUrl: ".", paths: { "@src/*.js": ["./src/*.ts"] } },
+        }),
+        "src/lib.ts": `export const greeting = "hi";`,
+      },
+      `import { greeting } from "@src/lib.js"; console.log(greeting);`,
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("hi\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("drops the key suffix when the target has no suffix", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      {
+        "tsconfig.json": JSON.stringify({
+          compilerOptions: { baseUrl: ".", paths: { "tie/*end": ["./tie-long/*"], "tie/*": ["./tie-short/*"] } },
+        }),
+        "tie-long/x.ts": `export const v = "long-x";`,
+        "tie-short/xend.ts": `export const v = "short-xend";`,
+      },
+      `import { v } from "tie/xend"; console.log(v);`,
+    );
+    expect(stderr).toBe("");
+    // Longest prefix is equal ("tie/"), longest suffix "end" wins over "", so
+    // "tie/xend" matches "tie/*end" with * = "x" and resolves to ./tie-long/x.
+    expect(stdout).toBe("long-x\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("substitutes into a '*' not on a segment boundary", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      {
+        "tsconfig.json": JSON.stringify({
+          compilerOptions: { baseUrl: ".", paths: { "t*t3/foo": ["./test3-succ*s.ts"] } },
+        }),
+        "test3-success.ts": `export default "test3-success";`,
+      },
+      `import v from "test3/foo"; console.log(v);`,
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("test3-success\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("still resolves plain prefix-only wildcards", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      {
+        "tsconfig.json": JSON.stringify({
+          compilerOptions: { baseUrl: ".", paths: { "@/*": ["./src/*"] } },
+        }),
+        "src/a/b.ts": `export const ok = 1;`,
+      },
+      `import { ok } from "@/a/b"; console.log(ok);`,
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("1\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("falls through to the next target when the first does not exist", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      {
+        "tsconfig.json": JSON.stringify({
+          compilerOptions: { baseUrl: ".", paths: { "lib/*.js": ["./first/*.ts", "./second/*.ts"] } },
+        }),
+        "second/thing.ts": `export const where = "second";`,
+      },
+      `import { where } from "lib/thing.js"; console.log(where);`,
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("second\n");
+    expect(exitCode).toBe(0);
+  });
+});
+
 // Stress the resolver's directory-info cache: resolve through hundreds of
 // distinct package directories (each `put` hands back a slot pointer into the
 // shared dir-cache that must stay valid while the cache keeps growing) plus a

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1029,7 +1029,7 @@ describe("tsconfig paths wildcard substitution", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return { dir: String(dir), stdout, stderr, exitCode };
+    return { stdout, stderr, exitCode };
   }
 
   it.concurrent("maps a .js key suffix to a .ts target suffix (issue #26193)", async () => {
@@ -1105,7 +1105,7 @@ describe("tsconfig paths wildcard substitution", () => {
       "src/lib.ts": `export const v = "hi";`,
     });
     const abs = String(base).replaceAll("\\", "/");
-    const { dir, stdout, exitCode } = await run(
+    const { stdout, exitCode } = await run(
       {
         "tsconfig.json": JSON.stringify({
           compilerOptions: { baseUrl: ".", paths: { "@pkg/*": [`${abs}/src/*`] } },
@@ -1113,7 +1113,6 @@ describe("tsconfig paths wildcard substitution", () => {
       },
       `console.log(Bun.resolveSync("@pkg/sub/../lib", import.meta.dir));`,
     );
-    void dir;
     expect({ stdout, exitCode }).toEqual({ stdout: join(String(base), "src", "lib.ts") + "\n", exitCode: 0 });
     expect(stdout).not.toContain("..");
   });


### PR DESCRIPTION
## What does this PR do?

`match_tsconfig_paths` built the candidate path by splitting the target at `*`, resolving `baseUrl + target[..star]`, then path-joining that with `matched_text + target[star+1..]` and the **key pattern's suffix** as a third part. The joiner inserts `/` between parts, so a key suffix becomes an extra path segment and a `*` that is not on a segment boundary gets a `/` inserted.

### Repro

```sh
D=$(mktemp -d) && cd "$D"
printf '{"compilerOptions":{"baseUrl":".","paths":{"@src/*.js":["./src/*.ts"]}}}' > tsconfig.json
mkdir src && echo 'export const greeting = "hi";' > src/lib.ts
bun -e 'import { greeting } from "@src/lib.js"; console.log(greeting)'
```

Before:
```
error: Cannot find module '@src/lib.js'
```

After:
```
hi
```

TypeScript's `--traceResolution` on the same setup:
```
Module name '@src/lib.js', matched pattern '@src/*.js'.
Trying substitution './src/*.ts', candidate module location: './src/lib.ts'.
```

### Fix

Build the substituted target as `before + matched + after` in one contiguous buffer, then run it through `abs_buf_checked([abs_base_url, substituted])` once. This is TypeScript's `replaceFirstStar` and esbuild's `strings.Replace(originalPath, "*", matchedText, 1)`. The normalize step runs unconditionally: the captured `*` text comes from the import specifier and may carry `..`, and `abs_buf_checked` already promotes an absolute part to the base so the absolute-target case needs no separate branch.

This fixes three shapes in one go:
- `"@src/*.js": ["./src/*.ts"]` (key suffix was re-appended as `./src/lib.ts/.js`)
- `"tie/*end": ["./tie-long/*"]` (key suffix was re-appended as `./tie-long/x/end`)
- `"t*t3/foo": ["./test3-succ*s.ts"]` (esbuild parity case: `*` not on a `/` boundary)

The third shape was the only blocker for the esbuild-ported `tsconfig/Paths` and `tsconfig/PathsNoBaseURL` bundler tests, so both are un-todo'd here.

Fixes #26193. Supersedes the auto-closed #26194, which targeted the pre-Rust source.

### How did you verify your code works?

- Six runtime cases in `test/js/bun/resolve/resolve.test.ts` (four for the bug, one guard for the common `@/*` case, one guard that an absolute target with `..` in the capture still normalizes).
- `tsconfig/Paths`, `tsconfig/PathsNoBaseURL` and the new `tsconfig/PathsWildcardKeySuffix` in `test/bundler/esbuild/tsconfig.test.ts`.

All bug cases fail on the unfixed build with `Cannot find module` / `Could not resolve` and pass with the fix. Also passing unchanged: `test/js/bun/resolve/resolve-error.test.ts`, `test/cli/run/tsconfig-override.test.ts`, `test/js/bun/resolve/tsconfig-extends-leak.test.ts`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/resolve/resolve-error.test.ts test/js/bun/resolve/resolve.test.ts

<!-- robobun:evidence:end -->