### PR TITLE
bun:ffi: decode double-encoded JSValues in JSVALUE_TO_INT32

### DIFF
--- a/src/runtime/ffi/FFI.h
+++ b/src/runtime/ffi/FFI.h
@@ -267,7 +267,13 @@ static EncodedJSValue DOUBLE_TO_JSVALUE(double val) {
 }
 
 static int32_t JSVALUE_TO_INT32(EncodedJSValue val) {
-  return val.asInt64;
+  if (JSVALUE_IS_INT32(val)) {
+    return (int32_t)val.asInt64;
+  }
+  // Decode a double-encoded integer (JIT tier-up, Math.* provenance, etc.);
+  // int64_t intermediate keeps u32 callers (uint32_t)JSVALUE_TO_INT32(...) defined.
+  val.asInt64 -= DoubleEncodeOffset;
+  return (int32_t)(int64_t)val.asDouble;
 }
 
 static EncodedJSValue INT32_TO_JSVALUE(int32_t val) {

--- a/src/runtime/ffi/FFI.h
+++ b/src/runtime/ffi/FFI.h
@@ -273,6 +273,8 @@ static int32_t JSVALUE_TO_INT32(EncodedJSValue val) {
   // Decode a double-encoded integer (JIT tier-up, Math.* provenance, etc.);
   // int64_t intermediate keeps u32 callers (uint32_t)JSVALUE_TO_INT32(...) defined.
   val.asInt64 -= DoubleEncodeOffset;
+  // NaN check also catches undefined/null/bool, whose decoded bits are all NaNs.
+  if (val.asDouble != val.asDouble) return 0;
   return (int32_t)(int64_t)val.asDouble;
 }
 

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -744,6 +744,89 @@ describe.skipIf(isFFIUnavailable)("double <-> JSValue conversions", () => {
     });
   });
 
+  // JSVALUE_TO_INT32 must decode double-encoded JSValues: whether a JS number
+  // is int32-tagged or double-encoded is the engine's choice (JIT tier, double
+  // speculation, Math.* provenance), so an int-typed JSCallback return that
+  // truncates the raw encoded bits hands C 0 once the callback tiers up.
+  it("double-encoded JS numbers returned from an int-typed JSCallback reach C as the integer", async () => {
+    using dir = tempDir("bun-ffi-int32-cb-return", {
+      "cb.c": /* c */ `
+        typedef int (*cb_i32)(int);
+        int call_i32(cb_i32 f, int x) { return f(x); }
+        typedef unsigned int (*cb_u32)(int);
+        unsigned int call_u32(cb_u32 f, int x) { return f(x); }
+        typedef signed char (*cb_i8)(int);
+        int call_i8(cb_i8 f, int x) { return (int)f(x); }
+        typedef unsigned short (*cb_u16)(int);
+        int call_u16(cb_u16 f, int x) { return (int)f(x); }
+      `,
+      "fixture.js": /* js */ `
+        import { cc, JSCallback } from "bun:ffi";
+        import path from "path";
+
+        const { symbols } = cc({
+          source: path.join(import.meta.dir, "cb.c"),
+          symbols: {
+            call_i32: { args: ["function", "i32"], returns: "i32" },
+            call_u32: { args: ["function", "i32"], returns: "u32" },
+            call_i8: { args: ["function", "i32"], returns: "i32" },
+            call_u16: { args: ["function", "i32"], returns: "i32" },
+          },
+        });
+
+        // +0.5 then -0.5 on a runtime value: integer-valued, but the intermediate
+        // pins a double-represented result regardless of JIT tier or const-folding.
+        const asDouble = x => {
+          const v = x + 0.5;
+          return v - 0.5;
+        };
+        const echoDouble = new JSCallback(asDouble, { args: ["i32"], returns: "i32" });
+        // Plain int32-tagged return must keep working.
+        const echoInt = new JSCallback(x => x, { args: ["i32"], returns: "i32" });
+        const fractional = new JSCallback(() => 5.7, { args: ["i32"], returns: "i32" });
+        const negFractional = new JSCallback(() => -5.7, { args: ["i32"], returns: "i32" });
+        const u32Double = new JSCallback(x => asDouble(x) + 3000000000, { args: ["i32"], returns: "u32" });
+        const i8Double = new JSCallback(asDouble, { args: ["i32"], returns: "i8" });
+        const u16Double = new JSCallback(asDouble, { args: ["i32"], returns: "u16" });
+
+        const results = {
+          echo_double: symbols.call_i32(echoDouble.ptr, 938),
+          echo_int: symbols.call_i32(echoInt.ptr, 938),
+          fractional: symbols.call_i32(fractional.ptr, 0),
+          neg_fractional: symbols.call_i32(negFractional.ptr, 0),
+          u32_double: symbols.call_u32(u32Double.ptr, 0),
+          i8_double: symbols.call_i8(i8Double.ptr, -7),
+          u16_double: symbols.call_u16(u16Double.ptr, 40000),
+        };
+        for (const cb of [echoDouble, echoInt, fractional, negFractional, u32Double, i8Double, u16Double]) cb.close();
+        console.log(JSON.stringify(results));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const results = stdout.startsWith("{") ? JSON.parse(stdout) : stdout;
+    expect({ results, stderr, exitCode }).toMatchObject({
+      results: {
+        echo_double: 938,
+        echo_int: 938,
+        fractional: 5,
+        neg_fractional: -5,
+        u32_double: 3000000000,
+        i8_double: -7,
+        u16_double: 40000,
+      },
+      exitCode: 0,
+    });
+  });
+
   // napi_create_double and napi_create_date take the double from the addon
   // verbatim, so they are the same boundary. cc()-compiled C resolves napi_*
   // from the host process; that lookup is only exercised on POSIX today (see

--- a/test/js/bun/ffi/ffi.test.fixture.callback.c
+++ b/test/js/bun/ffi/ffi.test.fixture.callback.c
@@ -269,7 +269,13 @@ static EncodedJSValue DOUBLE_TO_JSVALUE(double val) {
 }
 
 static int32_t JSVALUE_TO_INT32(EncodedJSValue val) {
-  return val.asInt64;
+  if (JSVALUE_IS_INT32(val)) {
+    return (int32_t)val.asInt64;
+  }
+  // Decode a double-encoded integer (JIT tier-up, Math.* provenance, etc.);
+  // int64_t intermediate keeps u32 callers (uint32_t)JSVALUE_TO_INT32(...) defined.
+  val.asInt64 -= DoubleEncodeOffset;
+  return (int32_t)(int64_t)val.asDouble;
 }
 
 static EncodedJSValue INT32_TO_JSVALUE(int32_t val) {

--- a/test/js/bun/ffi/ffi.test.fixture.callback.c
+++ b/test/js/bun/ffi/ffi.test.fixture.callback.c
@@ -275,6 +275,8 @@ static int32_t JSVALUE_TO_INT32(EncodedJSValue val) {
   // Decode a double-encoded integer (JIT tier-up, Math.* provenance, etc.);
   // int64_t intermediate keeps u32 callers (uint32_t)JSVALUE_TO_INT32(...) defined.
   val.asInt64 -= DoubleEncodeOffset;
+  // NaN check also catches undefined/null/bool, whose decoded bits are all NaNs.
+  if (val.asDouble != val.asDouble) return 0;
   return (int32_t)(int64_t)val.asDouble;
 }
 

--- a/test/js/bun/ffi/ffi.test.fixture.receiver.c
+++ b/test/js/bun/ffi/ffi.test.fixture.receiver.c
@@ -269,7 +269,13 @@ static EncodedJSValue DOUBLE_TO_JSVALUE(double val) {
 }
 
 static int32_t JSVALUE_TO_INT32(EncodedJSValue val) {
-  return val.asInt64;
+  if (JSVALUE_IS_INT32(val)) {
+    return (int32_t)val.asInt64;
+  }
+  // Decode a double-encoded integer (JIT tier-up, Math.* provenance, etc.);
+  // int64_t intermediate keeps u32 callers (uint32_t)JSVALUE_TO_INT32(...) defined.
+  val.asInt64 -= DoubleEncodeOffset;
+  return (int32_t)(int64_t)val.asDouble;
 }
 
 static EncodedJSValue INT32_TO_JSVALUE(int32_t val) {

--- a/test/js/bun/ffi/ffi.test.fixture.receiver.c
+++ b/test/js/bun/ffi/ffi.test.fixture.receiver.c
@@ -275,6 +275,8 @@ static int32_t JSVALUE_TO_INT32(EncodedJSValue val) {
   // Decode a double-encoded integer (JIT tier-up, Math.* provenance, etc.);
   // int64_t intermediate keeps u32 callers (uint32_t)JSVALUE_TO_INT32(...) defined.
   val.asInt64 -= DoubleEncodeOffset;
+  // NaN check also catches undefined/null/bool, whose decoded bits are all NaNs.
+  if (val.asDouble != val.asDouble) return 0;
   return (int32_t)(int64_t)val.asDouble;
 }
 


### PR DESCRIPTION
## What does this PR do?

`JSVALUE_TO_INT32` in `src/runtime/ffi/FFI.h` truncated the raw NaN-boxed `asInt64`, which only works when the JSValue is int32-tagged. Whether an integer-valued JS number is int32-tagged or double-encoded is the engine's choice (JIT tier, DFG double speculation, `Math.round`/`Math.floor` provenance), so an int-typed `JSCallback` could return the correct value for a loop's first ~12 iterations and then `0` once the callback body tiered up.

### Repro

```ts
import { cc, JSCallback, FFIType as t } from "bun:ffi";
import { mkdtempSync, writeFileSync } from "node:fs";
import { tmpdir } from "node:os";

const d = mkdtempSync(`${tmpdir()}/cbret-`);
writeFileSync(`${d}/cb.c`, "typedef int (*cbi)(int); int call1(cbi f, int x){ return f(x); }");
const C = cc({ source: `${d}/cb.c`, symbols: { call1: { args: [t.function, t.i32], returns: t.i32 } } }).symbols;

const cbH = new JSCallback(x => { const v = x + 0.5; return v - 0.5; }, { args: [t.i32], returns: t.i32 });
const cbF = new JSCallback(() => 5.7, { args: [t.i32], returns: t.i32 });
C.call1(cbH.ptr, 938); // 0, want 938
C.call1(cbF.ptr, 0);   // -858993459, want 5
```

### Fix

Mirror `JSVALUE_TO_DOUBLE`: check `JSVALUE_IS_INT32` first, otherwise subtract `DoubleEncodeOffset` and read `asDouble`. The `(int64_t)` intermediate cast keeps `(uint32_t)JSVALUE_TO_INT32(...)` defined for values in `(INT32_MAX, UINT32_MAX]` (the `u32` return type shares this macro).

All existing callers (`JSVALUE_TO_PTR`, `JSVALUE_TO_DOUBLE`, `JSVALUE_TO_INT64`, `JSVALUE_TO_UINT64`) already guard with `JSVALUE_IS_INT32` before calling this, so the added branch is a no-op for them.

A prior attempt at this area (#33095) wrapped the JS callback at construction time to coerce the return value; this change fixes the TinyCC-side decode instead, which costs nothing at call time and also covers any path that reaches `JSVALUE_TO_INT32` without going through `FFIBuilder`.

## How did you verify your code works?

New test in `test/js/bun/ffi/cc.test.ts` exercises `i32`/`u32`/`i8`/`u16` JSCallback returns with double-encoded integer values (pinned via `x + 0.5 - 0.5` on a runtime arg) and a fractional return. Fails on main with `echo_double: 0`, `fractional: -858993459`, etc.; passes with the fix.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/ffi/cc.test.ts

<!-- robobun:evidence:end -->