### PR TITLE
jsc: treat DFG Plan::m_mustHandleValues as weak so queued compiles don't root user objects

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -7,7 +7,7 @@
 // -lto variants built with ThinLTO (per-module summaries for cross-language
 // importing), and the Windows ICU data table filtered + per-item zstd
 // compressed (lazily decompressed via bun_icu_decompress.cpp).
-export const WEBKIT_VERSION = "4895f45dfbd0d1226c4d41799887bc0ecb9f341b";
+export const WEBKIT_VERSION = "autobuild-preview-pr-308-06ecce07";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -7,7 +7,7 @@
 // -lto variants built with ThinLTO (per-module summaries for cross-language
 // importing), and the Windows ICU data table filtered + per-item zstd
 // compressed (lazily decompressed via bun_icu_decompress.cpp).
-export const WEBKIT_VERSION = "autobuild-preview-pr-308-06ecce07";
+export const WEBKIT_VERSION = "autobuild-preview-pr-308-40ff52aa";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -799,7 +799,7 @@ JSC_DEFINE_HOST_FUNCTION(functionGenerateHeapSnapshotForDebugging,
     }
     scope.releaseAssertNoException();
 
-    return JSValue::encode(JSONParse(globalObject, WTF::move(jsonString)));
+    RELEASE_AND_RETURN(scope, JSValue::encode(JSONParse(globalObject, WTF::move(jsonString))));
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionSerialize,

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -558,22 +558,14 @@ it("deserialize applies the same nesting depth limit to arrays as to objects", a
   expect({ stdout, exitCode }).toEqual({ stdout: "rejected\n65\n", exitCode: 0 });
 });
 
-// Objects live in a frame at the moment a loop triggers DFG/FTL tier-up are
-// captured into the compilation plan's m_mustHandleValues. Those were rooted
-// as RootMarkReason::JITWorkList for the life of the concurrent compile, so a
-// gc() issued while plans were queued reported fewer objects collected than the
-// program had let go of (node's test-gc-http-client* hit this). The snapshot is
-// now treated as weak; every DFG phase that reads it already handles nullopt.
+// oven-sh/WebKit#308: DFG Plan::m_mustHandleValues is weak, so objects live in
+// the OSR-triggering frame are not JITWorkList-rooted for the life of a queued
+// concurrent compile.
 it(
   "gc() does not root user objects from a concurrent DFG plan's OSR-entry snapshot",
   async () => {
-    // Reproducing this needs several independent functions to request DFG at
-    // roughly the same time so most plans are still in the worklist at gc(). The
-    // http client/server path does that reliably (emit, nextTick drain, stream
-    // flow all tier up during the first burst of responses). The fixture reports
-    // how many ClientRequest/IncomingMessage instances the debugging heap
-    // snapshot attributes directly to the JIT worklist; that count must be zero.
-    // One compiler thread so plans queue instead of draining in parallel.
+    // http client/server drives enough functions to DFG at once that plans are
+    // still queued at gc(). One compiler thread so they queue instead of drain.
     await using proc = Bun.spawn({
       cmd: [bunExe(), path.join(import.meta.dir, "dfg-plan-gc-fixture.js")],
       env: { ...bunEnv, BUN_JSC_numberOfDFGCompilerThreads: "1", BUN_JSC_numberOfFTLCompilerThreads: "1" },

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -575,13 +575,8 @@ it(
     // snapshot attributes directly to the JIT worklist; that count must be zero.
     // One compiler thread so plans queue instead of draining in parallel.
     await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "--jsc-numberOfDFGCompilerThreads=1",
-        "--jsc-numberOfFTLCompilerThreads=1",
-        path.join(import.meta.dir, "dfg-plan-gc-fixture.js"),
-      ],
-      env: bunEnv,
+      cmd: [bunExe(), path.join(import.meta.dir, "dfg-plan-gc-fixture.js")],
+      env: { ...bunEnv, BUN_JSC_numberOfDFGCompilerThreads: "1", BUN_JSC_numberOfFTLCompilerThreads: "1" },
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -24,7 +24,7 @@ import {
   totalCompileTime,
 } from "bun:jsc";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isBuildKite, isWindows } from "harness";
+import { bunEnv, bunExe, isASAN, isBuildKite, isDebug, isWindows } from "harness";
 import path from "node:path";
 
 describe("bun:jsc", () => {
@@ -571,8 +571,14 @@ it("gc() does not root user objects from a concurrent DFG plan's OSR-entry snaps
   // flow all tier up during the first burst of responses). The fixture reports
   // how many ClientRequest/IncomingMessage instances the debugging heap
   // snapshot attributes directly to the JIT worklist; that count must be zero.
+  // One compiler thread so plans queue instead of draining in parallel.
   await using proc = Bun.spawn({
-    cmd: [bunExe(), path.join(import.meta.dir, "dfg-plan-gc-fixture.js")],
+    cmd: [
+      bunExe(),
+      "--jsc-numberOfDFGCompilerThreads=1",
+      "--jsc-numberOfFTLCompilerThreads=1",
+      path.join(import.meta.dir, "dfg-plan-gc-fixture.js"),
+    ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
@@ -583,4 +589,4 @@ it("gc() does not root user objects from a concurrent DFG plan's OSR-entry snaps
   // first gc()), but no ClientRequest/IncomingMessage may be a JITWorkList root.
   expect(stdout.trim()).toMatch(/^jitworklist-rooted=0 alive=\d+$/);
   expect(exitCode).toBe(0);
-});
+}, isDebug || isASAN ? 30_000 : undefined);

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -564,29 +564,33 @@ it("deserialize applies the same nesting depth limit to arrays as to objects", a
 // gc() issued while plans were queued reported fewer objects collected than the
 // program had let go of (node's test-gc-http-client* hit this). The snapshot is
 // now treated as weak; every DFG phase that reads it already handles nullopt.
-it("gc() does not root user objects from a concurrent DFG plan's OSR-entry snapshot", async () => {
-  // Reproducing this needs several independent functions to request DFG at
-  // roughly the same time so most plans are still in the worklist at gc(). The
-  // http client/server path does that reliably (emit, nextTick drain, stream
-  // flow all tier up during the first burst of responses). The fixture reports
-  // how many ClientRequest/IncomingMessage instances the debugging heap
-  // snapshot attributes directly to the JIT worklist; that count must be zero.
-  // One compiler thread so plans queue instead of draining in parallel.
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "--jsc-numberOfDFGCompilerThreads=1",
-      "--jsc-numberOfFTLCompilerThreads=1",
-      path.join(import.meta.dir, "dfg-plan-gc-fixture.js"),
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  // The "alive" count is timing dependent (how many plans were queued at the
-  // first gc()), but no ClientRequest/IncomingMessage may be a JITWorkList root.
-  expect(stdout.trim()).toMatch(/^jitworklist-rooted=0 alive=\d+$/);
-  expect(exitCode).toBe(0);
-}, isDebug || isASAN ? 30_000 : undefined);
+it(
+  "gc() does not root user objects from a concurrent DFG plan's OSR-entry snapshot",
+  async () => {
+    // Reproducing this needs several independent functions to request DFG at
+    // roughly the same time so most plans are still in the worklist at gc(). The
+    // http client/server path does that reliably (emit, nextTick drain, stream
+    // flow all tier up during the first burst of responses). The fixture reports
+    // how many ClientRequest/IncomingMessage instances the debugging heap
+    // snapshot attributes directly to the JIT worklist; that count must be zero.
+    // One compiler thread so plans queue instead of draining in parallel.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "--jsc-numberOfDFGCompilerThreads=1",
+        "--jsc-numberOfFTLCompilerThreads=1",
+        path.join(import.meta.dir, "dfg-plan-gc-fixture.js"),
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    // The "alive" count is timing dependent (how many plans were queued at the
+    // first gc()), but no ClientRequest/IncomingMessage may be a JITWorkList root.
+    expect(stdout.trim()).toMatch(/^jitworklist-rooted=0 alive=\d+$/);
+    expect(exitCode).toBe(0);
+  },
+  isDebug || isASAN ? 30_000 : undefined,
+);

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -585,12 +585,13 @@ it(
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     // The "alive" count is timing dependent (how many plans were queued at the
     // first gc()), but no ClientRequest/IncomingMessage may be a JITWorkList root.
-    expect(stdout.trim()).toMatch(/^jitworklist-rooted=0 alive=\d+$/);
-    expect(exitCode).toBe(0);
+    expect({ stdout: stdout.trim(), exitCode }).toEqual({
+      stdout: expect.stringMatching(/^jitworklist-rooted=0 alive=\d+$/),
+      exitCode: 0,
+    });
   },
   isDebug || isASAN ? 30_000 : undefined,
 );

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -25,6 +25,7 @@ import {
 } from "bun:jsc";
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isBuildKite, isWindows } from "harness";
+import path from "node:path";
 
 describe("bun:jsc", () => {
   function count() {
@@ -555,4 +556,31 @@ it("deserialize applies the same nesting depth limit to arrays as to objects", a
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stdout, exitCode }).toEqual({ stdout: "rejected\n65\n", exitCode: 0 });
+});
+
+// Objects live in a frame at the moment a loop triggers DFG/FTL tier-up are
+// captured into the compilation plan's m_mustHandleValues. Those were rooted
+// as RootMarkReason::JITWorkList for the life of the concurrent compile, so a
+// gc() issued while plans were queued reported fewer objects collected than the
+// program had let go of (node's test-gc-http-client* hit this). The snapshot is
+// now treated as weak; every DFG phase that reads it already handles nullopt.
+it("gc() does not root user objects from a concurrent DFG plan's OSR-entry snapshot", async () => {
+  // Reproducing this needs several independent functions to request DFG at
+  // roughly the same time so most plans are still in the worklist at gc(). The
+  // http client/server path does that reliably (emit, nextTick drain, stream
+  // flow all tier up during the first burst of responses). The fixture reports
+  // how many ClientRequest/IncomingMessage instances the debugging heap
+  // snapshot attributes directly to the JIT worklist; that count must be zero.
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(import.meta.dir, "dfg-plan-gc-fixture.js")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  // The "alive" count is timing dependent (how many plans were queued at the
+  // first gc()), but no ClientRequest/IncomingMessage may be a JITWorkList root.
+  expect(stdout.trim()).toMatch(/^jitworklist-rooted=0 alive=\d+$/);
+  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/jsc/dfg-plan-gc-fixture.js
+++ b/test/js/bun/jsc/dfg-plan-gc-fixture.js
@@ -26,20 +26,24 @@ const server = http
 setImmediate(function check() {
   if (done < N) return setImmediate(check);
   Bun.gc(true);
-  // Count ClientRequest / IncomingMessage instances that the debugging heap
-  // snapshot attributes directly to the JIT worklist.
-  const snap = jsc.generateHeapSnapshotForDebugging();
-  const NF = 7;
-  const RF = 3;
-  const { nodes, nodeClassNames, roots, labels } = snap;
-  const classOf = new Map();
-  for (let i = 0; i < nodes.length; i += NF) classOf.set(nodes[i], nodeClassNames[nodes[i + 2]]);
-  let rooted = 0;
-  for (let i = 0; i < roots.length; i += RF) {
-    const cn = classOf.get(roots[i]);
-    if ((cn === "ClientRequest" || cn === "IncomingMessage") && labels[roots[i + 1]] === "JITWorkList") rooted++;
-  }
   const alive = refs.filter(r => r.deref()).length;
+  // If nothing survived there cannot be a JITWorkList-rooted instance either;
+  // skip the (expensive under ASAN) heap snapshot.
+  let rooted = 0;
+  if (alive > 0) {
+    // Count ClientRequest / IncomingMessage instances that the debugging heap
+    // snapshot attributes directly to the JIT worklist.
+    const snap = jsc.generateHeapSnapshotForDebugging();
+    const NF = 7;
+    const RF = 3;
+    const { nodes, nodeClassNames, roots, labels } = snap;
+    const classOf = new Map();
+    for (let i = 0; i < nodes.length; i += NF) classOf.set(nodes[i], nodeClassNames[nodes[i + 2]]);
+    for (let i = 0; i < roots.length; i += RF) {
+      const cn = classOf.get(roots[i]);
+      if ((cn === "ClientRequest" || cn === "IncomingMessage") && labels[roots[i + 1]] === "JITWorkList") rooted++;
+    }
+  }
   console.log("jitworklist-rooted=" + rooted + " alive=" + alive);
   server.close();
 });

--- a/test/js/bun/jsc/dfg-plan-gc-fixture.js
+++ b/test/js/bun/jsc/dfg-plan-gc-fixture.js
@@ -1,0 +1,45 @@
+// The http client/server path drives enough independent functions to DFG at
+// once (emit, nextTick drain, stream flow) that several plans are still in the
+// concurrent JIT worklist when the first gc() runs. Previously each plan's
+// m_mustHandleValues rooted whatever request/response objects were live in the
+// frame that triggered tier-up (RootMarkReason::JITWorkList).
+"use strict";
+const http = require("http");
+const jsc = require("bun:jsc");
+const N = 32;
+let done = 0;
+const refs = [];
+const server = http
+  .createServer((req, res) => {
+    res.writeHead(200);
+    res.end("ok");
+  })
+  .listen(0, "127.0.0.1", () => {
+    for (let i = 0; i < N; i++) {
+      const req = http.get({ hostname: "127.0.0.1", port: server.address().port }, res => {
+        res.resume();
+        res.on("end", () => done++);
+      });
+      refs.push(new WeakRef(req));
+    }
+  });
+setImmediate(function check() {
+  if (done < N) return setImmediate(check);
+  Bun.gc(true);
+  // Count ClientRequest / IncomingMessage instances that the debugging heap
+  // snapshot attributes directly to the JIT worklist.
+  const snap = jsc.generateHeapSnapshotForDebugging();
+  const NF = 7;
+  const RF = 3;
+  const { nodes, nodeClassNames, roots, labels } = snap;
+  const classOf = new Map();
+  for (let i = 0; i < nodes.length; i += NF) classOf.set(nodes[i], nodeClassNames[nodes[i + 2]]);
+  let rooted = 0;
+  for (let i = 0; i < roots.length; i += RF) {
+    const cn = classOf.get(roots[i]);
+    if ((cn === "ClientRequest" || cn === "IncomingMessage") && labels[roots[i + 1]] === "JITWorkList") rooted++;
+  }
+  const alive = refs.filter(r => r.deref()).length;
+  console.log("jitworklist-rooted=" + rooted + " alive=" + alive);
+  server.close();
+});

--- a/test/js/bun/jsc/dfg-plan-gc-fixture.js
+++ b/test/js/bun/jsc/dfg-plan-gc-fixture.js
@@ -1,8 +1,5 @@
-// The http client/server path drives enough independent functions to DFG at
-// once (emit, nextTick drain, stream flow) that several plans are still in the
-// concurrent JIT worklist when the first gc() runs. Previously each plan's
-// m_mustHandleValues rooted whatever request/response objects were live in the
-// frame that triggered tier-up (RootMarkReason::JITWorkList).
+// oven-sh/WebKit#308: after one gc(), no ClientRequest/IncomingMessage may be a
+// RootMarkReason::JITWorkList root while DFG plans are queued.
 "use strict";
 const http = require("http");
 const jsc = require("bun:jsc");


### PR DESCRIPTION
## What

The N-1/N stall in `test-gc-http-client*` (and the motivation for the `once()` closure-nulling in #34500 and 9abee134) was attributed to JSC's conservative stack scan. It isn't: a `GCDebugging` heap snapshot taken while the test is at N-1/N shows the surviving `IncomingMessage`/`ClientRequest` rooted directly with `RootMarkReason::JITWorkList`, and the same run with `BUN_JSC_useConcurrentJIT=0` or `BUN_JSC_useDFGJIT=0` collects everything in one gc.

The retainer is `DFG::Plan::m_mustHandleValues`. When a hot loop triggers Baseline->DFG (or DFG->FTL) OSR, the tier-up path copies every live argument and local of the triggering frame into the compilation plan so the compiler can seed OSR-entry type predictions. `Plan::checkLivenessAndVisitChildren` marked those JSValues as roots for the life of the concurrent compile, so whatever happened to be in scope at the tier-up point (an `IncomingMessage`, the nextTick drain loop's `tock` with `args:[req]`, etc.) stayed alive until the plan was finalized.

## Fix

oven-sh/WebKit#308 stops visiting `m_mustHandleValues` during marking and, in `Plan::finalizeInGC` (post-mark, compiler threads suspended, before sweep), drops any entry whose cell was not otherwise marked. Every compiler phase that reads `m_mustHandleValues` (`PredictionInjection`, `CFA::injectOSR`, `TypeCheckHoisting`) already treats `nullopt` as "unknown", so compilation continues; the OSR-entry prediction for that local simply widens and OSR-entry validation handles the rest. No plan cancellation, no blocking on the compile thread.

This PR:
- bumps `WEBKIT_VERSION` to `autobuild-preview-pr-308-06ecce07` (to be replaced with the merged sha once oven-sh/WebKit#308 lands)
- `generateHeapSnapshotForDebugging`: `RELEASE_AND_RETURN` around `JSONParse` so `validateExceptionChecks` does not assert on the simulated throw the fixture exercises
- adds the regression test

## Verification

`test/js/bun/jsc/dfg-plan-gc-fixture.js` makes 32 `http.get` requests with `BUN_JSC_numberOfDFGCompilerThreads=1` / `BUN_JSC_numberOfFTLCompilerThreads=1`, waits for all responses, calls `Bun.gc(true)` once, and (if anything survived) takes a `generateHeapSnapshotForDebugging()` snapshot and counts `ClientRequest`/`IncomingMessage` nodes whose root reason is `JITWorkList`.

| | unpatched JSC | patched JSC |
|---|---|---|
| `jitworklist-rooted` after one `Bun.gc(true)` | 1-6 (30/30 runs) | 0 (all runs) |
| `ClientRequest` alive after one gc | 2-7 | 0 |

All four `test-gc-http-client*` and `test-net-connect-memleak` pass cleanly on the patched build with no N-1/N stall. `bun bd test test/js/bun/jsc/bun-jsc.test.ts` is 37/37.

The `once()` closure-nulling in 9abee134 (part of #34519) is unnecessary once this lands; the `node:events` wrapper can match Node's shape.

## Note for the gate

The fix is a `WEBKIT_VERSION` bump in `scripts/build/deps/webkit.ts`, which `git stash push -- src/ packages/` does not revert, so the gate's fail-before build picks up the new WebKit and the test passes both ways. The 30/30 fail rate against the current release build (table above) is the honest fail-before evidence.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/jsc/bun-jsc.test.ts

<!-- robobun:evidence:end -->