### PR TITLE
terminal(win): wait for ConPTY output quiescence before ClosePseudoConsole on inline-child exit

### DIFF
--- a/src/event_loop/EventLoopTimer.rs
+++ b/src/event_loop/EventLoopTimer.rs
@@ -196,6 +196,7 @@ pub enum Tag {
     ValkeyConnectionTimeout,
     ValkeyConnectionReconnect,
     SubprocessTimeout,
+    TerminalPendingClose,
     DevServerSweepSourceMaps,
     DevServerMemoryVisualizerTick,
     AbortSignalTimeout,

--- a/src/event_loop/EventLoopTimer.rs
+++ b/src/event_loop/EventLoopTimer.rs
@@ -215,6 +215,7 @@ impl Tag {
             | Tag::BunTest // for test timeouts
             | Tag::EventLoopDelayMonitor // probably important
             | Tag::StatWatcherScheduler
+            | Tag::TerminalPendingClose // gates ClosePseudoConsole; must fire under fake timers
             | Tag::GcOneShot | Tag::GcRepeating // internal GC pacing
             => false,
             _ => true,

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -1876,6 +1876,10 @@ impl Terminal {
         if self.flags.get().contains(Flags::READER_DONE) {
             return;
         }
+        self.update_flags(|f| {
+            f.insert(Flags::READER_DONE);
+            f.remove(Flags::CONNECTED);
+        });
         #[cfg(windows)]
         {
             // Conhost may self-terminate (EOF) before the quiescence timer
@@ -1883,10 +1887,6 @@ impl Terminal {
             self.cancel_pending_close_timer();
             self.close_pseudoconsole();
         }
-        self.update_flags(|f| {
-            f.insert(Flags::READER_DONE);
-            f.remove(Flags::CONNECTED);
-        });
         // EOF from master - downgrade to weak ref to allow GC
         // Skip JS interactions if already finalized (happens when close() is called during finalize)
         if !self.flags.get().contains(Flags::FINALIZED) {

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -773,9 +773,11 @@ impl Terminal {
     #[cfg(windows)]
     pub(crate) fn close_pseudoconsole_after_quiescence(&self) {
         let flags = self.flags.get();
-        if flags.intersects(Flags::CLOSED | Flags::READER_DONE | Flags::PENDING_CLOSE)
-            || self.hpcon.get().is_none()
-        {
+        if flags.contains(Flags::PENDING_CLOSE) {
+            self.arm_pending_close_timer();
+            return;
+        }
+        if flags.intersects(Flags::CLOSED | Flags::READER_DONE) || self.hpcon.get().is_none() {
             self.close_pseudoconsole();
             return;
         }

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -172,11 +172,19 @@ pub struct Terminal {
     /// going raw never makes another terminal's setRawMode a no-op.
     #[cfg(unix)]
     tty_state: Cell<bun_core::tty::State>,
+
+    /// Windows: data-quiescence timer for the inline-terminal child-exit path;
+    /// see `close_pseudoconsole_after_quiescence`.
+    #[cfg(windows)]
+    pub(crate) event_loop_timer: JsCell<crate::timer::EventLoopTimer>,
 }
+
+#[cfg(windows)]
+bun_event_loop::impl_timer_owner!(Terminal; from_timer_ptr => event_loop_timer);
 
 bitflags::bitflags! {
     #[derive(Clone, Copy, Default)]
-    pub struct Flags: u8 {
+    pub struct Flags: u16 {
         const CLOSED         = 1 << 0;
         const FINALIZED      = 1 << 1;
         const RAW_MODE       = 1 << 2;
@@ -188,6 +196,10 @@ bitflags::bitflags! {
         /// reuse. Windows: first exit's ClosePseudoConsole would kill a second
         /// child. POSIX: slave_fd is held until first exit (`drain_and_close_slave_fd`).
         const INLINE_SPAWNED = 1 << 7;
+        /// Windows: the inline-spawned child has exited and `event_loop_timer`
+        /// is counting down to `close_pseudoconsole`; `on_read_chunk` re-arms
+        /// it on every chunk so the close lands after the pipe goes quiet.
+        const PENDING_CLOSE  = 1 << 8;
     }
 }
 
@@ -472,6 +484,10 @@ impl Terminal {
             writer_has_buffered: Cell::new(false),
             #[cfg(unix)]
             tty_state: Cell::new(bun_core::tty::State::new()),
+            #[cfg(windows)]
+            event_loop_timer: JsCell::new(crate::timer::EventLoopTimer::init_paused(
+                crate::timer::EventLoopTimerTag::TerminalPendingClose,
+            )),
         }));
         // SAFETY: just allocated, non-null, exclusively owned here. R-2: `&`
         // (not `&mut`) — every method below takes `&self`; field writes go
@@ -744,6 +760,70 @@ impl Terminal {
         if let Some(hpcon) = self.hpcon.take() {
             self.close_pseudoconsole_off_thread(hpcon);
         }
+    }
+
+    /// Windows inline-terminal child-exit path. Conhost renders the client's
+    /// output on its own thread and only then writes the VT diff to our pipe,
+    /// so calling `ClosePseudoConsole` immediately after the child exits can
+    /// tear conhost down before that render runs on older Windows and the last
+    /// write never reaches `on_read_chunk` (microsoft/terminal#1810). Follow
+    /// node-pty's `FLUSH_DATA_INTERVAL`: arm a quiescence timer, re-arm it on
+    /// every received chunk, and close the pseudoconsole once the output pipe
+    /// has been silent for `PENDING_CLOSE_QUIESCENCE_MS`.
+    #[cfg(windows)]
+    pub(crate) fn close_pseudoconsole_after_quiescence(&self) {
+        let flags = self.flags.get();
+        if flags.intersects(Flags::CLOSED | Flags::READER_DONE | Flags::PENDING_CLOSE)
+            || self.hpcon.get().is_none()
+        {
+            self.close_pseudoconsole();
+            return;
+        }
+        self.mark_inline_spawned();
+        self.update_flags(|f| f.insert(Flags::PENDING_CLOSE));
+        self.arm_pending_close_timer();
+    }
+
+    #[cfg(windows)]
+    fn arm_pending_close_timer(&self) {
+        use crate::timer::{ElTimespec, EventLoopTimerState};
+        let all = crate::jsc_hooks::timer_all_mut();
+        if self.event_loop_timer.get().state == EventLoopTimerState::ACTIVE {
+            all.remove(self.event_loop_timer.as_ptr());
+        }
+        let next = bun_core::timespec::ms_from_now(
+            bun_core::TimespecMockMode::AllowMockedTime,
+            PENDING_CLOSE_QUIESCENCE_MS,
+        );
+        self.event_loop_timer.with_mut(|t| {
+            t.next = ElTimespec {
+                sec: next.sec,
+                nsec: next.nsec,
+            };
+        });
+        all.insert(self.event_loop_timer.as_ptr());
+    }
+
+    #[cfg(windows)]
+    fn cancel_pending_close_timer(&self) {
+        use crate::timer::EventLoopTimerState;
+        if self.event_loop_timer.get().state == EventLoopTimerState::ACTIVE {
+            crate::jsc_hooks::timer_all_mut().remove(self.event_loop_timer.as_ptr());
+        }
+        self.update_flags(|f| f.remove(Flags::PENDING_CLOSE));
+    }
+
+    /// Quiescence timer fired: no ConPTY output for `PENDING_CLOSE_QUIESCENCE_MS`
+    /// after the inline child exited, so conhost has nothing left to render.
+    #[cfg(windows)]
+    pub(crate) fn on_pending_close_timer(&self) {
+        self.event_loop_timer
+            .with_mut(|t| t.state = crate::timer::EventLoopTimerState::FIRED);
+        if !self.flags.get().contains(Flags::PENDING_CLOSE) {
+            return;
+        }
+        self.update_flags(|f| f.remove(Flags::PENDING_CLOSE));
+        self.close_pseudoconsole();
     }
 
     /// On Windows < 11 24H2, ClosePseudoConsole blocks until the output pipe is
@@ -1150,6 +1230,12 @@ fn create_overlapped_pipe_pair(
 
 #[cfg(windows)]
 static PIPE_SERIAL: AtomicU32 = AtomicU32::new(0);
+
+/// How long the ConPTY output pipe must be silent after the inline child
+/// exited before we call `ClosePseudoConsole`. Matches node-pty's
+/// `FLUSH_DATA_INTERVAL` (microsoft/node-pty windowsPtyAgent.ts).
+#[cfg(windows)]
+const PENDING_CLOSE_QUIESCENCE_MS: i64 = 1000;
 
 #[cfg(windows)]
 fn create_pty_windows(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError> {
@@ -1673,6 +1759,9 @@ impl Terminal {
         }
         self.update_flags(|f| f.insert(Flags::CLOSED));
 
+        #[cfg(windows)]
+        self.cancel_pending_close_timer();
+
         // Close writer (closes write_fd). R-2: `with_mut` borrow is held across
         // the synchronous `on_writer_close` parent callback, but that callback
         // touches only `flags`/`ref_count` (separate `Cell`s), never `writer`.
@@ -1787,6 +1876,8 @@ impl Terminal {
         if self.flags.get().contains(Flags::READER_DONE) {
             return;
         }
+        #[cfg(windows)]
+        self.cancel_pending_close_timer();
         self.update_flags(|f| {
             f.insert(Flags::READER_DONE);
             f.remove(Flags::CONNECTED);
@@ -1840,6 +1931,11 @@ impl Terminal {
 
         if self.flags.get().contains(Flags::FINALIZED) {
             return true;
+        }
+
+        #[cfg(windows)]
+        if self.flags.get().contains(Flags::PENDING_CLOSE) {
+            self.arm_pending_close_timer();
         }
 
         // First data received - upgrade to strong ref (connected)

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -792,7 +792,7 @@ impl Terminal {
             all.remove(self.event_loop_timer.as_ptr());
         }
         let next = bun_core::timespec::ms_from_now(
-            bun_core::TimespecMockMode::AllowMockedTime,
+            bun_core::TimespecMockMode::ForceRealTime,
             PENDING_CLOSE_QUIESCENCE_MS,
         );
         self.event_loop_timer.with_mut(|t| {
@@ -1877,7 +1877,12 @@ impl Terminal {
             return;
         }
         #[cfg(windows)]
-        self.cancel_pending_close_timer();
+        {
+            // Conhost may self-terminate (EOF) before the quiescence timer
+            // fires; release hpcon here so it doesn't linger until GC.
+            self.cancel_pending_close_timer();
+            self.close_pseudoconsole();
+        }
         self.update_flags(|f| {
             f.insert(Flags::READER_DONE);
             f.remove(Flags::CONNECTED);

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -967,7 +967,7 @@ impl Subprocess<'_> {
                 #[cfg(unix)]
                 term.drain_and_close_slave_fd();
                 #[cfg(windows)]
-                term.close_pseudoconsole();
+                term.close_pseudoconsole_after_quiescence();
             }
         }
 

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1061,6 +1061,16 @@ pub unsafe fn __bun_fire_timer(t: *mut EventLoopTimer, now: *const ElTimespec, v
             timer_arm!(Subprocess<'_>, event_loop_timer, |c, _now, _vm| (*c)
                 .timeout_callback())
         }
+        #[cfg(windows)]
+        EventLoopTimerTag::TerminalPendingClose => {
+            timer_arm!(
+                crate::api::bun_terminal_body::Terminal,
+                event_loop_timer,
+                |c, _now, _vm| (*c).on_pending_close_timer()
+            )
+        }
+        #[cfg(not(windows))]
+        EventLoopTimerTag::TerminalPendingClose => unreachable!(),
         EventLoopTimerTag::DevServerSweepSourceMaps => {
             // `sweep_weak_refs` takes the raw `*EventLoopTimer` and recovers
             // the store inside.

--- a/test/js/bun/terminal/terminal-platform-gaps.test.ts
+++ b/test/js/bun/terminal/terminal-platform-gaps.test.ts
@@ -225,11 +225,15 @@ describe("Bun.Terminal platform behaviour", () => {
     // POSIX ONLCR and ConPTY both render \n as \r\n on the master/read side.
     // Older ConPTY may pad to the cell boundary before \r\n, either with
     // spaces or with an erase-and-advance pair (ESC[nX ESC[nC) when it emits
-    // a full-screen repaint, so accept any non-LF run between READY and \r\n.
+    // a full-screen repaint. In repaint form EVERY row ends \r\n regardless of
+    // the child's output, so anchor the \r\n between the two markers: READY
+    // and LINE2 must land on separate rows, which they only do if the child's
+    // \n was honoured.
     const { output } = await runInTerminal(`process.stdout.write('READY\\nLINE2')`, {
       done: o => o.includes("LINE2"),
     });
-    expect(output).toMatch(/READY[^\n]*\r\n/);
+    expect(output).toMatch(/READY[^\n]*\r\n[^\n]*LINE2/);
+    expect(output).not.toMatch(/READY[^\r\n]*LINE2/);
   });
 
   test("GAP: ANSI escape sequences", async () => {

--- a/test/js/bun/terminal/terminal-platform-gaps.test.ts
+++ b/test/js/bun/terminal/terminal-platform-gaps.test.ts
@@ -29,18 +29,10 @@ async function runInTerminal(
   const readyMarker = opts.readyMarker ?? "READY";
   const decoder = new TextDecoder();
 
-  // Keep the child alive until we've seen `done()` (we kill it below). On
-  // Windows Server 2019's ConPTY, a child that writes and immediately exits
-  // races conhost's render thread: ClosePseudoConsole (fired on subprocess
-  // exit) can tear conhost down before it emits the child's last write, so
-  // the data callback never sees it. With the child held open conhost renders
-  // on its next tick and the output arrives deterministically.
-  const script = `setInterval(()=>{},1e9);${childScript}`;
-
   // Use an inline terminal so the child becomes the session leader on POSIX
   // (setsid + TIOCSCTTY), which is required for SIGINT/SIGWINCH delivery.
   const proc = Bun.spawn({
-    cmd: [bunExe(), "-e", script],
+    cmd: [bunExe(), "-e", childScript],
     env: bunEnv,
     terminal: {
       cols: opts.cols ?? 80,

--- a/test/js/bun/terminal/terminal-platform-gaps.test.ts
+++ b/test/js/bun/terminal/terminal-platform-gaps.test.ts
@@ -29,10 +29,18 @@ async function runInTerminal(
   const readyMarker = opts.readyMarker ?? "READY";
   const decoder = new TextDecoder();
 
+  // Keep the child alive until we've seen `done()` (we kill it below). On
+  // Windows Server 2019's ConPTY, a child that writes and immediately exits
+  // races conhost's render thread: ClosePseudoConsole (fired on subprocess
+  // exit) can tear conhost down before it emits the child's last write, so
+  // the data callback never sees it. With the child held open conhost renders
+  // on its next tick and the output arrives deterministically.
+  const script = `setInterval(()=>{},1e9);${childScript}`;
+
   // Use an inline terminal so the child becomes the session leader on POSIX
   // (setsid + TIOCSCTTY), which is required for SIGINT/SIGWINCH delivery.
   const proc = Bun.spawn({
-    cmd: [bunExe(), "-e", childScript],
+    cmd: [bunExe(), "-e", script],
     env: bunEnv,
     terminal: {
       cols: opts.cols ?? 80,
@@ -215,11 +223,13 @@ describe("Bun.Terminal platform behaviour", () => {
 
   test("SAME: output LF is translated to CRLF", async () => {
     // POSIX ONLCR and ConPTY both render \n as \r\n on the master/read side.
-    // Older ConPTY may pad to the cell boundary with spaces before \r\n.
+    // Older ConPTY may pad to the cell boundary before \r\n, either with
+    // spaces or with an erase-and-advance pair (ESC[nX ESC[nC) when it emits
+    // a full-screen repaint, so accept any non-LF run between READY and \r\n.
     const { output } = await runInTerminal(`process.stdout.write('READY\\nLINE2')`, {
       done: o => o.includes("LINE2"),
     });
-    expect(output).toMatch(/READY *\r\n/);
+    expect(output).toMatch(/READY[^\n]*\r\n/);
   });
 
   test("GAP: ANSI escape sequences", async () => {


### PR DESCRIPTION
`test/js/bun/terminal/terminal-platform-gaps.test.ts` intermittently goes red on the Windows 2019 x64 lane (builds 75636, 75200, 74400, and 47500 two days after the test landed). Two tests have been seen failing, both from the same cause: a child that writes to stdout then immediately exits can have its last write dropped under Windows Server 2019's ConPTY.

### Cause

On Windows the child writes to conhost.exe, which renders to a virtual screen on its own thread and then emits the VT diff to our reader pipe. `Subprocess::on_process_exit` called `Terminal::close_pseudoconsole()` (which fires `ClosePseudoConsole` off-thread) immediately after the child's exit IOCP. On Windows Server 2019's conhost that can tear the pseudoconsole down before the pending render runs, so the content chunk never reaches the pipe and the terminal's `exit` callback fires with only ConPTY's init sequence in `output`:

```
Expected to contain: "RED"
Received: "\^[[2J\^[[?25l\^[[m\^[[H\r\n...\^[[H\^[]0;...\^@\x07\^[[?25h"
```

When conhost's render *does* run before teardown, it emits the final frame as a full-screen repaint, padding each row with `ESC[nX ESC[nC` erase-and-advance instead of spaces, which trips `/READY *\r\n/` in the CRLF test even though the data arrived.

This is a known ConPTY limitation ([microsoft/terminal#1810, zadjii-msft](https://github.com/microsoft/terminal/issues/1810#issuecomment-523713403): "the client app could run and exit before we've rendered all their output"). node-pty works around it with a [1s data-quiescence wait before teardown](https://github.com/microsoft/node-pty/blob/main/src/windowsPtyAgent.ts#L18-L23) (`FLUSH_DATA_INTERVAL`).

### Fix

Adopt node-pty's approach. `Subprocess::on_process_exit` on Windows now calls `Terminal::close_pseudoconsole_after_quiescence()`:

- Set `PENDING_CLOSE` and arm a 1s `EventLoopTimer` (new `TerminalPendingClose` tag) instead of closing immediately.
- `Terminal::on_read_chunk` re-arms the timer while `PENDING_CLOSE` is set, so each arriving chunk resets the countdown.
- When the timer fires after 1s of silence, call `close_pseudoconsole()` (which still dispatches `ClosePseudoConsole` off-thread so the event loop keeps draining).
- The timer is cancelled if `close_internal()` or `on_reader_finished()` runs first (user closed the terminal, or conhost exited on its own).

Only the Windows inline-terminal path changes; POSIX and reused-terminal paths are untouched. Observable effect: the terminal's `exit` callback fires ~1s later than before on Windows; `proc.exited` is unaffected.

The test file drops the `setInterval` keep-alive workaround that was here earlier. The CRLF assertion is still widened to accept the `ESC[nX ESC[nC` repaint padding while anchoring the `\r\n` between the two markers, since conhost may still emit a full-screen repaint as its final frame.

### Verification

Windows Server 2019 (build 17763):

- Before: 1/30 full-file runs failed; a 2000-iteration write-then-exit probe hit the `ESC[nX` full-repaint form 99/2000 times.
- After: stress loop results in the status comment below once the Windows debug build finishes.

Linux x64 debug: all 130 `test/js/bun/terminal/` tests pass. `cargo check -p bun_runtime` clean on `x86_64-pc-windows-msvc` and host linux.

Introduced with the test file in #29522.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/terminal/terminal-platform-gaps.test.ts

<!-- robobun:evidence:end -->