### PR TITLE
Bun.serve: don't send two Date headers on static routes when the Response already has one

### DIFF
--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -43,6 +43,7 @@ pub struct FileRoute {
     has_last_modified_header: bool,
     has_content_length_header: bool,
     has_content_range_header: bool,
+    has_date_header: bool,
 }
 
 pub struct InitOptions<'a> {
@@ -122,6 +123,7 @@ impl FileRoute {
             has_last_modified_header: headers.get(b"last-modified").is_some(),
             has_content_length_header: headers.get(b"content-length").is_some(),
             has_content_range_header: headers.get(b"content-range").is_some(),
+            has_date_header: headers.get(b"date").is_some(),
             blob,
             headers,
             status_code: opts.status_code,
@@ -181,6 +183,7 @@ impl FileRoute {
                     has_last_modified_header: headers.get(b"last-modified").is_some(),
                     has_content_length_header: headers.get(b"content-length").is_some(),
                     has_content_range_header: headers.get(b"content-range").is_some(),
+                    has_date_header: headers.get(b"date").is_some(),
                     blob,
                     headers,
                     status_code,
@@ -205,6 +208,7 @@ impl FileRoute {
                     has_content_length_header: false,
                     has_last_modified_header: false,
                     has_content_range_header: false,
+                    has_date_header: false,
                     status_code: 200,
                     stat_hash: Cell::new(StatHash::default()),
                 }))));
@@ -500,6 +504,9 @@ impl FileRoute {
         req.set_yield(false);
 
         this.write_status_code(status_code, resp);
+        if this.has_date_header {
+            resp.mark_wrote_date_header();
+        }
         resp.write_mark();
         this.write_headers(resp);
 

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -666,6 +666,7 @@ impl Route {
                         headers,
                         cached_blob_size,
                         has_content_disposition: false,
+                        has_date: false,
                     }));
 
                     let mut route_path: &[u8] = &output_files[i].dest_path;

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -36,6 +36,7 @@ pub struct StaticRoute {
     pub blob: AnyBlob,
     pub cached_blob_size: u64,
     pub has_content_disposition: bool,
+    pub has_date: bool,
     pub headers: Headers,
 }
 
@@ -102,11 +103,13 @@ impl StaticRoute {
         }
 
         let cached_blob_size = blob.size();
+        let has_date = headers.get(b"date").is_some();
         bun_core::heap::into_raw(Box::new(StaticRoute {
             ref_count: Cell::new(1),
             blob,
             cached_blob_size,
             has_content_disposition: false,
+            has_date,
             headers,
             server: Cell::new(options.server),
             status_code: options.status_code,
@@ -138,6 +141,7 @@ impl StaticRoute {
             blob: AnyBlob::Blob(duped),
             cached_blob_size: self.cached_blob_size,
             has_content_disposition: self.has_content_disposition,
+            has_date: self.has_date,
             headers: self.headers.clone(),
             server: Cell::new(self.server.get()),
             status_code: self.status_code,
@@ -246,11 +250,13 @@ impl StaticRoute {
             }
 
             let cached_blob_size = blob.size();
+            let has_date = headers.get(b"date").is_some();
             return Ok(Some(bun_core::heap::into_raw(Box::new(StaticRoute {
                 ref_count: Cell::new(1),
                 blob,
                 cached_blob_size,
                 has_content_disposition,
+                has_date,
                 headers,
                 server: Cell::new(None),
                 status_code: response.status_code(),
@@ -483,6 +489,11 @@ impl StaticRoute {
 
     fn do_write_headers(&self, resp: AnyResponse) {
         use bun_http_types::ETag::HeaderEntryColumns;
+        // Date is a singleton field (RFC 9110 §6.6.1); when the snapshot already
+        // carries one, suppress uWS's auto-Date so only the user's value is sent.
+        if self.has_date {
+            resp.mark_wrote_date_header();
+        }
         let entries = self.headers.entries.slice();
         let names: &[StringPointer] = entries.items_name();
         let values: &[StringPointer] = entries.items_value();

--- a/src/uws_sys/Response.rs
+++ b/src/uws_sys/Response.rs
@@ -325,6 +325,10 @@ impl<const SSL: bool> Response<SSL> {
         c::uws_res_mark_wrote_content_length_header(Self::ssl_flag(), self.as_raw())
     }
 
+    pub fn mark_wrote_date_header(&mut self) {
+        c::uws_res_mark_wrote_date_header(Self::ssl_flag(), self.as_raw())
+    }
+
     pub fn write_mark(&mut self) {
         c::uws_res_write_mark(Self::ssl_flag(), self.as_raw())
     }
@@ -731,6 +735,10 @@ impl AnyResponse {
         any_dispatch!(self, |r| r.mark_wrote_content_length_header())
     }
 
+    pub fn mark_wrote_date_header(self) {
+        any_dispatch!(self, |r| r.mark_wrote_date_header())
+    }
+
     pub fn write_mark(self) {
         any_dispatch!(self, |r| r.write_mark())
     }
@@ -1083,6 +1091,7 @@ pub mod c {
     // unsafe.
     unsafe extern "C" {
         pub(crate) safe fn uws_res_mark_wrote_content_length_header(ssl: i32, res: &mut uws_res);
+        pub(crate) safe fn uws_res_mark_wrote_date_header(ssl: i32, res: &mut uws_res);
         pub(crate) safe fn uws_res_write_mark(ssl: i32, res: &mut uws_res);
         pub(crate) safe fn us_socket_mark_needs_more_not_ssl(socket: &mut uws_res);
         pub(crate) safe fn uws_res_state(ssl: c_int, res: &uws_res) -> State;

--- a/src/uws_sys/h3.rs
+++ b/src/uws_sys/h3.rs
@@ -188,6 +188,9 @@ impl Response {
     pub fn mark_wrote_content_length_header(&mut self) {
         c::uws_h3_res_mark_wrote_content_length_header(self)
     }
+    pub fn mark_wrote_date_header(&mut self) {
+        c::uws_h3_res_mark_wrote_date_header(self)
+    }
     pub fn write_continue(&mut self) {
         c::uws_h3_res_write_continue(self)
     }
@@ -730,6 +733,7 @@ mod c {
             v: u64,
         );
         pub(super) safe fn uws_h3_res_mark_wrote_content_length_header(res: &mut Response);
+        pub(super) safe fn uws_h3_res_mark_wrote_date_header(res: &mut Response);
         pub(super) safe fn uws_h3_res_write_mark(res: &mut Response);
         pub(super) safe fn uws_h3_res_flush_headers(res: &mut Response, immediate: bool);
         pub(super) fn uws_h3_res_write(res: *mut Response, p: *const u8, len: *mut usize) -> bool;

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -1265,6 +1265,16 @@ extern "C"
     }
   }
 
+  void uws_res_mark_wrote_date_header(int ssl, uws_res_r res) {
+    if (ssl) {
+      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+      uwsRes->getHttpResponseData()->state |= uWS::HttpResponseData<true>::HTTP_WROTE_DATE_HEADER;
+    } else {
+      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
+      uwsRes->getHttpResponseData()->state |= uWS::HttpResponseData<false>::HTTP_WROTE_DATE_HEADER;
+    }
+  }
+
   void uws_res_write_mark(int ssl, uws_res_r res) {
     if (ssl) {
       uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;

--- a/src/uws_sys/libuwsockets_h3.cpp
+++ b/src/uws_sys/libuwsockets_h3.cpp
@@ -161,6 +161,11 @@ void uws_h3_res_mark_wrote_content_length_header(uws_h3_res_t* res)
     ((Http3Response*)res)->getHttpResponseData()->state |= Http3ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER;
 }
 
+void uws_h3_res_mark_wrote_date_header(uws_h3_res_t* res)
+{
+    ((Http3Response*)res)->getHttpResponseData()->state |= Http3ResponseData::HTTP_WROTE_DATE_HEADER;
+}
+
 void uws_h3_res_write_mark(uws_h3_res_t* res) { ((Http3Response*)res)->writeMark(); }
 void uws_h3_res_flush_headers(uws_h3_res_t* res, bool) { ((Http3Response*)res)->flushHeaders(); }
 

--- a/test/js/bun/http/bun-serve-static.test.ts
+++ b/test/js/bun/http/bun-serve-static.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it, mock, test } from "bun:test";
-import { isBroken, isMacOS } from "harness";
+import { isBroken, isMacOS, tempDir } from "harness";
 import { routes, static_responses } from "./bun-serve-static-helpers";
 
 describe.todoIf(isBroken && isMacOS)("static", () => {
@@ -167,5 +167,88 @@ describe("static route Content-Type", () => {
 
     expect(await (await fetch(new URL("/a", server.url))).text()).toBe("▲");
     expect(await (await fetch(new URL("/b", server.url))).text()).toBe("▲");
+  });
+});
+
+// RFC 9110 §6.6.1: Date is a singleton field. When a Response already carries a
+// Date header, the static-route serializer must not append Bun's own clock.
+describe("static route Date header", () => {
+  const pinned = "Mon, 01 Jan 2001 00:00:00 GMT";
+
+  async function rawDateLines(port: number, path: string, method = "GET") {
+    const { promise, resolve } = Promise.withResolvers<string>();
+    let buf = "";
+    await Bun.connect({
+      hostname: "127.0.0.1",
+      port,
+      socket: {
+        open(s) {
+          s.write(`${method} ${path} HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n`);
+        },
+        data(_s, d) {
+          buf += Buffer.from(d).toString("latin1");
+        },
+        close() {
+          resolve(buf);
+        },
+        error() {
+          resolve(buf);
+        },
+      },
+    });
+    const head = (await promise).split("\r\n\r\n")[0];
+    return head.split("\r\n").filter(l => /^date:/i.test(l));
+  }
+
+  test("a user-set Date is sent exactly once", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      development: false,
+      routes: {
+        "/static": new Response("B", { headers: { date: pinned } }),
+        "/handler": () => new Response("B", { headers: { date: pinned } }),
+      },
+      fetch: () => new Response("B", { headers: { date: pinned } }),
+    });
+
+    expect({
+      static: await rawDateLines(server.port, "/static"),
+      handler: await rawDateLines(server.port, "/handler"),
+      fallback: await rawDateLines(server.port, "/fallback"),
+    }).toEqual({
+      static: [`Date: ${pinned}`],
+      handler: [`Date: ${pinned}`],
+      fallback: [`Date: ${pinned}`],
+    });
+
+    // HEAD and 304 go through the same header-writing path.
+    expect(await rawDateLines(server.port, "/static", "HEAD")).toEqual([`Date: ${pinned}`]);
+  });
+
+  test("a user-set Date on a Bun.file route is sent exactly once", async () => {
+    using dir = tempDir("static-date", { "a.txt": "hi" });
+    await using server = Bun.serve({
+      port: 0,
+      development: false,
+      routes: {
+        "/file": new Response(Bun.file(`${dir}/a.txt`), { headers: { date: pinned } }),
+      },
+      fetch: () => new Response("fallback"),
+    });
+
+    expect(await rawDateLines(server.port, "/file")).toEqual([`Date: ${pinned}`]);
+  });
+
+  test("without a user-set Date, exactly one auto Date is sent", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      development: false,
+      routes: { "/static": new Response("B") },
+      fetch: () => new Response("fallback"),
+    });
+
+    const dates = await rawDateLines(server.port, "/static");
+    expect(dates).toHaveLength(1);
+    expect(dates[0]).not.toContain(pinned);
   });
 });


### PR DESCRIPTION
## What

A `Bun.serve` static route whose `Response` already carries a `Date` header was serving **two** `Date` fields on the wire: the user's pinned value followed by Bun's own wall-clock value. RFC 9110 6.6.1 defines `Date` as a singleton field, and the two values disagree by construction, which confuses cache freshness/age computation (RFC 9111 4.2.3). The same `Response` served via a handler route or the `fetch` fallback correctly sends exactly one `Date`.

```js
const mk = () => new Response("B", { headers: { date: "Mon, 01 Jan 2001 00:00:00 GMT" } });
const srv = Bun.serve({
  port: 0, development: false,
  routes: { "/static": mk(), "/handler": () => mk() },
  fetch: () => mk(),
});
```

Raw HTTP/1.1 response for `GET /static`:
```
Date: Mon, 01 Jan 2001 00:00:00 GMT
Date: Sat, 18 Jul 2026 10:30:08 GMT
```
while `/handler` and the fetch fallback send only the user's `Date`.

## Why

The handler path goes through `writeFetchHeadersToUWSResponse`, which sets `HTTP_WROTE_DATE_HEADER` on the uWS response data when it sees a user `Date`, so `writeMark()` later skips its own. `StaticRoute::do_write_headers` and `FileRoute::write_headers` iterate the snapshot's `Headers` directly via `resp.write_header()` and never set that flag, so uWS's `writeMark()` appends a second `Date`. `FileRoute` is affected too (e.g. `new Response(Bun.file(p), { headers: { date } })`).

## Fix

Add a `uws_res_mark_wrote_date_header` C shim (mirroring the existing `uws_res_mark_wrote_content_length_header`) plus its HTTP/3 counterpart and Rust bindings. At route construction record whether the snapshot's headers already contain a `Date`, and when serving, set the flag before uWS would emit its own. When no user `Date` is present nothing changes and the auto-`Date` is still sent exactly once.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/bun-serve-static.test.ts

<!-- robobun:evidence:end -->