### PR TITLE
runtime: make uncaught exceptions during top-level await immediately fatal

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2481,7 +2481,22 @@ impl VirtualMachine {
                 return Ok(promise);
             }
             self.event_loop_mut().perform_gc();
-            self.wait_for_promise(jsc::AnyPromise::Internal(promise));
+            // Bail on `unhandled_error_counter` so a default-fatal uncaught
+            // exception while the entry module is suspended in top-level await
+            // stops evaluation, matching the main drain loop in `Run::start`.
+            while crate::JSPromise::status_ptr(promise) == crate::js_promise::Status::Pending
+                && self.unhandled_error_counter == 0
+            {
+                if self.jsc_vm().execution_forbidden() {
+                    break;
+                }
+                self.event_loop_mut().tick();
+                if crate::JSPromise::status_ptr(promise) == crate::js_promise::Status::Pending
+                    && self.unhandled_error_counter == 0
+                {
+                    self.auto_tick();
+                }
+            }
         }
 
         Ok(self.pending_internal_promise.unwrap_or(promise))

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2456,7 +2456,9 @@ impl VirtualMachine {
 
         // pending_internal_promise can change if hot module reloading is enabled
         if self.is_watcher_enabled() {
-            // accessed here (no overlapping `&mut EventLoop`).
+            // Watch mode survives errors (the outer loop in `Run::start` keeps
+            // ticking via `tick_possibly_forever` regardless of
+            // `unhandled_error_counter`), so no bail-out on it here.
             self.event_loop_mut().perform_gc();
             loop {
                 let Some(p) = self.pending_internal_promise else {

--- a/test/js/bun/spawn/exit-code-uncaught-during-tla-fixture.mjs
+++ b/test/js/bun/spawn/exit-code-uncaught-during-tla-fixture.mjs
@@ -1,7 +1,6 @@
-// An uncaught exception thrown while the entry module is suspended in
-// top-level await must be fatal immediately (node parity). The awaits below
-// must not resume once the timer callback throws with no
-// process.on('uncaughtException') listener installed.
+// An uncaught exception while the entry module is suspended in top-level
+// await must be immediately fatal (node parity): the awaits below must not
+// resume once the timer throws with no 'uncaughtException' listener.
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 setTimeout(() => {
   throw new Error("boom-during-tla");

--- a/test/js/bun/spawn/exit-code-uncaught-during-tla-fixture.mjs
+++ b/test/js/bun/spawn/exit-code-uncaught-during-tla-fixture.mjs
@@ -1,0 +1,10 @@
+// An uncaught exception thrown while the entry module is suspended in
+// top-level await must be fatal immediately (node parity). The awaits below
+// must not resume once the timer callback throws with no
+// process.on('uncaughtException') listener installed.
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+setTimeout(() => {
+  throw new Error("boom-during-tla");
+}, 1);
+for (let i = 0; i < 50; i++) await sleep(5);
+console.log("UNREACHABLE-AFTER-FATAL");

--- a/test/js/bun/spawn/exit-code-uncaught-during-tla-handled-fixture.mjs
+++ b/test/js/bun/spawn/exit-code-uncaught-during-tla-handled-fixture.mjs
@@ -1,0 +1,9 @@
+// With an 'uncaughtException' listener installed the exception is handled,
+// so top-level await evaluation must continue and the process exits 0.
+process.on("uncaughtException", err => console.log("caught:" + err.message));
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+setTimeout(() => {
+  throw new Error("boom-during-tla");
+}, 1);
+for (let i = 0; i < 50; i++) await sleep(5);
+console.log("module-end");

--- a/test/js/bun/spawn/exit-code-unhandled-rejection-during-tla-fixture.mjs
+++ b/test/js/bun/spawn/exit-code-unhandled-rejection-during-tla-fixture.mjs
@@ -1,0 +1,6 @@
+// #22546: an unhandled promise rejection while the entry module is suspended
+// in top-level await must stop evaluation (node/deno parity).
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+setTimeout(() => void Promise.reject(new Error("rejected-during-tla")), 1);
+for (let i = 0; i < 50; i++) await sleep(5);
+console.log("UNREACHABLE-AFTER-FATAL");

--- a/test/js/bun/spawn/exit-code.test.ts
+++ b/test/js/bun/spawn/exit-code.test.ts
@@ -63,6 +63,6 @@ it("uncaught exception during top-level await is survivable with a listener", as
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout).toBe("caught:boom-during-tla\nmodule-end\n");
-  expect(stderr).toBe("");
+  expect(stderr).not.toContain("boom-during-tla");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/spawn/exit-code.test.ts
+++ b/test/js/bun/spawn/exit-code.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { expect, it } from "bun:test";
-import { bunExe } from "harness";
+import { bunEnv, bunExe } from "harness";
 
 it("process.exit(1) works", () => {
   const { exitCode } = spawnSync([bunExe(), import.meta.dir + "/exit-code-1.js"]);
@@ -24,5 +24,32 @@ it("handled promise rejection reports exit code 0", () => {
 
 it("process.exit(0) works", () => {
   const { exitCode } = spawnSync([bunExe(), import.meta.dir + "/exit-code-0.js"]);
+  expect(exitCode).toBe(0);
+});
+
+it("uncaught exception during top-level await is immediately fatal", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), import.meta.dir + "/exit-code-uncaught-during-tla-fixture.mjs"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // Module evaluation must not resume after the default-fatal throw.
+  expect(stdout).toBe("");
+  expect(stderr).toContain("boom-during-tla");
+  expect(exitCode).toBe(1);
+});
+
+it("uncaught exception during top-level await is survivable with a listener", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), import.meta.dir + "/exit-code-uncaught-during-tla-handled-fixture.mjs"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("caught:boom-during-tla\nmodule-end\n");
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/spawn/exit-code.test.ts
+++ b/test/js/bun/spawn/exit-code.test.ts
@@ -41,6 +41,19 @@ it("uncaught exception during top-level await is immediately fatal", async () =>
   expect(exitCode).toBe(1);
 });
 
+it("unhandled rejection during top-level await is immediately fatal (#22546)", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), import.meta.dir + "/exit-code-unhandled-rejection-during-tla-fixture.mjs"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("");
+  expect(stderr).toContain("rejected-during-tla");
+  expect(exitCode).toBe(1);
+});
+
 it("uncaught exception during top-level await is survivable with a listener", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), import.meta.dir + "/exit-code-uncaught-during-tla-handled-fixture.mjs"],


### PR DESCRIPTION
## What

An uncaught exception thrown while the entry module is suspended in top-level `await` was not fatal: Bun printed the error, then resumed the suspended module and ran it to completion (potentially seconds of continued side effects), only exiting 1 at natural module end. Node exits immediately at the throw.

## Repro

```js
// a.mjs
const sleep = ms => new Promise(r => setTimeout(r, ms));
setTimeout(() => { throw new Error("boom-during-tla"); }, 50);
const t0 = Date.now();
while (Date.now() - t0 < 850) await sleep(25);
console.log("ALIVE 800ms after fatal error");   // bun: PRINTS; node: never reached
```

```
$ node a.mjs
Error: boom-during-tla
    at Timeout._onTimeout (a.mjs:2:26)
(exit 1, no further output)

$ bun a.mjs     # before
error: boom-during-tla
ALIVE 800ms after fatal error
(exit 1)
```

Any callback source triggers it (setTimeout throw, EventEmitter `'error'` with no listener, setImmediate, Worker `'error'`); the only condition is that the entry module is TLA-suspended when the exception reaches the top with no `uncaughtException` listener.

## Cause

`VirtualMachine::uncaught_exception` records the fatal state (`unhandled_error_counter += 1`, `exit_handler.exit_code = 1`) and returns. The main drain loop in `Run::start` checks `unhandled_error_counter` via `is_event_loop_alive()` and bails, which is why a throw *after* TLA settles is already fatal. But `load_entry_point` waited on the TLA promise via the generic `wait_for_promise`, which only watches promise status and never consults `unhandled_error_counter`, so the suspended module kept running until the promise settled naturally.

## Fix

Inline the wait loop in `load_entry_point`'s non-watcher arm and break on `unhandled_error_counter > 0`, matching the main drain loop. The generic `wait_for_promise` is left unchanged since other callers (macros, HTMLRewriter, test expect, REPL) have different error semantics.

Sibling TLA-wait sites left as-is and why:

- `load_entry_point` watcher arm: watch mode survives errors by design; the outer `tick_possibly_forever()` loop in `Run::start` keeps ticking regardless of `unhandled_error_counter`, so a guard here alone would be a no-op.
- `load_preloads` non-watcher arm (`jsc_hooks.rs`): same underlying gap for a `--preload` module suspended in TLA, but stopping post-fatal execution there also requires `reload_entry_point` to bail before loading the main module and `load_preloads` to skip remaining preloads, which is a broader change than this PR's scope. Left for a follow-up.
- `load_entry_point_for_test_runner`: `bun test` is designed to survive uncaught exceptions (records the failure, continues to the next file), so the guard does not belong there.

Controls verified to still hold:
- Same throw after TLA completes: fatal in both (unchanged).
- With `process.on('uncaughtException', ...)`: both survive, module completes, exit 0.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/spawn/exit-code.test.ts
(fail) uncaught exception during top-level await is immediately fatal
  expect(stdout).toBe("")
  + "UNREACHABLE-AFTER-FATAL\n"

$ bun bd test test/js/bun/spawn/exit-code.test.ts
 8 pass
 0 fail
```

Fixes #22546

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/spawn/exit-code.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (bd5ceb179)

test/js/bun/spawn/exit-code.test.ts:
(pass) process.exit(1) works [546.40ms]
(pass) await on a thrown value reports exit code 1 [482.12ms]
(pass) unhandled promise rejection reports exit code 1 [522.96ms]
(pass) handled promise rejection reports exit code 0 [156.10ms]
(pass) process.exit(0) works [478.44ms]
34 |     stdout: "pipe",
35 |     stderr: "pipe",
36 |   });
37 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
38 |   // Module evaluation must not resume after the default-fatal throw.
39 |   expect(stdout).toBe("");
                      ^
error: expect(received).toBe(expected)

- ""
+ "UNREACHABLE-AFTER-FATAL
+ "

- Expected  - 1
+ Received  + 2

 
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (23bd4d697)

test/js/bun/spawn/exit-code.test.ts:
(pass) process.exit(1) works [22.32ms]
(pass) await on a thrown value reports exit code 1 [17.10ms]
(pass) unhandled promise rejection reports exit code 1 [13.59ms]
(pass) handled promise rejection reports exit code 0 [3.14ms]
(pass) process.exit(0) works [12.35ms]
34 |     stdout: "pipe",
35 |     stderr: "pipe",
36 |   });
37 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
38 |   // Module evaluation must not resume after the default-fatal throw.
39 |   expect(stdout).toBe("");
                      ^
error: expect(received).toBe(expected)

- ""
+ "UNREACHABLE-AFTER-FATAL
+ "

- Expected  - 1
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/bun/spawn/exit-code.test.ts:39:18)
(fail) uncaught exception during top-level await is immediately fatal [279.01ms]
47 |     env: bunEnv,
48 |     stdout: "pipe",
49 |     stderr: "pipe",
50 |   });
51 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
52 |   expect(stdout).toBe("");
                      ^
error: ex
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/spawn/exit-code.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (bd5ceb179)

test/js/bun/spawn/exit-code.test.ts:
(pass) process.exit(1) works [697.82ms]
(pass) await on a thrown value reports exit code 1 [583.92ms]
(pass) unhandled promise rejection reports exit code 1 [513.14ms]
(pass) handled promise rejection reports exit code 0 [165.86ms]
(pass) process.exit(0) works [594.35ms]
(pass) uncaught exception during top-level await is immediately fatal [544.16ms]
(pass) unhandled rejection during top-level await is immediately fatal (#22546) [516.65ms]
(pass) uncaught exception during top-level await is survivable with a listener [938.85ms]

 8 pass
 0 fail
 14 expect() calls
Ran 8 tests across 1 file. [7.12s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 941ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs                          | 21 +++++++++--
 .../exit-code-uncaught-during-tla-fixture.mjs      |  9 +++++
 ...it-code-uncaught-during-tla-handled-fixture.mjs |  9 +++++
 ...code-unhandled-rejection-during-tla-fixture.mjs |  6 ++++
 test/js/bun/spawn/exit-code.test.ts                | 42 +++++++++++++++++++++-
 5 files changed, 84 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/VirtualMachine.rs                                     6      2      0
…/js/bun/spawn/exit-code-uncaught-during-tla-fixture.mjs      1      2      0
…spawn/exit-code-uncaught-during-tla-handled-fixture.mjs      0      1      0
…wn/exit-code-unhandled-rejection-during-tla-fixture.mjs      0      1      0
test/js/bun/spawn/exit-code.test.ts                           3      4      0
```

</details>

<!-- robobun:evidence:end -->