### PR TITLE
redis: fix heap-use-after-free from refcount over-release

### DIFF
--- a/src/ptr/ref_count.rs
+++ b/src/ptr/ref_count.rs
@@ -1048,6 +1048,13 @@ where
         // SAFETY: caller contract — `ptr` is non-null and live.
         Self(unsafe { NonNull::new_unchecked(ptr) })
     }
+
+    /// Defuse the guard without derefing, handing the ref to whatever adopts
+    /// it next. Inverse of [`adopt`](Self::adopt).
+    #[inline]
+    pub fn forget(self) {
+        let _ = core::mem::ManuallyDrop::new(self);
+    }
 }
 
 impl<T: AnyRefCounted> Drop for ScopedRef<T>

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -12,7 +12,7 @@ use bun_jsc::{
     self as jsc, CallFrame, GlobalRef, JSArray, JSGlobalObject, JSMap, JSPromise, JSValue, JsCell,
     JsRef, JsResult,
 };
-use bun_ptr::{AsCtxPtr, BackRef};
+use bun_ptr::{AsCtxPtr, BackRef, ScopedRef};
 use bun_uws as uws;
 
 use super::protocol_jsc;
@@ -54,22 +54,6 @@ fn narrow_terminated(r: JsResult<()>) -> JsTerminatedResult<()> {
 #[inline]
 fn vm_event_loop_ctx() -> bun_io::EventLoopCtx {
     bun_io::posix_event_loop::get_vm_ctx(bun_io::AllocatorType::Js)
-}
-
-/// Scope-guarded `ref/deref` over a raw pointer — sidesteps the
-/// `scopeguard`-captures-`&self` borrowck conflict that pervades this file.
-// R-2: takes `*const` now that every `JSValkeyClient` method is `&self`;
-// `deref()` (and `ref_()`) already only need a shared receiver.
-#[inline]
-pub(super) fn deref_guard(
-    this: *const JSValkeyClient,
-) -> scopeguard::ScopeGuard<*const JSValkeyClient, fn(*const JSValkeyClient)> {
-    fn drop_fn(p: *const JSValkeyClient) {
-        // SAFETY: `p` was a live `&JSValkeyClient` at guard creation; the
-        // intrusive `ref_()` taken just before guarantees liveness here.
-        unsafe { JSValkeyClient::deref(p.cast_mut()) }
-    }
-    scopeguard::guard(this, drop_fn as fn(*const JSValkeyClient))
 }
 
 bun_output::define_scoped_log!(debug, RedisJS, visible);
@@ -427,6 +411,13 @@ impl JSValkeyClient {
     pub unsafe fn deref(this: *mut Self) {
         // SAFETY: caller contract.
         unsafe { bun_ptr::RefCount::deref(this) };
+    }
+    /// RAII scoped ref: bumps on construction, derefs on `Drop`. Keeps `*self`
+    /// alive across re-entrant connect/close/fail paths.
+    #[inline]
+    pub fn ref_scope(&self) -> ScopedRef<Self> {
+        // SAFETY: `self` is live; the guard's own ref keeps it alive past Drop.
+        unsafe { ScopedRef::new(self.as_ctx_ptr()) }
     }
     #[inline]
     pub fn new(init: JSValkeyClient) -> *mut JSValkeyClient {
@@ -882,8 +873,7 @@ impl JSValkeyClient {
             self._subscription_ctx.get().is_subscriber
         );
         debug_assert!(self.client.get().status == valkey::Status::Connected);
-        self.ref_();
-        let _d = deref_guard(self);
+        let _guard = self.ref_scope();
 
         if !self._subscription_ctx.get().is_subscriber {
             let flags = &self.client.get().flags;
@@ -911,8 +901,7 @@ impl JSValkeyClient {
                 .has_subscriptions(&self.global_object)
                 .unwrap_or(false)
         );
-        self.ref_();
-        let _d = deref_guard(self);
+        let _guard = self.ref_scope();
 
         // This is the last subscription, restore original flags
         if !self
@@ -979,8 +968,7 @@ impl JSValkeyClient {
         global_object: &JSGlobalObject,
         this_value: JSValue,
     ) -> JsResult<JSValue> {
-        self.ref_();
-        let _d = deref_guard(self);
+        let _guard = self.ref_scope();
 
         // If already connected, resolve immediately
         if self.client.get().status == valkey::Status::Connected {
@@ -1054,8 +1042,7 @@ impl JSValkeyClient {
     pub fn js_disconnect(&self, _global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
         // `disconnect()` -> `close()` can dispatch `on_close` synchronously,
         // which derefs. Hold a ref so `&self` stays live across the call.
-        self.ref_();
-        let _d = deref_guard(self);
+        let _guard = self.ref_scope();
 
         if self.client.get().status == valkey::Status::Disconnected {
             return Ok(JSValue::UNDEFINED);
@@ -1080,8 +1067,7 @@ impl JSValkeyClient {
     fn add_timer(&self, timer: &JsCell<Timer::EventLoopTimer>, next_timeout_ms: u32) {
         // `timer` is `&self.timer` or `&self.reconnect_timer`; `JsCell` gives
         // us closure-scoped `&mut` without an open-coded raw deref.
-        self.ref_();
-        let _d = deref_guard(self);
+        let _guard = self.ref_scope();
 
         // If the timer is already active, we need to remove it first
         if timer.get().state == Timer::State::ACTIVE {
@@ -1160,13 +1146,10 @@ impl JSValkeyClient {
         // Mark timer as fired
         self.timer.with_mut(|t| t.state = Timer::State::FIRED);
 
-        // Increment ref to ensure 'self' stays alive throughout the function
-        self.ref_();
-        let _d = deref_guard(self);
-        // Release the keep-alive ref from add_timer; remove_timer/stop_timers skip FIRED timers.
-        // SAFETY: `_d` holds a balancing ref so the count stays > 0 and `self`
-        // remains live past this call.
-        unsafe { JSValkeyClient::deref(std::ptr::from_ref(self).cast_mut()) };
+        let _guard = self.ref_scope();
+        // SAFETY: adopts add_timer's keep-alive ref (remove_timer/stop_timers
+        // skip FIRED timers, so this scope is the only releaser).
+        let _timer_ref = unsafe { ScopedRef::adopt(self.as_ctx_ptr()) };
         if self.client.get().flags.failed {
             return;
         }
@@ -1218,13 +1201,10 @@ impl JSValkeyClient {
         self.reconnect_timer
             .with_mut(|t| t.state = Timer::State::FIRED);
 
-        // Increment ref to ensure 'self' stays alive throughout the function
-        self.ref_();
-        let _d = deref_guard(self);
-        // Release the keep-alive ref from add_timer; remove_timer/stop_timers skip FIRED timers.
-        // SAFETY: `_d` holds a balancing ref so the count stays > 0 and `self`
-        // remains live past this call.
-        unsafe { JSValkeyClient::deref(std::ptr::from_ref(self).cast_mut()) };
+        let _guard = self.ref_scope();
+        // SAFETY: adopts add_timer's keep-alive ref (remove_timer/stop_timers
+        // skip FIRED timers, so this scope is the only releaser).
+        let _timer_ref = unsafe { ScopedRef::adopt(self.as_ctx_ptr()) };
 
         // Execute reconnection logic
         self.reconnect();
@@ -1241,8 +1221,7 @@ impl JSValkeyClient {
         }
 
         // Ref to keep this alive during the reconnection
-        self.ref_();
-        let _d = deref_guard(self);
+        let _guard = self.ref_scope();
 
         // Ref the poll to keep event loop alive during connection
         self.poll_ref.with_mut(|r| {
@@ -1328,8 +1307,7 @@ impl JSValkeyClient {
     ///
     /// `SubscriptionCtx` will invoke this to communicate that it has added a new listener.
     pub fn on_new_subscription_callback_insert(&self) {
-        self.ref_();
-        let _d = deref_guard(self);
+        let _guard = self.ref_scope();
 
         self.client_mut().on_writable();
         self.update_poll_ref();
@@ -1339,8 +1317,7 @@ impl JSValkeyClient {
         debug_assert!(self.is_subscriber());
         debug_assert!(self.this_value.get().is_strong());
 
-        self.ref_();
-        let _d = deref_guard(self);
+        let _guard = self.ref_scope();
 
         let _ = value;
 
@@ -1404,6 +1381,12 @@ impl JSValkeyClient {
 
     // Callback for when Valkey client needs to reconnect
     pub fn on_valkey_reconnect(&self) {
+        // SAFETY: adopts connect()'s socket keep-alive ref for the just-closed
+        // socket. Reached only from `ValkeyClient::on_close()`'s reconnect
+        // branch, which never calls `on_valkey_close()`, so this scope is the
+        // sole releaser. The caller holds its own scoped ref, so count > 0.
+        let _socket_ref = unsafe { ScopedRef::adopt(self.as_ctx_ptr()) };
+
         // Schedule reconnection using our safe timer methods
         if self.reconnect_timer.get().state == Timer::State::ACTIVE {
             self.remove_timer(&self.reconnect_timer);
@@ -1413,32 +1396,16 @@ impl JSValkeyClient {
         if delay_ms > 0 {
             self.add_timer(&self.reconnect_timer, delay_ms);
         }
-
-        // Release the keep-alive ref `connect()` took for the just-closed
-        // socket. We only reach here from `ValkeyClient::on_close()`'s reconnect
-        // branch, which (unlike its other branches) does not call
-        // `on_valkey_close()` and so never balances that ref. The reconnect
-        // timer (and the next `connect()`) take their own refs, so without this
-        // every retry leaks one ref and the client is never freed.
-        // SAFETY: caller (`SocketHandler::on_close`/`on_connect_error`) holds a
-        // scoped ref across this call, so the count stays > 0.
-        unsafe { JSValkeyClient::deref(std::ptr::from_ref(self).cast_mut()) };
     }
 
     // Callback for when Valkey client closes
     pub fn on_valkey_close(&self) -> JsTerminatedResult<()> {
         let global_object = self.global_object;
 
-        let self_ptr = self.as_ctx_ptr();
-        let _defer = scopeguard::guard(self_ptr, |p| {
-            // SAFETY: `p` was `self.as_ctx_ptr()`; the socket dispatch path
-            // holds an intrusive ref across this scope so `*p` is live here.
-            // The trailing `deref` releases that ref.
-            unsafe {
-                (*p).update_poll_ref();
-                JSValkeyClient::deref(p);
-            }
-        });
+        // SAFETY: adopts connect()'s socket keep-alive ref; the caller holds
+        // its own scoped ref so count stays > 0 until this drops.
+        let _socket_ref = unsafe { ScopedRef::adopt(self.as_ctx_ptr()) };
+        let _defer = scopeguard::guard(BackRef::new(self), |p| p.update_poll_ref());
 
         let Some(this_jsvalue) = self.this_value.get().try_get() else {
             return Ok(());
@@ -1556,11 +1523,12 @@ impl JSValkeyClient {
     }
 
     pub fn finalize(self: Box<Self>) {
-        // Refcounted: `deref_guard` releases the JS wrapper's +1 at scope end;
+        // Refcounted: adopt the JS wrapper's +1 and release it at scope end;
         // allocation may outlive this call if other refs remain, so hand
         // ownership back to the raw refcount.
         let this: &Self = bun_core::heap::release(self);
-        let _d = deref_guard(this);
+        // SAFETY: the JS wrapper owned one ref; this scope consumes it.
+        let _guard = unsafe { ScopedRef::adopt(this.as_ctx_ptr()) };
 
         this.stop_timers();
         this.this_value.with_mut(|t| t.finalize());
@@ -1586,19 +1554,13 @@ impl JSValkeyClient {
     fn connect(&self) -> Result<(), crate::Error> {
         self.client_mut().flags.needs_to_open_socket = false;
 
-        self.ref_();
-        let _d = deref_guard(self);
+        let _guard = self.ref_scope();
 
         // Socket keep-alive ref, released by on_valkey_close/on_valkey_reconnect.
         // Taken before the TLS-context check so the `tls_ctx_failed` branch's
         // `on_valkey_close()` has a ref to consume instead of over-releasing.
-        self.ref_();
-        let self_ptr = self.as_ctx_ptr();
-        let errdefer_deref = scopeguard::guard(self_ptr, |p| {
-            // SAFETY: balances the `ref_()` just taken; `*p` is live until this
-            // guard releases that ref on early return.
-            unsafe { JSValkeyClient::deref(p) }
-        });
+        // Forgotten on success (the socket adopts it).
+        let socket_ref = self.ref_scope();
 
         let is_tls = self.client.get().tls != valkey::TLS::None;
         // `vm.rare_data()` needs `&mut VirtualMachine`; `client.vm`
@@ -1645,9 +1607,9 @@ impl JSValkeyClient {
                 b"Failed to create TLS context",
                 protocol::RedisError::ConnectionClosed,
             )?;
-            // `on_valkey_close()` releases the socket ref; disarm the errdefer
-            // so it isn't released twice.
-            scopeguard::ScopeGuard::into_inner(errdefer_deref);
+            // `on_valkey_close()` consumes the socket ref; hand it over so it
+            // isn't released twice.
+            core::mem::forget(socket_ref);
             self.client_mut().on_valkey_close()?;
             self.client_mut().status = valkey::Status::Disconnected;
             return Ok(());
@@ -1663,13 +1625,9 @@ impl JSValkeyClient {
 
         self.client_mut().status = valkey::Status::Connecting;
         self.update_poll_ref();
-        let errdefer_status = scopeguard::guard(self_ptr, |p| {
-            // SAFETY: `p` was `self.as_ctx_ptr()`; `errdefer_deref` (dropped
-            // after this guard) still holds the balancing ref, so `*p` is live.
-            unsafe {
-                (*p).client_mut().status = valkey::Status::Disconnected;
-                (*p).update_poll_ref();
-            }
+        let errdefer_status = scopeguard::guard(BackRef::new(self), |p| {
+            p.client_mut().status = valkey::Status::Disconnected;
+            p.update_poll_ref();
         });
         // The socket ext slot is typed `ExtSlot<JSValkeyClient>`
         // (uws_handlers.rs `Valkey<SSL> = NsHandler<JSValkeyClient, …>`); store
@@ -1690,9 +1648,9 @@ impl JSValkeyClient {
                 .connect(owner_ptr, &mut *group, ssl_ctx, is_tls)
         }?;
         self.client_mut().socket = socket;
-        // Disarm errdefers on success.
+        // Disarm on success: the socket now owns the keep-alive ref.
         scopeguard::ScopeGuard::into_inner(errdefer_status);
-        scopeguard::ScopeGuard::into_inner(errdefer_deref);
+        core::mem::forget(socket_ref);
         Ok(())
     }
 
@@ -1704,8 +1662,7 @@ impl JSValkeyClient {
     ) -> Result<*mut JSPromise, crate::Error> {
         // Keep `*self` alive across re-entrant connect/close paths below;
         // the host-fn shim passes a bare `&self` with no ref of its own.
-        self.ref_();
-        let _d = deref_guard(self);
+        let _guard = self.ref_scope();
 
         if self.client.get().flags.needs_to_open_socket {
             bun_core::hint::cold();
@@ -1913,8 +1870,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
             ),
         );
         let handshake_success = success == 1;
-        this.ref_();
-        let _d = deref_guard(this.as_ctx_ptr());
+        let _guard = this.ref_scope();
         let _update = scopeguard::guard(BackRef::new(this), |p| p.update_poll_ref());
         let vm = this.client.get().vm;
         if handshake_success {
@@ -2044,21 +2000,13 @@ impl<const SSL: bool> SocketHandler<SSL> {
         _code: i32,
         _reason: Option<*mut c_void>,
     ) {
-        // No need to deref since this.client.on_close() invokes on_valkey_close which does deref.
-
         debug!("Socket closed.");
-        this.ref_();
+        let _guard = this.ref_scope();
         // Ensure the socket pointer is updated.
         this.client_mut().socket = Socket::SocketTcp(uws::SocketTCP::detached());
-        let this_ptr = this.as_ctx_ptr();
-        let _defer = scopeguard::guard(this_ptr, |p| {
-            // SAFETY: `p` was `this.as_ctx_ptr()`; the `ref_()` taken above
-            // keeps `*p` live until this guard's `deref` releases it.
-            unsafe {
-                (*p).client_mut().status = valkey::Status::Disconnected;
-                (*p).update_poll_ref();
-                JSValkeyClient::deref(p);
-            }
+        let _defer = scopeguard::guard(BackRef::new(this), |p| {
+            p.client_mut().status = valkey::Status::Disconnected;
+            p.update_poll_ref();
         });
 
         let _ = this.client_mut().on_close(); // TODO: properly propagate exception upwards
@@ -2080,16 +2028,10 @@ impl<const SSL: bool> SocketHandler<SSL> {
     ) -> JsTerminatedResult<()> {
         // Ensure the socket pointer is updated.
         this.client_mut().socket = Socket::SocketTcp(uws::SocketTCP::detached());
-        this.ref_();
-        let this_ptr = this.as_ctx_ptr();
-        let _defer = scopeguard::guard(this_ptr, |p| {
-            // SAFETY: `p` was `this.as_ctx_ptr()`; the `ref_()` taken above
-            // keeps `*p` live until this guard's `deref` releases it.
-            unsafe {
-                (*p).client_mut().status = valkey::Status::Disconnected;
-                (*p).update_poll_ref();
-                JSValkeyClient::deref(p);
-            }
+        let _guard = this.ref_scope();
+        let _defer = scopeguard::guard(BackRef::new(this), |p| {
+            p.client_mut().status = valkey::Status::Disconnected;
+            p.update_poll_ref();
         });
 
         narrow_terminated(this.client_mut().on_close())
@@ -2106,16 +2048,14 @@ impl<const SSL: bool> SocketHandler<SSL> {
         // Ensure the socket pointer is updated.
         this.client_mut().socket = Self::_socket(socket);
 
-        this.ref_();
-        let _d = deref_guard(this);
+        let _guard = this.ref_scope();
         let _ = this.client_mut().on_data(data); // TODO: properly propagate exception upwards
         this.update_poll_ref();
     }
 
     pub fn on_writable(this: &JSValkeyClient, socket: SocketType<SSL>) {
         this.client_mut().socket = Self::_socket(socket);
-        this.ref_();
-        let _d = deref_guard(this);
+        let _guard = this.ref_scope();
         this.client_mut().on_writable();
         this.update_poll_ref();
     }

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -61,7 +61,7 @@ fn vm_event_loop_ctx() -> bun_io::EventLoopCtx {
 // R-2: takes `*const` now that every `JSValkeyClient` method is `&self`;
 // `deref()` (and `ref_()`) already only need a shared receiver.
 #[inline]
-fn deref_guard(
+pub(super) fn deref_guard(
     this: *const JSValkeyClient,
 ) -> scopeguard::ScopeGuard<*const JSValkeyClient, fn(*const JSValkeyClient)> {
     fn drop_fn(p: *const JSValkeyClient) {
@@ -1052,6 +1052,11 @@ impl JSValkeyClient {
 
     #[bun_jsc::host_fn(method)]
     pub fn js_disconnect(&self, _global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
+        // `disconnect()` -> `close()` can dispatch `on_close` synchronously,
+        // which derefs. Hold a ref so `&self` stays live across the call.
+        self.ref_();
+        let _d = deref_guard(self);
+
         if self.client.get().status == valkey::Status::Disconnected {
             return Ok(JSValue::UNDEFINED);
         }
@@ -1584,6 +1589,17 @@ impl JSValkeyClient {
         self.ref_();
         let _d = deref_guard(self);
 
+        // Socket keep-alive ref, released by on_valkey_close/on_valkey_reconnect.
+        // Taken before the TLS-context check so the `tls_ctx_failed` branch's
+        // `on_valkey_close()` has a ref to consume instead of over-releasing.
+        self.ref_();
+        let self_ptr = self.as_ctx_ptr();
+        let errdefer_deref = scopeguard::guard(self_ptr, |p| {
+            // SAFETY: balances the `ref_()` just taken; `*p` is live until this
+            // guard releases that ref on early return.
+            unsafe { JSValkeyClient::deref(p) }
+        });
+
         let is_tls = self.client.get().tls != valkey::TLS::None;
         // `vm.rare_data()` needs `&mut VirtualMachine`; `client.vm`
         // is `&'static`. Cast through raw — the per-thread VM is single-owner
@@ -1629,6 +1645,9 @@ impl JSValkeyClient {
                 b"Failed to create TLS context",
                 protocol::RedisError::ConnectionClosed,
             )?;
+            // `on_valkey_close()` releases the socket ref; disarm the errdefer
+            // so it isn't released twice.
+            scopeguard::ScopeGuard::into_inner(errdefer_deref);
             self.client_mut().on_valkey_close()?;
             self.client_mut().status = valkey::Status::Disconnected;
             return Ok(());
@@ -1642,15 +1661,6 @@ impl JSValkeyClient {
             valkey::TLS::Custom(_) => Some(self._secure.get().unwrap()),
         };
 
-        self.ref_();
-        // Balance the ref above if connect() throws — the caller (e.g. send())
-        // only knows to clean up its own state, not the keep-alive ref.
-        let self_ptr = self.as_ctx_ptr();
-        let errdefer_deref = scopeguard::guard(self_ptr, |p| {
-            // SAFETY: balances the `ref_()` just taken; `*p` is live until this
-            // guard releases that ref on early return.
-            unsafe { JSValkeyClient::deref(p) }
-        });
         self.client_mut().status = valkey::Status::Connecting;
         self.update_poll_ref();
         let errdefer_status = scopeguard::guard(self_ptr, |p| {
@@ -1692,6 +1702,11 @@ impl JSValkeyClient {
         _this_value: JSValue,
         command: &Command,
     ) -> Result<*mut JSPromise, crate::Error> {
+        // Keep `*self` alive across re-entrant connect/close paths below;
+        // the host-fn shim passes a bare `&self` with no ref of its own.
+        self.ref_();
+        let _d = deref_guard(self);
+
         if self.client.get().flags.needs_to_open_socket {
             bun_core::hint::cold();
 

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1609,7 +1609,7 @@ impl JSValkeyClient {
             )?;
             // `on_valkey_close()` consumes the socket ref; hand it over so it
             // isn't released twice.
-            core::mem::forget(socket_ref);
+            socket_ref.forget();
             self.client_mut().on_valkey_close()?;
             self.client_mut().status = valkey::Status::Disconnected;
             return Ok(());
@@ -1650,7 +1650,7 @@ impl JSValkeyClient {
         self.client_mut().socket = socket;
         // Disarm on success: the socket now owns the keep-alive ref.
         scopeguard::ScopeGuard::into_inner(errdefer_status);
-        core::mem::forget(socket_ref);
+        socket_ref.forget();
         Ok(())
     }
 

--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -1647,8 +1647,7 @@ impl JSValkeyClient {
         // `upsert_receive_handler`'s exit guard re-enters `on_writable` /
         // `update_poll_ref` before `send()` is reached; hold a ref so `*this`
         // stays live across those calls.
-        this.ref_();
-        let _d = super::js_valkey::deref_guard(this);
+        let _guard = this.ref_scope();
 
         let [channel_or_many, handler_callback] = frame.arguments_as_array::<2>();
         let mut redis_channels: Vec<JSArgument> = Vec::with_capacity(1);
@@ -1756,8 +1755,7 @@ impl JSValkeyClient {
     ) -> JsResult<JSValue> {
         // Hold a ref so `*this` stays live across the handler-map updates and
         // the `send()` below.
-        this.ref_();
-        let _d = super::js_valkey::deref_guard(this);
+        let _guard = this.ref_scope();
 
         // Check if we're in subscription mode
         require_subscriber(this, b"unsubscribe")?;

--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -1644,6 +1644,12 @@ impl JSValkeyClient {
 
     #[bun_jsc::host_fn(method)]
     pub fn subscribe(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+        // `upsert_receive_handler`'s exit guard re-enters `on_writable` /
+        // `update_poll_ref` before `send()` is reached; hold a ref so `*this`
+        // stays live across those calls.
+        this.ref_();
+        let _d = super::js_valkey::deref_guard(this);
+
         let [channel_or_many, handler_callback] = frame.arguments_as_array::<2>();
         let mut redis_channels: Vec<JSArgument> = Vec::with_capacity(1);
 
@@ -1748,6 +1754,11 @@ impl JSValkeyClient {
         global: &JSGlobalObject,
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
+        // Hold a ref so `*this` stays live across the handler-map updates and
+        // the `send()` below.
+        this.ref_();
+        let _d = super::js_valkey::deref_guard(this);
+
         // Check if we're in subscription mode
         require_subscriber(this, b"unsubscribe")?;
 

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -2,6 +2,105 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import net from "node:net";
 
+// Fuzzer found a heap-use-after-free: connect()'s tls_ctx_failed branch
+// called on_valkey_close() before the socket keep-alive ref was taken, so
+// on_valkey_close's unconditional deref over-released by one. do_connect's
+// scoped deref_guard then dropped the refcount to 0 and freed the
+// Box<JSValkeyClient> while the JS wrapper (and its ext ptr) was still
+// alive; the next property access read freed memory.
+test.concurrent("RedisClient survives a failed custom-TLS context without freeing the live client", async () => {
+  const src = `
+    for (let i = 0; i < 10; i++) {
+      const c = new Bun.RedisClient("rediss://127.0.0.1:1", {
+        tls: { key: "not a valid key", cert: "not a valid cert" },
+        autoReconnect: false,
+      });
+      c.onclose = () => {};
+      try { await c.connect(); } catch {}
+      // Before the fix the backing allocation was already freed here; ASAN
+      // reports heap-use-after-free on the status read inside this getter.
+      if (c.connected !== false) throw new Error("expected connected=false");
+      try { c.close(); } catch {}
+    }
+    Bun.gc(true);
+    await 1;
+    Bun.gc(true);
+    console.log("OK");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("OK");
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+});
+
+// Fuzzer found the same over-release reachable from subscribe() when the
+// socket dies mid-call: upsert_receive_handler's exit guard re-enters
+// on_writable/update_poll_ref before send() takes its own ref, so a
+// connect/close fault path inside could free the client under the live
+// `&self`. This variant races a server-side RST against subscribe()+close().
+test.concurrent("RedisClient survives subscribe() + close() against a server that resets the connection", async () => {
+  const src = `
+    const CRLF = "\\r\\n";
+    const blk = s => "$" + s.length + CRLF + s + CRLF;
+    const sockets = [];
+    const server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        open(s) { s.data = { buf: "" }; sockets.push(s); },
+        data(s, d) {
+          s.data.buf += d.toString("latin1");
+          if (s.data.buf.includes("HELLO")) s.write("%1" + CRLF + blk("proto") + ":3" + CRLF);
+          else if (s.data.buf.includes(CRLF)) s.write("+OK" + CRLF);
+          s.data.buf = "";
+        },
+        close() {},
+      },
+    });
+    for (let round = 0; round < 100; round++) {
+      const c = new Bun.RedisClient("redis://127.0.0.1:" + server.port, {
+        autoReconnect: true,
+        connectionTimeout: 2000,
+      });
+      c.onconnect = () => {}; c.onclose = () => {};
+      try { await c.connect(); } catch {}
+      const s = sockets.pop();
+      try { s?.terminate?.(); } catch {}
+      const t0 = Bun.nanoseconds();
+      while (Bun.nanoseconds() - t0 < 4e6) {}
+      try { c.subscribe("ch" + round, () => {}).catch(() => {}); } catch {}
+      try { c.close(); } catch {}
+      if (round % 8 === 0) Bun.gc(false);
+      await new Promise(r => setTimeout(r, 1));
+    }
+    server.stop(true);
+    console.log("OK");
+    process.exit(0);
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("OK");
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+});
+
 // Fuzzer found a flaky SIGILL when a RedisClient is constructed, a command
 // throws during argument validation (before any connection attempt), and the
 // client is then garbage collected. `updatePollRef` could be reached after

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -80,7 +80,7 @@ test.concurrent("RedisClient survives subscribe() + close() against a server tha
       try { c.subscribe("ch" + round, () => {}).catch(() => {}); } catch {}
       try { c.close(); } catch {}
       if (round % 8 === 0) Bun.gc(false);
-      await new Promise(r => setTimeout(r, 1));
+      await new Promise(r => setImmediate(r));
     }
     server.stop(true);
     console.log("OK");


### PR DESCRIPTION
## Problem

Fuzzing found a heap-use-after-free in `JSValkeyClient`: the native `Box<JSValkeyClient>` (880 bytes) is freed while the JS wrapper and armed event-loop timers still point at it. The fuzzer surfaced several faces of the same over-release: `subscribe` reading `flags.needs_to_open_socket` on a freed allocation, `on_connection_timeout`'s deref_guard freeing the box ahead of GC finalize, and a `RefCount` canary underflow during close-while-disconnecting.

```
==ERROR: AddressSanitizer: heap-use-after-free on address 0x... (READ of size 1)
    #0 <valkey::Status as PartialEq>::eq valkey.rs:77
    #1 JSValkeyClient::get_connected js_valkey.rs
    ...
freed by:
    #10 JSValkeyClient::deinit js_valkey.rs
    #14 JSValkeyClient::deref js_valkey.rs
    #15 deref_guard::drop_fn
    #19 JSValkeyClient::do_connect js_valkey.rs
```

## Cause

`connect()` took the socket keep-alive ref (released later by `on_valkey_close`/`on_valkey_reconnect`) **after** the custom-TLS context check. When SSL_CTX creation failed, the `tls_ctx_failed` branch called `on_valkey_close()` anyway, whose scope guard unconditionally derefs that socket ref. Since the ref had never been taken, this ate into the JS wrapper's +1 instead:

- start: count = 1 (JS wrapper)
- `do_connect`/`connect` scoped `ref_()` bumps
- `on_valkey_close` guard derefs the not-yet-taken socket ref: net -1
- scoped `deref_guard`s drop: count hits 0, `deinit()` frees the Box
- JS wrapper's ext ptr now dangles; the next `c.connected` / `c.close()` / GC finalize reads or writes freed memory

The host-fn shim (`host_fn_this_shared`) passes a bare `&self` with no ref of its own, so once a re-entrant fault path spends the wrapper's ref there is nothing keeping `*self` alive for the rest of the call. The fuzzer's non-TLS repro hits the same shape through `subscribe()`: `upsert_receive_handler`'s exit guard runs `on_writable()`/`update_poll_ref()` before `send()` is reached, and a dying socket's close path can release the remaining strong refs under the live borrow.

## Fix

- Move the socket keep-alive `ref_()` (and its `errdefer_deref`) to before the TLS-context check so `on_valkey_close()` always has a ref to consume. Disarm the errdefer before that call so the ref is released exactly once.
- Hold a scoped ref across `JSValkeyClient::send()`, `subscribe()`, `unsubscribe()` and `js_disconnect()` (the host-fn entry points that can synchronously re-enter connect/close/fail), so `*self` stays live for the duration of the call even if a re-entrant path releases every other ref.

## Verification

New tests in `test/js/valkey/valkey-gc.test.ts`:
- `RedisClient survives a failed custom-TLS context without freeing the live client` reproduces the over-release deterministically (ASAN heap-use-after-free on every run before the fix, clean after).
- `RedisClient survives subscribe() + close() against a server that resets the connection` exercises the fuzzer's RST-during-subscribe scenario.

```
$ bun bd test test/js/valkey/valkey-gc.test.ts
 7 pass
 0 fail
```