### PR TITLE
test: quarantine onGC-based Node compat tests on linux-x64-musl

### DIFF
--- a/test/expectations.txt
+++ b/test/expectations.txt
@@ -27,27 +27,28 @@
 [ WINDOWS ] test/bundler/native-plugin.test.ts [ SKIP ] # node-gyp needs a ClangCL toolset the Windows agents do not have
 
 # Verbatim node v26.3.0 tests that register an object with onGC() (a
-# FinalizationRegistry), call globalThis.gc(), then assert the cleanup
-# callback has fired. JSC is a conservative collector: a stale word on the
-# native stack that matches the object's address keeps it alive across gc().
-# On linux-x64-musl the release build's stack layout lands one such word in
-# an outer event-loop frame that the test's gc+setImmediate loop never
-# overwrites, so the assertion can never become true. The listeners ARE
-# removed and the requests ARE collectable (the same tests pass on glibc
-# and darwin, and test/js/node/http/node-http-client-request-gc.test.ts
-# from #34500 covers the deterministic case on every lane). These files are
-# verbatim upstream ports we do not edit; quarantined on the failing
-# linux-x64-musl matrix only.
+# FinalizationRegistry), call globalThis.gc(), then assert every registered
+# object's cleanup callback has fired. V8 is precise and delivers the
+# callback within one tick; JSC gives no such guarantee, and on the
+# linux-x64-musl release build one object out of N intermittently survives
+# the test's gc+setImmediate loop (http tests wedge at done/collected/total
+# 8/7/8; net/tls fail the single-tick assertion). The same tests pass on
+# glibc/darwin/windows and the deterministic retention check in
+# test/js/node/http/node-http-client-request-gc.test.ts (#34500) passes on
+# every lane, so ClientRequest IS collectable; the musl-only residual has
+# not been root-caused. The files are verbatim upstream ports we do not
+# edit (test/js/node/test/parallel/CLAUDE.md). Quarantined on the failing
+# linux-x64-musl matrix only so they keep running everywhere else.
 #
 # tls/net: single gc()+setImmediate, fails fast (builds 63145, 75280):
-[ LINUX-X64-MUSL ] test/js/node/test/parallel/test-tls-connect-memleak.js [ FLAKY ] # JSC conservative stack scan pins the connect listener closure on musl x64
-[ LINUX-X64-MUSL ] test/js/node/test/parallel/test-net-connect-memleak.js [ FLAKY ] # JSC conservative stack scan pins the connect listener closure on musl x64
+[ LINUX-X64-MUSL ] test/js/node/test/parallel/test-tls-connect-memleak.js [ FLAKY ] # onGC callback not delivered within one gc()+setImmediate on musl x64 release
+[ LINUX-X64-MUSL ] test/js/node/test/parallel/test-net-connect-memleak.js [ FLAKY ] # onGC callback not delivered within one gc()+setImmediate on musl x64 release
 # http: loops gc()+setImmediate until countGC === count; one ClientRequest
-# stays pinned so the loop never terminates (builds 74665, 75248, 75256):
-[ LINUX-X64-MUSL ] test/js/node/test/sequential/test-gc-http-client.js [ TIMEOUT ] # JSC conservative stack scan pins one ClientRequest on musl x64
-[ LINUX-X64-MUSL ] test/js/node/test/sequential/test-gc-http-client-onerror.js [ TIMEOUT ] # JSC conservative stack scan pins one ClientRequest on musl x64
-[ LINUX-X64-MUSL ] test/js/node/test/sequential/test-gc-http-client-timeout.js [ TIMEOUT ] # JSC conservative stack scan pins one ClientRequest on musl x64
-[ LINUX-X64-MUSL ] test/js/node/test/parallel/test-gc-http-client-connaborted.js [ TIMEOUT ] # JSC conservative stack scan pins one ClientRequest on musl x64
+# of N is not collected so the loop never terminates (builds 74665, 75248, 75256):
+[ LINUX-X64-MUSL ] test/js/node/test/sequential/test-gc-http-client.js [ TIMEOUT ] # one of N ClientRequests not collected by gc()+setImmediate loop on musl x64 release
+[ LINUX-X64-MUSL ] test/js/node/test/sequential/test-gc-http-client-onerror.js [ TIMEOUT ] # one of N ClientRequests not collected by gc()+setImmediate loop on musl x64 release
+[ LINUX-X64-MUSL ] test/js/node/test/sequential/test-gc-http-client-timeout.js [ TIMEOUT ] # one of N ClientRequests not collected by gc()+setImmediate loop on musl x64 release
+[ LINUX-X64-MUSL ] test/js/node/test/parallel/test-gc-http-client-connaborted.js [ TIMEOUT ] # one of N ClientRequests not collected by gc()+setImmediate loop on musl x64 release
 
 # Both tests mock _handle.setKeepAlive and assert it receives SECONDS
 # (libuv's uv_tcp_keepalive convention). In Bun, _handle is the public

--- a/test/expectations.txt
+++ b/test/expectations.txt
@@ -26,20 +26,28 @@
 # ships ClangCL. Runs everywhere else.
 [ WINDOWS ] test/bundler/native-plugin.test.ts [ SKIP ] # node-gyp needs a ClangCL toolset the Windows agents do not have
 
-# Verbatim node v26.3.0 test asserting a FinalizationRegistry callback fires
-# within ONE globalThis.gc() + ONE setImmediate after the connect callback's
-# closure is unreferenced. The FinalizationRegistry spec gives no timing
-# guarantee for cleanup callbacks; JSC schedules them via DeferredWorkTimer
-# with no defined ordering relative to the immediate queue. The connect
-# listener IS removed (verified: listenerCount("secureConnect") === 0 in
-# done()) and the object IS collected (test passes 70/70 on darwin and
-# glibc Linux); on alpine x64 the FR callback delivery slips past the single
-# setImmediate after this PR's added module loads at process startup shift
-# the heap layout. The robust fix is gcUntil() rather than a single tick,
-# but the file is a verbatim upstream port. Quarantined on the failing
-# linux-x64-musl matrix only; still runs everywhere else (build 63145:
-# alpine 3.23 x64 + x64-baseline only).
-[ LINUX-X64-MUSL ] test/js/node/test/parallel/test-tls-connect-memleak.js [ FLAKY ] # JSC FinalizationRegistry callback delivery vs setImmediate timing on musl x64
+# Verbatim node v26.3.0 tests that register an object with onGC() (a
+# FinalizationRegistry), call globalThis.gc(), then assert the cleanup
+# callback has fired. JSC is a conservative collector: a stale word on the
+# native stack that matches the object's address keeps it alive across gc().
+# On linux-x64-musl the release build's stack layout lands one such word in
+# an outer event-loop frame that the test's gc+setImmediate loop never
+# overwrites, so the assertion can never become true. The listeners ARE
+# removed and the requests ARE collectable (the same tests pass on glibc
+# and darwin, and test/js/node/http/node-http-client-request-gc.test.ts
+# from #34500 covers the deterministic case on every lane). These files are
+# verbatim upstream ports we do not edit; quarantined on the failing
+# linux-x64-musl matrix only.
+#
+# tls/net: single gc()+setImmediate, fails fast (builds 63145, 75280):
+[ LINUX-X64-MUSL ] test/js/node/test/parallel/test-tls-connect-memleak.js [ FLAKY ] # JSC conservative stack scan pins the connect listener closure on musl x64
+[ LINUX-X64-MUSL ] test/js/node/test/parallel/test-net-connect-memleak.js [ FLAKY ] # JSC conservative stack scan pins the connect listener closure on musl x64
+# http: loops gc()+setImmediate until countGC === count; one ClientRequest
+# stays pinned so the loop never terminates (builds 74665, 75248, 75256):
+[ LINUX-X64-MUSL ] test/js/node/test/sequential/test-gc-http-client.js [ TIMEOUT ] # JSC conservative stack scan pins one ClientRequest on musl x64
+[ LINUX-X64-MUSL ] test/js/node/test/sequential/test-gc-http-client-onerror.js [ TIMEOUT ] # JSC conservative stack scan pins one ClientRequest on musl x64
+[ LINUX-X64-MUSL ] test/js/node/test/sequential/test-gc-http-client-timeout.js [ TIMEOUT ] # JSC conservative stack scan pins one ClientRequest on musl x64
+[ LINUX-X64-MUSL ] test/js/node/test/parallel/test-gc-http-client-connaborted.js [ TIMEOUT ] # JSC conservative stack scan pins one ClientRequest on musl x64
 
 # Both tests mock _handle.setKeepAlive and assert it receives SECONDS
 # (libuv's uv_tcp_keepalive convention). In Bun, _handle is the public


### PR DESCRIPTION
## What

`test/js/node/test/sequential/test-gc-http-client-onerror.js` (and its three siblings) time out on the `:alpine: 3.23 x64` / `x64-baseline` lanes, stuck forever at `done/collected/total: 8/7/8`:

```
done/collected/total: 2/0/8
done/collected/total: 4/1/8
done/collected/total: 6/2/8
done/collected/total: 8/5/8
done/collected/total: 8/7/8
done/collected/total: 8/7/8
... (until the runner's timeout kills it)
```

`test-net-connect-memleak.js` fails fast on the same two lanes with `collected: false !== true`.

Observed in builds 74665, 75248, 75256, 75280; not observed on glibc/darwin/windows; not observed on the latest main build (75238). Roughly 1 in 8 PR builds hits one of them.

## Cause

These are verbatim Node.js tests that register objects with `onGC()` (backed by a `FinalizationRegistry`), call `globalThis.gc()`, and assert every object's cleanup callback has fired. V8's precise GC makes that deterministic; JSC does not, and on the linux-x64-musl release build one of N objects intermittently survives the `gc()+setImmediate` loop.

#34500 already removed the one deterministic retention path (`once()` in `internal/shared.ts` now drops its callback), and its deterministic check `test/js/node/http/node-http-client-request-gc.test.ts` passes on every lane including musl, so `ClientRequest` is collectable. I walked the remaining JS-side references (agent `sockets`/`freeSockets`/`requests`, `socket._httpMessage`, parser `incoming`/`outgoing`, the `nextTick` `FixedQueue` slot, the native `TCPSocket.m_data` slot) and all are cleared by the time the status loop runs; I could not reproduce the stuck state on glibc across 100+ debug runs and cannot run musl in this environment, so the musl-only residual is not root-caused here.

## Fix

Quarantine the affected files on `LINUX-X64-MUSL` only, next to `test-tls-connect-memleak.js` which is already there for the same class of failure. The files are verbatim upstream ports (`test/js/node/test/parallel/CLAUDE.md`) so the robust `gcUntil()` retry cannot be applied in-file. They continue to run on every other lane, and the deterministic retention check from #34500 continues to run on musl.

The comment block describes only what is observed on the lane and explicitly records that the musl residual is not root-caused, so the entry is a pointer for whoever picks the investigation back up rather than a terminal diagnosis.

Subsumes #33045 (which proposed the `net` entry alone).

Enabled in #34441.

Fixes #33044

## Verification

Parsed `test/expectations.txt` with the runner's own logic and simulated each lane:

```
On LINUX-X64-MUSL:
   SKIP js/node/test/parallel/test-tls-connect-memleak.js
   SKIP js/node/test/parallel/test-net-connect-memleak.js
   SKIP js/node/test/sequential/test-gc-http-client.js
   SKIP js/node/test/sequential/test-gc-http-client-onerror.js
   SKIP js/node/test/sequential/test-gc-http-client-timeout.js
   SKIP js/node/test/parallel/test-gc-http-client-connaborted.js
On LINUX-X64 (glibc):
   RUN  ... (all six)
On DARWIN-AARCH64:
   RUN  ... (all six)
```

All six still pass on glibc x64 against the current debug build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->