### PR TITLE
node:vm: run DONT_CONTEXTIFY contexts directly against the real global

### DIFF
--- a/src/js/node/vm.ts
+++ b/src/js/node/vm.ts
@@ -122,8 +122,7 @@ function runInNewContext(code, context, options) {
   return createScript(code, options).runInNewContext(context, options);
 }
 
-// runInNewContext's option names differ from createContext's; remap before
-// handing to createContext (matches Node's lib/vm.js getContextOptions).
+// Mirrors Node's lib/vm.js getContextOptions.
 function getContextOptions(options) {
   if (!options) return {};
   const { contextName, contextOrigin, contextCodeGeneration, microtaskMode } = options;

--- a/src/js/node/vm.ts
+++ b/src/js/node/vm.ts
@@ -118,8 +118,38 @@ function runInNewContext(code, context, options) {
   } else {
     options = { ...options };
   }
-  context = createContext(context, options);
+  context = createContext(context, getContextOptions(options));
   return createScript(code, options).runInNewContext(context, options);
+}
+
+// runInNewContext's option names differ from createContext's; remap before
+// handing to createContext (matches Node's lib/vm.js getContextOptions).
+function getContextOptions(options) {
+  if (!options) return {};
+  const { contextName, contextOrigin, contextCodeGeneration, microtaskMode } = options;
+  if (contextName !== undefined) validateString(contextName, "options.contextName");
+  if (contextOrigin !== undefined) validateString(contextOrigin, "options.contextOrigin");
+  const contextOptions: any = {
+    name: contextName,
+    origin: contextOrigin,
+    codeGeneration: undefined,
+    microtaskMode,
+  };
+  if (contextCodeGeneration !== undefined) {
+    validateObject(contextCodeGeneration, "options.contextCodeGeneration");
+    const { strings, wasm } = contextCodeGeneration;
+    const codeGeneration: any = {};
+    if (strings !== undefined) {
+      validateBoolean(strings, "options.contextCodeGeneration.strings");
+      codeGeneration.strings = strings;
+    }
+    if (wasm !== undefined) {
+      validateBoolean(wasm, "options.contextCodeGeneration.wasm");
+      codeGeneration.wasm = wasm;
+    }
+    contextOptions.codeGeneration = codeGeneration;
+  }
+  return contextOptions;
 }
 
 function createScript(code, options) {

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1849,6 +1849,7 @@ bool CompileFunctionOptions::fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& 
 
         if (!parsingContextValue.isEmpty() && !parsingContextValue.isUndefined()) {
             parsingContext = getGlobalObjectFromContext(globalObject, parsingContextValue, false);
+            RETURN_IF_EXCEPTION(scope, false);
             if (!parsingContext)
                 return ERR::INVALID_ARG_INSTANCE(scope, globalObject, "options.parsingContext"_s, "Context"_s, parsingContextValue);
 

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1848,17 +1848,7 @@ bool CompileFunctionOptions::fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& 
         RETURN_IF_EXCEPTION(scope, {});
 
         if (!parsingContextValue.isEmpty() && !parsingContextValue.isUndefined()) {
-            if (parsingContextValue.isNull() || !parsingContextValue.isObject())
-                return ERR::INVALID_ARG_INSTANCE(scope, globalObject, "options.parsingContext"_s, "Context"_s, parsingContextValue);
-
-            JSObject* context = asObject(parsingContextValue);
-            auto* zigGlobalObject = defaultGlobalObject(globalObject);
-            JSValue scopeValue = zigGlobalObject->vmModuleContextMap()->get(context);
-
-            if (scopeValue.isUndefined())
-                return ERR::INVALID_ARG_INSTANCE(scope, globalObject, "options.parsingContext"_s, "Context"_s, parsingContextValue);
-
-            parsingContext = dynamicDowncast<NodeVMGlobalObject>(scopeValue);
+            parsingContext = getGlobalObjectFromContext(globalObject, parsingContextValue, false);
             if (!parsingContext)
                 return ERR::INVALID_ARG_INSTANCE(scope, globalObject, "options.parsingContext"_s, "Context"_s, parsingContextValue);
 

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1467,9 +1467,7 @@ JSC_DEFINE_HOST_FUNCTION(vmModule_createContext, (JSGlobalObject * globalObject,
     RETURN_IF_EXCEPTION(scope, {});
 
     if (notContextified) {
-        // DONT_CONTEXTIFY promises a vanilla global with no contextify
-        // interceptors, so hand back the new global's own proxy and leave
-        // m_sandbox unset so the method-table overrides fall through to Base.
+        // The context's own global is the handle; there is no sandbox to install.
         return JSValue::encode(targetContext->globalThis());
     }
 

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -325,7 +325,7 @@ static JSPromise* importModuleInner(JSGlobalObject* globalObject, JSString* modu
         args.append(owner);
     } else if (auto* nodeVmGlobalObject = dynamicDowncast<NodeVMGlobalObject>(globalObject)) {
         if (nodeVmGlobalObject->isNotContextified()) {
-            args.append(nodeVmGlobalObject->specialSandbox());
+            args.append(nodeVmGlobalObject->globalThis());
         } else {
             args.append(nodeVmGlobalObject->contextifiedObject());
         }
@@ -783,10 +783,6 @@ NodeVMGlobalObject* getGlobalObjectFromContext(JSGlobalObject* globalObject, JSV
     auto* zigGlobalObject = defaultGlobalObject(globalObject);
     JSValue scopeValue = zigGlobalObject->vmModuleContextMap()->get(context);
     if (scopeValue.isUndefined()) {
-        if (auto* specialSandbox = dynamicDowncast<NodeVMSpecialSandbox>(context)) {
-            return specialSandbox->parentGlobal();
-        }
-
         if (auto* proxy = dynamicDowncast<JSGlobalProxy>(context)) {
             if (auto* nodeVmGlobalObject = dynamicDowncast<NodeVMGlobalObject>(proxy->target())) {
                 return nodeVmGlobalObject;
@@ -832,10 +828,6 @@ bool isContext(JSGlobalObject* globalObject, JSValue value)
         return true;
     }
 
-    if (value.inherits(NodeVMSpecialSandbox::info())) {
-        return true;
-    }
-
     if (auto* proxy = dynamicDowncast<JSGlobalProxy>(value); proxy && proxy->target()) {
         return proxy->target()->inherits(NodeVMGlobalObject::info());
     }
@@ -873,54 +865,6 @@ bool isUseMainContextDefaultLoaderConstant(JSGlobalObject* globalObject, JSValue
 } // namespace NodeVM
 
 using namespace NodeVM;
-
-template<typename, JSC::SubspaceAccess mode> JSC::GCClient::IsoSubspace* NodeVMSpecialSandbox::subspaceFor(JSC::VM& vm)
-{
-    if constexpr (mode == JSC::SubspaceAccess::Concurrently)
-        return nullptr;
-    return WebCore::subspaceForImpl<NodeVMSpecialSandbox, WebCore::UseCustomHeapCellType::No>(vm, BUN_SUBSPACE_SLOTS(m_clientSubspaceForNodeVMSpecialSandbox, m_subspaceForNodeVMSpecialSandbox));
-}
-
-NodeVMSpecialSandbox* NodeVMSpecialSandbox::create(VM& vm, NodeVMGlobalObject* globalObject)
-{
-    // The structure's prototype must be the sandbox realm's Object.prototype so that the
-    // prototype chain of globalThis inside a DONT_CONTEXTIFY context never reaches the
-    // host realm. This can't be cached on the host global because it differs per sandbox.
-    auto* structure = createStructure(vm, globalObject, globalObject->objectPrototype());
-    NodeVMSpecialSandbox* ptr = new (NotNull, allocateCell<NodeVMSpecialSandbox>(vm)) NodeVMSpecialSandbox(vm, structure, globalObject);
-    ptr->finishCreation(vm);
-    return ptr;
-}
-
-JSC::Structure* NodeVMSpecialSandbox::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-{
-    return Bun::createClassStructure(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
-}
-
-NodeVMSpecialSandbox::NodeVMSpecialSandbox(VM& vm, Structure* structure, NodeVMGlobalObject* globalObject)
-    : Base(vm, structure)
-{
-    m_parentGlobal.set(vm, this, globalObject);
-}
-
-void NodeVMSpecialSandbox::finishCreation(VM& vm)
-{
-    Base::finishCreation(vm);
-    ASSERT(inherits(info()));
-}
-
-const JSC::ClassInfo NodeVMSpecialSandbox::s_info = { "NodeVMSpecialSandbox"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(NodeVMSpecialSandbox) };
-
-template<typename Visitor>
-void NodeVMSpecialSandbox::visitChildrenImpl(JSCell* cell, Visitor& visitor)
-{
-    auto* thisObject = uncheckedDowncast<NodeVMSpecialSandbox>(cell);
-    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
-    Base::visitChildren(thisObject, visitor);
-    visitor.append(thisObject->m_parentGlobal);
-}
-
-DEFINE_VISIT_CHILDREN(NodeVMSpecialSandbox);
 
 NodeVMGlobalObject::NodeVMGlobalObject(JSC::VM& vm, JSC::Structure* structure, NodeVMContextOptions contextOptions, JSValue importer)
     : Base(vm, structure, &globalObjectMethodTable())
@@ -1131,7 +1075,7 @@ bool NodeVMGlobalObject::put(JSCell* cell, JSGlobalObject* globalObject, Propert
 {
     auto* thisObject = uncheckedDowncast<NodeVMGlobalObject>(cell);
 
-    if (!thisObject->m_sandbox) {
+    if (thisObject->isNotContextified() || !thisObject->m_sandbox) {
         return Base::put(cell, globalObject, propertyName, value, slot);
     }
 
@@ -1160,12 +1104,6 @@ bool NodeVMGlobalObject::put(JSCell* cell, JSGlobalObject* globalObject, Propert
         RELEASE_AND_RETURN(scope, Base::put(cell, globalObject, propertyName, value, slot));
     }
 
-    if (thisObject->m_contextOptions.notContextified) {
-        JSObject* specialSandbox = thisObject->specialSandbox();
-        slot.setThisValue(specialSandbox);
-        RELEASE_AND_RETURN(scope, specialSandbox->putInline(globalObject, propertyName, value, slot));
-    }
-
     slot.setThisValue(sandbox);
 
     bool result = sandbox->methodTable()->put(sandbox, globalObject, propertyName, value, slot);
@@ -1183,31 +1121,6 @@ bool NodeVMGlobalObject::put(JSCell* cell, JSGlobalObject* globalObject, Propert
 // This is copy-pasted from JSC's ProxyObject.cpp
 static const ASCIILiteral s_proxyAlreadyRevokedErrorMessage { "Proxy has already been revoked. No more operations are allowed to be performed on it"_s };
 
-bool NodeVMSpecialSandbox::getOwnPropertySlot(JSObject* cell, JSGlobalObject* globalObject, PropertyName propertyName, PropertySlot& slot)
-{
-    VM& vm = JSC::getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto* thisObject = uncheckedDowncast<NodeVMSpecialSandbox>(cell);
-    NodeVMGlobalObject* parentGlobal = thisObject->parentGlobal();
-
-    if (propertyName == vm.propertyNames->globalThis) [[unlikely]] {
-        slot.disableCaching();
-        slot.setThisValue(thisObject);
-        slot.setValue(thisObject, slot.attributes(), thisObject);
-        return true;
-    }
-
-    bool result = parentGlobal->getOwnPropertySlot(parentGlobal, globalObject, propertyName, slot);
-    RETURN_IF_EXCEPTION(scope, false);
-
-    if (result) {
-        return true;
-    }
-
-    RELEASE_AND_RETURN(scope, Base::getOwnPropertySlot(cell, globalObject, propertyName, slot));
-}
-
 bool NodeVMGlobalObject::getOwnPropertySlot(JSObject* cell, JSGlobalObject* globalObject, PropertyName propertyName, PropertySlot& slot)
 {
     VM& vm = JSC::getVM(globalObject);
@@ -1215,13 +1128,8 @@ bool NodeVMGlobalObject::getOwnPropertySlot(JSObject* cell, JSGlobalObject* glob
 
     auto* thisObject = uncheckedDowncast<NodeVMGlobalObject>(cell);
 
-    bool notContextified = thisObject->isNotContextified();
-
-    if (notContextified && propertyName == vm.propertyNames->globalThis) [[unlikely]] {
-        slot.disableCaching();
-        slot.setThisValue(thisObject);
-        slot.setValue(thisObject, slot.attributes(), thisObject->specialSandbox());
-        return true;
+    if (thisObject->isNotContextified()) {
+        RELEASE_AND_RETURN(scope, Base::getOwnPropertySlot(cell, globalObject, propertyName, slot));
     }
 
     if (JSObject* contextifiedObject = thisObject->contextifiedObject()) {
@@ -1297,33 +1205,31 @@ bool NodeVMGlobalObject::getOwnPropertySlot(JSObject* cell, JSGlobalObject* glob
             goto try_from_global;
         }
 
-        if (!notContextified) {
-            if (slot.internalMethodType() == JSC::PropertySlot::InternalMethodType::Get) {
-                bool result = contextifiedObject->getPropertySlot(globalObject, propertyName, slot);
+        if (slot.internalMethodType() == JSC::PropertySlot::InternalMethodType::Get) {
+            bool result = contextifiedObject->getPropertySlot(globalObject, propertyName, slot);
+            RETURN_IF_EXCEPTION(scope, false);
+            if (result) {
+                // Materialize the value (like V8's contextify GetterCallback) so that,
+                // when a lookup on the sandbox yields the sandbox object itself, we can
+                // substitute the context's global proxy to keep identities consistent.
+                JSValue value = slot.getValue(globalObject, propertyName);
                 RETURN_IF_EXCEPTION(scope, false);
-                if (result) {
-                    // Materialize the value (like V8's contextify GetterCallback) so that,
-                    // when a lookup on the sandbox yields the sandbox object itself, we can
-                    // substitute the context's global proxy to keep identities consistent.
-                    JSValue value = slot.getValue(globalObject, propertyName);
-                    RETURN_IF_EXCEPTION(scope, false);
-                    if (value == contextifiedObject)
-                        value = thisObject->globalThis();
-                    unsigned ignoredAttributes = 0;
-                    slot.disableCaching();
-                    slot.setValue(contextifiedObject, ignoredAttributes, value);
-                    return true;
-                }
-            } else {
-                // For [[GetOwnProperty]] and [[HasProperty]], only own properties of the
-                // sandbox may be reported on the context's global object. Properties from
-                // the sandbox's prototype chain remain readable through normal lookup
-                // (InternalMethodType::Get above) but must not appear as own properties,
-                // matching Node's contextify Query/Descriptor callbacks.
-                bool result = contextifiedObject->methodTable()->getOwnPropertySlot(contextifiedObject, globalObject, propertyName, slot);
-                RETURN_IF_EXCEPTION(scope, false);
-                if (result) return true;
+                if (value == contextifiedObject)
+                    value = thisObject->globalThis();
+                unsigned ignoredAttributes = 0;
+                slot.disableCaching();
+                slot.setValue(contextifiedObject, ignoredAttributes, value);
+                return true;
             }
+        } else {
+            // For [[GetOwnProperty]] and [[HasProperty]], only own properties of the
+            // sandbox may be reported on the context's global object. Properties from
+            // the sandbox's prototype chain remain readable through normal lookup
+            // (InternalMethodType::Get above) but must not appear as own properties,
+            // matching Node's contextify Query/Descriptor callbacks.
+            bool result = contextifiedObject->methodTable()->getOwnPropertySlot(contextifiedObject, globalObject, propertyName, slot);
+            RETURN_IF_EXCEPTION(scope, false);
+            if (result) return true;
         }
 
     try_from_global:
@@ -1332,19 +1238,7 @@ bool NodeVMGlobalObject::getOwnPropertySlot(JSObject* cell, JSGlobalObject* glob
         RETURN_IF_EXCEPTION(scope, false);
     }
 
-    bool result = Base::getOwnPropertySlot(cell, globalObject, propertyName, slot);
-    RETURN_IF_EXCEPTION(scope, false);
-
-    if (result) {
-        return true;
-    }
-
-    if (thisObject->m_contextOptions.notContextified) {
-        JSObject* specialSandbox = thisObject->specialSandbox();
-        RELEASE_AND_RETURN(scope, JSObject::getOwnPropertySlot(specialSandbox, globalObject, propertyName, slot));
-    }
-
-    return false;
+    RELEASE_AND_RETURN(scope, Base::getOwnPropertySlot(cell, globalObject, propertyName, slot));
 }
 
 bool NodeVMGlobalObject::getOwnPropertySlotByIndex(JSObject* cell, JSGlobalObject* globalObject, unsigned index, PropertySlot& slot)
@@ -1359,11 +1253,11 @@ bool NodeVMGlobalObject::defineOwnProperty(JSObject* cell, JSGlobalObject* globa
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* thisObject = uncheckedDowncast<NodeVMGlobalObject>(cell);
-    if (!thisObject->m_sandbox) [[likely]] {
+    if (thisObject->isNotContextified() || !thisObject->m_sandbox) {
         RELEASE_AND_RETURN(scope, Base::defineOwnProperty(cell, globalObject, propertyName, descriptor, shouldThrow));
     }
 
-    auto* contextifiedObject = thisObject->isNotContextified() ? thisObject->specialSandbox() : thisObject->m_sandbox.get();
+    auto* contextifiedObject = thisObject->m_sandbox.get();
 
     PropertySlot slot(globalObject, PropertySlot::InternalMethodType::GetOwnProperty, nullptr);
     bool isDeclaredOnGlobalProxy = globalObject->JSC::JSGlobalObject::getOwnPropertySlot(globalObject, globalObject, propertyName, slot);
@@ -1409,7 +1303,6 @@ void NodeVMGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     Base::visitChildren(cell, visitor);
     auto* thisObject = uncheckedDowncast<NodeVMGlobalObject>(cell);
     visitor.append(thisObject->m_sandbox);
-    visitor.append(thisObject->m_specialSandbox);
     visitor.append(thisObject->m_dynamicImportCallback);
 }
 
@@ -1562,13 +1455,6 @@ JSC_DEFINE_HOST_FUNCTION(vmModule_createContext, (JSGlobalObject * globalObject,
     JSObject* sandbox = asObject(contextArg);
 
     if (isContext(globalObject, sandbox)) {
-        if (auto* proxy = dynamicDowncast<JSC::JSGlobalProxy>(sandbox)) {
-            if (auto* targetContext = dynamicDowncast<NodeVMGlobalObject>(proxy->target())) {
-                if (targetContext->isNotContextified()) {
-                    return JSValue::encode(targetContext->specialSandbox());
-                }
-            }
-        }
         return JSValue::encode(sandbox);
     }
 
@@ -1580,18 +1466,18 @@ JSC_DEFINE_HOST_FUNCTION(vmModule_createContext, (JSGlobalObject * globalObject,
 
     RETURN_IF_EXCEPTION(scope, {});
 
+    if (notContextified) {
+        // DONT_CONTEXTIFY promises a vanilla global with no contextify
+        // interceptors, so hand back the new global's own proxy and leave
+        // m_sandbox unset so the method-table overrides fall through to Base.
+        return JSValue::encode(targetContext->globalThis());
+    }
+
     // Set sandbox as contextified object
     targetContext->setContextifiedObject(sandbox);
 
     // Store context in WeakMap for isContext checks
     zigGlobalObject->vmModuleContextMap()->set(vm, sandbox, targetContext);
-
-    if (notContextified) {
-        auto* specialSandbox = NodeVMSpecialSandbox::create(vm, targetContext);
-        RETURN_IF_EXCEPTION(scope, {});
-        targetContext->setSpecialSandbox(specialSandbox);
-        return JSValue::encode(targetContext->specialSandbox());
-    }
 
     return JSValue::encode(sandbox);
 }
@@ -1613,7 +1499,7 @@ const ClassInfo NodeVMGlobalObject::s_info = { "NodeVMGlobalObject"_s, &Base::s_
 bool NodeVMGlobalObject::deleteProperty(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, JSC::DeletePropertySlot& slot)
 {
     auto* thisObject = uncheckedDowncast<NodeVMGlobalObject>(cell);
-    if (!thisObject->m_sandbox) [[unlikely]] {
+    if (thisObject->isNotContextified() || !thisObject->m_sandbox) {
         return Base::deleteProperty(cell, globalObject, propertyName, slot);
     }
 

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -87,33 +87,6 @@ public:
     bool ownMicrotaskQueue = false;
 };
 
-class NodeVMGlobalObject;
-
-class NodeVMSpecialSandbox final : public JSC::JSNonFinalObject {
-public:
-    using Base = JSC::JSNonFinalObject;
-
-    static constexpr unsigned StructureFlags = Base::StructureFlags | JSC::OverridesGetOwnPropertySlot;
-
-    static NodeVMSpecialSandbox* create(VM& vm, NodeVMGlobalObject* globalObject);
-
-    DECLARE_INFO;
-    DECLARE_VISIT_CHILDREN;
-    template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm);
-    static Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype);
-
-    static bool getOwnPropertySlot(JSObject*, JSGlobalObject*, JSC::PropertyName, JSC::PropertySlot&);
-
-    NodeVMGlobalObject* parentGlobal() const { return m_parentGlobal.get(); }
-
-private:
-    WriteBarrier<NodeVMGlobalObject> m_parentGlobal;
-
-    NodeVMSpecialSandbox(VM& vm, Structure* structure, NodeVMGlobalObject* globalObject);
-
-    void finishCreation(VM&);
-};
-
 // This class represents a sandboxed global object for vm contexts
 class NodeVMGlobalObject final : public Bun::GlobalScope {
 public:
@@ -141,8 +114,6 @@ public:
     // Performs a microtask checkpoint on this context's own queue
     // (microtaskMode: "afterEvaluate" contexts only; no-op otherwise).
     void drainOwnMicrotasks();
-    NodeVMSpecialSandbox* specialSandbox() const { return m_specialSandbox.get(); }
-    void setSpecialSandbox(NodeVMSpecialSandbox* sandbox) { m_specialSandbox.set(vm(), this, sandbox); }
     JSValue dynamicImportCallback() const { return m_dynamicImportCallback.get(); }
 
     // Override property access to delegate to contextified object
@@ -157,8 +128,6 @@ public:
 private:
     // The contextified object that acts as the global proxy
     WriteBarrier<JSObject> m_sandbox;
-    // A special object used when the context is not contextified.
-    WriteBarrier<NodeVMSpecialSandbox> m_specialSandbox;
     WriteBarrier<Unknown> m_dynamicImportCallback;
     NodeVMContextOptions m_contextOptions {};
 

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -550,19 +550,19 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInNewContext, (JSGlobalObject * globalObject, 
         return {};
     }
 
-    // vm.ts runInNewContext() passes the DONT_CONTEXTIFY global created by createContext().
-    if (auto* proxy = dynamicDowncast<JSC::JSGlobalProxy>(contextObjectValue)) {
-        if (auto* existing = dynamicDowncast<NodeVMGlobalObject>(proxy->target()); existing && existing->isNotContextified()) {
-            RELEASE_AND_RETURN(scope, runInContext(existing, script, proxy, callFrame->argument(1)));
-        }
-    }
-
     JSValue contextOptionsArg = callFrame->argument(1);
     NodeVMContextOptions contextOptions {};
     JSValue importer;
 
     getNodeVMContextOptions(globalObject, vm, scope, contextOptionsArg, contextOptions, "contextCodeGeneration", &importer);
     RETURN_IF_EXCEPTION(scope, {});
+
+    // vm.ts runInNewContext() passes the DONT_CONTEXTIFY global created by createContext().
+    if (auto* proxy = dynamicDowncast<JSC::JSGlobalProxy>(contextObjectValue)) {
+        if (auto* existing = dynamicDowncast<NodeVMGlobalObject>(proxy->target()); existing && existing->isNotContextified()) {
+            RELEASE_AND_RETURN(scope, runInContext(existing, script, proxy, contextOptionsArg));
+        }
+    }
 
     contextOptions.notContextified = notContextified;
 

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -350,9 +350,7 @@ static JSC::EncodedJSValue runInContext(NodeVMGlobalObject* globalObject, NodeVM
         }
     }
 
-    // Set the contextified object before evaluating. A DONT_CONTEXTIFY context
-    // runs against the bare global (no sandbox interception), so leave
-    // m_sandbox unset there.
+    // A DONT_CONTEXTIFY context has no sandbox; its global is used directly.
     if (!globalObject->isNotContextified()) {
         globalObject->setContextifiedObject(contextifiedObject);
     }
@@ -552,9 +550,7 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInNewContext, (JSGlobalObject * globalObject, 
         return {};
     }
 
-    // vm.runInNewContext(code, DONT_CONTEXTIFY) hands us the vanilla context's
-    // global proxy (via createContext); run in that context rather than
-    // wrapping it as a contextified sandbox around a second global.
+    // vm.ts runInNewContext() passes the DONT_CONTEXTIFY global created by createContext().
     if (auto* proxy = dynamicDowncast<JSC::JSGlobalProxy>(contextObjectValue)) {
         if (auto* existing = dynamicDowncast<NodeVMGlobalObject>(proxy->target()); existing && existing->isNotContextified()) {
             RELEASE_AND_RETURN(scope, runInContext(existing, script, proxy, callFrame->argument(1)));

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -350,8 +350,12 @@ static JSC::EncodedJSValue runInContext(NodeVMGlobalObject* globalObject, NodeVM
         }
     }
 
-    // Set the contextified object before evaluating
-    globalObject->setContextifiedObject(contextifiedObject);
+    // Set the contextified object before evaluating. A DONT_CONTEXTIFY context
+    // runs against the bare global (no sandbox interception), so leave
+    // m_sandbox unset there.
+    if (!globalObject->isNotContextified()) {
+        globalObject->setContextifiedObject(contextifiedObject);
+    }
 
     NakedPtr<JSC::Exception> exception;
     JSValue result {};
@@ -548,6 +552,15 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInNewContext, (JSGlobalObject * globalObject, 
         return {};
     }
 
+    // vm.runInNewContext(code, DONT_CONTEXTIFY) hands us the vanilla context's
+    // global proxy (via createContext); run in that context rather than
+    // wrapping it as a contextified sandbox around a second global.
+    if (auto* proxy = dynamicDowncast<JSC::JSGlobalProxy>(contextObjectValue)) {
+        if (auto* existing = dynamicDowncast<NodeVMGlobalObject>(proxy->target()); existing && existing->isNotContextified()) {
+            RELEASE_AND_RETURN(scope, runInContext(existing, script, proxy, callFrame->argument(1)));
+        }
+    }
+
     JSValue contextOptionsArg = callFrame->argument(1);
     NodeVMContextOptions contextOptions {};
     JSValue importer;
@@ -565,10 +578,7 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInNewContext, (JSGlobalObject * globalObject, 
     RETURN_IF_EXCEPTION(scope, {});
 
     if (notContextified) {
-        auto* specialSandbox = NodeVMSpecialSandbox::create(vm, targetContext);
-        RETURN_IF_EXCEPTION(scope, {});
-        targetContext->setSpecialSandbox(specialSandbox);
-        RELEASE_AND_RETURN(scope, runInContext(targetContext, script, targetContext->specialSandbox(), callFrame->argument(1)));
+        RELEASE_AND_RETURN(scope, runInContext(targetContext, script, targetContext->globalThis(), callFrame->argument(1)));
     }
 
     RELEASE_AND_RETURN(scope, runInContext(targetContext, script, context, callFrame->argument(1)));

--- a/src/jsc/bindings/webcore/DOMClientIsoSubspaces.h
+++ b/src/jsc/bindings/webcore/DOMClientIsoSubspaces.h
@@ -39,7 +39,6 @@ public:
     GCClient::IsoSubspace* m_clientSubspaceForNapiExternal { nullptr };
     GCClient::IsoSubspace* m_clientSubspaceForBundlerPlugin { nullptr };
     GCClient::IsoSubspace* m_clientSubspaceForNodeVMGlobalObject { nullptr };
-    GCClient::IsoSubspace* m_clientSubspaceForNodeVMSpecialSandbox { nullptr };
     GCClient::IsoSubspace* m_clientSubspaceForNodeVMScript { nullptr };
     GCClient::IsoSubspace* m_clientSubspaceForNodeVMSourceTextModule { nullptr };
     GCClient::IsoSubspace* m_clientSubspaceForNodeVMSyntheticModule { nullptr };

--- a/src/jsc/bindings/webcore/DOMIsoSubspaces.h
+++ b/src/jsc/bindings/webcore/DOMIsoSubspaces.h
@@ -40,7 +40,6 @@ public:
     IsoSubspace* m_subspaceForImportMeta { nullptr };
     IsoSubspace* m_subspaceForBundlerPlugin { nullptr };
     IsoSubspace* m_subspaceForNodeVMGlobalObject { nullptr };
-    IsoSubspace* m_subspaceForNodeVMSpecialSandbox { nullptr };
     IsoSubspace* m_subspaceForNodeVMScript { nullptr };
     IsoSubspace* m_subspaceForNodeVMSourceTextModule { nullptr };
     IsoSubspace* m_subspaceForNodeVMSyntheticModule { nullptr };

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1305,6 +1305,54 @@ describe("DONT_CONTEXTIFY", () => {
     ctx.fromOutside = 456;
     expect(runInContext("fromOutside", ctx)).toBe(456);
   });
+
+  test("script-level this === globalThis and var/function declarations land on the real global", () => {
+    const ctx = createContext(constants.DONT_CONTEXTIFY);
+
+    expect(runInContext("this === globalThis", ctx)).toBe(true);
+    expect(runInContext("this", ctx)).toBe(ctx);
+
+    runInContext("var vv = 3; function ff() { return 99; }", ctx);
+    expect({
+      varPersists: runInContext("typeof vv", ctx),
+      fnPersists: runInContext("typeof ff", ctx),
+      varValue: runInContext("vv", ctx),
+      fnCall: runInContext("ff()", ctx),
+      handleVar: ctx.vv,
+      handleFnType: typeof ctx.ff,
+      sameScript: runInContext("var zz = 9; typeof zz", ctx),
+      indirectEvalVar: runInContext("(0, eval)('var ie = 7'); typeof ie", ctx),
+    }).toEqual({
+      varPersists: "number",
+      fnPersists: "function",
+      varValue: 3,
+      fnCall: 99,
+      handleVar: 3,
+      handleFnType: "function",
+      sameScript: "number",
+      indirectEvalVar: "number",
+    });
+
+    // Script#runInContext goes through the same path.
+    const script = new Script("var sv = 42; sv");
+    expect(script.runInContext(ctx)).toBe(42);
+    expect(runInContext("sv", ctx)).toBe(42);
+    expect(ctx.sv).toBe(42);
+  });
+
+  test("var/function declarations work via runInNewContext", () => {
+    expect(
+      runInNewContext(
+        "var a = 1; function b(){}; [this === globalThis, typeof a, typeof b]",
+        constants.DONT_CONTEXTIFY,
+      ),
+    ).toEqual([true, "number", "function"]);
+    expect(
+      new Script("var a = 1; function b(){}; [this === globalThis, typeof a, typeof b]").runInNewContext(
+        constants.DONT_CONTEXTIFY,
+      ),
+    ).toEqual([true, "number", "function"]);
+  });
 });
 
 test("Loader is not defined in vm context", () => {

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1188,8 +1188,10 @@ describe("context options with throwing getters", () => {
   // the process, so run the matrix in a subprocess.
   test.concurrent("the getter's exception propagates to the caller", async () => {
     // Each entry point tests the context-option keys it actually reads:
-    // createContext takes codeGeneration, Script#runInNewContext takes
-    // contextCodeGeneration, and vm.runInNewContext goes through both.
+    // createContext takes codeGeneration; Script#runInNewContext and
+    // vm.runInNewContext take contextCodeGeneration (vm.runInNewContext remaps
+    // it to codeGeneration before calling createContext, like Node, so a
+    // nested codeGeneration.* getter is never read there).
     // A dotted key puts the throwing getter on the nested object.
     const codeGenerationKeys = (key: string) => [key, `${key}.strings`, `${key}.wasm`];
     const contextKeys = (...codeGenerationKeyNames: string[]) => [
@@ -1201,7 +1203,7 @@ describe("context options with throwing getters", () => {
     ];
     const matrix = {
       createContext: contextKeys("codeGeneration"),
-      runInNewContext: contextKeys("codeGeneration", "contextCodeGeneration"),
+      runInNewContext: contextKeys("contextCodeGeneration"),
       scriptRunInNewContext: contextKeys("contextCodeGeneration"),
     };
     const code = `
@@ -1338,6 +1340,17 @@ describe("DONT_CONTEXTIFY", () => {
     expect(script.runInContext(ctx)).toBe(42);
     expect(runInContext("sv", ctx)).toBe(42);
     expect(ctx.sv).toBe(42);
+  });
+
+  test("vm.runInNewContext honors contextCodeGeneration with DONT_CONTEXTIFY", () => {
+    let thrown: unknown;
+    try {
+      runInNewContext("eval('1')", constants.DONT_CONTEXTIFY, { contextCodeGeneration: { strings: false } });
+    } catch (e) {
+      thrown = e;
+    }
+    // The EvalError comes from the context's own realm, so compare by name.
+    expect((thrown as Error)?.name).toBe("EvalError");
   });
 
   test("var/function declarations work via runInNewContext", () => {

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1356,6 +1356,14 @@ describe("DONT_CONTEXTIFY", () => {
     expect((thrown as Error)?.name).toBe("EvalError");
   });
 
+  test("invalid contextCodeGeneration is rejected when reusing a DONT_CONTEXTIFY context", () => {
+    const ctx = createContext(constants.DONT_CONTEXTIFY);
+    const invalid = expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" });
+    expect(() => new Script("1").runInNewContext(ctx, { contextCodeGeneration: 123 })).toThrow(invalid);
+    expect(() => new Script("1").runInNewContext(ctx, { contextCodeGeneration: { strings: 123 } })).toThrow(invalid);
+    expect(() => runInNewContext("1", ctx, { contextCodeGeneration: 123 })).toThrow(invalid);
+  });
+
   test("var/function declarations work via runInNewContext", () => {
     expect(
       runInNewContext(

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1346,14 +1346,25 @@ describe("DONT_CONTEXTIFY", () => {
   });
 
   test("vm.runInNewContext honors contextCodeGeneration with DONT_CONTEXTIFY", () => {
-    let thrown: unknown;
-    try {
-      runInNewContext("eval('1')", constants.DONT_CONTEXTIFY, { contextCodeGeneration: { strings: false } });
-    } catch (e) {
-      thrown = e;
-    }
-    // The EvalError comes from the context's own realm, so compare by name.
-    expect((thrown as Error)?.name).toBe("EvalError");
+    // The errors come from the context's own realm, so compare by name.
+    const thrownName = (code: string, contextCodeGeneration: object) => {
+      try {
+        runInNewContext(code, constants.DONT_CONTEXTIFY, { contextCodeGeneration });
+      } catch (e) {
+        return (e as Error).name;
+      }
+      return "did not throw";
+    };
+    const wasmModule = "new WebAssembly.Module(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0]))";
+    expect({
+      strings: thrownName("eval('1')", { strings: false }),
+      wasm: thrownName(wasmModule, { wasm: false }),
+      wasmAllowedByDefault: thrownName(wasmModule, {}),
+    }).toEqual({
+      strings: "EvalError",
+      wasm: "CompileError",
+      wasmAllowedByDefault: "did not throw",
+    });
   });
 
   test("invalid contextCodeGeneration is rejected when reusing a DONT_CONTEXTIFY context", () => {

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1315,6 +1315,7 @@ describe("DONT_CONTEXTIFY", () => {
     expect(runInContext("this", ctx)).toBe(ctx);
 
     runInContext("var vv = 3; function ff() { return 99; }", ctx);
+    runInContext("(0, eval)('var ie = 7')", ctx);
     expect({
       varPersists: runInContext("typeof vv", ctx),
       fnPersists: runInContext("typeof ff", ctx),
@@ -1323,7 +1324,8 @@ describe("DONT_CONTEXTIFY", () => {
       handleVar: ctx.vv,
       handleFnType: typeof ctx.ff,
       sameScript: runInContext("var zz = 9; typeof zz", ctx),
-      indirectEvalVar: runInContext("(0, eval)('var ie = 7'); typeof ie", ctx),
+      indirectEvalVarPersists: runInContext("ie", ctx),
+      handleIndirectEvalVar: ctx.ie,
     }).toEqual({
       varPersists: "number",
       fnPersists: "function",
@@ -1332,7 +1334,8 @@ describe("DONT_CONTEXTIFY", () => {
       handleVar: 3,
       handleFnType: "function",
       sameScript: "number",
-      indirectEvalVar: "number",
+      indirectEvalVarPersists: 7,
+      handleIndirectEvalVar: 7,
     });
 
     // Script#runInContext goes through the same path.
@@ -1365,6 +1368,18 @@ describe("DONT_CONTEXTIFY", () => {
         constants.DONT_CONTEXTIFY,
       ),
     ).toEqual([true, "number", "function"]);
+
+    // Passing an existing DONT_CONTEXTIFY handle runs in that context, so the
+    // declarations stay visible through the handle and to later scripts.
+    const ctx = createContext(constants.DONT_CONTEXTIFY);
+    runInNewContext("var q = 1; function qf() { return 2; }", ctx);
+    new Script("var r = 3").runInNewContext(ctx);
+    expect({ q: ctx.q, qf: typeof ctx.qf, r: ctx.r, later: runInContext("[q, qf(), r]", ctx) }).toEqual({
+      q: 1,
+      qf: "function",
+      r: 3,
+      later: [1, 2, 3],
+    });
   });
 
   test("compileFunction accepts a DONT_CONTEXTIFY context as parsingContext", () => {

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1366,6 +1366,15 @@ describe("DONT_CONTEXTIFY", () => {
       ),
     ).toEqual([true, "number", "function"]);
   });
+
+  test("compileFunction accepts a DONT_CONTEXTIFY context as parsingContext", () => {
+    const ctx = createContext(constants.DONT_CONTEXTIFY);
+    const fn = compileFunction("return [globalThis === g, Array]", ["g"], { parsingContext: ctx });
+    const [isContextGlobal, ctxArray] = fn(ctx);
+    expect(isContextGlobal).toBe(true);
+    expect(ctxArray).toBe(ctx.Array);
+    expect(ctxArray).not.toBe(Array);
+  });
 });
 
 test("Loader is not defined in vm context", () => {


### PR DESCRIPTION
### What does this PR do?

In a `vm.constants.DONT_CONTEXTIFY` context, top-level `this !== globalThis`, and every top-level `var` / `function` declaration was silently lost:

```js
import * as vm from "node:vm";
const c = vm.createContext(vm.constants.DONT_CONTEXTIFY);
vm.runInContext("this === globalThis", c);            // node: true     bun: false
vm.runInContext("var vv = 3; function ff(){}", c);
vm.runInContext("typeof vv", c);                      // node: "number"   bun: "undefined"
vm.runInContext("typeof ff", c);                      // node: "function" bun: "undefined"
c.vv;                                                 // node: 3          bun: undefined
vm.runInContext("(0,eval)('var ie=7'); typeof ie", c);// node: "number"   bun: "undefined"
```

The mode's whole contract (Node 22.8+) is "run code against the real, un-proxied global", so REPL/test hosts that rely on it break on the first declaration.

**Cause:** `createContext(DONT_CONTEXTIFY)` returned a `NodeVMSpecialSandbox` wrapper, and `runInContext` installed it as `m_sandbox`, so `NodeVMGlobalObject`'s contextify interceptors were active. JSC's `createGlobalVarBinding` then added the `var`/`function` slot to the global's symbol table (value `undefined`), while `put` was diverted to the wrapper, and subsequent lookups hit the symbol-table `undefined` first. Script-level `this` was the global proxy while `globalThis` was intercepted to return the wrapper.

**Fix:** a `DONT_CONTEXTIFY` context now returns the new global's own `globalThis()` proxy and never sets `m_sandbox`. Every `NodeVMGlobalObject` method-table override (`put`, `getOwnPropertySlot`, `defineOwnProperty`, `deleteProperty`) falls straight through to `Base::*` when `isNotContextified()`, so scripts run against the unintercepted global exactly as the mode promises. `Script#runInNewContext` reuses the existing vanilla context when handed its proxy instead of wrapping it as a sandbox around a second global. `NodeVMSpecialSandbox` is removed.

A second commit fixes a related option bug that the first commit exposed: `vm.runInNewContext(code, ctx, opts)` forwarded `opts` verbatim to `createContext`, which reads `codeGeneration`, so the documented `contextCodeGeneration` key was never applied on that path. `vm.ts` now remaps it with a `getContextOptions` helper that mirrors Node's `lib/vm.js`. The "throwing getters" matrix test is updated to match: like Node, `vm.runInNewContext` no longer reads nested `codeGeneration.*` keys.

A third commit closes the same gap in `vm.compileFunction`: `parsingContext` was resolved through `vmModuleContextMap` only, so a `DONT_CONTEXTIFY` handle (which is the context's global proxy and is not in that map) was rejected with `ERR_INVALID_ARG_TYPE` where Node accepts it. It now goes through `getGlobalObjectFromContext`, like the module entry points already do.

### How did you verify your code works?

New cases in `test/js/node/vm/vm.test.ts` under the `DONT_CONTEXTIFY` describe block cover `this === globalThis`, `var`/`function`/indirect-eval-var persistence across `runInContext` calls, visibility on the returned handle, both `runInNewContext` entry points, `contextCodeGeneration` on `vm.runInNewContext(..., DONT_CONTEXTIFY)`, and a `DONT_CONTEXTIFY` handle as `compileFunction`'s `parsingContext`.

```
# without the fix (main):  4 new tests fail
# with the fix (bun bd):   vm.test.ts 281 pass / 0 fail
```

Also ran the full `node:vm` parallel compat suite (`test/js/node/test/parallel/test-vm-*.js`, 95 files) and the other `test/js/node/vm/*.test.ts` files to green, including `test-vm-context-dont-contextify.js`.

Rebased onto current main twice. Conflicts were all in code this branch deletes or touches by one line: main removed the unused `vmModuleRunInNewContext` / `vmModuleRunInThisContext` host functions this branch had edited (took main's deletion), later refactored the `NodeVMSpecialSandbox` definitions this branch removes (kept the removal), and changed the `DOMIsoSubspaces` / `DOMClientIsoSubspaces` declarations to raw pointers (kept main's form, minus the one `NodeVMSpecialSandbox` slot).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/vm/vm.test.ts

<!-- robobun:evidence:end -->


