### PR TITLE
ast: count UTF-16 code units for diagnostic column, not codepoints

### DIFF
--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -882,8 +882,15 @@ impl Location {
             };
             let mut full_line = &source.contents[data.line_start..data.line_end];
             if full_line.len() > 80 + data.column_count {
-                full_line = &full_line[data.column_count.max(40) - 40
-                    ..(data.column_count + 40).min(full_line.len() - 40) + 40];
+                let mut lo = data.column_count.max(40) - 40;
+                let mut hi = (data.column_count + 40).min(full_line.len() - 40) + 40;
+                while lo > 0 && full_line[lo] & 0xC0 == 0x80 {
+                    lo -= 1;
+                }
+                while hi < full_line.len() && full_line[hi] & 0xC0 == 0x80 {
+                    hi += 1;
+                }
+                full_line = &full_line[lo..hi];
             }
 
             return Some(Location {
@@ -2748,7 +2755,10 @@ impl ErrorPositionState {
                     crossed_line_break = true;
                 }
                 _ => {
-                    self.column_number += 1;
+                    // UTF-16 code units: astral codepoints (> U+FFFF) occupy a surrogate
+                    // pair. This matches the convention of JSC stack frames, source-map
+                    // columns, and `line_col_to_byte_offset`.
+                    self.column_number += 1 + (iter.c > 0xFFFF) as usize;
                 }
             }
 
@@ -3827,6 +3837,36 @@ mod line_column_tracker_tests {
                 ),
                 "diverged at offset {offset} of {:?}",
                 bstr::BStr::new(source.contents())
+            );
+        }
+    }
+
+    #[test]
+    fn error_position_column_counts_utf16_code_units() {
+        // Offsets point at the `?` in each line. Expected columns are 1-based
+        // UTF-16 code units (JS `.length` semantics) of the prefix + 1.
+        let cases: &[(&str, usize, usize)] = &[
+            ("ascii/**/?", 9, 10),
+            ("\u{00E9}\u{00E9}\u{00E9}?", 6, 4),
+            ("\u{4E2D}\u{6587}?", 6, 3),
+            ("\u{1F600}?", 4, 3),
+            ("\u{1F600}\u{1F600}\u{1F600}?", 12, 7),
+            ("a\u{1F600}b\u{00E9}c?", 9, 7),
+        ];
+        for (src, offset, expected_column) in cases.iter().copied() {
+            let source = Source::init_path_string(b"t.js" as &[u8], src.as_bytes());
+            let pos = source.init_error_position(usize2loc(offset));
+            assert_eq!(
+                pos.column_count, expected_column,
+                "source {src:?} offset {offset}: expected column {expected_column}, got {}",
+                pos.column_count
+            );
+            let round_trip =
+                Source::line_col_to_byte_offset(src.as_bytes(), 1, 1, 1, expected_column as u64);
+            assert_eq!(
+                round_trip,
+                Some(offset),
+                "line_col_to_byte_offset round-trip failed for {src:?}"
             );
         }
     }

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -553,6 +553,42 @@ describe("Bun.build", () => {
     expect(x.logs[0].position).toBeTruthy();
   });
 
+  test.concurrent("BuildMessage.position.column counts UTF-16 code units", async () => {
+    // Parse errors after a run of astral (surrogate-pair) characters should
+    // report a column that indexes into the line as a JS string (UTF-16 code
+    // units), matching JSC stack frames and source-map columns. Previously the
+    // scanner counted Unicode codepoints, so each astral character shifted the
+    // reported column one to the left.
+    const cases: Array<{ prefix: string; suffix: string }> = [
+      { prefix: "/*\u{1F600}\u{1F600}\u{1F600}*/", suffix: "?" },
+      { prefix: 'var a="\u{1F600}\u{1F600}\u{1F600}";var ', suffix: "1" },
+      { prefix: '"\u{00E9}\u{1F600}\u{4E2D}";', suffix: "??;" },
+      { prefix: '"\u{00E9}\u{00E9}\u{00E9}";', suffix: "??;" },
+    ];
+
+    using dir = tempDir("build-msg-utf16-column", {
+      "entry0.js": cases[0].prefix + cases[0].suffix + "\n",
+      "entry1.js": cases[1].prefix + cases[1].suffix + "\n",
+      "entry2.js": cases[2].prefix + cases[2].suffix + "\n",
+      "entry3.js": cases[3].prefix + cases[3].suffix + "\n",
+    });
+
+    for (let i = 0; i < cases.length; i++) {
+      const { prefix } = cases[i];
+      const result = await buildNoThrow({
+        entrypoints: [join(String(dir), `entry${i}.js`)],
+      });
+      expect(result.success).toBe(false);
+      expect(result.logs.length).toBeGreaterThan(0);
+      const pos = result.logs[0].position!;
+      expect({ entry: i, line: pos.line, column: pos.column }).toEqual({
+        entry: i,
+        line: 1,
+        column: prefix.length + 1,
+      });
+    }
+  });
+
   test.concurrent("module() throws error", async () => {
     expect(() =>
       Bun.build({


### PR DESCRIPTION
## Repro

```js
new Bun.Transpiler().transformSync("/*\u{1F600}\u{1F600}\u{1F600}*/?", "js");
// BuildMessage.position.column === 8   (codepoints; wrong)
// should be                        11  (UTF-16 code units)
```

## Cause

`ErrorPositionState::advance` in `src/ast/lib.rs` increments `column_number` by 1 for every codepoint. Every other column surface in Bun counts UTF-16 code units: JSC stack frames, source-map columns, and `Source::line_col_to_byte_offset` in the same file (which explicitly documents "Columns count UTF-16 code units, the convention of JSC stack traces and source-map mappings"). So `BuildMessage.position.column` disagreed with all of them whenever an astral character appeared earlier on the line: each surrogate-pair codepoint shifted the reported column one to the left.

## Fix

Increment by `1 + (c > 0xFFFF) as usize` so astral codepoints count as 2. After this, `init_error_position` and `line_col_to_byte_offset` round-trip.

While here, the long-line `lineText` window (lines > ~80 + column bytes) is clamped to UTF-8 char boundaries so the approximate slice never lands inside a multi-byte sequence. The window math was already approximate (it used a non-byte unit as a byte index), so behaviour is otherwise unchanged; this just prevents split sequences at the edges.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test bun-build-api.test.ts -t "UTF-16 code units"
  expect(received).toEqual(expected)
    - "column": 11,
    + "column": 8,
  (fail) Bun.build > BuildMessage.position.column counts UTF-16 code units

$ bun bd test bun-build-api.test.ts -t "UTF-16 code units"
  (pass) Bun.build > BuildMessage.position.column counts UTF-16 code units
```

Also verified `test/bundler/transpiler/transpiler.test.js` (182 pass) and `test/js/bun/resolve/{build,resolve}-error.test.ts` (22 pass) are unaffected. A Rust unit test pins specific UTF-16 columns for ASCII, BMP 2-byte, BMP 3-byte, and astral inputs, and asserts the `line_col_to_byte_offset` round-trip.

Not covered here: the `path.win32` colon-tail and reserved-device-name guards noted in the same sweep; those are tracked separately.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-api.test.ts

<!-- robobun:evidence:end -->