### PR TITLE
ci: scope automatic retry to agent loss via signal_reason

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -305,20 +305,20 @@ function getRetry() {
     manual: {
       permit_on_passed: true,
     },
-    // Self-heal agent loss, and only agent loss. Within one rule the
-    // conditions are ANDed, so `signal_reason` scopes `exit_status: -1` to
-    // real connection loss (Buildkite records no signal reason for that) and
-    // `agent_stop` covers a graceful agent restart mid-job. The previous
-    // blanket `-1` / `255` rules defaulted to `signal_reason: "*"` and so also
-    // matched `cancel`, which is what a `timeout_in_minutes` kill records;
-    // across ~200 recent builds that auto-retried ~670 timed-out test shards
-    // and ~97% of them timed out again or were canceled before finishing,
-    // each one holding an agent for the full step timeout. User-canceled
+    // Self-heal agent/infra loss, and only that. Conditions within one rule
+    // are ANDed, so `signal_reason` scopes each rule to the failure mode it
+    // names: `none` is an agent that dropped its connection mid-job,
+    // `agent_stop` is a graceful agent restart mid-job, `process_run_error`
+    // is the bootstrap failing before the command ever ran. A blanket
+    // `exit_status: -1` / `255` also matches `cancel`, which is what a
+    // `timeout_in_minutes` kill records, so a timed-out shard would be
+    // re-queued just to time out again on the next agent. User-canceled
     // builds are state=canceled and never auto-retry regardless of these
     // rules.
     automatic: [
       { exit_status: -1, signal_reason: "none", limit: 1 },
       { signal_reason: "agent_stop", limit: 2 },
+      { signal_reason: "process_run_error", limit: 1 },
     ],
   };
 }

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -298,24 +298,27 @@ function getImageName(platform, options) {
 }
 
 /**
- * @param {number} [limit]
- * @link https://buildkite.com/docs/pipelines/command-step#retry-attributes
+ * @link https://buildkite.com/docs/pipelines/configure/retry#retry-attributes-automatic-retry-attributes
  */
 function getRetry() {
   return {
     manual: {
       permit_on_passed: true,
     },
-    // Self-heal infra deaths once instead of leaving the build failed until a
-    // human notices and clicks retry:
-    //   -1  = agent lost / process killed (box died, agent restarted)
-    //   255 = step timeout kill (timeout_in_minutes SIGTERM cascade)
-    // User-canceled jobs are state=canceled, which never triggers automatic
-    // retry, so this cannot resurrect deliberately canceled builds. limit: 1
-    // caps the cost when a suite genuinely crashes with these statuses.
+    // Self-heal agent loss, and only agent loss. Within one rule the
+    // conditions are ANDed, so `signal_reason` scopes `exit_status: -1` to
+    // real connection loss (Buildkite records no signal reason for that) and
+    // `agent_stop` covers a graceful agent restart mid-job. The previous
+    // blanket `-1` / `255` rules defaulted to `signal_reason: "*"` and so also
+    // matched `cancel`, which is what a `timeout_in_minutes` kill records;
+    // across ~200 recent builds that auto-retried ~670 timed-out test shards
+    // and ~97% of them timed out again or were canceled before finishing,
+    // each one holding an agent for the full step timeout. User-canceled
+    // builds are state=canceled and never auto-retry regardless of these
+    // rules.
     automatic: [
-      { exit_status: -1, limit: 1 },
-      { exit_status: 255, limit: 1 },
+      { exit_status: -1, signal_reason: "none", limit: 1 },
+      { signal_reason: "agent_stop", limit: 2 },
     ],
   };
 }


### PR DESCRIPTION
## What

Scope the automatic retry rules in `getRetry()` to agent/infra loss by adding `signal_reason` conditions:

```diff
 automatic: [
-  { exit_status: -1, limit: 1 },
-  { exit_status: 255, limit: 1 },
+  { exit_status: -1, signal_reason: "none", limit: 1 },
+  { signal_reason: "agent_stop", limit: 2 },
+  { signal_reason: "process_run_error", limit: 1 },
 ],
```

## Why

The previous rules omitted `signal_reason`, which Buildkite defaults to `"*"`. That makes them match `signal_reason=cancel`, which is what a `timeout_in_minutes` kill records. So every timed-out test shard was being auto-retried.

Across ~200 recent builds (`include_retried_jobs=true`), the `-1`/`255` rules triggered ~670 automatic retries on `state=timed_out` test shards. Outcomes of those retries:

| next attempt | count |
|---|---|
| timed_out again | 465 |
| canceled before finishing | 182 |
| failed with a real test exit code | 22 |

97% wasted. Each one holds an agent for the full step timeout (30 min Linux, 45 min macOS/Windows); on the fixed-size 20-box macOS fleet that directly lengthens the queue.

Buildkite distinguishes the cases we actually want to retry ([docs](https://buildkite.com/docs/pipelines/configure/retry#retry-attributes-automatic-retry-attributes)). Conditions within one rule are ANDed, so each rule names exactly one failure mode:

- `exit_status: -1` **with** `signal_reason: none` is the agent losing its connection mid-job (`agent.connection_state=lost`). Seen 18 times across 1000 recent builds; these are the retries worth keeping.
- `signal_reason: agent_stop` is a graceful agent restart while a job is running. `limit: 2` since a retry can land on another box mid-restart during a fleet-wide reboot.
- `signal_reason: process_run_error` is the agent bootstrap failing before the step command ran (exec failure, hook setup failure). Buildkite's agent maps this to `exit_status: -1` precisely so a `-1` retry rule catches it, and narrowing `-1` to `signal_reason: none` would otherwise drop it.

User-canceled builds are `state=canceled` which never auto-retries, so this can't resurrect a deliberate cancel.

### Not fixed here: darwin `expired` jobs

The same window has ~250 darwin test jobs in `state=expired` (runnable but no agent picked them up before the cluster's scheduled-job expiry). Those have `exit_status=null` and `signal_reason=null`, so step-level `retry.automatic` cannot match them; they still need a manual retry. The fix for those is agent availability / the cluster expiry setting, and #34367 removes one cause of mid-job agent death.

## Verification

```
$ node .buildkite/ci.mjs          # writes .buildkite/ci.yml
$ bk pipeline validate --file .buildkite/ci.yml
✅ Pipeline file is valid: .buildkite/ci.yml
```

The generated `retry` stanza on every step now reads:

```yaml
retry:
  manual:
    permit_on_passed: true
  automatic:
  - exit_status: -1
    signal_reason: none
    limit: 1
  - signal_reason: agent_stop
    limit: 2
  - signal_reason: process_run_error
    limit: 1
```

All three rules validate against [`buildkite/pipeline-schema`](https://github.com/buildkite/pipeline-schema)'s `automaticRetry` definition.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->
