### PR TITLE
io: harden POSIX pipe writer error paths against owner-dropping callbacks

### DIFF
--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -207,12 +207,11 @@ pub trait PosixPipeWriter {
                     drained += amt;
                 }
                 WriteResult::Err(err) => {
-                    if drained > 0 {
-                        self.on_error(err);
-                        return WriteResult::Wrote(drained);
-                    } else {
-                        return WriteResult::Err(err);
-                    }
+                    // Let `on_poll` dispatch `on_error` (its `Err` arm is
+                    // the terminal one). Returning `Wrote(drained)` would
+                    // make `on_poll` call `on_write` on a writer whose
+                    // `on_error` may have already freed the parent.
+                    return WriteResult::Err(err);
                 }
                 WriteResult::Done(amt) => {
                     drained += amt;
@@ -278,6 +277,15 @@ pub trait PosixBufferedWriterParent {
     /// # Safety
     /// `this` must point to a live `Self`.
     unsafe fn event_loop(this: *mut Self) -> EventLoopHandle;
+    /// Bump the parent's strong refcount so `this` (and its intrusive writer
+    /// field) stays live across a re-entrant callback.
+    /// # Safety
+    /// `this` must point to a live `Self`.
+    unsafe fn ref_(this: *mut Self);
+    /// Drop a strong ref taken by `ref_`. May free `this`.
+    /// # Safety
+    /// `this` must point to a live `Self`.
+    unsafe fn deref(this: *mut Self);
 }
 
 pub struct PosixBufferedWriter<Parent: PosixBufferedWriterParent> {
@@ -402,9 +410,16 @@ impl<Parent: PosixBufferedWriterParent> PosixBufferedWriter<Parent> {
     fn _on_error(&mut self, err: sys::Error) {
         debug_assert!(!err.is_retry());
 
+        // `Parent::on_error` may drop the last external strong ref to the
+        // parent (and so free `*self` as an intrusive field). Pin it with an
+        // extra ref so `close()` and its `on_close` dispatch stay live.
+        let parent = self.parent();
+        // SAFETY: type invariant — set-once parent backref outlives writer.
+        unsafe { Parent::ref_(parent) };
         self.parent_on_error(err);
-
         self.close();
+        // SAFETY: matches the `ref_` above; may free `*self`.
+        unsafe { Parent::deref(parent) };
     }
 
     pub fn get_force_sync(&self) -> bool {
@@ -451,6 +466,9 @@ impl<Parent: PosixBufferedWriterParent> PosixBufferedWriter<Parent> {
         }
     }
 
+    /// Dispatches `Parent::on_error` on registration failure; that callback
+    /// may drop the last strong ref to the parent, so the caller must not
+    /// touch `self` after this returns.
     pub fn register_poll(&mut self) {
         let Some(poll) = self.get_poll() else { return };
         // Use the event loop from the parent, not the global one
@@ -625,6 +643,15 @@ pub trait PosixStreamingWriterParent {
     /// # Safety
     /// `this` must point to a live `Self`.
     unsafe fn loop_(this: *mut Self) -> *mut bun_uws_sys::Loop;
+    /// Bump the parent's strong refcount so `this` (and its intrusive writer
+    /// field) stays live across a re-entrant callback.
+    /// # Safety
+    /// `this` must point to a live `Self`.
+    unsafe fn ref_(this: *mut Self);
+    /// Drop a strong ref taken by `ref_`. May free `this`.
+    /// # Safety
+    /// `this` must point to a live `Self`.
+    unsafe fn deref(this: *mut Self);
 }
 
 pub struct PosixStreamingWriter<Parent: PosixStreamingWriterParent> {
@@ -765,9 +792,17 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
         self.is_done = true;
         self.outgoing.reset();
 
+        // `Parent::on_error` may drop the last external strong ref to the
+        // parent (and so free `*self` as an intrusive field). Pin it with an
+        // extra ref so `close()` and its `on_close` dispatch stay live.
+        let parent = self.parent();
         // SAFETY: parent BACKREF set via set_parent; outlives this writer.
-        unsafe { Parent::on_error(self.parent(), err) };
+        unsafe { Parent::ref_(parent) };
+        // SAFETY: parent BACKREF set via set_parent; outlives this writer.
+        unsafe { Parent::on_error(parent, err) };
         self.close();
+        // SAFETY: matches the `ref_` above; may free `*self`.
+        unsafe { Parent::deref(parent) };
     }
 
     fn _on_write(&mut self, written: usize, status: WriteStatus) {
@@ -830,11 +865,17 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
                 // ASM-verified PROVEN_CACHED on the `self.close()` path's
                 // field reads. Launder so `close()` sees fresh state.
                 let this: *mut Self = core::hint::black_box(core::ptr::from_mut(self));
+                let parent = Self::r(this).parent();
+                // `Parent::on_error` may also drop the last external strong
+                // ref to the parent (`FileSink::on_error` → promise reject →
+                // user callback), freeing `*this`. Pin it so `close()` runs.
                 // SAFETY: parent BACKREF valid.
-                unsafe { Parent::on_error(Self::r(this).parent(), err) };
-                // `this` is still live (parent owns this writer; an on_error
-                // handler may end/detach but never frees mid-call).
+                unsafe { Parent::ref_(parent) };
+                // SAFETY: parent BACKREF valid.
+                unsafe { Parent::on_error(parent, err) };
                 Self::r(this).close();
+                // SAFETY: matches the `ref_` above; may free `*this`.
+                unsafe { Parent::deref(parent) };
             }
             sys::Result::Ok(()) => {}
         }
@@ -2672,6 +2713,20 @@ macro_rules! impl_streaming_writer_parent {
                 #[allow(unused_unsafe)]
                 unsafe { $uws }
             }
+            #[inline]
+            unsafe fn ref_(this: *mut Self) {
+                // SAFETY: see on_write. Intrusive refcount bump.
+                let $ref_this = this;
+                #[allow(unused_unsafe)]
+                unsafe { $ref_ };
+            }
+            #[inline]
+            unsafe fn deref(this: *mut Self) {
+                // SAFETY: see on_write. May free `this`.
+                let $deref_this = this;
+                #[allow(unused_unsafe)]
+                unsafe { $deref };
+            }
         }
 
         #[cfg(windows)]
@@ -2800,6 +2855,20 @@ macro_rules! impl_buffered_writer_parent {
                 let $el_this = this;
                 #[allow(unused_unsafe)]
                 unsafe { $el }
+            }
+            #[inline]
+            unsafe fn ref_(this: *mut Self) {
+                // SAFETY: see on_write. Intrusive refcount bump.
+                let $ref_this = this;
+                #[allow(unused_unsafe)]
+                unsafe { $ref_ };
+            }
+            #[inline]
+            unsafe fn deref(this: *mut Self) {
+                // SAFETY: see on_write. May free `this`.
+                let $deref_this = this;
+                #[allow(unused_unsafe)]
+                unsafe { $deref };
             }
         }
 

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -377,6 +377,18 @@ impl<Parent: PosixBufferedWriterParent> PosixBufferedWriter<Parent> {
         unsafe { Parent::on_error(self.parent(), err) }
     }
 
+    /// RAII keepalive: bumps the parent's intrusive refcount and derefs on
+    /// `Drop`, so re-entrant callbacks that drop the last external strong ref
+    /// cannot free `*self` while the guard is live. May free on drop.
+    #[inline]
+    fn parent_keepalive(&self) -> impl Drop + use<Parent> {
+        let parent = self.parent();
+        // SAFETY: type invariant — set-once parent backref outlives writer.
+        unsafe { Parent::ref_(parent) };
+        // SAFETY: matches the `ref_` above; may free the allocation on drop.
+        scopeguard::guard(parent, |p| unsafe { Parent::deref(p) })
+    }
+
     pub fn memory_cost(&self) -> usize {
         mem::size_of::<Self>()
     }
@@ -408,15 +420,11 @@ impl<Parent: PosixBufferedWriterParent> PosixBufferedWriter<Parent> {
         debug_assert!(!err.is_retry());
 
         // `Parent::on_error` may drop the last external strong ref to the
-        // parent (and so free `*self` as an intrusive field). Pin it with an
-        // extra ref so `close()` and its `on_close` dispatch stay live.
-        let parent = self.parent();
-        // SAFETY: type invariant — set-once parent backref outlives writer.
-        unsafe { Parent::ref_(parent) };
+        // parent (and so free `*self` as an intrusive field). Pin it so
+        // `close()` and its `on_close` dispatch stay live.
+        let _keepalive = self.parent_keepalive();
         self.parent_on_error(err);
         self.close();
-        // SAFETY: matches the `ref_` above; may free `*self`.
-        unsafe { Parent::deref(parent) };
     }
 
     pub fn get_force_sync(&self) -> bool {
@@ -472,13 +480,9 @@ impl<Parent: PosixBufferedWriterParent> PosixBufferedWriter<Parent> {
                 // Same shape as `_on_error`: pin the parent, dispatch the
                 // error, then close so `on_close` runs and the fd/owner ref
                 // are released.
-                let parent = self.parent();
-                // SAFETY: type invariant — set-once parent backref outlives writer.
-                unsafe { Parent::ref_(parent) };
+                let _keepalive = self.parent_keepalive();
                 self.parent_on_error(err);
                 self.close();
-                // SAFETY: matches the `ref_` above; may free `*self`.
-                unsafe { Parent::deref(parent) };
             }
             sys::Result::Ok(()) => {}
         }
@@ -748,6 +752,17 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
         unsafe { Parent::on_write(self.parent(), amount, status) }
     }
 
+    /// RAII keepalive: bumps the parent's intrusive refcount and derefs on
+    /// `Drop`, so re-entrant callbacks that drop the last external strong ref
+    /// cannot free `*self` while the guard is live. May free on drop.
+    #[inline]
+    fn parent_keepalive(parent: *mut Parent) -> impl Drop + use<Parent> {
+        // SAFETY: type invariant — set-once parent backref outlives writer.
+        unsafe { Parent::ref_(parent) };
+        // SAFETY: matches the `ref_` above; may free the allocation on drop.
+        scopeguard::guard(parent, |p| unsafe { Parent::deref(p) })
+    }
+
     pub fn get_force_sync(&self) -> bool {
         self.force_sync
     }
@@ -796,16 +811,13 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
         self.outgoing.reset();
 
         // `Parent::on_error` may drop the last external strong ref to the
-        // parent (and so free `*self` as an intrusive field). Pin it with an
-        // extra ref so `close()` and its `on_close` dispatch stay live.
+        // parent (and so free `*self` as an intrusive field). Pin it so
+        // `close()` and its `on_close` dispatch stay live.
         let parent = self.parent();
-        // SAFETY: parent BACKREF set via set_parent; outlives this writer.
-        unsafe { Parent::ref_(parent) };
+        let _keepalive = Self::parent_keepalive(parent);
         // SAFETY: parent BACKREF set via set_parent; outlives this writer.
         unsafe { Parent::on_error(parent, err) };
         self.close();
-        // SAFETY: matches the `ref_` above; may free `*self`.
-        unsafe { Parent::deref(parent) };
     }
 
     fn _on_write(&mut self, written: usize, status: WriteStatus) {
@@ -872,13 +884,10 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
                 // `Parent::on_error` may also drop the last external strong
                 // ref to the parent (`FileSink::on_error` → promise reject →
                 // user callback), freeing `*this`. Pin it so `close()` runs.
-                // SAFETY: parent BACKREF valid.
-                unsafe { Parent::ref_(parent) };
+                let _keepalive = Self::parent_keepalive(parent);
                 // SAFETY: parent BACKREF valid.
                 unsafe { Parent::on_error(parent, err) };
                 Self::r(this).close();
-                // SAFETY: matches the `ref_` above; may free `*this`.
-                unsafe { Parent::deref(parent) };
             }
             sys::Result::Ok(()) => {}
         }

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -177,8 +177,7 @@ pub trait PosixPipeWriter {
 
     /// Re-derives the slice from `self.get_buffer()` each iteration.
     /// `try_write` only needs `&self`, so the shared borrow of the buffer
-    /// coexists with it, and the `&mut self` for `on_error` is taken after
-    /// the temporary slice borrow has ended — no raw-pointer escape needed.
+    /// coexists with it.
     fn drain_buffered_data(&mut self, max_write_size: usize, received_hup: bool) -> WriteResult {
         let _ = received_hup; // autofix
 
@@ -193,10 +192,8 @@ pub trait PosixPipeWriter {
 
         while drained < limit {
             let force_sync = self.get_force_sync();
-            // `try_write` takes `&self`; re-fetching the buffer here keeps the
-            // shared borrow scoped to this statement so the `&mut self` for
-            // `on_error` below is unencumbered. `try_write` does not mutate
-            // `self`, so `get_buffer()` is stable across iterations.
+            // `try_write` takes `&self` and does not mutate it, so
+            // `get_buffer()` is stable across iterations.
             let attempt = self.try_write(force_sync, &self.get_buffer()[drained..limit]);
             match attempt {
                 WriteResult::Pending(pending) => {
@@ -466,16 +463,22 @@ impl<Parent: PosixBufferedWriterParent> PosixBufferedWriter<Parent> {
         }
     }
 
-    /// Dispatches `Parent::on_error` on registration failure; that callback
-    /// may drop the last strong ref to the parent, so the caller must not
-    /// touch `self` after this returns.
     pub fn register_poll(&mut self) {
         let Some(poll) = self.get_poll() else { return };
         // Use the event loop from the parent, not the global one
         let loop_ = self.parent_event_loop().loop_();
         match poll.register_with_fd(loop_, FilePollKind::Writable, poll.fd()) {
             sys::Result::Err(err) => {
+                // Same shape as `_on_error`: pin the parent, dispatch the
+                // error, then close so `on_close` runs and the fd/owner ref
+                // are released.
+                let parent = self.parent();
+                // SAFETY: type invariant — set-once parent backref outlives writer.
+                unsafe { Parent::ref_(parent) };
                 self.parent_on_error(err);
+                self.close();
+                // SAFETY: matches the `ref_` above; may free `*self`.
+                unsafe { Parent::deref(parent) };
             }
             sys::Result::Ok(()) => {}
         }

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -1991,6 +1991,15 @@ impl bun_io::pipe_writer::PosixStreamingWriterParent for Terminal {
     unsafe fn loop_(this: *mut Self) -> *mut bun_uws_sys::Loop {
         Self::from_parent_ptr(this).event_loop_handle.r#loop()
     }
+    unsafe fn ref_(this: *mut Self) {
+        // SAFETY: intrusive refcount bump via raw pointer; see the Windows
+        // `WindowsWriterParent::ref_` impl below for the aliasing rationale.
+        unsafe { bun_ptr::RefCount::<Terminal>::ref_(this) };
+    }
+    unsafe fn deref(this: *mut Self) {
+        // SAFETY: intrusive refcount drop via raw pointer; may free `this`.
+        unsafe { bun_ptr::RefCount::<Terminal>::deref(this) };
+    }
 }
 
 #[cfg(windows)]

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -701,12 +701,31 @@ pub unsafe fn __bun_run_file_poll(poll: *mut FilePoll, size_or_offset: i64) {
         }
 
         poll_tag::FILE_SINK => poll_arm!(FileSinkPoll),
-        poll_tag::STATIC_PIPE_WRITER => poll_arm!(StaticPipeWriterPoll<Subprocess<'_>>),
+        poll_tag::STATIC_PIPE_WRITER => poll_arm!(StaticPipeWriterPoll<Subprocess<'_>>, |h| {
+            // SAFETY: tag matched; `h` is the live owner set at `FilePoll::init`.
+            unsafe { bun_spawn::static_pipe_writer::on_poll(h, size_or_offset as isize, hup) }
+        }),
         poll_tag::SHELL_STATIC_PIPE_WRITER => {
-            poll_arm!(StaticPipeWriterPoll<crate::shell::subproc::ShellSubprocess>)
+            poll_arm!(
+                StaticPipeWriterPoll<crate::shell::subproc::ShellSubprocess>,
+                |h| {
+                    // SAFETY: tag matched; `h` is the live owner set at `FilePoll::init`.
+                    unsafe {
+                        bun_spawn::static_pipe_writer::on_poll(h, size_or_offset as isize, hup)
+                    }
+                }
+            )
         }
         poll_tag::SECURITY_SCAN_STATIC_PIPE_WRITER => {
-            poll_arm!(StaticPipeWriterPoll<bun_install::SecurityScanSubprocess<'_>>)
+            poll_arm!(
+                StaticPipeWriterPoll<bun_install::SecurityScanSubprocess<'_>>,
+                |h| {
+                    // SAFETY: tag matched; `h` is the live owner set at `FilePoll::init`.
+                    unsafe {
+                        bun_spawn::static_pipe_writer::on_poll(h, size_or_offset as isize, hup)
+                    }
+                }
+            )
         }
         // `bun.shell.Interpreter.IOWriter.Poll`
         poll_tag::SHELL_BUFFERED_WRITER => poll_arm!(ShellBufferedWriterPoll, |h| {

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -296,7 +296,23 @@ pub(super) mod lib_info {
             // bitcast u32 mach_port → i32 fd
             sys::Fd::from_native(machport as i32),
         );
-        debug_assert!(matches!(rc, sys::Result::Ok(_)));
+        if let sys::Result::Err(err) = rc {
+            // Registration failed: the machport callback will never fire.
+            // Return the poll slot and complete the request with an error so
+            // the promise rejects instead of hanging forever.
+            let _ = err;
+            poll.deinit();
+            // SAFETY: `request` is the live heap-allocated request; no other
+            // owner exists (the poll was never registered).
+            unsafe {
+                GetAddrInfoRequest::get_addr_info_async_callback(
+                    -1,
+                    ptr::null_mut(),
+                    request.cast::<c_void>(),
+                );
+            }
+            return promise_value;
+        }
 
         poll.enable_keeping_process_alive(ctx);
         // SAFETY: request is live (heap-allocated) and exclusively accessed on this thread.

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -300,7 +300,11 @@ pub(super) mod lib_info {
             // Registration failed: the machport callback will never fire.
             // Return the poll slot and complete the request with an error so
             // the promise rejects instead of hanging forever.
-            let _ = err;
+            bun_output::scoped_log!(
+                GetAddrInfoRequest,
+                "machport register_with_fd failed: {}",
+                err
+            );
             poll.deinit();
             // SAFETY: `request` is the live heap-allocated request; no other
             // owner exists (the poll was never registered).

--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -578,9 +578,6 @@ impl Builtin {
                 let cwd_fd = Self::cwd(interp, cmd);
                 let evtloop = interp.event_loop;
 
-                // Regular files are not pollable on linux/macos.
-                let is_pollable_default: bool = cfg!(windows);
-
                 let mut pollable = false;
                 let mut is_socket = false;
                 let mut is_nonblocking = false;
@@ -671,15 +668,13 @@ impl Builtin {
                     return None;
                 }
 
-                // The IOWriter receives the hardcoded platform const
-                // `is_pollable` (false on POSIX, true on Windows); the
-                // `pollable` out-param populated by `open_for_writing_impl`
-                // is intentionally ignored.
-                let _ = pollable;
+                // `open_for_writing_impl` fstats the fd and sets O_NONBLOCK on
+                // fifos/sockets; route those through the pollable IOWriter
+                // path or `do_file_write` hits EAGAIN.
                 let redirect_writer = IOWriter::init(
                     redirfd,
                     io_writer::Flags {
-                        pollable: is_pollable_default,
+                        pollable,
                         nonblock: is_nonblocking,
                         is_socket,
                         ..Default::default()

--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -1118,8 +1118,8 @@ bun_io::impl_buffered_writer_parent! {
     uv_loop    = |this| (*(*this).evtloop().loop_()).uv_loop,
     // INVARIANT: `this` is `Arc::as_ptr` stashed via `writer.set_parent` in
     // `IOWriter::init` (sole constructor); passing a non-Arc ptr is UB.
-    ref_       = |this| std::sync::Arc::increment_strong_count(this as *const Self),
-    deref      = |this| std::sync::Arc::decrement_strong_count(this as *const Self),
+    ref_       = |this| std::sync::Arc::increment_strong_count(this.cast_const()),
+    deref      = |this| std::sync::Arc::decrement_strong_count(this.cast_const()),
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -745,6 +745,10 @@ impl IOWriter {
     /// The `BufferedWriter.onWrite` hook. Runs on the event loop when the fd
     /// is writable.
     fn on_write_pollable(&self, amount: usize, status: bun_io::WriteStatus) {
+        // `run_yield` below re-enters child completions whose teardown may
+        // drop the last external `Arc<IOWriter>`; keep ourselves alive for
+        // the callback body (mirrors `on_error`).
+        let _keepalive = self.keepalive();
         // NOTE: `set_writing` re-derives `state()` on Windows, which would
         // invalidate `s` under Stacked Borrows; do it before binding `s`
         // (matches the ordering in `on_error`).
@@ -1193,12 +1197,10 @@ fn drain_buffered_data(
 
 impl Drop for IOWriter {
     fn drop(&mut self) {
-        // With `Arc` the last ref drops *after* the callback returns, so the
-        // synchronous path is safe (PipeWriter cannot touch us after free).
-        // TODO: if a PipeWriter callback is on the stack when the last
-        // Arc drops (possible via re-entrant child deinit), we need the async
-        // hop. Revisit once `bun_event_loop::EventLoopTask` is wired to the
-        // shell's `EventLoopHandle` shim.
+        // Every PipeWriter callback (`on_write_pollable`/`on_error`, and the
+        // POSIX `_on_error`/`register_poll` error arms via `Parent::ref_`)
+        // holds a keepalive strong ref, so the last `Arc` cannot drop while
+        // one is on the stack and Drop runs strictly after they return.
         let s = self.state.get_mut();
         crate::shell_log!("IOWriter(fd={}) deinit", s.fd);
         #[cfg(not(windows))]

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -526,11 +526,14 @@ impl ShellSubprocess {
             let mut subproc = unsafe { bun_core::heap::take(this) };
             for r in [&mut subproc.stdout, &mut subproc.stderr] {
                 if let Readable::Pipe(pipe) = r {
-                    // `start()` failed before any reader callback registered,
-                    // so the `Arc` is expected to be uniquely held. Write
-                    // unconditionally rather than via
-                    // `Arc::get_mut`, which would silently skip the state
-                    // transition if a future change bumped the strong count.
+                    // `start_pipe_reader` drops its local keepalive before
+                    // returning, so this slot's `Arc` is uniquely held here
+                    // even when stdout already started and only stderr's
+                    // start failed (the registered poll owns a raw pointer,
+                    // not a strong ref). Write unconditionally rather than
+                    // via `Arc::get_mut`, which would silently skip the
+                    // state transition if a future change bumped the strong
+                    // count.
                     debug_assert_eq!(Arc::strong_count(pipe), 1);
                     // SAFETY: single-threaded shell; no other borrow live.
                     let p = unsafe { &mut *Arc::as_ptr(pipe).cast_mut() };

--- a/src/spawn/static_pipe_writer.rs
+++ b/src/spawn/static_pipe_writer.rs
@@ -78,13 +78,11 @@ pub unsafe fn on_poll<P: StaticPipeWriterProcess>(
     let parent = unsafe { (*writer).parent }
         .expect("StaticPipeWriter writer.parent unset")
         .as_mut_ptr();
-    // SAFETY: intrusive refcount bump via raw pointer; `parent` is live.
-    unsafe { RefCount::<StaticPipeWriter<P>>::ref_(parent) };
-    // SAFETY: exclusive for this dispatch; the keepalive above keeps the
-    // allocation live past this call even if `on_poll` drops every other ref.
+    // SAFETY: `parent` is live (caller contract). The guard's ref keeps the
+    // allocation alive past `on_poll` even if it drops every other ref.
+    let _keepalive = unsafe { bun_ptr::ScopedRef::new(parent) };
+    // SAFETY: exclusive for this dispatch; keepalive holds the allocation.
     unsafe { (*writer).on_poll(size_hint, hup) };
-    // SAFETY: matches the `ref_` above; may free the allocation.
-    unsafe { RefCount::<StaticPipeWriter<P>>::deref(parent) };
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/spawn/static_pipe_writer.rs
+++ b/src/spawn/static_pipe_writer.rs
@@ -68,7 +68,11 @@ pub type Poll<P> = IOWriter<P>;
 /// # Safety
 /// `writer` must be the live `*mut Poll<P>` stored as the FilePoll owner.
 #[cfg(not(windows))]
-pub unsafe fn on_poll<P: StaticPipeWriterProcess>(writer: *mut Poll<P>, size_hint: isize, hup: bool) {
+pub unsafe fn on_poll<P: StaticPipeWriterProcess>(
+    writer: *mut Poll<P>,
+    size_hint: isize,
+    hup: bool,
+) {
     use bun_io::pipe_writer::PosixPipeWriter;
     // SAFETY: caller contract; `parent` is the backref set via `set_parent`.
     let parent = unsafe { (*writer).parent }

--- a/src/spawn/static_pipe_writer.rs
+++ b/src/spawn/static_pipe_writer.rs
@@ -60,6 +60,29 @@ pub struct StaticPipeWriter<P: StaticPipeWriterProcess> {
 pub type IOWriter<P> = BufferedWriter<StaticPipeWriter<P>>;
 pub type Poll<P> = IOWriter<P>;
 
+/// Poll-dispatch entry for the `STATIC_PIPE_WRITER` tags. Holds an extra
+/// intrusive ref across `on_poll` so the drained/error callbacks (which may
+/// drop the last external owner and release `start()`'s +1) cannot free the
+/// allocation while `on_poll`'s borrow is still on the stack.
+///
+/// # Safety
+/// `writer` must be the live `*mut Poll<P>` stored as the FilePoll owner.
+#[cfg(not(windows))]
+pub unsafe fn on_poll<P: StaticPipeWriterProcess>(writer: *mut Poll<P>, size_hint: isize, hup: bool) {
+    use bun_io::pipe_writer::PosixPipeWriter;
+    // SAFETY: caller contract; `parent` is the backref set via `set_parent`.
+    let parent = unsafe { (*writer).parent }
+        .expect("StaticPipeWriter writer.parent unset")
+        .as_mut_ptr();
+    // SAFETY: intrusive refcount bump via raw pointer; `parent` is live.
+    unsafe { RefCount::<StaticPipeWriter<P>>::ref_(parent) };
+    // SAFETY: exclusive for this dispatch; the keepalive above keeps the
+    // allocation live past this call even if `on_poll` drops every other ref.
+    unsafe { (*writer).on_poll(size_hint, hup) };
+    // SAFETY: matches the `ref_` above; may free the allocation.
+    unsafe { RefCount::<StaticPipeWriter<P>>::deref(parent) };
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // BufferedWriter parent vtable — wires bun_io callbacks to inherent methods
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/spawn/static_pipe_writer.rs
+++ b/src/spawn/static_pipe_writer.rs
@@ -249,13 +249,18 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
             err
         );
         // Clear the buffer before detaching: `buffer` aliases `self.source`'s
-        // storage, and `detach()` frees it. `drain_buffered_data` calls
-        // on_error() then Parent::on_write(), which would otherwise re-slice
-        // the freed allocation.
+        // storage, and `detach()` frees it.
         self.buffer = RawSlice::EMPTY;
         self.source.detach();
-        // Can't release start()'s +1 here: `drain_buffered_data` calls on_error() then
-        // Parent::on_write(); freeing here would UAF.
+        // `on_write` is not dispatched after `on_error`, so release start()'s
+        // +1 here. `_on_error` brackets us with `Parent::ref_/deref`, so this
+        // cannot free `self` before the trailing `close()` runs.
+        #[cfg(not(windows))]
+        if core::mem::replace(&mut self.started, false) {
+            // SAFETY: matches `start()`'s ref; `_on_error`'s keepalive keeps
+            // `self` alive past this deref.
+            unsafe { RefCount::<Self>::deref(std::ptr::from_mut::<Self>(self)) };
+        }
     }
 
     pub fn on_close(&mut self) {

--- a/test/js/bun/shell/shell-blocking-pipe.test.ts
+++ b/test/js/bun/shell/shell-blocking-pipe.test.ts
@@ -1,7 +1,10 @@
 import { $, generateHeapSnapshot } from "bun";
 
-import { test } from "bun:test";
-import { isWindows } from "harness";
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { mkfifo } from "mkfifo";
+import { createReadStream } from "node:fs";
+import { join } from "node:path";
 
 // We skip this test on Windows becasue:
 // 1. Windows didn't have this problem to begin with
@@ -30,4 +33,50 @@ test.skipIf(isWindows)("writing > send buffer size (with a variable) doesn't blo
   if (result !== expected + "\n") {
     throw new Error("Expected " + expected + "\n but got " + result);
   }
+});
+
+// Redirecting a builtin's stdout to a named pipe must go through the pollable
+// IOWriter path. Previously the redirect fd was hardcoded as non-pollable on
+// POSIX while open_for_writing_impl still set O_NONBLOCK, so a large echo hit
+// EAGAIN inside do_file_write and panicked with
+// "drainBufferedData returning .pending in IOWriter.doFileWrite should not happen".
+test.skipIf(isWindows)("builtin redirect to a named pipe larger than the pipe buffer", async () => {
+  using dir = tempDir("shell-fifo-redirect", {
+    "run.ts": `
+      // 200KB: larger than the default 64KB pipe buffer so the first write()
+      // only partially drains and the next one returns EAGAIN.
+      const big = Buffer.alloc(200_000, "bun!").toString();
+      await Bun.$\`echo \${big} > \${process.argv[2]}\`;
+    `,
+  });
+  const fifo = join(String(dir), "out.fifo");
+  mkfifo(fifo);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run.ts", fifo],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  // Open the read end so the child's O_WRONLY open unblocks; draining here
+  // is what lets the pollable writer make progress after EAGAIN.
+  const reader = createReadStream(fifo, { encoding: "utf8" });
+  let received = "";
+  const drained = new Promise<void>((resolve, reject) => {
+    reader.on("data", chunk => {
+      received += chunk;
+    });
+    reader.on("end", resolve);
+    reader.on("error", reject);
+  });
+
+  const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+  await drained;
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("");
+  expect(received).toBe(Buffer.alloc(200_000, "bun!").toString() + "\n");
+  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/shell/shell-blocking-pipe.test.ts
+++ b/test/js/bun/shell/shell-blocking-pipe.test.ts
@@ -68,12 +68,17 @@ test.skipIf(isWindows)("builtin redirect to a named pipe larger than the pipe bu
     reader.on("data", chunk => {
       received += chunk;
     });
-    reader.on("end", resolve);
+    reader.on("close", resolve);
     reader.on("error", reject);
   });
 
-  const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
-  await drained;
+  // If the child exits non-zero before (or without) opening the fifo, tear
+  // down the reader so `drained` settles instead of waiting for EOF forever.
+  const exited = proc.exited.then(code => {
+    if (code !== 0) reader.destroy();
+    return code;
+  });
+  const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), exited, drained]);
 
   expect(stderr).toBe("");
   expect(stdout).toBe("");

--- a/test/js/bun/shell/shell-blocking-pipe.test.ts
+++ b/test/js/bun/shell/shell-blocking-pipe.test.ts
@@ -80,14 +80,14 @@ test.skipIf(isWindows)("builtin redirect to a named pipe larger than the pipe bu
   });
   const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), exited, drained]);
 
+  // Surface the panic text first; exact-empty stderr is not asserted
+  // (ASAN/debug lanes may emit benign noise).
+  if (exitCode !== 0) throw new Error(`child exited ${exitCode}:\n${stderr}`);
   const expected = Buffer.alloc(200_000, "bun!").toString() + "\n";
-  // Combined object so stderr shows in the failure diff; exact-empty stderr is
-  // not asserted separately (ASAN/debug lanes may emit benign noise).
   expect({ stdout, receivedLen: received.length, exitCode }).toEqual({
     stdout: "",
     receivedLen: expected.length,
     exitCode: 0,
   });
-  if (exitCode !== 0) throw new Error(`child failed:\n${stderr}`);
   expect(received).toBe(expected);
 });

--- a/test/js/bun/shell/shell-blocking-pipe.test.ts
+++ b/test/js/bun/shell/shell-blocking-pipe.test.ts
@@ -80,8 +80,14 @@ test.skipIf(isWindows)("builtin redirect to a named pipe larger than the pipe bu
   });
   const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), exited, drained]);
 
-  expect(stderr).toBe("");
-  expect(stdout).toBe("");
-  expect(received).toBe(Buffer.alloc(200_000, "bun!").toString() + "\n");
-  expect(exitCode).toBe(0);
+  const expected = Buffer.alloc(200_000, "bun!").toString() + "\n";
+  // Combined object so stderr shows in the failure diff; exact-empty stderr is
+  // not asserted separately (ASAN/debug lanes may emit benign noise).
+  expect({ stdout, receivedLen: received.length, exitCode }).toEqual({
+    stdout: "",
+    receivedLen: expected.length,
+    exitCode: 0,
+  });
+  if (exitCode !== 0) throw new Error(`child failed:\n${stderr}`);
+  expect(received).toBe(expected);
 });

--- a/test/js/bun/shell/shell-blocking-pipe.test.ts
+++ b/test/js/bun/shell/shell-blocking-pipe.test.ts
@@ -1,6 +1,6 @@
 import { $, generateHeapSnapshot } from "bun";
 
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { mkfifo } from "mkfifo";
 import { createReadStream } from "node:fs";


### PR DESCRIPTION
Applies the writer-side hardening list from the error-path-drops-live-owner audit (same class as the shell `PipeReader::register_poll` fix: a syscall-error branch dispatches a callback that can drop the last strong ref to the struct embedding `self`, and the caller then touches `self`).

The fifo-redirect crash portion overlaps with #34696 (same root cause, same `Builtin.rs` change); this PR carries it so the regression test exercises the pollable writer path the hardening touches, but the net-new work here is the error-path keepalives.

### Crash fix

`Builtin::init_redirections` opened a `> path` redirect via `open_for_writing_impl`, which fstats the fd, sets `pollable = true` for `S_IFIFO`/`S_IFSOCK`, and flips it to `O_NONBLOCK`. The caller then discarded that result and passed a hardcoded `pollable = cfg!(windows)` to `IOWriter::init`, so a nonblocking fifo was routed through `do_file_write`. Once the pipe buffer filled the next `write()` returned `EAGAIN` and hit:

```
panic: internal error: entered unreachable code: drainBufferedData returning .pending in IOWriter.doFileWrite should not happen
```

Fixed by passing the computed `pollable` through.

### Error-path hardening

- `PosixBufferedWriterParent` / `PosixStreamingWriterParent`: add `ref_`/`deref` (the macros already receive them for the Windows impls; now also emitted on POSIX). `Terminal`'s direct impl picks them up too.
- `PosixBufferedWriter::_on_error`, `PosixStreamingWriter::_on_error`, `PosixStreamingWriter::register_poll` (error arm): hold a parent keepalive across `Parent::on_error` + the trailing `close()`. Previously, if `on_error` dropped the last external strong ref (e.g. `IOWriter::on_error`'s local keepalive ends, or `FileSink::on_error` rejects a promise whose handler drops the last sink ref), the `close()` ran on freed memory. Replaces the "an on_error handler may end/detach but never frees mid-call" comment, which was the hazard.
- `PosixPipeWriter::drain_buffered_data`: on a write error after a partial drain, return `Err` instead of calling `on_error` inline and returning `Wrote(drained)`. The previous shape made `on_poll` follow up with `on_write(drained, Drained)` on a writer whose parent may have been freed by `on_error`. Every parent's `on_error` already resets its write cursor, so the partial count was never used.
- `IOWriter::on_write_pollable`: take a keepalive `Arc` for the callback body, mirroring `on_error`. `run_yield` re-enters child completions whose teardown may drop the last external `Arc<IOWriter>`, and the tail of `on_write_pollable` still calls `register_poll()`. Updates the `Drop` comment to state the invariant this closes.
- `dns` (macOS libinfo backend): if kevent machport registration fails, return the `FilePoll` slot and complete the request with an error so the promise rejects, instead of `debug_assert`ing and then hanging the promise in release builds.
- `ShellSubprocess::abort_after_failed_start`: correct the strong-count comment to cover the stderr-fails-after-stdout-started case (the registered stdout poll owns a raw pointer, not an `Arc` ref, so the assert still holds; the old comment's premise did not).

### Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/shell/shell-blocking-pipe.test.ts -t "builtin redirect"
(fail) builtin redirect to a named pipe larger than the pipe buffer
  stderr: panic: internal error: entered unreachable code: drainBufferedData
          returning .pending in IOWriter.doFileWrite should not happen

$ bun bd test test/js/bun/shell/shell-blocking-pipe.test.ts
(pass) writing > send buffer size doesn't block the main thread
(pass) writing > send buffer size (with a variable) doesn't block the main thread
(pass) builtin redirect to a named pipe larger than the pipe buffer
```

`bunshell.test.ts` (412 pass), `filesink.test.ts` + `epipe.test.ts` (48 pass), `spawn-streaming-stdin.test.ts`, and `rust:check-all` are green.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 7 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/shell-blocking-pipe.test.ts

<!-- robobun:evidence:end -->