### PR TITLE
console: use Node's %s format semantics instead of engine ToString

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -3324,6 +3324,94 @@ pub mod formatter {
         }
     }
 
+    /// Approximates `!hasBuiltInToString` from Node's `util.format` `%s`:
+    /// walk the prototype chain to whichever object owns `toString` and treat
+    /// it as user-provided unless that object's own `constructor` names a core
+    /// ECMAScript built-in.
+    fn percent_s_has_user_to_string(value: JSValue, global: &JSGlobalObject) -> JsResult<bool> {
+        let mut pointer = value;
+        for _ in 0..64 {
+            if !pointer.is_cell() || !pointer.is_object() {
+                return Ok(false);
+            }
+            if pointer.js_type() == jsc::JSType::ProxyObject {
+                let target = pointer.get_proxy_internal_field(jsc::ProxyField::Target);
+                if target.is_empty_or_undefined_or_null() {
+                    return Ok(false);
+                }
+                pointer = target;
+                continue;
+            }
+            if let Some(to_string) = pointer.get_own_truthy(global, "toString")? {
+                if !to_string.is_callable() {
+                    return Ok(false);
+                }
+                let Some(ctor) = pointer.get_own_truthy(global, "constructor")? else {
+                    return Ok(true);
+                };
+                if !ctor.is_callable() {
+                    return Ok(true);
+                }
+                let name = ctor.get_name(global)?;
+                return Ok(!percent_s_is_builtin_ctor_name(&name));
+            }
+            let proto = pointer.get_prototype(global);
+            if proto.is_empty_or_undefined_or_null() {
+                return Ok(false);
+            }
+            pointer = proto;
+        }
+        Ok(false)
+    }
+
+    fn percent_s_is_builtin_ctor_name(name: &bun_core::String) -> bool {
+        for builtin in [
+            "Object",
+            "Array",
+            "Function",
+            "Boolean",
+            "Number",
+            "String",
+            "Symbol",
+            "BigInt",
+            "Date",
+            "RegExp",
+            "Error",
+            "AggregateError",
+            "EvalError",
+            "RangeError",
+            "ReferenceError",
+            "SyntaxError",
+            "TypeError",
+            "URIError",
+            "Map",
+            "Set",
+            "WeakMap",
+            "WeakSet",
+            "Promise",
+            "ArrayBuffer",
+            "SharedArrayBuffer",
+            "DataView",
+            "Int8Array",
+            "Uint8Array",
+            "Uint8ClampedArray",
+            "Int16Array",
+            "Uint16Array",
+            "Int32Array",
+            "Uint32Array",
+            "Float16Array",
+            "Float32Array",
+            "Float64Array",
+            "BigInt64Array",
+            "BigUint64Array",
+        ] {
+            if name.eql_comptime(builtin) {
+                return true;
+            }
+        }
+        false
+    }
+
     fn get_object_name(
         global_this: &JSGlobalObject,
         value: JSValue,
@@ -3870,6 +3958,10 @@ pub mod formatter {
             }
 
             drop(writer);
+            if percent_s_has_user_to_string(value, global).unwrap_or(false) {
+                return self.print_as::<false>(Tag::String, writer_, value, value.js_type());
+            }
+
             let prev_quote = self.quote_strings;
             let prev_single = self.single_line;
             let prev_max_depth = self.max_depth;

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -3363,7 +3363,7 @@ pub mod formatter {
             {
                 continue;
             }
-            let Some(ctor) = pointer.get_own_truthy(global, "constructor")? else {
+            let Some(ctor) = pointer.fast_get_direct(global, jsc::BuiltinName::constructor) else {
                 return Ok(true);
             };
             if !ctor.is_callable() {

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -3329,37 +3329,48 @@ pub mod formatter {
     /// it as user-provided unless that object's own `constructor` names a core
     /// ECMAScript built-in.
     fn percent_s_has_user_to_string(value: JSValue, global: &JSGlobalObject) -> JsResult<bool> {
+        if !value.is_cell() || !value.is_object() {
+            return Ok(false);
+        }
         let mut pointer = value;
-        for _ in 0..64 {
-            if !pointer.is_cell() || !pointer.is_object() {
+        while pointer.js_type() == jsc::JSType::ProxyObject {
+            let target = pointer.get_proxy_internal_field(jsc::ProxyField::Target);
+            if !target.is_cell() || !target.is_object() {
                 return Ok(false);
             }
-            if pointer.js_type() == jsc::JSType::ProxyObject {
-                let target = pointer.get_proxy_internal_field(jsc::ProxyField::Target);
-                if target.is_empty_or_undefined_or_null() {
-                    return Ok(false);
-                }
-                pointer = target;
-                continue;
-            }
-            if let Some(to_string) = pointer.get_own_truthy(global, "toString")? {
-                if !to_string.is_callable() {
-                    return Ok(false);
-                }
-                let Some(ctor) = pointer.get_own_truthy(global, "constructor")? else {
-                    return Ok(true);
-                };
-                if !ctor.is_callable() {
-                    return Ok(true);
-                }
-                let name = OwnedString::new(ctor.get_name(global)?);
-                return Ok(!percent_s_is_builtin_ctor_name(&*name));
-            }
+            pointer = target;
+        }
+        let owns_callable = |obj: JSValue, key: jsc::BuiltinName| -> JsResult<bool> {
+            Ok(obj
+                .fast_get_own(global, key)?
+                .is_some_and(|v| v.is_callable()))
+        };
+        // Own `toString` / `Symbol.toPrimitive` on the value itself is always
+        // user-provided.
+        if owns_callable(pointer, jsc::BuiltinName::toString)?
+            || owns_callable(pointer, jsc::BuiltinName::toPrimitive)?
+        {
+            return Ok(true);
+        }
+        for _ in 0..64 {
             let proto = pointer.get_prototype(global);
-            if proto.is_empty_or_undefined_or_null() {
+            if proto.is_empty_or_undefined_or_null() || !proto.is_object() {
                 return Ok(false);
             }
             pointer = proto;
+            if !owns_callable(pointer, jsc::BuiltinName::toString)?
+                && !owns_callable(pointer, jsc::BuiltinName::toPrimitive)?
+            {
+                continue;
+            }
+            let Some(ctor) = pointer.get_own_truthy(global, "constructor")? else {
+                return Ok(true);
+            };
+            if !ctor.is_callable() {
+                return Ok(true);
+            }
+            let name = OwnedString::new(ctor.get_name(global)?);
+            return Ok(!percent_s_is_builtin_ctor_name(&*name));
         }
         Ok(false)
     }

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -3354,6 +3354,9 @@ pub mod formatter {
         }
         for _ in 0..64 {
             let proto = pointer.get_prototype(global);
+            if global.has_exception() {
+                return Err(jsc::JsError::Thrown);
+            }
             if proto.is_empty_or_undefined_or_null() || !proto.is_object() {
                 return Ok(false);
             }

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -3352,8 +3352,8 @@ pub mod formatter {
                 if !ctor.is_callable() {
                     return Ok(true);
                 }
-                let name = ctor.get_name(global)?;
-                return Ok(!percent_s_is_builtin_ctor_name(&name));
+                let name = OwnedString::new(ctor.get_name(global)?);
+                return Ok(!percent_s_is_builtin_ctor_name(&*name));
             }
             let proto = pointer.get_prototype(global);
             if proto.is_empty_or_undefined_or_null() {
@@ -3958,7 +3958,7 @@ pub mod formatter {
             }
 
             drop(writer);
-            if percent_s_has_user_to_string(value, global).unwrap_or(false) {
+            if percent_s_has_user_to_string(value, global)? {
                 return self.print_as::<false>(Tag::String, writer_, value, value.js_type());
             }
 

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2535,12 +2535,7 @@ pub mod formatter {
                         const MIN_BEFORE_E_NOTATION: f64 = 0.000001;
                         match token {
                             PercentTag::S => {
-                                self.print_as::<ENABLE_ANSI_COLORS>(
-                                    Tag::String,
-                                    writer_,
-                                    next_value,
-                                    next_value.js_type(),
-                                )?;
+                                self.print_percent_s(writer_, next_value, global)?;
                                 writer = WrappedWriter {
                                     ctx: writer_,
                                     failed: false,
@@ -3791,6 +3786,106 @@ pub mod formatter {
                 self.failed = true;
             }
             Ok(())
+        }
+
+        /// Node's `util.format` `%s` semantics: numbers/bigints keep their sign
+        /// and suffix, other primitives go through `String()`, objects are
+        /// inspected with `{ depth: 0, compact: 3, colors: false }`.
+        #[inline(never)]
+        fn print_percent_s(
+            &mut self,
+            writer_: &mut dyn bun_io::Write,
+            value: JSValue,
+            global: &'a JSGlobalObject,
+        ) -> JsResult<()> {
+            if value.is_string() || (value.is_cell() && value.is_callable()) {
+                return self.print_as::<false>(Tag::String, writer_, value, value.js_type());
+            }
+
+            let mut writer = WrappedWriter {
+                ctx: writer_,
+                failed: false,
+                estimated_line_length: &mut self.estimated_line_length,
+            };
+            macro_rules! done {
+                () => {{
+                    if writer.failed {
+                        self.failed = true;
+                    }
+                    return Ok(());
+                }};
+            }
+            macro_rules! write_lit {
+                ($bytes:expr) => {{
+                    writer.add_for_new_line($bytes.len());
+                    writer.write_all($bytes);
+                    done!();
+                }};
+            }
+
+            if value.is_undefined() {
+                write_lit!(b"undefined");
+            }
+            if value.is_null() {
+                write_lit!(b"null");
+            }
+            if value.is_boolean() {
+                if value.as_boolean() {
+                    write_lit!(b"true");
+                } else {
+                    write_lit!(b"false");
+                }
+            }
+            if value.is_int32() {
+                let int = value.as_int32();
+                writer.add_for_new_line(bun_core::fmt::digit_count(int));
+                writer.print(format_args!("{int}"));
+                done!();
+            }
+            if value.is_number() {
+                let num = value.as_number();
+                if num.is_nan() {
+                    write_lit!(b"NaN");
+                }
+                if num.is_infinite() {
+                    if num > 0.0 {
+                        write_lit!(b"Infinity");
+                    } else {
+                        write_lit!(b"-Infinity");
+                    }
+                }
+                let mut buf = [0u8; 124];
+                let s = bun_core::fmt::FormatDouble::dtoa_with_negative_zero(&mut buf, num);
+                writer.add_for_new_line(s.len());
+                writer.write_all(s);
+                done!();
+            }
+            if value.is_big_int() {
+                drop(writer);
+                return self.print_bigint::<false>(writer_, value);
+            }
+            if value.is_symbol() {
+                let description = value.get_description(global);
+                writer.add_for_new_line("Symbol()".len() + description.len);
+                if description.len > 0 {
+                    writer.print(format_args!("Symbol({description})"));
+                } else {
+                    writer.write_all(b"Symbol()");
+                }
+                done!();
+            }
+
+            drop(writer);
+            let prev_quote = self.quote_strings;
+            let prev_single = self.single_line;
+            let prev_max_depth = self.max_depth;
+            let _r1 = defer_restore!(self.quote_strings, prev_quote);
+            let _r2 = defer_restore!(self.single_line, prev_single);
+            let _r3 = defer_restore!(self.max_depth, prev_max_depth);
+            self.quote_strings = true;
+            self.single_line = true;
+            self.max_depth = self.depth;
+            self.format::<false>(Tag::get(value, global)?, writer_, value, global)
         }
 
         #[inline(never)]

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -3865,23 +3865,19 @@ pub mod formatter {
                 return self.print_bigint::<false>(writer_, value);
             }
             if value.is_symbol() {
-                let description = value.get_description(global);
-                writer.add_for_new_line("Symbol()".len() + description.len);
-                if description.len > 0 {
-                    writer.print(format_args!("Symbol({description})"));
-                } else {
-                    writer.write_all(b"Symbol()");
-                }
-                done!();
+                drop(writer);
+                return self.print_symbol::<false>(writer_, value);
             }
 
             drop(writer);
             let prev_quote = self.quote_strings;
             let prev_single = self.single_line;
             let prev_max_depth = self.max_depth;
+            let prev_indent = self.indent;
             let _r1 = defer_restore!(self.quote_strings, prev_quote);
             let _r2 = defer_restore!(self.single_line, prev_single);
             let _r3 = defer_restore!(self.max_depth, prev_max_depth);
+            let _r4 = defer_restore!(self.indent, prev_indent);
             self.quote_strings = true;
             self.single_line = true;
             self.max_depth = self.depth;

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1141,6 +1141,24 @@ impl JSValue {
         }
     }
 
+    /// `JSValue.fastGetDirect(global, BuiltinName)` — own data-property slot
+    /// value via `JSObject::getDirect`: no prototype walk and no getter
+    /// invocation (accessor slots come back as the GetterSetter cell).
+    /// `self` must be known to be an object.
+    pub fn fast_get_direct(
+        self,
+        global: &JSGlobalObject,
+        builtin_name: BuiltinName,
+    ) -> Option<JSValue> {
+        debug_assert!(self.is_object());
+        let v = JSC__JSValue__fastGetDirect_(self, global, builtin_name as u8);
+        if v.is_empty() || v.is_undefined() {
+            None
+        } else {
+            Some(v)
+        }
+    }
+
     /// Safe to use on any JSValue.
     /// Returns true iff the value is an object whose `toString` property is a callable cell.
     pub fn implements_to_string(self, global: &JSGlobalObject) -> JsResult<bool> {
@@ -2060,6 +2078,11 @@ unsafe extern "C" {
     safe fn JSC__JSValue__coerceToInt64(this: JSValue, global: &JSGlobalObject) -> i64;
     safe fn JSC__JSValue__fastGet(this: JSValue, global: &JSGlobalObject, builtin: u8) -> JSValue;
     safe fn JSC__JSValue__fastGetOwn(
+        this: JSValue,
+        global: &JSGlobalObject,
+        builtin: u8,
+    ) -> JSValue;
+    safe fn JSC__JSValue__fastGetDirect_(
         this: JSValue,
         global: &JSGlobalObject,
         builtin: u8,

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1122,6 +1122,25 @@ impl JSValue {
         }
     }
 
+    /// `JSValue.fastGetOwn(global, BuiltinName)` — own-property lookup
+    /// (no prototype walk) using a preallocated `JSC::Identifier`.
+    /// `self` must be known to be an object.
+    pub fn fast_get_own(
+        self,
+        global: &JSGlobalObject,
+        builtin_name: BuiltinName,
+    ) -> JsResult<Option<JSValue>> {
+        debug_assert!(self.is_object());
+        let v = host_fn::from_js_host_call_generic(global, || {
+            JSC__JSValue__fastGetOwn(self, global, builtin_name as u8)
+        })?;
+        if v.is_empty() || v.is_undefined() {
+            Ok(None)
+        } else {
+            Ok(Some(v))
+        }
+    }
+
     /// Safe to use on any JSValue.
     /// Returns true iff the value is an object whose `toString` property is a callable cell.
     pub fn implements_to_string(self, global: &JSGlobalObject) -> JsResult<bool> {
@@ -2040,6 +2059,8 @@ unsafe extern "C" {
     safe fn JSC__JSValue__coerceToInt32(this: JSValue, global: &JSGlobalObject) -> i32;
     safe fn JSC__JSValue__coerceToInt64(this: JSValue, global: &JSGlobalObject) -> i64;
     safe fn JSC__JSValue__fastGet(this: JSValue, global: &JSGlobalObject, builtin: u8) -> JSValue;
+    safe fn JSC__JSValue__fastGetOwn(this: JSValue, global: &JSGlobalObject, builtin: u8)
+    -> JSValue;
     safe fn JSC__JSValue__jsonStringify(
         this: JSValue,
         global: &JSGlobalObject,

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2059,8 +2059,11 @@ unsafe extern "C" {
     safe fn JSC__JSValue__coerceToInt32(this: JSValue, global: &JSGlobalObject) -> i32;
     safe fn JSC__JSValue__coerceToInt64(this: JSValue, global: &JSGlobalObject) -> i64;
     safe fn JSC__JSValue__fastGet(this: JSValue, global: &JSGlobalObject, builtin: u8) -> JSValue;
-    safe fn JSC__JSValue__fastGetOwn(this: JSValue, global: &JSGlobalObject, builtin: u8)
-    -> JSValue;
+    safe fn JSC__JSValue__fastGetOwn(
+        this: JSValue,
+        global: &JSGlobalObject,
+        builtin: u8,
+    ) -> JSValue;
     safe fn JSC__JSValue__jsonStringify(
         this: JSValue,
         global: &JSGlobalObject,

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5058,17 +5058,19 @@ JSC::EncodedJSValue JSC__JSValue__fastGet(JSC::EncodedJSValue JSValue0, JSC::JSG
 
 extern "C" JSC::EncodedJSValue JSC__JSValue__fastGetOwn(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* globalObject, unsigned char arg2)
 {
+    ASSERT_NO_PENDING_EXCEPTION(globalObject);
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
     JSC::JSValue value = JSC::JSValue::decode(JSValue0);
     ASSERT(value.isCell());
     PropertySlot slot = PropertySlot(value, PropertySlot::InternalMethodType::GetOwnProperty);
-    const Identifier name = builtinNameMap(globalObject->vm(), arg2);
+    const Identifier name = builtinNameMap(vm, arg2);
     auto* object = value.getObject();
 
-    if (object->getOwnPropertySlot(object, globalObject, name, slot)) {
-        return JSValue::encode(slot.getValue(globalObject, name));
-    }
-
-    return {};
+    bool hasSlot = object->getOwnPropertySlot(object, globalObject, name, slot);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (!hasSlot) return {};
+    RELEASE_AND_RETURN(scope, JSValue::encode(slot.getValue(globalObject, name)));
 }
 
 __attribute__((__always_inline__)) bool JSC__JSValue__toBoolean(JSC::EncodedJSValue JSValue0)

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4940,6 +4940,7 @@ enum class BuiltinNamesMap : uint8_t {
     type,
     signal,
     cmd,
+    toPrimitive,
 };
 
 static inline const JSC::Identifier& builtinNameMap(JSC::VM& vm, unsigned char name)
@@ -5018,6 +5019,9 @@ static inline const JSC::Identifier& builtinNameMap(JSC::VM& vm, unsigned char n
     }
     case BuiltinNamesMap::cmd: {
         return clientData->builtinNames().cmdPublicName();
+    }
+    case BuiltinNamesMap::toPrimitive: {
+        return vm.propertyNames->toPrimitiveSymbol;
     }
     default: {
         ASSERT_NOT_REACHED();

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4941,6 +4941,7 @@ enum class BuiltinNamesMap : uint8_t {
     signal,
     cmd,
     toPrimitive,
+    constructor,
 };
 
 static inline const JSC::Identifier& builtinNameMap(JSC::VM& vm, unsigned char name)
@@ -5022,6 +5023,9 @@ static inline const JSC::Identifier& builtinNameMap(JSC::VM& vm, unsigned char n
     }
     case BuiltinNamesMap::toPrimitive: {
         return vm.propertyNames->toPrimitiveSymbol;
+    }
+    case BuiltinNamesMap::constructor: {
+        return vm.propertyNames->constructor;
     }
     default: {
         ASSERT_NOT_REACHED();

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1206,6 +1206,8 @@ bun_core::comptime_string_map! {
         b"type" => BuiltinName::type_,
         b"signal" => BuiltinName::signal,
         b"cmd" => BuiltinName::cmd,
+        b"toPrimitive" => BuiltinName::toPrimitive,
+        b"constructor" => BuiltinName::constructor,
     };
 }
 

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1148,6 +1148,7 @@ pub enum BuiltinName {
     signal,
     cmd,
     toPrimitive,
+    constructor,
 }
 
 #[allow(non_upper_case_globals)]

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1147,6 +1147,7 @@ pub enum BuiltinName {
     type_,
     signal,
     cmd,
+    toPrimitive,
 }
 
 #[allow(non_upper_case_globals)]

--- a/test/js/web/console/console-log.test.ts
+++ b/test/js/web/console/console-log.test.ts
@@ -164,6 +164,11 @@ it("console.log %s uses Node's format semantics, not engine ToString", async () 
     console.log("%s", new Date(1700000000000));
     console.log("%s %s", Symbol("a"), { x: 1 });
     console.log("%s %s %O", { a: 1 }, { b: 2 }, { c: 3 });
+    console.log("%s", { toString() { return "custom"; } });
+    class X { toString() { return "X!"; } }
+    console.log("%s", new X());
+    class P { a = 1 }
+    console.log("%s", new P());
   `;
   await using proc = spawn({
     cmd: [bunExe(), "-e", src],
@@ -194,6 +199,9 @@ it("console.log %s uses Node's format semantics, not engine ToString", async () 
     "{ a: 1 } { b: 2 } {",
     "  c: 3,",
     "}",
+    "custom",
+    "X!",
+    "P { a: 1 }",
     "",
   ].join("\n");
   expect({ out: out.replaceAll("\r\n", "\n"), err, exitCode }).toEqual({ out: expected, err: "", exitCode: 0 });

--- a/test/js/web/console/console-log.test.ts
+++ b/test/js/web/console/console-log.test.ts
@@ -169,6 +169,11 @@ it("console.log %s uses Node's format semantics, not engine ToString", async () 
     console.log("%s", new X());
     class P { a = 1 }
     console.log("%s", new P());
+    class M { [Symbol.toPrimitive]() { return "$12.34"; } }
+    console.log("%s", new M());
+    console.log("%s", { [Symbol.toPrimitive]() { return "prim"; } });
+    console.log("%s", { toString() { return "own"; }, constructor: Object });
+    console.log("%s", RegExp.prototype);
   `;
   await using proc = spawn({
     cmd: [bunExe(), "-e", src],
@@ -202,6 +207,10 @@ it("console.log %s uses Node's format semantics, not engine ToString", async () 
     "custom",
     "X!",
     "P { a: 1 }",
+    "$12.34",
+    "prim",
+    "own",
+    "/(?:)/",
     "",
   ].join("\n");
   expect({ out: out.replaceAll("\r\n", "\n"), err, exitCode }).toEqual({ out: expected, err: "", exitCode: 0 });

--- a/test/js/web/console/console-log.test.ts
+++ b/test/js/web/console/console-log.test.ts
@@ -163,6 +163,7 @@ it("console.log %s uses Node's format semantics, not engine ToString", async () 
     console.log("%s", "plain");
     console.log("%s", new Date(1700000000000));
     console.log("%s %s", Symbol("a"), { x: 1 });
+    console.log("%s %s %O", { a: 1 }, { b: 2 }, { c: 3 });
   `;
   await using proc = spawn({
     cmd: [bunExe(), "-e", src],
@@ -171,31 +172,31 @@ it("console.log %s uses Node's format semantics, not engine ToString", async () 
     stderr: "pipe",
   });
   const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(err).toBe("");
-  expect(out.replaceAll("\r\n", "\n")).toBe(
-    [
-      "Symbol(q)",
-      "Symbol()",
-      "{ a: 1 }",
-      "[ 1, 2 ]",
-      "-0",
-      "0",
-      "1.5",
-      "NaN",
-      "Infinity",
-      "-Infinity",
-      "42n",
-      "null",
-      "undefined",
-      "true",
-      "false",
-      "plain",
-      "2023-11-14T22:13:20.000Z",
-      "Symbol(a) { x: 1 }",
-      "",
-    ].join("\n"),
-  );
-  expect(exitCode).toBe(0);
+  const expected = [
+    "Symbol(q)",
+    "Symbol()",
+    "{ a: 1 }",
+    "[ 1, 2 ]",
+    "-0",
+    "0",
+    "1.5",
+    "NaN",
+    "Infinity",
+    "-Infinity",
+    "42n",
+    "null",
+    "undefined",
+    "true",
+    "false",
+    "plain",
+    "2023-11-14T22:13:20.000Z",
+    "Symbol(a) { x: 1 }",
+    "{ a: 1 } { b: 2 } {",
+    "  c: 3,",
+    "}",
+    "",
+  ].join("\n");
+  expect({ out: out.replaceAll("\r\n", "\n"), err, exitCode }).toEqual({ out: expected, err: "", exitCode: 0 });
 });
 
 it("console.log with SharedArrayBuffer", () => {

--- a/test/js/web/console/console-log.test.ts
+++ b/test/js/web/console/console-log.test.ts
@@ -143,6 +143,61 @@ NamedError: console.error a named error
 `);
 });
 
+it("console.log %s uses Node's format semantics, not engine ToString", async () => {
+  const src = `
+    try { console.log("%s", Symbol("q")); } catch (e) { console.log("THREW:" + e.constructor.name); }
+    console.log("%s", Symbol());
+    console.log("%s", { a: 1 });
+    console.log("%s", [1, 2]);
+    console.log("%s", -0);
+    console.log("%s", 0);
+    console.log("%s", 1.5);
+    console.log("%s", NaN);
+    console.log("%s", Infinity);
+    console.log("%s", -Infinity);
+    console.log("%s", 42n);
+    console.log("%s", null);
+    console.log("%s", undefined);
+    console.log("%s", true);
+    console.log("%s", false);
+    console.log("%s", "plain");
+    console.log("%s", new Date(1700000000000));
+    console.log("%s %s", Symbol("a"), { x: 1 });
+  `;
+  await using proc = spawn({
+    cmd: [bunExe(), "-e", src],
+    env: { ...bunEnv, TZ: "UTC" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(err).toBe("");
+  expect(out.replaceAll("\r\n", "\n")).toBe(
+    [
+      "Symbol(q)",
+      "Symbol()",
+      "{ a: 1 }",
+      "[ 1, 2 ]",
+      "-0",
+      "0",
+      "1.5",
+      "NaN",
+      "Infinity",
+      "-Infinity",
+      "42n",
+      "null",
+      "undefined",
+      "true",
+      "false",
+      "plain",
+      "2023-11-14T22:13:20.000Z",
+      "Symbol(a) { x: 1 }",
+      "",
+    ].join("\n"),
+  );
+  expect(exitCode).toBe(0);
+});
+
 it("console.log with SharedArrayBuffer", () => {
   // console.log(x) === Bun.inspect(x) + "\n" written to stdout.
   expect(Bun.inspect(new ArrayBuffer(0))).toBe("ArrayBuffer(0) []");


### PR DESCRIPTION
## Reproduction

```js
// TZ=UTC
try { console.log("%s", Symbol("q")); } catch (e) { console.log("THREW:" + e.constructor.name); }
console.log("%s", { a: 1 });
console.log("%s", [1, 2]);
console.log("%s", -0);
console.log("%s", new Date(1700000000000));
```

| | Node 26.3.0 | Bun before | Bun after |
| --- | --- | --- | --- |
| `Symbol("q")` | `Symbol(q)` | **TypeError: Cannot convert a symbol to a string** | `Symbol(q)` |
| `{ a: 1 }` | `{ a: 1 }` | `[object Object]` | `{ a: 1 }` |
| `[1, 2]` | `[ 1, 2 ]` | `1,2` | `[ 1, 2 ]` |
| `-0` | `-0` | `0` | `-0` |
| `new Date(...)` | `2023-11-14T22:13:20.000Z` | `Tue Nov 14 2023 22:13:20 GMT+0000 ...` | `2023-11-14T22:13:20.000Z` |

The Symbol case is the worst: a debug `console.log` that happens to receive a Symbol throws out of `console.log` itself, which in a server takes the request down.

## Cause

`PercentTag::S` in `src/jsc/ConsoleObject.rs` called `print_as(Tag::String, ...)`, which reaches `BunString::from_js` (the engine `ToString` abstract operation). `ToString(symbol)` throws per spec, and for objects/arrays/`-0`/`Date` it produces the generic string coercion instead of Node's `util.format` output.

## Fix

Add `print_percent_s`, mirroring Node's `formatWithOptionsInternal` handling of `%s`:

- numbers: printed via `dtoa_with_negative_zero` (preserves `-0`, `NaN`, `Infinity`)
- bigints: reuse `print_bigint` (adds the `n` suffix)
- symbols: reuse `print_symbol` (`Symbol(description)` via `get_description`, no throw)
- `null` / `undefined` / booleans: literal text
- strings and callables: existing `Tag::String` path (equivalent to `String(value)`)
- objects with a user `toString` or `Symbol.toPrimitive` (`percent_s_has_user_to_string`): existing `Tag::String` path, so `{toString(){...}}`, user classes with `toString`/`[Symbol.toPrimitive]`, `URL`, and the built-in prototype objects themselves keep printing their string form as before
- remaining objects: the existing inspect formatter with `single_line = true`, `quote_strings = true`, `max_depth = depth`, `indent` restored, colors forced off

`percent_s_has_user_to_string` approximates Node's `!hasBuiltInToString`: unwrap proxy targets, treat own callable `toString` / `Symbol.toPrimitive` on the value itself as always user-provided, otherwise walk prototypes to the first owner of either and treat it as built-in only when its own `constructor` names a core ECMAScript type (Object, Array, Date, Map, Set, the Error hierarchy, typed arrays, etc.). To support the symbol-keyed lookup this adds `BuiltinName::toPrimitive` (mapped to `vm.propertyNames->toPrimitiveSymbol` in `bindings.cpp`) and a `JSValue::fast_get_own` wrapper around the existing `JSC__JSValue__fastGetOwn`.

All `%s` output is emitted with `ENABLE_ANSI_COLORS = false`, matching Node's `colors: false`.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/web/console/console-log.test.ts -t "Node's format semantics"
(fail) console.log %s uses Node's format semantics, not engine ToString
  TypeError: Cannot convert a symbol to a string

$ bun bd test test/js/web/console/console-log.test.ts
 5 pass  0 fail
```

Also green: `test/js/web/console/`, `test/js/bun/console/`, `test/js/node/console/`, `test/js/bun/util/inspect.test.js`, `test/js/node/util/node-inspect-tests/parallel/util-format.test.js`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/console/console-log.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f281f8a14)

test/js/web/console/console-log.test.ts:
(pass) should log to console correctly [1199.20ms]
(pass) long arrays get cutoff [3.47ms]
(pass) console.group [522.10ms]
211 |     "prim",
212 |     "own",
213 |     "/(?:)/",
214 |     "",
215 |   ].join("\n");
216 |   expect({ out: out.replaceAll("\r\n", "\n"), err, exitCode }).toEqual({ out: expected, err: "", exitCode: 0 });
                                                                     ^
error: expect(received).toEqual(expected)

  {
-   "err": "",
-   "exitCode": 0,
+   "err": 
+ "1 | 
+ 2 |     try { console.log("%s", Symbol("q")); } catch (e) { console.log("THREW:" + e.constructor.name); }
+ 3 |     console.log("%s", Symbol());
+                 ^
+ TypeError:
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (983c4ace2)

test/js/web/console/console-log.test.ts:
(pass) should log to console correctly [22.43ms]
(pass) long arrays get cutoff [0.13ms]
(pass) console.group [13.40ms]
(pass) console.log %s uses Node's format semantics, not engine ToString [12.35ms]
(pass) console.log with SharedArrayBuffer [0.09ms]

 5 pass
 0 fail
 2 snapshots, 10 expect() calls
Ran 5 tests across 1 file. [220.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/console/console-log.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f281f8a14)

test/js/web/console/console-log.test.ts:
(pass) should log to console correctly [1144.83ms]
(pass) long arrays get cutoff [4.42ms]
(pass) console.group [708.94ms]
(pass) console.log %s uses Node's format semantics, not engine ToString [596.86ms]
(pass) console.log with SharedArrayBuffer [7.14ms]

 5 pass
 0 fail
 2 snapshots, 10 expect() calls
Ran 5 tests across 1 file. [5.12s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 989ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[2/22] gen cpp.rs (cppbind)
[3/22] gen JS modules (bundle-modules)
Preprocess modules (8325ms)
Bundle modules (67ms)
Postprocesss modules (141ms)
Bundle Functions (621ms)
Generate Code (118ms)

[9.29s] Bundled "src/js" for production
  2036 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[3/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rus
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConsoleObject.rs                | 209 +++++++++++++++++++++++++++++++-
 src/jsc/JSValue.rs                      |  47 +++++++
 src/jsc/bindings/bindings.cpp           |  22 +++-
 src/jsc/lib.rs                          |   4 +
 test/js/web/console/console-log.test.ts |  73 +++++++++++
 5 files changed, 343 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/jsc/ConsoleObject.rs                    16     14      0
src/jsc/JSValue.rs                           2      4      0
src/jsc/bindings/bindings.cpp                3      6      0
src/jsc/lib.rs                               3      4      0
test/js/web/console/console-log.test.ts      3      7      0
```

</details>

<!-- robobun:evidence:end -->