### PR TITLE
node:http2: hold a keepalive across on_native_writable's flush loop

### DIFF
--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -9594,6 +9594,10 @@ impl H2FrameParser {
     }
 
     pub(crate) fn on_native_writable(&self) {
+        // flush() re-enters JS (write callbacks, onStreamEnd, onWantTrailers);
+        // that JS can destroy the session and drop the socket's ref, so the
+        // keepalive must span the whole loop, not just each flush() call.
+        let _keepalive = self.keepalive();
         // flush() ends in flush_stream_queue() → write() → cork(), leaving the
         // newly-serialized frames in CORK_BUFFER (not on the wire). Returning
         // here would let loop.c see last_write_failed==0 and disarm WRITABLE,

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -2272,6 +2272,10 @@ impl Stream {
             client.outbound_queue_size.get()
         );
 
+        // dispatch_write_callback re-enters JS; a destroy there can drop the
+        // socket's ref and free `client` between iterations. Not during
+        // finalize: refcount is already 0 and a ref/deref would re-destroy.
+        let _keepalive = (!FINALIZING).then(|| client.keepalive());
         let mut queue = core::mem::take(&mut self.data_frame_queue);
         while let Some(item) = queue.dequeue() {
             let frame = item;
@@ -9614,6 +9618,9 @@ impl H2FrameParser {
 
     pub(crate) fn on_native_close(&self) {
         bun_output::scoped_log!(H2FrameParser, "onNativeClose");
+        // detach_native_socket can drop the socket's last ref (Writeonly deref),
+        // so match on_native_read/on_native_writable and hold our own +1.
+        let _keepalive = self.keepalive();
         self.detach_native_socket();
     }
 

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -3939,29 +3939,25 @@ pub enum NativeCallbacks {
 }
 
 impl NativeCallbacks {
+    /// `&self` borrows the socket's `JsCell<NativeCallbacks>`; the dispatch
+    /// re-enters JS, which can `detach_native_callback` and overwrite that cell.
+    /// Copy the parser pointer out first; the callee's `keepalive()` holds it.
     pub fn on_data(&self, data: &[u8]) -> bool {
-        match self {
-            NativeCallbacks::H2(h2) => {
-                // TODO: properly propagate exception upwards
-                // `RefPtr: Deref<Target = H2FrameParser>`; `on_native_read`
-                // takes `&self`.
-                if h2.on_native_read(data).is_err() {
-                    return false;
-                }
-                true
-            }
-            NativeCallbacks::None => false,
-        }
+        let h2 = match self {
+            NativeCallbacks::H2(h2) => h2.as_ptr(),
+            NativeCallbacks::None => return false,
+        };
+        // SAFETY: `on_native_read` takes a keepalive; `h2` stays live across re-entry.
+        unsafe { (*h2).on_native_read(data).is_ok() }
     }
     pub fn on_writable(&self) -> bool {
-        match self {
-            NativeCallbacks::H2(h2) => {
-                // `on_native_writable(&self)` — Deref through `RefPtr`.
-                h2.on_native_writable();
-                true
-            }
-            NativeCallbacks::None => false,
-        }
+        let h2 = match self {
+            NativeCallbacks::H2(h2) => h2.as_ptr(),
+            NativeCallbacks::None => return false,
+        };
+        // SAFETY: `on_native_writable` takes a keepalive; `h2` stays live across re-entry.
+        unsafe { (*h2).on_native_writable() };
+        true
     }
 }
 

--- a/test/js/node/http2/node-http2-syscall-fault.test.ts
+++ b/test/js/node/http2/node-http2-syscall-fault.test.ts
@@ -191,7 +191,6 @@ describe.skipIf(skip)("node:http2 under injected syscall faults", () => {
       expect(stdout.trim()).toBe("ok");
       expect(exitCode).toBe(0);
     },
-    30_000,
   );
 });
 

--- a/test/js/node/http2/node-http2-syscall-fault.test.ts
+++ b/test/js/node/http2/node-http2-syscall-fault.test.ts
@@ -182,7 +182,7 @@ describe.skipIf(skip)("node:http2 under injected syscall faults", () => {
       // on_native_writable, not an exception the test runner can catch.
       await using proc = Bun.spawn({
         cmd: [bunExe(), path.join(import.meta.dir, "node-http2-writable-destroy-fixture.ts")],
-        env: { ...bunEnv, ASAN_OPTIONS: "symbolize=0" },
+        env: { ...bunEnv, ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":") },
         stdout: "pipe",
         stderr: "pipe",
       });

--- a/test/js/node/http2/node-http2-syscall-fault.test.ts
+++ b/test/js/node/http2/node-http2-syscall-fault.test.ts
@@ -1,8 +1,9 @@
 import { socketFaultInjection as fault } from "bun:internal-for-testing";
 import { afterEach, describe, expect, test } from "bun:test";
-import { tls as certs, isWindows } from "harness";
+import { bunEnv, bunExe, isASAN, tls as certs, isWindows } from "harness";
 import { once } from "node:events";
 import http2 from "node:http2";
+import path from "node:path";
 
 const skip = !fault.available() || isWindows;
 
@@ -172,6 +173,30 @@ describe.skipIf(skip)("node:http2 under injected syscall faults", () => {
       server.close();
     }
   });
+
+  // Hive-pool user-poison, so only ASAN observes the freed-slot read.
+  test.skipIf(!isASAN)(
+    "send → backpressure then session.destroy() inside the drained write callback does not UAF",
+    async () => {
+      // Runs in a subprocess: the failure mode is an ASAN abort inside
+      // on_native_writable, not an exception the test runner can catch.
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), path.join(import.meta.dir, "node-http2-writable-destroy-fixture.ts")],
+        env: { ...bunEnv, ASAN_OPTIONS: "symbolize=0" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect(stderr).not.toContain("AddressSanitizer");
+      expect(stdout.trim()).toBe("ok");
+      expect(exitCode).toBe(0);
+    },
+    30_000,
+  );
 });
 
 describe.skipIf(skip)("node:http2 seeded short-I/O fuzz", () => {

--- a/test/js/node/http2/node-http2-syscall-fault.test.ts
+++ b/test/js/node/http2/node-http2-syscall-fault.test.ts
@@ -1,6 +1,6 @@
 import { socketFaultInjection as fault } from "bun:internal-for-testing";
 import { afterEach, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, tls as certs, isWindows } from "harness";
+import { bunEnv, bunExe, tls as certs, isASAN, isWindows } from "harness";
 import { once } from "node:events";
 import http2 from "node:http2";
 import path from "node:path";
@@ -186,11 +186,7 @@ describe.skipIf(skip)("node:http2 under injected syscall faults", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).not.toContain("AddressSanitizer");
       expect(stdout.trim()).toBe("ok");
       expect(exitCode).toBe(0);

--- a/test/js/node/http2/node-http2-writable-destroy-fixture.ts
+++ b/test/js/node/http2/node-http2-writable-destroy-fixture.ts
@@ -1,0 +1,83 @@
+// Drives the H2FrameParser writable path into a session.destroy() from inside
+// a write callback. Without a keepalive spanning on_native_writable's flush
+// loop, the parser is freed mid-loop and the next has_backpressure() reads a
+// poisoned HiveArray slot (ASAN use-after-poison).
+//
+// Sequence:
+//   1. A large DATA write goes out via the vectored batch path; send/writev
+//      is faulted to 0 so the tail lands in write_buffer (has_backpressure
+//      becomes true and usockets arms WRITABLE).
+//   2. The Writable callback for (1) fires via nextTick; the next buffered
+//      chunk reaches send_data with has_backpressure() true and is queued in
+//      data_frame_queue with its callback.
+//   3. fault.clear() runs (also via nextTick, after (2)); the next I/O poll
+//      delivers the writable event and on_native_writable drains write_buffer
+//      then flush_stream_queue, which invokes the queued callback
+//      synchronously inside the flush loop.
+//   4. Callback destroys the session and forces a full GC so the JS
+//      wrapper's +1 is released while flush()'s own keepalive is still on
+//      the stack; when flush() returns, that keepalive is the last ref.
+
+import { socketFaultInjection as fault } from "bun:internal-for-testing";
+import { once } from "node:events";
+import http2 from "node:http2";
+import type { AddressInfo } from "node:net";
+
+if (!fault.available()) {
+  console.log("ok");
+  process.exit(0);
+}
+
+const server = http2.createServer();
+server.on("stream", stream => {
+  stream.respond({ ":status": 200 });
+  stream.resume();
+  stream.on("end", () => stream.end());
+  stream.on("error", () => {});
+});
+server.on("sessionError", () => {});
+server.listen(0, "127.0.0.1");
+await once(server, "listening");
+const { port } = server.address() as AddressInfo;
+
+const client = http2.connect(`http://127.0.0.1:${port}`);
+client.on("error", () => {});
+await once(client, "connect");
+
+const req = client.request({ ":path": "/", ":method": "POST" });
+req.on("error", () => {});
+req.on("close", () => {});
+// Flush HEADERS now so the fault hits only the DATA batch.
+await new Promise<void>(r => setImmediate(r));
+
+// Force 0-byte sends on every outbound path the DATA batch can reach.
+fault.set({ syscall: "writev", action: "zero", repeat: -1 });
+fault.set({ syscall: "send", action: "zero", repeat: -1 });
+
+const { promise: destroyed, resolve } = Promise.withResolvers<void>();
+
+// (1) Large payload: multi-frame batch path → flush_batch_vectored → writev
+// returns 0, unwritten tail lands in write_buffer. Its Writable callback is
+// deferred via nextTick (direct path).
+req.write(Buffer.alloc(40000, "a"));
+
+// (2) Buffered in the Writable until (1)'s callback runs; when _write runs
+// has_backpressure() is true so send_data queues this frame with destroyCb.
+req.write(Buffer.alloc(64, "b"), function destroyCb() {
+  try {
+    client.destroy();
+  } catch {}
+  Bun.gc(true);
+  resolve();
+});
+
+// (3) Queued after (1)'s deferred callback: by the time this runs the second
+// chunk is in data_frame_queue; clear the fault so the writable event drains.
+process.nextTick(() => process.nextTick(() => fault.clear()));
+
+await destroyed;
+await new Promise<void>(r => setImmediate(r));
+
+server.close();
+console.log("ok");
+process.exit(0);


### PR DESCRIPTION
## Use-after-free in `H2FrameParser::on_native_writable`

Fleet ASAN fuzz hit (p-h2c cleartext harness, seed 1, `server-conn.recv.*:A8`):

```
use-after-poison READ 8 (shadow f7 = user poison, HiveArray slot re-poison)
  #0 Vec::len (write_buffer)
  #2 has_backpressure          h2_frame_parser.rs:3276
  #3 on_native_writable        h2_frame_parser.rs:9605
  #4 NewSocket<true>::on_writable  socket_body.rs:894
  #8 us_internal_ssl_on_writable   bun-usockets openssl.c:1851
allocated by: HiveArray Fallback<H2FrameParser,256>, H2FrameParser::constructor
```

### Cause

`on_native_writable` loops `flush()` and checks `has_backpressure()` between iterations. `flush()` re-enters JS via `flush_stream_queue` -> `dispatch_write_callback` / `onStreamEnd` / `onWantTrailers`. A callback that destroys the session reaches `detach_native_callback`, dropping the socket's `+1` on the parser. If that was the last external ref, `flush()`'s own keepalive is all that remains and drops on return, so the next `has_backpressure()` reads a HiveArray slot that was just `drop_in_place`'d and re-poisoned by `POOL.put`.

`on_native_read` already takes a `keepalive()` for exactly this reason (h2_frame_parser.rs:9590); `on_native_writable` did not.

In release builds there is no poison: the same ordering is a silent use-after-free in every `node:http2` server/client on a native socket. The read of a stale `write_buffer.len()` can satisfy the loop condition and send the next `flush()` into UAF writes on the freed parser.

### Fix

- Take a `keepalive()` for the extent of `on_native_writable`, mirroring `on_native_read`.
- `NativeCallbacks::on_data`/`on_writable`: copy the raw `*mut H2FrameParser` out of the enum before dispatching, so the `JsCell<NativeCallbacks>` borrow does not span a re-entrant `detach_native_callback` that overwrites the cell.

### Test

`test/js/node/http2/node-http2-writable-destroy-fixture.ts` reproduces the exact fleet stack under ASAN by faulting `send`/`writev` to 0 (backpressure, arms WRITABLE), queuing a DATA frame whose write callback runs `session.destroy()` + `Bun.gc(true)`, then clearing the fault so the writable event drains the queue inside `on_native_writable`. Added to `node-http2-syscall-fault.test.ts` as an ASAN-gated subprocess test.

<details><summary>Fail-before ASAN report (matches the fleet hit)</summary>

```
==ERROR: AddressSanitizer: use-after-poison on address 0x... 
READ of size 8 at 0x... thread T0
    #2 H2FrameParser::has_backpressure h2_frame_parser.rs:3276:33
    #3 H2FrameParser::on_native_writable h2_frame_parser.rs:9605:21
    #4 NativeCallbacks::on_writable socket_body.rs:3960:20
    #5 NewSocket<false>::on_writable socket_body.rs:894:39
allocated by thread T0 here:
    ... Fallback<H2FrameParser, 256>::new_boxed hive_array.rs:668
    ... H2FrameParser::constructor h2_frame_parser.rs:9800
SUMMARY: AddressSanitizer: use-after-poison ... Vec<u8>::len
```
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/http2/node-http2-syscall-fault.test.ts

<!-- robobun:evidence:end -->