### PR TITLE
Bun.serve: 404 on `false` routes when no fetch handler is configured

### DIFF
--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2305,18 +2305,20 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         }
 
         // --- 4. Register negative routes ---
+        // A `false` route means "fall through to the default handler": same
+        // ladder as the `/*` fallback in step 9. H3 stays on on_h3_request,
+        // which already falls back to on_h3_404 when on_request is empty.
+        let negative_h1 = if !self.config.on_node_http_request.is_empty() {
+            trampoline::on_node_http_request::<SSL, DEBUG>
+        } else if !self.config.on_request.is_empty() {
+            trampoline::on_request::<SSL, DEBUG>
+        } else {
+            trampoline::on_404::<SSL, DEBUG>
+        };
         for route_path in self.config.negative_routes.iter() {
             let p = route_path.as_bytes();
-            app.head(
-                p,
-                Some(trampoline::on_request::<SSL, DEBUG>),
-                self_ptr.cast(),
-            );
-            app.any(
-                p,
-                Some(trampoline::on_request::<SSL, DEBUG>),
-                self_ptr.cast(),
-            );
+            app.head(p, Some(negative_h1), self_ptr.cast());
+            app.any(p, Some(negative_h1), self_ptr.cast());
             if Self::HAS_H3 {
                 if let Some(h3_app) = self.h3_app {
                     // S008: `h3::App` is an `opaque_ffi!` ZST — safe deref.

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -1,7 +1,7 @@
 import type { BunRequest, ServeOptions, Server } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
-import net from "node:net";
 import { bunEnv, bunExe } from "harness";
+import net from "node:net";
 
 describe("path parameters", () => {
   let server: Server;

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -1041,7 +1041,6 @@ describe.concurrent("false route with no fetch handler", () => {
     expect(ok.status).toBe(200);
 
     proc.kill();
-    const [stderr] = await Promise.all([proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
+    await proc.exited;
   });
 });

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -1,6 +1,7 @@
 import type { BunRequest, ServeOptions, Server } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
 import net from "node:net";
+import { bunEnv, bunExe } from "harness";
 
 describe("path parameters", () => {
   let server: Server;
@@ -991,4 +992,56 @@ it("routes absolute-form request targets by path and derives request.url from th
     expect(rawUrl.pathname).toBe("/");
     expect(rawUrl.search).toBe(new URL(target).search);
   }
+});
+
+describe.concurrent("false route with no fetch handler", () => {
+  // A route value of `false` must fall through to the default handler. With no
+  // `fetch` configured that default is the built-in 404, not a call through an
+  // empty handler slot (which crashed the server process).
+  const serverSrc = /* ts */ `
+    const srv = Bun.serve({
+      port: 0,
+      development: false,
+      routes: {
+        "/x": new Response("x"),
+        "/off": false,
+        "/off/:id": false,
+        "/wild/*": false,
+      },
+    });
+    process.send!({ port: srv.port });
+  `;
+
+  test.each([
+    ["exact", "/off"],
+    ["param", "/off/7"],
+    ["wildcard", "/wild/z"],
+  ])("%s route 404s and the server survives", async (_label, path) => {
+    const { promise: portPromise, resolve: gotPort } = Promise.withResolvers<number>();
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", serverSrc],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      ipc(message: { port: number }) {
+        gotPort(message.port);
+      },
+    });
+    const port = await Promise.race([
+      portPromise,
+      proc.exited.then(code => Promise.reject(new Error(`server exited (${code}) before listening`))),
+    ]);
+
+    const res = await fetch(`http://127.0.0.1:${port}${path}`);
+    expect(res.status).toBe(404);
+
+    // The server must still be serving after the request above.
+    const ok = await fetch(`http://127.0.0.1:${port}/x`);
+    expect(await ok.text()).toBe("x");
+    expect(ok.status).toBe(200);
+
+    proc.kill();
+    const [stderr] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+  });
 });


### PR DESCRIPTION
A route value of `false` is the documented way to disable a route and fall through to the default handler. When a server has `routes` but no top-level `fetch`, requesting a `false` route crashes the process: release builds SEGV at 0x0, assert builds hit `panic: assertion failed: !on_request.is_empty()`.

```ts
const srv = Bun.serve({
  port: 0,
  routes: {
    "/x": new Response("x"),
    "/off": false,
  },
});
// GET /off  ->  server process dies (SEGV / assert abort)
```

### Cause

`set_routes` step 4 registers every negative route directly against `trampoline::on_request`, which dispatches the user `fetch` handler. With no `fetch` configured, `config.on_request` is empty; `NewServer::on_request` asserts on that (`debug_assert!(!on_request.is_empty())`) and then calls through the empty `JSValue` anyway. The negative-route registration is a concrete path in uWS, so it wins over the `/*` 404 fallback that step 9 installs for unmatched paths.

### Fix

Select the negative-route handler with the same ladder step 9 already uses for the `/*` fallback: `on_node_http_request` when present, else `on_request` when present, else `on_404`. H3 is unchanged; `on_h3_request` already falls back to `on_h3_404` at runtime when `on_request` is empty.

### Verification

New cases in `test/js/bun/http/bun-serve-routes.test.ts` spawn a routes-only server (no `fetch`) and request exact, param, and wildcard `false` routes. On 1.4.0 all three fail with `ECONNRESET` (server crashed); with this change they return 404 and a follow-up request to a live route still succeeds.

### Related crash reports

The `RouteHandler` / `executeHandlers` SEGV signature here matches #22809 (Linux x64, SEGV at 0x0, routes-only static server) and likely #22927 (macOS arm64, HTTPS). Neither issue includes a server config, so they are referenced rather than auto-closed.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-routes.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (fb5ca396b)

test/js/bun/http/bun-serve-routes.test.ts:
(pass) path parameters > handles single parameter [30.24ms]
RequestParams {
  postId: "456",
  commentId: "789",
}
(pass) path parameters > handles multiple parameters [22.40ms]
(pass) path parameters > handles encoded parameters [13.87ms]
(pass) path parameters > handles unicode parameters [8.31ms]
(pass) path parameters > decodes raw valid UTF-8 bytes in a parameter segment [389.31ms]
(pass) path parameters > decodes raw an invalid UTF-8 byte in a parameter segment [55.17ms]
(pass) HTTP methods > GET request [26.35ms]
(pass) HTTP methods > POST request [5.66ms]
(pass) HTTP methods > PUT request [10.76ms]
(pass) HTTP methods > DELETE request [4.99ms]
(pass) HTTP methods
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (ae060236e)

test/js/bun/http/bun-serve-routes.test.ts:
(pass) path parameters > handles single parameter [1.43ms]
RequestParams {
  postId: "456",
  commentId: "789",
}
(pass) path parameters > handles multiple parameters [0.36ms]
(pass) path parameters > handles encoded parameters [0.20ms]
(pass) path parameters > handles unicode parameters [0.18ms]
(pass) path parameters > decodes raw valid UTF-8 bytes in a parameter segment [5.87ms]
(pass) path parameters > decodes raw an invalid UTF-8 byte in a parameter segment [1.00ms]
(pass) HTTP methods > GET request [1.47ms]
(pass) HTTP methods > POST request [0.16ms]
(pass) HTTP methods > PUT request [0.11ms]
(pass) HTTP methods > DELETE request [0.12ms]
(pass) HTTP methods > PATCH request [0.09ms]
(pass) HTTP methods > OPTIONS request [0.09ms]
(pass) HTTP methods > HEAD request [0.10ms]
(pass) implicit HEAD for per-method route objects > HEAD is served by the GET handler when no HEAD handler is declared [1.64ms]
(pass) implicit HEAD for per-method route objects > HEAD does not 404 when there is no later route to fall through to [1.16ms]
(pass) implicit HEAD for per-method route objects > the GET 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-routes.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (fb5ca396b)

test/js/bun/http/bun-serve-routes.test.ts:
(pass) path parameters > handles single parameter [24.93ms]
RequestParams {
  postId: "456",
  commentId: "789",
}
(pass) path parameters > handles multiple parameters [16.37ms]
(pass) path parameters > handles encoded parameters [13.82ms]
(pass) path parameters > handles unicode parameters [7.64ms]
(pass) path parameters > decodes raw valid UTF-8 bytes in a parameter segment [376.05ms]
(pass) path parameters > decodes raw an invalid UTF-8 byte in a parameter segment [53.06ms]
(pass) HTTP methods > GET request [26.72ms]
(pass) HTTP methods > POST request [5.11ms]
(pass) HTTP methods > PUT request [11.56ms]
(pass) HTTP methods > DELETE request [5.29ms]
(pass) HTTP methods
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 809ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/server/mod.rs                 | 22 +++++++------
 test/js/bun/http/bun-serve-routes.test.ts | 52 +++++++++++++++++++++++++++++++
 2 files changed, 64 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/runtime/server/mod.rs                      4      1      0
test/js/bun/http/bun-serve-routes.test.ts      3      4      0
```

</details>

<!-- robobun:evidence:end -->