### PR TITLE
node:timers/promises: implement setInterval as async generator (lazy arm + iterator protocol)

### DIFF
--- a/src/js/node/timers.promises.ts
+++ b/src/js/node/timers.promises.ts
@@ -4,25 +4,9 @@
 const { validateBoolean, validateAbortSignal, validateObject, validateNumber } = require("internal/validators");
 const { resistStopPropagation } = require("internal/shared");
 
-const symbolAsyncIterator = Symbol.asyncIterator;
 const setImmediateGlobal = globalThis.setImmediate;
 const setTimeoutGlobal = globalThis.setTimeout;
 const setIntervalGlobal = globalThis.setInterval;
-
-function asyncIterator({ next: nextFunction, return: returnFunction }) {
-  const result = {};
-  if (typeof nextFunction === "function") {
-    result.next = nextFunction;
-  }
-  if (typeof returnFunction === "function") {
-    result.return = returnFunction;
-  }
-  result[symbolAsyncIterator] = function () {
-    return this;
-  };
-
-  return result;
-}
 
 function setTimeout(after = 1, value, options = {}) {
   const arguments_ = [].concat(value ?? []);
@@ -113,60 +97,23 @@ function setImmediate(value, options = {}) {
     : returnValue;
 }
 
-function setInterval(after = 1, value, options = {}) {
-  /* eslint-disable no-undefined, no-unreachable-loop, no-loop-func */
-  try {
-    // If after is a number, but an invalid one (too big, Infinity, NaN), we only want to emit a
-    // warning, not throw an error. So we can't call validateNumber as that will throw if the number
-    // is outside of a given range.
-    if (typeof after != "number") {
-      validateNumber(after, "delay");
-    }
-  } catch (error) {
-    return asyncIterator({
-      next: function () {
-        return Promise.$reject(error);
-      },
-    });
+async function* setInterval(after = 1, value, options = {}) {
+  // If after is a number, but an invalid one (too big, Infinity, NaN), we only want to emit a
+  // warning, not throw an error, so only validate non-number inputs here.
+  if (typeof after !== "number") {
+    validateNumber(after, "delay");
   }
-  try {
-    validateObject(options, "options");
-  } catch (error) {
-    return asyncIterator({
-      next: function () {
-        return Promise.$reject(error);
-      },
-    });
-  }
+  validateObject(options, "options");
   const { signal, ref: reference = true } = options;
-  try {
-    validateAbortSignal(signal, "options.signal");
-  } catch (error) {
-    return asyncIterator({
-      next: function () {
-        return Promise.$reject(error);
-      },
-    });
-  }
-  try {
-    validateBoolean(reference, "options.ref");
-  } catch (error) {
-    return asyncIterator({
-      next: function () {
-        return Promise.$reject(error);
-      },
-    });
-  }
+  validateAbortSignal(signal, "options.signal");
+  validateBoolean(reference, "options.ref");
+
   if (signal?.aborted) {
-    return asyncIterator({
-      next: function () {
-        return Promise.$reject($makeAbortError(undefined, { cause: signal.reason }));
-      },
-    });
+    throw $makeAbortError(undefined, { cause: signal.reason });
   }
 
-  let onCancel, interval;
-
+  let onCancel;
+  let interval;
   try {
     let notYielded = 0;
     let callback;
@@ -184,50 +131,25 @@ function setInterval(after = 1, value, options = {}) {
       onCancel = () => {
         clearInterval(interval);
         if (callback) {
-          callback();
+          callback(Promise.$reject($makeAbortError(undefined, { cause: signal.reason })));
           callback = undefined;
         }
       };
       signal.addEventListener("abort", onCancel, resistStopPropagation({ __proto__: null, once: true }));
     }
 
-    return asyncIterator({
-      next: function () {
-        return new Promise((resolve, reject) => {
-          if (!signal?.aborted) {
-            if (notYielded === 0) {
-              callback = resolve;
-            } else {
-              resolve();
-            }
-          } else if (notYielded === 0) {
-            reject($makeAbortError(undefined, { cause: signal.reason }));
-          } else {
-            resolve();
-          }
-        }).then(() => {
-          if (notYielded > 0) {
-            notYielded = notYielded - 1;
-            return { done: false, value: value };
-          } else if (signal?.aborted) {
-            throw $makeAbortError(undefined, { cause: signal.reason });
-          }
-          return { done: true };
-        });
-      },
-      return: function () {
-        clearInterval(interval);
-        signal?.removeEventListener("abort", onCancel);
-        return Promise.$resolve({});
-      },
-    });
-  } catch {
-    return asyncIterator({
-      next: function () {
-        clearInterval(interval);
-        signal?.removeEventListener("abort", onCancel);
-      },
-    });
+    while (!signal?.aborted) {
+      if (notYielded === 0) {
+        await new Promise(resolve => (callback = resolve));
+      }
+      for (; notYielded > 0; notYielded--) {
+        yield value;
+      }
+    }
+    throw $makeAbortError(undefined, { cause: signal?.reason });
+  } finally {
+    clearInterval(interval);
+    signal?.removeEventListener("abort", onCancel);
   }
 }
 

--- a/src/js/node/timers.promises.ts
+++ b/src/js/node/timers.promises.ts
@@ -98,8 +98,6 @@ function setImmediate(value, options = {}) {
 }
 
 async function* setInterval(after = 1, value, options = {}) {
-  // If after is a number, but an invalid one (too big, Infinity, NaN), we only want to emit a
-  // warning, not throw an error, so only validate non-number inputs here.
   if (typeof after !== "number") {
     validateNumber(after, "delay");
   }

--- a/test/js/node/timers.promises/timers.promises.test.ts
+++ b/test/js/node/timers.promises/timers.promises.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { setImmediate, setInterval, setTimeout } from "node:timers/promises";
 import { bunEnv, bunExe } from "harness";
+import { setImmediate, setInterval, setTimeout } from "node:timers/promises";
 
 const bound = <T>(p: Promise<T>, ms: number) =>
   Promise.race([

--- a/test/js/node/timers.promises/timers.promises.test.ts
+++ b/test/js/node/timers.promises/timers.promises.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "bun:test";
 import { setImmediate, setInterval, setTimeout } from "node:timers/promises";
+import { bunEnv, bunExe } from "harness";
+
+const bound = <T>(p: Promise<T>, ms: number) =>
+  Promise.race([
+    p.then(
+      v => ["settled", v] as const,
+      e => ["rejected", e] as const,
+    ),
+    setTimeout(ms, ["TIMEOUT"] as const),
+  ]);
 
 describe("setTimeout", () => {
   it("abort() does not emit global error", async () => {
@@ -102,5 +112,102 @@ describe("setInterval", () => {
       // On a build that ignores the abort the interval is still armed; clear it.
       await iterator.return!();
     }
+  });
+
+  it("does not arm the interval until the iterator is first consumed", async () => {
+    // An async iterator that is created but never iterated must not keep the event loop alive.
+    // Node arms the underlying interval lazily on the first next() (async generator semantics).
+    const src = `
+      const { setInterval } = require("node:timers/promises");
+      const it = setInterval(100000);
+      void it;
+      const t = setTimeout(() => { console.log("STILL_ALIVE"); process.exit(1); }, 2000);
+      t.unref();
+      console.log("created");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("created\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("settles every concurrent next() call", async () => {
+    const it = setInterval(10, "tick");
+    try {
+      const first = it.next();
+      const second = it.next();
+      const third = it.next();
+      expect(await bound(first, 500)).toEqual(["settled", { done: false, value: "tick" }]);
+      expect(await bound(second, 500)).toEqual(["settled", { done: false, value: "tick" }]);
+      expect(await bound(third, 500)).toEqual(["settled", { done: false, value: "tick" }]);
+    } finally {
+      await it.return();
+    }
+  });
+
+  it("return(value) resolves { value, done: true }", async () => {
+    const it = setInterval(10, "x");
+    await it.next();
+    expect(await it.return("RV")).toEqual({ value: "RV", done: true });
+    expect(await it.return("again")).toEqual({ value: "again", done: true });
+  });
+
+  it("next() after return() resolves { done: true }", async () => {
+    const it = setInterval(10, "x");
+    await it.next();
+    await it.return();
+    expect(await bound(it.next(), 500)).toEqual(["settled", { value: undefined, done: true }]);
+  });
+
+  it("next() after return() does not yield buffered ticks", async () => {
+    const it = setInterval(1, "buf");
+    await it.next();
+    await it.next();
+    await setTimeout(50);
+    await it.return();
+    expect(await bound(it.next(), 500)).toEqual(["settled", { value: undefined, done: true }]);
+  });
+
+  it("second for-await over the same iterator completes immediately", async () => {
+    const it = setInterval(10, "y");
+    let count = 0;
+    for await (const _ of it) {
+      if (++count >= 2) break;
+    }
+    expect(count).toBe(2);
+    let count2 = 0;
+    const loop = (async () => {
+      for await (const _ of it) count2++;
+    })();
+    expect(await bound(loop, 500)).toEqual(["settled", undefined]);
+    expect(count2).toBe(0);
+  });
+
+  it("has a throw() method that rejects and closes the iterator", async () => {
+    const it = setInterval(10, "x");
+    expect(typeof it.throw).toBe("function");
+    await it.next();
+    const err = new Error("boom");
+    const r = await bound(it.throw(err), 500);
+    expect(r[0]).toBe("rejected");
+    expect(r[1]).toBe(err);
+    expect(await bound(it.next(), 500)).toEqual(["settled", { value: undefined, done: true }]);
+  });
+
+  it("abort rejects a pending next() and subsequent next() resolves done", async () => {
+    const ac = new AbortController();
+    const it = setInterval(100, "tick", { signal: ac.signal });
+    const p = it.next();
+    ac.abort();
+    const r = await bound(p, 500);
+    expect(r[0]).toBe("rejected");
+    expect((r[1] as Error).name).toBe("AbortError");
+    expect(await bound(it.next(), 500)).toEqual(["settled", { value: undefined, done: true }]);
   });
 });


### PR DESCRIPTION
## Problem

The `timers/promises` `setInterval()` async iterator was a hand-rolled object that diverged from Node in several ways.

**Eager arming pins the event loop.** The interval is created inside `setInterval()` itself, before the iterator is ever consumed, so an iterator that is created but abandoned keeps the process alive forever. Node uses an async generator, whose body runs on the first `next()`:

```js
import { setInterval } from "node:timers/promises";
const it = setInterval(1000);   // created, never iterated
void it;
// node: exits 0 immediately (interval armed lazily on first next())
// bun:  hangs forever (interval armed at setInterval() call time)
```

**Iterator protocol gaps.** Separately, the hand-rolled object had a single pending-resolver slot and no completion latch:

```js
const it = tp.setInterval(10, "tick");
const first = it.next();
const second = it.next();   // overwrites the only resolver slot
await second;               // resolves
await first;                // hangs forever
```

| Case | Node | Bun (before) |
|---|---|---|
| Un-iterated iterator | process exits | event loop pinned |
| Concurrent `next()` | all settle in order | first pending promise never settles |
| `it.return(v)` | `{ value: v, done: true }` | `{}` |
| `next()` after `return()` | `{ done: true }` | never settles |
| `next()` after `return()` with buffered ticks | `{ done: true }` | `{ done: false, value }` from closed iterator |
| second `for await` over same iterator | completes immediately | hangs forever |
| `typeof it.throw` | `"function"` | `"undefined"` |
| `next()` after abort rejection | `{ done: true }` | rejects again |

## Cause

`src/js/node/timers.promises.ts` built the iterator by hand and called `setIntervalGlobal(...)` at factory time:

```js
function setInterval(after, value, options) {
  // ...
  interval = setIntervalGlobal(...);   // eager: runs before any next()
  // ...
  return asyncIterator({
    next() { ... callback = resolve; ... },   // single slot
    return() { ...; return Promise.$resolve({}); },   // wrong shape, no done latch
  });
}
```

## Fix

Replace the hand-rolled iterator with a real `async function*`, matching Node's implementation. The generator body runs lazily on the first `next()`, so an abandoned iterator never arms an interval. The async generator runtime provides correct `next()` queueing, `return(v)` shape, `throw()`, and done-latching for free, and the `try`/`finally` clears the interval on every exit path.

## Verification

New tests in `test/js/node/timers.promises/timers.promises.test.ts` cover the event-loop pin (subprocess exits 0 with an un-iterated iterator), concurrent `next()`, `return(v)` shape, post-return `next()`, buffered ticks after return, second `for await`, `throw()`, and abort-then-`next()`. All fail on current `main` and pass with this change. `test/js/node/test/parallel/test-timers-interval-promisified.js` continues to pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 7 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/timers.promises/timers.promises.test.ts
bun test v1.4.0 (bc59b8cfe)

test/js/node/timers.promises/timers.promises.test.ts:
(pass) setTimeout > abort() does not emit global error [213.81ms]
(pass) setTimeout > AbortController can be passed as the `options` argument [32.48ms]
(pass) setTimeout > should reject promise when AbortController is aborted [16.74ms]
(pass) setTimeout > rejects even when another listener stopped propagation [13.58ms]
(pass) setImmediate > abort() does not emit global error [139.96ms]
(pass) setImmediate > rejects even when another listener stopped propagation [19.75ms]
(pass) setInterval > ends the iterator even when another listener stopped propagation [308.85ms]
131 |       stdout: "pipe",
132 |       stderr: "pipe",
133 |     });
134 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
135 |     expect(stderr).toBe("");
136 |     expect(stdout).toBe("created\n");
                         ^
error: expect(received).toBe(expected)

  "crea
... (truncated)

release without fix: 11 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/timers.promises/timers.promises.test.ts:
(pass) setTimeout > abort() does not emit global error [104.24ms]
(pass) setTimeout > AbortController can be passed as the `options` argument [1.40ms]
(pass) setTimeout > should reject promise when AbortController is aborted [0.34ms]
56 |     abortController.signal.addEventListener("abort", e => e.stopImmediatePropagation());
57 | 
58 |     const promise = setTimeout(1, "not-aborted", { signal: abortController.signal });
59 |     abortController.abort();
60 | 
61 |     await expect(promise).rejects.toThrow(expect.objectContaining({ name: "AbortError" }));
                                       ^
error: expect(received).rejects.toThrow(expected)

Expected promise that rejects
Received promise that resolved: Promise { <resolved> }

      at <anonymous> (/workspace/bun/test/js/node/timers.promises/timers.promises.test.ts:61:35)
(fail) setTimeout > rejects even when another listener stopped propagation [1.43ms]
(pass) setImmediate > abort() does not emit global error [101.56ms]
91 |     abortController.signal.addEventListener("abort", e => e.stopImmediatePropagation());
92 | 
93 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/timers.promises/timers.promises.test.ts
bun test v1.4.0 (bc59b8cfe)

test/js/node/timers.promises/timers.promises.test.ts:
(pass) setTimeout > abort() does not emit global error [144.50ms]
(pass) setTimeout > AbortController can be passed as the `options` argument [10.98ms]
(pass) setTimeout > should reject promise when AbortController is aborted [12.25ms]
(pass) setTimeout > rejects even when another listener stopped propagation [14.29ms]
(pass) setImmediate > abort() does not emit global error [135.57ms]
(pass) setImmediate > rejects even when another listener stopped propagation [15.37ms]
(pass) setInterval > ends the iterator even when another listener stopped propagation [60.00ms]
(pass) setInterval > does not arm the interval until the iterator is first consumed [663.94ms]
(pass) setInterval > settles every concurrent next() call [62.31ms]
(pass) setInterval > return(value) resolves { value, done: true } [25.04ms]
(pass) setInterval > next() after return() resolves { done: true } [25.56ms]
(pass) setInterval > next()
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 986ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (15067ms)
Bundle modules (82ms)
Postprocesss modules (360ms)
Bundle Functions (2227ms)
Generate Code (39ms)

[17.80s] Bundled "src/js" for production
  2569 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 2m 31s
[2/5] link bun-profile
[3/5] bun-profile --revision
1.4.0-canary.1+bc59b8cfe
[5/5] strip bun
[build] done
bun test v1.4.0-canary.1 (bc59b8cfe)

test/js/node/timers.promises/timers.promises.test.ts:
(pass) setTimeout > abort() does not emit global error [102.04ms]
(pass) setTimeout > AbortController can be passed as the
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/timers.promises.ts                     | 126 ++++-----------------
 .../node/timers.promises/timers.promises.test.ts   | 107 +++++++++++++++++
 2 files changed, 130 insertions(+), 103 deletions(-)
```

</details>

**gate history** · 4 passed · 1 rejected · iteration 7

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/js/node/timers.promises.ts                            2      2      0
test/js/node/timers.promises/timers.promises.test.ts      2      4      0
```

</details>

<!-- robobun:evidence:end -->