### PR TITLE
node:vm: include WebAssembly field in measureMemory() result

### DIFF
--- a/src/js/node/vm.ts
+++ b/src/js/node/vm.ts
@@ -143,7 +143,9 @@ function measureMemory(options = kEmptyObject) {
 
   const measurement = () => ({ jsMemoryEstimate: current, jsMemoryRange: [current, upperBound] });
 
-  const result: any = { total: measurement() };
+  // Node always includes a WebAssembly: { code, metadata } entry (both modes).
+  // JSC exposes no equivalent wasm byte accounting, so report zeros for shape parity.
+  const result: any = { total: measurement(), WebAssembly: { code: 0, metadata: 0 } };
   if (mode === "detailed") {
     result.current = measurement();
     const other: object[] = [];

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -4,6 +4,7 @@ import {
   compileFunction,
   constants,
   createContext,
+  measureMemory,
   runInContext,
   runInNewContext,
   runInThisContext,
@@ -267,6 +268,23 @@ describe("vm", () => {
       } catch (e) {
         // Throwing is also acceptable
         expect(e).toBeTruthy();
+      }
+    });
+  });
+
+  describe("measureMemory()", () => {
+    test("result includes WebAssembly field in both summary and detailed modes", async () => {
+      const summary = (await measureMemory({ mode: "summary", execution: "eager" })) as any;
+      const detailed = (await measureMemory({ mode: "detailed", execution: "eager" })) as any;
+
+      expect(Object.keys(summary).sort()).toEqual(["WebAssembly", "total"]);
+      expect(Object.keys(detailed).sort()).toEqual(["WebAssembly", "current", "other", "total"]);
+
+      for (const result of [summary, detailed]) {
+        expect(result.WebAssembly).toEqual({
+          code: expect.any(Number),
+          metadata: expect.any(Number),
+        });
       }
     });
   });


### PR DESCRIPTION
## Repro

```js
import * as vm from "node:vm";
const s = await vm.measureMemory({ mode: "summary", execution: "eager" });
const d = await vm.measureMemory({ mode: "detailed", execution: "eager" });
Object.keys(s).sort(); // node: ["WebAssembly","total"]                    bun: ["total"]
Object.keys(d).sort(); // node: ["WebAssembly","current","other","total"]  bun: ["current","other","total"]
```

Node always includes a `WebAssembly: { code, metadata }` member in both summary and detailed modes. Bun omitted it, so `result.WebAssembly` was `undefined` and shape-parity checks against Node failed.

## Cause

`measureMemory()` in `src/js/node/vm.ts` builds `{ total[, current, other] }` from `bun:jsc` heap footprint numbers and never added the `WebAssembly` entry.

## Fix

Add `WebAssembly: { code: 0, metadata: 0 }` to the result in both modes. JSC does not expose a V8-equivalent wasm code/metadata byte breakdown, so zeros are reported for shape parity; this is consistent with the rest of the shim, which already reports whole-heap numbers for every context because JSC has no per-context accounting.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/js/node/vm/vm.test.ts -t measureMemory` fails (missing `WebAssembly` key)
- `bun bd test test/js/node/vm/vm.test.ts -t measureMemory` passes
- Full `bun bd test test/js/node/vm/vm.test.ts`: 208 pass / 0 fail
- `bun bd test/js/node/test/parallel/test-vm-measure-memory.js` exits 0