### PR TITLE
node:stream: propagate duplexPair() destroy to the peer side

### DIFF
--- a/src/js/internal/streams/duplexpair.ts
+++ b/src/js/internal/streams/duplexpair.ts
@@ -46,6 +46,24 @@ class DuplexSide extends Duplex {
     this.#otherSide.on("end", callback);
     this.#otherSide.push(null);
   }
+
+  _destroy(err, callback) {
+    const otherSide = this.#otherSide;
+
+    if (otherSide !== null && !otherSide.destroyed) {
+      process.nextTick(() => {
+        if (otherSide.destroyed) return;
+
+        if (err) {
+          otherSide.destroy();
+        } else {
+          otherSide.push(null);
+        }
+      });
+    }
+
+    callback(err);
+  }
 }
 
 function duplexPair(options) {

--- a/test/js/node/stream/duplexpair.test.ts
+++ b/test/js/node/stream/duplexpair.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { duplexPair, finished } from "node:stream";
+
+async function turns(n: number) {
+  for (let i = 0; i < n; i++) await new Promise<void>(r => setImmediate(r));
+}
+
+describe("stream.duplexPair destroy propagation", () => {
+  test("destroy() on one side signals end on the peer readable side", async () => {
+    const [a, b] = duplexPair();
+    const evs: string[] = [];
+    b.on("end", () => evs.push("end")).on("close", () => evs.push("close"));
+    b.resume();
+    a.destroy();
+    await turns(10);
+    // Peer readable side ends; peer writable side stays open (allowHalfOpen default).
+    expect(evs).toEqual(["end"]);
+  });
+
+  test("destroy(err) on one side closes the peer without emitting error on it", async () => {
+    const [a, b] = duplexPair();
+    const evs: string[] = [];
+    b.on("error", () => evs.push("error")).on("close", () => evs.push("close"));
+    b.resume();
+    a.on("error", () => {});
+    a.destroy(new Error("boom"));
+    await turns(10);
+    expect(evs).toEqual(["close"]);
+  });
+
+  test("pending data is delivered and followed by end after destroy()", async () => {
+    const [a, b] = duplexPair();
+    const got: string[] = [];
+    a.write("pend1");
+    await turns(2);
+    b.on("data", c => got.push(String(c))).on("end", () => got.push("<end>"));
+    a.destroy();
+    await turns(10);
+    expect(got).toEqual(["pend1", "<end>"]);
+  });
+
+  test("finished() on the peer readable side fires after counterpart destroy()", async () => {
+    const [a, b] = duplexPair();
+    b.resume();
+    const { promise, resolve, reject } = Promise.withResolvers<unknown>();
+    finished(b, { writable: false }, err => (err ? reject(err) : resolve(undefined)));
+    a.destroy();
+    await promise;
+  });
+
+  test("destroying both sides does not throw or double-signal", async () => {
+    const [a, b] = duplexPair();
+    const evs: string[] = [];
+    b.on("error", () => evs.push("b-error"));
+    a.on("error", () => evs.push("a-error"));
+    a.destroy();
+    b.destroy();
+    await turns(10);
+    expect(evs).toEqual([]);
+    expect(a.destroyed).toBe(true);
+    expect(b.destroyed).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

`stream.duplexPair()`'s `DuplexSide` implemented `_read`/`_write`/`_final` but not `_destroy`. Destroying one side left the peer's readable side open forever, so `finished(peer, { writable: false })` and any `pipeline()` through the pair would hang after the counterpart was destroyed.

## Repro

```js
import { duplexPair, finished } from "node:stream";
const [a, b] = duplexPair();
b.resume();
finished(b, { writable: false }, err => console.log("finished:", err ?? "ok"));
a.destroy();
// node:  finished: ok
// bun (before): never fires
```

## Fix

Port Node's `_destroy` from `lib/internal/streams/duplexpair.js`: on graceful `destroy()` push `null` to the peer (EOF), on `destroy(err)` call `peer.destroy()` without forwarding the error (so the peer closes without an unhandled `'error'`). Both are deferred to `nextTick` and guarded against the peer already being destroyed.

## Verification

New `test/js/node/stream/duplexpair.test.ts` covers:
- `destroy()` → peer `'end'`
- `destroy(err)` → peer `'close'` (no `'error'`)
- buffered data flushes, then `'end'`
- `finished(peer, { writable: false })` resolves
- destroying both sides concurrently stays clean

All assertions cross-checked against Node v26.3.0. Existing `test/js/node/test/parallel/test-stream-duplexpair.js` and `test-stream-duplex-destroy.js` still pass.