### PR TITLE
TextEncoder.encodeInto: reject non-Uint8Array destinations

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -229,7 +229,7 @@ interface TextEncoder extends Bun.__internal.LibEmptyOrNodeUtilTextEncoder {
    * @param src The text to encode.
    * @param dest The array that receives the encoded bytes.
    */
-  encodeInto(src?: string, dest?: Bun.BufferSource): import("node:util").TextEncoderEncodeIntoResult;
+  encodeInto(src?: string, dest?: Uint8Array<ArrayBufferLike>): import("node:util").TextEncoderEncodeIntoResult;
 }
 declare var TextEncoder: Bun.__internal.UseLibDomIfAvailable<
   "TextEncoder",

--- a/src/jsc/bindings/webcore/JSTextEncoder.cpp
+++ b/src/jsc/bindings/webcore/JSTextEncoder.cpp
@@ -63,6 +63,7 @@
 #include "DOMJITHelpers.h"
 #include <JavaScriptCore/DFGAbstractHeap.h>
 #include "BunClientData.h"
+#include "ErrorCode.h"
 
 namespace WebCore {
 using namespace JSC;
@@ -433,10 +434,9 @@ static inline JSC::EncodedJSValue jsTextEncoderPrototypeFunction_encodeIntoBody(
     auto source = str->view(lexicalGlobalObject);
     RETURN_IF_EXCEPTION(throwScope, {});
     EnsureStillAliveScope argument1 = callFrame->uncheckedArgument(1);
-    auto* destination = dynamicDowncast<JSC::JSArrayBufferView>(argument1.value());
+    auto* destination = dynamicDowncast<JSC::JSUint8Array>(argument1.value());
     if (!destination) {
-        throwVMTypeError(lexicalGlobalObject, throwScope, "Expected Uint8Array"_s);
-        return {};
+        return Bun::ERR::INVALID_ARG_TYPE_INSTANCE(throwScope, lexicalGlobalObject, "dest"_s, "Uint8Array"_s, argument1.value());
     }
 
     size_t res = 0;

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -707,7 +707,7 @@ describe("@types/bun integration test", () => {
         },
         {
           code: 2339,
-          line: "spawn.ts:107:38",
+          line: "spawn.ts:103:38",
           message: "Property 'text' does not exist on type 'ReadableStream<Uint8Array<ArrayBuffer>>'.",
         },
         {

--- a/test/integration/bun-types/fixture/spawn.ts
+++ b/test/integration/bun-types/fixture/spawn.ts
@@ -90,10 +90,6 @@ function depromise<T>(_promise: Promise<T>): T {
   const enc = new TextEncoder();
   proc.stdin.write(enc.encode(" world!"));
   enc.encodeInto(" world!", {} as any as Uint8Array);
-  // Bun-specific overloads
-  // these fail when lib.dom.d.ts is present
-  enc.encodeInto(" world!", new Uint32Array(124));
-  enc.encodeInto(" world!", {} as any as DataView);
 
   // send buffered data
   await proc.stdin.flush();

--- a/test/js/web/encoding/text-encoder.test.js
+++ b/test/js/web/encoding/text-encoder.test.js
@@ -13,6 +13,54 @@ const getByteLength = str => {
   return s;
 };
 
+describe("encodeInto rejects non-Uint8Array destinations", () => {
+  // WebIDL: encodeInto(USVString source, [AllowShared] Uint8Array destination)
+  const encoder = new TextEncoder();
+  const buf = new ArrayBuffer(8);
+
+  it.each([
+    ["Int8Array", new Int8Array(buf)],
+    ["Int16Array", new Int16Array(buf)],
+    ["Int32Array", new Int32Array(buf)],
+    ["Uint16Array", new Uint16Array(buf)],
+    ["Uint32Array", new Uint32Array(buf)],
+    ["Uint8ClampedArray", new Uint8ClampedArray(buf)],
+    ["BigInt64Array", new BigInt64Array(buf)],
+    ["BigUint64Array", new BigUint64Array(buf)],
+    ["Float16Array", new Float16Array(buf)],
+    ["Float32Array", new Float32Array(buf)],
+    ["Float64Array", new Float64Array(buf)],
+    ["DataView", new DataView(buf)],
+    ["ArrayBuffer", buf],
+    ["SharedArrayBuffer", new SharedArrayBuffer(8)],
+    ["Array", [0, 0, 0, 0]],
+    ["plain object", {}],
+    ["null", null],
+  ])("throws TypeError for %s", (name, dest) => {
+    expect(() => encoder.encodeInto("hi", dest)).toThrow(TypeError);
+    expect(() => encoder.encodeInto("hi", dest)).toThrow("must be an instance of Uint8Array");
+  });
+
+  it("does not write into a rejected destination's backing buffer", () => {
+    const backing = new ArrayBuffer(8);
+    const f64 = new Float64Array(backing);
+    expect(() => encoder.encodeInto("hi", f64)).toThrow(TypeError);
+    expect(Array.from(new Uint8Array(backing))).toEqual([0, 0, 0, 0, 0, 0, 0, 0]);
+  });
+
+  it("accepts Uint8Array and Buffer", () => {
+    expect(encoder.encodeInto("hi", new Uint8Array(8))).toEqual({ read: 2, written: 2 });
+    expect(encoder.encodeInto("hi", Buffer.alloc(8))).toEqual({ read: 2, written: 2 });
+  });
+
+  it("accepts Uint8Array backed by SharedArrayBuffer", () => {
+    const dest = new Uint8Array(new SharedArrayBuffer(8));
+    expect(encoder.encodeInto("hi", dest)).toEqual({ read: 2, written: 2 });
+    expect(dest[0]).toBe(0x68);
+    expect(dest[1]).toBe(0x69);
+  });
+});
+
 it("not enough space for replacement character", () => {
   const encoder = new TextEncoder();
   const bytes = new Uint8Array(2);


### PR DESCRIPTION
## What

`TextEncoder.prototype.encodeInto()` accepted any `ArrayBufferView` (`DataView`, `Int16Array`, `Float64Array`, `Uint8ClampedArray`, etc.) and wrote raw UTF-8 bytes into its backing buffer. The WebIDL signature is `encodeInto(USVString source, [AllowShared] Uint8Array destination)`, so every non-`Uint8Array` destination must throw `TypeError`.

```js
const enc = new TextEncoder();
const f = new Float64Array(2);
enc.encodeInto("hi", f);
// before: { read: 2, written: 2 }, text bytes in float storage
// after:  TypeError: The "dest" argument must be an instance of Uint8Array. Received an instance of Float64Array
```

Node v26 throws `TypeError` with `ERR_INVALID_ARG_TYPE` for all of these. WPT `encoding/encodeInto.any.js` covers each typed array type and `DataView` (24 subtests that were failing).

## Cause

`jsTextEncoderPrototypeFunction_encodeIntoBody` in `JSTextEncoder.cpp` downcast the destination with `dynamicDowncast<JSC::JSArrayBufferView>`, which matches every typed array and `DataView`.

## Fix

Downcast to `JSC::JSUint8Array` and throw `ERR_INVALID_ARG_TYPE` with the same message Node produces. `Uint8Array` (including `Buffer`) and `Uint8Array` over `SharedArrayBuffer` continue to work.

## Verification

- New `it.each` in `text-encoder.test.js` covers all typed arrays, `DataView`, `ArrayBuffer`, `SharedArrayBuffer`, plain object, array and `null`: all fail on released Bun, all pass on this build.
- Positive coverage: `Uint8Array`, `Buffer`, and `Uint8Array` backed by `SharedArrayBuffer` still encode.
- Full `text-encoder.test.js`: 62 pass / 0 fail.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 18 failed, 12 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/integration/bun-types/bun-types.test.ts test/js/web/encoding/text-encoder.test.js
bun test v1.4.0 (4d6c3e240)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [11.08ms]
(skip) @types/bun integration test > basic type checks > checks without lib.dom.d.ts
(skip) @types/bun integration test > tsgo (TypeScript 7 native preview) > checks without lib.dom.d.ts
(pass) @types/bun integration test > Bun.mmap > MMapOptions accepts offset and size [2100.35ms]
(skip) @types/bun integration test > Test Globals > checks without lib.dom.d.ts and test-globals references
(skip) @types/bun integration test > Test Globals > test-globals FAILS when the test-globals.d.ts is not referenced
(skip) @types/bun integration test > bun:bundle feature() > Registry augmentation restricts feature() to known flags
(skip) @types/bun integration test > bun:bundle feature() > Registry augmentation produces type errors for invalid flags
(skip) @types/bun integration test > bun:bundle feature() > w
... (truncated)

release without fix: 18 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [0.39ms]
(pass) @types/bun integration test > basic type checks > checks without lib.dom.d.ts [3781.70ms]
(pass) @types/bun integration test > tsgo (TypeScript 7 native preview) > checks without lib.dom.d.ts [667.28ms]
(pass) @types/bun integration test > Bun.mmap > MMapOptions accepts offset and size [79.00ms]
(pass) @types/bun integration test > Test Globals > checks without lib.dom.d.ts and test-globals references [2596.31ms]
(pass) @types/bun integration test > Test Globals > test-globals FAILS when the test-globals.d.ts is not referenced [2494.77ms]
(pass) @types/bun integration test > bun:bundle feature() > Registry augmentation restricts feature() to known flags [2655.95ms]
(pass) @types/bun integration test > bun:bundle feature() > Registry augmentation produces type errors for invalid flags [2716.05ms]
(pass) @types/bun integration test > bun:bundle feature() > without Registry augmentation, feature() accepts any string [2830.95ms]
(pass) @types/bun integration test > Bunland reaching for JSX > Bun.mark
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 12 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/integration/bun-types/bun-types.test.ts test/js/web/encoding/text-encoder.test.js
bun test v1.4.0 (4d6c3e240)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [7.79ms]
(skip) @types/bun integration test > basic type checks > checks without lib.dom.d.ts
(skip) @types/bun integration test > tsgo (TypeScript 7 native preview) > checks without lib.dom.d.ts
(pass) @types/bun integration test > Bun.mmap > MMapOptions accepts offset and size [1497.08ms]
(skip) @types/bun integration test > Test Globals > checks without lib.dom.d.ts and test-globals references
(skip) @types/bun integration test > Test Globals > test-globals FAILS when the test-globals.d.ts is not referenced
(skip) @types/bun integration test > bun:bundle feature() > Registry augmentation restricts feature() to known flags
(skip) @types/bun integration test > bun:bundle feature() > Registry augmentation produces type errors for invalid flags
(skip) @types/bun integration test > bun:bundle feature() > wi
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4d6c3e240d
  features     baseline

22 deps, 108 codegen, 1171 objects in 996ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [5.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [2.00ms]
[3/1234] gen ErrorCode+*.h
[4/1234] gen bindgenv2
[5/1234] fetch picohttpparser
[picohttpparser] up to date
[6/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [46.00ms]
[7/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1234] fetch tinycc
[tinycc] up to date
[9/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1234] fetch zlib
[zlib] u
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/globals.d.ts              |  2 +-
 src/jsc/bindings/webcore/JSTextEncoder.cpp   |  6 ++--
 test/integration/bun-types/bun-types.test.ts |  2 +-
 test/integration/bun-types/fixture/spawn.ts  |  4 ---
 test/js/web/encoding/text-encoder.test.js    | 48 ++++++++++++++++++++++++++++
 5 files changed, 53 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
packages/bun-types/globals.d.ts                   1      1      0
src/jsc/bindings/webcore/JSTextEncoder.cpp        1      2      0
test/integration/bun-types/bun-types.test.ts      1      1      0
test/integration/bun-types/fixture/spawn.ts       1      1      0
test/js/web/encoding/text-encoder.test.js         1      1      0
```

</details>

<!-- robobun:evidence:end -->