### PR TITLE
ci(asan): enable JSC validateGraphAtEachPhase on ASAN test lanes

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -777,6 +777,12 @@ async function runTests() {
           env.BUN_JSC_validateExceptionChecks = "1";
           env.BUN_JSC_dumpSimulatedThrows = "1";
         }
+        if (basename(execPath).includes("asan")) {
+          // Hunt the DFG CFA crash cluster (BUN-2YP4 et al): validate DFG graph
+          // invariants after every phase so a bad Node/Edge fails at the source.
+          // (validateAbstractInterpreterState is too slow: 26s+ for a trivial loop.)
+          env.BUN_JSC_validateGraphAtEachPhase = "1";
+        }
         if ((basename(execPath).includes("asan") || !isCI) && shouldValidateLeakSan(testPath)) {
           env.BUN_DESTRUCT_VM_ON_EXIT = "1";
           env.ASAN_OPTIONS = "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=1:abort_on_error=1";
@@ -1582,6 +1588,12 @@ async function spawnBunTest(execPath, testPath, opts = { cwd }) {
   if ((basename(execPath).includes("asan") || !isCI) && shouldValidateExceptions(relative(cwd, absPath))) {
     env.BUN_JSC_validateExceptionChecks = "1";
     env.BUN_JSC_dumpSimulatedThrows = "1";
+  }
+  if (basename(execPath).includes("asan")) {
+    // Hunt the DFG CFA crash cluster (BUN-2YP4 et al): validate DFG graph
+    // invariants after every phase so a bad Node/Edge fails at the source.
+    // (validateAbstractInterpreterState is too slow: 26s+ for a trivial loop.)
+    env.BUN_JSC_validateGraphAtEachPhase = "1";
   }
   if ((basename(execPath).includes("asan") || !isCI) && shouldValidateLeakSan(relative(cwd, absPath))) {
     env.BUN_DESTRUCT_VM_ON_EXIT = "1";


### PR DESCRIPTION
## What

Set `BUN_JSC_validateGraphAtEachPhase=1` in `scripts/runner.node.mjs` for ASAN test processes (both the bun test path and the Node compat test path).

## Why

There is a cluster of ~5900 Sentry events over the last 90 days in `JITWorklistThread -> DFG::Plan::compileInThreadImpl -> CFAPhase::performBlockCFA -> AbstractInterpreter<InPlaceAbstractState>::executeEffects`, grouped across BUN-2YP4 / BUN-2VC6 / BUN-2WRJ / BUN-2WR9 / BUN-2XV5 / BUN-36RW / BUN-3QAE / BUN-36ZX and a few more. ~98% Windows, but confirmed on Linux and macOS too.

Disassembly of the 1.3.14 windows-x64 PDB pins the BUN-2YP4 crash to:

```
mov  rax, [r13]          ; r13 = &AbstractInterpreter::m_state (this+0x18)
movzx eax, [rax+0x50]    ; m_state->m_isValid
```

with fault addresses of the form `(N<<32) | 0x150`, i.e. the 8-byte `m_state` reference on the CFAPhase stack has had its low dword overwritten (to `0x100`, which matches `asArrayModes(NonArrayWithContiguous)`) and its high dword set to a small monotone integer (matches `AbstractValueClobberEpoch`). That is exactly the `{m_arrayModes; m_effectEpoch}` pair inside an `AbstractValue`, so the shape is consistent with an `AbstractValue` write landing one slot off.

None of the relevant JSC options default to `ASSERT_ENABLED`:

- `validateGraph` / `validateGraphAtEachPhase`: default `false`
- `validateAbstractInterpreterState`: default `false` (Restricted)

so today's ASAN/assertions lanes do not run them. `validateGraphAtEachPhase` runs `DFGValidate.cpp` after every DFG phase and checks Node/Edge/block invariants, so if a prior phase is leaving the graph inconsistent CI will crash with a `VALIDATE((node, edge), ...)` message naming the broken node instead of segfaulting in CFA.

## What about `validateAbstractInterpreterState`

It is the more targeted check (re-runs CFA during FTL lowering and diffs the state) but it is far too slow for CI: a 5000-iteration sum over a 10k-element array takes 26s on release bun and times out on a debug build. `validateGraphAtEachPhase` alone adds <1s to the same loop.

## Smoke test

`BUN_JSC_validateGraphAtEachPhase=1` against `inspect.test.js`, `text-encoder.test.js`, `bun-serve-static.test.ts` on the debug build: 175 pass / 0 fail.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->