### PR TITLE
os: return empty-but-set $HOME from homedir(); read userInfo().homedir from passwd

### DIFF
--- a/src/runtime/node/node_os.rs
+++ b/src/runtime/node/node_os.rs
@@ -742,12 +742,10 @@ mod _impl {
         }
         #[cfg(not(windows))]
         {
-            // The posix implementation of uv_os_homedir first checks the HOME
-            // environment variable, then falls back to reading the passwd entry.
+            // uv_os_homedir returns $HOME verbatim whenever the variable is
+            // set (including empty) and only consults getpwuid_r when unset.
             if let Some(home) = env_var::HOME.get() {
-                if !home.is_empty() {
-                    return Ok(BunString::init(home));
-                }
+                return Ok(BunString::init(home));
             }
 
             // From libuv:

--- a/src/runtime/node/node_os.rs
+++ b/src/runtime/node/node_os.rs
@@ -747,85 +747,92 @@ mod _impl {
             if let Some(home) = env_var::HOME.get() {
                 return Ok(BunString::init(home));
             }
-
-            // From libuv:
-            // > Calling sysconf(_SC_GETPW_R_SIZE_MAX) would get the suggested size, but it
-            // > is frequently 1024 or 4096, so we can just use that directly. The pwent
-            // > will not usually be large.
-            // Instead of always using an allocation, first try a stack allocation
-            // of 4096, then fallback to heap.
-            let mut stack_string_bytes = [0u8; 4096];
-            let mut heap_bytes: Vec<u8>;
-            let mut string_bytes: &mut [u8] = &mut stack_string_bytes[..];
-            let mut using_heap = false;
-
-            // SAFETY: zeroed POD
-            let mut pw: libc::passwd = bun_core::ffi::zeroed();
-            let mut result: *mut libc::passwd = core::ptr::null_mut();
-
-            let ret: c_int = loop {
-                // SAFETY: valid buffers and out-pointer
-                let ret = unsafe {
-                    libc::getpwuid_r(
-                        libc::geteuid(),
-                        &raw mut pw,
-                        string_bytes.as_mut_ptr().cast::<c_char>(),
-                        string_bytes.len(),
-                        &raw mut result,
-                    )
-                };
-
-                if ret == bun_sys::E::EINTR as c_int {
-                    continue;
-                }
-
-                // If the system call wants more memory, double it.
-                if ret == bun_sys::E::ERANGE as c_int {
-                    let len = string_bytes.len();
-                    heap_bytes = vec![0u8; len * 2];
-                    string_bytes = &mut heap_bytes[..];
-                    using_heap = true;
-                    continue;
-                }
-
-                break ret;
-            };
-            let _ = using_heap;
-
-            if ret != 0 {
-                return Err(global.throw_value(
-                    bun_sys::Error::from_code(
-                        // `ret` is a libc errno; `E::from_raw` is the centralized
-                        // `@enumFromInt` (debug-asserts the discriminant).
-                        bun_sys::E::from_raw(ret as u16),
-                        bun_sys::Tag::uv_os_homedir,
-                    )
-                    .to_js(global),
-                ));
-            }
-
-            if result.is_null() {
-                // bionic has no passwd entries for app uids; with HOME also unset
-                // (zygote/run-as), return a usable default rather than throwing.
-                #[cfg(target_os = "android")]
-                {
-                    return Ok(BunString::static_("/data/local/tmp"));
-                }
-                // in uv__getpwuid_r, null result throws UV_ENOENT.
-                #[cfg(not(target_os = "android"))]
-                return Err(global.throw_value(
-                    bun_sys::Error::from_code(bun_sys::E::ENOENT, bun_sys::Tag::uv_os_homedir)
-                        .to_js(global),
-                ));
-            }
-
-            return Ok(if !pw.pw_dir.is_null() {
-                // SAFETY: pw_dir is a NUL-terminated C string from getpwuid_r
-                BunString::clone_utf8(unsafe { bun_core::ffi::cstr(pw.pw_dir) }.to_bytes())
-            } else {
-                BunString::empty()
-            });
+            homedir_from_passwd(global)
         }
+    }
+
+    // pw_dir of getpwuid_r(geteuid()). Node's os.userInfo().homedir comes from
+    // uv_os_get_passwd and never consults $HOME, so user_info() calls this
+    // directly while os.homedir() only reaches it when $HOME is unset.
+    #[cfg(not(windows))]
+    fn homedir_from_passwd(global: &JSGlobalObject) -> JsResult<BunString> {
+        // From libuv:
+        // > Calling sysconf(_SC_GETPW_R_SIZE_MAX) would get the suggested size, but it
+        // > is frequently 1024 or 4096, so we can just use that directly. The pwent
+        // > will not usually be large.
+        // Instead of always using an allocation, first try a stack allocation
+        // of 4096, then fallback to heap.
+        let mut stack_string_bytes = [0u8; 4096];
+        let mut heap_bytes: Vec<u8>;
+        let mut string_bytes: &mut [u8] = &mut stack_string_bytes[..];
+        let mut using_heap = false;
+
+        // SAFETY: zeroed POD
+        let mut pw: libc::passwd = bun_core::ffi::zeroed();
+        let mut result: *mut libc::passwd = core::ptr::null_mut();
+
+        let ret: c_int = loop {
+            // SAFETY: valid buffers and out-pointer
+            let ret = unsafe {
+                libc::getpwuid_r(
+                    libc::geteuid(),
+                    &raw mut pw,
+                    string_bytes.as_mut_ptr().cast::<c_char>(),
+                    string_bytes.len(),
+                    &raw mut result,
+                )
+            };
+
+            if ret == bun_sys::E::EINTR as c_int {
+                continue;
+            }
+
+            // If the system call wants more memory, double it.
+            if ret == bun_sys::E::ERANGE as c_int {
+                let len = string_bytes.len();
+                heap_bytes = vec![0u8; len * 2];
+                string_bytes = &mut heap_bytes[..];
+                using_heap = true;
+                continue;
+            }
+
+            break ret;
+        };
+        let _ = using_heap;
+
+        if ret != 0 {
+            return Err(global.throw_value(
+                bun_sys::Error::from_code(
+                    // `ret` is a libc errno; `E::from_raw` is the centralized
+                    // `@enumFromInt` (debug-asserts the discriminant).
+                    bun_sys::E::from_raw(ret as u16),
+                    bun_sys::Tag::uv_os_homedir,
+                )
+                .to_js(global),
+            ));
+        }
+
+        if result.is_null() {
+            // bionic has no passwd entries for app uids; with HOME also unset
+            // (zygote/run-as), return a usable default rather than throwing.
+            #[cfg(target_os = "android")]
+            {
+                return Ok(BunString::static_("/data/local/tmp"));
+            }
+            // in uv__getpwuid_r, null result throws UV_ENOENT.
+            #[cfg(not(target_os = "android"))]
+            return Err(global.throw_value(
+                bun_sys::Error::from_code(bun_sys::E::ENOENT, bun_sys::Tag::uv_os_homedir)
+                    .to_js(global),
+            ));
+        }
+
+        Ok(if !pw.pw_dir.is_null() {
+            // SAFETY: pw_dir is a NUL-terminated C string from getpwuid_r
+            BunString::clone_utf8(unsafe { bun_core::ffi::cstr(pw.pw_dir) }.to_bytes())
+        } else {
+            BunString::empty()
+        })
     }
 
     pub(crate) fn hostname(global: &JSGlobalObject) -> JsResult<JSValue> {
@@ -1591,7 +1598,10 @@ mod _impl {
 
         let result = JSValue::create_empty_object(global_this, 5);
 
+        #[cfg(windows)]
         let home = homedir(global_this)?;
+        #[cfg(not(windows))]
+        let home = homedir_from_passwd(global_this)?;
         let home = scopeguard::guard(home, |h| h.deref());
 
         result.put(global_this, b"homedir", home.to_js(global_this)?);

--- a/src/runtime/node/node_os.rs
+++ b/src/runtime/node/node_os.rs
@@ -813,8 +813,9 @@ mod _impl {
         }
 
         if result.is_null() {
-            // bionic has no passwd entries for app uids; with HOME also unset
-            // (zygote/run-as), return a usable default rather than throwing.
+            // bionic may have no passwd entry for app uids; return a usable
+            // default rather than ENOENT. os.homedir() reaches this only when
+            // $HOME is unset; os.userInfo() reaches it regardless of $HOME.
             #[cfg(target_os = "android")]
             {
                 return Ok(BunString::static_("/data/local/tmp"));

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -62,7 +62,7 @@ it("homedir", () => {
   expect(os.homedir() !== "unknown").toBe(true);
 });
 
-describe.skipIf(isWindows)("homedir honors $HOME", () => {
+it.skipIf(isWindows)("homedir honors $HOME; userInfo().homedir does not", async () => {
   const child = `
     const os = require("node:os");
     process.stdout.write(JSON.stringify({ homedir: os.homedir(), userInfo: os.userInfo().homedir }));
@@ -74,31 +74,25 @@ describe.skipIf(isWindows)("homedir honors $HOME", () => {
       stderr: "inherit",
     });
     const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    expect(exitCode).toBe(0);
-    return JSON.parse(stdout);
+    return { out: JSON.parse(stdout), exitCode };
   };
   const base = { ...bunEnv, HOME: undefined };
 
-  it.concurrent("returns $HOME verbatim when set", async () => {
-    const { homedir, userInfo } = await run({ ...base, HOME: "/bun-homedir-test" });
-    expect(homedir).toBe("/bun-homedir-test");
-    // os.userInfo().homedir comes from the passwd entry, not $HOME.
-    expect(userInfo).not.toBe("/bun-homedir-test");
-  });
+  const [unset, set, empty] = await Promise.all([
+    run({ ...base }),
+    run({ ...base, HOME: "/bun-homedir-test" }),
+    run({ ...base, HOME: "" }),
+  ]);
 
-  it.concurrent("returns $HOME verbatim when set to the empty string", async () => {
-    // uv_os_homedir: an empty-but-set $HOME is still "set"; Node returns "".
-    const { homedir, userInfo } = await run({ ...base, HOME: "" });
-    expect(homedir).toBe("");
-    expect(userInfo).not.toBe("");
+  // uv_os_homedir: $HOME whenever present (including ""), passwd only when absent.
+  // uv_os_get_passwd (os.userInfo().homedir): passwd regardless of $HOME.
+  const passwd = unset.out.userInfo;
+  expect({ unset: unset.out, set: set.out, empty: empty.out }).toEqual({
+    unset: { homedir: passwd, userInfo: passwd },
+    set: { homedir: "/bun-homedir-test", userInfo: passwd },
+    empty: { homedir: "", userInfo: passwd },
   });
-
-  it.concurrent("falls back to the passwd entry only when $HOME is unset", async () => {
-    const { homedir, userInfo } = await run({ ...base });
-    expect(typeof homedir).toBe("string");
-    expect(homedir).not.toBe("");
-    expect(homedir).toBe(userInfo);
-  });
+  expect([unset.exitCode, set.exitCode, empty.exitCode]).toEqual([0, 0, 0]);
 });
 
 it("tmpdir", () => {

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -63,35 +63,41 @@ it("homedir", () => {
 });
 
 describe.skipIf(isWindows)("homedir honors $HOME", () => {
-  const envVar = "HOME";
-  const child = `process.stdout.write(JSON.stringify(require("node:os").homedir()))`;
+  const child = `
+    const os = require("node:os");
+    process.stdout.write(JSON.stringify({ homedir: os.homedir(), userInfo: os.userInfo().homedir }));
+  `;
   const run = async env => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", child],
       env,
-      stderr: "pipe",
+      stderr: "inherit",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
     expect(exitCode).toBe(0);
-    return stdout;
+    return JSON.parse(stdout);
   };
-  // Minimal env so nothing else contributes a HOME.
-  const base = { PATH: bunEnv.PATH, BUN_DEBUG_QUIET_LOGS: "1", NO_COLOR: "1" };
+  const base = { ...bunEnv, HOME: undefined };
 
   it.concurrent("returns $HOME verbatim when set", async () => {
-    expect(await run({ ...base, [envVar]: "/bun-homedir-test" })).toBe('"/bun-homedir-test"');
+    const { homedir, userInfo } = await run({ ...base, HOME: "/bun-homedir-test" });
+    expect(homedir).toBe("/bun-homedir-test");
+    // os.userInfo().homedir comes from the passwd entry, not $HOME.
+    expect(userInfo).not.toBe("/bun-homedir-test");
   });
 
   it.concurrent("returns $HOME verbatim when set to the empty string", async () => {
     // uv_os_homedir: an empty-but-set $HOME is still "set"; Node returns "".
-    expect(await run({ ...base, [envVar]: "" })).toBe('""');
+    const { homedir, userInfo } = await run({ ...base, HOME: "" });
+    expect(homedir).toBe("");
+    expect(userInfo).not.toBe("");
   });
 
   it.concurrent("falls back to the passwd entry only when $HOME is unset", async () => {
-    const out = await run({ ...base });
-    expect(out).toStartWith('"');
-    expect(out).not.toBe('""');
+    const { homedir, userInfo } = await run({ ...base });
+    expect(typeof homedir).toBe("string");
+    expect(homedir).not.toBe("");
+    expect(homedir).toBe(userInfo);
   });
 });
 

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { realpathSync } from "fs";
-import { isWindows } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 import { isIPv4, isIPv6 } from "node:net";
 import * as os from "node:os";
 
@@ -60,6 +60,39 @@ it("loadavg", () => {
 
 it("homedir", () => {
   expect(os.homedir() !== "unknown").toBe(true);
+});
+
+describe.skipIf(isWindows)("homedir honors $HOME", () => {
+  const envVar = "HOME";
+  const child = `process.stdout.write(JSON.stringify(require("node:os").homedir()))`;
+  const run = async env => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", child],
+      env,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return stdout;
+  };
+  // Minimal env so nothing else contributes a HOME.
+  const base = { PATH: bunEnv.PATH, BUN_DEBUG_QUIET_LOGS: "1", NO_COLOR: "1" };
+
+  it.concurrent("returns $HOME verbatim when set", async () => {
+    expect(await run({ ...base, [envVar]: "/bun-homedir-test" })).toBe('"/bun-homedir-test"');
+  });
+
+  it.concurrent("returns $HOME verbatim when set to the empty string", async () => {
+    // uv_os_homedir: an empty-but-set $HOME is still "set"; Node returns "".
+    expect(await run({ ...base, [envVar]: "" })).toBe('""');
+  });
+
+  it.concurrent("falls back to the passwd entry only when $HOME is unset", async () => {
+    const out = await run({ ...base });
+    expect(out).toStartWith('"');
+    expect(out).not.toBe('""');
+  });
 });
 
 it("tmpdir", () => {


### PR DESCRIPTION
`os.homedir()` on POSIX treated an empty `$HOME` as unset and fell through to `getpwuid_r`, so `HOME=""` produced the passwd `pw_dir` (e.g. `/root`) instead of the empty string. Node returns the environment value verbatim whenever the variable is present.

Separately, `os.userInfo().homedir` delegated to `homedir()` and therefore tracked `$HOME`; Node's `os.userInfo()` wraps `uv_os_get_passwd` and is documented to return the OS response regardless of the environment.

## Repro

```js
import { spawnSync } from "node:child_process";

if (process.env.STAGE2) {
  const os = await import("node:os");
  console.log(JSON.stringify({ homedir: os.homedir(), userInfo: os.userInfo().homedir }));
  process.exit(0);
}
const base = { PATH: process.env.PATH, STAGE2: "1" };
const run = env =>
  spawnSync(process.execPath, [process.argv[1]], { env, encoding: "utf8" }).stdout.trim();

console.log("set  :", run({ ...base, HOME: "/x" }));
console.log("empty:", run({ ...base, HOME: "" }));
console.log("unset:", run({ ...base }));
```

```
              node 26.3.0                                 bun 1.4.0
set  :  {"homedir":"/x","userInfo":"/root"}         {"homedir":"/x","userInfo":"/x"}
empty:  {"homedir":"","userInfo":"/root"}           {"homedir":"/root","userInfo":"/root"}
unset:  {"homedir":"/root","userInfo":"/root"}      {"homedir":"/root","userInfo":"/root"}
```

Sandboxes and test harnesses commonly set `HOME=` (empty) specifically to disable home-directory lookups; Bun was re-enabling the passwd path they meant to block.

## Cause

`homedir()` in `src/runtime/node/node_os.rs` guarded the env read with `!home.is_empty()`, so an empty-but-set `$HOME` skipped the early return and reached the `getpwuid_r` fallback. libuv's `uv_os_homedir` (which Node wraps) checks `getenv("HOME")` and returns it whenever non-NULL; `getenv` distinguishes "unset" from "set to empty", and libuv does not special-case empty.

`user_info()` computed `.homedir` by calling `homedir()`, so it inherited the `$HOME` read. The two callers have opposite contracts in Node: `os.homedir()` consults the environment, `os.userInfo()` does not.

## Fix

Drop the `is_empty()` guard and factor the `getpwuid_r` path out into `homedir_from_passwd()`. `homedir()` returns `$HOME` whenever present and falls back to the helper when absent; `user_info()` calls the helper directly so `os.userInfo().homedir` always reports `pw_dir`.

Windows is unchanged (`os.homedir()` already delegates to `uv_os_homedir`). `os.userInfo()` on Windows still goes through `uv_os_homedir` rather than `uv_os_get_passwd`; #33481 rewrites `user_info()` in full and addresses that along with `username`/`shell`.

## Verification

`test/js/node/os/os.test.js` gains three subprocess cases under `homedir honors $HOME`, each asserting both `os.homedir()` and `os.userInfo().homedir`:

| `$HOME` | `os.homedir()` | `os.userInfo().homedir` | fail-before |
| --- | --- | --- | --- |
| `"/bun-homedir-test"` | `"/bun-homedir-test"` | passwd entry (not `$HOME`) | yes (userInfo leaked `$HOME`) |
| `""` | `""` | passwd entry (not `""`) | yes (homedir fell through) |
| unset | passwd entry | passwd entry (equal) | no (control) |

Output is byte-identical to Node v26.3.0 across all three rows. `test/js/node/test/parallel/test-os-homedir-no-envvar.js` continues to pass, and `bun run rust:check-all` is clean on all 10 targets.

#29248 is the separate stale-cache bug for `$HOME` mutated at runtime; this change is about the process-start environment.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/os/os.test.js

<!-- robobun:evidence:end -->