### PR TITLE
Bun.Transpiler: use the same AggregateError message for transform() and transformSync()

### DIFF
--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -880,7 +880,7 @@ impl<'a> TransformTask<'a> {
                     }
                 }
 
-                break 'brk self.log.to_js(self.global, "Transform failed");
+                break 'brk self.log.to_js(self.global, "Parse error");
             };
 
             promise.reject_with_async_stack(self.global, error_value)?;

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4210,6 +4210,32 @@ console.log(foo, array);
   });
 
   describe("transform", () => {
+    it("multi-diagnostic input throws the same AggregateError from transform and transformSync", async () => {
+      const ts = new Bun.Transpiler({ loader: "ts" });
+      // JSX under the "ts" loader produces 5 diagnostics, so both paths wrap in AggregateError.
+      const bad = `const el = <div a={1} {...p}>text {x}</div>;`;
+
+      let syncErr;
+      try {
+        ts.transformSync(bad);
+      } catch (e) {
+        syncErr = e;
+      }
+      let asyncErr;
+      try {
+        await ts.transform(bad);
+      } catch (e) {
+        asyncErr = e;
+      }
+
+      expect(syncErr).toBeInstanceOf(AggregateError);
+      expect(asyncErr).toBeInstanceOf(AggregateError);
+      expect(asyncErr.message).toBe(syncErr.message);
+      expect(asyncErr.message).toBe("Parse error");
+      expect(asyncErr.errors.map(e => e.message)).toEqual(syncErr.errors.map(e => e.message));
+      expect(asyncErr.errors.length).toBeGreaterThan(1);
+    });
+
     // Async transform doesn't work in the test runner. Skipping for now.
     // This might be caused by incorrectly using shared memory between the two files.
     it.skip("supports macros", async () => {


### PR DESCRIPTION
## Repro

```js
const tr = new Bun.Transpiler({ loader: "ts" });
const bad = `const el = <div a={1} {...p}>text {x}</div>;`; // JSX under ts loader: 5 diagnostics
try { tr.transformSync(bad); } catch (e) { console.log(e.constructor.name + ": " + e.message); }
try { await tr.transform(bad); } catch (e) { console.log(e.constructor.name + ": " + e.message); }
```

Before:
```
AggregateError: Parse error
AggregateError: Transform failed
```

After:
```
AggregateError: Parse error
AggregateError: Parse error
```

## Cause

`TransformTask::then` (the async `transform()` resolution path) passed `"Transform failed"` to `Log::to_js` when building the multi-diagnostic `AggregateError`, while `transformSync()` and `scan()` pass `"Parse error"` at the same point. The `.errors` array is identical on both paths; only the wrapper message differed.

## Fix

Use `"Parse error"` on the async path as well. The log that feeds the `AggregateError` is populated by the parser, so the label is accurate, and this brings async `transform()` in line with `transformSync()` and `scan()`.

Single-diagnostic inputs already had parity (both paths throw the bare `BuildMessage`), and valid inputs produce byte-identical output; only the multi-diagnostic wrapper message was skewed.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/bundler/transpiler/transpiler.test.js -t "multi-diagnostic"
(fail) ... Expected: "Parse error" / Received: "Transform failed"

$ bun bd test test/bundler/transpiler/transpiler.test.js -t "multi-diagnostic"
(pass) Bun.Transpiler > transform > multi-diagnostic input throws the same AggregateError from transform and transformSync
```

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ef5a9eabb)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.96ms]
(pass) Bun.Transpiler > normalizes \r\n [6.11ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [3.98ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [6.94ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.09ms]
(pass) Bun.Transpiler > property access inlining > works [2.39ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.43ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [16.97ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [2.60ms]
(pass) Bun
... (truncated)

release without fix: 22 skipped
bun test v1.4.0-canary.1 (d115ca809)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.11ms]
(pass) Bun.Transpiler > normalizes \r\n [0.15ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.08ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.10ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.03ms]
(pass) Bun.Transpiler > property access inlining > works [0.04ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.03ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [0.27ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.04ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [0.04ms]
(pass) Bun.Transpiler > TypeScript > reports Expected ":" for a conditional expression missing its colon [0.16ms]
(pass) Bun.Transpiler > TypeScript > contextual keywords used as plain identifiers keep their statements [0.25ms]
(pass) Bun.Transpiler > TypeScript > contextual keywords followed by a newline apply ASI instead of a
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ef5a9eabb)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.59ms]
(pass) Bun.Transpiler > normalizes \r\n [6.28ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.04ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [7.12ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.22ms]
(pass) Bun.Transpiler > property access inlining > works [2.45ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.54ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [17.45ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [2.70ms]
(pass) Bun
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 782ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[2/21] gen JS modules (bundle-modules)
Preprocess modules (7959ms)
Bundle modules (36ms)
Postprocesss modules (182ms)
Bundle Functions (814ms)
Generate Code (112ms)

[9.13s] Bundled "src/js" for production
  2036 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: c
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/JSTranspiler.rs            |  2 +-
 test/bundler/transpiler/transpiler.test.js | 26 ++++++++++++++++++++++++++
 2 files changed, 27 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/runtime/api/JSTranspiler.rs                 2      1      0
test/bundler/transpiler/transpiler.test.js      1      1      0
```

</details>

**root cause** · written by the author bot

The async `transform()` rejection path in `Bun.Transpiler` constructed its multi-diagnostic `AggregateError` with the wrapper message "Transform failed", while `transformSync()` and `scan()` used "Parse error" at the equivalent `Log::to_js` call site, so identical failing input produced different error messages depending on which API was called. The fix changes that single string literal in `TransformTask::then` to "Parse error", bringing the async path into parity with the sync and scan paths.

<!-- robobun:evidence:end -->