### PR TITLE
Bump WebKit to 639550acdcb2: skip preCommitStackMemory before VM entry on Windows

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -7,7 +7,7 @@
 // -lto variants built with ThinLTO (per-module summaries for cross-language
 // importing), and the Windows ICU data table filtered + per-item zstd
 // compressed (lazily decompressed via bun_icu_decompress.cpp).
-export const WEBKIT_VERSION = "4895f45dfbd0d1226c4d41799887bc0ecb9f341b";
+export const WEBKIT_VERSION = "639550acdcb2a5fba8a5812b03ff4184522e73fa";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.


### PR DESCRIPTION
### What does this PR do?

Bumps `WEBKIT_VERSION` to [oven-sh/WebKit@639550ac](https://github.com/oven-sh/WebKit/commit/639550acdcb2a5fba8a5812b03ff4184522e73fa) to pick up [oven-sh/WebKit#310](https://github.com/oven-sh/WebKit/pull/310).

### Problem

Sentry [BUN-2V26](https://bun-p9.sentry.io/issues/7403293491/) (`JSC::preCommitStackMemory`): 33k+ events, 100% Windows, `0xC00000FD EXCEPTION_STACK_OVERFLOW` at cold process start. 66% are `bun build --compile` standalone binaries, 64% the baseline dist.

### Cause

At `VM::VM()` time `m_stackPointerAtVMEntry` is null, so `updateStackLimits()` computes the soft limit against the full stack reserve (`GetCurrentThreadStackLimits`). Bun links `/STACK:0x1200000` (18MB), so `preCommitStackMemory` eagerly touches ~17.8MB of stack on every start; on commit-constrained Windows hosts the guard-page grow fails and raises `EXCEPTION_STACK_OVERFLOW`. The commit is wasted anyway since `maxPerThreadStackUsage` caps JIT stack usage at 5MB.

### Fix

oven-sh/WebKit#310 gates `preCommitStackMemory` on `m_stackPointerAtVMEntry`. `JSLock::didAcquireLock()` sets it and re-runs `updateStackLimits()` with the 5MB cap applied (and `VM::VM()` takes a `JSLockHolder` right after the initial call), so the commit still happens during construction, just bounded to ~5MB instead of ~18MB. Same saving on every Worker thread.

### Also in this range (oven-sh/WebKit 4895f45d..639550ac)

- [#306](https://github.com/oven-sh/WebKit/pull/306) Drop the ThrowScope from the reifyStaticProperty call sites
- [#304](https://github.com/oven-sh/WebKit/pull/304) WTF: use GetSystemTimePreciseAsFileTime for WallTime and QPC for MonotonicTime on Windows
- [#301](https://github.com/oven-sh/WebKit/pull/301) Consolidate AsyncLocalStorage save/restore with an RAII AsyncContextSwapScope
- [#298](https://github.com/oven-sh/WebKit/pull/298) Dockerfile.windows: enable assertions and disable /GF for the sanitizer build
- [#295](https://github.com/oven-sh/WebKit/pull/295) JSMicrotask: keep async context active while settling the async function promise
- [#282](https://github.com/oven-sh/WebKit/pull/282) Defer termination at the reifyStaticProperty call sites and propagate builder exceptions

Fixes #27987.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->