### PR TITLE
worker_threads: stop the 'beforeExit' drain when the worker is terminating

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1458,12 +1458,25 @@ impl VirtualMachine {
     }
 
     pub fn on_before_exit(&mut self) {
+        // Worker: an uncaught throw / `process.exit()` / parent `terminate()`
+        // during this drain arms the JSC termination trap; re-entering JS then
+        // asserts `!exception()` in `Interpreter::executeCallImpl`. Bail out
+        // like `spin()`; `shutdown()` clears the trap before the 'exit' emit.
+        let terminated =
+            |vm: &Self| vm.worker_ref().is_some_and(|w| w.has_requested_terminate());
+
         ExitHandler::dispatch_on_before_exit(self);
         let mut dispatch = false;
         loop {
             while self.is_event_loop_alive() {
                 self.tick();
+                if terminated(self) {
+                    return;
+                }
                 self.auto_tick_active();
+                if terminated(self) {
+                    return;
+                }
                 dispatch = true;
             }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1458,10 +1458,9 @@ impl VirtualMachine {
     }
 
     pub fn on_before_exit(&mut self) {
-        // Worker: an uncaught throw / `process.exit()` / parent `terminate()`
-        // during this drain arms the JSC termination trap; re-entering JS then
-        // asserts `!exception()` in `Interpreter::executeCallImpl`. Bail out
-        // like `spin()`; `shutdown()` clears the trap before the 'exit' emit.
+        // Worker: an uncaught throw / `process.exit()` / parent `terminate()` during
+        // this drain arms the JSC termination trap; re-entering JS then asserts
+        // `!exception()` in `Interpreter::executeCallImpl`. Bail out like `spin()`.
         let terminated = |vm: &Self| vm.worker_ref().is_some_and(|w| w.has_requested_terminate());
 
         ExitHandler::dispatch_on_before_exit(self);

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1462,8 +1462,7 @@ impl VirtualMachine {
         // during this drain arms the JSC termination trap; re-entering JS then
         // asserts `!exception()` in `Interpreter::executeCallImpl`. Bail out
         // like `spin()`; `shutdown()` clears the trap before the 'exit' emit.
-        let terminated =
-            |vm: &Self| vm.worker_ref().is_some_and(|w| w.has_requested_terminate());
+        let terminated = |vm: &Self| vm.worker_ref().is_some_and(|w| w.has_requested_terminate());
 
         ExitHandler::dispatch_on_before_exit(self);
         let mut dispatch = false;

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1756,3 +1756,81 @@ test("the SHARE_ENV founding thread's process.env stays live after the swap", as
   expect(stdout.trim()).toBe("yes,unset");
   expect(exitCode).toBe(0);
 });
+
+describe.concurrent("worker termination during the 'beforeExit' drain", () => {
+  // A worker whose 'beforeExit' listener schedules more work enters
+  // on_before_exit()'s inner drain loop. If that work arms termination (an
+  // uncaught throw, process.exit(), or a parent terminate()), re-dispatching
+  // 'beforeExit' re-enters JS with a termination exception pending and trips
+  // JSC's Interpreter::executeCallImpl `!exception()` assertion, aborting the
+  // whole process. These tests spawn a fresh process per case so the parent's
+  // exit code proves the worker did not take the process down.
+  const run = async (workerBody: string, extraMain: string = "") => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { Worker } = require("node:worker_threads");
+         const { writeSync } = require("node:fs");
+         const w = new Worker(${JSON.stringify(workerBody)}, { eval: true });
+         w.on("error", e => writeSync(1, "WORKER-ERROR " + e.message + "\\n"));
+         w.on("exit", code => writeSync(1, "WORKER-EXIT " + code + "\\n"));
+         ${extraMain}`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  };
+
+  test("uncaught throw from work a 'beforeExit' listener scheduled reports error and exits the worker", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `const { writeSync } = require("node:fs");
+       let n = 0;
+       process.on("beforeExit", () => {
+         writeSync(2, "W-BEFOREEXIT " + (++n) + "\\n");
+         if (n === 1) setImmediate(() => { throw new Error("boom"); });
+       });`,
+    );
+    expect(stderr.trim()).toBe("W-BEFOREEXIT 1");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["WORKER-ERROR boom", "WORKER-EXIT 1"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("process.exit() from work a 'beforeExit' listener scheduled exits the worker with that code", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `const { writeSync } = require("node:fs");
+       let n = 0;
+       process.on("beforeExit", () => {
+         writeSync(2, "W-BEFOREEXIT " + (++n) + "\\n");
+         if (n === 1) setImmediate(() => { process.exit(42); });
+       });`,
+    );
+    expect(stderr.trim()).toBe("W-BEFOREEXIT 1");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["WORKER-EXIT 42"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("parent terminate() while the worker is draining after 'beforeExit' stops the worker", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `const { writeSync } = require("node:fs");
+       const { parentPort } = require("node:worker_threads");
+       let n = 0;
+       process.on("beforeExit", () => {
+         writeSync(2, "W-BEFOREEXIT " + (++n) + "\\n");
+         if (n === 1) setImmediate(() => {
+           parentPort.postMessage("terminate-me");
+           // Stay inside the drain loop until terminate() lands; the loop
+           // safepoint between waits trips the termination trap.
+           const ia = new Int32Array(new SharedArrayBuffer(4));
+           for (let i = 0; i < 600; i++) Atomics.wait(ia, 0, 0, 50);
+         });
+       });`,
+      `w.on("message", () => w.terminate());`,
+    );
+    expect(stderr.trim()).toBe("W-BEFOREEXIT 1");
+    expect(stdout).toMatch(/^WORKER-EXIT [01]\n$/);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1781,7 +1781,7 @@ describe.concurrent("worker termination during the 'beforeExit' drain", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return { stdout, stderr, exitCode };
+    return { stdout: stdout.split("\n").filter(Boolean), stderr, exitCode };
   };
 
   test("uncaught throw from work a 'beforeExit' listener scheduled reports error and exits the worker", async () => {
@@ -1789,13 +1789,15 @@ describe.concurrent("worker termination during the 'beforeExit' drain", () => {
       `const { writeSync } = require("node:fs");
        let n = 0;
        process.on("beforeExit", () => {
-         writeSync(2, "W-BEFOREEXIT " + (++n) + "\\n");
+         writeSync(1, "W-BEFOREEXIT " + (++n) + "\\n");
          if (n === 1) setImmediate(() => { throw new Error("boom"); });
        });`,
     );
-    expect(stderr.trim()).toBe("W-BEFOREEXIT 1");
-    expect(stdout.split("\n").filter(Boolean)).toEqual(["WORKER-ERROR boom", "WORKER-EXIT 1"]);
-    expect(exitCode).toBe(0);
+    expect({ stdout, exitCode, stderr: exitCode === 0 ? "" : stderr }).toEqual({
+      stdout: ["W-BEFOREEXIT 1", "WORKER-ERROR boom", "WORKER-EXIT 1"],
+      exitCode: 0,
+      stderr: "",
+    });
   });
 
   test("process.exit() from work a 'beforeExit' listener scheduled exits the worker with that code", async () => {
@@ -1803,13 +1805,15 @@ describe.concurrent("worker termination during the 'beforeExit' drain", () => {
       `const { writeSync } = require("node:fs");
        let n = 0;
        process.on("beforeExit", () => {
-         writeSync(2, "W-BEFOREEXIT " + (++n) + "\\n");
+         writeSync(1, "W-BEFOREEXIT " + (++n) + "\\n");
          if (n === 1) setImmediate(() => { process.exit(42); });
        });`,
     );
-    expect(stderr.trim()).toBe("W-BEFOREEXIT 1");
-    expect(stdout.split("\n").filter(Boolean)).toEqual(["WORKER-EXIT 42"]);
-    expect(exitCode).toBe(0);
+    expect({ stdout, exitCode, stderr: exitCode === 0 ? "" : stderr }).toEqual({
+      stdout: ["W-BEFOREEXIT 1", "WORKER-EXIT 42"],
+      exitCode: 0,
+      stderr: "",
+    });
   });
 
   test("parent terminate() while the worker is draining after 'beforeExit' stops the worker", async () => {
@@ -1818,7 +1822,7 @@ describe.concurrent("worker termination during the 'beforeExit' drain", () => {
        const { parentPort } = require("node:worker_threads");
        let n = 0;
        process.on("beforeExit", () => {
-         writeSync(2, "W-BEFOREEXIT " + (++n) + "\\n");
+         writeSync(1, "W-BEFOREEXIT " + (++n) + "\\n");
          if (n === 1) setImmediate(() => {
            parentPort.postMessage("terminate-me");
            // Stay inside the drain loop until terminate() lands; the loop
@@ -1829,8 +1833,10 @@ describe.concurrent("worker termination during the 'beforeExit' drain", () => {
        });`,
       `w.on("message", () => w.terminate());`,
     );
-    expect(stderr.trim()).toBe("W-BEFOREEXIT 1");
-    expect(stdout).toMatch(/^WORKER-EXIT [01]\n$/);
-    expect(exitCode).toBe(0);
+    expect({ stdout, exitCode, stderr: exitCode === 0 ? "" : stderr }).toEqual({
+      stdout: ["W-BEFOREEXIT 1", expect.stringMatching(/^WORKER-EXIT [01]$/)],
+      exitCode: 0,
+      stderr: "",
+    });
   });
 });


### PR DESCRIPTION
## What

A `worker_threads` Worker whose `'beforeExit'` listener schedules async work that terminates the worker aborts the whole process instead of reporting the error / exit code to the parent.

## Repro

```js
// r.mjs
import { Worker, isMainThread } from 'node:worker_threads';
if (isMainThread) {
  const w = new Worker(new URL(import.meta.url));
  w.on('exit', code => console.log('WORKER-EXIT', code));
  w.on('error', e => console.log('WORKER-ERROR', e.message));
} else {
  let n = 0;
  process.on('beforeExit', () => {
    if (++n === 1) setImmediate(() => { throw new Error('boom'); });
  });
}
```

| | output | exit |
|---|---|---|
| Node v26.3.0 | `WORKER-ERROR boom`, `WORKER-EXIT 1` | 0 |
| Bun (before, debug) | `ASSERTION FAILED: !exception()` in `JSC::ExceptionScope::assertNoException` | 134 |
| Bun (after) | `WORKER-ERROR boom`, `WORKER-EXIT 1` | 0 |

The same abort reproduces with `setImmediate(() => process.exit(42))` and with a parent `worker.terminate()` that lands while the worker is inside the drain.

## Cause

A worker whose `'beforeExit'` listener schedules more work enters `VirtualMachine::on_before_exit()`'s inner drain loop. If that work arms worker termination (one of: an uncaught throw routed through `web_worker::on_unhandled_rejection`, a `process.exit()` call, or a parent `worker.terminate()`), each of those paths sets `requested_terminate` and calls `jsc_vm().notify_need_termination()`, which arms the JSC termination trap.

The drain loop has no termination check, so once `is_event_loop_alive()` falls false it re-dispatches `'beforeExit'`. That calls `WebCore::EventEmitter::emit` → `JSC::Interpreter::executeCallImpl`, which opens with `scope.assertNoException()` and aborts because a termination exception is (or is about to be) pending.

`spin()`'s main loop already guards `has_requested_terminate()` after every `tick()`/`auto_tick_active()`; the inner drain loop in `on_before_exit()` did not.

## Fix

Add the same `has_requested_terminate()` check inside `on_before_exit()`'s drain (after `tick()` and after `auto_tick_active()`). On a worker the loop now returns as soon as termination is requested; `spin()` then falls through to `shutdown()`, which clears the termination request before emitting `'exit'`. On the main thread `worker_ref()` is `None`, so the check is a no-op.

This is broader than the `unhandled_error_counter` gate in #34639: that PR covers the uncaught-throw path (because the counter is bumped there) but not `process.exit()` or a parent `terminate()`, which arm termination without touching the counter. Both PRs are compatible.

## Verification

```
$ bun bd test test/js/node/worker_threads/worker_threads.test.ts -t "beforeExit' drain"
(pass) uncaught throw from work a 'beforeExit' listener scheduled reports error and exits the worker
(pass) process.exit() from work a 'beforeExit' listener scheduled exits the worker with that code
(pass) parent terminate() while the worker is draining after 'beforeExit' stops the worker
```

Also passing: `test-worker-beforeexit-throw-exit.js`, `test-process-beforeexit*.js`, `test-worker-exit-*.js`, the full `worker_threads.test.ts`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (8607d7368)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1790.28ms]
(pass) all worker_threads module properties are present [25.37ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [25.86ms]
(pass) all worker_threads worker instance properties are present [163.42ms]
(pass) threadId module and worker property is consistent [205.59ms]
(pass) receiveMessageOnPort works across threads [1746.14ms]
(pass) receiveMessageOnPort works as FIFO [14.45ms]
(pass) you can override globalThis.postMessage [1749.19ms]
(pass) support require in eval [1730.32ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (8607d7368)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [28.28ms]
(pass) all worker_threads module properties are present [0.41ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [0.40ms]
(pass) all worker_threads worker instance properties are present [2.96ms]
(pass) threadId module and worker property is consistent [4.84ms]
(pass) receiveMessageOnPort works across threads [26.27ms]
(pass) receiveMessageOnPort works as FIFO [0.27ms]
(pass) you can override globalThis.postMessage [28.21ms]
(pass) support require in eval [27.73ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [26.00ms]
(pass) support require in eval for a file that doesnt exist [25.34ms]
(pass) support worker eval that throws [28.02ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [125.23ms]
(pass) execArgv option > provides empty execArgv when passed an empty array [61.45ms]
(pass) execArgv option > can specify an array of strings [64.13ms]
(pass) eval does not leak source code [1777.2
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (8607d7368)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1792.01ms]
(pass) all worker_threads module properties are present [26.63ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [27.81ms]
(pass) all worker_threads worker instance properties are present [169.57ms]
(pass) threadId module and worker property is consistent [206.52ms]
(pass) receiveMessageOnPort works across threads [1704.27ms]
(pass) receiveMessageOnPort works as FIFO [14.02ms]
(pass) you can override globalThis.postMessage [1750.24ms]
(pass) support require in eval [1802.76ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 686ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[9
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs                          | 11 +++
 test/js/node/worker_threads/worker_threads.test.ts | 84 ++++++++++++++++++++++
 2 files changed, 95 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/VirtualMachine.rs                              10      6      0
test/js/node/worker_threads/worker_threads.test.ts      5      5      0
```

</details>

<!-- robobun:evidence:end -->