### PR TITLE
node:path: fix win32.relative slice-bounds panic on slash-rooted prefix inputs

### DIFF
--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -2707,7 +2707,8 @@ pub(crate) fn relative_windows_t<'a, T: PathCharCwd>(
     // Lastly, append the rest of the destination (`to`) path that comes after
     // the common path parts
     if out_len > 0 {
-        let slice_size = to_end - to_start;
+        // JS `String.prototype.slice(toStart, toEnd)` yields "" when toStart > toEnd.
+        let slice_size = to_end.saturating_sub(to_start);
         buf_size = out_len;
         if slice_size > 0 {
             buf_offset = buf_size;
@@ -2720,10 +2721,11 @@ pub(crate) fn relative_windows_t<'a, T: PathCharCwd>(
         return Ok(&buf[0..buf_size]);
     }
 
-    if buf[to_start] == T::from_u8(CHAR_BACKWARD_SLASH) {
+    // JS `charCodeAt` returns NaN past the end, which never equals '\'.
+    if to_start < to_orig_len && buf[to_start] == T::from_u8(CHAR_BACKWARD_SLASH) {
         to_start += 1;
     }
-    Ok(&buf[to_start..to_end])
+    Ok(&buf[to_start.min(to_end)..to_end])
 }
 
 pub(crate) fn relative_posix_js_t<T: PathCharCwd>(

--- a/test/js/node/path/relative.test.js
+++ b/test/js/node/path/relative.test.js
@@ -36,13 +36,8 @@ describe("path.relative", () => {
           ["\\\\foo\\baz", "\\\\foo\\baz-quux", "..\\baz-quux"],
           ["C:\\baz", "\\\\foo\\bar\\baz", "\\\\foo\\bar\\baz"],
           ["\\\\foo\\bar\\baz", "C:\\baz", "C:\\baz"],
-          // Slash-rooted (no drive letter) inputs where the shorter side has
-          // trimmed length 2 and is a proper prefix of the other. Node's JS
-          // falls through to String#slice with an inverted range, which
-          // yields ""; a naive Rust slice with the same indices panics.
-          // These resolve through process.cwd() for a device root, so the
-          // expected values below only hold on a POSIX host (where cwd has
-          // no drive letter and resolve("/x.") yields "\\x.").
+          // Slash-rooted (no drive letter) inputs that hit the last_common_sep=Some(3) overshoot.
+          // win32.resolve pulls a device root from cwd, so expected values only hold on a POSIX host.
           ...(isWindows
             ? []
             : [

--- a/test/js/node/path/relative.test.js
+++ b/test/js/node/path/relative.test.js
@@ -1,4 +1,5 @@
 import { describe, test } from "bun:test";
+import { isWindows } from "harness";
 import assert from "node:assert";
 import path from "node:path";
 
@@ -39,15 +40,22 @@ describe("path.relative", () => {
           // trimmed length 2 and is a proper prefix of the other. Node's JS
           // falls through to String#slice with an inverted range, which
           // yields ""; a naive Rust slice with the same indices panics.
-          ["/x..", "/x.", ""],
-          ["/xy.", "/xy", ""],
-          ["/abc", "/ab", ""],
-          ["\\x..", "\\x.", ""],
-          ["\\ab.", "\\ab", ""],
-          ["/xyz.", "/xy", ".."],
-          ["/xyzw", "/xy", ".."],
-          ["/abcde", "/ab", ".."],
-          ["/x.", "/x..", "."],
+          // These resolve through process.cwd() for a device root, so the
+          // expected values below only hold on a POSIX host (where cwd has
+          // no drive letter and resolve("/x.") yields "\\x.").
+          ...(isWindows
+            ? []
+            : [
+                ["/x..", "/x.", ""],
+                ["/xy.", "/xy", ""],
+                ["/abc", "/ab", ""],
+                ["\\x..", "\\x.", ""],
+                ["\\ab.", "\\ab", ""],
+                ["/xyz.", "/xy", ".."],
+                ["/xyzw", "/xy", ".."],
+                ["/abcde", "/ab", ".."],
+                ["/x.", "/x..", "."],
+              ]),
         ],
       ],
       [

--- a/test/js/node/path/relative.test.js
+++ b/test/js/node/path/relative.test.js
@@ -35,6 +35,19 @@ describe("path.relative", () => {
           ["\\\\foo\\baz", "\\\\foo\\baz-quux", "..\\baz-quux"],
           ["C:\\baz", "\\\\foo\\bar\\baz", "\\\\foo\\bar\\baz"],
           ["\\\\foo\\bar\\baz", "C:\\baz", "C:\\baz"],
+          // Slash-rooted (no drive letter) inputs where the shorter side has
+          // trimmed length 2 and is a proper prefix of the other. Node's JS
+          // falls through to String#slice with an inverted range, which
+          // yields ""; a naive Rust slice with the same indices panics.
+          ["/x..", "/x.", ""],
+          ["/xy.", "/xy", ""],
+          ["/abc", "/ab", ""],
+          ["\\x..", "\\x.", ""],
+          ["\\ab.", "\\ab", ""],
+          ["/xyz.", "/xy", ".."],
+          ["/xyzw", "/xy", ".."],
+          ["/abcde", "/ab", ".."],
+          ["/x.", "/x..", "."],
         ],
       ],
       [


### PR DESCRIPTION
### What

`path.win32.relative()` aborts the process with a Rust slice-bounds panic on certain short slash-rooted inputs where one side is a proper prefix of the other:

```
$ bun -e 'console.log(require("node:path").win32.relative("/x..", "/x."))'
panic: slice index starts at 4 but ends at 3
oh no: Bun has crashed.
```

Node v26 returns `""` (exit 0) for the same input. Affects release builds (Rust bounds checks are always on). `path.win32` is exposed on every platform, so anything passing user-influenced Windows-style paths through `win32.relative` can be crashed by a 4-byte string.

Other inputs that hit the same panic: `("/xy.", "/xy")`, `("/abc", "/ab")`, `("\\x..", "\\x.")`, and with a longer `from` (`("/xyz.", "/xy")`, `("/abcde", "/ab")`) a second code path panics via `usize` subtraction underflow.

### Cause

`relative_windows_t` (src/runtime/node/path.rs) ports Node's `lib/path.js` `win32.relative` logic literally. When `smallest_length == 2` and the shorter side is a proper prefix of the longer one with no separator at the boundary, it sets `last_common_sep = Some(3)`. That constant is correct for drive-rooted paths (the intended case: `from='C:\foo'; to='C:\'`), but for single-slash-rooted inputs it pushes `to_start` past `to_end`.

Node has the identical `lastCommonSep = 3` line, but the subsequent `toOrig.slice(toStart, toEnd)` and `toOrig.charCodeAt(toStart)` silently return `""` / `NaN` when the index is inverted or out of range. The Rust port used `&buf[to_start..to_end]` and `to_end - to_start`, which panic instead.

### Fix

Clamp the three consumption sites to JS semantics so the port matches the reference behavior:

- `to_end.saturating_sub(to_start)` for the tail slice length in the `out_len > 0` branch
- bound the `buf[to_start] == '\\'` read by `to_start < to_orig_len` (JS `charCodeAt` past end is `NaN`, never matches)
- `to_start.min(to_end)` on the final `&buf[..]` slice

Output is byte-identical to Node v26 for the new cases and all existing `win32.relative` cases. `relative_posix_t` was audited and does not share this pattern (its device-root special case sets `Some(0)`, which cannot overshoot).

### Verification

Added 9 cases to the `path.win32.relative` table in `test/js/node/path/relative.test.js` covering both panic paths plus the reversed-direction case. Expected values taken from Node v26.3.0.

- `USE_SYSTEM_BUN=1 bun test test/js/node/path/relative.test.js` → panics (fail-before)
- `bun bd test test/js/node/path/` → 122 pass, 0 fail

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/path/relative.test.js

<!-- robobun:evidence:end -->