### PR TITLE
node:util: add getSystemErrorMap, getSystemErrorMessage, transferableAbortSignal, transferableAbortController

### DIFF
--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -258,7 +258,7 @@ function getSystemErrorMessage(err: any) {
   if (typeof err !== "number") throw $ERR_INVALID_ARG_TYPE("err", "number", err);
   if (err >= 0 || !NumberIsSafeInteger(err)) throw $ERR_OUT_OF_RANGE("err", "a negative integer", err);
   const uv = lazyUv();
-  const entry = (uv.errmap ??= uv.getErrorMap()).get(err);
+  const entry = (uv.errmap ??= uv.getErrorMap()).$get(err);
   return entry ? entry[1] : `Unknown system error ${err}`;
 }
 

--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -245,7 +245,7 @@ function getSystemErrorName(err: any) {
   return internalErrorName(err);
 }
 
-let uvBinding;
+let uvBinding, uvErrmap;
 function lazyUv() {
   return (uvBinding ??= process.binding("uv"));
 }
@@ -257,8 +257,7 @@ function getSystemErrorMap() {
 function getSystemErrorMessage(err: any) {
   if (typeof err !== "number") throw $ERR_INVALID_ARG_TYPE("err", "number", err);
   if (err >= 0 || !NumberIsSafeInteger(err)) throw $ERR_OUT_OF_RANGE("err", "a negative integer", err);
-  const uv = lazyUv();
-  const entry = (uv.errmap ??= uv.getErrorMap()).$get(err);
+  const entry = (uvErrmap ??= lazyUv().getErrorMap()).$get(err);
   return entry ? entry[1] : `Unknown system error ${err}`;
 }
 

--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -245,6 +245,38 @@ function getSystemErrorName(err: any) {
   return internalErrorName(err);
 }
 
+let uvBinding;
+function lazyUv() {
+  return (uvBinding ??= process.binding("uv"));
+}
+
+function getSystemErrorMap() {
+  return lazyUv().getErrorMap();
+}
+
+function getSystemErrorMessage(err: any) {
+  if (typeof err !== "number") throw $ERR_INVALID_ARG_TYPE("err", "number", err);
+  if (err >= 0 || !NumberIsSafeInteger(err)) throw $ERR_OUT_OF_RANGE("err", "a negative integer", err);
+  const uv = lazyUv();
+  const entry = (uv.errmap ??= uv.getErrorMap()).get(err);
+  return entry ? entry[1] : `Unknown system error ${err}`;
+}
+
+function transferableAbortSignal(signal: AbortSignal) {
+  if (!$isObject(signal) || !(signal instanceof AbortSignal)) {
+    throw $ERR_INVALID_ARG_TYPE("signal", "AbortSignal", signal);
+  }
+  // Node sets a transferable marker via markTransferMode; Bun's structured
+  // clone does not yet special-case AbortSignal, so this is a no-op mark.
+  return signal;
+}
+
+function transferableAbortController() {
+  const controller = new AbortController();
+  transferableAbortSignal(controller.signal);
+  return controller;
+}
+
 let lazyAbortedRegistry: FinalizationRegistry<{
   ref: WeakRef<AbortSignal>;
   unregisterToken: (...args: any[]) => void;
@@ -327,9 +359,9 @@ cjs_exports = {
   formatWithOptions,
   // getCallSite,
   // getCallSites,
-  // getSystemErrorMap,
+  getSystemErrorMap,
   getSystemErrorName,
-  // getSystemErrorMessage,
+  getSystemErrorMessage,
   inherits,
   inspect,
   isDeepStrictEqual,
@@ -337,8 +369,8 @@ cjs_exports = {
   setTraceSigInt,
   stripVTControlCharacters,
   toUSVString,
-  // transferableAbortSignal,
-  // transferableAbortController,
+  transferableAbortSignal,
+  transferableAbortController,
   aborted,
   types,
   parseEnv,

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -429,6 +429,88 @@ describe("util", () => {
       });
     }
   });
+
+  describe("getSystemErrorMap", () => {
+    it("is a function", () => {
+      expect(typeof util.getSystemErrorMap).toBe("function");
+    });
+    it("returns a Map of [name, message] keyed by negative errno", () => {
+      const map = util.getSystemErrorMap();
+      expect(map).toBeInstanceOf(Map);
+      const { UV_ENOENT, UV_EACCES } = process.binding("uv");
+      expect(map.get(UV_ENOENT)).toEqual(["ENOENT", "no such file or directory"]);
+      expect(map.get(UV_EACCES)).toEqual(["EACCES", "permission denied"]);
+      for (const [code, [name, msg]] of map) {
+        expect(code).toBeLessThan(0);
+        expect(typeof name).toBe("string");
+        expect(typeof msg).toBe("string");
+      }
+    });
+    it("returns a fresh Map on each call", () => {
+      expect(util.getSystemErrorMap()).not.toBe(util.getSystemErrorMap());
+    });
+  });
+
+  describe("getSystemErrorMessage", () => {
+    it("is a function", () => {
+      expect(typeof util.getSystemErrorMessage).toBe("function");
+    });
+    for (const item of ["test", {}, []]) {
+      it(`throws ERR_INVALID_ARG_TYPE for ${util.inspect(item)}`, () => {
+        expect(() => util.getSystemErrorMessage(item)).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+      });
+    }
+    for (const item of [0, 1, Infinity, -Infinity, NaN, 1.5]) {
+      it(`throws ERR_OUT_OF_RANGE for ${item}`, () => {
+        expect(() => util.getSystemErrorMessage(item)).toThrowWithCode(RangeError, "ERR_OUT_OF_RANGE");
+      });
+    }
+    it("returns the libuv description for known errnos", () => {
+      const { UV_ENOENT, UV_EINVAL } = process.binding("uv");
+      expect(util.getSystemErrorMessage(UV_ENOENT)).toBe("no such file or directory");
+      expect(util.getSystemErrorMessage(UV_EINVAL)).toBe("invalid argument");
+    });
+    it("matches getSystemErrorMap() for every known errno", () => {
+      for (const [code, [, msg]] of util.getSystemErrorMap()) {
+        expect(util.getSystemErrorMessage(code)).toBe(msg);
+      }
+    });
+    it("returns 'Unknown system error N' for unknown errnos", () => {
+      expect(util.getSystemErrorMessage(-111111)).toBe("Unknown system error -111111");
+    });
+  });
+
+  describe("transferableAbortSignal", () => {
+    it("is a function", () => {
+      expect(typeof util.transferableAbortSignal).toBe("function");
+    });
+    it("returns the same AbortSignal instance", () => {
+      const ac = new AbortController();
+      expect(util.transferableAbortSignal(ac.signal)).toBe(ac.signal);
+      const s = AbortSignal.abort("r");
+      expect(util.transferableAbortSignal(s)).toBe(s);
+    });
+    for (const item of [undefined, null, {}, { aborted: false }, new AbortController(), 1, "x"]) {
+      it(`throws ERR_INVALID_ARG_TYPE for ${util.inspect(item)}`, () => {
+        expect(() => util.transferableAbortSignal(item)).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+      });
+    }
+  });
+
+  describe("transferableAbortController", () => {
+    it("is a function", () => {
+      expect(typeof util.transferableAbortController).toBe("function");
+    });
+    it("returns a working AbortController", () => {
+      const ac = util.transferableAbortController();
+      expect(ac).toBeInstanceOf(AbortController);
+      expect(ac.signal).toBeInstanceOf(AbortSignal);
+      expect(ac.signal.aborted).toBe(false);
+      ac.abort("reason");
+      expect(ac.signal.aborted).toBe(true);
+      expect(ac.signal.reason).toBe("reason");
+    });
+  });
 });
 
 describe("util.parseEnv", () => {


### PR DESCRIPTION
Four documented `node:util` exports were `undefined` in Bun:

```js
import util from 'node:util';
typeof util.getSystemErrorMap          // node: function   bun: undefined
typeof util.getSystemErrorMessage      // node: function   bun: undefined
typeof util.transferableAbortController// node: function   bun: undefined
typeof util.transferableAbortSignal    // node: function   bun: undefined
```

### What changed

**`getSystemErrorMap()`** returns `process.binding('uv').getErrorMap()`: a fresh `Map<errno, [name, message]>` per call, same as Node.

**`getSystemErrorMessage(err)`** validates `err` exactly like `getSystemErrorName` (must be a negative safe integer), then returns the message column from the cached errno map, or `'Unknown system error N'` for unknown codes.

**`transferableAbortSignal(signal)`** throws `ERR_INVALID_ARG_TYPE` if `signal` is not an `AbortSignal`, otherwise returns the same signal. **`transferableAbortController()`** returns a new `AbortController`. These match Node's API surface and validation; actual transfer of an `AbortSignal` through `postMessage`/`structuredClone` is a separate structured-clone feature Bun does not implement yet, so the returned signal will still `DataCloneError` if placed in a transfer list.

### Verification

```
util.getSystemErrorMap().get(-2)   // ['ENOENT', 'no such file or directory']
util.getSystemErrorMessage(-2)     // 'no such file or directory'
util.transferableAbortSignal(s) === s  // true
```

27 new tests in `test/js/node/util/util.test.js` fail on main and pass with this change.


Fixes #22872

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 27 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/util.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (918425c5e)

test/js/node/util/util.test.js:
(pass) util > toUSVString [4.89ms]
(pass) util > inherits [5.60ms]
(pass) util > isArray > all cases [7.52ms]
(pass) util > isRegExp > all cases [4.63ms]
(pass) util > isDate > all cases [8.68ms]
(pass) util > isError > all cases [15.25ms]
(pass) util > isObject > all cases [4.50ms]
(pass) util > isPrimitive > all cases [9.67ms]
(pass) util > isBuffer > all cases [3.80ms]
(pass) util > _extend > all cases [8.09ms]
(pass) util > isBoolean > all cases [2.90ms]
(pass) util > isNull > all cases [3.16ms]
(pass) util > isUndefined > all cases [3.06ms]
(pass) util > isNullOrUndefined > all cases [3.02ms]
(pass) util > isNumber > all cases [2.73ms]
(pass) util > isString > all cases [2.76ms]
(pass) u
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (b5ba583d0)

test/js/node/util/util.test.js:
(pass) util > toUSVString [1.27ms]
(pass) util > inherits [0.13ms]
(pass) util > isArray > all cases [0.12ms]
(pass) util > isRegExp > all cases [0.06ms]
(pass) util > isDate > all cases [0.14ms]
(pass) util > isError > all cases [0.20ms]
(pass) util > isObject > all cases [0.04ms]
(pass) util > isPrimitive > all cases [0.16ms]
(pass) util > isBuffer > all cases [0.08ms]
(pass) util > _extend > all cases [0.71ms]
(pass) util > isBoolean > all cases [0.04ms]
(pass) util > isNull > all cases [0.04ms]
(pass) util > isUndefined > all cases [0.02ms]
(pass) util > isNullOrUndefined > all cases [0.04ms]
(pass) util > isNumber > all cases [0.03ms]
(pass) util > isString > all cases [0.02ms]
(pass) util > isSymbol > all cases [0.02ms]
(pass) util > isFunction > all cases [0.03ms]
(pass) util > types.isNativeError > all cases [0.05ms]
(pass) util > TextEncoder > is same as global TextEncoder [0.01ms]
(pass) util > TextDecoder > is same as global TextDecoder [0.02ms]
(pass) util > format [0.20ms]
(pass) util > formatWithOptions [0.21ms]
(pass) util > multiplecolors [0.09ms]
(pass) util > styleText [1.71ms]
(
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/util.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (918425c5e)

test/js/node/util/util.test.js:
(pass) util > toUSVString [8.15ms]
(pass) util > inherits [9.39ms]
(pass) util > isArray > all cases [8.75ms]
(pass) util > isRegExp > all cases [7.20ms]
(pass) util > isDate > all cases [8.38ms]
(pass) util > isError > all cases [23.12ms]
(pass) util > isObject > all cases [5.71ms]
(pass) util > isPrimitive > all cases [11.63ms]
(pass) util > isBuffer > all cases [5.72ms]
(pass) util > _extend > all cases [10.88ms]
(pass) util > isBoolean > all cases [3.34ms]
(pass) util > isNull > all cases [3.47ms]
(pass) util > isUndefined > all cases [3.33ms]
(pass) util > isNullOrUndefined > all cases [3.11ms]
(pass) util > isNumber > all cases [3.30ms]
(pass) util > isString > all cases [2.80ms]
(pass)
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 883ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/20] gen JS modules (bundle-modules)
Preprocess modules (11379ms)
Bundle modules (94ms)
Postprocesss modules (331ms)
Bundle Functions (1380ms)
Generate Code (109ms)

[13.31s] Bundled "src/js" for production
  2037 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/util.ts            | 39 +++++++++++++++++---
 test/js/node/util/util.test.js | 82 ++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 117 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
src/js/node/util.ts                 3      6      0
test/js/node/util/util.test.js      3      2      0
```

</details>

<!-- robobun:evidence:end -->