### PR TITLE
node:util: make aborted() reject instead of throwing on invalid args

### DIFF
--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -255,7 +255,7 @@ function onAbortedCallback(resolveFn: Function) {
   resolveFn();
 }
 
-function aborted(signal: AbortSignal, resource: object) {
+async function aborted(signal: AbortSignal, resource: object) {
   if (!$isObject(signal) || !(signal instanceof AbortSignal)) {
     throw $ERR_INVALID_ARG_TYPE("signal", "AbortSignal", signal);
   }
@@ -265,7 +265,7 @@ function aborted(signal: AbortSignal, resource: object) {
   }
 
   if (signal.aborted) {
-    return Promise.$resolve();
+    return;
   }
 
   const { promise, resolve } = $newPromiseCapability(Promise);

--- a/test/js/node/util/test-aborted.test.ts
+++ b/test/js/node/util/test-aborted.test.ts
@@ -69,7 +69,9 @@ test("fails with error if not provided abort signal", async () => {
   const invalidSignals = [{}, null, undefined, Symbol(), [], 1, 0, 1n, true, false, "a", () => {}];
 
   for (const sig of invalidSignals) {
-    await expect(() => aborted(sig, {})).toThrow();
+    await expect(aborted(sig, {})).rejects.toThrow(
+      expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE" }),
+    );
   }
 });
 
@@ -78,6 +80,21 @@ test("fails if not provided a resource", async () => {
   const invalidResources = [null, undefined, 0, 1, 0n, 1n, Symbol(), "", "a"];
 
   for (const resource of invalidResources) {
-    await expect(() => aborted(ac.signal, resource)).toThrow();
+    await expect(aborted(ac.signal, resource)).rejects.toThrow(
+      expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE" }),
+    );
   }
+});
+
+test("validation errors reject instead of throwing synchronously", () => {
+  let threw = false;
+  let promise;
+  try {
+    promise = aborted(42, {});
+  } catch {
+    threw = true;
+  }
+  expect(threw).toBe(false);
+  expect(promise).toBeInstanceOf(Promise);
+  return expect(promise).rejects.toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
 });


### PR DESCRIPTION
## What does this PR do?

`util.aborted()` in Node.js is an `async function`, so argument validation errors (`ERR_INVALID_ARG_TYPE` for a non-`AbortSignal` first argument or a non-object `resource`) surface as promise rejections. Bun validated before constructing the promise and threw synchronously.

That means well-formed Node code like:

```js
util.aborted(sig, res).catch(handleBadInput);
```

would bypass the `.catch()` on Bun and become an uncaught exception in the calling frame.

### Repro

```js
import util from "node:util";

try {
  util.aborted(42, {}).catch(e => console.log("async:" + e.code));
} catch (e) {
  console.log("sync:" + e.code);
}
// node v26:  async:ERR_INVALID_ARG_TYPE
// bun 1.4.0: sync:ERR_INVALID_ARG_TYPE
```

### Fix

Make `aborted` an `async function` so the validation `throw`s become rejections, matching [Node's implementation](https://github.com/nodejs/node/blob/main/lib/internal/abort_controller.js).

### Verification

- `test/js/node/util/test-aborted.test.ts`: updated the two invalid-arg tests to assert `.rejects.toThrow(...)` and added a test that explicitly asserts no synchronous throw occurs. All 6 tests pass with the fix; 3 fail without it.
- `test/js/node/util/util.test.js`: 193 pass, 0 fail.