### PR TITLE
install: re-download tarball when auto-install resolves from the .npm manifest cache

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -511,10 +511,15 @@ pub fn enqueue_dependency_to_root(
         }
     }
 
-    let resolution_id = match this.lockfile.buffers.resolutions[dep_id as usize] {
-        id if id == invalid_package_id => 'brk: {
-            this.drain_dependency_list();
+    // Flush/schedule any network tasks that the enqueue above wrote into
+    // `network_task_fifo` but did not schedule. When the on-disk `.npm`
+    // manifest cache resolves a package synchronously, the tarball download
+    // task is queued here and `resolutions[dep_id]` is already valid, so we
+    // must drain before deciding whether to wait.
+    this.drain_dependency_list();
 
+    let resolution_id = match this.lockfile.buffers.resolutions[dep_id as usize] {
+        id if id == invalid_package_id || this.pending_task_count() > 0 => 'brk: {
             struct Closure {
                 err: Option<crate::Error>,
                 // raw `*mut` — `sleep_until`

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -511,11 +511,9 @@ pub fn enqueue_dependency_to_root(
         }
     }
 
-    // Flush/schedule any network tasks that the enqueue above wrote into
-    // `network_task_fifo` but did not schedule. When the on-disk `.npm`
-    // manifest cache resolves a package synchronously, the tarball download
-    // task is queued here and `resolutions[dep_id]` is already valid, so we
-    // must drain before deciding whether to wait.
+    // Schedule anything the enqueue above left in `network_task_fifo`: a
+    // disk-cached `.npm` manifest resolves `resolutions[dep_id]` synchronously
+    // while only queuing (not scheduling) the tarball download.
     this.drain_dependency_list();
 
     let resolution_id = match this.lockfile.buffers.resolutions[dep_id as usize] {

--- a/src/install/error.rs
+++ b/src/install/error.rs
@@ -501,6 +501,18 @@ impl From<Error> for bun_core::Error {
             Error::Alloc(a) => bun_core::Error::Alloc(a),
             Error::WriteFailed => bun_core::Error::WriteFailed,
             Error::InvalidCharacter => bun_core::Error::InvalidCharacter,
+            // Preserve errno categories the resolver compares against
+            // (see `resolver.rs::load_node_modules` / `path_for_resolution`).
+            Error::FileNotFound | Error::Sys(bun_errno::SystemErrno::ENOENT) => {
+                bun_core::Error::FileNotFound
+            }
+            Error::AccessDenied | Error::Sys(bun_errno::SystemErrno::EACCES) => {
+                bun_core::Error::AccessDenied
+            }
+            Error::NameTooLong | Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG) => {
+                bun_core::Error::NameTooLong
+            }
+            Error::Sys(bun_errno::SystemErrno::ENOSPC) => bun_core::Error::NoSpaceLeft,
             _ => bun_core::Error::Unexpected,
         }
     }

--- a/test/cli/run/run-autoinstall.test.ts
+++ b/test/cli/run/run-autoinstall.test.ts
@@ -122,11 +122,8 @@ test("--install=fallback to install missing packages", async () => {
   expect(stdout?.toString("utf8")).toBe("true false\n");
 });
 
-// One transient tarball failure used to leave the on-disk `.npm` manifest cache
-// in a state where a later `--install=auto` run resolved the package
-// synchronously from that file and returned before the queued tarball download
-// was ever scheduled: the import failed with zero network I/O until the `.npm`
-// file was deleted by hand.
+// A cached `.npm` manifest with no extracted package on disk must still
+// schedule the tarball download instead of returning a stale resolution.
 describe("auto-install re-downloads when only the .npm manifest cache is present", () => {
   function makeTgz(files: Record<string, string>) {
     const enc = new TextEncoder();
@@ -162,7 +159,7 @@ describe("auto-install re-downloads when only the .npm manifest cache is present
     await using proc = Bun.spawn({
       cmd: [bunExe(), "--install=auto", "imp.mjs"],
       cwd: dir,
-      env: { ...bunEnv, HOME: dir, BUN_INSTALL_CACHE_DIR: cache },
+      env: { ...bunEnv, BUN_INSTALL: undefined, HOME: dir, BUN_INSTALL_CACHE_DIR: cache },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -170,7 +167,7 @@ describe("auto-install re-downloads when only the .npm manifest cache is present
     return { stdout: stdout.trim(), stderr, exitCode };
   }
 
-  test.concurrent("after the extracted package is removed from the cache", async () => {
+  test("after the extracted package is removed from the cache", async () => {
     const good = makeTgz({
       "package/package.json": JSON.stringify({ name: "pkg-cache-a", version: "1.0.0", main: "index.js" }),
       "package/index.js": 'module.exports = "OK";',
@@ -209,9 +206,8 @@ describe("auto-install re-downloads when only the .npm manifest cache is present
     mkdirSync(cache, { recursive: true });
 
     const r1 = await runImport(String(dir), cache);
-    expect({ ...r1, tarballRequests }).toEqual({
+    expect({ ...r1, tarballRequests }).toMatchObject({
       stdout: "IMPORT_OK OK",
-      stderr: "",
       exitCode: 0,
       tarballRequests: 1,
     });
@@ -229,15 +225,14 @@ describe("auto-install re-downloads when only the .npm manifest cache is present
 
     // Fresh process: the disk-loaded manifest must trigger a tarball download.
     const r2 = await runImport(String(dir), cache);
-    expect({ ...r2, tarballRequests }).toEqual({
+    expect({ ...r2, tarballRequests }).toMatchObject({
       stdout: "IMPORT_OK OK",
-      stderr: "",
       exitCode: 0,
       tarballRequests: 2,
     });
   });
 
-  test.concurrent("after an integrity failure on the first download", async () => {
+  test("after an integrity failure on the first download", async () => {
     const good = makeTgz({
       "package/package.json": JSON.stringify({ name: "pkg-cache-b", version: "1.0.0", main: "index.js" }),
       "package/index.js": 'module.exports = "OK";',
@@ -290,9 +285,8 @@ describe("auto-install re-downloads when only the .npm manifest cache is present
     serveBad = false;
 
     const r2 = await runImport(String(dir), cache);
-    expect({ ...r2, tarballRequests }).toEqual({
+    expect({ ...r2, tarballRequests }).toMatchObject({
       stdout: "IMPORT_OK OK",
-      stderr: "",
       exitCode: 0,
       tarballRequests: 2,
     });

--- a/test/cli/run/run-autoinstall.test.ts
+++ b/test/cli/run/run-autoinstall.test.ts
@@ -209,9 +209,12 @@ describe("auto-install re-downloads when only the .npm manifest cache is present
     mkdirSync(cache, { recursive: true });
 
     const r1 = await runImport(String(dir), cache);
-    expect(r1.stderr).toBe("");
-    expect(r1.stdout).toBe("IMPORT_OK OK");
-    expect(tarballRequests).toBe(1);
+    expect({ ...r1, tarballRequests }).toEqual({
+      stdout: "IMPORT_OK OK",
+      stderr: "",
+      exitCode: 0,
+      tarballRequests: 1,
+    });
 
     // Evict everything except the `.npm` manifest cache file.
     const kept: string[] = [];
@@ -226,10 +229,12 @@ describe("auto-install re-downloads when only the .npm manifest cache is present
 
     // Fresh process: the disk-loaded manifest must trigger a tarball download.
     const r2 = await runImport(String(dir), cache);
-    expect(r2.stderr).toBe("");
-    expect(r2.stdout).toBe("IMPORT_OK OK");
-    expect(tarballRequests).toBe(2);
-    expect(r2.exitCode).toBe(0);
+    expect({ ...r2, tarballRequests }).toEqual({
+      stdout: "IMPORT_OK OK",
+      stderr: "",
+      exitCode: 0,
+      tarballRequests: 2,
+    });
   });
 
   test.concurrent("after an integrity failure on the first download", async () => {
@@ -280,15 +285,16 @@ describe("auto-install re-downloads when only the .npm manifest cache is present
     // The `.npm` manifest cache was written (with the good integrity).
     expect(readdirSync(cache).some(f => f.endsWith(".npm"))).toBe(true);
 
-    // CDN healed.
+    // CDN healed. The second run must re-download the tarball rather than
+    // failing with zero network I/O against the cached manifest.
     serveBad = false;
 
     const r2 = await runImport(String(dir), cache);
-    expect(r2.stderr).toBe("");
-    expect(r2.stdout).toBe("IMPORT_OK OK");
-    // The second run must re-download the tarball rather than failing with
-    // zero network I/O against the cached manifest.
-    expect(tarballRequests).toBe(2);
-    expect(r2.exitCode).toBe(0);
+    expect({ ...r2, tarballRequests }).toEqual({
+      stdout: "IMPORT_OK OK",
+      stderr: "",
+      exitCode: 0,
+      tarballRequests: 2,
+    });
   });
 });

--- a/test/cli/run/run-autoinstall.test.ts
+++ b/test/cli/run/run-autoinstall.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync } from "fs";
+import { mkdirSync, readdirSync, rmSync } from "fs";
 import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
 
@@ -120,4 +120,175 @@ test("--install=fallback to install missing packages", async () => {
 
   expect(stderr?.toString("utf8")).not.toContain("error: Cannot find package 'is-odd'");
   expect(stdout?.toString("utf8")).toBe("true false\n");
+});
+
+// One transient tarball failure used to leave the on-disk `.npm` manifest cache
+// in a state where a later `--install=auto` run resolved the package
+// synchronously from that file and returned before the queued tarball download
+// was ever scheduled: the import failed with zero network I/O until the `.npm`
+// file was deleted by hand.
+describe("auto-install re-downloads when only the .npm manifest cache is present", () => {
+  function makeTgz(files: Record<string, string>) {
+    const enc = new TextEncoder();
+    const entry = (name: string, body: Uint8Array) => {
+      const h = new Uint8Array(512);
+      const put = (s: string, off: number) => h.set(enc.encode(s), off);
+      put(name, 0);
+      put("0000755\0", 100);
+      put("0000000\0", 108);
+      put("0000000\0", 116);
+      put(body.length.toString(8).padStart(11, "0") + "\0", 124);
+      put("00000000000\0", 136);
+      h.fill(32, 148, 156);
+      h[156] = 48;
+      put("ustar\0", 257);
+      put("00", 263);
+      let sum = 0;
+      for (let i = 0; i < 512; i++) sum += h[i];
+      put(sum.toString(8).padStart(6, "0") + "\0 ", 148);
+      const pad = (512 - (body.length % 512)) % 512;
+      const out = new Uint8Array(512 + body.length + pad);
+      out.set(h);
+      out.set(body, 512);
+      return out;
+    };
+    const parts: Uint8Array[] = [];
+    for (const [name, text] of Object.entries(files)) parts.push(entry(name, enc.encode(text)));
+    parts.push(new Uint8Array(1024));
+    return Bun.gzipSync(Buffer.concat(parts));
+  }
+
+  async function runImport(dir: string, cache: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--install=auto", "imp.mjs"],
+      cwd: dir,
+      env: { ...bunEnv, HOME: dir, BUN_INSTALL_CACHE_DIR: cache },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout: stdout.trim(), stderr, exitCode };
+  }
+
+  test.concurrent("after the extracted package is removed from the cache", async () => {
+    const good = makeTgz({
+      "package/package.json": JSON.stringify({ name: "pkg-cache-a", version: "1.0.0", main: "index.js" }),
+      "package/index.js": 'module.exports = "OK";',
+    });
+    const integrity = "sha512-" + new Bun.CryptoHasher("sha512").update(good).digest("base64");
+
+    let tarballRequests = 0;
+    await using registry = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/t.tgz") {
+          tarballRequests++;
+          return new Response(good);
+        }
+        return Response.json({
+          name: "pkg-cache-a",
+          "dist-tags": { latest: "1.0.0" },
+          versions: {
+            "1.0.0": {
+              name: "pkg-cache-a",
+              version: "1.0.0",
+              dist: { tarball: `http://127.0.0.1:${registry.port}/t.tgz`, integrity },
+            },
+          },
+        });
+      },
+    });
+
+    using dir = tempDir("autoinstall-npm-cache-evict", {
+      "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:${registry.port}/"\n`,
+      "imp.mjs": `try { const m = await import("pkg-cache-a"); console.log("IMPORT_OK " + m.default) } catch (e) { console.log("IMPORT_FAIL " + e.code) }`,
+    });
+    const cache = join(String(dir), ".cache");
+    mkdirSync(cache, { recursive: true });
+
+    const r1 = await runImport(String(dir), cache);
+    expect(r1.stderr).toBe("");
+    expect(r1.stdout).toBe("IMPORT_OK OK");
+    expect(tarballRequests).toBe(1);
+
+    // Evict everything except the `.npm` manifest cache file.
+    const kept: string[] = [];
+    for (const entry of readdirSync(cache)) {
+      if (entry.endsWith(".npm")) {
+        kept.push(entry);
+        continue;
+      }
+      rmSync(join(cache, entry), { recursive: true, force: true });
+    }
+    expect(kept.length).toBeGreaterThan(0);
+
+    // Fresh process: the disk-loaded manifest must trigger a tarball download.
+    const r2 = await runImport(String(dir), cache);
+    expect(r2.stderr).toBe("");
+    expect(r2.stdout).toBe("IMPORT_OK OK");
+    expect(tarballRequests).toBe(2);
+    expect(r2.exitCode).toBe(0);
+  });
+
+  test.concurrent("after an integrity failure on the first download", async () => {
+    const good = makeTgz({
+      "package/package.json": JSON.stringify({ name: "pkg-cache-b", version: "1.0.0", main: "index.js" }),
+      "package/index.js": 'module.exports = "OK";',
+    });
+    const bad = Bun.gzipSync(new Uint8Array(4096).map((_, i) => (i * 37 + 11) & 255));
+    // The manifest always advertises the GOOD integrity; only the tarball bytes
+    // are corrupted on the first request (a flaky CDN, not a bad registry).
+    const integrity = "sha512-" + new Bun.CryptoHasher("sha512").update(good).digest("base64");
+
+    let serveBad = true;
+    let tarballRequests = 0;
+    await using registry = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/t.tgz") {
+          tarballRequests++;
+          return new Response(serveBad ? bad : good);
+        }
+        return Response.json({
+          name: "pkg-cache-b",
+          "dist-tags": { latest: "1.0.0" },
+          versions: {
+            "1.0.0": {
+              name: "pkg-cache-b",
+              version: "1.0.0",
+              dist: { tarball: `http://127.0.0.1:${registry.port}/t.tgz`, integrity },
+            },
+          },
+        });
+      },
+    });
+
+    using dir = tempDir("autoinstall-npm-cache-flake", {
+      "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:${registry.port}/"\n`,
+      "imp.mjs": `try { const m = await import("pkg-cache-b"); console.log("IMPORT_OK " + m.default) } catch (e) { console.log("IMPORT_FAIL " + e.code) }`,
+    });
+    const cache = join(String(dir), ".cache");
+    mkdirSync(cache, { recursive: true });
+
+    const r1 = await runImport(String(dir), cache);
+    expect(r1.stdout).toBe("IMPORT_FAIL ERR_MODULE_NOT_FOUND");
+    expect(tarballRequests).toBe(1);
+    // The `.npm` manifest cache was written (with the good integrity).
+    expect(readdirSync(cache).some(f => f.endsWith(".npm"))).toBe(true);
+
+    // CDN healed.
+    serveBad = false;
+
+    const r2 = await runImport(String(dir), cache);
+    expect(r2.stderr).toBe("");
+    expect(r2.stdout).toBe("IMPORT_OK OK");
+    // The second run must re-download the tarball rather than failing with
+    // zero network I/O against the cached manifest.
+    expect(tarballRequests).toBe(2);
+    expect(r2.exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
## Problem

One transient tarball failure permanently poisoned auto-install for that package. With a `.npm` manifest cache file present but no extracted package in the cache store, every subsequent `bun --install=auto` run failed with zero network I/O:

```
IMPORT_FAIL ERR_MODULE_NOT_FOUND: Unexpected while resolving package 'pkg' [0 reqs]
```

The only recovery was to delete the `.npm` file by hand. Since the default cache is the shared global `~/.bun/install/cache`, one flaky CDN response bricked auto-install of that package machine-wide.

## Cause

When `enqueue_dependency_with_main_and_success_fn` loads a manifest from the on-disk `.npm` cache, it resolves the package synchronously, creates the tarball `NetworkTask`, and writes it to `network_task_fifo` via `enqueue_network_task` (which does not schedule). The scopeguard sets `resolutions[dep_id]` to the new package id.

`enqueue_dependency_to_root` then saw a valid `resolutions[dep_id]` and took the fast path, returning `Resolution{..}` without ever calling `drain_dependency_list()`. The tarball task sat in the fifo unscheduled. The resolver then hit `path_for_resolution` for a cache folder that did not exist; the `readlinkat` ENOENT was mapped through `install::Error -> bun_core::Error` to `Unexpected`, so the resolver's `FileNotFound` download fallback never fired either.

## Fix

* Hoist `drain_dependency_list()` above the resolution check in `enqueue_dependency_to_root` and enter the `sleep_until` loop when `pending_task_count() > 0`, so a tarball queued during a synchronous disk-cache resolve actually runs.
* Map `ENOENT`/`EACCES`/`ENAMETOOLONG`/`ENOSPC` through `From<install::Error> for bun_core::Error` so the resolver's `path_for_resolution` fallback can match on `FileNotFound`.

## Verification

Two new tests in `test/cli/run/run-autoinstall.test.ts` using a loopback mock registry, both failing on `main` and passing with this change:

* `.npm` present, extracted folder removed: second run re-downloads the tarball and imports successfully.
* First tarball request returns corrupted bytes (manifest integrity is correct): after the CDN heals, the second run re-downloads and imports successfully instead of failing with zero requests.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/run-autoinstall.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (cf5dbbb87)

test/cli/run/run-autoinstall.test.ts:
(pass) basic autoinstall > <no flag> with node_modules should not autoinstall [447.81ms]
(pass) basic autoinstall > <no flag> without node_modules should autoinstall [912.22ms]
(pass) basic autoinstall > -i with node_modules should autoinstall [847.02ms]
(pass) basic autoinstall > -i without node_modules should autoinstall [818.45ms]
(pass) basic autoinstall > --install=auto with node_modules should not autoinstall [427.64ms]
(pass) basic autoinstall > --install=auto without node_modules should autoinstall [801.73ms]
(pass) basic autoinstall > --install=fallback with node_modules should autoinstall [807.09ms]
(pass) basic autoinstall > --install=fallback without node_modules shoul
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (58d97a21c)

test/cli/run/run-autoinstall.test.ts:
(pass) basic autoinstall > <no flag> with node_modules should not autoinstall [12.27ms]
(pass) basic autoinstall > <no flag> without node_modules should autoinstall [115.38ms]
(pass) basic autoinstall > -i with node_modules should autoinstall [108.48ms]
(pass) basic autoinstall > -i without node_modules should autoinstall [116.77ms]
(pass) basic autoinstall > --install=auto with node_modules should not autoinstall [10.58ms]
(pass) basic autoinstall > --install=auto without node_modules should autoinstall [112.56ms]
(pass) basic autoinstall > --install=fallback with node_modules should autoinstall [110.63ms]
(pass) basic autoinstall > --install=fallback without node_modules should autoinstall [112.46ms]
(pass) basic autoinstall > --install=force with node_modules should autoinstall [115.43ms]
(pass) basic autoinstall > --install=force without node_modules should autoinstall [113.89ms]
(pass) auto-install in a project whose package.json has a name and version [13.97ms]
(pass) --install=fallback to install missing packages [183.74ms]
(pass) auto-install re-downloads when only the .npm manifest 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/run-autoinstall.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (cf5dbbb87)

test/cli/run/run-autoinstall.test.ts:
(pass) basic autoinstall > <no flag> with node_modules should not autoinstall [444.89ms]
(pass) basic autoinstall > <no flag> without node_modules should autoinstall [813.96ms]
(pass) basic autoinstall > -i with node_modules should autoinstall [844.43ms]
(pass) basic autoinstall > -i without node_modules should autoinstall [810.36ms]
(pass) basic autoinstall > --install=auto with node_modules should not autoinstall [426.44ms]
(pass) basic autoinstall > --install=auto without node_modules should autoinstall [816.30ms]
(pass) basic autoinstall > --install=fallback with node_modules should autoinstall [807.58ms]
(pass) basic autoinstall > --install=fallback without node_modules shoul
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 684ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../PackageManager/PackageManagerEnqueue.rs        |   9 +-
 src/install/error.rs                               |  12 ++
 test/cli/run/run-autoinstall.test.ts               | 173 ++++++++++++++++++++-
 3 files changed, 190 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/install/PackageManager/PackageManagerEnqueue.rs      8      2      0
src/install/error.rs                                     2      1      0
test/cli/run/run-autoinstall.test.ts                     4      7      0
```

</details>

<!-- robobun:evidence:end -->