### PR TITLE
node:path: use Unicode toLowerCase for win32.relative case-insensitive compare

### DIFF
--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -2690,9 +2690,7 @@ pub(crate) fn relative_windows_t<'a, T: PathCharCwd>(
                 }
                 v
             };
-            if i == 0 {
-                to_orig_slice.to_vec()
-            } else if i == length {
+            if i == length {
                 if to_seg_count > length {
                     join_tail(&to_segs[i..])
                 } else if from_seg_count > length {
@@ -2700,6 +2698,8 @@ pub(crate) fn relative_windows_t<'a, T: PathCharCwd>(
                 } else {
                     Vec::new()
                 }
+            } else if i == 0 {
+                to_orig_slice.to_vec()
             } else {
                 let mut v = dotdots(from_seg_count - i, true);
                 v.extend_from_slice(&join_tail(&to_segs[i..]));

--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -161,19 +161,32 @@ fn to_lower_t<T: PathCharCwd>(a_c: T) -> T {
     }
 }
 
-/// Unicode-lowercase a Windows path for case-insensitive comparison, matching
-/// JS `String.prototype.toLowerCase` as used by Node's `path.win32.relative`.
-/// ASCII bytes are folded per-byte; multi-byte WTF-8 is decoded and re-encoded.
+/// True iff every code unit is ASCII.
+#[inline]
+fn is_all_ascii_t<T: PathCharCwd>(s: &[T]) -> bool {
+    if T::IS_U16 {
+        return s.iter().all(|c| c.as_u32() < 0x80);
+    }
+    strings::is_all_ascii(bytemuck::cast_slice::<T, u8>(s))
+}
+
+/// Unicode-lowercase a path segment for case-insensitive comparison, matching
+/// JS `String.prototype.toLowerCase` (including the Final_Sigma Σ→ς rule) as
+/// used by Node's `path.win32.relative`.
 fn lowercase_windows_path_t<T: PathCharCwd>(src: &[T]) -> Vec<T> {
-    let mut out: Vec<T> = Vec::with_capacity(src.len());
     if T::IS_U16 {
         // The u16 instantiation is unreachable at runtime (all JS entry
         // points convert to UTF-8 and use T = u8); fold ASCII so the
         // generic body type-checks and behaves soundly if ever exercised.
-        out.extend(src.iter().map(|c| to_lower_t(*c)));
-        return out;
+        return src.iter().map(|c| to_lower_t(*c)).collect();
     }
     let bytes: &[u8] = bytemuck::cast_slice::<T, u8>(src);
+    // Valid UTF-8: str::to_lowercase implements Final_Sigma like JS.
+    if let Some(s) = strings::str_utf8(bytes) {
+        return s.to_lowercase().into_bytes().into_iter().map(T::from_u8).collect();
+    }
+    // WTF-8 with an unpaired surrogate: fall back to per-codepoint fold.
+    let mut out: Vec<T> = Vec::with_capacity(bytes.len());
     let mut i = 0usize;
     while i < bytes.len() {
         let b = bytes[i];
@@ -2622,24 +2635,10 @@ pub(crate) fn relative_windows_t<'a, T: PathCharCwd>(
         return Ok(&[]);
     }
 
-    // Node lowercases the resolved paths with StringPrototypeToLowerCase and
-    // performs all comparison/index math on the lowered copies; only the
-    // output tail is sliced from the original toOrig.
-    let from_lower_vec = lowercase_windows_path_t(from_orig);
-    let to_lower_vec = lowercase_windows_path_t(&buf[0..to_orig_len]);
-    let from_lower = from_lower_vec.as_slice();
-    let to_lower = to_lower_vec.as_slice();
-    let from_lower_len = from_lower.len();
-    let to_lower_len = to_lower.len();
-
-    if from_lower == to_lower {
-        return Ok(&[]);
-    }
-
-    if from_lower_len != from_orig.len() || to_lower_len != to_orig_len {
-        // toLowerCase changed the byte length (e.g. İ → i̇); the index-based
-        // comparison below would misalign against toOrig. Fall back to
-        // per-segment comparison, matching Node's handling of this case.
+    // Node lowercases the resolved paths with StringPrototypeToLowerCase before
+    // comparing. For non-ASCII input that fold can shift '\' byte offsets, so
+    // route any non-ASCII path through per-segment comparison (as Node does).
+    if !is_all_ascii_t(from_orig) || !is_all_ascii_t(&buf[0..to_orig_len]) {
         let bslash = T::from_u8(CHAR_BACKWARD_SLASH);
         let out: Vec<T> = {
             let to_orig_slice = &buf[0..to_orig_len];
@@ -2705,15 +2704,21 @@ pub(crate) fn relative_windows_t<'a, T: PathCharCwd>(
         return Ok(&buf[0..n]);
     }
 
+    // Both paths are all-ASCII: the per-byte ASCII fold below is exact.
+    if eql_ignore_case_t(from_orig, &buf[0..to_orig_len]) {
+        return Ok(&[]);
+    }
+    let from_orig_len = from_orig.len();
+
     // Trim leading backslashes
     let mut from_start: usize = 0;
-    while from_start < from_lower_len && from_lower[from_start] == T::from_u8(CHAR_BACKWARD_SLASH) {
+    while from_start < from_orig_len && from_orig[from_start] == T::from_u8(CHAR_BACKWARD_SLASH) {
         from_start += 1;
     }
 
     // Trim trailing backslashes (applicable to UNC paths only)
-    let mut from_end = from_lower_len;
-    while from_end - 1 > from_start && from_lower[from_end - 1] == T::from_u8(CHAR_BACKWARD_SLASH) {
+    let mut from_end = from_orig_len;
+    while from_end - 1 > from_start && from_orig[from_end - 1] == T::from_u8(CHAR_BACKWARD_SLASH) {
         from_end -= 1;
     }
 
@@ -2721,13 +2726,13 @@ pub(crate) fn relative_windows_t<'a, T: PathCharCwd>(
 
     // Trim leading backslashes
     let mut to_start: usize = 0;
-    while to_start < to_lower_len && to_lower[to_start] == T::from_u8(CHAR_BACKWARD_SLASH) {
+    while to_start < to_orig_len && buf[to_start] == T::from_u8(CHAR_BACKWARD_SLASH) {
         to_start += 1;
     }
 
     // Trim trailing backslashes (applicable to UNC paths only)
-    let mut to_end = to_lower_len;
-    while to_end - 1 > to_start && to_lower[to_end - 1] == T::from_u8(CHAR_BACKWARD_SLASH) {
+    let mut to_end = to_orig_len;
+    while to_end - 1 > to_start && buf[to_end - 1] == T::from_u8(CHAR_BACKWARD_SLASH) {
         to_end -= 1;
     }
 
@@ -2743,8 +2748,8 @@ pub(crate) fn relative_windows_t<'a, T: PathCharCwd>(
     {
         let mut i: usize = 0;
         while i < smallest_length {
-            let from_byte = from_lower[from_start + i];
-            if from_byte != to_lower[to_start + i] {
+            let from_byte = from_orig[from_start + i];
+            if to_lower_t(from_byte) != to_lower_t(buf[to_start + i]) {
                 break;
             } else if from_byte == T::from_u8(CHAR_BACKWARD_SLASH) {
                 last_common_sep = Some(i);
@@ -2762,7 +2767,7 @@ pub(crate) fn relative_windows_t<'a, T: PathCharCwd>(
         }
     } else {
         if to_len > smallest_length {
-            if to_lower[to_start + smallest_length] == T::from_u8(CHAR_BACKWARD_SLASH) {
+            if buf[to_start + smallest_length] == T::from_u8(CHAR_BACKWARD_SLASH) {
                 // We get here if `from` is the exact base path for `to`.
                 // For example: from='C:\foo\bar'; to='C:\foo\bar\baz'
                 return Ok(&buf[to_start + smallest_length + 1..to_orig_len]);
@@ -2774,7 +2779,7 @@ pub(crate) fn relative_windows_t<'a, T: PathCharCwd>(
             }
         }
         if from_len > smallest_length {
-            if from_lower[from_start + smallest_length] == T::from_u8(CHAR_BACKWARD_SLASH) {
+            if from_orig[from_start + smallest_length] == T::from_u8(CHAR_BACKWARD_SLASH) {
                 // We get here if `to` is the exact base path for `from`.
                 // For example: from='C:\foo\bar'; to='C:\foo'
                 last_common_sep = Some(smallest_length);
@@ -2800,7 +2805,7 @@ pub(crate) fn relative_windows_t<'a, T: PathCharCwd>(
         // and `from`.
         let mut i: usize = from_start + last_common_sep.map_or(0, |v| v + 1);
         while i <= from_end {
-            if i == from_end || from_lower[i] == T::from_u8(CHAR_BACKWARD_SLASH) {
+            if i == from_end || from_orig[i] == T::from_u8(CHAR_BACKWARD_SLASH) {
                 // Translated from the following JS code:
                 //   out += out.length === 0 ? '..' : '\\..';
                 if out_len > 0 {

--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -161,6 +161,54 @@ fn to_lower_t<T: PathCharCwd>(a_c: T) -> T {
     }
 }
 
+/// Unicode-lowercase a Windows path for case-insensitive comparison, matching
+/// JS `String.prototype.toLowerCase` as used by Node's `path.win32.relative`.
+/// ASCII bytes are folded per-byte; multi-byte WTF-8 is decoded and re-encoded.
+fn lowercase_windows_path_t<T: PathCharCwd>(src: &[T]) -> Vec<T> {
+    let mut out: Vec<T> = Vec::with_capacity(src.len());
+    if T::IS_U16 {
+        // The u16 instantiation is unreachable at runtime (all JS entry
+        // points convert to UTF-8 and use T = u8); fold ASCII so the
+        // generic body type-checks and behaves soundly if ever exercised.
+        out.extend(src.iter().map(|c| to_lower_t(*c)));
+        return out;
+    }
+    let bytes: &[u8] = bytemuck::cast_slice::<T, u8>(src);
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b < 0x80 {
+            out.push(T::from_u8(b.to_ascii_lowercase()));
+            i += 1;
+            continue;
+        }
+        let seq_len = strings::wtf8_byte_sequence_length(b) as usize;
+        let avail = (bytes.len() - i).min(4);
+        let mut quad = [0u8; 4];
+        quad[..avail].copy_from_slice(&bytes[i..i + avail]);
+        let cp = strings::decode_wtf8_rune_t::<u32>(quad, seq_len as u8, 0);
+        let consumed = seq_len.min(avail).max(1);
+        match char::from_u32(cp).filter(|_| cp != 0) {
+            Some(ch) => {
+                let mut enc = [0u8; 4];
+                for lc in ch.to_lowercase() {
+                    let n = strings::encode_wtf8_rune(&mut enc, lc as u32);
+                    for &eb in &enc[..n] {
+                        out.push(T::from_u8(eb));
+                    }
+                }
+            }
+            None => {
+                for &rb in &bytes[i..i + consumed] {
+                    out.push(T::from_u8(rb));
+                }
+            }
+        }
+        i += consumed;
+    }
+    out
+}
+
 // `jsc.Node.Maybe([]T, Syscall.Error)` → bun_sys::Result<&mut [T]>
 type MaybeBuf<'a, T> = bun_sys::Result<&'a mut [T]>;
 // `jsc.Node.Maybe([:0]const T, Syscall.Error)` → bun_sys::Result<&[T]>
@@ -2553,7 +2601,6 @@ pub(crate) fn relative_windows_t<'a, T: PathCharCwd>(
 
     // Backed by expandable buf2 because fromOrig may be long.
     let from_orig = resolve_windows_t(&[from], buf2, buf3)?;
-    let from_orig_len = from_orig.len();
     // Backed by buf.
     // Borrowck: resolve into buf, then operate via raw indices.
     // resolve_*_t may return a 'static literal (".") instead of a sub-slice of
@@ -2571,19 +2618,102 @@ pub(crate) fn relative_windows_t<'a, T: PathCharCwd>(
         len
     };
 
-    if from_orig == &buf[0..to_orig_len] || eql_ignore_case_t(from_orig, &buf[0..to_orig_len]) {
+    if from_orig == &buf[0..to_orig_len] {
         return Ok(&[]);
+    }
+
+    // Node lowercases the resolved paths with StringPrototypeToLowerCase and
+    // performs all comparison/index math on the lowered copies; only the
+    // output tail is sliced from the original toOrig.
+    let from_lower_vec = lowercase_windows_path_t(from_orig);
+    let to_lower_vec = lowercase_windows_path_t(&buf[0..to_orig_len]);
+    let from_lower = from_lower_vec.as_slice();
+    let to_lower = to_lower_vec.as_slice();
+    let from_lower_len = from_lower.len();
+    let to_lower_len = to_lower.len();
+
+    if from_lower == to_lower {
+        return Ok(&[]);
+    }
+
+    if from_lower_len != from_orig.len() || to_lower_len != to_orig_len {
+        // toLowerCase changed the byte length (e.g. İ → i̇); the index-based
+        // comparison below would misalign against toOrig. Fall back to
+        // per-segment comparison, matching Node's handling of this case.
+        let bslash = T::from_u8(CHAR_BACKWARD_SLASH);
+        let out: Vec<T> = {
+            let to_orig_slice = &buf[0..to_orig_len];
+            let mut from_segs: Vec<&[T]> = from_orig.split(|c| *c == bslash).collect();
+            if matches!(from_segs.last(), Some(s) if s.is_empty()) {
+                from_segs.pop();
+            }
+            let mut to_segs: Vec<&[T]> = to_orig_slice.split(|c| *c == bslash).collect();
+            if matches!(to_segs.last(), Some(s) if s.is_empty()) {
+                to_segs.pop();
+            }
+            let from_seg_count = from_segs.len();
+            let to_seg_count = to_segs.len();
+            let length = from_seg_count.min(to_seg_count);
+            let mut i = 0usize;
+            while i < length {
+                if lowercase_windows_path_t(from_segs[i]) != lowercase_windows_path_t(to_segs[i]) {
+                    break;
+                }
+                i += 1;
+            }
+            let dot = T::from_u8(CHAR_DOT);
+            let dotdots = |n: usize, trailing_sep: bool| -> Vec<T> {
+                let mut v = Vec::with_capacity(n * 3);
+                for k in 0..n {
+                    v.push(dot);
+                    v.push(dot);
+                    if trailing_sep || k + 1 < n {
+                        v.push(bslash);
+                    }
+                }
+                v
+            };
+            let join_tail = |segs: &[&[T]]| -> Vec<T> {
+                let mut v = Vec::new();
+                for (k, seg) in segs.iter().enumerate() {
+                    if k > 0 {
+                        v.push(bslash);
+                    }
+                    v.extend_from_slice(seg);
+                }
+                v
+            };
+            if i == 0 {
+                to_orig_slice.to_vec()
+            } else if i == length {
+                if to_seg_count > length {
+                    join_tail(&to_segs[i..])
+                } else if from_seg_count > length {
+                    dotdots(from_seg_count - i, false)
+                } else {
+                    Vec::new()
+                }
+            } else {
+                let mut v = dotdots(from_seg_count - i, true);
+                v.extend_from_slice(&join_tail(&to_segs[i..]));
+                v
+            }
+        };
+        let n = out.len();
+        buf[0..n].copy_from_slice(&out);
+        buf[n] = T::default();
+        return Ok(&buf[0..n]);
     }
 
     // Trim leading backslashes
     let mut from_start: usize = 0;
-    while from_start < from_orig_len && from_orig[from_start] == T::from_u8(CHAR_BACKWARD_SLASH) {
+    while from_start < from_lower_len && from_lower[from_start] == T::from_u8(CHAR_BACKWARD_SLASH) {
         from_start += 1;
     }
 
     // Trim trailing backslashes (applicable to UNC paths only)
-    let mut from_end = from_orig_len;
-    while from_end - 1 > from_start && from_orig[from_end - 1] == T::from_u8(CHAR_BACKWARD_SLASH) {
+    let mut from_end = from_lower_len;
+    while from_end - 1 > from_start && from_lower[from_end - 1] == T::from_u8(CHAR_BACKWARD_SLASH) {
         from_end -= 1;
     }
 
@@ -2591,13 +2721,13 @@ pub(crate) fn relative_windows_t<'a, T: PathCharCwd>(
 
     // Trim leading backslashes
     let mut to_start: usize = 0;
-    while to_start < to_orig_len && buf[to_start] == T::from_u8(CHAR_BACKWARD_SLASH) {
+    while to_start < to_lower_len && to_lower[to_start] == T::from_u8(CHAR_BACKWARD_SLASH) {
         to_start += 1;
     }
 
     // Trim trailing backslashes (applicable to UNC paths only)
-    let mut to_end = to_orig_len;
-    while to_end - 1 > to_start && buf[to_end - 1] == T::from_u8(CHAR_BACKWARD_SLASH) {
+    let mut to_end = to_lower_len;
+    while to_end - 1 > to_start && to_lower[to_end - 1] == T::from_u8(CHAR_BACKWARD_SLASH) {
         to_end -= 1;
     }
 
@@ -2613,8 +2743,8 @@ pub(crate) fn relative_windows_t<'a, T: PathCharCwd>(
     {
         let mut i: usize = 0;
         while i < smallest_length {
-            let from_byte = from_orig[from_start + i];
-            if to_lower_t(from_byte) != to_lower_t(buf[to_start + i]) {
+            let from_byte = from_lower[from_start + i];
+            if from_byte != to_lower[to_start + i] {
                 break;
             } else if from_byte == T::from_u8(CHAR_BACKWARD_SLASH) {
                 last_common_sep = Some(i);
@@ -2632,7 +2762,7 @@ pub(crate) fn relative_windows_t<'a, T: PathCharCwd>(
         }
     } else {
         if to_len > smallest_length {
-            if buf[to_start + smallest_length] == T::from_u8(CHAR_BACKWARD_SLASH) {
+            if to_lower[to_start + smallest_length] == T::from_u8(CHAR_BACKWARD_SLASH) {
                 // We get here if `from` is the exact base path for `to`.
                 // For example: from='C:\foo\bar'; to='C:\foo\bar\baz'
                 return Ok(&buf[to_start + smallest_length + 1..to_orig_len]);
@@ -2644,7 +2774,7 @@ pub(crate) fn relative_windows_t<'a, T: PathCharCwd>(
             }
         }
         if from_len > smallest_length {
-            if from_orig[from_start + smallest_length] == T::from_u8(CHAR_BACKWARD_SLASH) {
+            if from_lower[from_start + smallest_length] == T::from_u8(CHAR_BACKWARD_SLASH) {
                 // We get here if `to` is the exact base path for `from`.
                 // For example: from='C:\foo\bar'; to='C:\foo'
                 last_common_sep = Some(smallest_length);
@@ -2670,7 +2800,7 @@ pub(crate) fn relative_windows_t<'a, T: PathCharCwd>(
         // and `from`.
         let mut i: usize = from_start + last_common_sep.map_or(0, |v| v + 1);
         while i <= from_end {
-            if i == from_end || from_orig[i] == T::from_u8(CHAR_BACKWARD_SLASH) {
+            if i == from_end || from_lower[i] == T::from_u8(CHAR_BACKWARD_SLASH) {
                 // Translated from the following JS code:
                 //   out += out.length === 0 ? '..' : '\\..';
                 if out_len > 0 {

--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -2648,12 +2648,15 @@ pub(crate) fn relative_windows_t<'a, T: PathCharCwd>(
         let out: Vec<T> = {
             let to_orig_slice = &buf[0..to_orig_len];
             let mut from_segs: Vec<&[T]> = from_orig.split(|c| *c == bslash).collect();
-            if matches!(from_segs.last(), Some(s) if s.is_empty()) {
-                from_segs.pop();
-            }
             let mut to_segs: Vec<&[T]> = to_orig_slice.split(|c| *c == bslash).collect();
-            if matches!(to_segs.last(), Some(s) if s.is_empty()) {
-                to_segs.pop();
+            // Drop leading empties (UNC '\\' prefix) so different UNC roots
+            // hit the i==0 guard, and drop a trailing empty (root '\').
+            for segs in [&mut from_segs, &mut to_segs] {
+                if matches!(segs.last(), Some(s) if s.is_empty()) {
+                    segs.pop();
+                }
+                let skip = segs.iter().take_while(|s| s.is_empty()).count();
+                segs.drain(0..skip);
             }
             let from_seg_count = from_segs.len();
             let to_seg_count = to_segs.len();

--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -183,7 +183,12 @@ fn lowercase_windows_path_t<T: PathCharCwd>(src: &[T]) -> Vec<T> {
     let bytes: &[u8] = bytemuck::cast_slice::<T, u8>(src);
     // Valid UTF-8: str::to_lowercase implements Final_Sigma like JS.
     if let Some(s) = strings::str_utf8(bytes) {
-        return s.to_lowercase().into_bytes().into_iter().map(T::from_u8).collect();
+        return s
+            .to_lowercase()
+            .into_bytes()
+            .into_iter()
+            .map(T::from_u8)
+            .collect();
     }
     // WTF-8 with an unpaired surrogate: fall back to per-codepoint fold.
     let mut out: Vec<T> = Vec::with_capacity(bytes.len());

--- a/test/js/node/path/relative.test.js
+++ b/test/js/node/path/relative.test.js
@@ -74,9 +74,6 @@ describe("path.relative", () => {
           ["\\\\É\\bar", "\\\\é\\BAR\\x", "x"],
           ["\\\\foo\\É", "\\\\foo\\baz", "..\\baz"],
           ["\\\\foo\\É\\a", "\\\\foo\\é\\b", "..\\b"],
-          // One side resolves to a bare '\' (degenerate but reachable).
-          ["C:\\É", "\\\\", "..\\.."],
-          ["\\\\", "\\\\É\\bar", "É\\bar"],
         ],
       ],
       [

--- a/test/js/node/path/relative.test.js
+++ b/test/js/node/path/relative.test.js
@@ -74,6 +74,9 @@ describe("path.relative", () => {
           ["\\\\É\\bar", "\\\\é\\BAR\\x", "x"],
           ["\\\\foo\\É", "\\\\foo\\baz", "..\\baz"],
           ["\\\\foo\\É\\a", "\\\\foo\\é\\b", "..\\b"],
+          // One side resolves to a bare '\' (degenerate but reachable).
+          ["C:\\É", "\\\\", "..\\.."],
+          ["\\\\", "\\\\É\\bar", "É\\bar"],
         ],
       ],
       [

--- a/test/js/node/path/relative.test.js
+++ b/test/js/node/path/relative.test.js
@@ -35,6 +35,30 @@ describe("path.relative", () => {
           ["\\\\foo\\baz", "\\\\foo\\baz-quux", "..\\baz-quux"],
           ["C:\\baz", "\\\\foo\\bar\\baz", "\\\\foo\\bar\\baz"],
           ["\\\\foo\\bar\\baz", "C:\\baz", "C:\\baz"],
+          // Case-insensitive comparison must fold non-ASCII letters too
+          // (Node lowercases the whole resolved path with toLowerCase).
+          ["C:\\é", "C:\\É", ""],
+          ["C:\\É", "C:\\é", ""],
+          ["C:\\aéb", "C:\\AÉB", ""],
+          ["C:\\é\\x", "C:\\É\\y", "..\\y"],
+          ["C:\\É\\x", "C:\\é\\y", "..\\y"],
+          ["C:\\a\\Å\\b", "C:\\A\\å\\c", "..\\c"],
+          ["C:\\Ф", "C:\\ф", ""],
+          ["C:\\ф\\x", "C:\\Ф\\y", "..\\y"],
+          ["C:\\É", "C:\\É\\sub", "sub"],
+          ["C:\\É\\sub", "C:\\é", ".."],
+          // toLowerCase is not full case-folding: ß stays ß, so ß ≠ SS.
+          ["C:\\ß", "C:\\SS", "..\\SS"],
+          // Length-changing toLowerCase (İ → i̇, Ⱥ → ⱥ) takes the
+          // per-segment comparison path.
+          ["C:\\\u0130\\x", "C:\\\u0130\\y", "..\\y"],
+          ["C:\\\u0130\\x", "C:\\i\u0307\\y", "..\\y"],
+          ["C:\\\u0130", "C:\\\u0130\\sub", "sub"],
+          ["C:\\\u0130\\sub", "C:\\\u0130", ".."],
+          ["C:\\a\\\u0130\\b\\c", "C:\\a\\\u0130\\x", "..\\..\\x"],
+          ["C:\\\u023A\\x", "C:\\\u2C65\\y", "..\\y"],
+          ["C:\\\u023A", "C:\\\u2C65", ""],
+          ["C:\\\u0130", "D:\\x", "D:\\x"],
         ],
       ],
       [

--- a/test/js/node/path/relative.test.js
+++ b/test/js/node/path/relative.test.js
@@ -49,8 +49,8 @@ describe("path.relative", () => {
           ["C:\\É\\sub", "C:\\é", ".."],
           // toLowerCase is not full case-folding: ß stays ß, so ß ≠ SS.
           ["C:\\ß", "C:\\SS", "..\\SS"],
-          // Length-changing toLowerCase (İ → i̇, Ⱥ → ⱥ) takes the
-          // per-segment comparison path.
+          // Length-changing toLowerCase (İ → i̇, Ⱥ → ⱥ) must not
+          // misalign indices into the original toOrig.
           ["C:\\\u0130\\x", "C:\\\u0130\\y", "..\\y"],
           ["C:\\\u0130\\x", "C:\\i\u0307\\y", "..\\y"],
           ["C:\\\u0130", "C:\\\u0130\\sub", "sub"],
@@ -59,6 +59,13 @@ describe("path.relative", () => {
           ["C:\\\u023A\\x", "C:\\\u2C65\\y", "..\\y"],
           ["C:\\\u023A", "C:\\\u2C65", ""],
           ["C:\\\u0130", "D:\\x", "D:\\x"],
+          // Shrinking + growing mappings that cancel in total byte length
+          // (ẞ→ß 3→2, Ⱥ→ⱥ 2→3) must not slice mid-codepoint.
+          ["C:\\\u1E9E\\\u023A", "C:\\\u1E9E\\\u023Ax", "..\\\u023Ax"],
+          ["C:\\\u1E9E\\\u023A\\a", "C:\\\u00DF\\\u2C65\\b", "..\\b"],
+          // Final_Sigma: Σ at word end lowers to ς (not σ).
+          ["C:\\\u0391\u03A3", "C:\\\u03B1\u03C2", ""],
+          ["C:\\\u0391\u03A3\\x", "C:\\\u03B1\u03C2\\y", "..\\y"],
         ],
       ],
       [

--- a/test/js/node/path/relative.test.js
+++ b/test/js/node/path/relative.test.js
@@ -66,6 +66,14 @@ describe("path.relative", () => {
           // Final_Sigma: Σ at word end lowers to ς (not σ).
           ["C:\\\u0391\u03A3", "C:\\\u03B1\u03C2", ""],
           ["C:\\\u0391\u03A3\\x", "C:\\\u03B1\u03C2\\y", "..\\y"],
+          // UNC with non-ASCII: different roots return toOrig; same root
+          // compares segments case-insensitively.
+          ["\\\\É\\bar", "\\\\baz\\qux", "\\\\baz\\qux\\"],
+          ["\\\\É\\bar", "C:\\x", "C:\\x"],
+          ["\\\\É\\bar\\a", "\\\\É\\bar\\b", "..\\b"],
+          ["\\\\É\\bar", "\\\\é\\BAR\\x", "x"],
+          ["\\\\foo\\É", "\\\\foo\\baz", "..\\baz"],
+          ["\\\\foo\\É\\a", "\\\\foo\\é\\b", "..\\b"],
         ],
       ],
       [


### PR DESCRIPTION
### What

`path.win32.relative()` compared resolved paths with a per-byte ASCII-only lowercase, so any two paths differing only in non-ASCII letter case (é vs É, Å vs å, Cyrillic Ф vs ф) were treated as different and a spurious `..\` traversal was emitted. With the mismatch mid-path, it walked out of the common ancestor entirely.

### Repro

```js
import path from "node:path";
const w = path.win32;
w.relative("C:\\é", "C:\\É")          // bun: "..\\É"          node: ""
w.relative("C:\\é\\x", "C:\\É\\y")    // bun: "..\\..\\É\\y"   node: "..\\y"
w.relative("C:\\Ф", "C:\\ф")          // bun: "..\\ф"          node: ""
w.relative("abc", "ABC")              // bun: ""               node: ""  (ASCII was fine)
w.relative("C:\\ß", "C:\\SS")         // bun: "..\\SS"         node: "..\\SS"  (toLowerCase, not case-fold)
```

### Cause

`relative_windows_t` folded case with `to_lower_t`, which is `to_ascii_lowercase` per code unit. Node lowercases the whole resolved strings with `StringPrototypeToLowerCase` (full Unicode mapping) before comparing.

### Fix

When either resolved path contains non-ASCII, compare per-segment: split on `\`, lowercase each segment with `str::to_lowercase()` (matches JS `toLowerCase` including the Final_Sigma Σ→ς rule), and rebuild the relative path from the original `to` segments. This mirrors Node's per-segment fallback and is immune to `toLowerCase` shifting `\` byte offsets (e.g. ẞ→ß shrinking alongside Ⱥ→ⱥ growing, or İ→i̇ expanding). All-ASCII paths keep the existing index-based fast path unchanged.

`to_lower_t` / `eql_ignore_case_t` are left as-is: the remaining callers compare drive letters, which are ASCII.

### Verification

Added cases to `test/js/node/path/relative.test.js` covering é/É, Å/å, Cyrillic Ф/ф, mid-path variants, the ß-vs-SS contract pin, length-changing İ/Ⱥ, the ẞ+Ⱥ offset-cancellation case, and Final_Sigma ΑΣ/ας. All expected values were taken from Node v26.3.0. Fails on `main` (15 of the new cases mismatch), passes with this change; the rest of `test/js/node/path/` is unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/path/relative.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (496de71d5)

test/js/node/path/relative.test.js:
112 |             .join(",")})\n  expect=${JSON.stringify(expected)}\n  actual=${JSON.stringify(actual)}`;
113 |           failures.push(`\n${message}`);
114 |         }
115 |       });
116 |     });
117 |     assert.strictEqual(failures.length, 0, failures.join(""));
                 ^
AssertionError: 
path.win32.relative("C:\\é","C:\\É")
  expect=""
  actual="..\\É"
path.win32.relative("C:\\É","C:\\é")
  expect=""
  actual="..\\é"
path.win32.relative("C:\\aéb","C:\\AÉB")
  expect=""
  actual="..\\AÉB"
path.win32.relative("C:\\é\\x","C:\\É\\y")
  expect="..\\y"
  actual="..\\..\\É\\y"
path.win32.relative("C:\\É\\x","C:\\é\\y")
  expect="..\\y"
  actual="..\\..\\é\\y"
p
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (c1a955d48)

test/js/node/path/relative.test.js:
(pass) path.relative > general [0.94ms]
(pass) path.relative > very long paths [0.42ms]

 2 pass
 0 fail
Ran 2 tests across 1 file. [193.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/path/relative.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (496de71d5)

test/js/node/path/relative.test.js:
(pass) path.relative > general [40.60ms]
(pass) path.relative > very long paths [10.33ms]

 2 pass
 0 fail
Ran 2 tests across 1 file. [2.81s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 770ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/node/path.rs           | 147 ++++++++++++++++++++++++++++++++++++-
 test/js/node/path/relative.test.js |  42 +++++++++++
 2 files changed, 187 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 4 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/runtime/node/path.rs               10     20      0
test/js/node/path/relative.test.js      2      5      0
```

</details>

<!-- robobun:evidence:end -->