### PR TITLE
Fix native construct handlers that return a non-object

### DIFF
--- a/src/jsc/bindings/JSFFIFunction.cpp
+++ b/src/jsc/bindings/JSFFIFunction.cpp
@@ -107,7 +107,7 @@ DEFINE_VISIT_CHILDREN(JSFFIFunction);
 
 JSFFIFunction* JSFFIFunction::create(VM& vm, Zig::GlobalObject* globalObject, unsigned length, const String& name, FFIFunction FFIFunction, Intrinsic intrinsic, NativeFunction nativeConstructor)
 {
-    NativeExecutable* executable = vm.getHostFunction(FFIFunction, ImplementationVisibility::Public, intrinsic, FFIFunction, nullptr, length, name);
+    NativeExecutable* executable = vm.getHostFunction(FFIFunction, ImplementationVisibility::Public, intrinsic, nativeConstructor, nullptr, length, name);
     Structure* structure = globalObject->FFIFunctionStructure();
     JSFFIFunction* function = new (NotNull, allocateCell<JSFFIFunction>(vm)) JSFFIFunction(vm, executable, globalObject, structure, reinterpret_cast<CFFIFunction>(WTF::move(FFIFunction)));
     function->finishCreation(vm);
@@ -127,9 +127,9 @@ JSC_DEFINE_HOST_FUNCTION(JSFFIFunction::trampoline, (JSC::JSGlobalObject * globa
 JSFFIFunction* JSFFIFunction::createForFFI(VM& vm, Zig::GlobalObject* globalObject, unsigned length, const String& name, CFFIFunction FFIFunction)
 {
 #if OS(WINDOWS)
-    NativeExecutable* executable = vm.getHostFunction(trampoline, ImplementationVisibility::Public, NoIntrinsic, trampoline, nullptr, length, name);
+    NativeExecutable* executable = vm.getHostFunction(trampoline, ImplementationVisibility::Public, NoIntrinsic, callHostFunctionAsConstructor, nullptr, length, name);
 #else
-    NativeExecutable* executable = vm.getHostFunction(FFIFunction, ImplementationVisibility::Public, NoIntrinsic, FFIFunction, nullptr, length, name);
+    NativeExecutable* executable = vm.getHostFunction(FFIFunction, ImplementationVisibility::Public, NoIntrinsic, callHostFunctionAsConstructor, nullptr, length, name);
 #endif
     Structure* structure = globalObject->FFIFunctionStructure();
     JSFFIFunction* function = new (NotNull, allocateCell<JSFFIFunction>(vm)) JSFFIFunction(vm, executable, globalObject, structure, reinterpret_cast<CFFIFunction>(WTF::move(FFIFunction)));

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -87,6 +87,7 @@ inline To tryJSDynamicCast(JSC::WriteBarrier<WriteBarrierT>& from)
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionCall);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionConstruct);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_protoImpl);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_mock);
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetter_mockGetLastCall);
@@ -456,7 +457,7 @@ public:
     }
 
     JSMockFunction(JSC::VM& vm, JSC::Structure* structure, CallbackKind wrapKind)
-        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
+        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionConstruct)
     {
         initMock();
     }
@@ -825,7 +826,7 @@ static JSValue createMockResult(JSC::VM& vm, Zig::GlobalObject* globalObject, Mo
     return result;
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+static EncodedJSValue jsMockFunctionCallImpl(JSGlobalObject* lexicalGlobalObject, CallFrame* callframe, JSValue thisValue)
 {
     Zig::GlobalObject* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
     auto& vm = JSC::getVM(globalObject);
@@ -837,7 +838,6 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
     }
 
     JSC::ArgList args = JSC::ArgList(callframe);
-    JSValue thisValue = callframe->thisValue().toThis(globalObject, ECMAMode::strict());
     JSC::JSArray* argumentsArray = nullptr;
     {
         JSC::ObjectInitializationScope object(vm);
@@ -876,6 +876,20 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
             1);
         contexts->initializeIndex(object, 0, thisValue);
         fn->contexts.set(vm, fn, contexts);
+    }
+
+    JSC::JSArray* instances = fn->instances.get();
+    if (instances) {
+        instances->push(globalObject, thisValue);
+        RETURN_IF_EXCEPTION(scope, {});
+    } else {
+        JSC::ObjectInitializationScope object(vm);
+        instances = JSC::JSArray::tryCreateUninitializedRestricted(
+            object,
+            globalObject->arrayStructureForIndexingTypeDuringAllocation(JSC::ArrayWithContiguous),
+            1);
+        instances->initializeIndex(object, 0, thisValue);
+        fn->instances.set(vm, fn, instances);
     }
 
     auto invocationId = JSMockModule::nextInvocationId();
@@ -983,6 +997,32 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
     setReturnValue(createMockResult(vm, globalObject, MockResultType::Return, jsUndefined()));
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    return jsMockFunctionCallImpl(lexicalGlobalObject, callframe, callframe->thisValue().toThis(lexicalGlobalObject, ECMAMode::strict()));
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // Ordinary-function [[Construct]]; mocks have no default .prototype, so this falls back to Object.prototype.
+    JSC::JSObject* newTarget = asObject(callframe->newTarget());
+    JSC::JSGlobalObject* functionGlobalObject = JSC::getFunctionRealm(lexicalGlobalObject, newTarget);
+    RETURN_IF_EXCEPTION(scope, {});
+    JSC::Structure* structure = JSC::InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, functionGlobalObject->objectStructureForObjectConstructor());
+    RETURN_IF_EXCEPTION(scope, {});
+    JSC::JSObject* thisObject = JSC::constructEmptyObject(vm, structure);
+
+    JSValue result = JSValue::decode(jsMockFunctionCallImpl(lexicalGlobalObject, callframe, thisObject));
+    RETURN_IF_EXCEPTION(scope, {});
+
+    if (result.isObject())
+        return JSValue::encode(result);
+    return JSValue::encode(thisObject);
 }
 
 void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)

--- a/src/jsc/modules/NodeBufferModule.h
+++ b/src/jsc/modules/NodeBufferModule.h
@@ -194,17 +194,17 @@ DEFINE_NATIVE_MODULE(NodeBuffer)
     put(atobI, atobV);
     put(btoaI, btoaV);
 
-    auto* transcode = JSC::JSFunction::create(vm, globalObject, 3, "transcode"_s, jsBufferTranscode, ImplementationVisibility::Public, NoIntrinsic, jsBufferTranscode);
+    auto* transcode = JSC::JSFunction::create(vm, globalObject, 3, "transcode"_s, jsBufferTranscode, ImplementationVisibility::Public, NoIntrinsic);
 
     put(JSC::Identifier::fromString(vm, "transcode"_s), transcode);
 
-    auto* resolveObjectURL = JSC::JSFunction::create(vm, globalObject, 1, "resolveObjectURL"_s, jsFunctionResolveObjectURL, ImplementationVisibility::Public, NoIntrinsic, jsFunctionResolveObjectURL);
+    auto* resolveObjectURL = JSC::JSFunction::create(vm, globalObject, 1, "resolveObjectURL"_s, jsFunctionResolveObjectURL, ImplementationVisibility::Public, NoIntrinsic);
 
     put(JSC::Identifier::fromString(vm, "resolveObjectURL"_s), resolveObjectURL);
 
-    put(JSC::Identifier::fromString(vm, "isAscii"_s), JSC::JSFunction::create(vm, globalObject, 1, "isAscii"_s, jsBufferConstructorFunction_isAscii, ImplementationVisibility::Public, NoIntrinsic, jsBufferConstructorFunction_isAscii));
+    put(JSC::Identifier::fromString(vm, "isAscii"_s), JSC::JSFunction::create(vm, globalObject, 1, "isAscii"_s, jsBufferConstructorFunction_isAscii, ImplementationVisibility::Public, NoIntrinsic));
 
-    put(JSC::Identifier::fromString(vm, "isUtf8"_s), JSC::JSFunction::create(vm, globalObject, 1, "isUtf8"_s, jsBufferConstructorFunction_isUtf8, ImplementationVisibility::Public, NoIntrinsic, jsBufferConstructorFunction_isUtf8));
+    put(JSC::Identifier::fromString(vm, "isUtf8"_s), JSC::JSFunction::create(vm, globalObject, 1, "isUtf8"_s, jsBufferConstructorFunction_isUtf8, ImplementationVisibility::Public, NoIntrinsic));
 }
 
 } // namespace Zig

--- a/src/jsc/modules/NodeSqliteModule.h
+++ b/src/jsc/modules/NodeSqliteModule.h
@@ -29,7 +29,7 @@ DEFINE_NATIVE_MODULE(NodeSqlite)
     // ourselves.
     {
         auto id = JSC::Identifier::fromString(vm, "backup"_s);
-        put(id, JSC::JSFunction::create(vm, globalObject, 2, id.string(), Bun::jsNodeSqliteBackup, JSC::ImplementationVisibility::Public, JSC::NoIntrinsic, Bun::jsNodeSqliteBackup));
+        put(id, JSC::JSFunction::create(vm, globalObject, 2, id.string(), Bun::jsNodeSqliteBackup, JSC::ImplementationVisibility::Public, JSC::NoIntrinsic));
     }
 
     RETURN_NATIVE_MODULE();

--- a/src/jsc/modules/UTF8ValidateModule.h
+++ b/src/jsc/modules/UTF8ValidateModule.h
@@ -14,8 +14,7 @@ generateNativeModule_UTF8Validate(JSC::JSGlobalObject* globalObject,
     exportNames.append(vm.propertyNames->defaultKeyword);
     exportValues.append(JSC::JSFunction::create(
         vm, globalObject, 1, "utf8Validate"_s, jsBufferConstructorFunction_isUtf8,
-        ImplementationVisibility::Public, NoIntrinsic,
-        jsBufferConstructorFunction_isUtf8));
+        ImplementationVisibility::Public, NoIntrinsic));
 }
 
 } // namespace Zig

--- a/src/jsc/modules/_NativeModule.h
+++ b/src/jsc/modules/_NativeModule.h
@@ -113,7 +113,7 @@
     if (!value) {                                                              \
       auto *function = JSC::JSFunction::create(                                \
           vm, globalObject, 1, name.string(), ptr,                             \
-          JSC::ImplementationVisibility::Public, JSC::NoIntrinsic, ptr);       \
+          JSC::ImplementationVisibility::Public, JSC::NoIntrinsic);            \
       /* Match `put`: only populate the shared object on first build; a       \
          user-deleted property on the cached object stays deleted. */         \
       if (!defaultObjectWasCached)                                             \

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1,7 +1,8 @@
 import { afterAll, describe, expect, it } from "bun:test";
 import { existsSync } from "fs";
 import { bunEnv, bunExe, compileFixture, isDebug, isGlibcVersionAtLeast, isWindows, tempDir } from "harness";
-import { platform } from "os";
+import { freemem, platform } from "os";
+import { join } from "path";
 
 import {
   cc,
@@ -1098,6 +1099,93 @@ it("JSCallback tolerates worker.terminate() arriving inside the callback", async
     exitCode: 0,
     signalCode: null,
   });
+});
+
+// Runs in a subprocess for the same reason as the JSCallback tests above: the
+// linked library's native handle is not finalized on `bun test`'s exit path,
+// which the ASan lane's leak checker reports against this file.
+it("linkSymbols() functions are not constructors", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `import { JSCallback, linkSymbols } from "bun:ffi";
+      const cb = new JSCallback(() => 42, { returns: "int32_t", args: [] });
+      const lib = linkSymbols({ fn: { returns: "int32_t", args: [], ptr: cb.ptr } });
+      console.log(lib.symbols.fn());
+      // a native construct handler must never return a primitive
+      for (const construct of [() => new lib.symbols.fn(), () => Reflect.construct(lib.symbols.fn, [])]) {
+        try {
+          construct();
+          console.log("constructed");
+        } catch (e) {
+          console.log(e.constructor.name);
+        }
+      }
+      // non-constructible functions inspect as functions, not classes (#32103)
+      console.log(Bun.inspect(lib.symbols.fn));
+      lib.close();
+      cb.close();`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: "42\nTypeError\nTypeError\n[Function: fn]\n",
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+// cc() is the only path into JSFFIFunction::createForFFI. Subprocess for the
+// same leak-checker reason as above. The source has no #includes: bundled
+// TinyCC cannot see libc headers in CI, and its compile-error longjmp is what
+// conflicts with ASan (see cc.test.ts).
+it("cc()-compiled functions are not constructors", async () => {
+  using dir = tempDir("ffi-cc-construct", {
+    "returns_true.c": "_Bool returns_true(void) { return 1; }\n",
+  });
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `import { cc } from "bun:ffi";
+      const lib = cc({ source: process.argv[1], symbols: { returns_true: { args: [], returns: "bool" } } });
+      const { returns_true } = lib.symbols;
+      console.log(returns_true());
+      for (const construct of [() => new returns_true(), () => Reflect.construct(returns_true, [])]) {
+        try {
+          construct();
+          console.log("constructed");
+        } catch (e) {
+          console.log(e.constructor.name);
+        }
+      }
+      console.log(Bun.inspect(returns_true));
+      lib.close();`,
+      join(String(dir), "returns_true.c"),
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: "true\nTypeError\nTypeError\n[Function: returns_true]\n",
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+// runtime functions like the node:os natives are created through
+// JSFFIFunction::create rather than createForFFI, and do not need TinyCC
+it("runtime native functions are not constructors", () => {
+  expect(freemem()).toBeGreaterThan(0);
+  expect(() => new freemem()).toThrow(TypeError);
+  expect(() => Reflect.construct(freemem, [])).toThrow(TypeError);
+  expect(Bun.inspect(freemem)).toBe("[Function: freemem]");
 });
 
 const libPath =

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -78,6 +78,12 @@ describe("bun:jsc", () => {
     expect(isRope("a" + y + "b")).toBe(true);
     expect(isRope("abcdefgh")).toBe(false);
   });
+  it("native exports are not constructors", () => {
+    for (const fn of [isRope, heapSize, callerSourceOrigin, getRandomSeed, totalCompileTime]) {
+      expect(() => Reflect.construct(fn, [""])).toThrow(TypeError);
+      expect(Bun.inspect(fn)).toStartWith("[Function:");
+    }
+  });
   it("callerSourceOrigin", () => {
     expect(callerSourceOrigin()).toBe(import.meta.url);
   });

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -4,6 +4,7 @@
  *  `bunx vitest test/js/bun/test/mock-fn.test.js`
  *  `NODE_OPTIONS=--experimental-vm-modules npx jest test/js/bun/test/mock-fn.test.js`
  */
+import vm from "node:vm";
 import test_interop from "./test-interop.js";
 var { isBun, describe, test, it, expect, jest, vi, mock, spyOn } = await test_interop();
 
@@ -901,6 +902,138 @@ describe("mock()", () => {
     }
 
     expect(bar()()).toBe(true);
+  });
+
+  describe("constructing a mock", () => {
+    test("new mock() returns a new object and records the invocation", () => {
+      const fn = jest.fn();
+      const instance = new fn(1, 2);
+      expect(typeof instance).toBe("object");
+      expect(instance).not.toBeNull();
+      expect(fn.mock.calls).toEqual([[1, 2]]);
+      expect(fn.mock.instances).toHaveLength(1);
+      expect(fn.mock.instances[0]).toBe(instance);
+      expect(fn.mock.contexts[0]).toBe(instance);
+      expect(fn.mock.results).toEqual([{ type: "return", value: undefined }]);
+    });
+
+    test("Reflect.construct(mock) returns a new object", () => {
+      const fn = jest.fn();
+      const instance = Reflect.construct(fn, []);
+      expect(typeof instance).toBe("object");
+      expect(instance).not.toBeNull();
+      expect(fn.mock.instances[0]).toBe(instance);
+    });
+
+    test("the implementation runs with the new instance as this", () => {
+      const fn = jest.fn(function (x) {
+        this.x = x;
+        return 42;
+      });
+      const instance = new fn(5);
+      expect(instance.x).toBe(5);
+      // a primitive return value is discarded in favor of the new instance
+      expect(fn.mock.results).toEqual([{ type: "return", value: 42 }]);
+    });
+
+    test("an object returned from the implementation wins", () => {
+      const obj = { replaced: true };
+      const fn = jest.fn(() => obj);
+      expect(new fn()).toBe(obj);
+    });
+
+    test("mockReturnValue: object wins, primitive falls back to the instance", () => {
+      const obj = { replaced: true };
+      const fn = jest.fn();
+      fn.mockReturnValueOnce(obj).mockReturnValue(1);
+      expect(new fn()).toBe(obj);
+      const instance = new fn();
+      expect(typeof instance).toBe("object");
+      expect(instance).not.toBe(obj);
+    });
+
+    test("mock.prototype is used for the new instance", () => {
+      const fn = jest.fn();
+      fn.prototype = {
+        kind: "mocked",
+      };
+      const instance = new fn();
+      expect(instance instanceof fn).toBe(true);
+      expect(instance.kind).toBe("mocked");
+    });
+
+    test("Reflect.construct uses newTarget.prototype", () => {
+      function Target() {}
+      Target.prototype.tag = "target";
+      const fn = jest.fn();
+      const instance = Reflect.construct(fn, [], Target);
+      expect(instance.tag).toBe("target");
+      expect(fn.mock.instances[0]).toBe(instance);
+    });
+
+    test("newTarget.prototype that is a primitive falls back to Object.prototype", () => {
+      function Target() {}
+      Target.prototype = 1;
+      const fn = jest.fn();
+      const instance = Reflect.construct(fn, [], Target);
+      expect(Object.getPrototypeOf(instance)).toBe(Object.prototype);
+    });
+
+    if (isBun) {
+      test("a mock has no default .prototype, so new falls back to Object.prototype", () => {
+        const fn = jest.fn();
+        expect(fn.prototype).toBeUndefined();
+        expect(Object.getPrototypeOf(new fn())).toBe(Object.prototype);
+      });
+    }
+
+    if (isBun) {
+      test("cross-realm newTarget with a primitive prototype uses the newTarget realm's Object.prototype", () => {
+        const ctx = vm.createContext({});
+        const Target = vm.runInContext("(function Target() {})", ctx);
+        const otherObjectPrototype = vm.runInContext("Object.prototype", ctx);
+        Target.prototype = 1;
+        const fn = jest.fn();
+        const instance = Reflect.construct(fn, [], Target);
+        expect(Object.getPrototypeOf(instance)).toBe(otherObjectPrototype);
+        expect(Object.getPrototypeOf(instance)).not.toBe(Object.prototype);
+      });
+    }
+
+    test("a throwing implementation propagates and is recorded", () => {
+      const fn = jest.fn(() => {
+        throw new Error("boom");
+      });
+      expect(() => new fn()).toThrow("boom");
+      expect(fn.mock.results[0].type).toBe("throw");
+    });
+
+    test("constructing a spy returns a new object", () => {
+      const obj = {
+        method() {},
+      };
+      const spy = spyOn(obj, "method");
+      const instance = new obj.method();
+      expect(typeof instance).toBe("object");
+      expect(instance).not.toBeNull();
+      expect(spy.mock.instances[0]).toBe(instance);
+    });
+
+    test("instances is pushed on every invocation", () => {
+      const fn = jest.fn();
+      fn();
+      const instance = new fn();
+      expect(fn.mock.calls).toHaveLength(2);
+      expect(fn.mock.instances).toHaveLength(2);
+      expect(fn.mock.instances[0]).toBe(undefined);
+      expect(fn.mock.instances[1]).toBe(instance);
+      expect(fn.mock.contexts).toEqual(fn.mock.instances);
+
+      const obj = { m: jest.fn() };
+      obj.m();
+      expect(obj.m.mock.instances).toEqual([obj]);
+      expect(obj.m.mock.contexts).toEqual([obj]);
+    });
   });
 });
 

--- a/test/js/first_party/utf-8-validate/utf-8-validate.test.ts
+++ b/test/js/first_party/utf-8-validate/utf-8-validate.test.ts
@@ -5,3 +5,8 @@ test("utf-8-validate", () => {
   expect(isValidUTF8(Buffer.from("😀"))).toBeTrue();
   expect(isValidUTF8(Buffer.from([0xff]))).toBeFalse();
 });
+
+test("utf-8-validate is not a constructor", () => {
+  expect(() => Reflect.construct(isValidUTF8, [Buffer.from("x")])).toThrow(TypeError);
+  expect(Bun.inspect(isValidUTF8)).toBe("[Function: utf8Validate]");
+});

--- a/test/js/node/buffer-resolveObjectURL.test.ts
+++ b/test/js/node/buffer-resolveObjectURL.test.ts
@@ -47,3 +47,8 @@ test("buffer.resolveObjectURL args", async () => {
   ).toBeUndefined();
   URL.revokeObjectURL(id);
 });
+
+test("buffer.resolveObjectURL is not a constructor", () => {
+  expect(() => new (resolveObjectURL as any)("foo")).toThrow(TypeError);
+  expect(() => Reflect.construct(resolveObjectURL, ["foo"])).toThrow(TypeError);
+});

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -197,7 +197,8 @@ for (let withOverridenBufferWrite of [false, true]) {
         expect(isAscii(new Buffer(""))).toBeTrue();
         expect(isAscii(new Buffer([32, 32, 128]))).toBeFalse();
         expect(isAscii(new Buffer("What did the 🦊 say?"))).toBeFalse();
-        expect(new isAscii(new Buffer("What did the 🦊 say?"))).toBeFalse();
+        expect(() => new isAscii(new Buffer("abc"))).toThrow(TypeError);
+        expect(() => Reflect.construct(isAscii, [new Buffer("abc")])).toThrow(TypeError);
         expect(isAscii(new Buffer("").buffer)).toBeTrue();
         expect(isAscii(new Buffer([32, 32, 128]).buffer)).toBeFalse();
       });
@@ -207,6 +208,8 @@ for (let withOverridenBufferWrite of [false, true]) {
         expect(isAscii(new Buffer(""))).toBeTrue();
         expect(isUtf8(new Buffer("What did the 🦊 say?"))).toBeTrue();
         expect(isUtf8(new Buffer([129, 129, 129]))).toBeFalse();
+        expect(() => new isUtf8(new Buffer("abc"))).toThrow(TypeError);
+        expect(() => Reflect.construct(isUtf8, [new Buffer("abc")])).toThrow(TypeError);
 
         expect(isUtf8(new Buffer("abc").buffer)).toBeTrue();
         expect(isAscii(new Buffer("").buffer)).toBeTrue();
@@ -2899,6 +2902,8 @@ for (let withOverridenBufferWrite of [false, true]) {
       it("transcode", () => {
         expect(typeof BufferModule.transcode).toBe("function");
         const transcode = BufferModule.transcode;
+        expect(() => Reflect.construct(transcode, [Buffer.from("a"), "latin1", "utf8"])).toThrow(TypeError);
+        expect(Bun.inspect(transcode)).toBe("[Function: transcode]");
 
         expect(transcode(Buffer.from("hä", "latin1"), "latin1", "utf8")).toStrictEqual(Buffer.from("hä", "utf8"));
         expect(() => transcode(Buffer.from("a"), "b", "utf8")).toThrow(

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { realpathSync } from "fs";
-import { isWindows } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 import { isIPv4, isIPv6 } from "node:net";
 import * as os from "node:os";
 
@@ -310,22 +310,71 @@ it("setPriority throws ESRCH for a nonexistent pid", () => {
   );
 });
 
+const nativeOsFunctions = [
+  "freemem",
+  "getPriority",
+  "homedir",
+  "hostname",
+  "loadavg",
+  "networkInterfaces",
+  "release",
+  "setPriority",
+  "totalmem",
+  "uptime",
+  "userInfo",
+  "version",
+];
+
 // https://github.com/oven-sh/bun/issues/32103
 it("native os functions are inspected as functions, not classes", () => {
-  for (const name of [
-    "freemem",
-    "getPriority",
-    "homedir",
-    "hostname",
-    "loadavg",
-    "networkInterfaces",
-    "release",
-    "setPriority",
-    "totalmem",
-    "uptime",
-    "userInfo",
-    "version",
-  ]) {
+  for (const name of nativeOsFunctions) {
     expect(Bun.inspect(os[name])).toBe(`[Function: ${name}]`);
   }
+});
+
+// These functions come from Zig::JSFFIFunction::create, which passed the call
+// function as the native constructor too. Constructing one then read its result
+// as an object: a JSString cell for hostname and homedir, a double for totalmem
+// and freemem. Array.of, Array.from and Symbol.species all construct the callee,
+// so a release build aborts on the string returns and segfaults at address 0x0
+// on the number returns. Spawned because the failure takes the process down.
+it("native os functions are rejected as a construct target", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const os = require("os");
+        for (const name of ${JSON.stringify(nativeOsFunctions)}) {
+          const f = os[name];
+          const out = [];
+          const run = (label, fn) => {
+            try {
+              out.push(label + "=" + JSON.stringify(fn()));
+            } catch (e) {
+              out.push(label + "=" + e.constructor.name);
+            }
+          };
+          // Array.of and Array.from construct |this| only when it is a
+          // constructor, so they fall back to a plain array like Node does.
+          run("of", () => Array.of.call(f, 1, 2, 3));
+          run("from", () => Array.from.call(f, [1]));
+          // ArraySpeciesCreate needs a constructor, so it throws instead.
+          const a = [1, 2, 3];
+          a.constructor = { [Symbol.species]: f };
+          run("species", () => a.slice(1));
+          console.log(name, out.join(" "));
+        }
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr: exitCode === 0 ? "" : stderr, exitCode }).toEqual({
+    stdout: nativeOsFunctions.map(name => `${name} of=[1,2,3] from=[1] species=TypeError\n`).join(""),
+    stderr: "",
+    exitCode: 0,
+  });
 });

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -117,8 +117,8 @@ it("userInfo", () => {
   const info = os.userInfo();
 
   if (process.platform !== "win32") {
-    expect(info.username).toBe(process.env.USER);
-    expect(info.shell).toBe(process.env.SHELL || "unknown");
+    expect(info.username).toBe(process.env.USER ?? "unknown");
+    expect(info.shell).toBe(process.env.SHELL ?? "unknown");
     expect(info.uid >= 0).toBe(true);
     expect(info.gid >= 0).toBe(true);
   } else {
@@ -308,4 +308,24 @@ it("setPriority throws ESRCH for a nonexistent pid", () => {
       info: { errno: isWindows ? -4040 : -3, code: "ESRCH", message: "no such process", syscall: "uv_os_setpriority" },
     }),
   );
+});
+
+// https://github.com/oven-sh/bun/issues/32103
+it("native os functions are inspected as functions, not classes", () => {
+  for (const name of [
+    "freemem",
+    "getPriority",
+    "homedir",
+    "hostname",
+    "loadavg",
+    "networkInterfaces",
+    "release",
+    "setPriority",
+    "totalmem",
+    "uptime",
+    "userInfo",
+    "version",
+  ]) {
+    expect(Bun.inspect(os[name])).toBe(`[Function: ${name}]`);
+  }
 });

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -337,44 +337,53 @@ it("native os functions are inspected as functions, not classes", () => {
 // as an object: a JSString cell for hostname and homedir, a double for totalmem
 // and freemem. Array.of, Array.from and Symbol.species all construct the callee,
 // so a release build aborts on the string returns and segfaults at address 0x0
-// on the number returns. Spawned because the failure takes the process down.
+// on the number returns.
+//
+// One child per function, because the first construct takes the whole process
+// down: a single child would prove nothing about the functions after it.
 it("native os functions are rejected as a construct target", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
-        import * as os from "os";
-        for (const name of ${JSON.stringify(nativeOsFunctions)}) {
-          const f = os[name];
-          const out = [];
-          const run = (label, fn) => {
-            try {
-              out.push(label + "=" + JSON.stringify(fn()));
-            } catch (e) {
-              out.push(label + "=" + e.constructor.name);
-            }
-          };
-          // Array.of and Array.from construct |this| only when it is a
-          // constructor, so they fall back to a plain array like Node does.
-          run("of", () => Array.of.call(f, 1, 2, 3));
-          run("from", () => Array.from.call(f, [1]));
-          // ArraySpeciesCreate needs a constructor, so it throws instead.
-          const a = [1, 2, 3];
-          a.constructor = { [Symbol.species]: f };
-          run("species", () => a.slice(1));
-          console.log(name, out.join(" "));
-        }
-      `,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout, stderr, exitCode }).toEqual({
-    stdout: nativeOsFunctions.map(name => `${name} of=[1,2,3] from=[1] species=TypeError\n`).join(""),
-    stderr: "",
-    exitCode: 0,
-  });
+  const results = await Promise.all(
+    nativeOsFunctions.map(async name => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            import * as os from "os";
+            const f = os[${JSON.stringify(name)}];
+            const out = [];
+            const run = (label, fn) => {
+              try {
+                out.push(label + "=" + JSON.stringify(fn()));
+              } catch (e) {
+                out.push(label + "=" + e.constructor.name);
+              }
+            };
+            // Array.of and Array.from construct |this| only when it is a
+            // constructor, so they fall back to a plain array like Node does.
+            run("of", () => Array.of.call(f, 1, 2, 3));
+            run("from", () => Array.from.call(f, [1]));
+            // ArraySpeciesCreate needs a constructor, so it throws instead.
+            const a = [1, 2, 3];
+            a.constructor = { [Symbol.species]: f };
+            run("species", () => a.slice(1));
+            console.log(out.join(" "));
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { name, stdout, stderr, exitCode };
+    }),
+  );
+  expect(results).toEqual(
+    nativeOsFunctions.map(name => ({
+      name,
+      stdout: "of=[1,2,3] from=[1] species=TypeError\n",
+      stderr: "",
+      exitCode: 0,
+    })),
+  );
 });

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -372,7 +372,7 @@ it("native os functions are rejected as a construct target", async () => {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout, stderr: exitCode === 0 ? "" : stderr, exitCode }).toEqual({
+  expect({ stdout, stderr, exitCode }).toEqual({
     stdout: nativeOsFunctions.map(name => `${name} of=[1,2,3] from=[1] species=TypeError\n`).join(""),
     stderr: "",
     exitCode: 0,

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -344,7 +344,7 @@ it("native os functions are rejected as a construct target", async () => {
       bunExe(),
       "-e",
       `
-        const os = require("os");
+        import * as os from "os";
         for (const name of ${JSON.stringify(nativeOsFunctions)}) {
           const f = os[name];
           const out = [];

--- a/test/js/node/sqlite/node-sqlite.test.ts
+++ b/test/js/node/sqlite/node-sqlite.test.ts
@@ -388,6 +388,8 @@ describe("DatabaseSync", () => {
 
       expect(() => backup(db, ":memory:", undefined)).toThrow(invalidOptions);
       expect(() => backup(db, ":memory:", null)).toThrow(invalidOptions);
+      expect(() => Reflect.construct(backup, [db, ":memory:"])).toThrow(TypeError);
+      expect(Bun.inspect(backup)).toBe("[Function: backup]");
 
       // Controls: these are value-gated in Node (explicit undefined is the
       // same as omission) and must NOT throw.

--- a/test/js/node/util/test-util-types.test.js
+++ b/test/js/node/util/test-util-types.test.js
@@ -363,3 +363,12 @@ export default /BADD~!!!!;
   expect(types.isNativeError(buildError)).toBeTrue();
   expect(buildError.constructor.name).toBe("BuildMessage");
 });
+
+test("util/types functions are not constructors", () => {
+  for (const name of Object.keys(types)) {
+    const fn = types[name];
+    if (typeof fn !== "function") continue;
+    expect(() => Reflect.construct(fn, [new Date()])).toThrow(TypeError);
+    expect(Bun.inspect(fn)).toBe(`[Function: ${name}]`);
+  }
+});

--- a/test/js/node/util/test-util-types.test.js
+++ b/test/js/node/util/test-util-types.test.js
@@ -1,5 +1,6 @@
 import assert from "assert";
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import def, * as ns from "util/types";
 const req = require("util/types");
 const types = def;
@@ -364,6 +365,53 @@ export default /BADD~!!!!;
   expect(buildError.constructor.name).toBe("BuildMessage");
 });
 
+// Reflect.construct is not the only door into JSC::construct(). Array.of, Array.from
+// and every Symbol.species path construct the callee too, so one of these predicates
+// used as a species constructor reached asObject() with a boolean: a release build
+// segfaults at a small address, an asserts build reports ASSERTION FAILED: isCell().
+// Spawned because the failure takes the whole process down.
+test("util/types functions are rejected as a species constructor", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const f = require("util").types.isDate;
+        const lines = [];
+        const run = (label, fn) => {
+          try {
+            lines.push(label + " => " + JSON.stringify(fn()));
+          } catch (e) {
+            lines.push(label + " => " + e.constructor.name);
+          }
+        };
+        // Array.of and Array.from construct |this| only when it is a constructor,
+        // so with the fix they fall back to a plain array, like Node does.
+        run("of", () => Array.of.call(f, 1, 2, 3));
+        run("from", () => Array.from.call(f, [1]));
+        class A extends Array { static get [Symbol.species]() { return f } }
+        const a = new A(1, 2, 3);
+        // ArraySpeciesCreate requires a constructor, so these throw instead.
+        run("slice", () => a.slice(0));
+        run("map", () => a.map(x => x));
+        run("concat", () => a.concat([4]));
+        console.log(lines.join("\\n"));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr: exitCode === 0 ? "" : stderr, exitCode }).toEqual({
+    stdout: "of => [1,2,3]\nfrom => [1]\nslice => TypeError\nmap => TypeError\nconcat => TypeError\n",
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+// This one runs in process, so it must come after the spawned test above: on an
+// unfixed build it aborts the whole test runner instead of failing.
 test("util/types functions are not constructors", () => {
   for (const name of Object.keys(types)) {
     const fn = types[name];

--- a/test/js/node/util/test-util-types.test.js
+++ b/test/js/node/util/test-util-types.test.js
@@ -404,7 +404,7 @@ test("util/types functions are rejected as a species constructor", async () => {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout, stderr: exitCode === 0 ? "" : stderr, exitCode }).toEqual({
+  expect({ stdout, stderr, exitCode }).toEqual({
     stdout: "of => [1,2,3]\nfrom => [1]\nslice => TypeError\nmap => TypeError\nconcat => TypeError\n",
     stderr: "",
     exitCode: 0,

--- a/test/js/node/util/test-util-types.test.js
+++ b/test/js/node/util/test-util-types.test.js
@@ -376,7 +376,8 @@ test("util/types functions are rejected as a species constructor", async () => {
       bunExe(),
       "-e",
       `
-        const f = require("util").types.isDate;
+        import { types } from "util";
+        const f = types.isDate;
         const lines = [];
         const run = (label, fn) => {
           try {

--- a/test/js/node/util/test-util-types.test.js
+++ b/test/js/node/util/test-util-types.test.js
@@ -369,46 +369,61 @@ export default /BADD~!!!!;
 // and every Symbol.species path construct the callee too, so one of these predicates
 // used as a species constructor reached asObject() with a boolean: a release build
 // segfaults at a small address, an asserts build reports ASSERTION FAILED: isCell().
-// Spawned because the failure takes the whole process down.
+//
+// One child per door, because the first construct takes the whole process down: the
+// doors after it in a single child would never run.
 test("util/types functions are rejected as a species constructor", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
-        import { types } from "util";
-        const f = types.isDate;
-        const lines = [];
-        const run = (label, fn) => {
-          try {
-            lines.push(label + " => " + JSON.stringify(fn()));
-          } catch (e) {
-            lines.push(label + " => " + e.constructor.name);
-          }
-        };
-        // Array.of and Array.from construct |this| only when it is a constructor,
-        // so with the fix they fall back to a plain array, like Node does.
-        run("of", () => Array.of.call(f, 1, 2, 3));
-        run("from", () => Array.from.call(f, [1]));
-        class A extends Array { static get [Symbol.species]() { return f } }
-        const a = new A(1, 2, 3);
-        // ArraySpeciesCreate requires a constructor, so these throw instead.
-        run("slice", () => a.slice(0));
-        run("map", () => a.map(x => x));
-        run("concat", () => a.concat([4]));
-        console.log(lines.join("\\n"));
-      `,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout, stderr, exitCode }).toEqual({
-    stdout: "of => [1,2,3]\nfrom => [1]\nslice => TypeError\nmap => TypeError\nconcat => TypeError\n",
-    stderr: "",
-    exitCode: 0,
-  });
+  // Array.of and Array.from construct |this| only when it is a constructor, so with
+  // the fix they fall back to a plain array, like Node does. ArraySpeciesCreate
+  // requires a constructor, so the three array methods throw instead.
+  const doors = {
+    of: "[1,2,3]",
+    from: "[1]",
+    slice: "TypeError",
+    map: "TypeError",
+    concat: "TypeError",
+  };
+  const results = await Promise.all(
+    Object.keys(doors).map(async door => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            import { types } from "util";
+            const f = types.isDate;
+            class A extends Array { static get [Symbol.species]() { return f } }
+            const a = new A(1, 2, 3);
+            const doors = {
+              of: () => Array.of.call(f, 1, 2, 3),
+              from: () => Array.from.call(f, [1]),
+              slice: () => a.slice(0),
+              map: () => a.map(x => x),
+              concat: () => a.concat([4]),
+            };
+            try {
+              console.log(JSON.stringify(doors[${JSON.stringify(door)}]()));
+            } catch (e) {
+              console.log(e.constructor.name);
+            }
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { door, stdout, stderr, exitCode };
+    }),
+  );
+  expect(results).toEqual(
+    Object.entries(doors).map(([door, expected]) => ({
+      door,
+      stdout: `${expected}\n`,
+      stderr: "",
+      exitCode: 0,
+    })),
+  );
 });
 
 // This one runs in process, so it must come after the spawned test above: on an


### PR DESCRIPTION
### Problem
- One line with a plain `require` kills a release build:
  ```js
  Array.of.call(require("util").types.isDate, 1, 2, 3);
  ```
  Release 1.4.2 and 1.4.3: `panic(main thread): Segmentation fault at address 0xA`. An asserts build: `ASSERTION FAILED: isCell()`, `JSCJSValue.h:766`, from the unchecked `asObject` at the end of `JSC::Interpreter::executeConstruct`.
- Seven sites install a plain call function as the native `[[Construct]]` handler. `Construct(f, ...)` runs that call function and reads its boolean result as an object pointer. The widest one, `putNativeFn` (`src/jsc/modules/_NativeModule.h`), wires about 80 exports of `node:util/types`, `bun:jsc`, `node:tty` and `node:sqlite`.
- `Reflect.construct` is one door of many: `Array.of`, `Array.from`, `Symbol.species` on the array methods, `ArrayBuffer.prototype.slice`, and the `split` and `matchAll` species.

### Fix
- The native module helper and the `node:buffer`, `utf-8-validate` and `node:sqlite` exports it covers (`isUtf8`, `isAscii`, `resolveObjectURL`, `transcode`, `backup`) stop passing themselves as the constructor, so they are not constructable, like Node's.
- `JSMockFunction` gets a real construct handler. It builds `this` from `new.target`'s realm, runs the mock with it, and returns the result only when it is an object.
- `JSFFIFunction::createForFFI` passes `callHostFunctionAsConstructor`, so `new ffiFn()` throws.
- With the fix `Array.of.call(f, 1, 2, 3)` returns `[1, 2, 3]` and the species paths throw, like Node.
- Verified: `test/js/node/util/test-util-types.test.js`, whose spawned species test exits 134 with `src/` reset to main. Also `mock-fn`, `ffi`, `bun-jsc`, `buffer`, `os`, `node-sqlite`, `utf-8-validate`.

### Background
- A native `[[Construct]]` handler must return an object, and the interpreter does not check that.
- A handler is installed three ways: the `InternalFunction` constructor, `vm.getHostFunction`, and the `nativeConstructor` parameter of `JSFunction::create`.
- `Array.of` and `Array.from` construct `this` only when it is a constructor, and `ArraySpeciesCreate` requires one.

<details>
<summary>Notes</summary>

Local `test/js/bun/ffi/ffi.test.js` has one failure, `ptr argument: ArrayBuffer cells through an FTL-compiled call site`, which times out at 5 s. It fails the same way with `src/` reset to main, so it is a debug-build speed artifact, not this diff.

Sweep of the rebased tree for any site that passes one function as both the call and the construct handler, with a balanced-paren parse: `constructSlowBuffer`, `vmModule_createContext`, `jsNodeVmWasmDisallowed`. All three are safe. The first two always return an object and the third always throws.

The text below is the previous revision of this description, kept for the review history.

---

## What this fixes

```
ASSERTION FAILED: cell->isObjectSlow()
JavaScriptCore/JSObject.h(1051) : JSObject *JSC::asObject(JSCell *)
```

A native `[[Construct]]` must always return an object. `JSC::Interpreter::executeConstruct` (reached from `Reflect.construct`, `JSC::construct()`, proxy construct traps) ends with an unchecked `return asObject(JSValue::decode(result))`, so a primitive return is an assertion failure in debug and undefined behavior in release. Fuzzilli's `OP_CONSTRUCT` handler uses `Reflect.construct`, which routes straight through that path.

Seven call sites were passing a plain call function (which can return anything) as the native constructor:

**`JSMockFunction`** reused `jsMockFunctionCall` for both call and construct:
```cpp
: Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
```
`Reflect.construct(spyOn(obj, "stringProp"), [])` handed a `JSString` cell to `asObject()`. In release, `typeof Reflect.construct(mock(() => "s"), [])` was `"string"` and `new (mock(() => 42))()` evaluated to `42`.

**`JSFFIFunction`** passed the FFI call function as `nativeConstructor` to `vm.getHostFunction`:
```cpp
vm.getHostFunction(FFIFunction, ..., intrinsic, FFIFunction, nullptr, ...)
```
`Reflect.construct(ccCompiledFn, [...])` returned the FFI result (an int, a bool) through `asObject()`.

**`node:buffer`**'s `isUtf8`, `isAscii`, `resolveObjectURL`, and `transcode` passed themselves as `nativeConstructor` to `JSFunction::create`, so `Reflect.construct(require("node:buffer").isUtf8, [buf])` returned a boolean through `asObject()`. `transcode` (added to main after this PR was opened, picked up on rebase) always returns a Buffer or throws, so it cannot hit the assertion, but it is constructable when Node's is not and inspected as `[class transcode]`, the same surface bug as the three next to it.

**`INIT_NATIVE_MODULE`'s `putNativeFn` helper** (`_NativeModule.h`) passed `ptr` as both call and constructor to `JSFunction::create`, wiring ~80 exports across `node:util/types`, `node:tty`, `bun:jsc`, and `node:sqlite` the same way. `Reflect.construct(require("node:util").types.isDate, [new Date()])` and `Reflect.construct(require("bun:jsc").isRope, ["x"])` both returned a boolean through `asObject()`.

**`utf-8-validate`** (`UTF8ValidateModule.h`) passed `jsBufferConstructorFunction_isUtf8` as its own `nativeConstructor`, the same function pointer as `node:buffer`'s.

**`node:sqlite`'s `backup`** (`NodeSqliteModule.h`) hand-copied the pre-fix `putNativeFn` body to get `.length === 2`, so it bypassed the helper fix. `jsNodeSqliteBackup` has a `return jsUndefined()` after `scope.release()` on the termination-trap branch, and Node's `backup` is not constructable.

## The fix

- `JSMockFunction` gets its own `jsMockFunctionConstruct` that builds `this` from `new.target`'s realm via `getFunctionRealm` + `InternalFunction::createSubclassStructure` (the same pattern as `NapiClass` and JSC's `ObjectConstructor`), runs the mock with it, and returns the implementation's result only when it is an object. That is what an ordinary JS constructor does and matches jest (whose mocks are plain JS functions). `mock.instances` is now populated on every invocation, and `mock.contexts` records the constructed instance for `new` calls rather than `new.target`. One pre-existing gap is left as is and pinned by a test: mocks have no default `.prototype` (jest's do), so `new mock()` with nothing assigned yields a plain `Object.prototype` instance and `instanceof mock` throws, exactly as it did before this PR. Adding a default `.prototype` is a `bun:test` API change that deserves its own PR rather than riding on the crash fix.
- `JSFFIFunction::createForFFI` now passes `callHostFunctionAsConstructor` so `new ffiFn()` throws `TypeError: not a constructor` instead of reinterpreting the return value. `JSFFIFunction::create` now actually uses its `nativeConstructor` parameter (it was ignored before).
- `isUtf8` / `isAscii` / `resolveObjectURL` / `transcode`, the `putNativeFn` helper, `utf-8-validate`, and `node:sqlite`'s `backup` drop the redundant `nativeConstructor` argument so they are not constructable.

## Scope

A native construct handler gets installed three ways (`InternalFunction` ctor, `vm.getHostFunction`, `JSFunction::create` `nativeConstructor`). The first sweep used a single-line grep and missed sites spanning multiple lines (`putNativeFn`, `UTF8ValidateModule.h`); the second used a non-greedy regex that stopped at nested parens (`id.string()`) and missed `NodeSqliteModule.h`. The sweep now uses a balanced-paren parser over every 8-arg `JSFunction::create` call in the tree, and is re-run on each rebase since main keeps adding sites (that is how `transcode` was caught). Remaining self-as-`nativeConstructor` sites as of the current base, all verified safe:

- `NapiClass_ConstructorFunction<true>` — safe: construct path returns `frame.thisValue()`; both `jsUndefined()` returns follow `throwVMError`.
- `vm.createContext`, `SlowBuffer` — pass themselves as `nativeConstructor` but always return an object (verified with `Reflect.construct`, clean exit).
- `jsNodeVmWasmDisallowed` — always throws. (`node:tty`'s `notimpl` site, listed here earlier, has since been removed on main.)
- `JSCommonJSExtensions.cpp` loaders, `JSWrappingFunction`, `JSSQLStatement` — `callHostFunctionAsConstructor`.
- `JSBufferListConstructor`, `JSStringDecoderConstructor` — reuse one function for both but it always returns an object.

## Tests

- `mock-fn.test.js`: a `constructing a mock` block covering every primitive an implementation can return, object passthrough, `this` binding, `mockReturnValue`, `mock.prototype`, explicit `newTarget`, throwing implementations, constructing a spy, and `mock.instances` on every invocation.
- `ffi.test.js`: three tests, one per factory. A `cc()`-compiled `returns_true` (covers `Zig::JSFFIFunction::createForFFI`; compiles an include-free one-liner written to a `tempDir` from a subprocess that calls `close()`: the handle is not finalized on the test runner's exit path so LSan flags it in-process, bundled TinyCC cannot see libc headers in CI, and a TinyCC compile error longjmps in a way ASan rejects, so the source must not be able to fail to compile; this is the same shape as the ungated subprocess `cc()` test in `cc.test.ts`), `os.freemem` (covers `Zig::JSFFIFunction::create`), and a `linkSymbols()` case in a subprocess (engine-native `JSC::JSFFIFunction`, which this PR does not change; kept as a guard on the FFI surface generally). Verified by reverting the `createForFFI` hunk: only the `cc()` test fails, the other two still pass.
- `buffer.test.js` / `buffer-resolveObjectURL.test.ts`: `isUtf8` / `isAscii` / `resolveObjectURL` / `transcode` are not constructable.
- `os.test.js`: native `os` functions inspect as `[Function: name]`, not `[class name]` (a regression test for the constructable-function inspection change). The pre-existing `userInfo` assertions in the same file are adjusted from `process.env.USER` to `process.env.USER ?? "unknown"` (and `SHELL` likewise): Bun's `os.userInfo()` on non-Windows is `env_var::USER.get().unwrap_or(b"unknown")` (see `src/runtime/node/node_os.rs`), which falls back only when the variable is unset and preserves an explicitly empty value, so the old assertion was wrong on hosts without `$USER` and `||` would be wrong on hosts with `USER=`. Verified empirically in all three states (unset, empty, set).
- `test-util-types.test.js`, `bun-jsc.test.ts`, `utf-8-validate.test.ts`, `node-sqlite.test.ts`: representative exports from each `putNativeFn` consumer, `utf-8-validate`, and `node:sqlite`'s `backup` throw `TypeError` on `Reflect.construct` and inspect as `[Function: ...]`.
- `test-util-types.test.js` and `os.test.js` also drive the other doors into `JSC::construct()`: `Array.of.call(f, ...)` and `Array.from.call(f, ...)` (which construct `this` only when it is a constructor, so they now fall back to a plain array as in Node) and `Symbol.species` via `slice`/`map`/`concat` (where `ArraySpeciesCreate` now throws `TypeError`). On an unfixed build these crash the process, so they run in a subprocess and assert stdout, an empty stderr, and exit 0.

## Rebase notes

Squashed to one commit on the current main. One conflict: main rewrote `putNativeFn` in `_NativeModule.h` to cache module exports across builds, but the new body still passed `ptr` as the constructor, so the resolution is main's new body with that one argument dropped. The re-sweep of the rebased tree found the new `transcode` site described above; everything else applied cleanly. All seven sites re-verified against the rebased build, and every touched test file passes.

Second rebase, over #39509. That PR added a strict-mode `toThis()` on the receiver at the top of `jsMockFunctionCall` so a bare call through a captured binding records `undefined` instead of the scope object. This PR had already split that function into a shared body that takes the receiver as a parameter, so the line it changed no longer exists. Resolution: the `toThis()` now happens in the call wrapper before the body is entered, and the construct wrapper passes the freshly created instance, which needs no conversion. #39509's second hunk (`mockGetLastCall`) merged untouched. Its three new tests pass against the relocated call, its reduced repro still prints `undefined`, and the re-sweep found no new sites.

Third rebase (70 commits, including the #39829 WebKit bump): the only conflict was the `ffi.test.js` import block, resolved as the union of main's `isDebug` and this PR's `freemem`/`join`. All three installation shapes were re-swept on the new base with nothing new; all seven sites and the #39509 receiver fix re-verified against the bumped WebKit.

## History

Fuzzilli has independently found this assertion seven times on seven different main commits (`ffea69ae7c`, `d9b2811ea9` ×2, `a780f573a1`, `8f1a9540fd`, `b69e3ca0d6`, `074656dd73`). Every sample reduced to `Reflect.construct` on a `JSMockFunction` whose implementation returns a primitive.

This PR carries the same patch as #31955 and supersedes #31386 and #33301. I'm consolidating onto one branch because #31955's CI went red on two unrelated main breaks (a Docker Hub 500 pulling `postgres:15` and a `napi_release_threadsafe_function` segfault in next-swc on alpine-aarch64, both handed off separately) and it had gone conflicting once already; this branch is rebased on current main with everything re-verified. #31955 and #31386 will be closed pointing here.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 21 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/sqlite/node-sqlite.test.ts, test/js/node/os/os.test.js, test/js/node/buffer.test.js, test/js/bun/jsc/bun-jsc.test.ts, test/js/bun/ffi/ffi.test.js

<!-- robobun:evidence:end -->