### PR TITLE
process.env.TZ: invalidate cached local-time data on existing Date instances

### DIFF
--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -488,7 +488,7 @@ static constexpr ASCIILiteral kProxyEnvVarNames[] = {
 static void applyTZFromString(JSGlobalObject* globalObject, const String& value)
 {
     if (value.length() < 32 && WTF::setTimeZoneOverride(value))
-        JSC::getVM(globalObject).dateCache.resetIfNecessarySlow();
+        Bun::resetDateCacheForTimeZoneChange(JSC::getVM(globalObject));
 }
 static void applyTLSRejectFromString(JSGlobalObject*, const String& value)
 {

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -21,6 +21,11 @@
 #include "JavaScriptCore/GetterSetter.h"
 #include "JavaScriptCore/GlobalObjectMethodTable.h"
 #include "JavaScriptCore/Heap.h"
+#include "JavaScriptCore/HeapIterationScope.h"
+#include "JavaScriptCore/SubspaceInlines.h"
+#include "JavaScriptCore/MarkedBlockInlines.h"
+#include "JavaScriptCore/DateInstance.h"
+#include "JavaScriptCore/DateInstanceCache.h"
 #include "JavaScriptCore/DeferGCInlines.h"
 #include "JavaScriptCore/Identifier.h"
 #include "JavaScriptCore/InitializeThreading.h"
@@ -3324,7 +3329,7 @@ extern "C" bool JSGlobalObject__setTimeZone(JSC::JSGlobalObject* globalObject, c
     auto& vm = JSC::getVM(globalObject);
 
     if (WTF::setTimeZoneOverride(Zig::toString(*timeZone))) {
-        vm.dateCache.resetIfNecessarySlow();
+        Bun::resetDateCacheForTimeZoneChange(vm);
         return true;
     }
 
@@ -4177,6 +4182,26 @@ const JSC::ClassInfo GlobalObject::s_info = { "GlobalObject"_s, &Base::s_info, &
     CREATE_METHOD_TABLE(GlobalObject) };
 
 } // namespace Zig
+
+namespace Bun {
+
+void resetDateCacheForTimeZoneChange(JSC::VM& vm)
+{
+    vm.dateCache.resetIfNecessarySlow();
+    // DateInstance holds its own RefPtr<DateInstanceData>; the reset above does
+    // not reach it. Poison the local-time cache key so both the C++ and the
+    // DFG/FTL fast paths miss and recompute under the new zone.
+    JSC::HeapIterationScope iterationScope(vm.heap);
+    vm.heap.dateInstanceSpace.forEachLiveCell([](JSC::HeapCell* cell, JSC::HeapCell::Kind) {
+        auto* instance = static_cast<JSC::DateInstance*>(cell);
+        auto* dataSlot = std::bit_cast<RefPtr<JSC::DateInstanceData>*>(
+            std::bit_cast<char*>(instance) + JSC::DateInstance::offsetOfData());
+        if (JSC::DateInstanceData* data = dataSlot->get())
+            data->m_gregorianDateTimeCachedForMS = JSC::PNaN;
+    });
+}
+
+} // namespace Bun
 
 JSC_DEFINE_HOST_FUNCTION(jsFunctionNotImplemented, (JSGlobalObject * leixcalGlobalObject, CallFrame* callFrame))
 {

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -75,6 +75,8 @@ class JSCommonJSExtensions;
 class InternalModuleRegistry;
 class JSMockModule;
 class JSMockFunction;
+
+void resetDateCacheForTimeZoneChange(JSC::VM&);
 }
 
 namespace WebCore {

--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -651,7 +651,7 @@ JSC_DEFINE_HOST_FUNCTION(functionSetTimeZone, (JSGlobalObject * globalObject, Ca
             makeString("Invalid timezone: \""_s, timeZoneName, "\""_s));
         return {};
     }
-    vm.dateCache.resetIfNecessarySlow();
+    Bun::resetDateCacheForTimeZoneChange(vm);
     WTF::Vector<char16_t, 32> buffer;
     WTF::getTimeZoneOverride(buffer);
     WTF::String timeZoneString(buffer.span());

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -270,6 +270,35 @@ it("process.env.TZ", () => {
   expect(Intl.DateTimeFormat().resolvedOptions().timeZone).toBe(realOrigTimezone);
 });
 
+it("process.env.TZ reassignment updates the offset on existing Date instances", async () => {
+  const fixture = `
+    const d = new Date("2018-04-14T12:34:56.789Z");
+    process.env.TZ = "Europe/Amsterdam";
+    const a = { str: d.toString(), hours: d.getHours(), offset: d.getTimezoneOffset() };
+    process.env.TZ = "Europe/London";
+    const b = { str: d.toString(), hours: d.getHours(), offset: d.getTimezoneOffset() };
+    const { setTimeZone } = require("bun:jsc");
+    setTimeZone("Europe/Amsterdam");
+    const c = { str: d.toString(), hours: d.getHours(), offset: d.getTimezoneOffset() };
+    process.stdout.write(JSON.stringify({ a, b, c }));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const { a, b, c } = JSON.parse(stdout);
+  expect({ a, b, c }).toEqual({
+    a: { str: expect.stringMatching(/^Sat Apr 14 2018 14:34:56 GMT\+0200 \(.+\)$/), hours: 14, offset: -120 },
+    b: { str: expect.stringMatching(/^Sat Apr 14 2018 13:34:56 GMT\+0100 \(.+\)$/), hours: 13, offset: -60 },
+    c: { str: expect.stringMatching(/^Sat Apr 14 2018 14:34:56 GMT\+0200 \(.+\)$/), hours: 14, offset: -120 },
+  });
+  expect(exitCode).toBe(0);
+});
+
 it("process.version starts with v", () => {
   expect(process.version.startsWith("v")).toBeTruthy();
 });

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -289,14 +289,15 @@ it("process.env.TZ reassignment updates the offset on existing Date instances", 
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  const { a, b, c } = JSON.parse(stdout);
-  expect({ a, b, c }).toEqual({
-    a: { str: expect.stringMatching(/^Sat Apr 14 2018 14:34:56 GMT\+0200 \(.+\)$/), hours: 14, offset: -120 },
-    b: { str: expect.stringMatching(/^Sat Apr 14 2018 13:34:56 GMT\+0100 \(.+\)$/), hours: 13, offset: -60 },
-    c: { str: expect.stringMatching(/^Sat Apr 14 2018 14:34:56 GMT\+0200 \(.+\)$/), hours: 14, offset: -120 },
+  expect({ out: stdout && JSON.parse(stdout), stderr, exitCode }).toEqual({
+    out: {
+      a: { str: expect.stringMatching(/^Sat Apr 14 2018 14:34:56 GMT\+0200 \(.+\)$/), hours: 14, offset: -120 },
+      b: { str: expect.stringMatching(/^Sat Apr 14 2018 13:34:56 GMT\+0100 \(.+\)$/), hours: 13, offset: -60 },
+      c: { str: expect.stringMatching(/^Sat Apr 14 2018 14:34:56 GMT\+0200 \(.+\)$/), hours: 14, offset: -120 },
+    },
+    stderr: "",
+    exitCode: 0,
   });
-  expect(exitCode).toBe(0);
 });
 
 it("process.version starts with v", () => {


### PR DESCRIPTION
Reassigning `process.env.TZ` (or calling `require("bun:jsc").setTimeZone`) updated the timezone *name* shown by `Date#toString` but not the *offset*, producing internally inconsistent strings on Date instances that had already been formatted once under the previous zone.

### Repro

```js
process.env.TZ = "Europe/Amsterdam";
const d = new Date("2018-04-14T12:34:56.789Z");
d.toString(); // "Sat Apr 14 2018 14:34:56 GMT+0200 (Central European Summer Time)"
process.env.TZ = "Europe/London";
d.toString(); // bun:  "Sat Apr 14 2018 14:34:56 GMT+0200 (British Summer Time)"
              // node: "Sat Apr 14 2018 13:34:56 GMT+0100 (British Summer Time)"
```

`getHours()` and `getTimezoneOffset()` on the same instance were similarly stale. Newly constructed Date instances were correct; only instances whose local-time form had already been computed were affected.

### Cause

`DateCache::resetIfNecessarySlow()` clears the VM's `DateInstanceCache`, but every `DateInstance` also holds its own `RefPtr<DateInstanceData>` (`m_data`) obtained from that cache. `DateInstance::gregorianDateTime()` short-circuits on `m_data->m_gregorianDateTimeCachedForMS == internalNumber()` and returns the cached struct without consulting the VM cache, so the stale offset survives the reset. The timezone display name is fetched directly from `DateCache::timeZoneDisplayName()`, which *is* reset, hence the inconsistent string.

### Fix

After a successful `setTimeZoneOverride`, in addition to resetting the VM cache, walk `vm.heap.dateInstanceSpace` and set `m_gregorianDateTimeCachedForMS = PNaN` on every live `DateInstance`'s cached data. The NaN key makes both the C++ fast path and the DFG/FTL inlined fast path (which compare this field against `internalNumber()`) miss, forcing a recompute under the new zone. The UTC cache key is untouched since UTC values do not depend on the local zone.

The three entry points (`process.env.TZ` custom setter, `bun:jsc` `setTimeZone`, and the Rust-side `JSGlobalObject__setTimeZone`) now share a single `Bun::resetDateCacheForTimeZoneChange(vm)` helper.

### Verification

```
$ bun test test/js/node/process/process.test.js -t "reassignment updates the offset"
```

fails on main with `GMT+0200 (British Summer Time)`, passes with this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/process/process.test.js

<!-- robobun:evidence:end -->