### PR TITLE
util.parseArgs: match Node's property insertion order on tokens and result

### DIFF
--- a/src/runtime/node/util/parse_args.rs
+++ b/src/runtime/node/util/parse_args.rs
@@ -853,11 +853,6 @@ impl<'a> ParseArgsState<'a> {
                 Token::Option(token) => {
                     obj.put(
                         global,
-                        ZigString::static_("index"),
-                        JSValue::js_number(token.index as f64),
-                    );
-                    obj.put(
-                        global,
                         ZigString::static_("name"),
                         token.name.as_js_value(global)?,
                     );
@@ -865,6 +860,11 @@ impl<'a> ParseArgsState<'a> {
                         global,
                         ZigString::static_("rawName"),
                         token.make_raw_name_js_value(global)?,
+                    );
+                    obj.put(
+                        global,
+                        ZigString::static_("index"),
+                        JSValue::js_number(token.index as f64),
                     );
 
                     // value exists only for string options, otherwise the property exists with "undefined" as value

--- a/src/runtime/node/util/parse_args.rs
+++ b/src/runtime/node/util/parse_args.rs
@@ -1061,10 +1061,10 @@ fn parse_args_impl(
     bun_output::scoped_log!(parseArgs, "Phase 4: Build result object");
 
     let result = JSValue::create_empty_object(global, if return_tokens { 3 } else { 2 });
+    result.put(global, ZigString::static_("values"), state.values);
+    result.put(global, ZigString::static_("positionals"), state.positionals);
     if return_tokens {
         result.put(global, ZigString::static_("tokens"), state.tokens);
     }
-    result.put(global, ZigString::static_("values"), state.values);
-    result.put(global, ZigString::static_("positionals"), state.positionals);
     Ok(result)
 }

--- a/test/js/node/util/parse_args/parse-args-token-key-order.test.ts
+++ b/test/js/node/util/parse_args/parse-args-token-key-order.test.ts
@@ -1,9 +1,10 @@
 import { expect, test } from "bun:test";
 import { parseArgs } from "node:util";
 
-// Node.js emits option tokens with keys in the order {kind, name, rawName, index, value, inlineValue}.
-// Property insertion order is observable via Object.keys / JSON.stringify, so snapshot tests depend on it.
-test("parseArgs tokens: property insertion order matches Node.js", () => {
+// Node.js emits parseArgs result keys in the order {values, positionals, tokens?}, and option-token
+// keys in the order {kind, name, rawName, index, value, inlineValue}. Property insertion order is
+// observable via Object.keys / JSON.stringify, so snapshot tests depend on it.
+test("parseArgs: property insertion order matches Node.js", () => {
   const args = ["--x=v", "-ab", "--flag", "--", "pos"];
   const options = {
     x: { type: "string" },
@@ -11,8 +12,11 @@ test("parseArgs tokens: property insertion order matches Node.js", () => {
     b: { type: "boolean" },
     flag: { type: "boolean" },
   } as const;
-  const { tokens } = parseArgs({ args, options, allowPositionals: true, tokens: true });
-  expect(tokens.map(t => Object.keys(t).join(","))).toEqual([
+
+  const result = parseArgs({ args, options, allowPositionals: true, tokens: true });
+  expect(Object.keys(result)).toEqual(["values", "positionals", "tokens"]);
+
+  expect(result.tokens.map(t => Object.keys(t).join(","))).toEqual([
     "kind,name,rawName,index,value,inlineValue",
     "kind,name,rawName,index,value,inlineValue",
     "kind,name,rawName,index,value,inlineValue",
@@ -20,7 +24,9 @@ test("parseArgs tokens: property insertion order matches Node.js", () => {
     "kind,index",
     "kind,index,value",
   ]);
-  expect(JSON.stringify(tokens[0])).toBe(
+  expect(JSON.stringify(result.tokens[0])).toBe(
     '{"kind":"option","name":"x","rawName":"--x","index":0,"value":"v","inlineValue":true}',
   );
+
+  expect(Object.keys(parseArgs({ args: [], options: {} }))).toEqual(["values", "positionals"]);
 });

--- a/test/js/node/util/parse_args/parse-args-token-key-order.test.ts
+++ b/test/js/node/util/parse_args/parse-args-token-key-order.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test";
+import { parseArgs } from "node:util";
+
+// Node.js emits option tokens with keys in the order {kind, name, rawName, index, value, inlineValue}.
+// Property insertion order is observable via Object.keys / JSON.stringify, so snapshot tests depend on it.
+test("parseArgs tokens: property insertion order matches Node.js", () => {
+  const args = ["--x=v", "-ab", "--flag", "--", "pos"];
+  const options = {
+    x: { type: "string" },
+    a: { type: "boolean" },
+    b: { type: "boolean" },
+    flag: { type: "boolean" },
+  } as const;
+  const { tokens } = parseArgs({ args, options, allowPositionals: true, tokens: true });
+  expect(tokens.map(t => Object.keys(t).join(","))).toEqual([
+    "kind,name,rawName,index,value,inlineValue",
+    "kind,name,rawName,index,value,inlineValue",
+    "kind,name,rawName,index,value,inlineValue",
+    "kind,name,rawName,index,value,inlineValue",
+    "kind,index",
+    "kind,index,value",
+  ]);
+  expect(JSON.stringify(tokens[0])).toBe(
+    '{"kind":"option","name":"x","rawName":"--x","index":0,"value":"v","inlineValue":true}',
+  );
+});


### PR DESCRIPTION
## What does this PR do?

`util.parseArgs` now emits object keys in the same insertion order as Node.js, so `Object.keys()` / `JSON.stringify()` output is byte-identical across runtimes. Two sites are fixed:

- **Option tokens** (with `tokens: true`): `{kind, name, rawName, index, value, inlineValue}`. Previously Bun inserted `index` before `name`/`rawName`.
- **Top-level result** (with `tokens: true`): `{values, positionals, tokens}`. Previously Bun inserted `tokens` first.

Every field value already matched Node; only insertion order differed. Positional (`{kind, index, value}`) and option-terminator (`{kind, index}`) tokens already matched and are unchanged, as does the top-level result without `tokens: true`.

## Repro

```js
import { parseArgs } from "node:util";
const result = parseArgs({
  args: ["--x=v", "p"],
  options: { x: { type: "string" } },
  allowPositionals: true,
  tokens: true,
});
console.log(Object.keys(result).join(","));
console.log(Object.keys(result.tokens[0]).join(","));
// node:         values,positionals,tokens / kind,name,rawName,index,value,inlineValue
// bun (before): tokens,values,positionals / kind,index,name,rawName,value,inlineValue
// bun (after):  values,positionals,tokens / kind,name,rawName,index,value,inlineValue
```

## How did you verify your code works?

Added `test/js/node/util/parse_args/parse-args-token-key-order.test.ts` asserting `Object.keys()` order on the top-level result (with and without `tokens: true`) and on option/positional/option-terminator tokens across long-with-inline-value, short-group and boolean-long forms, plus a `JSON.stringify` byte-exact check. The test fails on main and passes with this change. All existing parseArgs tests continue to pass.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/parse_args/parse-args-token-key-order.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (11b58a83f)

test/js/node/util/parse_args/parse-args-token-key-order.test.ts:
12 |     b: { type: "boolean" },
13 |     flag: { type: "boolean" },
14 |   } as const;
15 | 
16 |   const result = parseArgs({ args, options, allowPositionals: true, tokens: true });
17 |   expect(Object.keys(result)).toEqual(["values", "positionals", "tokens"]);
                                   ^
error: expect(received).toEqual(expected)

  [
+   "tokens",
    "values",
    "positionals",
-   "tokens",
  ]

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/node/util/parse_args/parse-args-token-key-order.test.ts:17:31)
(fail) parseArgs: property insertion order matches Node.js [30.85ms]

 0 pass
 
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (11b58a83f)

test/js/node/util/parse_args/parse-args-token-key-order.test.ts:
(pass) parseArgs: property insertion order matches Node.js [34.38ms]

 1 pass
 0 fail
 4 expect() calls
Ran 1 test across 1 file. [581.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/parse_args/parse-args-token-key-order.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (11b58a83f)

test/js/node/util/parse_args/parse-args-token-key-order.test.ts:
(pass) parseArgs: property insertion order matches Node.js [29.59ms]

 1 pass
 0 fail
 4 expect() calls
Ran 1 test across 1 file. [3.24s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 1088ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/node/util/parse_args.rs                | 14 +++++-----
 .../parse_args/parse-args-token-key-order.test.ts  | 32 ++++++++++++++++++++++
 2 files changed, 39 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/runtime/node/util/parse_args.rs                           2      2      0
…node/util/parse_args/parse-args-token-key-order.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->