### PR TITLE
node:util: syntax-highlight RegExp in util.inspect with colors

### DIFF
--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -960,7 +960,12 @@ function highlightRegExp(regexpString) {
         write("]");
         i++;
         inClass = false;
-      } else if (ch === "-" && regexpString[i - 1] !== "[" && i + 1 < regexpString.length && regexpString[i + 1] !== "]") {
+      } else if (
+        ch === "-" &&
+        regexpString[i - 1] !== "[" &&
+        i + 1 < regexpString.length &&
+        regexpString[i + 1] !== "]"
+      ) {
         writeDepth("-", 1, 1);
       } else {
         write(ch);

--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -856,24 +856,247 @@ defineColorAlias("inverse", "swapColors");
 defineColorAlias("inverse", "swapcolors");
 defineColorAlias("doubleunderline", "doubleUnderline");
 
-// TODO(BridgeAR): Add function style support for more complex styles.
 // Don't use 'blue' not visible on cmd.exe
-inspect.styles = {
-  __proto__: null,
-  special: "cyan",
-  number: "yellow",
-  bigint: "yellow",
-  boolean: "yellow",
-  undefined: "grey",
-  null: "bold",
-  string: "green",
-  symbol: "green",
-  date: "magenta",
-  // "name": intentionally not styling
-  // TODO(BridgeAR): Highlight regular expressions properly.
-  regexp: "red",
-  module: "underline",
-};
+inspect.styles = ObjectAssign(
+  { __proto__: null },
+  {
+    special: "cyan",
+    number: "yellow",
+    bigint: "yellow",
+    boolean: "yellow",
+    undefined: "grey",
+    null: "bold",
+    string: "green",
+    symbol: "green",
+    date: "magenta",
+    // "name": intentionally not styling
+    regexp: highlightRegExp,
+    module: "underline",
+  },
+);
+
+// Define the palette for RegExp group depth highlighting. Can be changed by users.
+inspect.styles.regexp.colors = ["green", "red", "yellow", "cyan", "magenta"];
+
+const highlightRegExpColors = ArrayPrototypeSlice(inspect.styles.regexp.colors);
+
+// Colorize a JavaScript RegExp pattern per ECMAScript grammar. A tolerant
+// single-pass highlighter covering groups, assertions, alternation,
+// quantifiers, escapes (incl. Unicode properties), classes and backreferences.
+function highlightRegExp(regexpString) {
+  let out = "";
+  let i = 0;
+  let depth = 0;
+  let inClass = false;
+
+  const paletteNames = highlightRegExp.colors?.length > 0 ? highlightRegExp.colors : highlightRegExpColors;
+
+  const palette = [];
+  for (let j = 0; j < paletteNames.length; j++) {
+    const color = inspect.colors[paletteNames[j]];
+    if (color) ArrayPrototypePush.$call(palette, [`\u001b[${color[0]}m`, `\u001b[${color[1]}m`]);
+  }
+
+  function writeGroup(start, end, decreaseDepth = 1) {
+    let seq = "";
+    i++;
+    while (i < regexpString.length && regexpString[i] !== end) {
+      seq += regexpString[i++];
+    }
+    if (i < regexpString.length) {
+      depth -= decreaseDepth;
+      write(start);
+      writeDepth(seq, 1, 1);
+      write(end);
+      depth += decreaseDepth;
+    } else {
+      writeDepth(start, 1, -seq.length);
+    }
+  }
+
+  const write = str => {
+    const idx = depth % palette.length;
+    const color = palette[idx] ?? palette[0];
+    out += color[0] + str + color[1];
+    return idx;
+  };
+
+  function writeDepth(str, incDepth, incI) {
+    depth += incDepth;
+    write(str);
+    depth -= incDepth;
+    i += incI;
+  }
+
+  // Opening '/'
+  write("/");
+  depth++;
+  i = 1;
+
+  while (i < regexpString.length) {
+    const ch = regexpString[i];
+
+    if (inClass) {
+      if (ch === "\\") {
+        let seq = "\\";
+        i++;
+        if (i < regexpString.length) {
+          seq += regexpString[i++];
+          const next = seq[1];
+          if (next === "u" && regexpString[i] === "{") {
+            writeGroup(`${seq}{`, "}", 0);
+            continue;
+          } else if ((next === "p" || next === "P") && regexpString[i] === "{") {
+            writeGroup(`${seq}{`, "}", 0);
+            continue;
+          } else if (seq[1] === "x") {
+            seq += StringPrototypeSlice(regexpString, i, i + 2);
+            i += 2;
+          }
+        }
+        write(seq);
+      } else if (ch === "]") {
+        depth--;
+        write("]");
+        i++;
+        inClass = false;
+      } else if (ch === "-" && regexpString[i - 1] !== "[" && i + 1 < regexpString.length && regexpString[i + 1] !== "]") {
+        writeDepth("-", 1, 1);
+      } else {
+        write(ch);
+        i++;
+      }
+    } else if (ch === "[") {
+      write("[");
+      depth++;
+      i++;
+      inClass = true;
+    } else if (ch === "(") {
+      write("(");
+      depth++;
+      i++;
+      if (i < regexpString.length && regexpString[i] === "?") {
+        i++;
+        const a = i < regexpString.length ? regexpString[i] : "";
+        if (a === ":" || a === "=" || a === "!") {
+          writeDepth(`?${a}`, -1, 1);
+        } else {
+          const b = i + 1 < regexpString.length ? regexpString[i + 1] : "";
+          if (a === "<" && (b === "=" || b === "!")) {
+            writeDepth(`?<${b}`, -1, 2);
+          } else if (a === "<") {
+            i++;
+            const start = i;
+            while (i < regexpString.length && regexpString[i] !== ">") {
+              i++;
+            }
+            const name = StringPrototypeSlice(regexpString, start, i);
+            if (i < regexpString.length && regexpString[i] === ">") {
+              depth--;
+              write("?<");
+              writeDepth(name, 1, 0);
+              write(">");
+              depth++;
+              i++;
+            } else {
+              writeDepth("?<", -1, 0);
+              write(name);
+            }
+          } else {
+            write("?");
+          }
+        }
+      }
+    } else if (ch === ")") {
+      depth--;
+      write(")");
+      i++;
+    } else if (ch === "\\") {
+      let seq = "\\";
+      i++;
+      if (i < regexpString.length) {
+        seq += regexpString[i++];
+        const next = seq[1];
+        if (i < regexpString.length) {
+          if (next === "u" && regexpString[i] === "{") {
+            writeGroup(`${seq}{`, "}", 0);
+            continue;
+          } else if (next === "x") {
+            seq += StringPrototypeSlice(regexpString, i, i + 2);
+            i += 2;
+          } else if (next >= "0" && next <= "9") {
+            while (i < regexpString.length && regexpString[i] >= "0" && regexpString[i] <= "9") {
+              seq += regexpString[i++];
+            }
+          } else if (next === "k" && regexpString[i] === "<") {
+            writeGroup(`${seq}<`, ">");
+            continue;
+          } else if ((next === "p" || next === "P") && regexpString[i] === "{") {
+            writeGroup(`${seq}{`, "}", 0);
+            continue;
+          }
+        }
+      }
+      writeDepth(seq, 1, 0);
+    } else if (ch === "|" || ch === "+" || ch === "*" || ch === "?" || ch === "," || ch === "^" || ch === "$") {
+      writeDepth(ch, 3, 1);
+    } else if (ch === "{") {
+      i++;
+      let digits = "";
+      while (i < regexpString.length && regexpString[i] >= "0" && regexpString[i] <= "9") {
+        digits += regexpString[i++];
+      }
+      if (digits) {
+        write("{");
+        depth++;
+        writeDepth(digits, 1, 0);
+      }
+      if (i < regexpString.length) {
+        if (regexpString[i] === ",") {
+          if (!digits) {
+            write("{");
+            depth++;
+          }
+          write(",");
+          i++;
+        } else if (!digits) {
+          depth += 1;
+          write("{");
+          depth -= 1;
+          continue;
+        }
+      }
+      let digits2 = "";
+      while (i < regexpString.length && regexpString[i] >= "0" && regexpString[i] <= "9") {
+        digits2 += regexpString[i++];
+      }
+      if (digits2) {
+        writeDepth(digits2, 1, 0);
+      }
+      if (i < regexpString.length && regexpString[i] === "}") {
+        depth--;
+        write("}");
+        i++;
+      }
+      if (i < regexpString.length && regexpString[i] === "?") {
+        writeDepth("?", 3, 1);
+      }
+    } else if (ch === ".") {
+      writeDepth(ch, 2, 1);
+    } else if (ch === "/") {
+      break;
+    } else {
+      writeDepth(ch, 1, 1);
+    }
+  }
+
+  // Closing delimiter and flags
+  writeDepth("/", -1, 1);
+  if (i < regexpString.length) {
+    write(StringPrototypeSlice(regexpString, i));
+  }
+  return out;
+}
 
 function addQuotes(str, quotes) {
   if (quotes === -1) {
@@ -957,6 +1180,9 @@ function stylizeWithColor(str, styleType) {
   if (style !== undefined) {
     const color = inspect.colors[style];
     if (color !== undefined) return `\u001b[${color[0]}m${str}\u001b[${color[1]}m`;
+    if (typeof style === "function") {
+      return style(str);
+    }
   }
   return str;
 }
@@ -1357,8 +1583,9 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
       base = RegExpPrototypeToString(constructor !== null ? value : new RegExp(value));
       const prefix = getPrefix(constructor, tag, "RegExp");
       if (prefix !== "RegExp ") base = `${prefix}${base}`;
+      base = ctx.stylize(base, "regexp");
       if ((keys.length === 0 && protoProps === undefined) || (recurseTimes > ctx.depth && ctx.depth !== null)) {
-        return ctx.stylize(base, "regexp");
+        return base;
       }
     } else if (isDate(value)) {
       // Make dates with properties first say the date

--- a/test/js/node/util/node-inspect-tests/parallel/util-inspect-regexp.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-inspect-regexp.test.js
@@ -1,0 +1,102 @@
+// Adapted from Node.js: test/parallel/test-util-inspect-regexp.js
+import assert from "assert";
+import { expect, test } from "bun:test";
+import util from "util";
+
+function expectColored(regexp, expected) {
+  const colored = util.inspect(regexp, { colors: true });
+  const plain = util.inspect(regexp, { colors: false });
+  assert.strictEqual(util.stripVTControlCharacters(colored), plain);
+  assert.strictEqual(colored, expected);
+}
+
+// prettier-ignore
+const tests = [
+  [/a/, "\x1B[32m/\x1B[39m\x1B[33ma\x1B[39m\x1B[32m/\x1B[39m"],
+  [/a|b/, "\x1B[32m/\x1B[39m\x1B[33ma\x1B[39m\x1B[35m|\x1B[39m\x1B[33mb\x1B[39m\x1B[32m/\x1B[39m"],
+  [/^$/, "\x1B[32m/\x1B[39m\x1B[35m^\x1B[39m\x1B[35m$\x1B[39m\x1B[32m/\x1B[39m"],
+  [/ab+c/gi, "\x1B[32m/\x1B[39m\x1B[33ma\x1B[39m\x1B[33mb\x1B[39m\x1B[35m+\x1B[39m\x1B[33mc\x1B[39m\x1B[32m/\x1B[39m\x1B[31mgi\x1B[39m"],
+  [/^(?<year>\d{4})-(?<mon>0[1-9]|1[0-2])-(?<day>0[1-9]|[12]\d|3[01])$/u, "\x1B[32m/\x1B[39m\x1B[35m^\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?<\x1B[39m\x1B[33myear\x1B[39m\x1B[31m>\x1B[39m\x1B[36m\\d\x1B[39m\x1B[33m{\x1B[39m\x1B[35m4\x1B[39m\x1B[33m}\x1B[39m\x1B[31m)\x1B[39m\x1B[33m-\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?<\x1B[39m\x1B[33mmon\x1B[39m\x1B[31m>\x1B[39m\x1B[36m0\x1B[39m\x1B[33m[\x1B[39m\x1B[36m1\x1B[39m\x1B[35m-\x1B[39m\x1B[36m9\x1B[39m\x1B[33m]\x1B[39m\x1B[32m|\x1B[39m\x1B[36m1\x1B[39m\x1B[33m[\x1B[39m\x1B[36m0\x1B[39m\x1B[35m-\x1B[39m\x1B[36m2\x1B[39m\x1B[33m]\x1B[39m\x1B[31m)\x1B[39m\x1B[33m-\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?<\x1B[39m\x1B[33mday\x1B[39m\x1B[31m>\x1B[39m\x1B[36m0\x1B[39m\x1B[33m[\x1B[39m\x1B[36m1\x1B[39m\x1B[35m-\x1B[39m\x1B[36m9\x1B[39m\x1B[33m]\x1B[39m\x1B[32m|\x1B[39m\x1B[33m[\x1B[39m\x1B[36m1\x1B[39m\x1B[36m2\x1B[39m\x1B[33m]\x1B[39m\x1B[36m\\d\x1B[39m\x1B[32m|\x1B[39m\x1B[36m3\x1B[39m\x1B[33m[\x1B[39m\x1B[36m0\x1B[39m\x1B[36m1\x1B[39m\x1B[33m]\x1B[39m\x1B[31m)\x1B[39m\x1B[35m$\x1B[39m\x1B[32m/\x1B[39m\x1B[31mu\x1B[39m"],
+  [/^(?=.*[A-Z])(?=.*\d)(?=.*[^\w\s]).{12,}$/, "\x1B[32m/\x1B[39m\x1B[35m^\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?=\x1B[39m\x1B[35m.\x1B[39m\x1B[32m*\x1B[39m\x1B[33m[\x1B[39m\x1B[36mA\x1B[39m\x1B[35m-\x1B[39m\x1B[36mZ\x1B[39m\x1B[33m]\x1B[39m\x1B[31m)\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?=\x1B[39m\x1B[35m.\x1B[39m\x1B[32m*\x1B[39m\x1B[36m\\d\x1B[39m\x1B[31m)\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?=\x1B[39m\x1B[35m.\x1B[39m\x1B[32m*\x1B[39m\x1B[33m[\x1B[39m\x1B[36m^\x1B[39m\x1B[36m\\w\x1B[39m\x1B[36m\\s\x1B[39m\x1B[33m]\x1B[39m\x1B[31m)\x1B[39m\x1B[36m.\x1B[39m\x1B[31m{\x1B[39m\x1B[36m12\x1B[39m\x1B[33m,\x1B[39m\x1B[31m}\x1B[39m\x1B[35m$\x1B[39m\x1B[32m/\x1B[39m"],
+  [/\b(?<!\$)\d{1,3}(?:,\d{3})*(?:\.\d+)?\b/, "\x1B[32m/\x1B[39m\x1B[33m\\b\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?<!\x1B[39m\x1B[36m\\$\x1B[39m\x1B[31m)\x1B[39m\x1B[33m\\d\x1B[39m\x1B[31m{\x1B[39m\x1B[36m1\x1B[39m\x1B[33m,\x1B[39m\x1B[36m3\x1B[39m\x1B[31m}\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?:\x1B[39m\x1B[32m,\x1B[39m\x1B[36m\\d\x1B[39m\x1B[33m{\x1B[39m\x1B[35m3\x1B[39m\x1B[33m}\x1B[39m\x1B[31m)\x1B[39m\x1B[35m*\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?:\x1B[39m\x1B[36m\\.\x1B[39m\x1B[36m\\d\x1B[39m\x1B[32m+\x1B[39m\x1B[31m)\x1B[39m\x1B[35m?\x1B[39m\x1B[33m\\b\x1B[39m\x1B[32m/\x1B[39m"],
+  [/\b\w+(?=\s*:\s)/, "\x1B[32m/\x1B[39m\x1B[33m\\b\x1B[39m\x1B[33m\\w\x1B[39m\x1B[35m+\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?=\x1B[39m\x1B[36m\\s\x1B[39m\x1B[32m*\x1B[39m\x1B[36m:\x1B[39m\x1B[36m\\s\x1B[39m\x1B[31m)\x1B[39m\x1B[32m/\x1B[39m"],
+  [/^(?:(?!cat).)*$/s, "\x1B[32m/\x1B[39m\x1B[35m^\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?:\x1B[39m\x1B[33m(\x1B[39m\x1B[33m?!\x1B[39m\x1B[35mc\x1B[39m\x1B[35ma\x1B[39m\x1B[35mt\x1B[39m\x1B[33m)\x1B[39m\x1B[35m.\x1B[39m\x1B[31m)\x1B[39m\x1B[35m*\x1B[39m\x1B[35m$\x1B[39m\x1B[32m/\x1B[39m\x1B[31ms\x1B[39m"],
+  [/\b(0[xX])(?<hex>[0-9A-Fa-f]+)\b/, "\x1B[32m/\x1B[39m\x1B[33m\\b\x1B[39m\x1B[31m(\x1B[39m\x1B[36m0\x1B[39m\x1B[33m[\x1B[39m\x1B[36mx\x1B[39m\x1B[36mX\x1B[39m\x1B[33m]\x1B[39m\x1B[31m)\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?<\x1B[39m\x1B[33mhex\x1B[39m\x1B[31m>\x1B[39m\x1B[33m[\x1B[39m\x1B[36m0\x1B[39m\x1B[35m-\x1B[39m\x1B[36m9\x1B[39m\x1B[36mA\x1B[39m\x1B[35m-\x1B[39m\x1B[36mF\x1B[39m\x1B[36ma\x1B[39m\x1B[35m-\x1B[39m\x1B[36mf\x1B[39m\x1B[33m]\x1B[39m\x1B[32m+\x1B[39m\x1B[31m)\x1B[39m\x1B[33m\\b\x1B[39m\x1B[32m/\x1B[39m"],
+  [/\b([A-Za-z]+)\s+\1\b/i, "\x1B[32m/\x1B[39m\x1B[33m\\b\x1B[39m\x1B[31m(\x1B[39m\x1B[33m[\x1B[39m\x1B[36mA\x1B[39m\x1B[35m-\x1B[39m\x1B[36mZ\x1B[39m\x1B[36ma\x1B[39m\x1B[35m-\x1B[39m\x1B[36mz\x1B[39m\x1B[33m]\x1B[39m\x1B[32m+\x1B[39m\x1B[31m)\x1B[39m\x1B[33m\\s\x1B[39m\x1B[35m+\x1B[39m\x1B[33m\\1\x1B[39m\x1B[33m\\b\x1B[39m\x1B[32m/\x1B[39m\x1B[31mi\x1B[39m"],
+  [/^(?:\r\n|[\n\r\u2028\u2029])+$/, "\x1B[32m/\x1B[39m\x1B[35m^\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?:\x1B[39m\x1B[36m\\r\x1B[39m\x1B[36m\\n\x1B[39m\x1B[32m|\x1B[39m\x1B[33m[\x1B[39m\x1B[36m\\n\x1B[39m\x1B[36m\\r\x1B[39m\x1B[36m\\u\x1B[39m\x1B[36m2\x1B[39m\x1B[36m0\x1B[39m\x1B[36m2\x1B[39m\x1B[36m8\x1B[39m\x1B[36m\\u\x1B[39m\x1B[36m2\x1B[39m\x1B[36m0\x1B[39m\x1B[36m2\x1B[39m\x1B[36m9\x1B[39m\x1B[33m]\x1B[39m\x1B[31m)\x1B[39m\x1B[35m+\x1B[39m\x1B[35m$\x1B[39m\x1B[32m/\x1B[39m"],
+  [/^#[0-9A-Fa-f]{3}(?:[0-9A-Fa-f]{3})?$/, "\x1B[32m/\x1B[39m\x1B[35m^\x1B[39m\x1B[33m#\x1B[39m\x1B[31m[\x1B[39m\x1B[33m0\x1B[39m\x1B[36m-\x1B[39m\x1B[33m9\x1B[39m\x1B[33mA\x1B[39m\x1B[36m-\x1B[39m\x1B[33mF\x1B[39m\x1B[33ma\x1B[39m\x1B[36m-\x1B[39m\x1B[33mf\x1B[39m\x1B[31m]\x1B[39m\x1B[31m{\x1B[39m\x1B[36m3\x1B[39m\x1B[31m}\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?:\x1B[39m\x1B[33m[\x1B[39m\x1B[36m0\x1B[39m\x1B[35m-\x1B[39m\x1B[36m9\x1B[39m\x1B[36mA\x1B[39m\x1B[35m-\x1B[39m\x1B[36mF\x1B[39m\x1B[36ma\x1B[39m\x1B[35m-\x1B[39m\x1B[36mf\x1B[39m\x1B[33m]\x1B[39m\x1B[33m{\x1B[39m\x1B[35m3\x1B[39m\x1B[33m}\x1B[39m\x1B[31m)\x1B[39m\x1B[35m?\x1B[39m\x1B[35m$\x1B[39m\x1B[32m/\x1B[39m"],
+  [/^(?:\[(?:[^\]\\]|\.)*]|"(?:[^"\\]|\\.)*")$/, '\x1B[32m/\x1B[39m\x1B[35m^\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?:\x1B[39m\x1B[36m\\[\x1B[39m\x1B[33m(\x1B[39m\x1B[33m?:\x1B[39m\x1B[36m[\x1B[39m\x1B[35m^\x1B[39m\x1B[35m\\]\x1B[39m\x1B[35m\\\\\x1B[39m\x1B[36m]\x1B[39m\x1B[31m|\x1B[39m\x1B[35m\\.\x1B[39m\x1B[33m)\x1B[39m\x1B[32m*\x1B[39m\x1B[36m]\x1B[39m\x1B[32m|\x1B[39m\x1B[36m"\x1B[39m\x1B[33m(\x1B[39m\x1B[33m?:\x1B[39m\x1B[36m[\x1B[39m\x1B[35m^\x1B[39m\x1B[35m"\x1B[39m\x1B[35m\\\\\x1B[39m\x1B[36m]\x1B[39m\x1B[31m|\x1B[39m\x1B[35m\\\\\x1B[39m\x1B[32m.\x1B[39m\x1B[33m)\x1B[39m\x1B[32m*\x1B[39m\x1B[36m"\x1B[39m\x1B[31m)\x1B[39m\x1B[35m$\x1B[39m\x1B[32m/\x1B[39m'],
+  [/^(?<quote>["'])(?:\.|(?!\k<quote>)[\s\S])*\k<quote>$/, "\x1B[32m/\x1B[39m\x1B[35m^\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?<\x1B[39m\x1B[33mquote\x1B[39m\x1B[31m>\x1B[39m\x1B[33m[\x1B[39m\x1B[36m\"\x1B[39m\x1B[36m'\x1B[39m\x1B[33m]\x1B[39m\x1B[31m)\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?:\x1B[39m\x1B[36m\\.\x1B[39m\x1B[32m|\x1B[39m\x1B[33m(\x1B[39m\x1B[33m?!\x1B[39m\x1B[33m\\k<\x1B[39m\x1B[36mquote\x1B[39m\x1B[33m>\x1B[39m\x1B[33m)\x1B[39m\x1B[33m[\x1B[39m\x1B[36m\\s\x1B[39m\x1B[36m\\S\x1B[39m\x1B[33m]\x1B[39m\x1B[31m)\x1B[39m\x1B[35m*\x1B[39m\x1B[32m\\k<\x1B[39m\x1B[31mquote\x1B[39m\x1B[32m>\x1B[39m\x1B[35m$\x1B[39m\x1B[32m/\x1B[39m"],
+  [/^(?=.*\d)(?=.*[^\x61-\x7F])(?=.*[A-Za-z]).{8,}$/u, "\x1B[32m/\x1B[39m\x1B[35m^\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?=\x1B[39m\x1B[35m.\x1B[39m\x1B[32m*\x1B[39m\x1B[36m\\d\x1B[39m\x1B[31m)\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?=\x1B[39m\x1B[35m.\x1B[39m\x1B[32m*\x1B[39m\x1B[33m[\x1B[39m\x1B[36m^\x1B[39m\x1B[36m\\x61\x1B[39m\x1B[35m-\x1B[39m\x1B[36m\\x7F\x1B[39m\x1B[33m]\x1B[39m\x1B[31m)\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?=\x1B[39m\x1B[35m.\x1B[39m\x1B[32m*\x1B[39m\x1B[33m[\x1B[39m\x1B[36mA\x1B[39m\x1B[35m-\x1B[39m\x1B[36mZ\x1B[39m\x1B[36ma\x1B[39m\x1B[35m-\x1B[39m\x1B[36mz\x1B[39m\x1B[33m]\x1B[39m\x1B[31m)\x1B[39m\x1B[36m.\x1B[39m\x1B[31m{\x1B[39m\x1B[36m8\x1B[39m\x1B[33m,\x1B[39m\x1B[31m}\x1B[39m\x1B[35m$\x1B[39m\x1B[32m/\x1B[39m\x1B[31mu\x1B[39m"],
+  [/^\p{Lu}\p{Ll}+(?:\s\p{Lu}\p{Ll}+)+$/u, "\x1B[32m/\x1B[39m\x1B[35m^\x1B[39m\x1B[31m\\p{\x1B[39m\x1B[33mLu\x1B[39m\x1B[31m}\x1B[39m\x1B[31m\\p{\x1B[39m\x1B[33mLl\x1B[39m\x1B[31m}\x1B[39m\x1B[35m+\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?:\x1B[39m\x1B[36m\\s\x1B[39m\x1B[33m\\p{\x1B[39m\x1B[36mLu\x1B[39m\x1B[33m}\x1B[39m\x1B[33m\\p{\x1B[39m\x1B[36mLl\x1B[39m\x1B[33m}\x1B[39m\x1B[32m+\x1B[39m\x1B[31m)\x1B[39m\x1B[35m+\x1B[39m\x1B[35m$\x1B[39m\x1B[32m/\x1B[39m\x1B[31mu\x1B[39m"],
+  [/^[\p{Script=Greek}\p{Nd}]+$/u, "\x1B[32m/\x1B[39m\x1B[35m^\x1B[39m\x1B[31m[\x1B[39m\x1B[33m\\p{\x1B[39m\x1B[36mScript=Greek\x1B[39m\x1B[33m}\x1B[39m\x1B[33m\\p{\x1B[39m\x1B[36mNd\x1B[39m\x1B[33m}\x1B[39m\x1B[31m]\x1B[39m\x1B[35m+\x1B[39m\x1B[35m$\x1B[39m\x1B[32m/\x1B[39m\x1B[31mu\x1B[39m"],
+  [/(a)/, "\x1B[32m/\x1B[39m\x1B[31m(\x1B[39m\x1B[36ma\x1B[39m\x1B[31m)\x1B[39m\x1B[32m/\x1B[39m"],
+  [/(?:a)/, "\x1B[32m/\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?:\x1B[39m\x1B[36ma\x1B[39m\x1B[31m)\x1B[39m\x1B[32m/\x1B[39m"],
+  [/(?=a)/, "\x1B[32m/\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?=\x1B[39m\x1B[36ma\x1B[39m\x1B[31m)\x1B[39m\x1B[32m/\x1B[39m"],
+  [/(?!a)/, "\x1B[32m/\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?!\x1B[39m\x1B[36ma\x1B[39m\x1B[31m)\x1B[39m\x1B[32m/\x1B[39m"],
+  [/(?<=a)/, "\x1B[32m/\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?<=\x1B[39m\x1B[36ma\x1B[39m\x1B[31m)\x1B[39m\x1B[32m/\x1B[39m"],
+  [/(?<!a)/, "\x1B[32m/\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?<!\x1B[39m\x1B[36ma\x1B[39m\x1B[31m)\x1B[39m\x1B[32m/\x1B[39m"],
+  [/(?<name>a)/, "\x1B[32m/\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?<\x1B[39m\x1B[33mname\x1B[39m\x1B[31m>\x1B[39m\x1B[36ma\x1B[39m\x1B[31m)\x1B[39m\x1B[32m/\x1B[39m"],
+  [/(?<name>a)\k<name>/, "\x1B[32m/\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?<\x1B[39m\x1B[33mname\x1B[39m\x1B[31m>\x1B[39m\x1B[36ma\x1B[39m\x1B[31m)\x1B[39m\x1B[32m\\k<\x1B[39m\x1B[31mname\x1B[39m\x1B[32m>\x1B[39m\x1B[32m/\x1B[39m"],
+  [/\p{Letter}+/u, "\x1B[32m/\x1B[39m\x1B[31m\\p{\x1B[39m\x1B[33mLetter\x1B[39m\x1B[31m}\x1B[39m\x1B[35m+\x1B[39m\x1B[32m/\x1B[39m\x1B[31mu\x1B[39m"],
+  [/[\u{1F600}-\u{1F601}]/u, "\x1B[32m/\x1B[39m\x1B[31m[\x1B[39m\x1B[33m\\u{\x1B[39m\x1B[36m1F600\x1B[39m\x1B[33m}\x1B[39m\x1B[36m-\x1B[39m\x1B[33m\\u{\x1B[39m\x1B[36m1F601\x1B[39m\x1B[33m}\x1B[39m\x1B[31m]\x1B[39m\x1B[32m/\x1B[39m\x1B[31mu\x1B[39m"],
+  [/\x61/, "\x1B[32m/\x1B[39m\x1B[33m\\x61\x1B[39m\x1B[32m/\x1B[39m"],
+  [/\u{1F600}/u, "\x1B[32m/\x1B[39m\x1B[31m\\u{\x1B[39m\x1B[33m1F600\x1B[39m\x1B[31m}\x1B[39m\x1B[32m/\x1B[39m\x1B[31mu\x1B[39m"],
+  [/[a-z-]/, "\x1B[32m/\x1B[39m\x1B[31m[\x1B[39m\x1B[33ma\x1B[39m\x1B[36m-\x1B[39m\x1B[33mz\x1B[39m\x1B[33m-\x1B[39m\x1B[31m]\x1B[39m\x1B[32m/\x1B[39m"],
+  [/.{2,3}?abc?/, "\x1B[32m/\x1B[39m\x1B[36m.\x1B[39m\x1B[31m{\x1B[39m\x1B[36m2\x1B[39m\x1B[33m,\x1B[39m\x1B[36m3\x1B[39m\x1B[31m}\x1B[39m\x1B[35m?\x1B[39m\x1B[33ma\x1B[39m\x1B[33mb\x1B[39m\x1B[33mc\x1B[39m\x1B[35m?\x1B[39m\x1B[32m/\x1B[39m"],
+  [/a{2}/, "\x1B[32m/\x1B[39m\x1B[33ma\x1B[39m\x1B[31m{\x1B[39m\x1B[36m2\x1B[39m\x1B[31m}\x1B[39m\x1B[32m/\x1B[39m"],
+  [/\d/, "\x1B[32m/\x1B[39m\x1B[33m\\d\x1B[39m\x1B[32m/\x1B[39m"],
+  [/[^a-z\d\u{1F600}-\u{1F601}]/u, "\x1B[32m/\x1B[39m\x1B[31m[\x1B[39m\x1B[33m^\x1B[39m\x1B[33ma\x1B[39m\x1B[36m-\x1B[39m\x1B[33mz\x1B[39m\x1B[33m\\d\x1B[39m\x1B[33m\\u{\x1B[39m\x1B[36m1F600\x1B[39m\x1B[33m}\x1B[39m\x1B[36m-\x1B[39m\x1B[33m\\u{\x1B[39m\x1B[36m1F601\x1B[39m\x1B[33m}\x1B[39m\x1B[31m]\x1B[39m\x1B[32m/\x1B[39m\x1B[31mu\x1B[39m"],
+  [/(?<=Mr\.|Mrs.)\s[A-Z]\w+/, "\x1B[32m/\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?<=\x1B[39m\x1B[36mM\x1B[39m\x1B[36mr\x1B[39m\x1B[36m\\.\x1B[39m\x1B[32m|\x1B[39m\x1B[36mM\x1B[39m\x1B[36mr\x1B[39m\x1B[36ms\x1B[39m\x1B[35m.\x1B[39m\x1B[31m)\x1B[39m\x1B[33m\\s\x1B[39m\x1B[31m[\x1B[39m\x1B[33mA\x1B[39m\x1B[36m-\x1B[39m\x1B[33mZ\x1B[39m\x1B[31m]\x1B[39m\x1B[33m\\w\x1B[39m\x1B[35m+\x1B[39m\x1B[32m/\x1B[39m"],
+  [/a/giu, "\x1B[32m/\x1B[39m\x1B[33ma\x1B[39m\x1B[32m/\x1B[39m\x1B[31mgiu\x1B[39m"],
+  [/^p{Lu}p{Ll}+(?:sp{Lu}p{Ll}+)+$/, "\x1B[32m/\x1B[39m\x1B[35m^\x1B[39m\x1B[33mp\x1B[39m\x1B[33m{\x1B[39m\x1B[33mL\x1B[39m\x1B[33mu\x1B[39m\x1B[33m}\x1B[39m\x1B[33mp\x1B[39m\x1B[33m{\x1B[39m\x1B[33mL\x1B[39m\x1B[33ml\x1B[39m\x1B[33m}\x1B[39m\x1B[35m+\x1B[39m\x1B[31m(\x1B[39m\x1B[31m?:\x1B[39m\x1B[36ms\x1B[39m\x1B[36mp\x1B[39m\x1B[36m{\x1B[39m\x1B[36mL\x1B[39m\x1B[36mu\x1B[39m\x1B[36m}\x1B[39m\x1B[36mp\x1B[39m\x1B[36m{\x1B[39m\x1B[36mL\x1B[39m\x1B[36ml\x1B[39m\x1B[36m}\x1B[39m\x1B[32m+\x1B[39m\x1B[31m)\x1B[39m\x1B[35m+\x1B[39m\x1B[35m$\x1B[39m\x1B[32m/\x1B[39m"],
+];
+
+test("inspect.styles.regexp is a function with default color palette", () => {
+  expect(typeof util.inspect.styles.regexp).toBe("function");
+  expect(util.inspect.styles.regexp.colors).toEqual(["green", "red", "yellow", "cyan", "magenta"]);
+});
+
+test("util.inspect(regexp, {colors: true}) tokenizes per ECMAScript grammar", () => {
+  for (const [regexp, expected] of tests) {
+    expectColored(regexp, expected);
+  }
+});
+
+test("highlightRegExp palette can be customized and falls back when empty", () => {
+  const regexp = /(?<year>\d{4})-\d{2}|\d{2}-(?<year>\d{4})/;
+  const saved = util.inspect.styles.regexp;
+  const savedColors = saved.colors;
+  try {
+    const regular = util.inspect(regexp, { colors: true });
+
+    util.inspect.styles.regexp.colors = [];
+    assert.strictEqual(util.inspect(regexp, { colors: true }), regular);
+
+    util.inspect.styles.regexp.colors = undefined;
+    assert.strictEqual(util.inspect(regexp, { colors: true }), regular);
+
+    util.inspect.styles.regexp.colors = ["red", "yellow", "cyan"];
+    assert.strictEqual(
+      util.inspect(regexp, { colors: true }),
+      "\x1B[31m/\x1B[39m\x1B[33m(\x1B[39m\x1B[33m?<\x1B[39m\x1B[36myear\x1B[39m\x1B[33m>\x1B[39m\x1B[31m\\d\x1B[39m\x1B[36m{\x1B[39m\x1B[33m4\x1B[39m\x1B[36m}\x1B[39m\x1B[33m)\x1B[39m\x1B[36m-\x1B[39m\x1B[36m\\d\x1B[39m\x1B[33m{\x1B[39m\x1B[31m2\x1B[39m\x1B[33m}\x1B[39m\x1B[33m|\x1B[39m\x1B[36m\\d\x1B[39m\x1B[33m{\x1B[39m\x1B[31m2\x1B[39m\x1B[33m}\x1B[39m\x1B[36m-\x1B[39m\x1B[33m(\x1B[39m\x1B[33m?<\x1B[39m\x1B[36myear\x1B[39m\x1B[33m>\x1B[39m\x1B[31m\\d\x1B[39m\x1B[36m{\x1B[39m\x1B[33m4\x1B[39m\x1B[36m}\x1B[39m\x1B[33m)\x1B[39m\x1B[31m/\x1B[39m",
+    );
+
+    util.inspect.styles.regexp = "red";
+    assert.strictEqual(
+      util.inspect(regexp, { colors: true }),
+      "\x1B[31m/(?<year>\\d{4})-\\d{2}|\\d{2}-(?<year>\\d{4})/\x1B[39m",
+    );
+  } finally {
+    util.inspect.styles.regexp = saved;
+    util.inspect.styles.regexp.colors = savedColors;
+  }
+});
+
+test("RegExp with extra own properties still highlights the source", () => {
+  const re = Object.assign(/ab+c/gi, { x: 1 });
+  const out = util.inspect(re, { colors: true, breakLength: Infinity });
+  expect(out).toBe(
+    "\x1B[32m/\x1B[39m\x1B[33ma\x1B[39m\x1B[33mb\x1B[39m\x1B[35m+\x1B[39m\x1B[33mc\x1B[39m\x1B[32m/\x1B[39m\x1B[31mgi\x1B[39m { x: \x1B[33m1\x1B[39m }",
+  );
+});

--- a/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
@@ -828,7 +828,7 @@ test("no assertion failures 2", () => {
     testColorStyle("null", null);
     testColorStyle("string", "test string");
     testColorStyle("date", new Date());
-    testColorStyle("regexp", /regexp/);
+    // RegExp now uses token-level highlighting; verified in util-inspect-regexp.test.js.
   }
 
   // An object with "hasOwnProperty" overwritten should not throw.


### PR DESCRIPTION
## What

`util.inspect(re, { colors: true })` emitted a RegExp as a single red span. Node.js v26 replaced the `regexp: 'red'` style with a per-token highlighter, so any color-golden snapshot containing a regex diverges between runtimes. RegExp was the last remaining primitive whose colorized bytes differed.

## Repro

```js
const { inspect } = require('node:util');
console.log(JSON.stringify(inspect(/ab+c/gi, { colors: true })));
```

```
node v26.3.0: "\^[[32m/\^[[39m\^[[33ma\^[[39m\^[[33mb\^[[39m\^[[35m+\^[[39m\^[[33mc\^[[39m\^[[32m/\^[[39m\^[[31mgi\^[[39m"
bun (before): "\^[[31m/ab+c/gi\^[[39m"
```

The same shows via `formatWithOptions({colors:true}, '%O', re)` and the `Console` class with `colorMode: true`.

## Cause

`src/js/internal/util/inspect.js` still carried Node's old single-style rendering: `inspect.styles.regexp = 'red'` and a plain `ctx.stylize(base, 'regexp')` in the RegExp branch of `formatRaw`. Node v26 (`lib/internal/util/inspect.js`) replaced the style value with a `highlightRegExp(str)` function that walks the pattern as a single pass and colors each token using a depth-based palette, and taught `stylizeWithColor` to invoke function-valued styles.

## Fix

Port the upstream implementation:

- Add `highlightRegExp()` (groups/assertions/lookaround, alternation, quantifiers, escapes incl. `\u{...}` / `\p{...}` / `\x..`, character classes, named backreferences, flags).
- `inspect.styles.regexp` is now that function, with a user-overridable `.colors` palette (default `['green','red','yellow','cyan','magenta']`). A snapshot of the default palette is kept so an empty/undefined `.colors` falls back cleanly, matching Node.
- `stylizeWithColor` now calls `style(str)` when the style value is a function and no color name matched. Users who reassign `inspect.styles.regexp = 'red'` get the old single-span behaviour back.
- The RegExp branch of `formatRaw` now stylizes `base` unconditionally (not only on the early-return path), so a regexp with extra own properties still shows the highlighted source, matching Node.

## Verification

New `test/js/node/util/node-inspect-tests/parallel/util-inspect-regexp.test.js` adapted from Node's `test/parallel/test-util-inspect-regexp.js` covers 37 patterns plus the palette-override and extra-properties cases. All expected strings are Node v26.3.0 goldens; running Node's full upstream test array against the patched build passes 73/73 byte-identical.

```
USE_SYSTEM_BUN=1 bun test .../util-inspect-regexp.test.js   # 0 pass, 4 fail
bun bd test .../util-inspect-regexp.test.js                 # 4 pass, 0 fail
```

`util-inspect.test.js`'s `testColorStyle('regexp', /regexp/)` line is replaced with the same comment Node added upstream (that block assumes a string-valued style). The pre-existing `no assertion failures 2` timeout in that file under debug+ASAN reproduces on unmodified `main` and is unrelated.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js

<!-- robobun:evidence:end -->