### PR TITLE
css: fix column underflow on stray 0xF0-0xFF bytes in tokenizer

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -4252,7 +4252,9 @@ impl ParserState {
     pub fn source_location(&self) -> SourceLocation {
         SourceLocation {
             line: self.current_line_number,
-            column: u32::try_from(self.position - self.current_line_start_position + 1)
+            // `current_line_start_position` is maintained with wrapping arithmetic
+            // (see `consume_4byte_intro`), so the inverse must wrap as well.
+            column: u32::try_from(self.position.wrapping_sub(self.current_line_start_position) + 1)
                 .expect("int cast"),
         }
     }
@@ -4557,7 +4559,9 @@ impl<'a> Tokenizer<'a> {
     pub fn current_source_location(&self) -> SourceLocation {
         SourceLocation {
             line: self.current_line_number,
-            column: u32::try_from((self.position - self.current_line_start_position) + 1)
+            // `current_line_start_position` is maintained with wrapping arithmetic
+            // (see `consume_4byte_intro`), so the inverse must wrap as well.
+            column: u32::try_from(self.position.wrapping_sub(self.current_line_start_position) + 1)
                 .expect("int cast"),
         }
     }
@@ -5437,10 +5441,13 @@ impl<'a> Tokenizer<'a> {
     /// for a 4-byte sequence (0xF0..=0xF7).
     pub fn consume_4byte_intro(&mut self) {
         debug_assert!(self.next_byte_unchecked() & 0xF0 == 0xF0);
-        // This takes two UTF-16 characters to represent, so we actually have
-        // an undercount.
-        self.current_line_start_position = self.current_line_start_position.wrapping_sub(1);
         self.position += 1;
+        // 4 UTF-8 bytes encode 2 UTF-16 units (undercount). Input here is
+        // unvalidated bytes, so only apply the -1 when a continuation byte
+        // follows; a stray 0xF0..0xFF must not underflow the column math.
+        if self.next_byte().is_some_and(|b| b & 0xC0 == 0x80) {
+            self.current_line_start_position = self.current_line_start_position.wrapping_sub(1);
+        }
     }
 
     pub fn is_ident_start(&self) -> bool {
@@ -5492,7 +5499,12 @@ impl<'a> Tokenizer<'a> {
         debug_assert!(byte != b'\r' && byte != b'\n' && byte != FORM_FEED_BYTE);
         self.position += 1;
         if byte & 0xF0 == 0xF0 {
-            self.current_line_start_position = self.current_line_start_position.wrapping_sub(1);
+            // See `consume_4byte_intro`: input is unvalidated bytes, so only
+            // apply the UTF-16 undercount when a continuation byte follows.
+            if self.next_byte().is_some_and(|b| b & 0xC0 == 0x80) {
+                self.current_line_start_position =
+                    self.current_line_start_position.wrapping_sub(1);
+            }
         } else if byte & 0xC0 == 0x80 {
             self.current_line_start_position = self.current_line_start_position.wrapping_add(1);
         }

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -5502,8 +5502,7 @@ impl<'a> Tokenizer<'a> {
             // See `consume_4byte_intro`: input is unvalidated bytes, so only
             // apply the UTF-16 undercount when a continuation byte follows.
             if self.next_byte().is_some_and(|b| b & 0xC0 == 0x80) {
-                self.current_line_start_position =
-                    self.current_line_start_position.wrapping_sub(1);
+                self.current_line_start_position = self.current_line_start_position.wrapping_sub(1);
             }
         } else if byte & 0xC0 == 0x80 {
             self.current_line_start_position = self.current_line_start_position.wrapping_add(1);

--- a/test/js/bun/css/invalid-utf8-column.test.ts
+++ b/test/js/bun/css/invalid-utf8-column.test.ts
@@ -31,7 +31,7 @@ async function buildColumn(bytes: number[]): Promise<{ stdout: string; stderr: s
   return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
 }
 
-test("lone 0xF0 byte reports column 2, not 3, and does not panic", async () => {
+test.concurrent("lone 0xF0 byte reports column 2, not 3, and does not panic", async () => {
   const { stdout, stderr, exitCode } = await buildColumn([0xf0]);
   expect(stderr).not.toContain("panic");
   expect(stderr).not.toContain("overflow");
@@ -41,14 +41,14 @@ test("lone 0xF0 byte reports column 2, not 3, and does not panic", async () => {
   expect(exitCode).toBe(0);
 });
 
-test("three stray 0xF0 bytes report column 4, not 7", async () => {
+test.concurrent("three stray 0xF0 bytes report column 4, not 7", async () => {
   const { stdout, stderr, exitCode } = await buildColumn([0xf0, 0xf0, 0xf0]);
   expect(stderr).not.toContain("panic");
   expect(stdout).toBe(`{"line":1,"column":4}`);
   expect(exitCode).toBe(0);
 });
 
-test("stray 0xF0 on a non-first line does not skew the column", async () => {
+test.concurrent("stray 0xF0 on a non-first line does not skew the column", async () => {
   // "a{}\n" puts the stray byte at the start of line 2 where the true line
   // start is non-zero, exercising the same bookkeeping without the position-0
   // edge case.
@@ -59,7 +59,7 @@ test("stray 0xF0 on a non-first line does not skew the column", async () => {
   expect(exitCode).toBe(0);
 });
 
-test("valid 4-byte UTF-8 still counts as two UTF-16 columns", async () => {
+test.concurrent("valid 4-byte UTF-8 still counts as two UTF-16 columns", async () => {
   // U+1F600 GRINNING FACE: a well-formed 4-byte sequence is a surrogate pair in
   // UTF-16, so EOF after it is column 3. This must not regress.
   const { stdout, stderr, exitCode } = await buildColumn([0xf0, 0x9f, 0x98, 0x80]);

--- a/test/js/bun/css/invalid-utf8-column.test.ts
+++ b/test/js/bun/css/invalid-utf8-column.test.ts
@@ -32,38 +32,41 @@ async function buildColumn(bytes: number[]): Promise<{ stdout: string; stderr: s
 }
 
 test.concurrent("lone 0xF0 byte reports column 2, not 3, and does not panic", async () => {
-  const { stdout, stderr, exitCode } = await buildColumn([0xf0]);
-  expect(stderr).not.toContain("panic");
-  expect(stderr).not.toContain("overflow");
   // One byte in the file: the parse error at EOF is column 2. Previously the
-  // wrapped line-start made this column 3 (or panicked on overflow-checks).
-  expect(stdout).toBe(`{"line":1,"column":2}`);
-  expect(exitCode).toBe(0);
+  // wrapped line-start made this column 3 (release) or aborted the process
+  // (overflow-checked debug); either failure shows up in this diff.
+  expect(await buildColumn([0xf0])).toEqual({
+    stdout: `{"line":1,"column":2}`,
+    stderr: "",
+    exitCode: 0,
+  });
 });
 
 test.concurrent("three stray 0xF0 bytes report column 4, not 7", async () => {
-  const { stdout, stderr, exitCode } = await buildColumn([0xf0, 0xf0, 0xf0]);
-  expect(stderr).not.toContain("panic");
-  expect(stdout).toBe(`{"line":1,"column":4}`);
-  expect(exitCode).toBe(0);
+  expect(await buildColumn([0xf0, 0xf0, 0xf0])).toEqual({
+    stdout: `{"line":1,"column":4}`,
+    stderr: "",
+    exitCode: 0,
+  });
 });
 
 test.concurrent("stray 0xF0 on a non-first line does not skew the column", async () => {
   // "a{}\n" puts the stray byte at the start of line 2 where the true line
   // start is non-zero, exercising the same bookkeeping without the position-0
   // edge case.
-  const prefix = [...Buffer.from("a{}\n")];
-  const { stdout, stderr, exitCode } = await buildColumn([...prefix, 0xf0]);
-  expect(stderr).not.toContain("panic");
-  expect(stdout).toBe(`{"line":2,"column":2}`);
-  expect(exitCode).toBe(0);
+  expect(await buildColumn([...Buffer.from("a{}\n"), 0xf0])).toEqual({
+    stdout: `{"line":2,"column":2}`,
+    stderr: "",
+    exitCode: 0,
+  });
 });
 
 test.concurrent("valid 4-byte UTF-8 still counts as two UTF-16 columns", async () => {
   // U+1F600 GRINNING FACE: a well-formed 4-byte sequence is a surrogate pair in
   // UTF-16, so EOF after it is column 3. This must not regress.
-  const { stdout, stderr, exitCode } = await buildColumn([0xf0, 0x9f, 0x98, 0x80]);
-  expect(stderr).not.toContain("panic");
-  expect(stdout).toBe(`{"line":1,"column":3}`);
-  expect(exitCode).toBe(0);
+  expect(await buildColumn([0xf0, 0x9f, 0x98, 0x80])).toEqual({
+    stdout: `{"line":1,"column":3}`,
+    stderr: "",
+    exitCode: 0,
+  });
 });

--- a/test/js/bun/css/invalid-utf8-column.test.ts
+++ b/test/js/bun/css/invalid-utf8-column.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
+
+// The CSS tokenizer (a port of rust-cssparser) keeps a UTF-16 column adjustment
+// in `current_line_start_position` via wrapping_sub(1) for 0xF0..0xFF bytes,
+// relying on the three continuation bytes of a valid 4-byte sequence to add it
+// back. Bun tokenizes unvalidated bytes, so a lone 0xF0..0xFF byte at the start
+// of a line wraps the line-start to usize::MAX. On overflow-checked builds the
+// later `position - line_start` subtraction panics the whole process (escaping
+// `Bun.build({throw:false})`); on release it double-wraps back to a
+// small-but-wrong column past end of file.
+
+async function buildColumn(bytes: number[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  using dir = tempDir("css-invalid-utf8", {});
+  const css = join(String(dir), "in.css");
+  await Bun.write(css, new Uint8Array(bytes));
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const r = await Bun.build({ entrypoints: [${JSON.stringify(css)}], throw: false });
+       const p = r.logs[0]?.position;
+       console.log(JSON.stringify({ line: p?.line, column: p?.column }));`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+}
+
+test("lone 0xF0 byte reports column 2, not 3, and does not panic", async () => {
+  const { stdout, stderr, exitCode } = await buildColumn([0xf0]);
+  expect(stderr).not.toContain("panic");
+  expect(stderr).not.toContain("overflow");
+  // One byte in the file: the parse error at EOF is column 2. Previously the
+  // wrapped line-start made this column 3 (or panicked on overflow-checks).
+  expect(stdout).toBe(`{"line":1,"column":2}`);
+  expect(exitCode).toBe(0);
+});
+
+test("three stray 0xF0 bytes report column 4, not 7", async () => {
+  const { stdout, stderr, exitCode } = await buildColumn([0xf0, 0xf0, 0xf0]);
+  expect(stderr).not.toContain("panic");
+  expect(stdout).toBe(`{"line":1,"column":4}`);
+  expect(exitCode).toBe(0);
+});
+
+test("stray 0xF0 on a non-first line does not skew the column", async () => {
+  // "a{}\n" puts the stray byte at the start of line 2 where the true line
+  // start is non-zero, exercising the same bookkeeping without the position-0
+  // edge case.
+  const prefix = [...Buffer.from("a{}\n")];
+  const { stdout, stderr, exitCode } = await buildColumn([...prefix, 0xf0]);
+  expect(stderr).not.toContain("panic");
+  expect(stdout).toBe(`{"line":2,"column":2}`);
+  expect(exitCode).toBe(0);
+});
+
+test("valid 4-byte UTF-8 still counts as two UTF-16 columns", async () => {
+  // U+1F600 GRINNING FACE: a well-formed 4-byte sequence is a surrogate pair in
+  // UTF-16, so EOF after it is column 3. This must not regress.
+  const { stdout, stderr, exitCode } = await buildColumn([0xf0, 0x9f, 0x98, 0x80]);
+  expect(stderr).not.toContain("panic");
+  expect(stdout).toBe(`{"line":1,"column":3}`);
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Repro

```sh
printf '\xf0' > one.css
bun build one.css
```

Stock 1.4.0:
```
error: Unexpected end of input
    at one.css:1:3        # column 3 in a ONE-BYTE file
```

Debug / overflow-checked build on main:
```
panic: attempt to subtract with overflow
  at <bun_css::css_parser::Tokenizer>::current_source_location (src/css/css_parser.rs:4560)
```
The panic aborts the whole process and escapes `Bun.build({throw: false})`.

## Cause

The CSS tokenizer is a port of rust-cssparser that runs on raw `&[u8]` rather than `&str`. It keeps the UTF-16 column adjustment in `current_line_start_position` with wrapping arithmetic: `consume_4byte_intro()` does `wrapping_sub(1)` on the assumption that three continuation bytes will follow and each `wrapping_add(1)` back. Upstream that invariant is guaranteed by `&str`; here the bytes are unvalidated, so a lone 0xF0..0xFF byte at the start of a line wraps `current_line_start_position` to `usize::MAX`. The next `position - current_line_start_position` in `source_location()` then overflows (panic on overflow-checked builds) or double-wraps to a small-but-wrong column on release.

## Fix

- `consume_4byte_intro` / `consume_known_byte`: only apply the `-1` surrogate-pair adjustment when the next byte is actually a continuation byte. A stray high byte now counts as one column instead of two, and the accumulator no longer falls below the true line start.
- `ParserState::source_location` / `Tokenizer::current_source_location`: compute the column with `wrapping_sub`, the correct inverse of the wrapping accumulator, so the subtraction is total even mid-sequence.

Valid 4-byte UTF-8 is unchanged (still 2 UTF-16 columns); covered by a regression assertion in the new test.

## Verification

```
# before (USE_SYSTEM_BUN=1): 3 fail (column 3/7/3)
# after  (bun bd):           4 pass
bun bd test test/js/bun/css/invalid-utf8-column.test.ts
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/css/invalid-utf8-column.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (39947c0b9)

test/js/bun/css/invalid-utf8-column.test.ts:
52 | 
53 | test.concurrent("stray 0xF0 on a non-first line does not skew the column", async () => {
54 |   // "a{}\n" puts the stray byte at the start of line 2 where the true line
55 |   // start is non-zero, exercising the same bookkeeping without the position-0
56 |   // edge case.
57 |   expect(await buildColumn([...Buffer.from("a{}\n"), 0xf0])).toEqual({
                                                                  ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "stderr": "",
-   "stdout": "{"line":2,"column":2}",
+   "stdout": "{"line":2,"column":3}",
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/j
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (177fc6b84)

test/js/bun/css/invalid-utf8-column.test.ts:
(pass) stray 0xF0 on a non-first line does not skew the column [12.14ms]
(pass) lone 0xF0 byte reports column 2, not 3, and does not panic [14.79ms]
(pass) valid 4-byte UTF-8 still counts as two UTF-16 columns [12.15ms]
(pass) three stray 0xF0 bytes report column 4, not 7 [13.13ms]

 4 pass
 0 fail
 4 expect() calls
Ran 4 tests across 1 file. [163.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/css/invalid-utf8-column.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (39947c0b9)

test/js/bun/css/invalid-utf8-column.test.ts:
(pass) lone 0xF0 byte reports column 2, not 3, and does not panic [538.72ms]
(pass) stray 0xF0 on a non-first line does not skew the column [500.72ms]
(pass) three stray 0xF0 bytes report column 4, not 7 [511.07ms]
(pass) valid 4-byte UTF-8 still counts as two UTF-16 columns [483.84ms]

 4 pass
 0 fail
 4 expect() calls
Ran 4 tests across 1 file. [2.65s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 747ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/css_parser.rs                       | 23 ++++++---
 test/js/bun/css/invalid-utf8-column.test.ts | 72 +++++++++++++++++++++++++++++
 2 files changed, 89 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/css/css_parser.rs                            6      6      0
test/js/bun/css/invalid-utf8-column.test.ts      2      6      0
```

</details>

<!-- robobun:evidence:end -->