### PR TITLE
test-tonic: validate the protoc download instead of feeding error bodies to unzipper

### DIFF
--- a/test/js/third_party/grpc-js/test-tonic.test.ts
+++ b/test/js/third_party/grpc-js/test-tonic.test.ts
@@ -41,13 +41,32 @@ const cargoBin = Bun.which("cargo") as string;
 // re-compile the entire tonic/tokio dependency tree (~50s) on every run.
 const cacheDir = join(tmpdir(), "bun-test-tonic-cache");
 
+// A local-header PK signature at offset 0 is present in every protoc release
+// archive and is cheap to check; unzipper otherwise fails with an opaque
+// `FILE_ENDED` that doesn't say what it was actually handed.
+function isZip(bytes: Uint8Array): boolean {
+  return bytes.length > 4 && bytes[0] === 0x50 && bytes[1] === 0x4b && bytes[2] === 0x03 && bytes[3] === 0x04;
+}
+
 async function getProtocZipBytes(): Promise<Uint8Array> {
   const cachedPath = join(cacheDir, `protoc-${protoVersion}-${release}.zip`);
   const cached = Bun.file(cachedPath);
   if (await cached.exists()) {
-    return await cached.bytes();
+    const bytes = await cached.bytes();
+    if (isZip(bytes)) return bytes;
+    // Drop a corrupted cache instead of feeding it to unzipper; fall through to a fresh fetch.
+    rmSync(cachedPath, { force: true });
   }
-  const bytes = await fetch(releases[release]).then(res => res.bytes());
+  const res = await fetch(releases[release]);
+  const bytes = await res.bytes();
+  if (!res.ok || !isZip(bytes)) {
+    const snippet = Buffer.from(bytes.slice(0, 200)).toString("utf8").replace(/\s+/g, " ").trim();
+    throw new Error(
+      `protoc download did not return a zip (HTTP ${res.status} ${res.statusText}, ${bytes.length} bytes` +
+        (snippet ? `, body starts: ${JSON.stringify(snippet)}` : "") +
+        `). url: ${releases[release]}`,
+    );
+  }
   await mkdir(cacheDir, { recursive: true });
   // Write-then-rename so a concurrent/crashed run never leaves a truncated zip behind.
   const partial = `${cachedPath}.${process.pid}.tmp`;


### PR DESCRIPTION
`test/js/third_party/grpc-js/test-tonic.test.ts` went red on `:debian: 13 x64-asan` in [build 75748](https://buildkite.com/bun/bun/builds/75748#019f7a53-46eb-4052-8a33-b29a5cd125dd), failing all three runner retries:

```
error: FILE_ENDED
      at pull (test/node_modules/.bun/unzipper@0.12.3/node_modules/unzipper/lib/PullStream.js:78:32)
```

### Cause

`getProtocZipBytes()` does `fetch(url).then(res => res.bytes())` without checking `res.ok` or the response body. When GitHub's release endpoint returns an error page (rate limit, 5xx, CDN blip), those bytes go straight to `unzipper.Open.buffer()`, which scans the tail for the End-of-Central-Directory signature, fails to find it, and throws `FILE_ENDED` with no hint at what was actually received.

The timings in the job log back this up: attempt 1 took 574 ms, attempts 2 and 3 took ~58 ms each. 58 ms is far too fast to transfer the 3.5 MB zip (20/20 local fetches from this container take 160-190 ms for the full body), so the response was a small error body on every attempt. The unchecked fetch has been in place since the test was introduced in #20738 and carried through the caching added in #33622; build 75748 is the first recorded instance across the ~210 builds I scanned.

### Fix

Validate both the cached and freshly fetched bytes before handing them to unzipper:

- `isZip()` checks the `PK\x03\x04` local-header signature that every protoc release archive starts with.
- A cached file that fails the check is deleted and the download is retried instead of being used.
- A non-ok or non-zip download throws `protoc download did not return a zip (HTTP <status> <text>, <n> bytes, body starts: "...")` with the URL, and is never written to the cache.

The grpc-js flow-control test itself is unchanged; this only hardens the setup helper so the failure mode is diagnosable rather than `FILE_ENDED`.

### Verification

- Happy path: 20/20 fetches of `protoc-31.0-linux-x86_64.zip` pass `isZip()` and extract via `unzipper.Open.buffer()` (22 files, `bin/protoc` at 10 160 472 bytes).
- Error path: pointing the fetch at a nonexistent asset on the same release yields `protoc download did not return a zip (HTTP 404 Not Found, 9 bytes, body starts: "Not Found")`.
- Corrupt cache: a cached file without the PK signature is removed and the code falls through to a fresh fetch.

Test-only change; no `src/` diff.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->