### PR TITLE
node:http2: propagate the user's exception when a header value's toString() throws

### DIFF
--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -7943,20 +7943,7 @@ impl H2FrameParser {
                         return Err(global_object.throw_value(exception));
                     }
 
-                    let value_str = match item.to_js_string(global_object) {
-                        Ok(s) => s,
-                        Err(_) => {
-                            global_object.clear_exception();
-                            let exception = global_object.to_type_error(
-                                bun_jsc::ErrorCode::HTTP2_INVALID_HEADER_VALUE,
-                                format_args!(
-                                    "Invalid value for header \"{}\"",
-                                    BStr::new(validated_name)
-                                ),
-                            );
-                            return Err(global_object.throw_value(exception));
-                        }
-                    };
+                    let value_str = item.to_js_string(global_object)?;
 
                     // All-digit names can't be passed to get_truthy (integer-index-like names
                     // trip a debug assert in getIfPropertyExistsImpl) and can never be sensitive.
@@ -7990,20 +7977,7 @@ impl H2FrameParser {
                     }
                     single_value_headers[idx] = true;
                 }
-                let value_str = match js_value.to_js_string(global_object) {
-                    Ok(s) => s,
-                    Err(_) => {
-                        global_object.clear_exception();
-                        let exception = global_object.to_type_error(
-                            bun_jsc::ErrorCode::HTTP2_INVALID_HEADER_VALUE,
-                            format_args!(
-                                "Invalid value for header \"{}\"",
-                                BStr::new(validated_name)
-                            ),
-                        );
-                        return Err(global_object.throw_value(exception));
-                    }
-                };
+                let value_str = js_value.to_js_string(global_object)?;
 
                 // All-digit names can't be passed to get_truthy (integer-index-like names trip
                 // a debug assert in getIfPropertyExistsImpl) and can never be sensitive.
@@ -8374,18 +8348,7 @@ impl H2FrameParser {
                 if js_value.is_empty_or_undefined_or_null() {
                     continue;
                 }
-                let value_str = match js_value.to_js_string(global_object) {
-                    Ok(s) => s,
-                    Err(_) => {
-                        global_object.clear_exception();
-                        return Err(global_object
-                            .err(
-                                JscErrorCode::HTTP2_INVALID_HEADER_VALUE,
-                                format_args!("Invalid value for header \"{}\"", BStr::new(name)),
-                            )
-                            .throw());
-                    }
-                };
+                let value_str = js_value.to_js_string(global_object)?;
                 // All-digit names can't be passed to get_truthy (integer-index-like names trip
                 // a debug assert in getIfPropertyExistsImpl) and can never be sensitive.
                 let never_index = if Self::is_index_like_name(validated_name) {
@@ -8790,21 +8753,7 @@ impl H2FrameParser {
                         single_value_headers[idx] = true;
                     }
 
-                    let value_str = match value_js.to_js_string(global_object) {
-                        Ok(s) => s,
-                        Err(_) => {
-                            global_object.clear_exception();
-                            return Err(global_object
-                                .err(
-                                    JscErrorCode::HTTP2_INVALID_HEADER_VALUE,
-                                    format_args!(
-                                        "Invalid value for header \"{}\"",
-                                        BStr::new(name)
-                                    ),
-                                )
-                                .throw());
-                        }
-                    };
+                    let value_str = value_js.to_js_string(global_object)?;
 
                     let never_index = if Self::is_index_like_name(validated_name) {
                         false
@@ -8977,21 +8926,7 @@ impl H2FrameParser {
                             return Ok(JSValue::ZERO);
                         }
 
-                        let value_str = match item.to_js_string(global_object) {
-                            Ok(s) => s,
-                            Err(_) => {
-                                global_object.clear_exception();
-                                return Err(global_object
-                                    .err(
-                                        JscErrorCode::HTTP2_INVALID_HEADER_VALUE,
-                                        format_args!(
-                                            "Invalid value for header \"{}\"",
-                                            BStr::new(validated_name)
-                                        ),
-                                    )
-                                    .throw());
-                            }
-                        };
+                        let value_str = item.to_js_string(global_object)?;
 
                         let never_index = if Self::is_index_like_name(validated_name) {
                             false
@@ -9067,21 +9002,7 @@ impl H2FrameParser {
                         }
                         single_value_headers[idx] = true;
                     }
-                    let value_str = match js_value.to_js_string(global_object) {
-                        Ok(s) => s,
-                        Err(_) => {
-                            global_object.clear_exception();
-                            return Err(global_object
-                                .err(
-                                    JscErrorCode::HTTP2_INVALID_HEADER_VALUE,
-                                    format_args!(
-                                        "Invalid value for header \"{}\"",
-                                        BStr::new(name)
-                                    ),
-                                )
-                                .throw());
-                        }
-                    };
+                    let value_str = js_value.to_js_string(global_object)?;
 
                     let never_index = if Self::is_index_like_name(validated_name) {
                         false

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -2523,6 +2523,55 @@ it("http2 client.request() rejects header names longer than 4096 bytes with a ca
   expect(exitCode).toBe(0);
 });
 
+it("http2 client.request() propagates a throwing header-value toString() instead of masking it", async () => {
+  // Node calls `${value}` and lets the user's exception escape; it must not be
+  // replaced with ERR_HTTP2_INVALID_HEADER_VALUE.
+  const server = http2.createServer();
+  server.on("stream", stream => {
+    stream.respond({ ":status": 200 });
+    stream.end("ok");
+  });
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+  const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+  client.on("error", () => {});
+  await new Promise(resolve => client.once("connect", resolve));
+
+  try {
+    const boom = msg => ({
+      toString() {
+        throw new RangeError(msg);
+      },
+    });
+    const describeThrow = fn => {
+      try {
+        fn();
+        return { name: "<none>", code: "<none>", message: "<none>" };
+      } catch (e) {
+        return { name: e.constructor.name, code: e.code, message: e.message };
+      }
+    };
+
+    expect([
+      describeThrow(() => client.request({ ":path": "/", "x-a": boom("scalar") })),
+      describeThrow(() => client.request({ ":path": "/", "x-a": "ok", "x-b": boom("second") })),
+      describeThrow(() => client.request({ ":path": "/", "x-a": [boom("array0")] })),
+      describeThrow(() => client.request({ ":path": "/", "x-a": ["ok", boom("array1")] })),
+      describeThrow(() =>
+        client.request({ ":path": "/", "x-a": boom("sensitive"), [http2.sensitiveHeaders]: ["x-a"] }),
+      ),
+    ]).toEqual([
+      { name: "RangeError", code: undefined, message: "scalar" },
+      { name: "RangeError", code: undefined, message: "second" },
+      { name: "RangeError", code: undefined, message: "array0" },
+      { name: "RangeError", code: undefined, message: "array1" },
+      { name: "RangeError", code: undefined, message: "sensitive" },
+    ]);
+  } finally {
+    client.close();
+    server.close();
+  }
+});
+
 it("http2 server resets streams whose request headers contain CR, LF, or NUL octets", async () => {
   // RFC 9113 Section 8.2.1: a request carrying a field value with NUL, CR, or
   // LF is malformed and must be answered with a stream error, not delivered


### PR DESCRIPTION
## Reproduction

```js
import http2 from "node:http2";
const server = http2.createServer((req, res) => res.end("ok"));
await new Promise(r => server.listen(0, "127.0.0.1", r));
const session = http2.connect(`http://127.0.0.1:${server.address().port}`);
await new Promise(r => session.once("connect", r));
try {
  session.request({ ":path": "/", "x-a": { toString() { throw new RangeError("mine"); } } });
} catch (e) {
  console.log(e.constructor.name, e.code ?? "-", e.message);
}
session.close(); server.close();
```

```
node v26:  RangeError - mine
bun 1.4.0: TypeError ERR_HTTP2_INVALID_HEADER_VALUE Invalid value for header "x-a"
```

## Cause

Every `to_js_string()` error arm in the H2FrameParser header-write paths (`request`, `send_trailers`, `push_promise`; six sites) did `clear_exception()` and substituted `TypeError ERR_HTTP2_INVALID_HEADER_VALUE`. Node calls `` `${value}` `` and lets the user's exception escape from `session.request()` unchanged, so a throwing accessor in an application's header bag pointed at http2 instead of the user object.

## Fix

Propagate the original exception with `?`. The `null`/`undefined` arms already synthesize `ERR_HTTP2_INVALID_HEADER_VALUE` only when there is no pending exception; the `to_js_string()` failure path now matches.

## Verification

All five shapes (scalar, second-of-N, array first element, array second element, sensitive-marked) now surface the user's `RangeError` with the original message and no `.code`, matching Node v26.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (94fafbf38)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [925.92ms]
(pass) node none > Client Basics > should be able to send a POST request [653.48ms]
(pass) node none > Client Basics > constants [19.00ms]
(pass) node none > Client Basics > getDefaultSettings [8.13ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [26.21ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.75ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [4.36ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.60ms
... (truncated)

release without fix: 6 skipped
bun test v1.4.0-canary.1 (94fafbf38)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.92ms]
(pass) node none > Client Basics > getDefaultSettings [0.15ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.40ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.10ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.04ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.10ms]
(pass) node none > Client Basics > is possible to abort request [3.51ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.72ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.60ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [2.70ms]
(pass) node none > Client Basics > headers cannot be bigger than 65536 bytes [37.60ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > close callback [35
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (94fafbf38)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [955.33ms]
(pass) node none > Client Basics > should be able to send a POST request [694.19ms]
(pass) node none > Client Basics > constants [21.19ms]
(pass) node none > Client Basics > getDefaultSettings [8.70ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [25.21ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.97ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.58ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.59ms
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 805ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_collections v0.0.0 (/workspace/bun/src/collections)
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/h2_frame_parser.rs | 91 +++-------------------------------
 test/js/node/http2/node-http2.test.js  | 49 ++++++++++++++++++
 2 files changed, 55 insertions(+), 85 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/runtime/api/bun/h2_frame_parser.rs      5      7      0
test/js/node/http2/node-http2.test.js       2      2      0
```

</details>

<!-- robobun:evidence:end -->