### PR TITLE
node:assert: throw TypeError on deep-equality of a detached ArrayBuffer

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1150,9 +1150,11 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
         }
 
         if (left->isDetached() || right->isDetached()) [[unlikely]] {
-            // Node wraps each side in `new Uint8Array(buf)` to compare bytes, which
-            // throws on a detached ArrayBuffer; match that contract.
-            throwTypeError(globalObject, scope, "Cannot perform Construct on a detached ArrayBuffer"_s);
+            if constexpr (!enableAsymmetricMatchers) {
+                // Node wraps each side in `new Uint8Array(buf)` to compare bytes, which
+                // throws on a detached ArrayBuffer; match that contract for node:assert/util.
+                throwTypeError(globalObject, scope, "Cannot perform Construct on a detached ArrayBuffer"_s);
+            }
             return false;
         }
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1149,12 +1149,15 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
             return false;
         }
 
-        if (byteLength == 0)
-            return true;
-
-        if (right->isDetached() || left->isDetached()) [[unlikely]] {
+        if (left->isDetached() || right->isDetached()) [[unlikely]] {
+            // Node wraps each side in `new Uint8Array(buf)` to compare bytes, which
+            // throws on a detached ArrayBuffer; match that contract.
+            throwTypeError(globalObject, scope, "Cannot perform Construct on a detached ArrayBuffer"_s);
             return false;
         }
+
+        if (byteLength == 0)
+            return true;
 
         const void* vector = left->data();
         const void* rightVector = right->data();

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -1714,6 +1714,18 @@ describe("expect()", () => {
     expect(ab1).not.toEqual(new ArrayBuffer(1));
   });
 
+  test("toEqual detached ArrayBuffer is not equal to a zero-length ArrayBuffer", () => {
+    function detached() {
+      const buf = new ArrayBuffer(4);
+      buf.transfer();
+      return buf;
+    }
+    expect(detached()).not.toEqual(new ArrayBuffer(0));
+    expect(detached()).not.toEqual(detached());
+    expect(detached()).not.toStrictEqual(new ArrayBuffer(0));
+    expect({ x: detached() }).not.toEqual({ x: new ArrayBuffer(0) });
+  });
+
   test("symbol based keys in arrays are processed correctly", () => {
     const mySymbol = Symbol("test");
 

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -664,6 +664,8 @@ describe("detached ArrayBuffer", () => {
     expect(error?.code).toBe("ERR_ASSERTION");
   });
 
+  // Node v26 passes typed-array views directly to Buffer.compare (no re-wrap over
+  // .buffer), so a detached view compares as zero-length. Node v22 and earlier threw.
   test("a detached typed-array view is comparable as zero-length", () => {
     function detachedView() {
       const buf = new ArrayBuffer(4);

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -619,6 +619,63 @@ describe("util.isDeepStrictEqual", () => {
   });
 });
 
+describe("detached ArrayBuffer", () => {
+  function detached() {
+    const buf = new ArrayBuffer(4);
+    buf.transfer();
+    return buf;
+  }
+
+  const table: Array<[string, Thunk, Thunk]> = [
+    ["two distinct detached ArrayBuffers", detached, detached],
+    ["a detached ArrayBuffer and a zero-length ArrayBuffer", detached, () => new ArrayBuffer(0)],
+    ["a zero-length ArrayBuffer and a detached ArrayBuffer", () => new ArrayBuffer(0), detached],
+    ["nested detached ArrayBuffers", () => ({ x: detached() }), () => ({ x: detached() })],
+  ];
+
+  for (const [label, a, b] of table) {
+    test(`throws TypeError on ${label}`, () => {
+      expect(() => assert.deepStrictEqual(a(), b())).toThrow(TypeError);
+      expect(() => assert.deepEqual(a(), b())).toThrow(TypeError);
+      expect(() => assert.notDeepStrictEqual(a(), b())).toThrow(TypeError);
+      expect(() => assert.notDeepEqual(a(), b())).toThrow(TypeError);
+      expect(() => util.isDeepStrictEqual(a(), b())).toThrow(TypeError);
+    });
+  }
+
+  test("assert.partialDeepStrictEqual throws TypeError on a detached ArrayBuffer", () => {
+    expect(() => assert.partialDeepStrictEqual(detached(), new ArrayBuffer(0))).toThrow(TypeError);
+  });
+
+  test("error matches Node's message", () => {
+    const error = caught(() => assert.deepStrictEqual(detached(), new ArrayBuffer(0)));
+    expect(error).toBeInstanceOf(TypeError);
+    expect(error?.message).toBe("Cannot perform Construct on a detached ArrayBuffer");
+  });
+
+  test("reference-identical detached ArrayBuffer short-circuits as equal", () => {
+    const buf = detached();
+    expect(() => assert.deepStrictEqual(buf, buf)).not.toThrow();
+    expect(util.isDeepStrictEqual(buf, buf)).toBe(true);
+  });
+
+  test("detached ArrayBuffer vs non-zero-length ArrayBuffer is an ordinary mismatch", () => {
+    const error = caught(() => assert.deepStrictEqual(detached(), new ArrayBuffer(4)));
+    expect(error?.code).toBe("ERR_ASSERTION");
+  });
+
+  test("a detached typed-array view is comparable as zero-length", () => {
+    function detachedView() {
+      const buf = new ArrayBuffer(4);
+      const view = new Uint8Array(buf);
+      buf.transfer();
+      return view;
+    }
+    expect(() => assert.deepStrictEqual(detachedView(), detachedView())).not.toThrow();
+    expect(() => assert.deepStrictEqual(detachedView(), new Uint8Array(0))).not.toThrow();
+  });
+});
+
 describe("AssertionError", () => {
   test("deepStrictEqual reports actual, expected and operator", () => {
     const error = caught(() => assert.deepStrictEqual({ a: 1 }, { a: 2 })) as any;


### PR DESCRIPTION
## What

`assert.deepStrictEqual` (and `deepEqual` / `notDeepStrictEqual` / `notDeepEqual` / `partialDeepStrictEqual` / `util.isDeepStrictEqual` / `Bun.deepEquals`) treated a detached `ArrayBuffer` as an ordinary zero-length buffer, so a buffer that had been `transfer()`'d compared equal to another detached buffer or to a live `new ArrayBuffer(0)`. Node throws `TypeError: Cannot perform Construct on a detached ArrayBuffer` for all of these.

```js
import assert from "node:assert";
const det = new ArrayBuffer(4);
det.transfer();

assert.deepStrictEqual(det, new ArrayBuffer(0));
// node: TypeError: Cannot perform Construct on a detached ArrayBuffer
// bun:  passes (false green)
```

A test asserting "this buffer was not transferred" goes green on Bun after the transfer happened.

## Cause

The `ArrayBufferType` arm in `Bun__deepEquals` (`src/jsc/bindings/bindings.cpp`) checked `byteLength == 0` and returned `true` before checking `isDetached()`. A detached `ArrayBuffer` has `byteLength == 0`, so the detached check was unreachable for the 0/0 case.

Node's `areEqualArrayBuffers` does `Buffer.compare(new Uint8Array(a), new Uint8Array(b))`; `new Uint8Array(detached)` throws per the ES spec, and that `TypeError` propagates out of every deep-equality entry point.

## Fix

Check `isDetached()` before the `byteLength == 0` early return and throw the same `TypeError` Node does. The `byteLength` mismatch check still comes first, so `detached(0)` vs `live(4)` remains an `AssertionError` (matches Node). Typed-array views over a detached buffer continue to compare as zero-length, which also matches Node.

## Verification

Added a `detached ArrayBuffer` describe block to `test/js/node/assert/deep-equal.test.ts` covering both-detached, detached-vs-live(0) in both orders, nested, `partialDeepStrictEqual`, the error message, the reference-identity short-circuit, the byteLength-mismatch path, and typed-array views.

```
USE_SYSTEM_BUN=1 bun test test/js/node/assert/deep-equal.test.ts -t "detached ArrayBuffer"
  3 pass, 6 fail

bun bd test test/js/node/assert/deep-equal.test.ts
  260 pass, 0 fail

bun bd test test/js/node/assert/           360 pass, 0 fail
bun bd test test/js/bun/bun-object/deep-equals.spec.ts   44 pass, 2 skip, 0 fail
bun bd test test/js/bun/test/expect.test.js              406 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 failed, 10 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect.test.js test/js/node/assert/deep-equal.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (06318ddc9)

test/js/bun/test/expect.test.js:
(pass) expect() > () [840.57ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [2.64ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.64ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.39ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.41ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.39ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.93ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.41ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.38ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.41ms]
(pass) expect() > toBe() > expect(Symbol(a)).toB
... (truncated)

release without fix: 1 failed, 10 skipped
bun test v1.4.0-canary.1 (77b45f0c5)

test/js/bun/test/expect.test.js:
(pass) expect() > () [1.02ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.03ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(-0).toBe(-0) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true
(pass) expect() > toBe() > expect({}).toBe({}) == true
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true
(pass) expect() > toBe() > expect(0).toBe(false) == false [0.01ms]
(pass) expect() > toBe() > expect(0).toBe("") == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(1).toBe(2) == false
(pass) expect() > toBe() > expect(1).toBe(true) == false
(pass) expect() > toBe() > expect(1).toBe("1") == false
(pass) expect() > toBe() > expect(Infinity).toBe(-Infinity) == false
(pass) expect() > toBe() > expect("foo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 10 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect.test.js test/js/node/assert/deep-equal.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (06318ddc9)

test/js/bun/test/expect.test.js:
(pass) expect() > () [975.15ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [3.87ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.99ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.68ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.67ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.61ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.61ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.63ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [1.72ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.63ms]
(pass) expect() > toBe() > expect(Symbol(a)).toB
... (truncated)

release with fix: 10 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 3057ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen cpp.rs (cppbind)
[1/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/bindings.cpp          | 13 +++++---
 test/js/bun/test/expect.test.js        | 12 +++++++
 test/js/node/assert/deep-equal.test.ts | 59 ++++++++++++++++++++++++++++++++++
 3 files changed, 80 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/jsc/bindings/bindings.cpp               8      2      0
test/js/bun/test/expect.test.js             1      1      0
test/js/node/assert/deep-equal.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->