### PR TITLE
node:url: parse query with querystring.parse in url.parse(url, true)

### DIFF
--- a/src/js/node/url.ts
+++ b/src/js/node/url.ts
@@ -29,7 +29,7 @@ const { URL, URLSearchParams } = globalThis;
 const [domainToASCII, domainToUnicode] = $cpp("NodeURL.cpp", "Bun::createNodeURLBinding");
 const { urlToHttpOptions } = require("internal/url");
 const { validateString } = require("internal/validators");
-const ObjectSetPrototypeOf = Object.setPrototypeOf;
+let querystringParse: typeof import("node:querystring").parse | undefined;
 
 function Url() {
   this.protocol = null;
@@ -204,7 +204,8 @@ Url.prototype.parse = function parse(url: string, parseQueryString?: boolean, sl
       if (simplePath[2]) {
         this.search = simplePath[2];
         if (parseQueryString) {
-          this.query = ObjectSetPrototypeOf(new URLSearchParams(this.search.slice(1)).toJSON(), null);
+          querystringParse ??= require("node:querystring").parse;
+          this.query = querystringParse(this.search.slice(1));
         } else {
           this.query = this.search.slice(1);
         }
@@ -402,8 +403,8 @@ Url.prototype.parse = function parse(url: string, parseQueryString?: boolean, sl
     this.search = rest.substring(qm);
     this.query = rest.substring(qm + 1);
     if (parseQueryString) {
-      const query = this.query;
-      this.query = ObjectSetPrototypeOf(new URLSearchParams(query).toJSON(), null);
+      querystringParse ??= require("node:querystring").parse;
+      this.query = querystringParse(this.query);
     }
     rest = rest.slice(0, qm);
   } else if (parseQueryString) {

--- a/test/js/node/url/url-parse-query.test.js
+++ b/test/js/node/url/url-parse-query.test.js
@@ -17,6 +17,28 @@ describe("url.parse", () => {
     assert.strictEqual(query.toString, undefined);
   });
 
+  // parseQueryString is documented to use querystring.parse(), not URLSearchParams.
+  // Covers both code paths in Url.prototype.parse: the simplePath fast path (no
+  // protocol) and the full parse (with protocol).
+  describe.each([
+    ["simple path", "/p"],
+    ["full parse", "http://h/p"],
+  ])("parseQueryString uses querystring.parse semantics (%s)", (_, prefix) => {
+    test("preserves a leading ? in the first key", () => {
+      // search is "??a=1", so the query string is "?a=1".
+      assert.deepStrictEqual({ ...url.parse(prefix + "??a=1", true).query }, { "?a": "1" });
+    });
+
+    test("caps the number of parsed keys at 1000 (querystring's default maxKeys)", () => {
+      const big = Array.from({ length: 1500 }, (_, i) => `k${i}=v`).join("&");
+      const { query } = url.parse(prefix + "?" + big, true);
+      assert.strictEqual(Object.keys(query).length, 1000);
+      assert.strictEqual(query.k0, "v");
+      assert.strictEqual(query.k999, "v");
+      assert.strictEqual(query.k1000, undefined);
+    });
+  });
+
   test.todo("with query string", () => {
     function createWithNoPrototype(properties = []) {
       const noProto = { __proto__: null };


### PR DESCRIPTION
## Repro

```js
import * as url from "node:url";
import * as qs from "node:querystring";

url.parse("http://h/p??a=1", true).query;
// node v26.3.0:  { "?a": "1" }     bun 1.4.0: { "a": "1" }
qs.parse("?a=1");
// { "?a": "1" } in both runtimes; the drop is url.parse's alone

const big = Array.from({ length: 1500 }, (_, i) => `k${i}=v`).join("&");
Object.keys(url.parse("http://h/p?" + big, true).query).length;
// node: 1000 (capped)     bun 1.4.0: 1500 (unbounded)
```

Face 1 silently changes which key a handler sees for the same bytes on the
wire. Face 2 removes `querystring`'s default `maxKeys=1000` cap, so the
common `url.parse(req.url, true)` pattern produces an attacker-controlled
unbounded own-key count per request.

## Cause

`Url.prototype.parse` in `src/js/node/url.ts` built `this.query` with
`new URLSearchParams(str).toJSON()` at both call sites (the `simplePath`
fast path and the full parse). Node's `url.parse(url, true)` is documented
to use `querystring.parse()`, and `URLSearchParams` differs in exactly
these two places: its constructor strips one leading `?` from the init
string, and it has no key-count cap.

Duplicate-key arrays, `+` to space, invalid-`%` passthrough, `;`, null
prototype and `__proto__`-as-own-key already agree between the two, so the
leading `?` and `maxKeys` are the whole observable delta of the
substitution.

## Fix

Route both call sites through `querystring.parse`. The `require` is lazy
(`??=`) so only callers that pass `parseQueryString = true` load the
module. `querystring.parse` already returns a null-prototype object, so
the `Object.setPrototypeOf` wrapper is no longer needed and is removed.

Parse-side twin of #33428, which makes the matching change on the
`url.format` side with `querystring.stringify`.

## Verification

`test/js/node/url/url-parse-query.test.js` gains 4 cases (2 assertions x
2 code paths) that fail on `main` and pass with this change. Every
expected value is what node v26.3.0 produces.

The rest of `test/js/node/url/` and the ported node suites
`test-url-parse-query.js`, `test-url-parse-format.js` and
`test-querystring.js` stay green.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/url/url-parse-query.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b71396b17)

test/js/node/url/url-parse-query.test.js:
(pass) url.parse > parseQueryString returns a null-prototype query object [60.01ms]
24 |     ["simple path", "/p"],
25 |     ["full parse", "http://h/p"],
26 |   ])("parseQueryString uses querystring.parse semantics (%s)", (_, prefix) => {
27 |     test("preserves a leading ? in the first key", () => {
28 |       // search is "??a=1", so the query string is "?a=1".
29 |       assert.deepStrictEqual({ ...url.parse(prefix + "??a=1", true).query }, { "?a": "1" });
                  ^
AssertionError: Expected values to be strictly deep-equal:
+ actual - expected

  {
+   a: '1'
-   '?a': '1'
  }

      at innerFail (node:assert:62:32)
      at deepStrictEqual (node:assert:176:
... (truncated)

release without fix: 5 failed, 1 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/url/url-parse-query.test.js:
 6 |   // TODO: Support correct prototype and null values.
 7 |   test("parseQueryString returns a null-prototype query object", () => {
 8 |     const inputs = ["/foo/bar?baz=quux", "/foo/bar", "http://example.com/a?baz=quux", "http://example.com/a"];
 9 |     for (const input of inputs) {
10 |       const { query } = url.parse(input, true);
11 |       assert.strictEqual(Object.getPrototypeOf(query), null);
                  ^
AssertionError: Expected values to be strictly equal:
+ actual - expected

+ [Object: null prototype] {}
- null

      at innerFail (node:assert:37:32)
      at strictEqual (node:assert:160:14)
      at <anonymous> (/workspace/bun/test/js/node/url/url-parse-query.test.js:11:14)
(fail) url.parse > parseQueryString returns a null-prototype query object [3.00ms]
24 |     ["simple path", "/p"],
25 |     ["full parse", "http://h/p"],
26 |   ])("parseQueryString uses querystring.parse semantics (%s)", (_, prefix) => {
27 |     test("preserves a leading ? in the first key", () => {
28 |       // search is "??a=1", so the query string is "?a=1".
29 |       assert.deepStri
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/url/url-parse-query.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b71396b17)

test/js/node/url/url-parse-query.test.js:
(pass) url.parse > parseQueryString returns a null-prototype query object [98.73ms]
(pass) url.parse > parseQueryString uses querystring.parse semantics (simple path) > preserves a leading ? in the first key [5.57ms]
(pass) url.parse > parseQueryString uses querystring.parse semantics (simple path) > caps the number of parsed keys at 1000 (querystring's default maxKeys) [313.64ms]
(pass) url.parse > parseQueryString uses querystring.parse semantics (full parse) > preserves a leading ? in the first key [5.03ms]
(pass) url.parse > parseQueryString uses querystring.parse semantics (full parse) > caps the number of parsed keys at 1000 (querystring's default maxKeys) [299.15ms]
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 1165ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/20] gen JS modules (bundle-modules)
Preprocess modules (8904ms)
Bundle modules (132ms)
Postprocesss modules (464ms)
Bundle Functions (4259ms)
Generate Code (103ms)

[13.88s] Bundled "src/js" for production
  2036 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current ve
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/url.ts                       |  9 +++++----
 test/js/node/url/url-parse-query.test.js | 22 ++++++++++++++++++++++
 2 files changed, 27 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/js/node/url.ts                            1      3      0
test/js/node/url/url-parse-query.test.js      1      1      0
```

</details>

<!-- robobun:evidence:end -->