### PR TITLE
sql: trace cached result-row Structures from the Connection wrapper instead of per-statement Strongs

### DIFF
--- a/src/runtime/api/sql.classes.ts
+++ b/src/runtime/api/sql.classes.ts
@@ -57,7 +57,7 @@ for (const type of types) {
           this: true,
         },
       },
-      values: ["onconnect", "onclose", "queries"],
+      values: ["onconnect", "onclose", "queries", "cachedStructures"],
     }),
   );
 

--- a/src/sql_jsc/jsc.rs
+++ b/src/sql_jsc/jsc.rs
@@ -617,7 +617,7 @@ pub use bun_jsc::JsClass;
 
 pub mod codegen {
     ::bun_jsc::js_class_module!(JSPostgresSQLConnection = "PostgresSQLConnection"
-        as crate::postgres::PostgresSQLConnection { queries, onconnect, onclose });
+        as crate::postgres::PostgresSQLConnection { queries, onconnect, onclose, cachedStructures });
     ::bun_jsc::js_class_module!(
         JSPostgresSQLQuery = "PostgresSQLQuery" as crate::postgres::PostgresSQLQuery,
         impl_js_class {
@@ -629,7 +629,7 @@ pub mod codegen {
     );
 
     ::bun_jsc::js_class_module!(js_mysql_connection = "MySQLConnection"
-        as crate::mysql::js_my_sql_connection::JSMySQLConnection { queries, onconnect, onclose });
+        as crate::mysql::js_my_sql_connection::JSMySQLConnection { queries, onconnect, onclose, cachedStructures });
     pub use js_mysql_connection as JSMySQLConnection;
 
     ::bun_jsc::js_class_module!(

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -517,6 +517,8 @@ impl JSMySQLConnection {
         let _ = use_unnamed_prepared_statements;
         let allow_public_key_retrieval = callframe.argument(15).to_boolean();
 
+        let cached_structures = JSValue::create_empty_array(global_object, 0)?;
+
         // Ownership transferred into `ptr.connection`; disarm the errdefer so the
         // connect-fail `ptr.deref()` is the sole cleanup path from here on.
         let (secure, tls_config) = scopeguard::ScopeGuard::into_inner(tls_guard);
@@ -605,11 +607,7 @@ impl JSMySQLConnection {
             .with_mut(|r| r.set_strong(js_value, global_object));
         js::onconnect_set_cached(js_value, global_object, on_connect);
         js::onclose_set_cached(js_value, global_object, on_close);
-        js::cached_structures_set_cached(
-            js_value,
-            global_object,
-            JSValue::create_empty_array(global_object, 0)?,
-        );
+        js::cached_structures_set_cached(js_value, global_object, cached_structures);
 
         Ok(js_value)
     }
@@ -695,14 +693,18 @@ impl JSMySQLConnection {
 
     /// Append a freshly-built result-row `Structure` to this wrapper's
     /// `m_cachedStructures` array so GC traces it via `visitChildren` instead
-    /// of via a per-statement `Strong` handle.
-    fn add_cached_structure(&self, this_value: JSValue, structure: JSValue) {
-        let global = &self.global_object;
-        if let Some(array) = js::cached_structures_get_cached(this_value)
-            && array.push(global, structure).is_err()
-        {
-            global.clear_exception_except_termination();
+    /// of via a per-statement `Strong` handle. Returns whether the push
+    /// succeeded; on failure the caller keeps the Strong so the structure
+    /// stays rooted.
+    fn add_cached_structure(&self, this_value: JSValue, structure: JSValue) -> bool {
+        let Some(array) = js::cached_structures_get_cached(this_value) else {
+            return false;
+        };
+        if array.push(&self.global_object, structure).is_err() {
+            self.global_object.clear_exception_except_termination();
+            return false;
         }
+        true
     }
 
     #[inline]
@@ -838,13 +840,21 @@ impl JSMySQLConnection {
         // the `ParentRef` liveness invariant.
         let cached_structure: Option<ParentRef<CachedStructure>> = match result_mode {
             ResultMode::Objects => self.js_value.get().try_get().map(|value| {
-                let (cs, new_structure) = statement.structure(value, &self.global_object);
-                structure = cs.js_value().unwrap_or(JSValue::UNDEFINED);
-                let cs = ParentRef::new(cs);
-                if let Some(new_structure) = new_structure {
-                    self.add_cached_structure(value, new_structure);
+                let new_structure = statement.structure(value, &self.global_object);
+                // Only hand off to the connection's traced array when this
+                // statement lives in `connection.statements` (prepared).
+                // Per-query simple statements keep their Strong.
+                if let Some(new_structure) = new_structure
+                    && !request.is_simple()
+                    && self.add_cached_structure(value, new_structure)
+                {
+                    statement
+                        .cached_structure
+                        .mark_traced_from_connection(new_structure);
                 }
-                cs
+                let cs = &statement.cached_structure;
+                structure = cs.js_value().unwrap_or(JSValue::UNDEFINED);
+                ParentRef::new(cs)
             }),
             // no need to check for duplicate fields or structure
             ResultMode::Raw | ResultMode::Values => None,

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -52,6 +52,9 @@ pub struct JSMySQLConnection {
     // intrusive refcount (bun.ptr.RefCount mixin); destroy callback = `deinit`
     ref_count: Cell<u32>,
     js_value: JsCell<JsRef>,
+    /// Next free index into the wrapper's `m_cachedStructures` JSArray; written
+    /// via `putDirectIndex` so prototype index setters are never consulted.
+    cached_structures_len: Cell<u32>,
     // LIFETIMES.tsv: JSC_BORROW — assigned from createInstance param; never freed
     global_object: GlobalRef,
     // LIFETIMES.tsv: STATIC — globalObject.bunVM() singleton. `BackRef` so the
@@ -526,6 +529,7 @@ impl JSMySQLConnection {
         let ptr: *mut JSMySQLConnection = bun_core::heap::into_raw(Box::new(JSMySQLConnection {
             ref_count: Cell::new(1),
             js_value: JsCell::new(JsRef::empty()),
+            cached_structures_len: Cell::new(0),
             global_object: GlobalRef::from(global_object),
             vm: BackRef::new_mut(vm),
             poll_ref: JsCell::new(KeepAlive::default()),
@@ -691,20 +695,29 @@ impl JSMySQLConnection {
         JSValue::UNDEFINED
     }
 
-    /// Append a freshly-built result-row `Structure` to this wrapper's
+    /// Write a freshly-built result-row `Structure` into this wrapper's
     /// `m_cachedStructures` array so GC traces it via `visitChildren` instead
-    /// of via a per-statement `Strong` handle. Returns whether the push
-    /// succeeded; on failure the caller keeps the Strong so the structure
-    /// stays rooted.
-    fn add_cached_structure(&self, this_value: JSValue, structure: JSValue) -> bool {
-        let Some(array) = js::cached_structures_get_cached(this_value) else {
-            return false;
-        };
-        if array.push(&self.global_object, structure).is_err() {
+    /// of via a per-statement `Strong` handle. Each statement gets one stable
+    /// `slot` (so a column-shape change overwrites rather than grows). Returns
+    /// the slot written on success; on failure the caller keeps the Strong.
+    /// Uses `putDirectIndex` (own-slot write) so an index setter on
+    /// `Array.prototype` cannot observe or intercept the value.
+    fn add_cached_structure(
+        &self,
+        this_value: JSValue,
+        structure: JSValue,
+        slot: Option<u32>,
+    ) -> Option<u32> {
+        let array = js::cached_structures_get_cached(this_value)?;
+        let i = slot.unwrap_or(self.cached_structures_len.get());
+        if array.put_index(&self.global_object, i, structure).is_err() {
             self.global_object.clear_exception_except_termination();
-            return false;
+            return None;
         }
-        true
+        if slot.is_none() {
+            self.cached_structures_len.set(i + 1);
+        }
+        Some(i)
     }
 
     #[inline]
@@ -846,11 +859,15 @@ impl JSMySQLConnection {
                 // Per-query simple statements keep their Strong.
                 if let Some(new_structure) = new_structure
                     && !request.is_simple()
-                    && self.add_cached_structure(value, new_structure)
+                    && let Some(slot) = self.add_cached_structure(
+                        value,
+                        new_structure,
+                        statement.cached_structure.connection_slot,
+                    )
                 {
                     statement
                         .cached_structure
-                        .mark_traced_from_connection(new_structure);
+                        .mark_traced_from_connection(new_structure, slot);
                 }
                 let cs = &statement.cached_structure;
                 structure = cs.js_value().unwrap_or(JSValue::UNDEFINED);

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -605,6 +605,11 @@ impl JSMySQLConnection {
             .with_mut(|r| r.set_strong(js_value, global_object));
         js::onconnect_set_cached(js_value, global_object, on_connect);
         js::onclose_set_cached(js_value, global_object, on_close);
+        js::cached_structures_set_cached(
+            js_value,
+            global_object,
+            JSValue::create_empty_array(global_object, 0)?,
+        );
 
         Ok(js_value)
     }
@@ -686,6 +691,18 @@ impl JSMySQLConnection {
             return js::queries_get_cached(value).unwrap_or(JSValue::UNDEFINED);
         }
         JSValue::UNDEFINED
+    }
+
+    /// Append a freshly-built result-row `Structure` to this wrapper's
+    /// `m_cachedStructures` array so GC traces it via `visitChildren` instead
+    /// of via a per-statement `Strong` handle.
+    fn add_cached_structure(&self, this_value: JSValue, structure: JSValue) {
+        let global = &self.global_object;
+        if let Some(array) = js::cached_structures_get_cached(this_value)
+            && array.push(global, structure).is_err()
+        {
+            global.clear_exception_except_termination();
+        }
     }
 
     #[inline]
@@ -821,9 +838,13 @@ impl JSMySQLConnection {
         // the `ParentRef` liveness invariant.
         let cached_structure: Option<ParentRef<CachedStructure>> = match result_mode {
             ResultMode::Objects => self.js_value.get().try_get().map(|value| {
-                let cs = statement.structure(value, &self.global_object);
+                let (cs, new_structure) = statement.structure(value, &self.global_object);
                 structure = cs.js_value().unwrap_or(JSValue::UNDEFINED);
-                ParentRef::new(cs)
+                let cs = ParentRef::new(cs);
+                if let Some(new_structure) = new_structure {
+                    self.add_cached_structure(value, new_structure);
+                }
+                cs
             }),
             // no need to check for duplicate fields or structure
             ResultMode::Raw | ResultMode::Values => None,

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -709,7 +709,7 @@ impl JSMySQLConnection {
         slot: Option<u32>,
     ) -> Option<u32> {
         let array = js::cached_structures_get_cached(this_value)?;
-        let i = slot.unwrap_or(self.cached_structures_len.get());
+        let i = slot.unwrap_or_else(|| self.cached_structures_len.get());
         if array.put_index(&self.global_object, i, structure).is_err() {
             self.global_object.clear_exception_except_termination();
             return None;
@@ -844,11 +844,9 @@ impl JSMySQLConnection {
     ) -> Result<(), OnResultRowError> {
         let result_mode = request.get_result_mode();
         let mut structure: JSValue = JSValue::UNDEFINED;
-        // `MySQLStatement::structure(&mut self) -> &CachedStructure`
-        // would keep `*statement` exclusively borrowed for the lifetime of the
-        // returned ref, blocking the `&statement.columns` / `fields_flags` reads
-        // below. Stash a `ParentRef` (lifetime-erased `&T`)
-        // and `as_deref` at the `to_js` call site — `*statement`
+        // Hold `&statement.cached_structure` as a `ParentRef` (lifetime-erased
+        // `&T`) so the later `&statement.columns` / `&mut statement` borrows do
+        // not conflict; `as_deref` at the `to_js` call site. `*statement`
         // outlives this fn (held via `request`'s intrusive ref), satisfying
         // the `ParentRef` liveness invariant.
         let cached_structure: Option<ParentRef<CachedStructure>> = match result_mode {

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -1457,7 +1457,7 @@ impl MySQLConnection {
                         columns.resize_with(field_count, ColumnDefinition41::default);
                         statement.columns = columns;
                         statement.columns_received = 0;
-                        statement.cached_structure = Default::default();
+                        statement.cached_structure.reset();
                         statement.fields_flags = Default::default();
                     }
                     statement
@@ -1471,7 +1471,7 @@ impl MySQLConnection {
                     let changed = statement.columns[statement.columns_received as usize]
                         .decode(&mut reader)?;
                     if changed {
-                        statement.cached_structure = Default::default();
+                        statement.cached_structure.reset();
                         statement.fields_flags = Default::default();
                         statement
                             .execution_flags

--- a/src/sql_jsc/mysql/MySQLStatement.rs
+++ b/src/sql_jsc/mysql/MySQLStatement.rs
@@ -122,14 +122,16 @@ impl MySQLStatement {
 
     // Returning `&CachedStructure`
     // to avoid moving out of `self`; callers may need `.clone()` if they require
-    // an owned copy.
+    // an owned copy. The second tuple slot is `Some(structure)` when this call
+    // allocated a new `JSC::Structure`, so the caller can register it with the
+    // Connection wrapper for GC tracing.
     pub(crate) fn structure(
         &mut self,
         owner: JSValue,
         global_object: &JSGlobalObject,
-    ) -> &CachedStructure {
+    ) -> (&CachedStructure, Option<JSValue>) {
         if self.cached_structure.has() {
-            return &self.cached_structure;
+            return (&self.cached_structure, None);
         }
         self.check_for_duplicate_fields();
         self.cached_structure.build_from_columns(
@@ -137,7 +139,7 @@ impl MySQLStatement {
             owner,
             self.columns.iter().map(|c| &c.name_or_index),
         );
-        &self.cached_structure
+        (&self.cached_structure, self.cached_structure.js_value())
     }
 }
 

--- a/src/sql_jsc/mysql/MySQLStatement.rs
+++ b/src/sql_jsc/mysql/MySQLStatement.rs
@@ -120,18 +120,17 @@ impl MySQLStatement {
             dedupe_columns(self.columns.iter_mut().rev().map(|c| &mut c.name_or_index));
     }
 
-    // Returning `&CachedStructure`
-    // to avoid moving out of `self`; callers may need `.clone()` if they require
-    // an owned copy. The second tuple slot is `Some(structure)` when this call
-    // allocated a new `JSC::Structure`, so the caller can register it with the
-    // Connection wrapper for GC tracing.
+    /// Populate `self.cached_structure` for the current column set (no-op if
+    /// already built). Returns `Some(structure)` when this call allocated a new
+    /// `JSC::Structure`, so the caller can register it with the Connection
+    /// wrapper for GC tracing; `None` on cache hit or for the wide-row path.
     pub(crate) fn structure(
         &mut self,
         owner: JSValue,
         global_object: &JSGlobalObject,
-    ) -> (&CachedStructure, Option<JSValue>) {
+    ) -> Option<JSValue> {
         if self.cached_structure.has() {
-            return (&self.cached_structure, None);
+            return None;
         }
         self.check_for_duplicate_fields();
         self.cached_structure.build_from_columns(
@@ -139,7 +138,7 @@ impl MySQLStatement {
             owner,
             self.columns.iter().map(|c| &c.name_or_index),
         );
-        (&self.cached_structure, self.cached_structure.js_value())
+        self.cached_structure.js_value()
     }
 }
 

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -1180,6 +1180,8 @@ pub(crate) fn call(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsR
     let max_lifetime = arguments[13].to_int32();
     let use_unnamed_prepared_statements = arguments[14].as_boolean();
 
+    let cached_structures = JSValue::create_empty_array(global_object, 0)?;
+
     // Ownership transferred into `ptr`; disarm the errdefer and recover the
     // moved `secure`/`tls_config` for the struct literal below.
     let (secure, tls_config) = scopeguard::ScopeGuard::into_inner(errdefer_guard);
@@ -1298,11 +1300,7 @@ pub(crate) fn call(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsR
     this.js_value.set(crate::jsc::JsRef::init_weak(js_value));
     js::onconnect_set_cached(js_value, global_object, on_connect);
     js::onclose_set_cached(js_value, global_object, on_close);
-    js::cached_structures_set_cached(
-        js_value,
-        global_object,
-        JSValue::create_empty_array(global_object, 0)?,
-    );
+    js::cached_structures_set_cached(js_value, global_object, cached_structures);
     bun_analytics::features::postgres_connections.fetch_add(1, Ordering::Relaxed);
     Ok(js_value)
 }
@@ -2374,15 +2372,19 @@ impl PostgresSQLConnection {
 
     /// Append a freshly-built result-row `Structure` to this wrapper's
     /// `m_cachedStructures` array so GC traces it via `visitChildren` instead
-    /// of via a per-statement `Strong` handle.
-    fn add_cached_structure(&self, this_value: JSValue, structure: JSValue) {
+    /// of via a per-statement `Strong` handle. Returns whether the push
+    /// succeeded; on failure the caller keeps the Strong so the structure
+    /// stays rooted.
+    fn add_cached_structure(&self, this_value: JSValue, structure: JSValue) -> bool {
         debug_assert!(!this_value.is_empty());
-        let global = self.global();
-        if let Some(array) = js::cached_structures_get_cached(this_value)
-            && array.push(global, structure).is_err()
-        {
-            global.clear_exception_except_termination();
+        let Some(array) = js::cached_structures_get_cached(this_value) else {
+            return false;
+        };
+        if array.push(self.global(), structure).is_err() {
+            self.global().clear_exception_except_termination();
+            return false;
         }
+        true
     }
 
     // `message_type` is a runtime arg; the match
@@ -2426,14 +2428,27 @@ impl PostgresSQLConnection {
                 // explicit use switch without else so if new modes are added, we don't forget to check for duplicate fields
                 match request_flags.result_mode {
                     SQLQueryResultMode::Objects => {
-                        if let Some(owner) = self.js_value.get().try_get() {
-                            let (cs, new_structure) = statement.structure(owner, self.global());
-                            structure = cs.js_value().unwrap_or(JSValue::UNDEFINED);
-                            cached_structure = Some(ParentRef::new(cs));
-                            if let Some(new_structure) = new_structure {
-                                self.add_cached_structure(owner, new_structure);
-                            }
+                        let owner = self.js_value.get().try_get().unwrap_or(JSValue::ZERO);
+                        let new_structure = statement.structure(owner, self.global());
+                        // Only hand off to the connection's traced array when
+                        // this statement lives in `self.statements` (named
+                        // prepared). Per-query statements keep their Strong.
+                        if let Some(new_structure) = new_structure
+                            && !request_flags.simple
+                            && !self
+                                .flags
+                                .get()
+                                .contains(ConnectionFlags::USE_UNNAMED_PREPARED_STATEMENTS)
+                            && !owner.is_empty()
+                            && self.add_cached_structure(owner, new_structure)
+                        {
+                            statement
+                                .cached_structure
+                                .mark_traced_from_connection(new_structure);
                         }
+                        let cs = &statement.cached_structure;
+                        structure = cs.js_value().unwrap_or(JSValue::UNDEFINED);
+                        cached_structure = Some(ParentRef::new(cs));
                     }
                     SQLQueryResultMode::Raw | SQLQueryResultMode::Values => {
                         // no need to check for duplicate fields or structure

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -2389,7 +2389,7 @@ impl PostgresSQLConnection {
     ) -> Option<u32> {
         debug_assert!(!this_value.is_empty());
         let array = js::cached_structures_get_cached(this_value)?;
-        let i = slot.unwrap_or(self.cached_structures_len.get());
+        let i = slot.unwrap_or_else(|| self.cached_structures_len.get());
         if array.put_index(self.global(), i, structure).is_err() {
             self.global().clear_exception_except_termination();
             return None;
@@ -2430,9 +2430,8 @@ impl PostgresSQLConnection {
                     .statement_mut()
                     .ok_or(AnyPostgresError::ExpectedStatement)?;
                 let mut structure: JSValue = JSValue::UNDEFINED;
-                // reshaped for borrowck — `statement.structure()` borrows
-                // `&mut *statement` and returns `&CachedStructure`; capture it as a
-                // `ParentRef` (lifetime-erased `&T`) so `&statement.fields` below
+                // Hold `&statement.cached_structure` as a `ParentRef`
+                // (lifetime-erased `&T`) so the later `&statement.fields` borrow
                 // does not conflict, and `as_deref` for `to_js` at the call site.
                 // `*statement` outlives this arm (held via `request.statement`'s
                 // intrusive ref), satisfying the `ParentRef` liveness invariant.

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -125,6 +125,9 @@ pub struct PostgresSQLConnection {
     // so `vm_mut()`'s `&mut *as_ptr()` is sound.
     pub vm: BackRef<VirtualMachine>,
     pub statements: JsCell<PreparedStatementsMap>,
+    /// Next free index into the wrapper's `m_cachedStructures` JSArray; written
+    /// via `putDirectIndex` so prototype index setters are never consulted.
+    cached_structures_len: Cell<u32>,
     pub prepared_statement_id: Cell<u64>,
     pub pending_activity_count: AtomicU32,
     // Self-wrapper back-ref (the JS object that owns this payload). Stored as a
@@ -1208,6 +1211,7 @@ pub(crate) fn call(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsR
             // canonical `VirtualMachine::as_mut()` accessor.
             vm: BackRef::new_mut(vm),
             statements: JsCell::new(PreparedStatementsMap::default()),
+            cached_structures_len: Cell::new(0),
             prepared_statement_id: Cell::new(0),
             pending_activity_count: AtomicU32::new(0),
             js_value: JsCell::new(crate::jsc::JsRef::empty()),
@@ -2370,21 +2374,30 @@ impl PostgresSQLConnection {
         js::queries_get_cached(js_value).unwrap_or(JSValue::UNDEFINED)
     }
 
-    /// Append a freshly-built result-row `Structure` to this wrapper's
+    /// Write a freshly-built result-row `Structure` into this wrapper's
     /// `m_cachedStructures` array so GC traces it via `visitChildren` instead
-    /// of via a per-statement `Strong` handle. Returns whether the push
-    /// succeeded; on failure the caller keeps the Strong so the structure
-    /// stays rooted.
-    fn add_cached_structure(&self, this_value: JSValue, structure: JSValue) -> bool {
+    /// of via a per-statement `Strong` handle. Each statement gets one stable
+    /// `slot` (so a column-shape change overwrites rather than grows). Returns
+    /// the slot written on success; on failure the caller keeps the Strong.
+    /// Uses `putDirectIndex` (own-slot write) so an index setter on
+    /// `Array.prototype` cannot observe or intercept the value.
+    fn add_cached_structure(
+        &self,
+        this_value: JSValue,
+        structure: JSValue,
+        slot: Option<u32>,
+    ) -> Option<u32> {
         debug_assert!(!this_value.is_empty());
-        let Some(array) = js::cached_structures_get_cached(this_value) else {
-            return false;
-        };
-        if array.push(self.global(), structure).is_err() {
+        let array = js::cached_structures_get_cached(this_value)?;
+        let i = slot.unwrap_or(self.cached_structures_len.get());
+        if array.put_index(self.global(), i, structure).is_err() {
             self.global().clear_exception_except_termination();
-            return false;
+            return None;
         }
-        true
+        if slot.is_none() {
+            self.cached_structures_len.set(i + 1);
+        }
+        Some(i)
     }
 
     // `message_type` is a runtime arg; the match
@@ -2440,11 +2453,15 @@ impl PostgresSQLConnection {
                                 .get()
                                 .contains(ConnectionFlags::USE_UNNAMED_PREPARED_STATEMENTS)
                             && !owner.is_empty()
-                            && self.add_cached_structure(owner, new_structure)
+                            && let Some(slot) = self.add_cached_structure(
+                                owner,
+                                new_structure,
+                                statement.cached_structure.connection_slot,
+                            )
                         {
                             statement
                                 .cached_structure
-                                .mark_traced_from_connection(new_structure);
+                                .mark_traced_from_connection(new_structure, slot);
                         }
                         let cs = &statement.cached_structure;
                         structure = cs.js_value().unwrap_or(JSValue::UNDEFINED);
@@ -2669,7 +2686,7 @@ impl PostgresSQLConnection {
                 // the correct structure instead of reusing a stale cached one.
                 // Vec<FieldDescription> drop runs each field's Drop.
                 statement.fields = description.fields.into_vec();
-                statement.cached_structure = Default::default();
+                statement.cached_structure.reset();
                 statement.needs_duplicate_check = true;
                 statement.fields_flags = Default::default();
             }

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -1298,6 +1298,11 @@ pub(crate) fn call(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsR
     this.js_value.set(crate::jsc::JsRef::init_weak(js_value));
     js::onconnect_set_cached(js_value, global_object, on_connect);
     js::onclose_set_cached(js_value, global_object, on_close);
+    js::cached_structures_set_cached(
+        js_value,
+        global_object,
+        JSValue::create_empty_array(global_object, 0)?,
+    );
     bun_analytics::features::postgres_connections.fetch_add(1, Ordering::Relaxed);
     Ok(js_value)
 }
@@ -2367,6 +2372,19 @@ impl PostgresSQLConnection {
         js::queries_get_cached(js_value).unwrap_or(JSValue::UNDEFINED)
     }
 
+    /// Append a freshly-built result-row `Structure` to this wrapper's
+    /// `m_cachedStructures` array so GC traces it via `visitChildren` instead
+    /// of via a per-statement `Strong` handle.
+    fn add_cached_structure(&self, this_value: JSValue, structure: JSValue) {
+        debug_assert!(!this_value.is_empty());
+        let global = self.global();
+        if let Some(array) = js::cached_structures_get_cached(this_value)
+            && array.push(global, structure).is_err()
+        {
+            global.clear_exception_except_termination();
+        }
+    }
+
     // `message_type` is a runtime arg; the match
     // below still monomorphizes per-Context and the branch is trivially predictable.
     // `reader` is taken by-value as a `NewReaderWrap<&mut Context>`
@@ -2408,10 +2426,14 @@ impl PostgresSQLConnection {
                 // explicit use switch without else so if new modes are added, we don't forget to check for duplicate fields
                 match request_flags.result_mode {
                     SQLQueryResultMode::Objects => {
-                        let owner = self.js_value.get().try_get().unwrap_or(JSValue::ZERO);
-                        let cs = statement.structure(owner, self.global());
-                        structure = cs.js_value().unwrap_or(JSValue::UNDEFINED);
-                        cached_structure = Some(ParentRef::new(cs));
+                        if let Some(owner) = self.js_value.get().try_get() {
+                            let (cs, new_structure) = statement.structure(owner, self.global());
+                            structure = cs.js_value().unwrap_or(JSValue::UNDEFINED);
+                            cached_structure = Some(ParentRef::new(cs));
+                            if let Some(new_structure) = new_structure {
+                                self.add_cached_structure(owner, new_structure);
+                            }
+                        }
                     }
                     SQLQueryResultMode::Raw | SQLQueryResultMode::Values => {
                         // no need to check for duplicate fields or structure

--- a/src/sql_jsc/postgres/PostgresSQLStatement.rs
+++ b/src/sql_jsc/postgres/PostgresSQLStatement.rs
@@ -97,11 +97,7 @@ impl PostgresSQLStatement {
     /// already built). Returns `Some(structure)` when this call allocated a new
     /// `JSC::Structure`, so the caller can register it with the Connection
     /// wrapper for GC tracing; `None` on cache hit or for the wide-row path.
-    pub fn structure(
-        &mut self,
-        owner: JSValue,
-        global_object: &JSGlobalObject,
-    ) -> Option<JSValue> {
+    pub fn structure(&mut self, owner: JSValue, global_object: &JSGlobalObject) -> Option<JSValue> {
         if self.cached_structure.has() {
             return None;
         }

--- a/src/sql_jsc/postgres/PostgresSQLStatement.rs
+++ b/src/sql_jsc/postgres/PostgresSQLStatement.rs
@@ -95,14 +95,16 @@ impl PostgresSQLStatement {
 
     // Note: returning
     // `&CachedStructure` here to avoid moving out of `self` (CachedStructure owns
-    // a `Box<[ExternColumnIdentifier]>` and a `StrongOptional`, neither `Copy`).
+    // a `Box<[ExternColumnIdentifier]>`, not `Copy`). The second tuple slot is
+    // `Some(structure)` when this call allocated a new `JSC::Structure`, so the
+    // caller can register it with the Connection wrapper for GC tracing.
     pub fn structure(
         &mut self,
         owner: JSValue,
         global_object: &JSGlobalObject,
-    ) -> &PostgresCachedStructure {
+    ) -> (&PostgresCachedStructure, Option<JSValue>) {
         if self.cached_structure.has() {
-            return &self.cached_structure;
+            return (&self.cached_structure, None);
         }
         self.check_for_duplicate_fields();
         self.cached_structure.build_from_columns(
@@ -110,7 +112,7 @@ impl PostgresSQLStatement {
             owner,
             self.fields.iter().map(|f| &f.name_or_index),
         );
-        &self.cached_structure
+        (&self.cached_structure, self.cached_structure.js_value())
     }
 }
 

--- a/src/sql_jsc/postgres/PostgresSQLStatement.rs
+++ b/src/sql_jsc/postgres/PostgresSQLStatement.rs
@@ -93,18 +93,17 @@ impl PostgresSQLStatement {
             dedupe_columns(self.fields.iter_mut().rev().map(|f| &mut f.name_or_index));
     }
 
-    // Note: returning
-    // `&CachedStructure` here to avoid moving out of `self` (CachedStructure owns
-    // a `Box<[ExternColumnIdentifier]>`, not `Copy`). The second tuple slot is
-    // `Some(structure)` when this call allocated a new `JSC::Structure`, so the
-    // caller can register it with the Connection wrapper for GC tracing.
+    /// Populate `self.cached_structure` for the current column set (no-op if
+    /// already built). Returns `Some(structure)` when this call allocated a new
+    /// `JSC::Structure`, so the caller can register it with the Connection
+    /// wrapper for GC tracing; `None` on cache hit or for the wide-row path.
     pub fn structure(
         &mut self,
         owner: JSValue,
         global_object: &JSGlobalObject,
-    ) -> (&PostgresCachedStructure, Option<JSValue>) {
+    ) -> Option<JSValue> {
         if self.cached_structure.has() {
-            return (&self.cached_structure, None);
+            return None;
         }
         self.check_for_duplicate_fields();
         self.cached_structure.build_from_columns(
@@ -112,7 +111,7 @@ impl PostgresSQLStatement {
             owner,
             self.fields.iter().map(|f| &f.name_or_index),
         );
-        (&self.cached_structure, self.cached_structure.js_value())
+        self.cached_structure.js_value()
     }
 }
 

--- a/src/sql_jsc/shared/CachedStructure.rs
+++ b/src/sql_jsc/shared/CachedStructure.rs
@@ -12,6 +12,10 @@ pub struct CachedStructure {
     /// kept alive by the Connection wrapper's `m_cachedStructures` array
     /// (visited in `visitChildren`). At most one of `strong` / `traced` is set.
     traced: JSValue,
+    /// Index into the Connection wrapper's `m_cachedStructures` array once
+    /// assigned. Preserved across [`reset`] so a statement whose column shape
+    /// changes mid-lifetime overwrites its slot instead of growing the array.
+    pub connection_slot: Option<u32>,
     /// only populated if more than jsc.JSC__JSObject__maxInlineCapacity fields otherwise the structure will contain all fields inlined
     pub fields: Option<Box<[ExternColumnIdentifier]>>,
 }
@@ -31,13 +35,22 @@ impl CachedStructure {
         })
     }
 
-    /// Called once the Connection has pushed this structure onto its
-    /// `m_cachedStructures` array: release the per-statement Strong and keep
-    /// only the raw value, so connection-cached statements do not each hold a
-    /// GC-root handle.
-    pub fn mark_traced_from_connection(&mut self, structure: JSValue) {
+    /// Called once the Connection has written this structure into its
+    /// `m_cachedStructures` array at `slot`: release the per-statement Strong
+    /// and keep only the raw value, so connection-cached statements do not each
+    /// hold a GC-root handle.
+    pub fn mark_traced_from_connection(&mut self, structure: JSValue, slot: u32) {
         self.traced = structure;
+        self.connection_slot = Some(slot);
         self.strong.deinit();
+    }
+
+    /// Clear the cached structure so the next row rebuilds it, preserving
+    /// `connection_slot` so a connection-cached statement reuses its array slot.
+    pub fn reset(&mut self) {
+        self.strong.deinit();
+        self.traced = JSValue::ZERO;
+        self.fields = None;
     }
 
     /// Populate this `CachedStructure` from a column-identifier sequence —

--- a/src/sql_jsc/shared/CachedStructure.rs
+++ b/src/sql_jsc/shared/CachedStructure.rs
@@ -1,32 +1,39 @@
 use core::mem::{ManuallyDrop, MaybeUninit};
 
-use crate::jsc::{ExternColumnIdentifier, JSGlobalObject, JSObject, JSValue, StrongOptional};
+use crate::jsc::{ExternColumnIdentifier, JSGlobalObject, JSObject, JSValue};
 use bun_sql::shared::ColumnIdentifier;
 
 #[derive(Default)]
 pub struct CachedStructure {
-    pub structure: StrongOptional, // Strong.Optional = .empty
+    /// Raw `JSC::Structure*`. Not a GC root: kept alive by the owning
+    /// Connection wrapper's `m_cachedStructures` array (visited in
+    /// `visitChildren`), so it is valid only while that wrapper is live.
+    pub structure: JSValue,
     /// only populated if more than jsc.JSC__JSObject__maxInlineCapacity fields otherwise the structure will contain all fields inlined
     pub fields: Option<Box<[ExternColumnIdentifier]>>,
 }
 
 impl CachedStructure {
     pub fn has(&self) -> bool {
-        self.structure.has() || self.fields.is_some()
+        !self.structure.is_empty() || self.fields.is_some()
     }
 
     pub fn js_value(&self) -> Option<JSValue> {
-        self.structure.get()
+        if self.structure.is_empty() {
+            None
+        } else {
+            Some(self.structure)
+        }
     }
 
     pub fn set(
         &mut self,
-        global_object: &JSGlobalObject,
+        _global_object: &JSGlobalObject,
         value: Option<JSValue>,
         fields: Option<Box<[ExternColumnIdentifier]>>,
     ) {
         if let Some(v) = value {
-            self.structure.set(global_object, v);
+            self.structure = v;
         }
         self.fields = fields;
     }
@@ -114,24 +121,21 @@ impl CachedStructure {
             // Every element in `ids[..]` was `.write()`n above; C++ reads them as
             // `ExternColumnIdentifier` by raw pointer, so pass the buffer through
             // without materialising a typed slice (avoids an unsafe assume-init cast).
-            self.set(
-                global_object,
-                // SAFETY: every `ids[..len]` slot was initialized in the loop
-                // above; the stack buffer outlives the FFI call.
-                Some(unsafe {
-                    JSObject::create_structure(
-                        global_object,
-                        owner,
-                        ids.len() as u32,
-                        ids.as_mut_ptr().cast::<ExternColumnIdentifier>(),
-                    )
-                }),
-                None,
-            );
+            // SAFETY: every `ids[..len]` slot was initialized in the loop
+            // above; the stack buffer outlives the FFI call.
+            let structure = unsafe {
+                JSObject::create_structure(
+                    global_object,
+                    owner,
+                    ids.len() as u32,
+                    ids.as_mut_ptr().cast::<ExternColumnIdentifier>(),
+                )
+            };
+            self.set(global_object, Some(structure), None);
         }
     }
 }
 
-// No explicit `impl Drop` is needed: the GC-strong structure handle is freed
-// by `impl Drop for StrongOptional`, and the field array (including each
-// element's owned name) is freed by `Drop` on `Box<[ExternColumnIdentifier]>`.
+// No explicit `impl Drop` is needed: `structure` is a raw `JSValue` (GC-traced
+// via the owning Connection wrapper, not here), and the field array is freed
+// by `Drop` on `Box<[ExternColumnIdentifier]>`.

--- a/src/sql_jsc/shared/CachedStructure.rs
+++ b/src/sql_jsc/shared/CachedStructure.rs
@@ -1,41 +1,43 @@
 use core::mem::{ManuallyDrop, MaybeUninit};
 
-use crate::jsc::{ExternColumnIdentifier, JSGlobalObject, JSObject, JSValue};
+use crate::jsc::{ExternColumnIdentifier, JSGlobalObject, JSObject, JSValue, StrongOptional};
 use bun_sql::shared::ColumnIdentifier;
 
 #[derive(Default)]
 pub struct CachedStructure {
-    /// Raw `JSC::Structure*`. Not a GC root: kept alive by the owning
-    /// Connection wrapper's `m_cachedStructures` array (visited in
-    /// `visitChildren`), so it is valid only while that wrapper is live.
-    pub structure: JSValue,
+    /// GC root for per-query statements (simple / unnamed). Released when the
+    /// owning statement is dropped.
+    strong: StrongOptional,
+    /// Raw `JSC::Structure*` for connection-cached statements. Not a GC root:
+    /// kept alive by the Connection wrapper's `m_cachedStructures` array
+    /// (visited in `visitChildren`). At most one of `strong` / `traced` is set.
+    traced: JSValue,
     /// only populated if more than jsc.JSC__JSObject__maxInlineCapacity fields otherwise the structure will contain all fields inlined
     pub fields: Option<Box<[ExternColumnIdentifier]>>,
 }
 
 impl CachedStructure {
     pub fn has(&self) -> bool {
-        !self.structure.is_empty() || self.fields.is_some()
+        self.strong.has() || !self.traced.is_empty() || self.fields.is_some()
     }
 
     pub fn js_value(&self) -> Option<JSValue> {
-        if self.structure.is_empty() {
-            None
-        } else {
-            Some(self.structure)
-        }
+        self.strong.get().or_else(|| {
+            if self.traced.is_empty() {
+                None
+            } else {
+                Some(self.traced)
+            }
+        })
     }
 
-    pub fn set(
-        &mut self,
-        _global_object: &JSGlobalObject,
-        value: Option<JSValue>,
-        fields: Option<Box<[ExternColumnIdentifier]>>,
-    ) {
-        if let Some(v) = value {
-            self.structure = v;
-        }
-        self.fields = fields;
+    /// Called once the Connection has pushed this structure onto its
+    /// `m_cachedStructures` array: release the per-statement Strong and keep
+    /// only the raw value, so connection-cached statements do not each hold a
+    /// GC-root handle.
+    pub fn mark_traced_from_connection(&mut self, structure: JSValue) {
+        self.traced = structure;
+        self.strong.deinit();
     }
 
     /// Populate this `CachedStructure` from a column-identifier sequence —
@@ -116,7 +118,7 @@ impl CachedStructure {
             unsafe { heap_ids.set_len(non_duplicated_count) };
             // Ownership transfer of heap `ids` to CachedStructure, which
             // becomes responsible for freeing the alloc'd slice.
-            self.set(global_object, None, Some(heap_ids.into_boxed_slice()));
+            self.fields = Some(heap_ids.into_boxed_slice());
         } else {
             // Every element in `ids[..]` was `.write()`n above; C++ reads them as
             // `ExternColumnIdentifier` by raw pointer, so pass the buffer through
@@ -131,11 +133,12 @@ impl CachedStructure {
                     ids.as_mut_ptr().cast::<ExternColumnIdentifier>(),
                 )
             };
-            self.set(global_object, Some(structure), None);
+            self.strong.set(global_object, structure);
         }
     }
 }
 
-// No explicit `impl Drop` is needed: `structure` is a raw `JSValue` (GC-traced
+// No explicit `impl Drop` is needed: the GC-strong structure handle is freed
+// by `impl Drop for StrongOptional`, `traced` is a raw `JSValue` (GC-traced
 // via the owning Connection wrapper, not here), and the field array is freed
 // by `Drop` on `Box<[ExternColumnIdentifier]>`.

--- a/test/js/sql/sql-cached-structure-gc.test.ts
+++ b/test/js/sql/sql-cached-structure-gc.test.ts
@@ -59,6 +59,36 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
     expect(reused).toEqual([{ c0: 0 }]);
   });
 
+  test("cached Structures are written via putDirectIndex, not observable to Array.prototype setters", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 1 });
+    await sql.unsafe(`SELECT $1::int AS warm`, [0]);
+
+    let intercepted = 0;
+    Object.defineProperty(Array.prototype, 1, {
+      set() {
+        intercepted++;
+      },
+      configurable: true,
+    });
+    try {
+      async function once(a: number) {
+        const r = await sql.unsafe(`SELECT $1::int AS px, $2::int AS py`, [a, a + 1]);
+        expect(r).toEqual([{ px: a, py: a + 1 }]);
+      }
+      await once(1);
+      // An Array.prototype index setter must not observe the internal
+      // cachedStructures write (putDirectIndex bypasses prototype accessors).
+      expect(intercepted).toBe(0);
+      Bun.gc(true);
+      Bun.gc(true);
+      // The cached Structure must survive GC and shape a second result.
+      await once(3);
+    } finally {
+      delete (Array.prototype as any)[1];
+    }
+  });
+
   test("simple and prepare:false queries do not pin Structures on the connection", async () => {
     await container.ready;
     await using sql = new SQL({ url: url(), max: 1 });

--- a/test/js/sql/sql-cached-structure-gc.test.ts
+++ b/test/js/sql/sql-cached-structure-gc.test.ts
@@ -1,0 +1,83 @@
+// Each prepared statement caches a JSC::Structure for shaping result rows. That
+// Structure used to be held by a per-statement Strong handle, so N distinct
+// prepared statements on one connection meant N permanent GC roots for the
+// connection's lifetime. Now the Structure is traced from the Connection
+// wrapper's visitChildren (via an internal JSArray slot) instead of a Strong,
+// so preparing many statements does not grow the VM's protected-object set.
+
+import { SQL } from "bun";
+import { heapStats } from "bun:jsc";
+import { expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
+
+function protectedStructures(): number {
+  return heapStats().protectedObjectTypeCounts.Structure || 0;
+}
+
+describeWithContainer("postgres", { image: "postgres_plain" }, container => {
+  test("result-row Structures are traced from the connection, not Strong-held", async () => {
+    await container.ready;
+    await using sql = new SQL({
+      url: `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`,
+      max: 1,
+    });
+
+    // Warm up so any one-time Structures (e.g. for the pool's internal queries)
+    // are already accounted for in the baseline.
+    await sql`SELECT 1 AS warmup`;
+
+    Bun.gc(true);
+    const before = protectedStructures();
+
+    // Each iteration has a distinct column name, so it produces a distinct
+    // prepared statement and a distinct cached row Structure.
+    const N = 30;
+    for (let i = 0; i < N; i++) {
+      const rows = await sql.unsafe(`SELECT $1::int AS c${i}`, [i]);
+      expect(rows).toEqual([{ [`c${i}`]: i }]);
+    }
+
+    Bun.gc(true);
+    const after = protectedStructures();
+
+    // Previously: after - before == N (one Strong per statement).
+    // Now: the Structures are owned by the Connection's cachedStructures array
+    // and are reachable via visitChildren, not the HandleSet, so the protected
+    // count is unchanged. Allow a small slack for unrelated Strongs.
+    expect(after - before).toBeLessThan(10);
+
+    // Re-running a query that hits the cache still shapes rows correctly after
+    // a full GC, proving the cached Structure is still alive.
+    const reused = await sql.unsafe(`SELECT $1::int AS c0`, [0]);
+    expect(reused).toEqual([{ c0: 0 }]);
+  });
+});
+
+describeWithContainer("mysql", { image: "mysql_plain" }, container => {
+  test("result-row Structures are traced from the connection, not Strong-held", async () => {
+    await container.ready;
+    await using sql = new SQL({
+      url: `mysql://root@${container.host}:${container.port}/bun_sql_test`,
+      max: 1,
+    });
+
+    await sql`SELECT 1 AS warmup`;
+
+    Bun.gc(true);
+    const before = protectedStructures();
+
+    const N = 30;
+    for (let i = 0; i < N; i++) {
+      const rows = await sql.unsafe(`SELECT ? AS c${i}`, [i]);
+      expect(rows).toEqual([{ [`c${i}`]: i }]);
+    }
+
+    Bun.gc(true);
+    const after = protectedStructures();
+
+    expect(after - before).toBeLessThan(10);
+
+    const reused = await sql.unsafe(`SELECT ? AS c0`, [0]);
+    expect(reused).toEqual([{ c0: 0 }]);
+  });
+});

--- a/test/js/sql/sql-cached-structure-gc.test.ts
+++ b/test/js/sql/sql-cached-structure-gc.test.ts
@@ -4,6 +4,10 @@
 // connection's lifetime. Now the Structure is traced from the Connection
 // wrapper's visitChildren (via an internal JSArray slot) instead of a Strong,
 // so preparing many statements does not grow the VM's protected-object set.
+//
+// Simple / prepare:false queries allocate a fresh statement per execution and
+// so must NOT register with the connection's array (it would grow without
+// bound); they keep the short-lived per-statement Strong instead.
 
 import { SQL } from "bun";
 import { heapStats } from "bun:jsc";
@@ -14,13 +18,16 @@ function protectedStructures(): number {
   return heapStats().protectedObjectTypeCounts.Structure || 0;
 }
 
+function liveStructures(): number {
+  return heapStats().objectTypeCounts.Structure || 0;
+}
+
 describeWithContainer("postgres", { image: "postgres_plain" }, container => {
-  test("result-row Structures are traced from the connection, not Strong-held", async () => {
+  const url = () => `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`;
+
+  test("named prepared statements: result-row Structures are traced from the connection, not Strong-held", async () => {
     await container.ready;
-    await using sql = new SQL({
-      url: `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`,
-      max: 1,
-    });
+    await using sql = new SQL({ url: url(), max: 1 });
 
     // Warm up so any one-time Structures (e.g. for the pool's internal queries)
     // are already accounted for in the baseline.
@@ -51,15 +58,44 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
     const reused = await sql.unsafe(`SELECT $1::int AS c0`, [0]);
     expect(reused).toEqual([{ c0: 0 }]);
   });
+
+  test("simple and prepare:false queries do not pin Structures on the connection", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 1 });
+    await using sqlNoPrepare = new SQL({ url: url(), max: 1, prepare: false });
+
+    await sql`SELECT 1 AS warmup`.simple();
+    await sqlNoPrepare`SELECT ${1} AS warmup`;
+
+    Bun.gc(true);
+    const before = liveStructures();
+
+    const N = 30;
+    for (let i = 0; i < N; i++) {
+      const simple = await sql.unsafe(`SELECT 1 AS s${i}`);
+      expect(simple).toEqual([{ [`s${i}`]: 1 }]);
+      const unnamed = await sqlNoPrepare.unsafe(`SELECT $1::int AS u${i}`, [i]);
+      expect(unnamed).toEqual([{ [`u${i}`]: i }]);
+    }
+
+    Bun.gc(true);
+    Bun.gc(true);
+    const after = liveStructures();
+
+    // Per-query statements are dropped when each query completes, so the
+    // Structures they built must be collectible. Registering them on the
+    // connection's array would leak 2*N here; with the per-query Strong path
+    // they are released on query drop and collected.
+    expect(after - before).toBeLessThan(N);
+  });
 });
 
 describeWithContainer("mysql", { image: "mysql_plain" }, container => {
-  test("result-row Structures are traced from the connection, not Strong-held", async () => {
+  const url = () => `mysql://root@${container.host}:${container.port}/bun_sql_test`;
+
+  test("named prepared statements: result-row Structures are traced from the connection, not Strong-held", async () => {
     await container.ready;
-    await using sql = new SQL({
-      url: `mysql://root@${container.host}:${container.port}/bun_sql_test`,
-      max: 1,
-    });
+    await using sql = new SQL({ url: url(), max: 1 });
 
     await sql`SELECT 1 AS warmup`;
 
@@ -79,5 +115,27 @@ describeWithContainer("mysql", { image: "mysql_plain" }, container => {
 
     const reused = await sql.unsafe(`SELECT ? AS c0`, [0]);
     expect(reused).toEqual([{ c0: 0 }]);
+  });
+
+  test("simple queries do not pin Structures on the connection", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 1 });
+
+    await sql`SELECT 1 AS warmup`.simple();
+
+    Bun.gc(true);
+    const before = liveStructures();
+
+    const N = 30;
+    for (let i = 0; i < N; i++) {
+      const simple = await sql.unsafe(`SELECT 1 AS s${i}`);
+      expect(simple).toEqual([{ [`s${i}`]: 1 }]);
+    }
+
+    Bun.gc(true);
+    Bun.gc(true);
+    const after = liveStructures();
+
+    expect(after - before).toBeLessThan(N);
   });
 });


### PR DESCRIPTION
## What

Each Postgres/MySQL prepared statement caches a `JSC::Structure` used to shape result-row objects. That Structure is held by a `StrongOptional` on the native `PostgresSQLStatement` / `MySQLStatement` struct.

For **named prepared statements** (cached in `connection.statements` for the connection's lifetime), this means **N distinct prepared statements on one connection = N permanent GC roots** in the VM's `HandleSet` for as long as the connection is open. `JSC__createStructure` already calls `vm.writeBarrier(owner, structure)` with the Connection wrapper as `owner`, which is the right shape for tracing the structure from the wrapper's `visitChildren`, but nothing in the generated `visitChildren` actually visited it; the Strong was the only thing keeping the structure alive, and the write barrier had no matching edge.

This change moves that ownership to where it was meant to go, for named statements only:

- Add a `cachedStructures` entry to the Connection's `values:` list in `sql.classes.ts` (generates a `WriteBarrier<Unknown> m_cachedStructures` field visited in `visitChildren`), seeded with an empty `JSArray` at construction time (before the socket connects, so an OOM there cannot strand a half-initialised connection).
- `CachedStructure` now holds both a `StrongOptional` (for per-query statements) and a raw `traced: JSValue` (for connection-cached statements); at most one is set. It also records a `connection_slot: Option<u32>` that survives `reset()`.
- `build_from_columns` initially stores the new Structure in the Strong. When the DataRow handler sees a newly-built Structure on a **named** prepared statement (`!simple && !USE_UNNAMED_PREPARED_STATEMENTS` for Postgres, `!is_simple()` for MySQL), it writes the Structure into the statement's stable slot in the connection's `cachedStructures` array via `putDirectIndex` and then releases the Strong via `mark_traced_from_connection`. GC now traces `Connection wrapper → m_cachedStructures → JSArray → Structure`.
- `putDirectIndex` (own-slot write) is used instead of `JSArray::push` so an index setter on `Array.prototype` cannot observe or intercept the engine-internal `Structure*` cell; the next free index is tracked natively on the connection.
- Each connection-cached statement gets one stable array slot, so a prepared statement whose column shape changes between result sets (MySQL `CALL sp()` with multiple result sets, Postgres simple multi-statement) overwrites its slot rather than growing the array per execution.
- If `putDirectIndex` fails, the Strong is kept so the raw value never dangles.
- **Simple / `prepare:false` queries** allocate a fresh statement per execution owned solely by the query, so they keep the per-statement Strong (released when the query drops its statement, same as before). Registering those on the connection would grow the array without bound.

## Why this is correct

The only consumer of `cached_structure.structure` is the Connection's row-decode path (`on`/`on_result_row`), so a named statement's Structure only needs to stay alive while the Connection wrapper is alive; tracing it from the wrapper gives exactly that lifetime. If a Statement outlives its Connection via a Query ref, the raw `traced` value is never read again.

Per-query statements already had the right lifetime via the Strong, which is freed when the query drops; that path is unchanged.

## Verification

`heapStats().protectedObjectTypeCounts.Structure` counts cells reached from `forEachProtectedCell`, which includes Strong handles. The new tests prepare 30 distinct named statements on one connection and assert the protected-Structure count does not grow, run 30 distinct simple / `prepare:false` queries and assert the live-Structure count does not grow with the connection, and define an `Array.prototype[1]` setter around a named query to assert the internal array write is not observable and the cached Structure survives GC.

<details><summary>before</summary>

```
(fail) postgres > named prepared statements: ... Expected: < 10, Received: 30
(pass) postgres > cached Structures are written via putDirectIndex ...
(pass) postgres > simple and prepare:false queries do not pin Structures ...
(fail) mysql    > named prepared statements: ... Expected: < 10, Received: 30
(pass) mysql    > simple queries do not pin Structures ...
```
</details>

<details><summary>after</summary>

```
(pass) postgres > named prepared statements: result-row Structures are traced from the connection, not Strong-held
(pass) postgres > cached Structures are written via putDirectIndex, not observable to Array.prototype setters
(pass) postgres > simple and prepare:false queries do not pin Structures on the connection
(pass) mysql    > named prepared statements: result-row Structures are traced from the connection, not Strong-held
(pass) mysql    > simple queries do not pin Structures on the connection
```
</details>

Also stress-tested with 100 named statements under `BUN_GARBAGE_COLLECTOR_LEVEL=2` (cache miss then cache hit, multi-row results, wide rows exercising the `fields[]` fallback); all row shapes are correct and the protected count stays flat.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 9 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-cached-structure-gc.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (44991d59d)

test/js/sql/sql-cached-structure-gc.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
49 | 
50 |     // Previously: after - before == N (one Strong per statement).
51 |     // Now: the Structures are owned by the Connection's cachedStructures array
52 |     // and are reachable via visitChildren, not the HandleSet, so the protected
53 |     // count is unchanged. Allow a small slack for unrelated Strongs.
54 |     expect(after - before).toBeLessThan(10);
                                ^
error: expect(received).toBeLessThan(expected)

Expected: < 10
Received: 30

      at <anonymous> (/workspace/bun/test/js/sql/sql-cached-structure-gc.test.ts:54:28)
(fail) postgres > named prepared s
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (b8c486fbc)

test/js/sql/sql-cached-structure-gc.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) postgres > named prepared statements: result-row Structures are traced from the connection, not Strong-held [19.27ms]
(pass) postgres > cached Structures are written via putDirectIndex, not observable to Array.prototype setters [7.73ms]
(pass) postgres > simple and prepare:false queries do not pin Structures on the connection [20.28ms]
Container ready via docker-compose: mysql_plain at 127.0.0.1:3306
(pass) mysql > named prepared statements: result-row Structures are traced from the connection, not Strong-held [10.64ms]
(pass) mysql > simple queries do not pin Structures on the connection [10.61ms]

 5 pass
 0 fail
 159 expect() calls
Ran 5 tests across 1 file. [278.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-cached-structure-gc.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (44991d59d)

test/js/sql/sql-cached-structure-gc.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) postgres > named prepared statements: result-row Structures are traced from the connection, not Strong-held [847.30ms]
(pass) postgres > cached Structures are written via putDirectIndex, not observable to Array.prototype setters [218.07ms]
(pass) postgres > simple and prepare:false queries do not pin Structures on the connection [1228.87ms]
Container ready via docker-compose: mysql_plain at 127.0.0.1:3306
(pass) mysql > named prepared statements: result-row Structures are traced from the connection, not Strong-held [652.67ms]
(pass) mysql > simple queries do not pin Structures on the connecti
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     44991d59dc
  features     (none)

22 deps, 106 codegen, 1169 objects in 717ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (b8c486fbc)

Checked 124 installs across 170 packages (no changes) [13.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b8c486fbc)

Checked 1 install across 2 packages (no changes) [2.00ms]
[3/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b8c486fbc)

Checked 129 installs across 147 packages (no changes) [3.00ms]
[4/1231] gen ErrorCode+*.h
[5/1231] gen bindgenv2
[6/1231] fetch picohttpparser
[picohttpparser] up to date
[7/1231] gen .bind.ts → GeneratedBindings.cpp
[8/1231] 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/sql.classes.ts                |   2 +-
 src/sql_jsc/jsc.rs                            |   4 +-
 src/sql_jsc/mysql/JSMySQLConnection.rs        |  58 ++++++++-
 src/sql_jsc/mysql/MySQLConnection.rs          |   4 +-
 src/sql_jsc/mysql/MySQLStatement.rs           |  13 +-
 src/sql_jsc/postgres/PostgresSQLConnection.rs |  63 +++++++++-
 src/sql_jsc/postgres/PostgresSQLStatement.rs  |  17 ++-
 src/sql_jsc/shared/CachedStructure.rs         |  80 +++++++-----
 test/js/sql/sql-cached-structure-gc.test.ts   | 171 ++++++++++++++++++++++++++
 9 files changed, 350 insertions(+), 62 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/runtime/api/sql.classes.ts                     1      1      0
src/sql_jsc/jsc.rs                                 1      1      0
src/sql_jsc/mysql/JSMySQLConnection.rs            11     17      0
src/sql_jsc/mysql/MySQLConnection.rs               1      2      0
src/sql_jsc/mysql/MySQLStatement.rs                3      2      0
src/sql_jsc/postgres/PostgresSQLConnection.rs     14     23      0
src/sql_jsc/postgres/PostgresSQLStatement.rs       4      3      0
src/sql_jsc/shared/CachedStructure.rs              3      5      0
test/js/sql/sql-cached-structure-gc.test.ts        2      7      0
```

</details>

<!-- robobun:evidence:end -->