### PR TITLE
install: break folder dependency cycles in the hoist tree builder

### DIFF
--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -679,6 +679,35 @@ pub(crate) fn is_filtered_dependency_or_workspace(
 // process_subtree / hoist_dependency
 // ──────────────────────────────────────────────────────────────────────────
 
+// Folder deps bypass `hoist_dependency`, so a folder package whose dependency
+// graph reaches itself would otherwise re-enqueue its own subtree forever. The
+// dep is still placed so it appears in bun.lock; only the re-enqueue is cut.
+fn is_folder_cycle<const METHOD: BuilderMethod>(
+    pkg_id: PackageID,
+    from_tree: Id,
+    pkg_resolutions: &[Resolution],
+    builder: &Builder<'_, METHOD>,
+) -> bool {
+    if pkg_resolutions[pkg_id as usize].tag != crate::resolution::Tag::Folder {
+        return false;
+    }
+    let mut anc = from_tree;
+    loop {
+        let tree = builder.list.items_tree()[anc as usize];
+        let anc_pkg = match tree.dependency_id {
+            ROOT_DEP_ID => 0,
+            id => builder.resolutions[id as usize],
+        };
+        if anc_pkg == pkg_id {
+            return true;
+        }
+        if tree.parent == INVALID_ID {
+            return false;
+        }
+        anc = tree.parent;
+    }
+}
+
 impl Tree {
     pub fn process_subtree<const METHOD: BuilderMethod>(
         &self,
@@ -832,24 +861,6 @@ impl Tree {
                 }
 
                 if pkg_resolutions[pkg_id as usize].tag == crate::resolution::Tag::Folder {
-                    // Folder deps bypass `hoist_dependency`, so nothing dedupes a folder
-                    // package that reaches itself (directly or via another folder) and it
-                    // would re-enqueue forever. Skip if already an enclosing subtree.
-                    let mut anc = next_id;
-                    loop {
-                        let tree = builder.list.items_tree()[anc as usize];
-                        let anc_pkg = match tree.dependency_id {
-                            ROOT_DEP_ID => 0,
-                            id => builder.resolutions[id as usize],
-                        };
-                        if anc_pkg == pkg_id {
-                            continue 'dep;
-                        }
-                        if tree.parent == INVALID_ID {
-                            break;
-                        }
-                        anc = tree.parent;
-                    }
                     break 'hoisted HoistDependencyResult::Placement(Placement {
                         id: next_id,
                         bundled: false,
@@ -959,6 +970,7 @@ impl Tree {
                     }
                     if pkg_id != invalid_package_id
                         && builder.resolution_lists[pkg_id as usize].len > 0
+                        && !is_folder_cycle(pkg_id, next_id, pkg_resolutions, builder)
                     {
                         builder.queue.write_item(FillItem {
                             tree_id: dest.id,

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -832,6 +832,24 @@ impl Tree {
                 }
 
                 if pkg_resolutions[pkg_id as usize].tag == crate::resolution::Tag::Folder {
+                    // Folder deps bypass `hoist_dependency`, so nothing dedupes a folder
+                    // package that reaches itself (directly or via another folder) and it
+                    // would re-enqueue forever. Skip if already an enclosing subtree.
+                    let mut anc = next_id;
+                    loop {
+                        let tree = builder.list.items_tree()[anc as usize];
+                        let anc_pkg = match tree.dependency_id {
+                            ROOT_DEP_ID => 0,
+                            id => builder.resolutions[id as usize],
+                        };
+                        if anc_pkg == pkg_id {
+                            continue 'dep;
+                        }
+                        if tree.parent == INVALID_ID {
+                            break;
+                        }
+                        anc = tree.parent;
+                    }
                     break 'hoisted HoistDependencyResult::Placement(Placement {
                         id: next_id,
                         bundled: false,

--- a/test/cli/install/migration/migrate.test.ts
+++ b/test/cli/install/migration/migrate.test.ts
@@ -517,6 +517,60 @@ test.concurrent("package-lock.json migration does not platform-skip a regular fi
   expect(await Bun.file(join(testDir, "node_modules", "a", "package.json")).json()).toHaveProperty("name", "a");
 });
 
+// npm records a `file:` link target's declared dependencies in the lockfile but does not
+// install them, so for a link target that depends on its own name (or on another link
+// target that depends back on it) there is no nested `<target>/node_modules/<name>` entry.
+// Migration resolves such a dep through the root `node_modules/<name>` link, producing a
+// folder package whose dependency graph reaches itself. The hoist pass must break that
+// cycle; before this fix it re-enqueued the same subtree forever and the migration hung.
+function folderLockfile(rootDeps: Record<string, string>, folders: Record<string, Record<string, string>>) {
+  const packages: Record<string, unknown> = { "": { name: "root", dependencies: rootDeps } };
+  const files: Record<string, string> = { "package.json": JSON.stringify({ name: "root", dependencies: rootDeps }) };
+  for (const [name, dependencies] of Object.entries(folders)) {
+    files[`${name}/package.json`] = JSON.stringify({ name, version: "1.0.0", dependencies });
+    packages[name] = { version: "1.0.0", dependencies };
+    packages[`node_modules/${name}`] = { resolved: name, link: true };
+  }
+  files["package-lock.json"] = JSON.stringify({ name: "root", lockfileVersion: 3, requires: true, packages });
+  return files;
+}
+
+test.concurrent.each([
+  ["depends on its own name", folderLockfile({ pkg: "file:pkg" }, { pkg: { pkg: "^1.0.0" } })],
+  ["aliases its own name via npm:", folderLockfile({ pkg: "file:pkg" }, { pkg: { pkg: "npm:something@^1.0.0" } })],
+  [
+    "and another link target depend on each other",
+    folderLockfile({ a: "file:a", b: "file:b" }, { a: { b: "^1.0.0" }, b: { a: "^1.0.0" } }),
+  ],
+])("package-lock.json migration terminates when a file: link target %s", async (_desc, files) => {
+  const testDir = tempDirWithFiles("migrate-folder-cycle", files);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    env: bunEnv,
+    cwd: testDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    // Without the fix the spawned process never exits; bound the wait so the assertion
+    // below can report the hang instead of relying on the suite-level test timeout.
+    timeout: 30_000,
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("migrated lockfile from package-lock.json");
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+  expect(fs.existsSync(join(testDir, "bun.lock"))).toBeTrue();
+  for (const name of Object.keys(JSON.parse(files["package.json"]).dependencies)) {
+    expect(await Bun.file(join(testDir, "node_modules", name, "package.json")).json()).toHaveProperty("name", name);
+  }
+
+  // The bun.lock the migration wrote must round-trip through bun's own parser.
+  const second = await install(testDir, "--frozen-lockfile");
+  expect(second.stderr).not.toContain("Ignoring lockfile");
+  expect(second.exitCode).toBe(0);
+});
+
 test.concurrent("pnpm-lock.yaml migration does not platform-skip a regular file: folder dependency", async () => {
   // The pnpm migration copied the lockfile's `os`/`cpu` arrays into every package the
   // same way the npm one did. pnpm records them for any `packages:` entry whose manifest

--- a/test/cli/install/migration/migrate.test.ts
+++ b/test/cli/install/migration/migrate.test.ts
@@ -576,17 +576,17 @@ test.concurrent(
   async () => {
     // https://github.com/oven-sh/bun/issues/25202
     // Same hoist cycle as the migration cases above, reached without a foreign lockfile:
-    // `bun i ../dir1` resolves `foo: workspace:.` inside the folder package to the folder
-    // package itself, so the hoist builder re-enqueued its own subtree forever.
+    // `foo: workspace:.` inside the folder package resolves to the folder package itself
+    // under a different name, so the hoist builder re-enqueued its own subtree forever.
     const testDir = tempDirWithFiles("install-folder-self-workspace", {
+      "package.json": JSON.stringify({ name: "consumer", dependencies: { test: "file:dir1" } }),
       "dir1/package.json": JSON.stringify({ name: "test", version: "1.0.0", devDependencies: { foo: "workspace:." } }),
-      "dir2/package.json": JSON.stringify({ name: "consumer", dependencies: { test: "file:../dir1" } }),
     });
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "install"],
       env: bunEnv,
-      cwd: join(testDir, "dir2"),
+      cwd: testDir,
       stdout: "ignore",
       stderr: "pipe",
       timeout: 30_000,
@@ -596,7 +596,13 @@ test.concurrent(
     expect(stderr).toContain("Saved lockfile");
     expect(proc.signalCode).toBeNull();
     expect(exitCode).toBe(0);
-    expect(fs.existsSync(join(testDir, "dir2", "bun.lock"))).toBeTrue();
+    expect(fs.existsSync(join(testDir, "bun.lock"))).toBeTrue();
+
+    // The dep name (`foo`) differs from the package name (`test`), so the placement must
+    // still reach bun.lock for the parser to resolve it on reload.
+    const second = await install(testDir, "--frozen-lockfile");
+    expect(second.stderr).not.toContain("Ignoring lockfile");
+    expect(second.exitCode).toBe(0);
   },
 );
 

--- a/test/cli/install/migration/migrate.test.ts
+++ b/test/cli/install/migration/migrate.test.ts
@@ -571,6 +571,35 @@ test.concurrent.each([
   expect(second.exitCode).toBe(0);
 });
 
+test.concurrent(
+  "bun install terminates when a file: folder dependency declares a workspace:. self-reference",
+  async () => {
+    // https://github.com/oven-sh/bun/issues/25202
+    // Same hoist cycle as the migration cases above, reached without a foreign lockfile:
+    // `bun i ../dir1` resolves `foo: workspace:.` inside the folder package to the folder
+    // package itself, so the hoist builder re-enqueued its own subtree forever.
+    const testDir = tempDirWithFiles("install-folder-self-workspace", {
+      "dir1/package.json": JSON.stringify({ name: "test", version: "1.0.0", devDependencies: { foo: "workspace:." } }),
+      "dir2/package.json": JSON.stringify({ name: "consumer", dependencies: { test: "file:../dir1" } }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      env: bunEnv,
+      cwd: join(testDir, "dir2"),
+      stdout: "ignore",
+      stderr: "pipe",
+      timeout: 30_000,
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("Saved lockfile");
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(0);
+    expect(fs.existsSync(join(testDir, "dir2", "bun.lock"))).toBeTrue();
+  },
+);
+
 test.concurrent("pnpm-lock.yaml migration does not platform-skip a regular file: folder dependency", async () => {
   // The pnpm migration copied the lockfile's `os`/`cpu` arrays into every package the
   // same way the npm one did. pnpm records them for any `packages:` entry whose manifest


### PR DESCRIPTION
Fixes #25202.

## Repro

```sh
mkdir repro && cd repro
cat > package.json <<'JSON'
{ "name": "root", "dependencies": { "pkg": "file:pkg" } }
JSON
mkdir pkg && cat > pkg/package.json <<'JSON'
{ "name": "pkg", "version": "1.0.0", "dependencies": { "pkg": "^1.0.0" } }
JSON
npm install --package-lock-only   # npm 11.x
bun pm migrate                    # hangs at 100% CPU
```

Same hang for `bun install` with the `package-lock.json` present, for an `npm:` alias under the same name (`"pkg": "npm:other@^1.0.0"`), for two `file:` link targets that depend on each other (`a` depends on `b`, `b` depends on `a`), and (without any migration) for `bun install` on a `file:` folder whose `package.json` declares `foo: "workspace:."` (#25202).

The migration shape is what npm 11.x writes for `file:` linked folders: it records the target's declared dependencies but does not install them, so there is no nested `<target>/node_modules/<name>` lockfile entry.

## Cause

The npm lockfile migration resolves a link target's dependency by walking up to `node_modules/<name>`, which is the `"link": true` entry pointing back at a folder package. `workspace:.` inside a `file:` folder resolves that dep to the folder package itself. Either way a folder package ends up with a dependency that resolves to itself (direct case) or to another folder package that reaches back to it (mutual case).

`Tree::process_subtree` short-circuits folder resolutions straight to `Placement` without going through `hoist_dependency`, which is where the dedup (same package id already placed in an ancestor tree) lives. The placement handler then re-enqueues the package's subtree unconditionally, so a folder package that reaches itself re-enqueues forever.

## Fix

Before re-enqueueing a placed folder dependency's subtree, walk the enclosing subtree chain (`next_id` and its parents) and skip the enqueue if the same package id is already the subject of one. The dep is still placed, so its entry reaches `bun.lock` and the parser can resolve it on reload (needed for the aliased case where the dep name differs from the package name); only the re-enqueue that would loop is cut.

Only the subtree chain is consulted, not sibling placements, and the walk is gated on the resolution being `Folder`, so acyclic layouts and non-folder placements are unchanged.

## Verification

Four new cases in `test/cli/install/migration/migrate.test.ts`: three package-lock.json migrations (self-named dep, `npm:` alias under the same name, and a mutual `a`/`b` cycle, each the lockfile npm 11.x writes for that tree) and one plain `bun install` on a `file:` folder whose target declares `workspace:.` under a different name (#25202). Each spawns with a 30 s process timeout so the hang surfaces as a normal assertion failure, and each asserts the resulting `bun.lock` round-trips through `bun install --frozen-lockfile`.

```
$ git stash push -- src/ && bun bd test migrate.test.ts -t "terminates when a file:"
 0 pass, 4 fail  (each ~30 s, stderr empty)
$ git stash pop  && bun bd test migrate.test.ts -t "terminates when a file:"
 4 pass, 0 fail  (each <1 s)
```

The rest of `migrate.test.ts` and the `file:`/`folder` tests in `bun-install.test.ts` pass unchanged.

## Related issues

#25631, #21191, #23453 and #13223 report deep/infinite `node_modules` nesting for `file:..`-style folder dependencies. Those reproduce identically with and without this change; they are about the folder package being materialised by copying its source directory (which contains the dependent, whose `node_modules` contains the folder package again), not about the hoist tree builder, and are left for a separate fix.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/migration/migrate.test.ts

<!-- robobun:evidence:end -->