### PR TITLE
Fix event init write barriers

### DIFF
--- a/src/jsc/bindings/webcore/CustomEvent.cpp
+++ b/src/jsc/bindings/webcore/CustomEvent.cpp
@@ -57,16 +57,14 @@ Ref<CustomEvent> CustomEvent::create(const AtomString& type, const Init& initial
     return adoptRef(*new CustomEvent(type, initializer, isTrusted));
 }
 
-void CustomEvent::initCustomEvent(const AtomString& type, bool canBubble, bool cancelable, JSC::JSValue detail)
+void CustomEvent::initCustomEvent(JSC::VM& vm, const JSC::JSCell* owner, const AtomString& type, bool canBubble, bool cancelable, JSC::JSValue detail)
 {
     if (isBeingDispatched())
         return;
 
     initEvent(type, canBubble, cancelable);
 
-    // FIXME: This code is wrong: we should emit a write-barrier. Otherwise, GC can collect it.
-    // https://bugs.webkit.org/show_bug.cgi?id=236353
-    m_detail.setWeakly(detail);
+    m_detail.set(vm, owner, detail);
     m_cachedDetail.clear();
 }
 

--- a/src/jsc/bindings/webcore/CustomEvent.h
+++ b/src/jsc/bindings/webcore/CustomEvent.h
@@ -47,7 +47,7 @@ public:
 
     static Ref<CustomEvent> create(const AtomString& type, const Init&, IsTrusted = IsTrusted::No);
 
-    void initCustomEvent(const AtomString& type, bool canBubble, bool cancelable, JSC::JSValue detail = JSC::JSValue::JSUndefined);
+    void initCustomEvent(JSC::VM&, const JSC::JSCell*, const AtomString& type, bool canBubble, bool cancelable, JSC::JSValue detail = JSC::JSValue::JSUndefined);
 
     const JSValueInWrappedObject& detail() const { return m_detail; }
     JSValueInWrappedObject& cachedDetail() { return m_cachedDetail; }

--- a/src/jsc/bindings/webcore/JSCustomEvent.cpp
+++ b/src/jsc/bindings/webcore/JSCustomEvent.cpp
@@ -290,7 +290,7 @@ static inline JSC::EncodedJSValue jsCustomEventPrototypeFunction_initCustomEvent
     EnsureStillAliveScope argument3 = callFrame->argument(3);
     auto detail = argument3.value().isUndefined() ? jsNull() : convert<IDLAny>(*lexicalGlobalObject, argument3.value());
     RETURN_IF_EXCEPTION(throwScope, {});
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.initCustomEvent(type, WTF::move(bubbles), WTF::move(cancelable), WTF::move(detail)); })));
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.initCustomEvent(vm, castedThis, type, WTF::move(bubbles), WTF::move(cancelable), WTF::move(detail)); })));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsCustomEventPrototypeFunction_initCustomEvent, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))

--- a/src/jsc/bindings/webcore/JSMessageEvent.cpp
+++ b/src/jsc/bindings/webcore/JSMessageEvent.cpp
@@ -455,7 +455,7 @@ static inline JSC::EncodedJSValue jsMessageEventPrototypeFunction_initMessageEve
     EnsureStillAliveScope argument7 = callFrame->argument(7);
     auto messagePorts = argument7.value().isUndefined() ? Converter<IDLSequence<IDLInterface<MessagePort>>>::ReturnType {} : convert<IDLSequence<IDLInterface<MessagePort>>>(*lexicalGlobalObject, argument7.value());
     RETURN_IF_EXCEPTION(throwScope, {});
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.initMessageEvent(WTF::move(type), WTF::move(bubbles), WTF::move(cancelable), WTF::move(data), WTF::move(originArg), WTF::move(lastEventId), WTF::move(source), WTF::move(messagePorts)); })));
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.initMessageEvent(vm, castedThis, WTF::move(type), WTF::move(bubbles), WTF::move(cancelable), WTF::move(data), WTF::move(originArg), WTF::move(lastEventId), WTF::move(source), WTF::move(messagePorts)); })));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsMessageEventPrototypeFunction_initMessageEvent, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))

--- a/src/jsc/bindings/webcore/MessageEvent.cpp
+++ b/src/jsc/bindings/webcore/MessageEvent.cpp
@@ -119,7 +119,7 @@ auto MessageEvent::create(JSC::JSGlobalObject& globalObject, Ref<SerializedScrip
     return MessageEventWithStrongData { event, WTF::move(strongWrapper) };
 }
 
-void MessageEvent::initMessageEvent(const AtomString& type, bool canBubble, bool cancelable, JSValue data, const String& origin, const String& lastEventId, RefPtr<MessagePort>&& source, Vector<RefPtr<MessagePort>>&& ports)
+void MessageEvent::initMessageEvent(JSC::VM& vm, const JSC::JSCell* owner, const AtomString& type, bool canBubble, bool cancelable, JSValue data, const String& origin, const String& lastEventId, RefPtr<MessagePort>&& source, Vector<RefPtr<MessagePort>>&& ports)
 {
     if (isBeingDispatched())
         return;
@@ -130,9 +130,7 @@ void MessageEvent::initMessageEvent(const AtomString& type, bool canBubble, bool
         Locker locker { m_concurrentDataAccessLock };
         m_data = JSValueTag {};
     }
-    // FIXME: This code is wrong: we should emit a write-barrier. Otherwise, GC can collect it.
-    // https://bugs.webkit.org/show_bug.cgi?id=236353
-    m_jsData.setWeakly(data);
+    m_jsData.set(vm, owner, data);
     m_cachedData.clear();
     m_origin = origin;
     m_lastEventId = lastEventId;

--- a/src/jsc/bindings/webcore/MessageEvent.h
+++ b/src/jsc/bindings/webcore/MessageEvent.h
@@ -73,7 +73,7 @@ public:
 
     virtual ~MessageEvent();
 
-    void initMessageEvent(const AtomString& type, bool canBubble, bool cancelable, JSC::JSValue data, const String& origin, const String& lastEventId, RefPtr<MessagePort>&&, Vector<RefPtr<MessagePort>>&&);
+    void initMessageEvent(JSC::VM&, const JSC::JSCell*, const AtomString& type, bool canBubble, bool cancelable, JSC::JSValue data, const String& origin, const String& lastEventId, RefPtr<MessagePort>&&, Vector<RefPtr<MessagePort>>&&);
 
     const String& origin() const { return m_origin; }
     const String& lastEventId() const { return m_lastEventId; }

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -112,16 +112,47 @@ test("MessageEvent", () => {
   expect(called).toBe(true);
 });
 
-test("legacy event initializers retain object values across GC", () => {
-  const custom = new CustomEvent("custom");
-  const message = new MessageEvent("message");
-  custom.initCustomEvent("custom", false, false, { custom: true });
-  message.initMessageEvent("message", false, false, { message: true });
+test("legacy event initializers retain object values during concurrent GC", async () => {
+  const script = /* js */ `
+    const count = 5000;
+    const customEvents = [];
+    const messageEvents = [];
+    for (let i = 0; i < count; i++) {
+      const custom = new CustomEvent("custom");
+      const message = new MessageEvent("message");
+      customEvents.push(custom);
+      messageEvents.push(message);
+      const garbage = [];
+      for (let j = 0; j < 50; j++) garbage.push({ a: j, b: new Array(10).fill(j) });
+      custom.initCustomEvent("custom", false, false, new Error("custom-" + i));
+      message.initMessageEvent("message", false, false, new Error("message-" + i));
+    }
 
-  Bun.gc(true);
+    for (let i = 0; i < count; i++) {
+      const detail = customEvents[i].detail;
+      const data = messageEvents[i].data;
+      if (detail?.message !== "custom-" + i) throw new Error("lost CustomEvent detail");
+      if (data?.message !== "message-" + i) throw new Error("lost MessageEvent data");
+    }
+    console.log("OK");
+  `;
 
-  expect(custom.detail).toEqual({ custom: true });
-  expect(message.data).toEqual({ message: true });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: {
+      ...bunEnv,
+      BUN_JSC_collectContinuously: "1",
+      BUN_JSC_numberOfGCMarkers: "8",
+      BUN_JSC_verifyGC: "1",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("OK\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
 });
 
 it("crypto.getRandomValues", () => {

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -112,6 +112,18 @@ test("MessageEvent", () => {
   expect(called).toBe(true);
 });
 
+test("legacy event initializers retain object values across GC", () => {
+  const custom = new CustomEvent("custom");
+  const message = new MessageEvent("message");
+  custom.initCustomEvent("custom", false, false, { custom: true });
+  message.initMessageEvent("message", false, false, { message: true });
+
+  Bun.gc(true);
+
+  expect(custom.detail).toEqual({ custom: true });
+  expect(message.data).toEqual({ message: true });
+});
+
 it("crypto.getRandomValues", () => {
   var foo = new Uint8Array(32);
 


### PR DESCRIPTION
## Summary
Keep values assigned through legacy CustomEvent and MessageEvent initializers a live during GC.
     
## Fix
Emit JSC write barriers when storing `detail` and `data` on existing event wrappers.