### PR TITLE
node:events: validate emitter in static listenerCount like Node

### DIFF
--- a/src/js/internal/streams/legacy.ts
+++ b/src/js/internal/streams/legacy.ts
@@ -55,7 +55,7 @@ Stream.prototype.pipe = function (dest, options) {
   // Don't leave dangling pipes when there are errors.
   function onerror(er) {
     cleanup();
-    if (EE.listenerCount(this, "error") === 0) {
+    if (this.listenerCount?.("error") === 0) {
       this.emit("error", er);
     }
   }

--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -702,23 +702,9 @@ function listenerCount(emitter, type) {
   const evt_count = jsEventTargetGetEventListenersCount(emitter, type);
   if (evt_count !== undefined) return evt_count;
 
-  // EventEmitter's with no `.listenerCount`
-  return listenerCountSlow(emitter, type);
+  throw $ERR_INVALID_ARG_TYPE("emitter", ["EventEmitter", "EventTarget"], emitter);
 }
 Object.defineProperty(listenerCount, "name", { value: "listenerCount" });
-
-function listenerCountSlow(emitter, type) {
-  const events = emitter._events;
-  if (events !== undefined) {
-    const evlistener = events[type];
-    if (typeof evlistener === "function") {
-      return 1;
-    } else if (evlistener !== undefined) {
-      return evlistener.length;
-    }
-  }
-  return 0;
-}
 
 function eventTargetAgnosticRemoveListener(emitter, name, listener, flags?) {
   if (typeof emitter.removeListener === "function") {

--- a/test/js/node/events/event-emitter.test.ts
+++ b/test/js/node/events/event-emitter.test.ts
@@ -4,7 +4,13 @@ import { createRequire } from "module";
 
 // this is also testing that imports with default and named imports in the same statement work
 // our transpiler transform changes this to a var with import.meta.require
-import EventEmitter, { captureRejectionSymbol, getEventListeners, getMaxListeners, setMaxListeners } from "node:events";
+import EventEmitter, {
+  captureRejectionSymbol,
+  getEventListeners,
+  getMaxListeners,
+  listenerCount,
+  setMaxListeners,
+} from "node:events";
 
 describe("node:events", () => {
   test("captureRejectionSymbol", () => {
@@ -907,6 +913,27 @@ test("getEventListeners", () => {
   expect(getEventListeners(target, "hey").length).toBe(1);
   target.dispatchEvent(new Event("hey"));
   expect(getEventListeners(target, "hey").length).toBe(0);
+});
+
+test("events.listenerCount validates emitter argument", () => {
+  const ee = new EventEmitter();
+  ee.on("y", () => {});
+  expect(listenerCount(ee, "y")).toBe(1);
+
+  const et = new EventTarget();
+  et.addEventListener("k", () => {});
+  et.addEventListener("k", () => {});
+  expect(listenerCount(et, "k")).toBe(2);
+
+  const np = Object.create(null);
+  EventEmitter.call(np);
+  EventEmitter.prototype.on.call(np, "y", () => {});
+
+  for (const bad of [{}, 42, np]) {
+    expect(() => listenerCount(bad as any, "y")).toThrow(
+      expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE" }),
+    );
+  }
 });
 
 test("EventEmitter.name", () => {


### PR DESCRIPTION
## What

`events.listenerCount(emitter, type)` (the deprecated static) now throws `ERR_INVALID_ARG_TYPE` when `emitter` is neither an EventEmitter (anything with a callable `.listenerCount`) nor an `EventTarget`, matching Node.

## Repro

```js
import * as events from "node:events";
import { EventEmitter } from "node:events";

events.listenerCount({}, "y");   // node: TypeError ERR_INVALID_ARG_TYPE, bun before: 0
events.listenerCount(42, "y");   // node: TypeError ERR_INVALID_ARG_TYPE, bun before: 0

const np = Object.create(null);
EventEmitter.call(np);
EventEmitter.prototype.on.call(np, "y", () => {});
events.listenerCount(np, "y");   // node: TypeError ERR_INVALID_ARG_TYPE, bun before: 1
```

## Cause

Bun's `listenerCount` fell through to a `listenerCountSlow` helper that read `emitter._events` directly and returned 0 for anything without one. Node has no such fallback: after the duck-typed `.listenerCount` check and the `isEventTarget` check, it throws.

## Fix

Replace the `_events` fallback with the same `ERR_INVALID_ARG_TYPE("emitter", ["EventEmitter", "EventTarget"], emitter)` throw Node uses, and drop the now-unused `listenerCountSlow` helper. The EventEmitter path (callable `.listenerCount`) and EventTarget path (native listener count) are unchanged.

## Verification

- `bun bd test test/js/node/events/event-emitter.test.ts` passes (68 tests)
- New test fails on main / `USE_SYSTEM_BUN=1`
- `test/js/node/test/parallel/test-events-once.js` and `test-events-on-async-iterator.js` still pass

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/events/event-emitter.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (52cdccac8)

test/js/node/events/event-emitter.test.ts:
(pass) node:events > captureRejectionSymbol [27.31ms]
(pass) node:events > once [47.02ms]
(pass) node:events > once (abort) [46.36ms]
(pass) node:events > once (two events in same tick) [27.54ms]
(pass) node:events > once removes the listener afterwards [58.99ms]
(pass) node:events > once is an async function [1.83ms]
(pass) node:events > once with already-aborted signal rejects (not a synchronous throw) [57.74ms]
(pass) node:events > once with invalid options.signal rejects (not a synchronous throw) [16.75ms]
(pass) node:events > once with non-object options rejects (not a synchronous throw) [5.62ms]
(pass) EventEmitter > getEventListeners [6.89ms]
(pass) EventEmitter >
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (ed663e0f3)

test/js/node/events/event-emitter.test.ts:
(pass) node:events > captureRejectionSymbol [0.07ms]
(pass) node:events > once [0.96ms]
(pass) node:events > once (abort) [0.34ms]
(pass) node:events > once (two events in same tick) [10.52ms]
(pass) node:events > once removes the listener afterwards [1.20ms]
(pass) node:events > once is an async function [0.03ms]
(pass) node:events > once with already-aborted signal rejects (not a synchronous throw) [0.25ms]
(pass) node:events > once with invalid options.signal rejects (not a synchronous throw) [0.39ms]
(pass) node:events > once with non-object options rejects (not a synchronous throw) [0.10ms]
(pass) EventEmitter > getEventListeners [0.14ms]
(pass) EventEmitter > constructor [0.08ms]
(pass) EventEmitter > removeAllListeners() [1.09ms]
(pass) EventEmitter > removeAllListeners(type) [0.12ms]
(pass) EventEmitter > emit > different tick [0.11ms]
(pass) EventEmitter > emit > async microtask before [0.12ms]
(pass) EventEmitter > emit > async microtask after [0.11ms]
(pass) EventEmitter > emit > same tick [0.05ms]
(pass) EventEmitter > emit > setTimeout task [4.36ms]
(pass) EventEmitter > em
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/events/event-emitter.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (52cdccac8)

test/js/node/events/event-emitter.test.ts:
(pass) node:events > captureRejectionSymbol [2.63ms]
(pass) node:events > once [36.93ms]
(pass) node:events > once (abort) [12.98ms]
(pass) node:events > once (two events in same tick) [22.53ms]
(pass) node:events > once removes the listener afterwards [40.97ms]
(pass) node:events > once is an async function [1.64ms]
(pass) node:events > once with already-aborted signal rejects (not a synchronous throw) [13.51ms]
(pass) node:events > once with invalid options.signal rejects (not a synchronous throw) [13.62ms]
(pass) node:events > once with non-object options rejects (not a synchronous throw) [5.23ms]
(pass) EventEmitter > getEventListeners [6.49ms]
(pass) EventEmitter > 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 1039ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/20] gen JS modules (bundle-modules)
Preprocess modules (12312ms)
Bundle modules (54ms)
Postprocesss modules (779ms)
Bundle Functions (2013ms)
Generate Code (117ms)

[15.30s] Bundled "src/js" for production
  2036 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[build] done
bun test v1.4.0-canary.1 (52cdccac8)

test/js/node/events/event-emitter.test.ts:
(pass) node:events > captureRejectionSymbol [0.05ms]
(pass) node:events > once [0.58ms]
(pass) node:events > once (abort) [0.26ms]
(pass) node:events > once (two events in same tick) [10.34ms]
(pass) node:events > once removes the listener afterwards [0.72ms]
(pass) node:events > once is an async function [0.02ms]
(pass) node:events > once with already-aborted sig
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/streams/legacy.ts         |  2 +-
 src/js/node/events.ts                     | 16 +---------------
 test/js/node/events/event-emitter.test.ts | 29 ++++++++++++++++++++++++++++-
 3 files changed, 30 insertions(+), 17 deletions(-)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/internal/streams/legacy.ts              2      1      0
src/js/node/events.ts                          2      1      0
test/js/node/events/event-emitter.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->