### PR TITLE
jsc: free owned FFI allocations when the post-call trap check returns Err

### DIFF
--- a/src/jsc/FetchHeaders.rs
+++ b/src/jsc/FetchHeaders.rs
@@ -144,9 +144,22 @@ impl FetchHeaders {
         global: &JSGlobalObject,
         value: JSValue,
     ) -> JsResult<Option<NonNull<FetchHeaders>>> {
-        host_fn::from_js_host_call_generic(global, || {
-            NonNull::new(WebCore__FetchHeaders__createFromJS(global, value))
-        })
+        // Own the returned allocation before the post-call trap check so a
+        // termination request landing between C++'s RETURN_IF_EXCEPTION and
+        // ours does not drop the raw pointer (no-op) and leak it.
+        let mut raw: *mut FetchHeaders = core::ptr::null_mut();
+        let check = host_fn::from_js_host_call_generic(global, || {
+            raw = WebCore__FetchHeaders__createFromJS(global, value);
+        });
+        let headers = NonNull::new(raw);
+        if let Err(e) = check {
+            if let Some(mut p) = headers {
+                // SAFETY: `p` came from `createFromJS` above and has not been deref'd.
+                unsafe { p.as_mut() }.deref();
+            }
+            return Err(e);
+        }
+        Ok(headers)
     }
 
     pub fn put_default(
@@ -327,9 +340,20 @@ impl FetchHeaders {
         &mut self,
         global: &JSGlobalObject,
     ) -> JsResult<Option<NonNull<FetchHeaders>>> {
-        host_fn::from_js_host_call_generic(global, || {
-            NonNull::new(WebCore__FetchHeaders__cloneThis(self, global))
-        })
+        // Same trap-window hazard as `create_from_js`; see above.
+        let mut raw: *mut FetchHeaders = core::ptr::null_mut();
+        let check = host_fn::from_js_host_call_generic(global, || {
+            raw = WebCore__FetchHeaders__cloneThis(self, global);
+        });
+        let headers = NonNull::new(raw);
+        if let Err(e) = check {
+            if let Some(mut p) = headers {
+                // SAFETY: `p` came from `cloneThis` above and has not been deref'd.
+                unsafe { p.as_mut() }.deref();
+            }
+            return Err(e);
+        }
+        Ok(headers)
     }
 
     pub fn deref(&mut self) {

--- a/src/jsc/FetchHeaders.rs
+++ b/src/jsc/FetchHeaders.rs
@@ -144,22 +144,16 @@ impl FetchHeaders {
         global: &JSGlobalObject,
         value: JSValue,
     ) -> JsResult<Option<NonNull<FetchHeaders>>> {
-        // Own the returned allocation before the post-call trap check so a
-        // termination request landing between C++'s RETURN_IF_EXCEPTION and
-        // ours does not drop the raw pointer (no-op) and leak it.
-        let mut raw: *mut FetchHeaders = core::ptr::null_mut();
-        let check = host_fn::from_js_host_call_generic(global, || {
-            raw = WebCore__FetchHeaders__createFromJS(global, value);
-        });
-        let headers = NonNull::new(raw);
-        if let Err(e) = check {
-            if let Some(mut p) = headers {
-                // SAFETY: `p` came from `createFromJS` above and has not been deref'd.
-                unsafe { p.as_mut() }.deref();
-            }
-            return Err(e);
-        }
-        Ok(headers)
+        host_fn::from_js_host_call_owned(
+            global,
+            || NonNull::new(WebCore__FetchHeaders__createFromJS(global, value)),
+            // SAFETY: `p` came from `createFromJS` above and has not been deref'd.
+            |p| {
+                if let Some(mut p) = p {
+                    unsafe { p.as_mut() }.deref()
+                }
+            },
+        )
     }
 
     pub fn put_default(
@@ -340,20 +334,16 @@ impl FetchHeaders {
         &mut self,
         global: &JSGlobalObject,
     ) -> JsResult<Option<NonNull<FetchHeaders>>> {
-        // Same trap-window hazard as `create_from_js`; see above.
-        let mut raw: *mut FetchHeaders = core::ptr::null_mut();
-        let check = host_fn::from_js_host_call_generic(global, || {
-            raw = WebCore__FetchHeaders__cloneThis(self, global);
-        });
-        let headers = NonNull::new(raw);
-        if let Err(e) = check {
-            if let Some(mut p) = headers {
-                // SAFETY: `p` came from `cloneThis` above and has not been deref'd.
-                unsafe { p.as_mut() }.deref();
-            }
-            return Err(e);
-        }
-        Ok(headers)
+        host_fn::from_js_host_call_owned(
+            global,
+            || NonNull::new(WebCore__FetchHeaders__cloneThis(self, global)),
+            // SAFETY: `p` came from `cloneThis` above and has not been deref'd.
+            |p| {
+                if let Some(mut p) = p {
+                    unsafe { p.as_mut() }.deref()
+                }
+            },
+        )
     }
 
     pub fn deref(&mut self) {

--- a/src/jsc/JSBigInt.rs
+++ b/src/jsc/JSBigInt.rs
@@ -73,17 +73,10 @@ impl JSBigInt {
     }
 
     pub fn to_string(&self, global: &JSGlobalObject) -> JsResult<BunString> {
-        // Own the returned +1 before the post-call trap check so a termination
-        // request landing between C++'s RETURN_IF_EXCEPTION and ours does not
-        // drop it as a no-op (BunString is Copy, no Drop).
-        let mut out = BunString::DEAD;
-        let check = crate::host_fn::from_js_host_call_generic(global, || {
-            out = JSC__JSBigInt__toString(self, global);
-        });
-        if let Err(e) = check {
-            out.deref();
-            return Err(e);
-        }
-        Ok(out)
+        crate::host_fn::from_js_host_call_owned(
+            global,
+            || JSC__JSBigInt__toString(self, global),
+            |s| s.deref(),
+        )
     }
 }

--- a/src/jsc/JSBigInt.rs
+++ b/src/jsc/JSBigInt.rs
@@ -73,6 +73,17 @@ impl JSBigInt {
     }
 
     pub fn to_string(&self, global: &JSGlobalObject) -> JsResult<BunString> {
-        crate::host_fn::from_js_host_call_generic(global, || JSC__JSBigInt__toString(self, global))
+        // Own the returned +1 before the post-call trap check so a termination
+        // request landing between C++'s RETURN_IF_EXCEPTION and ours does not
+        // drop it as a no-op (BunString is Copy, no Drop).
+        let mut out = BunString::DEAD;
+        let check = crate::host_fn::from_js_host_call_generic(global, || {
+            out = JSC__JSBigInt__toString(self, global);
+        });
+        if let Err(e) = check {
+            out.deref();
+            return Err(e);
+        }
+        Ok(out)
     }
 }

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2715,24 +2715,16 @@ impl JSValue {
         if flags.for_storage {
             bits |= 1 << 1;
         }
-        // Own the returned allocation before the post-call trap check so a
-        // termination request landing between C++'s exception check and ours
-        // does not drop the raw handle (no-op) and leak it.
-        let mut ext = SerializedScriptValueExternal {
-            bytes: core::ptr::null(),
-            size: 0,
-            handle: core::ptr::null_mut(),
-        };
-        let check = host_fn::from_js_host_call_generic(global, || {
-            ext = Bun__serializeJSValue(global, self, bits);
-        });
-        if let Err(e) = check {
-            if !ext.handle.is_null() {
-                // SAFETY: `ext.handle` was leaked by `Bun__serializeJSValue` above.
-                unsafe { Bun__SerializedScriptSlice__free(ext.handle) };
-            }
-            return Err(e);
-        }
+        let ext = host_fn::from_js_host_call_owned(
+            global,
+            || Bun__serializeJSValue(global, self, bits),
+            |ext| {
+                if !ext.handle.is_null() {
+                    // SAFETY: `ext.handle` was leaked by `Bun__serializeJSValue` above.
+                    unsafe { Bun__SerializedScriptSlice__free(ext.handle) };
+                }
+            },
+        )?;
         if ext.bytes.is_null() || ext.handle.is_null() {
             return Err(JsError::Thrown);
         }

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2715,9 +2715,24 @@ impl JSValue {
         if flags.for_storage {
             bits |= 1 << 1;
         }
-        let ext = host_fn::from_js_host_call_generic(global, || {
-            Bun__serializeJSValue(global, self, bits)
-        })?;
+        // Own the returned allocation before the post-call trap check so a
+        // termination request landing between C++'s exception check and ours
+        // does not drop the raw handle (no-op) and leak it.
+        let mut ext = SerializedScriptValueExternal {
+            bytes: core::ptr::null(),
+            size: 0,
+            handle: core::ptr::null_mut(),
+        };
+        let check = host_fn::from_js_host_call_generic(global, || {
+            ext = Bun__serializeJSValue(global, self, bits);
+        });
+        if let Err(e) = check {
+            if !ext.handle.is_null() {
+                // SAFETY: `ext.handle` was leaked by `Bun__serializeJSValue` above.
+                unsafe { Bun__SerializedScriptSlice__free(ext.handle) };
+            }
+            return Err(e);
+        }
         if ext.bytes.is_null() || ext.handle.is_null() {
             return Err(JsError::Thrown);
         }

--- a/src/jsc/TopExceptionScope.rs
+++ b/src/jsc/TopExceptionScope.rs
@@ -697,6 +697,10 @@ pub fn call_null_is_throw<T>(
 /// so `simulateThrow()` is satisfied and the assertion fires on mismatch. In release
 /// builds the C++ validation machinery is compiled out: a single
 /// `Bun__RETURN_IF_EXCEPTION` FFI call after the closure (1 FFI hop instead of 3).
+///
+/// On `Err` the closure's return value is **dropped**. If `R` owns an FFI
+/// allocation with no `Drop` (raw pointer, `bun_core::String`), use
+/// [`call_check_slow_owned`] instead.
 #[inline]
 pub fn call_check_slow_at<R>(
     global: &JSGlobalObject,
@@ -731,6 +735,31 @@ pub fn call_check_slow_at<R>(
 #[inline]
 pub fn call_check_slow<R>(global: &JSGlobalObject, f: impl FnOnce() -> R) -> JsResult<R> {
     call_check_slow_at(global, SourceLocation::from_caller(), f)
+}
+
+/// [`call_check_slow`] for closures whose return owns an FFI allocation
+/// without `Drop`. If the post-call check reports an exception (including a
+/// termination trap set between C++'s own `RETURN_IF_EXCEPTION` and ours),
+/// `free` is invoked on the closure's return before the error is propagated;
+/// without it the `Err` arm drops `R` as a no-op and the allocation leaks.
+#[track_caller]
+#[inline]
+pub fn call_check_slow_owned<R>(
+    global: &JSGlobalObject,
+    f: impl FnOnce() -> R,
+    free: impl FnOnce(R),
+) -> JsResult<R> {
+    let mut slot = None;
+    let check = call_check_slow_at(global, SourceLocation::from_caller(), || slot = Some(f()));
+    // `call_check_slow_at` runs the closure exactly once on every path.
+    let r = slot.expect("call_check_slow_at ran the closure");
+    match check {
+        Ok(()) => Ok(r),
+        Err(e) => {
+            free(r);
+            Err(e)
+        }
+    }
 }
 
 /// Macro forms of the per-mode wrappers — expand [`src!`](crate::src) at the *call site* so

--- a/src/jsc/URL.rs
+++ b/src/jsc/URL.rs
@@ -70,37 +70,22 @@ impl URL {
     /// If it fails, the tag is marked Dead
     #[track_caller]
     pub fn href_from_js(value: JSValue, global: &JSGlobalObject) -> JsResult<String> {
-        // Own the returned +1 before the post-call trap check so a termination
-        // request landing between C++'s RETURN_IF_EXCEPTION and ours does not
-        // drop it as a no-op (String is Copy, no Drop).
-        let mut out = String::DEAD;
-        let check = crate::call_check_slow(global, || {
-            out = URL__getHrefFromJS(value, global);
-        });
-        if let Err(e) = check {
-            out.deref();
-            return Err(e);
-        }
-        Ok(out)
+        crate::call_check_slow_owned(global, || URL__getHrefFromJS(value, global), |s| s.deref())
     }
 
     #[track_caller]
     pub fn from_js(value: JSValue, global: &JSGlobalObject) -> JsResult<Option<NonNull<URL>>> {
-        // Own the returned allocation before the post-call trap check so a
-        // termination request landing between C++'s RETURN_IF_EXCEPTION and
-        // ours does not drop the raw pointer (no-op) and leak it.
-        let mut raw: *mut URL = core::ptr::null_mut();
-        let check = crate::call_check_slow(global, || {
-            raw = URL__fromJS(value, global);
-        });
-        if let Err(e) = check {
-            if !raw.is_null() {
-                // SAFETY: `raw` came from `URL__fromJS` above and has not been freed.
-                unsafe { URL__deinit(raw) };
-            }
-            return Err(e);
-        }
-        Ok(NonNull::new(raw))
+        crate::call_check_slow_owned(
+            global,
+            || URL__fromJS(value, global),
+            // SAFETY: `p` came from `URL__fromJS` above and has not been freed.
+            |p| {
+                if !p.is_null() {
+                    unsafe { URL__deinit(p) }
+                }
+            },
+        )
+        .map(NonNull::new)
     }
 
     pub fn from_utf8(input: &[u8]) -> Option<NonNull<URL>> {

--- a/src/jsc/URL.rs
+++ b/src/jsc/URL.rs
@@ -70,12 +70,37 @@ impl URL {
     /// If it fails, the tag is marked Dead
     #[track_caller]
     pub fn href_from_js(value: JSValue, global: &JSGlobalObject) -> JsResult<String> {
-        crate::call_check_slow(global, || URL__getHrefFromJS(value, global))
+        // Own the returned +1 before the post-call trap check so a termination
+        // request landing between C++'s RETURN_IF_EXCEPTION and ours does not
+        // drop it as a no-op (String is Copy, no Drop).
+        let mut out = String::DEAD;
+        let check = crate::call_check_slow(global, || {
+            out = URL__getHrefFromJS(value, global);
+        });
+        if let Err(e) = check {
+            out.deref();
+            return Err(e);
+        }
+        Ok(out)
     }
 
     #[track_caller]
     pub fn from_js(value: JSValue, global: &JSGlobalObject) -> JsResult<Option<NonNull<URL>>> {
-        crate::call_check_slow(global, || URL__fromJS(value, global)).map(NonNull::new)
+        // Own the returned allocation before the post-call trap check so a
+        // termination request landing between C++'s RETURN_IF_EXCEPTION and
+        // ours does not drop the raw pointer (no-op) and leak it.
+        let mut raw: *mut URL = core::ptr::null_mut();
+        let check = crate::call_check_slow(global, || {
+            raw = URL__fromJS(value, global);
+        });
+        if let Err(e) = check {
+            if !raw.is_null() {
+                // SAFETY: `raw` came from `URL__fromJS` above and has not been freed.
+                unsafe { URL__deinit(raw) };
+            }
+            return Err(e);
+        }
+        Ok(NonNull::new(raw))
     }
 
     pub fn from_utf8(input: &[u8]) -> Option<NonNull<URL>> {

--- a/src/jsc/host_fn.rs
+++ b/src/jsc/host_fn.rs
@@ -728,6 +728,19 @@ pub fn from_js_host_call_generic<R>(
     crate::call_check_slow(global_this, f)
 }
 
+/// [`from_js_host_call_generic`] for closures whose return owns an FFI
+/// allocation without `Drop`; `free` runs on the `Err` path. See
+/// [`crate::call_check_slow_owned`].
+#[track_caller]
+#[inline]
+pub fn from_js_host_call_owned<R>(
+    global_this: &JSGlobalObject,
+    f: impl FnOnce() -> R,
+    free: impl FnOnce(R),
+) -> Result<R, JsError> {
+    crate::call_check_slow_owned(global_this, f, free)
+}
+
 // ───────────────────────── error conversion helpers ─────────────────────────
 
 // For when bubbling up errors to functions that require a C ABI boundary

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -421,9 +421,9 @@ pub use self::exception::Exception;
 pub use self::js_type::JSType;
 pub use self::top_exception_scope::{
     ExceptionValidationScope, ExceptionValidationScopeGuard, SourceLocation, TopExceptionScope,
-    TopExceptionScopeGuard, call_check_slow, call_check_slow_at, call_false_is_throw,
-    call_false_is_throw_at, call_null_is_throw, call_null_is_throw_at, call_zero_is_throw,
-    call_zero_is_throw_at,
+    TopExceptionScopeGuard, call_check_slow, call_check_slow_at, call_check_slow_owned,
+    call_false_is_throw, call_false_is_throw_at, call_null_is_throw, call_null_is_throw_at,
+    call_zero_is_throw, call_zero_is_throw_at,
 };
 /// Generated FFI wrappers for C++ `[[ZIG_EXPORT(mode)]]` functions.
 /// Emitted by `src/codegen/cppbind.ts` into
@@ -808,7 +808,8 @@ pub use bun_core::mark_binding;
 
 pub use self::host_fn::{
     JSHostFn, JSHostFnZig, JSHostFnZigWithContext, JSHostFunctionTypeWithContext,
-    from_js_host_call, from_js_host_call_generic, host_construct_result, host_fn_result,
+    from_js_host_call, from_js_host_call_generic, from_js_host_call_owned, host_construct_result,
+    host_fn_result,
     host_setter_result, to_js_host_call, to_js_host_fn, to_js_host_fn_result,
     to_js_host_fn_with_context,
 };

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -809,8 +809,7 @@ pub use bun_core::mark_binding;
 pub use self::host_fn::{
     JSHostFn, JSHostFnZig, JSHostFnZigWithContext, JSHostFunctionTypeWithContext,
     from_js_host_call, from_js_host_call_generic, from_js_host_call_owned, host_construct_result,
-    host_fn_result,
-    host_setter_result, to_js_host_call, to_js_host_fn, to_js_host_fn_result,
+    host_fn_result, host_setter_result, to_js_host_call, to_js_host_fn, to_js_host_fn_result,
     to_js_host_fn_with_context,
 };
 pub use self::host_object::{HostFnEntry, create_host_function_object};

--- a/test/js/node/worker_threads/worker-terminate-ffi-alloc-parent-fixture.js
+++ b/test/js/node/worker_threads/worker-terminate-ffi-alloc-parent-fixture.js
@@ -1,0 +1,25 @@
+"use strict";
+// Parent driver for the "terminate() during allocating FFI wrapper" leak test.
+// Runs THREADS concurrent chains, each spawning ITERS workers back-to-back and
+// terminate()ing each as soon as it reports ready. The worker body spends most
+// of its time inside the allocating C++ `fill()` loop, so terminate() lands in
+// the trap-window reliably.
+const { Worker } = require("worker_threads");
+const path = require("path");
+
+const ITERS = Number(process.env.ITERS || 6);
+const THREADS = Number(process.env.THREADS || 6);
+const body = path.join(__dirname, "worker-terminate-ffi-alloc-worker-fixture.js");
+
+function chain(iter) {
+  const w = new Worker(body);
+  w.on("message", () => w.terminate());
+  w.on("error", err => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+  w.on("exit", () => {
+    if (iter < ITERS) chain(iter + 1);
+  });
+}
+for (let i = 0; i < THREADS; i++) chain(0);

--- a/test/js/node/worker_threads/worker-terminate-ffi-alloc-parent-fixture.js
+++ b/test/js/node/worker_threads/worker-terminate-ffi-alloc-parent-fixture.js
@@ -12,14 +12,17 @@ const THREADS = Number(process.env.THREADS || 6);
 const body = path.join(__dirname, "worker-terminate-ffi-alloc-worker-fixture.js");
 
 let finished = 0;
+let failed = false;
 function chain(iter) {
   const w = new Worker(body);
   w.on("message", () => w.terminate());
   w.on("error", err => {
+    failed = true;
     console.error(err);
     process.exitCode = 1;
   });
   w.on("exit", () => {
+    if (failed) return;
     if (iter < ITERS) chain(iter + 1);
     else if (++finished === THREADS) console.log("done");
   });

--- a/test/js/node/worker_threads/worker-terminate-ffi-alloc-parent-fixture.js
+++ b/test/js/node/worker_threads/worker-terminate-ffi-alloc-parent-fixture.js
@@ -11,6 +11,7 @@ const ITERS = Number(process.env.ITERS || 6);
 const THREADS = Number(process.env.THREADS || 6);
 const body = path.join(__dirname, "worker-terminate-ffi-alloc-worker-fixture.js");
 
+let finished = 0;
 function chain(iter) {
   const w = new Worker(body);
   w.on("message", () => w.terminate());
@@ -20,6 +21,7 @@ function chain(iter) {
   });
   w.on("exit", () => {
     if (iter < ITERS) chain(iter + 1);
+    else if (++finished === THREADS) console.log("done");
   });
 }
 for (let i = 0; i < THREADS; i++) chain(0);

--- a/test/js/node/worker_threads/worker-terminate-ffi-alloc-worker-fixture.js
+++ b/test/js/node/worker_threads/worker-terminate-ffi-alloc-worker-fixture.js
@@ -1,0 +1,22 @@
+"use strict";
+// Worker body for the "terminate() during allocating FFI wrapper" leak test.
+// `new Response(body, { headers: {plain object} })` drives the Rust
+// `FetchHeaders::create_from_js` wrapper, whose C++ side allocates a
+// `WebCore::FetchHeaders` on the heap and then runs `fill()` over every entry.
+// The final C++ guard is a bare `throwScope.exception()` (no trap handling),
+// so a termination trap set during `fill()` is only observed by Rust's
+// post-call check, which (before the fix) dropped the raw pointer and leaked
+// the allocation. Many headers keep `fill()` running long enough for the
+// parent's terminate() to land inside it; the "go" message goes out first so
+// termination arrives while the very first call is in flight.
+const { parentPort } = require("worker_threads");
+
+const hdrs = {};
+for (let i = 0; i < 200; i++) hdrs["x-h-" + i] = "v" + i;
+
+parentPort.postMessage("go");
+function go() {
+  new Response("", { headers: hdrs });
+  setImmediate(go);
+}
+go();

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isWindows, tmpdirSync } from "harness";
 import { once } from "node:events";
 import fs from "node:fs";
 import { join, relative, resolve } from "node:path";
@@ -1756,3 +1756,47 @@ test("the SHARE_ENV founding thread's process.env stays live after the swap", as
   expect(stdout.trim()).toBe("yes,unset");
   expect(exitCode).toBe(0);
 });
+
+// Rust FFI wrappers that return an owned C++ allocation through
+// call_check_slow / from_js_host_call_generic (URL::from_js, URL::href_from_js,
+// FetchHeaders::create_from_js, FetchHeaders::clone_this, JSBigInt::to_string,
+// JSValue::serialize) used to drop the raw pointer when a termination trap
+// landed between the C++ function's own exception guard and the Rust wrapper's
+// post-call trap check. For FetchHeaders::create_from_js the final C++ guard is
+// a bare throwScope.exception() (no trap handling), so the window includes the
+// whole headers->fill() loop; a headers object with many entries keeps a
+// terminate() landing inside it reliable. Malloc=1 routes WebCore::FetchHeaders
+// through system malloc so LSan sees it; pre-existing per-thread singletons
+// (WebCore::eventNames etc.) also show up under Malloc=1, so the assertion is
+// scoped to the FetchHeaders leak stack rather than a blanket LSan check.
+test.skipIf(!isASAN || isWindows)(
+  "terminate() during an allocating FFI wrapper does not leak the allocation",
+  async () => {
+    const env = {
+      ...bunEnv,
+      BUN_DESTRUCT_VM_ON_EXIT: "1",
+      Malloc: "1",
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+      LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+    };
+    // Several independent processes so one random miss does not mask a regression.
+    // Malloc=1 exposes unrelated per-thread singletons, so match only the stacks
+    // this fix covers rather than asserting on the whole LSan report.
+    const targets =
+      /WebCore__FetchHeaders__createFromJS|WebCore__FetchHeaders__cloneThis|URL__fromJS|URL__getHrefFromJS|JSC__JSBigInt__toString|Bun__serializeJSValue/;
+    const hits: string[] = [];
+    for (let i = 0; i < 4; i++) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(import.meta.dirname, "worker-terminate-ffi-alloc-parent-fixture.js")],
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      for (const line of stderr.split("\n")) if (targets.test(line)) hits.push(line.trim());
+      expect(stdout).toBe("");
+    }
+    expect(hits).toEqual([]);
+  },
+  180_000,
+);

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1794,7 +1794,13 @@ test.skipIf(!isASAN || isWindows)(
       });
       const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       for (const line of stderr.split("\n")) if (targets.test(line)) hits.push(line.trim());
-      expect(stdout).toBe("");
+      // Positive completion marker so a missing fixture or crash-before-LSan
+      // cannot satisfy the (otherwise purely negative) assertions; exitCode is
+      // 1 from pre-existing Malloc=1 singletons, so check stdout + signalCode.
+      expect({ stdout: stdout.trim(), signalCode: proc.signalCode }).toEqual({
+        stdout: "done",
+        signalCode: null,
+      });
     }
     expect(hits).toEqual([]);
   },


### PR DESCRIPTION
## What

`call_check_slow` / `from_js_host_call_generic` run the FFI closure, then check for a pending exception (including VMTraps). If a worker's `terminate()` sets the `NeedTermination` trap in the window between the C++ function's own `RETURN_IF_EXCEPTION` and the Rust post-call check, the wrapper returns `Err` and the closure's return value is dropped. When that value is a raw heap pointer (or a +1'd `BunString`, which is `Copy` with no `Drop`), the drop is a no-op and the allocation leaks.

Same class of bug #34574 fixed for `JSPropertyIterator`, without the `Ref<VM>` cascade: here the leak is just the one allocation per occurrence, so `~VM` still runs.

## Cause

A sweep of every `call_check_slow` / `from_js_host_call_generic` call site turned up six whose closure returns an owned allocation from C++:

| wrapper | returns | C++ alloc | destructor |
|---|---|---|---|
| `URL::from_js` | `*mut URL` | `new WTF::URL` (BunString.cpp) | `URL__deinit` |
| `URL::href_from_js` | `BunString` +1 | `toStringRef` (BunString.cpp) | `String::deref` |
| `FetchHeaders::create_from_js` | `*mut FetchHeaders` | `new WebCore::FetchHeaders` (bindings.cpp:1813) | `WebCore__FetchHeaders__deref` |
| `FetchHeaders::clone_this` | `*mut FetchHeaders` | `new WebCore::FetchHeaders` (bindings.cpp:1860) | `WebCore__FetchHeaders__deref` |
| `JSBigInt::to_string` | `BunString` +1 | `toStringRef` (JSBigIntBinding.cpp) | `String::deref` |
| `JSValue::serialize` | `SerializedScriptValue*` | `leakRef()` (Serialization.cpp) | `Bun__SerializedScriptSlice__free` |

For `FetchHeaders::create_from_js` the window is wider than just the return instruction: the final C++ guard is a bare `throwScope.exception()` (no trap handling), so a trap set during `headers->fill()` is not observed until the Rust side checks, and `fill()` iterates every header entry.

## Fix

Adds `call_check_slow_owned(global, f, free)` in `TopExceptionScope.rs` (with a `from_js_host_call_owned` alias in `host_fn.rs`): same shape as `call_check_slow`, but `free` runs on the closure's return before `Err` is propagated. The hazard is documented once on the helper and pointed at from `call_check_slow_at`'s doc comment. All six sites become a single call with the matching destructor as the `free` closure.

## Verification

New ASAN-only test `terminate() during an allocating FFI wrapper does not leak the allocation` in `worker_threads.test.ts`: a worker tight-loops `new Response("", {headers: {200 entries}})` (drives `FetchHeaders::create_from_js`) while the parent `terminate()`s it, under `Malloc=1 detect_leaks=1`. 4 processes x 42 workers each; the parent fixture prints `done` once every chain finishes and the test asserts on that plus a null `signalCode`.

LSan fail-before stack (3/3 runs):

```
Direct leak of 336 byte(s) in 3 object(s) allocated from:
    #10 in WebCore::FetchHeaders::operator new(unsigned long) .../FetchHeaders.h:44:5
    #11 in WebCore__FetchHeaders__createFromJS .../bindings.cpp:1813:21
    #16 in <bun_jsc::fetch_headers::FetchHeaders>::create_from_js .../FetchHeaders.rs:147:9
    #17 in <bun_runtime::webcore::response::HeadersRef>::create_from_js .../Response.rs:90:12
    #18 in <bun_runtime::webcore::response::Init>::init .../Response.rs:1412:34
    #19 in <bun_runtime::webcore::response::Response>::constructor .../Response.rs:1239:28
```

Pass-after 3/3. `worker_threads.test.ts` 92 pass, `headers.test.ts` 99 pass, `response.test.ts` 23 pass.

`Malloc=1` also surfaces pre-existing per-thread singletons (`WebCore::eventNames`, `Bun.main`'s AtomString) that are normally hidden by bmalloc, so the test assertion is scoped to the six C++ function names above rather than a blanket LSan check.

A couple of sites use an `&mut BunString` out-param instead of a closure return (`JSValue::get_name`, `jsonStringify`); those have the same hazard at the caller and are left for a follow-up since the fix shape is different.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/worker_threads/worker_threads.test.ts

<!-- robobun:evidence:end -->