### PR TITLE
process: print Node-style warning report and hide internal frames in emitWarning

### DIFF
--- a/src/js/internal/process/warning.ts
+++ b/src/js/internal/process/warning.ts
@@ -21,7 +21,11 @@ function lazyBasename(p: string): string {
     if (c === 47 /* / */ || c === 92 /* \ */) break;
     i--;
   }
-  return p.slice(i);
+  let base = p.slice(i);
+  if (process.platform === "win32" && base.length > 4 && base.slice(-4).toLowerCase() === ".exe") {
+    base = base.slice(0, -4);
+  }
+  return base;
 }
 
 function writeOut(msg: string): void {
@@ -35,7 +39,10 @@ function onWarning(warning: Error): void {
   if (!(warning instanceof Error)) return;
   const isDeprecation = warning.name === "DeprecationWarning";
   if (isDeprecation && process.noDeprecation) return;
-  const trace = hasExecFlag("--trace-warnings") || (isDeprecation && hasExecFlag("--trace-deprecation"));
+  const trace =
+    (process as any).traceProcessWarnings ||
+    hasExecFlag("--trace-warnings") ||
+    (isDeprecation && ((process as any).traceDeprecation || hasExecFlag("--trace-deprecation")));
   let msg = `(${process.release?.name || "node"}:${process.pid}) `;
   const code = (warning as any).code;
   if (code) msg += `[${code}] `;

--- a/src/js/internal/process/warning.ts
+++ b/src/js/internal/process/warning.ts
@@ -34,10 +34,7 @@ function onWarning(warning: Error): void {
   if (code) msg += `[${code}] `;
   let body: string;
   try {
-    body =
-      typeof warning.toString === "function"
-        ? `${warning.toString()}`
-        : ErrorPrototypeToString.$call(warning);
+    body = typeof warning.toString === "function" ? `${warning.toString()}` : ErrorPrototypeToString.$call(warning);
   } catch {
     body = ErrorPrototypeToString.$call(warning);
   }

--- a/src/js/internal/process/warning.ts
+++ b/src/js/internal/process/warning.ts
@@ -1,0 +1,60 @@
+// Default process warning printer, mirroring Node's lib/internal/process/warning.js
+// onWarning. Invoked from BunProcess.cpp's doEmitWarning nextTick handler after
+// the 'warning' event fires; it is not installed as a listener (so user
+// listeners do not suppress the stderr report, matching Node where onWarning is
+// just another listener alongside any user-installed ones).
+
+const ErrorPrototypeToString = Error.prototype.toString;
+
+let traceWarningHelperShown = false;
+
+function lazyBasename(p: string): string {
+  let i = p.length;
+  while (i > 0) {
+    const c = p.charCodeAt(i - 1);
+    if (c === 47 /* / */ || c === 92 /* \ */) break;
+    i--;
+  }
+  return p.slice(i);
+}
+
+function writeOut(msg: string): void {
+  const stderr = process.stderr;
+  if (stderr && typeof stderr.write === "function") {
+    stderr.write(msg + "\n");
+  }
+}
+
+function onWarning(warning: Error): void {
+  if (!(warning instanceof Error)) return;
+  const isDeprecation = warning.name === "DeprecationWarning";
+  if (isDeprecation && process.noDeprecation) return;
+  let msg = `(${process.release?.name || "node"}:${process.pid}) `;
+  const code = (warning as any).code;
+  if (code) msg += `[${code}] `;
+  let body: string;
+  try {
+    body =
+      typeof warning.toString === "function"
+        ? `${warning.toString()}`
+        : ErrorPrototypeToString.$call(warning);
+  } catch {
+    body = ErrorPrototypeToString.$call(warning);
+  }
+  msg += body;
+  const detail = (warning as any).detail;
+  if (typeof detail === "string") {
+    msg += `\n${detail}`;
+  }
+  if (!traceWarningHelperShown) {
+    const flag = isDeprecation ? "--trace-deprecation" : "--trace-warnings";
+    const argv0 = lazyBasename(process.argv0 || "node");
+    msg += `\n(Use \`${argv0} ${flag} ...\` to show where the warning was created)`;
+    traceWarningHelperShown = true;
+  }
+  writeOut(msg);
+}
+
+export default {
+  onWarning,
+};

--- a/src/js/internal/process/warning.ts
+++ b/src/js/internal/process/warning.ts
@@ -39,8 +39,9 @@ function onWarning(warning: Error): void {
   let msg = `(${process.release?.name || "node"}:${process.pid}) `;
   const code = (warning as any).code;
   if (code) msg += `[${code}] `;
-  if (trace && warning.stack) {
-    msg += `${warning.stack}`;
+  let stack: unknown;
+  if (trace && (stack = warning.stack)) {
+    msg += `${stack}`;
   } else {
     let body: string;
     try {

--- a/src/js/internal/process/warning.ts
+++ b/src/js/internal/process/warning.ts
@@ -8,6 +8,12 @@ const ErrorPrototypeToString = Error.prototype.toString;
 
 let traceWarningHelperShown = false;
 
+function hasExecFlag(flag: string): boolean {
+  const argv = process.execArgv;
+  for (let i = 0; i < argv.length; i++) if (argv[i] === flag) return true;
+  return false;
+}
+
 function lazyBasename(p: string): string {
   let i = p.length;
   while (i > 0) {
@@ -29,21 +35,26 @@ function onWarning(warning: Error): void {
   if (!(warning instanceof Error)) return;
   const isDeprecation = warning.name === "DeprecationWarning";
   if (isDeprecation && process.noDeprecation) return;
+  const trace = hasExecFlag("--trace-warnings") || (isDeprecation && hasExecFlag("--trace-deprecation"));
   let msg = `(${process.release?.name || "node"}:${process.pid}) `;
   const code = (warning as any).code;
   if (code) msg += `[${code}] `;
-  let body: string;
-  try {
-    body = typeof warning.toString === "function" ? `${warning.toString()}` : ErrorPrototypeToString.$call(warning);
-  } catch {
-    body = ErrorPrototypeToString.$call(warning);
+  if (trace && warning.stack) {
+    msg += `${warning.stack}`;
+  } else {
+    let body: string;
+    try {
+      body = typeof warning.toString === "function" ? `${warning.toString()}` : ErrorPrototypeToString.$call(warning);
+    } catch {
+      body = ErrorPrototypeToString.$call(warning);
+    }
+    msg += body;
   }
-  msg += body;
   const detail = (warning as any).detail;
   if (typeof detail === "string") {
     msg += `\n${detail}`;
   }
-  if (!traceWarningHelperShown) {
+  if (!trace && !traceWarningHelperShown) {
     const flag = isDeprecation ? "--trace-deprecation" : "--trace-warnings";
     const argv0 = lazyBasename(process.argv0 || "node");
     msg += `\n(Use \`${argv0} ${flag} ...\` to show where the warning was created)`;

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -2004,6 +2004,12 @@ JSValue Process::emitWarning(JSC::JSGlobalObject* lexicalGlobalObject, JSValue w
         auto s = warning.getString(globalObject);
         errorInstance = createError(globalObject, !s.isEmpty() ? s : "Warning"_s);
         errorInstance->putDirect(vm, vm.propertyNames->name, type, JSC::PropertyAttribute::DontEnum | 0);
+        // Only the synthesized error gets its stack re-captured past `ctor`;
+        // a caller-supplied Error keeps whatever .stack it already had.
+        if (ctor.isCallable()) {
+            Bun::captureStackTraceForError(globalObject, errorInstance, ctor);
+            RETURN_IF_EXCEPTION(scope, {});
+        }
     } else if (warning.isCell() && warning.asCell()->type() == ErrorInstanceType) {
         errorInstance = warning.getObject();
     } else {
@@ -2012,13 +2018,6 @@ JSValue Process::emitWarning(JSC::JSGlobalObject* lexicalGlobalObject, JSValue w
 
     if (!code.isUndefined()) errorInstance->putDirect(vm, builtinNames(vm).codePublicName(), code, JSC::PropertyAttribute::DontEnum | 0);
     if (!detail.isUndefined()) errorInstance->putDirect(vm, vm.propertyNames->detail, detail, JSC::PropertyAttribute::DontEnum | 0);
-
-    // Hide the internal emitter frames so --throw-deprecation reports the
-    // user's call site, matching Node's ErrorCaptureStackTrace(warning, ctor).
-    if (ctor.isCallable()) {
-        Bun::captureStackTraceForError(globalObject, errorInstance, ctor);
-        RETURN_IF_EXCEPTION(scope, {});
-    }
 
     RELEASE_AND_RETURN(scope, emitWarningErrorInstance(lexicalGlobalObject, errorInstance));
 }

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -2004,6 +2004,8 @@ JSValue Process::emitWarning(JSC::JSGlobalObject* lexicalGlobalObject, JSValue w
         auto s = warning.getString(globalObject);
         errorInstance = createError(globalObject, !s.isEmpty() ? s : "Warning"_s);
         errorInstance->putDirect(vm, vm.propertyNames->name, type, JSC::PropertyAttribute::DontEnum | 0);
+        if (!code.isUndefined()) errorInstance->putDirect(vm, builtinNames(vm).codePublicName(), code, JSC::PropertyAttribute::DontEnum | 0);
+        if (!detail.isUndefined()) errorInstance->putDirect(vm, vm.propertyNames->detail, detail, JSC::PropertyAttribute::DontEnum | 0);
         // Re-capture past ctor (util.deprecate passes its wrapper). Without
         // one, getFramesForCaller's framesToSkip=1 drops whichever native host
         // function reached here (process.emitWarning, generateKeyPair, ...).
@@ -2014,9 +2016,6 @@ JSValue Process::emitWarning(JSC::JSGlobalObject* lexicalGlobalObject, JSValue w
     } else {
         return JSValue::decode(Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "warning"_s, "string or Error"_s, warning));
     }
-
-    if (!code.isUndefined()) errorInstance->putDirect(vm, builtinNames(vm).codePublicName(), code, JSC::PropertyAttribute::DontEnum | 0);
-    if (!detail.isUndefined()) errorInstance->putDirect(vm, vm.propertyNames->detail, detail, JSC::PropertyAttribute::DontEnum | 0);
 
     RELEASE_AND_RETURN(scope, emitWarningErrorInstance(lexicalGlobalObject, errorInstance));
 }

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -2004,9 +2004,9 @@ JSValue Process::emitWarning(JSC::JSGlobalObject* lexicalGlobalObject, JSValue w
         auto s = warning.getString(globalObject);
         errorInstance = createError(globalObject, !s.isEmpty() ? s : "Warning"_s);
         errorInstance->putDirect(vm, vm.propertyNames->name, type, JSC::PropertyAttribute::DontEnum | 0);
-        // Re-capture past ctor (util.deprecate passes its wrapper). With no
-        // ctor, getFramesForCaller's single framesToSkip drops the enclosing
-        // host-function frame so the stack starts at the user's call site.
+        // Re-capture past ctor (util.deprecate passes its wrapper). Without
+        // one, getFramesForCaller's framesToSkip=1 drops whichever native host
+        // function reached here (process.emitWarning, generateKeyPair, ...).
         Bun::captureStackTraceForError(globalObject, errorInstance, ctor.isCallable() ? ctor : jsUndefined());
         RETURN_IF_EXCEPTION(scope, {});
     } else if (warning.isCell() && warning.asCell()->type() == ErrorInstanceType) {

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -2004,12 +2004,11 @@ JSValue Process::emitWarning(JSC::JSGlobalObject* lexicalGlobalObject, JSValue w
         auto s = warning.getString(globalObject);
         errorInstance = createError(globalObject, !s.isEmpty() ? s : "Warning"_s);
         errorInstance->putDirect(vm, vm.propertyNames->name, type, JSC::PropertyAttribute::DontEnum | 0);
-        // Only the synthesized error gets its stack re-captured past `ctor`;
-        // a caller-supplied Error keeps whatever .stack it already had.
-        if (ctor.isCallable()) {
-            Bun::captureStackTraceForError(globalObject, errorInstance, ctor);
-            RETURN_IF_EXCEPTION(scope, {});
-        }
+        // Re-capture past ctor (util.deprecate passes its wrapper). With no
+        // ctor, getFramesForCaller's single framesToSkip drops the enclosing
+        // host-function frame so the stack starts at the user's call site.
+        Bun::captureStackTraceForError(globalObject, errorInstance, ctor.isCallable() ? ctor : jsUndefined());
+        RETURN_IF_EXCEPTION(scope, {});
     } else if (warning.isCell() && warning.asCell()->type() == ErrorInstanceType) {
         errorInstance = warning.getObject();
     } else {

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1618,15 +1618,24 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_emitWarning, (JSC::JSGlobalObject * lexicalG
     auto value = callFrame->argument(0);
 
     auto ident = builtinNames(vm).warningPublicName();
-    if (process->wrapped().hasEventListeners(ident)) {
-        JSC::MarkedArgumentBuffer args;
-        args.append(value);
-        process->wrapped().emit(ident, args);
-        return JSValue::encode(jsUndefined());
-    } else if (!Bun__NODE_NO_WARNINGS()) {
-        auto jsArgs = JSValue::encode(value);
-        Bun__ConsoleObject__messageWithTypeAndLevel(reinterpret_cast<Bun::ConsoleObject*>(globalObject->consoleClient().get())->m_client, static_cast<uint32_t>(MessageType::Log), static_cast<uint32_t>(MessageLevel::Warning), globalObject, &jsArgs, 1);
+    JSC::MarkedArgumentBuffer args;
+    args.append(value);
+    process->wrapped().emit(ident, args);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    // Node's default onWarning printer runs alongside any user 'warning'
+    // listeners; mirror that by always printing unless --no-warnings.
+    if (!Bun__NODE_NO_WARNINGS()) {
+        auto module = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::InternalProcessWarning);
         RETURN_IF_EXCEPTION(scope, {});
+        auto onWarning = module.get(globalObject, Identifier::fromString(vm, "onWarning"_s));
+        RETURN_IF_EXCEPTION(scope, {});
+        if (onWarning.isCallable()) {
+            JSC::MarkedArgumentBuffer printArgs;
+            printArgs.append(value);
+            JSC::call(globalObject, onWarning, printArgs, "onWarning must be callable"_s);
+            RETURN_IF_EXCEPTION(scope, {});
+        }
     }
     return JSValue::encode(jsUndefined());
 }
@@ -2004,23 +2013,12 @@ JSValue Process::emitWarning(JSC::JSGlobalObject* lexicalGlobalObject, JSValue w
     if (!code.isUndefined()) errorInstance->putDirect(vm, builtinNames(vm).codePublicName(), code, JSC::PropertyAttribute::DontEnum | 0);
     if (!detail.isUndefined()) errorInstance->putDirect(vm, vm.propertyNames->detail, detail, JSC::PropertyAttribute::DontEnum | 0);
 
-    /*
-    // TODO: ErrorCaptureStackTrace(warning, ctor || process.emitWarning);
-    // This doesn't work, getStackTrace does not get any stack frames.
-    Vector<StackFrame> stackTrace;
-    const size_t framesToSkip = 1;
-    JSValue caller;
-    if (ctor.toBoolean(globalObject)) {
-        caller = ctor;
-    } else {
-        auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
-        auto* process = globalObject->processObject();
-        caller = process->get(globalObject, Identifier::fromString(vm, String("emitWarning"_s)));
+    // Hide the internal emitter frames so --throw-deprecation reports the
+    // user's call site, matching Node's ErrorCaptureStackTrace(warning, ctor).
+    if (ctor.isCallable()) {
+        Bun::captureStackTraceForError(globalObject, errorInstance, ctor);
         RETURN_IF_EXCEPTION(scope, {});
     }
-    vm.interpreter.getStackTrace(errorInstance, stackTrace, framesToSkip, globalObject->stackTraceLimit().value_or(0), caller.isCallable() ? caller.asCell() : nullptr);
-    errorInstance->putDirect(vm, vm.propertyNames->stack, jsString(vm, Interpreter::stackTraceAsString(vm, stackTrace)), static_cast<unsigned>(PropertyAttribute::DontEnum));
-    */
 
     RELEASE_AND_RETURN(scope, emitWarningErrorInstance(lexicalGlobalObject, errorInstance));
 }

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -756,6 +756,53 @@ JSC_DEFINE_CUSTOM_SETTER(errorInstanceLazyStackCustomSetter, (JSGlobalObject * g
     return true;
 }
 
+void captureStackTraceForError(Zig::GlobalObject* globalObject, JSC::JSObject* errorObject, JSC::JSValue caller)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    size_t stackTraceLimit = globalObject->stackTraceLimit().value_or(DEFAULT_ERROR_STACK_TRACE_LIMIT);
+    if (stackTraceLimit == 0) {
+        stackTraceLimit = DEFAULT_ERROR_STACK_TRACE_LIMIT;
+    }
+
+    WTF::Vector<JSC::StackFrame> stackTrace;
+    JSCStackTrace::getFramesForCaller(vm, nullptr, errorObject, caller, stackTrace, stackTraceLimit);
+
+    if (auto* instance = dynamicDowncast<JSC::ErrorInstance>(errorObject)) {
+        if (instance->hasMaterializedErrorInfo()) {
+            // Already materialized: setStackFrames here would later hit
+            // ASSERT(!m_errorInfoMaterialized) in computeErrorInfo during GC.
+            // Compute and write the .stack string eagerly instead.
+            OrdinalNumber line;
+            OrdinalNumber column;
+            String sourceURL;
+            JSValue result = computeErrorInfoToJSValue(vm, stackTrace, line, column, sourceURL, errorObject, nullptr);
+            RETURN_IF_EXCEPTION(scope, );
+            errorObject->putDirect(vm, vm.propertyNames->stack, result, JSC::PropertyAttribute::DontEnum | 0);
+        } else {
+            instance->setStackFrames(vm, WTF::move(stackTrace));
+
+            {
+                const auto& propertyName = vm.propertyNames->stack;
+                VM::DeletePropertyModeScope deleteScope(vm, VM::DeletePropertyMode::IgnoreConfigurable);
+                DeletePropertySlot slot;
+                JSObject::deleteProperty(instance, globalObject, propertyName, slot);
+            }
+            RETURN_IF_EXCEPTION(scope, );
+
+            instance->putDirectCustomAccessor(vm, vm.propertyNames->stack, globalObject->m_lazyStackCustomGetterSetter.get(globalObject), JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::CustomAccessor | 0);
+        }
+    } else {
+        OrdinalNumber line;
+        OrdinalNumber column;
+        String sourceURL;
+        JSValue result = computeErrorInfoToJSValue(vm, stackTrace, line, column, sourceURL, errorObject, nullptr);
+        RETURN_IF_EXCEPTION(scope, );
+        errorObject->putDirect(vm, vm.propertyNames->stack, result, JSC::PropertyAttribute::DontEnum | 0);
+    }
+}
+
 JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
 {
     Zig::GlobalObject* globalObject = static_cast<Zig::GlobalObject*>(lexicalGlobalObject);
@@ -770,49 +817,8 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace, (JSC::JSGlobalOb
     JSC::JSObject* errorObject = objectArg.asCell()->getObject();
     JSC::JSValue caller = callFrame->argument(1);
 
-    size_t stackTraceLimit = globalObject->stackTraceLimit().value_or(DEFAULT_ERROR_STACK_TRACE_LIMIT);
-    if (stackTraceLimit == 0) {
-        stackTraceLimit = DEFAULT_ERROR_STACK_TRACE_LIMIT;
-    }
-
-    WTF::Vector<JSC::StackFrame> stackTrace;
-    JSCStackTrace::getFramesForCaller(vm, callFrame, errorObject, caller, stackTrace, stackTraceLimit);
-
-    if (auto* instance = dynamicDowncast<JSC::ErrorInstance>(errorObject)) {
-        if (instance->hasMaterializedErrorInfo()) {
-            // Error info was already materialized (e.g. .stack was previously accessed).
-            // Don't call setStackFrames — it would leave m_errorInfoMaterialized=true with
-            // a non-null m_stackTrace, causing ASSERT(!m_errorInfoMaterialized) in
-            // computeErrorInfo when GC's finalizeUnconditionally finds unmarked frames.
-            // Eagerly compute and set the .stack property instead.
-            OrdinalNumber line;
-            OrdinalNumber column;
-            String sourceURL;
-            JSValue result = computeErrorInfoToJSValue(vm, stackTrace, line, column, sourceURL, errorObject, nullptr);
-            RETURN_IF_EXCEPTION(scope, {});
-            errorObject->putDirect(vm, vm.propertyNames->stack, result, JSC::PropertyAttribute::DontEnum | 0);
-        } else {
-            // Not yet materialized — safe to install new frames with a lazy getter.
-            instance->setStackFrames(vm, WTF::move(stackTrace));
-
-            {
-                const auto& propertyName = vm.propertyNames->stack;
-                VM::DeletePropertyModeScope deleteScope(vm, VM::DeletePropertyMode::IgnoreConfigurable);
-                DeletePropertySlot slot;
-                JSObject::deleteProperty(instance, globalObject, propertyName, slot);
-            }
-            RETURN_IF_EXCEPTION(scope, {});
-
-            instance->putDirectCustomAccessor(vm, vm.propertyNames->stack, globalObject->m_lazyStackCustomGetterSetter.get(globalObject), JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::CustomAccessor | 0);
-        }
-    } else {
-        OrdinalNumber line;
-        OrdinalNumber column;
-        String sourceURL;
-        JSValue result = computeErrorInfoToJSValue(vm, stackTrace, line, column, sourceURL, errorObject, nullptr);
-        RETURN_IF_EXCEPTION(scope, {});
-        errorObject->putDirect(vm, vm.propertyNames->stack, result, JSC::PropertyAttribute::DontEnum | 0);
-    }
+    captureStackTraceForError(globalObject, errorObject, caller);
+    RETURN_IF_EXCEPTION(scope, {});
 
     return JSC::JSValue::encode(JSC::jsUndefined());
 }

--- a/src/jsc/bindings/FormatStackTraceForJS.h
+++ b/src/jsc/bindings/FormatStackTraceForJS.h
@@ -70,6 +70,10 @@ WTF::String formatStackTrace(
     WTF::Vector<JSC::StackFrame>& stackTrace,
     JSC::JSObject* errorInstance);
 
+// Shared body of Error.captureStackTrace: collect frames (filtered past
+// `caller` when it is a function) and install them on `errorObject`.
+void captureStackTraceForError(Zig::GlobalObject* globalObject, JSC::JSObject* errorObject, JSC::JSValue caller);
+
 // JSC Host Functions - Error constructor methods
 JSC_DECLARE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace);
 JSC_DECLARE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace);

--- a/test/js/node/process/process-warning-output.test.ts
+++ b/test/js/node/process/process-warning-output.test.ts
@@ -117,7 +117,20 @@ describe("process.emitWarning default stderr report", () => {
     const { stderr, exitCode } = await run(["--trace-warnings"], src);
     expect(stderr.split("\n")[0]).toMatch(/^\(\w+:\d+\) \[CODE10\] CustomWarning: trace me$/);
     expect(stderr).toMatch(/^\s+at /m);
+    expect(stderr).not.toMatch(/at emitWarning/);
     expect(stderr).not.toContain("--trace-warnings ...");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("process.traceDeprecation = true enables stack printing at runtime", async () => {
+    const src = `
+      process.traceDeprecation = true;
+      require("node:util").deprecate(() => 1, "dep msg F", "DEP0T6")();
+    `;
+    const { stderr, exitCode } = await run([], src);
+    expect(stderr.split("\n")[0]).toMatch(/^\(\w+:\d+\) \[DEP0T6\] DeprecationWarning: dep msg F$/);
+    expect(stderr).toMatch(/^\s+at /m);
+    expect(stderr).not.toContain("--trace-deprecation ...");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/process/process-warning-output.test.ts
+++ b/test/js/node/process/process-warning-output.test.ts
@@ -96,19 +96,19 @@ describe("process.emitWarning default stderr report", () => {
     expect(exitCode).toBe(0);
   });
 
-  test.concurrent("passing an Error instance leaves its .stack untouched even when ctor is given", async () => {
+  test.concurrent("passing an Error instance leaves it unmutated even when ctor/code/detail are given", async () => {
     const src = `
       function outer() {
         const e = new Error("boom");
         const orig = e.stack;
-        process.emitWarning(e, { ctor: outer });
+        process.emitWarning(e, { ctor: outer, code: "X", detail: "Y" });
         process.emitWarning(e, "Type", "CODE", outer);
-        console.log(e.stack === orig ? "same" : "changed");
+        console.log(JSON.stringify({ stack: e.stack === orig, code: e.code, detail: e.detail }));
       }
       outer();
     `;
     const { stdout, exitCode } = await run([], src);
-    expect(stdout).toBe("same\n");
+    expect(JSON.parse(stdout)).toEqual({ stack: true, code: undefined, detail: undefined });
     expect(exitCode).toBe(0);
   });
 

--- a/test/js/node/process/process-warning-output.test.ts
+++ b/test/js/node/process/process-warning-output.test.ts
@@ -4,7 +4,7 @@ import { bunEnv, bunExe } from "harness";
 async function run(execArgv: string[], src: string) {
   await using proc = Bun.spawn({
     cmd: [bunExe(), ...execArgv, "-e", src],
-    env: bunEnv,
+    env: { ...bunEnv, NODE_NO_WARNINGS: undefined },
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/test/js/node/process/process-warning-output.test.ts
+++ b/test/js/node/process/process-warning-output.test.ts
@@ -96,6 +96,22 @@ describe("process.emitWarning default stderr report", () => {
     expect(exitCode).toBe(0);
   });
 
+  test.concurrent("passing an Error instance leaves its .stack untouched even when ctor is given", async () => {
+    const src = `
+      function outer() {
+        const e = new Error("boom");
+        const orig = e.stack;
+        process.emitWarning(e, { ctor: outer });
+        process.emitWarning(e, "Type", "CODE", outer);
+        console.log(e.stack === orig ? "same" : "changed");
+      }
+      outer();
+    `;
+    const { stdout, exitCode } = await run([], src);
+    expect(stdout).toBe("same\n");
+    expect(exitCode).toBe(0);
+  });
+
   test.concurrent("--trace-warnings prints the warning stack for non-deprecation warnings", async () => {
     const src = `process.emitWarning("trace me", "CustomWarning", "CODE10");`;
     const { stderr, exitCode } = await run(["--trace-warnings"], src);

--- a/test/js/node/process/process-warning-output.test.ts
+++ b/test/js/node/process/process-warning-output.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 async function run(execArgv: string[], src: string) {

--- a/test/js/node/process/process-warning-output.test.ts
+++ b/test/js/node/process/process-warning-output.test.ts
@@ -1,0 +1,85 @@
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+async function run(execArgv: string[], src: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...execArgv, "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe("process.emitWarning default stderr report", () => {
+  test.concurrent("a user 'warning' listener does not suppress the stderr report", async () => {
+    const src = `
+      const util = require("node:util");
+      process.on("warning", () => {});
+      util.deprecate(() => 1, "dep msg A", "DEP0T1")();
+      setTimeout(() => {}, 30);
+    `;
+    const { stderr, exitCode } = await run([], src);
+    const first = stderr.split("\n")[0];
+    expect(first).toMatch(/^\(\w+:\d+\) \[DEP0T1\] DeprecationWarning: dep msg A$/);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("default report uses Node's one-line (name:pid) [CODE] form", async () => {
+    const src = `
+      const util = require("node:util");
+      util.deprecate(() => 1, "dep msg B", "DEP0T2")();
+    `;
+    const { stderr, exitCode } = await run([], src);
+    const lines = stderr.split("\n");
+    expect(lines[0]).toMatch(/^\(\w+:\d+\) \[DEP0T2\] DeprecationWarning: dep msg B$/);
+    expect(lines[1]).toMatch(/--trace-deprecation/);
+    // No stack frames printed by default.
+    expect(stderr).not.toMatch(/^\s+at /m);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("process.emitWarning with code and detail formats Node-style", async () => {
+    const src = `process.emitWarning("plain msg", { type: "CustomWarning", code: "CODE9", detail: "some detail" });`;
+    const { stderr, exitCode } = await run([], src);
+    const lines = stderr.split("\n");
+    expect(lines[0]).toMatch(/^\(\w+:\d+\) \[CODE9\] CustomWarning: plain msg$/);
+    expect(lines[1]).toBe("some detail");
+    expect(lines[2]).toMatch(/--trace-warnings/);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("--throw-deprecation does not leak internal builtin source", async () => {
+    const src = `
+      const util = require("node:util");
+      util.deprecate(() => 1, "dep msg C", "DEP0T3")();
+    `;
+    const { stderr, exitCode } = await run(["--throw-deprecation"], src);
+    // The thrown DeprecationWarning's stack must start at the user's call
+    // site, not inside the internal util/deprecate emitter, so no builtin
+    // source snippet (with raw @-intrinsic syntax) should appear.
+    expect(stderr).not.toMatch(/getDeprecationWarningEmitter/);
+    expect(stderr).not.toMatch(/@undefined/);
+    expect(stderr).not.toMatch(/internal:util\/deprecate/);
+    expect(stderr).toContain("DeprecationWarning: dep msg C");
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("NODE_NO_WARNINGS=1 still delivers the event but suppresses stderr", async () => {
+    const src = `
+      process.on("warning", w => console.log("event:" + w.name + ":" + w.code));
+      process.emitWarning("hush", "DeprecationWarning", "DEP0T4");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: { ...bunEnv, NODE_NO_WARNINGS: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("event:DeprecationWarning:DEP0T4\n");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/node/process/process-warning-output.test.ts
+++ b/test/js/node/process/process-warning-output.test.ts
@@ -78,8 +78,30 @@ describe("process.emitWarning default stderr report", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
+    expect(stderr).not.toMatch(/DEP0T4|DeprecationWarning/);
     expect(stdout).toBe("event:DeprecationWarning:DEP0T4\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("--trace-deprecation prints the warning stack instead of the hint", async () => {
+    const src = `
+      const util = require("node:util");
+      util.deprecate(() => 1, "dep msg E", "DEP0T5")();
+    `;
+    const { stderr, exitCode } = await run(["--trace-deprecation"], src);
+    expect(stderr.split("\n")[0]).toMatch(/^\(\w+:\d+\) \[DEP0T5\] DeprecationWarning: dep msg E$/);
+    expect(stderr).toMatch(/^\s+at /m);
+    expect(stderr).not.toMatch(/internal:util\/deprecate/);
+    expect(stderr).not.toContain("--trace-deprecation ...");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("--trace-warnings prints the warning stack for non-deprecation warnings", async () => {
+    const src = `process.emitWarning("trace me", "CustomWarning", "CODE10");`;
+    const { stderr, exitCode } = await run(["--trace-warnings"], src);
+    expect(stderr.split("\n")[0]).toMatch(/^\(\w+:\d+\) \[CODE10\] CustomWarning: trace me$/);
+    expect(stderr).toMatch(/^\s+at /m);
+    expect(stderr).not.toContain("--trace-warnings ...");
     expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
Fixes three presentation problems in the `process.emitWarning` / `util.deprecate` warning path. Semantics (once-law, `[code]` dedup, `this`/args/return passthrough, `'warning'` event payload, `--no-deprecation`, `--throw-deprecation` exit 1) were already Node-correct; only the stderr report and thrown-error stack were off.

Fixes #9867. Supersedes #32433.

## Repro

```js
import { spawnSync } from "node:child_process";
const run = (args, src) => spawnSync(process.execPath, [...args, "-e", src], { encoding: "utf8" });
const LISTENER = `const util=require("node:util");process.on("warning",()=>{});util.deprecate(()=>1,"dep msg A","DEP0T1")();setTimeout(()=>{},30);`;
const PLAIN = `const util=require("node:util");util.deprecate(()=>1,"dep msg B","DEP0T2")();`;

console.log(run([], LISTENER).stderr.split("\n")[0]);
// node:   "(node:PID) [DEP0T1] DeprecationWarning: dep msg A"
// before: ""  (any 'warning' listener suppressed the stderr report entirely)

console.log(run([], PLAIN).stderr.split("\n")[0]);
// node:   "(node:PID) [DEP0T2] DeprecationWarning: dep msg B"
// before: "DeprecationWarning: dep msg B" then a separate ` code: "DEP0T2"` line

const r = run(["--throw-deprecation"], PLAIN);
console.log(/getDeprecationWarningEmitter|@undefined/.test(r.stderr));
// node:   false (warning + user stack)
// before: true (shows builtin source with raw `code !== @undefined` JSC intrinsic syntax)
```

## Cause

`jsFunction_emitWarning` (the nextTick handler) emitted the `'warning'` event *or* printed via the console error inspector, never both:

```cpp
if (process->wrapped().hasEventListeners(ident)) {
    process->wrapped().emit(ident, args);
} else if (!Bun__NODE_NO_WARNINGS()) {
    Bun__ConsoleObject__messageWithTypeAndLevel(...);  // inspected error, no [CODE] form
}
```

so installing any listener silenced the on-terminal deprecation trail, and when it did print it used the error inspector instead of Node's one-line form. Separately, `Process::emitWarning` built the warning `Error` with `createError()` but never re-captured its stack past the supplied `ctor`, leaving the internal `util/deprecate` emitter frames on top; under `--throw-deprecation` the uncaught-error reporter then showed a source snippet from the bundled builtin (complete with `@undefined` intrinsic syntax).

## Fix

- Always emit `'warning'`, then (unless `NODE_NO_WARNINGS`) call a new `internal/process/warning` `onWarning` that writes Node's `(name:pid) [CODE] Name: msg` line, `detail`, and the one-time `--trace-*` hint via `process.stderr.write`. A throwing `warning.toString()` falls back to `Error.prototype.toString` so the printer itself never escalates a diagnostic into an uncaught exception.
- Factor the body of `Error.captureStackTrace` into `captureStackTraceForError` and call it from `Process::emitWarning` with `ctor` so the warning's stack starts at the user's call site.

## Verification

```
bun bd test test/js/node/process/process-warning-output.test.ts
```

Node parallel tests `test-process-warning.js`, `test-process-emitwarning.js`, `test-process-no-deprecation.js`, `test-child-process-no-deprecation.js`, `test-util-deprecate.js`, `test-common-expect-warning.js`, and `test/js/node/v8/capture-stack-trace.test.js` all pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/process/process-warning-output.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (5f701eb79)

test/js/node/process/process-warning-output.test.ts:
42 | 
43 |   test.concurrent("process.emitWarning with code and detail formats Node-style", async () => {
44 |     const src = `process.emitWarning("plain msg", { type: "CustomWarning", code: "CODE9", detail: "some detail" });`;
45 |     const { stderr, exitCode } = await run([], src);
46 |     const lines = stderr.split("\n");
47 |     expect(lines[0]).toMatch(/^\(\w+:\d+\) \[CODE9\] CustomWarning: plain msg$/);
                          ^
error: expect(received).toMatch(expected)

Expected substring or pattern: /^\(\w+:\d+\) \[CODE9\] CustomWarning: plain msg$/
Received: "CustomWarning: plain msg"

      at <anonymous> (/workspace/bun/test/js/node/p
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (e6a0c1d0c)

test/js/node/process/process-warning-output.test.ts:
(pass) process.emitWarning default stderr report > NODE_NO_WARNINGS=1 still delivers the event but suppresses stderr [17.02ms]
(pass) process.emitWarning default stderr report > --throw-deprecation does not leak internal builtin source [20.00ms]
(pass) process.emitWarning default stderr report > process.emitWarning with code and detail formats Node-style [25.99ms]
106 |         console.log(JSON.stringify({ stack: e.stack === orig, code: e.code, detail: e.detail }));
107 |       }
108 |       outer();
109 |     `;
110 |     const { stdout, exitCode } = await run([], src);
111 |     expect(JSON.parse(stdout)).toEqual({ stack: true, code: undefined, detail: undefined });
                                     ^
error: expect(received).toEqual(expected)

  {
-   "code": undefined,
-   "detail": undefined,
+   "code": "CODE",
+   "detail": "Y",
    "stack": true,
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/node/process/process-warning-output.test.ts:111:32)
(fail) process.emitWarning default stderr report > passing an Error instance leaves it un
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/process/process-warning-output.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (5f701eb79)

test/js/node/process/process-warning-output.test.ts:
(pass) process.emitWarning default stderr report > NODE_NO_WARNINGS=1 still delivers the event but suppresses stderr [578.67ms]
(pass) process.emitWarning default stderr report > --throw-deprecation does not leak internal builtin source [909.74ms]
(pass) process.emitWarning default stderr report > process.emitWarning with code and detail formats Node-style [1296.79ms]
(pass) process.emitWarning default stderr report > default report uses Node's one-line (name:pid) [CODE] form [1605.10ms]
(pass) process.emitWarning default stderr report > a user 'warning' listener does not suppress the stderr report [1745.29ms]
(pass) process.emitWarning default stderr
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 890ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen cpp.rs (cppbind)
[2/22] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[3/22] gen JS modules (bundle-modules)
Preprocess modules (8098ms)
Bundle modules (49ms)
Postprocesss modules (236ms)
Bundle Functions (782ms)
Generate Code (110ms)

[9.29s] Bundled "src/js" for production
  2038 kb
  166 internal modules
  13 native modules
  90 internal functions across 19 files
[3/10] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/process/warning.ts                 |  76 ++++++++++++
 src/jsc/bindings/BunProcess.cpp                    |  53 ++++----
 src/jsc/bindings/FormatStackTraceForJS.cpp         |  46 ++++---
 src/jsc/bindings/FormatStackTraceForJS.h           |   4 +
 .../js/node/process/process-warning-output.test.ts | 136 +++++++++++++++++++++
 5 files changed, 266 insertions(+), 49 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/js/internal/process/warning.ts                       3      7      0
src/jsc/bindings/BunProcess.cpp                          6      7      0
src/jsc/bindings/FormatStackTraceForJS.cpp               3      3      0
src/jsc/bindings/FormatStackTraceForJS.h                 1      1      0
test/js/node/process/process-warning-output.test.ts      3      7      0
```

</details>

<!-- robobun:evidence:end -->