### PR TITLE
TextDecoderStream: reject undefined chunks with TypeError

### DIFF
--- a/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
@@ -411,6 +411,11 @@ static JSPromise* decodeAndEnqueue(JSGlobalObject* globalObject, JSTextDecoderSt
 
 JSPromise* textDecoderStreamTransform(JSGlobalObject* globalObject, JSTextDecoderStream* stream, JSTransformStreamDefaultController* controller, JSValue chunk)
 {
+    // https://encoding.spec.whatwg.org/#decode-and-enqueue-a-chunk step 1 converts `chunk` to a
+    // non-optional BufferSource, so `undefined` is a TypeError. TextDecoder.decode's first
+    // argument is optional and would treat it as an empty buffer instead.
+    if (chunk.isUndefined()) [[unlikely]]
+        return promiseRejectedWith(globalObject, createTypeError(globalObject, "TextDecoderStream: chunk must be an ArrayBuffer or ArrayBufferView"_s));
     return decodeAndEnqueue(globalObject, stream, controller, chunk, /* streaming */ true);
 }
 

--- a/test/js/web/encoding/text-decoder-stream.test.ts
+++ b/test/js/web/encoding/text-decoder-stream.test.ts
@@ -181,6 +181,34 @@ import { readableStreamFromArray } from "harness";
   });
 }
 
+{
+  // https://github.com/WebKit/WebKit/blob/443e796d1538654c34f2690e39600c70c8052b63/LayoutTests/imported/w3c/web-platform-tests/encoding/streams/decode-bad-chunks.any.js
+  // https://encoding.spec.whatwg.org/#decode-and-enqueue-a-chunk step 1: the chunk is converted
+  // to a non-optional BufferSource, so every non-BufferSource (including `undefined`) must error
+  // the stream. `undefined` is the interesting case: TextDecoder.decode's optional first argument
+  // would otherwise treat it as an empty buffer and let the write resolve.
+  const badChunks = [
+    { name: "undefined", value: undefined },
+    { name: "null", value: null },
+    { name: "numeric", value: 3.14 },
+    { name: "object, not BufferSource", value: {} },
+    { name: "array", value: [65] },
+  ];
+
+  for (const chunk of badChunks) {
+    test(`chunk of type ${chunk.name} should error the stream`, async () => {
+      const tds = new TextDecoderStream();
+      const reader = tds.readable.getReader();
+      const writer = tds.writable.getWriter();
+      const writePromise = writer.write(chunk.value);
+      const readPromise = reader.read();
+      readPromise.catch(() => {}); // handled below; avoid an unhandled-rejection flag while awaiting writePromise
+      await expect(writePromise).rejects.toBeInstanceOf(TypeError);
+      await expect(readPromise).rejects.toBeInstanceOf(TypeError);
+    });
+  }
+}
+
 // Web IDL: `new TextDecoderStream(label, options)` treats undefined/null options as {}.
 test("TextDecoderStream accepts undefined and null options", () => {
   for (const options of [undefined, null]) {


### PR DESCRIPTION
## Repro

```js
const tds = new TextDecoderStream();
const w = tds.writable.getWriter();
tds.readable.getReader().read().catch(() => {});
await w.write(undefined);  // bun: fulfilled. node/spec: rejects TypeError and errors the stream
```

## Cause

[decode and enqueue a chunk](https://encoding.spec.whatwg.org/#decode-and-enqueue-a-chunk) step 1 converts the chunk to a **non-optional** `[AllowShared] BufferSource`, which throws `TypeError` for `undefined`.

Bun's `textDecoderStreamTransform` delegates the conversion to `TextDecoder.prototype.decode(chunk, {stream: true})`, whose first argument is **optional**. `undefined` there means "not present", so it decoded an empty buffer and the write resolved. Every other non-BufferSource (`null`, numbers, plain objects, arrays) already rejected correctly because `decode` rejects them.

## Fix

Guard `undefined` in `textDecoderStreamTransform` and return a rejected promise before delegating to `decode`. The flush arm (`textDecoderStreamFlush`) intentionally passes `jsUndefined()` to `decodeAndEnqueue` for the final no-input decode, so the check lives in the transform arm only.

## Verification

Ported WPT `encoding/streams/decode-bad-chunks.any.js` into `test/js/web/encoding/text-decoder-stream.test.ts`. All 49 tests in the file pass under `bun bd test` (including `BUN_JSC_validateExceptionChecks=1`); the `undefined` case fails on the unpatched build with "Expected promise that rejects / Received promise that resolved".