### PR TITLE
sql(postgres): discard a partial Bind when a parameter fails to encode

### DIFF
--- a/src/sql/postgres/protocol/NewWriter.rs
+++ b/src/sql/postgres/protocol/NewWriter.rs
@@ -62,10 +62,7 @@ impl<C: WriterContext> NewWriter<C> {
         C::pwrite(self.wrapped, data, i)
     }
 
-    /// Run `f`. If it fails, discard every byte it wrote so that a partial
-    /// message never reaches the wire. Encoding a Bind parameter can throw in
-    /// JS (a `toString` that throws, a detached buffer) after the message
-    /// header and earlier parameters are already in the buffer.
+    /// Run `f`. If it fails, discard every byte it wrote.
     pub fn atomically(
         self,
         f: impl FnOnce(Self) -> Result<(), AnyPostgresError>,

--- a/src/sql/postgres/protocol/NewWriter.rs
+++ b/src/sql/postgres/protocol/NewWriter.rs
@@ -7,6 +7,8 @@ pub trait WriterContext: Copy {
     fn offset(self) -> usize;
     fn write(self, bytes: &[u8]) -> Result<(), AnyPostgresError>;
     fn pwrite(self, bytes: &[u8], offset: usize) -> Result<(), AnyPostgresError>;
+    /// Discard every byte written at or after `offset`.
+    fn truncate(self, offset: usize);
 }
 
 #[derive(Copy, Clone)]
@@ -58,6 +60,22 @@ impl<C: WriterContext> NewWriter<C> {
     #[inline]
     pub(crate) fn pwrite(self, data: &[u8], i: usize) -> Result<(), AnyPostgresError> {
         C::pwrite(self.wrapped, data, i)
+    }
+
+    /// Run `f`. If it fails, discard every byte it wrote so that a partial
+    /// message never reaches the wire. Encoding a Bind parameter can throw in
+    /// JS (a `toString` that throws, a detached buffer) after the message
+    /// header and earlier parameters are already in the buffer.
+    pub fn atomically(
+        self,
+        f: impl FnOnce(Self) -> Result<(), AnyPostgresError>,
+    ) -> Result<(), AnyPostgresError> {
+        let start = self.offset();
+        let result = f(self);
+        if result.is_err() {
+            C::truncate(self.wrapped, start);
+        }
+        result
     }
 
     pub fn int4(self, value: PostgresInt32) -> Result<(), AnyPostgresError> {

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -285,36 +285,38 @@ pub(crate) fn prepare_and_query_with_signature<Context: WriterContext>(
     global: &JSGlobalObject,
     query: &[u8],
     array_value: JSValue,
-    mut writer: protocol::NewWriter<Context>,
+    writer: protocol::NewWriter<Context>,
     signature: &mut Signature,
 ) -> Result<(), AnyPostgresError> {
-    write_query(
-        query,
-        &signature.prepared_statement_name,
-        &signature.fields,
-        writer,
-    )?;
-    write_bind(
-        &signature.prepared_statement_name,
-        &BunString::EMPTY,
-        global,
-        array_value,
-        JSValue::ZERO,
-        &[],
-        &[],
-        writer,
-    )?;
-    let exec = protocol::Execute {
-        p: protocol::PortalOrPreparedStatement::PreparedStatement(
+    writer.atomically(|mut writer| {
+        write_query(
+            query,
             &signature.prepared_statement_name,
-        ),
-        ..Default::default()
-    };
-    exec.write_internal(&mut writer)?;
+            &signature.fields,
+            writer,
+        )?;
+        write_bind(
+            &signature.prepared_statement_name,
+            &BunString::EMPTY,
+            global,
+            array_value,
+            JSValue::ZERO,
+            &[],
+            &[],
+            writer,
+        )?;
+        let exec = protocol::Execute {
+            p: protocol::PortalOrPreparedStatement::PreparedStatement(
+                &signature.prepared_statement_name,
+            ),
+            ..Default::default()
+        };
+        exec.write_internal(&mut writer)?;
 
-    writer.write(&protocol::FLUSH)?;
-    writer.write(&protocol::SYNC)?;
-    Ok(())
+        writer.write(&protocol::FLUSH)?;
+        writer.write(&protocol::SYNC)?;
+        Ok(())
+    })
 }
 
 pub(crate) fn bind_and_execute<Context: WriterContext>(
@@ -322,29 +324,31 @@ pub(crate) fn bind_and_execute<Context: WriterContext>(
     statement: &PostgresSQLStatement,
     array_value: JSValue,
     columns_value: JSValue,
-    mut writer: protocol::NewWriter<Context>,
+    writer: protocol::NewWriter<Context>,
 ) -> Result<(), AnyPostgresError> {
-    write_bind(
-        &statement.signature.prepared_statement_name,
-        &BunString::EMPTY,
-        global,
-        array_value,
-        columns_value,
-        &statement.parameters,
-        &statement.fields,
-        writer,
-    )?;
-    let exec = protocol::Execute {
-        p: protocol::PortalOrPreparedStatement::PreparedStatement(
+    writer.atomically(|mut writer| {
+        write_bind(
             &statement.signature.prepared_statement_name,
-        ),
-        ..Default::default()
-    };
-    exec.write_internal(&mut writer)?;
+            &BunString::EMPTY,
+            global,
+            array_value,
+            columns_value,
+            &statement.parameters,
+            &statement.fields,
+            writer,
+        )?;
+        let exec = protocol::Execute {
+            p: protocol::PortalOrPreparedStatement::PreparedStatement(
+                &statement.signature.prepared_statement_name,
+            ),
+            ..Default::default()
+        };
+        exec.write_internal(&mut writer)?;
 
-    writer.write(&protocol::FLUSH)?;
-    writer.write(&protocol::SYNC)?;
-    Ok(())
+        writer.write(&protocol::FLUSH)?;
+        writer.write(&protocol::SYNC)?;
+        Ok(())
+    })
 }
 
 /// Atomically sends Parse + [Describe] + Bind + Execute + Flush + Sync as a single message batch.
@@ -359,61 +363,63 @@ pub(crate) fn parse_and_bind_and_execute<Context: WriterContext>(
     array_value: JSValue,
     columns_value: JSValue,
     include_describe: bool,
-    mut writer: protocol::NewWriter<Context>,
+    writer: protocol::NewWriter<Context>,
 ) -> Result<(), AnyPostgresError> {
     let name = &statement.signature.prepared_statement_name;
 
-    // Parse
-    {
-        let q = protocol::Parse {
+    writer.atomically(|mut writer| {
+        // Parse
+        {
+            let q = protocol::Parse {
+                name,
+                params: &statement.signature.fields,
+                query,
+            };
+            q.write_internal(&mut writer)?;
+            bun_core::scoped_log!(Postgres, "Parse: {}", bun_fmt::quote(query));
+        }
+
+        // Describe (needed on first execution to learn parameter/result types for caching)
+        if include_describe {
+            let d = protocol::Describe {
+                p: protocol::PortalOrPreparedStatement::PreparedStatement(name),
+            };
+            d.write_internal(writer)?;
+            bun_core::scoped_log!(Postgres, "Describe: {}", bun_fmt::quote(name));
+        }
+
+        // Bind — use server-provided types if available (binary format), otherwise
+        // fall back to signature types (text format for unknowns). The server will
+        // handle text-to-type conversion based on the parameter types from Parse.
+        let param_fields = if !statement.parameters.is_empty() {
+            &statement.parameters[..]
+        } else {
+            &statement.signature.fields[..]
+        };
+        let result_fields = &statement.fields;
+
+        write_bind(
             name,
-            params: &statement.signature.fields,
-            query,
-        };
-        q.write_internal(&mut writer)?;
-        bun_core::scoped_log!(Postgres, "Parse: {}", bun_fmt::quote(query));
-    }
+            &BunString::EMPTY,
+            global,
+            array_value,
+            columns_value,
+            param_fields,
+            result_fields,
+            writer,
+        )?;
 
-    // Describe (needed on first execution to learn parameter/result types for caching)
-    if include_describe {
-        let d = protocol::Describe {
+        // Execute
+        let exec = protocol::Execute {
             p: protocol::PortalOrPreparedStatement::PreparedStatement(name),
+            ..Default::default()
         };
-        d.write_internal(writer)?;
-        bun_core::scoped_log!(Postgres, "Describe: {}", bun_fmt::quote(name));
-    }
+        exec.write_internal(&mut writer)?;
 
-    // Bind — use server-provided types if available (binary format), otherwise
-    // fall back to signature types (text format for unknowns). The server will
-    // handle text-to-type conversion based on the parameter types from Parse.
-    let param_fields = if !statement.parameters.is_empty() {
-        &statement.parameters[..]
-    } else {
-        &statement.signature.fields[..]
-    };
-    let result_fields = &statement.fields;
-
-    write_bind(
-        name,
-        &BunString::EMPTY,
-        global,
-        array_value,
-        columns_value,
-        param_fields,
-        result_fields,
-        writer,
-    )?;
-
-    // Execute
-    let exec = protocol::Execute {
-        p: protocol::PortalOrPreparedStatement::PreparedStatement(name),
-        ..Default::default()
-    };
-    exec.write_internal(&mut writer)?;
-
-    writer.write(&protocol::FLUSH)?;
-    writer.write(&protocol::SYNC)?;
-    Ok(())
+        writer.write(&protocol::FLUSH)?;
+        writer.write(&protocol::SYNC)?;
+        Ok(())
+    })
 }
 
 pub(crate) fn execute_query<Context: WriterContext>(

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -1596,6 +1596,7 @@ impl Writer {
 
     pub(crate) fn pwrite(&mut self, data: &[u8], index: usize) -> Result<(), AnyPostgresError> {
         self.connection.write_buffer.with_mut(|b| {
+            let index = b.head as usize + index;
             b.byte_list.slice_mut()[index..][..data.len()].copy_from_slice(data);
         });
         Ok(())
@@ -1603,6 +1604,13 @@ impl Writer {
 
     pub(crate) fn offset(self) -> usize {
         self.connection.write_buffer.get().len() as usize
+    }
+
+    pub(crate) fn truncate(&mut self, offset: usize) {
+        self.connection.write_buffer.with_mut(|b| {
+            let len = b.head as usize + offset;
+            b.byte_list.truncate(len);
+        });
     }
 }
 
@@ -1618,6 +1626,10 @@ impl protocol::WriterContext for Writer {
     #[inline]
     fn pwrite(mut self, bytes: &[u8], i: usize) -> Result<(), AnyPostgresError> {
         Writer::pwrite(&mut self, bytes, i)
+    }
+    #[inline]
+    fn truncate(mut self, offset: usize) {
+        Writer::truncate(&mut self, offset)
     }
 }
 

--- a/test/js/sql/postgres-bind-encode-throw.test.ts
+++ b/test/js/sql/postgres-bind-encode-throw.test.ts
@@ -1,0 +1,182 @@
+// Bind parameters are encoded straight into the connection's write buffer.
+// When a parameter throws while it is encoded (a `toString` that throws, an
+// array with a throwing getter), the query rejects with that error, but the
+// partial Bind message (header with length 0, the portal and statement names,
+// the format codes, the parameters before the bad one) stayed in the buffer.
+// The next query's bytes followed it on the wire. A real server reads the
+// zero length as a protocol violation and drops the connection, so every
+// query pipelined behind the bad one failed too.
+//
+// The fix records the buffer offset before a Parse/Bind/Execute group is
+// written and truncates back to it when any part of the group fails.
+import { SQL } from "bun";
+import { describe, expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
+import {
+  listeningServer,
+  pgAuthenticationOk,
+  pgBindComplete,
+  pgCommandComplete,
+  pgDataRow,
+  pgParameterDescription,
+  pgParseComplete,
+  pgReadyForQuery,
+  pgRowDescription,
+} from "./wire-frames";
+
+const throwingToString = {
+  toString() {
+    throw new Error("boom from toString");
+  },
+};
+
+describeWithContainer("postgres", { image: "postgres_plain" }, container => {
+  const url = () => `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`;
+
+  test("a parameter that throws while encoded does not break the queries pipelined behind it", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 1, idleTimeout: 5, connectionTimeout: 5 });
+
+    await sql`SELECT ${"warm"}::text AS v`;
+
+    const bad = sql`SELECT ${"a"}::text AS v, ${throwingToString}::text AS w`;
+    const sibling1 = sql`SELECT ${"x"}::text AS v`;
+    const sibling2 = sql`SELECT ${"y"}::text AS v`;
+
+    const [badResult, s1, s2] = await Promise.all([
+      bad.then(
+        () => "resolved",
+        e => e.message,
+      ),
+      sibling1,
+      sibling2,
+    ]);
+    expect({ badResult, s1, s2 }).toEqual({
+      badResult: "boom from toString",
+      s1: [{ v: "x" }],
+      s2: [{ v: "y" }],
+    });
+
+    // The connection is still usable afterwards.
+    expect(await sql`SELECT ${"after"}::text AS v`).toEqual([{ v: "after" }]);
+  });
+
+  test("a throwing parameter on the first execution of a statement does not break the next query", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 1, idleTimeout: 5, connectionTimeout: 5 });
+
+    // No warm-up: the statement is prepared and bound in the same batch.
+    const bad = sql`SELECT ${"a"}::text AS v, ${throwingToString}::text AS w, ${1}::int AS n`;
+    const sibling = sql`SELECT ${"x"}::text AS v`;
+
+    const [badResult, s] = await Promise.all([
+      bad.then(
+        () => "resolved",
+        e => e.message,
+      ),
+      sibling,
+    ]);
+    expect({ badResult, s }).toEqual({ badResult: "boom from toString", s: [{ v: "x" }] });
+  });
+});
+
+describe("postgres bind encode failure (mock server)", () => {
+  // Records every frontend message bun sends as "<type>" or, when the length
+  // field is not a valid message length, "<type>(len=<n>)". A partial Bind
+  // shows up as "B(len=0)".
+  async function mockServer(): Promise<{ port: number; server: import("node:net").Server; received: string[] }> {
+    const received: string[] = [];
+    const { port, server } = await listeningServer(socket => {
+      let buffered = Buffer.alloc(0);
+      let startup = true;
+      let paramCount = 0;
+      socket.on("data", (chunk: Buffer) => {
+        buffered = Buffer.concat([buffered, chunk]);
+        const out: Buffer[] = [];
+        for (;;) {
+          if (startup) {
+            if (buffered.length < 4 || buffered.length < buffered.readInt32BE(0)) break;
+            buffered = buffered.subarray(buffered.readInt32BE(0));
+            startup = false;
+            out.push(pgAuthenticationOk(), pgReadyForQuery());
+            continue;
+          }
+          if (buffered.length < 5) break;
+          const type = String.fromCharCode(buffered[0]);
+          const len = buffered.readInt32BE(1);
+          if (len < 4) {
+            received.push(`${type}(len=${len})`);
+            buffered = buffered.subarray(5);
+            continue;
+          }
+          if (buffered.length < 1 + len) break;
+          const body = buffered.subarray(5, 1 + len);
+          buffered = buffered.subarray(1 + len);
+          received.push(type);
+          switch (type) {
+            case "P":
+              paramCount = (body.toString("latin1").match(/\$\d+/g) ?? []).length;
+              out.push(pgParseComplete());
+              break;
+            case "D":
+              out.push(
+                pgParameterDescription(Array(paramCount).fill(25)),
+                pgRowDescription([{ name: "v", typeOid: 25 }]),
+              );
+              break;
+            case "B":
+              out.push(pgBindComplete());
+              break;
+            case "E":
+              out.push(pgDataRow([Buffer.from("1")]), pgCommandComplete("SELECT 1"));
+              break;
+            case "S":
+              out.push(pgReadyForQuery());
+              break;
+          }
+        }
+        if (out.length) socket.write(Buffer.concat(out));
+      });
+      socket.on("error", () => {});
+    });
+    return { port, server, received };
+  }
+
+  test("no partial Bind reaches the wire when a parameter throws", async () => {
+    const { port, server, received } = await mockServer();
+    try {
+      await using sql = new SQL({
+        url: `postgres://user@127.0.0.1:${port}/db`,
+        max: 1,
+        idleTimeout: 2,
+        connectionTimeout: 5,
+      });
+      await sql`select ${"w"}`;
+      const bad = sql`select ${"a"}, ${throwingToString}`.then(
+        () => "resolved",
+        e => e.message,
+      );
+      const s1 = sql`select ${"x"}`.then(
+        () => "ok",
+        e => e.message,
+      );
+      const s2 = sql`select ${"y"}`.then(
+        () => "ok",
+        e => e.message,
+      );
+      expect(await Promise.all([bad, s1, s2])).toEqual(["boom from toString", "ok", "ok"]);
+    } finally {
+      server.close();
+    }
+    expect(received.filter(m => m.includes("len="))).toEqual([]);
+    // warm-up: Parse Describe Sync, Bind Execute Flush Sync.
+    // bad: Parse Describe Sync, then nothing (its Bind is discarded).
+    // siblings: Bind Execute Flush Sync, twice.
+    expect(received).toEqual([
+      ...["P", "D", "S", "B", "E", "H", "S"],
+      ...["P", "D", "S"],
+      ...["B", "E", "H", "S"],
+      ...["B", "E", "H", "S"],
+    ]);
+  });
+});


### PR DESCRIPTION
### Problem
- A Bind parameter that throws while it is encoded (an object whose `toString` throws, an array with a throwing getter) rejects the query, but the bytes already written stay in the connection write buffer: `42 00 00 00 00` (a Bind header with length 0), the portal and statement names, the format codes, and the parameters before the bad one. The next query's messages follow them on the wire.
- A real PostgreSQL reads length 0 as `invalid message length` and drops the connection. Every query pipelined on that connection rejects with `ERR_POSTGRES_CONNECTION_CLOSED`. With `idleTimeout: 0` and a server that does not disconnect, the siblings hang forever.
- The cause is `write_bind` in `src/sql_jsc/postgres/PostgresRequest.rs:52`. It writes straight into `connection.write_buffer` and calls into JS per parameter. The error returns through `?` and nothing removes the partial message.

### Fix
- Add `WriterContext::truncate(offset)` and `NewWriter::atomically(|w| ...)`. The helper records `offset()`, runs the body, and truncates back to the recorded offset when the body fails.
- Wrap the three batch writers that reach `write_bind`: `bind_and_execute`, `prepare_and_query_with_signature`, `parse_and_bind_and_execute`. Every caller in `PostgresSQLConnection::advance` and `PostgresSQLQuery::run` gets the rollback.
- `Writer::pwrite` now adds `head` to the index, the same coordinate system that `offset()` and `truncate()` use. Before this, the two disagreed whenever `head` was not 0.
- Verified: `test/js/sql/postgres-bind-encode-throw.test.ts` (stock bun fails all 3: the real server closes the connection, the mock sees `B(len=0)`). Also every `describeWithContainer("postgres")` file under `test/js/sql/`.

### Background
- Bun uses the extended query protocol. One query is a batch of frontend messages: Parse, Describe, Bind, Execute, Flush, Sync. Each message is a type byte, an Int32 length, and a body.
- The length is not known until the body is written, so `NewWriter::length()` writes a 0 placeholder and patches it at the end through `pwrite`. A failure between the two leaves the 0 on the wire.
- `write_buffer` is an `OffsetByteList`: a `Vec<u8>` plus a `head` that marks the bytes the socket already consumed. `offset()` is relative to `head`.

<details><summary>Notes</summary>

This PR was refreshed on top of current main. The original version (July) had the same design and conflicted after the `ArrayList` writer context was removed. The previous test file `postgres-bind-throw-torn-frame.test.ts` is replaced by `postgres-bind-encode-throw.test.ts`.

Repro output on 1.4.3 against a byte-capturing stub: `P D S B E H S P D S B(INVALID len=0)`. With the fix: `P D S B E H S P D S B E H S B E H S` and both siblings resolve.

Cases checked on the unfixed build: a throwing `toString` on an already-prepared statement (Bind after ParameterDescription, in `advance`), and on the first execution of a statement (Parse+Describe+Bind in one batch). Both close the connection on a real PostgreSQL.

MySQL is not affected. `bind_and_execute_impl` converts every parameter to a native `Vec<Value>` before it touches the writer.

Suites run with the debug build: `sql.test.ts` (the docker-gated part is skipped in this environment), `postgres-prepared-pipeline-reorder`, `postgres-simple-query-pipeline`, `postgres-split-prepare-reorder`, `sql-prepare-false`, `sql-pool-transaction-isolation`, and all 11 `describeWithContainer("postgres")` files. One MySQL test in `sql-statement-cache-hash-collision.test.ts` fails on main in this environment with sqlState 28000 (local auth), unrelated.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 2 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/sql/postgres-bind-encode-throw.test.ts
bun test v1.4.3 (f42e98025)

test/js/sql/postgres-bind-encode-throw.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
204 |   return `{${values.map(arrayValueSerializer.bind(this, type, isPostgresNumericType(type), isPostgresJsonType(type))).join(delimiter)}}`;
205 | }
206 | function wrapPostgresError(error) {
207 |   if (Error.isError(error)) {
208 |     return error;
209 |   return new PostgresError(error.message, error);
               ^
PostgresError: Connection closed
 code: "ERR_POSTGRES_CONNECTION_CLOSED"

      at wrapPostgresError (internal:sql/postgres:209:10)
      at handleClose (internal:sql/shared:463:27)
(fail) postgres > a parameter that throws while encoded does not break the queries pipelined behind it [308.18ms]
204 |   return `{${values.map(arrayValueSerializer.bind(this, type, isPostgresNumericType(type), isPostgresJsonType(type))).join(delimiter)}}`;
205 | }
206 | function wrapPostgresError(error) {
207 |   if (Error.isError(error)) {
208 | 
... (truncated)

release without fix: 3 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/sql/postgres-bind-encode-throw.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
171 |   let delimiter = type === "BOX" ? ";" : ",";
172 |   return `{${values.map(arrayValueSerializer.bind(this, type, isPostgresNumericType(type), isPostgresJsonType(type))).join(delimiter)}}`;
173 | }
174 | function wrapPostgresError(error) {
175 |   if (Error.isError(error))
176 |   return new PostgresError(error.message, error);
               ^
PostgresError: Connection closed
 code: "ERR_POSTGRES_CONNECTION_CLOSED"

      at wrapPostgresError (internal:sql/postgres:176:10)
      at handleClose (internal:sql/shared:372:27)
(fail) postgres > a parameter that throws while encoded does not break the queries pipelined behind it [13.17ms]
171 |   let delimiter = type === "BOX" ? ";" : ",";
172 |   return `{${values.map(arrayValueSerializer.bind(this, type, isPostgresNumericType(type), isPostgresJsonType(type))).join(delimiter)}}`;
173 | }
174 | function wrapPostgresError(error) {
175 |   if (Error.isError(error))
176 |   return new PostgresError(error.message, error);
               ^
PostgresError: Connection cl
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/sql/postgres-bind-encode-throw.test.ts
bun test v1.4.3 (f42e98025)

test/js/sql/postgres-bind-encode-throw.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) postgres > a parameter that throws while encoded does not break the queries pipelined behind it [297.21ms]
(pass) postgres > a throwing parameter on the first execution of a statement does not break the next query [38.94ms]
(pass) postgres bind encode failure (mock server) > no partial Bind reaches the wire when a parameter throws [368.75ms]

 3 pass
 0 fail
 6 expect() calls
Ran 3 tests across 1 file. [3.42s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 771ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/38] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/38] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameParser (32 fields)
Found 9 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/sql/postgres/protocol/NewWriter.rs         |  15 ++
 src/sql_jsc/postgres/PostgresRequest.rs        | 192 +++++++++++++------------
 src/sql_jsc/postgres/PostgresSQLConnection.rs  |  12 ++
 test/js/sql/postgres-bind-encode-throw.test.ts | 182 +++++++++++++++++++++++
 4 files changed, 308 insertions(+), 93 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/sql/postgres/protocol/NewWriter.rs              2      4      0
src/sql_jsc/postgres/PostgresRequest.rs             2      3      1
src/sql_jsc/postgres/PostgresSQLConnection.rs       2      1      0
test/js/sql/postgres-bind-encode-throw.test.ts      0      0      0
```

</details>

<!-- robobun:evidence:end -->