### PR TITLE
worker: survive pthread_create EAGAIN at the thread/pids limit

### DIFF
--- a/test/js/web/workers/worker-thread-limit.test.ts
+++ b/test/js/web/workers/worker-thread-limit.test.ts
@@ -1,0 +1,105 @@
+// Worker churn at the kernel thread/pids limit used to abort the whole
+// process (RELEASE_ASSERT in WTF::Thread::create and PAS_ASSERT in
+// bmalloc's pas_scavenger) instead of failing just the affected Worker.
+//
+// POSIX-only: simulates a cgroup pids.max budget via RLIMIT_NPROC, which
+// the kernel ignores for uid 0.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { readdirSync } from "node:fs";
+
+const isRoot = process.getuid?.() === 0;
+// `ulimit -u` (RLIMIT_NPROC) is a bash builtin; POSIX sh (dash) rejects -u.
+const bash = isLinux ? Bun.which("bash") : null;
+
+// Linux-only: RLIMIT_NPROC counts threads there (the same thing cgroup
+// pids.max caps). Skipped under uid 0 since the kernel ignores the limit
+// for root, and when bash is unavailable for `ulimit -u`.
+test.skipIf(!isLinux || !bash || isRoot)(
+  "Worker churn at RLIMIT_NPROC survives instead of aborting",
+  async () => {
+    const fixture = `
+import { mkdtempSync, writeFileSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function threadCount() {
+  try { return readdirSync("/proc/self/task").length; } catch { return 0; }
+}
+
+const w = join(mkdtempSync(join(tmpdir(), "wlim-")), "w.js");
+writeFileSync(w, "self.onmessage = e => postMessage(e.data + 1)");
+
+let spawnFailures = 0;
+for (let r = 0; r < 8; r++) {
+  const ws = [];
+  for (let i = 0; i < 4; i++) {
+    try { ws.push(new Worker(w)); } catch { spawnFailures++; }
+  }
+  await Promise.all(
+    ws.map(
+      x =>
+        new Promise<void>(res => {
+          const t = setTimeout(res, 1500);
+          x.onmessage = () => { clearTimeout(t); res(); };
+          x.onerror = () => { clearTimeout(t); res(); };
+          x.postMessage(r);
+        }),
+    ),
+  );
+  for (const x of ws) x.terminate();
+  Bun.gc(true);
+}
+console.log(JSON.stringify({ ok: true, spawnFailures, threads: threadCount() }));
+`;
+
+    using dir = tempDir("worker-thread-limit", { "churn.ts": fixture });
+
+    // RLIMIT_NPROC caps the user's total thread count, so the limit has to
+    // accommodate every thread this test process already holds plus enough
+    // headroom for the child's own startup. Pick a value that lets the child
+    // boot but starves its later Worker/JSC helper spawns; the exact headroom
+    // isn't load-bearing because the fixture tolerates every Worker failing.
+    let preexisting = 16;
+    try {
+      preexisting = readdirSync("/proc/self/task").length;
+    } catch {}
+    const baselineProc = Bun.spawnSync({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const {readdirSync}=require("fs");console.log(readdirSync("/proc/self/task").length)`,
+      ],
+      env: bunEnv,
+    });
+    const childBaseline = parseInt(baselineProc.stdout.toString().trim(), 10) || 12;
+    const limit = preexisting + childBaseline + 4;
+
+    await using proc = Bun.spawn({
+      cmd: [bash!, "-c", `ulimit -u ${limit} && exec "$@"`, "bash", bunExe(), "churn.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    // Primary assertion: the process must not have been killed by SIGABRT/SIGTRAP.
+    // Before the fix, pthread_create EAGAIN inside JSC/WTF/bmalloc was a
+    // RELEASE_ASSERT/PAS_ASSERT and the child died with 134 or 133.
+    expect({ stdout, stderr: stderr.slice(-500), exitCode, signalCode: proc.signalCode }).toMatchObject({
+      exitCode: 0,
+      signalCode: null,
+    });
+    const result = JSON.parse(stdout.trim().split("\n").pop()!);
+    expect(result.ok).toBe(true);
+    // Confirm the limit actually bit (some Worker spawns were rejected), so a
+    // pass is meaningful and not just "limit too high".
+    expect(result.spawnFailures).toBeGreaterThan(0);
+  },
+);

--- a/test/js/web/workers/worker-thread-limit.test.ts
+++ b/test/js/web/workers/worker-thread-limit.test.ts
@@ -16,10 +16,8 @@ const bash = isLinux ? Bun.which("bash") : null;
 // Linux-only: RLIMIT_NPROC counts threads there (the same thing cgroup
 // pids.max caps). Skipped under uid 0 since the kernel ignores the limit
 // for root, and when bash is unavailable for `ulimit -u`.
-test.skipIf(!isLinux || !bash || isRoot)(
-  "Worker churn at RLIMIT_NPROC survives instead of aborting",
-  async () => {
-    const fixture = `
+test.skipIf(!isLinux || !bash || isRoot)("Worker churn at RLIMIT_NPROC survives instead of aborting", async () => {
+  const fixture = `
 import { mkdtempSync, writeFileSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -54,52 +52,43 @@ for (let r = 0; r < 8; r++) {
 console.log(JSON.stringify({ ok: true, spawnFailures, threads: threadCount() }));
 `;
 
-    using dir = tempDir("worker-thread-limit", { "churn.ts": fixture });
+  using dir = tempDir("worker-thread-limit", { "churn.ts": fixture });
 
-    // RLIMIT_NPROC caps the user's total thread count, so the limit has to
-    // accommodate every thread this test process already holds plus enough
-    // headroom for the child's own startup. Pick a value that lets the child
-    // boot but starves its later Worker/JSC helper spawns; the exact headroom
-    // isn't load-bearing because the fixture tolerates every Worker failing.
-    let preexisting = 16;
-    try {
-      preexisting = readdirSync("/proc/self/task").length;
-    } catch {}
-    const baselineProc = Bun.spawnSync({
-      cmd: [
-        bunExe(),
-        "-e",
-        `const {readdirSync}=require("fs");console.log(readdirSync("/proc/self/task").length)`,
-      ],
-      env: bunEnv,
-    });
-    const childBaseline = parseInt(baselineProc.stdout.toString().trim(), 10) || 12;
-    const limit = preexisting + childBaseline + 4;
+  // RLIMIT_NPROC caps the user's total thread count, so the limit has to
+  // accommodate every thread this test process already holds plus enough
+  // headroom for the child's own startup. Pick a value that lets the child
+  // boot but starves its later Worker/JSC helper spawns; the exact headroom
+  // isn't load-bearing because the fixture tolerates every Worker failing.
+  let preexisting = 16;
+  try {
+    preexisting = readdirSync("/proc/self/task").length;
+  } catch {}
+  const baselineProc = Bun.spawnSync({
+    cmd: [bunExe(), "-e", `const {readdirSync}=require("fs");console.log(readdirSync("/proc/self/task").length)`],
+    env: bunEnv,
+  });
+  const childBaseline = parseInt(baselineProc.stdout.toString().trim(), 10) || 12;
+  const limit = preexisting + childBaseline + 4;
 
-    await using proc = Bun.spawn({
-      cmd: [bash!, "-c", `ulimit -u ${limit} && exec "$@"`, "bash", bunExe(), "churn.ts"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+  await using proc = Bun.spawn({
+    cmd: [bash!, "-c", `ulimit -u ${limit} && exec "$@"`, "bash", bunExe(), "churn.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    // Primary assertion: the process must not have been killed by SIGABRT/SIGTRAP.
-    // Before the fix, pthread_create EAGAIN inside JSC/WTF/bmalloc was a
-    // RELEASE_ASSERT/PAS_ASSERT and the child died with 134 or 133.
-    expect({ stdout, stderr: stderr.slice(-500), exitCode, signalCode: proc.signalCode }).toMatchObject({
-      exitCode: 0,
-      signalCode: null,
-    });
-    const result = JSON.parse(stdout.trim().split("\n").pop()!);
-    expect(result.ok).toBe(true);
-    // Confirm the limit actually bit (some Worker spawns were rejected), so a
-    // pass is meaningful and not just "limit too high".
-    expect(result.spawnFailures).toBeGreaterThan(0);
-  },
-);
+  // Primary assertion: the process must not have been killed by SIGABRT/SIGTRAP.
+  // Before the fix, pthread_create EAGAIN inside JSC/WTF/bmalloc was a
+  // RELEASE_ASSERT/PAS_ASSERT and the child died with 134 or 133.
+  expect({ stdout, stderr: stderr.slice(-500), exitCode, signalCode: proc.signalCode }).toMatchObject({
+    exitCode: 0,
+    signalCode: null,
+  });
+  const result = JSON.parse(stdout.trim().split("\n").pop()!);
+  expect(result.ok).toBe(true);
+  // Confirm the limit actually bit (some Worker spawns were rejected), so a
+  // pass is meaningful and not just "limit too high".
+  expect(result.spawnFailures).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## What

`new Worker()` at a kernel thread limit (cgroup `pids.max`, `RLIMIT_NPROC`) currently aborts the whole process instead of failing that one Worker. Node at the same limit emits a per-Worker error and fully recovers.

The load-bearing fix is in **oven-sh/WebKit#311**; this PR adds the bun-side regression test and will bump `WEBKIT_VERSION` once that lands.

## Repro

```sh
# as any non-root user on Linux
bash -c 'ulimit -u 16 && exec bun worker-churn.mjs'
```

<details><summary>worker-churn.mjs</summary>

```js
import { mkdtempSync, writeFileSync } from "node:fs";
import { tmpdir } from "node:os";
import { join } from "node:path";
const w = join(mkdtempSync(join(tmpdir(), "t-")), "w.js");
writeFileSync(w, `self.onmessage = e => postMessage(e.data + 1)`);
for (let r = 0; r < 12; r++) {
  const ws = [];
  for (let i = 0; i < 4; i++) { try { ws.push(new Worker(w)); } catch {} }
  await Promise.all(ws.map(x => new Promise(res => {
    const t = setTimeout(res, 1200);
    x.onmessage = () => { clearTimeout(t); res() };
    x.onerror = () => { clearTimeout(t); res() };
    x.postMessage(r);
  })));
  ws.forEach(x => x.terminate());
  Bun.gc(true);
}
console.log("SURVIVED");
```
</details>

Stock 1.4.0 and current main: `SIGABRT` (134), silent in release. With debug assertions:

```
ASSERTION FAILED: success
vendor/WebKit/Source/WTF/wtf/Threading.cpp(331) : static Ref<Thread> WTF::Thread::create(...)
```

## Cause

Bun's own Worker OS thread (`std::thread::Builder::spawn` in `web_worker.rs`) already turns spawn failure into a JS `TypeError`. The abort comes from the JSC/WTF/bmalloc helper threads that the Worker churn triggers:

- `AutomaticThread::start` (GC marker `ParallelHelperPool`, JIT/Wasm worklists, per-VM Heap collector) calls `Thread::create` which `RELEASE_ASSERT`s on `pthread_create` EAGAIN.
- bmalloc's `pas_scavenger` does a raw `pthread_create` + `PAS_ASSERT(!result)`.
- `VMTraps`' process-global signal-sender `WorkQueue` is created lazily on the first `fireTrap`, which the first `worker.terminate()` reaches after Workers have consumed every pid slot.

## Fix (oven-sh/WebKit#311)

- New `WTF::Thread::tryCreate` returning `RefPtr<Thread>`.
- `AutomaticThread::start` uses it and backs off to the no-underlying-thread state so the next notify retries.
- `Heap::finishRelinquishingConn` re-takes the conn when the collector thread has no underlying thread, so the mutator drives GC instead of `waitForCollector` parking forever.
- `pas_scavenger` drops back to `no_thread` on failure instead of asserting.
- `VMTraps::initializeSignals` creates the signal-sender queue eagerly.

## Verification

Patched the five objects into the prebuilt debug-asan `libWTF.a`/`libbmalloc.a`/`libJavaScriptCore.a` and relinked; swept `ulimit -u` 13 through 28 on the repro. Every value now exits 0 where the unpatched build aborts. All existing `test/js/web/workers` and `test/js/node/worker_threads` tests pass against the patched build.

The new test (`test/js/web/workers/worker-thread-limit.test.ts`) runs the repro under `ulimit -u` and asserts exit 0. Linux-only, skipped under uid 0. It will stay red until `WEBKIT_VERSION` is bumped to include oven-sh/WebKit#311.

## Status

Draft until oven-sh/WebKit#311 merges and autobuilds; then this PR bumps `scripts/build/deps/webkit.ts` and goes green.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->