### PR TITLE
console: identify generator and async generator objects in console.log

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -5512,10 +5512,20 @@ pub mod formatter {
                     | jsc::JSType::AsyncGenerator
                     | jsc::JSType::AsyncFunctionGenerator
             ) {
+                let mut writer = WrappedWriter {
+                    ctx: writer_,
+                    failed: false,
+                    estimated_line_length: &mut self.estimated_line_length,
+                };
                 if let Some(name_str) = get_object_name(self.global_this, value)? {
-                    let _ = write!(writer_, "{name_str} ");
+                    writer.add_for_new_line(name_str.len + 1);
+                    writer.print(format_args!("{name_str} "));
                 }
-                let _ = writer_.write_all(b"{}");
+                writer.add_for_new_line(2);
+                writer.write_all(b"{}");
+                if writer.failed {
+                    self.failed = true;
+                }
                 return Ok(());
             }
 

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2365,6 +2365,9 @@ pub mod formatter {
                 | T::JSArrayIterator
                 | T::Iterator
                 | T::IteratorHelper
+                | T::Generator
+                | T::AsyncGenerator
+                | T::AsyncFunctionGenerator
                 | T::Object
                 | T::FinalObject
                 | T::ModuleNamespaceObject => TagPayload::Object,
@@ -5499,6 +5502,22 @@ pub mod formatter {
             let prev_quote_strings = self.quote_strings;
             self.quote_strings = true;
             let _qs = defer_restore!(self.quote_strings, prev_quote_strings);
+
+            // Generators expose iterator helper methods as enumerable properties.
+            // Print them like other empty named objects (`Generator {}`) instead of
+            // dumping the prototype method table (matches Node's empty-object shape).
+            if matches!(
+                js_type,
+                jsc::JSType::Generator
+                    | jsc::JSType::AsyncGenerator
+                    | jsc::JSType::AsyncFunctionGenerator
+            ) {
+                if let Some(name_str) = get_object_name(self.global_this, value)? {
+                    let _ = write!(writer_, "{name_str} ");
+                }
+                let _ = writer_.write_all(b"{}");
+                return Ok(());
+            }
 
             // We want to figure out if we should print this object on one line
             // or multiple lines.

--- a/test/js/web/console/console-log.test.ts
+++ b/test/js/web/console/console-log.test.ts
@@ -150,3 +150,28 @@ it("console.log with SharedArrayBuffer", () => {
   expect(Bun.inspect(new ArrayBuffer(3))).toBe("ArrayBuffer(3) [ 0, 0, 0 ]");
   expect(Bun.inspect(new SharedArrayBuffer(3))).toBe("SharedArrayBuffer(3) [ 0, 0, 0 ]");
 });
+
+// https://github.com/oven-sh/bun/issues/18324
+it("console.log identifies generator and async generator objects", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+function* syncGen() { yield 1; }
+async function* asyncGen() { yield 1; }
+console.log(syncGen());
+console.log(asyncGen());
+`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("Generator {}\nAsyncGenerator {}\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/web/console/console-log.test.ts
+++ b/test/js/web/console/console-log.test.ts
@@ -152,7 +152,7 @@ it("console.log with SharedArrayBuffer", () => {
 });
 
 // https://github.com/oven-sh/bun/issues/18324
-it("console.log identifies generator and async generator objects", async () => {
+it.concurrent("console.log identifies generator and async generator objects", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),


### PR DESCRIPTION
## Summary

- Fixes [#18324](https://github.com/oven-sh/bun/issues/18324): `console.log` of generator / async generator objects printed as bare `{}` because those `JSType`s fell through to `Tag::JSON` in `Tag::get_advanced`.
- Tag `Generator`, `AsyncGenerator`, and `AsyncFunctionGenerator` as `Object`, and print them as `Name {}` without dumping iterator helper methods from the prototype.
- Uses Bun's existing named-empty-object style (`Generator {}` / `AsyncGenerator {}`), not Node's exact `Object [AsyncGenerator] {}` formatting (broader inspect-parity, out of scope here).
- Earlier attempt [#18365](https://github.com/oven-sh/bun/pull/18365) patched the JSON printer; this tags upstream of `print_as` instead.

## Test plan

- [x] `USE_SYSTEM_BUN=1 bun test test/js/web/console/console-log.test.ts -t "console.log identifies generator"` fails (still `{}`)
- [x] `bun bd test test/js/web/console/console-log.test.ts -t "console.log identifies generator"` passes (`Generator {}\nAsyncGenerator {}\n`)
- [ ] CI green


Made with [Cursor](https://cursor.com)