### PR TITLE
semver: clamp desugared exclusive upper bound at u64::MAX instead of saturating to empty range

### DIFF
--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -631,29 +631,25 @@ impl Token {
                             ..Default::default()
                         },
                     };
-                    range.right = Comparator {
-                        op: RangeOp::Lt,
-                        ..Default::default()
-                    };
                     if let Some(minor) = version.minor {
                         range.left.version.minor = minor;
                         if let Some(patch) = version.patch {
                             range.left.version.patch = patch;
                             range.left.version.tag = version.tag;
                             if major == 0 {
-                                if minor == 0 {
-                                    range.right.version.patch = patch.saturating_add(1);
+                                range.right = if minor == 0 {
+                                    Comparator::lt_next_patch(0, 0, patch)
                                 } else {
-                                    range.right.version.minor = minor.saturating_add(1);
-                                }
+                                    Comparator::lt_next_minor(0, minor)
+                                };
                                 break 'done;
                             }
                         } else if major == 0 {
-                            range.right.version.minor = minor.saturating_add(1);
+                            range.right = Comparator::lt_next_minor(0, minor);
                             break 'done;
                         }
                     }
-                    range.right.version.major = major.saturating_add(1);
+                    range.right = Comparator::lt_next_major(major);
                 }
                 return range;
             }
@@ -671,21 +667,16 @@ impl Token {
                             ..Default::default()
                         },
                     };
-                    range.right = Comparator {
-                        op: RangeOp::Lt,
-                        ..Default::default()
-                    };
                     if let Some(minor) = version.minor {
                         range.left.version.minor = minor;
                         if let Some(patch) = version.patch {
                             range.left.version.patch = patch;
                             range.left.version.tag = version.tag;
                         }
-                        range.right.version.major = major;
-                        range.right.version.minor = minor.saturating_add(1);
+                        range.right = Comparator::lt_next_minor(major, minor);
                         break 'done;
                     }
-                    range.right.version.major = major.saturating_add(1);
+                    range.right = Comparator::lt_next_major(major);
                 }
                 return range;
             }
@@ -1031,35 +1022,49 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                     }
                     Wildcard::Minor => {
                         // "1.0.0 - 1.x" --> ">=1.0.0 < 2.0.0"
-                        second_version.major = second_version.major.saturating_add(1);
-                        second_version.minor = 0;
-                        second_version.patch = 0;
+                        let right = match second_version.major.checked_add(1) {
+                            Some(m) => {
+                                second_version.major = m;
+                                second_version.minor = 0;
+                                second_version.patch = 0;
+                                Comparator {
+                                    op: RangeOp::Lt,
+                                    version: second_version,
+                                }
+                            }
+                            None => Comparator::lt_next_major(second_version.major),
+                        };
 
                         Range {
                             left: Comparator {
                                 op: RangeOp::Gte,
                                 version,
                             },
-                            right: Comparator {
-                                op: RangeOp::Lt,
-                                version: second_version,
-                            },
+                            right,
                         }
                     }
                     Wildcard::Patch => {
                         // "1.0.0 - 1.0.x" --> ">=1.0.0 <1.1.0"
-                        second_version.minor = second_version.minor.saturating_add(1);
-                        second_version.patch = 0;
+                        let right = match second_version.minor.checked_add(1) {
+                            Some(m) => {
+                                second_version.minor = m;
+                                second_version.patch = 0;
+                                Comparator {
+                                    op: RangeOp::Lt,
+                                    version: second_version,
+                                }
+                            }
+                            None => {
+                                Comparator::lt_next_minor(second_version.major, second_version.minor)
+                            }
+                        };
 
                         Range {
                             left: Comparator {
                                 op: RangeOp::Gte,
                                 version,
                             },
-                            right: Comparator {
-                                op: RangeOp::Lt,
-                                version: second_version,
-                            },
+                            right,
                         }
                     }
                     Wildcard::None => Range {

--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -1054,9 +1054,10 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                                     version: second_version,
                                 }
                             }
-                            None => {
-                                Comparator::lt_next_minor(second_version.major, second_version.minor)
-                            }
+                            None => Comparator::lt_next_minor(
+                                second_version.major,
+                                second_version.minor,
+                            ),
                         };
 
                         Range {

--- a/src/semver/SemverRange.rs
+++ b/src/semver/SemverRange.rs
@@ -71,53 +71,28 @@ impl Range {
                 ..Default::default()
             },
 
-            Wildcard::Minor => {
-                let lhs = Version {
-                    major: version.major.saturating_add(1),
-                    // .raw = version.raw
-                    ..Default::default()
-                };
-                let rhs = Version {
-                    major: version.major,
-                    // .raw = version.raw
-                    ..Default::default()
-                };
-                Range {
-                    left: Comparator {
-                        op: Op::Lt,
-                        version: lhs,
+            Wildcard::Minor => Range {
+                left: Comparator::lt_next_major(version.major),
+                right: Comparator {
+                    op: Op::Gte,
+                    version: Version {
+                        major: version.major,
+                        ..Default::default()
                     },
-                    right: Comparator {
-                        op: Op::Gte,
-                        version: rhs,
-                    },
-                }
-            }
+                },
+            },
 
-            Wildcard::Patch => {
-                let lhs = Version {
-                    major: version.major,
-                    minor: version.minor.saturating_add(1),
-                    // .raw = version.raw;
-                    ..Default::default()
-                };
-                let rhs = Version {
-                    major: version.major,
-                    minor: version.minor,
-                    // .raw = version.raw;
-                    ..Default::default()
-                };
-                Range {
-                    left: Comparator {
-                        op: Op::Lt,
-                        version: lhs,
+            Wildcard::Patch => Range {
+                left: Comparator::lt_next_minor(version.major, version.minor),
+                right: Comparator {
+                    op: Op::Gte,
+                    version: Version {
+                        major: version.major,
+                        minor: version.minor,
+                        ..Default::default()
                     },
-                    right: Comparator {
-                        op: Op::Gte,
-                        version: rhs,
-                    },
-                }
-            }
+                },
+            },
         }
     }
 
@@ -237,6 +212,76 @@ pub struct Comparator {
 }
 
 impl Comparator {
+    /// `< {major+1}.0.0`, or `<= u64::MAX.u64::MAX.u64::MAX` when `major+1`
+    /// would overflow so the desugared range stays non-empty at the ceiling.
+    pub fn lt_next_major(major: u64) -> Comparator {
+        match major.checked_add(1) {
+            Some(m) => Comparator {
+                op: Op::Lt,
+                version: Version {
+                    major: m,
+                    ..Default::default()
+                },
+            },
+            None => Comparator {
+                op: Op::Lte,
+                version: Version {
+                    major: u64::MAX,
+                    minor: u64::MAX,
+                    patch: u64::MAX,
+                    ..Default::default()
+                },
+            },
+        }
+    }
+
+    /// `< {major}.{minor+1}.0`, or `<= {major}.u64::MAX.u64::MAX` on overflow.
+    pub fn lt_next_minor(major: u64, minor: u64) -> Comparator {
+        match minor.checked_add(1) {
+            Some(m) => Comparator {
+                op: Op::Lt,
+                version: Version {
+                    major,
+                    minor: m,
+                    ..Default::default()
+                },
+            },
+            None => Comparator {
+                op: Op::Lte,
+                version: Version {
+                    major,
+                    minor: u64::MAX,
+                    patch: u64::MAX,
+                    ..Default::default()
+                },
+            },
+        }
+    }
+
+    /// `< {major}.{minor}.{patch+1}`, or `<= {major}.{minor}.u64::MAX` on overflow.
+    pub fn lt_next_patch(major: u64, minor: u64, patch: u64) -> Comparator {
+        match patch.checked_add(1) {
+            Some(p) => Comparator {
+                op: Op::Lt,
+                version: Version {
+                    major,
+                    minor,
+                    patch: p,
+                    ..Default::default()
+                },
+            },
+            None => Comparator {
+                op: Op::Lte,
+                version: Version {
+                    major,
+                    minor,
+                    patch: u64::MAX,
+                    ..Default::default()
+                },
+            },
+        }
+    }
+
     #[inline]
     pub fn eql(self, rhs: Comparator) -> bool {
         self.op == rhs.op && self.version.eql(rhs.version)

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -260,6 +260,58 @@ describe("Bun.semver.satisfies()", () => {
     testSatisfies("^" + padded, "6.0.0", false);
   });
 
+  test("u64::MAX component does not collapse ^/~/x/hyphen ranges to empty", () => {
+    // Desugaring these range forms builds an exclusive `< {component+1}` upper bound.
+    // At u64::MAX that +1 must not saturate back to MAX (which yields `>=X <X`, an empty range).
+    const M = "18446744073709551615";
+    const M1 = "18446744073709551614";
+
+    // sanity: version is valid and exactly matchable
+    testSatisfies("*", `${M}.0.0`, true);
+    testSatisfies(`=${M}.0.0`, `${M}.0.0`, true);
+    testSatisfies(`>=${M}.0.0`, `${M}.0.0`, true);
+
+    // caret: major / minor (major==0) / patch (major==0,minor==0)
+    testSatisfies(`^${M}`, `${M}.0.0`, true);
+    testSatisfies(`^${M}.2.3`, `${M}.5.0`, true);
+    testSatisfies(`^0.${M}`, `0.${M}.7`, true);
+    testSatisfies(`^0.${M}.3`, `0.${M}.7`, true);
+    testSatisfies(`^0.0.${M}`, `0.0.${M}`, true);
+
+    // tilde: major / minor
+    testSatisfies(`~${M}`, `${M}.0.0`, true);
+    testSatisfies(`~${M}`, `${M}.9.9`, true);
+    testSatisfies(`~1.${M}`, `1.${M}.0`, true);
+    testSatisfies(`~1.${M}.3`, `1.${M}.3`, true);
+    testSatisfies(`~1.${M}.3`, `1.${M}.9`, true);
+
+    // bare partial and x-range (init_wildcard)
+    testSatisfies(M, `${M}.0.0`, true);
+    testSatisfies(`${M}.x`, `${M}.0.0`, true);
+    testSatisfies(`${M}.x`, `${M}.5.0`, true);
+    testSatisfies(`1.${M}`, `1.${M}.0`, true);
+    testSatisfies(`1.${M}.x`, `1.${M}.5`, true);
+
+    // hyphen range right endpoint (partial)
+    testSatisfies(`1.0.0 - ${M}`, `${M}.5.0`, true);
+    testSatisfies(`1.0.0 - ${M}.x`, `${M}.5.0`, true);
+    testSatisfies(`1.0.0 - 1.${M}`, `1.${M}.5`, true);
+    testSatisfies(`1.0.0 - 1.${M}.x`, `1.${M}.5`, true);
+
+    // upper bound is still enforced: the clamped range doesn't leak past its ceiling
+    testSatisfies(`^0.${M}`, `1.0.0`, false);
+    testSatisfies(`^0.0.${M}`, `0.1.0`, false);
+    testSatisfies(`~1.${M}.3`, `2.0.0`, false);
+    testSatisfies(`1.${M}.x`, `2.0.0`, false);
+    testSatisfies(`1.0.0 - 1.${M}`, `2.0.0`, false);
+
+    // control at MAX-1: every shape already worked and still works
+    testSatisfies(`^${M1}`, `${M1}.0.0`, true);
+    testSatisfies(`~${M1}`, `${M1}.0.0`, true);
+    testSatisfies(M1, `${M1}.0.0`, true);
+    testSatisfies(`^${M1}`, `${M}.0.0`, false);
+  });
+
   test("ranges", () => {
     testSatisfies("~1.2.3", "1.2.3", true);
     testSatisfies("~1.2", "1.2.0", true);


### PR DESCRIPTION
## Reproduction

```js
const M = "18446744073709551615"; // u64::MAX
Bun.semver.satisfies(`${M}.0.0`, `^${M}`);       // false, should be true
Bun.semver.satisfies(`${M}.0.0`, `~${M}`);       // false, should be true
Bun.semver.satisfies(`${M}.0.0`, M);             // false, should be true
Bun.semver.satisfies(`${M}.0.0`, `${M}.x`);      // false, should be true
Bun.semver.satisfies(`1.${M}.3`, `~1.${M}.3`);   // false, should be true
Bun.semver.satisfies(`0.0.${M}`, `^0.0.${M}`);   // false, should be true
Bun.semver.satisfies(`${M}.5.0`, `1.0.0 - ${M}`); // false, should be true
// control: MAX-1 works
Bun.semver.satisfies("18446744073709551614.0.0", "^18446744073709551614"); // true
```

## Cause

Caret, tilde, x-range, bare-partial, and hyphen-partial range forms all desugar to `>=X <{component+1}`. The ten desugar sites in `SemverQuery.rs` / `SemverRange.rs` computed the exclusive upper bound with `component.saturating_add(1)`. At `u64::MAX`, saturation leaves the component unchanged, so the right comparator becomes `<MAX.0.0` while the left is `>=MAX.0.0`: an empty range. A version at `u64::MAX` would satisfy `*` and `=v` but fail every partial-derived range that names it.

## Fix

Add `Comparator::lt_next_major` / `lt_next_minor` / `lt_next_patch` which use `checked_add(1)` and, on overflow, return `<= {ceiling}` (e.g. `<= MAX.MAX.MAX` for the major case) instead of a saturated `<`. Replace all ten `saturating_add(1)` sites. The non-overflow path produces byte-identical `Comparator` values, so this is a pure edge-case fix with no change to ordinary ranges.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/cli/install/semver.test.ts -t "u64::MAX"
(fail) Bun.semver.satisfies() > u64::MAX component does not collapse ^/~/x/hyphen ranges to empty

$ bun bd test test/cli/install/semver.test.ts
 28 pass
 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/semver.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (bc6259451)

test/cli/install/semver.test.ts:
(pass) Bun.semver.order() > whitespace bug fix [5.58ms]
(pass) Bun.semver.order() > comparisons [58.20ms]
(pass) Bun.semver.order() > loose compare("0", "0.0") [4.15ms]
(pass) Bun.semver.order() > loose compare("1", "1.0") [2.29ms]
(pass) Bun.semver.order() > loose compare("1.2", "1.2.0") [1.07ms]
(pass) Bun.semver.order() > loose compare("1.x", "1.0.x") [1.06ms]
(pass) Bun.semver.order() > loose compare("1.x.x", "1.0.x") [1.14ms]
(pass) Bun.semver.order() > loose compare("2.x", "1.x") [1.18ms]
(pass) Bun.semver.order() > loose compare("2.x", "2.1") [1.12ms]
(pass) Bun.semver.order() > loose compare("2", "1") [0.93ms]
(pass) Bun.semver.order() > loose compare("3.*", "3.1") [0.82ms]
(pass) B
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (bc6259451)

test/cli/install/semver.test.ts:
(pass) Bun.semver.order() > whitespace bug fix [0.07ms]
(pass) Bun.semver.order() > comparisons [0.28ms]
(pass) Bun.semver.order() > loose compare("0", "0.0") [0.05ms]
(pass) Bun.semver.order() > loose compare("1", "1.0")
(pass) Bun.semver.order() > loose compare("1.2", "1.2.0")
(pass) Bun.semver.order() > loose compare("1.x", "1.0.x")
(pass) Bun.semver.order() > loose compare("1.x.x", "1.0.x")
(pass) Bun.semver.order() > loose compare("2.x", "1.x")
(pass) Bun.semver.order() > loose compare("2.x", "2.1")
(pass) Bun.semver.order() > loose compare("2", "1")
(pass) Bun.semver.order() > loose compare("3.*", "3.1")
(pass) Bun.semver.order() > loose compare("3.2.*", "3.2.0")
(pass) Bun.semver.order() > loose compare("4294967295.4294967295.x", "4294967295.4294967295.4294967294")
(pass) Bun.semver.order() > loose compare("*", "4294967295.4294967295.4294967294") [0.02ms]
(pass) Bun.semver.order() > equality [0.26ms]
(pass) Bun.semver.satisfies() > expected errors [0.22ms]
(pass) Bun.semver.satisfies() > failures does not cause weird memory issues [90.46ms]
(pass) Bun.semver.satisfies() > exact versions [0
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/semver.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (bc6259451)

test/cli/install/semver.test.ts:
(pass) Bun.semver.order() > whitespace bug fix [4.61ms]
(pass) Bun.semver.order() > comparisons [40.00ms]
(pass) Bun.semver.order() > loose compare("0", "0.0") [3.74ms]
(pass) Bun.semver.order() > loose compare("1", "1.0") [1.81ms]
(pass) Bun.semver.order() > loose compare("1.2", "1.2.0") [1.05ms]
(pass) Bun.semver.order() > loose compare("1.x", "1.0.x") [1.51ms]
(pass) Bun.semver.order() > loose compare("1.x.x", "1.0.x") [0.90ms]
(pass) Bun.semver.order() > loose compare("2.x", "1.x") [0.91ms]
(pass) Bun.semver.order() > loose compare("2.x", "2.1") [0.92ms]
(pass) Bun.semver.order() > loose compare("2", "1") [0.97ms]
(pass) Bun.semver.order() > loose compare("3.*", "3.1") [1.00ms]
(pass) B
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 1451ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_semver v0.0.0 (/workspace/bun/src/semver)
[1m[92m   Compiling[0m bun_analytics v0.0.0 (/workspace/bun/src/analytics)
[1m[92m   Compiling[0m bun_install_types v0.0.0 (/workspace/bun/src/install_types)
[1m[92m   Compiling[0m bun_spawn_sys v0.0.0 (/wo
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/semver/SemverQuery.rs       |  66 +++++++++++---------
 src/semver/SemverRange.rs       | 135 ++++++++++++++++++++++++++--------------
 test/cli/install/semver.test.ts |  52 ++++++++++++++++
 3 files changed, 178 insertions(+), 75 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                             reads  edits  tests
src/semver/SemverQuery.rs            1      3      0
src/semver/SemverRange.rs            1      2      0
test/cli/install/semver.test.ts      2      1      0
```

</details>

<!-- robobun:evidence:end -->