### PR TITLE
process: add loadEnvFile, threadCpuUsage, sourceMapsEnabled, finalization

### DIFF
--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -551,6 +551,21 @@ export function windowsEnv(
   });
 }
 
+export function loadEnvFile() {
+  let path: any = $argument(0);
+  if (path != null) {
+    path = require("internal/validators").getValidatedFsPath(path);
+  } else {
+    path = ".env";
+  }
+  const parsed = require("node:util").parseEnv(require("node:fs").readFileSync(path, "utf8"));
+  const env = process.env;
+  for (const key of Object.keys(parsed)) {
+    // Node's Dotenv::SetEnvironment only assigns keys that are not already set.
+    if (env[key] === undefined) env[key] = parsed[key];
+  }
+}
+
 export function getChannel() {
   const EventEmitter = require("node:events");
   const setRef = $newRustFunction("node_cluster_binding.rs", "setRef", 1);

--- a/src/js/internal/process/finalization.ts
+++ b/src/js/internal/process/finalization.ts
@@ -1,0 +1,110 @@
+// Port of Node's lib/internal/process/finalization.js (on-exit-leak-free).
+
+type FinalizationEvent = "exit" | "beforeExit";
+type FinalizationCallback = (obj: object, event: FinalizationEvent) => void;
+type FinalizationRef = WeakRef<object> & { fn: FinalizationCallback };
+
+let registry: FinalizationRegistry<FinalizationRef> | null = null;
+
+const refs = {
+  __proto__: null,
+  exit: new Set<FinalizationRef>(),
+  beforeExit: new Set<FinalizationRef>(),
+} as Record<FinalizationEvent, Set<FinalizationRef>>;
+
+function onExit() {
+  callRefsToFree("exit");
+}
+
+function onBeforeExit() {
+  callRefsToFree("beforeExit");
+}
+
+const functions = {
+  __proto__: null,
+  exit: onExit,
+  beforeExit: onBeforeExit,
+};
+
+function install(event: FinalizationEvent) {
+  if (refs[event].size > 0) {
+    return;
+  }
+  process.on(event, functions[event]);
+}
+
+function uninstall(event: FinalizationEvent) {
+  if (refs[event].size > 0) {
+    return;
+  }
+  process.removeListener(event, functions[event]);
+  if (refs.exit.size === 0 && refs.beforeExit.size === 0) {
+    registry = null;
+  }
+}
+
+function callRefsToFree(event: FinalizationEvent) {
+  for (const ref of refs[event]) {
+    const obj = ref.deref();
+    const fn = ref.fn;
+    if (obj !== undefined) {
+      fn(obj, event);
+    }
+  }
+  refs[event].clear();
+}
+
+function clear(ref: FinalizationRef) {
+  if (refs.exit.delete(ref)) uninstall("exit");
+  if (refs.beforeExit.delete(ref)) uninstall("beforeExit");
+}
+
+function validateFinalizationObject(obj: unknown) {
+  if (obj === null || (typeof obj !== "object" && typeof obj !== "function") || $isJSArray(obj)) {
+    throw $ERR_INVALID_ARG_TYPE("obj", "object", obj);
+  }
+}
+
+function _register(event: FinalizationEvent, obj: object, fn: FinalizationCallback) {
+  install(event);
+
+  const ref = new WeakRef(obj) as FinalizationRef;
+  ref.fn = fn;
+
+  registry ||= new FinalizationRegistry(clear);
+  registry.register(obj, ref, obj);
+
+  refs[event].add(ref);
+}
+
+function register(obj: object, fn: FinalizationCallback) {
+  validateFinalizationObject(obj);
+  _register("exit", obj, fn);
+}
+
+function registerBeforeExit(obj: object, fn: FinalizationCallback) {
+  validateFinalizationObject(obj);
+  _register("beforeExit", obj, fn);
+}
+
+function unregister(obj: object) {
+  if (!registry) {
+    return;
+  }
+  registry.unregister(obj);
+  for (const event of ["exit", "beforeExit"] as const) {
+    for (const ref of refs[event]) {
+      const _obj = ref.deref();
+      if (!_obj || _obj === obj) {
+        refs[event].delete(ref);
+      }
+    }
+    uninstall(event);
+  }
+}
+
+export default {
+  register,
+  registerBeforeExit,
+  unregister,
+};

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3515,31 +3515,12 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionResourceUsage, (JSC::JSGlobalObject * g
     return JSValue::encode(result);
 }
 
-JSC_DEFINE_HOST_FUNCTION(Process_functionCpuUsage, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+static JSC::EncodedJSValue constructCpuUsageResult(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callFrame, JSC::ThrowScope& throwScope, double user, double system)
 {
     auto& vm = JSC::getVM(globalObject);
-    auto throwScope = DECLARE_THROW_SCOPE(vm);
-#if !OS(WINDOWS)
-    struct rusage rusage;
-    if (getrusage(RUSAGE_SELF, &rusage) != 0) {
-        throwSystemError(throwScope, globalObject, "Failed to get CPU usage"_s, "getrusage"_s, errno);
-        return {};
-    }
-#else
-    uv_rusage_t rusage;
-    int err = uv_getrusage(&rusage);
-    if (err) {
-        throwSystemError(throwScope, globalObject, "Failed to get CPU usage"_s, "uv_getrusage"_s, err);
-        return {};
-    }
-#endif
-
     auto* process = getProcessObject(globalObject, callFrame->thisValue());
 
     Structure* cpuUsageStructure = process->cpuUsageStructure();
-
-    double user = std::chrono::microseconds::period::den * rusage.ru_utime.tv_sec + rusage.ru_utime.tv_usec;
-    double system = std::chrono::microseconds::period::den * rusage.ru_stime.tv_sec + rusage.ru_stime.tv_usec;
 
     if (callFrame->argumentCount() > 0) {
         JSValue comparatorValue = callFrame->argument(0);
@@ -3595,7 +3576,78 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionCpuUsage, (JSC::JSGlobalObject * global
     result->putDirectOffset(vm, 0, JSC::jsNumber(user));
     result->putDirectOffset(vm, 1, JSC::jsNumber(system));
 
-    RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(result));
+    return JSC::JSValue::encode(result);
+}
+
+JSC_DEFINE_HOST_FUNCTION(Process_functionCpuUsage, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+#if !OS(WINDOWS)
+    struct rusage rusage;
+    if (getrusage(RUSAGE_SELF, &rusage) != 0) {
+        throwSystemError(throwScope, globalObject, "Failed to get CPU usage"_s, "getrusage"_s, errno);
+        return {};
+    }
+#else
+    uv_rusage_t rusage;
+    int err = uv_getrusage(&rusage);
+    if (err) {
+        throwSystemError(throwScope, globalObject, "Failed to get CPU usage"_s, "uv_getrusage"_s, err);
+        return {};
+    }
+#endif
+
+    double user = std::chrono::microseconds::period::den * rusage.ru_utime.tv_sec + rusage.ru_utime.tv_usec;
+    double system = std::chrono::microseconds::period::den * rusage.ru_stime.tv_sec + rusage.ru_stime.tv_usec;
+
+    RELEASE_AND_RETURN(throwScope, constructCpuUsageResult(globalObject, callFrame, throwScope, user, system));
+}
+
+JSC_DEFINE_HOST_FUNCTION(Process_functionThreadCpuUsage, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    double user = 0;
+    double system = 0;
+#if OS(WINDOWS)
+    uv_rusage_t rusage;
+    int err = uv_getrusage_thread(&rusage);
+    if (err) {
+        throwSystemError(throwScope, globalObject, "Failed to get thread CPU usage"_s, "uv_getrusage_thread"_s, err);
+        return {};
+    }
+    user = std::chrono::microseconds::period::den * rusage.ru_utime.tv_sec + rusage.ru_utime.tv_usec;
+    system = std::chrono::microseconds::period::den * rusage.ru_stime.tv_sec + rusage.ru_stime.tv_usec;
+#elif defined(__APPLE__)
+    // Darwin has no RUSAGE_THREAD; use mach thread_info for the calling thread.
+    mach_port_t machThread = mach_thread_self();
+    thread_basic_info_data_t tinfo;
+    mach_msg_type_number_t tcount = THREAD_BASIC_INFO_COUNT;
+    kern_return_t kr = thread_info(machThread, THREAD_BASIC_INFO, reinterpret_cast<thread_info_t>(&tinfo), &tcount);
+    mach_port_deallocate(mach_task_self(), machThread);
+    if (kr != KERN_SUCCESS) {
+        throwSystemError(throwScope, globalObject, "Failed to get thread CPU usage"_s, "thread_info"_s, EINVAL);
+        return {};
+    }
+    user = static_cast<double>(tinfo.user_time.seconds) * std::chrono::microseconds::period::den + tinfo.user_time.microseconds;
+    system = static_cast<double>(tinfo.system_time.seconds) * std::chrono::microseconds::period::den + tinfo.system_time.microseconds;
+#else
+    struct rusage rusage;
+#if defined(RUSAGE_THREAD)
+    int who = RUSAGE_THREAD;
+#else
+    int who = RUSAGE_SELF;
+#endif
+    if (getrusage(who, &rusage) != 0) {
+        throwSystemError(throwScope, globalObject, "Failed to get thread CPU usage"_s, "getrusage"_s, errno);
+        return {};
+    }
+    user = std::chrono::microseconds::period::den * rusage.ru_utime.tv_sec + rusage.ru_utime.tv_usec;
+    system = std::chrono::microseconds::period::den * rusage.ru_stime.tv_sec + rusage.ru_stime.tv_usec;
+#endif
+
+    RELEASE_AND_RETURN(throwScope, constructCpuUsageResult(globalObject, callFrame, throwScope, user, system));
 }
 
 extern "C" int getRSS(size_t* rss)
@@ -3874,6 +3926,17 @@ JSC_DEFINE_HOST_FUNCTION(Process_setSourceMapsEnabled, (JSC::JSGlobalObject * le
     return JSValue::encode(jsUndefined());
 }
 
+JSC_DEFINE_CUSTOM_GETTER(processSourceMapsEnabled, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
+{
+    return JSValue::encode(jsBoolean(defaultGlobalObject(lexicalGlobalObject)->processObject()->m_sourceMapsEnabled));
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setProcessSourceMapsEnabled, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, JSC::PropertyName))
+{
+    // Node exposes this as a getter-only accessor; assignment is a no-op.
+    return true;
+}
+
 JSC_DEFINE_HOST_FUNCTION(Process_stubFunctionReturningArray, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     return JSValue::encode(JSC::constructEmptyArray(globalObject, nullptr));
@@ -3899,6 +3962,32 @@ static JSValue Process_stubEmptySet(VM& vm, JSObject* processObject)
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSSet* result = JSSet::create(vm, globalObject->setStructure());
     RETURN_IF_EXCEPTION(scope, {});
+    return result;
+}
+
+static JSValue constructLoadEnvFile(VM& vm, JSObject* processObject)
+{
+    auto* globalObject = processObject->globalObject();
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    JSFunction* fn = JSC::JSFunction::create(vm, globalObject, processObjectInternalsLoadEnvFileCodeGenerator(vm), globalObject);
+    // Reify the lazy name first so the subsequent putDirect is not overwritten
+    // by JSFunction's on-demand name reification.
+    fn->get(globalObject, vm.propertyNames->name);
+    scope.assertNoException();
+    fn->putDirect(vm, vm.propertyNames->name, jsString(vm, String("loadEnvFile"_s)), JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontEnum);
+    return fn;
+}
+
+static JSValue constructFinalization(VM& vm, JSObject* processObject)
+{
+    auto* globalObject = defaultGlobalObject(processObject->globalObject());
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    JSValue result = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::InternalProcessFinalization);
+    if (auto* exception = scope.exception()) [[unlikely]] {
+        (void)scope.tryClearException();
+        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        return JSC::jsUndefined();
+    }
     return result;
 }
 
@@ -4470,12 +4559,14 @@ extern "C" void Process__emitErrorEvent(Zig::GlobalObject* global, EncodedJSValu
   exit                             Process_functionExit                                Function 1
   exitCode                         processExitCode                                     CustomAccessor|DontDelete
   features                         constructFeatures                                   PropertyCallback
+  finalization                     constructFinalization                               PropertyCallback
   getActiveResourcesInfo           Process_stubFunctionReturningArray                  Function 0
   getBuiltinModule                 Process_functionLoadBuiltinModule                   Function 1
   hasUncaughtExceptionCaptureCallback Process_hasUncaughtExceptionCaptureCallback      Function 0
   hrtime                           constructProcessHrtimeObject                        PropertyCallback
   isBun                            constructIsBun                                      PropertyCallback
   kill                             Process_functionKill                                Function 2
+  loadEnvFile                      constructLoadEnvFile                                PropertyCallback
   mainModule                       constructMainModuleProperty                         PropertyCallback
   memoryUsage                      constructMemoryUsage                                PropertyCallback
   moduleLoadList                   Process_stubEmptyArray                              PropertyCallback
@@ -4494,9 +4585,11 @@ extern "C" void Process__emitErrorEvent(Zig::GlobalObject* global, EncodedJSValu
   send                             constructProcessSend                                PropertyCallback
   setSourceMapsEnabled             Process_setSourceMapsEnabled                           Function 1
   setUncaughtExceptionCaptureCallback Process_setUncaughtExceptionCaptureCallback      Function 1
+  sourceMapsEnabled                processSourceMapsEnabled                            CustomAccessor
   stderr                           constructStderr                                     PropertyCallback
   stdin                            constructStdin                                      PropertyCallback
   stdout                           constructStdout                                     PropertyCallback
+  threadCpuUsage                   Process_functionThreadCpuUsage                      Function 1
   throwDeprecation                 processThrowDeprecation                             CustomAccessor
   title                            processTitle                                        CustomAccessor
   umask                            Process_functionUmask                               Function 1

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -766,6 +766,179 @@ describe.concurrent(() => {
     });
   });
 
+  describe("process.threadCpuUsage", () => {
+    it("works", () => {
+      expect(process.threadCpuUsage()).toEqual({
+        user: expect.any(Number),
+        system: expect.any(Number),
+      });
+    });
+
+    it("throws for negative input", () => {
+      expect(() => process.threadCpuUsage({ user: -1, system: 100 })).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE", name: "RangeError" }),
+      );
+      expect(() => process.threadCpuUsage({ user: 100, system: -1 })).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE", name: "RangeError" }),
+      );
+    });
+
+    it("throws on non-object prevValue", () => {
+      expect(() => process.threadCpuUsage(123)).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE", name: "TypeError" }),
+      );
+    });
+
+    it.skipIf(process.platform === "win32")("works with diff", () => {
+      const init = process.threadCpuUsage();
+      init.user = 0;
+      init.system = 0;
+      const delta = process.threadCpuUsage(init);
+      expect(delta.user).toBeGreaterThan(0);
+      expect(delta.system).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe("process.sourceMapsEnabled", () => {
+    it("reflects setSourceMapsEnabled", async () => {
+      // Run in a subprocess so toggling the global does not leak into other tests.
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const out = [];
+            out.push(typeof process.sourceMapsEnabled);
+            out.push(process.sourceMapsEnabled);
+            process.setSourceMapsEnabled(true);
+            out.push(process.sourceMapsEnabled);
+            process.sourceMapsEnabled = false;
+            out.push(process.sourceMapsEnabled);
+            process.setSourceMapsEnabled(false);
+            out.push(process.sourceMapsEnabled);
+            console.log(JSON.stringify(out));
+          `,
+        ],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual(["boolean", false, true, true, false]);
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  describe("process.loadEnvFile", () => {
+    it("loads a .env file into process.env without overwriting existing keys", async () => {
+      using dir = tempDir("process-loadenv", {
+        "my.env": 'A=1\nB="two words"\nexport C=3\nPATH=should-not-overwrite\n',
+        "index.js": `
+          process.loadEnvFile("my.env");
+          console.log(JSON.stringify({
+            A: process.env.A,
+            B: process.env.B,
+            C: process.env.C,
+            PATH: process.env.PATH === "should-not-overwrite" ? "overwritten" : "kept",
+            name: process.loadEnvFile.name,
+            length: process.loadEnvFile.length,
+          }));
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "index.js"],
+        env: { ...bunEnv, A: undefined, B: undefined, C: undefined },
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({
+        A: "1",
+        B: "two words",
+        C: "3",
+        PATH: "kept",
+        name: "loadEnvFile",
+        length: 0,
+      });
+      expect(exitCode).toBe(0);
+    });
+
+    it("defaults to './.env'", async () => {
+      using dir = tempDir("process-loadenv-default", {
+        ".env": "DEFAULT_ENV_KEY=default-value\n",
+        "index.js": `
+          process.loadEnvFile();
+          console.log(process.env.DEFAULT_ENV_KEY);
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--no-env-file", "index.js"],
+        env: { ...bunEnv, DEFAULT_ENV_KEY: undefined },
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("default-value");
+      expect(exitCode).toBe(0);
+    });
+
+    it("throws ERR_INVALID_ARG_TYPE for a non-path", () => {
+      expect(() => process.loadEnvFile(123)).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE", name: "TypeError" }),
+      );
+    });
+
+    it("throws ENOENT for a missing file", () => {
+      expect(() => process.loadEnvFile(join(tmpdirSync(), "does-not-exist.env"))).toThrow(
+        expect.objectContaining({ code: "ENOENT" }),
+      );
+    });
+  });
+
+  describe("process.finalization", () => {
+    it("exposes register/registerBeforeExit/unregister", () => {
+      expect(typeof process.finalization.register).toBe("function");
+      expect(typeof process.finalization.registerBeforeExit).toBe("function");
+      expect(typeof process.finalization.unregister).toBe("function");
+      expect(process.finalization.register.length).toBe(2);
+      expect(process.finalization.registerBeforeExit.length).toBe(2);
+      expect(process.finalization.unregister.length).toBe(1);
+    });
+
+    it("validates the obj argument", () => {
+      for (const bad of [123, null, "str", true, []]) {
+        expect(() => process.finalization.register(bad, () => {})).toThrow(
+          expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+        );
+        expect(() => process.finalization.registerBeforeExit(bad, () => {})).toThrow(
+          expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+        );
+      }
+    });
+
+    it("unregister with nothing registered is a no-op", () => {
+      expect(() => process.finalization.unregister({})).not.toThrow();
+    });
+
+    it.concurrent.each([
+      ["close.mjs", ""],
+      ["unregister.mjs", ""],
+      ["before-exit.mjs", ""],
+    ])("fixture %s", async (fixture, expectedStdout) => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(import.meta.dir, "..", "test", "fixtures", "process", fixture)],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe(expectedStdout);
+      expect(exitCode).toBe(0);
+    });
+  });
+
   if (process.platform !== "win32") {
     it("process.getegid", () => {
       expect(typeof process.getegid()).toBe("number");


### PR DESCRIPTION
Four documented `process` APIs were missing, so ported Node packages would hit `TypeError: process.loadEnvFile is not a function` or read `undefined`:

```
loadEnvFile: undefined                      // node >=20.12
finalization: undefined                     // node >=22.5
threadCpuUsage: undefined                   // node >=23.2
sourceMapsEnabled: undefined                // getter for state setSourceMapsEnabled already sets
```

### What changed

* **`process.sourceMapsEnabled`**: new CustomAccessor reading the existing `Process::m_sourceMapsEnabled` that `setSourceMapsEnabled` already toggles. Assignment is a no-op, matching Node's getter-only accessor.
* **`process.threadCpuUsage([prev])`**: shares `cpuUsage`'s prevValue validation and `{user, system}` result structure (factored into `constructCpuUsageResult`) and reads per-thread times via `getrusage(RUSAGE_THREAD)` on Linux, mach `thread_info` on Darwin, and `uv_getrusage_thread` on Windows (same cross-platform path `JSWorker::cpuUsageInternal` already uses).
* **`process.loadEnvFile([path])`**: JS builtin that validates `path` like `fs` does (string/Buffer/URL, default `./.env`), reads the file, parses with the existing `util.parseEnv` dotenv loader, and assigns each key into `process.env` unless that key is already set (Node's `Dotenv::SetEnvironment` skips existing keys). `.name === "loadEnvFile"`, `.length === 0`.
* **`process.finalization`**: new `internal/process/finalization` module, a port of Node's on-exit-leak-free-based implementation. `register`/`registerBeforeExit` hold a `WeakRef` to `obj`, install a single `exit`/`beforeExit` listener on demand, and a `FinalizationRegistry` removes entries whose object has been collected. `unregister(obj)` drops every matching ref. Each worker gets its own instance because the internal-module registry is per-VM.

### Verification

`test/js/node/process/process.test.js` gains coverage for each API (shape, error codes, diffing, skip-existing env keys, default `.env`, Node's own `process/finalization` fixture scripts). All 15 new tests fail on the current release and pass with this change. The existing `process.cpuUsage` describe block continues to pass after the refactor.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/process/process.test.js

<!-- robobun:evidence:end -->

Fixes #6618
Fixes #23345
Fixes #23890
