### PR TITLE
types: add offset and size options to Bun.mmap

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4551,6 +4551,16 @@ declare module "bun" {
      * @default true
      */
     shared?: boolean;
+    /**
+     * Byte offset into the file where the mapping starts.
+     * @default 0
+     */
+    offset?: number;
+    /**
+     * Maximum number of bytes to map. Clamped to the file size
+     * (minus `offset`). Defaults to mapping the rest of the file.
+     */
+    size?: number;
   }
   /**
    * Open a file as a live-updating `Uint8Array` without copying memory

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -388,7 +388,7 @@ describe("@types/bun integration test", () => {
       expect(stderr.trim()).toBe("");
       expect(stdout.trim()).toBe("");
       expect(exitCode).toBe(0);
-    }, 60_000);
+    });
   });
 
   describe("Test Globals", () => {

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -370,7 +370,9 @@ describe("@types/bun integration test", () => {
       await makeTree(checkDir, {
         "tsconfig.json": JSON.stringify(tsconfig, null, 2),
         "mmap-options.ts": `const view = Bun.mmap("./data.bin", { shared: true, sync: false, offset: 4096, size: 1024 });
-           view satisfies Uint8Array<ArrayBuffer>;`,
+           view satisfies Uint8Array<ArrayBuffer>;
+           Bun.mmap("./data.bin", { offset: 4096 }) satisfies Uint8Array<ArrayBuffer>;
+           Bun.mmap("./data.bin", { size: 1024 }) satisfies Uint8Array<ArrayBuffer>;`,
       });
 
       await using proc = Bun.spawn({

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -358,6 +358,37 @@ describe("@types/bun integration test", () => {
     });
   });
 
+  // Runs on debug builds too: spawning tsc over a single file is cheap,
+  // unlike the in-process LanguageService runs above.
+  describe("Bun.mmap", () => {
+    test("MMapOptions accepts offset and size", async () => {
+      const checkDir = join(TEMP_DIR, "mmap-options-check");
+      const tsconfig = structuredClone(sourceTsconfig);
+      tsconfig.include = ["mmap-options.ts"];
+      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
+      await mkdir(checkDir, { recursive: true });
+      await makeTree(checkDir, {
+        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
+        "mmap-options.ts": `const view = Bun.mmap("./data.bin", { shared: true, sync: false, offset: 4096, size: 1024 });
+           view satisfies Uint8Array<ArrayBuffer>;`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+        env: bunEnv,
+        cwd: checkDir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr.trim()).toBe("");
+      expect(stdout.trim()).toBe("");
+      expect(exitCode).toBe(0);
+    }, 60_000);
+  });
+
   describe("Test Globals", () => {
     const code = `
       const test_shouldBeAFunction: Function = test;

--- a/test/integration/bun-types/fixture/bun.ts
+++ b/test/integration/bun-types/fixture/bun.ts
@@ -90,3 +90,6 @@ tsd
     }),
   )
   .is<Uint8Array<ArrayBuffer>>();
+
+tsd.expectType(Bun.mmap("./data.bin", { offset: 4096 })).is<Uint8Array<ArrayBuffer>>();
+tsd.expectType(Bun.mmap("./data.bin", { size: 1024 })).is<Uint8Array<ArrayBuffer>>();

--- a/test/integration/bun-types/fixture/bun.ts
+++ b/test/integration/bun-types/fixture/bun.ts
@@ -79,3 +79,14 @@ tsd
     }),
   )
   .is<Promise<boolean>>();
+
+tsd
+  .expectType(
+    Bun.mmap("./data.bin", {
+      shared: true,
+      sync: false,
+      offset: 4096,
+      size: 1024,
+    }),
+  )
+  .is<Uint8Array<ArrayBuffer>>();


### PR DESCRIPTION
### What does this PR do?

`Bun.mmap` has accepted `offset` and `size` options in the native implementation for a long time, but `MMapOptions` in bun-types only declares `sync` and `shared`, so TypeScript rejects them:

```ts
// error TS2353: Object literal may only specify known properties,
// and 'offset' does not exist in type 'MMapOptions'.
const view = Bun.mmap("./data.bin", { offset: 4096, size: 1024 });
```

This declares both options with doc comments and adds a type check to the bun-types fixture.

Surfaced by #34572, which asks for offset-based random access into large mmap'd files; the runtime already supports it, the types just did not expose it.

Note: offset view semantics are being fixed separately in #34120; the doc comment here stays neutral on page alignment.

### How did you verify your code works?

`bun test test/integration/bun-types/bun-types.test.ts` passes with the change and fails (9 fixture type errors) with the `.d.ts` change reverted.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 12 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/integration/bun-types/bun-types.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (57f9c8f95)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [6.11ms]
(skip) @types/bun integration test > basic type checks > checks without lib.dom.d.ts
(skip) @types/bun integration test > tsgo (TypeScript 7 native preview) > checks without lib.dom.d.ts
384 |       });
385 | 
386 |       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
387 | 
388 |       expect(stderr.trim()).toBe("");
389 |       expect(stdout.trim()).toBe("");
                                  ^
error: expect(received).toBe(expected)

- ""
+ "mmap-options.ts(1,66): error TS2353: Object literal may only specify known proper
... (truncated)

release without fix: 10 FAILED
bun test v1.4.0-canary.1 (8d5c47a1c)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [0.20ms]
126 |     expect(emptyInterfaces).toEqual(config.emptyInterfaces);
127 | 
128 |     if (typeof config.diagnostics === "function") {
129 |       config.diagnostics(diagnostics);
130 |     } else {
131 |       expect(diagnostics).toEqual(config.diagnostics);
                                ^
error: expect(received).toEqual(expected)

- []
+ [
+   {
+     "code": 2353,
+     "line": "bun.ts:88:7",
+     "message": "Object literal may only specify known properties, and 'offset' does not exist in type 'MMapOptions'.",
+   },
+   {
+     "code": 2353,
+     "line": "bun.ts:94:41",
+     "message": "Object literal may only specify known properties, and 'offset' does not exist in type 'MMapOptions'.",
+   },
+   {
+     "code": 2353,
+     "line": "bun.ts:95:41",
+     "message": "Object literal may only specify known properties, and 'size' does not exist in type 'MMapOptions'.",
+   },
+ ]

- Expected  - 1
+ Received  + 17

      at <anonymous> (/workspace/bun/test/integration/bun-types/bun-types.test.ts:131:2
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 12 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/integration/bun-types/bun-types.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (57f9c8f95)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [6.38ms]
(skip) @types/bun integration test > basic type checks > checks without lib.dom.d.ts
(skip) @types/bun integration test > tsgo (TypeScript 7 native preview) > checks without lib.dom.d.ts
(pass) @types/bun integration test > Bun.mmap > MMapOptions accepts offset and size [1486.21ms]
(skip) @types/bun integration test > Test Globals > checks without lib.dom.d.ts and test-globals references
(skip) @types/bun integration test > Test Globals > test-globals FAILS when the test-globals.d.ts is not referenced
(skip) @types/bun integration test > bun:bundle feature() > Registry augmentation re
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 686ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
ninja: no work to do.
[build] done
bun test v1.4.0-canary.1 (57f9c8f95)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [0.18ms]
(pass) @types/bun integration test > basic type checks > checks without lib.dom.d.ts [2862.23ms]
(pass) @types/bun integration test > tsgo (TypeScript 7 native preview) > checks without lib.dom.d.ts [456.44ms]
(pass) @types/bun integration test > Bun.mmap > MMapOptions accepts offset and size [76.63ms]
(pass) @types/bun integration test > Test Globals > checks without lib.dom.d.ts and test-globals references [2396.53ms]
(pass) @types/bun integration test > Test Globals > test-globals FAILS when the test-globals.d.ts is not referenced [2178.85ms]
(pass) @ty
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/bun.d.ts                  | 10 +++++++++
 test/integration/bun-types/bun-types.test.ts | 33 ++++++++++++++++++++++++++++
 test/integration/bun-types/fixture/bun.ts    | 14 ++++++++++++
 3 files changed, 57 insertions(+)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
packages/bun-types/bun.d.ts                       2      3      0
test/integration/bun-types/bun-types.test.ts      1      5      0
test/integration/bun-types/fixture/bun.ts         1      2      0
```

</details>

**root cause** · written by the author bot

The runtime implementation of Bun.mmap already read optional offset and size fields from its options object, but the MMapOptions interface in the published type declarations never declared them, so valid calls failed type checking. The fix adds offset and size as optional number properties to MMapOptions in bun.d.ts, with doc comments matching the native behavior of offset defaulting to zero and size clamping to the file size minus the offset. Type-level assertions in the fixture and a spawned tsc test over the packed declarations cover the combined, offset-only, and size-only cases to keep…

<!-- robobun:evidence:end -->