### PR TITLE
node:string_decoder: make `encoding` an enumerable own data property

### DIFF
--- a/src/jsc/bindings/JSStringDecoder.cpp
+++ b/src/jsc/bindings/JSStringDecoder.cpp
@@ -28,7 +28,6 @@ static JSC_DECLARE_HOST_FUNCTION(jsStringDecoderPrototypeFunction_text);
 static JSC_DECLARE_CUSTOM_GETTER(jsStringDecoder_lastChar);
 static JSC_DECLARE_CUSTOM_GETTER(jsStringDecoder_lastNeed);
 static JSC_DECLARE_CUSTOM_GETTER(jsStringDecoder_lastTotal);
-static JSC_DECLARE_CUSTOM_GETTER(jsStringDecoder_encoding);
 
 // Checks the type of a UTF-8 byte, whether it's ASCII, a leading byte, or a
 // continuation byte.
@@ -108,6 +107,9 @@ static inline JSStringDecoder* jsStringDecoderCast(JSGlobalObject* globalObject,
 void JSStringDecoder::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
 {
     Base::finishCreation(vm);
+    // Node assigns `this.encoding = normalizeEncoding(encoding)` in the constructor, producing an
+    // enumerable own data property (so Object.hasOwn / spread / JSON.stringify all see it).
+    putDirect(vm, WebCore::clientData(vm)->builtinNames().encodingPublicName(), convertEnumerationToJS<BufferEncodingType>(*globalObject, m_encoding), 0);
 }
 
 // Checks at most 3 bytes at the end of a Buffer in order to detect an
@@ -519,22 +521,12 @@ static JSC_DEFINE_CUSTOM_GETTER(jsStringDecoder_lastTotal, (JSGlobalObject * lex
     RELEASE_AND_RETURN(scope, JSC::JSValue::encode(JSC::jsNumber(castedThis->m_lastTotal)));
 }
 
-static JSC_DEFINE_CUSTOM_GETTER(jsStringDecoder_encoding, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName attributeName))
-{
-    auto& vm = JSC::getVM(lexicalGlobalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    JSStringDecoder* castedThis = jsStringDecoderCast(lexicalGlobalObject, JSC::JSValue::decode(thisValue), "encoding"_s);
-    RETURN_IF_EXCEPTION(scope, {});
-    return JSC::JSValue::encode(WebCore::convertEnumerationToJS<BufferEncodingType>(*lexicalGlobalObject, castedThis->m_encoding));
-}
-
 /* Hash table for prototype */
 static const HashTableValue JSStringDecoderPrototypeTableValues[]
     = {
           { "lastChar"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute), NoIntrinsic, { HashTableValue::GetterSetterType, jsStringDecoder_lastChar, 0 } },
           { "lastNeed"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute), NoIntrinsic, { HashTableValue::GetterSetterType, jsStringDecoder_lastNeed, 0 } },
           { "lastTotal"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute), NoIntrinsic, { HashTableValue::GetterSetterType, jsStringDecoder_lastTotal, 0 } },
-          { "encoding"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute), NoIntrinsic, { HashTableValue::GetterSetterType, jsStringDecoder_encoding, 0 } },
           { "write"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsStringDecoderPrototypeFunction_write, 1 } },
           { "end"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsStringDecoderPrototypeFunction_end, 1 } },
           { "text"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsStringDecoderPrototypeFunction_text, 2 } },
@@ -598,7 +590,7 @@ JSC::EncodedJSValue JSStringDecoderConstructor::construct(JSC::JSGlobalObject* l
         JSObject* thisObject = asObject(callFrame->thisValue());
 
         thisObject->putDirect(vm, clientData->builtinNames().decodePrivateName(), jsObject, JSC::PropertyAttribute::DontEnum | 0);
-        thisObject->putDirect(vm, clientData->builtinNames().encodingPublicName(), convertEnumerationToJS<BufferEncodingType>(*lexicalGlobalObject, encoding), JSC::PropertyAttribute::DontEnum | 0);
+        thisObject->putDirect(vm, clientData->builtinNames().encodingPublicName(), convertEnumerationToJS<BufferEncodingType>(*lexicalGlobalObject, encoding), 0);
         return JSC::JSValue::encode(thisObject);
     }
 

--- a/test/js/node/string_decoder/string-decoder.test.js
+++ b/test/js/node/string_decoder/string-decoder.test.js
@@ -242,6 +242,40 @@ for (const StringDecoder of [FakeStringDecoderCall, RealStringDecoder]) {
   });
 }
 
+// Node assigns `this.encoding` in the constructor, so it's an enumerable own
+// data property. Shape-sensitive operations (hasOwn, spread, JSON.stringify)
+// must see it; previously Bun exposed it only via a prototype accessor.
+it("encoding is an enumerable own data property", () => {
+  const d = new RealStringDecoder("utf16le");
+  expect({
+    value: d.encoding,
+    hasOwn: Object.hasOwn(d, "encoding"),
+    ownNames: Object.getOwnPropertyNames(d),
+    spread: { ...d },
+    json: JSON.stringify(d),
+    desc: Object.getOwnPropertyDescriptor(d, "encoding"),
+    protoDesc: Object.getOwnPropertyDescriptor(RealStringDecoder.prototype, "encoding"),
+  }).toEqual({
+    value: "utf16le",
+    hasOwn: true,
+    ownNames: ["encoding"],
+    spread: { encoding: "utf16le" },
+    json: '{"encoding":"utf16le"}',
+    desc: { value: "utf16le", writable: true, enumerable: true, configurable: true },
+    protoDesc: undefined,
+  });
+
+  // Same shape when StringDecoder is applied to a foreign `this` (util.inherits path).
+  const f = new FakeStringDecoderCall("utf16le");
+  expect({
+    desc: Object.getOwnPropertyDescriptor(f, "encoding"),
+    spread: { ...f },
+  }).toEqual({
+    desc: { value: "utf16le", writable: true, enumerable: true, configurable: true },
+    spread: { encoding: "utf16le" },
+  });
+});
+
 // Node's normalizeEncoding() maps every UTF-16LE alias (including the legacy
 // ucs2/ucs-2 spellings) to the canonical name "utf16le", and
 // StringDecoder#encoding exposes the normalized name.


### PR DESCRIPTION
### Problem
- A `StringDecoder` instance has no own `encoding` property. `Object.hasOwn(d, "encoding")` is `false`. `{ ...d }` and `JSON.stringify(d)` give `{}`. Node gives `{"encoding":"utf16le"}`. A read of `d.encoding` works on both.
- The cause: `encoding` was a read-only `CustomAccessor` in the prototype table of `src/jsc/bindings/JSStringDecoder.cpp`. Node's constructor runs `this.encoding = normalizeEncoding(encoding)`, which makes an enumerable own data property.
- `StringDecoder.call(obj, enc)` did set an own `encoding` on `obj`, but with `DontEnum`, so spread dropped it there too.

### Fix
- `JSStringDecoder::finishCreation` puts `encoding` on the instance with attributes `0` (writable, enumerable, configurable). Node's descriptor is the same.
- The prototype accessor and its getter are removed, because Node has no `encoding` on the prototype. The call path drops `DontEnum`. `lastChar`, `lastNeed` and `lastTotal` do not change.
- Correct because decoding reads the C++ field `m_encoding`, never the property. An assignment to `d.encoding` changes only the property, as in Node.
- Verified: `test/js/node/string_decoder/string-decoder.test.js` (144 pass with the fix, the new test fails without it). Node's three `test-string-decoder*.js` files pass.

### Background
- `JSStringDecoder` is the native class behind `node:string_decoder`. It keeps the encoding in the C++ field `m_encoding`.
- `finishCreation` is the JavaScriptCore hook that runs once, right after the object is allocated.
- A `CustomAccessor` in a prototype table is a native getter on the prototype. Spread, `JSON.stringify` and `Object.hasOwn` read own properties only, so they do not see it.
- The call path serves `util.inherits` code. `StringDecoder.call(obj, enc)` stores a hidden native decoder on `obj` and sets `obj.encoding`.

<details><summary>Notes</summary>

Repro:

```js
import { StringDecoder } from "node:string_decoder";

const d = new StringDecoder("utf16le");
console.log(Object.hasOwn(d, "encoding"));      // node: true      bun: false
console.log(Object.getOwnPropertyNames(d));     // node: ["encoding"]   bun: []
console.log({ ...d });                          // node: { encoding: "utf16le" }   bun: {}
console.log(JSON.stringify(d));                 // node: {"encoding":"utf16le"}    bun: {}
console.log(Object.getOwnPropertyDescriptor(d, "encoding"));
// node: { value: "utf16le", writable: true, enumerable: true, configurable: true }
// bun:  undefined
```

The test asserts the full own-property descriptor, `getOwnPropertyNames`, spread, `JSON.stringify`, and the absence of `encoding` on the prototype. It covers four cases: `new StringDecoder`, the `util.inherits` call path, a subclass instance, and an assignment to `d.encoding` followed by a `write()`.

Compared with Node v26.3.0 on the merge with main (367d939d9a): the descriptor and `JSON.stringify` output are equal for every encoding name, for a subclass, for `StringDecoder.call(obj, enc)`, after `d.encoding = "hex"`, and after `delete d.encoding`.

The internal readers of `decoder.encoding` are `src/js/internal/streams/readable.ts` (`setEncoding`) and `src/js/node/crypto.ts` (`getDecoder`). Both read the same value as before. `test-stream2-set-encoding.js`, `test-stream-readable-setEncoding-null.js`, `test-stream-readable-setEncoding-existing-buffers.js`, `test-crypto-cipheriv-decipheriv.js` and `test-crypto-encoding-validation-error.js` pass.

Overlap with #42575: that PR rewrites the same `putDirect` line in `JSStringDecoderConstructor::call` to use `defineOwnProperty`, and it keeps `DontEnum` on `encoding`. The second of the two PRs to merge needs a rebase, and `encoding` must stay enumerable there. The test in this PR fails if it does not.

Not in this PR: `StringDecoder.call(Object.freeze({}), "utf8")` still adds the property to the frozen object (Node throws). #42575 covers that.

</details>
