### PR TITLE
hot: reset unhandled-error state on reload so timers recover after a failed reload

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3581,6 +3581,14 @@ impl VirtualMachine {
         // the JSC module loader registry.
         self.global().reload().expect("Failed to reload");
         self.hot_reload_counter += 1;
+        // A previous generation's failure left this nonzero, wedging
+        // `is_event_loop_alive()` false and the run loop in `tick_possibly_forever`
+        // (which never drains timers). Each reload is a fresh start.
+        self.unhandled_error_counter = 0;
+        // `on_before_exit` (reached via the same wedged path) armed this; leave
+        // it set and the recovered generation's first uncaught exception exits
+        // the process instead of surviving like a fresh `--hot` run would.
+        self.exit_on_uncaught_exception = false;
         if self.pending_internal_promise_is_protected {
             if let Some(p) = self.pending_internal_promise {
                 JSValue::from_cell(p).unprotect();

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -846,10 +846,17 @@ it(
     // (which never drains timers) and this never resolves.
     await waitFor(() => countTicks(2) >= 3, "gen 2 ticks after fix");
 
-    // One more good edit to confirm recovery is durable.
-    writeFileSync(root, src(3));
-    await waitFor(() => out.includes("EVAL 3"), "EVAL 3");
-    await waitFor(() => countTicks(3) >= 3, "gen 3 ticks");
+    // on_before_exit() on the wedged path armed exit_on_uncaught_exception;
+    // without the matching reset the next uncaught exception would exit the
+    // process instead of surviving like a fresh --hot run.
+    writeFileSync(root, src(3) + `setTimeout(() => { throw new Error("post-recovery-throw"); }, 0);\n`);
+    await waitFor(() => err.includes("post-recovery-throw"), "post-recovery uncaught exception on stderr");
+    expect(exited).toBe(false);
+
+    // Recovery is durable: one more good edit's timers fire.
+    writeFileSync(root, src(4));
+    await waitFor(() => out.includes("EVAL 4"), "EVAL 4");
+    await waitFor(() => countTicks(4) >= 3, "gen 4 ticks");
 
     runner.kill();
   },

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -776,3 +776,82 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
   },
   longTimeout,
 );
+
+it(
+  "timers keep firing after a failed reload is fixed",
+  async () => {
+    const root = join(cwd, "hot-timer-entry.ts");
+    const src = (gen: number) =>
+      `const GEN = ${gen};\n` +
+      `setInterval(() => console.log("TICK " + GEN), 16);\n` +
+      `console.log("EVAL " + GEN);\n`;
+    writeFileSync(root, src(1));
+
+    await using runner = spawn({
+      cmd: [bunExe(), "--hot", "run", root],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+
+    let out = "";
+    let err = "";
+    let exited = false;
+    let waiters: Array<() => void> = [];
+    const notify = () => {
+      for (const w of waiters.splice(0)) w();
+    };
+    (async () => {
+      for await (const chunk of runner.stdout) {
+        out += new TextDecoder().decode(chunk);
+        notify();
+      }
+    })();
+    (async () => {
+      for await (const chunk of runner.stderr) {
+        err += new TextDecoder().decode(chunk);
+        notify();
+      }
+    })();
+    runner.exited.then(() => {
+      exited = true;
+      notify();
+    });
+
+    const waitFor = async (pred: () => boolean, what: string) => {
+      while (!pred()) {
+        if (exited) {
+          throw new Error(`child exited before "${what}"\nstdout:\n${out}\nstderr:\n${err}`);
+        }
+        await new Promise<void>(r => waiters.push(r));
+      }
+    };
+
+    const countTicks = (gen: number) => (out.match(new RegExp(`TICK ${gen}\\b`, "g")) ?? []).length;
+
+    // Generation 1 evaluates and its interval fires.
+    await waitFor(() => out.includes("EVAL 1"), "EVAL 1");
+    await waitFor(() => countTicks(1) >= 3, "gen 1 ticks");
+
+    // Break the file with a syntax error; wait for the error on stderr.
+    writeFileSync(root, "const GEN = ((;\n");
+    await waitFor(() => /error/i.test(err), "syntax error on stderr");
+
+    // Fix the file. The new generation must evaluate AND its interval must fire.
+    writeFileSync(root, src(2));
+    await waitFor(() => out.includes("EVAL 2"), "EVAL 2 after fix");
+    // Without the fix the run loop is wedged in tick_possibly_forever()
+    // (which never drains timers) and this never resolves.
+    await waitFor(() => countTicks(2) >= 3, "gen 2 ticks after fix");
+
+    // One more good edit to confirm recovery is durable.
+    writeFileSync(root, src(3));
+    await waitFor(() => out.includes("EVAL 3"), "EVAL 3");
+    await waitFor(() => countTicks(3) >= 3, "gen 3 ticks");
+
+    runner.kill();
+  },
+  timeout,
+);

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -781,11 +781,21 @@ it(
   "timers keep firing after a failed reload is fixed",
   async () => {
     const root = join(cwd, "hot-timer-entry.ts");
-    const src = (gen: number) =>
-      `const GEN = ${gen};\n` +
-      `setInterval(() => console.log("TICK " + GEN), 16);\n` +
-      `console.log("EVAL " + GEN);\n`;
-    writeFileSync(root, src(1));
+    // Every write is padded to the same width so a reload that races the write
+    // (cached-fd read mid-overwrite) never sees a stale tail from a longer
+    // previous generation.
+    const PAD = 256;
+    const pad = (s: string) => s + Buffer.alloc(PAD - s.length, " ").toString() + "\n";
+    const src = (gen: number, extra = "") =>
+      pad(
+        `const GEN = ${gen};\n` +
+          `setInterval(() => console.log("TICK " + GEN), 16);\n` +
+          `console.log("EVAL " + GEN);\n` +
+          extra,
+      );
+    let lastWrite = src(1);
+    const save = (content: string) => writeFileSync(root, (lastWrite = content));
+    save(src(1));
 
     await using runner = spawn({
       cmd: [bunExe(), "--hot", "run", root],
@@ -820,6 +830,13 @@ it(
       notify();
     });
 
+    // Re-save periodically in case the watcher coalesced or raced the edit
+    // (same pattern driveErrorReloadCycle uses above).
+    const resave = setInterval(() => {
+      writeFileSync(root, lastWrite);
+      notify();
+    }, 1000);
+
     const waitFor = async (pred: () => boolean, what: string) => {
       while (!pred()) {
         if (exited) {
@@ -828,37 +845,46 @@ it(
         await new Promise<void>(r => waiters.push(r));
       }
     };
-
     const countTicks = (gen: number) => (out.match(new RegExp(`TICK ${gen}\\b`, "g")) ?? []).length;
 
-    // Generation 1 evaluates and its interval fires.
-    await waitFor(() => out.includes("EVAL 1"), "EVAL 1");
-    await waitFor(() => countTicks(1) >= 3, "gen 1 ticks");
+    try {
+      // Generation 1 evaluates and its interval fires.
+      await waitFor(() => out.includes("EVAL 1"), "EVAL 1");
+      await waitFor(() => countTicks(1) >= 3, "gen 1 ticks");
 
-    // Break the file with a syntax error; wait for the error on stderr.
-    writeFileSync(root, "const GEN = ((;\n");
-    await waitFor(() => /error/i.test(err), "syntax error on stderr");
+      // Break the file with a syntax error; wait for the error on stderr.
+      save(pad("const GEN = ((;\n"));
+      await waitFor(() => /error/i.test(err), "syntax error on stderr");
 
-    // Fix the file. The new generation must evaluate AND its interval must fire.
-    writeFileSync(root, src(2));
-    await waitFor(() => out.includes("EVAL 2"), "EVAL 2 after fix");
-    // Without the fix the run loop is wedged in tick_possibly_forever()
-    // (which never drains timers) and this never resolves.
-    await waitFor(() => countTicks(2) >= 3, "gen 2 ticks after fix");
+      // Fix the file. The new generation must evaluate AND its interval must fire.
+      save(src(2));
+      await waitFor(() => out.includes("EVAL 2"), "EVAL 2 after fix");
+      // Without the fix the run loop is wedged in tick_possibly_forever()
+      // (which never drains timers) and this never resolves.
+      await waitFor(() => countTicks(2) >= 3, "gen 2 ticks after fix");
 
-    // on_before_exit() on the wedged path armed exit_on_uncaught_exception;
-    // without the matching reset the next uncaught exception would exit the
-    // process instead of surviving like a fresh --hot run.
-    writeFileSync(root, src(3) + `setTimeout(() => { throw new Error("post-recovery-throw"); }, 0);\n`);
-    await waitFor(() => err.includes("post-recovery-throw"), "post-recovery uncaught exception on stderr");
-    expect(exited).toBe(false);
+      // on_before_exit() on the wedged path armed exit_on_uncaught_exception;
+      // without the matching reset the next uncaught exception would exit the
+      // process instead of surviving like a fresh --hot run. Guard on a global
+      // so duplicate reloads of this generation schedule at most one throw.
+      save(
+        src(
+          3,
+          `if (!globalThis.__thrown) { globalThis.__thrown = 1; ` +
+            `setTimeout(() => { throw new Error("post-recovery-throw"); }, 0); }\n`,
+        ),
+      );
+      await waitFor(() => err.includes("post-recovery-throw"), "post-recovery uncaught exception on stderr");
+      expect(exited).toBe(false);
 
-    // Recovery is durable: one more good edit's timers fire.
-    writeFileSync(root, src(4));
-    await waitFor(() => out.includes("EVAL 4"), "EVAL 4");
-    await waitFor(() => countTicks(4) >= 3, "gen 4 ticks");
-
-    runner.kill();
+      // Recovery is durable: one more good edit's timers fire.
+      save(src(4));
+      await waitFor(() => out.includes("EVAL 4"), "EVAL 4");
+      await waitFor(() => countTicks(4) >= 3, "gen 4 ticks");
+    } finally {
+      clearInterval(resave);
+      runner.kill();
+    }
   },
   timeout,
 );


### PR DESCRIPTION
### Problem
- Under `bun --hot`, one failed reload (syntax error or top-level throw) stops all timers until the process restarts. The fixing save evaluates, but `setInterval`, `setTimeout` and `Bun.sleep` never fire.
- If a module awaits a timer at top level, the fixing generation stops there. The entry promise stays pending, so `reload()` defers every later save.
- Cause: the failed reload increments `unhandled_error_counter`. While it is nonzero, `is_event_loop_alive()` is false and the run loop (`src/runtime/cli/run_command.rs`) only calls `tick_possibly_forever()`, which never drains timers. `reload()` never cleared it.

### Fix
- `VirtualMachine::reload()` (`src/jsc/VirtualMachine.rs`) clears `unhandled_error_counter` and `exit_on_uncaught_exception` when it starts a new generation.
- Correct because those errors belong to the generation that `reload()` replaces. A new generation that fails increments the counter again.
- `on_before_exit()` sets `exit_on_uncaught_exception` while the counter is nonzero. Without the second reset, the first uncaught exception after recovery exits the process.
- Verified: three new tests in `test/cli/hot/hot.test.ts`. Stock 1.4.2 and a release build of main fail all three. Also ran all of `test/cli/hot/`.

### Background
- `--hot` reloads in one process: each save runs `reload()`, which clears the module registry and evaluates the entry point again. `--watch` restarts the process instead.
- `unhandled_error_counter` counts errors that no script handled. A normal run uses it to stop the event loop and exit with code 1.
- On Linux and macOS only `auto_tick_active()` drains the JS timer heap. On Windows libuv drains it, so only the exit symptom shows there.
- #38206 is a wider alternative for the same bug.

<details><summary>Notes</summary>

**The run loop** (`Run::start`, watcher arm):

```rust
loop {
    while vm.is_event_loop_alive() {   // false while unhandled_error_counter != 0
        vm.tick();
        vm.report_exception_in_hot_reloaded_module_if_needed();
        vm.auto_tick_active();          // the only caller of drain_timers on POSIX
    }
    vm.on_before_exit();               // returns early and sets exit_on_uncaught_exception
    vm.report_exception_in_hot_reloaded_module_if_needed();
    vm.event_loop_ref().tick_possibly_forever();  // parks up to 1s, runs tasks, never drains timers
}
```

The fixing save's `HotReloadTask` runs inside `tick_possibly_forever()`, so `reload()` runs and the module evaluates. The loop stays in the `tick_possibly_forever` arm because nothing cleared the counter.

**Repro 1, timers** (`bun --hot t.ts`, save `const x = ((;`, save the original back): `EVAL` prints, `TICK` never does.

```js
setInterval(() => console.log("TICK"), 150);
console.log("EVAL");
```

Tick counts per 1.2 s with the repro from the report (boot / good edit / broken / fixed / next edit): stock `8 8 0 0 0`, this PR `8 8 0 8 8`.

**Repro 2, top-level await** (`app.ts` imports `dep.ts`; `dep.ts` is `await new Promise(r => setTimeout(r, 100)); export const v = N;`; save a broken `dep.ts`, then `v = 2`, `3`, `4`):

| build | with the await | without the await |
| --- | --- | --- |
| stock 1.4.2, syntax error | `GEN v=1 error: Unexpected` | `GEN v=1 error: Unexpected GEN v=2 GEN v=3 GEN v=4` |
| stock 1.4.2, top-level throw | `GEN v=1 error: boomdep` | `GEN v=1 error: boomdep GEN v=2 GEN v=3 GEN v=4` |
| this PR, syntax error | `GEN v=1 error: Unexpected GEN v=2 GEN v=3 GEN v=4` | same |
| this PR, top-level throw | `GEN v=1 error: boomdep GEN v=2 GEN v=3 GEN v=4` | same |

**Tests**

- `timers keep firing after a failed reload is fixed`: syntax error in the entry, fix, ticks resume. Then a `setTimeout` throw after recovery must not exit the child (this covers the `exit_on_uncaught_exception` reset: the test fails with that line removed). Then one more edit.
- `keeps reloading after a syntax error / a top-level throw when a module awaits a timer at top level`: the second repro.
- Fail-before: stock 1.4.2 and a release build of main at 09bb54630 time out at `gen 2 ticks after fix` and `GEN v=2 after fix`.
- Stress: 150 runs of the three tests under 10-way parallel load on a release build, 450 of 450 pass. 32 runs on the debug ASAN build, 96 of 96 pass.
- The tests pad every save to one width, guard the deferred throw with a global, and save again once per second. An earlier version of the first test failed on three CI lanes: one save can cause two reloads of the same generation, and the second copy of the deferred throw fired after the next generation had loaded.

**Scope**

- This PR recovers on the next reload. Between the failed save and the fixing save the timers of the old generation stay stopped, as before. #38206 changes that period too.
- `--watch` is unchanged: `reload()` replaces the process before it reaches these lines.
- Related: #38206 never counts these errors under a watcher, so the counter stays zero. #38613 replaces a generation whose top-level await never settles for any reason. Both are open and independent of this PR.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/hot/hot.test.ts

<!-- robobun:evidence:end -->