### PR TITLE
process.env: coerce assigned values to strings across all construction paths

### DIFF
--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -492,7 +492,9 @@ export function windowsEnv(
     set(_, p, value) {
       const k = String(p).toUpperCase();
       $assert(typeof p === "string"); // proxy is only string and symbol. the symbol would have thrown by now
-      value = String(value); // If toString() throws, we want to avoid it existing in the envMapList
+      // Spec ToString, not String(): Symbol values must throw TypeError (Node.js
+      // behavior), and a throwing toString() must fire before envMapList is touched.
+      value = `${value}`;
       // Track the key for enumeration if it isn't already there. Don't gate on
       // `k in internalEnv`: the proxy-related env-var accessors (HTTP_PROXY,
       // HTTPS_PROXY, NO_PROXY and lowercase variants) always exist on
@@ -533,7 +535,7 @@ export function windowsEnv(
       // Node coerces env values to strings on defineProperty too, same as assignment.
       let coerced: string | undefined;
       if ("value" in attributes) {
-        coerced = String(attributes.value);
+        coerced = `${attributes.value}`;
         attributes = { ...attributes, value: coerced };
       }
       $Object.$defineProperty(internalEnv, k, attributes);

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -536,12 +536,12 @@ export function windowsEnv(
         coerced = String(attributes.value);
         attributes = { ...attributes, value: coerced };
       }
-      if (!(k in internalEnv) && !envMapList.includes(p)) {
+      $Object.$defineProperty(internalEnv, k, attributes);
+      // Sync the new value and record the key for enumeration only after a
+      // successful define, so a failed define leaves no phantom state.
+      if (!envMapList.includes(p) && !envMapList.some(x => x.toUpperCase() === k)) {
         envMapList.push(p);
       }
-      $Object.$defineProperty(internalEnv, k, attributes);
-      // Sync the new value after a successful define so the OS env sees it (the
-      // pre-define internalEnv[k] was the old value, or undefined for a new key).
       if (coerced !== undefined) editWindowsEnvVar(k, coerced);
       return true;
     },

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -531,14 +531,19 @@ export function windowsEnv(
       const k = String(p).toUpperCase();
       $assert(typeof p === "string"); // proxy is only string and symbol. the symbol would have thrown by now
       // Node coerces env values to strings on defineProperty too, same as assignment.
+      let coerced: string | undefined;
       if ("value" in attributes) {
-        attributes = { ...attributes, value: String(attributes.value) };
+        coerced = String(attributes.value);
+        attributes = { ...attributes, value: coerced };
       }
       if (!(k in internalEnv) && !envMapList.includes(p)) {
         envMapList.push(p);
       }
-      editWindowsEnvVar(k, internalEnv[k]);
-      return $Object.$defineProperty(internalEnv, k, attributes);
+      $Object.$defineProperty(internalEnv, k, attributes);
+      // Sync the new value after a successful define so the OS env sees it (the
+      // pre-define internalEnv[k] was the old value, or undefined for a new key).
+      if (coerced !== undefined) editWindowsEnvVar(k, coerced);
+      return true;
     },
     getOwnPropertyDescriptor(target, p) {
       if (typeof p === "string") {

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -530,6 +530,10 @@ export function windowsEnv(
     defineProperty(_, p, attributes) {
       const k = String(p).toUpperCase();
       $assert(typeof p === "string"); // proxy is only string and symbol. the symbol would have thrown by now
+      // Node coerces env values to strings on defineProperty too, same as assignment.
+      if ("value" in attributes) {
+        attributes = { ...attributes, value: String(attributes.value) };
+      }
       if (!(k in internalEnv) && !envMapList.includes(p)) {
         envMapList.push(p);
       }

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -744,13 +744,9 @@ RefPtr<SharedEnvStore> ensureSharedEnvStoreForWorker(Zig::GlobalObject* globalOb
     return store;
 }
 
-#if !OS(WINDOWS)
-// The default (non-SHARE_ENV) process.env object. Identical to a plain object for
-// reads, but overrides put/putByIndex/defineOwnProperty so every assigned value is
-// coerced to a string before it lands, matching Node.js (`process.env.x = 42` reads
-// back as "42", `= undefined` reads back as "undefined" rather than deleting).
-// Windows keeps a plain object: the windowsEnv Proxy's set/defineProperty traps do
-// the coercion there, and also store own functions (toJSON) on the target directly.
+// Default (non-SHARE_ENV) process.env: plain object for reads, with put/putByIndex/
+// defineOwnProperty overridden to toString() the value first so `= 42` reads back
+// "42" and `= undefined` reads back "undefined", matching Node.js.
 class JSProcessEnvMap final : public JSC::JSNonFinalObject {
 public:
     using Base = JSC::JSNonFinalObject;
@@ -838,7 +834,13 @@ bool JSProcessEnvMap::defineOwnProperty(JSObject* object, JSGlobalObject* global
     coerced.setValue(string);
     RELEASE_AND_RETURN(scope, Base::defineOwnProperty(object, globalObject, propertyName, coerced, shouldThrow));
 }
-#endif
+
+JSObject* createProcessEnvMapObject(Zig::GlobalObject* globalObject)
+{
+    VM& vm = globalObject->vm();
+    auto* structure = JSProcessEnvMap::createStructure(vm, globalObject, globalObject->objectPrototype());
+    return JSProcessEnvMap::create(vm, structure);
+}
 
 JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
 {
@@ -848,9 +850,8 @@ JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
     void* list;
     size_t count = Bun__getEnvCount(globalObject, &list);
 #if OS(WINDOWS)
-    // Windows wraps this object in the windowsEnv Proxy whose set/defineProperty
-    // traps already coerce values, and which stores own functions (toJSON,
-    // inspect.custom) on it directly. Keep it a plain object so those survive.
+    // The windowsEnv Proxy's set/defineProperty traps coerce, and windowsEnv()
+    // stores a toJSON function on this object directly: keep it a plain object.
     JSC::JSObject* object = nullptr;
     if (count < 63) {
         object = constructEmptyObject(globalObject, globalObject->objectPrototype(), count);
@@ -860,8 +861,7 @@ JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
     JSArray* keyArray = constructEmptyArray(globalObject, nullptr, count);
     RETURN_IF_EXCEPTION(scope, {});
 #else
-    auto* structure = JSProcessEnvMap::createStructure(vm, globalObject, globalObject->objectPrototype());
-    JSC::JSObject* object = JSProcessEnvMap::create(vm, structure);
+    JSC::JSObject* object = createProcessEnvMapObject(globalObject);
 #endif
 
     static NeverDestroyed<String> TZ = MAKE_STATIC_STRING_IMPL("TZ");

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -744,6 +744,98 @@ RefPtr<SharedEnvStore> ensureSharedEnvStoreForWorker(Zig::GlobalObject* globalOb
     return store;
 }
 
+// The default (non-SHARE_ENV) process.env object. Identical to a plain object for
+// reads, but overrides put/putByIndex/defineOwnProperty so every assigned value is
+// coerced to a string before it lands, matching Node.js (`process.env.x = 42` reads
+// back as "42", `= undefined` reads back as "undefined" rather than deleting).
+class JSProcessEnvMap final : public JSC::JSNonFinalObject {
+public:
+    using Base = JSC::JSNonFinalObject;
+
+    static constexpr unsigned StructureFlags = Base::StructureFlags | JSC::OverridesPut;
+
+    template<typename CellType, JSC::SubspaceAccess>
+    static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
+    {
+        STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSProcessEnvMap, Base);
+        return &vm.plainObjectSpace();
+    }
+
+    DECLARE_INFO;
+
+    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+    {
+        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
+    }
+
+    static JSProcessEnvMap* create(JSC::VM& vm, JSC::Structure* structure)
+    {
+        JSProcessEnvMap* ptr = new (NotNull, JSC::allocateCell<JSProcessEnvMap>(vm)) JSProcessEnvMap(vm, structure);
+        ptr->finishCreation(vm);
+        return ptr;
+    }
+
+    static bool put(JSCell*, JSGlobalObject*, JSC::PropertyName, JSC::JSValue, JSC::PutPropertySlot&);
+    static bool putByIndex(JSCell*, JSGlobalObject*, unsigned, JSC::JSValue, bool shouldThrow);
+    static bool defineOwnProperty(JSObject*, JSGlobalObject*, JSC::PropertyName, const JSC::PropertyDescriptor&, bool shouldThrow);
+
+private:
+    JSProcessEnvMap(JSC::VM& vm, JSC::Structure* structure)
+        : Base(vm, structure)
+    {
+    }
+
+    void finishCreation(JSC::VM& vm)
+    {
+        Base::finishCreation(vm);
+    }
+};
+
+const JSC::ClassInfo JSProcessEnvMap::s_info = { "ProcessEnv"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSProcessEnvMap) };
+
+bool JSProcessEnvMap::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, JSValue value, PutPropertySlot& slot)
+{
+    VM& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (propertyName.isSymbol()) {
+        RELEASE_AND_RETURN(scope, Base::put(cell, globalObject, propertyName, value, slot));
+    }
+
+    JSString* string = value.toString(globalObject);
+    RETURN_IF_EXCEPTION(scope, false);
+
+    RELEASE_AND_RETURN(scope, Base::put(cell, globalObject, propertyName, string, slot));
+}
+
+bool JSProcessEnvMap::putByIndex(JSCell* cell, JSGlobalObject* globalObject, unsigned index, JSValue value, bool shouldThrow)
+{
+    VM& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSString* string = value.toString(globalObject);
+    RETURN_IF_EXCEPTION(scope, false);
+
+    RELEASE_AND_RETURN(scope, Base::putByIndex(cell, globalObject, index, string, shouldThrow));
+}
+
+bool JSProcessEnvMap::defineOwnProperty(JSObject* object, JSGlobalObject* globalObject, PropertyName propertyName, const PropertyDescriptor& descriptor, bool shouldThrow)
+{
+    VM& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (propertyName.isSymbol() || !descriptor.isDataDescriptor() || !descriptor.value()) {
+        RELEASE_AND_RETURN(scope, Base::defineOwnProperty(object, globalObject, propertyName, descriptor, shouldThrow));
+    }
+
+    JSString* string = descriptor.value().toString(globalObject);
+    RETURN_IF_EXCEPTION(scope, false);
+
+    PropertyDescriptor coerced(descriptor);
+    coerced.setValue(string);
+    RELEASE_AND_RETURN(scope, Base::defineOwnProperty(object, globalObject, propertyName, coerced, shouldThrow));
+}
+
 JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
 {
     VM& vm = globalObject->vm();
@@ -751,12 +843,8 @@ JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
 
     void* list;
     size_t count = Bun__getEnvCount(globalObject, &list);
-    JSC::JSObject* object = nullptr;
-    if (count < 63) {
-        object = constructEmptyObject(globalObject, globalObject->objectPrototype(), count);
-    } else {
-        object = constructEmptyObject(globalObject, globalObject->objectPrototype());
-    }
+    auto* structure = JSProcessEnvMap::createStructure(vm, globalObject, globalObject->objectPrototype());
+    JSC::JSObject* object = JSProcessEnvMap::create(vm, structure);
 
 #if OS(WINDOWS)
     JSArray* keyArray = constructEmptyArray(globalObject, nullptr, count);

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -842,6 +842,11 @@ JSObject* createProcessEnvMapObject(Zig::GlobalObject* globalObject)
     return JSProcessEnvMap::create(vm, structure);
 }
 
+bool isEnvironmentVariablesMapObject(const JSC::ClassInfo* info)
+{
+    return info == JSProcessEnvMap::info() || info == JSSharedEnvMap::info();
+}
+
 JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
 {
     VM& vm = globalObject->vm();

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -744,10 +744,13 @@ RefPtr<SharedEnvStore> ensureSharedEnvStoreForWorker(Zig::GlobalObject* globalOb
     return store;
 }
 
+#if !OS(WINDOWS)
 // The default (non-SHARE_ENV) process.env object. Identical to a plain object for
 // reads, but overrides put/putByIndex/defineOwnProperty so every assigned value is
 // coerced to a string before it lands, matching Node.js (`process.env.x = 42` reads
 // back as "42", `= undefined` reads back as "undefined" rather than deleting).
+// Windows keeps a plain object: the windowsEnv Proxy's set/defineProperty traps do
+// the coercion there, and also store own functions (toJSON) on the target directly.
 class JSProcessEnvMap final : public JSC::JSNonFinalObject {
 public:
     using Base = JSC::JSNonFinalObject;
@@ -835,6 +838,7 @@ bool JSProcessEnvMap::defineOwnProperty(JSObject* object, JSGlobalObject* global
     coerced.setValue(string);
     RELEASE_AND_RETURN(scope, Base::defineOwnProperty(object, globalObject, propertyName, coerced, shouldThrow));
 }
+#endif
 
 JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
 {
@@ -843,12 +847,21 @@ JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
 
     void* list;
     size_t count = Bun__getEnvCount(globalObject, &list);
-    auto* structure = JSProcessEnvMap::createStructure(vm, globalObject, globalObject->objectPrototype());
-    JSC::JSObject* object = JSProcessEnvMap::create(vm, structure);
-
 #if OS(WINDOWS)
+    // Windows wraps this object in the windowsEnv Proxy whose set/defineProperty
+    // traps already coerce values, and which stores own functions (toJSON,
+    // inspect.custom) on it directly. Keep it a plain object so those survive.
+    JSC::JSObject* object = nullptr;
+    if (count < 63) {
+        object = constructEmptyObject(globalObject, globalObject->objectPrototype(), count);
+    } else {
+        object = constructEmptyObject(globalObject, globalObject->objectPrototype());
+    }
     JSArray* keyArray = constructEmptyArray(globalObject, nullptr, count);
     RETURN_IF_EXCEPTION(scope, {});
+#else
+    auto* structure = JSProcessEnvMap::createStructure(vm, globalObject, globalObject->objectPrototype());
+    JSC::JSObject* object = JSProcessEnvMap::create(vm, structure);
 #endif
 
     static NeverDestroyed<String> TZ = MAKE_STATIC_STRING_IMPL("TZ");

--- a/src/jsc/bindings/JSEnvironmentVariableMap.h
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.h
@@ -13,6 +13,10 @@ namespace Bun {
 
 JSC::JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject);
 
+// Bare JSProcessEnvMap (no OS-env getters, no Windows Proxy wrap): coerces
+// assigned values to strings like Node.js. For worker env: {...} snapshots.
+JSC::JSObject* createProcessEnvMapObject(Zig::GlobalObject* globalObject);
+
 // worker_threads SHARE_ENV: a `process.env` whose reads/writes/enumeration go
 // through the SharedEnvStore of the tree its global belongs to.
 JSC::JSValue createSharedEnvironmentVariablesMap(Zig::GlobalObject* globalObject);

--- a/src/jsc/bindings/JSEnvironmentVariableMap.h
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.h
@@ -17,6 +17,10 @@ JSC::JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject);
 // assigned values to strings like Node.js. For worker env: {...} snapshots.
 JSC::JSObject* createProcessEnvMapObject(Zig::GlobalObject* globalObject);
 
+// True for JSProcessEnvMap/JSSharedEnvMap classInfo; both structured-clone like
+// a plain object (Node.js structuredClone(process.env) succeeds).
+bool isEnvironmentVariablesMapObject(const JSC::ClassInfo*);
+
 // worker_threads SHARE_ENV: a `process.env` whose reads/writes/enumeration go
 // through the SharedEnvStore of the tree its global belongs to.
 JSC::JSValue createSharedEnvironmentVariablesMap(Zig::GlobalObject* globalObject);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -566,7 +566,7 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
                     strings.append(jsString(vm, value));
                 }
 
-                auto env = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), size >= JSFinalObject::maxInlineCapacity ? JSFinalObject::maxInlineCapacity : size);
+                auto env = Bun::createProcessEnvMapObject(globalObject);
                 size_t i = 0;
                 for (auto k : map) {
                     // They can have environment variables with numbers as keys.

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -566,12 +566,17 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
                     strings.append(jsString(vm, value));
                 }
 
+                // JSProcessEnvMap is a JSNonFinalObject, so indexed putDirectMayBeIndex
+                // routes through the method-table defineOwnProperty with a throw scope;
+                // a top scope keeps exception-check validation balanced.
+                auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
                 auto env = Bun::createProcessEnvMapObject(globalObject);
                 size_t i = 0;
                 for (auto k : map) {
                     // They can have environment variables with numbers as keys.
                     // So we must use putDirectMayBeIndex to handle that.
                     env->putDirectMayBeIndex(globalObject, JSC::Identifier::fromString(vm, WTF::move(k.key)), strings.at(i++));
+                    scope.assertNoException();
                 }
                 globalObject->m_processEnvObject.set(vm, globalObject, env);
             } else if (options.sharedEnvStore) {

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -120,6 +120,7 @@
 #include "CryptoKeyType.h"
 #include "JSNodePerformanceHooksHistogram.h"
 #include "../napi.h"
+#include "../JSEnvironmentVariableMap.h"
 #include <limits>
 #include <algorithm>
 
@@ -2812,7 +2813,9 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
             // like a plain object from JS's perspective (matches Node.js).
             // ObjectPrototype is allowed because %Object.prototype% is an immutable
             // prototype exotic object that the spec carves out of this rejection.
-            if (inObject->classInfo() != JSFinalObject::info() && inObject->classInfo() != Zig::NapiPrototype::info() && inObject->classInfo() != JSC::ObjectPrototype::info())
+            // process.env (JSProcessEnvMap / JSSharedEnvMap) is allowed because
+            // Node.js structured-clones it as a plain object of its string entries.
+            if (inObject->classInfo() != JSFinalObject::info() && inObject->classInfo() != Zig::NapiPrototype::info() && inObject->classInfo() != JSC::ObjectPrototype::info() && !Bun::isEnvironmentVariablesMapObject(inObject->classInfo()))
                 return SerializationReturnCode::DataCloneError;
             inputObjectStack.append(inObject);
             indexStack.append(0);

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -901,8 +901,7 @@ for (const shell of ["system", "bun"]) {
   });
 }
 
-const todoOnPosix = process.platform !== "win32" ? test.todo : test;
-todoOnPosix("setting process.env coerces the value to a string", () => {
+test("setting process.env coerces the value to a string", () => {
   // @ts-expect-error
   process.env.SET_TO_TRUE = true;
   let did_call = 0;

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -902,19 +902,24 @@ for (const shell of ["system", "bun"]) {
 }
 
 test("setting process.env coerces the value to a string", () => {
-  // @ts-expect-error
-  process.env.SET_TO_TRUE = true;
-  let did_call = 0;
-  // @ts-expect-error
-  process.env.SET_TO_BUN = {
-    toString() {
-      did_call++;
-      return "bun!";
-    },
-  };
-  expect(process.env.SET_TO_TRUE).toBe("true");
-  expect(process.env.SET_TO_BUN).toBe("bun!");
-  expect(did_call).toBe(1);
+  try {
+    // @ts-expect-error
+    process.env.SET_TO_TRUE = true;
+    let did_call = 0;
+    // @ts-expect-error
+    process.env.SET_TO_BUN = {
+      toString() {
+        did_call++;
+        return "bun!";
+      },
+    };
+    expect(process.env.SET_TO_TRUE).toBe("true");
+    expect(process.env.SET_TO_BUN).toBe("bun!");
+    expect(did_call).toBe(1);
+  } finally {
+    delete process.env.SET_TO_TRUE;
+    delete process.env.SET_TO_BUN;
+  }
 });
 
 test("NODE_ENV=test loads .env.test even when .env.production exists", () => {

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -274,7 +274,16 @@ it("process.env coerces assigned values to strings", () => {
     }).toThrow("boom");
     expect(process.env.COERCE_THROWS).toBeUndefined();
   } finally {
-    for (const k of ["COERCE_UNDEF", "COERCE_NUM", "COERCE_NULL", "COERCE_BOOL", "COERCE_OBJ", "COERCE_DEF", "COERCE_THROWS", "4242424242"]) {
+    for (const k of [
+      "COERCE_UNDEF",
+      "COERCE_NUM",
+      "COERCE_NULL",
+      "COERCE_BOOL",
+      "COERCE_OBJ",
+      "COERCE_DEF",
+      "COERCE_THROWS",
+      "4242424242",
+    ]) {
       delete process.env[k];
     }
   }

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -231,6 +231,55 @@ it("process.env is spreadable and editable", () => {
   expect(eval(`globalThis.process.env.USER = "${orig}"`)).toBe(String(orig));
 });
 
+it("process.env coerces assigned values to strings", () => {
+  try {
+    process.env.COERCE_UNDEF = "initial";
+    process.env.COERCE_UNDEF = undefined;
+    process.env.COERCE_NUM = 42;
+    process.env.COERCE_NULL = null;
+    process.env.COERCE_BOOL = true;
+    process.env.COERCE_OBJ = { toString: () => "from-toString" };
+    process.env["4242424242"] = 55;
+    Object.defineProperty(process.env, "COERCE_DEF", {
+      value: 7,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+
+    expect({
+      undef: process.env.COERCE_UNDEF,
+      num: process.env.COERCE_NUM,
+      null: process.env.COERCE_NULL,
+      bool: process.env.COERCE_BOOL,
+      obj: process.env.COERCE_OBJ,
+      idx: process.env["4242424242"],
+      def: process.env.COERCE_DEF,
+    }).toEqual({
+      undef: "undefined",
+      num: "42",
+      null: "null",
+      bool: "true",
+      obj: "from-toString",
+      idx: "55",
+      def: "7",
+    });
+
+    expect(() => {
+      process.env.COERCE_THROWS = {
+        toString() {
+          throw new Error("boom");
+        },
+      };
+    }).toThrow("boom");
+    expect(process.env.COERCE_THROWS).toBeUndefined();
+  } finally {
+    for (const k of ["COERCE_UNDEF", "COERCE_NUM", "COERCE_NULL", "COERCE_BOOL", "COERCE_OBJ", "COERCE_DEF", "COERCE_THROWS", "4242424242"]) {
+      delete process.env[k];
+    }
+  }
+});
+
 const MIN_ICU_VERSIONS_BY_PLATFORM_ARCH = {
   "darwin-x64": "70.1",
   "darwin-arm64": "72.1",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -273,6 +273,8 @@ it("process.env coerces assigned values to strings", () => {
       };
     }).toThrow("boom");
     expect(process.env.COERCE_THROWS).toBeUndefined();
+
+    expect(structuredClone(process.env).COERCE_NUM).toBe("42");
   } finally {
     for (const k of [
       "COERCE_UNDEF",
@@ -301,8 +303,10 @@ it("process.env coerces assigned values to strings in a worker with an explicit 
           process.env.Y = undefined;
           Object.defineProperty(process.env, "Z", { value: 7, writable: true, enumerable: true, configurable: true });
           require("worker_threads").parentPort.postMessage({
+            SEED: process.env.SEED,
             X: process.env.X, Y: process.env.Y, Z: process.env.Z,
             xt: typeof process.env.X, yt: typeof process.env.Y, zt: typeof process.env.Z,
+            clone: structuredClone(process.env),
           });\`,
          { eval: true, env: { SEED: "seed" } },
        );
@@ -313,9 +317,19 @@ it("process.env coerces assigned values to strings in a worker with an explicit 
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(JSON.parse(stdout)).toEqual({ X: "42", Y: "undefined", Z: "7", xt: "string", yt: "string", zt: "string" });
-  expect(exitCode).toBe(0);
+  expect({ result: JSON.parse(stdout.trim() || stderr), exitCode }).toEqual({
+    result: {
+      SEED: "seed",
+      X: "42",
+      Y: "undefined",
+      Z: "7",
+      xt: "string",
+      yt: "string",
+      zt: "string",
+      clone: { SEED: "seed", X: "42", Y: "undefined", Z: "7" },
+    },
+    exitCode: 0,
+  });
 });
 
 const MIN_ICU_VERSIONS_BY_PLATFORM_ARCH = {

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -289,6 +289,35 @@ it("process.env coerces assigned values to strings", () => {
   }
 });
 
+it("process.env coerces assigned values to strings in a worker with an explicit env", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const { Worker } = require("worker_threads");
+       const w = new Worker(
+         \`process.env.X = 42;
+          process.env.Y = "y";
+          process.env.Y = undefined;
+          Object.defineProperty(process.env, "Z", { value: 7, writable: true, enumerable: true, configurable: true });
+          require("worker_threads").parentPort.postMessage({
+            X: process.env.X, Y: process.env.Y, Z: process.env.Z,
+            xt: typeof process.env.X, yt: typeof process.env.Y, zt: typeof process.env.Z,
+          });\`,
+         { eval: true, env: { SEED: "seed" } },
+       );
+       w.on("message", m => { console.log(JSON.stringify(m)); });
+       w.on("error", e => { console.error(String(e)); process.exitCode = 1; });`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({ X: "42", Y: "undefined", Z: "7", xt: "string", yt: "string", zt: "string" });
+  expect(exitCode).toBe(0);
+});
+
 const MIN_ICU_VERSIONS_BY_PLATFORM_ARCH = {
   "darwin-x64": "70.1",
   "darwin-arm64": "72.1",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -274,7 +274,11 @@ it("process.env coerces assigned values to strings", () => {
     }).toThrow("boom");
     expect(process.env.COERCE_THROWS).toBeUndefined();
 
-    expect(structuredClone(process.env).COERCE_NUM).toBe("42");
+    // structuredClone(process.env) must keep working now that the backing object
+    // has its own ClassInfo. Windows wraps it in a Proxy that was never clonable.
+    if (!isWindows) {
+      expect(structuredClone(process.env).COERCE_NUM).toBe("42");
+    }
   } finally {
     for (const k of [
       "COERCE_UNDEF",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -238,8 +238,12 @@ it("process.env coerces assigned values to strings", () => {
     process.env.COERCE_NUM = 42;
     process.env.COERCE_NULL = null;
     process.env.COERCE_BOOL = true;
+    process.env.COERCE_BIG = 42n;
+    process.env.COERCE_ARR = [1, 2];
+    process.env.COERCE_FN = function f() {};
     process.env.COERCE_OBJ = { toString: () => "from-toString" };
     process.env["4242424242"] = 55;
+    Object.assign(process.env, { COERCE_ASN: 7 });
     Object.defineProperty(process.env, "COERCE_DEF", {
       value: 7,
       writable: true,
@@ -252,18 +256,29 @@ it("process.env coerces assigned values to strings", () => {
       num: process.env.COERCE_NUM,
       null: process.env.COERCE_NULL,
       bool: process.env.COERCE_BOOL,
+      big: process.env.COERCE_BIG,
+      arr: process.env.COERCE_ARR,
+      fn: process.env.COERCE_FN,
       obj: process.env.COERCE_OBJ,
       idx: process.env["4242424242"],
+      asn: process.env.COERCE_ASN,
       def: process.env.COERCE_DEF,
     }).toEqual({
       undef: "undefined",
       num: "42",
       null: "null",
       bool: "true",
+      big: "42",
+      arr: "1,2",
+      fn: String(function f() {}),
       obj: "from-toString",
       idx: "55",
+      asn: "7",
       def: "7",
     });
+
+    expect(Object.values(process.env).every(v => typeof v === "string")).toBe(true);
+    expect(JSON.parse(JSON.stringify(process.env)).COERCE_BIG).toBe("42");
 
     expect(() => {
       process.env.COERCE_THROWS = {
@@ -273,6 +288,19 @@ it("process.env coerces assigned values to strings", () => {
       };
     }).toThrow("boom");
     expect(process.env.COERCE_THROWS).toBeUndefined();
+
+    // Node throws on Symbol values (ToString on Symbol throws) for set, assign, and defineProperty.
+    expect(() => (process.env.COERCE_SYM = Symbol("s"))).toThrow(TypeError);
+    expect(() => Object.assign(process.env, { COERCE_SYM: Symbol("s") })).toThrow(TypeError);
+    expect(() =>
+      Object.defineProperty(process.env, "COERCE_SYM", {
+        value: Symbol("s"),
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      }),
+    ).toThrow(TypeError);
+    expect(process.env.COERCE_SYM).toBeUndefined();
 
     // structuredClone(process.env) must keep working now that the backing object
     // has its own ClassInfo. Windows wraps it in a Proxy that was never clonable.
@@ -285,9 +313,14 @@ it("process.env coerces assigned values to strings", () => {
       "COERCE_NUM",
       "COERCE_NULL",
       "COERCE_BOOL",
+      "COERCE_BIG",
+      "COERCE_ARR",
+      "COERCE_FN",
       "COERCE_OBJ",
+      "COERCE_ASN",
       "COERCE_DEF",
       "COERCE_THROWS",
+      "COERCE_SYM",
       "4242424242",
     ]) {
       delete process.env[k];


### PR DESCRIPTION
Node.js documents that every `process.env` assignment coerces the value to a string. Bun stored the value verbatim on two of the three construction paths, so assigning a non-string read back as the raw value:

```js
process.env.NUM = 1; process.env.BOOL = true; process.env.BIG = 42n;
Object.assign(process.env, { ASN: 7 });
console.log([process.env.NUM, process.env.BOOL, process.env.BIG, process.env.ASN].map(v => typeof v));
// bun: ["number","boolean","bigint","number"]   node: all "string"
process.env.SYM = Symbol("s");                   // bun: stored; node: TypeError
JSON.stringify(process.env);                     // bun: TypeError (BigInt); node: ok
```

Two user-visible consequences beyond the raw readback: after a BigInt assignment, `JSON.stringify(process.env)` throws for the rest of the process (breaking error reporters and config dumpers); and `process.env.X = Symbol()` is silently accepted instead of throwing like Node.

### Cause

`process.env` is built in three places, only one of which coerced on assignment:

- `createEnvironmentVariablesMap` (main thread, default): a plain `JSObject` populated with `CustomValue` getters for lazy OS-env reads. Those getters have no setter, so writes went straight to `JSObject::put` and stored whatever `JSValue` arrived. On Windows the same object is wrapped in the `windowsEnv` Proxy whose `set` trap called `String(value)`, which coerces everything but special-cases Symbol (returns `"Symbol(s)"` instead of throwing).
- `ZigGlobalObject` `initializeWorker` with `{ env: {...} }`: a plain `constructEmptyObject` assigned directly to `m_processEnvObject`, bypassing `createEnvironmentVariablesMap` on every platform.
- `JSSharedEnvMap` (SHARE_ENV): already coerced via `toWTFString` in its `put` hook.

### Fix

- Introduce `JSProcessEnvMap`, a `JSNonFinalObject` subclass whose `put`/`putByIndex`/`defineOwnProperty` call `value.toString()` (spec `ToString`: throws on Symbol) before delegating to `Base`. Symbol keys fall through unchanged, matching `JSSharedEnvMap::put`.
- `createEnvironmentVariablesMap` uses it on POSIX. Windows keeps a plain object as the Proxy target, because `windowsEnv()` stores `toJSON` as an own function on that object directly and the Proxy's traps already coerce.
- The Windows `set`/`defineProperty` traps now use template-literal coercion instead of `String()` so Symbol values throw `TypeError` the same as POSIX and Node. The `defineProperty` trap now also syncs the *new* value to the OS env after a successful define (it previously synced the old value or `undefined`, which tripped a debug `ASSERT`).
- The worker-with-explicit-`env` path at `ZigGlobalObject.cpp` builds its object via a new `createProcessEnvMapObject()` factory, so workers on every platform coerce.
- `SerializedScriptValue` whitelists the new class so `structuredClone(process.env)` keeps working.

### Verification

- `test/js/node/process/process.test.js`: new "process.env coerces assigned values to strings" case covering number, boolean, `null`, `undefined`, BigInt, array, function, object with `toString`, `Object.assign`, indexed key, `Object.defineProperty`, a throwing `toString`, Symbol-throws on all three paths, the `Object.values(process.env)` all-string invariant, and `JSON.stringify(process.env)` after a BigInt write; plus "... in a worker with an explicit env". Both fail on main, pass with the fix.
- `test/cli/run/env.test.ts`: un-todos the pre-existing "setting process.env coerces the value to a string" test, which was `todoOnPosix` for exactly this reason.
- `test/js/node/worker_threads/worker_threads.test.ts`: all SHARE_ENV tests still pass.

Related: #31831 is a broader process-compat omnibus that includes this among many other fixes; #34727 adds `defineOwnProperty` descriptor validation to the same class. Whichever lands first, the others rebase over it.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/env.test.ts test/js/node/process/process.test.js

<!-- robobun:evidence:end -->