### PR TITLE
ci: add lint:tests to catch flake anti-patterns in new test code

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,3 +22,18 @@ jobs:
           bun install --frozen-lockfile
       - name: Lint
         run: bun lint
+
+  lint-tests:
+    name: "Lint Tests"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Need the merge-base to scope findings to lines added in this PR.
+          fetch-depth: 0
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - name: Lint test files
+        run: bun scripts/lint-tests.ts --quiet --changed "origin/${{ github.base_ref || 'main' }}"

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "fmt:rust": "cargo fmt --all",
     "lint": "oxlint --config=oxlint.json --format=github src/js",
     "lint:fix": "oxlint --config oxlint.json --fix",
+    "lint:tests": "bun scripts/lint-tests.ts",
     "test": "node scripts/runner.node.mjs --exec-path ./build/debug/bun-debug",
     "testleak": "BUN_DESTRUCT_VM_ON_EXIT=1 ASAN_OPTIONS=detect_leaks=1 LSAN_OPTIONS=malloc_context_size=100:print_suppressions=1:suppressions=$npm_config_local_prefix/test/leaksan.supp ./build/debug/bun-debug",
     "test:release": "node scripts/runner.node.mjs --exec-path ./build/release/bun",

--- a/scripts/lint-tests.ts
+++ b/scripts/lint-tests.ts
@@ -263,6 +263,31 @@ function listTestFiles(): string[] {
   return out.sort();
 }
 
+/** Parse `git diff -U0` text into file -> Set of 1-based added line numbers. */
+export function parseUnifiedDiff(text: string): Map<string, Set<number>> {
+  const map = new Map<string, Set<number>>();
+  let current: Set<number> | undefined;
+  for (const line of text.split("\n")) {
+    if (line.startsWith("+++ ")) {
+      let path = line.slice(4);
+      if (path.startsWith("b/")) path = path.slice(2);
+      if (path === "/dev/null") {
+        current = undefined;
+        continue;
+      }
+      current = new Set();
+      map.set(path, current);
+    } else if (current && line.startsWith("@@")) {
+      const m = /\+(\d+)(?:,(\d+))?/.exec(line); // @@ -a[,b] +c[,d] @@
+      if (!m) continue;
+      const start = parseInt(m[1], 10);
+      const count = m[2] ? parseInt(m[2], 10) : 1;
+      for (let i = 0; i < count; i++) current.add(start + i);
+    }
+  }
+  return map;
+}
+
 /** file -> Set of 1-based line numbers added relative to `base`. */
 function addedLines(base: string): Map<string, Set<number>> {
   // Diff from merge-base(base, HEAD) to the *working tree*, so uncommitted
@@ -294,27 +319,7 @@ function addedLines(base: string): Map<string, Set<number>> {
     console.error(`error: git diff against '${base}' failed:\n${diff.stderr || diff.error}`);
     process.exit(1);
   }
-  const map = new Map<string, Set<number>>();
-  let current: Set<number> | undefined;
-  for (const line of diff.stdout.split("\n")) {
-    if (line.startsWith("+++ ")) {
-      let path = line.slice(4);
-      if (path.startsWith("b/")) path = path.slice(2);
-      if (path === "/dev/null") {
-        current = undefined;
-        continue;
-      }
-      current = new Set();
-      map.set(path, current);
-    } else if (current && line.startsWith("@@")) {
-      const m = /\+(\d+)(?:,(\d+))?/.exec(line); // @@ -a[,b] +c[,d] @@
-      if (!m) continue;
-      const start = parseInt(m[1], 10);
-      const count = m[2] ? parseInt(m[2], 10) : 1;
-      for (let i = 0; i < count; i++) current.add(start + i);
-    }
-  }
-  return map;
+  return parseUnifiedDiff(diff.stdout);
 }
 
 // ── scan ────────────────────────────────────────────────────────────────────
@@ -329,73 +334,77 @@ interface Finding {
   error: boolean;
 }
 
-const changed = changedBase ? addedLines(changedBase) : undefined;
-const started = performance.now();
-const findings: Finding[] = [];
-let scanned = 0;
+function main() {
+  const changed = changedBase ? addedLines(changedBase) : undefined;
+  const started = performance.now();
+  const findings: Finding[] = [];
+  let scanned = 0;
 
-for (const file of listTestFiles()) {
-  let text: string;
-  try {
-    text = readFileSync(resolve(ROOT, file), "utf8");
-  } catch {
-    continue;
-  }
-  scanned++;
-  const lines = text.split("\n");
-  const fileAdded = changed?.get(file);
-  const state: LineState = { inTemplate: false, inBlockComment: false };
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    const code = classify(line, state);
-    if (!TRIGGER.test(line) || ALLOW_COMMENT.test(line)) continue;
-    for (const rule of rules) {
-      const col = rule.match(line, code);
-      if (col < 0) continue;
-      if (i > 0 && ALLOW_COMMENT_LINE.test(lines[i - 1])) continue;
-      const error = allErrors || (changed ? !!fileAdded?.has(i + 1) : false);
-      findings.push({
-        file,
-        line: i + 1,
-        col: col + 1,
-        rule: rule.name,
-        why: rule.why,
-        text: line.trim().slice(0, 200),
-        error,
-      });
+  for (const file of listTestFiles()) {
+    let text: string;
+    try {
+      text = readFileSync(resolve(ROOT, file), "utf8");
+    } catch {
+      continue;
+    }
+    scanned++;
+    const lines = text.split("\n");
+    const fileAdded = changed?.get(file);
+    const state: LineState = { inTemplate: false, inBlockComment: false };
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const code = classify(line, state);
+      if (!TRIGGER.test(line) || ALLOW_COMMENT.test(line)) continue;
+      for (const rule of rules) {
+        const col = rule.match(line, code);
+        if (col < 0) continue;
+        if (i > 0 && ALLOW_COMMENT_LINE.test(lines[i - 1])) continue;
+        const error = allErrors || (changed ? !!fileAdded?.has(i + 1) : false);
+        findings.push({
+          file,
+          line: i + 1,
+          col: col + 1,
+          rule: rule.name,
+          why: rule.why,
+          text: line.trim().slice(0, 200),
+          error,
+        });
+      }
     }
   }
-}
 
-// ── report ──────────────────────────────────────────────────────────────────
+  // ── report ──────────────────────────────────────────────────────────────────
 
-const elapsed = ((performance.now() - started) / 1000).toFixed(2);
-const errors = findings.filter(f => f.error);
+  const elapsed = ((performance.now() - started) / 1000).toFixed(2);
+  const errors = findings.filter(f => f.error);
 
-if (asJson) {
-  console.log(JSON.stringify({ scanned, elapsed: +elapsed, findings }, null, 2));
-} else {
-  const visible = quiet ? errors : findings;
-  for (const f of visible) {
-    const level = f.error ? "error" : "warning";
-    if (isGithubActions) {
-      console.log(`::${level} file=${f.file},line=${f.line},col=${f.col},title=lint-tests/${f.rule}::${f.why}`);
+  if (asJson) {
+    console.log(JSON.stringify({ scanned, elapsed: +elapsed, findings }, null, 2));
+  } else {
+    const visible = quiet ? errors : findings;
+    for (const f of visible) {
+      const level = f.error ? "error" : "warning";
+      if (isGithubActions) {
+        console.log(`::${level} file=${f.file},line=${f.line},col=${f.col},title=lint-tests/${f.rule}::${f.why}`);
+      }
+      const tag = f.error ? "\x1b[31merror\x1b[0m" : "\x1b[33mwarning\x1b[0m";
+      console.log(`${f.file}:${f.line}:${f.col}: ${tag} [${f.rule}] ${f.why}`);
+      console.log(`  ${f.text}`);
     }
-    const tag = f.error ? "\x1b[31merror\x1b[0m" : "\x1b[33mwarning\x1b[0m";
-    console.log(`${f.file}:${f.line}:${f.col}: ${tag} [${f.rule}] ${f.why}`);
-    console.log(`  ${f.text}`);
+    const byRule = new Map<string, number>();
+    for (const f of findings) byRule.set(f.rule, (byRule.get(f.rule) ?? 0) + 1);
+    const summary = [...byRule.entries()].map(([r, n]) => `${r}: ${n}`).join(", ");
+    console.error(
+      `\nlint-tests: scanned ${scanned} files in ${elapsed}s; ` +
+        `${findings.length} finding(s), ${errors.length} error(s)` +
+        (summary ? `  (${summary})` : ""),
+    );
+    if (errors.length) {
+      console.error(`  suppress a finding with \`// lint-tests-allow: <reason>\` on the line above.`);
+    }
   }
-  const byRule = new Map<string, number>();
-  for (const f of findings) byRule.set(f.rule, (byRule.get(f.rule) ?? 0) + 1);
-  const summary = [...byRule.entries()].map(([r, n]) => `${r}: ${n}`).join(", ");
-  console.error(
-    `\nlint-tests: scanned ${scanned} files in ${elapsed}s; ` +
-      `${findings.length} finding(s), ${errors.length} error(s)` +
-      (summary ? `  (${summary})` : ""),
-  );
-  if (errors.length) {
-    console.error(`  suppress a finding with \`// lint-tests-allow: <reason>\` on the line above.`);
-  }
+
+  process.exit(errors.length ? 1 : 0);
 }
 
-process.exit(errors.length ? 1 : 0);
+if (import.meta.main) main();

--- a/scripts/lint-tests.ts
+++ b/scripts/lint-tests.ts
@@ -27,6 +27,9 @@ import { relative, resolve } from "node:path";
 
 const ROOT = resolve(import.meta.dir, "..");
 const ALLOW_COMMENT = /\/\/\s*lint-tests-allow\b/;
+// A standalone allow-comment suppresses the *next* line; a trailing one only
+// suppresses its own line (so one comment can't silently excuse two lines).
+const ALLOW_COMMENT_LINE = /^\s*\/\/\s*lint-tests-allow\b/;
 // Cheap pre-filter: skip rule matching on lines that can't possibly hit any rule.
 const TRIGGER = /port:|sleep|setTimeout|setDefaultTimeout|fetch\(|fetch \(|tmpdirSync/;
 const isGithubActions = !!process.env.GITHUB_ACTIONS;
@@ -266,16 +269,32 @@ function addedLines(base: string): Map<string, Set<number>> {
   // edits are covered locally and CI (clean tree) sees the branch's commits.
   const mb = spawnSync("git", ["merge-base", base, "HEAD"], { cwd: ROOT, encoding: "utf8" });
   const from = mb.status === 0 ? mb.stdout.trim() : base;
-  const diff = spawnSync("git", ["diff", "--unified=0", "--diff-filter=AM", from, "--", "test/"], {
-    cwd: ROOT,
-    encoding: "utf8",
-    maxBuffer: 64 * 1024 * 1024,
-  });
-  const map = new Map<string, Set<number>>();
+  // Pin the diff format so user-level git config (color.diff, diff.external,
+  // diff.mnemonicPrefix, diff.renames) can't break the parser below.
+  const diff = spawnSync(
+    "git",
+    [
+      "diff",
+      "--no-color",
+      "--no-ext-diff",
+      "--no-renames",
+      "--src-prefix=a/",
+      "--dst-prefix=b/",
+      "--unified=0",
+      "--diff-filter=AM",
+      from,
+      "--",
+      "test/",
+    ],
+    { cwd: ROOT, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+  );
   if (diff.status !== 0) {
-    console.error(`warning: git diff against '${base}' failed; treating all findings as warnings`);
-    return map;
+    // --changed was explicitly requested; failing to compute the diff must not
+    // silently pass the gate.
+    console.error(`error: git diff against '${base}' failed:\n${diff.stderr || diff.error}`);
+    process.exit(1);
   }
+  const map = new Map<string, Set<number>>();
   let current: Set<number> | undefined;
   for (const line of diff.stdout.split("\n")) {
     if (line.startsWith("+++ ")) {
@@ -333,7 +352,7 @@ for (const file of listTestFiles()) {
     for (const rule of rules) {
       const col = rule.match(line, code);
       if (col < 0) continue;
-      if (i > 0 && ALLOW_COMMENT.test(lines[i - 1])) continue;
+      if (i > 0 && ALLOW_COMMENT_LINE.test(lines[i - 1])) continue;
       const error = allErrors || (changed ? !!fileAdded?.has(i + 1) : false);
       findings.push({
         file,

--- a/scripts/lint-tests.ts
+++ b/scripts/lint-tests.ts
@@ -1,0 +1,382 @@
+#!/usr/bin/env bun
+/**
+ * Lint test files for known flake anti-patterns.
+ *
+ * Scans every `test/**\/*.test.*` and flags patterns that have repeatedly
+ * caused flakes in CI. All findings are reported; with `--changed <base>`
+ * only findings on lines *added* relative to `<base>` are treated as errors
+ * (exit 1), the rest stay warnings. That way existing violations don't block
+ * a PR that happens to touch the same file, and day-one adoption needs no
+ * sweeping cleanup.
+ *
+ * Suppress a single finding with a `// lint-tests-allow: <reason>` comment on
+ * the same line or the line above.
+ *
+ *   bun scripts/lint-tests.ts                  # warnings only, exit 0
+ *   bun scripts/lint-tests.ts --changed main   # error on lines added vs main
+ *   bun scripts/lint-tests.ts --all-errors     # every finding is an error
+ *   bun scripts/lint-tests.ts --json           # machine-readable
+ *   bun scripts/lint-tests.ts path/to/a.test.ts ...   # only these files
+ *
+ * Runs under the system bun, no build needed.
+ */
+
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { relative, resolve } from "node:path";
+
+const ROOT = resolve(import.meta.dir, "..");
+const ALLOW_COMMENT = /\/\/\s*lint-tests-allow\b/;
+// Cheap pre-filter: skip rule matching on lines that can't possibly hit any rule.
+const TRIGGER = /port:|sleep|setTimeout|setDefaultTimeout|fetch\(|fetch \(|tmpdirSync/;
+const isGithubActions = !!process.env.GITHUB_ACTIONS;
+
+const args = process.argv.slice(2);
+const asJson = args.includes("--json");
+const allErrors = args.includes("--all-errors");
+const quiet = args.includes("--quiet"); // errors only, hide warnings
+const changedIdx = args.indexOf("--changed");
+const changedBase = changedIdx >= 0 ? args[changedIdx + 1] || "origin/main" : undefined;
+const explicitFiles = args.filter((a, i) => !a.startsWith("--") && !(changedIdx >= 0 && i === changedIdx + 1));
+
+// ── lexical classification ──────────────────────────────────────────────────
+// Regex on source text hits noise inside strings and comments. Rather than a
+// full parse, track just enough state per line to know which byte ranges are
+// "code" vs string/comment. This is not a tokenizer; it's the minimum to stop
+// multiline template literals and /* */ blocks from triggering every rule.
+
+interface LineState {
+  inTemplate: boolean;
+  inBlockComment: boolean;
+}
+
+const CODE = 0,
+  TMPL = 1,
+  BLOCK = 2,
+  SQ = 3,
+  DQ = 4;
+let maskBuf = new Uint8Array(1024);
+
+/** Byte-mask over `line`: 1 where the char is live code (not string/comment). */
+function classify(line: string, state: LineState): Uint8Array {
+  const n = line.length;
+  if (maskBuf.length < n) maskBuf = new Uint8Array(n * 2);
+  const code = maskBuf;
+  let i = 0;
+  let mode = state.inTemplate ? TMPL : state.inBlockComment ? BLOCK : CODE;
+  while (i < n) {
+    const c = line.charCodeAt(i);
+    if (mode === CODE) {
+      if (c === 47 /* / */) {
+        const next = line.charCodeAt(i + 1);
+        if (next === 47 /* / */) {
+          while (i < n) code[i++] = 0;
+          break;
+        }
+        if (next === 42 /* * */) {
+          mode = BLOCK;
+          code[i] = 0;
+          code[i + 1] = 0;
+          i += 2;
+          continue;
+        }
+      }
+      if (c === 34 /* " */) {
+        mode = DQ;
+        code[i++] = 1;
+        continue;
+      }
+      if (c === 39 /* ' */) {
+        mode = SQ;
+        code[i++] = 1;
+        continue;
+      }
+      if (c === 96 /* ` */) {
+        mode = TMPL;
+        code[i++] = 1;
+        continue;
+      }
+      code[i++] = 1;
+      continue;
+    }
+    if (mode === BLOCK) {
+      if (c === 42 /* * */ && line.charCodeAt(i + 1) === 47 /* / */) {
+        mode = CODE;
+        code[i] = 0;
+        code[i + 1] = 0;
+        i += 2;
+        continue;
+      }
+      code[i++] = 0;
+      continue;
+    }
+    if (mode === DQ || mode === SQ) {
+      if (c === 92 /* \\ */) {
+        code[i] = 0;
+        code[i + 1] = 0;
+        i += 2;
+        continue;
+      }
+      if ((mode === DQ && c === 34) || (mode === SQ && c === 39)) {
+        mode = CODE;
+        code[i++] = 1;
+        continue;
+      }
+      code[i++] = 0;
+      continue;
+    }
+    // TMPL. Interpolation bodies stay "in template"; good enough for FP suppression.
+    if (c === 92 /* \\ */) {
+      code[i] = 0;
+      code[i + 1] = 0;
+      i += 2;
+      continue;
+    }
+    if (c === 96 /* ` */) {
+      mode = CODE;
+      code[i++] = 1;
+      continue;
+    }
+    code[i++] = 0;
+  }
+  state.inTemplate = mode === TMPL;
+  state.inBlockComment = mode === BLOCK;
+  return code;
+}
+
+// ── rules ───────────────────────────────────────────────────────────────────
+
+interface Rule {
+  name: string;
+  why: string;
+  // Return the 0-based column of the finding, or -1 for none.
+  // `code[i]` is 1 iff byte i of `line` is live code.
+  match: (line: string, code: Uint8Array) => number;
+}
+
+function firstCodeMatch(line: string, code: Uint8Array, re: RegExp): RegExpExecArray | null {
+  re.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(line))) {
+    if (code[m.index]) return m;
+    if (!re.global) break;
+  }
+  return null;
+}
+
+const rules: Rule[] = [
+  {
+    name: "hardcoded-port",
+    why: "use `port: 0` and read back the bound port; hardcoded ports race in parallel CI",
+    match(line, code) {
+      // port: <1024-65535> as a literal. More digits would be >65535 and already invalid.
+      const m = firstCodeMatch(line, code, /\bport:\s*([1-9]\d{3,4})(?![\d_])/g);
+      if (!m) return -1;
+      // Skip obvious assertion/data-table lines; they don't bind a socket.
+      if (/\b(?:expect|assert|toEqual|toBe|toMatchObject|deepStrictEqual)\b/.test(line)) return -1;
+      return m.index;
+    },
+  },
+  {
+    name: "long-sleep",
+    why: "sleep >=1s is almost always 'wait and hope'; await the condition instead",
+    match(line, code) {
+      const m = firstCodeMatch(
+        line,
+        code,
+        /\b(?:Bun\.sleep(?:Sync)?|await\s+sleep)\s*\(\s*[1-9][\d_]{3,}\b|\bsetTimeout\s*\(\s*resolve\s*,\s*[1-9][\d_]{3,}\b/g,
+      );
+      if (!m) return -1;
+      // `Promise.race([x, Bun.sleep(N)])` is a timeout guard, not wait-and-hope.
+      if (/\bPromise\.race\b/.test(line)) return -1;
+      return m.index;
+    },
+  },
+  {
+    name: "long-default-timeout",
+    why: "a 2min+ default timeout multiplies into hours across retries when a test hangs",
+    match(line, code) {
+      const m = firstCodeMatch(line, code, /\bsetDefaultTimeout\s*\(\s*([^)]+)\)/g);
+      if (!m) return -1;
+      const expr = m[1].replace(/_/g, "");
+      if (!/^[\d\s*+]+$/.test(expr)) return -1; // non-literal (e.g. a variable), skip
+      let ms: number;
+      try {
+        ms = Function(`"use strict"; return (${expr})`)();
+      } catch {
+        return -1;
+      }
+      return ms >= 120_000 ? m.index : -1;
+    },
+  },
+  {
+    name: "external-fetch",
+    why: "live-internet fetch flakes; use a local server, unix socket, or proxy to localhost",
+    match(line, code) {
+      const re = /\bfetch\s*\(\s*["'`]https?:\/\/([A-Za-z0-9][^/"'`\s:?#]*)/g;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(line))) {
+        if (!code[m.index]) continue;
+        const host = m[1].toLowerCase();
+        if (host === "localhost" || host === "0.0.0.0" || host.startsWith("127.")) continue;
+        if (host.includes("${")) continue;
+        return m.index;
+      }
+      return -1;
+    },
+  },
+  {
+    name: "tmpdirSync",
+    why: "use `tempDir` from 'harness' (auto-cleanup via `using`); tmpdirSync leaks directories",
+    match(line, code) {
+      const m = firstCodeMatch(line, code, /\btmpdirSync\s*\(/g);
+      return m ? m.index : -1;
+    },
+  },
+];
+
+// ── collect test files ──────────────────────────────────────────────────────
+
+function listTestFiles(): string[] {
+  if (explicitFiles.length) {
+    return explicitFiles.map(f => relative(ROOT, resolve(f)).replaceAll("\\", "/"));
+  }
+  const glob = new Bun.Glob("test/**/*.{test,spec}.{ts,tsx,js,jsx,mjs,cjs,mts,cts}");
+  const out: string[] = [];
+  for (let f of glob.scanSync({ cwd: ROOT })) {
+    f = f.replaceAll("\\", "/");
+    if (
+      f.includes("/node_modules/") ||
+      f.includes("/fixtures/") ||
+      f.includes("/fixture/") ||
+      f.includes("/snapshots/") ||
+      f.includes("/__snapshots__/") ||
+      // Vendored/adapted upstream test suites; not held to our authored-test conventions.
+      f.startsWith("test/js/third_party/")
+    )
+      continue;
+    out.push(f);
+  }
+  return out.sort();
+}
+
+/** file -> Set of 1-based line numbers added relative to `base`. */
+function addedLines(base: string): Map<string, Set<number>> {
+  // Diff from merge-base(base, HEAD) to the *working tree*, so uncommitted
+  // edits are covered locally and CI (clean tree) sees the branch's commits.
+  const mb = spawnSync("git", ["merge-base", base, "HEAD"], { cwd: ROOT, encoding: "utf8" });
+  const from = mb.status === 0 ? mb.stdout.trim() : base;
+  const diff = spawnSync("git", ["diff", "--unified=0", "--diff-filter=AM", from, "--", "test/"], {
+    cwd: ROOT,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  const map = new Map<string, Set<number>>();
+  if (diff.status !== 0) {
+    console.error(`warning: git diff against '${base}' failed; treating all findings as warnings`);
+    return map;
+  }
+  let current: Set<number> | undefined;
+  for (const line of diff.stdout.split("\n")) {
+    if (line.startsWith("+++ ")) {
+      let path = line.slice(4);
+      if (path.startsWith("b/")) path = path.slice(2);
+      if (path === "/dev/null") {
+        current = undefined;
+        continue;
+      }
+      current = new Set();
+      map.set(path, current);
+    } else if (current && line.startsWith("@@")) {
+      const m = /\+(\d+)(?:,(\d+))?/.exec(line); // @@ -a[,b] +c[,d] @@
+      if (!m) continue;
+      const start = parseInt(m[1], 10);
+      const count = m[2] ? parseInt(m[2], 10) : 1;
+      for (let i = 0; i < count; i++) current.add(start + i);
+    }
+  }
+  return map;
+}
+
+// ── scan ────────────────────────────────────────────────────────────────────
+
+interface Finding {
+  file: string;
+  line: number;
+  col: number;
+  rule: string;
+  why: string;
+  text: string;
+  error: boolean;
+}
+
+const changed = changedBase ? addedLines(changedBase) : undefined;
+const started = performance.now();
+const findings: Finding[] = [];
+let scanned = 0;
+
+for (const file of listTestFiles()) {
+  let text: string;
+  try {
+    text = readFileSync(resolve(ROOT, file), "utf8");
+  } catch {
+    continue;
+  }
+  scanned++;
+  const lines = text.split("\n");
+  const fileAdded = changed?.get(file);
+  const state: LineState = { inTemplate: false, inBlockComment: false };
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const code = classify(line, state);
+    if (!TRIGGER.test(line) || ALLOW_COMMENT.test(line)) continue;
+    for (const rule of rules) {
+      const col = rule.match(line, code);
+      if (col < 0) continue;
+      if (i > 0 && ALLOW_COMMENT.test(lines[i - 1])) continue;
+      const error = allErrors || (changed ? !!fileAdded?.has(i + 1) : false);
+      findings.push({
+        file,
+        line: i + 1,
+        col: col + 1,
+        rule: rule.name,
+        why: rule.why,
+        text: line.trim().slice(0, 200),
+        error,
+      });
+    }
+  }
+}
+
+// ── report ──────────────────────────────────────────────────────────────────
+
+const elapsed = ((performance.now() - started) / 1000).toFixed(2);
+const errors = findings.filter(f => f.error);
+
+if (asJson) {
+  console.log(JSON.stringify({ scanned, elapsed: +elapsed, findings }, null, 2));
+} else {
+  const visible = quiet ? errors : findings;
+  for (const f of visible) {
+    const level = f.error ? "error" : "warning";
+    if (isGithubActions) {
+      console.log(`::${level} file=${f.file},line=${f.line},col=${f.col},title=lint-tests/${f.rule}::${f.why}`);
+    }
+    const tag = f.error ? "\x1b[31merror\x1b[0m" : "\x1b[33mwarning\x1b[0m";
+    console.log(`${f.file}:${f.line}:${f.col}: ${tag} [${f.rule}] ${f.why}`);
+    console.log(`  ${f.text}`);
+  }
+  const byRule = new Map<string, number>();
+  for (const f of findings) byRule.set(f.rule, (byRule.get(f.rule) ?? 0) + 1);
+  const summary = [...byRule.entries()].map(([r, n]) => `${r}: ${n}`).join(", ");
+  console.error(
+    `\nlint-tests: scanned ${scanned} files in ${elapsed}s; ` +
+      `${findings.length} finding(s), ${errors.length} error(s)` +
+      (summary ? `  (${summary})` : ""),
+  );
+  if (errors.length) {
+    console.error(`  suppress a finding with \`// lint-tests-allow: <reason>\` on the line above.`);
+  }
+}
+
+process.exit(errors.length ? 1 : 0);

--- a/test/internal/lint-tests.test.ts
+++ b/test/internal/lint-tests.test.ts
@@ -5,8 +5,9 @@
 // Bun build artifacts.
 
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir } from "harness";
 import path from "node:path";
+import { parseUnifiedDiff } from "../../scripts/lint-tests.ts";
 
 const root = path.resolve(import.meta.dir, "..", "..");
 const script = path.join(root, "scripts", "lint-tests.ts");
@@ -31,10 +32,12 @@ async function lint(files: Record<string, string>, extraArgs: string[] = []) {
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   let findings: Finding[] = [];
-  try {
-    findings = JSON.parse(stdout).findings;
-  } catch {
-    throw new Error(`lint-tests did not emit JSON:\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+  if (stdout.trim()) {
+    try {
+      findings = JSON.parse(stdout).findings;
+    } catch {
+      throw new Error(`lint-tests did not emit JSON:\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+    }
   }
   return { findings, exitCode, stderr };
 }
@@ -120,10 +123,51 @@ describe("scripts/lint-tests.ts", () => {
     expect(exitCode).toBe(1);
   });
 
+  test("--changed with an unresolvable base ref fails closed", async () => {
+    const { exitCode, stderr } = await lint({ "bad.test.ts": `Bun.serve({ port: 4567 });` }, [
+      "--changed",
+      "lint-tests-no-such-ref",
+    ]);
+    expect(stderr).toContain("git diff against 'lint-tests-no-such-ref' failed");
+    expect(exitCode).toBe(1);
+  });
+
+  test.each([
+    {
+      name: "new file",
+      diff: ["--- /dev/null", "+++ b/test/a.test.ts", "@@ -0,0 +1,3 @@", "+x", "+y", "+z"],
+      want: { "test/a.test.ts": [1, 2, 3] },
+    },
+    {
+      name: "single-line hunk (no count) and multi-hunk",
+      diff: [
+        "--- a/test/b.test.ts",
+        "+++ b/test/b.test.ts",
+        "@@ -4 +4 @@",
+        "-old",
+        "+new",
+        "@@ -10,0 +11,2 @@",
+        "+p",
+        "+q",
+      ],
+      want: { "test/b.test.ts": [4, 11, 12] },
+    },
+    {
+      name: "deletion is ignored",
+      diff: ["--- a/test/c.test.ts", "+++ /dev/null", "@@ -1,5 +0,0 @@", "-a", "-b"],
+      want: {},
+    },
+  ])("parseUnifiedDiff: $name", ({ diff, want }) => {
+    const got = Object.fromEntries(
+      [...parseUnifiedDiff(diff.join("\n"))].map(([k, v]) => [k, [...v].sort((a, b) => a - b)]),
+    );
+    expect(got).toEqual(want);
+  });
+
   // The full-tree scan is a CI smoke check run with a release bun; under the
   // debug/ASAN binary the per-char classifier is two orders of magnitude
   // slower, so skip there.
-  test.skipIf(isDebug)("full repo scan stays fast and reports warnings only", async () => {
+  test.skipIf(isDebug || isASAN)("full repo scan reports warnings only in default mode", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), script, "--json"],
       env: bunEnv,
@@ -136,7 +180,6 @@ describe("scripts/lint-tests.ts", () => {
     // None of the existing baseline should be errors in default mode.
     expect(out.findings.some((f: Finding) => f.error)).toBe(false);
     expect(out.scanned).toBeGreaterThan(1000);
-    expect(out.elapsed).toBeLessThan(5);
     expect(exitCode).toBe(0);
   });
 });

--- a/test/internal/lint-tests.test.ts
+++ b/test/internal/lint-tests.test.ts
@@ -102,15 +102,16 @@ describe("scripts/lint-tests.ts", () => {
     expect(findings).toEqual([]);
   });
 
-  test("allow-comment on same line or line above suppresses", async () => {
+  test("allow-comment on same line or line above suppresses exactly one line", async () => {
     const { findings } = await lint({
       "allowed.test.ts": [
-        `// lint-tests-allow: testing a privileged-port error path`,
-        `Bun.serve({ port: 1003, fetch: () => new Response("") });`,
-        `await Bun.sleep(5000); // lint-tests-allow: testing`,
+        /* 1 */ `// lint-tests-allow: testing a privileged-port error path`,
+        /* 2 */ `Bun.serve({ port: 1003, fetch: () => new Response("") });`,
+        /* 3 */ `await Bun.sleep(5000); // lint-tests-allow: subprocess warmup`,
+        /* 4 */ `Bun.serve({ port: 4567 });`, // trailing allow on line 3 must NOT leak here
       ].join("\n"),
     });
-    expect(findings).toEqual([]);
+    expect(byRule(findings)).toEqual({ "hardcoded-port": [4] });
   });
 
   test("--all-errors turns warnings into errors and exits 1", async () => {
@@ -122,24 +123,20 @@ describe("scripts/lint-tests.ts", () => {
   // The full-tree scan is a CI smoke check run with a release bun; under the
   // debug/ASAN binary the per-char classifier is two orders of magnitude
   // slower, so skip there.
-  test.skipIf(isDebug)(
-    "full repo scan stays under 2s and reports warnings only",
-    async () => {
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), script, "--json"],
-        env: bunEnv,
-        cwd: root,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      const out = JSON.parse(stdout);
-      // None of the existing baseline should be errors in default mode.
-      expect(out.findings.some((f: Finding) => f.error)).toBe(false);
-      expect(out.scanned).toBeGreaterThan(1000);
-      expect(out.elapsed).toBeLessThan(5);
-      expect(exitCode).toBe(0);
-    },
-    15_000,
-  );
+  test.skipIf(isDebug)("full repo scan stays fast and reports warnings only", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), script, "--json"],
+      env: bunEnv,
+      cwd: root,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const out = JSON.parse(stdout);
+    // None of the existing baseline should be errors in default mode.
+    expect(out.findings.some((f: Finding) => f.error)).toBe(false);
+    expect(out.scanned).toBeGreaterThan(1000);
+    expect(out.elapsed).toBeLessThan(5);
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/internal/lint-tests.test.ts
+++ b/test/internal/lint-tests.test.ts
@@ -1,0 +1,145 @@
+// Tests for scripts/lint-tests.ts (flake anti-pattern linter for test/).
+//
+// The script runs under the system bun and has no native dependencies, so
+// this test exercises it directly with bunExe() rather than relying on any
+// Bun build artifacts.
+
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+import path from "node:path";
+
+const root = path.resolve(import.meta.dir, "..", "..");
+const script = path.join(root, "scripts", "lint-tests.ts");
+
+interface Finding {
+  file: string;
+  line: number;
+  col: number;
+  rule: string;
+  error: boolean;
+}
+
+async function lint(files: Record<string, string>, extraArgs: string[] = []) {
+  using dir = tempDir("lint-tests", files);
+  const targets = Object.keys(files).map(f => path.join(String(dir), f));
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), script, "--json", ...extraArgs, ...targets],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  let findings: Finding[] = [];
+  try {
+    findings = JSON.parse(stdout).findings;
+  } catch {
+    throw new Error(`lint-tests did not emit JSON:\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+  }
+  return { findings, exitCode, stderr };
+}
+
+function byRule(findings: Finding[]) {
+  const m: Record<string, number[]> = {};
+  for (const f of findings) (m[f.rule] ??= []).push(f.line);
+  return m;
+}
+
+describe("scripts/lint-tests.ts", () => {
+  test("flags each anti-pattern on the right line", async () => {
+    const { findings, exitCode } = await lint({
+      "bad.test.ts": [
+        /* 1 */ `import { test } from "bun:test";`,
+        /* 2 */ `test("x", async () => {`,
+        /* 3 */ `  Bun.serve({ port: 4567, fetch: () => new Response("") });`,
+        /* 4 */ `  await Bun.sleep(5000);`,
+        /* 5 */ `  await new Promise(resolve => setTimeout(resolve, 2500));`,
+        /* 6 */ `  setDefaultTimeout(1000 * 60 * 5);`,
+        /* 7 */ `  await fetch("https://example.org/x");`,
+        /* 8 */ `  const d = tmpdirSync();`,
+        /* 9 */ `});`,
+      ].join("\n"),
+    });
+    expect(byRule(findings)).toEqual({
+      "hardcoded-port": [3],
+      "long-sleep": [4, 5],
+      "long-default-timeout": [6],
+      "external-fetch": [7],
+      "tmpdirSync": [8],
+    });
+    // default mode: warnings only
+    expect(exitCode).toBe(0);
+  });
+
+  test("does not flag the safe forms", async () => {
+    const { findings } = await lint({
+      "ok.test.ts": [
+        `Bun.serve({ port: 0, fetch: () => new Response("") });`,
+        `await Bun.sleep(100);`,
+        `setDefaultTimeout(30_000);`,
+        `await fetch("http://localhost:1234/x");`,
+        `await fetch("http://127.0.0.1/x");`,
+        `await fetch(\`http://\${host}:\${port}/x\`);`,
+        `await Promise.race([p, Bun.sleep(5000)]);`, // timeout guard, not wait-and-hope
+        `using dir = tempDir("x", {});`,
+      ].join("\n"),
+    });
+    expect(findings).toEqual([]);
+  });
+
+  test("ignores matches inside strings, comments and multiline template literals", async () => {
+    const { findings } = await lint({
+      "strings.test.ts": [
+        `const cmd = [bunExe(), "-e", "await Bun.sleep(100000)"];`,
+        `// port: 4567`,
+        `/* await fetch("https://example.org") */`,
+        "const yaml = `",
+        "  port: 5432",
+        "`;",
+        `expect(obj).toEqual({ host: "x", port: 8080 });`, // assertion, not a bind
+      ].join("\n"),
+    });
+    expect(findings).toEqual([]);
+  });
+
+  test("allow-comment on same line or line above suppresses", async () => {
+    const { findings } = await lint({
+      "allowed.test.ts": [
+        `// lint-tests-allow: testing a privileged-port error path`,
+        `Bun.serve({ port: 1003, fetch: () => new Response("") });`,
+        `await Bun.sleep(5000); // lint-tests-allow: testing`,
+      ].join("\n"),
+    });
+    expect(findings).toEqual([]);
+  });
+
+  test("--all-errors turns warnings into errors and exits 1", async () => {
+    const { findings, exitCode } = await lint({ "bad.test.ts": `Bun.serve({ port: 4567 });` }, ["--all-errors"]);
+    expect(findings.map(f => ({ rule: f.rule, error: f.error }))).toEqual([{ rule: "hardcoded-port", error: true }]);
+    expect(exitCode).toBe(1);
+  });
+
+  // The full-tree scan is a CI smoke check run with a release bun; under the
+  // debug/ASAN binary the per-char classifier is two orders of magnitude
+  // slower, so skip there.
+  test.skipIf(isDebug)(
+    "full repo scan stays under 2s and reports warnings only",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), script, "--json"],
+        env: bunEnv,
+        cwd: root,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const out = JSON.parse(stdout);
+      // None of the existing baseline should be errors in default mode.
+      expect(out.findings.some((f: Finding) => f.error)).toBe(false);
+      expect(out.scanned).toBeGreaterThan(1000);
+      expect(out.elapsed).toBeLessThan(5);
+      expect(exitCode).toBe(0);
+    },
+    15_000,
+  );
+});

--- a/test/internal/lint-tests.test.ts
+++ b/test/internal/lint-tests.test.ts
@@ -48,7 +48,7 @@ function byRule(findings: Finding[]) {
   return m;
 }
 
-describe("scripts/lint-tests.ts", () => {
+describe.concurrent("scripts/lint-tests.ts", () => {
   test("flags each anti-pattern on the right line", async () => {
     const { findings, exitCode } = await lint({
       "bad.test.ts": [


### PR DESCRIPTION
## What

A fast lint pass over `test/**/*.{test,spec}.*` that fails the Lint workflow when a PR *adds* a line matching a known flake anti-pattern. It does not require a Bun build; it runs under the system bun in ~0.2s over ~1800 files.

Rules (baseline counts on main):

| rule | pattern | existing |
| --- | --- | --- |
| `hardcoded-port` | `port: <1024-65535>` literal outside an assertion | 25 |
| `long-sleep` | `Bun.sleep(N)` / `await sleep(N)` / `setTimeout(resolve, N)` with N >= 1000, not inside `Promise.race` | 16 |
| `long-default-timeout` | `setDefaultTimeout(N)` with N >= 2 min | 23 |
| `external-fetch` | `fetch("http(s)://<host>...")` where host is not localhost/127.*/0.0.0.0 | 9 |
| `tmpdirSync` | `tmpdirSync(` (vs `tempDir` from harness, which auto-cleans) | 258 |

A tiny per-line string/comment classifier keeps matches inside string literals, multiline template literals, `//` and `/* */` comments, and assertion lines (`expect`/`toEqual`/...) from firing. Vendored suites (`test/js/third_party/`, `fixtures/`, `snapshots/`, `node_modules/`) are excluded.

## Why

These five patterns account for most "passes locally, flakes in CI" incidents, and test/CLAUDE.md already documents them as banned. A pre-merge check is cheaper than debugging a flake after it lands.

## How adoption works

- Default run reports everything as warnings, exit 0.
- `--changed <base>` diffs from `merge-base(<base>, HEAD)` to the working tree and only promotes findings on **added lines** to errors. Editing a file with pre-existing violations does not block a PR; only the lines you add are checked. Existing ~330 findings stay warnings.
- `// lint-tests-allow: <reason>` on the same line or the line above suppresses a single finding (for e.g. `port: 1003` privileged-port tests, or `fetch("http://example.com", { proxy: ... })`).

## Wiring

- `package.json`: `bun run lint:tests`
- `.github/workflows/lint.yml`: new `Lint Tests` job alongside the existing oxlint job; runs `bun scripts/lint-tests.ts --quiet --changed origin/<base>` and emits `::error file=...` annotations for inline PR review.

## Verification

```
$ bun scripts/lint-tests.ts --changed main --quiet
lint-tests: scanned 1791 files in 0.23s; 331 finding(s), 0 error(s)
```

```
$ bun bd test test/internal/lint-tests.test.ts
 5 pass, 1 skip (full-tree timing check skipped under debug build)
```

A synthetic new violation added and removed during development was correctly promoted to an error with exit 1.

<!-- robobun:evidence:begin -->

---

**[decide:dep]** gate passed · iteration 0 · 4 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/internal/lint-tests.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/internal/lint-tests.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (2be39f828)

test/internal/lint-tests.test.ts:
(pass) scripts/lint-tests.ts > flags each anti-pattern on the right line [1457.60ms]
(pass) scripts/lint-tests.ts > does not flag the safe forms [1421.35ms]
(pass) scripts/lint-tests.ts > parseUnifiedDiff: new file [23.70ms]
(pass) scripts/lint-tests.ts > parseUnifiedDiff: single-line hunk (no count) and multi-hunk [3.14ms]
(pass) scripts/lint-tests.ts > parseUnifiedDiff: deletion is ignored [0.88ms]
(skip) scripts/lint-tests.ts > full repo scan reports warnings only in default mode
(pass) scripts/lint-tests.ts > ignores matches inside strings, comments and multiline template literals [1438.19ms]
(pass) scripts/lint-tests.ts > allow-comment on same line or line above suppresses exactly one line [1427.20ms]
(pass) scripts/lint-tests.ts > --all-errors turns warnings into errors and exits 1 [1422.38ms]
(pass) scripts/lint-tests.ts > --changed with an unresolvable base ref fails closed [1451.93ms]

 9 pass
 1 skip
 0 fail
 12 expect() calls
Ran 10 tests across 1 file. [5.03s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.github/workflows/lint.yml       |  15 ++
 package.json                     |   1 +
 scripts/lint-tests.ts            | 410 +++++++++++++++++++++++++++++++++++++++
 test/internal/lint-tests.test.ts | 185 ++++++++++++++++++
 4 files changed, 611 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
.github/workflows/lint.yml            2      1      0
package.json                          1      1      0
scripts/lint-tests.ts                 4     19      0
test/internal/lint-tests.test.ts      4     12      0
```

</details>

<!-- robobun:evidence:end -->