### PR TITLE
node:test: report t.test() after parent finished as a parentAlreadyFinished failure

### DIFF
--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -1652,6 +1652,9 @@ function runLateSubtest(
   if (!child.todoFlag && !child.skipped) {
     reportLateFailure(child.fullName, failure);
   }
+  // Node replaces a {skip:true} body with a noop, so a late skip's body never
+  // runs; a late todo's body does (Node runs todo bodies).
+  if (child.skipped) return Promise.resolve(undefined);
   // Node runs the body and awaits it; its outcome is discarded in favour of the
   // parentAlreadyFinished failure above, and the returned promise resolves. A
   // no-op done keeps a `(t, done)` body from throwing on `done()`.
@@ -1662,10 +1665,15 @@ function runLateSubtest(
       fn.length === 2 ? fn.$call(undefined, ctx, kDefaultFunction) : fn.$call(undefined, ctx),
     );
   } catch {}
-  return Promise.resolve(body).then(
-    () => undefined,
-    () => undefined,
-  );
+  // Mirror executeTestNode's cleanup so a late body's t.mock.method() does not
+  // leak into later tests (Node's postRun() resets mocks here too).
+  const settle = () => {
+    try {
+      child.mockTracker?.reset();
+    } catch {}
+    return undefined;
+  };
+  return Promise.resolve(body).then(settle, settle);
 }
 
 // Awaits a node's subtest chain, including links appended while waiting.

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -1640,8 +1640,9 @@ function runLateSubtest(
   mode: "skip" | "todo" | undefined,
   isSuite: boolean,
 ): Promise<undefined> {
+  // isExecutionPhase=true keeps isRunning() true without `started`, so a nested
+  // t.test() inside the body goes to scheduleSubtest instead of recursing here.
   const child = new TestNode(name, parent, options, isSuite, true);
-  child.finished = true;
   if (mode === "todo" || options.todo) child.todoFlag = true;
   if (mode === "skip" || options.skip) child.skipped = true;
   const failure = makeTestFailure("test could not be started because its parent finished");
@@ -1665,15 +1666,20 @@ function runLateSubtest(
       fn.length === 2 ? fn.$call(undefined, ctx, kDefaultFunction) : fn.$call(undefined, ctx),
     );
   } catch {}
-  // Mirror executeTestNode's cleanup so a late body's t.mock.method() does not
-  // leak into later tests (Node's postRun() resets mocks here too).
+  // Mirror executeTestNode: drain nested subtests the body scheduled, then
+  // reset mocks so a late body's t.mock.method() does not leak into later
+  // tests (Node's postRun() does both).
   const settle = () => {
+    child.finished = true;
     try {
       child.mockTracker?.reset();
     } catch {}
     return undefined;
   };
-  return Promise.resolve(body).then(settle, settle);
+  return Promise.resolve(body)
+    .catch(kDefaultFunction)
+    .then(() => drainSubtestChain(child))
+    .then(settle, settle);
 }
 
 // Awaits a node's subtest chain, including links appended while waiting.

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -922,6 +922,9 @@ const fileGeneration = $newRustFunction("jest.rs", "jsFileGeneration", 0);
 // `done` binds the intended sequence so a late call after the bun:test watchdog
 // moved on cannot write onto the currently-running test.
 const markCurrentResult = $newRustFunction("jest.rs", "jsNodeTestMarkResult", 2);
+// Books a late subtest's parentAlreadyFinished failure into the reporter so the
+// run prints it and exits 1. bun:test has no entry to fail for a late subtest.
+const reportLateFailure = $newRustFunction("jest.rs", "jsNodeTestReportLateFailure", 2);
 
 let rootNode: TestNode | undefined;
 let rootGeneration = -1;
@@ -1629,6 +1632,38 @@ function recordSuiteFailure(suite: TestNode, err: unknown) {
   suite.firstSubtestError ??= err ?? makeTestFailure("suite failed");
 }
 
+function runLateSubtest(
+  parent: TestNode,
+  name: string,
+  options: TestOptions,
+  fn: TestFn,
+  mode: "skip" | "todo" | undefined,
+  isSuite: boolean,
+): Promise<undefined> {
+  const child = new TestNode(name, parent, options, isSuite, true);
+  child.finished = true;
+  if (mode === "todo" || options.todo) child.todoFlag = true;
+  if (mode === "skip" || options.skip) child.skipped = true;
+  const failure = makeTestFailure("test could not be started because its parent finished");
+  (failure as { failureType?: string }).failureType = "parentAlreadyFinished";
+  child.error = failure;
+  // Node still counts a late skip/todo as skip/todo (exit 0); only a plain late
+  // subtest flips the run to failing.
+  if (!child.todoFlag && !child.skipped) {
+    reportLateFailure(child.fullName, failure);
+  }
+  // Node runs the body and awaits it; its outcome is discarded in favour of the
+  // parentAlreadyFinished failure above, and the returned promise resolves.
+  let body: unknown;
+  try {
+    body = runWithNode(child, () => fn.$call(undefined, isSuite ? child.getSuiteCtx() : child.getCtx()));
+  } catch {}
+  return Promise.resolve(body).then(
+    () => undefined,
+    () => undefined,
+  );
+}
+
 // Awaits a node's subtest chain, including links appended while waiting.
 async function drainSubtestChain(node: TestNode) {
   let chain;
@@ -1754,9 +1789,10 @@ function addTest(
   const runningNode = executionParent ?? currentNode();
   if (runningNode !== undefined) {
     if (runningNode.finished) {
-      // t.test() escaped its parent: Node fails the late subtest but resolves
-      // the promise; don't fall through to bun:test's internal-phase throw.
-      return Promise.resolve(undefined);
+      // t.test() escaped its parent: Node runs the body, fails the late subtest
+      // with parentAlreadyFinished (resolving the returned promise), and reports
+      // it at the root so the run exits 1.
+      return runLateSubtest(runningNode, name, options, fn, mode, false);
     }
     if (runningNode.isRunning()) {
       // Subtest of a running test (or of an inline suite created inside one).
@@ -1821,7 +1857,7 @@ function addSuite(
 
   const runningNode = executionParent ?? currentNode();
   if (runningNode !== undefined && runningNode.finished) {
-    return Promise.resolve(undefined);
+    return runLateSubtest(runningNode, name, options, fn, mode, true);
   }
   if (runningNode !== undefined && runningNode.isRunning()) {
     const suite = new TestNode(name, runningNode, options, true, true);

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -1653,10 +1653,14 @@ function runLateSubtest(
     reportLateFailure(child.fullName, failure);
   }
   // Node runs the body and awaits it; its outcome is discarded in favour of the
-  // parentAlreadyFinished failure above, and the returned promise resolves.
+  // parentAlreadyFinished failure above, and the returned promise resolves. A
+  // no-op done keeps a `(t, done)` body from throwing on `done()`.
+  const ctx = isSuite ? child.getSuiteCtx() : child.getCtx();
   let body: unknown;
   try {
-    body = runWithNode(child, () => fn.$call(undefined, isSuite ? child.getSuiteCtx() : child.getCtx()));
+    body = runWithNode(child, () =>
+      fn.length === 2 ? fn.$call(undefined, ctx, kDefaultFunction) : fn.$call(undefined, ctx),
+    );
   } catch {}
   return Promise.resolve(body).then(
     () => undefined,

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -631,9 +631,9 @@ pub(crate) fn js_node_test_report_late_failure(
     let mut line = Vec::<u8>::new();
     let display = bstr::BStr::new(name_slice.slice());
     if Output::enable_ansi_colors_stderr() {
-        let _ = write!(&mut line, "{} {}\n", Output::pretty_fmt::<true>("<r><red>✗<r>"), display);
+        let _ = writeln!(&mut line, "{} {}", Output::pretty_fmt::<true>("<r><red>✗<r>"), display);
     } else {
-        let _ = write!(&mut line, "{} {}\n", Output::pretty_fmt::<false>("<r><red>(fail)<r>"), display);
+        let _ = writeln!(&mut line, "{} {}", Output::pretty_fmt::<false>("<r><red>(fail)<r>"), display);
     }
     if let Some(idx) = worker_idx {
         crate::cli::test::parallel_runner::worker_emit_test_done(idx, &line);

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -629,12 +629,8 @@ pub(crate) fn js_node_test_report_late_failure(
         (rep, unsafe { (*rep.as_ptr()).worker_ipc_file_idx })
     };
     let mut line = Vec::<u8>::new();
-    let display = bstr::BStr::new(name_slice.slice());
-    if Output::enable_ansi_colors_stderr() {
-        let _ = writeln!(&mut line, "{} {}", Output::pretty_fmt::<true>("<r><red>✗<r>"), display);
-    } else {
-        let _ = writeln!(&mut line, "{} {}", Output::pretty_fmt::<false>("<r><red>(fail)<r>"), display);
-    }
+    crate::cli::test_command::write_test_status_line(super::execution::Result::Fail, &mut line);
+    let _ = writeln!(&mut line, " {}", bstr::BStr::new(name_slice.slice()));
     if let Some(idx) = worker_idx {
         crate::cli::test::parallel_runner::worker_emit_test_done(idx, &line);
     } else {

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -605,6 +605,51 @@ pub(crate) fn js_node_test_mark_result(
     Ok(JSValue::UNDEFINED)
 }
 
+/// Reached only from `node:test` when `t.test()` is called after its parent
+/// finished: Node fails the late subtest with `parentAlreadyFinished` and exits
+/// non-zero. bun:test has no entry for it, so book the failure here directly.
+pub(crate) fn js_node_test_report_late_failure(
+    global: &JSGlobalObject,
+    callframe: &CallFrame,
+) -> JsResult<JSValue> {
+    let [name, error] = callframe.arguments_as_array::<2>();
+    let name_slice = name.to_slice(global)?;
+    let Some(buntest_strong) = bun_test::clone_active_strong() else {
+        return Ok(JSValue::UNDEFINED);
+    };
+    let rep = {
+        // SAFETY: single-threaded JS VM; short-lived borrow for the
+        // reporter read and the on_before_print dot-break.
+        let buntest = unsafe { bun_test::buntest_as_mut(&buntest_strong) };
+        let Some(rep) = buntest.reporter else {
+            return Ok(JSValue::UNDEFINED);
+        };
+        buntest.bun_test_root.on_before_print();
+        rep
+    };
+    let mut line = Vec::<u8>::new();
+    let display = bstr::BStr::new(name_slice.slice());
+    if Output::enable_ansi_colors_stderr() {
+        let _ = write!(&mut line, "{} {}\n", Output::pretty_fmt::<true>("<r><red>✗<r>"), display);
+    } else {
+        let _ = write!(&mut line, "{} {}\n", Output::pretty_fmt::<false>("<r><red>(fail)<r>"), display);
+    }
+    let _ = Output::error_writer().write_all(&line);
+    Output::flush();
+    if !error.is_empty_or_undefined_or_null() {
+        global.bun_vm().as_mut().run_error_handler(error, None);
+        Output::flush();
+    }
+    // SAFETY: `BunTest.reporter` carries write provenance from `enter_file`'s
+    // `&mut`; single-threaded test runner, sole writer for this update.
+    let reporter: &mut CommandLineReporter = unsafe { &mut *rep.as_ptr() };
+    if !reporter.reporters.dots && !reporter.reporters.only_failures {
+        reporter.failures_to_repeat_buf.extend_from_slice(&line);
+    }
+    reporter.summary().fail += 1;
+    Ok(JSValue::UNDEFINED)
+}
+
 pub mod on_unhandled_rejection {
     use super::*;
 

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -634,19 +634,25 @@ pub(crate) fn js_node_test_report_late_failure(
     } else {
         let _ = write!(&mut line, "{} {}\n", Output::pretty_fmt::<false>("<r><red>(fail)<r>"), display);
     }
-    let _ = Output::error_writer().write_all(&line);
-    Output::flush();
+    {
+        // SAFETY: `BunTest.reporter` carries write provenance from `enter_file`'s
+        // `&mut`; single-threaded test runner, sole writer for this update.
+        let reporter: &mut CommandLineReporter = unsafe { &mut *rep.as_ptr() };
+        if let Some(idx) = reporter.worker_ipc_file_idx {
+            crate::cli::test::parallel_runner::worker_emit_test_done(idx, &line);
+        } else {
+            let _ = Output::error_writer().write_all(&line);
+            Output::flush();
+        }
+        if !reporter.reporters.dots && !reporter.reporters.only_failures {
+            reporter.failures_to_repeat_buf.extend_from_slice(&line);
+        }
+        reporter.summary().fail += 1;
+    }
     if !error.is_empty_or_undefined_or_null() {
         global.bun_vm().as_mut().run_error_handler(error, None);
         Output::flush();
     }
-    // SAFETY: `BunTest.reporter` carries write provenance from `enter_file`'s
-    // `&mut`; single-threaded test runner, sole writer for this update.
-    let reporter: &mut CommandLineReporter = unsafe { &mut *rep.as_ptr() };
-    if !reporter.reporters.dots && !reporter.reporters.only_failures {
-        reporter.failures_to_repeat_buf.extend_from_slice(&line);
-    }
-    reporter.summary().fail += 1;
     Ok(JSValue::UNDEFINED)
 }
 

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -617,7 +617,7 @@ pub(crate) fn js_node_test_report_late_failure(
     let Some(buntest_strong) = bun_test::clone_active_strong() else {
         return Ok(JSValue::UNDEFINED);
     };
-    let rep = {
+    let (rep, worker_idx) = {
         // SAFETY: single-threaded JS VM; short-lived borrow for the
         // reporter read and the on_before_print dot-break.
         let buntest = unsafe { bun_test::buntest_as_mut(&buntest_strong) };
@@ -625,7 +625,8 @@ pub(crate) fn js_node_test_report_late_failure(
             return Ok(JSValue::UNDEFINED);
         };
         buntest.bun_test_root.on_before_print();
-        rep
+        // SAFETY: same reporter write-provenance invariant as below.
+        (rep, unsafe { (*rep.as_ptr()).worker_ipc_file_idx })
     };
     let mut line = Vec::<u8>::new();
     let display = bstr::BStr::new(name_slice.slice());
@@ -634,24 +635,35 @@ pub(crate) fn js_node_test_report_late_failure(
     } else {
         let _ = write!(&mut line, "{} {}\n", Output::pretty_fmt::<false>("<r><red>(fail)<r>"), display);
     }
-    {
-        // SAFETY: `BunTest.reporter` carries write provenance from `enter_file`'s
-        // `&mut`; single-threaded test runner, sole writer for this update.
-        let reporter: &mut CommandLineReporter = unsafe { &mut *rep.as_ptr() };
-        if let Some(idx) = reporter.worker_ipc_file_idx {
-            crate::cli::test::parallel_runner::worker_emit_test_done(idx, &line);
-        } else {
-            let _ = Output::error_writer().write_all(&line);
-            Output::flush();
-        }
-        if !reporter.reporters.dots && !reporter.reporters.only_failures {
-            reporter.failures_to_repeat_buf.extend_from_slice(&line);
-        }
-        reporter.summary().fail += 1;
+    if let Some(idx) = worker_idx {
+        crate::cli::test::parallel_runner::worker_emit_test_done(idx, &line);
+    } else {
+        let _ = Output::error_writer().write_all(&line);
+        Output::flush();
     }
     if !error.is_empty_or_undefined_or_null() {
         global.bun_vm().as_mut().run_error_handler(error, None);
         Output::flush();
+    }
+    // No JUnit entry: `maybe_print_junit_line` needs a bun:test sequence/entry
+    // that a late subtest doesn't have (same as `unhandled_errors_between_tests`).
+    // SAFETY: `BunTest.reporter` carries write provenance from `enter_file`'s
+    // `&mut`; single-threaded test runner, sole writer for this update.
+    let reporter: &mut CommandLineReporter = unsafe { &mut *rep.as_ptr() };
+    if !reporter.reporters.dots && !reporter.reporters.only_failures {
+        reporter.failures_to_repeat_buf.extend_from_slice(&line);
+    }
+    reporter.summary().fail += 1;
+    if reporter.summary().fail == reporter.jest.bail {
+        reporter.print_summary();
+        bun_core::pretty_error!(
+            "\nBailed out after {} failure{}<r>\n",
+            reporter.jest.bail,
+            if reporter.jest.bail == 1 { "" } else { "s" }
+        );
+        Output::flush();
+        reporter.write_junit_report_if_needed();
+        bun_core::Global::exit(1);
     }
     Ok(JSValue::UNDEFINED)
 }

--- a/test/js/node/test_runner/fixtures/16-plan-and-late-subtest.js
+++ b/test/js/node/test_runner/fixtures/16-plan-and-late-subtest.js
@@ -22,7 +22,9 @@ test.describe("plan capture at first t.assert access", () => {
 
 // t.test() after the parent finished: Node fails the late subtest with
 // parentAlreadyFinished but resolves the returned promise (undefined); it must
-// not reject or fall through to bun:test's internal-phase throw.
+// not reject or fall through to bun:test's internal-phase throw. The late
+// subtest is also booked as a run failure; see fixture 25 for the exit-code
+// assertion. skip:true here keeps this fixture's own exit code at 0.
 test("late subtest after parent finished", async t => {
   let saved;
   await t.test("parent", pt => {
@@ -30,7 +32,7 @@ test("late subtest after parent finished", async t => {
   });
   let outcome;
   await saved
-    .test("late", () => {})
+    .test("late", { skip: true }, () => {})
     .then(
       v => (outcome = { resolved: true, value: v }),
       e => (outcome = { rejected: true, code: e?.code }),

--- a/test/js/node/test_runner/fixtures/25-late-subtest-failure.js
+++ b/test/js/node/test_runner/fixtures/25-late-subtest-failure.js
@@ -34,9 +34,18 @@ test("observer", async () => {
   });
   console.log("SUITE_BODY_RAN=" + String(suiteBodyRan));
   // A late skip/todo subtest is not counted as a failure (Node exits 0 for
-  // those); these must not add further fail entries to this run.
-  await saved.test("late-skip", { skip: true }, () => {});
-  await saved.test("late-todo", { todo: true }, () => {});
+  // those); these must not add further fail entries to this run. Node replaces
+  // a {skip:true} body with a noop, so it must not run; a {todo:true} body does.
+  let skipBodyRan = false;
+  let todoBodyRan = false;
+  await saved.test("late-skip", { skip: true }, () => {
+    skipBodyRan = true;
+  });
+  await saved.test("late-todo", { todo: true }, () => {
+    todoBodyRan = true;
+  });
+  console.log("SKIP_BODY_RAN=" + String(skipBodyRan));
+  console.log("TODO_BODY_RAN=" + String(todoBodyRan));
 });
 
 process.on("exit", () => {

--- a/test/js/node/test_runner/fixtures/25-late-subtest-failure.js
+++ b/test/js/node/test_runner/fixtures/25-late-subtest-failure.js
@@ -45,7 +45,7 @@ test("observer", async () => {
     todoBodyRan = true;
   });
   console.log("SKIP_BODY_RAN=" + String(skipBodyRan));
-  console.log("TODO_BODY_RAN=" + String(todoBodyRan));
+  console.log("MARKED_BODY_RAN=" + String(todoBodyRan));
 });
 
 process.on("exit", () => {

--- a/test/js/node/test_runner/fixtures/25-late-subtest-failure.js
+++ b/test/js/node/test_runner/fixtures/25-late-subtest-failure.js
@@ -7,6 +7,8 @@ const assert = require("node:assert");
 // fix, bun resolved the promise but dropped the failure and exited 0.
 let saved;
 let bodyRan = false;
+let doneBodyRan = false;
+let suiteBodyRan = false;
 let resolvedWith = "unset";
 
 test("parent", t => {
@@ -20,6 +22,17 @@ test("observer", async () => {
   resolvedWith = result;
   console.log("RESOLVED_WITH=" + String(resolvedWith));
   console.log("BODY_RAN=" + String(bodyRan));
+  // A (t, done) body must receive a callable done so the body runs to completion.
+  await saved.test("late-done", (_t, done) => {
+    done();
+    doneBodyRan = true;
+  });
+  console.log("DONE_BODY_RAN=" + String(doneBodyRan));
+  // t.describe() after the parent finished takes the same path (isSuite=true).
+  await saved.describe("late-suite", () => {
+    suiteBodyRan = true;
+  });
+  console.log("SUITE_BODY_RAN=" + String(suiteBodyRan));
   // A late skip/todo subtest is not counted as a failure (Node exits 0 for
   // those); these must not add further fail entries to this run.
   await saved.test("late-skip", { skip: true }, () => {});

--- a/test/js/node/test_runner/fixtures/25-late-subtest-failure.js
+++ b/test/js/node/test_runner/fixtures/25-late-subtest-failure.js
@@ -1,0 +1,32 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+
+// A t.test() that escapes its parent (the forgot-to-await shape): Node runs the
+// body, resolves the returned promise with undefined, and records the late
+// subtest as a parentAlreadyFinished failure so the run exits 1. Before the
+// fix, bun resolved the promise but dropped the failure and exited 0.
+let saved;
+let bodyRan = false;
+let resolvedWith = "unset";
+
+test("parent", t => {
+  saved = t;
+});
+
+test("observer", async () => {
+  const result = await saved.test("late", () => {
+    bodyRan = true;
+  });
+  resolvedWith = result;
+  console.log("RESOLVED_WITH=" + String(resolvedWith));
+  console.log("BODY_RAN=" + String(bodyRan));
+  // A late skip/todo subtest is not counted as a failure (Node exits 0 for
+  // those); these must not add further fail entries to this run.
+  await saved.test("late-skip", { skip: true }, () => {});
+  await saved.test("late-todo", { todo: true }, () => {});
+});
+
+process.on("exit", () => {
+  assert.strictEqual(bodyRan, true, "late subtest body must run (Node runs it)");
+  assert.strictEqual(resolvedWith, undefined, "late subtest promise must resolve to undefined");
+});

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -255,6 +255,8 @@ describe("node:test", () => {
     expect(stdout).toContain("BODY_RAN=true");
     expect(stdout).toContain("DONE_BODY_RAN=true");
     expect(stdout).toContain("SUITE_BODY_RAN=true");
+    expect(stdout).toContain("SKIP_BODY_RAN=false");
+    expect(stdout).toContain("TODO_BODY_RAN=true");
     expect(stderr).toContain("parent > late\n");
     expect(stderr).toContain("parent > late-done\n");
     expect(stderr).toContain("parent > late-suite\n");

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -256,7 +256,7 @@ describe("node:test", () => {
     expect(stdout).toContain("DONE_BODY_RAN=true");
     expect(stdout).toContain("SUITE_BODY_RAN=true");
     expect(stdout).toContain("SKIP_BODY_RAN=false");
-    expect(stdout).toContain("TODO_BODY_RAN=true");
+    expect(stdout).toContain("MARKED_BODY_RAN=true");
     expect(stderr).toContain("parent > late\n");
     expect(stderr).toContain("parent > late-done\n");
     expect(stderr).toContain("parent > late-suite\n");

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -253,13 +253,16 @@ describe("node:test", () => {
     const { exitCode, stdout, stderr } = await runTests(["25-late-subtest-failure.js"]);
     expect(stdout).toContain("RESOLVED_WITH=undefined");
     expect(stdout).toContain("BODY_RAN=true");
+    expect(stdout).toContain("DONE_BODY_RAN=true");
+    expect(stdout).toContain("SUITE_BODY_RAN=true");
     expect(stderr).toContain("parent > late");
+    expect(stderr).toContain("parent > late-suite");
     expect(stderr).toContain("test could not be started because its parent finished");
-    // Only the plain late subtest fails; the late skip/todo ones do not.
+    // Only the plain late subtests fail; the late skip/todo ones do not.
     expect(stderr).toContain("2 pass");
     expect({ exitCode, stderr }).toMatchObject({
       exitCode: 1,
-      stderr: expect.stringContaining("1 fail"),
+      stderr: expect.stringContaining("3 fail"),
     });
   });
 

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -249,6 +249,20 @@ describe("node:test", () => {
     });
   });
 
+  test("should fail the run when t.test() is called after its parent finished", async () => {
+    const { exitCode, stdout, stderr } = await runTests(["25-late-subtest-failure.js"]);
+    expect(stdout).toContain("RESOLVED_WITH=undefined");
+    expect(stdout).toContain("BODY_RAN=true");
+    expect(stderr).toContain("parent > late");
+    expect(stderr).toContain("test could not be started because its parent finished");
+    // Only the plain late subtest fails; the late skip/todo ones do not.
+    expect(stderr).toContain("2 pass");
+    expect({ exitCode, stderr }).toMatchObject({
+      exitCode: 1,
+      stderr: expect.stringContaining("1 fail"),
+    });
+  });
+
   test("should resolve the promise of a test that a name pattern filters out", async () => {
     const { exitCode, stderr } = await runTests(["23-filtered-test-promise.js"], {}, ["-t", "should resolve"]);
     expect(stderr).not.toContain("timed out");

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -255,10 +255,13 @@ describe("node:test", () => {
     expect(stdout).toContain("BODY_RAN=true");
     expect(stdout).toContain("DONE_BODY_RAN=true");
     expect(stdout).toContain("SUITE_BODY_RAN=true");
-    expect(stderr).toContain("parent > late");
-    expect(stderr).toContain("parent > late-suite");
+    expect(stderr).toContain("parent > late\n");
+    expect(stderr).toContain("parent > late-done\n");
+    expect(stderr).toContain("parent > late-suite\n");
     expect(stderr).toContain("test could not be started because its parent finished");
     // Only the plain late subtests fail; the late skip/todo ones do not.
+    expect(stderr).not.toContain("parent > late-skip");
+    expect(stderr).not.toContain("parent > late-todo");
     expect(stderr).toContain("2 pass");
     expect({ exitCode, stderr }).toMatchObject({
       exitCode: 1,


### PR DESCRIPTION
When `t.test()` is called after its parent test already finished (the typical forgot-to-await shape), Node runs the body, resolves the returned promise with `undefined`, and records the late subtest as a failed test with `failureType: 'parentAlreadyFinished'` so the run exits 1. Bun resolved the promise but dropped the late subtest entirely, so a suite that Node fails red would pass green.

## Repro

```js
// bun test file.mjs   vs   node --test file.mjs
import { test } from 'node:test';
test('parent', async (t) => {
  setTimeout(async () => {
    const p = t.test('late subtest', () => { console.log('LOG:late-body-ran'); });
    try { await p; console.log('LOG:await=resolved'); }
    catch (e) { console.log('LOG:await=rejected code=' + e.code); }
  }, 30);
});
test('keepalive', async () => { await new Promise(r => setTimeout(r, 150)); });
```

Node v26.3.0: `LOG:late-body-ran`, `✖ late subtest` with `test could not be started because its parent finished`, pass 2 / fail 1, exit 1.
Bun (before): `LOG:await=resolved`, body never runs, `2 pass / 0 fail`, exit 0.

## Cause

`addTest()` in `src/js/node/test.ts` returned `Promise.resolve(undefined)` when `runningNode.finished` without booking the failure into the run results. The adjacent comment noted Node fails the late subtest but nothing recorded it.

## Fix

`addTest()`/`addSuite()` now route the late subtest through `runLateSubtest()`, which runs the body (as Node does), discards its outcome, and calls a new native hook `js_node_test_report_late_failure` in `jest.rs` to print a `(fail) <name>` line with the error and bump the reporter's fail counter so the run exits 1. Late `skip`/`todo` subtests are left alone (Node exits 0 for those too).

## Verification

Bun (after):
```
(pass) parent
(fail) parent > late subtest
error: test could not be started because its parent finished
 failureType: "parentAlreadyFinished",
       code: "ERR_TEST_FAILURE"
LOG:late-body-ran
LOG:await=resolved
(pass) keepalive
 2 pass
 1 fail
EXIT=1
```

New `test/js/node/test_runner/fixtures/25-late-subtest-failure.js` covers body-runs + promise-resolves + fail-count + exit-1. All 41 cases in `node-test.test.ts` pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/test_runner/node-test.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b7234910c)

test/js/node/test_runner/node-test.test.ts:
killed 1 dangling process
(fail) node:test > should run basic tests [5000.64ms]
  ^ this test timed out after 5000ms.

# Unhandled error between tests
-------------------------------
4 | import { join } from "node:path";
5 | 
6 | describe("node:test", () => {
7 |   test("should run basic tests", async () => {
8 |     const { exitCode, stderr } = await runTests(["01-harness.js"]);
9 |     expect({ exitCode, stderr }).toMatchObject({
                                     ^
error: expect(received).toMatchObject(expected)

  {
-   "exitCode": 0,
-   "stderr": StringContaining "0 fail",
+   "exitCode": 143,
+   "stderr": 
+ "
+ test/js/node/test_runner/fixtures/01-harness.js
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (274b5fe9f)

test/js/node/test_runner/node-test.test.ts:
(pass) node:test > should run basic tests [98.21ms]
(pass) node:test > should run hooks in the right order [76.39ms]
(pass) node:test > should run tests with different variations [52.63ms]
(pass) node:test > should run async tests [116.00ms]
(pass) node:test > should run all tests from multiple files [123.06ms]
(pass) node:test > should run test() and describe() called inside another test() as subtests [49.95ms]
(pass) node:test > should run before hooks created on a running test once and validate hook options [56.80ms]
(pass) node:test > should fail tests whose hooks, bodies, or inline suite callbacks fail [56.08ms]
(pass) node:test > should support done callbacks in tests and hooks [51.40ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip and keep runner timers real under mock timers [55.59ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip under --concurrent too [68.62ms]
(pass) node:test > should run todo bodies under --todo instead of registering an empty function [54.48ms]
(pass) node:test > should forward Infinity and finite timeouts
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/test_runner/node-test.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b7234910c)

test/js/node/test_runner/node-test.test.ts:
(pass) node:test > should run basic tests [4672.57ms]
(pass) node:test > should run hooks in the right order [4918.87ms]
(pass) node:test > should run tests with different variations [4565.82ms]
(pass) node:test > should run async tests [3597.10ms]
(pass) node:test > should run all tests from multiple files [4552.20ms]
(pass) node:test > should run test() and describe() called inside another test() as subtests [3770.41ms]
(pass) node:test > should run before hooks created on a running test once and validate hook options [4488.83ms]
(pass) node:test > should fail tests whose hooks, bodies, or inline suite callbacks fail [4206.45ms]
(pass) node:test > should support done
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 1285ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[2/21] gen JS modules (bundle-modules)
Preprocess modules (8041ms)
Bundle modules (68ms)
Postprocesss modules (140ms)
Bundle Functions (1142ms)
Generate Code (111ms)

[9.52s] Bundled "src/js" for production
  2037 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nig
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/test.ts                                | 62 ++++++++++++++++++++--
 src/runtime/test_runner/jest.rs                    | 59 ++++++++++++++++++++
 .../fixtures/16-plan-and-late-subtest.js           |  6 ++-
 .../fixtures/25-late-subtest-failure.js            | 54 +++++++++++++++++++
 test/js/node/test_runner/node-test.test.ts         | 22 ++++++++
 5 files changed, 197 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/node/test.ts                                          16     11      0
src/runtime/test_runner/jest.rs                              11      8      0
…s/node/test_runner/fixtures/16-plan-and-late-subtest.js      1      1      0
…js/node/test_runner/fixtures/25-late-subtest-failure.js      3      4      0
test/js/node/test_runner/node-test.test.ts                    6      6      0
```

</details>

<!-- robobun:evidence:end -->