### PR TITLE
install: don't debug_assert on untrusted registry packument version keys

### DIFF
--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -3172,14 +3172,13 @@ impl PackageManifest {
 
                     if cfg!(debug_assertions) {
                         if cloned_versions.len() > 1 {
-                            // Sanity check:
-                            // When reading the versions, we iterate through the
-                            // list backwards to choose the highest matching
-                            // version
+                            // Sanity check: we iterate backwards to pick the highest match.
+                            // Untrusted registry keys may parse to duplicate canonical
+                            // versions (e.g. "1.0.0" and "01.0.0"), so allow Equal.
                             let first = semver_versions_[0];
                             let second = semver_versions_[1];
                             let order = second.order(first, string_bytes, string_bytes);
-                            debug_assert!(order == core::cmp::Ordering::Greater);
+                            debug_assert!(order != core::cmp::Ordering::Less);
                         }
                     }
                 }

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -2081,7 +2081,6 @@ impl PackageManifest {
                 let sliced_version = SlicedString::init(version_name, version_name);
                 let parsed_version = Semver::Version::parse(sliced_version);
 
-                debug_assert!(parsed_version.valid);
                 if !parsed_version.valid {
                     log.add_error_fmt(
                         Some(&source),
@@ -2363,7 +2362,9 @@ impl PackageManifest {
                 let mut sliced_version = SlicedString::init(version_name, version_name);
                 let mut parsed_version = Semver::Version::parse(sliced_version);
 
-                debug_assert!(parsed_version.valid);
+                if !parsed_version.valid {
+                    continue;
+                }
                 // We only need to copy the version tags if it contains pre and/or build
                 if parsed_version.version.tag.has_build() || parsed_version.version.tag.has_pre() {
                     let version_string = string_builder.append::<SemverString>(version_name);
@@ -2374,9 +2375,6 @@ impl PackageManifest {
                         parsed_version.version.tag.has_build()
                             || parsed_version.version.tag.has_pre()
                     );
-                }
-                if !parsed_version.valid {
-                    continue;
                 }
 
                 let version_obj = prop.value.as_object();

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -2685,15 +2685,8 @@ impl PackageManifest {
 
                         for item in items {
                             let name_str = item.key.slice();
-                            let version_str = match item.value.as_str() {
-                                Some(s) => s,
-                                None => {
-                                    if cfg!(debug_assertions) {
-                                        unreachable!("non-value Expr from JSON parser")
-                                    } else {
-                                        continue;
-                                    }
-                                }
+                            let Some(version_str) = item.value.as_str() else {
+                                continue;
                             };
 
                             all_extern_strings[names_base + i] =
@@ -2920,10 +2913,12 @@ impl PackageManifest {
                             }
 
                             // Per-element string-content checks against the
-                            // source JSON. Skipped when meta-only
-                            // optional peers may have been synthesised, since
-                            // `items[j]` correspondence no longer holds then.
-                            if !is_peer || optional_peer_dep_names.is_empty() {
+                            // source JSON. Skipped when `items[j]` no longer
+                            // lines up 1:1 (meta-only peers synthesised, or
+                            // non-string dependency values skipped above).
+                            if count == items.len()
+                                && (!is_peer || optional_peer_dep_names.is_empty())
+                            {
                                 let string_buf: &[u8] = string_builder.allocated_slice();
                                 for (j, dep_name) in name_dependencies.iter().enumerate() {
                                     debug_assert!(

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -2517,7 +2517,11 @@ describe.concurrent("bun-install", () => {
         if (request.url.endsWith(".tgz")) {
           return new Response(file(join(import.meta.dir, "bar-0.0.2.tgz")));
         }
-        const entry = (v: string) => ({ name: "bar", version: v, dist: { tarball: `${ctx.registry_url}bar-0.0.2.tgz` } });
+        const entry = (v: string) => ({
+          name: "bar",
+          version: v,
+          dist: { tarball: `${ctx.registry_url}bar-0.0.2.tgz` },
+        });
         return Response.json({
           name: "bar",
           "dist-tags": { latest: "0.0.2" },

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -2455,6 +2455,59 @@ describe.concurrent("bun-install", () => {
     });
   });
 
+  it("should skip non-semver keys in registry packument `versions` without crashing", async () => {
+    // Registries and proxies are untrusted input; a corrupt mirror or hostile registry can
+    // serve a `versions` object containing keys that are not valid semver. Bun must report
+    // and skip them rather than assert on them.
+    await withContext(defaultOpts, async ctx => {
+      const urls: string[] = [];
+      setContextHandler(ctx, async request => {
+        urls.push(request.url);
+        if (request.url.endsWith(".tgz")) {
+          return new Response(file(join(import.meta.dir, "bar-0.0.2.tgz")));
+        }
+        return Response.json({
+          name: "bar",
+          "dist-tags": { latest: "0.0.2" },
+          versions: {
+            "not-a-version": {},
+            "0.0.2": {
+              name: "bar",
+              version: "0.0.2",
+              dist: { tarball: `${ctx.registry_url}bar-0.0.2.tgz` },
+            },
+          },
+        });
+      });
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({
+          name: "foo",
+          version: "0.0.1",
+          dependencies: { bar: "^0.0.2" },
+        }),
+      );
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+      expect(err).toContain("Failed to parse dependency not-a-version");
+      expect(err).toContain("Saved lockfile");
+      expect(out).toContain("+ bar@0.0.2");
+      expect(urls.sort()).toEqual([`${ctx.registry_url}bar`, `${ctx.registry_url}bar-0.0.2.tgz`]);
+      expect(await file(join(ctx.package_dir, "node_modules", "bar", "package.json")).json()).toEqual({
+        name: "bar",
+        version: "0.0.2",
+      });
+      expect(exitCode).toBe(1);
+    });
+  });
+
   it("should handle caret range in dependencies when the registry has prereleased packages, issue#4398", async () => {
     await withContext(defaultOpts, async ctx => {
       const urls: string[] = [];

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -2508,6 +2508,52 @@ describe.concurrent("bun-install", () => {
     });
   });
 
+  it("should handle registry packument `versions` keys that parse to duplicate canonical versions, issue#20371", async () => {
+    // A private registry can serve keys like "0.0.2" and "00.0.2" that are distinct JSON keys
+    // but parse to the same canonical semver. The post-sort ordering check must not assert
+    // strict Greater on adjacent equal entries.
+    await withContext(defaultOpts, async ctx => {
+      setContextHandler(ctx, async request => {
+        if (request.url.endsWith(".tgz")) {
+          return new Response(file(join(import.meta.dir, "bar-0.0.2.tgz")));
+        }
+        const entry = (v: string) => ({ name: "bar", version: v, dist: { tarball: `${ctx.registry_url}bar-0.0.2.tgz` } });
+        return Response.json({
+          name: "bar",
+          "dist-tags": { latest: "0.0.2" },
+          versions: {
+            "0.0.2": entry("0.0.2"),
+            "00.0.2": entry("00.0.2"),
+          },
+        });
+      });
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({
+          name: "foo",
+          version: "0.0.1",
+          dependencies: { bar: "^0.0.2" },
+        }),
+      );
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+      expect(err).toContain("Saved lockfile");
+      expect(out).toContain("+ bar@0.0.2");
+      expect(await file(join(ctx.package_dir, "node_modules", "bar", "package.json")).json()).toEqual({
+        name: "bar",
+        version: "0.0.2",
+      });
+      expect(exitCode).toBe(0);
+    });
+  });
+
   it("should handle caret range in dependencies when the registry has prereleased packages, issue#4398", async () => {
     await withContext(defaultOpts, async ctx => {
       const urls: string[] = [];

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -2558,6 +2558,55 @@ describe.concurrent("bun-install", () => {
     });
   });
 
+  it("should skip non-string dependency values in registry packument without crashing", async () => {
+    // A registry packument is untrusted input; a version entry may carry a dependency
+    // map with a non-string value (null, number, object). Bun must skip such entries
+    // rather than assert on them.
+    await withContext(defaultOpts, async ctx => {
+      setContextHandler(ctx, async request => {
+        if (request.url.endsWith(".tgz")) {
+          return new Response(file(join(import.meta.dir, "bar-0.0.2.tgz")));
+        }
+        return Response.json({
+          name: "bar",
+          "dist-tags": { latest: "0.0.2" },
+          versions: {
+            "0.0.2": {
+              name: "bar",
+              version: "0.0.2",
+              dependencies: { baz: null, qux: 123 },
+              dist: { tarball: `${ctx.registry_url}bar-0.0.2.tgz` },
+            },
+          },
+        });
+      });
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({
+          name: "foo",
+          version: "0.0.1",
+          dependencies: { bar: "^0.0.2" },
+        }),
+      );
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+      expect(err).toContain("Saved lockfile");
+      expect(out).toContain("+ bar@0.0.2");
+      expect(await file(join(ctx.package_dir, "node_modules", "bar", "package.json")).json()).toEqual({
+        name: "bar",
+        version: "0.0.2",
+      });
+      expect(exitCode).toBe(0);
+    });
+  });
+
   it("should handle caret range in dependencies when the registry has prereleased packages, issue#4398", async () => {
     await withContext(defaultOpts, async ctx => {
       const urls: string[] = [];


### PR DESCRIPTION
Fixes #20371

## What

Debug builds abort in `PackageManifest::parse` (`src/install/npm.rs`) on registry packuments containing malformed version data. Release builds already handle each case gracefully; the asserts sit immediately before or after the existing graceful path.

Three triggers, all from untrusted registry data:

1. A `versions` key that does not parse as semver at all (`"not-a-version"`, `"__proto__"`, `""`):
   ```
   panic: assertion failed: parsed_version.valid
   ```
2. Two `versions` keys that parse to the same canonical version (`"1.0.0"` and `"01.0.0"`, or `"0.0.2"` and `"00.0.2"`), reported in #20371:
   ```
   panic: assertion failed: order == core::cmp::Ordering::Greater
   ```
3. A non-string value in a version's `dependencies` / `optionalDependencies` / `peerDependencies` map (`{"dependencies":{"baz":null}}`):
   ```
   panic: internal error: entered unreachable code: non-value Expr from JSON parser
   ```

All three are reachable from every manifest fetch (`bun install`, `bun add`, `bun update`, `--install=auto`) against any registry, proxy, or mirror.

## Fix

- Remove the two `debug_assert!(parsed_version.valid)` checks on the raw `versions` key. The surrounding code already logs `Failed to parse dependency ...` and skips the entry. In the second pass, hoist the validity check above the pre/build tag copy so `string_builder.append` is never called on a key that was not counted in the first pass.
- Relax the post-sort sanity check from `== Greater` to `!= Less`. `find_best_version` only requires non-decreasing order for backwards iteration; duplicate canonical versions sort as `Equal` and work correctly.
- Replace the `if cfg!(debug_assertions) { unreachable!(...) } else { continue }` on non-string dependency values with a plain `continue` (the first-pass counting loop already treats them as `b""` via `.unwrap_or`). Gate the debug-only `items[j]` cross-check on `count == items.len()` so it is skipped when any entry was filtered.

## Verification

Three new tests in `test/cli/install/bun-install.test.ts` serve packuments from the mock registry.

Without the fix (`bun bd` on main):
```
(fail) should skip non-semver keys in registry packument `versions` without crashing
  Received: "...panic: assertion failed: parsed_version.valid"
(fail) should handle registry packument `versions` keys that parse to duplicate canonical versions, issue#20371
  Received: "...panic: assertion failed: order == core::cmp::Ordering::Greater"
(fail) should skip non-string dependency values in registry packument without crashing
  Received: "...panic: internal error: entered unreachable code: non-value Expr from JSON parser"
```

With the fix: all three install `bar@0.0.2` to `node_modules`, matching release-build behavior.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts

<!-- robobun:evidence:end -->