### PR TITLE
node:events: fix ReferenceError in EventEmitter.prototype.listenerCount

### DIFF
--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -522,18 +522,23 @@ EventEmitterPrototype.rawListeners = function rawListeners(type) {
 };
 
 EventEmitterPrototype.listenerCount = function listenerCount(type, method) {
-  if (method == null) return listenerCountSlow(this, type);
   var handlers = this._events?.[type];
-  if (!handlers) return 0;
-  if (typeof handlers === "function") return handlers === method || handlers.listener === method ? 1 : 0;
-  var length = 0;
-  for (let i = 0; i < handlers.length; i++) {
-    const handler = handlers[i];
-    if (handler === method || handler.listener === method) {
-      length++;
-    }
+  if (handlers === undefined) return 0;
+  if (typeof handlers === "function") {
+    if (method != null) return handlers === method || handlers.listener === method ? 1 : 0;
+    return 1;
   }
-  return length;
+  if (method != null) {
+    var length = 0;
+    for (let i = 0; i < handlers.length; i++) {
+      const handler = handlers[i];
+      if (handler === method || handler.listener === method) {
+        length++;
+      }
+    }
+    return length;
+  }
+  return handlers.length;
 };
 Object.defineProperty(EventEmitterPrototype.listenerCount, "name", { value: "listenerCount" });
 

--- a/test/js/node/events/event-emitter.test.ts
+++ b/test/js/node/events/event-emitter.test.ts
@@ -916,6 +916,33 @@ test("getEventListeners", () => {
   expect(getEventListeners(target, "hey").length).toBe(0);
 });
 
+test("EventEmitter.prototype.listenerCount", () => {
+  const ee = new EventEmitter();
+  const a = () => {};
+  const b = () => {};
+
+  expect(ee.listenerCount("x")).toBe(0);
+  expect(ee.listenerCount("x", a)).toBe(0);
+
+  ee.on("x", a);
+  expect(ee.listenerCount("x")).toBe(1);
+  expect(ee.listenerCount("x", a)).toBe(1);
+  expect(ee.listenerCount("x", b)).toBe(0);
+
+  ee.on("x", b);
+  expect(ee.listenerCount("x")).toBe(2);
+  expect(ee.listenerCount("x", a)).toBe(1);
+  expect(ee.listenerCount("x", b)).toBe(1);
+
+  ee.once("y", a);
+  expect(ee.listenerCount("y")).toBe(1);
+  expect(ee.listenerCount("y", a)).toBe(1);
+
+  // null/undefined listener arg means "count all", same as omitting it
+  expect(ee.listenerCount("x", null as any)).toBe(2);
+  expect(ee.listenerCount("x", undefined)).toBe(2);
+});
+
 test("events.listenerCount validates emitter argument", () => {
   const ee = new EventEmitter();
   ee.on("y", () => {});


### PR DESCRIPTION
## Repro

```js
const { EventEmitter } = require("events");
new EventEmitter().listenerCount("x");
```

```
ReferenceError: listenerCountSlow is not defined
      at listenerCount (node:events:450:29)
```

Every single-argument `emitter.listenerCount(type)` call hits this, which broke `test/js/node/http2/node-http2.test.js` (38 fail) via `emitSessionCloseNT` calling `listenerCount("close")`, along with anything else that counts listeners.

## Cause

#34605 (efab3b24cc) removed the `listenerCountSlow` helper when it dropped the fallback path from the static `events.listenerCount`, but `EventEmitterPrototype.listenerCount` (added in a227ad991b) still called it for the common 1-argument form.

## Fix

Inline the lookup into the prototype method, structured the same way as Node's own `listenerCount`: read `_events[type]` once, then handle the bare-function and array storage shapes for both the 1-arg (`return 1` / `handlers.length`) and 2-arg (match against `method`) forms.

## Verification

- `bun bd test test/js/node/events/event-emitter.test.ts`: 70 pass
- New `EventEmitter.prototype.listenerCount` test fails on main with `ReferenceError: listenerCountSlow is not defined`, passes with the fix
- All 26 `test/js/node/test/parallel/test-event-emitter-*.js` pass
- Test expectations checked against Node.js