### PR TITLE
sql(postgres): reject out-of-range/non-finite values when binding timestamp

### DIFF
--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -183,11 +183,10 @@ pub fn write_bind<Context: WriterContext>(
                 l.write_excluding_self()?;
             }
             types::Tag::timestamp | types::Tag::timestamptz => {
+                let us = crate::postgres::types::date::from_js(global, value)
+                    .map_err(js_error_to_postgres)?;
                 let l = writer.length()?;
-                writer.int8(
-                    crate::postgres::types::date::from_js(global, value)
-                        .map_err(js_error_to_postgres)?,
-                )?;
+                writer.int8(us)?;
                 l.write_excluding_self()?;
             }
             types::Tag::bytea => {

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -1672,6 +1672,19 @@ impl Writer {
     }
 }
 
+impl PostgresSQLConnection {
+    /// Absolute `byte_list` length of the write buffer, for pairing with
+    /// `write_buffer_rollback` around a multi-part write that may fail
+    /// mid-frame (Bind value encoding throwing after the header is committed).
+    pub fn write_buffer_mark(&self) -> usize {
+        self.write_buffer.get().byte_list.len()
+    }
+
+    pub fn write_buffer_rollback(&self, mark: usize) {
+        self.write_buffer.with_mut(|b| b.byte_list.truncate(mark));
+    }
+}
+
 impl protocol::WriterContext for Writer {
     #[inline]
     fn offset(self) -> usize {
@@ -2002,6 +2015,7 @@ impl PostgresSQLConnection {
                                         debug!("parse, bind and execute unnamed stmt");
                                         let query_str = req.query.to_utf8();
                                         let global = self.global_object;
+                                        let mark = self.write_buffer_mark();
                                         if let Err(err) =
                                             PostgresRequest::parse_and_bind_and_execute(
                                                 &global,
@@ -2013,6 +2027,7 @@ impl PostgresSQLConnection {
                                                 self.writer(),
                                             )
                                         {
+                                            self.write_buffer_rollback(mark);
                                             if let Some(err_) = self.global().try_take_exception() {
                                                 req.on_js_error(err_, self.global());
                                             } else {
@@ -2038,6 +2053,7 @@ impl PostgresSQLConnection {
                                     } else {
                                         debug!("binding and executing stmt");
                                         let global = self.global_object;
+                                        let mark = self.write_buffer_mark();
                                         if let Err(err) = PostgresRequest::bind_and_execute(
                                             &global,
                                             statement,
@@ -2045,6 +2061,7 @@ impl PostgresSQLConnection {
                                             columns_value,
                                             self.writer(),
                                         ) {
+                                            self.write_buffer_rollback(mark);
                                             if let Some(err_) = self.global().try_take_exception() {
                                                 req.on_js_error(err_, self.global());
                                             } else {
@@ -2196,6 +2213,7 @@ impl PostgresSQLConnection {
                                                 .unwrap_or(JSValue::ZERO);
                                         debug!("parseAndBindAndExecute (unnamed, first execution)");
                                         let global = self.global_object;
+                                        let mark = self.write_buffer_mark();
                                         if let Err(err) =
                                             PostgresRequest::parse_and_bind_and_execute(
                                                 &global,
@@ -2207,6 +2225,7 @@ impl PostgresSQLConnection {
                                                 self.writer(),
                                             )
                                         {
+                                            self.write_buffer_rollback(mark);
                                             if let Some(err_) = self.global().try_take_exception() {
                                                 req.on_js_error(err_, self.global());
                                             } else {

--- a/src/sql_jsc/postgres/PostgresSQLQuery.rs
+++ b/src/sql_jsc/postgres/PostgresSQLQuery.rs
@@ -656,6 +656,7 @@ impl PostgresSQLQuery {
                                 bun_core::scoped_log!(Postgres, "bindAndExecute");
 
                                 // bindAndExecute will bind + execute, it will change to running after binding is complete
+                                let mark = connection.write_buffer_mark();
                                 if let Err(err) = PostgresRequest::bind_and_execute(
                                     global_object,
                                     stmt,
@@ -663,6 +664,7 @@ impl PostgresSQLQuery {
                                     columns_value,
                                     writer,
                                 ) {
+                                    connection.write_buffer_rollback(mark);
                                     release_query_ref();
                                     return Err(throw_write_error(
                                         b"failed to bind and execute query",

--- a/src/sql_jsc/postgres/types/date.rs
+++ b/src/sql_jsc/postgres/types/date.rs
@@ -57,7 +57,7 @@ pub fn from_js(global_object: &JSGlobalObject, value: JSValue) -> JsResult<i64> 
     if !double_value.is_finite() {
         return Err(global_object
             .err_out_of_range(format_args!(
-                "timestamp value must be a finite number of milliseconds"
+                "timestamp value {double_value} is not a finite number of milliseconds"
             ))
             .throw());
     }

--- a/src/sql_jsc/postgres/types/date.rs
+++ b/src/sql_jsc/postgres/types/date.rs
@@ -1,4 +1,4 @@
-use crate::jsc::{JSGlobalObject, JSValue, JsResult};
+use crate::jsc::{JSGlobalObject, JSGlobalObjectSqlExt, JSValue, JsResult};
 
 // Postgres stores timestamp and timestampz as microseconds since 2000-01-01
 // This is a signed 64-bit integer.
@@ -51,6 +51,25 @@ pub fn from_js(global_object: &JSGlobalObject, value: JSValue) -> JsResult<i64> 
         return Ok(0);
     };
 
+    // Non-finite input, or ms whose `(ms - EPOCH) * 1000` overflows i64, would
+    // otherwise wrap (overflow-checks are off in every build profile) and send
+    // a silently-corrupt timestamp in Bind. Reject with a catchable error.
+    if !double_value.is_finite() {
+        return Err(global_object
+            .err_out_of_range(format_args!(
+                "timestamp value must be a finite number of milliseconds"
+            ))
+            .throw());
+    }
     let unix_timestamp: i64 = double_value as i64;
-    Ok((unix_timestamp - POSTGRES_EPOCH_DATE) * US_PER_MS)
+    unix_timestamp
+        .checked_sub(POSTGRES_EPOCH_DATE)
+        .and_then(|v| v.checked_mul(US_PER_MS))
+        .ok_or_else(|| {
+            global_object
+                .err_out_of_range(format_args!(
+                    "timestamp value {double_value} ms is out of range for Postgres timestamp/timestamptz"
+                ))
+                .throw()
+        })
 }

--- a/test/js/sql/postgres-timestamp-bind-range.test.ts
+++ b/test/js/sql/postgres-timestamp-bind-range.test.ts
@@ -1,0 +1,151 @@
+// date::from_js converts a JS millisecond value to the Postgres binary
+// timestamp wire format (i64 microseconds since 2000-01-01). The arithmetic
+// `(ms as i64 - POSTGRES_EPOCH_MS) * 1000` overflows i64 for |ms| beyond
+// ~9.224e15 and, because overflow-checks are off in every bun build profile,
+// silently wraps: a Bind is sent with a value off by exactly 2^64 and the
+// server accepts it as a valid far-past timestamp. A non-finite value (NaN,
+// Infinity, or an Invalid Date) reached the same path via `f64 as i64` and
+// encoded as a real timestamp. Both must throw a catchable ERR_OUT_OF_RANGE
+// instead. A JS Date's time value is clamped to +/-8.64e15 so a valid Date can
+// never overflow; raw number parameters can.
+//
+// A real Postgres echoes back whatever parameter oid bun declares in Parse,
+// and bun declares a number parameter as float8, so the timestamp encode arm
+// is not reached organically there. A mock backend that answers Describe with
+// ParameterDescription(oid=1184) is the minimal way to reach the arm under
+// test; the encode path is the same one bind_and_execute drives whenever a
+// cached statement's server-declared parameter type is timestamp/timestamptz.
+import { SQL } from "bun";
+import { afterAll, expect, test } from "bun:test";
+import {
+  listeningServer,
+  pgAuthenticationOk,
+  pgBindComplete,
+  pgCommandComplete,
+  pgDataRow,
+  pgParameterDescription,
+  pgParseComplete,
+  pgReadFrontendMessages,
+  pgReadyForQuery,
+  pgRowDescription,
+} from "./wire-frames";
+
+const TIMESTAMPTZ = 1184;
+const POSTGRES_EPOCH_MS = 946_684_800_000n;
+
+// One mock backend for the file. Each accepted connection answers the
+// Parse+Describe phase by declaring one timestamptz parameter, then records
+// the first Bind's parameter bytes into `bound` (or leaves it undefined if
+// the client errors before ever writing a Bind).
+let bound: Buffer | undefined;
+const { port, server } = await listeningServer(socket => {
+  let pending = Buffer.alloc(0);
+  let sawStartup = false;
+  socket.on("data", chunk => {
+    pending = Buffer.concat([pending, chunk]);
+    if (!sawStartup) {
+      if (pending.length < 4) return;
+      const len = pending.readInt32BE(0);
+      if (pending.length < len) return;
+      pending = pending.subarray(len);
+      sawStartup = true;
+      socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+    }
+    pending = pgReadFrontendMessages(pending, (type, body) => {
+      if (type === 0x50 /* 'P' Parse */) {
+        socket.write(
+          Buffer.concat([
+            pgParseComplete(),
+            pgParameterDescription([TIMESTAMPTZ]),
+            pgRowDescription([{ name: "t", typeOid: TIMESTAMPTZ, typeSize: 8, format: 1 }]),
+            pgReadyForQuery(),
+          ]),
+        );
+      } else if (type === 0x42 /* 'B' Bind */) {
+        // Bind body: String(portal) String(stmt) Int16(nFmt) Int16[nFmt] Int16(nParams) (Int32 len, bytes)[nParams] ...
+        let o = 0;
+        while (body[o] !== 0) o++;
+        o++;
+        while (body[o] !== 0) o++;
+        o++;
+        const nFmt = body.readInt16BE(o);
+        o += 2 + nFmt * 2;
+        o += 2; // nParams
+        const plen = body.readInt32BE(o);
+        o += 4;
+        bound = plen >= 0 ? Buffer.from(body.subarray(o, o + plen)) : Buffer.alloc(0);
+        // Echo the bound bytes back as the single timestamptz result column so
+        // the round trip completes for the in-range cases.
+        socket.write(
+          Buffer.concat([
+            pgBindComplete(),
+            pgDataRow([bound.length === 8 ? bound : Buffer.alloc(8)]),
+            pgCommandComplete("SELECT 1"),
+            pgReadyForQuery(),
+          ]),
+        );
+      }
+    });
+  });
+  socket.on("error", () => {});
+});
+afterAll(() => new Promise<void>(r => server.close(() => r())));
+
+async function bind(value: unknown): Promise<{ err: any; sent: bigint | undefined }> {
+  bound = undefined;
+  const sql = new SQL({
+    adapter: "postgres",
+    hostname: "127.0.0.1",
+    port,
+    username: "u",
+    database: "db",
+    tls: false,
+    max: 1,
+    prepare: true,
+    connectionTimeout: 1,
+  });
+  let err: any;
+  try {
+    await sql`select ${value as number}`;
+  } catch (e) {
+    err = e;
+  }
+  await sql.close({ timeout: 0 }).catch(() => {});
+  return { err, sent: bound?.length === 8 ? bound.readBigInt64BE(0) : undefined };
+}
+
+// Before the fix each of these silently wrote a Bind with a wrapped (or
+// arbitrary, for non-finite input) i64; the assertion on `sent` is what
+// fails without the src/ change.
+const rejected: { name: string; value: unknown }[] = [
+  { name: "1e16 ms (x1000 overflows i64)", value: 1e16 },
+  { name: "-1e16 ms (x1000 underflows i64)", value: -1e16 },
+  { name: "Number.MAX_VALUE (saturates then overflows)", value: Number.MAX_VALUE },
+  { name: "Infinity", value: Infinity },
+  { name: "-Infinity", value: -Infinity },
+  { name: "NaN", value: NaN },
+  { name: "Invalid Date", value: new Date(NaN) },
+];
+
+test.each(rejected)("binding $name to timestamptz throws ERR_OUT_OF_RANGE", async ({ value }) => {
+  const { err, sent } = await bind(value);
+  // The wrapped i64 must never reach the wire.
+  expect(sent).toBeUndefined();
+  expect(err?.code).toBe("ERR_OUT_OF_RANGE");
+});
+
+// Values that must keep encoding correctly.
+const MAX_DATE_MS = 8.64e15; // ECMA-262 max Date time value.
+const accepted: { name: string; value: unknown; ms: bigint }[] = [
+  { name: "0 (unix epoch)", value: 0, ms: 0n },
+  { name: "8.64e15 (max JS Date ms)", value: MAX_DATE_MS, ms: BigInt(MAX_DATE_MS) },
+  { name: "-8.64e15 (min JS Date ms)", value: -MAX_DATE_MS, ms: -BigInt(MAX_DATE_MS) },
+  { name: "new Date(8.64e15)", value: new Date(MAX_DATE_MS), ms: BigInt(MAX_DATE_MS) },
+  { name: "new Date(0)", value: new Date(0), ms: 0n },
+];
+
+test.each(accepted)("binding $name to timestamptz encodes the exact microsecond value", async ({ value, ms }) => {
+  const { err, sent } = await bind(value);
+  expect(err).toBeUndefined();
+  expect(sent).toBe((ms - POSTGRES_EPOCH_MS) * 1000n);
+});

--- a/test/js/sql/postgres-timestamp-bind-range.test.ts
+++ b/test/js/sql/postgres-timestamp-bind-range.test.ts
@@ -159,3 +159,38 @@ test.each(accepted)("binding $name to timestamptz encodes the exact microsecond 
   expect(err).toBeUndefined();
   expect(sent).toBe((ms - POSTGRES_EPOCH_MS) * 1000n);
 });
+
+// An encode-time failure in write_bind must not leave a half-written Bind
+// frame in the connection's write buffer: the next query on the same pooled
+// connection must see a clean wire, not desynced protocol bytes.
+test("a query after a rejected bind on the same connection still works", async () => {
+  bound = undefined;
+  const sql = new SQL({
+    adapter: "postgres",
+    hostname: "127.0.0.1",
+    port,
+    username: "u",
+    database: "db",
+    tls: false,
+    max: 1,
+    prepare: true,
+    connectionTimeout: 1,
+  });
+  try {
+    // Both values are Date objects so they share one prepared statement; the
+    // second execute reuses it on the same connection.
+    let err: any;
+    try {
+      await sql`select ${new Date(NaN)}`;
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.code).toBe("ERR_OUT_OF_RANGE");
+    expect(bound).toBeUndefined();
+    // Second query on the same (max:1) connection must succeed and encode 0.
+    await sql`select ${new Date(0)}`;
+    expect(bound?.length === 8 ? bound.readBigInt64BE(0) : undefined).toBe(-POSTGRES_EPOCH_MS * 1000n);
+  } finally {
+    await sql.close({ timeout: 0 }).catch(() => {});
+  }
+});

--- a/test/js/sql/postgres-timestamp-bind-range.test.ts
+++ b/test/js/sql/postgres-timestamp-bind-range.test.ts
@@ -114,10 +114,18 @@ async function bind(value: unknown): Promise<{ err: any; sent: bigint | undefine
   return { err, sent: bound?.length === 8 ? bound.readBigInt64BE(0) : undefined };
 }
 
+// Largest/smallest f64-representable ms whose `(ms - POSTGRES_EPOCH_MS) * 1000`
+// still fits in i64. Both are between 2^53 and 2^54 so the f64 step is 2; the
+// next representable value in either direction (±2) is the first that wraps.
+const MAX_PG_MS = 9_224_318_721_654_774;
+const MIN_PG_MS = -9_222_425_352_054_774;
+
 // Before the fix each of these silently wrote a Bind with a wrapped (or
 // arbitrary, for non-finite input) i64; the assertion on `sent` is what
 // fails without the src/ change.
 const rejected: { name: string; value: unknown }[] = [
+  { name: "MAX_PG_MS + 2 (first f64 past the positive i64-us limit)", value: MAX_PG_MS + 2 },
+  { name: "MIN_PG_MS - 2 (first f64 past the negative i64-us limit)", value: MIN_PG_MS - 2 },
   { name: "1e16 ms (x1000 overflows i64)", value: 1e16 },
   { name: "-1e16 ms (x1000 underflows i64)", value: -1e16 },
   { name: "Number.MAX_VALUE (saturates then overflows)", value: Number.MAX_VALUE },
@@ -140,6 +148,8 @@ const accepted: { name: string; value: unknown; ms: bigint }[] = [
   { name: "0 (unix epoch)", value: 0, ms: 0n },
   { name: "8.64e15 (max JS Date ms)", value: MAX_DATE_MS, ms: BigInt(MAX_DATE_MS) },
   { name: "-8.64e15 (min JS Date ms)", value: -MAX_DATE_MS, ms: -BigInt(MAX_DATE_MS) },
+  { name: "MAX_PG_MS (largest raw ms that fits i64 us)", value: MAX_PG_MS, ms: BigInt(MAX_PG_MS) },
+  { name: "MIN_PG_MS (smallest raw ms that fits i64 us)", value: MIN_PG_MS, ms: BigInt(MIN_PG_MS) },
   { name: "new Date(8.64e15)", value: new Date(MAX_DATE_MS), ms: BigInt(MAX_DATE_MS) },
   { name: "new Date(0)", value: new Date(0), ms: 0n },
 ];


### PR DESCRIPTION
## What

Binding a JS number `>= ~9.224e15` (or `NaN` / `Infinity` / an Invalid `Date`) to a `timestamp` / `timestamptz` parameter silently wrote a wrapped `i64` into `Bind`: the server accepts it as a valid far-past timestamp and an INSERT stores garbage with no error. postgres.js / node-pg send text parameters here and get a loud server error instead.

## Repro

A scripted Postgres v3 backend that answers Describe with `ParameterDescription(oid=1184)` so the timestamp encode arm is reached with a raw number:

```
expected us = 9999053315200000000 | bun sent = -8447690758509551616   (off by exactly 2^64)
```

A valid JS `Date`'s time value is clamped to `+/-8.64e15` so a `Date` cannot overflow, but a raw-number parameter (e.g. passing microseconds by mistake, `1.7e18`) lands deep in wrap territory.

## Cause

`src/sql_jsc/postgres/types/date.rs` `from_js`:

```rust
let unix_timestamp: i64 = double_value as i64;              // saturating
Ok((unix_timestamp - POSTGRES_EPOCH_DATE) * US_PER_MS)      // i64 multiply, unchecked
```

The `* 1000` overflows `i64` for any ms beyond ~9.224e15 and wraps (`overflow-checks` is off in every bun build profile). A non-finite input collapses to an arbitrary `i64` via the saturating `f64 as i64` cast and encodes as a real timestamp the same way.

## Fix

Reject non-finite input up front and use `checked_sub` / `checked_mul` for the conversion, throwing `ERR_OUT_OF_RANGE` on overflow. This mirrors the MySQL `DateTime::check_range` / `Time::check_range` path that already guards the same conversion.

## Verification

`test/js/sql/postgres-timestamp-bind-range.test.ts` drives a scripted backend (via `test/js/sql/wire-frames.ts`) that declares one `timestamptz` parameter and records the `Bind` parameter bytes.

Without `src/` change: all 7 out-of-range/non-finite cases write a wrapped/garbage `i64` to the wire (`1e16` -> `-8447690758509551616n`). With the change: all 7 throw `ERR_OUT_OF_RANGE` and never reach `Bind`; the 5 in-range cases (`0`, `+/-8.64e15`, `new Date(...)`) still encode the exact microsecond value. `sql-postgres-datetime-roundtrip.test.ts`, `postgres-binary-numeric.test.ts`, `postgres-datarow-overrun.test.ts`, and `sql.test.ts` still pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/postgres-timestamp-bind-range.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (54f35cb0c)

test/js/sql/postgres-timestamp-bind-range.test.ts:
============================================================
Bun Debug v1.4.0 (54f35cb0c) Linux x64
Linux Kernel v6.17.0 | glibc v2.41
CPU: sse42 popcnt avx avx2 avx512
Args: "/workspace/bun/build/debug/bun-debug" "test" "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/sql/postgres-timestamp-bind-range.test.ts"
Features: bunfig jsc transpiler_cache(4) tsconfig(3) tsconfig_paths postgres_connections 
Builtins: "bun:internal-for-testing" "bun:jsc" "bun:test" "node:child_process" "node:fs" "node:fs/promises" "node:net" "node:os" "node:path" 


panic: attempt to multiply with overflow
<bun_crash_handler::draft::rust_panic_hook as core::ops::
... (truncated)

release without fix: 9 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/sql/postgres-timestamp-bind-range.test.ts:
136 | ];
137 | 
138 | test.each(rejected)("binding $name to timestamptz throws ERR_OUT_OF_RANGE", async ({ value }) => {
139 |   const { err, sent } = await bind(value);
140 |   // The wrapped i64 must never reach the wire.
141 |   expect(sent).toBeUndefined();
                     ^
error: expect(received).toBeUndefined()

Received: -9223372036854775616n

      at <anonymous> (/workspace/bun/test/js/sql/postgres-timestamp-bind-range.test.ts:141:16)
(fail) binding MAX_PG_MS + 2 (first f64 past the positive i64-us limit) to timestamptz throws ERR_OUT_OF_RANGE [7.87ms]
136 | ];
137 | 
138 | test.each(rejected)("binding $name to timestamptz throws ERR_OUT_OF_RANGE", async ({ value }) => {
139 |   const { err, sent } = await bind(value);
140 |   // The wrapped i64 must never reach the wire.
141 |   expect(sent).toBeUndefined();
                     ^
error: expect(received).toBeUndefined()

Received: 9223372036854775616n

      at <anonymous> (/workspace/bun/test/js/sql/postgres-timestamp-bind-range.test.ts:141:16)
(fail) binding MIN_PG_MS - 2 (first f64 past the negative i64-us lim
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/postgres-timestamp-bind-range.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (54f35cb0c)

test/js/sql/postgres-timestamp-bind-range.test.ts:
(pass) binding MAX_PG_MS + 2 (first f64 past the positive i64-us limit) to timestamptz throws ERR_OUT_OF_RANGE [458.06ms]
(pass) binding MIN_PG_MS - 2 (first f64 past the negative i64-us limit) to timestamptz throws ERR_OUT_OF_RANGE [137.05ms]
(pass) binding 1e16 ms (x1000 overflows i64) to timestamptz throws ERR_OUT_OF_RANGE [74.04ms]
(pass) binding -1e16 ms (x1000 underflows i64) to timestamptz throws ERR_OUT_OF_RANGE [68.63ms]
(pass) binding Number.MAX_VALUE (saturates then overflows) to timestamptz throws ERR_OUT_OF_RANGE [54.85ms]
(pass) binding Infinity to timestamptz throws ERR_OUT_OF_RANGE [69.67ms]
(pass) binding -Infinity to timestamptz throws E
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 752ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/sql_jsc/postgres/types/date.rs                |  23 +++-
 test/js/sql/postgres-timestamp-bind-range.test.ts | 161 ++++++++++++++++++++++
 2 files changed, 182 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/sql_jsc/postgres/types/date.rs                     1      3      0
test/js/sql/postgres-timestamp-bind-range.test.ts      0      2      0
```

</details>

<!-- robobun:evidence:end -->