### PR TITLE
test(node:http): don't let the client's EPIPE reject the close wait in socket-end-drain

### DIFF
--- a/test/js/node/http/node-http-server-socket-end-drain.test.ts
+++ b/test/js/node/http/node-http-server-socket-end-drain.test.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-// res.socket.end() half-closes the connection; the server must still drain the
-// unconsumed request body so the peer's FIN arrives and server.close() resolves.
-// A net client is used so the peer's FIN is deterministic (c.end() on 'end');
-// Bun's fetch client may pool the connection after the upload fails, which
-// leaves the server waiting on the peer and is a separate concern.
+// res.socket.end() half-closes the connection; the server must still release the
+// socket (drain the unconsumed body on epoll, or take kqueue's EVFILT_WRITE
+// EV_EOF from its own SHUT_WR) so server.close() resolves. On macOS that early
+// close can RST the still-writing client, so the client's EPIPE is expected and
+// the close wait must not be once(c, "close"), which would reject on it.
 test("server.close() completes after res.socket.end() with a 2 MB upload in flight", async () => {
   await using proc = Bun.spawn({
     cmd: [
@@ -29,11 +29,11 @@ test("server.close() completes after res.socket.end() with a 2 MB upload in flig
         const c = net.connect(port, "127.0.0.1");
         await once(c, "connect");
         const body = Buffer.alloc(2 * 1024 * 1024, 0x61);
+        c.on("error", () => {});
         c.write("POST / HTTP/1.1\\r\\nHost: x\\r\\nContent-Length: " + body.length + "\\r\\nConnection: close\\r\\n\\r\\n");
         c.write(body);
-        c.on("error", () => {});
         c.on("end", () => c.end());
-        const socketClosed = once(c, "close");
+        const socketClosed = new Promise(r => c.once("close", r));
         await handled.promise;
         const serverClosed = new Promise(r => server.close(() => r()));
         const watchdog = setTimeout(() => {


### PR DESCRIPTION
Fixes `test/js/node/http/node-http-server-socket-end-drain.test.ts` going red on macOS (both arm64 and x64) since #34356 landed.

### Failure

```
expect(received).toEqual(expected)
  {
-   exitCode: 0,
-   stderr: "",
-   stdout: "closed destroyed=true\n",
+   exitCode: 1,
+   stderr: "EPIPE: broken pipe, write\n syscall: \"write\", errno: -32, ...",
+   stdout: "",
  }
```

Reproduced on a macOS arm64 box at 39/50 runs with the exact child script.

### Cause

On kqueue, the server socket is paused (poll = `WRITABLE` only) when the request handler runs. `res.socket.end()` then does:

1. `us_internal_socket_raw_shutdown`: `us_poll_change(W & R = 0)`. `kqueue_change` going `W -> 0` does **not** `EV_DELETE` the one-shot `EVFILT_WRITE` (the `!readable && !writable` branch only adds, never deletes). Stored events become `0`; kqueue still has `EVFILT_WRITE`.
2. `bsd_shutdown_socket` (`SHUT_WR`): macOS now reports `EV_EOF` on that `EVFILT_WRITE`.
3. `us_socket_resume`: `us_poll_change(0 -> R)` adds `EVFILT_READ`.

The next `kevent64()` returns `EVFILT_WRITE|EV_EOF` and `EVFILT_READ` for the same poll. The coalescing pass (`epoll_kqueue.c:241,252`) ORs `eof=1` from the write filter into the dispatched event. `events &= us_poll_events(poll)` masks `WRITABLE` out, but `eof` passes through, so `loop.c:829` sees `eof && us_socket_is_shut_down` and closes the socket as "got FIN back after sending it".

The server fd is closed with unread body bytes in the receive buffer, so macOS RSTs the client, and the client's next write fails with `EPIPE`/`ECONNRESET`. That error is swallowed by `c.on("error", () => {})`, but `once(c, "close")` also listens for `'error'` and **rejects** with it; the rejection reaches the top-level `await Promise.all` and becomes the unhandled error on stderr.

The #34356 code comment already names the kqueue path ("kqueue's one-shot EVFILT_WRITE (which delivers EV_EOF on SHUT_WR) is not deleted"), so the server closing early on macOS is the intended release mechanism there; only the test's wait was wrong.

### Fix

Wait for the client's `'close'` with a plain listener instead of `once()`, so the expected EPIPE cannot reject `Promise.all`. The assertion (`server.close()` fires, server socket destroyed, client closes) is unchanged and still exercises the #34356 code path: without the `us_socket_resume` the child times out on Linux and (most runs) on macOS.

Also moved the client's error handler ahead of the writes for clarity.

### Verification

- darwin-aarch64, main build 75566 binary: **100/100** `closed destroyed=true`
- darwin-aarch64, 1.3.14 (no #34356): 4/5 `timeout` (fail-before holds)
- linux x64 `bun bd test`: pass
- linux x64 `USE_SYSTEM_BUN=1 bun test`: fail (timeout)

Culprit PR: #34356.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/http/node-http-server-socket-end-drain.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/http/node-http-server-socket-end-drain.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (6d450e2a3)

test/js/node/http/node-http-server-socket-end-drain.test.ts:
(pass) server.close() completes after res.socket.end() with a 2 MB upload in flight [2948.87ms]

 1 pass
 0 fail
 1 expect() calls
Ran 1 test across 1 file. [5.17s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../js/node/http/node-http-server-socket-end-drain.test.ts | 14 +++++++-------
 1 file changed, 7 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…/js/node/http/node-http-server-socket-end-drain.test.ts      1      1      0
```

</details>

**self-review** · no surviving concerns

26 concerns were raised and did not survive verification.

<!-- robobun:evidence:end -->