### PR TITLE
Bun.spawn: copy ArrayBuffer stdin to native memory instead of a Strong-rooted Uint8Array

### DIFF
--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -568,7 +568,12 @@ impl Stdio {
 
             // Copy into native memory so the async pipe writer owns the bytes
             // outright (no GC root required while draining stdin).
-            *out_stdio = Stdio::OwnedBuffer(bytes.to_vec());
+            let mut owned = Vec::new();
+            if owned.try_reserve_exact(bytes.len()).is_err() {
+                return Err(global.throw_out_of_memory());
+            }
+            owned.extend_from_slice(bytes);
+            *out_stdio = Stdio::OwnedBuffer(owned);
             return Ok(());
         }
 

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -57,6 +57,9 @@ pub enum Stdio {
     Path(PathLike),
     Blob(webcore::blob::Any),
     ArrayBuffer(jsc::array_buffer::ArrayBufferStrong),
+    /// Bytes copied from a user-supplied ArrayBuffer/TypedArray stdin. Owned
+    /// natively so the pipe writer needs no GC root for the async drain.
+    OwnedBuffer(Vec<u8>),
     Memfd(Fd),
     Pipe,
     /// Like `Pipe` at indices >= 3, but the parent end of the socketpair is
@@ -109,6 +112,7 @@ impl Stdio {
             // Vec<u8> outlives this Stdio.
             Self::Capture(c) => unsafe { (*c.buf).slice() },
             Self::ArrayBuffer(ab) => ab.array_buffer.byte_slice(),
+            Self::OwnedBuffer(b) => b,
             Self::Blob(blob) => blob.slice(),
             _ => &[],
         }
@@ -123,7 +127,7 @@ impl Stdio {
         #[cfg(any(target_os = "linux", target_os = "android"))]
         match self {
             Self::Blob(blob) => !blob.needs_to_read_file(),
-            Self::Memfd(_) | Self::ArrayBuffer(_) => true,
+            Self::Memfd(_) | Self::ArrayBuffer(_) | Self::OwnedBuffer(_) => true,
             // `Self::Pipe` is never memfd: a memfd has no EOF signal, so a
             // grandchild still writing after the child exits would be lost.
             _ => false,
@@ -285,9 +289,11 @@ impl Stdio {
                 out: d.out,
                 to: d.to,
             }),
-            Self::Capture(_) | Self::Pipe | Self::ArrayBuffer(_) | Self::ReadableStream(_) => {
-                buffer()
-            }
+            Self::Capture(_)
+            | Self::Pipe
+            | Self::ArrayBuffer(_)
+            | Self::OwnedBuffer(_)
+            | Self::ReadableStream(_) => buffer(),
             #[cfg(not(windows))]
             Self::SocketFd => SpawnOptionsStdio::SocketFd,
             // Windows extra-stdio is a libuv pipe handle (no raw-fd ownership
@@ -313,6 +319,7 @@ impl Stdio {
         match self {
             Self::Capture(_)
             | Self::ArrayBuffer(_)
+            | Self::OwnedBuffer(_)
             | Self::Blob(_)
             | Self::Pipe
             | Self::ReadableStream(_) => true,
@@ -552,21 +559,16 @@ impl Stdio {
         }
 
         if let Some(array_buffer) = value.as_array_buffer(global) {
+            let bytes = array_buffer.byte_slice();
             // Change in Bun v1.0.34: don't throw for empty ArrayBuffer
-            if array_buffer.byte_slice().is_empty() {
+            if bytes.is_empty() {
                 *out_stdio = Stdio::Ignore;
                 return Ok(());
             }
 
-            let copied_value =
-                jsc::array_buffer::ArrayBuffer::create_buffer(global, array_buffer.byte_slice())?;
-            let copied = copied_value
-                .as_array_buffer(global)
-                .expect("create_buffer returns a Uint8Array");
-            *out_stdio = Stdio::ArrayBuffer(jsc::array_buffer::ArrayBufferStrong {
-                array_buffer: copied,
-                held: jsc::StrongOptional::create(copied.value, global),
-            });
+            // Copy into native memory so the async pipe writer owns the bytes
+            // outright (no GC root required while draining stdin).
+            *out_stdio = Stdio::OwnedBuffer(bytes.to_vec());
             return Ok(());
         }
 

--- a/src/runtime/api/bun/subprocess/Readable.rs
+++ b/src/runtime/api/bun/subprocess/Readable.rs
@@ -167,7 +167,7 @@ impl Readable {
             Stdio::Pipe => {
                 Readable::Pipe(PipeReader::create(event_loop, process, result, max_size))
             }
-            Stdio::ArrayBuffer(..) | Stdio::Blob(..) => {
+            Stdio::ArrayBuffer(..) | Stdio::OwnedBuffer(..) | Stdio::Blob(..) => {
                 panic!("TODO: implement ArrayBuffer & Blob support in Stdio readable")
             }
             Stdio::Capture(..) => panic!("TODO: implement capture support in Stdio readable"),

--- a/src/runtime/api/bun/subprocess/Writable.rs
+++ b/src/runtime/api/bun/subprocess/Writable.rs
@@ -276,9 +276,7 @@ impl<'a> Writable<'a> {
                         evtloop,
                         subprocess as *mut Subprocess<'a>,
                         result,
-                        super::Source::from_owned_bytes(
-                            core::mem::take(bytes).into_boxed_slice(),
-                        ),
+                        super::Source::from_owned_bytes(core::mem::take(bytes).into_boxed_slice()),
                     )));
                 }
                 Stdio::Fd(fd) => {

--- a/src/runtime/api/bun/subprocess/Writable.rs
+++ b/src/runtime/api/bun/subprocess/Writable.rs
@@ -271,6 +271,16 @@ impl<'a> Writable<'a> {
                         super::source_from_array_buffer(core::mem::take(array_buffer)),
                     )));
                 }
+                Stdio::OwnedBuffer(bytes) => {
+                    return Ok(Writable::Buffer(StaticPipeWriter::create(
+                        evtloop,
+                        subprocess as *mut Subprocess<'a>,
+                        result,
+                        super::Source::from_owned_bytes(
+                            core::mem::take(bytes).into_boxed_slice(),
+                        ),
+                    )));
+                }
                 Stdio::Fd(fd) => {
                     return Ok(Writable::Fd(*fd));
                 }
@@ -373,6 +383,12 @@ impl<'a> Writable<'a> {
                 std::ptr::from_mut::<Subprocess<'a>>(subprocess),
                 result,
                 super::source_from_array_buffer(core::mem::take(array_buffer)),
+            ))),
+            Stdio::OwnedBuffer(bytes) => Ok(Writable::Buffer(StaticPipeWriter::create(
+                evtloop,
+                std::ptr::from_mut::<Subprocess<'a>>(subprocess),
+                result,
+                super::Source::from_owned_bytes(core::mem::take(bytes).into_boxed_slice()),
             ))),
             Stdio::Memfd(_) => {
                 // Transfer ownership: `Stdio`'s Drop would close the memfd, so

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -749,7 +749,7 @@ impl Cmd {
                         stdio[STDIN_NO] = if bytes.is_empty() {
                             Stdio::Ignore
                         } else {
-                            Stdio::Blob(crate::webcore::blob::Any::from_owned_slice(bytes.to_vec()))
+                            Stdio::OwnedBuffer(bytes.to_vec())
                         };
                     }
                     if flags.duplicate_out() {

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -749,7 +749,12 @@ impl Cmd {
                         stdio[STDIN_NO] = if bytes.is_empty() {
                             Stdio::Ignore
                         } else {
-                            Stdio::OwnedBuffer(bytes.to_vec())
+                            let mut owned = Vec::new();
+                            if owned.try_reserve_exact(bytes.len()).is_err() {
+                                return Err(global.throw_out_of_memory());
+                            }
+                            owned.extend_from_slice(bytes);
+                            Stdio::OwnedBuffer(owned)
                         };
                     }
                     if flags.duplicate_out() {

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -1086,6 +1086,16 @@ impl Writable {
                         JscSubprocess::source_from_array_buffer(core::mem::take(array_buffer)),
                     )));
                 }
+                Stdio::OwnedBuffer(bytes) => {
+                    return Ok(Writable::Buffer(StaticPipeWriter::create(
+                        event_loop,
+                        subprocess,
+                        result,
+                        JscSubprocess::Source::from_owned_bytes(
+                            core::mem::take(bytes).into_boxed_slice(),
+                        ),
+                    )));
+                }
                 Stdio::Fd(fd) => {
                     return Ok(Writable::Fd(*fd));
                 }
@@ -1144,6 +1154,14 @@ impl Writable {
                     subprocess,
                     result,
                     JscSubprocess::source_from_array_buffer(core::mem::take(array_buffer)),
+                ))),
+                Stdio::OwnedBuffer(bytes) => Ok(Writable::Buffer(StaticPipeWriter::create(
+                    event_loop,
+                    subprocess,
+                    result,
+                    JscSubprocess::Source::from_owned_bytes(
+                        core::mem::take(bytes).into_boxed_slice(),
+                    ),
                 ))),
                 Stdio::Memfd(memfd) => {
                     debug_assert!(memfd.is_valid());
@@ -1327,6 +1345,8 @@ impl Readable {
                     };
                     Readable::Pipe(pipe)
                 }
+                // Shell never builds OwnedBuffer; only `Stdio::extract` does.
+                Stdio::OwnedBuffer(_) => Readable::Ignore,
                 Stdio::Capture(_) => Readable::Pipe(PipeReader::create(
                     event_loop, process, result, shellio, out_type, interp,
                 )),
@@ -1372,6 +1392,8 @@ impl Readable {
                     };
                     Readable::Pipe(pipe)
                 }
+                // Shell never builds OwnedBuffer; only `Stdio::extract` does.
+                Stdio::OwnedBuffer(_) => Readable::Ignore,
                 Stdio::Capture(_) => Readable::Pipe(PipeReader::create(
                     event_loop, process, result, shellio, out_type, interp,
                 )),

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -1345,7 +1345,7 @@ impl Readable {
                     };
                     Readable::Pipe(pipe)
                 }
-                // Shell never builds OwnedBuffer; only `Stdio::extract` does.
+                // OwnedBuffer is stdin-only; Readable handles stdout/stderr.
                 Stdio::OwnedBuffer(_) => Readable::Ignore,
                 Stdio::Capture(_) => Readable::Pipe(PipeReader::create(
                     event_loop, process, result, shellio, out_type, interp,
@@ -1392,7 +1392,7 @@ impl Readable {
                     };
                     Readable::Pipe(pipe)
                 }
-                // Shell never builds OwnedBuffer; only `Stdio::extract` does.
+                // OwnedBuffer is stdin-only; Readable handles stdout/stderr.
                 Stdio::OwnedBuffer(_) => Readable::Ignore,
                 Stdio::Capture(_) => Readable::Pipe(PipeReader::create(
                     event_loop, process, result, shellio, out_type, interp,

--- a/test/js/bun/spawn/spawn-stdin-arraybuffer-gc.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-arraybuffer-gc.test.ts
@@ -94,11 +94,19 @@ describe("Bun.spawn stdin: ArrayBuffer bytes reach the child intact", () => {
     const ab = new ArrayBuffer(hugeBuf.length);
     new Uint8Array(ab).set(hugeBuf);
 
+    // Non-zero-offset views with sentinel bytes on either side, so a bug that
+    // copies the whole backing store instead of just the view range fails.
+    const framed = new ArrayBuffer(7 + hugeBuf.length + 11);
+    new Uint8Array(framed).fill(0xee);
+    new Uint8Array(framed, 7, hugeBuf.length).set(hugeBuf);
+
     const inputs = {
       ArrayBuffer: ab,
       Uint8Array: new Uint8Array(ab),
       Buffer: hugeBuf,
       DataView: new DataView(ab),
+      "Uint8Array(offset)": new Uint8Array(framed, 7, hugeBuf.length),
+      "DataView(offset)": new DataView(framed, 7, hugeBuf.length),
     };
 
     const results = {};
@@ -132,15 +140,16 @@ describe("Bun.spawn stdin: ArrayBuffer bytes reach the child intact", () => {
   `;
 
   const hash = Bun.SHA1.hash(Buffer.alloc(50000 * 5, "hello"), "hex");
+  const labels = ["ArrayBuffer", "Uint8Array", "Buffer", "DataView", "Uint8Array(offset)", "DataView(offset)"];
   const expected = Object.fromEntries(
-    ["ArrayBuffer", "Uint8Array", "Buffer", "DataView"].flatMap(label => [
+    labels.flatMap(label => [
       [`spawn:${label}`, hash],
       [`spawnSync:${label}`, hash],
     ]),
   );
 
   for (const disableMemfd of memfdMatrix) {
-    test.concurrent(`BUN_FEATURE_FLAG_DISABLE_MEMFD=${disableMemfd}`, async () => {
+    test(`BUN_FEATURE_FLAG_DISABLE_MEMFD=${disableMemfd}`, async () => {
       await using proc = Bun.spawn({
         cmd: [bunExe(), "-e", fixture],
         env: { ...bunEnv, BUN_FEATURE_FLAG_DISABLE_MEMFD: disableMemfd },

--- a/test/js/bun/spawn/spawn-stdin-arraybuffer-gc.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-arraybuffer-gc.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Child reads all of stdin via Bun.stdin (avoids node:streams so this stays
+// hermetic to spawn's stdin handling) and prints the SHA-1 of what it received.
+const catScript =
+  "Bun.readableStreamToArrayBuffer(Bun.stdin.stream()).then(b => console.log(Bun.SHA1.hash(b, 'hex')))";
+
+// Bun.spawn copies ArrayBuffer/TypedArray stdin into its own storage before
+// writing it to the child. That copy should live in native memory owned by the
+// pipe writer, not a JSC-allocated Uint8Array held via a Strong handle: a
+// Strong outliving the JS stack is an unnecessary GC root and heap allocation.
+//
+// Run in a subprocess so the heap baseline is clean. Disable the Linux memfd
+// fast path so the pipe writer actually holds the buffer across the async
+// write (otherwise the copy is flushed to a memfd synchronously and dropped).
+describe("Bun.spawn stdin: ArrayBuffer does not create a JSC Strong for the copied bytes", () => {
+  for (const disableMemfd of ["1", "0"]) {
+    test(`BUN_FEATURE_FLAG_DISABLE_MEMFD=${disableMemfd}`, async () => {
+      const fixture = /* js */ `
+        const { heapStats } = require("bun:jsc");
+
+        const protectedU8 = () => heapStats().protectedObjectTypeCounts.Uint8Array ?? 0;
+        const liveU8 = () => heapStats().objectTypeCounts.Uint8Array ?? 0;
+
+        Bun.gc(true);
+        const protectedBefore = protectedU8();
+
+        // A plain ArrayBuffer (not a Uint8Array) so any Uint8Array we observe
+        // afterwards is one Bun allocated internally, not ours.
+        const payload = new ArrayBuffer(64 * 1024);
+        new Uint8Array(payload).fill(65);
+        const expectedHash = Bun.SHA1.hash(payload, "hex");
+
+        const proc = Bun.spawn({
+          cmd: [process.execPath, "-e", ${JSON.stringify(catScript)}],
+          stdin: payload,
+          stdout: "pipe",
+          stderr: "inherit",
+          env: process.env,
+        });
+
+        Bun.gc(true);
+        const protectedDuring = protectedU8();
+        const liveDuring = liveU8();
+
+        const out = await proc.stdout.text();
+        await proc.exited;
+
+        if (out.trim() !== expectedHash) {
+          throw new Error("child did not receive stdin intact: " + JSON.stringify(out));
+        }
+
+        console.log(JSON.stringify({
+          protectedBefore,
+          protectedDuring,
+          liveDuring,
+        }));
+      `;
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: { ...bunEnv, BUN_FEATURE_FLAG_DISABLE_MEMFD: disableMemfd },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+
+      expect(stderr).toBe("");
+      const { protectedBefore, protectedDuring, liveDuring } = JSON.parse(stdout.trim());
+      // No Strong root is taken for the copied stdin bytes.
+      expect(protectedDuring).toBe(protectedBefore);
+      // No internal JSC Uint8Array is allocated for the copy (the user passed a
+      // plain ArrayBuffer, so any Uint8Array here is an internal allocation).
+      expect(liveDuring).toBe(0);
+      expect(exitCode).toBe(0);
+    });
+  }
+});
+
+// Functional coverage independent of node:streams: the bytes the child reads
+// from stdin match what the parent passed, for every ArrayBuffer-ish input
+// Stdio::extract accepts, under both spawn and spawnSync, with and without the
+// Linux memfd fast path.
+describe("Bun.spawn stdin: ArrayBuffer bytes reach the child intact", () => {
+  const N = 50000;
+  const hugeBuf = Buffer.alloc(N * 5, "hello");
+  const hugeAB = (() => {
+    const ab = new ArrayBuffer(hugeBuf.length);
+    new Uint8Array(ab).set(hugeBuf);
+    return ab;
+  })();
+  const expectedHash = Bun.SHA1.hash(hugeBuf, "hex");
+
+  const inputs = [
+    ["ArrayBuffer", () => hugeAB],
+    ["Uint8Array", () => new Uint8Array(hugeAB)],
+    ["Buffer", () => hugeBuf],
+    ["DataView", () => new DataView(hugeAB)],
+  ] as const;
+
+  describe.each(["1", "0"])("BUN_FEATURE_FLAG_DISABLE_MEMFD=%s", disableMemfd => {
+    const env = { ...bunEnv, BUN_FEATURE_FLAG_DISABLE_MEMFD: disableMemfd };
+
+    for (const [label, mk] of inputs) {
+      test.concurrent(`spawn with ${label}`, async () => {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "-e", catScript],
+          stdin: mk(),
+          stdout: "pipe",
+          stderr: "pipe",
+          env,
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([
+          proc.stdout.text(),
+          proc.stderr.text(),
+          proc.exited,
+        ]);
+        expect(stderr).toBe("");
+        expect(stdout.trim()).toBe(expectedHash);
+        expect(exitCode).toBe(0);
+      });
+
+      test.concurrent(`spawnSync with ${label}`, () => {
+        const { stdout, stderr, exitCode } = Bun.spawnSync({
+          cmd: [bunExe(), "-e", catScript],
+          stdin: mk(),
+          env,
+        });
+        expect(stderr.toString()).toBe("");
+        expect(stdout.toString().trim()).toBe(expectedHash);
+        expect(exitCode).toBe(0);
+      });
+    }
+  });
+});

--- a/test/js/bun/spawn/spawn-stdin-arraybuffer-gc.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-arraybuffer-gc.test.ts
@@ -80,52 +80,73 @@ describe("Bun.spawn stdin: ArrayBuffer does not create a JSC Strong for the copi
 // Functional coverage independent of node:streams: the bytes the child reads
 // from stdin match what the parent passed, for every ArrayBuffer-ish input
 // Stdio::extract accepts, under both spawn and spawnSync, with and without the
-// Linux memfd fast path.
+// Linux memfd fast path. The memfd decision is made by the process calling
+// Bun.spawn, so the flag must be set on an intermediate subprocess (not on the
+// leaf child) for it to take effect.
 describe("Bun.spawn stdin: ArrayBuffer bytes reach the child intact", () => {
-  const N = 50000;
-  const hugeBuf = Buffer.alloc(N * 5, "hello");
-  const hugeAB = (() => {
+  const fixture = /* js */ `
+    const catScript = ${JSON.stringify(catScript)};
+    const hugeBuf = Buffer.alloc(50000 * 5, "hello");
     const ab = new ArrayBuffer(hugeBuf.length);
     new Uint8Array(ab).set(hugeBuf);
-    return ab;
-  })();
-  const expectedHash = Bun.SHA1.hash(hugeBuf, "hex");
 
-  const inputs = [
-    ["ArrayBuffer", () => hugeAB],
-    ["Uint8Array", () => new Uint8Array(hugeAB)],
-    ["Buffer", () => hugeBuf],
-    ["DataView", () => new DataView(hugeAB)],
-  ] as const;
+    const inputs = {
+      ArrayBuffer: ab,
+      Uint8Array: new Uint8Array(ab),
+      Buffer: hugeBuf,
+      DataView: new DataView(ab),
+    };
 
-  describe.each(["1", "0"])("BUN_FEATURE_FLAG_DISABLE_MEMFD=%s", disableMemfd => {
-    const env = { ...bunEnv, BUN_FEATURE_FLAG_DISABLE_MEMFD: disableMemfd };
-
-    for (const [label, mk] of inputs) {
-      test.concurrent(`spawn with ${label}`, async () => {
-        await using proc = Bun.spawn({
-          cmd: [bunExe(), "-e", catScript],
-          stdin: mk(),
-          stdout: "pipe",
-          stderr: "pipe",
-          env,
-        });
-        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-        expect(stderr).toBe("");
-        expect(stdout.trim()).toBe(expectedHash);
-        expect(exitCode).toBe(0);
+    const results = {};
+    const procs = [];
+    for (const [label, stdin] of Object.entries(inputs)) {
+      const proc = Bun.spawn({
+        cmd: [process.execPath, "-e", catScript],
+        stdin,
+        stdout: "pipe",
+        stderr: "inherit",
+        env: process.env,
       });
-
-      test.concurrent(`spawnSync with ${label}`, () => {
-        const { stdout, stderr, exitCode } = Bun.spawnSync({
-          cmd: [bunExe(), "-e", catScript],
-          stdin: mk(),
-          env,
-        });
-        expect(stderr.toString()).toBe("");
-        expect(stdout.toString().trim()).toBe(expectedHash);
-        expect(exitCode).toBe(0);
-      });
+      procs.push(
+        Promise.all([proc.stdout.text(), proc.exited]).then(([out]) => {
+          results["spawn:" + label] = out.trim();
+        }),
+      );
     }
-  });
+    await Promise.all(procs);
+
+    for (const [label, stdin] of Object.entries(inputs)) {
+      const { stdout } = Bun.spawnSync({
+        cmd: [process.execPath, "-e", catScript],
+        stdin,
+        env: process.env,
+      });
+      results["spawnSync:" + label] = stdout.toString().trim();
+    }
+
+    console.log(JSON.stringify(results));
+  `;
+
+  const hash = Bun.SHA1.hash(Buffer.alloc(50000 * 5, "hello"), "hex");
+  const expected = Object.fromEntries(
+    ["ArrayBuffer", "Uint8Array", "Buffer", "DataView"].flatMap(label => [
+      [`spawn:${label}`, hash],
+      [`spawnSync:${label}`, hash],
+    ]),
+  );
+
+  for (const disableMemfd of ["1", "0"]) {
+    test.concurrent(`BUN_FEATURE_FLAG_DISABLE_MEMFD=${disableMemfd}`, async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: { ...bunEnv, BUN_FEATURE_FLAG_DISABLE_MEMFD: disableMemfd },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout.trim())).toEqual(expected);
+      expect(exitCode).toBe(0);
+    });
+  }
 });

--- a/test/js/bun/spawn/spawn-stdin-arraybuffer-gc.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-arraybuffer-gc.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isLinux } from "harness";
 
 // Child reads all of stdin via Bun.stdin (avoids node:streams so this stays
 // hermetic to spawn's stdin handling) and prints the SHA-1 of what it received.
 const catScript = "Bun.readableStreamToArrayBuffer(Bun.stdin.stream()).then(b => console.log(Bun.SHA1.hash(b, 'hex')))";
+
+// BUN_FEATURE_FLAG_DISABLE_MEMFD is Linux-only (can_use_memfd() is a constant
+// false elsewhere), so on macOS/Windows both values exercise the same path.
+const memfdMatrix = isLinux ? ["1", "0"] : ["1"];
 
 // Bun.spawn copies ArrayBuffer/TypedArray stdin into its own storage before
 // writing it to the child. That copy should live in native memory owned by the
@@ -14,7 +18,7 @@ const catScript = "Bun.readableStreamToArrayBuffer(Bun.stdin.stream()).then(b =>
 // fast path so the pipe writer actually holds the buffer across the async
 // write (otherwise the copy is flushed to a memfd synchronously and dropped).
 describe("Bun.spawn stdin: ArrayBuffer does not create a JSC Strong for the copied bytes", () => {
-  for (const disableMemfd of ["1", "0"]) {
+  for (const disableMemfd of memfdMatrix) {
     test(`BUN_FEATURE_FLAG_DISABLE_MEMFD=${disableMemfd}`, async () => {
       const fixture = /* js */ `
         const { heapStats } = require("bun:jsc");
@@ -135,7 +139,7 @@ describe("Bun.spawn stdin: ArrayBuffer bytes reach the child intact", () => {
     ]),
   );
 
-  for (const disableMemfd of ["1", "0"]) {
+  for (const disableMemfd of memfdMatrix) {
     test.concurrent(`BUN_FEATURE_FLAG_DISABLE_MEMFD=${disableMemfd}`, async () => {
       await using proc = Bun.spawn({
         cmd: [bunExe(), "-e", fixture],

--- a/test/js/bun/spawn/spawn-stdin-arraybuffer-gc.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-arraybuffer-gc.test.ts
@@ -3,8 +3,7 @@ import { bunEnv, bunExe } from "harness";
 
 // Child reads all of stdin via Bun.stdin (avoids node:streams so this stays
 // hermetic to spawn's stdin handling) and prints the SHA-1 of what it received.
-const catScript =
-  "Bun.readableStreamToArrayBuffer(Bun.stdin.stream()).then(b => console.log(Bun.SHA1.hash(b, 'hex')))";
+const catScript = "Bun.readableStreamToArrayBuffer(Bun.stdin.stream()).then(b => console.log(Bun.SHA1.hash(b, 'hex')))";
 
 // Bun.spawn copies ArrayBuffer/TypedArray stdin into its own storage before
 // writing it to the child. That copy should live in native memory owned by the
@@ -64,11 +63,7 @@ describe("Bun.spawn stdin: ArrayBuffer does not create a JSC Strong for the copi
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
       expect(stderr).toBe("");
       const { protectedBefore, protectedDuring, liveDuring } = JSON.parse(stdout.trim());
@@ -115,11 +110,7 @@ describe("Bun.spawn stdin: ArrayBuffer bytes reach the child intact", () => {
           stderr: "pipe",
           env,
         });
-        const [stdout, stderr, exitCode] = await Promise.all([
-          proc.stdout.text(),
-          proc.stderr.text(),
-          proc.exited,
-        ]);
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
         expect(stderr).toBe("");
         expect(stdout.trim()).toBe(expectedHash);
         expect(exitCode).toBe(0);

--- a/test/js/bun/spawn/spawn-stdin-arraybuffer-gc.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-arraybuffer-gc.test.ts
@@ -51,8 +51,7 @@ describe("Bun.spawn stdin: ArrayBuffer does not create a JSC Strong for the copi
         }
 
         console.log(JSON.stringify({
-          protectedBefore,
-          protectedDuring,
+          protectedDelta: protectedDuring - protectedBefore,
           liveDuring,
         }));
       `;
@@ -64,15 +63,16 @@ describe("Bun.spawn stdin: ArrayBuffer does not create a JSC Strong for the copi
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      if (exitCode !== 0) throw new Error(`fixture failed (exit ${exitCode}):\n${stderr}\n${stdout}`);
 
-      expect(stderr).toBe("");
-      const { protectedBefore, protectedDuring, liveDuring } = JSON.parse(stdout.trim());
-      // No Strong root is taken for the copied stdin bytes.
-      expect(protectedDuring).toBe(protectedBefore);
-      // No internal JSC Uint8Array is allocated for the copy (the user passed a
-      // plain ArrayBuffer, so any Uint8Array here is an internal allocation).
-      expect(liveDuring).toBe(0);
-      expect(exitCode).toBe(0);
+      // No Strong root is taken for the copied stdin bytes (protectedDelta 0),
+      // and no internal JSC Uint8Array is allocated for the copy (the user
+      // passed a plain ArrayBuffer, so liveDuring counts only Bun-internal
+      // Uint8Arrays).
+      expect(JSON.parse(stdout.trim())).toEqual({
+        protectedDelta: 0,
+        liveDuring: 0,
+      });
     });
   }
 });
@@ -144,9 +144,9 @@ describe("Bun.spawn stdin: ArrayBuffer bytes reach the child intact", () => {
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
+      if (exitCode !== 0) throw new Error(`fixture failed (exit ${exitCode}):\n${stderr}\n${stdout}`);
+
       expect(JSON.parse(stdout.trim())).toEqual(expected);
-      expect(exitCode).toBe(0);
     });
   }
 });

--- a/test/js/bun/spawn/spawn-stdin-arraybuffer-gc.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-arraybuffer-gc.test.ts
@@ -26,14 +26,18 @@ describe("Bun.spawn stdin: ArrayBuffer does not create a JSC Strong for the copi
         const protectedU8 = () => heapStats().protectedObjectTypeCounts.Uint8Array ?? 0;
         const liveU8 = () => heapStats().objectTypeCounts.Uint8Array ?? 0;
 
+        // A plain ArrayBuffer as stdin so a Bun-internal Uint8Array copy shows
+        // up as a positive liveDelta. Setup runs in a nested frame so its own
+        // Uint8Array temporary is out of scope before the baseline GC below.
+        const [payload, expectedHash] = (() => {
+          const p = new ArrayBuffer(64 * 1024);
+          new Uint8Array(p).fill(65);
+          return [p, Bun.SHA1.hash(p, "hex")];
+        })();
+
         Bun.gc(true);
         const protectedBefore = protectedU8();
-
-        // A plain ArrayBuffer (not a Uint8Array) so any Uint8Array we observe
-        // afterwards is one Bun allocated internally, not ours.
-        const payload = new ArrayBuffer(64 * 1024);
-        new Uint8Array(payload).fill(65);
-        const expectedHash = Bun.SHA1.hash(payload, "hex");
+        const liveBefore = liveU8();
 
         const proc = Bun.spawn({
           cmd: [process.execPath, "-e", ${JSON.stringify(catScript)}],
@@ -56,7 +60,7 @@ describe("Bun.spawn stdin: ArrayBuffer does not create a JSC Strong for the copi
 
         console.log(JSON.stringify({
           protectedDelta: protectedDuring - protectedBefore,
-          liveDuring,
+          liveDelta: liveDuring - liveBefore,
         }));
       `;
 
@@ -70,12 +74,10 @@ describe("Bun.spawn stdin: ArrayBuffer does not create a JSC Strong for the copi
       if (exitCode !== 0) throw new Error(`fixture failed (exit ${exitCode}):\n${stderr}\n${stdout}`);
 
       // No Strong root is taken for the copied stdin bytes (protectedDelta 0),
-      // and no internal JSC Uint8Array is allocated for the copy (the user
-      // passed a plain ArrayBuffer, so liveDuring counts only Bun-internal
-      // Uint8Arrays).
+      // and no internal JSC Uint8Array is allocated for the copy (liveDelta 0).
       expect(JSON.parse(stdout.trim())).toEqual({
         protectedDelta: 0,
-        liveDuring: 0,
+        liveDelta: 0,
       });
     });
   }


### PR DESCRIPTION
## What

`Bun.spawn({ stdin: arrayBuffer })` copies the user's bytes before handing them to the pipe writer. Previously that copy went into a freshly-allocated JSC `Uint8Array` wrapped in an `ArrayBufferStrong`, which holds a `JSC::Strong` handle for the entire async stdin write (`StaticPipeWriter` stores it as `Source::Any(Box<dyn SourceData>)`). A `Strong` that outlives the JS stack is an unnecessary opaque GC root and an extra HandleBlock allocation per spawn.

Since the bytes are already being copied, copy them into a native `Vec<u8>` instead (new `Stdio::OwnedBuffer` variant) and feed them to `StaticPipeWriter` as the existing `Source::OwnedBytes`. No JS allocation, no Strong handle, and `Source::OwnedBytes` reports its length as `memory_cost` where `ArrayBufferSource` previously returned 0.

The shell's `cmd < ${buf}` stdin redirect already copied to native memory (via an `InternalBlob`); this PR switches it to `Stdio::OwnedBuffer` as well so there is a single canonical "owned native stdin bytes" representation. `Stdio::ArrayBuffer(ArrayBufferStrong)` is retained for the shell's output-redirect case (`cmd > ${buf}`), which writes *into* a user-supplied buffer and does need a GC root for the user's object.

## Why a new variant instead of reusing `Stdio::Blob(Any::InternalBlob)`

`Stdio::Blob` in `as_spawn_option` rejects indices 1 and 2 with "Blobs are immutable, and cannot be used for stdout/stderr". `Bun.spawn({ stdout: uint8array })` currently turns into a memfd on Linux (and panics elsewhere); routing through `Stdio::Blob` would change that to a thrown error whose message mentions "Blob" for a `Uint8Array` input. `Stdio::OwnedBuffer` mirrors the existing `Stdio::ArrayBuffer` arms exactly so user-visible behavior at every index is preserved, and the pipe writer receives `Source::OwnedBytes(Box<[u8]>)` directly instead of a `Box<dyn SourceData>` wrapping an `AnyBlob`.

## Why this instead of a WriteBarrier slot

A WriteBarrier slot on the Subprocess wrapper would be the right fix if the bytes were the user's original buffer. They are not: `Stdio::extract` already copies. Copying to native memory is strictly simpler than copying to JSC memory plus a wrapper slot plus clearing the slot on completion.

## Verification

`heapStats()` observes the difference directly. With `BUN_FEATURE_FLAG_DISABLE_MEMFD=1` (so the pipe writer actually holds the buffer across the async write rather than flushing to a memfd synchronously on Linux):

Before:
```
protectedObjectTypeCounts: {"Subprocess":1,"Uint8Array":1,...}
objectTypeCounts.Uint8Array: 2   (user's + internal copy)
```

After:
```
protectedObjectTypeCounts: {"Subprocess":1,...}        (no Uint8Array)
objectTypeCounts.Uint8Array: 0                         (no internal copy)
```

New test `test/js/bun/spawn/spawn-stdin-arraybuffer-gc.test.ts` asserts the heap counts and independently verifies (via SHA-1 of the child's received stdin) that the bytes are delivered intact for `ArrayBuffer`/`Uint8Array`/`Buffer`/`DataView` inputs under both `spawn` and `spawnSync`, with and without the memfd fast path.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/spawn-stdin-arraybuffer-gc.test.ts

<!-- robobun:evidence:end -->