### PR TITLE
transpiler: mangle reserved-word JSON/TOML top-level keys to valid identifiers

### DIFF
--- a/src/ast/lexer_tables.rs
+++ b/src/ast/lexer_tables.rs
@@ -157,7 +157,8 @@ pub fn keyword(s: &[u8]) -> Option<T> {
 // `STRICT_MODE_RESERVED_WORDS` is now `[&[u8]; 9]` — `.len()`/`.iter()`-
 // compatible with the former `phf::Set` callers (renamer.rs).
 pub use bun_core::lexer_tables::{
-    STRICT_MODE_RESERVED_WORDS, is_strict_mode_reserved_word, strict_mode_reserved_word_remap,
+    STRICT_MODE_RESERVED_WORDS, binding_reserved_word_remap, is_binding_reserved_word,
+    is_strict_mode_reserved_word, strict_mode_reserved_word_remap,
 };
 
 bun_core::comptime_string_map! {

--- a/src/ast/lexer_tables.rs
+++ b/src/ast/lexer_tables.rs
@@ -157,8 +157,7 @@ pub fn keyword(s: &[u8]) -> Option<T> {
 // `STRICT_MODE_RESERVED_WORDS` is now `[&[u8]; 9]` — `.len()`/`.iter()`-
 // compatible with the former `phf::Set` callers (renamer.rs).
 pub use bun_core::lexer_tables::{
-    STRICT_MODE_RESERVED_WORDS, binding_reserved_word_remap, is_binding_reserved_word,
-    is_strict_mode_reserved_word, strict_mode_reserved_word_remap,
+    STRICT_MODE_RESERVED_WORDS, is_strict_mode_reserved_word, unsafe_binding_name_remap,
 };
 
 bun_core::comptime_string_map! {
@@ -734,7 +733,7 @@ mod tests {
     fn strict_mode_reserved_fn_matches_table() {
         for k in STRICT_MODE_RESERVED_WORDS.iter() {
             assert!(is_strict_mode_reserved_word(k), "{:?}", k);
-            assert!(strict_mode_reserved_word_remap(k).is_some(), "{:?}", k);
+            assert!(unsafe_binding_name_remap(k).is_some(), "{:?}", k);
         }
         for k in [
             b"" as &[u8],
@@ -748,7 +747,22 @@ mod tests {
             b"interfaces",
         ] {
             assert!(!is_strict_mode_reserved_word(k), "{:?}", k);
-            assert!(strict_mode_reserved_word_remap(k).is_none(), "{:?}", k);
+        }
+        for k in KEYWORDS.keys() {
+            assert!(unsafe_binding_name_remap(k).is_some(), "{:?}", k);
+        }
+        for k in [
+            b"NaN" as &[u8],
+            b"Infinity",
+            b"undefined",
+            b"await",
+            b"arguments",
+            b"eval",
+        ] {
+            assert!(unsafe_binding_name_remap(k).is_some(), "{:?}", k);
+        }
+        for k in [b"" as &[u8], b"foo", b"lett", b"async", b"of", b"nan"] {
+            assert!(unsafe_binding_name_remap(k).is_none(), "{:?}", k);
         }
     }
 

--- a/src/bun_core/string/MutableString.rs
+++ b/src/bun_core/string/MutableString.rs
@@ -152,7 +152,7 @@ impl MutableString {
         }
 
         if !needs_gap {
-            let remapped = js_lexer_tables::strict_mode_reserved_word_remap(str).unwrap_or(str);
+            let remapped = js_lexer_tables::binding_reserved_word_remap(str).unwrap_or(str);
             return Ok(Box::<[u8]>::from(remapped));
         }
 

--- a/src/bun_core/string/MutableString.rs
+++ b/src/bun_core/string/MutableString.rs
@@ -113,9 +113,11 @@ impl MutableString {
         Ok(mutable)
     }
 
-    /// Convert `str` to a valid ES identifier, replacing any run of non
-    /// `ID_Continue` code points with a single `_`. Valid Unicode identifier
-    /// code points (including non-BMP) are preserved.
+    /// Convert `str` to an ES identifier that is safe to declare at the top
+    /// level of a module: any run of non `ID_Continue` code points becomes a
+    /// single `_`, and reserved words / global value properties (`if`,
+    /// `NaN`) get a `_` prefix. Valid Unicode identifier code points
+    /// (including non-BMP) are preserved.
     pub fn ensure_valid_identifier(str: &[u8]) -> Result<Box<[u8]>, AllocError> {
         // The result could be either the input borrow or a fresh allocation;
         // rather than a lifetime + Cow we always return owned `Box<[u8]>` and
@@ -152,7 +154,7 @@ impl MutableString {
         }
 
         if !needs_gap {
-            let remapped = js_lexer_tables::binding_reserved_word_remap(str).unwrap_or(str);
+            let remapped = js_lexer_tables::unsafe_binding_name_remap(str).unwrap_or(str);
             return Ok(Box::<[u8]>::from(remapped));
         }
 

--- a/src/bun_core/string/MutableString.rs
+++ b/src/bun_core/string/MutableString.rs
@@ -113,11 +113,9 @@ impl MutableString {
         Ok(mutable)
     }
 
-    /// Convert `str` to an ES identifier that is safe to declare at the top
-    /// level of a module: any run of non `ID_Continue` code points becomes a
-    /// single `_`, and reserved words / global value properties (`if`,
-    /// `NaN`) get a `_` prefix. Valid Unicode identifier code points
-    /// (including non-BMP) are preserved.
+    /// Convert `str` to an identifier that is safe to declare at module top
+    /// level: each run of non `ID_Continue` code points becomes one `_`, and
+    /// names in `UNSAFE_BINDING_NAME_REMAP` (`if`, `NaN`) get a `_` prefix.
     pub fn ensure_valid_identifier(str: &[u8]) -> Result<Box<[u8]>, AllocError> {
         // The result could be either the input borrow or a fresh allocation;
         // rather than a lifetime + Cow we always return owned `Box<[u8]>` and

--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -1755,6 +1755,84 @@ pub mod lexer_tables {
     pub fn strict_mode_reserved_word_remap(s: &[u8]) -> Option<&'static [u8]> {
         STRICT_MODE_RESERVED_WORD_REMAP.get(s).copied()
     }
+
+    crate::comptime_string_map! {
+        /// Every identifier-shaped name that is invalid as a `BindingIdentifier`
+        /// in module (strict-mode) code, mapped to an underscore-prefixed
+        /// replacement. Superset of [`STRICT_MODE_RESERVED_WORD_REMAP`]; also
+        /// covers the ES keywords (`if`, `class`, `var`, ...), module-reserved
+        /// `await`, and the strict-mode binding restrictions `arguments`/`eval`.
+        /// Used by `MutableString::ensure_valid_identifier` so that JSON/TOML
+        /// top-level keys (and path-derived names) never emit `var if = ...`.
+        static BINDING_RESERVED_WORD_REMAP: &'static [u8] = {
+            // ES keywords (ES2015 §11.6.2.1)
+            b"break" => b"_break",
+            b"case" => b"_case",
+            b"catch" => b"_catch",
+            b"class" => b"_class",
+            b"const" => b"_const",
+            b"continue" => b"_continue",
+            b"debugger" => b"_debugger",
+            b"default" => b"_default",
+            b"delete" => b"_delete",
+            b"do" => b"_do",
+            b"else" => b"_else",
+            b"enum" => b"_enum",
+            b"export" => b"_export",
+            b"extends" => b"_extends",
+            b"false" => b"_false",
+            b"finally" => b"_finally",
+            b"for" => b"_for",
+            b"function" => b"_function",
+            b"if" => b"_if",
+            b"import" => b"_import",
+            b"in" => b"_in",
+            b"instanceof" => b"_instanceof",
+            b"new" => b"_new",
+            b"null" => b"_null",
+            b"return" => b"_return",
+            b"super" => b"_super",
+            b"switch" => b"_switch",
+            b"this" => b"_this",
+            b"throw" => b"_throw",
+            b"true" => b"_true",
+            b"try" => b"_try",
+            b"typeof" => b"_typeof",
+            b"var" => b"_var",
+            b"void" => b"_void",
+            b"while" => b"_while",
+            b"with" => b"_with",
+            // strict-mode future reserved words (ES2015 §11.6.2.2)
+            b"implements" => b"_implements",
+            b"interface" => b"_interface",
+            b"let" => b"_let",
+            b"package" => b"_package",
+            b"private" => b"_private",
+            b"protected" => b"_protected",
+            b"public" => b"_public",
+            b"static" => b"_static",
+            b"yield" => b"_yield",
+            // reserved in module code
+            b"await" => b"_await",
+            // disallowed as a BindingIdentifier in strict mode
+            b"arguments" => b"_arguments",
+            b"eval" => b"_eval",
+        };
+    }
+
+    /// Membership check for [`BINDING_RESERVED_WORD_REMAP`].
+    #[inline]
+    pub fn is_binding_reserved_word(s: &[u8]) -> bool {
+        BINDING_RESERVED_WORD_REMAP.contains_key(s)
+    }
+
+    /// Underscore-prefixed replacement for any name that cannot be a
+    /// `BindingIdentifier` in module code (`b"if"` → `b"_if"`); `None` for
+    /// any other input.
+    #[inline]
+    pub fn binding_reserved_word_remap(s: &[u8]) -> Option<&'static [u8]> {
+        BINDING_RESERVED_WORD_REMAP.get(s).copied()
+    }
 }
 
 /// Process-wide WTF::StringImpl character-count cap, exported for C++ as

--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -1708,36 +1708,30 @@ pub mod lexer {
 }
 
 pub mod lexer_tables {
-    crate::comptime_string_map! {
-        /// The 9 strict-mode reserved words (ES2015 §11.6.2.2) mapped to the
-        /// underscore-prefixed replacement used by
-        /// `MutableString::ensure_valid_identifier` to mangle a name that is
-        /// already a syntactically valid identifier but would collide with a
-        /// strict-mode reserved word. Single source of truth —
-        /// [`STRICT_MODE_RESERVED_WORDS`], [`is_strict_mode_reserved_word`],
-        /// and [`strict_mode_reserved_word_remap`] all derive from it.
-        static STRICT_MODE_RESERVED_WORD_REMAP: &'static [u8] = {
-            b"implements" => b"_implements",
-            b"interface" => b"_interface",
-            b"let" => b"_let",
-            b"package" => b"_package",
-            b"private" => b"_private",
-            b"protected" => b"_protected",
-            b"public" => b"_public",
-            b"static" => b"_static",
-            b"yield" => b"_yield",
+    crate::comptime_string_set! {
+        /// The 9 strict-mode future reserved words (ES2015 §11.6.2.2).
+        static STRICT_MODE_RESERVED_WORD_SET = {
+            b"implements",
+            b"interface",
+            b"let",
+            b"package",
+            b"private",
+            b"protected",
+            b"public",
+            b"static",
+            b"yield",
         };
     }
 
     /// The 9 strict-mode reserved words as a plain array, for callers that
     /// only need `.len()` / `.iter()`.
     pub const STRICT_MODE_RESERVED_WORDS: [&[u8]; 9] = {
-        let entries = __ComptimeStringMap_STRICT_MODE_RESERVED_WORD_REMAP::ENTRIES;
-        assert!(entries.len() == 9);
+        let keys = __ComptimeStringSet_STRICT_MODE_RESERVED_WORD_SET::KEYS;
+        assert!(keys.len() == 9);
         let mut out: [&[u8]; 9] = [&[]; 9];
         let mut i = 0;
         while i < out.len() {
-            out[i] = entries[i].0;
+            out[i] = keys[i];
             i += 1;
         }
         out
@@ -1746,21 +1740,15 @@ pub mod lexer_tables {
     /// Hot-path strict-mode reserved-word membership check.
     #[inline]
     pub fn is_strict_mode_reserved_word(s: &[u8]) -> bool {
-        STRICT_MODE_RESERVED_WORD_REMAP.contains_key(s)
-    }
-
-    /// Underscore-prefixed replacement for a strict-mode reserved word
-    /// (`b"let"` → `b"_let"`); `None` for any other input.
-    #[inline]
-    pub fn strict_mode_reserved_word_remap(s: &[u8]) -> Option<&'static [u8]> {
-        STRICT_MODE_RESERVED_WORD_REMAP.get(s).copied()
+        STRICT_MODE_RESERVED_WORD_SET.contains(s)
     }
 
     crate::comptime_string_map! {
-        /// Identifier-shaped names that cannot be a binding in module code,
-        /// mapped to an underscore-prefixed replacement. Superset of
-        /// [`STRICT_MODE_RESERVED_WORD_REMAP`].
-        static BINDING_RESERVED_WORD_REMAP: &'static [u8] = {
+        /// Identifier-shaped names that a generated top-level binding must not
+        /// use, mapped to an underscore-prefixed replacement: reserved words
+        /// (a syntax error) and the global value properties (`var NaN` would
+        /// shadow the `NaN` the printer emits for NaN literals).
+        static UNSAFE_BINDING_NAME_REMAP: &'static [u8] = {
             // ES keywords (ES2015 §11.6.2.1)
             b"break" => b"_break",
             b"case" => b"_case",
@@ -1813,20 +1801,18 @@ pub mod lexer_tables {
             // disallowed as a BindingIdentifier in strict mode
             b"arguments" => b"_arguments",
             b"eval" => b"_eval",
+            // global value properties
+            b"Infinity" => b"_Infinity",
+            b"NaN" => b"_NaN",
+            b"undefined" => b"_undefined",
         };
     }
 
-    /// Membership check for [`BINDING_RESERVED_WORD_REMAP`].
-    #[inline]
-    pub fn is_binding_reserved_word(s: &[u8]) -> bool {
-        BINDING_RESERVED_WORD_REMAP.contains_key(s)
-    }
-
-    /// Underscore-prefixed replacement for a binding reserved word
+    /// Underscore-prefixed replacement for an unsafe binding name
     /// (`b"if"` → `b"_if"`); `None` for any other input.
     #[inline]
-    pub fn binding_reserved_word_remap(s: &[u8]) -> Option<&'static [u8]> {
-        BINDING_RESERVED_WORD_REMAP.get(s).copied()
+    pub fn unsafe_binding_name_remap(s: &[u8]) -> Option<&'static [u8]> {
+        UNSAFE_BINDING_NAME_REMAP.get(s).copied()
     }
 }
 

--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -1744,10 +1744,9 @@ pub mod lexer_tables {
     }
 
     crate::comptime_string_map! {
-        /// Identifier-shaped names that a generated top-level binding must not
-        /// use, mapped to an underscore-prefixed replacement: reserved words
-        /// (a syntax error) and the global value properties (`var NaN` would
-        /// shadow the `NaN` the printer emits for NaN literals).
+        /// Names a generated top-level binding must not use, each mapped to a
+        /// `_`-prefixed replacement: reserved words (a syntax error) and the
+        /// globals that printed literals read (`var NaN` shadows `NaN`).
         static UNSAFE_BINDING_NAME_REMAP: &'static [u8] = {
             // ES keywords (ES2015 §11.6.2.1)
             b"break" => b"_break",
@@ -1808,8 +1807,7 @@ pub mod lexer_tables {
         };
     }
 
-    /// Underscore-prefixed replacement for an unsafe binding name
-    /// (`b"if"` → `b"_if"`); `None` for any other input.
+    /// `b"if"` → `Some(b"_if")`; `None` when `s` is not in the table.
     #[inline]
     pub fn unsafe_binding_name_remap(s: &[u8]) -> Option<&'static [u8]> {
         UNSAFE_BINDING_NAME_REMAP.get(s).copied()

--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -1757,13 +1757,9 @@ pub mod lexer_tables {
     }
 
     crate::comptime_string_map! {
-        /// Every identifier-shaped name that is invalid as a `BindingIdentifier`
-        /// in module (strict-mode) code, mapped to an underscore-prefixed
-        /// replacement. Superset of [`STRICT_MODE_RESERVED_WORD_REMAP`]; also
-        /// covers the ES keywords (`if`, `class`, `var`, ...), module-reserved
-        /// `await`, and the strict-mode binding restrictions `arguments`/`eval`.
-        /// Used by `MutableString::ensure_valid_identifier` so that JSON/TOML
-        /// top-level keys (and path-derived names) never emit `var if = ...`.
+        /// Identifier-shaped names that cannot be a binding in module code,
+        /// mapped to an underscore-prefixed replacement. Superset of
+        /// [`STRICT_MODE_RESERVED_WORD_REMAP`].
         static BINDING_RESERVED_WORD_REMAP: &'static [u8] = {
             // ES keywords (ES2015 §11.6.2.1)
             b"break" => b"_break",
@@ -1826,9 +1822,8 @@ pub mod lexer_tables {
         BINDING_RESERVED_WORD_REMAP.contains_key(s)
     }
 
-    /// Underscore-prefixed replacement for any name that cannot be a
-    /// `BindingIdentifier` in module code (`b"if"` → `b"_if"`); `None` for
-    /// any other input.
+    /// Underscore-prefixed replacement for a binding reserved word
+    /// (`b"if"` → `b"_if"`); `None` for any other input.
     #[inline]
     pub fn binding_reserved_word_remap(s: &[u8]) -> Option<&'static [u8]> {
         BINDING_RESERVED_WORD_REMAP.get(s).copied()

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2021,11 +2021,8 @@ fn parse_data_loader<'a>(
                     // actually-populated entries.
                     *visited.value_ptr = count as u32;
 
-                    // Mangle the key into a valid binding identifier, then
-                    // suffix on collision with an earlier mangled name so
-                    // e.g. `{"if":1,"_if":2}` or `{"b c":1,"b_c":2}` get
-                    // distinct `var` bindings instead of re-declaring the
-                    // same one.
+                    // Two keys can mangle to one identifier (`{"if":1,"_if":2}`);
+                    // suffix the later one so each key gets its own binding.
                     let ident = match bun_core::MutableString::ensure_valid_identifier(name) {
                         Ok(boxed) => boxed,
                         Err(_) => return None,
@@ -2038,12 +2035,9 @@ fn parse_data_loader<'a>(
                         Ok(e) => Some(*e.value_ptr),
                         Err(_) => return None,
                     };
-                    // The identifier lives in the per-parse arena. Arena-copy
-                    // the owned bytes so they are freed with the arena instead
-                    // of leaking (PORTING.md §Forbidden patterns bars
-                    // `heap::alloc` for `&'static`).
                     // SAFETY: ARENA — `arena` outlives the returned
-                    // `ParseResult.ast`.
+                    // `ParseResult.ast`, so the copied name lives as long as
+                    // the symbol that points at it.
                     let arena_ident: &[u8] = if let Some(mut tries) = start_tries {
                         let mut buf: Vec<u8> = Vec::with_capacity(ident.len() + 4);
                         buf.extend_from_slice(&ident);

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2021,8 +2021,7 @@ fn parse_data_loader<'a>(
                     // actually-populated entries.
                     *visited.value_ptr = count as u32;
 
-                    // Two keys can mangle to one identifier (`{"if":1,"_if":2}`);
-                    // suffix the later one so each key gets its own binding.
+                    // `{"if":1,"_if":2}`: both keys mangle to `_if`; suffix the second.
                     let ident = match bun_core::MutableString::ensure_valid_identifier(name) {
                         Ok(boxed) => boxed,
                         Err(_) => return None,
@@ -2035,9 +2034,7 @@ fn parse_data_loader<'a>(
                         Ok(e) => Some(*e.value_ptr),
                         Err(_) => return None,
                     };
-                    // SAFETY: ARENA — `arena` outlives the returned
-                    // `ParseResult.ast`, so the copied name lives as long as
-                    // the symbol that points at it.
+                    // SAFETY: ARENA — `arena` outlives the returned `ParseResult.ast`.
                     let arena_ident: &[u8] = if let Some(mut tries) = start_tries {
                         let mut buf: Vec<u8> = Vec::with_capacity(ident.len() + 4);
                         buf.extend_from_slice(&ident);

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1983,6 +1983,8 @@ fn parse_data_loader<'a>(
                 let export_clauses = arena.alloc_slice_fill_default::<bun_ast::ClauseItem>(n);
                 let mut duplicate_key_checker: bun_collections::StringHashMap<u32> =
                     bun_collections::StringHashMap::default();
+                let mut mangled_names: bun_collections::StringHashMap<u32> =
+                    bun_collections::StringHashMap::default();
                 // duplicate_key_checker drops at end of scope (defer .deinit())
                 let mut count: usize = 0;
                 // reshaped for borrowck — cannot zip 4
@@ -2019,20 +2021,56 @@ fn parse_data_loader<'a>(
                     // actually-populated entries.
                     *visited.value_ptr = count as u32;
 
+                    // Mangle the key into a valid binding identifier, then
+                    // suffix on collision with an earlier mangled name so
+                    // e.g. `{"if":1,"_if":2}` or `{"b c":1,"b_c":2}` get
+                    // distinct `var` bindings instead of re-declaring the
+                    // same one.
+                    let ident = match bun_core::MutableString::ensure_valid_identifier(name) {
+                        Ok(boxed) => boxed,
+                        Err(_) => return None,
+                    };
+                    let start_tries: Option<u32> = match mangled_names.get_or_put(&ident) {
+                        Ok(e) if !e.found_existing => {
+                            *e.value_ptr = 1;
+                            None
+                        }
+                        Ok(e) => Some(*e.value_ptr),
+                        Err(_) => return None,
+                    };
+                    // The identifier lives in the per-parse arena. Arena-copy
+                    // the owned bytes so they are freed with the arena instead
+                    // of leaking (PORTING.md §Forbidden patterns bars
+                    // `heap::alloc` for `&'static`).
+                    // SAFETY: ARENA — `arena` outlives the returned
+                    // `ParseResult.ast`.
+                    let arena_ident: &[u8] = if let Some(mut tries) = start_tries {
+                        let mut buf: Vec<u8> = Vec::with_capacity(ident.len() + 4);
+                        buf.extend_from_slice(&ident);
+                        let mut digits = [0u8; 20];
+                        loop {
+                            tries += 1;
+                            buf.truncate(ident.len());
+                            buf.extend_from_slice(bun_core::fmt::int_as_bytes(&mut digits, tries));
+                            match mangled_names.get_or_put(&buf) {
+                                Ok(e) if !e.found_existing => {
+                                    *e.value_ptr = 1;
+                                    break;
+                                }
+                                Ok(_) => {}
+                                Err(_) => return None,
+                            }
+                        }
+                        if let Ok(e) = mangled_names.get_or_put(&ident) {
+                            *e.value_ptr = tries;
+                        }
+                        arena.alloc_slice_copy(&buf)
+                    } else {
+                        arena.alloc_slice_copy(&ident)
+                    };
+
                     symbols[count] = bun_ast::Symbol {
-                        original_name: match bun_core::MutableString::ensure_valid_identifier(name)
-                        {
-                            // The identifier lives in the
-                            // per-parse arena. Arena-copy the
-                            // owned `Box<[u8]>` so it is freed
-                            // with the arena instead of leaking
-                            // (PORTING.md §Forbidden patterns
-                            // bars `heap::alloc` for `&'static`).
-                            // SAFETY: ARENA — `arena` outlives
-                            // the returned `ParseResult.ast`.
-                            Ok(boxed) => bun_ast::StoreStr::new(arena.alloc_slice_copy(&boxed)),
-                            Err(_) => return None,
-                        },
+                        original_name: bun_ast::StoreStr::new(arena_ident),
                         ..Default::default()
                     };
 

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -737,9 +737,7 @@ fn valid_identifier_for(name: &[u8]) -> Option<Box<[u8]>> {
     // when the input is already a valid ASCII identifier; the binding
     // reserved-word remap is the only transform that fires for an
     // otherwise-valid ASCII name.
-    if is_simple_ascii_identifier(name)
-        && !bun_ast::lexer_tables::is_binding_reserved_word(name)
-    {
+    if is_simple_ascii_identifier(name) && !bun_ast::lexer_tables::is_binding_reserved_word(name) {
         debug_assert!(js_lexer::is_identifier(name));
         return None;
     }

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -733,10 +733,9 @@ trait NameScopes {
 /// `name` made a valid identifier (`let` → `_let`, non-ASCII escapes), or
 /// `None` when it already is one.
 fn valid_identifier_for(name: &[u8]) -> Option<Box<[u8]>> {
-    // `MutableString::ensure_valid_identifier` always heap-allocates, even
-    // when the input is already a valid ASCII identifier. A parsed symbol
-    // name only needs it for a strict-mode reserved word (`let` in a sloppy
-    // file); `arguments`/`eval` stay as written for non-strict output.
+    // `ensure_valid_identifier` allocates even for a valid ASCII name, so only
+    // a strict-mode reserved word (`let` in a sloppy file) takes that path;
+    // `arguments`/`eval` stay as written for non-strict output.
     if is_simple_ascii_identifier(name)
         && !bun_ast::lexer_tables::is_strict_mode_reserved_word(name)
     {
@@ -1146,10 +1145,7 @@ impl<'r> NestedRenamer<'r> {
     }
 }
 
-/// Fast-path for `MutableString::ensure_valid_identifier`: returns `true` iff
-/// `s` is a non-empty ASCII identifier (`[A-Za-z_$][A-Za-z0-9_$]*`), for which
-/// that function returns the input unchanged (modulo the unsafe binding
-/// name remap, handled by the caller) but still allocates.
+/// `s` is a non-empty ASCII identifier (`[A-Za-z_$][A-Za-z0-9_$]*`).
 #[inline]
 fn is_simple_ascii_identifier(s: &[u8]) -> bool {
     let Some((&first, rest)) = s.split_first() else {

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -730,15 +730,15 @@ trait NameScopes {
     }
 }
 
-/// `name` made a valid identifier (`let` → `_let`, non-ASCII escapes), or
-/// `None` when it already is one.
+/// `name` made a valid identifier (`let` → `_let`, `if` → `_if`, non-ASCII
+/// escapes), or `None` when it already is one.
 fn valid_identifier_for(name: &[u8]) -> Option<Box<[u8]>> {
     // `MutableString::ensure_valid_identifier` always heap-allocates, even
-    // when the input is already a valid ASCII identifier; the strict-mode
+    // when the input is already a valid ASCII identifier; the binding
     // reserved-word remap is the only transform that fires for an
     // otherwise-valid ASCII name.
     if is_simple_ascii_identifier(name)
-        && !bun_ast::lexer_tables::is_strict_mode_reserved_word(name)
+        && !bun_ast::lexer_tables::is_binding_reserved_word(name)
     {
         debug_assert!(js_lexer::is_identifier(name));
         return None;
@@ -1148,7 +1148,7 @@ impl<'r> NestedRenamer<'r> {
 
 /// Fast-path for `MutableString::ensure_valid_identifier`: returns `true` iff
 /// `s` is a non-empty ASCII identifier (`[A-Za-z_$][A-Za-z0-9_$]*`), for which
-/// that function returns the input unchanged (modulo the strict-mode reserved
+/// that function returns the input unchanged (modulo the binding reserved
 /// word remap, handled by the caller) but still allocates.
 #[inline]
 fn is_simple_ascii_identifier(s: &[u8]) -> bool {

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -734,10 +734,12 @@ trait NameScopes {
 /// `None` when it already is one.
 fn valid_identifier_for(name: &[u8]) -> Option<Box<[u8]>> {
     // `MutableString::ensure_valid_identifier` always heap-allocates, even
-    // when the input is already a valid ASCII identifier; the binding
-    // reserved-word remap is the only transform that fires for an
-    // otherwise-valid ASCII name.
-    if is_simple_ascii_identifier(name) && !bun_ast::lexer_tables::is_binding_reserved_word(name) {
+    // when the input is already a valid ASCII identifier. A parsed symbol
+    // name only needs it for a strict-mode reserved word (`let` in a sloppy
+    // file); `arguments`/`eval` stay as written for non-strict output.
+    if is_simple_ascii_identifier(name)
+        && !bun_ast::lexer_tables::is_strict_mode_reserved_word(name)
+    {
         debug_assert!(js_lexer::is_identifier(name));
         return None;
     }
@@ -1146,8 +1148,8 @@ impl<'r> NestedRenamer<'r> {
 
 /// Fast-path for `MutableString::ensure_valid_identifier`: returns `true` iff
 /// `s` is a non-empty ASCII identifier (`[A-Za-z_$][A-Za-z0-9_$]*`), for which
-/// that function returns the input unchanged (modulo the binding reserved
-/// word remap, handled by the caller) but still allocates.
+/// that function returns the input unchanged (modulo the unsafe binding
+/// name remap, handled by the caller) but still allocates.
 #[inline]
 fn is_simple_ascii_identifier(s: &[u8]) -> bool {
     let Some((&first, rest)) = s.split_first() else {

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -730,8 +730,8 @@ trait NameScopes {
     }
 }
 
-/// `name` made a valid identifier (`let` → `_let`, `if` → `_if`, non-ASCII
-/// escapes), or `None` when it already is one.
+/// `name` made a valid identifier (`let` → `_let`, non-ASCII escapes), or
+/// `None` when it already is one.
 fn valid_identifier_for(name: &[u8]) -> Option<Box<[u8]>> {
     // `MutableString::ensure_valid_identifier` always heap-allocates, even
     // when the input is already a valid ASCII identifier; the binding

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -6141,24 +6141,16 @@ describe("json/toml loader with reserved-word top-level keys", () => {
     "await", "arguments", "eval",
   ];
 
-  it("emits valid JS for every reserved-word key (json)", () => {
-    const t = new Bun.Transpiler();
-    const failures = [];
-    for (const k of reserved) {
-      const out = t.transformSync(JSON.stringify({ [k]: 1 }), "json");
-      if (reparses(out) !== "ok") failures.push({ key: k, out });
-    }
-    expect(failures).toEqual([]);
-  });
+  describe.each(reserved)("%s as a top-level key", key => {
+    it("emits valid JS (json)", () => {
+      const out = new Bun.Transpiler().transformSync(JSON.stringify({ [key]: 1 }), "json");
+      expect({ out, verdict: reparses(out) }).toEqual({ out, verdict: "ok" });
+    });
 
-  it("emits valid JS for every reserved-word key (toml)", () => {
-    const t = new Bun.Transpiler();
-    const failures = [];
-    for (const k of reserved) {
-      const out = t.transformSync(`${k} = 1`, "toml");
-      if (reparses(out) !== "ok") failures.push({ key: k, out });
-    }
-    expect(failures).toEqual([]);
+    it("emits valid JS (toml)", () => {
+      const out = new Bun.Transpiler().transformSync(`${key} = 1`, "toml");
+      expect({ out, verdict: reparses(out) }).toEqual({ out, verdict: "ok" });
+    });
   });
 
   it("aliases reserved-word keys and preserves the exported name", () => {
@@ -6192,30 +6184,27 @@ describe("json/toml loader with reserved-word top-level keys", () => {
     expect(out).toContain("_if as if");
   });
 
-  it("suffixes when a mangled key collides with a sibling", () => {
-    const t = new Bun.Transpiler();
-    for (const [src, decl, aliases] of [
-      ['{"if":1,"_if":2}', "var _if = 1, _if2 = 2;", ["_if as if", "_if2 as _if"]],
-      ['{"_if":1,"if":2}', "var _if = 1, _if2 = 2;", ["_if", "_if2 as if"]],
-      ['{"let":1,"_let":2}', "var _let = 1, _let2 = 2;", ["_let as let", "_let2 as _let"]],
-      ['{"b c":1,"b_c":2}', "var b_c = 1, b_c2 = 2;", ['b_c as "b c"', "b_c2 as b_c"]],
-      ['{"if":1,"_if":2,"_if2":3}', "var _if = 1, _if2 = 2, _if22 = 3;", ["_if as if", "_if2 as _if", "_if22 as _if2"]],
-    ]) {
-      const out = t.transformSync(src, "json");
-      expect({ src, verdict: reparses(out) }).toEqual({ src, verdict: "ok" });
-      expect(out.split("\n")[0]).toBe(decl);
-      for (const a of aliases) expect(out).toContain(a);
-    }
+  // prettier-ignore
+  it.each([
+    ['{"if":1,"_if":2}', "var _if = 1, _if2 = 2;", ["_if as if", "_if2 as _if"]],
+    ['{"_if":1,"if":2}', "var _if = 1, _if2 = 2;", ["_if", "_if2 as if"]],
+    ['{"let":1,"_let":2}', "var _let = 1, _let2 = 2;", ["_let as let", "_let2 as _let"]],
+    ['{"b c":1,"b_c":2}', "var b_c = 1, b_c2 = 2;", ['b_c as "b c"', "b_c2 as b_c"]],
+    ['{"if":1,"_if":2,"_if2":3}', "var _if = 1, _if2 = 2, _if22 = 3;", ["_if as if", "_if2 as _if", "_if22 as _if2"]],
+  ])("suffixes a mangled key that collides with a sibling: %s", (src, decl, aliases) => {
+    const out = new Bun.Transpiler().transformSync(src, "json");
+    expect({ out, verdict: reparses(out) }).toEqual({ out, verdict: "ok" });
+    expect(out.split("\n")[0]).toBe(decl);
+    for (const alias of aliases) expect(out).toContain(alias);
   });
 
   // `var NaN = NaN;` would shadow the global and export `undefined`.
   it("does not shadow NaN / Infinity / undefined", () => {
-    const t = new Bun.Transpiler();
-    const out = t.transformSync("NaN = nan\nInfinity = inf\nundefined = 1\nx = nan", "toml");
-    expect(reparses(out)).toBe("ok");
+    const out = new Bun.Transpiler().transformSync("NaN = nan\nInfinity = inf\nundefined = 1\nx = nan", "toml");
+    expect({ out, verdict: reparses(out) }).toEqual({ out, verdict: "ok" });
     expect(out.split("\n")[0]).toBe("var _NaN = NaN, _Infinity = 1 / 0, _undefined = 1, x = NaN;");
-    for (const a of ["_NaN as NaN", "_Infinity as Infinity", "_undefined as undefined"]) {
-      expect(out).toContain(a);
+    for (const alias of ["_NaN as NaN", "_Infinity as Infinity", "_undefined as undefined"]) {
+      expect(out).toContain(alias);
     }
   });
 });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -6207,4 +6207,15 @@ describe("json/toml loader with reserved-word top-level keys", () => {
       for (const a of aliases) expect(out).toContain(a);
     }
   });
+
+  // `var NaN = NaN;` would shadow the global and export `undefined`.
+  it("does not shadow NaN / Infinity / undefined", () => {
+    const t = new Bun.Transpiler();
+    const out = t.transformSync("NaN = nan\nInfinity = inf\nundefined = 1\nx = nan", "toml");
+    expect(reparses(out)).toBe("ok");
+    expect(out.split("\n")[0]).toBe("var _NaN = NaN, _Infinity = 1 / 0, _undefined = 1, x = NaN;");
+    for (const a of ["_NaN as NaN", "_Infinity as Infinity", "_undefined as undefined"]) {
+      expect(out).toContain(a);
+    }
+  });
 });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -6191,4 +6191,20 @@ describe("json/toml loader with reserved-word top-level keys", () => {
     expect(out).toContain('b_c as "b c"');
     expect(out).toContain("_if as if");
   });
+
+  it("suffixes when a mangled key collides with a sibling", () => {
+    const t = new Bun.Transpiler();
+    for (const [src, decl, aliases] of [
+      ['{"if":1,"_if":2}', "var _if = 1, _if2 = 2;", ["_if as if", "_if2 as _if"]],
+      ['{"_if":1,"if":2}', "var _if = 1, _if2 = 2;", ["_if", "_if2 as if"]],
+      ['{"let":1,"_let":2}', "var _let = 1, _let2 = 2;", ["_let as let", "_let2 as _let"]],
+      ['{"b c":1,"b_c":2}', "var b_c = 1, b_c2 = 2;", ['b_c as "b c"', "b_c2 as b_c"]],
+      ['{"if":1,"_if":2,"_if2":3}', "var _if = 1, _if2 = 2, _if22 = 3;", ["_if as if", "_if2 as _if", "_if22 as _if2"]],
+    ]) {
+      const out = t.transformSync(src, "json");
+      expect({ src, verdict: reparses(out) }).toEqual({ src, verdict: "ok" });
+      expect(out.split("\n")[0]).toBe(decl);
+      for (const a of aliases) expect(out).toContain(a);
+    }
+  });
 });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -6117,3 +6117,78 @@ describe("same-target destructuring with an unstable target", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe("json/toml loader with reserved-word top-level keys", () => {
+  const js = new Bun.Transpiler({ loader: "js" });
+  const reparses = out => {
+    try {
+      js.transformSync(out);
+      return "ok";
+    } catch (e) {
+      return (e.errors ?? [e]).map(x => x.message).join(" | ");
+    }
+  };
+
+  // prettier-ignore
+  const reserved = [
+    "break", "case", "catch", "class", "const", "continue", "debugger",
+    "delete", "do", "else", "enum", "export", "extends", "false", "finally",
+    "for", "function", "if", "import", "in", "instanceof", "new", "null",
+    "return", "super", "switch", "this", "throw", "true", "try", "typeof",
+    "var", "void", "while", "with",
+    "implements", "interface", "let", "package", "private", "protected",
+    "public", "static", "yield",
+    "await", "arguments", "eval",
+  ];
+
+  it("emits valid JS for every reserved-word key (json)", () => {
+    const t = new Bun.Transpiler();
+    const failures = [];
+    for (const k of reserved) {
+      const out = t.transformSync(JSON.stringify({ [k]: 1 }), "json");
+      if (reparses(out) !== "ok") failures.push({ key: k, out });
+    }
+    expect(failures).toEqual([]);
+  });
+
+  it("emits valid JS for every reserved-word key (toml)", () => {
+    const t = new Bun.Transpiler();
+    const failures = [];
+    for (const k of reserved) {
+      const out = t.transformSync(`${k} = 1`, "toml");
+      if (reparses(out) !== "ok") failures.push({ key: k, out });
+    }
+    expect(failures).toEqual([]);
+  });
+
+  it("aliases reserved-word keys and preserves the exported name", () => {
+    const t = new Bun.Transpiler();
+    expect(t.transformSync('{"if":1,"ok":2}', "json")).toBe(
+      "var _if = 1, ok = 2;\n\nexport {\n  _if as if,\n  ok\n};\nexport default { if: _if, ok };\n",
+    );
+    expect(t.transformSync('{"class":1}', "json")).toBe(
+      "var _class = 1;\n\nexport {\n  _class as class\n};\nexport default { class: _class };\n",
+    );
+    expect(t.transformSync("if = 1", "toml")).toBe(
+      "var _if = 1;\n\nexport {\n  _if as if\n};\nexport default {\n  if: _if\n};\n",
+    );
+  });
+
+  it("emits valid JS when many reserved-word keys are combined", () => {
+    const t = new Bun.Transpiler();
+    const obj = Object.fromEntries(reserved.map((k, i) => [k, i]));
+    obj.plain = 999;
+    const out = t.transformSync(JSON.stringify(obj), "json");
+    expect({ out, verdict: reparses(out) }).toEqual({ out, verdict: "ok" });
+    for (const k of reserved) expect(out).toContain(` as ${k}`);
+    expect(out).toContain("plain");
+  });
+
+  it("still handles non-identifier and default keys", () => {
+    const t = new Bun.Transpiler();
+    const out = t.transformSync('{"b c":1,"default":2,"if":3}', "json");
+    expect(reparses(out)).toBe("ok");
+    expect(out).toContain('b_c as "b c"');
+    expect(out).toContain("_if as if");
+  });
+});


### PR DESCRIPTION
### Problem
- The JSON/TOML/JSON5 data loader emits one `var` per top-level key. A key that is a reserved word is passed through, so `new Bun.Transpiler().transformSync('{"if":1}', "json")` returns `var if = 1; export { if };`, which no parser accepts: `SyntaxError: Expected identifier but found "if"`. Every keyword reproduces, plus `await`, `arguments` and `eval`. This reaches `bun build --no-bundle` and any plugin that feeds the output onward.
- Two further cases in the same emission: a key named `NaN` gives `var NaN = NaN`, which shadows the global and exports `undefined`, and two keys that mangle to one name (`{"if":1,"_if":2}`, or the older `{"let":1,"_let":2}`) both declare it, so each reference reads the last value.
- The cause is `MutableString::ensure_valid_identifier` (`src/bun_core/string/MutableString.rs:155`). It mangled non-identifier keys (`"b c"` -> `b_c`) and the 9 strict-mode reserved words (`let` -> `_let`), and nothing else.

### Fix
- Replace the 9-entry remap with `UNSAFE_BINDING_NAME_REMAP` (`src/bun_core/string/mod.rs`): every reserved word, `await`, `arguments`, `eval`, and the globals a printed literal reads (`NaN`, `Infinity`, `undefined`). `ensure_valid_identifier` uses it, so the loader emits `var _if = 1; export { _if as if };`. The exported name is unchanged, so importers are unaffected.
- `parse_data_loader` (`src/bundler/transpiler.rs`) now keys a second map on the mangled name and appends a numeric suffix on a collision: `{"if":1,"_if":2}` gives `var _if = 1, _if2 = 2;`.
- `NumberScope`'s renamer fast path keeps the strict-mode-only check. A sloppy-mode `var arguments` must stay as written for CJS and IIFE output (`edgecase/SloppyArgumentsDeclaration*`).
- Verified: `test/bundler/transpiler/transpiler.test.js`, 103 cases in a new block, 85 fail on release bun. Also `bundler_edgecase`, `bundler_loader`, `bundler_minify`, `runtime-transpiler`, `esbuild/loader`, `yaml`, and `bun_ast`'s unit tests under Miri.

### Background
- A data loader turns a data file into a module: one `var` per top-level key, an `export {}` clause that aliases each back to its original key, and a default export object. `Bun.Transpiler` and `bun build --no-bundle` print that AST directly, with no renamer, so the names the loader picks are the names in the output.
- `ensure_valid_identifier` is the one place that makes a byte string safe to use as a binding. Its other callers derive a name from a file path (an import namespace, `bun create`), so they gain the same protection.
- The bundling path (`bun build` without `--no-bundle`) builds these exports elsewhere and runs the renamer. `arguments`/`eval`/`await` there are #34361. A YAML key that is not a string is #41827.

<details><summary>Notes</summary>

- `STRICT_MODE_RESERVED_WORD_REMAP` became a plain set. Its remap accessor lost its last caller when `ensure_valid_identifier` moved to the wider table, and `REVIEW.md` asks for dead helpers to go in the same PR. `is_strict_mode_reserved_word` and `STRICT_MODE_RESERVED_WORDS` still have live callers (the parser, `compute_initial_reserved_names`).
- `default` was already skipped before the mangle (no named export), so the `_default` entry in the table only matters for path-derived names.
- Suffixing is O(1) amortized: the counter for a base name is stored back, as `NumberScope::find_unused_name` does, so repeated collisions on one base stay linear.
- Self-reviewed, and two review rounds: the sibling-collision case and the `NaN` shadowing both came from review and are fixed here with tests. The parameterized cases use `describe.each`/`it.each` per the repo test guide.
- Keys that are valid identifiers are untouched, so the common case has no output change and no extra allocation.

</details>
