### PR TITLE
napi: keep exceptions thrown by JS during env cleanup visible to the addon

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -146,10 +146,19 @@ using namespace Zig;
         napi_set_last_error((_env), napi_object_expected))
 
 // Return an error code if an exception was thrown after NAPI_PREAMBLE
-#define NAPI_RETURN_IF_VM_EXCEPTION(_env) RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error((_env), napi_pending_exception))
+// During env cleanup, first move any VM exception into the env's pending
+// slot (see NapiEnv::stashExceptionDuringCleanup); for pure value producers
+// this also means they keep working while that exception is pending,
+// matching Node, whose equivalents never check the exception state.
+#define NAPI_RETURN_IF_VM_EXCEPTION(_env)                                                                          \
+    do {                                                                                                           \
+        (_env)->stashExceptionDuringCleanup();                                                                     \
+        RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error((_env), napi_pending_exception));     \
+    } while (0)
 
 #define NAPI_RETURN_IF_EXCEPTION_WITH_SCOPE(_env, _scope)                                   \
     do {                                                                                    \
+        (_env)->stashExceptionDuringCleanup();                                              \
         RETURN_IF_EXCEPTION((_scope), napi_set_last_error((_env), napi_pending_exception)); \
         if ((_env)->hasPendingException()) {                                                \
             return napi_set_last_error((_env), napi_pending_exception);                     \
@@ -1357,9 +1366,12 @@ extern "C" napi_status napi_get_and_clear_last_exception(napi_env env,
     auto globalObject = toJS(env);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(JSC::getVM(globalObject));
     if (scope.exception()) [[unlikely]] {
-        *result = toNapi(JSValue(scope.exception()->value()), globalObject);
+        JSValue value = JSValue(scope.exception()->value());
+        *result = toNapi(value, globalObject);
+        env->noteExceptionHandedToAddonDuringCleanup(value);
     } else if (std::optional<JSValue> pending = env->pendingException()) {
         *result = toNapi(pending.value(), globalObject);
+        env->noteExceptionHandedToAddonDuringCleanup(pending.value());
         env->clearPendingException();
     } else {
         *result = toNapi(JSC::jsUndefined(), globalObject);
@@ -1387,6 +1399,17 @@ extern "C" napi_status napi_throw(napi_env env, napi_value error)
     NAPI_PREAMBLE(env);
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     if (env->isFinishingFinalizers()) {
+        // Bun (unlike Node) lets finalizers run JS during env cleanup. If
+        // that JS threw, the addon received the exception from
+        // napi_get_and_clear_last_exception and may rethrow it here;
+        // node-addon-api's Error::ThrowAsJavaScriptException aborts the
+        // process if this call fails (#34663), so accept the rethrow. New
+        // exceptions still fail, matching Node, which cannot run JS during
+        // teardown at all.
+        if (error && env->isExceptionHandedToAddonDuringCleanup(toJS(error))) {
+            env->scheduleException(toJS(error));
+            return napi_set_last_error(env, napi_ok);
+        }
         return napi_set_last_error(env, env->napiModule().nm_version >= 10 ? napi_cannot_run_js : napi_pending_exception);
     }
     NAPI_CHECK_ARG(env, error);
@@ -3150,7 +3173,10 @@ extern "C" napi_status napi_call_function(napi_env env, napi_value recv,
     const napi_value* argv,
     napi_value* result)
 {
-    if (env->throwPendingException()) {
+    // During cleanup, keep a scheduled exception in the env slot instead of
+    // promoting it onto the VM (the preamble below still refuses the call);
+    // a VM exception would be invisible to napi_is_exception_pending there.
+    if (env->isFinishingFinalizers() ? env->hasPendingException() : env->throwPendingException()) {
         return napi_set_last_error(env, napi_pending_exception);
     }
 
@@ -3371,4 +3397,16 @@ void NapiEnv::clearExceptionsBetweenFinalizers()
     // from one finalizer does not trip debug asserts in the next.
     DECLARE_TOP_EXCEPTION_SCOPE(m_vm).clearException();
     m_pendingException.clear();
+    m_cleanupExceptionHandedToAddon.clear();
+}
+
+void NapiEnv::stashExceptionDuringCleanupSlow()
+{
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(m_vm);
+    JSC::Exception* exception = scope.exception();
+    if (!exception || m_vm.hasPendingTerminationException()) {
+        return;
+    }
+    m_pendingException.set(m_vm, exception->value());
+    scope.clearException();
 }

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -145,14 +145,19 @@ using namespace Zig;
     RETURN_IF_EXCEPTION(napi_preamble_throw_scope__,             \
         napi_set_last_error((_env), napi_object_expected))
 
-// Return an error code if an exception was thrown after NAPI_PREAMBLE
-// During env cleanup, first move any VM exception into the env's pending
-// slot (see NapiEnv::stashExceptionDuringCleanup); for pure value producers
-// this also means they keep working while that exception is pending,
-// matching Node, whose equivalents never check the exception state.
+// Return an error code if an exception was thrown after NAPI_PREAMBLE.
+// During env cleanup, a VM exception is first moved into the env's pending
+// slot (see NapiEnv::stashExceptionDuringCleanup) so it stays visible to
+// napi_is_exception_pending; the call still fails. The stash must not
+// swallow the failure: this macro also guards calls made mid-body (rope
+// resolution, JSBigInt::createFrom) whose throw must surface as
+// napi_pending_exception, not as napi_ok with a null result.
 #define NAPI_RETURN_IF_VM_EXCEPTION(_env)                                                                      \
     do {                                                                                                       \
-        (_env)->stashExceptionDuringCleanup();                                                                 \
+        if ((_env)->isFinishingFinalizers() && napi_preamble_throw_scope__.exception()) [[unlikely]] {         \
+            (_env)->stashExceptionDuringCleanup();                                                             \
+            return napi_set_last_error((_env), napi_pending_exception);                                        \
+        }                                                                                                      \
         RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error((_env), napi_pending_exception)); \
     } while (0)
 

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -150,10 +150,10 @@ using namespace Zig;
 // slot (see NapiEnv::stashExceptionDuringCleanup); for pure value producers
 // this also means they keep working while that exception is pending,
 // matching Node, whose equivalents never check the exception state.
-#define NAPI_RETURN_IF_VM_EXCEPTION(_env)                                                                          \
-    do {                                                                                                           \
-        (_env)->stashExceptionDuringCleanup();                                                                     \
-        RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error((_env), napi_pending_exception));     \
+#define NAPI_RETURN_IF_VM_EXCEPTION(_env)                                                                      \
+    do {                                                                                                       \
+        (_env)->stashExceptionDuringCleanup();                                                                 \
+        RETURN_IF_EXCEPTION(napi_preamble_throw_scope__, napi_set_last_error((_env), napi_pending_exception)); \
     } while (0)
 
 #define NAPI_RETURN_IF_EXCEPTION_WITH_SCOPE(_env, _scope)                                   \

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -457,6 +457,34 @@ public:
         return static_cast<bool>(m_pendingException);
     }
 
+    // During env cleanup a finalizer may run JS (Bun allows this, unlike
+    // Node) and that JS may throw. napi_is_exception_pending deliberately
+    // skips the VM check during cleanup, so an exception left on the VM is
+    // invisible to the addon while still failing its next napi call;
+    // node-addon-api escalates that mismatch to napi_fatal_error (#34663).
+    // Mirror Node's per-call TryCatch capture: move the exception into
+    // m_pendingException, where napi_is_exception_pending and
+    // napi_get_and_clear_last_exception see it.
+    void stashExceptionDuringCleanup()
+    {
+        if (!m_isFinishingFinalizers) [[likely]] {
+            return;
+        }
+        stashExceptionDuringCleanupSlow();
+    }
+
+    void noteExceptionHandedToAddonDuringCleanup(JSC::JSValue value)
+    {
+        if (m_isFinishingFinalizers) [[unlikely]] {
+            m_cleanupExceptionHandedToAddon.set(m_vm, value);
+        }
+    }
+
+    bool isExceptionHandedToAddonDuringCleanup(JSC::JSValue value) const
+    {
+        return m_cleanupExceptionHandedToAddon && m_cleanupExceptionHandedToAddon.get() == value;
+    }
+
     inline Zig::GlobalObject* globalObject() const { return m_globalObject; }
     // `bun test --isolate` creates a fresh Zig::GlobalObject per file and
     // gcUnprotect()s the previous one. NapiEnv outlives its owning global —
@@ -590,6 +618,9 @@ private:
     JSC::VM& m_vm;
     Napi::HookSet m_cleanupHooks;
     JSC::Strong<JSC::Unknown> m_pendingException;
+    // The exception napi_get_and_clear_last_exception handed to the addon
+    // during cleanup; napi_throw accepts rethrowing exactly this value.
+    JSC::Strong<JSC::Unknown> m_cleanupExceptionHandedToAddon;
     size_t m_cleanupHookCounter = 0;
 
     WTF::Lock m_threadSafeFunctionsLock;
@@ -602,6 +633,7 @@ private:
     // (which has JS_EXPORT_PRIVATE ctor/dtor under
     // ENABLE_EXCEPTION_SCOPE_VERIFICATION) are confined to one TU.
     void clearExceptionsBetweenFinalizers();
+    void stashExceptionDuringCleanupSlow();
 
     // Returns a vector of hooks in reverse order of insertion.
     std::vector<Napi::EitherCleanupHook> getHooks() const

--- a/test/napi/napi-app/test_finalizer_create_error.c
+++ b/test/napi/napi-app/test_finalizer_create_error.c
@@ -168,10 +168,86 @@ static napi_value setup_single(napi_env env, napi_callback_info info) {
   return obj;
 }
 
+// Regression test for oven-sh/bun#34663 (node-sqlite3's CleanQueue shape).
+//
+// A wrap finalizer running during env cleanup calls a JS function via
+// napi_call_function and the JS throws (node-sqlite3: emitting 'error' on
+// an EventEmitter with no listener). node-addon-api then does:
+//   napi_is_exception_pending -> napi_get_and_clear_last_exception ->
+//   napi_throw (Error::ThrowAsJavaScriptException rethrows), aborting via
+//   napi_fatal_error if any step disagrees with the others.
+// Before the fix the thrown exception stayed on the JSC VM, where
+// napi_is_exception_pending (which skips the VM check during cleanup)
+// could not see it, and the rethrow was rejected. This finalizer performs
+// the same sequence with raw napi calls and prints each status.
+static napi_ref rethrow_fn_ref = NULL;
+
+static void finalize_rethrow(napi_env env, void *data, void *hint) {
+  (void)data;
+  (void)hint;
+
+  napi_value fn;
+  if (!rethrow_fn_ref ||
+      napi_get_reference_value(env, rethrow_fn_ref, &fn) != napi_ok || !fn) {
+    printf("rethrow: could not get function\n");
+    fflush(stdout);
+    return;
+  }
+
+  napi_value undef;
+  napi_get_undefined(env, &undef);
+
+  // The JS function throws; expect napi_pending_exception.
+  napi_status call_status = napi_call_function(env, undef, fn, 0, NULL, NULL);
+
+  // node-addon-api's Error::New(env): the exception must be visible here,
+  // or it falls into the napi_create_error path and aborts.
+  bool pending = false;
+  napi_status pending_status = napi_is_exception_pending(env, &pending);
+
+  napi_value exception = NULL;
+  napi_status get_status =
+      napi_get_and_clear_last_exception(env, &exception);
+
+  // Error::Error(env, value) takes a reference on the exception object.
+  napi_ref exception_ref = NULL;
+  napi_status ref_status =
+      napi_create_reference(env, exception, 1, &exception_ref);
+
+  // Error::ThrowAsJavaScriptException rethrows; a failure here is fatal in
+  // node-addon-api.
+  napi_status throw_status = napi_throw(env, exception);
+
+  printf("rethrow: call=%d is_pending=%d pending=%d get=%d ref=%d throw=%d\n",
+         call_status, pending_status, pending ? 1 : 0, get_status, ref_status,
+         throw_status);
+  fflush(stdout);
+}
+
+// setupRethrow(fnThatThrows: () => never): object
+static napi_value setup_rethrow(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  napi_get_cb_info(env, info, &argc, args, NULL, NULL);
+  if (argc < 1) {
+    napi_throw_error(env, NULL, "setupRethrow needs throwing fn");
+    return NULL;
+  }
+
+  napi_create_reference(env, args[0], 1, &rethrow_fn_ref);
+
+  napi_value obj;
+  napi_create_object(env, &obj);
+  napi_wrap(env, obj, NULL, finalize_rethrow, NULL, NULL);
+  return obj;
+}
+
 NAPI_MODULE_INIT(/* napi_env env, napi_value exports */) {
   napi_property_descriptor props[] = {
       {"setup", NULL, setup, NULL, NULL, NULL, napi_default, NULL},
       {"setupSingle", NULL, setup_single, NULL, NULL, NULL, napi_default, NULL},
+      {"setupRethrow", NULL, setup_rethrow, NULL, NULL, NULL, napi_default,
+       NULL},
   };
   napi_define_properties(env, exports, sizeof(props) / sizeof(props[0]), props);
   return exports;

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -1155,6 +1155,36 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     expect(stderr).toBe("");
   });
 
+  it("a finalizer can observe and rethrow an exception thrown by JS it ran during env cleanup (#34663)", async () => {
+    // The node-sqlite3 shape of #34663: a Statement wrap finalizer running
+    // at env teardown emits 'error' on an EventEmitter with no listener,
+    // so the emit throws. node-addon-api then checks
+    // napi_is_exception_pending, fetches the exception with
+    // napi_get_and_clear_last_exception, and rethrows it with napi_throw,
+    // aborting the process (NAPI FATAL ERROR: Error::New
+    // napi_create_error) if any of those disagree. Before the fix the
+    // exception stayed on the JSC VM where napi_is_exception_pending
+    // (which skips the VM check during cleanup) could not see it, and the
+    // rethrow was rejected.
+    const code = `
+      const addon = require(${JSON.stringify(join(__dirname, "napi-app/build/Debug/test_finalizer_create_error.node"))});
+      globalThis.keep = addon.setupRethrow(() => { throw new Error("from js"); });
+    `;
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // call fails with napi_pending_exception (10); the exception is visible
+    // to napi_is_exception_pending; get/ref/rethrow all succeed. Before the
+    // fix this printed is_pending=0 pending=0 ... throw=10.
+    expect(stdout.trim()).toBe("rethrow: call=10 is_pending=0 pending=1 get=0 ref=0 throw=0");
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+  });
+
   it("napi_reference_unref can be called from finalizers in regular modules", async () => {
     // This test ensures that napi_reference_unref can be called during GC
     // without triggering the NAPI_CHECK_ENV_NOT_IN_GC assertion for regular modules.


### PR DESCRIPTION
Fixes #34663

### Repro

Sequelize + sqlite3 where a Statement still has queued calls when the process exits (the issue's project does this via two connections to the same file plus an unhandled rejection):

```
panic(main thread): NAPI FATAL ERROR: Error::New napi_create_error
```

On a debug/ASAN build the same run aborts earlier:

```
ASSERTION FAILED: Unexpected exception observed on thread ...
Error Exception: SQLITE_MISUSE: Statement is already finalized
void JSC::ExceptionScope::releaseAssertNoException()
```

### Cause

Bun runs napi wrap finalizers at env cleanup and, unlike Node, allows them to call into JS. node-sqlite3's `Statement::CleanQueue` finalizer emits an `'error'` event with no listener, so EventEmitter throws. That exception stayed on the JSC VM across the `napi_call_function` boundary, where:

- `napi_is_exception_pending` deliberately skips the VM check during cleanup (#30286), so it reported `false`;
- the next napi call with an exception check failed with `napi_pending_exception` anyway.

node-addon-api's `Error::New(env)` sees "call failed but no exception pending", takes the `napi_create_error` path, and escalates any failure in it with `NAPI_FATAL_IF_FAILED` -> `napi_fatal_error` -> panic. Even with the #30286 tolerance in `napi_create_error`, the chain still aborted later: `Error::Error`'s `napi_create_reference`/`napi_create_object` failed on the VM exception, and `Error::ThrowAsJavaScriptException`'s rethrow was rejected by `napi_throw`'s cleanup guard, which is also fatal in node-addon-api builds without `NODE_API_SWALLOW_UNTHROWABLE_EXCEPTIONS` (sqlite3's prebuilt binary is one).

### Fix

Mirror Node's per-call `TryCatch` capture, scoped to env cleanup:

- napi calls that find an exception on the VM during cleanup move it into the env's pending-exception slot (`NapiEnv::stashExceptionDuringCleanup`, invoked from the shared exception-check macros), where `napi_is_exception_pending` and `napi_get_and_clear_last_exception` already look. Termination exceptions stay put so they keep unwinding.
- `napi_get_and_clear_last_exception` remembers the value it handed out during cleanup, and `napi_throw` accepts rethrowing exactly that value (node-addon-api aborts if the rethrow fails). New exceptions during cleanup still fail with `napi_cannot_run_js`/`napi_pending_exception`, matching Node, which cannot run JS during teardown at all.
- `napi_call_function` no longer promotes a scheduled exception onto the VM during cleanup; the preamble still refuses the call.

The env teardown loop already clears exceptions between finalizers (#30291), which also drops the handed-out marker.

### Verification

- New napi-app finalizer test performs node-addon-api's exact sequence with raw napi calls and asserts each status: without the fix it prints `is_pending=0 pending=0 ... throw=10`, with it `pending=1 ... throw=0` and exits 0.
- The issue's Sequelize repro and a minimal two-connection sqlite3 repro no longer crash (exit 1 from the unhandled rejection, same as Node); 8/8 runs clean on a debug/ASAN build that previously aborted every run.
- `test/napi/napi.test.ts` passes, including the Node-parity teardown tests (`test_deferred_exceptions` via checkSameOutput, the #30286 finalizer tests) and `node-napi-tests/test/js-native-api/test_cannot_run_js`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->