### PR TITLE
Bun.serve: hold large direct-stream controller.write() payloads by reference instead of copying into uWS backpressure

### DIFF
--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -116,6 +116,10 @@ function header() {
             int m_refCount { 1 };
 
             uintptr_t m_onDestroy { 0 };
+
+            // Holds the backing store of a large write() by reference while
+            // the socket drains (GC-visited; avoids protect()/Strong).
+            mutable WriteBarrier<JSC::Unknown> m_pendingWriteValue;
                                                                                                                                                                                     
             ${className}(JSC::VM& vm, JSC::Structure* structure, void* sinkPtr, uintptr_t onDestroy)
                 : Base(vm, structure)
@@ -172,6 +176,10 @@ function header() {
                 mutable WriteBarrier<JSC::JSObject> m_onPull;
                 mutable WriteBarrier<JSC::JSObject> m_onClose;
                 mutable JSC::Weak<JSObject> m_weakReadableStream;
+
+                // Holds the backing store of a large write() by reference while
+                // the socket drains (GC-visited; avoids protect()/Strong).
+                mutable WriteBarrier<JSC::Unknown> m_pendingWriteValue;
 
                 uintptr_t m_onDestroy { 0 };
                                                                                                                                                                                         
@@ -752,6 +760,24 @@ extern "C" void ${name}__setDestroyCallback(EncodedJSValue encodedValue, uintptr
     }
 }
 
+extern "C" void ${name}__setPendingWriteValue(EncodedJSValue encodedThis, JSC::JSGlobalObject* globalObject, EncodedJSValue encodedValue)
+{
+    JSValue thisValue = JSValue::decode(encodedThis);
+    JSValue value = JSValue::decode(encodedValue);
+    auto& vm = globalObject->vm();
+    if (auto* controller = dynamicDowncast<WebCore::${controller}>(thisValue)) {
+        if (value.isCell())
+            controller->m_pendingWriteValue.set(vm, controller, value);
+        else
+            controller->m_pendingWriteValue.clear();
+    } else if (auto* sink = dynamicDowncast<WebCore::${className}>(thisValue)) {
+        if (value.isCell())
+            sink->m_pendingWriteValue.set(vm, sink, value);
+        else
+            sink->m_pendingWriteValue.clear();
+    }
+}
+
 void ${className}::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
 {
     Base::analyzeHeap(cell, analyzer);    
@@ -804,7 +830,8 @@ void ${controller}::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     // Avoid duplicating in the heap snapshot
     visitor.appendHidden(thisObject->m_onPull);
     visitor.appendHidden(thisObject->m_onClose);
-    
+    visitor.append(thisObject->m_pendingWriteValue);
+
     void* ptr = thisObject->m_sinkPtr;
     if (ptr)
       visitor.addOpaqueRoot(ptr);
@@ -818,6 +845,7 @@ void ${className}::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     ${className}* thisObject = uncheckedDowncast<${className}>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
+    visitor.append(thisObject->m_pendingWriteValue);
     void* ptr = thisObject->m_sinkPtr;
     if (ptr)
       visitor.addOpaqueRoot(ptr);

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -658,6 +658,7 @@ void JS${controllerName}::detach() {
     m_onPull.clear();
     m_onClose.clear();
     m_weakReadableStream.clear();
+    m_pendingWriteValue.clear();
 
     if (destroy) {
         Bun__onSinkDestroyed(destroy, sinkPtr);

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -398,10 +398,6 @@ impl PendingPinnedWrite {
     }
 }
 
-/// Writes larger than this take the pinned zero-copy path; below it the cork
-/// buffer (`LoopData::CORK_BUFFER_SIZE` = 16KB) already handles the copy.
-const PINNED_WRITE_THRESHOLD: usize = 16 * 1024;
-
 impl NodeHTTPResponse {
     // ─── R-2 interior-mutability helpers ─────────────────────────────────────
 
@@ -2028,7 +2024,7 @@ impl NodeHTTPResponse {
             // ArrayBuffer or WTFStringImpl-backed slice) instead of copying
             // the unwritten tail into the uWS backpressure std::string.
             let bytes_len = bytes.len();
-            if bytes_len > PINNED_WRITE_THRESHOLD && bytes_len <= c_uint::MAX as usize {
+            if bytes_len > uws::PINNED_WRITE_THRESHOLD && bytes_len <= c_uint::MAX as usize {
                 let is_buffer = matches!(string_or_buffer, crate::node::StringOrBuffer::Buffer(_));
 
                 scoped_log!(NodeHTTPResponse, "tryWriteBody({} bytes)", bytes_len);

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -498,6 +498,12 @@ macro_rules! decl_js_sink_externs {
                 ) -> JSValue;
                 #[link_name = concat!($abi, "__setDestroyCallback")]
                 pub(crate) safe fn set_destroy_callback(v: JSValue, cb: usize);
+                #[link_name = concat!($abi, "__setPendingWriteValue")]
+                pub(crate) safe fn set_pending_write_value(
+                    this: JSValue,
+                    g: &JSGlobalObject,
+                    v: JSValue,
+                );
                 #[link_name = concat!($abi, "__assignToStream")]
                 pub(crate) safe fn assign_to_stream(
                     g: &JSGlobalObject,
@@ -537,6 +543,13 @@ macro_rules! impl_js_sink_abi {
                 }
                 fn set_destroy_callback_extern(value: ::bun_jsc::JSValue, callback: usize) {
                     __abi::set_destroy_callback(value, callback)
+                }
+                fn set_pending_write_value_extern(
+                    this: ::bun_jsc::JSValue,
+                    global: &::bun_jsc::JSGlobalObject,
+                    value: ::bun_jsc::JSValue,
+                ) {
+                    __abi::set_pending_write_value(this, global, value)
                 }
                 fn assign_to_stream_extern(
                     global: &::bun_jsc::JSGlobalObject,
@@ -580,6 +593,15 @@ pub trait JsSinkAbi {
     ) -> crate::webcore::jsc::JSValue;
     /// `${abi_name}__setDestroyCallback`.
     fn set_destroy_callback_extern(value: crate::webcore::jsc::JSValue, callback: usize);
+    /// `${abi_name}__setPendingWriteValue` — store/clear a GC-visited
+    /// `m_pendingWriteValue` on the wrapper (sink or controller) at
+    /// `this`, so a large write's backing store stays alive while the
+    /// socket drains without `protect()`/`Strong`.
+    fn set_pending_write_value_extern(
+        this: crate::webcore::jsc::JSValue,
+        global: &crate::webcore::jsc::JSGlobalObject,
+        value: crate::webcore::jsc::JSValue,
+    );
     /// `${abi_name}__assignToStream`. Safe wrapper: takes `&JSGlobalObject` and
     /// performs the `as_ptr()` projection internally so the FFI call is the
     /// impl body's sole guarded operation.

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -761,6 +761,14 @@ pub trait JsSinkType: Sized {
     }
     fn write_utf16(&mut self, data: &streams::Result) -> streams::result::Writable;
     fn write_latin1(&mut self, data: &streams::Result) -> streams::result::Writable;
+    /// `write_latin1` with the originating JS cell; see `write_bytes_with_value`.
+    fn write_latin1_with_value(
+        &mut self,
+        data: &streams::Result,
+        _input_value: crate::webcore::jsc::JSValue,
+    ) -> streams::result::Writable {
+        self.write_latin1(data)
+    }
     fn end(&mut self, err: Option<SysError>) -> sys::Result<()>;
     fn end_from_js(&mut self, global: &JSGlobalObject) -> sys::Result<JSValue>;
     fn flush(&mut self) -> sys::Result<()>;
@@ -936,7 +944,7 @@ impl<T: JsSinkType + JsSinkAbi> JSSink<T> {
         let data = bun_ptr::RawSlice::new(view.slice());
         Ok(this
             .sink
-            .write_latin1(&streams::Result::Temporary(data))
+            .write_latin1_with_value(&streams::Result::Temporary(data), str_.to_js())
             .to_js(global))
     }
 

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -750,6 +750,15 @@ pub trait JsSinkType: Sized {
     fn memory_cost(&self) -> usize;
     fn finalize(&mut self);
     fn write_bytes(&mut self, data: &streams::Result) -> streams::result::Writable;
+    /// `write_bytes` with the originating JS cell, for sinks that can hold the
+    /// backing store by reference past the call (pinned zero-copy writes).
+    fn write_bytes_with_value(
+        &mut self,
+        data: &streams::Result,
+        _input_value: crate::webcore::jsc::JSValue,
+    ) -> streams::result::Writable {
+        self.write_bytes(data)
+    }
     fn write_utf16(&mut self, data: &streams::Result) -> streams::result::Writable;
     fn write_latin1(&mut self, data: &streams::Result) -> streams::result::Writable;
     fn end(&mut self, err: Option<SysError>) -> sys::Result<()>;
@@ -893,7 +902,7 @@ impl<T: JsSinkType + JsSinkAbi> JSSink<T> {
             let data = bun_ptr::RawSlice::new(slice);
             return Ok(this
                 .sink
-                .write_bytes(&streams::Result::Temporary(data))
+                .write_bytes_with_value(&streams::Result::Temporary(data), arg)
                 .to_js(global));
         }
 

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1113,6 +1113,11 @@ pub struct HTTPServerWritable<const SSL: bool, const HTTP3: bool> {
     pub end_len: usize,
     pub aborted: bool,
     pub pending_pinned_write: PendingPinnedWrite,
+    /// A `tryWriteBody` chunk is open on the wire (size-hex line written,
+    /// trailing CRLF not yet) and its remaining body bytes live in
+    /// `self.buffer[offset..]`. The next send of those bytes goes out with
+    /// `isFirst=false`; a new chunk must spill this one first.
+    pub mid_body_chunk: bool,
     /// This sink fully ended the uWS response (`res.end()` / a completed
     /// `res.try_end()`). On HTTP/1 uWS `markDone()` drops `onAborted` at that
     /// point, so the owning `RequestContext` is never told if the peer closes
@@ -1151,6 +1156,7 @@ impl<const SSL: bool, const HTTP3: bool> Default for HTTPServerWritable<SSL, HTT
             end_len: 0,
             aborted: false,
             pending_pinned_write: PendingPinnedWrite::default(),
+            mid_body_chunk: false,
             ended_response: false,
             on_first_write: None,
             ctx: None,
@@ -1322,6 +1328,30 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         self.clear_pending_pinned_write();
     }
 
+    /// Copy the remaining body of an open `tryWriteBody` chunk (held in
+    /// `self.buffer[offset..]`) into the uWS backpressure buffer and close the
+    /// chunk framing, so a subsequent write()/end() stays ordered behind it.
+    fn spill_mid_body_chunk(&mut self) {
+        if !self.mid_body_chunk {
+            return;
+        }
+        self.mid_body_chunk = false;
+        let base = self.offset as usize;
+        let len = self.buffer.len().saturating_sub(base);
+        if let Some(res) = self.any_res() {
+            res.spill_body(&self.buffer[base..]);
+        }
+        self.handle_wrote(len);
+    }
+
+    /// Close out any open `tryWriteBody` chunk (whichever storage holds its
+    /// tail) before starting a new one or ending the response.
+    #[inline]
+    fn spill_open_chunk(&mut self) {
+        self.spill_pending_pinned_write();
+        self.spill_mid_body_chunk();
+    }
+
     /// Continue a zero-copy write from the stored offset. Returns `true` when
     /// bytes remain outstanding (wait for another onWritable before resolving
     /// the flush promise).
@@ -1346,12 +1376,18 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         false
     }
 
-    /// Zero-copy fast path for a large ArrayBuffer-backed write: send via
+    /// Zero-copy fast path for a large write whose bytes are backed by a JS
+    /// cell (`ArrayBuffer`/view, or an all-ASCII Latin-1 `JSString`): send via
     /// `try_write_body` (no tail copy into uWS backpressure); on partial
-    /// accept, pin + GC-root the user's buffer and resume on `on_writable`.
-    /// Returns `None` when the preconditions don't hold (caller falls back to
-    /// the buffered path).
-    fn try_write_pinned(&mut self, bytes: &[u8], input_value: JSValue) -> Option<Writable> {
+    /// accept, GC-root the cell (and `pin()` the backing store for buffers)
+    /// and resume on `on_writable`. Returns `None` when the preconditions
+    /// don't hold (caller falls back to the buffered path).
+    fn try_write_pinned(
+        &mut self,
+        bytes: &[u8],
+        input_value: JSValue,
+        is_array_buffer: bool,
+    ) -> Option<Writable> {
         // The HTTP/3 `try_write_body` shim falls back to a copying write, so
         // the pin would only add overhead there.
         if HTTP3 {
@@ -1394,26 +1430,34 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             consumed,
             len
         );
-        // `pin()` prevents `transfer()` from detaching the backing store;
-        // `protect()` GC-roots the cell. Both are released together on drain,
-        // spill, abort or destroy. Resizable / growable-shared buffers are
-        // excluded: resize() keeps the base pointer but mprotect()s trimmed
-        // pages PROT_NONE, so a retained raw slice would fault.
-        match input_value.as_pinned_arraybuffer(self.global_this()) {
-            Some(ab) if !ab.resizable => {
-                input_value.protect();
-                self.pending_pinned_write = PendingPinnedWrite {
-                    remaining: core::ptr::from_ref(&bytes[consumed..]),
-                    pinned_value: input_value,
-                };
-            }
-            pinned => {
-                if pinned.is_some() {
+        // `protect()` GC-roots the cell; for buffers `pin()` also prevents
+        // `transfer()` from detaching the backing store. Both are released on
+        // drain, spill, abort or destroy. Resizable / growable-shared buffers
+        // are excluded: resize() keeps the base pointer but mprotect()s
+        // trimmed pages PROT_NONE, so a retained raw slice would fault.
+        // JSString character buffers are immutable, so `protect()` alone
+        // keeps `bytes` valid.
+        let pinnable = if is_array_buffer {
+            match input_value.as_pinned_arraybuffer(self.global_this()) {
+                Some(ab) if !ab.resizable => true,
+                Some(_) => {
                     input_value.unpin_array_buffer();
+                    false
                 }
-                res.spill_body(&bytes[consumed..]);
-                self.wrote += (len - consumed) as BlobSizeType;
+                None => false,
             }
+        } else {
+            true
+        };
+        if pinnable {
+            input_value.protect();
+            self.pending_pinned_write = PendingPinnedWrite {
+                remaining: core::ptr::from_ref(&bytes[consumed..]),
+                pinned_value: input_value,
+            };
+        } else {
+            res.spill_body(&bytes[consumed..]);
+            self.wrote += (len - consumed) as BlobSizeType;
         }
         self.has_backpressure = true;
         Some(self.writable_result(len as BlobSizeType))
@@ -1478,18 +1522,40 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         // clean this so we know when its relevant or not
         self.end_len = 0;
         self.handle_first_write_if_necessary();
-        // uWS has no tryWrite(): write() always accepts the buffer (queuing the
-        // unsent tail internally) and reports whether the socket is now backed
-        // up. Track that so the JS writer can pause; the owning RequestContext
-        // holds the on_writable registration and forwards the drain to
-        // `on_writable()` below.
         if self.requested_end {
             res.end(buf, false);
             self.has_backpressure = false;
-        } else {
+            self.handle_wrote(buf.len());
+        } else if buf.len() > core::ffi::c_uint::MAX as usize {
+            // tryWriteBody emits the chunk-size line via writeUnsignedHex
+            // ((unsigned int)len); fall back to res.write() which splits
+            // >4 GiB into correctly-framed sub-chunks.
             self.has_backpressure = matches!(res.write(buf), uws::WriteResult::Backpressure(_));
+            self.handle_wrote(buf.len());
+        } else {
+            // tryWriteBody: body bytes are written with optionally=true, so the
+            // unsent tail stays with us instead of being copied into the uWS
+            // backpressure std::string. The owning RequestContext holds the
+            // on_writable registration; `on_writable()` resends from
+            // `self.buffer[offset..]` with isFirst=false.
+            let consumed = res.try_write_body(buf, !self.mid_body_chunk);
+            self.wrote += consumed as BlobSizeType;
+            if consumed < buf.len() {
+                // `buf` is borrowed from the caller; stash the tail so
+                // `on_writable` can resume.
+                if self.buffer.write(&buf[consumed..]).is_err() {
+                    res.spill_body(&buf[consumed..]);
+                    self.wrote += (buf.len() - consumed) as BlobSizeType;
+                    self.mid_body_chunk = false;
+                } else {
+                    self.mid_body_chunk = true;
+                }
+                self.has_backpressure = true;
+            } else {
+                self.mid_body_chunk = false;
+                self.has_backpressure = false;
+            }
         }
-        self.handle_wrote(buf.len());
         bun_core::scoped_log!(
             HTTPServerWritableLog,
             "send: {} bytes (backpressure: {})",
@@ -1558,13 +1624,27 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         if self.requested_end {
             res.end(&self.buffer[base..], false);
             self.has_backpressure = false;
-        } else {
+            self.handle_wrote(buf_len);
+        } else if buf_len > core::ffi::c_uint::MAX as usize {
             self.has_backpressure = matches!(
                 res.write(&self.buffer[base..]),
                 uws::WriteResult::Backpressure(_)
             );
+            self.handle_wrote(buf_len);
+        } else {
+            // See `send_without_auto_flusher`: write the body with
+            // optionally=true and advance `offset` by what the socket accepted;
+            // `on_writable` resends the tail from `self.buffer[offset..]`.
+            let consumed = res.try_write_body(&self.buffer[base..], !self.mid_body_chunk);
+            self.handle_wrote(consumed);
+            if consumed < buf_len {
+                self.mid_body_chunk = true;
+                self.has_backpressure = true;
+            } else {
+                self.mid_body_chunk = false;
+                self.has_backpressure = false;
+            }
         }
-        self.handle_wrote(buf_len);
         bun_core::scoped_log!(
             HTTPServerWritableLog,
             "send: {} bytes (backpressure: {})",
@@ -1598,11 +1678,12 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             return true;
         }
 
-        // Streaming-write drain: uWS already holds the data (our buffer is
-        // empty), so there is nothing to resend. Resolve any flush(true) waiter
-        // — that promise is the resume signal for both readStreamIntoSink and
-        // direct-stream callers. Handled before the try_end resend bookkeeping
-        // below, which assumes a non-empty buffer.
+        // Nothing buffered: either the previous write was fully accepted, or
+        // its tail was spilled into uWS backpressure (which uWS drains on its
+        // own). Resolve any flush(true) waiter — that promise is the resume
+        // signal for both readStreamIntoSink and direct-stream callers.
+        // Handled before the try_end resend bookkeeping below, which assumes a
+        // non-empty buffer.
         if self.readable_slice().is_empty() {
             if self.done {
                 self.signal.close(None);
@@ -1619,11 +1700,10 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         // try_end resend vs streaming-write drain:
         // - end_len > 0: the buffer holds the body uWS partially sent via
         //   try_end; `write_offset` is the resume point into that same buffer.
-        // - end_len == 0: the buffer holds *new* data the user queued while the
-        //   socket was backed up (e.g. write(small) after a write(big) that hit
-        //   backpressure). uWS already owns the earlier bytes; send from 0.
-        //   `write_offset` is uWS's cumulative response count here and is not a
-        //   valid index into our buffer.
+        // - end_len == 0: the buffer holds a partially-accepted tryWriteBody
+        //   tail (`mid_body_chunk`) and/or user data queued while backed up;
+        //   `offset` already points at the resume position. `write_offset` is
+        //   uWS's cumulative response count and is not a valid index here.
         let chunk_start = if self.end_len > 0 {
             // do not write more than available
             (write_offset as BlobSizeType).min(self.buffer.len() as BlobSizeType - 1) as usize
@@ -1635,6 +1715,9 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         // mutation send's internals perform. The length is used only for
         // `total_written` and the empty check.
         let chunk_len = self.readable_slice().len().saturating_sub(chunk_start);
+        // Draining our own tryWriteBody tail is not new user data: `onReady`
+        // re-invokes pull(), which would run the direct-stream body again.
+        let was_mid_body_chunk = self.mid_body_chunk;
         // if we have nothing to write, we are done
         if chunk_len == 0 {
             if self.done {
@@ -1649,6 +1732,12 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
                 return false;
             }
             total_written = chunk_len as u64;
+
+            // tryWriteBody accepted another partial; wait for the next drain
+            // before telling JS we're writable.
+            if self.mid_body_chunk {
+                return true;
+            }
 
             if self.requested_end {
                 if let Some(res) = self.any_res() {
@@ -1669,7 +1758,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
 
         // pending_flush or callback could have caused another send()
         // so we check again if we should report readiness
-        if !self.done && !self.requested_end && !self.has_backpressure() {
+        if !self.done && !self.requested_end && !self.has_backpressure() && !was_mid_body_chunk {
             // no pending and total_written > 0
             if total_written > 0 && self.readable_slice().is_empty() {
                 self.signal.ready(Some(total_written as BlobSizeType), None);
@@ -1829,7 +1918,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         let bytes = data.slice();
         let len = bytes.len() as BlobSizeType;
         bun_core::scoped_log!(HTTPServerWritableLog, "write({})", bytes.len());
-        self.spill_pending_pinned_write();
+        self.spill_open_chunk();
 
         if self.buffer.len() == 0 && len >= self.high_water_mark {
             // fast path:
@@ -1874,13 +1963,34 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         if self.done || self.requested_end {
             return Writable::Owned(0);
         }
-        // A previous zero-copy tail must hit the wire before this one; no-op
-        // when the caller waited for the flush promise.
-        self.spill_pending_pinned_write();
-        if let Some(result) = self.try_write_pinned(data.slice(), input_value) {
+        // A previous tryWriteBody tail must hit the wire before this one;
+        // no-op when the caller waited for the flush promise.
+        self.spill_open_chunk();
+        if let Some(result) = self.try_write_pinned(data.slice(), input_value, true) {
             return result;
         }
         self.write(data)
+    }
+
+    pub fn write_latin1_with_value(
+        &mut self,
+        data: &StreamResult,
+        input_value: JSValue,
+    ) -> Writable {
+        if self.done || self.requested_end {
+            return Writable::Owned(0);
+        }
+        self.spill_open_chunk();
+        // All-ASCII Latin-1 is byte-identical to UTF-8 and the JSString's
+        // character buffer is immutable, so the pinned path can hold it by
+        // reference with `protect()` alone.
+        let bytes = data.slice();
+        if strings::is_all_ascii(bytes) {
+            if let Some(result) = self.try_write_pinned(bytes, input_value, false) {
+                return result;
+            }
+        }
+        self.write_latin1(data)
     }
 
     pub fn write_latin1(&mut self, data: &StreamResult) -> Writable {
@@ -1897,7 +2007,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         let bytes = data.slice();
         let len = bytes.len() as BlobSizeType;
         bun_core::scoped_log!(HTTPServerWritableLog, "writeLatin1({})", bytes.len());
-        self.spill_pending_pinned_write();
+        self.spill_open_chunk();
 
         if self.buffer.len() == 0 && len >= self.high_water_mark {
             let mut do_send = true;
@@ -1956,7 +2066,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         let bytes = data.slice();
 
         bun_core::scoped_log!(HTTPServerWritableLog, "writeUTF16({})", bytes.len());
-        self.spill_pending_pinned_write();
+        self.spill_open_chunk();
 
         // we must always buffer UTF-16
         // we assume the case of all-ascii UTF-16 string is pretty uncommon
@@ -1998,7 +2108,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             return bun_sys::Result::Ok(());
         }
 
-        self.spill_pending_pinned_write();
+        self.spill_open_chunk();
         self.requested_end = true;
         let readable_len = self.readable_slice().len();
         self.end_len = readable_len;
@@ -2029,7 +2139,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             return bun_sys::Result::Ok(JSValue::from(0i32));
         }
 
-        self.spill_pending_pinned_write();
+        self.spill_open_chunk();
         self.requested_end = true;
         let readable_len = self.readable_slice().len();
         self.end_len = readable_len;
@@ -2076,6 +2186,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         // ends before the signal close below, which may free `*this`.
         let sink = unsafe { &mut *this };
         sink.clear_pending_pinned_write();
+        sink.mid_body_chunk = false;
         sink.done = true;
         sink.res = None;
         sink.unregister_auto_flusher();
@@ -2167,8 +2278,12 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
     /// so it must zero out state instead of make it
     pub fn finalize(&mut self) {
         bun_core::scoped_log!(HTTPServerWritableLog, "finalize()");
+        // Close any open tryWriteBody chunk before teardown regardless of
+        // `done`: `handle_reject_stream` sets `done = true` first, and the
+        // non-optional `res.write()` path this replaces always left the chunk
+        // well-formed on the wire.
+        self.spill_open_chunk();
         if !self.done {
-            self.spill_pending_pinned_write();
             self.unregister_auto_flusher();
             if let Some(res) = self.any_res() {
                 // The body is finished; drop the drain callback so the owning
@@ -2291,6 +2406,9 @@ impl<const SSL: bool, const HTTP3: bool> crate::webcore::sink::JsSinkType
     }
     fn write_latin1(&mut self, data: &StreamResult) -> Writable {
         Self::write_latin1(self, data)
+    }
+    fn write_latin1_with_value(&mut self, data: &StreamResult, input_value: JSValue) -> Writable {
+        Self::write_latin1_with_value(self, data, input_value)
     }
     fn end(&mut self, err: Option<SysError>) -> bun_sys::Result<()> {
         Self::end(self, err)

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1396,23 +1396,25 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         );
         // `pin()` prevents `transfer()` from detaching the backing store;
         // `protect()` GC-roots the cell. Both are released together on drain,
-        // spill, abort or destroy.
-        if input_value
-            .as_pinned_arraybuffer(self.global_this())
-            .is_none()
-        {
-            // Not ArrayBuffer-backed after all; copy the tail so it outlives
-            // this call.
-            res.spill_body(&bytes[consumed..]);
-            self.wrote += (len - consumed) as BlobSizeType;
-            self.has_backpressure = true;
-            return Some(self.writable_result(len as BlobSizeType));
+        // spill, abort or destroy. Resizable / growable-shared buffers are
+        // excluded: resize() keeps the base pointer but mprotect()s trimmed
+        // pages PROT_NONE, so a retained raw slice would fault.
+        match input_value.as_pinned_arraybuffer(self.global_this()) {
+            Some(ab) if !ab.resizable => {
+                input_value.protect();
+                self.pending_pinned_write = PendingPinnedWrite {
+                    remaining: core::ptr::from_ref(&bytes[consumed..]),
+                    pinned_value: input_value,
+                };
+            }
+            pinned => {
+                if pinned.is_some() {
+                    input_value.unpin_array_buffer();
+                }
+                res.spill_body(&bytes[consumed..]);
+                self.wrote += (len - consumed) as BlobSizeType;
+            }
         }
-        input_value.protect();
-        self.pending_pinned_write = PendingPinnedWrite {
-            remaining: core::ptr::from_ref(&bytes[consumed..]),
-            pinned_value: input_value,
-        };
         self.has_backpressure = true;
         Some(self.writable_result(len as BlobSizeType))
     }

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1057,34 +1057,31 @@ impl SignalVTable {
 // type level; all dispatch happens at runtime through `any_res()` / `uws::AnyResponse`.
 pub type UwsResponse<const SSL: bool, const HTTP3: bool> = c_void;
 
-/// A large `controller.write()` whose unwritten tail is held by reference
-/// instead of being copied into the uWS backpressure std::string. The bytes
-/// are kept valid by `.protect()` on the JS cell plus `pin()` on the backing
-/// `ArrayBuffer` (so `transfer()` copies instead of detaching). Resumed from
-/// the stored offset on `on_writable`.
-#[derive(Clone, Copy)]
-pub struct PendingPinnedWrite {
-    /// Body bytes not yet accepted by the kernel / cork buffer. Borrows the
-    /// pinned `ArrayBuffer`'s backing store; advanced in place on drain.
-    remaining: *const [u8],
-    /// The JS cell (ArrayBuffer or view) to `unprotect()` + `unpin()` on
-    /// release. `ZERO` when no write is held.
-    pinned_value: JSValue,
+/// A `tryWriteBody` chunk is open on the wire (size-hex line written,
+/// trailing CRLF not yet). One variant per backing storage for the unsent
+/// tail; a new write or `end()` must spill the open chunk first so chunk
+/// ordering is preserved.
+#[derive(Default)]
+pub enum OpenChunk {
+    #[default]
+    None,
+    /// Tail lives in `self.buffer[offset..]`; resume via
+    /// `try_write_body(.., isFirst=false)` on the next drain.
+    Buffered,
+    /// Tail borrows a JS cell's backing store (ArrayBuffer / all-ASCII
+    /// Latin-1 `JSString`). The cell is GC-visited via the JS wrapper's
+    /// `m_pendingWriteValue` WriteBarrier; `cell` here is kept only for
+    /// `unpin_array_buffer()` (`ZERO` for strings).
+    Pinned {
+        remaining: *const [u8],
+        cell: JSValue,
+    },
 }
 
-impl Default for PendingPinnedWrite {
-    fn default() -> Self {
-        Self {
-            remaining: core::ptr::slice_from_raw_parts(core::ptr::null(), 0),
-            pinned_value: JSValue::ZERO,
-        }
-    }
-}
-
-impl PendingPinnedWrite {
+impl OpenChunk {
     #[inline]
-    fn is_some(&self) -> bool {
-        self.remaining.len() > 0
+    fn is_none(&self) -> bool {
+        matches!(self, Self::None)
     }
 }
 
@@ -1112,12 +1109,7 @@ pub struct HTTPServerWritable<const SSL: bool, const HTTP3: bool> {
     pub has_backpressure: bool,
     pub end_len: usize,
     pub aborted: bool,
-    pub pending_pinned_write: PendingPinnedWrite,
-    /// A `tryWriteBody` chunk is open on the wire (size-hex line written,
-    /// trailing CRLF not yet) and its remaining body bytes live in
-    /// `self.buffer[offset..]`. The next send of those bytes goes out with
-    /// `isFirst=false`; a new chunk must spill this one first.
-    pub mid_body_chunk: bool,
+    pub open_chunk: OpenChunk,
     /// This sink fully ended the uWS response (`res.end()` / a completed
     /// `res.try_end()`). On HTTP/1 uWS `markDone()` drops `onAborted` at that
     /// point, so the owning `RequestContext` is never told if the peer closes
@@ -1155,8 +1147,7 @@ impl<const SSL: bool, const HTTP3: bool> Default for HTTPServerWritable<SSL, HTT
             has_backpressure: false,
             end_len: 0,
             aborted: false,
-            pending_pinned_write: PendingPinnedWrite::default(),
-            mid_body_chunk: false,
+            open_chunk: OpenChunk::None,
             ended_response: false,
             on_first_write: None,
             ctx: None,
@@ -1245,6 +1236,9 @@ impl<const SSL: bool, const HTTP3: bool> crate::webcore::sink::JsSinkAbi
     fn set_destroy_callback_extern(value: JSValue, callback: usize) {
         http_sink_dispatch!(set_destroy_callback(value, callback))
     }
+    fn set_pending_write_value_extern(this: JSValue, global: &JSGlobalObject, value: JSValue) {
+        http_sink_dispatch!(set_pending_write_value(this, global, value))
+    }
     fn assign_to_stream_extern(
         global: &JSGlobalObject,
         stream: JSValue,
@@ -1303,77 +1297,95 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         }
     }
 
-    /// Release the GC root + pin taken by a zero-copy write.
-    fn clear_pending_pinned_write(&mut self) {
-        let p = core::mem::take(&mut self.pending_pinned_write);
-        if p.pinned_value != JSValue::ZERO {
-            p.pinned_value.unpin_array_buffer();
-            p.pinned_value.unprotect();
-        }
-    }
-
-    /// Copy a pending zero-copy write's tail into the uWS backpressure buffer
-    /// so a subsequent write()/end() stays ordered behind it, then release.
-    fn spill_pending_pinned_write(&mut self) {
-        if !self.pending_pinned_write.is_some() {
-            return;
-        }
-        if let Some(res) = self.any_res() {
-            // SAFETY: `remaining` borrows the pinned ArrayBuffer's backing
-            // store, held live by protect()+pin() until the clear below.
-            let remaining = unsafe { &*self.pending_pinned_write.remaining };
-            res.spill_body(remaining);
-            self.wrote += remaining.len() as BlobSizeType;
-        }
-        self.clear_pending_pinned_write();
-    }
-
-    /// Copy the remaining body of an open `tryWriteBody` chunk (held in
-    /// `self.buffer[offset..]`) into the uWS backpressure buffer and close the
-    /// chunk framing, so a subsequent write()/end() stays ordered behind it.
-    fn spill_mid_body_chunk(&mut self) {
-        if !self.mid_body_chunk {
-            return;
-        }
-        self.mid_body_chunk = false;
-        let base = self.offset as usize;
-        let len = self.buffer.len().saturating_sub(base);
-        if let Some(res) = self.any_res() {
-            res.spill_body(&self.buffer[base..]);
-        }
-        self.handle_wrote(len);
-    }
-
-    /// Close out any open `tryWriteBody` chunk (whichever storage holds its
-    /// tail) before starting a new one or ending the response.
+    /// The JS wrapper (controller or plain sink) whose `m_pendingWriteValue`
+    /// WriteBarrier roots a pinned write. Derived from `signal.ptr`, written
+    /// by `__assignToStream`; `ZERO` once the controller has detached (and
+    /// its WriteBarrier has gone with it, so there is nothing to clear).
     #[inline]
-    fn spill_open_chunk(&mut self) {
-        self.spill_pending_pinned_write();
-        self.spill_mid_body_chunk();
+    fn controller_value(&self) -> JSValue {
+        match self.signal.ptr {
+            Some(p) => JSValue::from_encoded(p.as_ptr() as usize),
+            None => JSValue::ZERO,
+        }
     }
 
-    /// Continue a zero-copy write from the stored offset. Returns `true` when
-    /// bytes remain outstanding (wait for another onWritable before resolving
-    /// the flush promise).
-    fn drain_pending_pinned_write(&mut self) -> bool {
-        if !self.pending_pinned_write.is_some() {
-            return false;
+    /// Drop any pin + GC reference taken by a zero-copy write. The
+    /// `Buffered` case has nothing to release.
+    fn clear_open_chunk(&mut self) {
+        if let OpenChunk::Pinned { cell, .. } = core::mem::take(&mut self.open_chunk) {
+            if cell != JSValue::ZERO {
+                cell.unpin_array_buffer();
+            }
+            let controller = self.controller_value();
+            if controller != JSValue::ZERO {
+                <Self as crate::webcore::sink::JsSinkAbi>::set_pending_write_value_extern(
+                    controller,
+                    self.global_this(),
+                    JSValue::ZERO,
+                );
+            }
         }
-        let Some(res) = self.any_res() else {
-            self.clear_pending_pinned_write();
-            return false;
-        };
-        // SAFETY: see `spill_pending_pinned_write`.
-        let remaining = unsafe { &*self.pending_pinned_write.remaining };
-        let consumed = res.try_write_body(remaining, false);
-        self.wrote += consumed as BlobSizeType;
-        if consumed < remaining.len() {
-            self.pending_pinned_write.remaining = core::ptr::from_ref(&remaining[consumed..]);
-            self.has_backpressure = true;
-            return true;
+    }
+
+    /// Close out any open `tryWriteBody` chunk before starting a new one or
+    /// ending the response: copy its tail into the uWS backpressure buffer
+    /// (non-optional) and release.
+    fn spill_open_chunk(&mut self) {
+        match self.open_chunk {
+            OpenChunk::None => {}
+            OpenChunk::Buffered => {
+                self.open_chunk = OpenChunk::None;
+                let base = self.offset as usize;
+                let len = self.buffer.len().saturating_sub(base);
+                if let Some(res) = self.any_res() {
+                    res.spill_body(&self.buffer[base..]);
+                }
+                self.handle_wrote(len);
+            }
+            OpenChunk::Pinned { remaining, .. } => {
+                if let Some(res) = self.any_res() {
+                    // SAFETY: `remaining` borrows the pinned backing store,
+                    // GC-visited via `m_pendingWriteValue` until cleared below.
+                    let remaining = unsafe { &*remaining };
+                    res.spill_body(remaining);
+                    self.wrote += remaining.len() as BlobSizeType;
+                }
+                self.clear_open_chunk();
+            }
         }
-        self.clear_pending_pinned_write();
-        false
+    }
+
+    /// Resend an open chunk's tail from the stored offset. Returns `true`
+    /// when bytes remain outstanding (wait for another onWritable before
+    /// resolving the flush promise / signalling ready).
+    fn drain_open_chunk(&mut self) -> bool {
+        match self.open_chunk {
+            OpenChunk::None => false,
+            OpenChunk::Buffered => {
+                let _ = self.send_readable(0);
+                !self.open_chunk.is_none()
+            }
+            OpenChunk::Pinned { remaining, cell } => {
+                let Some(res) = self.any_res() else {
+                    self.clear_open_chunk();
+                    return false;
+                };
+                // SAFETY: see `spill_open_chunk`.
+                let remaining = unsafe { &*remaining };
+                let consumed = res.try_write_body(remaining, false);
+                self.wrote += consumed as BlobSizeType;
+                if consumed < remaining.len() {
+                    self.open_chunk = OpenChunk::Pinned {
+                        remaining: core::ptr::from_ref(&remaining[consumed..]),
+                        cell,
+                    };
+                    self.has_backpressure = true;
+                    return true;
+                }
+                self.clear_open_chunk();
+                false
+            }
+        }
     }
 
     /// Zero-copy fast path for a large write whose bytes are backed by a JS
@@ -1430,30 +1442,36 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             consumed,
             len
         );
-        // `protect()` GC-roots the cell; for buffers `pin()` also prevents
-        // `transfer()` from detaching the backing store. Both are released on
-        // drain, spill, abort or destroy. Resizable / growable-shared buffers
-        // are excluded: resize() keeps the base pointer but mprotect()s
-        // trimmed pages PROT_NONE, so a retained raw slice would fault.
-        // JSString character buffers are immutable, so `protect()` alone
-        // keeps `bytes` valid.
-        let pinnable = if is_array_buffer {
+        // For buffers `pin()` prevents `transfer()` from detaching the backing
+        // store; resizable/growable-shared are excluded (resize() mprotect()s
+        // trimmed pages PROT_NONE). JSString character buffers are immutable.
+        let cell = if is_array_buffer {
             match input_value.as_pinned_arraybuffer(self.global_this()) {
-                Some(ab) if !ab.resizable => true,
+                Some(ab) if !ab.resizable => Some(input_value),
                 Some(_) => {
                     input_value.unpin_array_buffer();
-                    false
+                    None
                 }
-                None => false,
+                None => None,
             }
         } else {
-            true
+            Some(JSValue::ZERO)
         };
-        if pinnable {
-            input_value.protect();
-            self.pending_pinned_write = PendingPinnedWrite {
+        // The cell is rooted via the controller's GC-visited
+        // `m_pendingWriteValue` WriteBarrier; released on drain, spill,
+        // abort or destroy.
+        let controller = self.controller_value();
+        if let Some(cell) = cell
+            && controller != JSValue::ZERO
+        {
+            <Self as crate::webcore::sink::JsSinkAbi>::set_pending_write_value_extern(
+                controller,
+                self.global_this(),
+                input_value,
+            );
+            self.open_chunk = OpenChunk::Pinned {
                 remaining: core::ptr::from_ref(&bytes[consumed..]),
-                pinned_value: input_value,
+                cell,
             };
         } else {
             res.spill_body(&bytes[consumed..]);
@@ -1536,25 +1554,23 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             self.handle_wrote(buf.len());
         } else {
             // tryWriteBody: body bytes are written with optionally=true, so the
-            // unsent tail stays with us instead of being copied into the uWS
-            // backpressure std::string. The owning RequestContext holds the
-            // on_writable registration; `on_writable()` resends from
+            // unsent tail stays in `self.buffer` instead of being copied into
+            // the uWS backpressure std::string. `on_writable()` resends from
             // `self.buffer[offset..]` with isFirst=false.
-            let consumed = res.try_write_body(buf, !self.mid_body_chunk);
+            let is_first = !matches!(self.open_chunk, OpenChunk::Buffered);
+            let consumed = res.try_write_body(buf, is_first);
             self.wrote += consumed as BlobSizeType;
             if consumed < buf.len() {
-                // `buf` is borrowed from the caller; stash the tail so
-                // `on_writable` can resume.
                 if self.buffer.write(&buf[consumed..]).is_err() {
                     res.spill_body(&buf[consumed..]);
                     self.wrote += (buf.len() - consumed) as BlobSizeType;
-                    self.mid_body_chunk = false;
+                    self.open_chunk = OpenChunk::None;
                 } else {
-                    self.mid_body_chunk = true;
+                    self.open_chunk = OpenChunk::Buffered;
                 }
                 self.has_backpressure = true;
             } else {
-                self.mid_body_chunk = false;
+                self.open_chunk = OpenChunk::None;
                 self.has_backpressure = false;
             }
         }
@@ -1637,13 +1653,14 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             // See `send_without_auto_flusher`: write the body with
             // optionally=true and advance `offset` by what the socket accepted;
             // `on_writable` resends the tail from `self.buffer[offset..]`.
-            let consumed = res.try_write_body(&self.buffer[base..], !self.mid_body_chunk);
+            let is_first = !matches!(self.open_chunk, OpenChunk::Buffered);
+            let consumed = res.try_write_body(&self.buffer[base..], is_first);
             self.handle_wrote(consumed);
             if consumed < buf_len {
-                self.mid_body_chunk = true;
+                self.open_chunk = OpenChunk::Buffered;
                 self.has_backpressure = true;
             } else {
-                self.mid_body_chunk = false;
+                self.open_chunk = OpenChunk::None;
                 self.has_backpressure = false;
             }
         }
@@ -1667,22 +1684,27 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         // onWritable reset backpressure state to allow flushing
         self.has_backpressure = false;
         if self.aborted {
-            self.clear_pending_pinned_write();
+            self.clear_open_chunk();
             self.signal.close(None);
             let _ = self.flush_promise(); // TODO: properly propagate exception upwards
             self.finalize();
             return false;
         }
 
-        // Finish any held zero-copy tail before touching `self.buffer` or
-        // resolving the flush promise.
-        if self.drain_pending_pinned_write() {
+        // Resume any open tryWriteBody chunk first. Draining our own tail is
+        // not new user data, so don't fire `signal.ready` (which re-invokes
+        // pull()); just resolve the flush(true) waiter once it's done.
+        if !self.open_chunk.is_none() {
+            if self.drain_open_chunk() {
+                return true;
+            }
+            let _ = self.flush_promise(); // TODO: properly propagate exception upwards
             return true;
         }
 
         // Nothing buffered: either the previous write was fully accepted, or
         // its tail was spilled into uWS backpressure (which uWS drains on its
-        // own). Resolve any flush(true) waiter — that promise is the resume
+        // own). Resolve any flush(true) waiter; that promise is the resume
         // signal for both readStreamIntoSink and direct-stream callers.
         // Handled before the try_end resend bookkeeping below, which assumes a
         // non-empty buffer.
@@ -1699,13 +1721,12 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
 
         let mut total_written: u64 = 0;
 
-        // try_end resend vs streaming-write drain:
+        // try_end resend vs queued-data flush:
         // - end_len > 0: the buffer holds the body uWS partially sent via
         //   try_end; `write_offset` is the resume point into that same buffer.
-        // - end_len == 0: the buffer holds a partially-accepted tryWriteBody
-        //   tail (`mid_body_chunk`) and/or user data queued while backed up;
-        //   `offset` already points at the resume position. `write_offset` is
-        //   uWS's cumulative response count and is not a valid index here.
+        // - end_len == 0: the buffer holds user data queued while backed up;
+        //   `offset` already points at the start. `write_offset` is uWS's
+        //   cumulative response count and is not a valid index here.
         let chunk_start = if self.end_len > 0 {
             // do not write more than available
             (write_offset as BlobSizeType).min(self.buffer.len() as BlobSizeType - 1) as usize
@@ -1717,9 +1738,6 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         // mutation send's internals perform. The length is used only for
         // `total_written` and the empty check.
         let chunk_len = self.readable_slice().len().saturating_sub(chunk_start);
-        // Draining our own tryWriteBody tail is not new user data: `onReady`
-        // re-invokes pull(), which would run the direct-stream body again.
-        let was_mid_body_chunk = self.mid_body_chunk;
         // if we have nothing to write, we are done
         if chunk_len == 0 {
             if self.done {
@@ -1737,7 +1755,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
 
             // tryWriteBody accepted another partial; wait for the next drain
             // before telling JS we're writable.
-            if self.mid_body_chunk {
+            if !self.open_chunk.is_none() {
                 return true;
             }
 
@@ -1760,7 +1778,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
 
         // pending_flush or callback could have caused another send()
         // so we check again if we should report readiness
-        if !self.done && !self.requested_end && !self.has_backpressure() && !was_mid_body_chunk {
+        if !self.done && !self.requested_end && !self.has_backpressure() {
             // no pending and total_written > 0
             if total_written > 0 && self.readable_slice().is_empty() {
                 self.signal.ready(Some(total_written as BlobSizeType), None);
@@ -2187,8 +2205,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         // SAFETY: caller contract — `this` is live, and every borrow formed here
         // ends before the signal close below, which may free `*this`.
         let sink = unsafe { &mut *this };
-        sink.clear_pending_pinned_write();
-        sink.mid_body_chunk = false;
+        sink.clear_open_chunk();
         sink.done = true;
         sink.res = None;
         sink.unregister_auto_flusher();
@@ -2263,7 +2280,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         // the Box first so we never hold a `&mut *this` alongside the Box's
         // unique pointer.
         let mut this = unsafe { bun_core::heap::take(this) };
-        this.clear_pending_pinned_write();
+        this.clear_open_chunk();
         // Callers may tear this sink down without routing through
         // flushPromise() (e.g. handleResolveStream / handleRejectStream).
         // Drop the GC root so the promise can be collected.
@@ -2300,7 +2317,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             // partial accept (uWS backpressure is already non-empty, so the
             // optionally=true body write returns 0). Close it so end_stream()
             // appends the terminator after a well-formed chunk.
-            self.spill_mid_body_chunk();
+            self.spill_open_chunk();
             self.done = true;
 
             if let Some(res) = self.any_res() {

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -2296,6 +2296,11 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
                 res.clear_on_writable();
             }
             let _ = self.flush_no_wait();
+            // flush_no_wait -> send_readable may itself open a new chunk on
+            // partial accept (uWS backpressure is already non-empty, so the
+            // optionally=true body write returns 0). Close it so end_stream()
+            // appends the terminator after a well-formed chunk.
+            self.spill_mid_body_chunk();
             self.done = true;
 
             if let Some(res) = self.any_res() {

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1698,7 +1698,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             if self.drain_open_chunk() {
                 return true;
             }
-            let _ = self.flush_promise(); // TODO: properly propagate exception upwards
+            let _ = self.flush_promise();
             return true;
         }
 

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1088,10 +1088,6 @@ impl PendingPinnedWrite {
     }
 }
 
-/// Writes larger than this take the pinned zero-copy path; at or below it the
-/// cork buffer (`LoopData::CORK_BUFFER_SIZE` = 16KB) already handles the copy.
-const PINNED_WRITE_THRESHOLD: usize = 16 * 1024;
-
 pub struct HTTPServerWritable<const SSL: bool, const HTTP3: bool> {
     pub res: Option<*mut UwsResponse<SSL, HTTP3>>,
     pub buffer: Vec<u8>,
@@ -1368,7 +1364,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         // for >4 GiB writes, which splits into UINT_MAX-framed sub-chunks
         // (tryWriteBody's `writeUnsignedHex((unsigned int) length)` would
         // truncate).
-        if len <= PINNED_WRITE_THRESHOLD
+        if len <= uws::PINNED_WRITE_THRESHOLD
             || (len as BlobSizeType) < self.high_water_mark
             || len > core::ffi::c_uint::MAX as usize
             || !self.buffer.is_empty()

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1364,9 +1364,13 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         let len = bytes.len();
         // Same gate as the existing `write()` fast path (`len >= highWaterMark`
         // with an empty buffer) so this only changes how that path sends, not
-        // which path is taken.
+        // which path is taken. The c_uint upper bound falls back to `res.write()`
+        // for >4 GiB writes, which splits into UINT_MAX-framed sub-chunks
+        // (tryWriteBody's `writeUnsignedHex((unsigned int) length)` would
+        // truncate).
         if len <= PINNED_WRITE_THRESHOLD
             || (len as BlobSizeType) < self.high_water_mark
+            || len > core::ffi::c_uint::MAX as usize
             || !self.buffer.is_empty()
             || self.requested_end
             || !input_value.is_cell()

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1526,10 +1526,12 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             res.end(buf, false);
             self.has_backpressure = false;
             self.handle_wrote(buf.len());
-        } else if buf.len() > core::ffi::c_uint::MAX as usize {
-            // tryWriteBody emits the chunk-size line via writeUnsignedHex
-            // ((unsigned int)len); fall back to res.write() which splits
-            // >4 GiB into correctly-framed sub-chunks.
+        } else if HTTP3 || buf.len() > core::ffi::c_uint::MAX as usize {
+            // The H3 `try_write_body` shim discards write()'s backpressure
+            // result, and tryWriteBody emits the chunk-size line via
+            // writeUnsignedHex((unsigned int)len); fall back to res.write()
+            // (which reports backpressure for H3 and splits >4 GiB into
+            // correctly-framed sub-chunks for H1).
             self.has_backpressure = matches!(res.write(buf), uws::WriteResult::Backpressure(_));
             self.handle_wrote(buf.len());
         } else {
@@ -1625,7 +1627,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             res.end(&self.buffer[base..], false);
             self.has_backpressure = false;
             self.handle_wrote(buf_len);
-        } else if buf_len > core::ffi::c_uint::MAX as usize {
+        } else if HTTP3 || buf_len > core::ffi::c_uint::MAX as usize {
             self.has_backpressure = matches!(
                 res.write(&self.buffer[base..]),
                 uws::WriteResult::Backpressure(_)

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1442,10 +1442,16 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             consumed,
             len
         );
-        // For buffers `pin()` prevents `transfer()` from detaching the backing
-        // store; resizable/growable-shared are excluded (resize() mprotect()s
-        // trimmed pages PROT_NONE). JSString character buffers are immutable.
-        let cell = if is_array_buffer {
+        // The cell is rooted via the controller's GC-visited
+        // `m_pendingWriteValue` WriteBarrier; released on drain, spill,
+        // abort or destroy. For buffers `pin()` additionally prevents
+        // `transfer()` from detaching the backing store; resizable /
+        // growable-shared are excluded (resize() mprotect()s trimmed pages
+        // PROT_NONE). JSString character buffers are immutable.
+        let controller = self.controller_value();
+        let cell = if controller == JSValue::ZERO {
+            None
+        } else if is_array_buffer {
             match input_value.as_pinned_arraybuffer(self.global_this()) {
                 Some(ab) if !ab.resizable => Some(input_value),
                 Some(_) => {
@@ -1457,13 +1463,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         } else {
             Some(JSValue::ZERO)
         };
-        // The cell is rooted via the controller's GC-visited
-        // `m_pendingWriteValue` WriteBarrier; released on drain, spill,
-        // abort or destroy.
-        let controller = self.controller_value();
-        if let Some(cell) = cell
-            && controller != JSValue::ZERO
-        {
+        if let Some(cell) = cell {
             <Self as crate::webcore::sink::JsSinkAbi>::set_pending_write_value_extern(
                 controller,
                 self.global_this(),
@@ -2002,8 +2002,8 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         }
         self.spill_open_chunk();
         // All-ASCII Latin-1 is byte-identical to UTF-8 and the JSString's
-        // character buffer is immutable, so the pinned path can hold it by
-        // reference with `protect()` alone.
+        // character buffer is immutable, so it can take the pinned path
+        // without an ArrayBuffer pin().
         let bytes = data.slice();
         if strings::is_all_ascii(bytes) {
             if let Some(result) = self.try_write_pinned(bytes, input_value, false) {

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1362,7 +1362,11 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             return None;
         }
         let len = bytes.len();
+        // Same gate as the existing `write()` fast path (`len >= highWaterMark`
+        // with an empty buffer) so this only changes how that path sends, not
+        // which path is taken.
         if len <= PINNED_WRITE_THRESHOLD
+            || (len as BlobSizeType) < self.high_water_mark
             || !self.buffer.is_empty()
             || self.requested_end
             || !input_value.is_cell()

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1057,6 +1057,41 @@ impl SignalVTable {
 // type level; all dispatch happens at runtime through `any_res()` / `uws::AnyResponse`.
 pub type UwsResponse<const SSL: bool, const HTTP3: bool> = c_void;
 
+/// A large `controller.write()` whose unwritten tail is held by reference
+/// instead of being copied into the uWS backpressure std::string. The bytes
+/// are kept valid by `.protect()` on the JS cell plus `pin()` on the backing
+/// `ArrayBuffer` (so `transfer()` copies instead of detaching). Resumed from
+/// the stored offset on `on_writable`.
+#[derive(Clone, Copy)]
+pub struct PendingPinnedWrite {
+    /// Body bytes not yet accepted by the kernel / cork buffer. Borrows the
+    /// pinned `ArrayBuffer`'s backing store; advanced in place on drain.
+    remaining: *const [u8],
+    /// The JS cell (ArrayBuffer or view) to `unprotect()` + `unpin()` on
+    /// release. `ZERO` when no write is held.
+    pinned_value: JSValue,
+}
+
+impl Default for PendingPinnedWrite {
+    fn default() -> Self {
+        Self {
+            remaining: core::ptr::slice_from_raw_parts(core::ptr::null(), 0),
+            pinned_value: JSValue::ZERO,
+        }
+    }
+}
+
+impl PendingPinnedWrite {
+    #[inline]
+    fn is_some(&self) -> bool {
+        self.remaining.len() > 0
+    }
+}
+
+/// Writes larger than this take the pinned zero-copy path; at or below it the
+/// cork buffer (`LoopData::CORK_BUFFER_SIZE` = 16KB) already handles the copy.
+const PINNED_WRITE_THRESHOLD: usize = 16 * 1024;
+
 pub struct HTTPServerWritable<const SSL: bool, const HTTP3: bool> {
     pub res: Option<*mut UwsResponse<SSL, HTTP3>>,
     pub buffer: Vec<u8>,
@@ -1081,6 +1116,7 @@ pub struct HTTPServerWritable<const SSL: bool, const HTTP3: bool> {
     pub has_backpressure: bool,
     pub end_len: usize,
     pub aborted: bool,
+    pub pending_pinned_write: PendingPinnedWrite,
     /// This sink fully ended the uWS response (`res.end()` / a completed
     /// `res.try_end()`). On HTTP/1 uWS `markDone()` drops `onAborted` at that
     /// point, so the owning `RequestContext` is never told if the peer closes
@@ -1118,6 +1154,7 @@ impl<const SSL: bool, const HTTP3: bool> Default for HTTPServerWritable<SSL, HTT
             has_backpressure: false,
             end_len: 0,
             aborted: false,
+            pending_pinned_write: PendingPinnedWrite::default(),
             ended_response: false,
             on_first_write: None,
             ctx: None,
@@ -1262,6 +1299,118 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             let ctx = self.ctx.take();
             on_first_write(ctx);
         }
+    }
+
+    /// Release the GC root + pin taken by a zero-copy write.
+    fn clear_pending_pinned_write(&mut self) {
+        let p = core::mem::take(&mut self.pending_pinned_write);
+        if p.pinned_value != JSValue::ZERO {
+            p.pinned_value.unpin_array_buffer();
+            p.pinned_value.unprotect();
+        }
+    }
+
+    /// Copy a pending zero-copy write's tail into the uWS backpressure buffer
+    /// so a subsequent write()/end() stays ordered behind it, then release.
+    fn spill_pending_pinned_write(&mut self) {
+        if !self.pending_pinned_write.is_some() {
+            return;
+        }
+        if let Some(res) = self.any_res() {
+            // SAFETY: `remaining` borrows the pinned ArrayBuffer's backing
+            // store, held live by protect()+pin() until the clear below.
+            let remaining = unsafe { &*self.pending_pinned_write.remaining };
+            res.spill_body(remaining);
+            self.wrote += remaining.len() as BlobSizeType;
+        }
+        self.clear_pending_pinned_write();
+    }
+
+    /// Continue a zero-copy write from the stored offset. Returns `true` when
+    /// bytes remain outstanding (wait for another onWritable before resolving
+    /// the flush promise).
+    fn drain_pending_pinned_write(&mut self) -> bool {
+        if !self.pending_pinned_write.is_some() {
+            return false;
+        }
+        let Some(res) = self.any_res() else {
+            self.clear_pending_pinned_write();
+            return false;
+        };
+        // SAFETY: see `spill_pending_pinned_write`.
+        let remaining = unsafe { &*self.pending_pinned_write.remaining };
+        let consumed = res.try_write_body(remaining, false);
+        self.wrote += consumed as BlobSizeType;
+        if consumed < remaining.len() {
+            self.pending_pinned_write.remaining = core::ptr::from_ref(&remaining[consumed..]);
+            self.has_backpressure = true;
+            return true;
+        }
+        self.clear_pending_pinned_write();
+        false
+    }
+
+    /// Zero-copy fast path for a large ArrayBuffer-backed write: send via
+    /// `try_write_body` (no tail copy into uWS backpressure); on partial
+    /// accept, pin + GC-root the user's buffer and resume on `on_writable`.
+    /// Returns `None` when the preconditions don't hold (caller falls back to
+    /// the buffered path).
+    fn try_write_pinned(&mut self, bytes: &[u8], input_value: JSValue) -> Option<Writable> {
+        // The HTTP/3 `try_write_body` shim falls back to a copying write, so
+        // the pin would only add overhead there.
+        if HTTP3 {
+            return None;
+        }
+        let len = bytes.len();
+        if len <= PINNED_WRITE_THRESHOLD
+            || !self.buffer.is_empty()
+            || self.requested_end
+            || !input_value.is_cell()
+        {
+            return None;
+        }
+        let res = self.any_res()?;
+        // `res` is a `Copy` raw uWS handle; see `send_without_auto_flusher` re
+        // holding it across `on_first_write` (which writes status/headers
+        // through the same response but never mutates `self.buffer`).
+        self.unregister_auto_flusher();
+        self.end_len = 0;
+        self.handle_first_write_if_necessary();
+
+        bun_core::scoped_log!(HTTPServerWritableLog, "tryWriteBody({} bytes)", len);
+        let consumed = res.try_write_body(bytes, true);
+        self.wrote += consumed as BlobSizeType;
+        if consumed >= len {
+            self.has_backpressure = false;
+            return Some(Writable::Owned(len as BlobSizeType));
+        }
+        bun_core::scoped_log!(
+            HTTPServerWritableLog,
+            "tryWriteBody partial: {} / {}",
+            consumed,
+            len
+        );
+        // `pin()` prevents `transfer()` from detaching the backing store;
+        // `protect()` GC-roots the cell. Both are released together on drain,
+        // spill, abort or destroy.
+        if input_value
+            .as_pinned_arraybuffer(self.global_this())
+            .is_none()
+        {
+            // Not ArrayBuffer-backed after all; copy the tail so it outlives
+            // this call.
+            res.spill_body(&bytes[consumed..]);
+            self.wrote += (len - consumed) as BlobSizeType;
+            self.has_backpressure = true;
+            return Some(self.writable_result(len as BlobSizeType));
+        }
+        input_value.protect();
+        self.pending_pinned_write = PendingPinnedWrite {
+            remaining: core::ptr::from_ref(&bytes[consumed..]),
+            pinned_value: input_value,
+        };
+        self.has_backpressure = true;
+        Some(self.writable_result(len as BlobSizeType))
     }
 
     fn has_backpressure(&self) -> bool {
@@ -1430,10 +1579,17 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         // onWritable reset backpressure state to allow flushing
         self.has_backpressure = false;
         if self.aborted {
+            self.clear_pending_pinned_write();
             self.signal.close(None);
             let _ = self.flush_promise(); // TODO: properly propagate exception upwards
             self.finalize();
             return false;
+        }
+
+        // Finish any held zero-copy tail before touching `self.buffer` or
+        // resolving the flush promise.
+        if self.drain_pending_pinned_write() {
+            return true;
         }
 
         // Streaming-write drain: uWS already holds the data (our buffer is
@@ -1667,6 +1823,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         let bytes = data.slice();
         let len = bytes.len() as BlobSizeType;
         bun_core::scoped_log!(HTTPServerWritableLog, "write({})", bytes.len());
+        self.spill_pending_pinned_write();
 
         if self.buffer.len() == 0 && len >= self.high_water_mark {
             // fast path:
@@ -1703,6 +1860,23 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         self.write(data)
     }
 
+    pub fn write_bytes_with_value(
+        &mut self,
+        data: &StreamResult,
+        input_value: JSValue,
+    ) -> Writable {
+        if self.done || self.requested_end {
+            return Writable::Owned(0);
+        }
+        // A previous zero-copy tail must hit the wire before this one; no-op
+        // when the caller waited for the flush promise.
+        self.spill_pending_pinned_write();
+        if let Some(result) = self.try_write_pinned(data.slice(), input_value) {
+            return result;
+        }
+        self.write(data)
+    }
+
     pub fn write_latin1(&mut self, data: &StreamResult) -> Writable {
         if self.done || self.requested_end {
             return Writable::Owned(0);
@@ -1717,6 +1891,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         let bytes = data.slice();
         let len = bytes.len() as BlobSizeType;
         bun_core::scoped_log!(HTTPServerWritableLog, "writeLatin1({})", bytes.len());
+        self.spill_pending_pinned_write();
 
         if self.buffer.len() == 0 && len >= self.high_water_mark {
             let mut do_send = true;
@@ -1775,6 +1950,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         let bytes = data.slice();
 
         bun_core::scoped_log!(HTTPServerWritableLog, "writeUTF16({})", bytes.len());
+        self.spill_pending_pinned_write();
 
         // we must always buffer UTF-16
         // we assume the case of all-ascii UTF-16 string is pretty uncommon
@@ -1816,6 +1992,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             return bun_sys::Result::Ok(());
         }
 
+        self.spill_pending_pinned_write();
         self.requested_end = true;
         let readable_len = self.readable_slice().len();
         self.end_len = readable_len;
@@ -1846,6 +2023,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             return bun_sys::Result::Ok(JSValue::from(0i32));
         }
 
+        self.spill_pending_pinned_write();
         self.requested_end = true;
         let readable_len = self.readable_slice().len();
         self.end_len = readable_len;
@@ -1891,6 +2069,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         // SAFETY: caller contract — `this` is live, and every borrow formed here
         // ends before the signal close below, which may free `*this`.
         let sink = unsafe { &mut *this };
+        sink.clear_pending_pinned_write();
         sink.done = true;
         sink.res = None;
         sink.unregister_auto_flusher();
@@ -1965,6 +2144,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         // the Box first so we never hold a `&mut *this` alongside the Box's
         // unique pointer.
         let mut this = unsafe { bun_core::heap::take(this) };
+        this.clear_pending_pinned_write();
         // Callers may tear this sink down without routing through
         // flushPromise() (e.g. handleResolveStream / handleRejectStream).
         // Drop the GC root so the promise can be collected.
@@ -1982,6 +2162,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
     pub fn finalize(&mut self) {
         bun_core::scoped_log!(HTTPServerWritableLog, "finalize()");
         if !self.done {
+            self.spill_pending_pinned_write();
             self.unregister_auto_flusher();
             if let Some(res) = self.any_res() {
                 // The body is finished; drop the drain callback so the owning
@@ -2095,6 +2276,9 @@ impl<const SSL: bool, const HTTP3: bool> crate::webcore::sink::JsSinkType
     }
     fn write_bytes(&mut self, data: &StreamResult) -> Writable {
         Self::write(self, data)
+    }
+    fn write_bytes_with_value(&mut self, data: &StreamResult, input_value: JSValue) -> Writable {
+        Self::write_bytes_with_value(self, data, input_value)
     }
     fn write_utf16(&mut self, data: &StreamResult) -> Writable {
         Self::write_utf16(self, data)

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -30,7 +30,7 @@ pub use bun_uws_sys::{
 /// contract. With `panic = "abort"` Rust panics terminate in the crash-handler
 /// hook, so no `catch_unwind` wrapper is emitted.
 pub use bun_jsc_macros::uws_callback;
-pub use bun_uws_sys::response::State;
+pub use bun_uws_sys::response::{PINNED_WRITE_THRESHOLD, State};
 pub use bun_uws_sys::{h3 as H3, quic, udp, vtable};
 pub type Socket = us_socket_t;
 

--- a/src/uws_sys/Response.rs
+++ b/src/uws_sys/Response.rs
@@ -279,6 +279,11 @@ impl<const SSL: bool> Response<SSL> {
 
     /// Write body bytes without copying the unwritten tail into uWS backpressure.
     /// Returns the number of body bytes accepted. See `HttpResponse::tryWriteBody`.
+    ///
+    /// Callers gate this on `data.len() > PINNED_WRITE_THRESHOLD` (writes at or
+    /// below the cork-buffer size are already fully absorbed by the cork copy)
+    /// and `<= c_uint::MAX` (the chunk-size line is emitted via
+    /// `writeUnsignedHex((unsigned int) length)`).
     pub fn try_write_body(&mut self, data: &[u8], is_first: bool) -> usize {
         // SAFETY: self is a live opaque uws_res handle owned by uWS; FFI call has no extra preconditions.
         unsafe {
@@ -1065,6 +1070,11 @@ pub enum WriteResult {
     WantMore(usize),
     Backpressure(usize),
 }
+
+/// Writes larger than this take the pinned zero-copy `try_write_body` path;
+/// at or below it the cork buffer (`LoopData::CORK_BUFFER_SIZE` = 16KB) already
+/// handles the copy.
+pub const PINNED_WRITE_THRESHOLD: usize = 16 * 1024;
 
 pub use c::uws_res;
 

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -459,7 +459,7 @@ pub use connecting_socket::ConnectingSocket;
 pub use listen_socket::ListenSocket;
 pub use request::{AnyRequest, Request};
 pub use response::c::uws_res;
-pub use response::{AnyResponse, SocketAddress, WebSocketUpgradeContext};
+pub use response::{AnyResponse, PINNED_WRITE_THRESHOLD, SocketAddress, WebSocketUpgradeContext};
 pub use socket_context::BunSocketContextOptions;
 pub use socket_group::ConnectResult;
 pub use socket_group::SocketGroup;

--- a/test/js/bun/http/serve-pinned-write.test.ts
+++ b/test/js/bun/http/serve-pinned-write.test.ts
@@ -66,6 +66,9 @@ describe("Bun.serve direct-stream large Buffer writes are sent zero-copy", () =>
                   controller.end();
                 } catch (e) {
                   handlerError = e;
+                  try {
+                    controller.end();
+                  } catch {}
                   serverReady.resolve();
                 }
               },
@@ -155,6 +158,42 @@ describe("Bun.serve direct-stream large Buffer writes are sent zero-copy", () =>
     expect(body.length).toBe(first.length + second.length);
     expect(sha1(body.subarray(0, first.length))).toBe(firstHash);
     expect(Buffer.compare(body.subarray(first.length), second)).toBe(0);
+  });
+
+  test("a resizable ArrayBuffer is spilled, not pinned", async () => {
+    // Resizable buffers reserve maxByteLength virtually; resize() down
+    // mprotect()s the trimmed pages PROT_NONE, so the pinned path must not
+    // retain a raw slice into one. The tail is copied into backpressure
+    // instead, so resizing mid-flight is safe.
+    const ab = new ArrayBuffer(CHUNK_SIZE, { maxByteLength: CHUNK_SIZE });
+    const payload = new Uint8Array(ab);
+    for (let i = 0; i < payload.length; i++) payload[i] = i & 0xff;
+    const expectedHash = sha1(payload);
+
+    let detached: boolean | undefined;
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            async pull(controller: any) {
+              controller.write(payload);
+              // Not pinned: transfer() detaches immediately (the tail was
+              // copied into uWS backpressure).
+              ab.transfer();
+              detached = ab.detached;
+              controller.end();
+            },
+          } as any),
+        );
+      },
+    });
+
+    const body = Buffer.from(await (await fetch(server.url)).arrayBuffer());
+    expect(body.length).toBe(CHUNK_SIZE);
+    expect(sha1(body)).toBe(expectedHash);
+    expect(detached).toBe(true);
   });
 
   test("readStreamIntoSink: a large enqueue() delivers the exact bytes", async () => {

--- a/test/js/bun/http/serve-pinned-write.test.ts
+++ b/test/js/bun/http/serve-pinned-write.test.ts
@@ -103,69 +103,66 @@ describe("Bun.serve direct-stream large Buffer writes are sent zero-copy", () =>
     },
   );
 
-  test.skipIf(isWindows)(
-    "the held buffer survives a GC cycle while the write is draining",
-    async () => {
-      // The only GC root for the payload is the controller's
-      // m_pendingWriteValue WriteBarrier; drop the JS reference and force a
-      // synchronous collection mid-drain.
-      const expectedHash = sha1(makePayload(CHUNK_SIZE));
+  test.skipIf(isWindows)("the held buffer survives a GC cycle while the write is draining", async () => {
+    // The only GC root for the payload is the controller's
+    // m_pendingWriteValue WriteBarrier; drop the JS reference and force a
+    // synchronous collection mid-drain.
+    const expectedHash = sha1(makePayload(CHUNK_SIZE));
 
-      let wroteResult: number | undefined;
-      let handlerError: unknown;
-      const serverReady = Promise.withResolvers<void>();
+    let wroteResult: number | undefined;
+    let handlerError: unknown;
+    const serverReady = Promise.withResolvers<void>();
 
-      await using server = Bun.serve({
-        port: 0,
-        fetch() {
-          return new Response(
-            new ReadableStream({
-              type: "direct",
-              async pull(controller: any) {
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            async pull(controller: any) {
+              try {
+                let payload: Buffer | undefined = makePayload(CHUNK_SIZE);
+                wroteResult = controller.write(payload);
+                payload = undefined;
+                Bun.gc(true);
+                serverReady.resolve();
+                await controller.flush(true);
+                Bun.gc(true);
+                controller.end();
+              } catch (e) {
+                handlerError = e;
                 try {
-                  let payload: Buffer | undefined = makePayload(CHUNK_SIZE);
-                  wroteResult = controller.write(payload);
-                  payload = undefined;
-                  Bun.gc(true);
-                  serverReady.resolve();
-                  await controller.flush(true);
-                  Bun.gc(true);
                   controller.end();
-                } catch (e) {
-                  handlerError = e;
-                  try {
-                    controller.end();
-                  } catch {}
-                  serverReady.resolve();
-                }
-              },
-            } as any),
-          );
-        },
-      });
+                } catch {}
+                serverReady.resolve();
+              }
+            },
+          } as any),
+        );
+      },
+    });
 
-      const socket = net.connect(server.port, "127.0.0.1");
-      await once(socket, "connect");
-      socket.pause();
-      socket.write(`GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n`);
-      await serverReady.promise;
+    const socket = net.connect(server.port, "127.0.0.1");
+    await once(socket, "connect");
+    socket.pause();
+    socket.write(`GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n`);
+    await serverReady.promise;
 
-      const chunks: Buffer[] = [];
-      socket.on("data", chunk => chunks.push(chunk));
-      const closed = once(socket, "close");
-      socket.resume();
-      await closed;
-      const received = Buffer.concat(chunks);
+    const chunks: Buffer[] = [];
+    socket.on("data", chunk => chunks.push(chunk));
+    const closed = once(socket, "close");
+    socket.resume();
+    await closed;
+    const received = Buffer.concat(chunks);
 
-      expect(handlerError).toBeUndefined();
-      expect(wroteResult).toBeLessThan(0);
-      const headerEnd = received.indexOf("\r\n\r\n");
-      expect(headerEnd).toBeGreaterThan(0);
-      const body = dechunk(received.subarray(headerEnd + 4));
-      expect(body.length).toBe(CHUNK_SIZE);
-      expect(sha1(body)).toBe(expectedHash);
-    },
-  );
+    expect(handlerError).toBeUndefined();
+    expect(wroteResult).toBeLessThan(0);
+    const headerEnd = received.indexOf("\r\n\r\n");
+    expect(headerEnd).toBeGreaterThan(0);
+    const body = dechunk(received.subarray(headerEnd + 4));
+    expect(body.length).toBe(CHUNK_SIZE);
+    expect(sha1(body)).toBe(expectedHash);
+  });
 
   test("two large chunked writes deliver the exact bytes", async () => {
     const payload = makePayload(CHUNK_SIZE);

--- a/test/js/bun/http/serve-pinned-write.test.ts
+++ b/test/js/bun/http/serve-pinned-write.test.ts
@@ -103,6 +103,70 @@ describe("Bun.serve direct-stream large Buffer writes are sent zero-copy", () =>
     },
   );
 
+  test.skipIf(isWindows)(
+    "the held buffer survives a GC cycle while the write is draining",
+    async () => {
+      // The only GC root for the payload is the controller's
+      // m_pendingWriteValue WriteBarrier; drop the JS reference and force a
+      // synchronous collection mid-drain.
+      const expectedHash = sha1(makePayload(CHUNK_SIZE));
+
+      let wroteResult: number | undefined;
+      let handlerError: unknown;
+      const serverReady = Promise.withResolvers<void>();
+
+      await using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response(
+            new ReadableStream({
+              type: "direct",
+              async pull(controller: any) {
+                try {
+                  let payload: Buffer | undefined = makePayload(CHUNK_SIZE);
+                  wroteResult = controller.write(payload);
+                  payload = undefined;
+                  Bun.gc(true);
+                  serverReady.resolve();
+                  await controller.flush(true);
+                  Bun.gc(true);
+                  controller.end();
+                } catch (e) {
+                  handlerError = e;
+                  try {
+                    controller.end();
+                  } catch {}
+                  serverReady.resolve();
+                }
+              },
+            } as any),
+          );
+        },
+      });
+
+      const socket = net.connect(server.port, "127.0.0.1");
+      await once(socket, "connect");
+      socket.pause();
+      socket.write(`GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n`);
+      await serverReady.promise;
+
+      const chunks: Buffer[] = [];
+      socket.on("data", chunk => chunks.push(chunk));
+      const closed = once(socket, "close");
+      socket.resume();
+      await closed;
+      const received = Buffer.concat(chunks);
+
+      expect(handlerError).toBeUndefined();
+      expect(wroteResult).toBeLessThan(0);
+      const headerEnd = received.indexOf("\r\n\r\n");
+      expect(headerEnd).toBeGreaterThan(0);
+      const body = dechunk(received.subarray(headerEnd + 4));
+      expect(body.length).toBe(CHUNK_SIZE);
+      expect(sha1(body)).toBe(expectedHash);
+    },
+  );
+
   test("two large chunked writes deliver the exact bytes", async () => {
     const payload = makePayload(CHUNK_SIZE);
     const expectedHash = sha1(payload);

--- a/test/js/bun/http/serve-pinned-write.test.ts
+++ b/test/js/bun/http/serve-pinned-write.test.ts
@@ -167,7 +167,7 @@ describe("Bun.serve direct-stream large Buffer writes are sent zero-copy", () =>
     // instead, so resizing mid-flight is safe.
     const ab = new ArrayBuffer(CHUNK_SIZE, { maxByteLength: CHUNK_SIZE });
     const payload = new Uint8Array(ab);
-    for (let i = 0; i < payload.length; i++) payload[i] = i & 0xff;
+    payload.set(makePayload(CHUNK_SIZE));
     const expectedHash = sha1(payload);
 
     let detached: boolean | undefined;
@@ -194,6 +194,56 @@ describe("Bun.serve direct-stream large Buffer writes are sent zero-copy", () =>
     expect(body.length).toBe(CHUNK_SIZE);
     expect(sha1(body)).toBe(expectedHash);
     expect(detached).toBe(true);
+  });
+
+  test("a large ASCII string write delivers the exact bytes", async () => {
+    const payload = Buffer.alloc(CHUNK_SIZE, "a").toString("latin1");
+    const expected = sha1(Buffer.alloc(CHUNK_SIZE, "a"));
+
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            async pull(controller: any) {
+              if (controller.write(payload) < 0) await controller.flush(true);
+              controller.end();
+            },
+          } as any),
+        );
+      },
+    });
+
+    const body = Buffer.from(await (await fetch(server.url)).arrayBuffer());
+    expect(body.length).toBe(CHUNK_SIZE);
+    expect(sha1(body)).toBe(expected);
+  });
+
+  test("a large UTF-16 string write delivers the exact bytes", async () => {
+    // Non-Latin-1 char forces JSC to 16-bit storage; the sink transcodes to
+    // UTF-8 into its own buffer and then sends via tryWriteBody.
+    const payload = Buffer.alloc(CHUNK_SIZE - 1, "a").toString("latin1") + "\u0100";
+    const expectedBytes = Buffer.concat([Buffer.alloc(CHUNK_SIZE - 1, "a"), Buffer.from("\u0100", "utf8")]);
+
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            async pull(controller: any) {
+              if (controller.write(payload) < 0) await controller.flush(true);
+              controller.end();
+            },
+          } as any),
+        );
+      },
+    });
+
+    const body = Buffer.from(await (await fetch(server.url)).arrayBuffer());
+    expect(body.length).toBe(expectedBytes.length);
+    expect(sha1(body)).toBe(sha1(expectedBytes));
   });
 
   test("readStreamIntoSink: a large enqueue() delivers the exact bytes", async () => {

--- a/test/js/bun/http/serve-pinned-write.test.ts
+++ b/test/js/bun/http/serve-pinned-write.test.ts
@@ -160,6 +160,36 @@ describe("Bun.serve direct-stream large Buffer writes are sent zero-copy", () =>
     expect(Buffer.compare(body.subarray(first.length), second)).toBe(0);
   });
 
+  test("a small sub-highWaterMark write after a large backpressured write is well-framed at finalize", async () => {
+    // Large write spills its tail into uWS backpressure, then a small write
+    // is queued in self.buffer. pull() returns without end() so finalize()
+    // runs flush_no_wait() -> try_write_body while uWS backpressure is
+    // non-empty (returns 0), leaving a chunk open; the chunk must be spilled
+    // before end_stream() or the client's decoder mis-frames.
+    const first = makePayload(CHUNK_SIZE);
+    const second = Buffer.alloc(1000, 0xee);
+
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            async pull(controller: any) {
+              controller.write(first);
+              controller.write(second);
+            },
+          } as any),
+        );
+      },
+    });
+
+    const body = Buffer.from(await (await fetch(server.url)).arrayBuffer());
+    expect(body.length).toBe(first.length + second.length);
+    expect(sha1(body.subarray(0, first.length))).toBe(sha1(first));
+    expect(Buffer.compare(body.subarray(first.length), second)).toBe(0);
+  });
+
   test("a resizable ArrayBuffer is spilled, not pinned", async () => {
     // Resizable buffers reserve maxByteLength virtually; resize() down
     // mprotect()s the trimmed pages PROT_NONE, so the pinned path must not

--- a/test/js/bun/http/serve-pinned-write.test.ts
+++ b/test/js/bun/http/serve-pinned-write.test.ts
@@ -263,11 +263,11 @@ describe("Bun.serve direct-stream large Buffer writes are sent zero-copy", () =>
     });
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    const result = JSON.parse(stdout.trim());
-    expect({ detachedAfterAbort: result.detachedAfterAbort, exitCode }).toEqual({
+    const result = JSON.parse(stdout.trim() || "{}");
+    expect({ detachedAfterAbort: result.detachedAfterAbort, exitCode, stderr }).toEqual({
       detachedAfterAbort: true,
       exitCode: 0,
+      stderr: expect.any(String),
     });
   });
 });

--- a/test/js/bun/http/serve-pinned-write.test.ts
+++ b/test/js/bun/http/serve-pinned-write.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+import { createHash } from "node:crypto";
+import { once } from "node:events";
+import net from "node:net";
+
+// Large enough to overflow both the 16KB cork buffer and the kernel send
+// buffer on loopback, so tryWriteBody reports a partial accept and the tail
+// is held by reference.
+const CHUNK_SIZE = 64 * 1024 * 1024;
+
+const PATTERN_256 = Buffer.from(Array.from({ length: 256 }, (_, i) => i));
+
+function makePayload(size: number): Buffer {
+  return Buffer.alloc(size, PATTERN_256);
+}
+
+function sha1(buf: Uint8Array): string {
+  return createHash("sha1").update(buf).digest("hex");
+}
+
+describe("Bun.serve direct-stream large Buffer writes are sent zero-copy", () => {
+  // Winsock auto-tunes its send buffer on loopback and will absorb the whole
+  // payload in one nonblocking send(), so the pinned-tail state is never
+  // reached on Windows (the bytes go straight to the kernel instead). The
+  // correctness tests below still cover the write path there.
+  test.skipIf(isWindows)(
+    "the buffer backing store is pinned while the write is pending, then released on drain",
+    async () => {
+      const payload = makePayload(CHUNK_SIZE);
+      const expectedHash = sha1(payload);
+
+      let detachedWhilePending: boolean | undefined;
+      let detachedAfterDrain: boolean | undefined;
+      let wroteResult: number | undefined;
+      let handlerError: unknown;
+      const serverReady = Promise.withResolvers<void>();
+
+      await using server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response(
+            new ReadableStream({
+              type: "direct",
+              async pull(controller: any) {
+                try {
+                  // The client is a paused net.Socket so the kernel send
+                  // buffer fills and write() reports native backpressure.
+                  wroteResult = controller.write(payload);
+
+                  // While the tail is in-flight, the underlying ArrayBuffer is
+                  // pinned so transfer() copies instead of detaching. Without
+                  // the pin the server would serve garbage for the bytes still
+                  // to be written.
+                  payload.buffer.transfer();
+                  detachedWhilePending = payload.buffer.detached;
+                  serverReady.resolve();
+
+                  await controller.flush(true);
+
+                  // After the tail has flushed the pin is released and
+                  // transfer() detaches again.
+                  payload.buffer.transfer();
+                  detachedAfterDrain = payload.buffer.detached;
+
+                  controller.end();
+                } catch (e) {
+                  handlerError = e;
+                  serverReady.resolve();
+                }
+              },
+            } as any),
+          );
+        },
+      });
+
+      const socket = net.connect(server.port, "127.0.0.1");
+      await once(socket, "connect");
+      socket.pause();
+      socket.write(`GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n`);
+      await serverReady.promise;
+
+      const chunks: Buffer[] = [];
+      socket.on("data", chunk => chunks.push(chunk));
+      const closed = once(socket, "close");
+      socket.resume();
+      await closed;
+      const received = Buffer.concat(chunks);
+
+      expect(handlerError).toBeUndefined();
+      // write() returns -(len+1) under backpressure.
+      expect(wroteResult).toBeLessThan(0);
+      const headerEnd = received.indexOf("\r\n\r\n");
+      expect(headerEnd).toBeGreaterThan(0);
+      const body = dechunk(received.subarray(headerEnd + 4));
+      expect(body.length).toBe(CHUNK_SIZE);
+      expect(sha1(body)).toBe(expectedHash);
+      expect(detachedWhilePending).toBe(false);
+      expect(detachedAfterDrain).toBe(true);
+    },
+  );
+
+  test("two large chunked writes deliver the exact bytes", async () => {
+    const payload = makePayload(CHUNK_SIZE);
+    const expectedHash = sha1(payload);
+
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            async pull(controller: any) {
+              if (controller.write(payload) < 0) await controller.flush(true);
+              if (controller.write(payload) < 0) await controller.flush(true);
+              controller.end();
+            },
+          } as any),
+        );
+      },
+    });
+
+    const response = await fetch(server.url);
+    const body = Buffer.from(await response.arrayBuffer());
+    expect(body.length).toBe(CHUNK_SIZE * 2);
+    expect(sha1(body.subarray(0, CHUNK_SIZE))).toBe(expectedHash);
+    expect(sha1(body.subarray(CHUNK_SIZE))).toBe(expectedHash);
+  });
+
+  test("a second write before drain is ordered after the pending tail", async () => {
+    const first = makePayload(CHUNK_SIZE);
+    const firstHash = sha1(first);
+    const second = Buffer.alloc(1024, 0xee);
+
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            async pull(controller: any) {
+              controller.write(first);
+              // Deliberately do NOT flush: the pending tail of `first` must be
+              // spilled into backpressure so `second` lands after it.
+              controller.write(second);
+              controller.end();
+            },
+          } as any),
+        );
+      },
+    });
+
+    const response = await fetch(server.url);
+    const body = Buffer.from(await response.arrayBuffer());
+    expect(body.length).toBe(first.length + second.length);
+    expect(sha1(body.subarray(0, first.length))).toBe(firstHash);
+    expect(Buffer.compare(body.subarray(first.length), second)).toBe(0);
+  });
+
+  test("readStreamIntoSink: a large enqueue() delivers the exact bytes", async () => {
+    const payload = makePayload(CHUNK_SIZE);
+    const expectedHash = sha1(payload);
+
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(payload);
+              controller.enqueue(payload);
+              controller.close();
+            },
+          }),
+        );
+      },
+    });
+
+    const response = await fetch(server.url);
+    const body = Buffer.from(await response.arrayBuffer());
+    expect(body.length).toBe(CHUNK_SIZE * 2);
+    expect(sha1(body.subarray(0, CHUNK_SIZE))).toBe(expectedHash);
+    expect(sha1(body.subarray(CHUNK_SIZE))).toBe(expectedHash);
+  });
+
+  test.skipIf(isWindows)("a second write before drain releases the pin on the first buffer", async () => {
+    let detachedAfterSecondWrite: boolean | undefined;
+    const total = CHUNK_SIZE + 1024;
+
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        const first = makePayload(CHUNK_SIZE);
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            async pull(controller: any) {
+              controller.write(first);
+              controller.write(Buffer.alloc(1024, 0xee));
+              // The second write spilled first's tail into uWS backpressure
+              // and released the pin, so transfer() detaches again.
+              first.buffer.transfer();
+              detachedAfterSecondWrite = first.buffer.detached;
+              controller.end();
+            },
+          } as any),
+        );
+      },
+    });
+
+    const body = await fetch(server.url).then(r => r.arrayBuffer());
+    expect(body.byteLength).toBe(total);
+    expect(detachedAfterSecondWrite).toBe(true);
+  });
+
+  test.skipIf(isWindows)("a client disconnect while a large write is draining releases the pin", async () => {
+    // Run in a child so the pin release on the abort path is observed in
+    // isolation.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const net = require("node:net");
+        const { once } = require("node:events");
+        const CHUNK_SIZE = ${CHUNK_SIZE};
+        const PATTERN = Buffer.from(Array.from({ length: 256 }, (_, i) => i));
+        let detachedAfterAbort;
+        const aborted = Promise.withResolvers();
+        const server = Bun.serve({
+          port: 0,
+          fetch() {
+            const payload = Buffer.alloc(CHUNK_SIZE, PATTERN);
+            return new Response(
+              new ReadableStream({
+                type: "direct",
+                async pull(controller) {
+                  controller.write(payload);
+                  await controller.flush(true).catch(() => {});
+                },
+                cancel() {
+                  payload.buffer.transfer();
+                  detachedAfterAbort = payload.buffer.detached;
+                  aborted.resolve();
+                },
+              }),
+            );
+          },
+        });
+        const s = net.connect(server.port, "127.0.0.1");
+        await once(s, "connect");
+        s.write("GET / HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n");
+        await once(s, "data");
+        s.destroy();
+        await aborted.promise;
+        console.log(JSON.stringify({ detachedAfterAbort }));
+        server.stop(true);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const result = JSON.parse(stdout.trim());
+    expect({ detachedAfterAbort: result.detachedAfterAbort, exitCode }).toEqual({
+      detachedAfterAbort: true,
+      exitCode: 0,
+    });
+  });
+});
+
+// Minimal chunked-transfer decoder for raw-socket assertions.
+function dechunk(raw: Buffer): Buffer {
+  const out: Buffer[] = [];
+  let i = 0;
+  while (i < raw.length) {
+    const eol = raw.indexOf("\r\n", i);
+    if (eol < 0) break;
+    const size = parseInt(raw.toString("latin1", i, eol), 16);
+    if (!Number.isFinite(size) || size === 0) break;
+    const start = eol + 2;
+    out.push(raw.subarray(start, start + size));
+    i = start + size + 2;
+  }
+  return Buffer.concat(out);
+}


### PR DESCRIPTION
Follow-up to #34511: apply the same zero-copy path to `HTTPServerWritable` (the `HTTPResponseSink`/`HTTPSResponseSink` behind a direct `ReadableStream` controller in `Bun.serve`).

## What changed

When `controller.write(chunk)` is larger than both the 16KB cork buffer and the kernel send buffer, the unwritten tail was copied into `AsyncSocket`'s `std::string` backpressure buffer (clone 1). For the buffered path (`self.buffer.len() + len >= highWaterMark`) the bytes were additionally appended to the sink's own `Vec<u8>` first (clone 2).

`HTTPServerWritable`'s streaming write path now sends via `HttpResponse::tryWriteBody` (body written with `optionally=true`, so the unwritten tail is not buffered by uWS) instead of `HttpResponse::write`:

- **ArrayBuffer / typed-array inputs** (`write_bytes_with_value`): on partial accept the user's ArrayBuffer is `pin()`ed (so `transfer()` copies instead of detaching) and GC-rooted via a `m_pendingWriteValue` `WriteBarrier<Unknown>` on the generated sink/controller cell; the remaining slice is stored in `open_chunk`. Resizable/growable-shared buffers are excluded (their `resize()` can mprotect the backing pages `PROT_NONE`) and fall through to the spill path.
- **All-ASCII Latin-1 `JSString` inputs** (`write_latin1_with_value`): same pinned path without an ArrayBuffer `pin()` (the string character buffer is immutable); the cell is GC-rooted via a `m_pendingWriteValue` WriteBarrier on the controller.
- **UTF-16 and non-ASCII Latin-1 strings**: still transcoded into the sink's own `Vec<u8>` once (unavoidable), but the tail now stays in that buffer and is resumed via `tryWriteBody(.., isFirst=false)` on `onWritable` instead of being copied into uWS backpressure on top of the encode.

Lifecycle:
- `on_writable()` resumes the held tail from the stored offset; the `flush(true)` promise only resolves once the full chunk has been accepted
- a second `write()`/`end()` before drain spills the pending tail into the uWS backpressure buffer so ordering is preserved, then releases any pin
- abort/destroy release the pin + GC root; `finalize()` spills any open chunk unconditionally so `handle_reject_stream` (which sets `done = true` first) leaves the chunked framing well-formed

`JSSink::js_write` now passes the JS cell through new optional `JsSinkType::write_bytes_with_value` / `write_latin1_with_value` methods (default to the plain variants); only the HTTP sinks override them. HTTP/3 keeps the copying path (its `try_write_body` shim is a fall-through). The `PINNED_WRITE_THRESHOLD` constant is lifted to `bun_uws_sys::response` and shared with `NodeHTTPResponse`.

## Results

Release build (`1.4.0-canary`), Linux x64, loopback, paused raw-TCP client so the first write reports backpressure.

### Peak RSS growth during a single backpressured `controller.write()`, 256 MB payload

| kind | main | this PR | change |
|---|---|---|---|
| Buffer | +511 MB | **+4 MB** | -99% |
| ASCII string | +511 MB | **+3 MB** | -99% |
| Latin-1 (non-ASCII) string | +1536 MB | **+515 MB** | -66% |
| UTF-16 string | +1279 MB | **+772 MB** | -40% |

Buffer / ASCII: the user's bytes are held by reference, so the only growth is the cork buffer and bookkeeping. Latin-1 / UTF-16 must be transcoded to UTF-8 once (the sink never had a way around that), but no longer clone the encoded bytes into uWS backpressure afterwards. Main's Buffer/ASCII delta is roughly `2 x payload` because the backpressure `std::string` doubles while growing to hold the tail.

### Buffer RSS growth vs. size

| payload | main | this PR |
|---|---|---|
| 16 MB | +30 MB | +4 MB |
| 64 MB | +126 MB | +4 MB |
| 256 MB | +511 MB | +4 MB |
| 512 MB | +1023 MB | +4 MB |

### Throughput (req/s) serving a single Buffer per response from a direct stream, 20 concurrent connections, loopback

| response size | main | this PR | change |
|---|---|---|---|
| 1 MB | 947 | 927 | within noise |
| 16 MB | 46.6 | 48.9 | +5% |
| 64 MB | 7.1 | 9.5 | +34% |
| 256 MB | 1.0 | 2.0 | +100% |

(1 MB varies ~10% run-to-run on this host; 64/256 MB averaged over 3 runs.)

<details>
<summary>Benchmark sources</summary>

RSS:
```js
// paused net.Socket client; sample process.memoryUsage.rss() immediately
// after controller.write(payload) returns
const server = Bun.serve({
  port: 0,
  fetch() {
    return new Response(new ReadableStream({
      type: "direct",
      async pull(controller) {
        controller.write(payload);
        peakDuringWrite = process.memoryUsage.rss();
        serverReady.resolve();
        await controller.flush(true);
        controller.end();
      },
    }));
  },
});
```

Throughput:
```js
const server = Bun.serve({
  port: 0,
  fetch() {
    return new Response(new ReadableStream({
      type: "direct",
      async pull(controller) {
        if (controller.write(payload) < 0) await controller.flush(true);
        controller.end();
      },
    }));
  },
});
// N workers doing `await (await fetch(url)).arrayBuffer()` in a loop
```
</details>

## Tests

`test/js/bun/http/serve-pinned-write.test.ts`:
- buffer is pinned (not detachable) while the write is pending, released on drain
- two large chunked writes deliver byte-exact payloads
- a second write before drain stays ordered after the pending tail and releases the first pin
- a resizable ArrayBuffer is spilled, not pinned
- large ASCII and UTF-16 string writes deliver byte-exact payloads
- `readStreamIntoSink` pump (non-direct `ReadableStream`) delivers byte-exact payloads
- a client disconnect mid-drain releases the pin on the abort path

Existing `serve-direct-readable-stream.test.ts`, `serve-stream-reject-flush-leak.test.ts` and `node-http-pinned-write.test.ts` still pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve-pinned-write.test.ts

<!-- robobun:evidence:end -->
