### PR TITLE
build(rust): enable overflow-checks in the release assertions profile

### DIFF
--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -761,6 +761,11 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
     // `debug_assert!` sites compile to nothing under ASAN. The `dev` profile
     // (debug builds) already defaults it on, so this is a no-op there.
     env.CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS = "true";
+    // `debug-assertions` does NOT imply `overflow-checks`; without this, Rust
+    // integer arithmetic still wraps silently in the assert/ASAN profiles and
+    // the narrowing-conversion class of bug is invisible to every fuzzable
+    // build. Turning it on makes those sites panic instead of corrupting data.
+    env.CARGO_PROFILE_RELEASE_OVERFLOW_CHECKS = "true";
   }
   if (rustflags.length > 0) env.CARGO_ENCODED_RUSTFLAGS = rustflags.join("\x1f");
 


### PR DESCRIPTION
The release-assertions / release-asan Cargo profile overrides set `CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true` but not the separate `CARGO_PROFILE_RELEASE_OVERFLOW_CHECKS` knob. In Rust those are independent: `debug-assertions` does not imply `overflow-checks`, so integer `+`/`-`/`*` still wrapped silently in every CI build we fuzz against. The Cargo `dev` profile (what `bun bd` builds) already defaults this on, so debug builds panic on overflow while the ASAN lanes quietly two's-complement.

This is the build-config finding from static-pattern audit #5 (narrowing-conversion-consumed-as-trusted): the whole bug class is undetectable by the current assert profile. Concrete instances it would have surfaced as panics (each now has its own fix PR):

- #34706 `days * 24` wrap in the MySQL binary TIME decoder
- #34707 `(ms - POSTGRES_EPOCH) * 1000` wrap in the Postgres timestamp binder

### Change

One line in `scripts/build/rust.ts`, alongside the existing `DEBUG_ASSERTIONS` override in the `cfg.assertions` block. The workspace `[profile.release]` in `Cargo.toml` is unchanged, so the plain `release` profile keeps wrapping semantics (no perf impact on shipped builds).

### Verification

`bun bd` is unaffected (dev profile already has this on). The release-asan lanes will now panic on any reachable integer overflow instead of wrapping; the audit's enumeration of this class found no surviving sites reachable from the existing test suite after #34706 / #34707 / #34708.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->