### PR TITLE
terminal(windows): release the ConDrv \Reference handle after inline spawn

### DIFF
--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -735,15 +735,16 @@ impl Terminal {
     }
 
     /// Windows analogue of `drain_and_close_slave_fd`'s tail: once the direct
-    /// child has exited, an inline terminal no longer keeps the event loop
-    /// alive. The reader stays registered, so if the child left a grandchild
-    /// attached to conhost its output still arrives while anything else keeps
-    /// the loop running; conhost self-exits (and EOF arrives) once that last
-    /// client disconnects.
+    /// child has exited the writer no longer pins the event loop. The reader
+    /// stays ref'd so the loop keeps running until conhost delivers the final
+    /// frame and EOF (which `release_pseudoconsole_reference` arranged to
+    /// happen once the last client disconnects); unreffing it here could let
+    /// the loop exit between child-exit and that asynchronous EOF.
     #[cfg(windows)]
     pub(crate) fn unref_after_inline_child_exit(&self) {
         if !self.flags.get().contains(Flags::CLOSED) {
-            self.update_ref(false);
+            let ctx = self.event_loop_handle.as_event_loop_ctx();
+            self.writer.with_mut(|w| w.update_ref(ctx, false));
         }
     }
 
@@ -1576,20 +1577,23 @@ impl Terminal {
 
         #[cfg(windows)]
         {
-            // READER_DONE ⇒ conhost has exited and the signal pipe is broken;
-            // ResizePseudoConsole would fail with ERROR_NO_DATA. Skip to match
-            // POSIX where master_fd is already INVALID on that path.
-            if !self.flags.get().contains(Flags::READER_DONE) {
-                if let Some(hpcon) = self.hpcon.get() {
-                    let size = windows::COORD {
-                        X: clamp_to_coord(new_cols),
-                        Y: clamp_to_coord(new_rows),
-                    };
-                    // SAFETY: hpcon is a valid open HPCON.
-                    let hr = unsafe { windows::ResizePseudoConsole(hpcon, size) };
-                    if hr < 0 {
-                        return Err(global_object.throw(format_args!("Failed to resize terminal")));
-                    }
+            // HRESULT_FROM_WIN32(ERROR_NO_DATA | ERROR_BROKEN_PIPE): the signal
+            // pipe's read end is gone because conhost has exited. For inline
+            // terminals that can happen any time after the child disconnects
+            // (the \Reference handle is released at spawn); treat it as a
+            // no-op so resize() keeps its pre-existing no-throw behaviour in
+            // the window between child exit and reader EOF.
+            const HR_NO_DATA: i32 = 0x8007_00E8u32 as i32;
+            const HR_BROKEN_PIPE: i32 = 0x8007_006Du32 as i32;
+            if let Some(hpcon) = self.hpcon.get() {
+                let size = windows::COORD {
+                    X: clamp_to_coord(new_cols),
+                    Y: clamp_to_coord(new_rows),
+                };
+                // SAFETY: hpcon is a valid open HPCON.
+                let hr = unsafe { windows::ResizePseudoConsole(hpcon, size) };
+                if hr < 0 && hr != HR_NO_DATA && hr != HR_BROKEN_PIPE {
+                    return Err(global_object.throw(format_args!("Failed to resize terminal")));
                 }
             }
         }

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -1588,9 +1588,7 @@ impl Terminal {
                     // SAFETY: hpcon is a valid open HPCON.
                     let hr = unsafe { windows::ResizePseudoConsole(hpcon, size) };
                     if hr < 0 {
-                        return Err(
-                            global_object.throw(format_args!("Failed to resize terminal"))
-                        );
+                        return Err(global_object.throw(format_args!("Failed to resize terminal")));
                     }
                 }
             }

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -185,8 +185,8 @@ bitflags::bitflags! {
         const READER_DONE    = 1 << 5;
         const WRITER_DONE    = 1 << 6;
         /// Set once an inline-created terminal is attached to a spawn; blocks
-        /// reuse. Windows: first exit's ClosePseudoConsole would kill a second
-        /// child. POSIX: slave_fd is held until first exit (`drain_and_close_slave_fd`).
+        /// reuse. Windows: the ConDrv `\Reference` handle is released at spawn.
+        /// POSIX: slave_fd is held until first exit (`drain_and_close_slave_fd`).
         const INLINE_SPAWNED = 1 << 7;
     }
 }
@@ -734,15 +734,43 @@ impl Terminal {
         drop(guard);
     }
 
-    /// Windows: close only the ConPTY handle so conhost releases its pipe ends and
-    /// our reader observes EOF. Leaves the Terminal itself open (closed=false),
-    /// matching POSIX semantics where child exit delivers EOF without closing the
-    /// master fd.
-    #[allow(dead_code)]
-    pub(crate) fn close_pseudoconsole(&self) {
-        #[cfg(windows)]
-        if let Some(hpcon) = self.hpcon.take() {
-            self.close_pseudoconsole_off_thread(hpcon);
+    /// Windows analogue of `drain_and_close_slave_fd`'s tail: once the direct
+    /// child has exited, an inline terminal no longer keeps the event loop
+    /// alive. The reader stays registered, so if the child left a grandchild
+    /// attached to conhost its output still arrives while anything else keeps
+    /// the loop running; conhost self-exits (and EOF arrives) once that last
+    /// client disconnects.
+    #[cfg(windows)]
+    pub(crate) fn unref_after_inline_child_exit(&self) {
+        if !self.flags.get().contains(Flags::CLOSED) {
+            self.update_ref(false);
+        }
+    }
+
+    /// Close this HPCON's ConDrv `\Reference` handle so conhost exits on its own
+    /// once the last attached client disconnects: the output pipe then breaks
+    /// and our reader observes EOF without `on_process_exit` having to tear
+    /// ConPTY down (which races conhost's render thread on older builds and can
+    /// drop the child's last write). Equivalent to kernel32's
+    /// `ReleasePseudoConsole` (Windows 11 24H2+) / conpty.dll's
+    /// `ConptyReleasePseudoConsole`; neither is exported from the inbox
+    /// kernel32 on older builds so we reach into the struct directly. Further
+    /// spawns against this pseudoconsole are impossible afterwards.
+    #[cfg(windows)]
+    pub(crate) fn release_pseudoconsole_reference(&self) {
+        let Some(hpcon) = self.hpcon.get() else {
+            return;
+        };
+        // SAFETY: `hpcon` was returned from inbox `CreatePseudoConsole`, which
+        // heap-allocates a `PseudoConsole` and returns it as HPCON.
+        // `ClosePseudoConsole` later skips the field when it reads null.
+        let pc = hpcon.cast::<PseudoConsole>();
+        unsafe {
+            let r#ref = (*pc).h_pty_reference;
+            if !r#ref.is_null() && r#ref != windows::INVALID_HANDLE_VALUE {
+                let _ = windows::CloseHandle(r#ref);
+                (*pc).h_pty_reference = core::ptr::null_mut();
+            }
         }
     }
 
@@ -1068,6 +1096,17 @@ fn create_pty_posix(cols: u16, rows: u16) -> Result<PtyResult, CreatePtyError> {
 pub(crate) struct PipePair {
     pub server: windows::HANDLE,
     pub client: windows::HANDLE,
+}
+
+/// Inbox kernel32's HPCON layout. Stable ABI since build 17763: documented as
+/// "part of an ABI shared with the rest of the operating system" in
+/// microsoft/terminal `src/winconpty/winconpty.h`.
+#[cfg(windows)]
+#[repr(C)]
+struct PseudoConsole {
+    h_signal: windows::HANDLE,
+    h_pty_reference: windows::HANDLE,
+    h_conpty_process: windows::HANDLE,
 }
 
 /// Create one end of a pipe pair as an overlapped named pipe (server) and the
@@ -1537,15 +1576,22 @@ impl Terminal {
 
         #[cfg(windows)]
         {
-            if let Some(hpcon) = self.hpcon.get() {
-                let size = windows::COORD {
-                    X: clamp_to_coord(new_cols),
-                    Y: clamp_to_coord(new_rows),
-                };
-                // SAFETY: hpcon is a valid open HPCON.
-                let hr = unsafe { windows::ResizePseudoConsole(hpcon, size) };
-                if hr < 0 {
-                    return Err(global_object.throw(format_args!("Failed to resize terminal")));
+            // READER_DONE ⇒ conhost has exited and the signal pipe is broken;
+            // ResizePseudoConsole would fail with ERROR_NO_DATA. Skip to match
+            // POSIX where master_fd is already INVALID on that path.
+            if !self.flags.get().contains(Flags::READER_DONE) {
+                if let Some(hpcon) = self.hpcon.get() {
+                    let size = windows::COORD {
+                        X: clamp_to_coord(new_cols),
+                        Y: clamp_to_coord(new_rows),
+                    };
+                    // SAFETY: hpcon is a valid open HPCON.
+                    let hr = unsafe { windows::ResizePseudoConsole(hpcon, size) };
+                    if hr < 0 {
+                        return Err(
+                            global_object.throw(format_args!("Failed to resize terminal"))
+                        );
+                    }
                 }
             }
         }
@@ -1688,8 +1734,7 @@ impl Terminal {
             if let Some(hpcon) = self.hpcon.take() {
                 self.close_pseudoconsole_off_thread(hpcon);
             }
-            // Reader stays open even if hpcon was already null (closePseudoconsole
-            // may have dispatched it earlier); onReaderDone closes on EOF.
+            // Leave the reader open; onReaderDone closes it on EOF.
             let flags = self.flags.get();
             if flags.contains(Flags::READER_STARTED) && !flags.contains(Flags::READER_DONE) {
                 return;

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1460,10 +1460,16 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
         terminal_js_value = info.js_value;
         #[cfg(unix)]
         info.term().mark_inline_spawned();
-        // Windows: ConPTY's conhost buffers output, so the client handle can go
-        // now; EOF is delivered via close_pseudoconsole on exit.
         #[cfg(windows)]
-        info.term().close_slave_fd();
+        {
+            // ConPTY has no slave fd; this just marks inline_spawned.
+            info.term().close_slave_fd();
+            // Release the ConDrv \Reference handle now that the child holds a
+            // copy: conhost then exits on its own once the child disconnects
+            // and the reader observes EOF without us having to tear ConPTY
+            // down from on_process_exit.
+            info.term().release_pseudoconsole_reference();
+        }
         subprocess.update_flags(|f| f.insert(Subprocess::Flags::OWNS_TERMINAL));
     }
     // existing_terminal: don't close slave_fd - user manages lifecycle and can reuse

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -961,7 +961,8 @@ impl Subprocess<'_> {
             // slave close). Windows: the ConDrv \Reference handle was released
             // at spawn time, so conhost exits and breaks the output pipe once
             // its last client (this child, or a grandchild it left behind) has
-            // disconnected; unref the reader so that wait doesn't pin the loop.
+            // disconnected; unref the writer here and leave the reader ref'd
+            // until that EOF arrives.
             if let Some(terminal) = self.terminal.get() {
                 // `BackRef` invariant holds: the terminal is owned by (or
                 // borrowed from a JS wrapper kept live by) this subprocess and

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -956,9 +956,12 @@ impl Subprocess<'_> {
         unsafe { (*jsc_vm).on_subprocess_exit(NonNull::new_unchecked(process)) };
 
         if self.flags.get().contains(Flags::OWNS_TERMINAL) {
-            // Deliver EOF to the terminal reader without closing the Terminal:
+            // Deliver EOF to the terminal reader without closing the Terminal.
             // POSIX drains then releases slave_fd (BSD kernels flush on last
-            // slave close); Windows closes the ConPTY pseudoconsole.
+            // slave close). Windows: the ConDrv \Reference handle was released
+            // at spawn time, so conhost exits and breaks the output pipe once
+            // its last client (this child, or a grandchild it left behind) has
+            // disconnected; unref the reader so that wait doesn't pin the loop.
             if let Some(terminal) = self.terminal.get() {
                 // `BackRef` invariant holds: the terminal is owned by (or
                 // borrowed from a JS wrapper kept live by) this subprocess and
@@ -967,7 +970,7 @@ impl Subprocess<'_> {
                 #[cfg(unix)]
                 term.drain_and_close_slave_fd();
                 #[cfg(windows)]
-                term.close_pseudoconsole();
+                term.unref_after_inline_child_exit();
             }
         }
 

--- a/test/internal/source-lints/dead-code-escape-limits.json
+++ b/test/internal/source-lints/dead-code-escape-limits.json
@@ -16,7 +16,7 @@
   "src/jsc_macros/lib.rs": 2,
   "src/opaque/lib.rs": 5,
   "src/patch/lib.rs": 2,
-  "src/runtime/api/bun/Terminal.rs": 2,
+  "src/runtime/api/bun/Terminal.rs": 1,
   "src/runtime/cli/test/ChangedFilesFilter.rs": 1,
   "src/runtime/dns_jsc/dns.rs": 5,
   "src/runtime/image/backend_coregraphics.rs": 14,

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -1278,10 +1278,13 @@ describe.concurrent("Bun.spawn with terminal option", () => {
   });
 
   // An inline terminal must not keep the event loop alive after its subprocess
-  // exits: on_process_exit drives the reader to EOF and unrefs both polls, so a
-  // script that never calls terminal.close() still exits. Regression for #33882
-  // which deferred the reader's EOF to a later poll tick. POSIX-only: Windows
-  // delivers EOF via close_pseudoconsole off-thread and was not affected.
+  // exits: on_process_exit drives the reader to EOF and unrefs both polls on
+  // POSIX (drain_and_close_slave_fd) and unrefs them on Windows
+  // (unref_after_inline_child_exit), so a script that never calls
+  // terminal.close() still exits. Regression for #33882 which deferred the
+  // reader's EOF to a later poll tick. POSIX-only assertions: on Windows EOF
+  // arrives asynchronously once conhost self-exits, so the exit callback may
+  // not have fired by the time child.exited resolves.
   test.skipIf(isWindows)("process exits after subprocess with inline terminal (no terminal.close)", async () => {
     await using proc = Bun.spawn({
       cmd: [
@@ -1353,9 +1356,35 @@ describe.concurrent("Bun.spawn with terminal option", () => {
       // The exit callback fires on reader EOF: on Windows that is conhost closing
       // the output pipe from its IoThread; on POSIX it is drain_and_close_slave_fd.
       expect(outputAtExit).toContain("LAST-FRAME");
+      // After EOF conhost has exited; resize() must keep its no-throw contract
+      // (ResizePseudoConsole would fail on the broken signal pipe).
+      expect(() => proc.terminal!.resize(100, 40)).not.toThrow();
     } finally {
       proc.terminal?.close();
     }
+  });
+
+  // Cross-platform loop-exit check: after an inline terminal's child exits,
+  // nothing else in the inner script refs the event loop. POSIX drains to EOF
+  // synchronously; Windows unrefs the reader and conhost self-exits. Either way
+  // the inner process must not hang.
+  test("process exits after inline-terminal child exits without terminal.close()", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `await Bun.spawn([process.execPath, "-e", "process.stdout.write('ok')"], {
+           env: process.env,
+           terminal: { data() {}, exit() {} },
+         }).exited;`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr }).toEqual({ stdout: "", stderr: "" });
+    expect(exitCode).toBe(0);
   });
 
   // https://github.com/oven-sh/bun/issues/33187

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -1278,13 +1278,14 @@ describe.concurrent("Bun.spawn with terminal option", () => {
   });
 
   // An inline terminal must not keep the event loop alive after its subprocess
-  // exits: on_process_exit drives the reader to EOF and unrefs both polls on
-  // POSIX (drain_and_close_slave_fd) and unrefs them on Windows
-  // (unref_after_inline_child_exit), so a script that never calls
-  // terminal.close() still exits. Regression for #33882 which deferred the
-  // reader's EOF to a later poll tick. POSIX-only assertions: on Windows EOF
-  // arrives asynchronously once conhost self-exits, so the exit callback may
-  // not have fired by the time child.exited resolves.
+  // exits: on POSIX on_process_exit drives the reader to EOF and unrefs both
+  // polls (drain_and_close_slave_fd); on Windows it unrefs only the writer
+  // (unref_after_inline_child_exit) and the reader stays ref'd until conhost
+  // self-exits and delivers EOF, so a script that never calls terminal.close()
+  // still exits. Regression for #33882 which deferred the reader's EOF to a
+  // later poll tick. POSIX-only assertions: on Windows EOF arrives
+  // asynchronously once conhost self-exits, so the exit callback may not have
+  // fired by the time child.exited resolves.
   test.skipIf(isWindows)("process exits after subprocess with inline terminal (no terminal.close)", async () => {
     await using proc = Bun.spawn({
       cmd: [

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -1367,8 +1367,8 @@ describe.concurrent("Bun.spawn with terminal option", () => {
 
   // Cross-platform loop-exit check: after an inline terminal's child exits,
   // nothing else in the inner script refs the event loop. POSIX drains to EOF
-  // synchronously; Windows unrefs the reader and conhost self-exits. Either way
-  // the inner process must not hang.
+  // synchronously; on Windows the reader stays ref'd only until conhost
+  // self-exits and delivers EOF. Either way the inner process must not hang.
   test("process exits after inline-terminal child exits without terminal.close()", async () => {
     await using proc = Bun.spawn({
       cmd: [
@@ -1384,8 +1384,7 @@ describe.concurrent("Bun.spawn with terminal option", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr }).toEqual({ stdout: "", stderr: "" });
-    expect(exitCode).toBe(0);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: expect.any(String), exitCode: 0 });
   });
 
   // https://github.com/oven-sh/bun/issues/33187

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -1323,6 +1323,41 @@ describe.concurrent("Bun.spawn with terminal option", () => {
     });
   });
 
+  // On Windows, Subprocess::on_process_exit used to fire ClosePseudoConsole
+  // immediately; that routes teardown through conhost's PtySignalInputThread,
+  // which on Server 2019 races the ConsoleIoThread still processing the
+  // child's last WriteConsole and can drop the final render. The inline
+  // pseudoconsole now releases its ConDrv \Reference handle at spawn time so
+  // conhost exits via its IoThread (sequentially after the last write) and the
+  // reader sees every byte before EOF.
+  test("inline terminal: fast-exiting child's output is delivered before exit callback", async () => {
+    let output = "";
+    let outputAtExit = "";
+    const eof = Promise.withResolvers<void>();
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "process.stdout.write('LAST-FRAME', () => process.exit(0))"],
+      env: bunEnv,
+      terminal: {
+        data(_t, chunk) {
+          output += Buffer.from(chunk).toString();
+        },
+        exit() {
+          outputAtExit = output;
+          eof.resolve();
+        },
+      },
+    });
+    try {
+      await proc.exited;
+      await eof.promise;
+      // The exit callback fires on reader EOF: on Windows that is conhost closing
+      // the output pipe from its IoThread; on POSIX it is drain_and_close_slave_fd.
+      expect(outputAtExit).toContain("LAST-FRAME");
+    } finally {
+      proc.terminal?.close();
+    }
+  });
+
   // https://github.com/oven-sh/bun/issues/33187
   // Not `test.concurrent`: spawns run concurrently inside the body; the serial
   // `Bun.spawn` loop must be the only contention to reproduce the race.


### PR DESCRIPTION
When a child spawned under an inline `terminal: {...}` exits on Windows, `Subprocess::on_process_exit` was firing `ClosePseudoConsole` immediately. On Windows Server 2019 that can drop the child's final write, so the terminal's data callback never sees it. This is the cause of the intermittent `terminal-platform-gaps.test.ts` failures on the Windows 2019 lane (builds 47500, 74400, 75200, 75636; `Expected to contain: "RED"` with only the ConPTY init sequence in `Received`). #34689 deflakes the test by keeping the child alive; this PR fixes the underlying race so a fast-exiting child under `terminal: {...}` keeps its output.

### Cause

`ClosePseudoConsole` closes the signal pipe first. conhost's `PtySignalInputThread` reads EOF, calls `_Shutdown` → `RundownAndExit` → `ExitProcess`. On build 17763 that thread can run while conhost's `ConsoleIoThread` is still processing the child's last `WriteConsole` (it holds the console lock; the signal thread doesn't), and while the renderer's pending frame for it has not been painted to the output pipe. `ExitProcess` terminates both and the frame is lost.

### Fix

Instead of tearing ConPTY down from the exit path, release the HPCON's ConDrv `\Reference` handle right after the child is spawned. Once the child (now the only holder) disconnects, ConDrv breaks conhost's server handle; conhost's `ConsoleIoThread` sees `ERROR_PIPE_NOT_CONNECTED` *on the same loop that just processed the child's final write*, runs `RundownAndExit` → `TriggerTeardown` (final paint) and exits, and our reader sees the last frame followed by EOF. The shutdown is sequenced after the write by construction.

This is what Windows Terminal does (`ConptyReleasePseudoConsole` in `ConptyConnection::Start`) and what Windows 11 24H2 exposes as `kernel32!ReleasePseudoConsole`. On older builds the inbox kernel32 does not export it, so we close `hPtyReference` directly via the HPCON struct layout (`{ hSignal, hPtyReference, hConPtyProcess }`), which is the documented OS ABI since build 17763 (microsoft/terminal `src/winconpty/winconpty.h`: "part of an ABI shared with the rest of the operating system", unchanged since the September 2019 open-sourcing). `ClosePseudoConsole`'s own members-close path skips a null `hPtyReference`, so explicit `terminal.close()` keeps working.

`Subprocess::on_process_exit` now only unrefs the writer; the reader stays ref'd until conhost delivers the final frame and EOF (which `release_pseudoconsole_reference` arranged to happen once the last client disconnects). `resize()` treats `ERROR_NO_DATA`/`ERROR_BROKEN_PIPE` from `ResizePseudoConsole` as a no-op so it keeps its pre-existing no-throw behaviour in the window between child exit and reader EOF.

Existing (non-inline) terminals still hold `hPtyReference` so they can be attached to further spawns; their lifecycle is unchanged.

### Verification

Windows Server 2019 (build 17763):

```
// 600 concurrent fast-exiting children, snapshot output at exit callback:
{"dropped":0,"total":600}
// EOF latency relative to proc.exited across 40 concurrent:
{"eofDelayMs":{"min":0,"p50":0,"max":281}}
// await proc.exited; await eof (reader unref'd on exit), single-spawn:
fails=0 / 100
// nothing after proc.exited; observe beforeExit:
{"exitFired":true,"gotMarker":true} (0 / 50 bad)
// resize() after exit callback:
{"threw":null}
```

- `bun bd test test/js/bun/terminal/` on Server 2019: 111 pass / 0 fail
- `terminal-platform-gaps.test.ts` × 30 on Server 2019: 30 pass
- `bun bd test test/js/bun/terminal/` on Windows 11 24H2 aarch64: 111 pass / 0 fail
- `bun bd test test/js/bun/terminal/` on Linux x64: 130 pass / 0 fail
- `bun run rust:check-all`: 10/10 targets

The gate runs on Linux where the Windows code path is `#[cfg(windows)]`-gated, so it cannot observe the before/after difference; the new test covers the behaviour on both platforms and the Windows evidence is the stress runs and the 30-loop above.

Follow-up to #34689 (test-side deflake); related upstream discussion: microsoft/terminal#1810, microsoft/terminal#14544.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/terminal/terminal.test.ts

<!-- robobun:evidence:end -->
