### PR TITLE
webcrypto: vendor test-webcrypto-cryptokey-hidden-slots (+1), and map the remaining 21

### DIFF
--- a/test/js/node/test/parallel/test-webcrypto-cryptokey-hidden-slots.js
+++ b/test/js/node/test/parallel/test-webcrypto-cryptokey-hidden-slots.js
@@ -1,0 +1,226 @@
+'use strict';
+
+// CryptoKey prototype getters (`type`, `extractable`,
+// `algorithm`, `usages`) are configurable in the Web Crypto IDL and
+// can therefore be replaced by user code. Internal consumers of those
+// attributes, and the custom inspect output, must NOT go through the
+// public prototype getters, they must read the underlying native
+// internal slots directly. This test mutates the prototype getters
+// (and mutates the per-instance `algorithm`/`usages` caches returned
+// by those getters) and asserts that:
+//
+//   1. util.inspect() shows the real internal values, unaffected by
+//      the replacement getters.
+//   2. Internal Web Crypto and Node.js crypto bridge operations that
+//      receive the mutated CryptoKey still succeed and observe the real
+//      internal state, not the replaced one.
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('node:assert');
+const {
+  createHmac,
+  KeyObject,
+  sign: cryptoSign,
+  verify: cryptoVerify,
+} = require('node:crypto');
+const { inspect } = require('node:util');
+const { subtle } = globalThis.crypto;
+
+common.expectWarning({
+  DeprecationWarning: {
+    DEP0203: 'Passing a CryptoKey to node:crypto functions is deprecated.',
+  },
+});
+
+(async () => {
+  const key = await subtle.generateKey(
+    { name: 'HMAC', hash: 'SHA-256' },
+    true,
+    ['sign', 'verify'],
+  );
+  const { publicKey: ecPublicKey, privateKey: ecPrivateKey } =
+    await subtle.generateKey(
+      { name: 'ECDSA', namedCurve: 'P-256' },
+      false,
+      ['sign', 'verify'],
+    );
+  const { publicKey: rsaPublicKey } = await subtle.generateKey(
+    {
+      name: 'RSA-PSS',
+      modulusLength: 1024,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: 'SHA-256',
+    },
+    true,
+    ['sign', 'verify'],
+  );
+
+  // Public algorithm/usages objects are mutable, but they must be
+  // separate from the native-backed internal slots.
+  rsaPublicKey.algorithm.name = 'FORGED-ALGORITHM';
+  rsaPublicKey.algorithm.hash.name = 'FORGED-HASH';
+  rsaPublicKey.algorithm.publicExponent[0] = 0xff;
+  rsaPublicKey.usages.push('forged-usage');
+
+  const clonedRsaPublicKey = structuredClone(rsaPublicKey);
+  assert.strictEqual(clonedRsaPublicKey.algorithm.name, 'RSA-PSS');
+  assert.strictEqual(clonedRsaPublicKey.algorithm.hash.name, 'SHA-256');
+  assert.deepStrictEqual(
+    clonedRsaPublicKey.algorithm.publicExponent,
+    new Uint8Array([1, 0, 1]));
+  assert.deepStrictEqual(clonedRsaPublicKey.usages, ['verify']);
+
+  const rsaJwk = await subtle.exportKey('jwk', rsaPublicKey);
+  assert.strictEqual(rsaJwk.alg, 'PS256');
+  assert.deepStrictEqual(rsaJwk.key_ops, ['verify']);
+
+  Object.defineProperties(Object.prototype, {
+    hash: {
+      configurable: true,
+      value: { name: 'FORGED-HASH' },
+    },
+    publicExponent: {
+      configurable: true,
+      value: new Uint8Array([0xff]),
+    },
+  });
+
+  try {
+    const aesKey = await subtle.generateKey(
+      { name: 'AES-GCM', length: 128 },
+      true,
+      ['encrypt'],
+    );
+    assert.deepStrictEqual(aesKey.algorithm, {
+      name: 'AES-GCM',
+      length: 128,
+    });
+    assert.strictEqual(Object.hasOwn(aesKey.algorithm, 'hash'), false);
+    assert.strictEqual(
+      Object.hasOwn(aesKey.algorithm, 'publicExponent'),
+      false);
+
+    const clonedAesKey = structuredClone(aesKey);
+    assert.deepStrictEqual(clonedAesKey.algorithm, {
+      name: 'AES-GCM',
+      length: 128,
+    });
+  } finally {
+    delete Object.prototype.hash;
+    delete Object.prototype.publicExponent;
+  }
+
+  // Snapshot the real values BEFORE tampering.
+  const realType = key.type;
+  const realExtractable = key.extractable;
+  const realAlgorithm = { ...key.algorithm, hash: { ...key.algorithm.hash } };
+  const realUsages = [...key.usages];
+
+  // 1) Replace all four prototype getters.
+  let proto = Object.getPrototypeOf(key);
+  while (proto && !Object.getOwnPropertyDescriptor(proto, 'type')) {
+    proto = Object.getPrototypeOf(proto);
+  }
+  assert.ok(proto, 'could not find CryptoKey.prototype');
+  const forgedDescriptors = {
+    type: {
+      configurable: true,
+      enumerable: true,
+      get() { return 'FORGED-TYPE'; },
+    },
+    extractable: {
+      configurable: true,
+      enumerable: true,
+      get() { return 'FORGED-EXTRACTABLE'; },
+    },
+    algorithm: {
+      configurable: true,
+      enumerable: true,
+      get() { return { name: 'FORGED-ALGORITHM', hash: { name: 'FORGED-HASH' } }; },
+    },
+    usages: {
+      configurable: true,
+      enumerable: true,
+      get() { return ['forged-usage']; },
+    },
+  };
+  const originalDescriptors = {};
+  for (const [name, descriptor] of Object.entries(forgedDescriptors)) {
+    originalDescriptors[name] = Object.getOwnPropertyDescriptor(proto, name);
+    Object.defineProperty(proto, name, descriptor);
+  }
+
+  try {
+    // Confirm the forgeries are in effect from user-code perspective.
+    assert.strictEqual(key.type, 'FORGED-TYPE');
+    assert.strictEqual(key.extractable, 'FORGED-EXTRACTABLE');
+    assert.strictEqual(key.algorithm.name, 'FORGED-ALGORITHM');
+    assert.deepStrictEqual(key.usages, ['forged-usage']);
+
+    // 2) util.inspect() must not be influenced by the forged getters,
+    //    it must read the real internal slots directly.
+    const rendered = inspect(key, { depth: 4 });
+    assert.match(rendered, /type: 'secret'/);
+    assert.match(rendered, /extractable: true/);
+    assert.match(rendered, /name: 'HMAC'/);
+    assert.match(rendered, /name: 'SHA-256'/);
+    assert.match(rendered, /'sign'/);
+    assert.match(rendered, /'verify'/);
+    assert.doesNotMatch(rendered, /FORGED/);
+
+    // 3) Internal consumers that receive this CryptoKey must see the
+    //    real internal slots. exportKey('jwk') reads [[type]],
+    //    [[extractable]], [[algorithm]], and [[usages]]; if any
+    //    went through the user-visible getter the call would either
+    //    throw or produce forged output.
+    const jwk = await subtle.exportKey('jwk', key);
+    assert.strictEqual(jwk.kty, 'oct');
+    assert.strictEqual(jwk.alg, 'HS256');
+    assert.strictEqual(jwk.ext, true);
+    assert.deepStrictEqual(jwk.key_ops.sort(), ['sign', 'verify']);
+
+    // 4) The Node.js crypto bridge must also read the real native
+    //    slots directly, both for KeyObject.from() and for deprecated
+    //    direct CryptoKey consumption.
+    const keyObject = KeyObject.from(key);
+    assert.strictEqual(keyObject.type, 'secret');
+    assert.deepStrictEqual(keyObject.export(), Buffer.from(jwk.k, 'base64url'));
+
+    const payload = Buffer.from('payload');
+    const digest = createHmac('sha256', key).update(payload).digest('hex');
+    const expectedDigest =
+      createHmac('sha256', keyObject).update(payload).digest('hex');
+    assert.strictEqual(digest, expectedDigest);
+
+    const signature = cryptoSign('sha256', payload, ecPrivateKey);
+    assert.strictEqual(
+      cryptoVerify('sha256', payload, ecPublicKey, signature),
+      true);
+
+    // 5) Importing back from the exported JWK must yield an equivalent
+    //    key, i.e. the real algorithm and usages round-trip.
+    const reimported = await subtle.importKey('jwk', jwk,
+                                              { name: 'HMAC', hash: 'SHA-256' },
+                                              true, ['sign', 'verify']);
+    // Reimported's prototype is the same mutated prototype, so we must
+    // also inspect() the reimported key to check real slots.
+    const rerendered = inspect(reimported, { depth: 4 });
+    assert.match(rerendered, /type: 'secret'/);
+    assert.match(rerendered, /name: 'HMAC'/);
+    assert.doesNotMatch(rerendered, /FORGED/);
+  } finally {
+    // Restore the original getters so subsequent tests are unaffected.
+    for (const [name, descriptor] of Object.entries(originalDescriptors)) {
+      Object.defineProperty(proto, name, descriptor);
+    }
+  }
+
+  // After restoration, the real values come back through the public API.
+  assert.strictEqual(key.type, realType);
+  assert.strictEqual(key.extractable, realExtractable);
+  assert.deepStrictEqual(key.algorithm, realAlgorithm);
+  assert.deepStrictEqual(key.usages, realUsages);
+})().then(common.mustCall());


### PR DESCRIPTION
Vendors `test-webcrypto-cryptokey-hidden-slots` from Node v26.3.0, copied verbatim. Passes on this branch as-is.

Stacked on #34431. No source changes.

It is a substantive file rather than a smoke test: it forges all four `CryptoKey` prototype getters and checks that `util.inspect`, `exportKey('jwk')`, `KeyObject.from`, `createHmac` and `crypto.sign/verify` all read the native slots rather than the forged ones, plus that `Object.prototype` pollution of `hash` / `publicExponent` doesn't leak into a generated AES-GCM key.

## Verification

3/3 green; tamper-checked (`/type: 'secret'/` → `/type: 'sekret'/`) and it fails on Bun **and** on the real node v26.3.0 binary as a control, so it isn't vacuous.

Regressions: all 29 vendored `test-webcrypto-*` green; 112 vendored `test-crypto-*` are 111 green with 1 pre-existing red (`test-crypto-verify-failure.js`, unrelated — no source changed here); `bun test test/js/node/crypto` is 908 pass / 0 fail.

## The remaining webcrypto gap, measured

A real per-file check: 50 upstream `test-webcrypto-*` files, 28 already vendored, **22 missing**. All 22 pass on real node, so the nominal ceiling is 22 — but the real one is much lower.

| Root cause | N | Reachable? |
|---|---|---|
| `internal/crypto/*` modules | 5 | No — no shim exists, and these were the only files in the whole vendored tree referencing them |
| ML-DSA / ML-KEM not registered as **WebCrypto** algorithms (+ missing `KeyObject.prototype.toCryptoKey`) | 5 | Yes, but it's #34549's territory — that PR adds the EVP-level support |
| v26 SubtleCrypto surface absent: `getPublicKey`, `encapsulateBits/Key`, `decapsulateBits/Key`, `SubtleCrypto.supports` | 4 | One feature unlocks all four |
| `'raw-secret'` importKey format + ChaCha20-Poly1305 / AES-OCB | 3 | One feature unlocks all three |
| TurboSHAKE digest unrecognized | 2 | One feature |
| CryptoKey brand-check / inspect internals | 1 | Needs inspect internals |
| RSA-PSS `saltLength` range check | 1 | Needs error-`cause` plumbing |

Worth stating explicitly since it has been misread before: these ML-DSA/ML-KEM blocks genuinely **run** on Bun rather than skipping. Node gates them as `hasOpenSSL(3,5) || process.features.openssl_is_boringssl`, and since Bun reports `openssl_is_boringssl`, the disjunct selects Bun in. Skip discrimination throughout was done at the source (`common.skip` exits, `printSkipMessage` keeps running) rather than by grepping for `1..0 # Skipped` — `deduplicate-usages` prints five such lines and still really fails.

## Two that looked cheap and weren't

The HMAC JWK-`alg` message (`CryptoAlgorithmHMAC.cpp:145`) collapses several distinct `importJwk` failures into one empty-message `DataError`; fixing it alone still wouldn't convert `export-import`, which also needs `'raw-secret'`. RSA-PSS `saltLength` would need an error `cause` threaded through the shared `ExceptionCallback(ExceptionCode, String)` plumbing used by every WebCrypto algorithm — too much blast radius for one test.
