### PR TITLE
node:http2: reclaim H2FrameParser native allocations at worker thread exit

### DIFF
--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -218,8 +218,6 @@ unsafe extern "C" {
     safe fn WebWorker__dispatchExit(cpp_worker: *mut c_void, exit_code: i32);
     // safe: no args; frees this thread's lazily-allocated HPACK scratch buffer.
     safe fn Bun__freeSharedHeaderBufferForThreadExit();
-    // safe: no args; reclaims any H2FrameParser the worker's VM failed to finalize.
-    safe fn Bun__H2FrameParser__onThreadExit();
     // Re-declared here (also private in VM.rs) so `thread_main` can take the
     // API lock as a raw FFI call with NO RAII guard — see the note there.
     safe fn JSC__VM__getAPILock(vm: &jsc::VM);
@@ -1398,10 +1396,6 @@ impl WebWorker {
         // guaranteed to run before the process exits, so free the HPACK scratch buffer that any
         // http2 session on this thread allocated.
         Bun__freeSharedHeaderBufferForThreadExit();
-        // ~VM's lastChanceToFinalize does not always reach every JSH2FrameParser cell when the
-        // worker was terminated mid-dispatch; reclaim any stragglers' native allocations now
-        // that the VM is down.
-        Bun__H2FrameParser__onThreadExit();
         // Free this thread's lazily-created uWS loop and its 512 KiB recv
         // buffer. The C++ thread_local `~LoopCleaner` does not fire here:
         // we return normally and

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -218,6 +218,8 @@ unsafe extern "C" {
     safe fn WebWorker__dispatchExit(cpp_worker: *mut c_void, exit_code: i32);
     // safe: no args; frees this thread's lazily-allocated HPACK scratch buffer.
     safe fn Bun__freeSharedHeaderBufferForThreadExit();
+    // safe: no args; reclaims any H2FrameParser the worker's VM failed to finalize.
+    safe fn Bun__H2FrameParser__onThreadExit();
     // Re-declared here (also private in VM.rs) so `thread_main` can take the
     // API lock as a raw FFI call with NO RAII guard — see the note there.
     safe fn JSC__VM__getAPILock(vm: &jsc::VM);
@@ -1396,6 +1398,10 @@ impl WebWorker {
         // guaranteed to run before the process exits, so free the HPACK scratch buffer that any
         // http2 session on this thread allocated.
         Bun__freeSharedHeaderBufferForThreadExit();
+        // ~VM's lastChanceToFinalize does not always reach every JSH2FrameParser cell when the
+        // worker was terminated mid-dispatch; reclaim any stragglers' native allocations now
+        // that the VM is down.
+        Bun__H2FrameParser__onThreadExit();
         // Free this thread's lazily-created uWS loop and its 512 KiB recv
         // buffer. The C++ thread_local `~LoopCleaner` does not fire here:
         // we return normally and

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1282,11 +1282,33 @@ thread_local! {
     // `ManuallyDrop` inside the `Box`: the TLS destructor runs after
     // `WebWorker::destroy` has raw-deallocated the VM, so `HiveArray::Drop`
     // on any leaked parser would touch freed JSC/uws state. Skip slot
-    // teardown (a leaked parser is a bug anyway) while still freeing the
-    // pool allocation itself.
+    // teardown while still freeing the pool allocation itself. A leaked
+    // parser's native-heap fields are released by
+    // `free_leaked_parsers_for_thread_exit` (worker teardown step 5).
     static POOL: RefCell<Option<Box<ManuallyDrop<H2FrameParserHiveAllocator>>>> =
         const { RefCell::new(None) };
     static SHARED_REQUEST_BUFFER: RefCell<Box<[u8; 16384]>> = RefCell::new(Box::new([0u8; 16384]));
+}
+
+/// Worker-thread teardown hook: reclaim any parser the JSC VM failed to finalize. Called from
+/// `WebWorker::shutdown` after `~VM`, so every JSC-backed handle on a leaked parser is dangling;
+/// `free_native_for_thread_exit` forgets those and drops the pure-Rust/C allocations (engine's
+/// stream HashMap, lshpack state, per-stream boxes, scratch Vecs). The pool itself is taken so
+/// the slot storage is released here rather than by the TLS destructor.
+#[unsafe(no_mangle)]
+pub extern "C" fn Bun__H2FrameParser__onThreadExit() {
+    let Some(pool) = POOL.with_borrow_mut(Option::take) else {
+        return;
+    };
+    let mut it = pool.hive.used.iter_set();
+    while let Some(index) = it.next() {
+        let slot = pool.hive.ptr_at(index);
+        // SAFETY: `used` bit set ⇒ slot is a fully-initialized parser whose `finalize()` never
+        // ran; this thread is the sole remaining owner (the VM that could have touched it is
+        // gone) and the shared borrow touches only interior-mutable fields.
+        unsafe { (*slot).free_native_for_thread_exit() };
+    }
+    drop(pool);
 }
 
 /// One wire-order piece of a multi-frame send_data batch (see BATCH_SEGMENTS).
@@ -2320,6 +2342,34 @@ impl Stream {
         if !FINALIZING {
             VirtualMachine::get().event_loop_mut().process_gc_timer();
         }
+    }
+
+    /// Free this stream's heap allocations after the owning worker's JSC VM has been torn down.
+    /// JSC-backed fields (Strong handles, the AbortSignal listener) are forgotten rather than
+    /// dropped: their backing storage lives in the VM's HandleSet / heap, already freed by ~VM,
+    /// so running their Drop would touch freed memory. See free_leaked_parsers_for_thread_exit.
+    ///
+    /// # Safety
+    /// `this` is a heap::alloc'd Stream still linked from a parser that finalize() never reached.
+    /// The worker's JSC VM must already be torn down and no other reference to `*this` may exist.
+    unsafe fn free_native_for_thread_exit(this: *mut Self) {
+        // SAFETY: caller contract; sole owner.
+        let stream = unsafe { &mut *this };
+        let _ = ManuallyDrop::new(core::mem::take(&mut stream.js_context));
+        if let Some(signal) = stream.signal.take() {
+            // SignalRef::Drop detaches from the (freed) AbortSignal and derefs the parser; skip
+            // it and reclaim only the Box.
+            let raw = Box::into_raw(signal);
+            // SAFETY: `raw` is the unique Box allocation; ManuallyDrop<T> is repr(transparent).
+            drop(unsafe { Box::from_raw(raw.cast::<ManuallyDrop<SignalRef>>()) });
+        }
+        for frame in core::mem::take(&mut stream.data_frame_queue).data.drain(..) {
+            let PendingFrame { callback, .. } = frame;
+            let _ = ManuallyDrop::new(callback);
+        }
+        // SAFETY: caller contract; every field whose Drop would touch JSC has been taken above,
+        // so the remaining auto-Drop (Vec<u8> etc.) is pure heap.
+        drop(unsafe { bun_core::heap::take(this) });
     }
 }
 
@@ -10033,6 +10083,44 @@ impl H2FrameParser {
         for _ in 0..stranded {
             self.deref();
         }
+    }
+
+    /// Free every heap allocation this parser owns after the worker's JSC VM has been torn down.
+    /// `finalize()` is the owning path, but ~VM's lastChanceToFinalize does not always reach the
+    /// JSH2FrameParser cell when a worker is terminated mid-stream (the same gap the
+    /// no-validate-leaksan.txt worker tests cover). The slot then leaks every field's allocation,
+    /// because the POOL is ManuallyDrop. This walks the JSC-free path of deinit(): pure-Rust/C
+    /// allocations are dropped, and the JSC-backed handles (whose storage already went down with
+    /// the VM) are forgotten so their Drop cannot touch freed memory.
+    fn free_native_for_thread_exit(&self) {
+        *self.engine.borrow_mut() = None;
+        self.hpack.set(None);
+        self.read_buffer.set(MutableString::default());
+        self.write_buffer.set(Vec::new());
+        self.custom_settings.set(Vec::new());
+        self.wire_custom_settings.set(Vec::new());
+        self.remote_custom_settings_filter.set(Vec::new());
+        self.remote_custom_settings.set(Vec::new());
+        self.pending_stream_send_consumed.set(Vec::new());
+        self.pending_settings_window_submissions.set(Vec::new());
+        self.pending_engine_stream_closes.set(Vec::new());
+        self.rewrite_tail.set(Vec::new());
+        self.hdr_block.set(Vec::new());
+        self.hdr_meta.set(Vec::new());
+        let _ = ManuallyDrop::new(self.strong_this.replace(JsRef::empty()));
+        let mut sctx = self.sctx.replace(BunHashMap::default());
+        let ids: Vec<u32> = sctx.keys().copied().collect();
+        for id in ids {
+            let _ = ManuallyDrop::new(sctx.remove(&id));
+        }
+        drop(sctx);
+        let streams = self.streams.replace(BunHashMap::default());
+        for (_, item) in streams.iter() {
+            // SAFETY: each entry is the heap::alloc'd *mut Stream owned by this parser; the VM
+            // is gone and this is the only remaining owner.
+            unsafe { Stream::free_native_for_thread_exit(*item) };
+        }
+        drop(streams);
     }
 
     fn deinit(&self) {

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1284,21 +1284,20 @@ thread_local! {
     // on any leaked parser would touch freed JSC/uws state. Skip slot
     // teardown while still freeing the pool allocation itself. A leaked
     // parser's native-heap fields are released by
-    // `Bun__H2FrameParser__onThreadExit` (worker teardown step 5).
+    // `h2_frame_parser_on_thread_exit` (worker teardown step 5).
     static POOL: RefCell<Option<Box<ManuallyDrop<H2FrameParserHiveAllocator>>>> =
         const { RefCell::new(None) };
     static SHARED_REQUEST_BUFFER: RefCell<Box<[u8; 16384]>> = RefCell::new(Box::new([0u8; 16384]));
 }
 
-/// Worker-thread teardown hook: reclaim any parser the JSC VM failed to finalize. Called from
-/// `WebWorker::shutdown` after `~VM`, so every JSC-backed handle on a leaked parser is dangling;
-/// `free_native_for_thread_exit` forgets those and drops the pure-Rust/C allocations (engine's
-/// stream HashMap, lshpack state, per-stream boxes, scratch Vecs). The pool itself is taken so
-/// the slot storage is released here rather than by the TLS destructor. Only the 256 inline
-/// hive slots are enumerated; `Fallback` keeps no record of heap-spill slots (>256 concurrent
-/// parsers on one thread), so those would still leak in that case.
-#[unsafe(no_mangle)]
-pub extern "C" fn Bun__H2FrameParser__onThreadExit() {
+/// Worker-thread teardown hook: reclaim any parser the JSC VM failed to finalize. Registered
+/// with `bun_core::register_thread_exit_pool_destructor` at first POOL use and run from
+/// `WebWorker::shutdown`'s `delete_all_pools_for_thread_exit` after `~VM`, so every JSC-backed
+/// handle on a leaked parser is dangling; `free_native_for_thread_exit` disarms those and lets
+/// the struct's ordinary Drop free the engine's stream HashMap, lshpack state, per-stream boxes
+/// and scratch Vecs. Only the 256 inline hive slots are enumerated; `Fallback` keeps no record
+/// of heap-spill slots (>256 concurrent parsers on one thread), so those would still leak.
+fn h2_frame_parser_on_thread_exit() {
     let Some(pool) = POOL.with_borrow_mut(Option::take) else {
         return;
     };
@@ -1307,8 +1306,9 @@ pub extern "C" fn Bun__H2FrameParser__onThreadExit() {
         let slot = pool.hive.ptr_at(index);
         // SAFETY: `used` bit set ⇒ slot is a fully-initialized parser whose `finalize()` never
         // ran; this thread is the sole remaining owner (the VM that could have touched it is
-        // gone) and the shared borrow touches only interior-mutable fields.
-        unsafe { (*slot).free_native_for_thread_exit() };
+        // gone). The ManuallyDrop wrapper on `pool` skips HiveArray::Drop, so `drop(pool)` below
+        // only deallocates the slot storage and cannot double-drop this slot.
+        unsafe { H2FrameParser::free_native_for_thread_exit(slot) };
     }
     drop(pool);
 }
@@ -2349,7 +2349,7 @@ impl Stream {
     /// Free this stream's heap allocations after the owning worker's JSC VM has been torn down.
     /// JSC-backed fields (Strong handles, the AbortSignal listener) are forgotten rather than
     /// dropped: their backing storage lives in the VM's HandleSet / heap, already freed by ~VM,
-    /// so running their Drop would touch freed memory. See Bun__H2FrameParser__onThreadExit.
+    /// so running their Drop would touch freed memory. See h2_frame_parser_on_thread_exit.
     ///
     /// # Safety
     /// `this` is a heap::alloc'd Stream still linked from a parser that finalize() never reached.
@@ -9842,6 +9842,12 @@ impl H2FrameParser {
         let this: *mut H2FrameParser = if ENABLE_ALLOCATOR_POOL {
             POOL.with_borrow_mut(|pool| {
                 let pool = pool.get_or_insert_with(|| {
+                    static REGISTER_THREAD_EXIT: std::sync::Once = std::sync::Once::new();
+                    REGISTER_THREAD_EXIT.call_once(|| {
+                        bun_core::register_thread_exit_pool_destructor(
+                            h2_frame_parser_on_thread_exit,
+                        );
+                    });
                     // SAFETY: `new_boxed` returns a `Box::leak`ed, fully
                     // initialized allocation; `from_raw` reclaims that exact
                     // pointer back into an owning `Box`. `ManuallyDrop<T>` is
@@ -10091,38 +10097,34 @@ impl H2FrameParser {
     /// `finalize()` is the owning path, but ~VM's lastChanceToFinalize does not always reach the
     /// JSH2FrameParser cell when a worker is terminated mid-stream (the same gap the
     /// no-validate-leaksan.txt worker tests cover). The slot then leaks every field's allocation,
-    /// because the POOL is ManuallyDrop. This walks the JSC-free path of deinit(): pure-Rust/C
-    /// allocations are dropped, and the JSC-backed handles (whose storage already went down with
-    /// the VM) are forgotten so their Drop cannot touch freed memory.
-    fn free_native_for_thread_exit(&self) {
-        *self.engine.borrow_mut() = None;
-        self.hpack.set(None);
-        self.read_buffer.set(MutableString::default());
-        self.write_buffer.set(Vec::new());
-        self.custom_settings.set(Vec::new());
-        self.wire_custom_settings.set(Vec::new());
-        self.remote_custom_settings_filter.set(Vec::new());
-        self.remote_custom_settings.set(Vec::new());
-        self.pending_stream_send_consumed.set(Vec::new());
-        self.pending_settings_window_submissions.set(Vec::new());
-        self.pending_engine_stream_closes.set(Vec::new());
-        self.rewrite_tail.set(Vec::new());
-        self.hdr_block.set(Vec::new());
-        self.hdr_meta.set(Vec::new());
-        let _ = ManuallyDrop::new(self.strong_this.replace(JsRef::empty()));
-        let mut sctx = self.sctx.replace(BunHashMap::default());
+    /// because the POOL is ManuallyDrop. Disarm the three JSC-backed fields (whose storage already
+    /// went down with the VM) and let the struct's ordinary Drop free everything else; that is the
+    /// same `drop_in_place` the normal `deinit()` → `pool.put()` path runs.
+    ///
+    /// # Safety
+    /// `slot` is a fully-initialized parser whose `finalize()` never ran; the worker's JSC VM
+    /// must already be torn down and no other reference to `*slot` may exist.
+    unsafe fn free_native_for_thread_exit(slot: *mut Self) {
+        // SAFETY: caller contract; sole owner. Interior-mutable access only.
+        let this = unsafe { &*slot };
+        let _ = ManuallyDrop::new(this.strong_this.replace(JsRef::empty()));
+        let mut sctx = this.sctx.replace(BunHashMap::default());
         let ids: Vec<u32> = sctx.keys().copied().collect();
         for id in ids {
             let _ = ManuallyDrop::new(sctx.remove(&id));
         }
         drop(sctx);
-        let streams = self.streams.replace(BunHashMap::default());
+        let streams = this.streams.replace(BunHashMap::default());
         for (_, item) in streams.iter() {
             // SAFETY: each entry is the heap::alloc'd *mut Stream owned by this parser; the VM
             // is gone and this is the only remaining owner.
             unsafe { Stream::free_native_for_thread_exit(*item) };
         }
         drop(streams);
+        // SAFETY: every remaining field's Drop is JSC-free (engine/hpack/Vecs/MutableString are
+        // pure Rust/C; Handlers/GlobalRef/BunSocket/AutoFlusher/RefCount have trivial Drop), so
+        // this is the same drop_in_place `HiveArray::put` runs in the finalize path.
+        unsafe { core::ptr::drop_in_place(slot) };
     }
 
     fn deinit(&self) {

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1284,7 +1284,7 @@ thread_local! {
     // on any leaked parser would touch freed JSC/uws state. Skip slot
     // teardown while still freeing the pool allocation itself. A leaked
     // parser's native-heap fields are released by
-    // `free_leaked_parsers_for_thread_exit` (worker teardown step 5).
+    // `Bun__H2FrameParser__onThreadExit` (worker teardown step 5).
     static POOL: RefCell<Option<Box<ManuallyDrop<H2FrameParserHiveAllocator>>>> =
         const { RefCell::new(None) };
     static SHARED_REQUEST_BUFFER: RefCell<Box<[u8; 16384]>> = RefCell::new(Box::new([0u8; 16384]));
@@ -2347,7 +2347,7 @@ impl Stream {
     /// Free this stream's heap allocations after the owning worker's JSC VM has been torn down.
     /// JSC-backed fields (Strong handles, the AbortSignal listener) are forgotten rather than
     /// dropped: their backing storage lives in the VM's HandleSet / heap, already freed by ~VM,
-    /// so running their Drop would touch freed memory. See free_leaked_parsers_for_thread_exit.
+    /// so running their Drop would touch freed memory. See Bun__H2FrameParser__onThreadExit.
     ///
     /// # Safety
     /// `this` is a heap::alloc'd Stream still linked from a parser that finalize() never reached.

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1294,7 +1294,9 @@ thread_local! {
 /// `WebWorker::shutdown` after `~VM`, so every JSC-backed handle on a leaked parser is dangling;
 /// `free_native_for_thread_exit` forgets those and drops the pure-Rust/C allocations (engine's
 /// stream HashMap, lshpack state, per-stream boxes, scratch Vecs). The pool itself is taken so
-/// the slot storage is released here rather than by the TLS destructor.
+/// the slot storage is released here rather than by the TLS destructor. Only the 256 inline
+/// hive slots are enumerated; `Fallback` keeps no record of heap-spill slots (>256 concurrent
+/// parsers on one thread), so those would still leak in that case.
 #[unsafe(no_mangle)]
 pub extern "C" fn Bun__H2FrameParser__onThreadExit() {
     let Some(pool) = POOL.with_borrow_mut(Option::take) else {

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3489,3 +3489,37 @@ it("http2 server sends each session's frames to its own peer under interleaved r
     server.close();
   }
 });
+
+// When a worker is terminated mid-stream, ~VM's lastChanceToFinalize can miss the JSH2FrameParser
+// cell for that worker (the same gap the no-validate-leaksan.txt worker tests cover). The parser
+// slot sits in a ManuallyDrop hive, so without Bun__H2FrameParser__onThreadExit its engine's
+// stream HashMap, lshpack state and per-stream boxes leak. This asserts only that no
+// h2-frame-parser allocation shows up in LeakSanitizer's report; the gap itself also leaks other
+// cell types (Immediate, Blob) that are out of scope here.
+it.skipIf(!isASAN)(
+  "terminating a worker mid-stream releases the H2 parser's native allocations",
+  async () => {
+    const fixture = path.join(import.meta.dir, "worker-terminate-h2-leak-parent.fixture.js");
+    const run = async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), fixture],
+        env: {
+          ...bunEnv,
+          BUN_DESTRUCT_VM_ON_EXIT: "1",
+          ASAN_OPTIONS: "detect_leaks=1",
+        },
+        stderr: "pipe",
+        stdout: "ignore",
+      });
+      const [stderr] = await Promise.all([proc.stderr.text(), proc.exited]);
+      return stderr.match(/^.*(?:h2_frame_parser|h2::connection|h2::hpack).*$/m)?.[0] ?? "";
+    };
+    let h2Leak = "";
+    // The miss is timing-dependent; probe until it fires or we run out of attempts.
+    for (let round = 0; round < 8 && !h2Leak; round++) {
+      h2Leak = await run();
+    }
+    expect(h2Leak).toBe("");
+  },
+  240_000,
+);

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3492,7 +3492,7 @@ it("http2 server sends each session's frames to its own peer under interleaved r
 
 // When a worker is terminated mid-stream, ~VM's lastChanceToFinalize can miss the JSH2FrameParser
 // cell for that worker (the same gap the no-validate-leaksan.txt worker tests cover). The parser
-// slot sits in a ManuallyDrop hive, so without Bun__H2FrameParser__onThreadExit its engine's
+// slot sits in a ManuallyDrop hive, so without h2_frame_parser_on_thread_exit its engine's
 // stream HashMap, lshpack state and per-stream boxes leak. This asserts only that no
 // h2-frame-parser allocation shows up in LeakSanitizer's report; the gap itself also leaks other
 // cell types (Immediate, Blob) that are out of scope here.

--- a/test/js/node/http2/worker-terminate-h2-leak-parent.fixture.js
+++ b/test/js/node/http2/worker-terminate-h2-leak-parent.fixture.js
@@ -1,0 +1,22 @@
+"use strict";
+// Parent driver for the node-http2.test.js "terminating a worker mid-stream" leak test. Runs
+// THREADS concurrent chains, each spawning ITERS workers back-to-back and terminate()ing each as
+// soon as it asks. The chain shape matches node's test-worker-http2-stream-terminate.js: the
+// exit→spawn handoff is where ~VM's lastChanceToFinalize most often misses a JSH2FrameParser
+// cell on a worker that is being torn down while its successor starts up.
+const { Worker } = require("worker_threads");
+const path = require("path");
+
+const ITERS = 6;
+const THREADS = 6;
+const body = path.join(__dirname, "worker-terminate-h2-leak.fixture.js");
+
+function spin(iter) {
+  const w = new Worker(body);
+  w.on("message", () => w.terminate());
+  w.on("error", () => {});
+  w.on("exit", () => {
+    if (iter < ITERS) spin(iter + 1);
+  });
+}
+for (let i = 0; i < THREADS; i++) spin(0);

--- a/test/js/node/http2/worker-terminate-h2-leak.fixture.js
+++ b/test/js/node/http2/worker-terminate-h2-leak.fixture.js
@@ -22,7 +22,7 @@ function go() {
   // One request per tick carries an AbortSignal so the per-stream SignalRef box is live on
   // both parsers when terminate() lands, exercising the signal disarm in
   // Stream::free_native_for_thread_exit.
-  client.request({ ":path": "/", signal: AbortSignal.timeout(1e6) }).end();
+  client.request({ ":path": "/" }, { signal: AbortSignal.timeout(1e6) }).end();
   for (let i = 0; i < 2; i++) client.request().end();
   setImmediate(go);
 }

--- a/test/js/node/http2/worker-terminate-h2-leak.fixture.js
+++ b/test/js/node/http2/worker-terminate-h2-leak.fixture.js
@@ -19,7 +19,11 @@ server.emit("connection", serverSide);
 const client = http2.connect("http://localhost:80", { createConnection: () => clientSide });
 
 function go() {
-  for (let i = 0; i < 3; i++) client.request().end();
+  // One request per tick carries an AbortSignal so the per-stream SignalRef box is live on
+  // both parsers when terminate() lands, exercising the signal disarm in
+  // Stream::free_native_for_thread_exit.
+  client.request({ ":path": "/", signal: AbortSignal.timeout(1e6) }).end();
+  for (let i = 0; i < 2; i++) client.request().end();
   setImmediate(go);
 }
 go();

--- a/test/js/node/http2/worker-terminate-h2-leak.fixture.js
+++ b/test/js/node/http2/worker-terminate-h2-leak.fixture.js
@@ -1,0 +1,25 @@
+"use strict";
+// Worker body for node-http2.test.js "terminating a worker mid-stream releases the H2 parser's
+// native allocations": create a server+client H2 session over a JS duplex pair, drive requests
+// in a loop, and ask the parent to terminate() us while both parsers are live. Across many
+// workers the terminate() lands at arbitrary points in the inbound dispatch path.
+const http2 = require("http2");
+const { duplexPair } = require("stream");
+const { parentPort } = require("worker_threads");
+
+const server = http2.createServer();
+let seen = 0;
+server.on("stream", stream => {
+  if (seen++ === 1) parentPort.postMessage("terminate");
+  stream.end("");
+});
+
+const [clientSide, serverSide] = duplexPair();
+server.emit("connection", serverSide);
+const client = http2.connect("http://localhost:80", { createConnection: () => clientSide });
+
+function go() {
+  for (let i = 0; i < 3; i++) client.request().end();
+  setImmediate(go);
+}
+go();


### PR DESCRIPTION
## What

Terminating a worker while it has live HTTP/2 sessions over a JS duplex leaks the H2 frame parser's native allocations. Seen in build 74745 (debian x64-asan) running `test-worker-http2-stream-terminate.js` on #34424:

```
Direct leak of 512 byte(s) in 1 object(s) allocated from:
    ...
    HashMap<u32, h2::connection::Stream>::grow src/collections/zig_hash_map.rs:259
    Connection::handle_headers src/runtime/api/bun/h2/connection.rs:928
    Connection::receive src/runtime/api/bun/h2/connection.rs:518
    H2FrameParser::rewrite_read src/runtime/api/bun/h2_frame_parser.rs:5755
```

## Cause

`~VM`'s `lastChanceToFinalize` does not always reach the `JSH2FrameParser` cell when a worker is terminated mid-dispatch. Instrumented with atomic counters across 36 workers: 72 slots obtained from the thread-local hive, 70 `~JSH2FrameParser` destructors called, 0 with `m_ctx == nullptr`. The worker reaches `shutdown()` step 5 (past `teardownJSCVM`) with the two cells still undestroyed. This is the same gap the `test-worker-*` entries in `test/no-validate-leaksan.txt` cover; it is not h2-specific (the same run leaks `ImmediateObject` and `Blob` boxes for the missed worker).

The `H2FrameParser` slot sits in a `ManuallyDrop` hive (by design, so the TLS destructor cannot touch JSC state). With `finalize()` never reached, every field's heap allocation leaks: the inbound engine's `streams: HashMap<u32, Stream>` and `hpack::Coder` (lshpack C state), the legacy per-stream boxes, the HPACK handle, the write/read buffers, the `sctx` map backing, and assorted scratch Vecs.

## Fix

Add a thread-exit destructor `h2_frame_parser_on_thread_exit`, registered via `bun_core::register_thread_exit_pool_destructor` at first POOL use (so `WebWorker::shutdown`'s existing `delete_all_pools_for_thread_exit` call runs it after `~VM`). For any remaining used hive slot it:

- disarms the three JSC-backed fields (`strong_this`, `sctx`'s `StrongOptional` values, each per-stream box's `js_context` / `SignalRef` / queued-frame callback) with `ManuallyDrop` so their `Drop` cannot touch the already-freed `HandleSet` / `AbortSignal`,
- then runs `core::ptr::drop_in_place` on the slot, letting the struct's ordinary `Drop` reclaim engine, hpack, every `Vec`/`HashMap` backing, and the per-stream boxes. That is the same `drop_in_place` the normal `deinit()` → `HiveArray::put` path already runs, so future fields need no mirroring here.

In the normal case (finalize ran) the hive has no used slots and the hook just takes and drops the pool box.

## Verification

New ASAN-only test `terminating a worker mid-stream releases the H2 parser's native allocations` in `test/js/node/http2/node-http2.test.js` spawns the worker-terminate scenario (one request per tick carrying an `AbortSignal` so the `SignalRef` disarm path is reached) and asserts LeakSanitizer reports no `h2_frame_parser` / `h2::connection` / `h2::hpack` frames. The miss is timing-dependent: across 12 probe runs against an unpatched build it fired 3 times (each reporting the engine's `HashMap::grow`, `lshpack_dec_decode`, `PendingLocalSettings`, per-stream box and `sctx` allocations); against this build it fired 0/40. The same gap still leaks other cell types (`ImmediateObject`, `Blob`) for the missed worker, so the assertion is scoped to h2 frames only.

`test/js/node/http2/node-http2.test.js`: 306 pass, 6 skip. `test/js/node/worker_threads/worker_threads.test.ts`: 91 pass. `rust:check-all` 10/10.

## Note on fail-before

The sweep miss is a scheduling race: ~25% of probe runs hit it on this container without the fix. The test loops 8 probes, so fail-before reliability is roughly 90%; a gate run that happens not to hit the race will pass both ways. The evidence above (and the upstream CI failure that prompted this) is the probe record.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (4cef8e235)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [794.29ms]
(pass) node none > Client Basics > should be able to send a POST request [559.50ms]
(pass) node none > Client Basics > constants [18.65ms]
(pass) node none > Client Basics > getDefaultSettings [7.02ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [22.50ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [4.83ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.50ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.08ms
... (truncated)

release without fix: 89 failed, 7 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.81ms]
(pass) node none > Client Basics > getDefaultSettings [0.16ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.43ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.12ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.06ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.08ms]
(pass) node none > Client Basics > headers cannot be bigger than 65536 bytes [1.75ms]
(pass) node none > Client Basics > is possible to abort request [1.02ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.75ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.63ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.01ms]
782 |           client.on("error", reject);
783 |           const req = client.request({ ":path": "/", "test-hea
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (4cef8e235)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [790.63ms]
(pass) node none > Client Basics > should be able to send a POST request [552.31ms]
(pass) node none > Client Basics > constants [18.41ms]
(pass) node none > Client Basics > getDefaultSettings [7.20ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [22.64ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [4.93ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.52ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.06ms
... (truncated)

release with fix: 7 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4cef8e235a
  features     (none)

22 deps, 106 codegen, 1169 objects in 798ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1232] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [9.00ms]
[2/1232] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1232] gen bindgenv2
[4/1232] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [5.00ms]
[5/1232] gen ErrorCode+*.h
[6/1232] fetch tinycc
[tinycc] up to date
[7/1231] gen .bind.ts → GeneratedBindings.cpp
[8/1231] fetch picohttppar
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/h2_frame_parser.rs             | 96 +++++++++++++++++++++-
 test/js/node/http2/node-http2.test.js              | 34 ++++++++
 .../worker-terminate-h2-leak-parent.fixture.js     | 22 +++++
 .../node/http2/worker-terminate-h2-leak.fixture.js | 29 +++++++
 4 files changed, 179 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/runtime/api/bun/h2_frame_parser.rs                       22     31      0
test/js/node/http2/node-http2.test.js                         1      6      0
…s/node/http2/worker-terminate-h2-leak-parent.fixture.js      0      5      0
test/js/node/http2/worker-terminate-h2-leak.fixture.js        0      5      0
```

</details>

<!-- robobun:evidence:end -->