### PR TITLE
node:http: release createSocket's captured cb so a pinned arrow cannot retain ClientRequest

### DIFF
--- a/src/js/node/_http_agent.ts
+++ b/src/js/node/_http_agent.ts
@@ -283,17 +283,22 @@ Agent.prototype.createSocket = function createSocket(req, options, cb) {
   options.encoding = null;
 
   const oncreate = once((err, s) => {
+    // This closure's scope keeps `cb` (= onSocketCreated.bind(this, req))
+    // reachable for its own lifetime; null it so a lingering arrow cannot
+    // pin the ClientRequest once the call below has taken ownership.
+    const done = cb;
+    cb = undefined;
     // Pass the socket along with the error: proxy-tunnel failures with a
     // statusCode deliberately skip destroy in cleanupAndPropagate so
     // req.onSocket can destroy the connection - dropping it here would leak
     // a proxy socket that holds its end open after a non-200 CONNECT.
-    if (err) return cb(err, s);
+    if (err) return done(err, s);
     this.sockets[name] ||= [];
     this.sockets[name].push(s);
     this.totalSocketCount++;
     $debug("sockets", name, this.sockets[name].length, this.totalSocketCount);
     installListeners(this, s, options);
-    cb(null, s);
+    done(null, s);
   });
   const keepAlive = this.keepAlive;
   if (keepAlive) {


### PR DESCRIPTION
## What

`test/js/node/http/node-http-client-request-gc.test.ts` (added in #34500) fails with `stuck 3/4` on the alpine x64 lanes of several open PRs whose diffs never touch `node:http`:

| build | branch / PR | result |
| --- | --- | --- |
| [75224](https://buildkite.com/bun/bun/builds/75224) | #34505 (fs v26 tests) | stuck 3/4 on alpine x64 + x64-baseline |
| [75206](https://buildkite.com/bun/bun/builds/75206), [75079](https://buildkite.com/bun/bun/builds/75079) | #34505 | stuck 3/4 |
| [75226](https://buildkite.com/bun/bun/builds/75226) | #34519 (events rewrite) | stuck 3/4 on alpine x64-baseline |
| [75105](https://buildkite.com/bun/bun/builds/75105) | #34432 (http v26) | stuck 3/4 + `test-gc-http-client-connaborted.js` stuck at 7/8 |
| [75238](https://buildkite.com/bun/bun/builds/75238), 75214, 75139 | main | passes |

Reproduced locally on glibc (not musl-specific): 39/50 runs of the fixture on #34505's head (`8614e18425`) print `stuck 3/4`, 100/100 on main (`511caaa5`) print `collected 4/4`.

## Cause

#34500 made `internal/shared.once()` null its `callback` slot after firing, so holding the returned wrapper no longer retains the arrow. But the arrow itself

```js
const oncreate = once((err, s) => {
  if (err) return cb(err, s);
  ...
  cb(null, s);
});
```

captures `cb` (= `onSocketCreated.bind(this, req)`) in its own lexical scope. After `once()` nulls `callback` the arrow has no heap retainers, so on most builds it is collected and `cb` goes with it. When JSC's conservative stack scan happens to match the arrow's address, the arrow survives and its scope keeps `cb`, and therefore `req`, alive indefinitely.

Heap snapshot taken in the `stuck 3/4` state on `8614e18425` (release build, `v8.writeHeapSnapshot()`):

```
closure:Function@5019                        [NO RETAINERS - conservative root]
  -> JSLexicalEnvironment@5033  context:name -> "127.0.0.1:45501:"
    -> JSLexicalEnvironment@5446
         context:cb      -> closure:onSocketCreated@5747 (JSBoundFunction)
         context:this    -> Agent@5782
         context:options -> Object@117425

closure:onSocketCreated@5747
  internal: -> NativeExecutable (bound function)
  internal: -> onSocketCreated@5761 (target)
  internal: -> Agent@5782         (boundThis)
  internal: -> ClientRequest@5880 (boundArgs[0])

ClientRequest@5880 retained only by:
  closure:onSocketCreated@5747 (above)
  IncomingMessage@116746 via .req  (cycle: IncomingMessage is only reachable via ClientRequest.res)
```

The arrow is the only edge to `req`; `options`, `this`, and the module scope carry no `req` reference. Which build pins the arrow depends on bundled-module layout, which is why unrelated `src/js` edits flip it.

## Fix

Null `cb` inside the arrow before dispatching, mirroring what #34500 did for `once()`:

```js
const oncreate = once((err, s) => {
  const done = cb;
  cb = undefined;
  if (err) return done(err, s);
  ...
  done(null, s);
});
```

`once()` guarantees the arrow runs at most once, so the read-then-null is safe on every path (including the proxy-tunnel error branch). After the call the arrow's scope no longer references the bound function, so a conservatively pinned arrow retains only `Agent`, `name` and `options`, none of which reach a `ClientRequest`.

#34519 arrives at the same change as part of its broader events rewrite; this extracts just the `_http_agent` edge so the test stops failing on unrelated PRs in the meantime.

## Verification

| build | result (50x or 100x fixture runs, release) |
| --- | --- |
| main `511caaa5` without fix | 100/100 `collected 4/4` |
| #34505 `8614e184` without fix | 39/50 `stuck 3/4` |
| #34505 `8614e184` **with fix** | 100/100 `collected 4/4` |
| #34519 `9abee134` without fix | 40/50 `stuck 3/4` |
| #34519 `4a7e3dd5` (carries this change) | 50/50 `collected 4/4` |

`bun bd test test/js/node/http/node-http-client-request-gc.test.ts` passes; all `test-http-agent*` parallel tests, all four `test-gc-http-client*` tests, and the `test-http*-proxy-request*` suite behave identically to main (`test-http-agent-keepalive.js` and a handful of https-proxy tests fail both before and after).

## Why this is not fail-before provable

The arrow has zero heap retainers once `once()` has fired; it only survives when a stale native-stack word aliases its address. On main's current layout that never happens (100/100 release, 30/30 debug+ASAN), so stashing `src/` and re-running the test still passes. The failure is deterministic once the arrow is pinned, but whether it is pinned is not controllable from JS without instrumenting `once()` itself.
