### PR TITLE
node:cluster: hold per-worker internal IPC state in the Subprocess wrapper, not as GC roots

### DIFF
--- a/src/jsc/ipc.rs
+++ b/src/jsc/ipc.rs
@@ -51,37 +51,81 @@ use bun_uws;
 /// Note: moved down from `bun_runtime::node::node_cluster_binding` (cycle-break per
 /// docs/PORTING.md) — `SendQueue` stores one inline so the struct must live at this tier.
 /// All field accesses + dispatch methods need only `bun_jsc`/`bun_collections` symbols.
+///
+/// The `worker`/`cb`/`callbacks`/`messages` fields back the child-side
+/// process singleton only. The primary side stores the same state in the
+/// `Subprocess` wrapper's WriteBarrier slots so a worker's object graph is not
+/// pinned by a GC root (see `node_cluster_binding`).
 pub struct InternalMsgHolder {
     pub seq: i32,
 
-    // TODO: move this to an Array or a JS Object or something which doesn't
-    // individually create a Strong for every single IPC message...
-    pub callbacks: bun_collections::ArrayHashMap<i32, crate::StrongOptional>,
+    /// JS null-prototype object keyed by stringified seq. One root regardless
+    /// of how many acks are in flight. Lazily created.
+    pub callbacks: crate::StrongOptional,
     pub worker: crate::StrongOptional,
     pub cb: crate::StrongOptional,
-    pub messages: Vec<crate::StrongOptional>,
+    /// JS Array of messages that arrived before the listener was installed.
+    /// Lazily created.
+    pub messages: crate::StrongOptional,
 }
 
 impl Default for InternalMsgHolder {
     fn default() -> Self {
         Self {
             seq: 0,
-            callbacks: bun_collections::ArrayHashMap::default(),
+            callbacks: crate::StrongOptional::empty(),
             worker: crate::StrongOptional::empty(),
             cb: crate::StrongOptional::empty(),
-            messages: Vec::new(),
+            messages: crate::StrongOptional::empty(),
         }
     }
 }
 
 impl InternalMsgHolder {
+    /// Prefixed so the key is never an array index; `putDirect` asserts on
+    /// numeric-string property names.
+    #[inline]
+    fn seq_key(buf: &mut [u8; 13], seq: i32) -> &[u8] {
+        bun_core::fmt::buf_print_infallible(buf, format_args!("s{seq}"))
+    }
+
+    /// Store `callback` under `seq` on the given JS callbacks object.
+    pub fn put_callback(&self, map: JSValue, global: &JSGlobalObject, seq: i32, callback: JSValue) {
+        let mut buf = [0u8; 13];
+        map.put(global, Self::seq_key(&mut buf, seq), callback);
+    }
+
+    /// Remove and return the callback stored under `seq` on the given JS
+    /// callbacks object, or `None` when absent.
+    pub fn take_callback(
+        &self,
+        map: JSValue,
+        global: &JSGlobalObject,
+        seq: i32,
+    ) -> JsResult<Option<JSValue>> {
+        let mut buf = [0u8; 13];
+        let key = Self::seq_key(&mut buf, seq);
+        let Some(cb) = map.get(global, key)? else {
+            return Ok(None);
+        };
+        map.delete_property(global, key);
+        Ok(Some(cb))
+    }
+
     pub fn is_ready(&self) -> bool {
         self.worker.has() && self.cb.has()
     }
 
-    pub fn enqueue(&mut self, message: JSValue, global: &JSGlobalObject) {
-        self.messages
-            .push(crate::StrongOptional::create(message, global));
+    pub fn enqueue(&mut self, message: JSValue, global: &JSGlobalObject) -> JsResult<()> {
+        let arr = match self.messages.get() {
+            Some(a) => a,
+            None => {
+                let a = JSValue::create_empty_array(global, 0)?;
+                self.messages.set(global, a);
+                a
+            }
+        };
+        arr.push(global, message)
     }
 
     pub fn dispatch(
@@ -93,8 +137,7 @@ impl InternalMsgHolder {
         if !self.is_ready() {
             // Queued messages drop their handle; the cluster listener is
             // installed before any handle-bearing reply can arrive.
-            self.enqueue(message, global);
-            return Ok(());
+            return self.enqueue(message, global);
         }
         self.dispatch_unsafe(message, handle, global)
     }
@@ -113,20 +156,11 @@ impl InternalMsgHolder {
         if let Some(p) = message.get(global, "ack")? {
             if !p.is_undefined() {
                 let ack = p.to_int32();
-                // Note: peek the JSValue first (ending the immutable borrow),
-                // then swap_remove (which drops the Strong).
-                let entry = self.callbacks.get(&ack).map(|s| s.get());
-                if let Some(callback_opt) = entry {
-                    if let Some(callback) = callback_opt {
-                        self.callbacks.swap_remove(&ack);
-                        event_loop.run_callback(
-                            callback,
-                            global,
-                            self.worker.get().unwrap(),
-                            &[message, handle],
-                        );
+                if let Some(map) = self.callbacks.get() {
+                    if let Some(callback) = self.take_callback(map, global, ack)? {
+                        event_loop.run_callback(callback, global, worker, &[message, handle]);
+                        return Ok(());
                     }
-                    return Ok(());
                 }
             }
         }
@@ -136,28 +170,28 @@ impl InternalMsgHolder {
 
     pub fn flush(&mut self, global: &JSGlobalObject) -> JsResult<()> {
         debug_assert!(self.is_ready());
+        let Some(messages) = self.messages.try_swap() else {
+            return Ok(());
+        };
+        let _keep = crate::EnsureStillAlive(messages);
         // PORT_NOTES_PLAN R-2: `&mut self` carries LLVM `noalias`, but
         // `dispatch_unsafe` → `event_loop.run_callback` runs the JS IPC
-        // listener which can re-enter via a fresh `&mut Self` from the
-        // owner's `m_ctx` and write `self.cb` / `self.worker` /
-        // `self.callbacks`. With the loop body inlined, LLVM was hoisting the
-        // `self.cb`/`self.worker` reads (at the top of `dispatch_unsafe`) out
-        // of the loop — ASM-verified PROVEN_CACHED. Launder so each iteration
-        // re-reads through an opaque pointer.
+        // listener which can re-enter via a fresh `&mut Self` and write
+        // `self.cb` / `self.worker` / `self.callbacks`. Launder so each
+        // iteration re-reads through an opaque pointer.
         let this: *mut Self = core::hint::black_box(core::ptr::from_mut(self));
-        // SAFETY: `this` aliases the live `&mut self`; single JS thread.
-        let messages = core::mem::take(unsafe { &mut (*this).messages });
-        for strong in messages {
-            if let Some(message) = strong.get() {
-                // SAFETY: `this` is still live across re-entry — the IPC
-                // dispatcher is owned by the Subprocess/Worker which outlives
-                // this `flush` frame; `&mut *this` is the unique mutable view
-                // for this call.
-                unsafe { &mut *this }.dispatch_unsafe(message, JSValue::NULL, global)?;
+        let len = messages.get_length(global)? as u32;
+        for i in 0..len {
+            let message = messages.get_index(global, i)?;
+            if message.is_undefined_or_null() {
+                continue;
             }
-            // strong drops here (== `strong.deinit()`)
+            // SAFETY: `this` is still live across re-entry — the IPC
+            // dispatcher is owned by the Subprocess/Worker which outlives
+            // this `flush` frame; `&mut *this` is the unique mutable view
+            // for this call.
+            unsafe { &mut *this }.dispatch_unsafe(message, JSValue::NULL, global)?;
         }
-        // messages Vec drops here (== `messages.deinit(bun.default_allocator)`)
         Ok(())
     }
 
@@ -903,6 +937,12 @@ impl SendQueue {
         // `owner` is set in `init()` / by the embedder before first use and
         // never null afterward.
         unsafe { &*self.owner }
+    }
+
+    /// The owning Subprocess's JS wrapper, or `ZERO` for the VM-side owner.
+    #[inline]
+    pub fn owner_this_jsvalue(&self) -> JSValue {
+        self.owner_ref().this_jsvalue()
     }
 
     pub fn init(mode: Mode, owner: *mut dyn SendQueueOwner, socket: SocketUnion) -> Self {

--- a/src/jsc/ipc.rs
+++ b/src/jsc/ipc.rs
@@ -108,7 +108,7 @@ impl InternalMsgHolder {
         let Some(cb) = map.get(global, key)? else {
             return Ok(None);
         };
-        map.delete_property(global, key);
+        crate::host_fn::from_js_host_call_generic(global, || map.delete_property(global, key))?;
         Ok(Some(cb))
     }
 

--- a/src/jsc/ipc.rs
+++ b/src/jsc/ipc.rs
@@ -51,16 +51,13 @@ use bun_uws;
 /// Note: moved down from `bun_runtime::node::node_cluster_binding` (cycle-break per
 /// docs/PORTING.md) — `SendQueue` stores one inline so the struct must live at this tier.
 /// All field accesses + dispatch methods need only `bun_jsc`/`bun_collections` symbols.
-///
-/// The `worker`/`cb`/`callbacks`/`messages` fields back the child-side
-/// process singleton only. The primary side stores the same state in the
-/// `Subprocess` wrapper's WriteBarrier slots so a worker's object graph is not
-/// pinned by a GC root (see `node_cluster_binding`).
 pub struct InternalMsgHolder {
     pub seq: i32,
 
-    /// JS null-prototype object keyed by stringified seq. One root regardless
-    /// of how many acks are in flight. Lazily created.
+    // These fields back the child-side process singleton; the primary side stores
+    // the same state in the Subprocess wrapper's WriteBarrier slots instead.
+    /// JS Map keyed by seq number. One root regardless of how many acks are in
+    /// flight. Lazily created.
     pub callbacks: crate::StrongOptional,
     pub worker: crate::StrongOptional,
     pub cb: crate::StrongOptional,
@@ -82,33 +79,37 @@ impl Default for InternalMsgHolder {
 }
 
 impl InternalMsgHolder {
-    /// Prefixed so the key is never an array index; `putDirect` asserts on
-    /// numeric-string property names.
     #[inline]
-    fn seq_key(buf: &mut [u8; 13], seq: i32) -> &[u8] {
-        bun_core::fmt::buf_print_infallible(buf, format_args!("s{seq}"))
+    fn as_map(map: JSValue) -> &'static mut crate::JSMap {
+        // `JSMap` is an `opaque_ffi!` ZST; the slot was seeded with
+        // `JSMap::create` so `from_js` is non-null. Single JS thread.
+        crate::JSMap::opaque_mut(crate::JSMap::from_js(map).unwrap().as_ptr())
     }
 
-    /// Store `callback` under `seq` on the given JS callbacks object.
-    pub fn put_callback(&self, map: JSValue, global: &JSGlobalObject, seq: i32, callback: JSValue) {
-        let mut buf = [0u8; 13];
-        map.put(global, Self::seq_key(&mut buf, seq), callback);
+    /// Store `callback` under `seq` on the given JS callbacks Map.
+    pub fn put_callback(
+        map: JSValue,
+        global: &JSGlobalObject,
+        seq: i32,
+        callback: JSValue,
+    ) -> JsResult<()> {
+        Self::as_map(map).set(global, JSValue::js_number(seq as f64), callback)
     }
 
     /// Remove and return the callback stored under `seq` on the given JS
-    /// callbacks object, or `None` when absent.
+    /// callbacks Map, or `None` when absent.
     pub fn take_callback(
-        &self,
         map: JSValue,
         global: &JSGlobalObject,
         seq: i32,
     ) -> JsResult<Option<JSValue>> {
-        let mut buf = [0u8; 13];
-        let key = Self::seq_key(&mut buf, seq);
-        let Some(cb) = map.get(global, key)? else {
+        let key = JSValue::js_number(seq as f64);
+        let map = Self::as_map(map);
+        let cb = map.get(global, key)?;
+        if cb.is_undefined() {
             return Ok(None);
-        };
-        crate::host_fn::from_js_host_call_generic(global, || map.delete_property(global, key))?;
+        }
+        map.remove(global, key)?;
         Ok(Some(cb))
     }
 
@@ -157,7 +158,7 @@ impl InternalMsgHolder {
             if !p.is_undefined() {
                 let ack = p.to_int32();
                 if let Some(map) = self.callbacks.get() {
-                    if let Some(callback) = self.take_callback(map, global, ack)? {
+                    if let Some(callback) = Self::take_callback(map, global, ack)? {
                         event_loop.run_callback(callback, global, worker, &[message, handle]);
                         return Ok(());
                     }

--- a/src/runtime/api/BunObject.classes.ts
+++ b/src/runtime/api/BunObject.classes.ts
@@ -128,6 +128,14 @@ export default [
         cache: true,
       },
     },
-    values: ["exitedPromise", "onExitCallback", "onDisconnectCallback", "ipcCallback"],
+    values: [
+      "exitedPromise",
+      "onExitCallback",
+      "onDisconnectCallback",
+      "ipcCallback",
+      "ipcWorker",
+      "ipcInternalCallback",
+      "ipcAckCallbacks",
+    ],
   }),
 ];

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -73,7 +73,10 @@ pub mod js {
         exitedPromise,
         onExitCallback,
         onDisconnectCallback,
-        ipcCallback
+        ipcCallback,
+        ipcWorker,
+        ipcInternalCallback,
+        ipcAckCallbacks
     );
 }
 
@@ -1443,6 +1446,11 @@ impl Subprocess<'_> {
         if !this_jsvalue.is_empty() {
             // Avoid keeping the callback alive longer than necessary
             js::ipc_callback_set_cached(this_jsvalue, global_this, JSValue::ZERO);
+            // No further internal message can arrive or be acked once the
+            // channel is gone; drop the cluster-internal references.
+            js::ipc_worker_set_cached(this_jsvalue, global_this, JSValue::ZERO);
+            js::ipc_internal_callback_set_cached(this_jsvalue, global_this, JSValue::ZERO);
+            js::ipc_ack_callbacks_set_cached(this_jsvalue, global_this, JSValue::ZERO);
 
             // Call the onDisconnectCallback if it exists and prevent it from being kept alive longer than necessary
             if let Some(callback) =

--- a/src/runtime/node/node_cluster_binding.rs
+++ b/src/runtime/node/node_cluster_binding.rs
@@ -6,9 +6,9 @@
 
 use bun_core::String as BunString;
 use bun_jsc::ipc::{Handle, IsInternal, SerializeAndSendResult};
-use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, StringJsc as _, StrongOptional};
+use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, StringJsc as _};
 
-use crate::api::bun::subprocess::Subprocess;
+use crate::api::bun::subprocess::{Subprocess, js as subprocess_js};
 
 // Struct moved to `bun_jsc::ipc` (cycle-break per docs/PORTING.md) —
 // `SendQueue` stores one inline so it must live at that tier. Re-exported here so
@@ -74,17 +74,22 @@ pub(crate) fn send_helper_child(global: &JSGlobalObject, frame: &CallFrame) -> J
         return Err(global.throw_invalid_argument_type_value("message", "object", message));
     }
     let singleton = child_singleton();
+    let seq = singleton.seq;
     if callback.is_function() {
-        // TODO: remove this strong. This is expensive and would be an easy way to create a memory leak.
-        // These sequence numbers shouldn't exist from JavaScript's perspective at all.
-        let _ = singleton
-            .callbacks
-            .put(singleton.seq, StrongOptional::create(callback, global));
+        let map = match singleton.callbacks.get() {
+            Some(m) => m,
+            None => {
+                let m = JSValue::create_empty_object_with_null_prototype(global);
+                singleton.callbacks.set(global, m);
+                m
+            }
+        };
+        singleton.put_callback(map, global, seq, callback);
     }
 
     // sequence number for InternalMsgHolder
-    message.put(global, b"seq", JSValue::js_number(singleton.seq as f64));
-    singleton.seq = singleton.seq.wrapping_add(1);
+    message.put(global, b"seq", JSValue::js_number(seq as f64));
+    singleton.seq = seq.wrapping_add(1);
 
     // similar code as Bun__Process__send
     #[cfg(debug_assertions)]
@@ -146,9 +151,8 @@ pub(crate) fn on_internal_message_child(
     bun_output::scoped_log!(IPC, "onInternalMessageChild");
     let arguments = frame.arguments_old::<2>().ptr;
     let singleton = child_singleton();
-    // TODO: we should not create two jsc.Strong.Optional here. If absolutely necessary, a single Array. should be all we use.
-    singleton.worker = StrongOptional::create(arguments[0], global);
-    singleton.cb = StrongOptional::create(arguments[1], global);
+    singleton.worker.set(global, arguments[0]);
+    singleton.cb.set(global, arguments[1]);
     singleton.flush(global)?;
     Ok(JSValue::UNDEFINED)
 }
@@ -232,20 +236,25 @@ pub(crate) fn send_helper_primary(global: &JSGlobalObject, frame: &CallFrame) ->
         }
     };
 
+    let seq = ipc_data.internal_msg_queue.seq;
     if callback.is_function() {
-        let _ = ipc_data.internal_msg_queue.callbacks.put(
-            ipc_data.internal_msg_queue.seq,
-            StrongOptional::create(callback, global),
-        );
+        // Ack callbacks live in a JS object held by the Subprocess wrapper's
+        // WriteBarrier slot: one GC edge regardless of how many are in flight,
+        // and not a GC root, so the Subprocess stays collectable.
+        let map = match subprocess_js::ipc_ack_callbacks_get_cached(arguments[0]) {
+            Some(m) => m,
+            None => {
+                let m = JSValue::create_empty_object_with_null_prototype(global);
+                subprocess_js::ipc_ack_callbacks_set_cached(arguments[0], global, m);
+                m
+            }
+        };
+        ipc_data.internal_msg_queue.put_callback(map, global, seq, callback);
     }
 
     // sequence number for InternalMsgHolder
-    message.put(
-        global,
-        b"seq",
-        JSValue::js_number(ipc_data.internal_msg_queue.seq as f64),
-    );
-    ipc_data.internal_msg_queue.seq = ipc_data.internal_msg_queue.seq.wrapping_add(1);
+    message.put(global, b"seq", JSValue::js_number(seq as f64));
+    ipc_data.internal_msg_queue.seq = seq.wrapping_add(1);
 
     // similar code as bun.jsc.Subprocess.doSend
     #[cfg(debug_assertions)]
@@ -279,12 +288,14 @@ pub(crate) fn on_internal_message_primary(
     let Some(subprocess) = arguments[0].as_class_ref::<Subprocess<'_>>() else {
         return Ok(JSValue::UNDEFINED);
     };
-    let Some(ipc_data) = subprocess.ipc() else {
+    if subprocess.ipc().is_none() {
         return Ok(JSValue::UNDEFINED);
-    };
-    // TODO: remove these strongs.
-    ipc_data.internal_msg_queue.worker = StrongOptional::create(arguments[1], global);
-    ipc_data.internal_msg_queue.cb = StrongOptional::create(arguments[2], global);
+    }
+    // Stored in the Subprocess wrapper's WriteBarrier slots: visited by GC but
+    // not a root, so a finished worker's whole object graph is collectable once
+    // user code releases it.
+    subprocess_js::ipc_worker_set_cached(arguments[0], global, arguments[1]);
+    subprocess_js::ipc_internal_callback_set_cached(arguments[0], global, arguments[2]);
     Ok(JSValue::UNDEFINED)
 }
 
@@ -296,10 +307,18 @@ pub(crate) fn handle_internal_message_primary(
     let Some(ipc_data) = subprocess.ipc() else {
         return Ok(());
     };
-
-    if !ipc_data.internal_msg_queue.is_ready() {
+    let this_jsvalue = ipc_data.owner_this_jsvalue();
+    let _keep = bun_jsc::EnsureStillAlive(this_jsvalue);
+    if this_jsvalue.is_empty() {
         return Ok(());
     }
+
+    let (Some(worker), Some(cb)) = (
+        subprocess_js::ipc_worker_get_cached(this_jsvalue),
+        subprocess_js::ipc_internal_callback_get_cached(this_jsvalue),
+    ) else {
+        return Ok(());
+    };
 
     let event_loop = global.bun_vm().event_loop_mut();
 
@@ -307,39 +326,17 @@ pub(crate) fn handle_internal_message_primary(
     if let Some(p) = message.get(global, "ack")? {
         if !p.is_undefined() {
             let ack = p.to_int32();
-            // Peek the JSValue first (ending the immutable borrow), then
-            // swap_remove (which drops the Strong).
-            let entry = ipc_data
-                .internal_msg_queue
-                .callbacks
-                .get(&ack)
-                .map(|s| s.get());
-            if let Some(callback_opt) = entry {
-                ipc_data.internal_msg_queue.callbacks.swap_remove(&ack);
-                let cb = callback_opt.unwrap();
-                event_loop.run_callback(
-                    cb,
-                    global,
-                    ipc_data.internal_msg_queue.worker.get().unwrap(),
-                    &[
-                        message,
-                        JSValue::NULL, // handle
-                    ],
-                );
-                return Ok(());
+            if let Some(map) = subprocess_js::ipc_ack_callbacks_get_cached(this_jsvalue) {
+                if let Some(callback) =
+                    ipc_data.internal_msg_queue.take_callback(map, global, ack)?
+                {
+                    event_loop.run_callback(callback, global, worker, &[message, JSValue::NULL]);
+                    return Ok(());
+                }
             }
         }
     }
-    let cb = ipc_data.internal_msg_queue.cb.get().unwrap();
-    event_loop.run_callback(
-        cb,
-        global,
-        ipc_data.internal_msg_queue.worker.get().unwrap(),
-        &[
-            message,
-            JSValue::NULL, // handle
-        ],
-    );
+    event_loop.run_callback(cb, global, worker, &[message, JSValue::NULL]);
     Ok(())
 }
 

--- a/src/runtime/node/node_cluster_binding.rs
+++ b/src/runtime/node/node_cluster_binding.rs
@@ -79,12 +79,12 @@ pub(crate) fn send_helper_child(global: &JSGlobalObject, frame: &CallFrame) -> J
         let map = match singleton.callbacks.get() {
             Some(m) => m,
             None => {
-                let m = JSValue::create_empty_object_with_null_prototype(global);
+                let m = bun_jsc::JSMap::create(global);
                 singleton.callbacks.set(global, m);
                 m
             }
         };
-        singleton.put_callback(map, global, seq, callback);
+        InternalMsgHolder::put_callback(map, global, seq, callback)?;
     }
 
     // sequence number for InternalMsgHolder
@@ -238,20 +238,18 @@ pub(crate) fn send_helper_primary(global: &JSGlobalObject, frame: &CallFrame) ->
 
     let seq = ipc_data.internal_msg_queue.seq;
     if callback.is_function() {
-        // Ack callbacks live in a JS object held by the Subprocess wrapper's
+        // Ack callbacks live in a JS Map held by the Subprocess wrapper's
         // WriteBarrier slot: one GC edge regardless of how many are in flight,
         // and not a GC root, so the Subprocess stays collectable.
         let map = match subprocess_js::ipc_ack_callbacks_get_cached(arguments[0]) {
             Some(m) => m,
             None => {
-                let m = JSValue::create_empty_object_with_null_prototype(global);
+                let m = bun_jsc::JSMap::create(global);
                 subprocess_js::ipc_ack_callbacks_set_cached(arguments[0], global, m);
                 m
             }
         };
-        ipc_data
-            .internal_msg_queue
-            .put_callback(map, global, seq, callback);
+        InternalMsgHolder::put_callback(map, global, seq, callback)?;
     }
 
     // sequence number for InternalMsgHolder
@@ -329,10 +327,7 @@ pub(crate) fn handle_internal_message_primary(
         if !p.is_undefined() {
             let ack = p.to_int32();
             if let Some(map) = subprocess_js::ipc_ack_callbacks_get_cached(this_jsvalue) {
-                if let Some(callback) = ipc_data
-                    .internal_msg_queue
-                    .take_callback(map, global, ack)?
-                {
+                if let Some(callback) = InternalMsgHolder::take_callback(map, global, ack)? {
                     event_loop.run_callback(callback, global, worker, &[message, JSValue::NULL]);
                     return Ok(());
                 }

--- a/src/runtime/node/node_cluster_binding.rs
+++ b/src/runtime/node/node_cluster_binding.rs
@@ -249,7 +249,9 @@ pub(crate) fn send_helper_primary(global: &JSGlobalObject, frame: &CallFrame) ->
                 m
             }
         };
-        ipc_data.internal_msg_queue.put_callback(map, global, seq, callback);
+        ipc_data
+            .internal_msg_queue
+            .put_callback(map, global, seq, callback);
     }
 
     // sequence number for InternalMsgHolder
@@ -327,8 +329,9 @@ pub(crate) fn handle_internal_message_primary(
         if !p.is_undefined() {
             let ack = p.to_int32();
             if let Some(map) = subprocess_js::ipc_ack_callbacks_get_cached(this_jsvalue) {
-                if let Some(callback) =
-                    ipc_data.internal_msg_queue.take_callback(map, global, ack)?
+                if let Some(callback) = ipc_data
+                    .internal_msg_queue
+                    .take_callback(map, global, ack)?
                 {
                     event_loop.run_callback(callback, global, worker, &[message, JSValue::NULL]);
                     return Ok(());

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -228,27 +228,27 @@ process.exit(0);
     cmd: [bunExe(), "primary.ts"],
     env: bunEnv,
     cwd: String(dir),
-    stderr: "pipe",
+    stderr: "inherit",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
-  expect(stderr.trim()).toBe("");
   const { N, before, during, liveSubprocess } = JSON.parse(stdout.trim());
   // No per-worker protected roots while the workers are alive. Strict equality
   // against the baseline: a regression shows up as `before + N`.
   expect({
     protectedFunctionDelta: during.Function - before.Function,
     protectedObjectDelta: during.Object - before.Object,
+    exitCode,
   }).toEqual({
     protectedFunctionDelta: 0,
     protectedObjectDelta: 0,
+    exitCode: 0,
   });
   // After every worker exits and user code holds no reference, the Subprocess
   // wrappers are collectable. Allow one straggler for a conservatively rooted
   // async frame; a root-cycle leak retains all N.
   expect(liveSubprocess).toBeLessThanOrEqual(1);
   expect(liveSubprocess).toBeLessThan(N);
-  expect(exitCode).toBe(0);
 });
 
 test("disconnect() on a cluster.Worker built around a plain object does not abort", async () => {

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, bunRun, joinP, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, bunRun, joinP, tempDir, tempDirWithFiles } from "harness";
 
 test("cloneable and transferable equals", () => {
   const dir = tempDirWithFiles("bun-test", {
@@ -159,6 +159,96 @@ process.send("regular message");
   });
   const { stdout } = bunRun(joinP(dir, "parent.ts"), bunEnv);
   expect(stdout).toContain("P received regular message");
+});
+
+test("primary does not root the worker object graph per live worker", async () => {
+  // `onInternalMessagePrimary` stores the Worker object and the internal
+  // message callback for each forked worker. Storing them as GC roots (one
+  // `JSC::Strong` each) means:
+  //   * every live worker adds two entries to the protected-object set, and
+  //   * Worker → ChildProcess → Subprocess → ipc_data → Strong(Worker) is a
+  //     cycle through a root, so the whole graph survives GC after the worker
+  //     exits.
+  // Held in the Subprocess wrapper's own WriteBarrier slots instead, they are
+  // a GC edge rather than a GC root: neither effect occurs.
+  using dir = tempDir("cluster-internal-msg-roots", {
+    "primary.ts": `
+import cluster from "node:cluster";
+import { heapStats } from "bun:jsc";
+
+if (!cluster.isPrimary) {
+  process.on("message", () => {});
+  await new Promise(() => {});
+}
+
+const N = 6;
+
+function protectedCounts() {
+  Bun.gc(true);
+  const p = heapStats().protectedObjectTypeCounts;
+  return { Function: p.Function ?? 0, Object: p.Object ?? 0 };
+}
+
+const before = protectedCounts();
+
+const workers: import("node:cluster").Worker[] = [];
+for (let i = 0; i < N; i++) workers.push(cluster.fork());
+await Promise.all(workers.map(w => new Promise<void>(r => w.once("online", () => r()))));
+
+const during = protectedCounts();
+
+// Kill every worker, wait for the channel to close, then drop user references.
+for (const w of workers) w.process.kill();
+await Promise.all(
+  workers.map(w => new Promise<void>(r => {
+    let n = 0;
+    const step = () => { if (++n === 2) r(); };
+    w.once("exit", step);
+    w.once("disconnect", step);
+  })),
+);
+workers.length = 0;
+
+// Bounded poll across event-loop turns: finalization may need a few extra
+// turns, while a Strong-rooted Subprocess never goes away.
+let liveSubprocess = Infinity;
+for (let i = 0; i < 60; i++) {
+  await new Promise<void>(r => setImmediate(r));
+  Bun.gc(true);
+  liveSubprocess = heapStats().objectTypeCounts.Subprocess ?? 0;
+  if (liveSubprocess <= 1) break;
+}
+
+console.log(JSON.stringify({ N, before, during, liveSubprocess }));
+process.exit(0);
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "primary.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr.trim()).toBe("");
+  const { N, before, during, liveSubprocess } = JSON.parse(stdout.trim());
+  // No per-worker protected roots while the workers are alive. Strict equality
+  // against the baseline: a regression shows up as `before + N`.
+  expect({
+    protectedFunctionDelta: during.Function - before.Function,
+    protectedObjectDelta: during.Object - before.Object,
+  }).toEqual({
+    protectedFunctionDelta: 0,
+    protectedObjectDelta: 0,
+  });
+  // After every worker exits and user code holds no reference, the Subprocess
+  // wrappers are collectable. Allow one straggler for a conservatively rooted
+  // async frame; a root-cycle leak retains all N.
+  expect(liveSubprocess).toBeLessThanOrEqual(1);
+  expect(liveSubprocess).toBeLessThan(N);
+  expect(exitCode).toBe(0);
 });
 
 test("disconnect() on a cluster.Worker built around a plain object does not abort", async () => {

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -162,15 +162,6 @@ process.send("regular message");
 });
 
 test("primary does not root the worker object graph per live worker", async () => {
-  // `onInternalMessagePrimary` stores the Worker object and the internal
-  // message callback for each forked worker. Storing them as GC roots (one
-  // `JSC::Strong` each) means:
-  //   * every live worker adds two entries to the protected-object set, and
-  //   * Worker → ChildProcess → Subprocess → ipc_data → Strong(Worker) is a
-  //     cycle through a root, so the whole graph survives GC after the worker
-  //     exits.
-  // Held in the Subprocess wrapper's own WriteBarrier slots instead, they are
-  // a GC edge rather than a GC root: neither effect occurs.
   using dir = tempDir("cluster-internal-msg-roots", {
     "primary.ts": `
 import cluster from "node:cluster";
@@ -209,11 +200,11 @@ await Promise.all(
 );
 workers.length = 0;
 
-// Bounded poll across event-loop turns: finalization may need a few extra
-// turns, while a Strong-rooted Subprocess never goes away.
+// Bounded poll: finalization may need a few real event-loop idles, while a
+// Strong-rooted Subprocess never goes away no matter how long we wait.
 let liveSubprocess = Infinity;
 for (let i = 0; i < 60; i++) {
-  await new Promise<void>(r => setImmediate(r));
+  await Bun.sleep(25);
   Bun.gc(true);
   liveSubprocess = heapStats().objectTypeCounts.Subprocess ?? 0;
   if (liveSubprocess <= 1) break;
@@ -245,10 +236,10 @@ process.exit(0);
     exitCode: 0,
   });
   // After every worker exits and user code holds no reference, the Subprocess
-  // wrappers are collectable. Allow one straggler for a conservatively rooted
-  // async frame; a root-cycle leak retains all N.
-  expect(liveSubprocess).toBeLessThanOrEqual(1);
+  // wrappers are collectable. A root-cycle leak retains every one of the N;
+  // allow one straggler for a conservatively rooted async frame.
   expect(liveSubprocess).toBeLessThan(N);
+  expect(liveSubprocess).toBeLessThanOrEqual(1);
 });
 
 test("disconnect() on a cluster.Worker built around a plain object does not abort", async () => {


### PR DESCRIPTION
### Problem

`onInternalMessagePrimary` stores two `JSC::Strong` handles (the cluster `Worker` object and the internal-message callback) in each subprocess's `InternalMsgHolder`, and `sendHelperPrimary` registers each ack callback as another `Strong`. A `Strong` is a GC root, so:

- every live worker adds two entries to `heapStats().protectedObjectTypeCounts`, plus one per in-flight ack,
- `Strong(Worker)` → `Worker.process` → `ChildProcess` → `Subprocess` → `ipc_data` → `Strong(Worker)` is a cycle through a root, so the whole per-worker object graph survives GC after the worker exits and `cluster.workers` is empty.

```js
import cluster from "node:cluster";
import { heapStats } from "bun:jsc";

if (cluster.isPrimary) {
  for (let i = 0; i < 6; i++) cluster.fork();
  // wait for 'online' on each, then:
  Bun.gc(true);
  console.log(heapStats().protectedObjectTypeCounts);
  // before: { Function: 6, Object: 6, Subprocess: 6, ... }
  // after:  {                         Subprocess: 6, ... }
}
```

For a cluster primary that recycles workers (crash respawn, rolling restarts), the cycle leaks one worker object graph per generation for the primary's lifetime.

The source already carried a `TODO: move this to an Array or a JS Object or something which doesn't individually create a Strong for every single IPC message` on these fields.

### Fix

Store the primary-side state in `WriteBarrier` slots on the `Subprocess` JS wrapper (new `values:` entries `ipcWorker` / `ipcInternalCallback` / `ipcAckCallbacks`), the same way the existing `onExitCallback` / `ipcCallback` slots work. They are visited via `visitChildren` but are not roots, so:

- no per-worker growth in the protected-object set, and
- once the worker exits and user code releases its references, the `Subprocess` and its whole graph are collectable; there is no root cycle to break.

`Subprocess::handle_ipc_close` clears the new slots alongside `ipcCallback`.

The child-side process singleton (`CHILD_SINGLETON`, no JS wrapper, process lifetime) keeps the two fixed `Strong`s for `worker` / `cb`, but the unbounded `ArrayHashMap<i32, Strong>` and `Vec<Strong>` become a single `Strong` holding a JS `Map` keyed by seq and a single `Strong` holding a JS array (queued messages) respectively.

#33057 addresses the leak half of this by releasing the `Strong`s when the socket closes; this change removes the roots on the primary side entirely so there is no cycle to release.

### Verification

New test in `test/js/node/cluster.test.ts` forks 6 workers and asserts:

- `protectedObjectTypeCounts.{Function,Object}` do not grow per worker while the workers are live, and
- after the workers exit and references are dropped, `objectTypeCounts.Subprocess` drops to at most 1.

```
$ USE_SYSTEM_BUN=1 bun test test/js/node/cluster.test.ts -t "primary does not root"
  { "protectedFunctionDelta": 6, "protectedObjectDelta": 6 }   # fail

$ bun bd test test/js/node/cluster.test.ts -t "primary does not root"
  { "protectedFunctionDelta": 0, "protectedObjectDelta": 0 }   # pass
```

All 48 `test/js/node/test/parallel/test-cluster-*.js` that pass on `main` still pass; the existing `spawn.ipc*`, `spawn-ipc-gc`, and `child_process_ipc*` suites are unchanged. Round-robin handoff (which exercises the ack-callback store and lookup on every connection) is covered by `test-cluster-rr-*` and passes.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/cluster.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f4f0f4498)

test/js/node/cluster.test.ts:
W ArrayBuffer(7) [ 21, 11, 96, 126, 243, 128, 164 ]
(pass) cloneable and transferable equals [2457.65ms]
P O FileRef ("/tmp/bun-test_jasxUg/index.ts") {
  type: "text/javascript;charset=utf-8"
}
W {
  file: {},
}
P M {}
(pass) cloneable and non-transferable not-equals (BunFile) [1893.62ms]
P O BlockList {
  addAddress: [Function: addAddress],
  addRange: [Function: addRange],
  addSubnet: [Function: addSubnet],
  check: [Function: check],
  rules: [],
}
W {
  blocklist: {},
}
P M {}
(pass) cloneable and non-transferable not-equals (net.BlockList) [3046.43ms]
(pass) non-cluster parent ignores cluster-internal IPC messages from a forked child [2072.24ms]
killed 1 dangling process
(fail) primary doe
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/cluster.test.ts:
W ArrayBuffer(7) [ 21, 11, 96, 126, 243, 128, 164 ]
(pass) cloneable and transferable equals [51.76ms]
P O FileRef ("/tmp/bun-test_YMoSsU/index.ts") {
  type: "text/javascript;charset=utf-8"
}
W {
  file: {},
}
P M {}
(pass) cloneable and non-transferable not-equals (BunFile) [49.28ms]
P O BlockList {
  addAddress: [Function: addAddress],
  addRange: [Function: addRange],
  addSubnet: [Function: addSubnet],
  check: [Function: check],
  rules: [],
}
W {
  blocklist: {},
}
P M {}
(pass) cloneable and non-transferable not-equals (net.BlockList) [48.95ms]
(pass) non-cluster parent ignores cluster-internal IPC messages from a forked child [34.06ms]
228 |   // against the baseline: a regression shows up as `before + N`.
229 |   expect({
230 |     protectedFunctionDelta: during.Function - before.Function,
231 |     protectedObjectDelta: during.Object - before.Object,
232 |     exitCode,
233 |   }).toEqual({
           ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
-   "protectedFunctionDelta": 0,
-   "protectedObjectDelta": 0,
+   "protectedFunctionDelta": 6,
+   "protectedObjectDelta
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/cluster.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f4f0f4498)

test/js/node/cluster.test.ts:
W ArrayBuffer(7) [ 21, 11, 96, 126, 243, 128, 164 ]
(pass) cloneable and transferable equals [2133.88ms]
P O FileRef ("/tmp/bun-test_cw2Caa/index.ts") {
  type: "text/javascript;charset=utf-8"
}
W {
  file: {},
}
P M {}
(pass) cloneable and non-transferable not-equals (BunFile) [2051.44ms]
P O BlockList {
  addAddress: [Function: addAddress],
  addRange: [Function: addRange],
  addSubnet: [Function: addSubnet],
  check: [Function: check],
  rules: [],
}
W {
  blocklist: {},
}
P M {}
(pass) cloneable and non-transferable not-equals (net.BlockList) [3144.17ms]
(pass) non-cluster parent ignores cluster-internal IPC messages from a forked child [1889.55ms]
(pass) primary does not root the worker obje
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     f4f0f44986
  features     (none)

22 deps, 106 codegen, 1169 objects in 1108ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1232] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [19.00ms]
[2/1232] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [5.00ms]
[3/1232] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [6.00ms]
[4/1232] gen ErrorCode+*.h
[5/1232] gen bindgenv2
[6/1232] gen .bind.ts → GeneratedBindings.cpp
[7/1232] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1232] f
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ipc.rs                           | 123 ++++++++++++++++++++-----------
 src/runtime/api/BunObject.classes.ts     |  10 ++-
 src/runtime/api/bun/subprocess.rs        |  10 ++-
 src/runtime/node/node_cluster_binding.rs | 113 ++++++++++++++--------------
 test/js/node/cluster.test.ts             |  83 ++++++++++++++++++++-
 5 files changed, 236 insertions(+), 103 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/jsc/ipc.rs                                7      9      0
src/runtime/api/BunObject.classes.ts          2      1      0
src/runtime/api/bun/subprocess.rs             2      2      0
src/runtime/node/node_cluster_binding.rs      3     10      0
test/js/node/cluster.test.ts                  4      7      0
```

</details>

<!-- robobun:evidence:end -->