### PR TITLE
node:events: restore 'bound onceWrapper' name on once() wrapper

### DIFF
--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -376,8 +376,7 @@ function overflowWarning(emitter, type, handlers) {
 // plus onceWrapper.bind(state): one allocation instead of two per once().
 function _onceWrap(target, type, listener) {
   let fired = false;
-  // Named `onceWrapper` so inspect/rawListeners() output tracks node's.
-  const wrapped = function onceWrapper() {
+  const wrapped = function () {
     if (!fired) {
       fired = true;
       // Drop closure refs so anything that retains the fired wrapper (a cached
@@ -392,6 +391,9 @@ function _onceWrap(target, type, listener) {
       return l.$apply(t, arguments);
     }
   };
+  // Node builds this as onceWrapper.bind(state), so the observable name is
+  // "bound onceWrapper"; match it so rawListeners()/inspect() output agrees.
+  Object.defineProperty(wrapped, "name", { value: "bound onceWrapper", configurable: true });
   wrapped.listener = listener;
   return wrapped;
 }

--- a/test/js/node/events/event-emitter.test.ts
+++ b/test/js/node/events/event-emitter.test.ts
@@ -397,6 +397,27 @@ describe("EventEmitter", () => {
     expect([rawListeners[0], rawListeners[1].listener]).toEqual([fn, fn3]);
   });
 
+  test("once() wrapper name matches node's 'bound onceWrapper'", () => {
+    const ee = new EventEmitter();
+    const handler = function handler() {};
+    ee.once("x", handler);
+    const wrapped = ee.rawListeners("x")[0] as Function & { listener?: Function };
+    expect({
+      name: wrapped.name,
+      length: wrapped.length,
+      listener: wrapped.listener,
+      descriptor: Object.getOwnPropertyDescriptor(wrapped, "name"),
+    }).toEqual({
+      name: "bound onceWrapper",
+      length: 0,
+      listener: handler,
+      descriptor: { value: "bound onceWrapper", writable: false, enumerable: false, configurable: true },
+    });
+
+    ee.prependOnceListener("y", handler);
+    expect(ee.rawListeners("y")[0].name).toBe("bound onceWrapper");
+  });
+
   test("eventNames", () => {
     const myEmitter = new EventEmitter();
     expect(myEmitter.eventNames()).toEqual([]);


### PR DESCRIPTION
Regression from #34519.

## Repro

```js
import { EventEmitter } from "node:events";
const ee = new EventEmitter();
ee.once("x", function handler() {});
console.log(ee.rawListeners("x")[0].name);
// node v26.3.0:     "bound onceWrapper"
// bun 1.4.0:        "bound onceWrapper"
// main a227ad991b:  "onceWrapper"
```

## Cause

#34519 replaced `onceWrapper.bind(state)` with a named closure to save one allocation per `once()`. The closure was named `function onceWrapper()`, so its `.name` is `"onceWrapper"`; Node's `.bind()` construction yields `"bound onceWrapper"`. Visible via `rawListeners()[i].name`, `util.inspect()` of the wrapper or `_events`, and `'removeListener'` payloads.

## Fix

Set `.name` to `"bound onceWrapper"` via `Object.defineProperty` (matching the descriptor `.bind()` produces: non-writable, non-enumerable, configurable). The single-allocation closure is kept.

## Verification

New test in `test/js/node/events/event-emitter.test.ts` asserts `.name`, `.length`, `.listener`, and the full `name` descriptor against Node's values, for both `once()` and `prependOnceListener()`. Fails on main without the `src/` change, passes with it. All 26 `test/js/node/test/parallel/test-event-emitter-*.js` pass.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/events/event-emitter.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (539d97adc)

test/js/node/events/event-emitter.test.ts:
(pass) node:events > captureRejectionSymbol [2.61ms]
(pass) node:events > once [40.23ms]
(pass) node:events > once (abort) [13.88ms]
(pass) node:events > once (two events in same tick) [53.85ms]
(pass) node:events > once removes the listener afterwards [106.23ms]
(pass) node:events > once is an async function [2.01ms]
(pass) node:events > once with already-aborted signal rejects (not a synchronous throw) [13.18ms]
(pass) node:events > once with invalid options.signal rejects (not a synchronous throw) [13.19ms]
(pass) node:events > once with non-object options rejects (not a synchronous throw) [5.26ms]
(pass) EventEmitter > getEventListeners [34.36ms]
(pass) EventEmitter 
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/events/event-emitter.test.ts:
(pass) node:events > captureRejectionSymbol [0.06ms]
(pass) node:events > once [0.70ms]
(pass) node:events > once (abort) [0.26ms]
(pass) node:events > once (two events in same tick) [18.96ms]
(pass) node:events > once removes the listener afterwards [0.79ms]
(pass) node:events > once is an async function [0.02ms]
(pass) node:events > once with already-aborted signal rejects (not a synchronous throw) [0.19ms]
(pass) node:events > once with invalid options.signal rejects (not a synchronous throw) [0.21ms]
(pass) node:events > once with non-object options rejects (not a synchronous throw) [0.08ms]
(pass) EventEmitter > getEventListeners [0.14ms]
(pass) EventEmitter > constructor [0.05ms]
(pass) EventEmitter > removeAllListeners() [2.68ms]
(pass) EventEmitter > removeAllListeners(type) [0.07ms]
(pass) EventEmitter > emit > different tick [0.05ms]
(pass) EventEmitter > emit > async microtask before [0.10ms]
(pass) EventEmitter > emit > async microtask after [0.07ms]
(pass) EventEmitter > emit > same tick [0.02ms]
(pass) EventEmitter > emit > setTimeout task [3.62ms]
(pass) EventEmitter > em
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/events/event-emitter.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (539d97adc)

test/js/node/events/event-emitter.test.ts:
(pass) node:events > captureRejectionSymbol [2.97ms]
(pass) node:events > once [38.88ms]
(pass) node:events > once (abort) [12.54ms]
(pass) node:events > once (two events in same tick) [21.29ms]
(pass) node:events > once removes the listener afterwards [39.06ms]
(pass) node:events > once is an async function [1.97ms]
(pass) node:events > once with already-aborted signal rejects (not a synchronous throw) [12.67ms]
(pass) node:events > once with invalid options.signal rejects (not a synchronous throw) [12.40ms]
(pass) node:events > once with non-object options rejects (not a synchronous throw) [4.90ms]
(pass) EventEmitter > getEventListeners [6.00ms]
(pass) EventEmitter > 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 732ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/20] gen JS modules (bundle-modules)
Preprocess modules (7446ms)
Bundle modules (34ms)
Postprocesss modules (165ms)
Bundle Functions (750ms)
Generate Code (84ms)

[8.50s] Bundled "src/js" for production
  2039 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[1/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/events.ts                     |  6 ++++--
 test/js/node/events/event-emitter.test.ts | 21 +++++++++++++++++++++
 2 files changed, 25 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/node/events.ts                          1      1      0
test/js/node/events/event-emitter.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->