### PR TITLE
console: print [Circular] for %j on self-referencing objects instead of throwing

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2707,8 +2707,8 @@ pub mod formatter {
                             PercentTag::J => {
                                 // JSON.stringify the value using FastStringifier
                                 // for SIMD optimization
-                                // `OwnedString` releases the
-                                // +1 WTF ref on every exit (incl. the `?` below).
+                                // `OwnedString` releases the +1 WTF ref on
+                                // every exit (incl. the early-return arms).
                                 let mut str = OwnedString::new(BunString::empty());
                                 match next_value.json_stringify_fast(global, &mut str) {
                                     Ok(()) => {
@@ -2725,6 +2725,19 @@ pub mod formatter {
                                         let err = exception.to_error().unwrap_or(exception);
                                         let is_circular = 'c: {
                                             if !err.is_object() {
+                                                break 'c false;
+                                            }
+                                            let Some(name) =
+                                                err.fast_get(global, jsc::BuiltinName::name)?
+                                            else {
+                                                break 'c false;
+                                            };
+                                            if !name.is_string() {
+                                                break 'c false;
+                                            }
+                                            let name =
+                                                OwnedString::new(name.to_bun_string(global)?);
+                                            if !name.eql_comptime(b"TypeError") {
                                                 break 'c false;
                                             }
                                             let Some(msg) =

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2710,9 +2710,45 @@ pub mod formatter {
                                 // `OwnedString` releases the
                                 // +1 WTF ref on every exit (incl. the `?` below).
                                 let mut str = OwnedString::new(BunString::empty());
-                                next_value.json_stringify_fast(global, &mut str)?;
-                                writer.add_for_new_line(str.length());
-                                writer.print(format_args!("{str}"));
+                                match next_value.json_stringify_fast(global, &mut str) {
+                                    Ok(()) => {
+                                        writer.add_for_new_line(str.length());
+                                        writer.print(format_args!("{str}"));
+                                    }
+                                    Err(jsc::JsError::Thrown) => {
+                                        // Node's `%j` prints `[Circular]` for the
+                                        // cyclic-structure TypeError and rethrows
+                                        // everything else (toJSON throws, BigInt).
+                                        let Some(exception) = global.try_take_exception() else {
+                                            return Err(jsc::JsError::Thrown);
+                                        };
+                                        let err = exception.to_error().unwrap_or(exception);
+                                        let is_circular = 'c: {
+                                            if !err.is_object() {
+                                                break 'c false;
+                                            }
+                                            let Some(msg) =
+                                                err.fast_get(global, jsc::BuiltinName::Message)?
+                                            else {
+                                                break 'c false;
+                                            };
+                                            if !msg.is_string() {
+                                                break 'c false;
+                                            }
+                                            let msg = OwnedString::new(msg.to_bun_string(global)?);
+                                            msg.eql_comptime(
+                                                b"JSON.stringify cannot serialize cyclic structures.",
+                                            )
+                                        };
+                                        if is_circular {
+                                            writer.add_for_new_line(10);
+                                            writer.write_all(b"[Circular]");
+                                        } else {
+                                            return Err(global.throw_value(err));
+                                        }
+                                    }
+                                    Err(e) => return Err(e),
+                                }
                             }
                         }
                         if self.remaining_values.is_empty() {

--- a/test/js/web/console/console-log.test.ts
+++ b/test/js/web/console/console-log.test.ts
@@ -151,18 +151,21 @@ it("console.log %j prints [Circular] for self-referencing objects", async () => 
       `
         const c = { a: 1 }; c.self = c;
         try { console.log("pre %j post", c); } catch (e) { console.log("THREW:" + e.constructor.name); }
-        try { console.log("%j", { toJSON() { throw new Error("tj"); } }); } catch { console.log("ctl-tojson:THREW"); }
-        try { console.log("%j", 10n); } catch { console.log("ctl-bigint:THREW"); }
+        try { console.log("%j", { toJSON() { throw new Error("tj"); } }); }
+        catch (e) { console.log("ctl-tojson:" + e.constructor.name + ":" + e.message); }
+        try { console.log("%j", 10n); }
+        catch (e) { console.log("ctl-bigint:" + e.constructor.name + ":" + String(e.message).includes("BigInt")); }
       `,
     ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout.replaceAll("\r\n", "\n")).toBe("pre [Circular] post\nctl-tojson:THREW\nctl-bigint:THREW\n");
-  expect(stderr).toBe("");
-  expect(exitCode).toBe(0);
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect({ stdout: stdout.replaceAll("\r\n", "\n"), exitCode }).toEqual({
+    stdout: "pre [Circular] post\nctl-tojson:Error:tj\nctl-bigint:TypeError:true\n",
+    exitCode: 0,
+  });
 });
 
 it("console.log with SharedArrayBuffer", () => {

--- a/test/js/web/console/console-log.test.ts
+++ b/test/js/web/console/console-log.test.ts
@@ -161,7 +161,7 @@ it("console.log %j prints [Circular] for self-referencing objects", async () => 
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stdout: stdout.replaceAll("\r\n", "\n"), exitCode }).toEqual({
     stdout: "pre [Circular] post\nctl-tojson:Error:tj\nctl-bigint:TypeError:true\n",
     exitCode: 0,

--- a/test/js/web/console/console-log.test.ts
+++ b/test/js/web/console/console-log.test.ts
@@ -143,6 +143,28 @@ NamedError: console.error a named error
 `);
 });
 
+it("console.log %j prints [Circular] for self-referencing objects", async () => {
+  await using proc = spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const c = { a: 1 }; c.self = c;
+        try { console.log("pre %j post", c); } catch (e) { console.log("THREW:" + e.constructor.name); }
+        try { console.log("%j", { toJSON() { throw new Error("tj"); } }); } catch { console.log("ctl-tojson:THREW"); }
+        try { console.log("%j", 10n); } catch { console.log("ctl-bigint:THREW"); }
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout.replaceAll("\r\n", "\n")).toBe("pre [Circular] post\nctl-tojson:THREW\nctl-bigint:THREW\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
 it("console.log with SharedArrayBuffer", () => {
   // console.log(x) === Bun.inspect(x) + "\n" written to stdout.
   expect(Bun.inspect(new ArrayBuffer(0))).toBe("ArrayBuffer(0) []");


### PR DESCRIPTION
## Repro

```js
const c = { a: 1 }; c.self = c;
try { console.log("%j", c); } catch (e) { console.log("THREW:" + e.constructor.name); }
// node:  [Circular]
// bun:   THREW:TypeError
```

`TypeError: JSON.stringify cannot serialize cyclic structures.` propagates out of `console.log`, so a `%j` in any log format string turns a self-referencing object (ORM rows, req/res pairs, DOM-ish trees) into an exception from the logging call itself.

## Cause

`PercentTag::J` in `src/jsc/ConsoleObject.rs` called `json_stringify_fast` and propagated any throw with `?`. Node's `util.format` (and Bun's own ported `util.format`) wrap the stringify in try/catch and map the circular-structure TypeError to the literal `[Circular]`, rethrowing everything else (throwing `toJSON`, BigInt).

## Fix

Catch the stringify exception in the `%j` arm, unwrap the `JSC::Exception` cell, and compare the error's `message` against JSC's fixed `"JSON.stringify cannot serialize cyclic structures."` string. On a match print `[Circular]`; otherwise rethrow the original value unchanged.

## Verification

```
$ bun bd -e 'const c={a:1}; c.self=c; console.log("pre %j post", c)'
pre [Circular] post
```

Controls still throw (matching Node): `{toJSON(){throw new Error}}`, `10n`, `{toJSON(){throw "str"}}`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/console/console-log.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (a542d29c8)

test/js/web/console/console-log.test.ts:
(pass) should log to console correctly [1739.01ms]
(pass) long arrays get cutoff [10.98ms]
(pass) console.group [1715.74ms]
160 |     env: bunEnv,
161 |     stdout: "pipe",
162 |     stderr: "pipe",
163 |   });
164 |   const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
165 |   expect({ stdout: stdout.replaceAll("\r\n", "\n"), exitCode }).toEqual({
                                                                      ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "stdout": 
- "pre [Circular] post
+ "pre THREW:TypeError
  ctl-tojson:Error:tj
  ctl-bigint:TypeError:true
  "
  ,
  }

- Expected  - 1
+ R
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/console/console-log.test.ts:
(pass) should log to console correctly [195.88ms]
(pass) long arrays get cutoff [0.17ms]
(pass) console.group [64.97ms]
160 |     env: bunEnv,
161 |     stdout: "pipe",
162 |     stderr: "pipe",
163 |   });
164 |   const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
165 |   expect({ stdout: stdout.replaceAll("\r\n", "\n"), exitCode }).toEqual({
                                                                      ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "stdout": 
- "pre [Circular] post
+ "pre THREW:TypeError
  ctl-tojson:Error:tj
  ctl-bigint:TypeError:true
  "
  ,
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/web/console/console-log.test.ts:165:65)
(fail) console.log %j prints [Circular] for self-referencing objects [94.45ms]
(pass) console.log with SharedArrayBuffer [0.09ms]

 4 pass
 1 fail
 2 snapshots, 10 expect() calls
Ran 5 tests across 1 file. [554.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/console/console-log.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (a542d29c8)

test/js/web/console/console-log.test.ts:
(pass) should log to console correctly [1451.09ms]
(pass) long arrays get cutoff [22.57ms]
(pass) console.group [720.54ms]
(pass) console.log %j prints [Circular] for self-referencing objects [494.39ms]
(pass) console.log with SharedArrayBuffer [11.57ms]

 5 pass
 0 fail
 2 snapshots, 10 expect() calls
Ran 5 tests across 1 file. [6.81s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 2124ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[9
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConsoleObject.rs                | 59 ++++++++++++++++++++++++++++++---
 test/js/web/console/console-log.test.ts | 25 ++++++++++++++
 2 files changed, 79 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/jsc/ConsoleObject.rs                     8      6      0
test/js/web/console/console-log.test.ts      4      4      0
```

</details>

<!-- robobun:evidence:end -->