### PR TITLE
transpiler cache: include module_type in features hash

### DIFF
--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -259,6 +259,10 @@ impl<'a> Options<'a> {
             hasher.update(b"no_dce");
         }
 
+        // package.json `"type"` / .mjs / .cjs: picks `exports_kind` for
+        // syntactically-ambiguous files, so it shapes the output.
+        hasher.update(&[self.module_type as u8]);
+
         self.features.hash_for_runtime_transpiler(hasher);
     }
 

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -43,7 +43,10 @@ bun_core::declare_scope!(cache, visible);
 /// path reinstates the bug for any previously-cached TLA module (#30887).
 /// Version 23: `jsx.runtime`/`jsx.development` participate in the features hash,
 /// and tsconfig `"jsx": "react-jsx"` now emits the production runtime (#4227).
-const EXPECTED_VERSION: u32 = 23;
+/// Version 24: `module_type` participates in the features hash. Entries written
+/// before this could serve ESM-format output to a CommonJS consumer (and vice
+/// versa) when identical source bytes were loaded under both formats.
+const EXPECTED_VERSION: u32 = 24;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -223,7 +223,7 @@ describe("transpiler cache", () => {
     expect(b.stdout == "production 5");
     expect(newCacheCount()).toBe(0);
   });
-  test("module_type (package.json \"type\") invalidates cache", () => {
+  test('module_type (package.json "type") invalidates cache', () => {
     // A file with a top-level `return` and no ESM/CJS-forcing syntax is valid
     // CommonJS but a SyntaxError as an ES module. Same bytes, different
     // package.json "type" must not share a cache entry.

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -248,19 +248,22 @@ describe("transpiler cache", () => {
     // Prime the cache from the ESM side. This is a legitimate SyntaxError.
     const esm = run("esm");
     expect(esm.stderr.toString()).toContain("SyntaxError");
-    expect(esm.exitCode).toBe(1);
     expect(existsSync(cache_dir)).toBeTrue();
     expect(newCacheCount()).toBe(1);
+    expect(esm.exitCode).toBe(1);
 
     // Same bytes loaded as CommonJS must not reuse the ESM-format entry.
+    // features_hash mismatch -> unlink + rewrite, same filename, net count 0.
     const cjs = run("cjs");
     expect(cjs.stderr.toString()).toBe("");
     expect(cjs.stdout.toString().trim()).toBe("cjs ok");
+    expect(newCacheCount()).toBe(0);
     expect(cjs.exitCode).toBe(0);
 
     // And running CJS again is now a cache hit.
     const cjs2 = run("cjs");
     expect(cjs2.stdout.toString().trim()).toBe("cjs ok");
+    expect(newCacheCount()).toBe(0);
     expect(cjs2.exitCode).toBe(0);
   });
   test("--feature flag invalidates cache", () => {

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -255,7 +255,6 @@ describe("transpiler cache", () => {
     // Same bytes loaded as CommonJS must not reuse the ESM-format entry.
     // features_hash mismatch -> unlink + rewrite, same filename, net count 0.
     const cjs = run("cjs");
-    expect(cjs.stderr.toString()).toBe("");
     expect(cjs.stdout.toString().trim()).toBe("cjs ok");
     expect(newCacheCount()).toBe(0);
     expect(cjs.exitCode).toBe(0);

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -223,6 +223,46 @@ describe("transpiler cache", () => {
     expect(b.stdout == "production 5");
     expect(newCacheCount()).toBe(0);
   });
+  test("module_type (package.json \"type\") invalidates cache", () => {
+    // A file with a top-level `return` and no ESM/CJS-forcing syntax is valid
+    // CommonJS but a SyntaxError as an ES module. Same bytes, different
+    // package.json "type" must not share a cache entry.
+    const pad = Buffer.alloc(50 * 1024, "/").toString();
+    const body = `let x = 1;\nif (x === 2) return;\nconsole.log("cjs ok");\n//${pad}\n`;
+    mkdirSync(join(temp_dir, "esm"));
+    mkdirSync(join(temp_dir, "cjs"));
+    writeFileSync(join(temp_dir, "esm", "t.js"), body);
+    writeFileSync(join(temp_dir, "cjs", "t.js"), body);
+    writeFileSync(join(temp_dir, "esm", "package.json"), `{"type":"module"}`);
+    writeFileSync(join(temp_dir, "cjs", "package.json"), `{"type":"commonjs"}`);
+
+    const run = (sub: string) =>
+      Bun.spawnSync({
+        cmd: [bunExe(), "t.js"],
+        cwd: join(temp_dir, sub),
+        env,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+
+    // Prime the cache from the ESM side. This is a legitimate SyntaxError.
+    const esm = run("esm");
+    expect(esm.stderr.toString()).toContain("SyntaxError");
+    expect(esm.exitCode).toBe(1);
+    expect(existsSync(cache_dir)).toBeTrue();
+    expect(newCacheCount()).toBe(1);
+
+    // Same bytes loaded as CommonJS must not reuse the ESM-format entry.
+    const cjs = run("cjs");
+    expect(cjs.stderr.toString()).toBe("");
+    expect(cjs.stdout.toString().trim()).toBe("cjs ok");
+    expect(cjs.exitCode).toBe(0);
+
+    // And running CJS again is now a cache hit.
+    const cjs2 = run("cjs");
+    expect(cjs2.stdout.toString().trim()).toBe("cjs ok");
+    expect(cjs2.exitCode).toBe(0);
+  });
   test("--feature flag invalidates cache", () => {
     // feature() can only appear in an if/ternary, so wrap it
     const code = `import { feature } from "bun:bundle";\nif (feature("SUPER_SECRET")) console.log("enabled"); else console.log("disabled");`;


### PR DESCRIPTION
## Problem

The on-disk runtime transpiler cache (`~/.bun/install/cache/@t@/*.pile`) keys entries by a content hash of the source bytes, then validates a `features_hash` stored in the entry header. `hash_for_runtime_transpiler` covered jsx, ts, dce-annotations and the parser feature flags, but not `options.module_type` (the package.json `"type"` field / `.mjs` / `.cjs`).

`module_type` decides `exports_kind` for files that have no explicit ESM or CJS syntax, so identical bytes produce different transpiled output depending on whether they sit under `"type": "module"` or `"type": "commonjs"`.

Running a file once in an ESM scope writes an ESM-format entry. Loading the same bytes later as CommonJS, anywhere on the machine, served that ESM artifact. A valid CJS file would then fail with `SyntaxError: Return statements are only valid inside functions` (or other format-mismatch errors) until the shared cache was wiped. Any single-byte edit "fixed" it by changing the content hash.

## Repro

```sh
d=$(mktemp -d); export BUN_RUNTIME_TRANSPILER_CACHE_PATH="$d/cache"
mkdir -p "$d/cache" "$d/esm" "$d/cjs"
python3 - "$d" <<'PY'
import sys
body = "let x = 1;\nif (x === 2) return;\nconsole.log('cjs ok');\n"
while len(body) < 4300: body += "// pad " + "q"*72 + "\n"
for k in ("esm","cjs"): open(f"{sys.argv[1]}/{k}/t.js","w").write(body)
PY
echo '{"type":"module"}'   > "$d/esm/package.json"
echo '{"type":"commonjs"}' > "$d/cjs/package.json"
(cd "$d/esm" && bun t.js) || true   # SyntaxError (expected in ESM), writes cache
(cd "$d/cjs" && bun t.js)           # SyntaxError -- BUG, should print "cjs ok"
```

## Fix

Hash `self.module_type` in `Options::hash_for_runtime_transpiler`, and bump `EXPECTED_VERSION` to 24 so existing (potentially poisoned) entries are invalidated. This mirrors the version 23 change that added `jsx.runtime`/`jsx.development` to the same hash.

On a `features_hash` mismatch the cache loader already deletes the stale entry and re-transpiles, so the CJS consumer now gets a fresh CJS-format artifact.

## Verification

New test in `test/cli/run/transpiler-cache.test.ts` primes the cache from the ESM side and then asserts the CJS consumer runs cleanly. Fails on current main with the `SyntaxError` above; passes with this change. All 12 existing tests in that file still pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/transpiler-cache.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (7dbb1c68e)

test/cli/run/transpiler-cache.test.ts:
(pass) transpiler cache > works [1638.74ms]
(pass) transpiler cache > works with empty files [1716.94ms]
(pass) transpiler cache > ignores files under the minimum cache size [704.50ms]
(pass) transpiler cache > it is indeed content addressable [2288.28ms]
(pass) transpiler cache > doing 50 buns at once does not crash [6004.02ms]
(pass) transpiler cache > disables the cache instead of falling back to the shared temp directory [1503.78ms]
(pass) transpiler cache > works if the cache is not user-readable [2392.10ms]
(pass) transpiler cache > works if the cache is not user-writable [779.26ms]
(pass) transpiler cache > does not inline process.env [1482.06ms]
253 |     expect(esm.exit
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/cli/run/transpiler-cache.test.ts:
(pass) transpiler cache > works [47.24ms]
(pass) transpiler cache > works with empty files [53.85ms]
(pass) transpiler cache > ignores files under the minimum cache size [21.79ms]
(pass) transpiler cache > it is indeed content addressable [131.06ms]
(pass) transpiler cache > doing 50 buns at once does not crash [238.39ms]
(pass) transpiler cache > disables the cache instead of falling back to the shared temp directory [97.16ms]
(pass) transpiler cache > works if the cache is not user-readable [107.57ms]
(pass) transpiler cache > works if the cache is not user-writable [110.16ms]
(pass) transpiler cache > does not inline process.env [70.19ms]
253 |     expect(esm.exitCode).toBe(1);
254 | 
255 |     // Same bytes loaded as CommonJS must not reuse the ESM-format entry.
256 |     // features_hash mismatch -> unlink + rewrite, same filename, net count 0.
257 |     const cjs = run("cjs");
258 |     expect(cjs.stdout.toString().trim()).toBe("cjs ok");
                                               ^
error: expect(received).toBe(expected)

Expected: "cjs ok"
Received: ""

      at <anonymous> (/wor
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/transpiler-cache.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (7dbb1c68e)

test/cli/run/transpiler-cache.test.ts:
(pass) transpiler cache > works [1626.00ms]
(pass) transpiler cache > works with empty files [1310.26ms]
(pass) transpiler cache > ignores files under the minimum cache size [588.18ms]
(pass) transpiler cache > it is indeed content addressable [2254.22ms]
(pass) transpiler cache > doing 50 buns at once does not crash [4264.51ms]
(pass) transpiler cache > disables the cache instead of falling back to the shared temp directory [1465.25ms]
(pass) transpiler cache > works if the cache is not user-readable [2132.01ms]
(pass) transpiler cache > works if the cache is not user-writable [660.14ms]
(pass) transpiler cache > does not inline process.env [1307.90ms]
(pass) transpiler cache >
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     7dbb1c68e3
  features     (none)

22 deps, 106 codegen, 1169 objects in 1030ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1232] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [18.00ms]
[2/1232] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1232] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [19.00ms]
[4/1232] gen ErrorCode+*.h
[5/1232] fetch picohttpparser
[picohttpparser] up to date
[6/1232] fetch tinycc
[tinycc] up to date
[7/1231] fetch libjpeg-turbo
[libjpe
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/parse/parse_entry.rs    |  4 ++++
 src/jsc/RuntimeTranspilerCache.rs     |  5 ++++-
 test/cli/run/transpiler-cache.test.ts | 42 +++++++++++++++++++++++++++++++++++
 3 files changed, 50 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/js_parser/parse/parse_entry.rs         3      1      0
src/jsc/RuntimeTranspilerCache.rs          1      1      0
test/cli/run/transpiler-cache.test.ts      2      3      0
```

</details>

**root cause** · written by the author bot

The runtime transpiler cache keyed entries only by source content hash, so a file first transpiled as an ES module would have its ESM-format output served to any later CommonJS consumer of the same bytes, producing syntax errors on valid CJS code. The fix folds the resolved module type into the cache hash so ESM and CJS transpilations of identical source occupy distinct entries. The cache compatibility version is also bumped to invalidate any already-poisoned entries on disk.

<!-- robobun:evidence:end -->