### PR TITLE
shell: route FIFO redirect targets through the pollable IOWriter path

### DIFF
--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -578,9 +578,6 @@ impl Builtin {
                 let cwd_fd = Self::cwd(interp, cmd);
                 let evtloop = interp.event_loop;
 
-                // Regular files are not pollable on linux/macos.
-                let is_pollable_default: bool = cfg!(windows);
-
                 let mut pollable = false;
                 let mut is_socket = false;
                 let mut is_nonblocking = false;
@@ -671,15 +668,13 @@ impl Builtin {
                     return None;
                 }
 
-                // The IOWriter receives the hardcoded platform const
-                // `is_pollable` (false on POSIX, true on Windows); the
-                // `pollable` out-param populated by `open_for_writing_impl`
-                // is intentionally ignored.
-                let _ = pollable;
+                // Honor the `pollable` computed by `open_for_writing_impl` on
+                // POSIX so a FIFO/socket target (whose fd is now O_NONBLOCK)
+                // takes the pollable path; Windows keeps the async writer.
                 let redirect_writer = IOWriter::init(
                     redirfd,
                     io_writer::Flags {
-                        pollable: is_pollable_default,
+                        pollable: if cfg!(windows) { true } else { pollable },
                         nonblock: is_nonblocking,
                         is_socket,
                         ..Default::default()

--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -716,10 +716,26 @@ impl IOWriter {
         // holding a stale `&mut`.
         let amt = match result {
             bun_io::WriteResult::Done(amt) | bun_io::WriteResult::Wrote(amt) => amt,
-            bun_io::WriteResult::Pending(_) => {
-                unreachable!(
-                    "drainBufferedData returning .pending in IOWriter.doFileWrite should not happen"
-                );
+            bun_io::WriteResult::Pending(amt) => {
+                // EAGAIN from a target that was classified non-pollable (a
+                // FIFO or chardev opened by path with O_NONBLOCK). Record the
+                // partial write and restart this writer on the pollable path.
+                let s = self.state();
+                let lo = s.total_bytes_written;
+                s.writers[idx].tee(&s.buf[lo..lo + amt]);
+                s.total_bytes_written += amt;
+                s.writers[idx].written += amt;
+                s.flags.pollable = true;
+                s.flags.nonblock = true;
+                s.started = false;
+                return match self.write() {
+                    WriteOutcome::Suspended => Yield::suspended(),
+                    WriteOutcome::IsActuallyFile => self.on_sync_error(
+                        child,
+                        &sys::Error::from_code(E::EAGAIN, sys::Tag::write),
+                    ),
+                    WriteOutcome::Failed(e) => self.on_sync_error(child, &e),
+                };
             }
             // The caller is inside the enqueuing child's trampoline, so the
             // error completion is returned, not `Yield::run` from here.

--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -693,6 +693,17 @@ impl IOWriter {
 
     // ── file write (non-pollable sync path) ─────────────────────────────
 
+    /// Tee `amt` bytes from the current buffer position into `writers[idx]`'s
+    /// capture and advance its `written` / `total_bytes_written` counters.
+    #[cfg(not(windows))]
+    fn record_write_progress(&self, idx: usize, amt: usize) {
+        let s = self.state();
+        let lo = s.total_bytes_written;
+        s.writers[idx].tee(&s.buf[lo..lo + amt]);
+        s.total_bytes_written += amt;
+        s.writers[idx].written += amt;
+    }
+
     /// POSIX-only. `child` is the writer being enqueued (see `on_sync_error`).
     #[cfg(not(windows))]
     fn do_file_write(&self, child: ChildPtr) -> Yield {
@@ -720,11 +731,8 @@ impl IOWriter {
                 // EAGAIN from a target that was classified non-pollable (a
                 // FIFO or chardev opened by path with O_NONBLOCK). Record the
                 // partial write and restart this writer on the pollable path.
+                self.record_write_progress(idx, amt);
                 let s = self.state();
-                let lo = s.total_bytes_written;
-                s.writers[idx].tee(&s.buf[lo..lo + amt]);
-                s.total_bytes_written += amt;
-                s.writers[idx].written += amt;
                 s.flags.pollable = true;
                 s.flags.nonblock = true;
                 s.started = false;
@@ -739,12 +747,8 @@ impl IOWriter {
             // error completion is returned, not `Yield::run` from here.
             bun_io::WriteResult::Err(e) => return self.on_sync_error(child, &e),
         };
-        let s = self.state();
-        let lo = s.total_bytes_written;
-        s.writers[idx].tee(&s.buf[lo..lo + amt]);
-        s.total_bytes_written += amt;
-        s.writers[idx].written += amt;
-        if !s.writers[idx].wrote_everything() {
+        self.record_write_progress(idx, amt);
+        if !self.state().writers[idx].wrote_everything() {
             // The only case where we get partial writes is when an error is
             // encountered, which returns above.
             unreachable!(

--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -730,10 +730,8 @@ impl IOWriter {
                 s.started = false;
                 return match self.write() {
                     WriteOutcome::Suspended => Yield::suspended(),
-                    WriteOutcome::IsActuallyFile => self.on_sync_error(
-                        child,
-                        &sys::Error::from_code(E::EAGAIN, sys::Tag::write),
-                    ),
+                    WriteOutcome::IsActuallyFile => self
+                        .on_sync_error(child, &sys::Error::from_code(E::EAGAIN, sys::Tag::write)),
                     WriteOutcome::Failed(e) => self.on_sync_error(child, &e),
                 };
             }

--- a/test/js/bun/shell/file-io.test.ts
+++ b/test/js/bun/shell/file-io.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isPosix, tempDir } from "harness";
+import * as fs from "node:fs";
+import { join } from "node:path";
 import { createTestBuilder } from "./test_builder";
 const TestBuilder = createTestBuilder(import.meta.path);
 
@@ -47,6 +49,82 @@ describe("IOWriter file output redirection", () => {
 
   describe("special file types", () => {
     TestBuilder.command`echo "disappear" > /dev/null`.exitCode(0).stdout("").runAsTest("write to /dev/null");
+
+    // A FIFO opened by path for `>` must take the pollable path; once the pipe
+    // buffer fills, write(2) returns EAGAIN and the writer has to poll for
+    // writability instead of treating the fd as an EAGAIN-free regular file.
+    test.concurrent.skipIf(!isPosix)("redirect to a FIFO whose reader drains slowly applies backpressure", async () => {
+      const payloadLen = 200 * 1024;
+      using dir = tempDir("shell-fifo-redirect", {
+        "fixture.ts": /* ts */ `
+          import { $ } from "bun";
+          import * as fs from "node:fs";
+          const fifo = process.env.FIFO!;
+          // Reader (nonblocking so open succeeds with no writer yet).
+          const rfd = fs.openSync(fifo, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+          // Writer used to pre-fill the pipe buffer so the shell's first
+          // write is guaranteed to hit EAGAIN regardless of drain timing.
+          const wfd = fs.openSync(fifo, fs.constants.O_WRONLY | fs.constants.O_NONBLOCK);
+          const fill = Buffer.alloc(4096, "y");
+          try { while (true) fs.writeSync(wfd, fill); } catch {}
+
+          const big = Buffer.alloc(${payloadLen}, "z").toString();
+          let shell: Awaited<ReturnType<typeof $>> | undefined;
+          const pending = $\`echo \${big} > \${fifo}\`.quiet().nothrow().then(r => (shell = r));
+
+          const buf = Buffer.alloc(65536);
+          let zs = 0;
+          while (!shell) {
+            let n = 0;
+            try { n = fs.readSync(rfd, buf); } catch (e: any) { if (e.code !== "EAGAIN") throw e; }
+            for (let i = 0; i < n; i++) if (buf[i] === 0x7a) zs++;
+            await new Promise<void>(r => setImmediate(r));
+          }
+          await pending;
+          fs.closeSync(wfd);
+          // Drain whatever is left now that all writers are closed.
+          while (true) {
+            let n = 0;
+            try { n = fs.readSync(rfd, buf); } catch (e: any) { if (e.code !== "EAGAIN") throw e; n = 0; }
+            if (n === 0) break;
+            for (let i = 0; i < n; i++) if (buf[i] === 0x7a) zs++;
+          }
+          fs.closeSync(rfd);
+          console.log(JSON.stringify({ exitCode: shell!.exitCode, zs }));
+        `,
+      });
+      const fifo = join(String(dir), "out.fifo");
+      await using mk = Bun.spawn({ cmd: [Bun.which("mkfifo")!, fifo], env: bunEnv });
+      await mk.exited;
+
+      // Hold a read end in the parent so the FIFO survives a child abort
+      // without the tempDir teardown racing an open writer.
+      const holder = fs.openSync(fifo, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+      try {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "--debug-crash-handler-use-trace-string", "fixture.ts"],
+          cwd: String(dir),
+          env: { ...bunEnv, FIFO: fifo },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(stdout.trim().split("\n").pop() ?? "");
+        } catch {
+          parsed = stdout;
+        }
+        // echo appends "\n" (0x0a, not 'z'), so the 'z' count equals payloadLen.
+        expect({ parsed, stderr, exitCode }).toEqual({
+          parsed: { exitCode: 0, zs: payloadLen },
+          stderr: expect.any(String),
+          exitCode: 0,
+        });
+      } finally {
+        fs.closeSync(holder);
+      }
+    });
   });
 
   describe("writer queue and bump behavior", () => {


### PR DESCRIPTION
### Repro

```ts
import { $ } from "bun";
import { execSync } from "node:child_process";
import * as fs from "node:fs";
const fifo = `/tmp/fifo-${process.pid}.fifo`;
execSync(`mkfifo ${fifo}`);
// a reader exists so open(O_WRONLY) succeeds, but it never drains
const rfd = fs.openSync(fifo, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
$.nothrow();
await $`echo ${"z".repeat(200 * 1024)} > ${fifo}`.quiet();
// before: rc=134 abort
// panic: internal error: entered unreachable code: drainBufferedData returning
//        .pending in IOWriter.doFileWrite should not happen
```

Deterministic on Linux and macOS.

### Cause

`Builtin` opens a `>`-redirect target via `open_for_writing_impl`, which fstats the fd, reports `pollable = true` for `S_IFIFO`/`S_IFSOCK`, and sets `O_NONBLOCK`. On POSIX the caller then discarded that result and passed a hardcoded `pollable = false` to `IOWriter::init`, so the writer took the synchronous file path (`do_file_write`). That path drives `write(2)` in a loop and treats `WriteResult::Pending` (EAGAIN) as `unreachable!()` on the assumption that a "file" never returns EAGAIN. A FIFO with a slow reader does: once the pipe buffer fills, the next write returns EAGAIN and the process aborts. Pipeline stdout (`echo big | slow`) already went through the pollable writer and handled the same fd shape correctly.

### Fix

- `Builtin.rs`: pass the `pollable` value computed by `open_for_writing_impl` to the redirect `IOWriter` on POSIX (Windows keeps its unconditional async writer). FIFO/socket redirect targets now take the pollable path and poll for writability under backpressure.
- `IOWriter::do_file_write`: replace the `unreachable!()` for `Pending` with an in-place upgrade: record the partial write, flip `flags.pollable`/`nonblock`, and restart via `write()` so the remainder drains through the poll machinery. If the fd turns out to also be un-epollable, the EAGAIN is surfaced as the chunk's write error instead of aborting.

### Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/shell/file-io.test.ts -t FIFO
(fail) redirect to a FIFO whose reader drains slowly applies backpressure
  exitCode: 134
  stderr: panic: internal error: entered unreachable code: drainBufferedData
          returning .pending in IOWriter.doFileWrite should not happen

$ bun bd test test/js/bun/shell/file-io.test.ts -t FIFO
(pass) redirect to a FIFO whose reader drains slowly applies backpressure
```

The full `file-io.test.ts` (27 tests) and `bunshell.test.ts` (412 tests) suites pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/file-io.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (eaec13dc0)

test/js/bun/shell/file-io.test.ts:
(pass) IOWriter file output redirection > basic file redirection > simple echo to file [59.66ms]
(pass) IOWriter file output redirection > basic file redirection > empty output to file [7.65ms]
(pass) IOWriter file output redirection > basic file redirection > zero-length write should trigger onIOWriterChunk callback [6.36ms]
(pass) IOWriter file output redirection > drainBufferedData edge cases > large single write [17.95ms]
(pass) IOWriter file output redirection > drainBufferedData edge cases > write to subdirectory [8.22ms]
bun: Not a directory: /dev/null/invalid/path(pass) IOWriter file output redirection > file system error conditions > write to invalid path should fail [22.73ms]

... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (85c00e9f8)

test/js/bun/shell/file-io.test.ts:
(pass) IOWriter file output redirection > basic file redirection > simple echo to file [1.35ms]
(pass) IOWriter file output redirection > basic file redirection > empty output to file [0.37ms]
(pass) IOWriter file output redirection > basic file redirection > zero-length write should trigger onIOWriterChunk callback [0.25ms]
(pass) IOWriter file output redirection > drainBufferedData edge cases > large single write [0.48ms]
(pass) IOWriter file output redirection > drainBufferedData edge cases > write to subdirectory [0.30ms]
bun: Not a directory: /dev/null/invalid/path(pass) IOWriter file output redirection > file system error conditions > write to invalid path should fail [0.25ms]
bun: No such file or directory: /nonexistent/file.txt(pass) IOWriter file output redirection > file system error conditions > write to non-existent directory should fail [0.11ms]
(pass) IOWriter file output redirection > special file types > write to /dev/null [0.07ms]
(pass) IOWriter file output redirection > special file types > redirect to a FIFO whose reader drains slowly applies backpressure [32.02ms]
(pass) IO
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/file-io.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (eaec13dc0)

test/js/bun/shell/file-io.test.ts:
(pass) IOWriter file output redirection > basic file redirection > simple echo to file [58.79ms]
(pass) IOWriter file output redirection > basic file redirection > empty output to file [7.43ms]
(pass) IOWriter file output redirection > basic file redirection > zero-length write should trigger onIOWriterChunk callback [6.06ms]
(pass) IOWriter file output redirection > drainBufferedData edge cases > large single write [5.85ms]
(pass) IOWriter file output redirection > drainBufferedData edge cases > write to subdirectory [22.60ms]
bun: Not a directory: /dev/null/invalid/path(pass) IOWriter file output redirection > file system error conditions > write to invalid path should fail [16.45ms]

... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 707ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/shell/Builtin.rs      | 13 ++-----
 src/runtime/shell/IOWriter.rs     | 38 ++++++++++++++-----
 test/js/bun/shell/file-io.test.ts | 80 ++++++++++++++++++++++++++++++++++++++-
 3 files changed, 111 insertions(+), 20 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/runtime/shell/Builtin.rs           3      2      0
src/runtime/shell/IOWriter.rs          3      4      0
test/js/bun/shell/file-io.test.ts      1      6      0
```

</details>

<!-- robobun:evidence:end -->