### PR TITLE
FileSystemRouter: surface route-load errors from reload() like the constructor does

### DIFF
--- a/src/runtime/api/filesystem_router.rs
+++ b/src/runtime/api/filesystem_router.rs
@@ -529,6 +529,11 @@ impl FileSystemRouter {
             }
         }
 
+        if log.errors + log.warnings > 0 {
+            let err_value = log.to_js(global_this, "loading routes");
+            return Err(global_this.throw_value(err_value?));
+        }
+
         // `this.router.deinit(); this.arena.deinit(); destroy(this.arena)` — drop old values.
         // Note: order matters — old router borrows slices from old arena, so it must drop
         // first.

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -402,6 +402,66 @@ it("reload() works", () => {
   expect(router.match("/posts")!.name).toBe("/posts");
 });
 
+it("reload() throws the same validation errors the constructor would", () => {
+  // The constructor and reload() share one route scan, and any tree the
+  // constructor rejects must also be rejected by reload() on a live router
+  // instead of being partially loaded with routes silently dropped or
+  // reassigned.
+  const cases: { label: string; mutate: (dir: string) => void; message: string | RegExp }[] = [
+    {
+      label: "duplicate static route via second extension",
+      mutate: dir => fs.writeFileSync(path.join(dir, "a.js"), "export default 2;"),
+      message: /^Route "\/a" is already defined by /,
+    },
+    {
+      label: "catch-all directory with children",
+      mutate: dir => {
+        fs.mkdirSync(path.join(dir, "[...x]"));
+        fs.writeFileSync(path.join(dir, "[...x]", "child.tsx"), "export default 3;");
+      },
+      message: "Catch-all route must be at the end of the path",
+    },
+    {
+      label: "non-ASCII route filename",
+      mutate: dir => fs.writeFileSync(path.join(dir, "résumé.tsx"), "export default 4;"),
+      message: "Route name must be plaintext",
+    },
+  ];
+  // Dangling symlinks are a POSIX-only shape: Windows symlink creation needs
+  // privileges and the resolver path differs.
+  if (!isWindows) {
+    cases.push({
+      label: "dangling symlink",
+      mutate: dir => fs.symlinkSync(path.join(dir, "nowhere.tsx"), path.join(dir, "dangling.tsx")),
+      message: /^ENOENT opening route: /,
+    });
+  }
+
+  for (const { label, mutate, message } of cases) {
+    const { dir } = make(["a.tsx"]);
+    const router = new Bun.FileSystemRouter({ dir, style: "nextjs" });
+    const originalFile = router.match("/a")!.filePath;
+    expect(originalFile).toBe(`${dir}/a.tsx`);
+
+    mutate(dir);
+
+    // reload() busts the resolver's directory cache and rescans; the rescan
+    // must surface the same error the constructor would on this tree.
+    expect(() => router.reload(), `[${label}] reload() should throw`).toThrow(message);
+
+    // A failed reload leaves the previously loaded routes in place; in
+    // particular the file backing /a must not have flipped to a.js.
+    expect(router.match("/a")!.filePath, `[${label}] route unchanged after failed reload`).toBe(originalFile);
+
+    // reload() already invalidated the directory cache above, so a fresh
+    // constructor call now sees the mutated tree and must reject it too.
+    expect(
+      () => new Bun.FileSystemRouter({ dir, style: "nextjs" }),
+      `[${label}] constructor should reject the mutated tree`,
+    ).toThrow(message);
+  }
+});
+
 it("reload() works with new dirs/files", () => {
   const { dir } = make(["posts.tsx"]);
 


### PR DESCRIPTION
## What

`Bun.FileSystemRouter.prototype.reload()` silently accepted directory trees that the constructor rejects as fatal. The same scan ran with two different contracts.

## Reproduction

```js
import * as fs from "node:fs";
const dir = fs.mkdtempSync("/tmp/fsr-") + "/pages"; fs.mkdirSync(dir);
fs.writeFileSync(dir + "/a.tsx", "export default 1;");
const r = new Bun.FileSystemRouter({ style: "nextjs", dir });
r.match("/a").filePath;                      // .../a.tsx

fs.writeFileSync(dir + "/a.js", "export default 2;");
// fresh process: new Bun.FileSystemRouter({style:"nextjs",dir}) THROWS
//   Route "/a" is already defined by .../a.js
r.reload();                                  // ...but reload(): no error
r.match("/a").filePath;                      // .../a.js (served file flipped silently)
```

The same skew applied to dangling symlinks (`ENOENT opening route`), a `[...x]` directory with children (`Catch-all route must be at the end of the path`), and non-ASCII filenames (`Route name must be plaintext`): the constructor throws, `reload()` returns cleanly with the offending routes dropped.

## Cause

`Router::load_routes` always returns `Ok(())`; every validation failure is recorded on the `bun_ast::Log` it is handed. The constructor checks `log.errors + log.warnings > 0` after the scan and throws. `reload()` ran the identical scan but never inspected the log, so every logged error was discarded and the partially-loaded route table was installed.

## Fix

Add the same `log.errors + log.warnings > 0` check to `reload()`, before the new router replaces the old one. A failed reload now throws the constructor's error and the previously loaded routes stay in place.

## Test

`test/js/bun/util/filesystem_router.test.ts` gains a table-driven case covering all four shapes: for each, `reload()` must throw the constructor's message, the pre-reload route must not flip, and (after the cache has been busted by reload) a fresh constructor on the same tree must throw the same error.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/filesystem_router.test.ts

<!-- robobun:evidence:end -->