### PR TITLE
node:util: match Node.js ansi-regex semantics in stripVTControlCharacters

### DIFF
--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -2665,7 +2665,6 @@ function formatWithOptionsInternal(inspectOptions, args) {
   }
   return str;
 }
-const stripANSI = Bun.stripANSI;
 const internalGetStringWidth = $newCppFunction("stringWidth.cpp", "jsFunctionBunStringWidth", 1);
 /**
  * Returns the number of columns required to display the given string.
@@ -2676,9 +2675,22 @@ function getStringWidth(str, removeControlChars = true) {
   return internalGetStringWidth(str);
 }
 
+// Matches Node.js's `ansi` pattern (originally from the `ansi-regex` npm package).
+// Anything this regex does not match is treated as data and preserved verbatim.
+const ansi = new RegExp(
+  "[\\u001B\\u009B][[\\]()#;?]*" +
+    "(?:(?:(?:(?:;[-a-zA-Z\\d\\/\\#&.:=?%@~_]+)*" +
+    "|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/\\#&.:=?%@~_]*)*)?" +
+    "(?:\\u0007|\\u001B\\u005C|\\u009C))" +
+    "|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?" +
+    "[\\dA-PR-TZcf-nq-uy=><~]))",
+  "g",
+);
+
 function stripVTControlCharacters(str) {
   if (typeof str !== "string") throw new codes.ERR_INVALID_ARG_TYPE("str", "string", str);
-  return stripANSI(str);
+  if (StringPrototypeIndexOf(str, "\u001B") === -1 && StringPrototypeIndexOf(str, "\u009B") === -1) return str;
+  return RegExpPrototypeSymbolReplace(ansi, str, "");
 }
 
 // utils

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -436,3 +436,35 @@ describe("util.parseEnv", () => {
     expect(util.parseEnv(new String("FOO=bar"))).toEqual({ FOO: "bar" });
   });
 });
+
+describe("util.stripVTControlCharacters", () => {
+  // Node.js implements this as a regex match-and-remove (ansi-regex). Input that the
+  // regex does not match is preserved verbatim; in particular, unterminated or
+  // malformed escape sequences must not swallow trailing data.
+  describe.each([
+    ["unterminated OSC consumes only the regex match, not to end-of-string", "a\x1b]0;titleXYZ", "aitleXYZ"],
+    ["unterminated DCS consumes only the introducer", "a\x1bPdata no end", "adata no end"],
+    ["lone ESC followed by a non-sequence letter is preserved", "a\x1bbcd", "a\x1bbcd"],
+    ["trailing lone ESC is preserved", "abc\x1b", "abc\x1b"],
+    ["incomplete C1 CSI with no valid final byte is preserved", "a\x9bxyz", "a\x9bxyz"],
+    ["APC (ESC _) is preserved verbatim", "a\x1b_payload\x1b\\b", "a\x1b_payload\x1b\\b"],
+    ["C1 OSC/ST bytes are preserved verbatim", "a\x9d0;t\x9cb", "a\x9d0;t\x9cb"],
+    ["CSI SGR is stripped", "\x1b[31mred\x1b[39m", "red"],
+    ["complete C1 CSI is stripped", "a\x9b31mb", "ab"],
+    ["OSC hyperlink terminated by BEL is stripped", "\x1b]8;;http://example.com\x07text\x1b]8;;\x07", "text"],
+    ["OSC hyperlink terminated by ESC \\ is stripped", "\x1b]8;;http://example.com\x1b\\text\x1b]8;;\x1b\\", "text"],
+    ["OSC terminated by C1 ST is stripped", "\x1b]0;title\x9cafter", "after"],
+    ["ESC ( B charset designator is stripped", "a\x1b(Bb", "ab"],
+    ["truecolor SGR is stripped", "\x1b[38;2;255;100;0mtruecolor\x1b[0m", "truecolor"],
+    ["string with no escapes is returned unchanged", "plain text", "plain text"],
+    ["empty string", "", ""],
+  ])("%s", (_label, input, expected) => {
+    it(`${JSON.stringify(input)} -> ${JSON.stringify(expected)}`, () => {
+      expect(util.stripVTControlCharacters(input)).toBe(expected);
+    });
+  });
+
+  it("throws ERR_INVALID_ARG_TYPE for non-string input", () => {
+    expect(() => util.stripVTControlCharacters(123)).toThrow(/"str" argument must be of type string/);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

`util.stripVTControlCharacters` was routing through `Bun.stripANSI`, which is a full terminal escape-sequence parser. That parser:

- consumes an unterminated OSC / DCS all the way to end-of-string,
- strips a lone `ESC` (and `ESC` + following letter),
- treats APC (`ESC _ ... ST`) and C1 OSC (`\x9d ... \x9c`) as control sequences and removes them.

Node.js implements this function as a single regex replace (the `ansi-regex` pattern) and preserves everything the regex does not match. So a log scrubber that hits a truncated escape at a read boundary keeps the trailing user text in Node but silently drops it in Bun.

#### Repro

```js
import { stripVTControlCharacters as strip } from "node:util";
console.log(JSON.stringify(strip("a\x1b]0;titleXYZ")));    // node: "aitleXYZ"          bun (before): "a"
console.log(JSON.stringify(strip("a\x1bPdata no end")));   // node: "adata no end"      bun (before): "a"
console.log(JSON.stringify(strip("a\x1bbcd")));            // node: "a\u001bbcd"        bun (before): "acd"
console.log(JSON.stringify(strip("abc\x1b")));             // node: "abc\u001b"         bun (before): "abc"
console.log(JSON.stringify(strip("a\x9bxyz")));            // node: "a\u009bxyz"        bun (before): "ayz"
console.log(JSON.stringify(strip("a\x1b_payload\x1b\\b")));// node: unchanged           bun (before): "ab"
console.log(JSON.stringify(strip("a\x9d0;t\x9cb")));       // node: unchanged           bun (before): "ab"
```

Well-formed `ESC[` CSI, complete C1 CSI (`\x9b...m`), and BEL/ST-terminated OSC hyperlinks were already byte-identical and remain so.

#### Fix

Replace the `Bun.stripANSI` call in `src/js/internal/util/inspect.js` with Node's exact `ansi` regex and the same `ESC`/`\u009B` fast-path short-circuit Node uses before invoking the regex. `Bun.stripANSI` itself is unchanged; it is still the right tool for terminal rendering.

#### Verification

- `bun bd test test/js/node/util/util.test.js`: 210 pass (17 new cases, 7 of which fail without the `src/` change)
- `bun bd test/js/node/test/parallel/test-util-stripvtcontrolcharacters.js`: exit 0
- `diff <(node cases.mjs) <(bun-debug cases.mjs)`: empty across 18 inputs covering malformed, C1, and well-formed sequences