### PR TITLE
expect.closeTo: keep precision as a double instead of coercing via ToInt32

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -553,9 +553,11 @@ AsymmetricMatcherResult matchAsymmetricMatcherAndGetFlags(JSGlobalObject* global
         if ((received == infinity && expected == infinity) || (received == -infinity && expected == -infinity)) {
             return AsymmetricMatcherResult::PASS;
         } else {
-            int32_t digits = digitsValue.toInt32(globalObject);
+            // Jest: threshold = Math.pow(10, -precision) / 2 with precision as a
+            // double. ToInt32 would map Infinity/NaN to 0 and truncate fractions.
+            double precision = digitsValue.toNumber(globalObject);
 
-            double threshold = 0.5 * std::pow(10.0, -digits);
+            double threshold = 0.5 * std::pow(10.0, -precision);
             bool isClose = std::abs(expected - received) < threshold;
             return isClose ? AsymmetricMatcherResult::PASS : AsymmetricMatcherResult::FAIL;
         }

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -2933,23 +2933,23 @@ impl JestPrettyFormat {
                 return Ok(true);
             };
 
-            let number = number_value.to_int32();
-            let digits = digits_value.to_int32();
+            let number = number_value.as_number();
+            let digits = digits_value.as_number();
 
             let flags = matcher.flags.get();
             Self::print_asymmetric_matcher_promise_prefix(flags, this, writer);
             if flags.not() {
-                this.amf_add_for_new_line(b"NumberNotCloseTo".len());
-                writer.write_all(b"NumberNotCloseTo");
+                this.amf_add_for_new_line(b"NumberNotCloseTo ".len());
+                writer.write_all(b"NumberNotCloseTo ");
             } else {
                 this.amf_add_for_new_line(b"NumberCloseTo ".len());
                 writer.write_all(b"NumberCloseTo ");
             }
             writer.print(format_args!(
                 "{} ({} digit{})",
-                number,
-                digits,
-                if digits == 1 { "" } else { "s" },
+                bun_fmt::FormatDouble { number },
+                bun_fmt::FormatDouble { number: digits },
+                if digits == 1.0 { "" } else { "s" },
             ));
         } else if let Some(matcher) = value.as_class_ref::<expect::ExpectObjectContaining>() {
             let Some(object_value) =

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -4582,9 +4582,20 @@ describe("expect()", () => {
       test("-Infinity precision: threshold is Infinity, any finite received matches", () => {
         expect(1e300).toEqual(expect.closeTo(0, -Infinity));
       });
-      test("precision beyond int32 range does not overflow", () => {
-        expect(1.001).not.toEqual(expect.closeTo(1, 2147483648));
+      test("precision beyond int32 range does not wrap via ToInt32", () => {
+        // ToInt32(4294967298) would be 2 (threshold 0.005, 0.001 matches); as a
+        // double the threshold underflows to 0.
+        expect(1.001).not.toEqual(expect.closeTo(1, 4294967298));
       });
+      if (isBun) {
+        test("number and precision are printed as-is, not truncated to int32", () => {
+          expect(Bun.inspect(expect.closeTo(1.5, 2.7))).toBe("NumberCloseTo 1.5 (2.7 digits)");
+          expect(Bun.inspect(expect.closeTo(1, Infinity))).toBe("NumberCloseTo 1 (Infinity digits)");
+          expect(Bun.inspect(expect.closeTo(1, NaN))).toBe("NumberCloseTo 1 (NaN digits)");
+          expect(Bun.inspect(expect.closeTo(1, 1))).toBe("NumberCloseTo 1 (1 digit)");
+          expect(Bun.inspect(expect.not.closeTo(1.5, 2))).toBe("NumberNotCloseTo 1.5 (2 digits)");
+        });
+      }
     });
   });
 

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -4560,6 +4560,31 @@ describe("expect()", () => {
       test("notCloseTo return false if received is not number", () => {
         expect(expect.not.closeTo(1)).not.toEqual("a");
       });
+
+      // Jest keeps precision as a double: threshold = Math.pow(10, -precision) / 2.
+      // ToInt32 coercion would map Infinity/NaN to 0 (threshold 0.5) and truncate
+      // fractional precision, turning these into false passes.
+      test("Infinity precision: threshold is 0, never matches", () => {
+        expect(1.001).not.toEqual(expect.closeTo(1, Infinity));
+        expect(1).not.toEqual(expect.closeTo(1, Infinity));
+        expect(1.001).toEqual(expect.not.closeTo(1, Infinity));
+      });
+      test("NaN precision: threshold is NaN, never matches", () => {
+        expect(1.001).not.toEqual(expect.closeTo(1, NaN));
+        expect(1).not.toEqual(expect.closeTo(1, NaN));
+        expect(1.001).toEqual(expect.not.closeTo(1, NaN));
+      });
+      test("fractional precision is not truncated to an integer", () => {
+        expect(1.003).not.toEqual(expect.closeTo(1, 2.7));
+        expect(1.0005).toEqual(expect.closeTo(1, 2.7));
+        expect(1.003).toEqual(expect.closeTo(1, 2));
+      });
+      test("-Infinity precision: threshold is Infinity, any finite received matches", () => {
+        expect(1e300).toEqual(expect.closeTo(0, -Infinity));
+      });
+      test("precision beyond int32 range does not overflow", () => {
+        expect(1.001).not.toEqual(expect.closeTo(1, 2147483648));
+      });
     });
   });
 


### PR DESCRIPTION
## What

`expect.closeTo(number, precision)` (the asymmetric matcher) was coercing `precision` through `toInt32` before computing the comparison threshold, diverging from jest and from bun's own `toBeCloseTo`:

```js
import { expect } from "bun:test";
expect(1.001).toEqual(expect.closeTo(1, Infinity)); // bun passed; jest fails (threshold 0)
expect(1.001).toEqual(expect.closeTo(1, NaN));      // bun passed; jest fails (never matches)
expect(1.003).toEqual(expect.closeTo(1, 2.7));      // bun passed; jest fails (thr ~0.000998)
```

These are false passes: a jest suite that uses `closeTo(x, Infinity)` to mean "must match exactly" stops asserting anything after porting.

## Cause

`matchAsymmetricMatcherAndGetFlags` in `src/jsc/bindings/bindings.cpp` read the stored precision as `int32_t digits = digitsValue.toInt32(globalObject)` and then computed `0.5 * std::pow(10.0, -digits)`. ECMAScript `ToInt32` maps `Infinity`/`NaN` to `0` (threshold 0.5) and truncates `2.7` to `2` (threshold 0.005). Jest keeps the value as a number and computes `Math.pow(10, -precision) / 2`. The direct `expect(x).toBeCloseTo(y, precision)` path in `toBeCloseTo.rs` already kept an `f64` and was correct.

Also latent in the int32 path: `precision = 2147483648` wraps to `INT32_MIN` and negating that is signed overflow.

## Fix

Read precision as `double` and compute the threshold with it directly. The stored value was already validated as a JS number at construction time.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/test/expect.test.js -t "precision"
 1 pass  4 fail

$ bun bd test test/js/bun/test/expect.test.js -t "precision"
 5 pass  0 fail

$ bun bd test test/js/bun/test/expect.test.js
 411 pass  10 todo  0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 failed, 10 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (14c2df10d)

test/js/bun/test/expect.test.js:
(pass) expect() > () [630.76ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [2.59ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.61ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.38ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.39ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.37ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.40ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.36ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.63ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.37ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.39ms]
(pass) ex
... (truncated)

release without fix: 10 skipped
bun test v1.4.0-canary.1 (14c2df10d)

test/js/bun/test/expect.test.js:
(pass) expect() > () [0.97ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.03ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(-0).toBe(-0) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true
(pass) expect() > toBe() > expect({}).toBe({}) == true
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true
(pass) expect() > toBe() > expect(0).toBe(false) == false [0.01ms]
(pass) expect() > toBe() > expect(0).toBe("") == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(1).toBe(2) == false
(pass) expect() > toBe() > expect(1).toBe(true) == false
(pass) expect() > toBe() > expect(1).toBe("1") == false
(pass) expect() > toBe() > expect(Infinity).toBe(-Infinity) == false
(pass) expect() > toBe() > expect("foo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 10 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (14c2df10d)

test/js/bun/test/expect.test.js:
(pass) expect() > () [759.43ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [3.53ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.59ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.62ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.37ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.40ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.37ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.40ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.37ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.39ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.37ms]
(pass) ex
... (truncated)

release with fix: 10 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 751ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[2/7] cxx obj/src/jsc/bindings/bindings.cpp.o
[3/7] gen cpp.rs (cppbind)
[3/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/bindings.cpp            |  6 ++++--
 src/runtime/test_runner/pretty_format.rs | 14 ++++++-------
 test/js/bun/test/expect.test.js          | 36 ++++++++++++++++++++++++++++++++
 3 files changed, 47 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/jsc/bindings/bindings.cpp                 1      2      0
src/runtime/test_runner/pretty_format.rs      3      2      0
test/js/bun/test/expect.test.js               1      3      0
```

</details>

<!-- robobun:evidence:end -->