### PR TITLE
util.MIMEType: match Node.js ERR_INVALID_MIME_SYNTAX message

### DIFF
--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -1616,10 +1616,10 @@ JSC::EncodedJSValue INVALID_MIME_SYNTAX(JSC::ThrowScope& scope, JSC::JSGlobalObj
     WTF::StringBuilder builder;
     builder.append("The MIME syntax for a "_s);
     builder.append(part);
-    builder.append(" in "_s);
+    builder.append(" in \""_s);
     builder.append(input);
 
-    builder.append(" is invalid"_s);
+    builder.append("\" is invalid"_s);
     if (position != -1) {
         builder.append(" at "_s);
         builder.append(String::number(position));

--- a/src/jsc/bindings/webcore/JSMIMEType.cpp
+++ b/src/jsc/bindings/webcore/JSMIMEType.cpp
@@ -229,18 +229,15 @@ static std::tuple<String, String, size_t> parseTypeAndSubtype(JSGlobalObject* gl
     size_t typeEnd = input->find('/', position);
     if (typeEnd == notFound) {
         StringView remaining = input->substring(position);
-        size_t invalidIndex = findFirstInvalidHTTPTokenChar(remaining);
-        // Adjust index relative to original string
-        size_t originalIndex = (invalidIndex == -1) ? notFound : position + invalidIndex;
-        Bun::ERR::INVALID_MIME_SYNTAX(scope, globalObject, "type"_s, input->toString(), originalIndex);
+        int invalidTypeIndex = findFirstInvalidHTTPTokenChar(remaining);
+        Bun::ERR::INVALID_MIME_SYNTAX(scope, globalObject, "type"_s, input->toString(), invalidTypeIndex);
         return {};
     }
 
     StringView typeView = input->substring(position, typeEnd - position);
     int invalidTypeIndex = findFirstInvalidHTTPTokenChar(typeView);
     if (typeView.isEmpty() || invalidTypeIndex != -1) {
-        size_t originalIndex = (invalidTypeIndex == -1) ? position : position + invalidTypeIndex;
-        Bun::ERR::INVALID_MIME_SYNTAX(scope, globalObject, "type"_s, input->toString(), originalIndex);
+        Bun::ERR::INVALID_MIME_SYNTAX(scope, globalObject, "type"_s, input->toString(), invalidTypeIndex);
         return {};
     }
     String type = typeView.convertToASCIILowercase();
@@ -265,8 +262,7 @@ static std::tuple<String, String, size_t> parseTypeAndSubtype(JSGlobalObject* gl
 
     int invalidSubtypeIndex = findFirstInvalidHTTPTokenChar(subtypeView);
     if (subtypeView.isEmpty() || invalidSubtypeIndex != -1) {
-        size_t originalIndex = (invalidSubtypeIndex == -1) ? position : position + invalidSubtypeIndex;
-        Bun::ERR::INVALID_MIME_SYNTAX(scope, globalObject, "subtype"_s, input->toString(), originalIndex);
+        Bun::ERR::INVALID_MIME_SYNTAX(scope, globalObject, "subtype"_s, input->toString(), invalidSubtypeIndex);
         return {};
     }
     String subtype = subtypeView.convertToASCIILowercase();

--- a/test/js/node/util/mime-api.test.ts
+++ b/test/js/node/util/mime-api.test.ts
@@ -407,3 +407,32 @@ test("Exact match with node", () => {
     "
   `);
 });
+
+test("ERR_INVALID_MIME_SYNTAX message matches Node.js", () => {
+  const msg = (input: string) => {
+    try {
+      new MIMEType(input);
+    } catch (e) {
+      return (e as Error).message;
+    }
+    return undefined;
+  };
+
+  expect({
+    "text/ html": msg("text/ html"),
+    "aaaa/bbb@c": msg("aaaa/bbb@c"),
+    "text /html": msg("text /html"),
+    " text /html": msg(" text /html"),
+    "/html": msg("/html"),
+    "text/": msg("text/"),
+    "texthtml": msg("texthtml"),
+  }).toEqual({
+    "text/ html": 'The MIME syntax for a subtype in "text/ html" is invalid at 0',
+    "aaaa/bbb@c": 'The MIME syntax for a subtype in "aaaa/bbb@c" is invalid at 3',
+    "text /html": 'The MIME syntax for a type in "text /html" is invalid at 4',
+    " text /html": 'The MIME syntax for a type in " text /html" is invalid at 4',
+    "/html": 'The MIME syntax for a type in "/html" is invalid',
+    "text/": 'The MIME syntax for a subtype in "text/" is invalid',
+    "texthtml": 'The MIME syntax for a type in "texthtml" is invalid',
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Brings `util.MIMEType` parse-error messages to exact parity with Node.js.

### Repro

```js
import util from "node:util";
for (const s of ["text/ html", "aaaa/bbb@c", "/html", "text/"]) {
  try { new util.MIMEType(s); } catch (e) { console.log(e.message); }
}
```

Before:
```
The MIME syntax for a subtype in text/ html is invalid at 5
The MIME syntax for a subtype in aaaa/bbb@c is invalid at 8
The MIME syntax for a type in /html is invalid at 0
The MIME syntax for a subtype in text/ is invalid at 5
```

Node.js (and after this PR):
```
The MIME syntax for a subtype in "text/ html" is invalid at 0
The MIME syntax for a subtype in "aaaa/bbb@c" is invalid at 3
The MIME syntax for a type in "/html" is invalid
The MIME syntax for a subtype in "text/" is invalid
```

### Cause

- `ERR::INVALID_MIME_SYNTAX` in `ErrorCode.cpp` interpolated the input unquoted; Node wraps it in `"..."`.
- `parseTypeAndSubtype` in `JSMIMEType.cpp` adjusted the invalid-char index to an absolute offset into the full input string. Node reports the index relative to the trimmed type/subtype substring and passes `-1` (omitting the `at N` suffix) when the type/subtype is empty.

### Fix

- Quote the input in the error message builder.
- Pass the relative index returned by `findFirstInvalidHTTPTokenChar` directly, which is already `-1` for the empty case.

### How did you verify your code works?

Added a test to `test/js/node/util/mime-api.test.ts` asserting exact message strings for seven inputs (subtype offset, type offset, leading whitespace, empty type, empty subtype, no slash). Fails on `main`, passes with this change; the full `mime-api.test.ts` suite passes.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/mime-api.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (c76d19cf8)

test/js/node/util/mime-api.test.ts:
(pass) MIME API > class instance integrity [30.14ms]
(pass) MIME API > basic properties and string conversion [16.38ms]
(pass) MIME API > type property manipulation [33.80ms]
(pass) MIME API > subtype property manipulation [33.98ms]
(pass) MIME API > parameters manipulation [39.15ms]
(pass) MIME API > invalid parameter names [27.10ms]
(pass) MIME API > invalid parameter values [13.87ms]
(pass) Exact match with node [1535.82ms]
424 |     "text /html": msg("text /html"),
425 |     " text /html": msg(" text /html"),
426 |     "/html": msg("/html"),
427 |     "text/": msg("text/"),
428 |     "texthtml": msg("texthtml"),
429 |   }).toEqual({
           ^
error: expect(received).toEqual(exp
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/util/mime-api.test.ts:
(pass) MIME API > class instance integrity [0.16ms]
(pass) MIME API > basic properties and string conversion [0.24ms]
(pass) MIME API > type property manipulation [0.35ms]
(pass) MIME API > subtype property manipulation [0.33ms]
(pass) MIME API > parameters manipulation [0.43ms]
(pass) MIME API > invalid parameter names [0.22ms]
(pass) MIME API > invalid parameter values [0.11ms]
(pass) Exact match with node [36.42ms]
424 |     "text /html": msg("text /html"),
425 |     " text /html": msg(" text /html"),
426 |     "/html": msg("/html"),
427 |     "text/": msg("text/"),
428 |     "texthtml": msg("texthtml"),
429 |   }).toEqual({
           ^
error: expect(received).toEqual(expected)

  {
-   " text /html": "The MIME syntax for a type in " text /html" is invalid at 4",
-   "/html": "The MIME syntax for a type in "/html" is invalid",
-   "aaaa/bbb@c": "The MIME syntax for a subtype in "aaaa/bbb@c" is invalid at 3",
-   "text /html": "The MIME syntax for a type in "text /html" is invalid at 4",
-   "text/": "The MIME syntax for a subtype in "text/" is invalid",
-   "text/ html": "The MIME syntax f
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/mime-api.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (c76d19cf8)

test/js/node/util/mime-api.test.ts:
(pass) MIME API > class instance integrity [21.62ms]
(pass) MIME API > basic properties and string conversion [13.52ms]
(pass) MIME API > type property manipulation [25.26ms]
(pass) MIME API > subtype property manipulation [27.36ms]
(pass) MIME API > parameters manipulation [27.46ms]
(pass) MIME API > invalid parameter names [19.89ms]
(pass) MIME API > invalid parameter values [10.23ms]
(pass) Exact match with node [1108.21ms]
(pass) ERR_INVALID_MIME_SYNTAX message matches Node.js [9.00ms]

 9 pass
 0 fail
 1 snapshots, 87 expect() calls
Ran 9 tests across 1 file. [4.08s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 920ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/71] gen ErrorCode+*.h
[2/8] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[3/8] cxx obj/src/jsc/bindings/webcore/JSMIMEType.cpp.o
[4/8] gen cpp.rs (cppbind)
[4/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Finished[0m `release` profile [optimiz
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ErrorCode.cpp          |  4 ++--
 src/jsc/bindings/webcore/JSMIMEType.cpp | 12 ++++--------
 test/js/node/util/mime-api.test.ts      | 29 +++++++++++++++++++++++++++++
 3 files changed, 35 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/jsc/bindings/ErrorCode.cpp               2      1      0
src/jsc/bindings/webcore/JSMIMEType.cpp      2      1      0
test/js/node/util/mime-api.test.ts           2      1      0
```

</details>

<!-- robobun:evidence:end -->