### PR TITLE
util: MIMEParams get/has/delete should not stringify the lookup name

### DIFF
--- a/src/jsc/bindings/webcore/JSMIMEParams.cpp
+++ b/src/jsc/bindings/webcore/JSMIMEParams.cpp
@@ -399,19 +399,18 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMEParamsProtoFuncGet, (JSGlobalObject * globalObjec
         RETURN_IF_EXCEPTION(scope, {});
     }
 
-    // 2. Get argument
+    // 2. Get argument. Node.js passes the name to the internal Map without
+    // string coercion, so a non-string key never matches a stored string key.
     JSValue nameValue = callFrame->argument(0);
-    String name = nameValue.toWTFString(globalObject);
-    RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
     // 3. Perform operation on the map
     JSMap* map = thisObject->jsMap();
-    auto has = map->has(globalObject, jsString(vm, name));
+    auto has = map->has(globalObject, nameValue);
     RETURN_IF_EXCEPTION(scope, {});
     if (!has) {
         return JSValue::encode(jsNull());
     }
-    JSValue result = map->get(globalObject, jsString(vm, name));
+    JSValue result = map->get(globalObject, nameValue);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
     // 4. Return result (null if not found)
@@ -430,11 +429,9 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMEParamsProtoFuncHas, (JSGlobalObject * globalObjec
     }
 
     JSValue nameValue = callFrame->argument(0);
-    String name = nameValue.toWTFString(globalObject);
-    RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
     JSMap* map = thisObject->jsMap();
-    bool result = map->has(globalObject, jsString(vm, name));
+    bool result = map->has(globalObject, nameValue);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
     return JSValue::encode(jsBoolean(result));
@@ -494,11 +491,9 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMEParamsProtoFuncDelete, (JSGlobalObject * globalOb
     }
 
     JSValue nameValue = callFrame->argument(0);
-    String name = nameValue.toWTFString(globalObject);
-    RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
     JSMap* map = thisObject->jsMap();
-    map->remove(globalObject, jsString(vm, name));
+    map->remove(globalObject, nameValue);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
     return JSValue::encode(jsUndefined());

--- a/test/js/node/util/mime-api.test.ts
+++ b/test/js/node/util/mime-api.test.ts
@@ -214,6 +214,49 @@ describe("MIME API", () => {
     expect(() => params.set("x", `${NOT_HTTP_QUOTED_STRING_CODE_POINT}x`)).toThrow(/parameter value/i);
     expect(() => params.set("x", `x${NOT_HTTP_QUOTED_STRING_CODE_POINT}`)).toThrow(/parameter value/i);
   });
+
+  test("get/has/delete do not stringify the lookup name", () => {
+    // Node.js forwards the argument directly to the internal Map, so non-string
+    // names never match stored (string) keys and toString is not invoked.
+    const mk = () => new MIMEType("a/b;undefined=u;null=n;1=one;true=t").params;
+
+    expect(mk().get(undefined as any)).toBe(null);
+    expect(mk().get(null as any)).toBe(null);
+    expect(mk().get(1 as any)).toBe(null);
+    expect(mk().get(true as any)).toBe(null);
+
+    expect(mk().has(undefined as any)).toBe(false);
+    expect(mk().has(null as any)).toBe(false);
+    expect(mk().has(1 as any)).toBe(false);
+    expect(mk().has(true as any)).toBe(false);
+
+    // delete(non-string) must be a no-op on the matching string key
+    const p = mk();
+    p.delete(1 as any);
+    expect(p.has("1")).toBe(true);
+    expect(p.get("1")).toBe("one");
+    p.delete(undefined as any);
+    expect(p.has("undefined")).toBe(true);
+
+    // toString must not be invoked on the argument
+    let called = false;
+    const obj = {
+      toString() {
+        called = true;
+        return "1";
+      },
+    };
+    expect(mk().get(obj as any)).toBe(null);
+    expect(mk().has(obj as any)).toBe(false);
+    const p2 = mk();
+    p2.delete(obj as any);
+    expect(p2.has("1")).toBe(true);
+    expect(called).toBe(false);
+
+    // string keys must still work
+    expect(mk().get("1")).toBe("one");
+    expect(mk().has("true")).toBe(true);
+  });
 });
 
 test("Exact match with node", () => {


### PR DESCRIPTION
### What does this PR do?

Fixes `util.MIMEParams` `get()` / `has()` / `delete()` to match Node.js semantics: the name argument is passed to the backing `Map` without string coercion.

```js
import util from "node:util";
const p = new util.MIMEType("a/b;undefined=u;null=n;1=one;true=t").params;
p.get(1);         // node: null    bun (before): "one"
p.has(undefined); // node: false   bun (before): true
p.delete(1);
p.has("1");       // node: true    bun (before): false (removed the "1" param)
```

Node.js implements `MIMEParams` on top of a private `Map` and forwards the `name` argument directly to `Map.prototype.get` / `has` / `delete`. Map keys are compared by SameValueZero, so a non-string name never matches a stored string key and `toString` is never invoked on the argument.

Bun's `jsMIMEParamsProtoFuncGet` / `Has` / `Delete` called `nameValue.toWTFString(globalObject)` and looked up `jsString(vm, name)` in the backing `JSMap`, so `get(1)` / `has(undefined)` matched parameters named `"1"` / `"undefined"`, `delete(1)` removed the `"1"` parameter, and `toString`/`Symbol.toPrimitive` ran on object arguments.

The fix passes the raw `JSValue` to the backing `JSMap`'s `has` / `get` / `remove`. `set()` keeps its string coercion on both name and value, which matches Node.

### How did you verify your code works?

```
bun bd test test/js/node/util/mime-api.test.ts
 9 pass, 0 fail
```

The new `get/has/delete do not stringify the lookup name` test fails on `main` (`expect(received).toBe(null)` receives `"u"`) and passes with this change. The upstream `test/js/node/test/parallel/test-mime-api.js` and `test-mime-whatwg.js` also pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/mime-api.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (fbcef09a0)

test/js/node/util/mime-api.test.ts:
(pass) MIME API > class instance integrity [24.41ms]
(pass) MIME API > basic properties and string conversion [11.12ms]
(pass) MIME API > type property manipulation [21.95ms]
(pass) MIME API > subtype property manipulation [23.29ms]
(pass) MIME API > parameters manipulation [25.69ms]
(pass) MIME API > invalid parameter names [16.08ms]
(pass) MIME API > invalid parameter values [8.13ms]
218 |   test("get/has/delete do not stringify the lookup name", () => {
219 |     // Node.js forwards the argument directly to the internal Map, so non-string
220 |     // names never match stored (string) keys and toString is not invoked.
221 |     const mk = () => new MIMEType("a/b;undefined=u;null=n;
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/util/mime-api.test.ts:
(pass) MIME API > class instance integrity [0.15ms]
(pass) MIME API > basic properties and string conversion [0.29ms]
(pass) MIME API > type property manipulation [0.46ms]
(pass) MIME API > subtype property manipulation [0.37ms]
(pass) MIME API > parameters manipulation [0.43ms]
(pass) MIME API > invalid parameter names [0.27ms]
(pass) MIME API > invalid parameter values [0.10ms]
218 |   test("get/has/delete do not stringify the lookup name", () => {
219 |     // Node.js forwards the argument directly to the internal Map, so non-string
220 |     // names never match stored (string) keys and toString is not invoked.
221 |     const mk = () => new MIMEType("a/b;undefined=u;null=n;1=one;true=t").params;
222 | 
223 |     expect(mk().get(undefined as any)).toBe(null);
                                             ^
error: expect(received).toBe(expected)

Expected: null
Received: "u"

      at <anonymous> (/workspace/bun/test/js/node/util/mime-api.test.ts:223:40)
(fail) MIME API > get/has/delete do not stringify the lookup name [0.37ms]
(pass) Exact match with node [25.21ms]

 8 pass
 1 fail
 1 snaps
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/mime-api.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (fbcef09a0)

test/js/node/util/mime-api.test.ts:
(pass) MIME API > class instance integrity [15.23ms]
(pass) MIME API > basic properties and string conversion [11.63ms]
(pass) MIME API > type property manipulation [22.89ms]
(pass) MIME API > subtype property manipulation [22.70ms]
(pass) MIME API > parameters manipulation [25.68ms]
(pass) MIME API > invalid parameter names [15.68ms]
(pass) MIME API > invalid parameter values [8.63ms]
(pass) MIME API > get/has/delete do not stringify the lookup name [14.57ms]
(pass) Exact match with node [965.75ms]

 9 pass
 0 fail
 1 snapshots, 103 expect() calls
Ran 9 tests across 1 file. [3.57s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     fbcef09a0e
  features     (none)

22 deps, 106 codegen, 1169 objects in 1008ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1232] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [69.00ms]
[2/1232] gen ErrorCode+*.h
[3/1232] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1232] gen .bind.ts → GeneratedBindings.cpp
[5/1232] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1232] gen bindgenv2
[7/1232] fetch picohttpparser
[picohttpparser] up to date
[8/1232] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 ins
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/JSMIMEParams.cpp | 17 +++++-------
 test/js/node/util/mime-api.test.ts        | 43 +++++++++++++++++++++++++++++++
 2 files changed, 49 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/jsc/bindings/webcore/JSMIMEParams.cpp      1      3      0
test/js/node/util/mime-api.test.ts             1      1      0
```

</details>

<!-- robobun:evidence:end -->