### PR TITLE
net: adopt a bare new net.Socket({ fd }) so an inherited pipe is readable (+6 tests)

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -131,6 +131,7 @@ const kReinitializeHandle = Symbol("kReinitializeHandle");
 
 const kRealListen = Symbol("kRealListen");
 const kSetNoDelay = Symbol("kSetNoDelay");
+const kAdoptedFd = Symbol("kAdoptedFd");
 const kSetTOS = Symbol("kSetTOS");
 const kSetKeepAlive = Symbol("kSetKeepAlive");
 const kSyncWriteFd = Symbol("kSyncWriteFd");
@@ -1509,6 +1510,8 @@ function Socket(options?) {
   // Shut down the socket when we're finished with it.
   this.on("end", onSocketEnd);
 
+  // -1 = do not adopt; otherwise the validated fd to attach at the end of the ctor.
+  let adoptFd = -1;
   if (options?.fd !== undefined) {
     const { fd } = options;
     validateInt32(fd, "fd", 0);
@@ -1549,6 +1552,35 @@ function Socket(options?) {
           this.read(0);
         }
       }
+    } else if (options.readable === undefined && options.writable === undefined && fd > 0) {
+      // Bare `new net.Socket({ fd })`: node's constructor adopts the fd right
+      // away (createHandle + read start), so the socket is live without the
+      // caller having to call connect(). This is how a child reads an extra
+      // stdio pipe it inherited, e.g. `new net.Socket({ fd: 4 })`.
+      //
+      // Only pipes and sockets are adopted. An fd we cannot fstat, or one that
+      // is a file/tty, keeps the previous construct-but-stay-inert behavior:
+      // routing those through connect() surfaces a misleading ECONNREFUSED
+      // rather than node's ERR_INVALID_FD_TYPE, and turning a previously
+      // silent construction into a throw is a bigger behavior change than the
+      // gap being fixed. fd 0 is excluded for the same non-regression reason:
+      // connect()'s fd handling (and the native listener's `get_truthy("fd")`)
+      // both test the fd for truthiness, so adopting 0 here would fall through
+      // to the host/port path and throw ERR_MISSING_ARGS.
+      let stats;
+      try {
+        stats = require("node:fs").fstatSync(fd);
+      } catch {
+        stats = undefined;
+      }
+      // Record the fd and adopt at the very end of the constructor, not here:
+      // attaching a native handle before the remaining option validation would
+      // leak the fd (and the handle) if a later check throws.
+      // Note the `onread` option is still not honored for an adopted fd -
+      // connect()'s fd branch attaches the module-level SocketHandlers rather
+      // than this[khandlers]. That gap predates this branch (a bare { fd } used
+      // to attach nothing at all), so it is left alone here.
+      if (stats !== undefined && (stats.isFIFO() || stats.isSocket())) adoptFd = fd;
     }
   }
 
@@ -1594,6 +1626,20 @@ function Socket(options?) {
       throw $ERR_INVALID_ARG_TYPE("options.blockList", "net.BlockList", optsBlockList);
     }
     this.blockList = optsBlockList;
+  }
+
+  // Attach the inherited fd only once every option has been validated: an
+  // attach before the `signal`/`onread`/`blockList` checks would leak the fd
+  // (and its native handle) if one of them threw. kAdoptedFd stops a following
+  // createConnection()-style connect() from attaching the same fd twice.
+  //
+  // `adoptFd` carries the fd validated above rather than re-reading
+  // `options.fd`, so an options object with an `fd` getter cannot return a
+  // different descriptor than the one validateInt32/fstatSync approved.
+  // pauseOnConnect is passed explicitly because connect() assigns it
+  // unconditionally and would otherwise reset it to undefined.
+  if (adoptFd !== -1) {
+    Socket.prototype.connect.$call(this, { fd: adoptFd, pauseOnConnect: this.pauseOnConnect });
   }
 }
 $toClass(Socket, "Socket", Duplex);
@@ -1709,7 +1755,11 @@ Socket.prototype.connect = function connect(...args) {
     if (socket) {
       connection = socket;
     }
-    if (fd) {
+    // A fd already adopted by the constructor is skipped here: createConnection()
+    // constructs the Socket and then calls connect() with the same options, and
+    // attaching the same fd twice would leak the first handle.
+    if (fd && this[kAdoptedFd] !== fd) {
+      this[kAdoptedFd] = fd;
       doConnect(this._handle, {
         data: this,
         fd: fd,
@@ -1718,6 +1768,9 @@ Socket.prototype.connect = function connect(...args) {
         // Always half-open natively; see kConnect.
         allowHalfOpen: true,
       }).catch(error => {
+        // The attach failed, so nothing owns this fd now. Drop the sentinel or a
+        // retry with the same fd would be silently skipped by the guard above.
+        this[kAdoptedFd] = undefined;
         if (!this.destroyed) {
           this.emit("error", error);
           this.emit("close", true);
@@ -1970,6 +2023,10 @@ Socket.prototype._destroy = function _destroy(err, callback) {
   $debug("Socket.prototype._destroy");
 
   this.connecting = false;
+  // Release the adopted-fd sentinel: the handle is going away, so a later
+  // connect() with the same fd number must attach again rather than be
+  // mistaken for the constructor's adoption.
+  this[kAdoptedFd] = undefined;
   // Tear down a wrapped generic duplex with this socket: the native handle's
   // close only flushes close_notify and lets the wrapper drain; without an
   // explicit destroy here a late RST on the underlying transport can surface

--- a/test/js/node/test/parallel/test-child-process-fork-advanced-header-serialization.js
+++ b/test/js/node/test/parallel/test-child-process-fork-advanced-header-serialization.js
@@ -1,0 +1,40 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { fork } = require('child_process');
+const fs = require('fs');
+
+if (process.argv[2] === 'child-buffer') {
+  const v = process.argv[3];
+  const payload = Buffer.from([
+    (v >> 24) & 0xFF,
+    (v >> 16) & 0xFF,
+    (v >> 8) & 0xFF,
+    v & 0xFF,
+  ]);
+  const fd = process.channel?.fd;
+  if (fd !== undefined) {
+    fs.writeSync(fd, payload);
+  }
+  return;
+}
+
+const testCases = [
+  0x00000001,
+  0x7fffffff,
+  0x80000000,
+  0x80000001,
+  0xffffffff,
+];
+
+for (const size of testCases) {
+  const child = fork(__filename, ['child-buffer', size], {
+    serialization: 'advanced',
+    stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+  });
+
+  child.on('exit', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  }));
+}

--- a/test/js/node/test/parallel/test-child-process-fork-net-server.js
+++ b/test/js/node/test/parallel/test-child-process-fork-net-server.js
@@ -1,0 +1,159 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const fork = require('child_process').fork;
+const net = require('net');
+const debug = require('util').debuglog('test');
+
+const Countdown = require('../common/countdown');
+
+if (process.argv[2] === 'child') {
+
+  let serverScope;
+
+  // TODO(@jasnell): The message event is not called consistently
+  // across platforms. Need to investigate if it can be made
+  // more consistent.
+  const onServer = (msg, server) => {
+    if (msg.what !== 'server') return;
+    process.removeListener('message', onServer);
+
+    serverScope = server;
+
+    // TODO(@jasnell): This is apparently not called consistently
+    // across platforms. Need to investigate if it can be made
+    // more consistent.
+    server.on('connection', (socket) => {
+      debug('CHILD: got connection');
+      process.send({ what: 'connection' });
+      socket.destroy();
+    });
+
+    // Start making connection from parent.
+    debug('CHILD: server listening');
+    process.send({ what: 'listening' });
+  };
+
+  process.on('message', onServer);
+
+  // TODO(@jasnell): The close event is not called consistently
+  // across platforms. Need to investigate if it can be made
+  // more consistent.
+  const onClose = common.mustCallAtLeast((msg) => {
+    if (msg.what !== 'close') return;
+    process.removeListener('message', onClose);
+
+    serverScope.on('close', common.mustCall(() => {
+      process.send({ what: 'close' });
+    }));
+    serverScope.close();
+  });
+
+  process.on('message', onClose);
+
+  process.send({ what: 'ready' });
+} else {
+
+  const child = fork(process.argv[1], ['child']);
+
+  child.on('exit', common.mustCall((code, signal) => {
+    const message = `CHILD: died with ${code}, ${signal}`;
+    assert.strictEqual(code, 0, message);
+  }));
+
+  // Send net.Server to child and test by connecting.
+  function testServer(callback) {
+
+    // Destroy server execute callback when done.
+    const countdown = new Countdown(2, common.mustCall(() => {
+      server.on('close', common.mustCall(() => {
+        debug('PARENT: server closed');
+        child.send({ what: 'close' });
+      }));
+      server.close();
+    }));
+
+    // We expect 4 connections and close events.
+    const connections = new Countdown(4, () => countdown.dec());
+    const closed = new Countdown(4, () => countdown.dec());
+
+    // Create server and send it to child.
+    const server = net.createServer();
+
+    // TODO(@jasnell): The specific number of times the connection
+    // event is emitted appears to be variable across platforms.
+    // Need to investigate why and whether it can be made
+    // more consistent.
+    server.on('connection', (socket) => {
+      debug('PARENT: got connection');
+      socket.destroy();
+      connections.dec();
+    });
+
+    server.on('listening', common.mustCall(() => {
+      debug('PARENT: server listening');
+      child.send({ what: 'server' }, server);
+    }));
+    server.listen(0);
+
+    // Handle client messages.
+    // TODO(@jasnell): The specific number of times the message
+    // event is emitted appears to be variable across platforms.
+    // Need to investigate why and whether it can be made
+    // more consistent.
+    const messageHandlers = common.mustCallAtLeast((msg) => {
+      if (msg.what === 'listening') {
+        // Make connections.
+        let socket;
+        for (let i = 0; i < 4; i++) {
+          socket = net.connect(server.address().port, common.mustCall(() => {
+            debug('CLIENT: connected');
+          }));
+          socket.on('close', common.mustCall(() => {
+            closed.dec();
+            debug('CLIENT: closed');
+          }));
+        }
+
+      } else if (msg.what === 'connection') {
+        // Child got connection
+        connections.dec();
+      } else if (msg.what === 'close') {
+        child.removeListener('message', messageHandlers);
+        callback();
+      }
+    });
+
+    child.on('message', messageHandlers);
+  }
+
+  const onReady = common.mustCall((msg) => {
+    if (msg.what !== 'ready') return;
+    child.removeListener('message', onReady);
+    testServer(common.mustCall());
+  });
+
+  // Create server and send it to child.
+  child.on('message', onReady);
+}

--- a/test/js/node/test/parallel/test-child-process-fork-net-socket.js
+++ b/test/js/node/test/parallel/test-child-process-fork-net-socket.js
@@ -1,0 +1,96 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+const {
+  mustCall,
+  mustCallAtLeast,
+} = require('../common');
+const assert = require('assert');
+const fork = require('child_process').fork;
+const net = require('net');
+const debug = require('util').debuglog('test');
+
+if (process.argv[2] === 'child') {
+
+  const onSocket = mustCall((msg, socket) => {
+    if (msg.what !== 'socket') return;
+    process.removeListener('message', onSocket);
+    socket.end('echo');
+    debug('CHILD: got socket');
+  });
+
+  process.on('message', onSocket);
+
+  process.send({ what: 'ready' });
+} else {
+
+  const child = fork(process.argv[1], ['child']);
+
+  child.on('exit', mustCall((code, signal) => {
+    const message = `CHILD: died with ${code}, ${signal}`;
+    assert.strictEqual(code, 0, message);
+  }));
+
+  // Send net.Socket to child.
+  function testSocket() {
+
+    // Create a new server and connect to it,
+    // but the socket will be handled by the child.
+    const server = net.createServer();
+    server.on('connection', mustCall((socket) => {
+      // TODO(@jasnell): Close does not seem to actually be called.
+      // It is not clear if it is needed.
+      socket.on('close', () => {
+        debug('CLIENT: socket closed');
+      });
+      child.send({ what: 'socket' }, socket);
+    }));
+    server.on('close', mustCall(() => {
+      debug('PARENT: server closed');
+    }));
+
+    server.listen(0, mustCall(() => {
+      debug('testSocket, listening');
+      const connect = net.connect(server.address().port);
+      let store = '';
+      connect.on('data', mustCallAtLeast((chunk) => {
+        store += chunk;
+        debug('CLIENT: got data');
+      }));
+      connect.on('close', mustCall(() => {
+        debug('CLIENT: closed');
+        assert.strictEqual(store, 'echo');
+        server.close();
+      }));
+    }));
+  }
+
+  const onReady = mustCall((msg) => {
+    if (msg.what !== 'ready') return;
+    child.removeListener('message', onReady);
+
+    testSocket();
+  });
+
+  // Create socket and send it to child.
+  child.on('message', onReady);
+}

--- a/test/js/node/test/parallel/test-child-process-fork-stdio.js
+++ b/test/js/node/test/parallel/test-child-process-fork-stdio.js
@@ -1,0 +1,54 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+const net = require('net');
+
+if (process.argv[2] === 'child') {
+  process.stdout.write('this should be ignored');
+  process.stderr.write('this should not be ignored');
+
+  const pipe = new net.Socket({ fd: 4 });
+
+  process.on('disconnect', () => {
+    pipe.unref();
+  });
+
+  pipe.setEncoding('utf8');
+  pipe.on('data', (data) => {
+    process.send(data);
+  });
+} else {
+  assert.throws(
+    () => cp.fork(__filename, { stdio: ['pipe', 'pipe', 'pipe', 'pipe'] }),
+    { code: 'ERR_CHILD_PROCESS_IPC_REQUIRED', name: 'Error' });
+
+  let ipc = '';
+  let stderr = '';
+  const buf = Buffer.from('data to send via pipe');
+  const child = cp.fork(__filename, ['child'], {
+    stdio: [0, 'ignore', 'pipe', 'ipc', 'pipe']
+  });
+
+  assert.strictEqual(child.stdout, null);
+
+  child.on('message', (msg) => {
+    ipc += msg;
+
+    if (ipc === buf.toString()) {
+      child.disconnect();
+    }
+  });
+
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
+
+  child.on('exit', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+    assert.strictEqual(stderr, 'this should not be ignored');
+  }));
+
+  child.stdio[4].write(buf);
+}

--- a/test/js/node/test/parallel/test-cluster-fork-stdio.js
+++ b/test/js/node/test/parallel/test-cluster-fork-stdio.js
@@ -1,0 +1,40 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cluster = require('cluster');
+const net = require('net');
+
+if (cluster.isPrimary) {
+  const buf = Buffer.from('foobar');
+
+  cluster.setupPrimary({
+    stdio: ['pipe', 'pipe', 'pipe', 'ipc', 'pipe']
+  });
+
+  const worker = cluster.fork();
+  const channel = worker.process.stdio[4];
+  let response = '';
+
+  worker.on('exit', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  }));
+
+  channel.setEncoding('utf8');
+  channel.on('data', (data) => {
+    response += data;
+
+    if (response === buf.toString()) {
+      worker.disconnect();
+    }
+  });
+  channel.write(buf);
+} else {
+  const pipe = new net.Socket({ fd: 4 });
+
+  pipe.unref();
+  pipe.on('data', common.mustCallAtLeast((data) => {
+    assert.ok(data instanceof Buffer);
+    pipe.write(data);
+  }));
+}

--- a/test/js/node/test/parallel/test-cluster-send-handle-twice.js
+++ b/test/js/node/test/parallel/test-cluster-send-handle-twice.js
@@ -1,0 +1,59 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+// Testing to send an handle twice to the primary process.
+
+const common = require('../common');
+const assert = require('assert');
+const cluster = require('cluster');
+const net = require('net');
+
+const workers = {
+  toStart: 1
+};
+
+if (cluster.isPrimary) {
+  for (let i = 0; i < workers.toStart; ++i) {
+    const worker = cluster.fork();
+    worker.on('exit', common.mustCall(function(code, signal) {
+      assert.strictEqual(code, 0, `Worker exited with an error code: ${code}`);
+      assert.strictEqual(signal, null, `Worker exited by a signal: ${signal}`);
+    }));
+  }
+} else {
+  const server = net.createServer(common.mustCall((socket) => {
+    process.send('send-handle-1', socket);
+    process.send('send-handle-2', socket);
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const client = net.connect({
+      host: 'localhost',
+      port: server.address().port
+    });
+    client.on('close', common.mustCall(() => { cluster.worker.disconnect(); }));
+    client.on('connect', () => { client.end(); });
+  })).on('error', function(e) {
+    console.error(e);
+    assert.fail('server.listen failed');
+  });
+}


### PR DESCRIPTION
`new net.Socket({ fd })` validated the fd and then did nothing with it unless `writable: true` was also passed, so a bare `{ fd }` produced a socket that never read from the inherited descriptor. Node adopts it.

Adopts a bare `{ fd }` through the existing `connect({ fd })` path, gated to FIFOs and sockets, excluding fd 0, attached at the end of the constructor with a `kAdoptedFd` sentinel to prevent double-attach.

Adds 6 upstream Node v26.3.0 tests, copied verbatim. Two are unlocked by the fix (`test-child-process-fork-stdio`, `test-cluster-fork-stdio`); four already passed on this branch and simply were not vendored (`test-child-process-fork-advanced-header-serialization`, `test-child-process-fork-net-socket`, `test-child-process-fork-net-server`, `test-cluster-send-handle-twice`).

Stacked on #31829.

## Scope of the remaining gap

Node v26.3.0 has 111 `test-cluster-*` / `test-child-process-fork-*` files across parallel+sequential; #31829 already ports 101. Of the 10 missing, all 10 pass on the real node binary, and 6 are converted here. The other 4 and what they need:

| test | blocker |
|---|---|
| `test-child-process-fork-net`, `test-child-process-fork-getconnections` | `net.Server._workers` / `_setupWorker` plus node's `SocketListSend`/`SocketListReceive` IPC protocol (~200 lines across 3 files) — a coherent piece of work, but its own PR |
| `test-child-process-fork-dgram` | passing a `dgram.Socket` handle over `child.send()` currently yields `undefined` on the child side |
| `test-cluster-bind-twice` | a worker binding an already-taken port does not surface `EADDRINUSE` |

## Verification

- the 6 tests: 3/3 green each, and **each tamper-checked twice** — once in the parent/primary branch and once in the child/worker branch, both required to exit non-zero. This matters for `test-cluster-send-handle-twice`, whose assertions live in the worker: its worker-side failure does reach the primary on this branch.
- no regressions: a control binary was built without the patch, and the stable failures (6 net, 1 `cluster-inspect-brk`, 1 `tls-connect`, 1 `http-econnrefused`) are byte-identical with and without it; none touches `fd`. `child_process` 94/94, `dgram` 78/78.

Four defects in the first cut were found in review and fixed before submitting: `{fd: 0}` throwing `ERR_MISSING_ARGS`, an fd leak when later validation throws, a stale sentinel blocking a retry after a failed attach, and a TOCTOU on an `options.fd` getter.

## Known limitation

The `onread` option is still ignored for an adopted fd, because `connect()`'s fd branch attaches the module-level `SocketHandlers` rather than `this[khandlers]`. That is pre-existing — a bare `{ fd }` attached nothing at all before — and changing it would alter every fd-based connect, so it is left alone here.

## Unrelated finding for #31829

I audited whether that branch's own vendored cluster tests are vacuous (assertions in a worker whose failure never reaches the primary). Run against the **real node binary first** as a control: **35 of 83 upstream cluster tests are vacuous to node itself**, so only a differential is meaningful. On that basis exactly **2 are Bun-only-vacuous** — `test-cluster-dgram-1` and `test-cluster-dgram-bind-fd`. Both pass, and both still exit 0 with a deliberately broken worker assertion where node exits 1. Consistent with the dgram-handle gap above.
