### PR TITLE
fix(error): don't capture stack trace on materialized ErrorInstance in appendStackTrace

### DIFF
--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -668,11 +668,11 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace, (JSC::JSGlobalObj
         return {};
     }
 
-    if (!destination->stackTrace()) {
+    if (!destination->stackTrace() && !destination->hasMaterializedErrorInfo()) {
         destination->captureStackTrace(vm, globalObject, 1);
     }
 
-    if (source->stackTrace()) {
+    if (source->stackTrace() && destination->stackTrace() && source != destination) {
         destination->stackTrace()->appendVector(*source->stackTrace());
         source->stackTrace()->clear();
     }

--- a/test/js/bun/util/error-gc-test.test.js
+++ b/test/js/bun/util/error-gc-test.test.js
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "fs";
-import { tmpdirSync } from "harness";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
 import { join } from "path";
 // This test checks that printing stack traces increments and decrements
 // reference-counted strings
@@ -43,6 +43,32 @@ test("error gc test #3", () => {
     Bun.inspect(err);
     Bun.gc();
   }
+});
+
+test("Error.appendStackTrace after materialized error info doesn't crash in GC", async () => {
+  const src = `
+    let keep = [];
+    for (let i = 0; i < 200; i++) {
+      eval(\`(function inner\${i}() {
+        const a = new Error();
+        const b = new Error();
+        a.sourceURL;
+        b.sourceURL;
+        Error.appendStackTrace(a, b);
+        keep.push(b);
+      })();\`);
+    }
+    Bun.gc(true);
+    Bun.gc(true);
+    process.stdout.write("ok");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, exitCode }).toEqual({ stdout: "ok", exitCode: 0 });
 });
 
 // This test fails if:

--- a/test/js/bun/util/error-gc-test.test.js
+++ b/test/js/bun/util/error-gc-test.test.js
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "fs";
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { tmpdirSync } from "harness";
 import { join } from "path";
 // This test checks that printing stack traces increments and decrements
 // reference-counted strings
@@ -43,35 +43,6 @@ test("error gc test #3", () => {
     Bun.inspect(err);
     Bun.gc();
   }
-});
-
-test("Error.appendStackTrace after materialized error info doesn't crash in GC", async () => {
-  const src = `
-    let keep = [];
-    for (let i = 0; i < 200; i++) {
-      eval(\`(function inner\${i}() {
-        const a = new Error();
-        const b = new Error();
-        a.sourceURL;
-        b.sourceURL;
-        Error.appendStackTrace(a, b);
-        keep.push(b);
-        const self = new Error();
-        Error.appendStackTrace(self, self);
-        keep.push(self);
-      })();\`);
-    }
-    Bun.gc(true);
-    Bun.gc(true);
-    process.stdout.write("ok");
-  `;
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", src],
-    env: bunEnv,
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
 });
 
 // This test fails if:

--- a/test/js/bun/util/error-gc-test.test.js
+++ b/test/js/bun/util/error-gc-test.test.js
@@ -56,6 +56,9 @@ test("Error.appendStackTrace after materialized error info doesn't crash in GC",
         b.sourceURL;
         Error.appendStackTrace(a, b);
         keep.push(b);
+        const self = new Error();
+        Error.appendStackTrace(self, self);
+        keep.push(self);
       })();\`);
     }
     Bun.gc(true);
@@ -68,7 +71,7 @@ test("Error.appendStackTrace after materialized error info doesn't crash in GC",
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout, exitCode }).toEqual({ stdout: "ok", exitCode: 0 });
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
 });
 
 // This test fails if:

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1121,3 +1121,32 @@ test("lazy error-info materialization does not store an empty stack value when t
   });
   expect(exitCode).toBe(0);
 });
+
+test("Error.appendStackTrace on an error with materialized info does not crash in GC", async () => {
+  const src = `
+    let keep = [];
+    for (let i = 0; i < 200; i++) {
+      eval(\`(function inner\${i}() {
+        const a = new Error();
+        const b = new Error();
+        a.sourceURL;
+        b.sourceURL;
+        Error.appendStackTrace(a, b);
+        keep.push(b);
+        const self = new Error();
+        Error.appendStackTrace(self, self);
+        keep.push(self);
+      })();\`);
+    }
+    Bun.gc(true);
+    Bun.gc(true);
+    process.stdout.write("ok");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
+});

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1133,6 +1133,11 @@ test("Error.appendStackTrace on an error with materialized info does not crash i
         b.sourceURL;
         Error.appendStackTrace(a, b);
         keep.push(b);
+        const c = new Error();
+        const d = new Error();
+        d.sourceURL;
+        Error.appendStackTrace(c, d);
+        keep.push(c, d);
         const self = new Error();
         Error.appendStackTrace(self, self);
         keep.push(self);


### PR DESCRIPTION
Fuzzilli found a debug assertion failure (fingerprint `667a4a9c2a9a6191`):

```
ASSERTION FAILED: !m_errorInfoMaterialized
vendor/WebKit/Source/JavaScriptCore/runtime/ErrorInstance.cpp(368) : void JSC::ErrorInstance::computeErrorInfo(VM &, bool)
```

### Cause

`Error.appendStackTrace(source, destination)` calls `destination->captureStackTrace()` whenever `destination->stackTrace()` is null, without checking `hasMaterializedErrorInfo()`. Once an error's `.sourceURL`/`.stack`/etc has been accessed, its error info is materialized and its internal `m_stackTrace` is cleared. Calling `captureStackTrace` at that point installs a fresh `m_stackTrace` while `m_errorInfoMaterialized` stays `true`, which is an inconsistent state.

Later, during GC, `ErrorInstance::finalizeUnconditionally` sees the non-null `m_stackTrace`, finds an unmarked frame, and calls `computeErrorInfo`, which asserts `!m_errorInfoMaterialized`.

Repro:
```js
let keep = [];
for (let i = 0; i < 200; i++) {
  eval(`(function inner${i}() {
    const a = new Error();
    const b = new Error();
    a.sourceURL;
    b.sourceURL;
    Error.appendStackTrace(a, b);
    keep.push(b);
  })();`);
}
Bun.gc(true);
Bun.gc(true);
```

### Fix

Skip `captureStackTrace` when `destination` has already materialized its error info, matching the existing guard in `errorConstructorFuncCaptureStackTrace`. Also guard the append against a null destination trace and skip when `source == destination` (self-appending a `WTF::Vector` then clearing it is pointless at best).

### How did you verify your code works?

Added a subprocess test in `test/js/node/v8/capture-stack-trace.test.js` that exercises three shapes:
- materialized source + materialized destination (the original crash)
- unmaterialized source + materialized destination (covers the null-check guard)
- self-append on an unmaterialized error (covers the `source != destination` guard)

Verified the test crashes with `exitCode: 134` and `ASSERTION FAILED: !m_errorInfoMaterialized` on the unfixed debug build and passes with the fix. Also mutation-tested each new guard: removing `!hasMaterializedErrorInfo()` restores the original assertion, and removing `destination->stackTrace()` trips a UBSAN null-pointer member call. All 44 tests in the file pass under both ASAN debug and release builds.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 3 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/v8/capture-stack-trace.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (dca95ca18)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [12.19ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [6.83ms]
(pass) capture stack trace [6.26ms]
(pass) capture stack trace with message [7.26ms]
(pass) capture stack trace with constructor [4.98ms]
(pass) capture stack trace limit [22.09ms]
(pass) prepare stack trace [11.00ms]
(pass) capture stack trace second argument [17.41ms]
(pass) capture stack trace edge cases [11.36ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [20.98ms]
(pass) prepare stack trace call sites [12.10ms]
(pass) sanity check [12.97ms]
(pass) CallFrame isEval works as expected [6.70ms]
(pass) CallFrame isTopLevel returns false for Functi
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (801a50530)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [1.13ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [0.13ms]
(pass) capture stack trace [0.10ms]
(pass) capture stack trace with message [0.10ms]
(pass) capture stack trace with constructor [0.09ms]
(pass) capture stack trace limit [0.33ms]
(pass) prepare stack trace [0.16ms]
(pass) capture stack trace second argument [0.29ms]
(pass) capture stack trace edge cases [0.17ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [0.36ms]
(pass) prepare stack trace call sites [0.18ms]
(pass) sanity check [0.23ms]
(pass) CallFrame isEval works as expected [0.14ms]
(pass) CallFrame isTopLevel returns false for Function constructor [0.15ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [0.14ms]
(pass) CallFrame.p.isConstructor [0.05ms]
(pass) CallFrame.p.isNative [0.04ms]
(pass) return non-strings from Error.prepareStackTrace [0.05ms]
(pass) CallFrame.p.toString [0.04ms]
(pass) err.stack should invoke prepareStackTrace [0.34ms]
(pass) Error.prepareStackTrace inside a node:vm works [7.43ms]
(pass) Error.captureStackTrace i
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/v8/capture-stack-trace.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (dca95ca18)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [12.72ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [6.69ms]
(pass) capture stack trace [6.36ms]
(pass) capture stack trace with message [7.87ms]
(pass) capture stack trace with constructor [5.26ms]
(pass) capture stack trace limit [23.73ms]
(pass) prepare stack trace [15.80ms]
(pass) capture stack trace second argument [19.15ms]
(pass) capture stack trace edge cases [11.79ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [21.86ms]
(pass) prepare stack trace call sites [14.67ms]
(pass) sanity check [13.21ms]
(pass) CallFrame isEval works as expected [7.00ms]
(pass) CallFrame isTopLevel returns false for Functi
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 809ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[2/7] gen cpp.rs (cppbind)
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/FormatStackTraceForJS.cpp  |  4 ++--
 test/js/node/v8/capture-stack-trace.test.js | 34 +++++++++++++++++++++++++++++
 2 files changed, 36 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 2 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/jsc/bindings/FormatStackTraceForJS.cpp       2      1      0
test/js/node/v8/capture-stack-trace.test.js      2      2      0
```

</details>

<!-- robobun:evidence:end -->