### PR TITLE
bun:test: keep the constructor type of expect.any() on the not, resolvesTo and rejectsTo chains

### DIFF
--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -1881,7 +1881,13 @@ impl ExpectStatic {
                 return Err(global_this.throw_out_of_memory());
             };
             // SAFETY: from_js_ptr returns the live m_ctx payload owned by instance_jsvalue.
-            unsafe { (*instance).flags_cell().set(this.flags) };
+            let cell = unsafe { (*instance).flags_cell() };
+            // Merge: copy `not`/`promise` from the ExpectStatic chain while keeping
+            // anything T::invoke already set (e.g. ExpectAny's constructor type).
+            let mut flags = cell.get();
+            flags.set_not(this.flags.not());
+            flags.set_promise(this.flags.promise());
+            cell.set(flags);
         }
         Ok(instance_jsvalue)
     }

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -1882,8 +1882,6 @@ impl ExpectStatic {
             };
             // SAFETY: from_js_ptr returns the live m_ctx payload owned by instance_jsvalue.
             let cell = unsafe { (*instance).flags_cell() };
-            // Merge: copy `not`/`promise` from the ExpectStatic chain while keeping
-            // anything T::invoke already set (e.g. ExpectAny's constructor type).
             let mut flags = cell.get();
             flags.set_not(this.flags.not());
             flags.set_promise(this.flags.promise());

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -4214,6 +4214,40 @@ describe("expect()", () => {
       );
     });
 
+    test("expect.not.any is the complement of expect.any for primitives", () => {
+      // primitives that match any(Ctor) must NOT match not.any(Ctor)
+      expect(5).toEqual(expect.any(Number));
+      expect(5).not.toEqual(expect.not.any(Number));
+      expect("s").toEqual(expect.any(String));
+      expect("s").not.toEqual(expect.not.any(String));
+      expect(true).toEqual(expect.any(Boolean));
+      expect(true).not.toEqual(expect.not.any(Boolean));
+      expect(1n).toEqual(expect.any(BigInt));
+      expect(1n).not.toEqual(expect.not.any(BigInt));
+      expect(Symbol()).toEqual(expect.any(Symbol));
+      expect(Symbol()).not.toEqual(expect.not.any(Symbol));
+
+      // primitives that do NOT match any(Ctor) must match not.any(Ctor)
+      expect(5).not.toEqual(expect.any(String));
+      expect(5).toEqual(expect.not.any(String));
+      expect("s").not.toEqual(expect.any(Number));
+      expect("s").toEqual(expect.not.any(Number));
+
+      // boxed primitives were already correct, keep them covered
+      expect(new Number(5)).not.toEqual(expect.not.any(Number));
+      expect(new String("s")).not.toEqual(expect.not.any(String));
+
+      // nested inside object matching
+      expect({ a: 1 }).toEqual({ a: expect.not.any(String) });
+      expect({ a: 1 }).not.toEqual({ a: expect.not.any(Number) });
+    });
+
+    test("expect.not.any with user class", () => {
+      class Thing {}
+      expect(new Thing()).not.toEqual(expect.not.any(Thing));
+      expect({}).toEqual(expect.not.any(Thing));
+    });
+
     test("Anything matches any type", () => {
       expect(expect.anything()).toEqual("jest");
       expect(expect.anything()).toEqual(1);

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -4237,6 +4237,10 @@ describe("expect()", () => {
       expect(new Number(5)).not.toEqual(expect.not.any(Number));
       expect(new String("s")).not.toEqual(expect.not.any(String));
 
+      // any(Object) is `typeof other === "object"`: null matches, a function does not
+      expect(null).not.toEqual(expect.not.any(Object));
+      expect(() => {}).toEqual(expect.not.any(Object));
+
       // nested inside object matching
       expect({ a: 1 }).toEqual({ a: expect.not.any(String) });
       expect({ a: 1 }).not.toEqual({ a: expect.not.any(Number) });

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -4704,6 +4704,32 @@ describe("expect()", () => {
           }),
         ).toEqual(expect.resolvesTo.stringContaining("a"));
       });
+
+      test("expect.resolvesTo.any and expect.rejectsTo.any match primitives by constructor type", async () => {
+        await expect(Promise.resolve("s")).toEqual(expect.resolvesTo.any(String));
+        await expect(Promise.resolve(5)).toEqual(expect.resolvesTo.any(Number));
+        await expect(Promise.resolve(true)).toEqual(expect.resolvesTo.any(Boolean));
+        await expect(Promise.resolve(1n)).toEqual(expect.resolvesTo.any(BigInt));
+        await expect(Promise.resolve(Symbol())).toEqual(expect.resolvesTo.any(Symbol));
+        await expect(Promise.resolve({})).toEqual(expect.resolvesTo.any(Object));
+        await expect(Promise.resolve(5)).not.toEqual(expect.resolvesTo.any(String));
+
+        await expect(Promise.reject("s")).toEqual(expect.rejectsTo.any(String));
+        await expect(Promise.reject(5)).toEqual(expect.rejectsTo.any(Number));
+        await expect(Promise.reject(5)).not.toEqual(expect.rejectsTo.any(String));
+
+        // .not is the complement
+        await expect(Promise.resolve(5)).not.toEqual(expect.not.resolvesTo.any(Number));
+        await expect(Promise.resolve(5)).toEqual(expect.not.resolvesTo.any(String));
+        await expect(Promise.reject(5)).not.toEqual(expect.not.rejectsTo.any(Number));
+        await expect(Promise.reject(5)).toEqual(expect.not.rejectsTo.any(String));
+
+        // nested in an object, and as a mock call argument
+        await expect({ a: Promise.resolve("s") }).toEqual({ a: expect.resolvesTo.any(String) });
+        const fn = jest.fn();
+        fn(Promise.resolve("s"));
+        expect(fn).toHaveBeenCalledWith(expect.resolvesTo.any(String));
+      });
     }
   });
 

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -4214,43 +4214,46 @@ describe("expect()", () => {
       );
     });
 
-    test("expect.not.any is the complement of expect.any for primitives", () => {
-      // primitives that match any(Ctor) must NOT match not.any(Ctor)
-      expect(5).toEqual(expect.any(Number));
-      expect(5).not.toEqual(expect.not.any(Number));
-      expect("s").toEqual(expect.any(String));
-      expect("s").not.toEqual(expect.not.any(String));
-      expect(true).toEqual(expect.any(Boolean));
-      expect(true).not.toEqual(expect.not.any(Boolean));
-      expect(1n).toEqual(expect.any(BigInt));
-      expect(1n).not.toEqual(expect.not.any(BigInt));
-      expect(Symbol()).toEqual(expect.any(Symbol));
-      expect(Symbol()).not.toEqual(expect.not.any(Symbol));
+    // Jest and Vitest have no expect.not.any()
+    if (isBun) {
+      test("expect.not.any is the complement of expect.any for primitives", () => {
+        // primitives that match any(Ctor) must NOT match not.any(Ctor)
+        expect(5).toEqual(expect.any(Number));
+        expect(5).not.toEqual(expect.not.any(Number));
+        expect("s").toEqual(expect.any(String));
+        expect("s").not.toEqual(expect.not.any(String));
+        expect(true).toEqual(expect.any(Boolean));
+        expect(true).not.toEqual(expect.not.any(Boolean));
+        expect(1n).toEqual(expect.any(BigInt));
+        expect(1n).not.toEqual(expect.not.any(BigInt));
+        expect(Symbol()).toEqual(expect.any(Symbol));
+        expect(Symbol()).not.toEqual(expect.not.any(Symbol));
 
-      // primitives that do NOT match any(Ctor) must match not.any(Ctor)
-      expect(5).not.toEqual(expect.any(String));
-      expect(5).toEqual(expect.not.any(String));
-      expect("s").not.toEqual(expect.any(Number));
-      expect("s").toEqual(expect.not.any(Number));
+        // primitives that do NOT match any(Ctor) must match not.any(Ctor)
+        expect(5).not.toEqual(expect.any(String));
+        expect(5).toEqual(expect.not.any(String));
+        expect("s").not.toEqual(expect.any(Number));
+        expect("s").toEqual(expect.not.any(Number));
 
-      // boxed primitives were already correct, keep them covered
-      expect(new Number(5)).not.toEqual(expect.not.any(Number));
-      expect(new String("s")).not.toEqual(expect.not.any(String));
+        // boxed primitives were already correct, keep them covered
+        expect(new Number(5)).not.toEqual(expect.not.any(Number));
+        expect(new String("s")).not.toEqual(expect.not.any(String));
 
-      // any(Object) is `typeof other === "object"`: null matches, a function does not
-      expect(null).not.toEqual(expect.not.any(Object));
-      expect(() => {}).toEqual(expect.not.any(Object));
+        // any(Object) is `typeof other === "object"`: null matches, a function does not
+        expect(null).not.toEqual(expect.not.any(Object));
+        expect(() => {}).toEqual(expect.not.any(Object));
 
-      // nested inside object matching
-      expect({ a: 1 }).toEqual({ a: expect.not.any(String) });
-      expect({ a: 1 }).not.toEqual({ a: expect.not.any(Number) });
-    });
+        // nested inside object matching
+        expect({ a: 1 }).toEqual({ a: expect.not.any(String) });
+        expect({ a: 1 }).not.toEqual({ a: expect.not.any(Number) });
+      });
 
-    test("expect.not.any with user class", () => {
-      class Thing {}
-      expect(new Thing()).not.toEqual(expect.not.any(Thing));
-      expect({}).toEqual(expect.not.any(Thing));
-    });
+      test("expect.not.any with user class", () => {
+        class Thing {}
+        expect(new Thing()).not.toEqual(expect.not.any(Thing));
+        expect({}).toEqual(expect.not.any(Thing));
+      });
+    }
 
     test("Anything matches any type", () => {
       expect(expect.anything()).toEqual("jest");


### PR DESCRIPTION
### Problem
- `expect.not.any(Ctor)`, `expect.resolvesTo.any(Ctor)` and `expect.rejectsTo.any(Ctor)` lose the constructor type of the matcher. An asserts build aborts on the first match: `ASSERTION FAILED: Invalid constructor type` in `matchAsymmetricMatcherAndGetFlags` (`src/jsc/bindings/bindings.cpp:449`).
- A release build gives the wrong verdict for primitives. `expect(5).toEqual(expect.not.any(Number))` passes. `expect(Promise.resolve("s")).toEqual(expect.resolvesTo.any(String))` fails.
- The cause is `ExpectStatic::create_asymmetric_matcher_with_flags` (`src/runtime/test_runner/expect.rs:1884`). `ExpectAny::call` stores the constructor type in the flags of the new matcher. The function then replaced those flags with the chain flags, which have constructor type `None`.

### Fix
- Copy only `not` and `promise` from the chain onto the flags of the matcher. The constructor type stays.
- Correct because the chain can only set `not` and `promise`, and `ExpectAny` is the only matcher that sets anything else. The other matchers start from `Flags::default()`, so they behave as before.
- Verified: three new tests in `test/js/bun/test/expect.test.js`. Without the fix the debug build aborts on them, and bun 1.4.3-canary.1 fails two of the three. The full file passes.

### Background
- An asymmetric matcher (`expect.any(Number)`) is an object that `toEqual` and similar matchers call to decide a match.
- `Flags` is one packed byte on each matcher: `promise`, `not`, and for `expect.any` the constructor type. The C++ matcher switches on that type to match primitives with `typeof` semantics. With `None` it only calls `hasInstance`, which is false for a primitive.
- `ExpectStatic` is the object that `expect.not`, `expect.resolvesTo` and `expect.rejectsTo` return. It holds the chain flags.

<details><summary>Notes</summary>

Repro:

```js
import { test, expect } from "bun:test";
test("repro", () => {
  expect(5).not.toEqual(expect.not.any(Number)); // release: fails, debug: abort
  expect(Promise.resolve("s")).toEqual(expect.resolvesTo.any(String)); // release: fails, debug: abort
});
```

- Affected constructors: `Number`, `String`, `Boolean`, `BigInt`, `Symbol`. `Object` also lost its type: `expect(null).not.toEqual(expect.not.any(Object))` fails on release, because `any(Object)` is `typeof other === "object"` and the fallthrough only calls `hasInstance`. `Array` gives the same verdict either way for the ordinary cases I tried. Boxed values (`new Number(5)`) and class instances were already correct.
- The same shapes fail when the matcher is nested in an object or passed to `toHaveBeenCalledWith`. The new async test covers both.
- Fail-before on the debug build at `f04caca828`: `bun bd test test/js/bun/test/expect.test.js -t "resolvesTo.any"` aborts at `bindings.cpp(449)`.
- Fail-before on release: `USE_SYSTEM_BUN=1 bun test test/js/bun/test/expect.test.js -t "expect.not.any|resolvesTo.any"` gives 1 pass, 2 fail. The passing one is the user class test, which was already correct through `hasInstance`.
- Full file on the debug build with the fix: 419 pass, 2 todo, 0 fail.
- The two `expect.not.any` tests are inside `if (isBun)`, because the file also runs under Jest and Vitest and their `expect.not` has no `any()`.
- Also ran `test/js/bun/test/jest-extended.test.js` on the first revision: 57 pass.
- The branch was rebased from `a227ad991b` to `f04caca828`.

</details>
