### PR TITLE
node:util: match Node.js class shape for MIMEType/MIMEParams

### DIFF
--- a/src/jsc/bindings/webcore/JSMIMEParams.cpp
+++ b/src/jsc/bindings/webcore/JSMIMEParams.cpp
@@ -395,8 +395,8 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMEParamsProtoFuncGet, (JSGlobalObject * globalObjec
     // 1. Get this value
     auto* thisObject = dynamicDowncast<JSMIMEParams>(callFrame->thisValue());
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEParams"));
-        RETURN_IF_EXCEPTION(scope, {});
+        throwTypeError(globalObject, scope, "Receiver must be an instance of class MIMEParams"_s);
+        return {};
     }
 
     // 2. Get argument
@@ -425,8 +425,8 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMEParamsProtoFuncHas, (JSGlobalObject * globalObjec
 
     auto* thisObject = dynamicDowncast<JSMIMEParams>(callFrame->thisValue());
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEParams"));
-        RETURN_IF_EXCEPTION(scope, {});
+        throwTypeError(globalObject, scope, "Receiver must be an instance of class MIMEParams"_s);
+        return {};
     }
 
     JSValue nameValue = callFrame->argument(0);
@@ -447,8 +447,8 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMEParamsProtoFuncSet, (JSGlobalObject * globalObjec
 
     auto* thisObject = dynamicDowncast<JSMIMEParams>(callFrame->thisValue());
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEParams"));
-        RETURN_IF_EXCEPTION(scope, {});
+        throwTypeError(globalObject, scope, "Receiver must be an instance of class MIMEParams"_s);
+        return {};
     }
 
     // 1. Validate Arguments
@@ -489,8 +489,8 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMEParamsProtoFuncDelete, (JSGlobalObject * globalOb
 
     auto* thisObject = dynamicDowncast<JSMIMEParams>(callFrame->thisValue());
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEParams"));
-        RETURN_IF_EXCEPTION(scope, {});
+        throwTypeError(globalObject, scope, "Receiver must be an instance of class MIMEParams"_s);
+        return {};
     }
 
     JSValue nameValue = callFrame->argument(0);
@@ -511,8 +511,8 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMEParamsProtoFuncToString, (JSGlobalObject * global
 
     auto* thisObject = dynamicDowncast<JSMIMEParams>(callFrame->thisValue());
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEParams"));
-        RETURN_IF_EXCEPTION(scope, {});
+        throwTypeError(globalObject, scope, "Receiver must be an instance of class MIMEParams"_s);
+        return {};
     }
 
     JSMap* map = thisObject->jsMap();
@@ -563,8 +563,8 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMEParamsProtoFuncEntries, (JSGlobalObject * globalO
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* thisObject = dynamicDowncast<JSMIMEParams>(callFrame->thisValue());
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEParams"));
-        RETURN_IF_EXCEPTION(scope, {});
+        throwTypeError(globalObject, scope, "Receiver must be an instance of class MIMEParams"_s);
+        return {};
     }
     RELEASE_AND_RETURN(scope, JSValue::encode(JSMapIterator::create(vm, globalObject->mapIteratorStructure(), thisObject->jsMap(), IterationKind::Entries)));
 }
@@ -575,8 +575,8 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMEParamsProtoFuncKeys, (JSGlobalObject * globalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* thisObject = dynamicDowncast<JSMIMEParams>(callFrame->thisValue());
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEParams"));
-        RETURN_IF_EXCEPTION(scope, {});
+        throwTypeError(globalObject, scope, "Receiver must be an instance of class MIMEParams"_s);
+        return {};
     }
     RELEASE_AND_RETURN(scope, JSValue::encode(JSMapIterator::create(vm, globalObject->mapIteratorStructure(), thisObject->jsMap(), IterationKind::Keys)));
 }
@@ -587,8 +587,8 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMEParamsProtoFuncValues, (JSGlobalObject * globalOb
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* thisObject = dynamicDowncast<JSMIMEParams>(callFrame->thisValue());
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEParams"));
-        RETURN_IF_EXCEPTION(scope, {});
+        throwTypeError(globalObject, scope, "Receiver must be an instance of class MIMEParams"_s);
+        return {};
     }
     RELEASE_AND_RETURN(scope, JSValue::encode(JSMapIterator::create(vm, globalObject->mapIteratorStructure(), thisObject->jsMap(), IterationKind::Values)));
 }
@@ -599,14 +599,14 @@ JSC_DECLARE_HOST_FUNCTION(constructMIMEParams);
 
 // Define the properties and functions on the prototype
 static const HashTableValue JSMIMEParamsPrototypeTableValues[] = {
-    { "get"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMIMEParamsProtoFuncGet, 1 } },
-    { "has"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMIMEParamsProtoFuncHas, 1 } },
-    { "set"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMIMEParamsProtoFuncSet, 2 } },
-    { "delete"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMIMEParamsProtoFuncDelete, 1 } },
-    { "toString"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMIMEParamsProtoFuncToString, 0 } },
-    { "entries"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMIMEParamsProtoFuncEntries, 0 } },
-    { "keys"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMIMEParamsProtoFuncKeys, 0 } },
-    { "values"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMIMEParamsProtoFuncValues, 0 } },
+    { "get"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMIMEParamsProtoFuncGet, 1 } },
+    { "has"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMIMEParamsProtoFuncHas, 1 } },
+    { "set"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMIMEParamsProtoFuncSet, 2 } },
+    { "delete"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMIMEParamsProtoFuncDelete, 1 } },
+    { "toString"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMIMEParamsProtoFuncToString, 0 } },
+    { "entries"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMIMEParamsProtoFuncEntries, 0 } },
+    { "keys"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMIMEParamsProtoFuncKeys, 0 } },
+    { "values"_s, static_cast<unsigned>(PropertyAttribute::Function | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMIMEParamsProtoFuncValues, 0 } },
 };
 
 void JSMIMEParamsPrototype::finishCreation(VM& vm)
@@ -618,9 +618,7 @@ void JSMIMEParamsPrototype::finishCreation(VM& vm)
     putDirectWithoutTransition(vm, vm.propertyNames->iteratorSymbol, getDirect(vm, Identifier::fromString(vm, "entries"_s)), PropertyAttribute::DontEnum | 0);
 
     // Set toJSON to toString
-    putDirectWithoutTransition(vm, vm.propertyNames->toJSON, getDirect(vm, vm.propertyNames->toString), PropertyAttribute::Function | 0);
-
-    JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
+    putDirectWithoutTransition(vm, vm.propertyNames->toJSON, getDirect(vm, vm.propertyNames->toString), PropertyAttribute::Function | PropertyAttribute::DontEnum | 0);
 }
 
 //-- JSMIMEParamsConstructor Implementation --

--- a/src/jsc/bindings/webcore/JSMIMEType.cpp
+++ b/src/jsc/bindings/webcore/JSMIMEType.cpp
@@ -346,7 +346,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsMIMETypeProtoGetterType, (JSGlobalObject * globalObje
 
     auto* thisObject = dynamicDowncast<JSMIMEType>(JSC::JSValue::decode(thisValue));
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEType"));
+        throwTypeError(globalObject, scope, "Cannot read private member #type from an object whose class did not declare it"_s);
         return {};
     }
 
@@ -360,7 +360,7 @@ JSC_DEFINE_CUSTOM_SETTER(jsMIMETypeProtoSetterType, (JSGlobalObject * globalObje
 
     auto* thisObject = dynamicDowncast<JSMIMEType>(JSC::JSValue::decode(thisValue));
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEType"));
+        throwTypeError(globalObject, scope, "Cannot write private member #type to an object whose class did not declare it"_s);
         return {};
     }
 
@@ -386,7 +386,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsMIMETypeProtoGetterSubtype, (JSGlobalObject * globalO
 
     auto* thisObject = dynamicDowncast<JSMIMEType>(JSC::JSValue::decode(thisValue));
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEType"));
+        throwTypeError(globalObject, scope, "Cannot read private member #subtype from an object whose class did not declare it"_s);
         return {};
     }
 
@@ -400,7 +400,7 @@ JSC_DEFINE_CUSTOM_SETTER(jsMIMETypeProtoSetterSubtype, (JSGlobalObject * globalO
 
     auto* thisObject = dynamicDowncast<JSMIMEType>(JSC::JSValue::decode(thisValue));
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEType"));
+        throwTypeError(globalObject, scope, "Cannot write private member #subtype to an object whose class did not declare it"_s);
         return {};
     }
 
@@ -426,7 +426,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsMIMETypeProtoGetterEssence, (JSGlobalObject * globalO
 
     auto* thisObject = dynamicDowncast<JSMIMEType>(JSC::JSValue::decode(thisValue));
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEType"));
+        throwTypeError(globalObject, scope, "Cannot read private member #type from an object whose class did not declare it"_s);
         return {};
     }
 
@@ -441,7 +441,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsMIMETypeProtoGetterParams, (JSGlobalObject * globalOb
 
     auto* thisObject = dynamicDowncast<JSMIMEType>(JSC::JSValue::decode(thisValue));
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEType"));
+        throwTypeError(globalObject, scope, "Cannot read private member #parameters from an object whose class did not declare it"_s);
         return {};
     }
 
@@ -455,7 +455,7 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMETypeProtoFuncToString, (JSGlobalObject * globalOb
 
     auto* thisObject = dynamicDowncast<JSMIMEType>(callFrame->thisValue());
     if (!thisObject) [[unlikely]] {
-        scope.throwException(globalObject, Bun::createInvalidThisError(globalObject, thisObject, "MIMEType"));
+        throwTypeError(globalObject, scope, "Cannot read private member #type from an object whose class did not declare it"_s);
         return {};
     }
 
@@ -483,11 +483,11 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMETypeProtoFuncToString, (JSGlobalObject * globalOb
 
 // Define the properties and functions on the prototype
 static const HashTableValue JSMIMETypePrototypeValues[] = {
-    { "type"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsMIMETypeProtoGetterType, jsMIMETypeProtoSetterType } },
-    { "subtype"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsMIMETypeProtoGetterSubtype, jsMIMETypeProtoSetterSubtype } },
-    { "essence"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsMIMETypeProtoGetterEssence, 0 } },
-    { "params"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsMIMETypeProtoGetterParams, 0 } },
-    { "toString"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMIMETypeProtoFuncToString, 0 } },
+    { "type"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsMIMETypeProtoGetterType, jsMIMETypeProtoSetterType } },
+    { "subtype"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsMIMETypeProtoGetterSubtype, jsMIMETypeProtoSetterSubtype } },
+    { "essence"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsMIMETypeProtoGetterEssence, 0 } },
+    { "params"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsMIMETypeProtoGetterParams, 0 } },
+    { "toString"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::NativeFunctionType, jsMIMETypeProtoFuncToString, 0 } },
 };
 
 void JSMIMETypePrototype::finishCreation(VM& vm)
@@ -498,9 +498,7 @@ void JSMIMETypePrototype::finishCreation(VM& vm)
     reifyStaticProperties(vm, JSMIMEType::info(), JSMIMETypePrototypeValues, *this);
 
     // Set toJSON to toString
-    putDirectWithoutTransition(vm, vm.propertyNames->toJSON, getDirect(vm, vm.propertyNames->toString), PropertyAttribute::Function | 0);
-
-    JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
+    putDirectWithoutTransition(vm, vm.propertyNames->toJSON, getDirect(vm, vm.propertyNames->toString), PropertyAttribute::Function | PropertyAttribute::DontEnum | 0);
 }
 
 //-- JSMIMETypeConstructor Implementation --

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -2814,9 +2814,15 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
             // like a plain object from JS's perspective (matches Node.js).
             // ObjectPrototype is allowed because %Object.prototype% is an immutable
             // prototype exotic object that the spec carves out of this rejection.
-            // JSMIMEType/JSMIMEParams are allowed because in Node.js they are plain
-            // JS classes whose instances clone as empty objects.
-            if (inObject->classInfo() != JSFinalObject::info() && inObject->classInfo() != Zig::NapiPrototype::info() && inObject->classInfo() != JSC::ObjectPrototype::info() && inObject->classInfo() != WebCore::JSMIMEType::info() && inObject->classInfo() != WebCore::JSMIMEParams::info())
+            // JSMIMEType/JSMIMEParams (and their prototype objects) are allowed
+            // because in Node.js they are plain JS classes that clone as empty objects.
+            if (inObject->classInfo() != JSFinalObject::info()
+                && inObject->classInfo() != Zig::NapiPrototype::info()
+                && inObject->classInfo() != JSC::ObjectPrototype::info()
+                && inObject->classInfo() != WebCore::JSMIMEType::info()
+                && inObject->classInfo() != WebCore::JSMIMEParams::info()
+                && inObject->classInfo() != WebCore::JSMIMETypePrototype::info()
+                && inObject->classInfo() != WebCore::JSMIMEParamsPrototype::info())
                 return SerializationReturnCode::DataCloneError;
             inputObjectStack.append(inObject);
             indexStack.append(0);

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -120,6 +120,8 @@
 #include "CryptoKeyType.h"
 #include "JSNodePerformanceHooksHistogram.h"
 #include "../napi.h"
+#include "JSMIMEType.h"
+#include "JSMIMEParams.h"
 #include <limits>
 #include <algorithm>
 
@@ -2812,7 +2814,9 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
             // like a plain object from JS's perspective (matches Node.js).
             // ObjectPrototype is allowed because %Object.prototype% is an immutable
             // prototype exotic object that the spec carves out of this rejection.
-            if (inObject->classInfo() != JSFinalObject::info() && inObject->classInfo() != Zig::NapiPrototype::info() && inObject->classInfo() != JSC::ObjectPrototype::info())
+            // JSMIMEType/JSMIMEParams are allowed because in Node.js they are plain
+            // JS classes whose instances clone as empty objects.
+            if (inObject->classInfo() != JSFinalObject::info() && inObject->classInfo() != Zig::NapiPrototype::info() && inObject->classInfo() != JSC::ObjectPrototype::info() && inObject->classInfo() != WebCore::JSMIMEType::info() && inObject->classInfo() != WebCore::JSMIMEParams::info())
                 return SerializationReturnCode::DataCloneError;
             inputObjectStack.append(inObject);
             indexStack.append(0);

--- a/test/js/node/util/mime-api.test.ts
+++ b/test/js/node/util/mime-api.test.ts
@@ -92,6 +92,9 @@ describe("MIME API", () => {
       const clonedParams = structuredClone(p);
       expect(Object.getPrototypeOf(clonedParams)).toBe(Object.prototype);
       expect(Object.getOwnPropertyNames(clonedParams)).toEqual([]);
+
+      expect(structuredClone(MIMEType.prototype)).toEqual({});
+      expect(structuredClone(MIMEParams.prototype)).toEqual({});
     });
   });
 

--- a/test/js/node/util/mime-api.test.ts
+++ b/test/js/node/util/mime-api.test.ts
@@ -3,6 +3,98 @@ import { bunExe } from "harness";
 import { MIMEParams, MIMEType } from "util";
 
 describe("MIME API", () => {
+  // In Node.js, MIMEType and MIMEParams are plain JS classes (private fields for state,
+  // no Symbol.toStringTag, non-enumerable prototype members). Match that shape here.
+  describe("class shape matches Node.js", () => {
+    test("no Symbol.toStringTag on prototypes", () => {
+      const m = new MIMEType("a/b;x=1");
+      expect(Object.prototype.toString.call(m)).toBe("[object Object]");
+      expect(Object.prototype.toString.call(m.params)).toBe("[object Object]");
+      expect(Symbol.toStringTag in MIMEType.prototype).toBe(false);
+      expect(Symbol.toStringTag in MIMEParams.prototype).toBe(false);
+    });
+
+    test("prototype members are non-enumerable (for-in yields nothing)", () => {
+      const m = new MIMEType("a/b;x=1");
+      const keys: string[] = [];
+      for (const k in m) keys.push(k);
+      expect(keys).toEqual([]);
+
+      const pkeys: string[] = [];
+      for (const k in m.params) pkeys.push(k);
+      expect(pkeys).toEqual([]);
+    });
+
+    test("prototype property descriptors match Node.js", () => {
+      for (const name of ["type", "subtype", "essence", "params"]) {
+        const d = Object.getOwnPropertyDescriptor(MIMEType.prototype, name)!;
+        expect({ name, enumerable: d.enumerable, configurable: d.configurable }).toEqual({
+          name,
+          enumerable: false,
+          configurable: true,
+        });
+      }
+      for (const name of ["toString", "toJSON"]) {
+        const d = Object.getOwnPropertyDescriptor(MIMEType.prototype, name)!;
+        expect({ name, enumerable: d.enumerable, configurable: d.configurable, writable: d.writable }).toEqual({
+          name,
+          enumerable: false,
+          configurable: true,
+          writable: true,
+        });
+      }
+      for (const name of ["get", "has", "set", "delete", "entries", "keys", "values", "toString", "toJSON"]) {
+        const d = Object.getOwnPropertyDescriptor(MIMEParams.prototype, name)!;
+        expect({ name, enumerable: d.enumerable, configurable: d.configurable, writable: d.writable }).toEqual({
+          name,
+          enumerable: false,
+          configurable: true,
+          writable: true,
+        });
+      }
+    });
+
+    test("brand-check throws plain TypeError with no .code", () => {
+      for (const fn of [
+        () => MIMEType.prototype.toString.call({}),
+        () => MIMEType.prototype.toJSON.call({}),
+        () => Reflect.get(MIMEType.prototype, "type", {}),
+        () => Reflect.get(MIMEType.prototype, "subtype", {}),
+        () => Reflect.get(MIMEType.prototype, "essence", {}),
+        () => Reflect.get(MIMEType.prototype, "params", {}),
+        () => Reflect.set(MIMEType.prototype, "type", "x", {}),
+        () => Reflect.set(MIMEType.prototype, "subtype", "x", {}),
+        () => MIMEParams.prototype.get.call({}, "x"),
+        () => MIMEParams.prototype.has.call({}, "x"),
+        () => MIMEParams.prototype.set.call({}, "x", "y"),
+        () => MIMEParams.prototype.delete.call({}, "x"),
+        () => MIMEParams.prototype.toString.call({}),
+        () => MIMEParams.prototype.toJSON.call({}),
+      ]) {
+        let err: any;
+        try {
+          fn();
+        } catch (e) {
+          err = e;
+        }
+        expect(err).toBeInstanceOf(TypeError);
+        expect(err.code).toBeUndefined();
+      }
+    });
+
+    test("structuredClone serializes instances as plain empty objects", () => {
+      const m = new MIMEType("a/b;x=1");
+      const cloned = structuredClone(m);
+      expect(Object.getPrototypeOf(cloned)).toBe(Object.prototype);
+      expect(Object.getOwnPropertyNames(cloned)).toEqual([]);
+
+      const p = m.params;
+      const clonedParams = structuredClone(p);
+      expect(Object.getPrototypeOf(clonedParams)).toBe(Object.prototype);
+      expect(Object.getOwnPropertyNames(clonedParams)).toEqual([]);
+    });
+  });
+
   const WHITESPACES = "\t\n\f\r ";
   const NOT_HTTP_TOKEN_CODE_POINT = ",";
   const NOT_HTTP_QUOTED_STRING_CODE_POINT = "\n";

--- a/test/js/node/util/mime-api.test.ts
+++ b/test/js/node/util/mime-api.test.ts
@@ -70,6 +70,12 @@ describe("MIME API", () => {
         () => MIMEParams.prototype.delete.call({}, "x"),
         () => MIMEParams.prototype.toString.call({}),
         () => MIMEParams.prototype.toJSON.call({}),
+        // entries/keys/values are generator methods in Node, so the brand check
+        // fires on .next() there; Bun throws at call time. The .next() form
+        // throws a plain TypeError with no .code in both.
+        () => MIMEParams.prototype.entries.call({}).next(),
+        () => MIMEParams.prototype.keys.call({}).next(),
+        () => MIMEParams.prototype.values.call({}).next(),
       ]) {
         let err: any;
         try {

--- a/test/js/node/util/mime-api.test.ts
+++ b/test/js/node/util/mime-api.test.ts
@@ -102,25 +102,6 @@ describe("MIME API", () => {
   const NOT_HTTP_TOKEN_CODE_POINT = ",";
   const NOT_HTTP_QUOTED_STRING_CODE_POINT = "\n";
 
-  test("class instance integrity", () => {
-    const mime = new MIMEType("application/ecmascript; ");
-    const mime_descriptors = Object.getOwnPropertyDescriptors(mime);
-    const mime_proto = Object.getPrototypeOf(mime);
-    const mime_impersonator = { __proto__: mime_proto };
-
-    for (const key of Object.keys(mime_descriptors)) {
-      const descriptor = mime_descriptors[key];
-      if (descriptor.get) {
-        const getter = descriptor.get;
-        expect(() => getter.call(mime_impersonator)).toThrow(/invalid receiver/i);
-      }
-      if (descriptor.set) {
-        const setter = descriptor.set;
-        expect(() => setter.call(mime_impersonator, "x")).toThrow(/invalid receiver/i);
-      }
-    }
-  });
-
   test("basic properties and string conversion", () => {
     const mime = new MIMEType("application/ecmascript; ");
 


### PR DESCRIPTION
## What

`util.MIMEType` / `util.MIMEParams` in Node.js are plain JS classes (state in private fields). Bun ships them as native host classes, and the shape differences leaked into user code in four ways.

## Repro

```js
import util from "node:util";
const m = new util.MIMEType("a/b;x=1");
Object.prototype.toString.call(m);        // node: "[object Object]"  | bun: "[object MIMEType]"
for (const k in m) console.log(k);        // node: (nothing)          | bun: type,subtype,essence,params,toString,toJSON
Object.getOwnPropertyDescriptor(util.MIMEType.prototype, "type").enumerable;
                                          // node: false              | bun: true
try { util.MIMEType.prototype.toString.call({}); } catch (e) { e.code; }
                                          // node: undefined          | bun: "ERR_INVALID_THIS"
structuredClone(m);                       // node: {}                 | bun: DataCloneError
```

## Cause

`JSMIMETypePrototype::finishCreation` / `JSMIMEParamsPrototype::finishCreation` installed `Symbol.toStringTag`, defined all prototype members without `DontEnum`, and brand-check failures went through `Bun::createInvalidThisError` (which sets `.code = "ERR_INVALID_THIS"`). `SerializedScriptValue` rejects any object whose `classInfo()` isn't in its plain-object allowlist, so `MIMEType`/`MIMEParams` instances threw `DataCloneError` instead of cloning as `{}` like in Node.

## Fix

- Drop `JSC_TO_STRING_TAG_WITHOUT_TRANSITION()` from both prototypes.
- Mark every prototype accessor/method `PropertyAttribute::DontEnum` (including `toJSON`).
- Throw a plain `TypeError` (no `.code`) on brand failure, with Node's message text (private-field brand error for `MIMEType`, `Receiver must be an instance of class MIMEParams` for `MIMEParams`).
- Allow `JSMIMEType::info()` / `JSMIMEParams::info()` through the ordinary-object path in `SerializedScriptValue` so instances clone as empty objects.

## Verification

`bun bd test test/js/node/util/mime-api.test.ts` passes (13 tests including 5 new shape tests that fail on current main). `test/js/node/test/parallel/test-mime-{api,whatwg}.js` and the undici primordials test also pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/mime-api.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (d90a62972)

test/js/node/util/mime-api.test.ts:
 6 |   // In Node.js, MIMEType and MIMEParams are plain JS classes (private fields for state,
 7 |   // no Symbol.toStringTag, non-enumerable prototype members). Match that shape here.
 8 |   describe("class shape matches Node.js", () => {
 9 |     test("no Symbol.toStringTag on prototypes", () => {
10 |       const m = new MIMEType("a/b;x=1");
11 |       expect(Object.prototype.toString.call(m)).toBe("[object Object]");
                                                     ^
error: expect(received).toBe(expected)

Expected: "[object Object]"
Received: "[object MIMEType]"

      at <anonymous> (/workspace/bun/test/js/node/util/mime-api.test.ts:11:49)
(fail) MIME API > class shape match
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (f625b8ef0)

test/js/node/util/mime-api.test.ts:
(pass) MIME API > class shape matches Node.js > no Symbol.toStringTag on prototypes [1.34ms]
(pass) MIME API > class shape matches Node.js > prototype members are non-enumerable (for-in yields nothing) [0.12ms]
(pass) MIME API > class shape matches Node.js > prototype property descriptors match Node.js [0.18ms]
(pass) MIME API > class shape matches Node.js > brand-check throws plain TypeError with no .code [0.39ms]
(pass) MIME API > class shape matches Node.js > structuredClone serializes instances as plain empty objects [0.08ms]
(pass) MIME API > basic properties and string conversion [0.16ms]
(pass) MIME API > type property manipulation [1.40ms]
(pass) MIME API > subtype property manipulation [0.23ms]
(pass) MIME API > parameters manipulation [0.24ms]
(pass) MIME API > invalid parameter names [0.15ms]
(pass) MIME API > invalid parameter values [0.07ms]
(pass) Exact match with node [201.63ms]

 12 pass
 0 fail
 1 snapshots, 147 expect() calls
Ran 12 tests across 1 file. [1041.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/mime-api.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (d90a62972)

test/js/node/util/mime-api.test.ts:
(pass) MIME API > class shape matches Node.js > no Symbol.toStringTag on prototypes [40.93ms]
(pass) MIME API > class shape matches Node.js > prototype members are non-enumerable (for-in yields nothing) [8.87ms]
(pass) MIME API > class shape matches Node.js > prototype property descriptors match Node.js [24.33ms]
(pass) MIME API > class shape matches Node.js > brand-check throws plain TypeError with no .code [98.20ms]
(pass) MIME API > class shape matches Node.js > structuredClone serializes instances as plain empty objects [14.15ms]
(pass) MIME API > basic properties and string conversion [21.61ms]
(pass) MIME API > type property manipulation [48.61ms]
(pass) MIME API > subtype prope
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 2009ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/24] gen cpp.rs (cppbind)
[2/24] gen JS modules (bundle-modules)
Preprocess modules (19940ms)
Bundle modules (109ms)
Postprocesss modules (154ms)
Bundle Functions (974ms)
Generate Code (116ms)

[21.37s] Bundled "src/js" for production
  2036 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[3/8] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-2.cpp.o
[4/8] cxx obj/src/jsc/bindings/webcore/SerializedScriptValue.cpp.o
[5/8] cxx obj/src/jsc/bindings/webcore/JSMIMEType.cpp.o
[5/8] link bun-profile
[6/8] bun-profile --revision
1.4.0-canary.1+f625b8ef0
[8/8] strip bun
[build] done
bun test v1.4.0-canary.1 (f625b8ef0)

test/js/node/util/mime-api.test.ts:
(pass) MIME API > class shape matches Node.js > no Symbol.to
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/JSMIMEParams.cpp          |  52 +++++----
 src/jsc/bindings/webcore/JSMIMEType.cpp            |  28 +++--
 src/jsc/bindings/webcore/SerializedScriptValue.cpp |  12 ++-
 test/js/node/util/mime-api.test.ts                 | 120 +++++++++++++++++----
 4 files changed, 150 insertions(+), 62 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/webcore/JSMIMEParams.cpp               1      1      0
src/jsc/bindings/webcore/JSMIMEType.cpp                 1      2      0
src/jsc/bindings/webcore/SerializedScriptValue.cpp      3      3      0
test/js/node/util/mime-api.test.ts                      3      4      0
```

</details>

<!-- robobun:evidence:end -->