### PR TITLE
node:http2: collapse the per-stream JS context into a single Strong root

### DIFF
--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -5638,12 +5638,6 @@ impl H2FrameParser {
         }
     }
 
-    /// Resolve the JS stream context for the rewrite engine's dispatches (see `stream_ctx`; kept
-    /// as an alias so the Sink impl's per-callback shape stays legible).
-    fn rewrite_stream_ctx(&self, stream_id: u32) -> JSValue {
-        self.stream_ctx(stream_id)
-    }
-
     /// Record outbound DATA the legacy encoder wrote so the engine's send windows track reality.
     /// Buffered in cells and applied in rewrite_read: inbound WINDOW_UPDATE handling always goes
     /// through rewrite_read first, so the windows are in sync before any overflow check runs.
@@ -6176,7 +6170,7 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
                 JSValue::js_number(flags as f64),
             );
         } else {
-            let stream_ctx = self.rewrite_stream_ctx(stream_id);
+            let stream_ctx = self.stream_ctx(stream_id);
             self.dispatch_with_2_extra(
                 JSH2FrameParser::Gc::onStreamHeaders,
                 stream_ctx,
@@ -6188,7 +6182,7 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
 
     fn on_data(&self, stream_id: u32, data: &[u8]) {
         let g = self.global();
-        let stream_ctx = self.rewrite_stream_ctx(stream_id);
+        let stream_ctx = self.stream_ctx(stream_id);
         // Skip the JS dispatch when conversion fails (VM terminating).
         let Ok(chunk) = self.handlers.get().binary_type.to_js(data, &g) else {
             return;
@@ -6223,7 +6217,7 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
                 };
             }
         }
-        let stream_ctx = self.rewrite_stream_ctx(stream_id);
+        let stream_ctx = self.stream_ctx(stream_id);
         self.dispatch_with_extra(
             JSH2FrameParser::Gc::onStreamEnd,
             stream_ctx,
@@ -6282,7 +6276,7 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
                 (*stream).rst_code = code;
             }
         }
-        let stream_ctx = self.rewrite_stream_ctx(stream_id);
+        let stream_ctx = self.stream_ctx(stream_id);
         if code == crate::api::h2::wire::ErrorCode::Cancel.as_u32() {
             // A peer CANCEL is an abort, not an error (node emits 'aborted' and closes with
             // rstCode 8 without an 'error' event).

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1483,7 +1483,8 @@ pub struct H2FrameParser {
     /// Promised stream id whose PUSH_PROMISE header block is being delivered by the engine (its
     /// on_headers_complete dispatches onStreamPush instead of onStreamHeaders).
     rewrite_pending_push: Cell<u32>,
-    /// stream id -> JS stream context object, for the rewrite engine's Sink callbacks.
+    /// stream id -> JS stream context object (the Http2Stream). Single store: dispatches read it
+    /// via `stream_ctx` and the legacy `Stream::get_identifier` wrapper.
     sctx: JsCell<BunHashMap<u32, StrongOptional>>,
     /// In-progress decoded header array + sensitive-name array, accumulated across on_header.
     /// Packed name/value bytes of the header block being decoded (reused per block).
@@ -1518,6 +1519,32 @@ impl H2FrameParser {
     #[inline]
     fn as_ctx_ptr(&self) -> *mut Self {
         std::ptr::from_ref::<Self>(self).cast_mut()
+    }
+
+    /// The JS stream context object for `stream_id` (the Http2Stream instance the JS layer
+    /// registered via `setStreamContext` / the `streamStart` return value / `request()`'s stream
+    /// argument). Falls back to the numeric id for dispatches that fire before JS has supplied one.
+    #[inline]
+    pub(crate) fn stream_ctx(&self, stream_id: u32) -> JSValue {
+        self.sctx
+            .get()
+            .get(&stream_id)
+            .and_then(|s| s.get())
+            .unwrap_or_else(|| JSValue::js_number(stream_id as f64))
+    }
+
+    /// Record (or replace) the JS stream context for `stream_id`. A single `sctx` entry is the
+    /// only GC root the parser holds per stream.
+    #[inline]
+    pub(crate) fn set_stream_ctx(
+        &self,
+        stream_id: u32,
+        value: JSValue,
+        global_object: &JSGlobalObject,
+    ) {
+        self.sctx.with_mut(|m| {
+            m.insert(stream_id, StrongOptional::create(value, global_object));
+        });
     }
 
     /// Hold a `+1` for the extent of a native frame that can re-enter JS (and therefore free the
@@ -1608,7 +1635,6 @@ enum StreamState {
 pub struct Stream {
     id: u32,
     state: StreamState,
-    js_context: StrongOptional, // jsc.Strong.Optional
     wait_for_trailers: bool,
     end_after_headers: bool,
     is_waiting_more_headers: bool,
@@ -2002,9 +2028,12 @@ impl Stream {
             if self.data_frame_queue.is_empty() {
                 if _frame.end_stream {
                     if self.wait_for_trailers {
-                        client.dispatch(JSH2FrameParser::Gc::onWantTrailers, self.get_identifier());
+                        client.dispatch(
+                            JSH2FrameParser::Gc::onWantTrailers,
+                            self.get_identifier(client),
+                        );
                     } else {
-                        let identifier = self.get_identifier();
+                        let identifier = self.get_identifier(client);
                         identifier.ensure_still_alive();
                         if self.state == StreamState::HALF_CLOSED_REMOTE {
                             self.state = StreamState::CLOSED;
@@ -2179,7 +2208,6 @@ impl Stream {
         Stream {
             id: stream_identifier,
             state: StreamState::OPEN,
-            js_context: StrongOptional::empty(),
             wait_for_trailers: false,
             end_after_headers: false,
             is_waiting_more_headers: false,
@@ -2225,18 +2253,8 @@ impl Stream {
         )
     }
 
-    pub fn set_context(&mut self, value: JSValue, global_object: &JSGlobalObject) {
-        let old = core::mem::replace(
-            &mut self.js_context,
-            StrongOptional::create(value, global_object),
-        );
-        drop(old);
-    }
-
-    pub fn get_identifier(&self) -> JSValue {
-        self.js_context
-            .get()
-            .unwrap_or_else(|| JSValue::js_number(self.id as f64))
+    pub fn get_identifier(&self, client: &H2FrameParser) -> JSValue {
+        client.stream_ctx(self.id)
     }
 
     pub fn attach_signal(&mut self, parser: &H2FrameParser, signal: &mut AbortSignal) {
@@ -2257,10 +2275,6 @@ impl Stream {
         // TODO: We should not need this ref counting here, since Parser owns Stream
         parser.ref_();
         self.signal = Some(signal_ref);
-    }
-
-    pub fn detach_context(&mut self) {
-        self.js_context.deinit();
     }
 
     fn clean_queue<const FINALIZING: bool>(&mut self, client: &H2FrameParser) {
@@ -2305,13 +2319,11 @@ impl Stream {
             client
                 .pending_engine_stream_closes
                 .with_mut(|v| v.push(self.id));
-            // Release the engine-dispatch context root too; without this the Strong JS
-            // stream object lives until the session dies.
-            client.sctx.with_mut(|m| {
-                m.remove(&self.id);
-            });
         }
-        self.detach_context();
+        // Release the per-stream JS context root so the JS stream object can be collected.
+        client.sctx.with_mut(|m| {
+            m.remove(&self.id);
+        });
         self.clean_queue::<FINALIZING>(client);
         if let Some(signal) = self.signal.take() {
             drop(signal);
@@ -2599,7 +2611,7 @@ impl H2FrameParser {
         let _ = writer_stream.write_all(&value.to_ne_bytes());
         let old_state = stream.state;
         stream.state = StreamState::CLOSED;
-        let identifier = stream.get_identifier();
+        let identifier = stream.get_identifier(self);
         identifier.ensure_still_alive();
         stream.free_resources::<false>(self);
         self.dispatch_with_2_extra(
@@ -2637,7 +2649,7 @@ impl H2FrameParser {
         let _ = writer_stream.write_all(&value.to_ne_bytes());
 
         stream.state = StreamState::CLOSED;
-        let identifier = stream.get_identifier();
+        let identifier = stream.get_identifier(self);
         identifier.ensure_still_alive();
         stream.free_resources::<false>(self);
         if rst_code == ErrorCode::NO_ERROR {
@@ -4134,7 +4146,7 @@ impl H2FrameParser {
 
         self.dispatch_with_3_extra(
             JSH2FrameParser::Gc::onStreamHeaders,
-            stream.get_identifier(),
+            stream.get_identifier(self),
             headers,
             sensitive_headers,
             JSValue::js_number(flags as f64),
@@ -4289,7 +4301,7 @@ impl H2FrameParser {
                 if let Ok(chunk) = self.handlers.get().binary_type.to_js(payload, &global) {
                     self.dispatch_with_extra(
                         JSH2FrameParser::Gc::onStreamData,
-                        stream.get_identifier(),
+                        stream.get_identifier(self),
                         chunk,
                     );
                 }
@@ -4307,7 +4319,7 @@ impl H2FrameParser {
                 };
             }
             if frame.flags & DataFrameFlags::END_STREAM as u8 != 0 {
-                let identifier = stream.get_identifier();
+                let identifier = stream.get_identifier(self);
                 identifier.ensure_still_alive();
 
                 if stream.state == StreamState::HALF_CLOSED_LOCAL {
@@ -4591,7 +4603,7 @@ impl H2FrameParser {
             let end = content.end;
             self.read_buffer.with_mut(|rb| rb.reset());
             stream.state = StreamState::CLOSED;
-            let identifier = stream.get_identifier();
+            let identifier = stream.get_identifier(self);
             identifier.ensure_still_alive();
             stream.free_resources::<false>(self);
             if rst_code == ErrorCode::NO_ERROR.0 {
@@ -4852,7 +4864,7 @@ impl H2FrameParser {
         if stream.state == StreamState::CLOSED {
             return;
         }
-        let identifier = stream.get_identifier();
+        let identifier = stream.get_identifier(self);
         identifier.ensure_still_alive();
 
         // no more continuation headers we can call it closed
@@ -5316,12 +5328,7 @@ impl H2FrameParser {
                 // streamStart returns the JS stream it created; storing it here saves the
                 // setStreamContext host call the JS layer used to make per stream.
                 if returned.is_object() {
-                    self.sctx.with_mut(|m| {
-                        m.insert(stream_identifier, StrongOptional::create(returned, &global));
-                    });
-                    // SAFETY: stream is *mut Stream from self.streams; valid while the map
-                    // entry exists
-                    unsafe { (*stream).set_context(returned, &global) };
+                    self.set_stream_ctx(stream_identifier, returned, &global);
                 }
             }
         }
@@ -5631,18 +5638,10 @@ impl H2FrameParser {
         }
     }
 
-    /// Resolve the JS stream context for the rewrite engine's dispatches: the `sctx` map (populated
-    /// by setStreamContext, i.e. server-side inbound streams) or the legacy stream's own context
-    /// (populated directly by the legacy request() for client-initiated streams).
+    /// Resolve the JS stream context for the rewrite engine's dispatches (see `stream_ctx`; kept
+    /// as an alias so the Sink impl's per-callback shape stays legible).
     fn rewrite_stream_ctx(&self, stream_id: u32) -> JSValue {
-        if let Some(ctx) = self.sctx.get().get(&stream_id).and_then(|s| s.get()) {
-            return ctx;
-        }
-        if let Some(stream) = self.streams.get().get(&stream_id).copied() {
-            // SAFETY: stream is *mut Stream from self.streams; valid while the map entry exists
-            return unsafe { (*stream).get_identifier() };
-        }
-        JSValue::UNDEFINED
+        self.stream_ctx(stream_id)
     }
 
     /// Record outbound DATA the legacy encoder wrote so the engine's send windows track reality.
@@ -6112,8 +6111,7 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
     fn on_stream_open(&self, stream_id: u32) {
         // Bridge: create the legacy stream entry (the legacy outbound host fns — respond/sendData/
         // rstStream/getStreamState — look streams up there) AND dispatch onStreamStart, which the
-        // legacy helper already does. The JS streamStart handler then calls setStreamContext,
-        // populating both `sctx` and the legacy stream context.
+        // legacy helper already does. The JS streamStart handler's return value populates `sctx`.
         let _ = self.handle_received_stream_id(stream_id);
     }
 
@@ -7564,9 +7562,12 @@ impl H2FrameParser {
             }
             if close {
                 if stream.wait_for_trailers {
-                    self.dispatch(JSH2FrameParser::Gc::onWantTrailers, stream.get_identifier());
+                    self.dispatch(
+                        JSH2FrameParser::Gc::onWantTrailers,
+                        stream.get_identifier(self),
+                    );
                 } else {
-                    let identifier = stream.get_identifier();
+                    let identifier = stream.get_identifier(self);
                     identifier.ensure_still_alive();
                     if stream.state == StreamState::HALF_CLOSED_REMOTE {
                         stream.state = StreamState::CLOSED;
@@ -7884,7 +7885,7 @@ impl H2FrameParser {
                         Err(global_object.throw(format_args!("Failed to allocate header buffer")))
                     }
                     Err(_) => {
-                        let identifier = stream.get_identifier();
+                        let identifier = stream.get_identifier(this);
                         identifier.ensure_still_alive();
                         this.dispatch_with_2_extra(
                             JSH2FrameParser::Gc::onFrameError,
@@ -8093,7 +8094,7 @@ impl H2FrameParser {
                 offset += chunk_size;
             }
         }
-        let identifier = stream.get_identifier();
+        let identifier = stream.get_identifier(this);
         identifier.ensure_still_alive();
         if stream.state == StreamState::HALF_CLOSED_REMOTE {
             stream.state = StreamState::CLOSED;
@@ -8490,12 +8491,17 @@ impl H2FrameParser {
             return Err(global_object.throw(format_args!("Expected stream_id to be a number")));
         }
 
-        let Some(stream) = this.streams.get().get(&stream_id_arg.to_u32()).copied() else {
+        let stream_id = stream_id_arg.to_u32();
+        if !this.streams.get().contains_key(&stream_id) {
             return Err(global_object.throw(format_args!("Invalid stream id")));
-        };
+        }
 
-        // SAFETY: stream is *mut Stream from self.streams; valid while the map entry exists
-        Ok(unsafe { (*stream).js_context.get() }.unwrap_or(JSValue::UNDEFINED))
+        Ok(this
+            .sctx
+            .get()
+            .get(&stream_id)
+            .and_then(|s| s.get())
+            .unwrap_or(JSValue::UNDEFINED))
     }
 
     #[bun_jsc::host_fn(method)]
@@ -8529,20 +8535,7 @@ impl H2FrameParser {
             return Err(global_object.throw(format_args!("Expected context to be an object")));
         }
 
-        // Rewrite engine: record the JS stream context for the engine's Sink callbacks. Dropping a
-        // previous entry releases its root (StrongOptional: Drop -> destroy).
-        this.sctx.with_mut(|m| {
-            m.insert(
-                stream_id,
-                StrongOptional::create(context_arg, global_object),
-            );
-        });
-
-        // Legacy path: also set on the legacy stream if it still exists (best-effort).
-        if let Some(stream) = this.streams.get().get(&stream_id).copied() {
-            // SAFETY: stream is *mut Stream from self.streams; valid while the map entry exists
-            unsafe { (*stream).set_context(context_arg, global_object) };
-        }
+        this.set_stream_ctx(stream_id, context_arg, global_object);
         Ok(JSValue::UNDEFINED)
     }
 
@@ -8566,7 +8559,8 @@ impl H2FrameParser {
         let mut it = StreamResumableIterator::init(this);
         while let Some(stream) = it.next() {
             // SAFETY: stream is *mut Stream from self.streams; valid while the map entry exists
-            let Some(value) = (unsafe { (*stream).js_context.get() }) else {
+            let id = unsafe { (*stream).id };
+            let Some(value) = this.sctx.get().get(&id).and_then(|s| s.get()) else {
                 continue;
             };
             this.handlers.get().vm.event_loop_mut().run_callback(
@@ -8605,7 +8599,7 @@ impl H2FrameParser {
                 let old_state = stream.state;
                 stream.state = StreamState::CLOSED;
                 stream.rst_code = ErrorCode::CANCEL.0;
-                let identifier = stream.get_identifier();
+                let identifier = stream.get_identifier(this);
                 identifier.ensure_still_alive();
                 stream.free_resources::<false>(this);
                 this.dispatch_with_2_extra(
@@ -8648,7 +8642,7 @@ impl H2FrameParser {
             if stream.state != StreamState::CLOSED {
                 stream.state = StreamState::CLOSED;
                 stream.rst_code = rst_code;
-                let identifier = stream.get_identifier();
+                let identifier = stream.get_identifier(this);
                 identifier.ensure_still_alive();
                 stream.free_resources::<false>(this);
                 this.dispatch_with_extra(JSH2FrameParser::Gc::onStreamError, identifier, error_arg);
@@ -8850,12 +8844,12 @@ impl H2FrameParser {
                         if !stream_ctx_arg.is_empty_or_undefined_or_null()
                             && stream_ctx_arg.is_object()
                         {
-                            stream.set_context(stream_ctx_arg, global_object);
+                            this.set_stream_ctx(stream_id, stream_ctx_arg, global_object);
                         }
                         stream.rst_code = ErrorCode::COMPRESSION_ERROR.0;
                         this.dispatch_with_extra(
                             JSH2FrameParser::Gc::onStreamError,
-                            stream.get_identifier(),
+                            stream.get_identifier(this),
                             JSValue::js_number(stream.rst_code as f64),
                         );
                         return Ok(JSValue::js_number(stream_id as f64));
@@ -9036,13 +9030,13 @@ impl H2FrameParser {
                             if !stream_ctx_arg.is_empty_or_undefined_or_null()
                                 && stream_ctx_arg.is_object()
                             {
-                                stream.set_context(stream_ctx_arg, global_object);
+                                this.set_stream_ctx(stream_id, stream_ctx_arg, global_object);
                             }
                             stream.state = StreamState::CLOSED;
                             stream.rst_code = ErrorCode::COMPRESSION_ERROR.0;
                             this.dispatch_with_extra(
                                 JSH2FrameParser::Gc::onStreamError,
-                                stream.get_identifier(),
+                                stream.get_identifier(this),
                                 JSValue::js_number(stream.rst_code as f64),
                             );
                             return Ok(JSValue::UNDEFINED);
@@ -9127,12 +9121,12 @@ impl H2FrameParser {
                         if !stream_ctx_arg.is_empty_or_undefined_or_null()
                             && stream_ctx_arg.is_object()
                         {
-                            stream.set_context(stream_ctx_arg, global_object);
+                            this.set_stream_ctx(stream_id, stream_ctx_arg, global_object);
                         }
                         stream.rst_code = ErrorCode::COMPRESSION_ERROR.0;
                         this.dispatch_with_extra(
                             JSH2FrameParser::Gc::onStreamError,
-                            stream.get_identifier(),
+                            stream.get_identifier(this),
                             JSValue::js_number(stream.rst_code as f64),
                         );
                         return Ok(JSValue::js_number(stream_id as f64));
@@ -9148,7 +9142,7 @@ impl H2FrameParser {
         // The `options` getters below can run user JS while `stream` is borrowed.
         let mut stream = this.enter_stream_dispatch(stream_ptr);
         if !stream_ctx_arg.is_empty_or_undefined_or_null() && stream_ctx_arg.is_object() {
-            stream.set_context(stream_ctx_arg, global_object);
+            this.set_stream_ctx(stream_id, stream_ctx_arg, global_object);
         }
         let mut flags: u8 = HeadersFrameFlags::END_HEADERS as u8;
         let mut exclusive: bool = false;
@@ -9165,7 +9159,7 @@ impl H2FrameParser {
                 stream.rst_code = ErrorCode::INTERNAL_ERROR.0;
                 this.dispatch_with_extra(
                     JSH2FrameParser::Gc::onStreamError,
-                    stream.get_identifier(),
+                    stream.get_identifier(this),
                     JSValue::js_number(stream.rst_code as f64),
                 );
                 return Ok(JSValue::js_number(stream_id as f64));
@@ -9243,7 +9237,7 @@ impl H2FrameParser {
                         stream.rst_code = ErrorCode::INTERNAL_ERROR.0;
                         this.dispatch_with_extra(
                             JSH2FrameParser::Gc::onStreamError,
-                            stream.get_identifier(),
+                            stream.get_identifier(this),
                             JSValue::js_number(stream.rst_code as f64),
                         );
                         return Ok(JSValue::js_number(stream.id as f64));
@@ -9267,7 +9261,7 @@ impl H2FrameParser {
                         stream.rst_code = ErrorCode::INTERNAL_ERROR.0;
                         this.dispatch_with_extra(
                             JSH2FrameParser::Gc::onStreamError,
-                            stream.get_identifier(),
+                            stream.get_identifier(this),
                             JSValue::js_number(stream.rst_code as f64),
                         );
                         return Ok(JSValue::js_number(stream_id as f64));
@@ -9286,7 +9280,7 @@ impl H2FrameParser {
                     stream.rst_code = ErrorCode::INTERNAL_ERROR.0;
                     this.dispatch_with_extra(
                         JSH2FrameParser::Gc::onStreamError,
-                        stream.get_identifier(),
+                        stream.get_identifier(this),
                         JSValue::js_number(stream.rst_code as f64),
                     );
                     return Ok(JSValue::js_number(stream_id as f64));
@@ -9323,7 +9317,7 @@ impl H2FrameParser {
             this.rejected_streams.set(this.rejected_streams.get() + 1);
             this.dispatch_with_extra(
                 JSH2FrameParser::Gc::onStreamError,
-                stream.get_identifier(),
+                stream.get_identifier(this),
                 JSValue::js_number(stream.rst_code as f64),
             );
             if this.rejected_streams.get() >= this.max_rejected_streams.get() {
@@ -9359,14 +9353,14 @@ impl H2FrameParser {
 
             this.dispatch_with_2_extra(
                 JSH2FrameParser::Gc::onFrameError,
-                stream.get_identifier(),
+                stream.get_identifier(this),
                 JSValue::js_number(FrameType::HTTP_FRAME_HEADERS as u8 as f64),
                 JSValue::js_number(ErrorCode::FRAME_SIZE_ERROR.0 as f64),
             );
 
             this.dispatch_with_extra(
                 JSH2FrameParser::Gc::onStreamError,
-                stream.get_identifier(),
+                stream.get_identifier(this),
                 JSValue::js_number(stream.rst_code as f64),
             );
             return Ok(JSValue::js_number(stream_id as f64));
@@ -9524,7 +9518,10 @@ impl H2FrameParser {
 
             if wait_for_trailers {
                 stream.state = StreamState::HALF_CLOSED_LOCAL;
-                this.dispatch(JSH2FrameParser::Gc::onWantTrailers, stream.get_identifier());
+                this.dispatch(
+                    JSH2FrameParser::Gc::onWantTrailers,
+                    stream.get_identifier(this),
+                );
                 return Ok(JSValue::js_number(stream_id as f64));
             }
 
@@ -9536,7 +9533,7 @@ impl H2FrameParser {
             // response regressed the state to HALF_CLOSED_LOCAL and never
             // told JS, leaking the stream (and the session's connection
             // count) until socket close.
-            let identifier = stream.get_identifier();
+            let identifier = stream.get_identifier(this);
             identifier.ensure_still_alive();
             if stream.state == StreamState::HALF_CLOSED_REMOTE {
                 stream.state = StreamState::CLOSED;

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -914,7 +914,9 @@ describe("inbound stream lifecycle", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    const result = JSON.parse(stdout.trim().split("\n")[0]);
+    expect(stderr).toBe("");
+    expect(proc.signalCode).toBeNull();
+    const result = JSON.parse(stdout.trim().split("\n")[0] || "null");
     expect(result).toEqual({ refs: 8, cbErrs: 8, live: 0 });
     expect(exitCode).toBe(0);
   }, 30_000);

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -848,6 +848,77 @@ describe("inbound stream lifecycle", () => {
     }
   });
 
+  // pushStream() that fails header validation destroys the pushed ServerHttp2Stream before it
+  // reaches the wire; the JS layer releases the native context root (setStreamContext(id,
+  // undefined)). Previously the same value was also rooted on the per-stream native state and
+  // never cleared, pinning the pushed stream (and everything it references) until the session
+  // died. Run in a subprocess: the never-delivered stream's destroy(err) emits 'error' with no
+  // listener, which must not leak into this test process.
+  test("releases a pushed ServerHttp2Stream whose PUSH_PROMISE was rejected before going on the wire", async () => {
+    const fixture = String.raw`
+      const http2 = require("node:http2");
+      const dc = require("node:diagnostics_channel");
+      const { once } = require("node:events");
+      process.on("uncaughtException", e => {
+        console.log(JSON.stringify({ uncaught: String(e?.message || e) }));
+        process.exit(0);
+      });
+      const refs = [];
+      dc.subscribe("http2.server.stream.created", msg => {
+        if (msg?.stream && typeof msg.stream.id === "number" && msg.stream.id % 2 === 0) {
+          msg.stream.on("error", () => {});
+          refs.push(new WeakRef(msg.stream));
+        }
+      });
+      const server = http2.createServer();
+      let cbErrs = 0;
+      const done = Promise.withResolvers();
+      server.on("stream", stream => {
+        let remaining = 8;
+        const next = () => {
+          if (remaining-- === 0) {
+            stream.respond({ ":status": 200 });
+            stream.end("ok");
+            done.resolve();
+            return;
+          }
+          stream.pushStream({ ":path": "/p", "bad header": "x" }, err => {
+            if (err?.code === "ERR_INVALID_HTTP_TOKEN") cbErrs++;
+            next();
+          });
+        };
+        next();
+      });
+      server.listen(0);
+      await once(server, "listening");
+      const client = http2.connect("http://127.0.0.1:" + server.address().port, {
+        settings: { enablePush: true },
+      });
+      const req = client.request({ ":path": "/" });
+      req.on("error", () => {});
+      req.resume();
+      req.end();
+      await done.promise;
+      for (let i = 0; i < 50 && refs.some(r => r.deref() !== undefined); i++) {
+        await new Promise(r => setImmediate(r));
+        Bun.gc(true);
+        await Bun.sleep(1);
+      }
+      const live = refs.filter(r => r.deref() !== undefined).length;
+      console.log(JSON.stringify({ refs: refs.length, cbErrs, live }));
+      process.exit(0);
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const result = JSON.parse(stdout.trim().split("\n")[0]);
+    expect(result).toEqual({ refs: 8, cbErrs: 8, live: 0 });
+    expect(exitCode).toBe(0);
+  }, 30_000);
+
   // A header-value `toString` runs user JS while sendTrailers holds the native `&mut Stream`;
   // feeding the stream's own RST_STREAM (then another read) back into the parser from that
   // callback must not free the Stream out from under the caller (use-after-free under ASAN).


### PR DESCRIPTION
## What

Each `H2FrameParser` stream kept its JS `Http2Stream` object rooted in two places: the parser-level `sctx: HashMap<u32, StrongOptional>` and the per-stream `Stream.js_context: StrongOptional`. Both are JSC `HandleSet` slots pointing at the same value, so a session with N live streams held 2N Strong roots where N suffice.

The two stores were written together everywhere except `setStreamContext(id, undefined)`, which the JS layer uses to release a server-pushed stream whose `PUSH_PROMISE` was rejected before it went on the wire (`pushStream` with a bad header): that cleared only `sctx`, leaving `Stream.js_context` rooting the `ServerHttp2Stream` (and whatever it transitively referenced) until the whole session was torn down. The never-announced stream's `_destroy` deliberately skips the RST host call, so nothing ever frees the legacy stream box on that path.

## Fix

`Stream.js_context` is removed. `sctx` is the single per-stream context store:

- `H2FrameParser::stream_ctx(id)` / `set_stream_ctx(id, value, global)` are the read/write helpers; `Stream::get_identifier` takes the parser and delegates so every existing dispatch call site keeps its shape.
- `request()`'s per-stream `set_context` writes and `handle_received_stream_id`'s `streamStart`-return store go through `set_stream_ctx` (one Strong instead of two).
- `setStreamContext(id, undefined)` now fully releases the root, and `free_resources` removes the `sctx` entry on both the normal and finalizing paths.

`PendingFrame.callback` (one Strong per queued DATA frame) is unchanged: those are released as each frame drains or when `clean_queue` runs at stream teardown, and the count is bounded by `maxSessionMemory`.

## Verification

New test in `h2-conformance.test.ts` exercises the release path: a server does 8 `pushStream` calls with an invalid header name, captures the pushed `ServerHttp2Stream` instances via the `http2.server.stream.created` diagnostics channel as `WeakRef`s, and asserts they collect while the session is still alive.

```
without fix: { refs: 8, cbErrs: 8, live: 8 }
with fix:    { refs: 8, cbErrs: 8, live: 0 }
```

`test/js/node/http2/`: 386 pass, 6 skip (1 unrelated timeout in `node-http2-streams-rehash.test.ts` reproduces on main). `rust:check-all` 10/10.

## Note

#34563 touches the same file to disarm `js_context` at worker thread exit; with this change that disarm step has one fewer field to handle.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/h2-conformance.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (c45c4b224)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [409.70ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [139.26ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [112.35ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [84.29ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§
... (truncated)

release without fix: 14 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [7.46ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [2.22ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [1.24ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [0.78ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [0.76ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [0.70ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [0.66ms]
(pass) PING (checklist §3.7) > a PING on a non-zero stream id is a PROTOCOL_ERROR [1.53ms]
(pass) WINDOW_UPDATE (checklist §6) > a connection-level WINDOW_UPDATE with a 0 increment is a PROTOCOL_ERROR [0.77ms]
(pass) WINDOW_UPDATE
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/h2-conformance.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (c45c4b224)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [413.80ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [139.92ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [114.52ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [85.48ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     c45c4b224d
  features     (none)

22 deps, 106 codegen, 1169 objects in 735ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1232] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [17.00ms]
[2/1232] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1232] gen bindgenv2
[4/1232] gen ErrorCode+*.h
[5/1232] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [5.00ms]
[6/1232] gen .bind.ts → GeneratedBindings.cpp
[7/1232] fetch picohttpparser
[picohttpparser] up to date
[8/1232] 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/h2_frame_parser.rs    | 193 ++++++++++++++----------------
 test/js/node/http2/h2-conformance.test.ts |  73 +++++++++++
 2 files changed, 165 insertions(+), 101 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/runtime/api/bun/h2_frame_parser.rs        16     41      0
test/js/node/http2/h2-conformance.test.ts      4      5      0
```

</details>

<!-- robobun:evidence:end -->