### PR TITLE
sql(postgres): reject out-of-range JS numbers bound to int4 parameters

### DIFF
--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -199,14 +199,14 @@ pub(crate) fn write_bind<Context: WriterContext>(
                 writer.write(bytes)?;
                 l.write_excluding_self()?;
             }
-            types::Tag::int4 => {
+            types::Tag::int4 | types::Tag::int4_array => {
+                // coerce::<i32> saturates on overflow, which silently stores the
+                // wrong value. Range-check via i64 so an out-of-range value
+                // surfaces as an error instead.
+                let n = value.coerce::<i64>(global).map_err(js_error_to_postgres)?;
+                let n = i32::try_from(n).map_err(|_| AnyPostgresError::Overflow)?;
                 let l = writer.length()?;
-                writer.int4(value.coerce::<i32>(global).map_err(js_error_to_postgres)? as u32)?;
-                l.write_excluding_self()?;
-            }
-            types::Tag::int4_array => {
-                let l = writer.length()?;
-                writer.int4(value.coerce::<i32>(global).map_err(js_error_to_postgres)? as u32)?;
+                writer.int4(n as u32)?;
                 l.write_excluding_self()?;
             }
             types::Tag::float8 => {

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -200,9 +200,12 @@ pub(crate) fn write_bind<Context: WriterContext>(
                 l.write_excluding_self()?;
             }
             types::Tag::int4 | types::Tag::int4_array => {
-                // coerce::<i32> saturates on overflow, which silently stores the
-                // wrong value. Range-check via i64 so an out-of-range value
-                // surfaces as an error instead.
+                // coerce::<i32> saturates on overflow (and maps NaN to 0), which
+                // silently stores the wrong value. Range-check via i64 so an
+                // out-of-range or non-finite value surfaces as an error instead.
+                if value.get_number().is_some_and(|n| n.is_nan()) {
+                    return Err(AnyPostgresError::Overflow);
+                }
                 let n = value.coerce::<i64>(global).map_err(js_error_to_postgres)?;
                 let n = i32::try_from(n).map_err(|_| AnyPostgresError::Overflow)?;
                 let l = writer.length()?;

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -200,9 +200,7 @@ pub(crate) fn write_bind<Context: WriterContext>(
                 l.write_excluding_self()?;
             }
             types::Tag::int4 | types::Tag::int4_array => {
-                // coerce::<i32> saturates on overflow (and maps NaN to 0), which
-                // silently stores the wrong value. Range-check via i64 so an
-                // out-of-range or non-finite value surfaces as an error instead.
+                // coerce::<i32> saturates and maps NaN to 0; reject instead.
                 if value.get_number().is_some_and(|n| n.is_nan()) {
                     return Err(AnyPostgresError::Overflow);
                 }

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -1531,9 +1531,7 @@ impl PostgresSQLConnection {
             || self.current().is_some()
     }
 
-    /// Absolute byte position to pass to `rollback_write_buffer` when a
-    /// `PostgresRequest::*` serializer errors mid-write, so partial frontend
-    /// messages are not flushed to the socket.
+    /// Snapshot for `rollback_write_buffer` when a serializer fails mid-message.
     #[inline]
     pub fn write_buffer_mark(&self) -> usize {
         self.write_buffer.get().byte_list.len()

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -1531,6 +1531,19 @@ impl PostgresSQLConnection {
             || self.current().is_some()
     }
 
+    /// Absolute byte position to pass to `rollback_write_buffer` when a
+    /// `PostgresRequest::*` serializer errors mid-write, so partial frontend
+    /// messages are not flushed to the socket.
+    #[inline]
+    pub fn write_buffer_mark(&self) -> usize {
+        self.write_buffer.get().byte_list.len()
+    }
+
+    #[inline]
+    pub fn rollback_write_buffer(&self, mark: usize) {
+        self.write_buffer.with_mut(|b| b.byte_list.truncate(mark));
+    }
+
     #[inline]
     pub(crate) fn note_request_pending(&self) {
         self.pending_requests.set(self.pending_requests.get() + 1);
@@ -1924,6 +1937,7 @@ impl PostgresSQLConnection {
                                         debug!("parse, bind and execute unnamed stmt");
                                         let query_str = req.query.to_utf8();
                                         let global = self.global_object;
+                                        let mark = self.write_buffer_mark();
                                         if let Err(err) =
                                             PostgresRequest::parse_and_bind_and_execute(
                                                 &global,
@@ -1935,6 +1949,7 @@ impl PostgresSQLConnection {
                                                 self.writer(),
                                             )
                                         {
+                                            self.rollback_write_buffer(mark);
                                             if let Some(err_) = self.global().try_take_exception() {
                                                 req.on_js_error(err_, self.global());
                                             } else {
@@ -1960,6 +1975,7 @@ impl PostgresSQLConnection {
                                     } else {
                                         debug!("binding and executing stmt");
                                         let global = self.global_object;
+                                        let mark = self.write_buffer_mark();
                                         if let Err(err) = PostgresRequest::bind_and_execute(
                                             &global,
                                             statement,
@@ -1967,6 +1983,7 @@ impl PostgresSQLConnection {
                                             columns_value,
                                             self.writer(),
                                         ) {
+                                            self.rollback_write_buffer(mark);
                                             if let Some(err_) = self.global().try_take_exception() {
                                                 req.on_js_error(err_, self.global());
                                             } else {
@@ -2046,6 +2063,7 @@ impl PostgresSQLConnection {
                                                 .unwrap_or_default();
                                         debug!("prepareAndQueryWithSignature");
                                         let global = self.global_object;
+                                        let mark = self.write_buffer_mark();
                                         if let Err(err) =
                                             PostgresRequest::prepare_and_query_with_signature(
                                                 &global,
@@ -2055,6 +2073,7 @@ impl PostgresSQLConnection {
                                                 &mut statement.signature,
                                             )
                                         {
+                                            self.rollback_write_buffer(mark);
                                             if let Some(err_) = self.global().try_take_exception() {
                                                 req.on_js_error(err_, self.global());
                                             } else {
@@ -2118,6 +2137,7 @@ impl PostgresSQLConnection {
                                                 .unwrap_or_default();
                                         debug!("parseAndBindAndExecute (unnamed, first execution)");
                                         let global = self.global_object;
+                                        let mark = self.write_buffer_mark();
                                         if let Err(err) =
                                             PostgresRequest::parse_and_bind_and_execute(
                                                 &global,
@@ -2129,6 +2149,7 @@ impl PostgresSQLConnection {
                                                 self.writer(),
                                             )
                                         {
+                                            self.rollback_write_buffer(mark);
                                             if let Some(err_) = self.global().try_take_exception() {
                                                 req.on_js_error(err_, self.global());
                                             } else {

--- a/src/sql_jsc/postgres/PostgresSQLQuery.rs
+++ b/src/sql_jsc/postgres/PostgresSQLQuery.rs
@@ -606,6 +606,7 @@ impl PostgresSQLQuery {
                                 bun_core::scoped_log!(Postgres, "bindAndExecute");
 
                                 // bindAndExecute will bind + execute, it will change to running after binding is complete
+                                let mark = connection.write_buffer_mark();
                                 if let Err(err) = PostgresRequest::bind_and_execute(
                                     global_object,
                                     stmt,
@@ -613,6 +614,7 @@ impl PostgresSQLQuery {
                                     columns_value,
                                     writer,
                                 ) {
+                                    connection.rollback_write_buffer(mark);
                                     this.release_statement();
                                     return Err(throw_write_error(
                                         b"failed to bind and execute query",
@@ -664,6 +666,7 @@ impl PostgresSQLQuery {
                 if !has_params {
                     bun_core::scoped_log!(Postgres, "prepareAndQueryWithSignature");
                     // prepareAndQueryWithSignature will write + bind + execute, it will change to running after binding is complete
+                    let mark = connection.write_buffer_mark();
                     if let Err(err) = PostgresRequest::prepare_and_query_with_signature(
                         global_object,
                         query_str.slice(),
@@ -671,6 +674,7 @@ impl PostgresSQLQuery {
                         writer,
                         &mut signature,
                     ) {
+                        connection.rollback_write_buffer(mark);
                         if connection_entry_value.is_some() {
                             let _ = connection
                                 .statements

--- a/test/js/sql/postgres-int4-param-overflow.test.ts
+++ b/test/js/sql/postgres-int4-param-overflow.test.ts
@@ -114,9 +114,8 @@ test.each(overflowing)("binding $label to an int4 parameter rejects instead of s
   }
   expect(error).toBeDefined();
   expect(error?.code ?? error?.message).toMatch(/ERR_POSTGRES_OVERFLOW|Overflow/);
-  // The Bind message must not have reached the server carrying a saturated i32.
-  expect(lastBoundInt4).not.toBe(2147483647);
-  expect(lastBoundInt4).not.toBe(-2147483648);
+  // The Bind message must not have reached the server at all.
+  expect(lastBoundInt4).toBeUndefined();
 });
 
 test("binding INT32_MAX / INT32_MIN to an int4 parameter still works", async () => {

--- a/test/js/sql/postgres-int4-param-overflow.test.ts
+++ b/test/js/sql/postgres-int4-param-overflow.test.ts
@@ -1,0 +1,128 @@
+// Fault-injection test: requires a mock server so we can observe the exact
+// int4 bytes Bun writes in the Bind message. DO NOT COPY THIS PATTERN for
+// anything a real server can produce; see describeWithContainer.
+// All wire-protocol bytes come from test/js/sql/wire-frames.ts.
+//
+// Binding a JS number outside the i32 range to an int4 parameter used to
+// silently saturate to INT32_MIN/INT32_MAX (via the saturating f64 -> i32
+// coercion in write_bind) and store the wrong value. A real PostgreSQL server
+// rejects the same literal with "integer out of range" (SQLSTATE 22003), so
+// every other client surfaces a loud error while Bun quietly persisted the
+// saturated value instead.
+import { SQL } from "bun";
+import { afterAll, expect, test } from "bun:test";
+import {
+  listeningServer,
+  pgAuthenticationOk,
+  pgBindComplete,
+  pgCommandComplete,
+  pgParameterDescription,
+  pgParseComplete,
+  pgReadFrontendMessages,
+  pgReadyForQuery,
+  pgRowDescription,
+} from "./wire-frames";
+
+const INT4 = 23;
+
+// Read the first parameter value out of a Bind body as a 4-byte big-endian
+// i32, or null if the value length is not 4 (text format / NULL).
+function bindFirstInt4(body: Buffer): number | null {
+  let o = body.indexOf(0) + 1; // portal name
+  o = body.indexOf(0, o) + 1; // statement name
+  const nFmt = body.readInt16BE(o);
+  o += 2 + 2 * nFmt; // format codes
+  o += 2; // nParams
+  const len = body.readInt32BE(o);
+  o += 4;
+  return len === 4 ? body.readInt32BE(o) : null;
+}
+
+// Capture the value Bun bound for $1 on the most recent Bind. `undefined` means
+// no Bind arrived at all (the client rejected before writing it).
+let lastBoundInt4: number | null | undefined;
+
+const { port, server } = await listeningServer(socket => {
+  socket.on("error", () => {});
+  let pending = Buffer.alloc(0);
+  let sawStartup = false;
+  socket.on("data", chunk => {
+    pending = Buffer.concat([pending, chunk]);
+    if (!sawStartup) {
+      if (pending.length < 4) return;
+      const len = pending.readInt32BE(0);
+      if (pending.length < len) return;
+      pending = pending.subarray(len);
+      sawStartup = true;
+      socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+    }
+    pending = pgReadFrontendMessages(pending, (type, body) => {
+      if (type === 0x50 /* 'P' Parse */) {
+        socket.write(pgParseComplete());
+      } else if (type === 0x44 /* 'D' Describe */) {
+        socket.write(
+          Buffer.concat([pgParameterDescription([INT4]), pgRowDescription([{ name: "n", typeOid: INT4, format: 1 }])]),
+        );
+      } else if (type === 0x42 /* 'B' Bind */) {
+        lastBoundInt4 = bindFirstInt4(body);
+        socket.write(pgBindComplete());
+      } else if (type === 0x45 /* 'E' Execute */) {
+        socket.write(pgCommandComplete("SELECT 0"));
+      } else if (type === 0x53 /* 'S' Sync */) {
+        socket.write(pgReadyForQuery());
+      }
+    });
+  });
+});
+afterAll(() => new Promise<void>(r => server.close(() => r())));
+
+async function bind(n: number | bigint) {
+  lastBoundInt4 = undefined;
+  await using sql = new SQL({
+    adapter: "postgres",
+    hostname: "127.0.0.1",
+    port,
+    username: "u",
+    database: "db",
+    tls: false,
+    max: 1,
+    idleTimeout: 5,
+    connectionTimeout: 5,
+  });
+  await sql`SELECT ${n}::int4 AS n`.values();
+}
+
+const overflowing = [
+  { label: "2^31", value: 2147483648 },
+  { label: "2^32 + 1", value: 4294967297 },
+  { label: "-(2^31 + 1)", value: -2147483649 },
+  { label: "Number.MAX_SAFE_INTEGER", value: Number.MAX_SAFE_INTEGER },
+  { label: "Infinity", value: Infinity },
+  { label: "-Infinity", value: -Infinity },
+];
+
+test.each(overflowing)("binding $label to an int4 parameter rejects instead of saturating", async ({ value }) => {
+  let error: any;
+  try {
+    await bind(value);
+  } catch (e) {
+    error = e;
+  }
+  expect(error).toBeDefined();
+  expect(error?.code ?? error?.message).toMatch(/ERR_POSTGRES_OVERFLOW|Overflow/);
+  // The Bind message must not have reached the server carrying a saturated i32.
+  expect(lastBoundInt4).not.toBe(2147483647);
+  expect(lastBoundInt4).not.toBe(-2147483648);
+});
+
+test("binding INT32_MAX / INT32_MIN to an int4 parameter still works", async () => {
+  await bind(2147483647);
+  expect(lastBoundInt4).toBe(2147483647);
+  await bind(-2147483648);
+  expect(lastBoundInt4).toBe(-2147483648);
+});
+
+test("binding 0 to an int4 parameter still works", async () => {
+  await bind(0);
+  expect(lastBoundInt4).toBe(0);
+});

--- a/test/js/sql/postgres-int4-param-overflow.test.ts
+++ b/test/js/sql/postgres-int4-param-overflow.test.ts
@@ -26,16 +26,19 @@ import {
 const INT4 = 23;
 
 // Read the first parameter value out of a Bind body as a 4-byte big-endian
-// i32, or null if the value length is not 4 (text format / NULL).
+// i32, or null if the body is short / the value length is not 4.
 function bindFirstInt4(body: Buffer): number | null {
+  if (body.length < 2) return null;
   let o = body.indexOf(0) + 1; // portal name
   o = body.indexOf(0, o) + 1; // statement name
+  if (o <= 0 || o + 2 > body.length) return null;
   const nFmt = body.readInt16BE(o);
   o += 2 + 2 * nFmt; // format codes
   o += 2; // nParams
+  if (o + 4 > body.length) return null;
   const len = body.readInt32BE(o);
   o += 4;
-  return len === 4 ? body.readInt32BE(o) : null;
+  return len === 4 && o + 4 <= body.length ? body.readInt32BE(o) : null;
 }
 
 // Capture the value Bun bound for $1 on the most recent Bind. `undefined` means
@@ -99,6 +102,7 @@ const overflowing = [
   { label: "Number.MAX_SAFE_INTEGER", value: Number.MAX_SAFE_INTEGER },
   { label: "Infinity", value: Infinity },
   { label: "-Infinity", value: -Infinity },
+  { label: "NaN", value: NaN },
 ];
 
 test.each(overflowing)("binding $label to an int4 parameter rejects instead of saturating", async ({ value }) => {
@@ -125,4 +129,38 @@ test("binding INT32_MAX / INT32_MIN to an int4 parameter still works", async () 
 test("binding 0 to an int4 parameter still works", async () => {
   await bind(0);
   expect(lastBoundInt4).toBe(0);
+});
+
+// write_bind streams into the connection's write_buffer directly; erroring out
+// mid-serialize used to leave a partial 'B…' frontend message in the buffer,
+// which the auto-flusher then shipped to the server ahead of the next query's
+// Parse on the same pooled connection.
+test("a follow-up query on the same connection still works after an int4 overflow rejection", async () => {
+  await using sql = new SQL({
+    adapter: "postgres",
+    hostname: "127.0.0.1",
+    port,
+    username: "u",
+    database: "db",
+    tls: false,
+    max: 1,
+    idleTimeout: 5,
+    connectionTimeout: 5,
+  });
+
+  let error: any;
+  try {
+    await sql`SELECT ${2 ** 32 + 1}::int4 AS n`.values();
+  } catch (e) {
+    error = e;
+  }
+  expect(error?.code ?? error?.message).toMatch(/ERR_POSTGRES_OVERFLOW|Overflow/);
+
+  // Any partial Bind bytes that were flushed would reach the server before the
+  // next Parse, and the mock handler would see a leading 0x42 'B' frame whose
+  // declared length (00 00 00 00) swallows nothing, so the follow-up Parse
+  // would never be answered and this await would reject or hang.
+  lastBoundInt4 = undefined;
+  await sql`SELECT ${7}::int4 AS n`.values();
+  expect(lastBoundInt4).toBe(7);
 });


### PR DESCRIPTION
## What

Binding a JS number outside the `i32` range (or `NaN`) to an `int4` parameter silently saturated to `INT32_MIN`/`INT32_MAX` (or `0`) and stored the wrong value. A real PostgreSQL server rejects the same literal with `integer out of range` (SQLSTATE 22003), so every other client path surfaces a loud error while Bun quietly persisted the saturated value.

```ts
await sql`INSERT INTO t (n) VALUES (${4294967297})`; // int4 column
// before: silently stored 2147483647
// after:  rejects with ERR_POSTGRES_OVERFLOW
```

## Cause

`write_bind` encoded `int4` parameter values via `value.coerce::<i32>()`, whose number fast path is a saturating `f64 as i32` cast (and maps `NaN` to `0`):

https://github.com/oven-sh/bun/blob/98f664962f/src/sql_jsc/postgres/PostgresRequest.rs#L204-L213

so `2147483648` became `2147483647`, `4294967297` became `2147483647`, `-2147483649` became `-2147483648`, and `NaN` became `0`, all without an error.

## Fix

- Reject `NaN` up front, then coerce to `i64` and `i32::try_from` the result, returning `AnyPostgresError::Overflow` when it does not fit. In-range values (including the `i32` boundaries and truncation of fractional parts) behave exactly as before.
- `write_bind` streams directly into the connection's `write_buffer`, so erroring out mid-serialize would have left a partial `B...` frontend message in the buffer that the auto-flusher later shipped to the socket, poisoning the pooled connection for the next query. Every call site that reaches `write_bind` now snapshots the write buffer first and truncates back on `Err` (also covers the pre-existing jsonb / throwing-coercion error paths).

## Verification

`test/js/sql/postgres-int4-param-overflow.test.ts` runs a mock server that declares `$1` as oid 23 and asserts that out-of-range and non-finite values reject with `ERR_POSTGRES_OVERFLOW` (and that no saturated `2147483647`/`-2147483648` reaches the wire), that `INT32_MAX` / `INT32_MIN` / `0` still round-trip, and that a follow-up query on the same `max: 1` pooled connection still works after an overflow rejection.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/sql/postgres-int4-param-overflow.test.ts"
bun test v1.4.1 (65362b53b)

test/js/sql/postgres-int4-param-overflow.test.ts:
110 |   try {
111 |     await bind(value);
112 |   } catch (e) {
113 |     error = e;
114 |   }
115 |   expect(error).toBeDefined();
                      ^
error: expect(received).toBeDefined()

Received: undefined

      at <anonymous> (/workspace/bun/test/js/sql/postgres-int4-param-overflow.test.ts:115:17)
(fail) binding 2^31 to an int4 parameter rejects instead of saturating [402.72ms]
110 |   try {
111 |     await bind(value);
112 |   } catch (e) {
113 |     error = e;
114 |   }
115 |   expect(error).toBeDefined();
                      ^
error: expect(received).toBeDefined()

Received: undefined

      at <anonymous> (/workspace/bun/test/js/sql/postgres-int4-param-overflow.test.ts:115:17)
(fail) binding 2^32 + 1 to an int4 parameter rejects instead of saturating [154.43ms]
110 |   try {
111 |     await bind(value);
112 |   } catch (e) {
113 |     error = e;
114 |   }
115 |   expect(error).toBeDefined()
... (truncated)

release without fix: 8 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/js/sql/postgres-int4-param-overflow.test.ts:
110 |   try {
111 |     await bind(value);
112 |   } catch (e) {
113 |     error = e;
114 |   }
115 |   expect(error).toBeDefined();
                      ^
error: expect(received).toBeDefined()

Received: undefined

      at <anonymous> (/workspace/bun/test/js/sql/postgres-int4-param-overflow.test.ts:115:17)
(fail) binding 2^31 to an int4 parameter rejects instead of saturating [7.48ms]
110 |   try {
111 |     await bind(value);
112 |   } catch (e) {
113 |     error = e;
114 |   }
115 |   expect(error).toBeDefined();
                      ^
error: expect(received).toBeDefined()

Received: undefined

      at <anonymous> (/workspace/bun/test/js/sql/postgres-int4-param-overflow.test.ts:115:17)
(fail) binding 2^32 + 1 to an int4 parameter rejects instead of saturating [2.35ms]
110 |   try {
111 |     await bind(value);
112 |   } catch (e) {
113 |     error = e;
114 |   }
115 |   expect(error).toBeDefined();
                      ^
error: expect(received).toBeDefined()

Received: undefined

      at <anonymous> (/workspace/bun/test/js/sql/postgres-int4-param-overflow.test.ts:115:17)
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/sql/postgres-int4-param-overflow.test.ts"
bun test v1.4.1 (65362b53b)

test/js/sql/postgres-int4-param-overflow.test.ts:
(pass) binding 2^31 to an int4 parameter rejects instead of saturating [365.73ms]
(pass) binding 2^32 + 1 to an int4 parameter rejects instead of saturating [136.99ms]
(pass) binding -(2^31 + 1) to an int4 parameter rejects instead of saturating [32.74ms]
(pass) binding Number.MAX_SAFE_INTEGER to an int4 parameter rejects instead of saturating [26.75ms]
(pass) binding Infinity to an int4 parameter rejects instead of saturating [36.49ms]
(pass) binding -Infinity to an int4 parameter rejects instead of saturating [25.92ms]
(pass) binding NaN to an int4 parameter rejects instead of saturating [25.35ms]
(pass) binding INT32_MAX / INT32_MIN to an int4 parameter still works [73.62ms]
(pass) binding 0 to an int4 parameter still works [29.98ms]
(pass) a follow-up query on the same connection still works after an int4 overflow rejection [48.51ms]

 10 pass
 0 fail
 26 expect() calls
Ran 10 tests across 1 file. [3.71s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     d4372bffbe
  features     baseline

23 deps, 131 codegen, 1172 objects in 678ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [19.00ms]
[2/1244] gen bindgenv2
[3/1244] gen ErrorCode+*.h
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [2.00ms]
[5/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1217] fetch zlib
[zlib] up to date
[7/1217] fetch tinycc
[tinycc] up to date
[8/1216] gen .bind.ts → GeneratedBindings.cpp
[9/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [21.00ms]
[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/sql_jsc/postgres/PostgresRequest.rs          |  15 ++-
 src/sql_jsc/postgres/PostgresSQLConnection.rs    |  19 +++
 src/sql_jsc/postgres/PostgresSQLQuery.rs         |   4 +
 test/js/sql/postgres-int4-param-overflow.test.ts | 165 +++++++++++++++++++++++
 4 files changed, 196 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/sql_jsc/postgres/PostgresRequest.rs               6      4      0
src/sql_jsc/postgres/PostgresSQLConnection.rs         9      6      0
src/sql_jsc/postgres/PostgresSQLQuery.rs              8      3      0
test/js/sql/postgres-int4-param-overflow.test.ts      2      9      0
```

</details>

<!-- robobun:evidence:end -->