### PR TITLE
logger: count JS/TS/TOML diagnostic columns in UTF-16 code units

### DIFF
--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -884,11 +884,12 @@ impl Location {
             // Window a very long line to ~120 bytes around the error. The
             // window bounds are BYTE offsets into `full_line`; `column_count`
             // is UTF-16 units, so windowing on it mis-slices non-ASCII lines.
-            let offset_in_line =
-                clamp_error_offset(&source.contents, r.loc).saturating_sub(data.line_start);
-            if full_line.len() > 80 + offset_in_line {
-                let mut lo = offset_in_line.max(40) - 40;
-                let mut hi = (offset_in_line + 40).min(full_line.len() - 40) + 40;
+            if full_line.len() > 120 {
+                let offset_in_line = clamp_error_offset(&source.contents, r.loc)
+                    .saturating_sub(data.line_start)
+                    .min(full_line.len());
+                let mut lo = offset_in_line.saturating_sub(40);
+                let mut hi = (offset_in_line + 80).min(full_line.len());
                 while lo > 0 && !bun_core::strings::is_utf8_char_boundary(full_line[lo]) {
                     lo -= 1;
                 }

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -881,13 +881,13 @@ impl Location {
                 None => source.init_error_position(r.loc),
             };
             let mut full_line = &source.contents[data.line_start..data.line_end];
-            // Window a very long line to ~120 bytes around the error. The
-            // window bounds are BYTE offsets into `full_line`; `column_count`
-            // is UTF-16 units, so windowing on it mis-slices non-ASCII lines.
-            if full_line.len() > 120 {
-                let offset_in_line = clamp_error_offset(&source.contents, r.loc)
-                    .saturating_sub(data.line_start)
-                    .min(full_line.len());
+            // Window a long line to ~120 bytes around the error. Bounds are
+            // BYTE offsets; the gate keeps the original shape (no left trim for
+            // an error in the last 80 bytes) so `write_format`'s caret aligns.
+            let offset_in_line = clamp_error_offset(&source.contents, r.loc)
+                .saturating_sub(data.line_start)
+                .min(full_line.len());
+            if full_line.len() > 80 + offset_in_line {
                 let mut lo = offset_in_line.saturating_sub(40);
                 let mut hi = (offset_in_line + 80).min(full_line.len());
                 while lo > 0 && !bun_core::strings::is_utf8_char_boundary(full_line[lo]) {

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -881,9 +881,23 @@ impl Location {
                 None => source.init_error_position(r.loc),
             };
             let mut full_line = &source.contents[data.line_start..data.line_end];
-            if full_line.len() > 80 + data.column_count {
-                full_line = &full_line[data.column_count.max(40) - 40
-                    ..(data.column_count + 40).min(full_line.len() - 40) + 40];
+            // Window a very long line to ~120 bytes around the error. The
+            // window bounds are BYTE offsets into `full_line`; `column_count`
+            // is UTF-16 units, so windowing on it mis-slices non-ASCII lines.
+            let offset_in_line =
+                clamp_error_offset(&source.contents, r.loc).saturating_sub(data.line_start);
+            if full_line.len() > 80 + offset_in_line {
+                let mut lo = offset_in_line.max(40) - 40;
+                let mut hi = (offset_in_line + 40).min(full_line.len() - 40) + 40;
+                while lo > 0 && !bun_core::strings::is_utf8_char_boundary(full_line[lo]) {
+                    lo -= 1;
+                }
+                while hi < full_line.len()
+                    && !bun_core::strings::is_utf8_char_boundary(full_line[hi])
+                {
+                    hi += 1;
+                }
+                full_line = &full_line[lo..hi];
             }
 
             return Some(Location {
@@ -2748,7 +2762,9 @@ impl ErrorPositionState {
                     crossed_line_break = true;
                 }
                 _ => {
-                    self.column_number += 1;
+                    // Columns count UTF-16 code units (JSC/V8 stack traces, the
+                    // source-map spec, and the CSS logger all agree on this).
+                    self.column_number += 1 + (iter.c > 0xFFFF) as usize;
                 }
             }
 
@@ -3829,5 +3845,23 @@ mod line_column_tracker_tests {
                 bstr::BStr::new(source.contents())
             );
         }
+    }
+
+    #[test]
+    fn error_position_counts_utf16_columns() {
+        // `]` sits at UTF-16 unit index 18 (1-based col 19); the two U+1F600
+        // take two UTF-16 units each. Previously columns counted codepoints
+        // and this returned 17.
+        let src = "const a = \"\u{1F600}\u{1F600}\"; ]".as_bytes();
+        let source = Source::init_path_string(b"t.js" as &[u8], src);
+        let pos = source.init_error_position(usize2loc(src.len() - 1));
+        assert_eq!(pos.column_count, 19);
+
+        // BMP-only control: `é` is one UTF-16 unit, so astral vs BMP lines
+        // with the same layout must agree.
+        let bmp = "const a = \"\u{00E9}\u{00E9}\u{00E9}\u{00E9}\"; ]".as_bytes();
+        let bmp_source = Source::init_path_string(b"t.js" as &[u8], bmp);
+        let bmp_pos = bmp_source.init_error_position(usize2loc(bmp.len() - 1));
+        assert_eq!(bmp_pos.column_count, 19);
     }
 }

--- a/test/js/bun/transpiler/parse-error-column.test.ts
+++ b/test/js/bun/transpiler/parse-error-column.test.ts
@@ -2,10 +2,9 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "node:path";
 
-// JS/TS/TOML parse diagnostics reported columns in Unicode codepoints while
-// runtime stack traces (JSC), CSS diagnostics, and the source-map spec all
-// count UTF-16 code units. An astral-plane character before the error shifted
-// the column by one per character relative to every other channel.
+// JS/TS/TOML parse diagnostics must count columns in UTF-16 code units, the
+// same convention as runtime stack traces (JSC), CSS diagnostics, and the
+// source-map spec.
 
 async function buildPosition(
   filename: string,
@@ -121,10 +120,9 @@ async function lineTextWindow(source: string): Promise<{ stdout: string; stderr:
 }
 
 test.concurrent("long non-ASCII line's lineText window covers the error token", async () => {
-  // 120 copies of U+00E9 (2 UTF-8 bytes, 1 UTF-16 unit each) then ` ]`: 242
-  // source bytes, `]` at byte 241 / column 122. The long-line window is sliced
-  // in bytes; indexing it by the column put the window at bytes 82..202 which
-  // dropped the error token entirely.
+  // 120 copies of U+00E9 (2 UTF-8 bytes, 1 UTF-16 unit each) then ` ]`:
+  // 242 source bytes, `]` at byte 241 / column 122. The window is a byte
+  // slice, so indexing it by column missed the token on non-ASCII lines.
   expect(await lineTextWindow(Buffer.alloc(240, "\u00E9").toString() + " ]")).toEqual({
     stdout: `{"column":122,"hasToken":true,"chars":[" ","]","\u00E9"]}`,
     stderr: "",
@@ -134,8 +132,7 @@ test.concurrent("long non-ASCII line's lineText window covers the error token", 
 
 test.concurrent("long non-ASCII line's lineText window does not split a UTF-8 sequence", async () => {
   // `]` at byte 160 of a 321-byte line: the window is applied, and its
-  // bounds are snapped to UTF-8 char boundaries. Indexing by column landed
-  // on a continuation byte and garbled the decoded text.
+  // bounds are snapped to UTF-8 char boundaries.
   const half = Buffer.alloc(160, "\u00E9").toString();
   expect(await lineTextWindow(half + "]" + half)).toEqual({
     stdout: `{"column":81,"hasToken":true,"chars":["]","\u00E9"]}`,

--- a/test/js/bun/transpiler/parse-error-column.test.ts
+++ b/test/js/bun/transpiler/parse-error-column.test.ts
@@ -1,0 +1,145 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
+
+// JS/TS/TOML parse diagnostics reported columns in Unicode codepoints while
+// runtime stack traces (JSC), CSS diagnostics, and the source-map spec all
+// count UTF-16 code units. An astral-plane character before the error shifted
+// the column by one per character relative to every other channel.
+
+async function buildPosition(
+  filename: string,
+  bytes: Uint8Array | string,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  using dir = tempDir("parse-col", {});
+  const file = join(String(dir), filename);
+  await Bun.write(file, bytes);
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const r = await Bun.build({ entrypoints: [${JSON.stringify(file)}], throw: false });
+       const p = r.logs[0]?.position;
+       console.log(JSON.stringify({ line: p?.line, column: p?.column }));`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+}
+
+test.concurrent("JS parse error after astral characters reports UTF-16 column", async () => {
+  // U+1F600 GRINNING FACE is one codepoint but two UTF-16 code units. `]`
+  // sits at UTF-16 unit index 18 (column 19). With codepoint counting this
+  // was reported as 17.
+  expect(await buildPosition("in.js", 'const a = "\u{1F600}\u{1F600}"; ]')).toEqual({
+    stdout: `{"line":1,"column":19}`,
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+test.concurrent("JS parse error column agrees for BMP vs astral lines of equal UTF-16 width", async () => {
+  // Four one-unit BMP characters and two two-unit astral characters both put
+  // `]` at column 19.
+  const astral = await buildPosition("a.js", 'const a = "\u{1F600}\u{1F600}"; ]');
+  const bmp = await buildPosition("b.js", 'const a = "\u00E9\u00E9\u00E9\u00E9"; ]');
+  expect({ astral: astral.stdout, bmp: bmp.stdout }).toEqual({
+    astral: `{"line":1,"column":19}`,
+    bmp: `{"line":1,"column":19}`,
+  });
+});
+
+test.concurrent("JS parse error column matches JSC runtime column for the same line", async () => {
+  // Parse error and runtime error originate at the same UTF-16 offset; before
+  // the fix only the parse column drifted.
+  using dir = tempDir("parse-col-rt", {});
+  const rt = join(String(dir), "rt.js");
+  await Bun.write(rt, 'const a = "\u{1F600}\u{1F600}"; f();\nfunction f(){ throw new Error("x") }');
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const parse = await Bun.build({ entrypoints: [${JSON.stringify(join(String(dir), "bad.js"))}], throw: false })
+         .then(r => r.logs[0].position.column);
+       let runtime;
+       try { await import(${JSON.stringify(rt)}); } catch (e) {
+         runtime = +e.stack.match(/rt\\.js:1:(\\d+)/)[1];
+       }
+       console.log(JSON.stringify({ parse, runtime }));`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await Bun.write(join(String(dir), "bad.js"), 'const a = "\u{1F600}\u{1F600}"; ]');
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr: stderr.trim(), exitCode }).toEqual({
+    stdout: `{"parse":19,"runtime":19}`,
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+test.concurrent("TOML parse error after astral characters reports UTF-16 column", async () => {
+  // Two astral characters are 4 UTF-16 units, same as "xxxx", so both lines
+  // put `]` at column 12. With codepoint counting the astral line was 10.
+  const astral = await buildPosition("a.toml", 'k = "\u{1F600}\u{1F600}" ]');
+  const ascii = await buildPosition("b.toml", 'k = "xxxx" ]');
+  expect({ astral: astral.stdout, ascii: ascii.stdout }).toEqual({
+    astral: `{"line":1,"column":12}`,
+    ascii: `{"line":1,"column":12}`,
+  });
+});
+
+async function lineTextWindow(
+  source: string,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  using dir = tempDir("parse-col-window", {});
+  const file = join(String(dir), "long.js");
+  await Bun.write(file, source);
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const r = await Bun.build({ entrypoints: [${JSON.stringify(file)}], throw: false });
+       const p = r.logs[0].position;
+       console.log(JSON.stringify({
+         column: p.column,
+         hasToken: p.lineText.includes("]"),
+         chars: [...new Set(p.lineText)].sort(),
+       }));`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+}
+
+test.concurrent("long non-ASCII line's lineText window covers the error token", async () => {
+  // 120 copies of U+00E9 (2 UTF-8 bytes, 1 UTF-16 unit each) then ` ]`: 242
+  // source bytes, `]` at byte 241 / column 122. The long-line window is sliced
+  // in bytes; indexing it by the column put the window at bytes 82..202 which
+  // dropped the error token entirely.
+  expect(await lineTextWindow(Buffer.alloc(240, "\u00E9").toString() + " ]")).toEqual({
+    stdout: `{"column":122,"hasToken":true,"chars":[" ","]","\u00E9"]}`,
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+test.concurrent("long non-ASCII line's lineText window does not split a UTF-8 sequence", async () => {
+  // `]` at byte 160 of a 321-byte line: the window is applied, and its
+  // bounds are snapped to UTF-8 char boundaries. Indexing by column landed
+  // on a continuation byte and garbled the decoded text.
+  const half = Buffer.alloc(160, "\u00E9").toString();
+  expect(await lineTextWindow(half + "]" + half)).toEqual({
+    stdout: `{"column":81,"hasToken":true,"chars":["]","\u00E9"]}`,
+    stderr: "",
+    exitCode: 0,
+  });
+});

--- a/test/js/bun/transpiler/parse-error-column.test.ts
+++ b/test/js/bun/transpiler/parse-error-column.test.ts
@@ -140,3 +140,23 @@ test.concurrent("long non-ASCII line's lineText window does not split a UTF-8 se
     exitCode: 0,
   });
 });
+
+test.concurrent("CLI caret stays under the token for an error at the end of a long line", async () => {
+  // `write_format` offsets the caret by `column - 1` with no knowledge of any
+  // left-trim, so the window gate must not left-trim this case.
+  using dir = tempDir("parse-col-caret", {
+    "long.js": Buffer.alloc(150, "a").toString() + "]",
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "long.js"],
+    env: { ...bunEnv, NO_COLOR: "1" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const lines = stderr.split("\n");
+  const textLine = lines.find(l => l.includes("]"))!;
+  const caretLine = lines.find(l => l.trimEnd().endsWith("^"))!;
+  expect({ token: textLine.indexOf("]"), caret: caretLine.indexOf("^") }).toEqual({ token: 154, caret: 154 });
+});

--- a/test/js/bun/transpiler/parse-error-column.test.ts
+++ b/test/js/bun/transpiler/parse-error-column.test.ts
@@ -94,9 +94,7 @@ test.concurrent("TOML parse error after astral characters reports UTF-16 column"
   });
 });
 
-async function lineTextWindow(
-  source: string,
-): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+async function lineTextWindow(source: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   using dir = tempDir("parse-col-window", {});
   const file = join(String(dir), "long.js");
   await Bun.write(file, source);

--- a/test/js/bun/transpiler/parse-error-column.test.ts
+++ b/test/js/bun/transpiler/parse-error-column.test.ts
@@ -55,14 +55,17 @@ test.concurrent("JS parse error column agrees for BMP vs astral lines of equal U
 test.concurrent("JS parse error column matches JSC runtime column for the same line", async () => {
   // Parse error and runtime error originate at the same UTF-16 offset; before
   // the fix only the parse column drifted.
-  using dir = tempDir("parse-col-rt", {});
+  using dir = tempDir("parse-col-rt", {
+    "rt.js": 'const a = "\u{1F600}\u{1F600}"; f();\nfunction f(){ throw new Error("x") }',
+    "bad.js": 'const a = "\u{1F600}\u{1F600}"; ]',
+  });
   const rt = join(String(dir), "rt.js");
-  await Bun.write(rt, 'const a = "\u{1F600}\u{1F600}"; f();\nfunction f(){ throw new Error("x") }');
+  const bad = join(String(dir), "bad.js");
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
-      `const parse = await Bun.build({ entrypoints: [${JSON.stringify(join(String(dir), "bad.js"))}], throw: false })
+      `const parse = await Bun.build({ entrypoints: [${JSON.stringify(bad)}], throw: false })
          .then(r => r.logs[0].position.column);
        let runtime;
        try { await import(${JSON.stringify(rt)}); } catch (e) {
@@ -74,7 +77,6 @@ test.concurrent("JS parse error column matches JSC runtime column for the same l
     stdout: "pipe",
     stderr: "pipe",
   });
-  await Bun.write(join(String(dir), "bad.js"), 'const a = "\u{1F600}\u{1F600}"; ]');
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stdout: stdout.trim(), stderr: stderr.trim(), exitCode }).toEqual({
     stdout: `{"parse":19,"runtime":19}`,


### PR DESCRIPTION
## Reproduction

```js
await Bun.write("/tmp/bad.js", 'const a = "\u{1F600}\u{1F600}"; ]');
const r = await Bun.build({ entrypoints: ["/tmp/bad.js"], throw: false });
console.log(r.logs[0].position.column);   // 17, should be 19
```

The `]` sits at UTF-16 code unit 18 (column 19). A runtime error at the same position in the same line reports `file:1:19` via JSC, and a CSS diagnostic with the same layout also reports the UTF-16 column. Only the JS/TS/TOML/JSON parse logger counted codepoints, so any tool consuming `position.column` (or the CLI `at file:line:col`) pointed one unit early per preceding astral-plane character, and Bun disagreed with itself across channels.

## Cause

`ErrorPositionState::advance` in `src/ast/lib.rs` increments the column once per codepoint. The source-map pipeline (`LineOffsetTable`, `Chunk`) and the CSS tokenizer already use the `+ (c > 0xFFFF)` idiom for UTF-16 columns; this was the one position scanner that did not.

A second face of the same state: `Location::init_or_null` windows a very long `lineText` to ~120 bytes around the error by indexing the byte slice with `column_count`. On a non-ASCII line the column is not a byte offset, so the window could miss the error token entirely and land mid-UTF-8-sequence at either end.

## Fix

* Count UTF-16 code units in `ErrorPositionState::advance`: `column_number += 1 + (iter.c > 0xFFFF) as usize`.
* Compute the `lineText` window from the error's byte offset within the line (already at hand via `clamp_error_offset`) and snap both bounds to UTF-8 char boundaries.

## Verification

`test/js/bun/transpiler/parse-error-column.test.ts` covers the JS and TOML column against ASCII / BMP / runtime-stack controls, plus both `lineText` windowing cases. All six fail on the current release and pass with the fix. Existing `invalid-utf8-column.test.ts`, `build-error.test.ts`, `resolve-error.test.ts`, and the `test/js/bun/transpiler/` suite are unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/transpiler/parse-error-column.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (7dc5f9d4e)

test/js/bun/transpiler/parse-error-column.test.ts:
31 | 
32 | test.concurrent("JS parse error after astral characters reports UTF-16 column", async () => {
33 |   // U+1F600 GRINNING FACE is one codepoint but two UTF-16 code units. `]`
34 |   // sits at UTF-16 unit index 18 (column 19). With codepoint counting this
35 |   // was reported as 17.
36 |   expect(await buildPosition("in.js", 'const a = "\u{1F600}\u{1F600}"; ]')).toEqual({
                                                                                 ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "stderr": "",
-   "stdout": "{"line":1,"column":19}",
+   "stdout": "{"line":1,"column":17}",
  }

- Expected  - 1
+ Receiv
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (e710a33de)

test/js/bun/transpiler/parse-error-column.test.ts:
(pass) JS parse error after astral characters reports UTF-16 column [15.66ms]
(pass) JS parse error column matches JSC runtime column for the same line [16.15ms]
(pass) long non-ASCII line's lineText window covers the error token [14.51ms]
(pass) long non-ASCII line's lineText window does not split a UTF-8 sequence [13.76ms]
(pass) JS parse error column agrees for BMP vs astral lines of equal UTF-16 width [27.62ms]
(pass) TOML parse error after astral characters reports UTF-16 column [28.28ms]

 6 pass
 0 fail
 6 expect() calls
Ran 6 tests across 1 file. [181.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/transpiler/parse-error-column.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (7dc5f9d4e)

test/js/bun/transpiler/parse-error-column.test.ts:
(pass) JS parse error after astral characters reports UTF-16 column [548.19ms]
(pass) JS parse error column matches JSC runtime column for the same line [547.80ms]
(pass) long non-ASCII line's lineText window covers the error token [519.41ms]
(pass) long non-ASCII line's lineText window does not split a UTF-8 sequence [523.48ms]
(pass) JS parse error column agrees for BMP vs astral lines of equal UTF-16 width [1025.45ms]
(pass) TOML parse error after astral characters reports UTF-16 column [1013.50ms]

 6 pass
 0 fail
 6 expect() calls
Ran 6 tests across 1 file. [3.28s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 748ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/lib.rs                                    |  43 ++++++-
 test/js/bun/transpiler/parse-error-column.test.ts | 142 ++++++++++++++++++++++
 2 files changed, 181 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/ast/lib.rs                                         5      4      0
test/js/bun/transpiler/parse-error-column.test.ts      3      6      0
```

</details>

<!-- robobun:evidence:end -->