### PR TITLE
bun:test: propagate throwing Proxy traps through strict deepEquals and error construction

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -740,28 +740,26 @@ impl JSGlobalObject {
         Ok(Some(result))
     }
 
-    /// `args` formatted as UTF-8. If a `Display` impl fails mid-way (e.g. a
-    /// JS `Symbol.toPrimitive` threw), the pending exception is cleared and
-    /// the partial message is used rather than an error about an error.
-    fn error_message(&self, args: Arguments<'_>) -> Vec<u8> {
+    /// `args` formatted as UTF-8, or `None` when formatting threw a JS exception (left pending).
+    fn error_message(&self, args: Arguments<'_>) -> Option<Vec<u8>> {
         let mut buf: Vec<u8> = Vec::with_capacity(2048);
         use core::fmt::Write;
-        if write!(WriteVec(&mut buf), "{}", args).is_err() {
-            let _ = self.clear_exception_except_termination();
+        let _ = write!(WriteVec(&mut buf), "{}", args);
+        if self.has_exception() {
+            return None;
         }
-        buf
+        Some(buf)
     }
 
     /// An argument-free ASCII literal is atomized (`String::static_`);
-    /// anything else is formatted/copied once.
+    /// anything else is formatted/copied once. Empty when formatting threw.
     fn error_instance(&self, kind: ErrorKind, args: Arguments<'_>) -> JSValue {
         match args.as_str() {
             Some(_) => error_instance(&BunString::create_format(args), self, kind),
-            None => error_instance(
-                &StringView::borrow_utf8(&self.error_message(args)),
-                self,
-                kind,
-            ),
+            None => match self.error_message(args) {
+                Some(message) => error_instance(&StringView::borrow_utf8(&message), self, kind),
+                None => JSValue::ZERO,
+            },
         }
     }
 
@@ -790,9 +788,10 @@ impl JSGlobalObject {
             Some(lit) => {
                 EncodedSlice::from_bytes(lit.as_bytes()).to_dom_exception_instance(self, code)
             }
-            None => {
-                EncodedSlice::utf8(&self.error_message(args)).to_dom_exception_instance(self, code)
-            }
+            None => match self.error_message(args) {
+                Some(message) => EncodedSlice::utf8(&message).to_dom_exception_instance(self, code),
+                None => JSValue::ZERO,
+            },
         }
     }
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1075,9 +1075,35 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
         return true;
     }
 
-    if constexpr (isStrict && !checkPrototypes && !skipPrototypeIdentity) {
-        if (!equal(JSObject::calculatedClassName(o1), JSObject::calculatedClassName(o2))) {
-            return false;
+    if constexpr (isStrict) {
+        const bool hasProxy = c1->type() == ProxyObjectType || c2->type() == ProxyObjectType;
+        if constexpr (!checkPrototypes && !skipPrototypeIdentity) {
+            if (hasProxy) {
+                // calculatedClassName() is "ProxyObject" for every Proxy; compare the observable prototype.
+                JSValue p1 = o1->getPrototype(globalObject);
+                RETURN_IF_EXCEPTION(scope, false);
+                JSValue p2 = o2->getPrototype(globalObject);
+                RETURN_IF_EXCEPTION(scope, false);
+                if (p1 != p2) {
+                    return false;
+                }
+            } else if (!equal(JSObject::calculatedClassName(o1), JSObject::calculatedClassName(o2))) {
+                return false;
+            }
+        }
+        // The generic walk below skips non-enumerable .length; a Proxy bypassed the fast path that checks it.
+        if (hasProxy && v1Array && v2Array) {
+            JSValue len1 = o1->get(globalObject, vm.propertyNames->length);
+            RETURN_IF_EXCEPTION(scope, false);
+            uint64_t length1 = len1.toLength(globalObject);
+            RETURN_IF_EXCEPTION(scope, false);
+            JSValue len2 = o2->get(globalObject, vm.propertyNames->length);
+            RETURN_IF_EXCEPTION(scope, false);
+            uint64_t length2 = len2.toLength(globalObject);
+            RETURN_IF_EXCEPTION(scope, false);
+            if (length1 != length2) {
+                return false;
+            }
         }
     }
 

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -1409,6 +1409,10 @@ impl Expect {
             matcher_name,
             result.to_fmt(&mut formatter),
         ));
+        // Empty means formatting `result` ran user JS that threw; that exception is pending.
+        if err.is_empty() {
+            return JsError::Thrown;
+        }
         match bun_core::String::static_("InvalidMatcherError").to_js(global_this) {
             Ok(name) => err.put(global_this, b"name", name),
             // An exception (e.g. OOM) is already pending from to_js; propagate it

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -710,6 +710,104 @@ describe("expect()", () => {
         signalCode: null,
       });
     });
+
+    const caught = fn => {
+      try {
+        fn();
+      } catch (e) {
+        return e;
+      }
+      throw new Error("expected throw");
+    };
+
+    test("strict deepEquals propagates a throwing Proxy get trap like loose mode", () => {
+      const trapErr = new RangeError("trapG");
+      const thr = () =>
+        new Proxy(
+          {},
+          {
+            get() {
+              throw trapErr;
+            },
+            ownKeys() {
+              return ["a"];
+            },
+            getOwnPropertyDescriptor() {
+              return { enumerable: true, configurable: true, value: 1 };
+            },
+          },
+        );
+
+      // loose already propagated; strict used to short-circuit on calculatedClassName and return false.
+      expect(caught(() => Bun.deepEquals(thr(), { a: 1 }))).toBe(trapErr);
+      expect(caught(() => Bun.deepEquals(thr(), { a: 1 }, true))).toBe(trapErr);
+      // toEqual / toStrictEqual surface the trap throw (previously aborted on assert builds).
+      expect(caught(() => expect(thr()).toEqual({ a: 1 }))).toBe(trapErr);
+      expect(caught(() => expect(thr()).toStrictEqual({ a: 1 }))).toBe(trapErr);
+      expect(caught(() => expect({ a: 1 }).toStrictEqual(thr()))).toBe(trapErr);
+
+      // A transparent Proxy now passes the strict type gate (Node's util.isDeepStrictEqual agrees).
+      expect(Bun.deepEquals(new Proxy({ a: 1 }, {}), { a: 1 }, true)).toBe(true);
+      expect(Bun.deepEquals({ a: 1 }, new Proxy({ a: 1 }, {}), true)).toBe(true);
+      expect(new Proxy({ a: 1 }, {})).toStrictEqual({ a: 1 });
+      class Foo {}
+      expect(Bun.deepEquals(new Proxy(new Foo(), {}), new Foo(), true)).toBe(true);
+      expect(Bun.deepEquals(new Proxy({}, {}), new Foo(), true)).toBe(false);
+
+      // Proxy skips the array fast path (which compares length); the generic walk never sees
+      // non-enumerable .length, so it must be compared explicitly. Matches Node/Jest.
+      expect(Bun.deepEquals(new Proxy(new Array(5), {}), [], true)).toBe(false);
+      // eslint-disable-next-line no-sparse-arrays
+      expect(Bun.deepEquals(new Proxy([1, ,], {}), [1], true)).toBe(false);
+      expect(Bun.deepEquals(new Proxy([1, 2, 3], {}), [1, 2, 3], true)).toBe(true);
+      expect(Bun.deepEquals([1, 2, 3], new Proxy([1, 2, 3], {}), true)).toBe(true);
+      expect(Bun.deepEquals(new Proxy([1, 2], {}), new Proxy([1, 2, 3], {}), true)).toBe(false);
+    });
+
+    test("matcher failure messages propagate a throw from formatting the value", () => {
+      // Array target vs object: deepEquals returns false at the isArray gate without running
+      // the trap, so formatting the received value for the diff is what throws. The exact
+      // trap error must surface, not a matcher error built over it.
+      const trapErr = new RangeError("trapG");
+      const thrArr = () =>
+        new Proxy([1], {
+          get() {
+            throw trapErr;
+          },
+        });
+      expect(caught(() => expect(thrArr()).toStrictEqual({ a: 1 }))).toBe(trapErr);
+      expect(caught(() => expect({ a: 1 }).toStrictEqual(thrArr()))).toBe(trapErr);
+      expect(caught(() => expect(thrArr()).toEqual({ a: 1 }))).toBe(trapErr);
+      expect(caught(() => expect(thrArr()).toMatchObject({ a: 1 }))).toBe(trapErr);
+
+      // this.utils.matcherHint formats user-supplied received/expected the same way.
+      let hintErr;
+      expect.extend({
+        toHitThrowingProxy() {
+          try {
+            this.utils.matcherHint("toHitThrowingProxy", thrArr(), { a: 1 });
+          } catch (e) {
+            hintErr = e;
+          }
+          return { pass: true, message: () => "" };
+        },
+      });
+      expect(0).toHitThrowingProxy();
+      expect(hintErr).toBe(trapErr);
+
+      // An invalid matcher return (no `pass`) is console-formatted into the error message;
+      // a throwing inspect.custom on that value must propagate, not be masked.
+      expect.extend({
+        toReturnThrowingInspect() {
+          return {
+            [Symbol.for("nodejs.util.inspect.custom")]() {
+              throw trapErr;
+            },
+          };
+        },
+      });
+      expect(caught(() => expect(0).toReturnThrowingInspect())).toBe(trapErr);
+    });
   }
 
   test("deepEquals works with sets/maps/dates/strings", () => {


### PR DESCRIPTION
### Problem
- `Bun.deepEquals(p, { a: 1 }, true)` returns `false` for a Proxy `p` whose `get` trap throws. Loose mode, Node's `util.isDeepStrictEqual` and Jest all throw the trap's `RangeError`. The same gate makes `new Proxy({ a: 1 }, {})` strictly unequal to `{ a: 1 }` (#9103).
- Cause: the strict gate in `Bun__deepEquals` (`src/jsc/bindings/bindings.cpp`) compares `calculatedClassName()`, which is `"ProxyObject"` for every Proxy, so it returns before any trap runs.
- Separately, `error_message()` (`src/jsc/JSGlobalObject.rs`) cleared an exception thrown while formatting an error message and used the partial text. A custom matcher whose bad return value has a throwing `inspect.custom` got `InvalidMatcherError` instead of its own throw.

### Fix
- When either side is a Proxy, compare `getPrototype()` results instead of class names. A transparent Proxy passes; a throwing trap runs on the property walk and propagates.
- A Proxy skips the array fast path, and the generic walk never reads `.length`. When both sides are arrays, compare the observable `length` first.
- `error_message()` now returns `None` with the exception left pending. The error instance comes back empty, which every caller already treats as "already thrown". `throw_invalid_matcher_error` checks for it before `put`.
- Verified: two new tests in `test/js/bun/test/expect.test.js` fail on main's `src/` and pass with the fix under `BUN_JSC_validateExceptionChecks=1`. Also `test/js/node/assert/`, `expect-extend`, `jest-extended`, `mock-fn`, `deep-equals` (743 pass).

### Background
- `Bun__deepEquals<isStrict, …, checkPrototypes, …>` is the one native deep-equality walker. `Bun.deepEquals(…, true)` and `toStrictEqual` use `isStrict`. `util.isDeepStrictEqual` sets `checkPrototypes` and has its own constructor rule (#40131), so it does not take the new branch.
- `calculatedClassName()` reads `constructor` in VMInquiry mode (no traps) and falls back to the `ClassInfo` name.
- `getPrototype()`, `get(length)` and `toLength()` run traps and can throw. Each is followed by `RETURN_IF_EXCEPTION`.

<details><summary>Notes</summary>

Original report (maintainer thread): on an assert build, `expect(thr()).toStrictEqual({ a: 1 })` with a throwing `get` trap aborted with `ASSERTION FAILED: Unexpected exception observed (ExceptionScope.h:63)`, because `DiffFormatter::fmt` dropped the `JestPrettyFormat` error and re-entered JSC with the exception pending. Earlier revisions of this PR fixed that in `diff_format.rs`, `matcherHint` and `Bun__deepMatch`. #40068 has since landed the same restructuring on main (`DiffFormatter::new(...)?` formats up front, `deepMatch` checks after `isArray`), so those hunks dropped out on rebase. What remains is the strict-gate change plus the `error_message()` policy.

Behavior after this PR (matches Node `util.isDeepStrictEqual` / Jest `toStrictEqual`):

| case | before | after |
|---|---|---|
| `Bun.deepEquals(throwingProxy, {a:1}, true)` | `false` | throws the trap error |
| `Bun.deepEquals(new Proxy({a:1},{}), {a:1}, true)` | `false` | `true` |
| `Bun.deepEquals(new Proxy(new Foo(),{}), new Foo(), true)` | `false` | `true` |
| `Bun.deepEquals(new Proxy({},{}), new Foo(), true)` | `false` | `false` |
| `Bun.deepEquals(new Proxy([1,,],{}), [1], true)` | `false` | `false` (via the new length check) |
| custom matcher returns `{ [inspect.custom]() { throw e } }` | `InvalidMatcherError` | `e` |

Fail-before on main at a3e0ab60ce with this PR's tests and main's `src/`:

```
(fail) strict deepEquals propagates a throwing Proxy get trap like loose mode   (expected throw)
(fail) matcher failure messages propagate a throw from formatting the value     (InvalidMatcherError instead of trapErr)
```

`create_error_instance` and its siblings return an empty `JSValue` to mean "an exception is already pending"; `throw()`, `throw_value()`, `throw_todo()` and `throw_sys_error()` check `is_empty()` / `has_exception()` before use, so the `error_message()` change needs no caller updates beyond `throw_invalid_matcher_error`.

Rebase history: rebased four times as overlapping work landed (#34660's `checkPrototypes`/`skipPrototypeIdentity` params, #40131's node constructor rule, #40374's `error_message()` consolidation, #40068's `DiffFormatter`/`deepMatch` exception checks) and squashed to one commit.

Related: #32948 makes the same Proxy-transparency change in `Bun__deepEquals` and additionally fixes `toMatchObject` for Proxy-over-array; it composes with this. #29784 / #28538 patched the old `DiffFormatter` abort by clearing the exception; main now propagates instead, so those are superseded by #40068 rather than by this PR.

Self-reviewed across several automated review rounds: 9 concerns raised, 9 addressed (matcherHint `format!` panic, sibling `create_*_error_instance` consistency, sparse-array `.length`, duplicate test helper, double `getPrototypeOf` under `checkPrototypes`, `toMatchObject` coverage, `create_dom_exception_instance`, `throw_invalid_matcher_error` empty guard, exact error identity in tests).
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 6 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/expect.test.js
bun test v1.4.3 (a3e0ab60c)

test/js/bun/test/expect.test.js:
(pass) expect() > () [328.10ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [2.63ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.52ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.25ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.25ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.27ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.24ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.23ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.27ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.24ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.25ms]
(pass) expect() > toBe() > expect(0).toBe(false) == false [1.97ms]
(pass) expect() > toBe() > expect(0).toBe("") == false [0.51ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.38ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.36ms]
(pass) ex
... (truncated)

release without fix: 2 failed, 2 skipped
bun test v1.4.2 (744846f84)

test/js/bun/test/expect.test.js:
(pass) expect() > () [0.63ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.02ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(-0).toBe(-0) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true
(pass) expect() > toBe() > expect({}).toBe({}) == true
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true
(pass) expect() > toBe() > expect(0).toBe(false) == false [0.02ms]
(pass) expect() > toBe() > expect(0).toBe("") == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(1).toBe(2) == false
(pass) expect() > toBe() > expect(1).toBe(true) == false
(pass) expect() > toBe() > expect(1).toBe("1") == false
(pass) expect() > toBe() > expect(Infinity).toBe(-Infinity) == false
(pass) expect() > toBe() > expect("foo").toBe("
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/expect.test.js
bun test v1.4.3 (a3e0ab60c)

test/js/bun/test/expect.test.js:
(pass) expect() > () [338.28ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [3.11ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.64ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.41ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.41ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.39ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.39ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.41ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.41ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.47ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.42ms]
(pass) expect() > toBe() > expect(0).toBe(false) == false [2.87ms]
(pass) expect() > toBe() > expect(0).toBe("") == false [0.60ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.36ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.37ms]
(pass) ex
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     c3a2725808
  features     baseline

23 deps, 131 codegen, 1172 objects in 992ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1248] mkdir stamps
[2/1248] mkdir codegen
[3/1248] mkdir obj
[4/1248] mkdir pch
[5/1248] gen bindgenv2
[6/1248] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[7/1248] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[8/1248] install /workspace/bun
bun install v1.4.2 (744846f84)

Checked 22 installs across 61 packages (no changes) [235.00ms]
[9/1248] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1248] install /workspace/bun/packages/bun-error
bun install v1.4.2 (744846f84)

Checked 1 install across 2 packages (no ch
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/JSGlobalObject.rs         | 31 ++++++-------
 src/jsc/bindings/bindings.cpp     | 32 +++++++++++--
 src/runtime/test_runner/expect.rs |  4 ++
 test/js/bun/test/expect.test.js   | 98 +++++++++++++++++++++++++++++++++++++++
 4 files changed, 146 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 6 passed · 0 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/jsc/JSGlobalObject.rs             13     12     75
src/jsc/bindings/bindings.cpp         15     13     75
src/runtime/test_runner/expect.rs      5      5     75
test/js/bun/test/expect.test.js        6     12     75
```

</details>

<!-- robobun:evidence:end -->





