### PR TITLE
node:stream: fix Writable.toWeb() backpressure for non-object-mode streams

### DIFF
--- a/src/js/internal/webstreams_adapters.ts
+++ b/src/js/internal/webstreams_adapters.ts
@@ -210,7 +210,16 @@ function newWritableStreamFromStreamWritable(streamWritable, options = kEmptyObj
   }
 
   const highWaterMark = streamWritable.writableHighWaterMark;
-  const strategy = streamWritable.writableObjectMode ? new CountQueuingStrategy({ highWaterMark }) : { highWaterMark };
+  const strategy = streamWritable.writableObjectMode
+    ? new CountQueuingStrategy({ highWaterMark })
+    : {
+        highWaterMark,
+        // Size chunks in bytes so desiredSize reflects the byte-based
+        // highWaterMark and pipeTo applies backpressure.
+        size(chunk) {
+          return chunk?.byteLength ?? chunk?.length ?? 1;
+        },
+      };
 
   let controller;
   let backpressurePromise;

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -770,6 +770,69 @@ describe("webstreams adapters (Node v26 sync)", () => {
     await writer.write(new Uint8Array([4, 5, 6]));
   });
 
+  // Upstream: nodejs/node#62986 (fixes nodejs/node#56269, oven-sh/bun#34588) —
+  // non-object-mode Writable.toWeb must size chunks in bytes so desiredSize
+  // reflects the byte-based highWaterMark.
+  it("Writable.toWeb desiredSize is byte-based for non-object-mode writables", () => {
+    const writable = new Writable({
+      highWaterMark: 1024,
+      write(chunk, encoding, callback) {
+        // hold the write in flight so the chunk stays queued
+      },
+    });
+
+    const writer = Writable.toWeb(writable).getWriter();
+    expect(writer.desiredSize).toBe(1024);
+    void writer.write(new Uint8Array(64 * 1024));
+    // 1024 - 65536; without byte sizing this would be 1023.
+    expect(writer.desiredSize).toBe(1024 - 64 * 1024);
+  });
+
+  it("pipeTo into Writable.toWeb applies backpressure instead of buffering the whole source (#34588)", async () => {
+    const TOTAL = 20;
+    let writes = 0;
+    let writeArrived = Promise.withResolvers();
+    const writable = new Writable({
+      highWaterMark: 1024,
+      write(chunk, encoding, callback) {
+        writes++;
+        writeArrived.resolve(callback);
+      },
+    });
+
+    let pulled = 0;
+    const chunk = new Uint8Array(64 * 1024);
+    const source = new ReadableStream(
+      {
+        pull(controller) {
+          pulled++;
+          if (pulled > TOTAL) return controller.close();
+          controller.enqueue(chunk.slice());
+        },
+      },
+      { highWaterMark: 1, size: c => c.byteLength },
+    );
+
+    const pipe = source.pipeTo(Writable.toWeb(writable));
+
+    // Hold the first write in flight and let pending microtasks drain; with
+    // backpressure the source is only a few chunks ahead, without it the
+    // whole source (TOTAL + 1 pulls) is buffered while the sink is blocked.
+    const firstCallback = await writeArrived.promise;
+    await new Promise(resolve => setImmediate(resolve));
+    expect(pulled).toBeLessThanOrEqual(4);
+
+    writeArrived = Promise.withResolvers();
+    firstCallback();
+    while (writes < TOTAL) {
+      const callback = await writeArrived.promise;
+      writeArrived = Promise.withResolvers();
+      callback();
+    }
+    await pipe;
+    expect(writes).toBe(TOTAL);
+  });
+
   // Upstream: v26 newStreamWritableFromWritableStream writev done() shape —
   // a rejected chunk write during a corked writev must error the stream with
   // the original error and must not produce an unhandled rejection.


### PR DESCRIPTION
Fixes #34588

### Problem

`Writable.toWeb()` on a non-object-mode writable built its queuing strategy as `{ highWaterMark: streamWritable.writableHighWaterMark }` with no `size()` function. The high-water mark is a byte count (e.g. 65536 for `fs.createWriteStream`), but without `size()` every chunk counts as 1, so `desiredSize` stays positive until 65536 chunks are queued. `writer.ready` never blocks, `pipeTo` drains the whole source into the WritableStream's queue, and RSS grows linearly with bytes piped (OOM on large pipes; the reporter hit it piping a 1.86 GB download on a 1.5 GB VM).

Repro:

```ts
import { createWriteStream } from "node:fs";
import { Writable } from "node:stream";

const chunk = new Uint8Array(10 * 1024 * 1024);
let produced = 0;
const source = new ReadableStream({
  pull(controller) {
    if (produced >= 300 * 1024 * 1024) return controller.close();
    controller.enqueue(chunk.slice());
    produced += chunk.byteLength;
  },
}, { highWaterMark: 1, size: (c) => c.byteLength });

await source.pipeTo(Writable.toWeb(createWriteStream("/tmp/out.bin")));
console.log(`rss=${Math.round(process.memoryUsage.rss() / 1e6)}MB`);
// before: rss scales with bytes piped (365MB for 300MB, 1306MB for 1200MB)
// after: rss stays flat regardless of payload size
```

### Fix

Port of nodejs/node#62986 (fixes nodejs/node#56269, not yet in a Node release): give the non-object-mode strategy a `size()` of `chunk?.byteLength ?? chunk?.length ?? 1`, so `desiredSize` is byte-accurate and `pipeTo` awaits `writer.ready`. The adapter's drain-based sink backpressure was already correct; only the queue accounting was wrong. `Duplex.toWeb` uses the same helper and is fixed as well.

### Verification

Two tests in `test/js/node/stream/node-stream.test.js`, both fail on the current release and pass with this change:

- `desiredSize` goes negative (1024 - 65536) after writing a 64 KB chunk to a writable with `highWaterMark: 1024` (previously 1023)
- with the first sink write held in flight, `pipeTo` pulls at most a few chunks from the source instead of draining all of it

Full `node-stream.test.js` suite and `test-webstreams-adapters-writable-buffer-sources.js` pass with the change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/stream/node-stream.test.js

<!-- robobun:evidence:end -->