### PR TITLE
crypto: make generate-root-certs.pl fail loudly on certdata.txt format drift

### DIFF
--- a/packages/bun-usockets/generate-root-certs.pl
+++ b/packages/bun-usockets/generate-root-certs.pl
@@ -247,6 +247,11 @@ while (<TXT>) {
     print CRT "/* $1 */\n";
   }
 
+  # A CKO_NSS_TRUST object should only ever be consumed by the scan-forward
+  # loop below; reaching one here means it had no preceding CKO_CERTIFICATE.
+  if (/^CKA_CLASS CK_OBJECT_CLASS CKO_NSS_TRUST/) {
+    die "Parse error: orphan CKO_NSS_TRUST object at input line $. (no preceding CKO_CERTIFICATE)\n";
+  }
   # this is a match for the start of a certificate
   if (/^CKA_CLASS CK_OBJECT_CLASS CKO_CERTIFICATE/) {
     $start_of_cert = 1
@@ -259,6 +264,9 @@ while (<TXT>) {
     my $data;
     while (<TXT>) {
       last if (/^END/);
+      # Skip inline comments; split(/\\/) would otherwise decode any escape
+      # sequences after the '#' into junk bytes in the emitted DER.
+      next if (/^#/);
       chomp;
       my @octets = split(/\\/);
       shift @octets;
@@ -266,18 +274,27 @@ while (<TXT>) {
         $data .= chr(oct);
       }
     }
-    # scan forwards until the trust part
+    # Scan forward to this cert's trust object. Die if we hit another
+    # CKO_CERTIFICATE or EOF first: otherwise the next cert's trust bits would
+    # silently be attributed to this one and the next cert's DER swallowed.
+    my $found_trust = 0;
     while (<TXT>) {
-      last if (/^CKA_CLASS CK_OBJECT_CLASS CKO_NSS_TRUST/);
+      if (/^CKA_CLASS CK_OBJECT_CLASS CKO_NSS_TRUST/) { $found_trust = 1; last; }
+      if (/^CKA_CLASS CK_OBJECT_CLASS CKO_CERTIFICATE/) {
+        die "Parse error: no CKO_NSS_TRUST for \"$caname\" (next CKO_CERTIFICATE at input line $.)\n";
+      }
       chomp;
     }
+    die "Parse error: no CKO_NSS_TRUST for \"$caname\" (reached EOF)\n" unless $found_trust;
     # now scan the trust part to determine how we should trust this cert.
     # A trust object ends at a blank line; inline comments such as
     # "# For Server Distrust After:" must be skipped, not treated as the end.
+    my $trust_lines = 0;
     while (<TXT>) {
       last if (/^\s*$/);
       next if (/^#/);
-      if (/^CKA_TRUST_([A-Z_]+)\s+CK_TRUST\s+CKT_NSS_([A-Z_]+)\s*$/) {
+      if (/^\s*CKA_TRUST_([A-Z_]+)\s+CK_TRUST\s+CKT_NSS_([A-Z_]+)\s*$/) {
+        $trust_lines++;
         if ( !is_in_list($1,@valid_mozilla_trust_purposes) ) {
           report "Warning: Unrecognized trust purpose for cert: $caname. Trust purpose: $1. Trust Level: $2";
         } elsif ( !is_in_list($2,@valid_mozilla_trust_levels) ) {
@@ -287,6 +304,8 @@ while (<TXT>) {
         }
       }
     }
+    die "Parse error: CKO_NSS_TRUST for \"$caname\" ended before any CKA_TRUST_* line was seen (blank line or malformed trust object?)\n"
+      unless $trust_lines;
 
     if ( !should_output_cert(%trust_purposes_by_level) ) {
       $skipnum ++;
@@ -353,6 +372,14 @@ while (<TXT>) {
 print CRT "};\n";
 close(TXT) or die "Couldn't close $txt: $!\n";
 close(CRT) or die "Couldn't close $crt.~: $!\n";
+# Tripwire: every CKO_NSS_TRUST object in certdata.txt must have been consumed
+# by exactly one CKO_CERTIFICATE above. A mismatch means format drift silently
+# dropped or mis-paired a root (the #31611 Izenpe class of bug).
+open(TXT, "$txt") or die "Couldn't reopen $txt: $!\n";
+my $trust_objects = grep { /^CKA_CLASS CK_OBJECT_CLASS CKO_NSS_TRUST/ } <TXT>;
+close(TXT);
+die "Parse error: certdata.txt has $trust_objects CKO_NSS_TRUST objects but $certnum emitted + $skipnum skipped = ${\($certnum + $skipnum)}\n"
+  if $trust_objects != $certnum + $skipnum;
 unless( $stdout ) {
     rename "$crt.~", $crt or die "Failed to rename $crt.~ to $crt: $!\n";
 }

--- a/packages/bun-usockets/generate-root-certs.pl
+++ b/packages/bun-usockets/generate-root-certs.pl
@@ -293,6 +293,9 @@ while (<TXT>) {
     while (<TXT>) {
       last if (/^\s*$/);
       next if (/^#/);
+      if (/^CKA_LABEL UTF8 "(.*)"/ && $1 ne $caname) {
+        die "Parse error: CKO_NSS_TRUST label \"$1\" does not match certificate \"$caname\" at input line $.\n";
+      }
       if (/^\s*CKA_TRUST_([A-Z_]+)\s+CK_TRUST\s+CKT_NSS_([A-Z_]+)\s*$/) {
         $trust_lines++;
         if ( !is_in_list($1,@valid_mozilla_trust_purposes) ) {

--- a/test/regression/issue/31611.test.ts
+++ b/test/regression/issue/31611.test.ts
@@ -214,19 +214,39 @@ describe.concurrent.skipIf(!perl)("generate-root-certs.pl fails loudly on malfor
     expect(status).not.toBe(0);
   });
 
-  // Cross-check tripwire: a trust object the main loop never consumed.
+  // Adjacent certs with their trust objects swapped: each trust object exists
+  // and is well-formed, so none of the structural guards fire, but applying
+  // B's policy to A's DER is exactly the Izenpe-class silent misattribution.
+  test("trust object with a mismatched CKA_LABEL is a hard error", () => {
+    const { status, stderr } = runGenerator(
+      joinObjects(
+        `BEGINDATA`,
+        certObject("Repro Root A", CERT_OCTAL_A),
+        trustObject("Repro Root B", String.raw`\001\002`, TRUSTED),
+        certObject("Repro Root B", CERT_OCTAL_B),
+        trustObject("Repro Root A", String.raw`\003\004`, TRUSTED),
+      ),
+    );
+    expect(stderr).toContain(`CKO_NSS_TRUST label "Repro Root B" does not match certificate "Repro Root A"`);
+    expect(status).not.toBe(0);
+  });
+
+  // Cross-check tripwire: a stray CKO_NSS_TRUST line the inline guards do not
+  // see (consumed inside the trust-scan loop as an unrecognised attribute).
+  // Only the final re-read count check can catch this.
   test("final trust-object count must equal processed cert count", () => {
     const { status, stderr } = runGenerator(
       joinObjects(
         `BEGINDATA`,
         certObject("Repro Root A", CERT_OCTAL_A),
-        trustObject("Repro Root A", String.raw`\001\002`, TRUSTED),
-        // Second trust object for the same cert: valid NSS, but the parser
-        // only pairs one trust per cert so this must surface, not vanish.
-        trustObject("Repro Root A", String.raw`\001\002`, TRUSTED),
+        trustObject(
+          "Repro Root A",
+          String.raw`\001\002`,
+          `CKA_CLASS CK_OBJECT_CLASS CKO_NSS_TRUST\n` + TRUSTED,
+        ),
       ),
     );
-    expect(stderr).toMatch(/orphan CKO_NSS_TRUST|2 CKO_NSS_TRUST objects but/);
+    expect(stderr).toContain("2 CKO_NSS_TRUST objects but 1 emitted + 0 skipped");
     expect(status).not.toBe(0);
   });
 });

--- a/test/regression/issue/31611.test.ts
+++ b/test/regression/issue/31611.test.ts
@@ -4,7 +4,6 @@
 
 import { describe, expect, test } from "bun:test";
 import { bunEnv, tempDir } from "harness";
-import { spawnSync } from "node:child_process";
 import { X509Certificate } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -95,16 +94,19 @@ const TRUSTED = [
 
 const script = readFileSync(join(usocketsDir, "generate-root-certs.pl"), "utf8");
 
-function runGenerator(certdata: string) {
+async function runGenerator(certdata: string) {
   using dir = tempDir("root-certs-parser", {
     "generate-root-certs.pl": script,
     "certdata.txt": certdata,
   });
-  const { status, stderr } = spawnSync(perl!, ["generate-root-certs.pl", "root_certs.h"], {
-    cwd: String(dir),
+  await using proc = Bun.spawn({
+    cmd: [perl!, "generate-root-certs.pl", "root_certs.h"],
     env: bunEnv,
-    encoding: "utf8",
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
   });
+  const [, stderr, status] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   const output = status === 0 ? readFileSync(join(String(dir), "root_certs.h"), "utf8") : "";
   const emitted = new Map<string, Buffer>();
   // Emitted certs are `/* <label> */` then a PEM body as a wrapped C string.
@@ -117,7 +119,7 @@ function runGenerator(certdata: string) {
 
 // Unit check on the checked-in generator: feed it a fixture shaped like
 // Izenpe.com's trust object (inline comment before CKA_TRUST_SERVER_AUTH).
-test.skipIf(!perl)("generate-root-certs.pl keeps roots with an inline trust-object comment (Izenpe.com)", () => {
+test.skipIf(!perl)("generate-root-certs.pl keeps roots with an inline trust-object comment (Izenpe.com)", async () => {
   const certdata = joinObjects(
     `# Minimal certdata.txt fixture\nCVS_ID "fixture"`,
     // Control: trust bits appear directly, no inline comment.
@@ -148,7 +150,7 @@ test.skipIf(!perl)("generate-root-certs.pl keeps roots with an inline trust-obje
     ),
   );
 
-  const { status, emitted } = runGenerator(certdata);
+  const { status, emitted } = await runGenerator(certdata);
 
   // Control root + inline-comment root must both survive.
   expect([...emitted.keys()]).toEqual(["DirectTrustRoot", "DistrustAfterRoot"]);
@@ -161,8 +163,8 @@ test.skipIf(!perl)("generate-root-certs.pl keeps roots with an inline trust-obje
 describe.concurrent.skipIf(!perl)("generate-root-certs.pl fails loudly on malformed certdata", () => {
   // Face 1: cert A has no trust object; cert B is trusted. The old scan-forward
   // loop swallowed B entirely and attributed B's trust bits to A's DER.
-  test("cert without a CKO_NSS_TRUST object is a hard error, not a silent swallow", () => {
-    const { status, stderr } = runGenerator(
+  test("cert without a CKO_NSS_TRUST object is a hard error, not a silent swallow", async () => {
+    const { status, stderr } = await runGenerator(
       joinObjects(
         `BEGINDATA`,
         certObject("Repro Root A", CERT_OCTAL_A),
@@ -176,8 +178,8 @@ describe.concurrent.skipIf(!perl)("generate-root-certs.pl fails loudly on malfor
 
   // Face 2: trust-before-cert ordering. Previously the orphan trust was
   // ignored and A's scan-forward then swallowed B just like face 1.
-  test("orphan CKO_NSS_TRUST before its cert is a hard error", () => {
-    const { status, stderr } = runGenerator(
+  test("orphan CKO_NSS_TRUST before its cert is a hard error", async () => {
+    const { status, stderr } = await runGenerator(
       joinObjects(
         `BEGINDATA`,
         trustObject("Repro Root A", String.raw`\001\002`, TRUSTED),
@@ -193,8 +195,8 @@ describe.concurrent.skipIf(!perl)("generate-root-certs.pl fails loudly on malfor
   // Face 4: blank line inside the trust object before the CKA_TRUST_* lines.
   // The Izenpe fix's own `last if /^\s*$/` ends the scan early with zero
   // trust bits read, which previously skipped the cert silently.
-  test("trust object that ends before any CKA_TRUST_* line is a hard error", () => {
-    const { status, stderr } = runGenerator(
+  test("trust object that ends before any CKA_TRUST_* line is a hard error", async () => {
+    const { status, stderr } = await runGenerator(
       joinObjects(
         `BEGINDATA`,
         certObject("Repro Root A", CERT_OCTAL_A),
@@ -217,8 +219,8 @@ describe.concurrent.skipIf(!perl)("generate-root-certs.pl fails loudly on malfor
   // Adjacent certs with their trust objects swapped: each trust object exists
   // and is well-formed, so none of the structural guards fire, but applying
   // B's policy to A's DER is exactly the Izenpe-class silent misattribution.
-  test("trust object with a mismatched CKA_LABEL is a hard error", () => {
-    const { status, stderr } = runGenerator(
+  test("trust object with a mismatched CKA_LABEL is a hard error", async () => {
+    const { status, stderr } = await runGenerator(
       joinObjects(
         `BEGINDATA`,
         certObject("Repro Root A", CERT_OCTAL_A),
@@ -234,8 +236,8 @@ describe.concurrent.skipIf(!perl)("generate-root-certs.pl fails loudly on malfor
   // Cross-check tripwire: a stray CKO_NSS_TRUST line the inline guards do not
   // see (consumed inside the trust-scan loop as an unrecognised attribute).
   // Only the final re-read count check can catch this.
-  test("final trust-object count must equal processed cert count", () => {
-    const { status, stderr } = runGenerator(
+  test("final trust-object count must equal processed cert count", async () => {
+    const { status, stderr } = await runGenerator(
       joinObjects(
         `BEGINDATA`,
         certObject("Repro Root A", CERT_OCTAL_A),
@@ -250,8 +252,8 @@ describe.concurrent.skipIf(!perl)("generate-root-certs.pl fails loudly on malfor
 describe.concurrent.skipIf(!perl)("generate-root-certs.pl tolerates benign certdata formatting drift", () => {
   // Face 3: leading whitespace on the CKA_TRUST_SERVER_AUTH line. The
   // ^-anchored regex used to miss it and silently skip the cert.
-  test("leading whitespace on CKA_TRUST_* lines", () => {
-    const { status, emitted } = runGenerator(
+  test("leading whitespace on CKA_TRUST_* lines", async () => {
+    const { status, emitted } = await runGenerator(
       joinObjects(
         `BEGINDATA`,
         certObject("Repro Root A", CERT_OCTAL_A),
@@ -272,10 +274,10 @@ describe.concurrent.skipIf(!perl)("generate-root-certs.pl tolerates benign certd
   // Face 5: a '#' comment inside the MULTILINE_OCTAL block that happens to
   // contain backslash-escapes. split(/\\/) would decode those into junk bytes
   // in the emitted DER; the line must be skipped entirely.
-  test("'#' comments inside CKA_VALUE MULTILINE_OCTAL do not inject bytes into DER", () => {
+  test("'#' comments inside CKA_VALUE MULTILINE_OCTAL do not inject bytes into DER", async () => {
     const lines = CERT_OCTAL_A.split("\n");
     const withComment = [...lines.slice(0, 3), String.raw`#\101\102\103 stray escapes`, ...lines.slice(3)].join("\n");
-    const { status, emitted } = runGenerator(
+    const { status, emitted } = await runGenerator(
       joinObjects(
         `BEGINDATA`,
         certObject("Repro Root A", withComment),
@@ -288,8 +290,8 @@ describe.concurrent.skipIf(!perl)("generate-root-certs.pl tolerates benign certd
   });
 
   // Control: well-formed input still emits both roots with the right DER.
-  test("well-formed two-root input", () => {
-    const { status, emitted } = runGenerator(
+  test("well-formed two-root input", async () => {
+    const { status, emitted } = await runGenerator(
       joinObjects(
         `BEGINDATA`,
         certObject("Repro Root A", CERT_OCTAL_A),

--- a/test/regression/issue/31611.test.ts
+++ b/test/regression/issue/31611.test.ts
@@ -239,11 +239,7 @@ describe.concurrent.skipIf(!perl)("generate-root-certs.pl fails loudly on malfor
       joinObjects(
         `BEGINDATA`,
         certObject("Repro Root A", CERT_OCTAL_A),
-        trustObject(
-          "Repro Root A",
-          String.raw`\001\002`,
-          `CKA_CLASS CK_OBJECT_CLASS CKO_NSS_TRUST\n` + TRUSTED,
-        ),
+        trustObject("Repro Root A", String.raw`\001\002`, `CKA_CLASS CK_OBJECT_CLASS CKO_NSS_TRUST\n` + TRUSTED),
       ),
     );
     expect(stderr).toContain("2 CKO_NSS_TRUST objects but 1 emitted + 0 skipped");

--- a/test/regression/issue/31611.test.ts
+++ b/test/regression/issue/31611.test.ts
@@ -2,9 +2,9 @@
 // generate-root-certs.pl treated any '#' line as end-of-trust-object, so an inline
 // "# For Server Distrust After:" comment made it drop Izenpe.com from the bundle.
 
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, tempDir } from "harness";
-import { execFileSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { X509Certificate } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -35,7 +35,7 @@ test("tls.rootCertificates contains every SERVER_AUTH TRUSTED_DELEGATOR from cer
 
 // Throwaway self-signed DER cert as NSS MULTILINE_OCTAL; the generator only
 // base64-encodes it so the bytes themselves do not matter.
-const CERT_OCTAL = String.raw`\060\202\001\047\060\201\316\240\003\002\001\002\002\011\000\375
+const CERT_OCTAL_A = String.raw`\060\202\001\047\060\201\316\240\003\002\001\002\002\011\000\375
 \177\346\040\234\273\377\307\060\012\006\010\052\206\110\316\075
 \004\003\002\060\017\061\015\060\013\006\003\125\004\003\014\004
 \124\145\163\164\060\036\027\015\062\064\060\061\060\061\060\060
@@ -50,7 +50,14 @@ const CERT_OCTAL = String.raw`\060\202\001\047\060\201\316\240\003\002\001\002\0
 \060\012\006\010\052\206\110\316\075\004\003\002\003\107\000\060
 \104`;
 
-function certObject(label: string): string {
+// Distinct DER payload so the "swallow" tests can tell which cert was emitted.
+const CERT_OCTAL_B = CERT_OCTAL_A.replace(String.raw`\011\000\375`, String.raw`\011\000\376`);
+
+function octalToBuffer(octal: string): Buffer {
+  return Buffer.from([...octal.matchAll(/\\([0-7]{3})/g)].map(m => parseInt(m[1], 8)));
+}
+
+function certObject(label: string, octal = CERT_OCTAL_A): string {
   return [
     `# Certificate "${label}"`,
     `CKA_CLASS CK_OBJECT_CLASS CKO_CERTIFICATE`,
@@ -58,7 +65,7 @@ function certObject(label: string): string {
     `CKA_LABEL UTF8 "${label}"`,
     `CKA_CERTIFICATE_TYPE CK_CERTIFICATE_TYPE CKC_X_509`,
     `CKA_VALUE MULTILINE_OCTAL`,
-    CERT_OCTAL,
+    octal,
     `END`,
   ].join("\n");
 }
@@ -80,11 +87,37 @@ function joinObjects(...objects: string[]): string {
   return objects.join("\n\n") + "\n";
 }
 
+const TRUSTED = [
+  `CKA_TRUST_SERVER_AUTH CK_TRUST CKT_NSS_TRUSTED_DELEGATOR`,
+  `CKA_TRUST_EMAIL_PROTECTION CK_TRUST CKT_NSS_MUST_VERIFY_TRUST`,
+  `CKA_TRUST_STEP_UP_APPROVED CK_BBOOL CK_FALSE`,
+].join("\n");
+
+const script = readFileSync(join(usocketsDir, "generate-root-certs.pl"), "utf8");
+
+function runGenerator(certdata: string) {
+  using dir = tempDir("root-certs-parser", {
+    "generate-root-certs.pl": script,
+    "certdata.txt": certdata,
+  });
+  const { status, stderr } = spawnSync(perl!, ["generate-root-certs.pl", "root_certs.h"], {
+    cwd: String(dir),
+    env: bunEnv,
+    encoding: "utf8",
+  });
+  const output = status === 0 ? readFileSync(join(String(dir), "root_certs.h"), "utf8") : "";
+  const emitted = new Map<string, Buffer>();
+  // Emitted certs are `/* <label> */` then a PEM body as a wrapped C string.
+  for (const m of output.matchAll(/^\/\* (.+) \*\/\n\{([^}]*)\}/gm)) {
+    const b64 = [...m[2].matchAll(/"([A-Za-z0-9+/=]+)\\n"/g)].map(x => x[1]).join("");
+    emitted.set(m[1], Buffer.from(b64, "base64"));
+  }
+  return { status, stderr, output, emitted };
+}
+
 // Unit check on the checked-in generator: feed it a fixture shaped like
 // Izenpe.com's trust object (inline comment before CKA_TRUST_SERVER_AUTH).
 test.skipIf(!perl)("generate-root-certs.pl keeps roots with an inline trust-object comment (Izenpe.com)", () => {
-  const script = readFileSync(join(usocketsDir, "generate-root-certs.pl"), "utf8");
-
   const certdata = joinObjects(
     `# Minimal certdata.txt fixture\nCVS_ID "fixture"`,
     // Control: trust bits appear directly, no inline comment.
@@ -115,21 +148,143 @@ test.skipIf(!perl)("generate-root-certs.pl keeps roots with an inline trust-obje
     ),
   );
 
-  using dir = tempDir("root-certs-parser", {
-    "generate-root-certs.pl": script,
-    "certdata.txt": certdata,
-  });
-
-  execFileSync(perl!, ["generate-root-certs.pl", "root_certs.h"], {
-    cwd: String(dir),
-    env: bunEnv,
-    encoding: "utf8",
-  });
-
-  const generated = readFileSync(join(String(dir), "root_certs.h"), "utf8");
+  const { status, emitted } = runGenerator(certdata);
 
   // Control root + inline-comment root must both survive.
-  expect(generated).toContain("DirectTrustRoot");
-  expect(generated).toContain("DistrustAfterRoot");
-  expect(generated.match(/-----BEGIN CERTIFICATE-----/g) ?? []).toHaveLength(2);
+  expect([...emitted.keys()]).toEqual(["DirectTrustRoot", "DistrustAfterRoot"]);
+  expect(status).toBe(0);
+});
+
+// Further silent-failure shapes in the same parser family as the Izenpe bug:
+// each of these used to exit 0 with no warning while either emitting the wrong
+// cert, dropping a trusted cert, or corrupting the emitted DER.
+describe.concurrent.skipIf(!perl)("generate-root-certs.pl fails loudly on malformed certdata", () => {
+  // Face 1: cert A has no trust object; cert B is trusted. The old scan-forward
+  // loop swallowed B entirely and attributed B's trust bits to A's DER.
+  test("cert without a CKO_NSS_TRUST object is a hard error, not a silent swallow", () => {
+    const { status, stderr } = runGenerator(
+      joinObjects(
+        `BEGINDATA`,
+        certObject("Repro Root A", CERT_OCTAL_A),
+        certObject("Repro Root B", CERT_OCTAL_B),
+        trustObject("Repro Root B", String.raw`\001\002`, TRUSTED),
+      ),
+    );
+    expect(stderr).toContain(`no CKO_NSS_TRUST for "Repro Root A"`);
+    expect(status).not.toBe(0);
+  });
+
+  // Face 2: trust-before-cert ordering. Previously the orphan trust was
+  // ignored and A's scan-forward then swallowed B just like face 1.
+  test("orphan CKO_NSS_TRUST before its cert is a hard error", () => {
+    const { status, stderr } = runGenerator(
+      joinObjects(
+        `BEGINDATA`,
+        trustObject("Repro Root A", String.raw`\001\002`, TRUSTED),
+        certObject("Repro Root A", CERT_OCTAL_A),
+        certObject("Repro Root B", CERT_OCTAL_B),
+        trustObject("Repro Root B", String.raw`\001\002`, TRUSTED),
+      ),
+    );
+    expect(stderr).toContain("orphan CKO_NSS_TRUST");
+    expect(status).not.toBe(0);
+  });
+
+  // Face 4: blank line inside the trust object before the CKA_TRUST_* lines.
+  // The Izenpe fix's own `last if /^\s*$/` ends the scan early with zero
+  // trust bits read, which previously skipped the cert silently.
+  test("trust object that ends before any CKA_TRUST_* line is a hard error", () => {
+    const { status, stderr } = runGenerator(
+      joinObjects(
+        `BEGINDATA`,
+        certObject("Repro Root A", CERT_OCTAL_A),
+        // Same as trustObject() but with a blank line before the trust bits.
+        [
+          `CKA_CLASS CK_OBJECT_CLASS CKO_NSS_TRUST`,
+          `CKA_LABEL UTF8 "Repro Root A"`,
+          `CKA_CERT_SHA1_HASH MULTILINE_OCTAL`,
+          String.raw`\001\002\003\004`,
+          `END`,
+          ``,
+          TRUSTED,
+        ].join("\n"),
+      ),
+    );
+    expect(stderr).toContain(`CKO_NSS_TRUST for "Repro Root A" ended before any CKA_TRUST_* line`);
+    expect(status).not.toBe(0);
+  });
+
+  // Cross-check tripwire: a trust object the main loop never consumed.
+  test("final trust-object count must equal processed cert count", () => {
+    const { status, stderr } = runGenerator(
+      joinObjects(
+        `BEGINDATA`,
+        certObject("Repro Root A", CERT_OCTAL_A),
+        trustObject("Repro Root A", String.raw`\001\002`, TRUSTED),
+        // Second trust object for the same cert: valid NSS, but the parser
+        // only pairs one trust per cert so this must surface, not vanish.
+        trustObject("Repro Root A", String.raw`\001\002`, TRUSTED),
+      ),
+    );
+    expect(stderr).toMatch(/orphan CKO_NSS_TRUST|2 CKO_NSS_TRUST objects but/);
+    expect(status).not.toBe(0);
+  });
+});
+
+describe.concurrent.skipIf(!perl)("generate-root-certs.pl tolerates benign certdata formatting drift", () => {
+  // Face 3: leading whitespace on the CKA_TRUST_SERVER_AUTH line. The
+  // ^-anchored regex used to miss it and silently skip the cert.
+  test("leading whitespace on CKA_TRUST_* lines", () => {
+    const { status, emitted } = runGenerator(
+      joinObjects(
+        `BEGINDATA`,
+        certObject("Repro Root A", CERT_OCTAL_A),
+        trustObject(
+          "Repro Root A",
+          String.raw`\001\002`,
+          TRUSTED.split("\n")
+            .map(l => "  " + l)
+            .join("\n"),
+        ),
+      ),
+    );
+    expect([...emitted.keys()]).toEqual(["Repro Root A"]);
+    expect(emitted.get("Repro Root A")).toEqual(octalToBuffer(CERT_OCTAL_A));
+    expect(status).toBe(0);
+  });
+
+  // Face 5: a '#' comment inside the MULTILINE_OCTAL block that happens to
+  // contain backslash-escapes. split(/\\/) would decode those into junk bytes
+  // in the emitted DER; the line must be skipped entirely.
+  test("'#' comments inside CKA_VALUE MULTILINE_OCTAL do not inject bytes into DER", () => {
+    const lines = CERT_OCTAL_A.split("\n");
+    const withComment = [...lines.slice(0, 3), String.raw`#\101\102\103 stray escapes`, ...lines.slice(3)].join("\n");
+    const { status, emitted } = runGenerator(
+      joinObjects(
+        `BEGINDATA`,
+        certObject("Repro Root A", withComment),
+        trustObject("Repro Root A", String.raw`\001\002`, TRUSTED),
+      ),
+    );
+    expect([...emitted.keys()]).toEqual(["Repro Root A"]);
+    expect(emitted.get("Repro Root A")).toEqual(octalToBuffer(CERT_OCTAL_A));
+    expect(status).toBe(0);
+  });
+
+  // Control: well-formed input still emits both roots with the right DER.
+  test("well-formed two-root input", () => {
+    const { status, emitted } = runGenerator(
+      joinObjects(
+        `BEGINDATA`,
+        certObject("Repro Root A", CERT_OCTAL_A),
+        trustObject("Repro Root A", String.raw`\001\002`, TRUSTED),
+        certObject("Repro Root B", CERT_OCTAL_B),
+        trustObject("Repro Root B", String.raw`\003\004`, TRUSTED),
+      ),
+    );
+    expect([...emitted.keys()]).toEqual(["Repro Root A", "Repro Root B"]);
+    expect(emitted.get("Repro Root A")).toEqual(octalToBuffer(CERT_OCTAL_A));
+    expect(emitted.get("Repro Root B")).toEqual(octalToBuffer(CERT_OCTAL_B));
+    expect(status).toBe(0);
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Follow-up to #31612. The `certdata.txt` parser in `generate-root-certs.pl` has five further silent-failure shapes of the same family as the Izenpe drop: each is a single comment / blank / indent / ordering drift in NSS's `certdata.txt` away from shipping a wrong root store with `rc=0` and no warning. The currently-committed `certdata.txt` is clean (regenerated output is byte-identical, 121 roots) so this is about hardening the **next** NSS import.

| # | shape | unpatched behaviour (rc=0, no warning) | now |
|---|---|---|---|
| 1 | `CKO_CERTIFICATE` with no following `CKO_NSS_TRUST` | scan-forward swallows the next cert object; the **next** cert's trust bits attach to **this** cert's DER. Untrusted root ships as trusted; trusted root vanishes | `die` |
| 2 | `CKO_NSS_TRUST` before its certificate | orphan trust ignored, then same swallow as (1) | `die` |
| 3 | leading whitespace on `CKA_TRUST_*` | `^`-anchored regex misses it, cert silently skipped | tolerated |
| 4 | blank line inside a trust object before `CKA_TRUST_*` | the Izenpe fix's own `last if /^\s*$/` ends the scan with zero trust bits, cert silently skipped | `die` |
| 5 | `#\101\102\103` inside a `MULTILINE_OCTAL` block | `split(/\\/)` decodes the escapes after `#` into junk bytes in the emitted DER | skipped |

A final cross-check asserts `CKO_NSS_TRUST` object count == processed cert count (emitted + skipped).

### Reproduction

Smallest case (shape 1): `Root A` has no trust object, `Root B` is trusted.

```
CKA_CLASS CK_OBJECT_CLASS CKO_CERTIFICATE
CKA_LABEL UTF8 "Root A"
CKA_VALUE MULTILINE_OCTAL
\060\202...
END

CKA_CLASS CK_OBJECT_CLASS CKO_CERTIFICATE
CKA_LABEL UTF8 "Root B"
CKA_VALUE MULTILINE_OCTAL
\060\202...
END

CKA_CLASS CK_OBJECT_CLASS CKO_NSS_TRUST
CKA_LABEL UTF8 "Root B"
CKA_TRUST_SERVER_AUTH CK_TRUST CKT_NSS_TRUSTED_DELEGATOR
```

```
$ perl generate-root-certs.pl out.h
Done (1 CA certs processed, 0 skipped).      # main: Root A emitted with B's trust
Parse error: no CKO_NSS_TRUST for "Root A" (next CKO_CERTIFICATE at input line 26)   # this PR
```

### Fix

```perl
# scan-forward: die on another CKO_CERTIFICATE or EOF before CKO_NSS_TRUST
# octal loop:   next if /^#/
# trust scan:   /^\s*CKA_TRUST_.../; die if zero CKA_TRUST_* lines read
# outer loop:   die on orphan CKO_NSS_TRUST
# end:          die if CKO_NSS_TRUST count != certnum + skipnum
```

### Verification

```
$ perl generate-root-certs.pl out.h   # against committed certdata.txt
Done (121 CA certs processed, 46 skipped).
$ md5sum out.h packages/bun-usockets/src/crypto/root_certs.h
962a4043fa3a41bf2f5b229499b8069b  out.h
962a4043fa3a41bf2f5b229499b8069b  packages/bun-usockets/src/crypto/root_certs.h
```

`test/regression/issue/31611.test.ts` gains seven generator fixtures (four die-cases, two tolerate-cases with DER byte-equality, one well-formed control). All seven fail against main's generator.

Related: #34553 changes this script's output to raw DER; whichever lands second will need the `runGenerator` output regex adjusted.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/31611.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (7b2a059e3)

test/regression/issue/31611.test.ts:
(pass) tls.rootCertificates contains every SERVER_AUTH TRUSTED_DELEGATOR from certdata.txt [224.18ms]
(pass) generate-root-certs.pl keeps roots with an inline trust-object comment (Izenpe.com) [159.25ms]
170 |         certObject("Repro Root A", CERT_OCTAL_A),
171 |         certObject("Repro Root B", CERT_OCTAL_B),
172 |         trustObject("Repro Root B", String.raw`\001\002`, TRUSTED),
173 |       ),
174 |     );
175 |     expect(stderr).toContain(`no CKO_NSS_TRUST for "Repro Root A"`);
                         ^
error: expect(received).toContain(expected)

Expected to contain: "no CKO_NSS_TRUST for \"Repro Root A\""
Received: "Done (1 CA certs processed, 0 skipped).\n"

      at
... (truncated)

release without fix: 7 FAILED
bun test v1.4.0-canary.1 (2031cea64)

test/regression/issue/31611.test.ts:
(pass) tls.rootCertificates contains every SERVER_AUTH TRUSTED_DELEGATOR from certdata.txt [9.95ms]
(pass) generate-root-certs.pl keeps roots with an inline trust-object comment (Izenpe.com) [14.57ms]
170 |         certObject("Repro Root A", CERT_OCTAL_A),
171 |         certObject("Repro Root B", CERT_OCTAL_B),
172 |         trustObject("Repro Root B", String.raw`\001\002`, TRUSTED),
173 |       ),
174 |     );
175 |     expect(stderr).toContain(`no CKO_NSS_TRUST for "Repro Root A"`);
                         ^
error: expect(received).toContain(expected)

Expected to contain: "no CKO_NSS_TRUST for \"Repro Root A\""
Received: "Done (1 CA certs processed, 0 skipped).\n"

      at <anonymous> (/workspace/bun/test/regression/issue/31611.test.ts:175:20)
(fail) generate-root-certs.pl fails loudly on malformed certdata > cert without a CKO_NSS_TRUST object is a hard error, not a silent swallow [19.80ms]
186 |         certObject("Repro Root A", CERT_OCTAL_A),
187 |         certObject("Repro Root B", CERT_OCTAL_B),
188 |         trustObject("Repro Root B", String.raw`\001\002`, TRUSTED),
189 |       )
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/31611.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (7b2a059e3)

test/regression/issue/31611.test.ts:
(pass) tls.rootCertificates contains every SERVER_AUTH TRUSTED_DELEGATOR from certdata.txt [127.11ms]
(pass) generate-root-certs.pl keeps roots with an inline trust-object comment (Izenpe.com) [91.89ms]
(pass) generate-root-certs.pl fails loudly on malformed certdata > cert without a CKO_NSS_TRUST object is a hard error, not a silent swallow [95.55ms]
(pass) generate-root-certs.pl fails loudly on malformed certdata > orphan CKO_NSS_TRUST before its cert is a hard error [106.39ms]
(pass) generate-root-certs.pl fails loudly on malformed certdata > trust object that ends before any CKA_TRUST_* line is a hard error [108.16ms]
(pass) generate-root-certs.pl fails loudly on malformed cer
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 794ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/28] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[2/28] gen cpp.rs (cppbind)
[3/28] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileS
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/generate-root-certs.pl |  36 ++++-
 test/regression/issue/31611.test.ts          | 213 ++++++++++++++++++++++++---
 2 files changed, 226 insertions(+), 23 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
packages/bun-usockets/generate-root-certs.pl      2      5      0
test/regression/issue/31611.test.ts               4     12      0
```

</details>

<!-- robobun:evidence:end -->