### PR TITLE
Fix test runner file collisions

### DIFF
--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -241,10 +241,9 @@ impl<'a> TestRunner<'a> {
     }
 
     pub fn get_or_put_file(&mut self, file_path: &'static [u8]) -> GetOrPutFileResult {
-        // TODO: this is wrong. you can't put a hash as the key in a hashmap.
         let entry = self
             .index
-            .get_or_put(bun_wyhash::hash(file_path) as u32)
+            .get_or_put(file_path)
             .expect("unreachable");
         if entry.found_existing {
             return GetOrPutFileResult {
@@ -312,8 +311,7 @@ bun_collections::multi_array_columns! {
         log: bun_ast::Log,
     }
 }
-// u32 keys hash as identity in bun_collections.
-pub(crate) type FileMap = ArrayHashMap<u32, u32>;
+pub(crate) type FileMap = bun_collections::StringArrayHashMap<FileId>;
 
 #[allow(non_snake_case)]
 pub mod Jest {

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -3,7 +3,7 @@ use std::io::Write as _;
 
 use crate::cli::command::TestOptions;
 use crate::cli::test_command::CommandLineReporter;
-use bun_collections::{ArrayHashMap, MultiArrayList};
+use bun_collections::MultiArrayList;
 use bun_core::Output;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -3,11 +3,48 @@ import { spawn, spawnSync } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test } from "bun:test";
 import { copyFileSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "fs";
 import { rm, writeFile } from "fs/promises";
-import { bunEnv, bunExe, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import { tmpdir } from "os";
-import { dirname, join } from "path";
+import { basename, dirname, join } from "path";
+import { constructStdCollision } from "../../../cli/install/wyhash-std-collision.js";
 
 const tmp = realpathSync(tmpdir());
+
+test("test files with colliding hashes use distinct snapshot files", async () => {
+  using dir = tempDir("test-file-hash-collision", {});
+  const prefix = `${realpathSync(String(dir))}/`;
+  const collision = constructStdCollision({ prefixStr: prefix, suffixStr: ".test.js" });
+  const first = collision.str1;
+  const second = collision.str2;
+
+  expect(first).not.toBe(second);
+  expect(Bun.hash.wyhash(first)).toBe(Bun.hash.wyhash(second));
+
+  await Promise.all([
+    Bun.write(first, `import { test, expect } from "bun:test"; test("alpha", () => expect("alpha").toMatchSnapshot());`),
+    Bun.write(second, `import { test, expect } from "bun:test"; test("beta", () => expect("beta").toMatchSnapshot());`),
+  ]);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--update-snapshots", first, second],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const snapshotDir = join(String(dir), "__snapshots__");
+  const [firstSnapshot, secondSnapshot] = await Promise.all([
+    Bun.file(join(snapshotDir, `${basename(first)}.snap`)).text(),
+    Bun.file(join(snapshotDir, `${basename(second)}.snap`)).text(),
+  ]);
+
+  expect({ stdout, stderr, firstSnapshot, secondSnapshot }).toMatchObject({
+    firstSnapshot: expect.stringContaining('exports[`alpha 1`] = `"alpha"`;'),
+    secondSnapshot: expect.stringContaining('exports[`beta 1`] = `"beta"`;'),
+  });
+  expect(exitCode).toBe(0);
+});
 
 it("shouldn't crash when async test runner callback throws", async () => {
   console.log("it(shouldn't crash when async test runner callback throws)");


### PR DESCRIPTION
## Summary
Prevent distinct test files from sharing the same internal file ID when their hashes collide.
## Fix
Key test-runner file records by the complete path instead of a truncated 32-bit hash.