### PR TITLE
ci: bump darwin test-bun parallelism 2 -> 5

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -864,7 +864,9 @@ function getTestBunStep(platform, options, testOptions = {}) {
     // darwin was held at 2 when builds also ran on the mac fleet (#21690).
     // Builds now cross-compile from Linux (#31303) so the fleet is test-only;
     // at 2 shards darwin x64 is the ~21 min critical path on every PR build.
-    parallelism: os === "darwin" ? 6 : os === "windows" ? 8 : 20,
+    // 5 matches the smallest test-darwin pool (aarch64 `previous`, 5 agents;
+    // aarch64 `latest` has 7, x64 has 8 per build-agent census 2026-07).
+    parallelism: os === "darwin" ? 5 : os === "windows" ? 8 : 20,
     timeout_in_minutes: profile === "asan" || os === "windows" || os === "darwin" ? 45 : 30,
     env: {
       ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=0",

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -861,7 +861,10 @@ function getTestBunStep(platform, options, testOptions = {}) {
     agents: getTestAgent(platform, options),
     retry: getRetry(),
     cancel_on_build_failing: isMergeQueue(),
-    parallelism: os === "darwin" ? 2 : os === "windows" ? 8 : 20,
+    // darwin was held at 2 when builds also ran on the mac fleet (#21690).
+    // Builds now cross-compile from Linux (#31303) so the fleet is test-only;
+    // at 2 shards darwin x64 is the ~21 min critical path on every PR build.
+    parallelism: os === "darwin" ? 6 : os === "windows" ? 8 : 20,
     timeout_in_minutes: profile === "asan" || os === "windows" || os === "darwin" ? 45 : 30,
     env: {
       ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=0",


### PR DESCRIPTION
## What

Raise the darwin `test-bun` step from 2 shards to 5.

## Why

darwin is the critical path on essentially every PR build. From build 75517 (a clean passing run):

| lane | shards | per-shard | done at |
| --- | --- | --- | --- |
| darwin 14 x64 | 2 | 21.5m / 21.0m | **+35.8m** |
| darwin 14 aarch64 | 2 | 19.3m / 13.5m | +32.9m |
| darwin 26 aarch64 | 2 | 18.1m / 13.7m | +31.7m |
| alpine 3.23 x64 | 20 | ~4-8m | +36.2m (one outlier shard; most by +33m) |
| debian 13 x64 | 20 | ~3m | +30.5m |
| windows 2019 x64 | 8 | ~6m | +22.8m |

The 2-shard cap dates from #21690, which reverted #21530 (parallelism 7). At that time darwin builds also ran on the mac fleet and there were 4 darwin test platforms, so 7 shards starved builds. Since #31303 darwin builds cross-compile from Linux and the mac agents are test-only across 3 lanes, so that contention is gone. #32032 and #32194 then bumped the darwin timeout to 45 min to survive the long 2-shard runs; this goes at the root instead.

**Why 5:** a census of the agents that ran darwin test jobs across builds 75308-75617 gives the current `test-darwin` fleet as:

| pool | agents | hosts |
| --- | --- | --- |
| aarch64 `latest` | 7 | baguette/challah/ciabatta/focaccia/sourdough tart-26 + breadstick + crouton |
| aarch64 `previous` | 5 | baguette/challah/ciabatta/focaccia/sourdough tart-15 |
| x64 (untargeted) | 8 | bagel/cornbread/flatbread/matzo/pretzel + naan/pita/rye |

5 is the largest value that fits every pool without serialising a shard. At 6 the aarch64-previous lane would run 5 then 1, making it slower than 5 shards running once. (The "smaller pool" comments at L184-187/L467-469 predate the x64 fleet growing from 5 to 8; x64 is not the bottleneck now.)

At 5 shards the per-shard time drops to ~8-9 min and darwin finishes around +22m (build artifacts are ready at ~+13m). Agent-minutes stay roughly constant (5x8.4 ~= 2x21) so fleet load is unchanged; jobs just clear the fixed pool 2.5x faster.

Sharding uses the LPT packer in `scripts/runner.node.mjs`; darwin maps to the `default` lane in `test/expected-durations.json` (linux x64 timings), which is a close enough proxy for balanced bins.

Timeout left at 45 min for now; can be dropped once 5-shard runs are proven stable.

## Verification

Generated the pipeline locally with `node .buildkite/ci.mjs` and confirmed all three darwin `test-bun` steps emit `parallelism: 5`:

```
key: darwin-aarch64-26-test-bun   parallelism: 5   timeout_in_minutes: 45
key: darwin-aarch64-14-test-bun   parallelism: 5   timeout_in_minutes: 45
key: darwin-x64-14-test-bun       parallelism: 5   timeout_in_minutes: 45
```

windows (8) and linux (20) unchanged. The real proof is this PR's own CI run.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->