### PR TITLE
structuredClone: detach MessagePorts in the transfer list

### DIFF
--- a/src/jsc/bindings/webcore/StructuredClone.cpp
+++ b/src/jsc/bindings/webcore/StructuredClone.cpp
@@ -33,6 +33,7 @@
 #include "SerializedScriptValue.h"
 #include "MessagePort.h"
 #include "JSStructuredSerializeOptions.h"
+#include "ZigGlobalObject.h"
 
 namespace WebCore {
 using namespace JSC;
@@ -148,7 +149,19 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionStructuredClone, (JSC::JSGlobalObject * globa
     }
     throwScope.assertNoException();
 
-    JSValue deserialized = serialized.releaseReturnValue()->deserialize(*globalObject, globalObject, ports);
+    // StructuredSerializeWithTransfer sets [[Detached]] on every transferable and
+    // StructuredDeserializeWithTransfer creates a fresh object per transferDataHolder.
+    // Without this hop a transferred MessagePort is never detached and the caller's
+    // original port is handed straight back, so a detached port is accepted on retry.
+    auto disentangled = MessagePort::disentanglePorts(WTF::move(ports));
+    if (disentangled.hasException()) {
+        WebCore::propagateException(*globalObject, throwScope, disentangled.releaseException());
+        RELEASE_AND_RETURN(throwScope, {});
+    }
+    auto* context = defaultGlobalObject(globalObject)->scriptExecutionContext();
+    auto entangled = MessagePort::entanglePorts(*context, disentangled.releaseReturnValue());
+
+    JSValue deserialized = serialized.releaseReturnValue()->deserialize(*globalObject, globalObject, entangled);
     RETURN_IF_EXCEPTION(throwScope, {});
 
     return JSValue::encode(deserialized);
@@ -211,7 +224,15 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionStructuredCloneAdvanced, (JSC::JSGlobalObject
     }
     throwScope.assertNoException();
 
-    JSValue deserialized = serialized.releaseReturnValue()->deserialize(*globalObject, globalObject, ports);
+    auto disentangled = MessagePort::disentanglePorts(WTF::move(ports));
+    if (disentangled.hasException()) {
+        WebCore::propagateException(*globalObject, throwScope, disentangled.releaseException());
+        RELEASE_AND_RETURN(throwScope, {});
+    }
+    auto* context = defaultGlobalObject(globalObject)->scriptExecutionContext();
+    auto entangled = MessagePort::entanglePorts(*context, disentangled.releaseReturnValue());
+
+    JSValue deserialized = serialized.releaseReturnValue()->deserialize(*globalObject, globalObject, entangled);
     RETURN_IF_EXCEPTION(throwScope, {});
 
     return JSValue::encode(deserialized);

--- a/src/jsc/bindings/webcore/StructuredClone.cpp
+++ b/src/jsc/bindings/webcore/StructuredClone.cpp
@@ -151,8 +151,6 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionStructuredClone, (JSC::JSGlobalObject * globa
 
     // StructuredSerializeWithTransfer sets [[Detached]] on every transferable and
     // StructuredDeserializeWithTransfer creates a fresh object per transferDataHolder.
-    // Without this hop a transferred MessagePort is never detached and the caller's
-    // original port is handed straight back, so a detached port is accepted on retry.
     auto disentangled = MessagePort::disentanglePorts(WTF::move(ports));
     if (disentangled.hasException()) {
         WebCore::propagateException(*globalObject, throwScope, disentangled.releaseException());

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -502,6 +502,49 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
           expect(cloned.buffer.byteLength).toBe(8);
           expect(buffer.byteLength).toBe(0);
         });
+        // https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer
+        // WPT: html/webappapis/structured-clone "A detached platform object cannot be transferred"
+        test("A detached MessagePort cannot be transferred", () => {
+          const { port1, port2 } = new MessageChannel();
+          structuredCloneFn(null, { transfer: [port1] });
+          let error: unknown;
+          try {
+            structuredCloneFn(port1, { transfer: [port1] });
+          } catch (e) {
+            error = e;
+          }
+          expect(error).toBeInstanceOf(DOMException);
+          expect((error as DOMException).name).toBe("DataCloneError");
+          expect((error as DOMException).code).toBe(DOMException.DATA_CLONE_ERR);
+          port2.close();
+        });
+        test("transferring a MessagePort detaches the original and returns a new entangled port", async () => {
+          const { port1, port2 } = new MessageChannel();
+          const cloned = structuredCloneFn(port1, { transfer: [port1] });
+          expect(cloned).toBeInstanceOf(MessagePort);
+          expect(cloned).not.toBe(port1);
+          // the original is now detached: a second transfer over any path must throw
+          const sink = new MessageChannel();
+          expect(() => sink.port1.postMessage(null, [port1])).toThrow(DOMException);
+          expect(() => structuredCloneFn(null, { transfer: [port1] })).toThrow(DOMException);
+          // the returned port took over port1's end of the channel
+          const { promise, resolve } = Promise.withResolvers<unknown>();
+          port2.onmessage = e => resolve(e.data);
+          cloned.postMessage("hello");
+          expect(await promise).toBe("hello");
+          cloned.close();
+          port2.close();
+          sink.port1.close();
+          sink.port2.close();
+        });
+        test("a rejected MessagePort transfer leaves sibling ArrayBuffers attached", () => {
+          const { port1, port2 } = new MessageChannel();
+          structuredCloneFn(null, { transfer: [port1] });
+          const buffer = new ArrayBuffer(8);
+          expect(() => structuredCloneFn(null, { transfer: [buffer, port1] })).toThrow(DOMException);
+          expect(buffer.byteLength).toBe(8);
+          port2.close();
+        });
       });
     }
   });


### PR DESCRIPTION
## Problem

`structuredClone` with a `MessagePort` in its transfer list never detaches the port. A second transfer of the same port therefore succeeds and returns a clone of a dead port, where HTML requires a `DataCloneError`.

```js
const c = new MessageChannel();
structuredClone(null, { transfer: [c.port1] });    // should detach port1
structuredClone(c.port1, { transfer: [c.port1] }); // bun: returns a dead port; node/spec: DataCloneError
```

Node v26.3.0 and the WPT case `html/webappapis/structured-clone` "A detached platform object cannot be transferred" both throw here. The sibling `postMessage` paths (`MessagePort.postMessage`, `worker_threads`) already reject a detached port; only the `structuredClone` entry point was wrong.

## Cause

`jsFunctionStructuredClone` called `SerializedScriptValue::create` to populate the port list and then passed the same list straight to `deserialize`. The `isDetached()` check in `SerializedScriptValue::create` is in place, but nothing ever set `m_isDetached` because `MessagePort::disentanglePorts` was never called on this path. `MessagePort::postMessage` and `Worker::postMessage` both call it after serialization.

## Fix

Round-trip the ports through `MessagePort::disentanglePorts` / `entanglePorts` between serialize and deserialize in both `jsFunctionStructuredClone` and `jsFunctionStructuredCloneAdvanced`, matching the `postMessage` paths and the HTML StructuredSerializeWithTransfer / StructuredDeserializeWithTransfer pair. The original port is detached and the caller receives a fresh `MessagePort` entangled with the original peer.

## Tests

Three new cases in the existing `transferables` block of `test/js/web/workers/structured-clone.test.ts`:

- a detached `MessagePort` cannot be transferred (throws `DataCloneError`)
- transferring a `MessagePort` detaches the original and returns a new entangled port (verified by round-tripping a message through the peer)
- a rejected `MessagePort` transfer leaves a sibling `ArrayBuffer` attached

```
USE_SYSTEM_BUN=1 bun test test/js/web/workers/structured-clone.test.ts -t MessagePort   # 3 fail
bun bd test test/js/web/workers/structured-clone.test.ts -t MessagePort                  # 3 pass
bun bd test test/js/web/workers/message-channel.test.ts test/js/node/worker_threads/worker-transfer-list.test.ts  # 19 pass
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/structured-clone.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (82f3e8d58)

test/js/web/workers/structured-clone.test.ts:
(pass) structuredClone > primitive undefined [4.86ms]
(pass) structuredClone > primitive null [0.63ms]
(pass) structuredClone > primitive true [0.47ms]
(pass) structuredClone > primitive false [0.45ms]
(pass) structuredClone > primitive string, empty string [0.37ms]
(pass) structuredClone > primitive string, lone high surrogate [0.39ms]
(pass) structuredClone > primitive string, lone low surrogate [0.37ms]
(pass) structuredClone > primitive string, NUL [0.36ms]
(pass) structuredClone > primitive string, astral character [0.61ms]
(pass) structuredClone > primitive number, 0.2 [0.42ms]
(pass) structuredClone > primitive number, 0 [0.69ms]
(pass) structuredClone > pri
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (17b1a302a)

test/js/web/workers/structured-clone.test.ts:
(pass) structuredClone > primitive undefined [1.21ms]
(pass) structuredClone > primitive null [0.03ms]
(pass) structuredClone > primitive true
(pass) structuredClone > primitive false
(pass) structuredClone > primitive string, empty string
(pass) structuredClone > primitive string, lone high surrogate
(pass) structuredClone > primitive string, lone low surrogate
(pass) structuredClone > primitive string, NUL
(pass) structuredClone > primitive string, astral character [0.01ms]
(pass) structuredClone > primitive number, 0.2
(pass) structuredClone > primitive number, 0
(pass) structuredClone > primitive number, -0
(pass) structuredClone > primitive number, NaN
(pass) structuredClone > primitive number, Infinity
(pass) structuredClone > primitive number, -Infinity
(pass) structuredClone > primitive number, 9007199254740992
(pass) structuredClone > primitive number, -9007199254740992 [0.02ms]
(pass) structuredClone > primitive number, 9007199254740994
(pass) structuredClone > primitive number, -9007199254740994
(pass) structuredClone > primitive BigInt, 0n
(pass) structuredClone > primiti
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/structured-clone.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (82f3e8d58)

test/js/web/workers/structured-clone.test.ts:
(pass) structuredClone > primitive undefined [4.69ms]
(pass) structuredClone > primitive null [0.65ms]
(pass) structuredClone > primitive true [0.49ms]
(pass) structuredClone > primitive false [0.46ms]
(pass) structuredClone > primitive string, empty string [0.37ms]
(pass) structuredClone > primitive string, lone high surrogate [0.41ms]
(pass) structuredClone > primitive string, lone low surrogate [0.38ms]
(pass) structuredClone > primitive string, NUL [0.41ms]
(pass) structuredClone > primitive string, astral character [0.62ms]
(pass) structuredClone > primitive number, 0.2 [0.74ms]
(pass) structuredClone > primitive number, 0 [0.39ms]
(pass) structuredClone > pri
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 765ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-4.cpp.o
[2/8] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[3/8] gen cpp.rs (cppbind)
[3/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspa
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/StructuredClone.cpp | 23 +++++++++++++--
 test/js/web/workers/structured-clone.test.ts | 43 ++++++++++++++++++++++++++++
 2 files changed, 64 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/jsc/bindings/webcore/StructuredClone.cpp      2      4      0
test/js/web/workers/structured-clone.test.ts      4      4      0
```

</details>

<!-- robobun:evidence:end -->