### PR TITLE
ci: quarantine worker transfer-terminate tests on ASAN; widen node-net mimalloc threshold

### DIFF
--- a/test/expectations.txt
+++ b/test/expectations.txt
@@ -92,13 +92,17 @@ test/js/bun/spawn/spawn-maxbuf.test.ts [ FLAKY ]
 # builder returns with it pending and reifyStaticProperty reports the slot
 # found, tripping JSC's "ASSERTION FAILED: !scope.exception() || !result"
 # in getOwnPropertyDescriptor / JSValue::get. Tracked in #34095; fix PRs
-# #33966 and #33418. The stress test is the bun-owned amplified form of the
-# vendored one and dies with the same assertion (or ExceptionScope.h:61
-# assertNoException). Both SIGABRT on the x64-asan lane only (e.g. builds
-# 75570, 75604); release lanes are unaffected. Remove both entries once
-# either fix PR lands.
+# #33966 and #33418. x64-asan only (e.g. builds 75570, 75601); release
+# lanes are unaffected. Remove once either fix PR lands.
 [ ASAN ] test/js/node/test/parallel/test-worker-message-port-transfer-terminate.js [ CRASH ] # #34095: JSC assertion when terminate() interrupts a lazy PropertyCallback builder
-[ ASAN ] test/js/node/worker_threads/worker-transfer-terminate-stress.test.ts [ CRASH ] # #34095: same terminate-vs-lazy-builder assertion
+# The stress test is the bun-owned 8×10-worker amplification of the above,
+# but on CI it only ever hits JSC::ExceptionScope::assertNoException at
+# ExceptionScope.h:61 (6/6: builds 75493/75495/75514/75597/75604/75606),
+# which #33966 reports still reproducing at ~1/4000 workers AFTER its
+# lazy-builder fix ("termination landing later in the bootstrap, after the
+# stdio builders have completed"). Tracked separately in #34690; this entry
+# is NOT removable with the one above.
+[ ASAN ] test/js/node/worker_threads/worker-transfer-terminate-stress.test.ts [ CRASH ] # #34690: ExceptionScope::assertNoException during worker terminate bootstrap
 
 # Tests failed due to ASAN: use-after-poison
 [ ASAN ] test/js/node/test/parallel/test-worker-unref-from-message-during-exit.js [ CRASH ]

--- a/test/expectations.txt
+++ b/test/expectations.txt
@@ -86,6 +86,20 @@ test/js/bun/spawn/spawn-maxbuf.test.ts [ FLAKY ]
 # Tests failed due to ASAN: SEGV on unknown address
 [ ASAN ] test/integration/next-pages/test/dev-server.test.ts [ CRASH ]
 
+# worker.terminate() lands while a process.* lazy PropertyCallback builder
+# (stdout/stderr/stdin/nextTick/mainModule, via setupWorkerStdio) is in JS;
+# tryClearException() refuses to clear the TerminationException, so the
+# builder returns with it pending and reifyStaticProperty reports the slot
+# found, tripping JSC's "ASSERTION FAILED: !scope.exception() || !result"
+# in getOwnPropertyDescriptor / JSValue::get. Tracked in #34095; fix PRs
+# #33966 and #33418. The stress test is the bun-owned amplified form of the
+# vendored one and dies with the same assertion (or ExceptionScope.h:61
+# assertNoException). Both SIGABRT on the x64-asan lane only (e.g. builds
+# 75570, 75604); release lanes are unaffected. Remove both entries once
+# either fix PR lands.
+[ ASAN ] test/js/node/test/parallel/test-worker-message-port-transfer-terminate.js [ CRASH ] # #34095: JSC assertion when terminate() interrupts a lazy PropertyCallback builder
+[ ASAN ] test/js/node/worker_threads/worker-transfer-terminate-stress.test.ts [ CRASH ] # #34095: same terminate-vs-lazy-builder assertion
+
 # Tests failed due to ASAN: use-after-poison
 [ ASAN ] test/js/node/test/parallel/test-worker-unref-from-message-during-exit.js [ CRASH ]
 [ ASAN ] test/napi/napi.test.ts [ CRASH ] # can throw an exception from an async_complete_callback

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -965,8 +965,8 @@ it.skipIf(isWindows)(
     const { before, after, delta } = JSON.parse(stdout.trim().split("\n").pop()!);
     // Without the balancing deref: +25 pages (release) / +163 (debug+ASAN).
     // With it the socket delta is 0, but since #34009 JSC shares mimalloc and
-    // adds +10..13 of heap noise on aarch64 release (builds 75570/75589).
-    expect(delta, `mimalloc page count: ${before} -> ${after}`).toBeLessThan(18);
+    // adds up to +14 of heap noise on aarch64/darwin release (build 75589).
+    expect(delta, `mimalloc page count: ${before} -> ${after}`).toBeLessThan(20);
     expect(exitCode).toBe(0);
   },
   60_000,

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -963,9 +963,10 @@ it.skipIf(isWindows)(
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     const { before, after, delta } = JSON.parse(stdout.trim().split("\n").pop()!);
-    // Without the balancing deref: +25 pages (release) / +163 pages
-    // (debug+ASAN). With it: 0 ± 2. The threshold sits well clear of both.
-    expect(delta, `mimalloc page count: ${before} -> ${after}`).toBeLessThan(10);
+    // Without the balancing deref: +25 pages (release) / +163 (debug+ASAN).
+    // With it the socket delta is 0, but since #34009 JSC shares mimalloc and
+    // adds +10..13 of heap noise on aarch64 release (builds 75570/75589).
+    expect(delta, `mimalloc page count: ${before} -> ${after}`).toBeLessThan(18);
     expect(exitCode).toBe(0);
   },
   60_000,


### PR DESCRIPTION
## What

Stops three test files from turning unrelated PR builds red on main. All three are pre-existing failures that the CI annotation tagger marks `[pre-existing]` on every PR that hits them.

Surveyed builds 75470–75621 via the Buildkite `/annotations` API:

| test | lane | signature |
|---|---|---|
| `test-worker-message-port-transfer-terminate.js` | debian 13 x64-asan only | SIGABRT, `JSObject.cpp:3936` (11/12) / `JSCJSValuePropertyInlines.h:51` (1/12) |
| `worker-transfer-terminate-stress.test.ts` | debian 13 x64-asan only | SIGABRT, `ExceptionScope.h:61 assertNoException` (6/6) |
| `node-net.test.ts` (one case) | alpine 3.23 aarch64, debian 13 aarch64, ubuntu 25.04 aarch64/x64-baseline, darwin 26 aarch64 | mimalloc page delta 10..14 |

## Worker transfer-terminate (ASAN quarantine)

Two distinct crash paths, both x64-asan only, release lanes unaffected:

**Vendored test** (`test-worker-message-port-transfer-terminate.js`): `worker.terminate()` lands while a `process.*` lazy `PropertyCallback` builder (`stdout`/`stderr`/`stdin`/`nextTick`/`mainModule`, via `setupWorkerStdio`) is in JS; `tryClearException()` refuses to clear the `TerminationException`, so the builder returns with it pending and `reifyStaticProperty` reports the slot found, tripping:

```
ASSERTION FAILED: !scope.exception() || !result
vendor/WebKit/Source/JavaScriptCore/runtime/JSObject.cpp(3936) : bool JSC::JSObject::getOwnPropertyDescriptor(...)
```

Tracked in #34095; fix PRs #33966 and #33418. Remove this entry once either lands. Verbatim upstream port we do not edit.

**Stress test** (`worker-transfer-terminate-stress.test.ts`): the bun-owned 8×10-worker amplification of the above, but on CI it only ever hits:

```
ASSERTION FAILED: (null)
!exception()
vendor/WebKit/Source/JavaScriptCore/runtime/ExceptionScope.h(61) : void JSC::ExceptionScope::assertNoException()
```

6/6 observed (builds 75493/75495/75514/75597/75604/75606). #33966's Verification section reports this path still reproducing at ~1/4000 workers after its lazy-builder fix ("termination landing later in the bootstrap, after the stdio builders have completed"), so it is **not** the same bug. Tracked separately in #34690; this entry is not removable with the vendored-test entry.

## node-net.test.ts threshold

Only one case fails: `should not leak when connect({path}) fails synchronously on a reused handle`. It asserts the mimalloc page delta across two equal 8000-iteration runs is `< 10`.

```
error: mimalloc page count: 128 -> 139
Expected: < 10
Received: 11
```

Since #34009 JSC shares mimalloc, and on aarch64/darwin release lanes its heap adds up to +14 of noise over the measured run even after the equal-size warmup (observed deltas across `style=error` + `style=warning` annotations: 10, 10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 12, 12, 12, 13, 13, 14). The native-socket leak this test guards against shows **+25** per 8000 iterations on release, so raising the threshold to 20 keeps clear separation from both the observed noise ceiling and the leak signal. The file stays in the run everywhere; per the `expectations.txt` header, a single broken case is fixed in-file, not quarantined.

## Not in this PR

`test/js/node/test/parallel/test-net-connect-memleak.js` (the fourth file in the original report) fails only on `linux-x64-musl` with the onGC/FinalizationRegistry timing issue and is handled by #34631 (which also covers its `test-gc-http-client*` siblings) and #33045.

## Verification

Parsing `test/expectations.txt` with the runner's own filtering (replicated from `scripts/runner.node.mjs` `getRelevantTests`):

```
ASAN (debian 13 x64-asan):
  SKIP js/node/test/parallel/test-worker-message-port-transfer-terminate.js
  SKIP js/node/worker_threads/worker-transfer-terminate-stress.test.ts
  RUN  js/node/net/node-net.test.ts

LINUX-X64 (glibc), LINUX-X64-MUSL, DARWIN-AARCH64, WINDOWS-X64:
  RUN  (all three)
```

Build 75622 on this branch: neither worker test appeared in the x64-asan lane's annotations and `node-net.test.ts` did not appear on any lane, so the filtering and threshold are working. The remaining red on that build was pre-existing (`node-http-server-socket-end-drain.test.ts` on darwin 14 x64, `test-net-connect-memleak.js` on alpine x64; both owned by other sessions) plus a darwin 26 tart-VM provisioning failure.

No source changes; this is test-infra only, so there is no fail-before/pass-after to capture.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->