### PR TITLE
JSModuleLoader: do not abort when terminate() lands during a worker’s module loads (WebKit pin bump)

### DIFF
--- a/test/js/node/worker_threads/worker-terminate-during-preload.test.ts
+++ b/test/js/node/worker_threads/worker-terminate-during-preload.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isDebug } from "harness";
+
+// Terminating a node:worker_threads Worker while its startup preloads are
+// running can land the NeedTermination trap inside
+// JSModuleLoader::hostLoadImportedModule's resolve() call. JSC used to treat
+// the resulting TerminationException like an ordinary resolution error: it
+// cached it in m_resolutionFailures, returned early from
+// rejectWithCaughtException (TRY_CLEAR_EXCEPTION won't clear a termination),
+// and entered continueDynamicImport with the termination still pending on the
+// VM, where scope.assertNoException() aborts under
+// ENABLE(EXCEPTION_SCOPE_VERIFICATION) (debug/ASAN builds).
+//
+// The window is the tail end of worker startup, so the child calibrates on a
+// warm worker's time-to-'online' and sweeps terminate() through a band just
+// below it. Explicit builtin preloads widen the cumulative resolve() window so
+// the sweep lands in it regardless of host speed.
+test(
+  "terminate() during worker preload does not abort in the module loader",
+  async () => {
+    const script = /* js */ `
+      const { Worker } = require("node:worker_threads");
+      const preload = [
+        "node:events", "node:path", "node:util", "node:url", "node:buffer",
+        "node:stream", "node:os", "node:fs", "node:crypto", "node:assert",
+        "node:querystring", "node:string_decoder", "node:timers", "node:zlib",
+      ];
+      async function timeToOnline() {
+        const t0 = Bun.nanoseconds();
+        const w = new Worker("", { eval: true, preload });
+        await new Promise((res, rej) => {
+          w.once("online", res);
+          w.once("error", rej);
+          w.once("exit", code => rej(new Error("worker exited before 'online' with code " + code)));
+        });
+        const dt = Bun.nanoseconds() - t0;
+        await w.terminate();
+        return dt;
+      }
+      (async () => {
+        await timeToOnline(); // cold; discard
+        const T = Math.min(await timeToOnline(), await timeToOnline());
+        for (let f = 0.55; f <= 1.05; f += 0.02) {
+          const w = new Worker("", { eval: true, preload });
+          const spinUntil = Bun.nanoseconds() + T * f;
+          while (Bun.nanoseconds() < spinUntil) {}
+          await w.terminate();
+        }
+        console.log("ok");
+      })().catch(e => { console.error(e); process.exit(1); });
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // stderr is kept in the assertion object so an abort's output appears in
+    // the failure diff, but not matched exactly (debug/ASAN builds may emit
+    // benign warnings on this lane).
+    expect({ stdout: stdout.trim(), exitCode, stderr }).toEqual({
+      stdout: "ok",
+      exitCode: 0,
+      stderr: expect.any(String),
+    });
+  },
+  isDebug ? 240_000 : 30_000,
+);


### PR DESCRIPTION
### What does this PR do?

Bumps `WEBKIT_VERSION` from `ddea71318fec` to `171babe26c3b` (one commit: oven-sh/WebKit#391, `JSModuleLoader: propagate a TerminationException from resolve() instead of treating it as a resolution failure`) and adds a stress test for terminating `node:worker_threads` Workers mid-preload.

`test/js/node/worker_threads/worker-transfer-list.test.ts` intermittently SIGABRTs on the debug+ASAN lane (seen in build 75365; test-side workaround in #34644):

```
ASSERTION FAILED: !exception()
vendor/WebKit/Source/JavaScriptCore/runtime/ExceptionScope.h(61) : void JSC::ExceptionScope::assertNoException()
```

### Cause

Since #31216 every `node:worker_threads` `Worker` preloads `node:worker_threads` on startup, so even `new Worker("", { eval: true })` runs module-loader microtasks during startup. `terminate()` fires the `NeedTermination` trap on the worker VM; when that lands inside `JSModuleLoader::hostLoadImportedModule`'s `resolve()` call, the `TerminationException` was caught as a resolution error: cached in `m_resolutionFailures`, left pending by `rejectWithCaughtException` (`TRY_CLEAR_EXCEPTION` refuses to clear a termination), and carried into `finishLoadingImportedModule` -> `continueDynamicImport`, whose `scope.assertNoException()` aborts under `ENABLE(EXCEPTION_SCOPE_VERIFICATION)`. Frame-pointer trace from the worker thread at the abort:

```
continueDynamicImport              JSModuleLoader.cpp
finishLoadingImportedModule        JSModuleLoader.cpp
hostLoadImportedModule             JSModuleLoader.cpp
loadModule                         JSModuleLoader.cpp
moduleLoadTopSettled               JSMicrotask.cpp
drainMicrotasks / load_preloads
```

Release builds are unaffected: without `ENABLE(EXCEPTION_SCOPE_VERIFICATION)` the assertion compiles to an empty `ASSERT` and the next `RETURN_IF_EXCEPTION` in the caller unwinds normally.

### Fix

oven-sh/WebKit#391 (merged): `hostLoadImportedModule` returns early when the exception caught from `resolve()` is a `TerminationException`, so the caller's `RETURN_IF_EXCEPTION` unwinds instead of entering `FinishLoadingImportedModule` with a termination pending. This PR pins that commit.

### Testing

`test/js/node/worker_threads/worker-terminate-during-preload.test.ts` spawns a child that calibrates a warm worker's time-to-`online`, then sweeps `terminate()` through a band just below it against workers started with fourteen explicit `node:` preloads (widening the cumulative `resolve()` window so the sweep lands in it on any host speed). On the unfixed WebKit the child aborts; with the fix it exits 0.

Multi-run probe on debug+ASAN linux-x64 (the assertion only exists under exception-scope verification):

```
before (pin without the fix): 8/8 runs fail
  - ASSERTION FAILED: !exception()  (continueDynamicImport)
  - plus two adjacent termination-delivery symptoms in reifyStaticProperty /
    getOwnPropertyDescriptor, fixed by oven-sh/WebKit#282/#306 (already in the pin)
after  (pin with the fix): 23/23 runs pass
```

The fix-side change is the `WEBKIT_VERSION` bump in `scripts/build/deps/webkit.ts`; there is no `src/` diff for the fail-before gate to stash, so the probe above is the fail-before evidence.

Supersedes the test-side workaround in #34644.

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 4 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/worker_threads/worker-terminate-during-preload.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/worker_threads/worker-terminate-during-preload.test.ts
bun test v1.4.0 (bd9359dd7)

test/js/node/worker_threads/worker-terminate-during-preload.test.ts:
(pass) terminate() during worker preload does not abort in the module loader [84533.68ms]

 1 pass
 0 fail
 1 expect() calls
Ran 1 test across 1 file. [88.03s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                       |  5 +-
 .../worker-terminate-during-preload.test.ts        | 71 ++++++++++++++++++++++
 2 files changed, 75 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 4 passed · 1 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
scripts/build/deps/webkit.ts                                  2      6      0
…/worker_threads/worker-terminate-during-preload.test.ts      2      8      0
```

</details>

<!-- robobun:evidence:end -->