### PR TITLE
process: skip 'beforeExit' after a fatal uncaught exception

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1459,8 +1459,12 @@ impl VirtualMachine {
 
     pub fn on_before_exit(&mut self) {
         // Node only emits 'beforeExit' on a natural drain; a fatal uncaught
-        // exception that brought us here is an implicit process.exit(1).
+        // exception that brought us here is an implicit process.exit(1). Arm
+        // the hard-exit flag ourselves since we're skipping the dispatch that
+        // would have set it, so a throw from an 'exit' listener still stops
+        // subsequent listeners.
         if self.unhandled_error_counter > 0 {
+            self.exit_on_uncaught_exception = true;
             return;
         }
         ExitHandler::dispatch_on_before_exit(self);

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1472,7 +1472,10 @@ impl VirtualMachine {
                 dispatch = true;
             }
 
-            if dispatch {
+            // Same guard as on entry: a fatal throw during the inner drain
+            // must not re-dispatch. The main-thread case already hard-exits
+            // via `exit_on_uncaught_exception`; this covers workers.
+            if dispatch && self.unhandled_error_counter == 0 {
                 ExitHandler::dispatch_on_before_exit(self);
                 dispatch = false;
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1458,6 +1458,11 @@ impl VirtualMachine {
     }
 
     pub fn on_before_exit(&mut self) {
+        // Node only emits 'beforeExit' on a natural drain; a fatal uncaught
+        // exception that brought us here is an implicit process.exit(1).
+        if self.unhandled_error_counter > 0 {
+            return;
+        }
         ExitHandler::dispatch_on_before_exit(self);
         let mut dispatch = false;
         loop {

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -671,6 +671,27 @@ describe.concurrent(() => {
       expect(exitCode).toBe(0);
     });
 
+    it("a throw from an exit listener after a fatal throw still stops subsequent exit listeners", async () => {
+      // Skipping the beforeExit dispatch also skips the call that arms
+      // exit_on_uncaught_exception; on_before_exit() arms it itself so a throw
+      // from 'exit' still short-circuits the remaining listeners like Node.
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `process.on("exit", c => { console.log("first", c); throw new Error("b"); });
+           process.on("exit", c => console.log("second", c));
+           setTimeout(() => { throw new Error("boom"); }, 1);`,
+        ],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("first 1\n");
+      expect(stderr).toInclude("error: boom");
+      expect(exitCode).toBe(1);
+    });
+
     it("exits 1, not 7, when an exit listener also throws and nothing handles it", async () => {
       await using proc = Bun.spawn({
         cmd: [

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -631,6 +631,46 @@ describe.concurrent(() => {
       expect(exitCode).toBe(0);
     });
 
+    it("is skipped after a fatal uncaught exception", async () => {
+      // Node's fatal-exception path is effectively process.exit(1); 'beforeExit'
+      // is only emitted on a natural drain, never for conditions causing
+      // explicit termination.
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `process.on("beforeExit", () => console.log("beforeExit"));
+           process.on("exit", c => console.log("exit", c));
+           setTimeout(() => { throw new Error("boom"); }, 1);`,
+        ],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("exit 1\n");
+      expect(stderr).toInclude("error: boom");
+      expect(exitCode).toBe(1);
+    });
+
+    it("still fires when an uncaughtException listener handled the throw", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `process.on("uncaughtException", e => console.log("caught", e.message));
+           process.on("beforeExit", c => console.log("beforeExit", c));
+           process.on("exit", c => console.log("exit", c));
+           setTimeout(() => { throw new Error("boom"); }, 1);`,
+        ],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("caught boom\nbeforeExit 0\nexit 0\n");
+      expect(stderr).not.toInclude("error: boom");
+      expect(exitCode).toBe(0);
+    });
+
     it("exits 1, not 7, when an exit listener also throws and nothing handles it", async () => {
       await using proc = Bun.spawn({
         cmd: [


### PR DESCRIPTION
## What

`process.on('beforeExit', ...)` fired after a default-fatal uncaught exception. Node never emits `'beforeExit'` in that case: its fatal-exception path is effectively `process.exit(1)`, and the docs say `'beforeExit'` is "not emitted for conditions causing explicit termination, such as calling process.exit() or uncaught exceptions".

## Repro

```js
process.on('beforeExit', () => console.log('BEFOREEXIT'));
process.on('exit', c => console.log('EXIT', c));
setTimeout(() => { throw new Error('boom'); }, 1);
```

| | stdout | exit |
|---|---|---|
| Node v26.3.0 | `EXIT 1` | 1 |
| Bun (before) | `BEFOREEXIT` then `EXIT 1` | 1 |
| Bun (after) | `EXIT 1` | 1 |

## Cause

`VirtualMachine::uncaught_exception()` has two paths when no `'uncaughtException'` listener handled the error:

- If `exit_on_uncaught_exception` is set, it hard-exits via `process_exit(global, 1)`. But that flag is only armed inside `Process__dispatchOnBeforeExit`, i.e. *after* `beforeExit` has already fired.
- Otherwise it records the fatal state (`unhandled_error_counter += 1`, `exit_handler.exit_code = 1`), prints the error and returns. The main drain loop in `Run::start` then falls out (because `is_event_loop_alive()` sees the nonzero counter) and unconditionally calls `vm.on_before_exit()`.

## Fix

Gate both dispatch sites in `on_before_exit()` on `unhandled_error_counter == 0` so `'beforeExit'` only fires on a natural drain:

- Entry: skip entirely when we arrived via a fatal throw. Arm `exit_on_uncaught_exception` ourselves here since the skipped `Process__dispatchOnBeforeExit` was its sole setter; without it a throw from an `'exit'` listener after a fatal throw would fall through and let subsequent `'exit'` listeners run.
- Re-dispatch inside the drain loop: skip when work scheduled by a `beforeExit` listener itself threw. On the main thread `exit_on_uncaught_exception` already hard-exits this case; the guard covers workers where that flag's hard-exit is main-thread-only.

Controls verified:
- With `process.on('uncaughtException', ...)` installed: `beforeExit` still fires, exit 0. (New regression-guard test.)
- After a fatal throw, a throw from the first `'exit'` listener still stops subsequent `'exit'` listeners. (New regression-guard test; would regress without the flag-arming.)
- `test/cli/hot/hot.test.ts` including "should recover from errors" passes; the watcher loop is unaffected since it proceeds to `tick_possibly_forever()` either way, and `exit_on_uncaught_exception` was already armed by the previous unconditional dispatch.
- All `test-process-beforeexit*` / `test-process-exit*` / `test-worker-*beforeexit*` / `test-promises-unhandled-*` Node parallel tests pass.

### Side effect: unhandled rejections

`unhandled_error_counter` is also bumped on the unhandled-rejection path (`Mode::Bun` fallthrough, `Mode::Throw`), so this guard now also skips `'beforeExit'` when an unhandled rejection is processed before the drain loop exits (e.g. `Promise.reject(...); setImmediate(() => {});`). That is a Node-parity improvement on that path, but it is not the whole story: Bun's default mode still processes some rejections only at `handle_rejected_promises()` *after* `on_before_exit()`, so `setTimeout(() => Promise.reject(...), 1)` is unchanged. The full fix (routing the default unhandled-rejection mode through `uncaughtException`) is #32814's backed-out scope and needs the watcher/worker hardening first; no test pins the partial behavior here.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/node/process/process.test.js -t "is skipped after a fatal"
(fail) process.onBeforeExit > is skipped after a fatal uncaught exception
  + "beforeExit
  + exit 1
  "

$ bun bd test test/js/node/process/process.test.js -t "is skipped after a fatal"
(pass) process.onBeforeExit > is skipped after a fatal uncaught exception
```

Found while investigating #34627; reproduces with or without top-level `await`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/process/process.test.js

<!-- robobun:evidence:end -->