### PR TITLE
fix(spawn): detach ReadableStream stdin before FileSink free

### DIFF
--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -790,6 +790,16 @@ impl Subprocess<'_> {
         Ok(JSValue::UNDEFINED)
     }
 
+    /// Called from `FileSink` when ReadableStream stdin is rejected/finalized.
+    /// `signal` cannot notify the Subprocess in that mode (JSSink owns it).
+    ///
+    /// # Safety
+    /// `subprocess` must point at a live `Subprocess` on the JS thread.
+    pub unsafe fn detach_stdin_file_sink(subprocess: *mut Subprocess<'_>) {
+        // SAFETY: caller contract.
+        Writable::on_close(unsafe { &*subprocess }, None);
+    }
+
     pub fn on_stdin_destroyed(&self) {
         let must_deref = self.flags.get().contains(Flags::DEREF_ON_STDIN_DESTROYED);
         self.update_flags(|f| {

--- a/src/runtime/api/bun/subprocess/Writable.rs
+++ b/src/runtime/api/bun/subprocess/Writable.rs
@@ -159,6 +159,7 @@ impl<'a> Writable<'a> {
                 buffer.deref();
             }
             Writable::Pipe(pipe) => {
+                Self::pipe_sink(pipe).spawn_stdin_subprocess.set(None);
                 Self::pipe_release(pipe);
             }
             _ => {}
@@ -239,6 +240,9 @@ impl<'a> Writable<'a> {
                                 return Err(crate::Error::JSError);
                             }
                             *promise_for_stream = assign_result;
+                            pipe.spawn_stdin_subprocess.set(NonNull::new(
+                                std::ptr::from_mut::<Subprocess<'a>>(subprocess).cast::<c_void>(),
+                            ));
                         }
 
                         return Ok(Writable::Pipe(pipe_nn));
@@ -345,6 +349,12 @@ impl<'a> Writable<'a> {
                         return Err(crate::Error::JSError);
                     }
                     *promise_for_stream = assign_result;
+                    // `assign_to_stream` parks the JSSink controller in `signal`, so
+                    // the Subprocess close signal cannot be wired. Keep a reverse
+                    // owner pointer for reject/finalize detach (#31887).
+                    pipe.spawn_stdin_subprocess.set(NonNull::new(
+                        std::ptr::from_mut::<Subprocess<'a>>(subprocess).cast::<c_void>(),
+                    ));
                 }
 
                 Ok(Writable::Pipe(pipe_nn))

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1,5 +1,6 @@
 use core::cell::Cell;
 use core::ffi::c_void;
+use core::ptr::NonNull;
 use core::sync::atomic::{AtomicI32, Ordering};
 
 #[cfg(windows)]
@@ -64,6 +65,13 @@ pub struct FileSink {
     /// while an async operation is pending. This is set when endFromJS returns a
     /// pending Promise and cleared when the operation completes.
     pub js_sink_ref: JsCell<bun_jsc::strong::Optional>,
+
+    /// Owning `Bun.spawn` Subprocess when this sink is that child's ReadableStream
+    /// stdin. `signal` cannot carry the Subprocess back-pointer in that mode
+    /// (it holds the JSSink controller JSValue), so reject/finalize must detach
+    /// stdin through this owner instead — otherwise `weak_file_sink_stdin_ptr`
+    /// / `Writable::Pipe` dangle and `on_process_exit` UAF (#31887).
+    pub spawn_stdin_subprocess: Cell<Option<NonNull<c_void>>>,
 }
 
 // `bun.ptr.RefCount(FileSink, "ref_count", deinit, .{})` — intrusive single-thread
@@ -315,6 +323,7 @@ impl FileSink {
             let _guard = FileSinkRef::new_ref(this);
 
             (*this).done.set(true);
+            (*this).detach_spawn_stdin_owner();
             let mut readable_stream = (*this)
                 .readable_stream
                 .replace(readable_stream::Strong::default());
@@ -935,6 +944,7 @@ impl FileSink {
         self.readable_stream.set(readable_stream::Strong::default());
         self.pending.set(streams::WritablePending::default());
         self.js_sink_ref.with_mut(|r| r.deinit());
+        self.detach_spawn_stdin_owner();
         // SAFETY: `&mut self` carries write provenance over the whole
         // allocation; this is the last use of `self` in `finalize`.
         unsafe { FileSink::deref(std::ptr::from_mut::<Self>(self)) };
@@ -1336,6 +1346,7 @@ impl FileSink {
             run_pending_later: FlushPendingTask::default(),
             readable_stream: JsCell::new(readable_stream::Strong::default()),
             js_sink_ref: JsCell::new(bun_jsc::strong::Optional::empty()),
+            spawn_stdin_subprocess: Cell::new(None),
         }
     }
 }
@@ -1378,8 +1389,23 @@ impl FileSink {
             stream.done(global_this);
         }
 
+        self.detach_spawn_stdin_owner();
+
         if !self.done.get() {
             self.writer.with_mut(|w| w.close());
+        }
+    }
+
+    /// Detach `Bun.spawn` stdin ownership before the FileSink can be freed.
+    /// Idempotent (`take`).
+    fn detach_spawn_stdin_owner(&self) {
+        let Some(owner) = self.spawn_stdin_subprocess.take() else {
+            return;
+        };
+        // SAFETY: set only from `Writable::init` to a live Subprocess that outlives
+        // this sink for the detach call; single JS thread.
+        unsafe {
+            crate::api::bun_subprocess::Subprocess::detach_stdin_file_sink(owner.as_ptr().cast());
         }
     }
 
@@ -1389,6 +1415,10 @@ impl FileSink {
             stream.abort(global_this);
             self.readable_stream.set(readable_stream::Strong::default());
         }
+
+        // Clear Subprocess stdin / weak pointer before close/GC can free `self`
+        // while `Writable::Pipe` still aliases it (#31887).
+        self.detach_spawn_stdin_owner();
 
         if !self.done.get() {
             self.writer.with_mut(|w| w.close());

--- a/test/js/bun/spawn/spawn-stdin-stream-reject.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-stream-reject.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/31887
+// Rejecting a type:"direct" stdin ReadableStream while the child is still
+// exiting must not UAF Subprocess::on_process_exit via a dangling FileSink.
+test("spawn stdin direct stream reject does not crash on process exit", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+const child = Bun.spawn({
+  stdin: new ReadableStream({
+    type: "direct",
+    async pull(c) {
+      c.write(new TextEncoder().encode("y"));
+      await Bun.sleep(10);
+      throw new Error("boom");
+    },
+  }),
+  cmd: ["sh", "-c", "sleep 0.2; cat >/dev/null"],
+  stdout: "ignore",
+  stderr: "ignore",
+});
+await child.exited.catch(() => {});
+console.log("ok", child.exitCode ?? 0);
+`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("AddressSanitizer");
+  expect(stderr).not.toContain("heap-use-after-free");
+  expect(stdout.trim()).toMatch(/^ok /);
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Summary

- Fixes [#31887](https://github.com/oven-sh/bun/issues/31887): heap-use-after-free in `Subprocess::on_process_exit` when a `type: "direct"` stdin `ReadableStream` rejects mid-pull.
- Root cause: for ReadableStream stdin, `FileSink.assign_to_stream` parks the JSSink controller in `FileSink.signal`, so the usual Subprocess close signal is never wired. Stream reject can free the `FileSink` without `Writable::on_close`, leaving `weak_file_sink_stdin_ptr` / `Writable::Pipe` dangling until child exit.
- Fix: store a reverse `spawn_stdin_subprocess` owner on `FileSink` (set from `Writable::init` after `assign_to_stream`), and detach via the existing `Writable::on_close` path from reject / resolve / finalize / `on_attached_process_exit`. Idempotent (`take`).

## Test plan

- [x] `bun bd test test/js/bun/spawn/spawn-stdin-stream-reject.test.ts`
- [x] ASAN debug stress loop (20× issue repro) — no UAF
- [ ] CI / Buildkite (fork PRs may need maintainer unblock)