### PR TITLE
harden partial-construction sites flagged in static audit #4

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -26,13 +26,6 @@
 #endif
 #define CONCURRENT_CONNECTIONS 4
 
-#if defined(BUN_DEBUG) || (defined(__has_feature) && __has_feature(address_sanitizer)) || defined(__SANITIZE_ADDRESS__)
-#include <assert.h>
-#define US_ASSERT(x) assert(x)
-#else
-#define US_ASSERT(x) ((void)0)
-#endif
-
 // clang-format off
 
 /* Forward-declared so this file does not depend on OpenSSL headers. */

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -896,6 +896,7 @@ SSL_CTX *us_ssl_ctx_build_raw(struct us_bun_socket_context_options_t options,
   ERR_clear_error();
 
   SSL_CTX *ssl_context = SSL_CTX_new(TLS_method());
+  if (!ssl_context) Bun__outOfMemory();
   atomic_fetch_add(&ssl_ctx_live, 1);
   /* Register the live-count free_func first thing so every exit (including
    * build_fail) balances. The packed reneg policy reuses the same slot. */
@@ -1273,6 +1274,7 @@ void us_internal_ssl_attach(struct us_socket_t *s, SSL_CTX *ctx,
   struct loop_ssl_data *loop_ssl_data = (struct loop_ssl_data *)s->group->loop->data.ssl_data;
 
   SSL *ssl = SSL_new(ctx);
+  if (!ssl) Bun__outOfMemory();
   /* Only Bun.connect / node:tls sockets surface the 'session' event; tagging
    * just those keeps the new-session callback a no-op for every other TLS
    * consumer (fetch, Bun.serve, postgres, websockets) instead of serializing
@@ -1280,8 +1282,8 @@ void us_internal_ssl_attach(struct us_socket_t *s, SSL_CTX *ctx,
   /* The listener's own kind is always 0; the kind it assigns to accepted
    * sockets lives in accept_kind and may not have been copied onto `s` yet
    * when its SSL is initialized. */
-  if (ssl && (us_socket_kind(s) == BUN_SOCKET_KIND_BUN_SOCKET_TLS ||
-              (listener && listener->accept_kind == BUN_SOCKET_KIND_BUN_SOCKET_TLS))) {
+  if (us_socket_kind(s) == BUN_SOCKET_KIND_BUN_SOCKET_TLS ||
+      (listener && listener->accept_kind == BUN_SOCKET_KIND_BUN_SOCKET_TLS)) {
     /* The very first TLS attach in a process can be a client connection, and
      * nothing on that path has registered the ex_data indices yet - using the
      * still--1 index would make CRYPTO_set_ex_data grow its slot array toward

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -585,6 +585,10 @@ void us_poll_change(struct us_poll_t *p, struct us_loop_t *loop, int events) {
         do {
             rc = epoll_ctl(loop->fd, EPOLL_CTL_MOD, p->state.fd, &event);
         } while (IS_EINTR(rc));
+        /* MOD invariant: the fd was ADDed by us_poll_start_rc on this epoll, so
+         * MOD cannot fail for resource reasons (ENOSPC is ADD-only); rc != 0
+         * means the fd was closed behind the poll's back, a lifetime bug. */
+        US_ASSERT(rc == 0);
 #else
         kqueue_change(loop->fd, p->state.fd, old_events, events, p);
 #endif

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -75,6 +75,14 @@ extern void __attribute__((__noreturn__)) Bun__panic(const char *message, size_t
  * allocations this library has no way to fail gracefully from. */
 extern void __attribute__((__noreturn__)) Bun__outOfMemory(void);
 
+/* Debug/ASan-only invariant check. Compiles out in release. */
+#if defined(BUN_DEBUG) || (defined(__has_feature) && __has_feature(address_sanitizer)) || defined(__SANITIZE_ADDRESS__)
+#include <assert.h>
+#define US_ASSERT(x) assert(x)
+#else
+#define US_ASSERT(x) ((void)0)
+#endif
+
 #ifdef _WIN32
 #define IS_EINTR(rc) (rc == SOCKET_ERROR && WSAGetLastError() == WSAEINTR)
 #define LIBUS_ERR WSAGetLastError()

--- a/src/boringssl/lib.rs
+++ b/src/boringssl/lib.rs
@@ -176,7 +176,9 @@ pub fn init_client() -> *mut boring::SSL {
             .0
             .as_ptr();
 
-        let ssl = boring::SSL_new(ctx);
+        let ssl = ptr::NonNull::new(boring::SSL_new(ctx))
+            .expect("SSL_new")
+            .as_ptr();
         boring::SSL_set_connect_state(ssl);
 
         ssl

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2120,6 +2120,10 @@ where
         // scope (including the `?` below) once `cookies_to_write` drops.
         let mut cookies_to_write = upgrader.cookies.take();
 
+        // Mark upgraded before the 101 write so any error below cannot make the
+        // caller render a response over already-emitted bytes (issue #1339).
+        upgrader.upgrade_context = Some(usize::MAX as *mut WebSocketUpgradeContext);
+
         // Write status, custom headers, and cookies in one place
         if fetch_headers_to_use.is_some() || cookies_to_write.is_some() {
             resp.write_status(b"101 Switching Protocols");
@@ -2139,9 +2143,6 @@ where
             }
         }
 
-        // --- After this point, do not throw an exception
-        // See https://github.com/oven-sh/bun/issues/1339
-        upgrader.upgrade_context = Some(usize::MAX as *mut WebSocketUpgradeContext);
         let signal = upgrader.signal.take();
         upgrader.resp = None;
         request.request_context = AnyRequestContext::NULL;

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -3622,6 +3622,12 @@ impl<const SSL: bool> NewSocket<SSL> {
         // original net.Socket, not the TLS one.
         TLSSocket::data_set_cached(raw_js_value, global, original_data);
 
+        // Allocate the [raw, tls] result before on_open / start_tls_handshake
+        // so a JS-side OOM here does not leave a ClientHello already in flight.
+        let array = JSValue::create_empty_array(global, 2)?;
+        array.put_index(global, 0, raw_js_value)?;
+        array.put_index(global, 1, tls_js_value)?;
+
         tls.mark_active();
         if was_reffed {
             tls.poll_ref.with_mut(|p| {
@@ -3648,9 +3654,6 @@ impl<const SSL: bool> NewSocket<SSL> {
             bun_opaque::opaque_deref_mut(new_raw.as_ptr()).tls_feed(initial_data.as_slice());
         }
 
-        let array = JSValue::create_empty_array(global, 2)?;
-        array.put_index(global, 0, raw_js_value)?;
-        array.put_index(global, 1, tls_js_value)?;
         Ok(array)
     }
 


### PR DESCRIPTION
Hardening pass from the partial-construction / cleanup-ordering sweep at `3f65f0846` (src + bun-usockets + bun-uws). 726 targeted fault-injection runs were all negative; these are the hazardous-latent sites where a multi-step constructor's step N−1 has registered with the loop / written to the wire before step N can still fail.

### Changes

**`packages/bun-usockets/src/crypto/openssl.c`**
`us_internal_ssl_attach`: `SSL_new(ctx)` was dereferenced by `SSL_set_bio` and every subsequent `SSL_*` call without a null check (the existing `if (ssl && ...)` guarded only the ex-data set). Now `Bun__outOfMemory()` on null, same as the neighbouring `BIO_meth_new`/`BIO_new` checks. Same for `SSL_CTX_new(TLS_method())` in `us_ssl_ctx_build_raw`.

**`packages/bun-usockets/src/eventing/epoll_kqueue.c`**
`us_poll_change` now debug-asserts `epoll_ctl(EPOLL_CTL_MOD) == 0` and documents why that holds: the fd was registered via `us_poll_start_rc` (whose `EPOLL_CTL_ADD` is checked), and MOD on a registered fd cannot fail for resource reasons; a non-zero rc means the fd was closed behind the poll's back. `US_ASSERT` lifted from context.c to `internal/internal.h` so the eventing layer can use it.

**`src/runtime/server/server_body.rs`**
`server.upgrade()`: the `upgrade_context = usize::MAX` sentinel (which `did_upgrade_web_socket()` reads) is now set *before* `write_status(b"101 Switching Protocols")` and the fallible cookie write. If that write (or the `?`) errors after bytes are on the wire, the caller's error path already sees the socket as upgraded and will not render a response on top of it.

**`src/runtime/socket/socket_body.rs`**
`upgradeTLS`: the `[raw, tls]` result array is now allocated before `on_open` / `start_tls_handshake()` / `resume()` / `tls_feed()` instead of after. An allocation failure on the result no longer leaves a ClientHello already sent with the original TCP wrapper detached.

**`src/boringssl/lib.rs`**
`init_client()` (currently uncalled) asserts `SSL_new` non-null, matching the `NonNull::new(...).expect("SSL_CTX_new")` one line above.

### Not changed

The carried `Thread::create` item is not actionable here: `WTF::Thread::create` returns `Ref<Thread>` and `RELEASE_ASSERT`s on `establishHandle` failure (vendor/WebKit/Source/WTF/wtf/Threading.cpp:331), so the only Bun call site (SigintWatcher.cpp) cannot observe null. The Worker thread spawn is `std::thread::Builder::spawn` and already unregisters / unrefs / frees on `Err` (src/jsc/web_worker.rs:607).

### Verification

Ran under the debug+ASan build:
- `test/js/bun/websocket/websocket-server-upgrade-reentrant.test.ts`, `websocket-upgrade-signal-gc.test.ts`
- `test/js/bun/net/socket.test.ts -t upgradeTLS`, `socket-retention.test.ts`, `test/regression/issue/12117.test.ts`
- `test/js/node/tls/node-tls-connect.test.ts`
- `test/js/bun/http/tls-keepalive.test.ts`, `tls-bunfile-leak.test.ts`

Unrelated pre-existing failures in the local environment (ECONNREFUSED in socket.test.ts fixtures, ASan benchmark timeouts in websocket-server.test.ts) reproduce identically on main at 98f66496.