### PR TITLE
test(worker_threads): wait for 'online' before terminate() in worker-transfer-list test

### DIFF
--- a/test/js/node/worker_threads/worker-transfer-list.test.ts
+++ b/test/js/node/worker_threads/worker-transfer-list.test.ts
@@ -21,12 +21,14 @@ test("an invalid transferList entry throws before anything is detached", async (
 test("a valid transferList still detaches the transferred buffer", async () => {
   const buf = new ArrayBuffer(8);
   const worker = new Worker("", { eval: true, workerData: buf, transferList: [buf] });
+  // Captured before any await: the transfer detaches buf synchronously in the constructor.
+  const len = buf.byteLength;
   try {
-    expect(buf.byteLength).toBe(0);
     // Let startup finish before terminate(): terminate() mid-preload trips
     // JSModuleLoader::continueDynamicImport's scope.assertNoException() on the
     // pending TerminationException (debug/ASAN only).
     await once(worker, "online");
+    expect(len).toBe(0);
   } finally {
     await worker.terminate();
   }

--- a/test/js/node/worker_threads/worker-transfer-list.test.ts
+++ b/test/js/node/worker_threads/worker-transfer-list.test.ts
@@ -14,7 +14,10 @@ test("an invalid transferList entry throws before anything is detached", async (
     }).toThrow(TypeError);
     expect(buf.byteLength).toBe(8);
   } finally {
-    await worker?.terminate();
+    if (worker) {
+      await once(worker, "online").catch(() => {});
+      await worker.terminate();
+    }
   }
 });
 

--- a/test/js/node/worker_threads/worker-transfer-list.test.ts
+++ b/test/js/node/worker_threads/worker-transfer-list.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { once } from "events";
 import { Worker } from "worker_threads";
 
 // The transferList option is converted as a whole before workerData is serialized,
@@ -22,6 +23,10 @@ test("a valid transferList still detaches the transferred buffer", async () => {
   const worker = new Worker("", { eval: true, workerData: buf, transferList: [buf] });
   try {
     expect(buf.byteLength).toBe(0);
+    // Let startup finish before terminate(): terminate() mid-preload trips
+    // JSModuleLoader::continueDynamicImport's scope.assertNoException() on the
+    // pending TerminationException (debug/ASAN only).
+    await once(worker, "online");
   } finally {
     await worker.terminate();
   }


### PR DESCRIPTION
`test/js/node/worker_threads/worker-transfer-list.test.ts` intermittently SIGABRTs on the x64-asan lane (seen in build 75365, reproduces locally at roughly 1-10% depending on load):

```
(pass) an invalid transferList entry throws before anything is detached
ASSERTION FAILED: (null)
!exception()
vendor/WebKit/Source/JavaScriptCore/runtime/ExceptionScope.h(61) : void JSC::ExceptionScope::assertNoException()
```

### Cause

The second test does `new Worker("", { eval: true, ... })` immediately followed by `await worker.terminate()`. Since #31216 every `node:worker_threads` `Worker` automatically preloads `node:worker_threads` on startup so that `process.std{in,out,err}` are rebound even when the worker never requires it. An empty eval worker therefore now runs real module-loader microtasks during startup where it previously ran almost nothing.

`terminate()` fires the `VMTraps::NeedTermination` trap on the worker VM. If that lands while a preload-driven `moduleLoadTopSettled` microtask is inside `JSModuleLoader::hostLoadImportedModule`, the trap surfaces as a `TerminationException` from `resolve()`. `hostLoadImportedModule` then calls `promise->rejectWithCaughtException(vm, scope)`, whose `TRY_CLEAR_EXCEPTION` refuses to clear a termination exception and returns early, and proceeds into `finishLoadingImportedModule` with the termination still pending on the VM. That reaches `continueDynamicImport`:

```cpp
// vendor/WebKit/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
promise->reject(vm, (*exception)->value());
scope.assertNoException();   // TerminationException is still on the VM: SIGABRT
```

Frame-pointer trace from the worker thread at the abort:

```
continueDynamicImport              JSModuleLoader.cpp:1026
finishLoadingImportedModule        JSModuleLoader.cpp:959
hostLoadImportedModule             JSModuleLoader.cpp:662
loadModule                         JSModuleLoader.cpp:790
moduleLoadTopSettled               JSMicrotask.cpp:1082
runInternalMicrotask / drainMicrotasks
Zig::GlobalObject::drainMicrotasks ZigGlobalObject.cpp:3231
EventLoop::tick / wait_for_promise
load_preloads                      jsc_hooks.rs
reload_entry_point                 VirtualMachine.rs:2378
load_entry_point_for_web_worker    VirtualMachine.rs:4626
WebWorker::spin                    web_worker.rs:1101
```

Release builds are unaffected: without `ENABLE(EXCEPTION_SCOPE_VERIFICATION)` that `assertNoException()` compiles to an empty `ASSERT`, and the very next `RETURN_IF_EXCEPTION` in the caller observes the termination and unwinds normally.

### Fix

Wait for `'online'` before `terminate()`. By the time `'online'` fires the worker has evaluated its preloads and entry and is in `Status::Running`, where `terminate()` takes the event-loop path that already handles termination cleanly. The assertion under test (that `transferList: [buf]` detaches `buf` synchronously in the constructor) runs before the wait, so the test still covers exactly what it covered before.

The underlying `continueDynamicImport` assertion belongs in `oven-sh/WebKit` (it should be `assertNoExceptionExceptTermination()`, or `hostLoadImportedModule` should `RETURN_IF_EXCEPTION` after `rejectWithCaughtException`); that is tracked separately since changing it here would not take effect against the prebuilt WebKit this build links.

### Verification

- Before: 4/300 debug+ASAN runs SIGABRT with the assertion above.
- After: 200/200 debug+ASAN runs pass.

This is a test-only change for a timing race, so a single fail-before run is unlikely to reproduce it; the 4/300 and 200/200 figures above are the multi-run probe.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/worker_threads/worker-transfer-list.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/worker_threads/worker-transfer-list.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (228516ef6)

test/js/node/worker_threads/worker-transfer-list.test.ts:
(pass) an invalid transferList entry throws before anything is detached [59.23ms]
(pass) a valid transferList still detaches the transferred buffer [1679.22ms]

 2 pass
 0 fail
 3 expect() calls
Ran 2 tests across 1 file. [3.86s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/node/worker_threads/worker-transfer-list.test.ts | 14 ++++++++++++--
 1 file changed, 12 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
test/js/node/worker_threads/worker-transfer-list.test.ts      3      3      0
```

</details>

<!-- robobun:evidence:end -->