### PR TITLE
shell: reject NUL bytes in .cwd() and .env() options

### DIFF
--- a/src/runtime/shell/ParsedShellScript.rs
+++ b/src/runtime/shell/ParsedShellScript.rs
@@ -2,7 +2,7 @@ use core::cell::Cell;
 use core::mem::size_of;
 use core::sync::atomic::Ordering;
 
-use bun_core::{OwnedString, String as BunString, strings};
+use bun_core::{OwnedString, String as BunString, fmt, strings};
 use bun_jsc::{
     CallFrame, ErrorCode, JSGlobalObject, JSPropertyIterator, JSPropertyIteratorOptions, JSValue,
     JsCell, JsRef, JsResult, MarkedArgumentBuffer, StringJsc as _,
@@ -121,12 +121,13 @@ impl ParsedShellScript {
         };
         let str = OwnedString::new(BunString::from_js(str_js, global)?);
         if str.index_of_ascii_char(0).is_some() {
+            let bytes = str.to_owned_slice();
             return Err(global
                 .err(
                     ErrorCode::INVALID_ARG_VALUE,
                     format_args!(
-                        "cwd must be a string without null bytes. Received \"{}\"",
-                        str.to_zig_string()
+                        "cwd must be a string without null bytes. Received {}",
+                        fmt::quote(&bytes)
                     ),
                 )
                 .throw());
@@ -176,12 +177,13 @@ impl ParsedShellScript {
             }
 
             if key.index_of_ascii_char(0).is_some() {
+                let bytes = key.to_owned_slice();
                 return Err(global
                     .err(
                         ErrorCode::INVALID_ARG_VALUE,
                         format_args!(
-                            "env key must be a string without null bytes. Received \"{}\"",
-                            key.to_zig_string()
+                            "env key must be a string without null bytes. Received {}",
+                            fmt::quote(&bytes)
                         ),
                     )
                     .throw());
@@ -198,9 +200,9 @@ impl ParsedShellScript {
                     .err(
                         ErrorCode::INVALID_ARG_VALUE,
                         format_args!(
-                            "env value for \"{}\" must be a string without null bytes. Received \"{}\"",
-                            key.to_zig_string(),
-                            value_str
+                            "env value for {} must be a string without null bytes. Received {}",
+                            fmt::quote(&keyslice),
+                            fmt::quote(&slice)
                         ),
                     )
                     .throw());

--- a/src/runtime/shell/ParsedShellScript.rs
+++ b/src/runtime/shell/ParsedShellScript.rs
@@ -2,10 +2,10 @@ use core::cell::Cell;
 use core::mem::size_of;
 use core::sync::atomic::Ordering;
 
-use bun_core::String as BunString;
+use bun_core::{strings, OwnedString, String as BunString};
 use bun_jsc::{
-    CallFrame, JSGlobalObject, JSPropertyIterator, JSPropertyIteratorOptions, JSValue, JsCell,
-    JsRef, JsResult, MarkedArgumentBuffer, StringJsc as _,
+    CallFrame, ErrorCode, JSGlobalObject, JSPropertyIterator, JSPropertyIteratorOptions, JSValue,
+    JsCell, JsRef, JsResult, MarkedArgumentBuffer, StringJsc as _,
 };
 
 use super::interpreter::ShellArgs;
@@ -119,11 +119,22 @@ impl ParsedShellScript {
         let Some(str_js) = arguments.next_eat() else {
             return Err(global.throw(format_args!("$`...`.cwd(): expected a string argument")));
         };
-        let str = BunString::from_js(str_js, global)?;
+        let str = OwnedString::new(BunString::from_js(str_js, global)?);
+        if str.index_of_ascii_char(0).is_some() {
+            return Err(global
+                .err(
+                    ErrorCode::INVALID_ARG_VALUE,
+                    format_args!(
+                        "cwd must be a string without null bytes. Received \"{}\"",
+                        str.to_zig_string()
+                    ),
+                )
+                .throw());
+        }
         if let Some(prev) = self.cwd.get() {
             prev.deref();
         }
-        self.cwd.set(Some(str));
+        self.cwd.set(Some(str.into_inner()));
         Ok(JSValue::UNDEFINED)
     }
 
@@ -164,12 +175,36 @@ impl ParsedShellScript {
                 continue;
             }
 
+            if key.index_of_ascii_char(0).is_some() {
+                return Err(global
+                    .err(
+                        ErrorCode::INVALID_ARG_VALUE,
+                        format_args!(
+                            "env key must be a string without null bytes. Received \"{}\"",
+                            key.to_zig_string()
+                        ),
+                    )
+                    .throw());
+            }
+
             let keyslice = key.to_owned_slice();
             // errdefer free(keyslice) — Drop on early-return handles this.
             let value_str = value.get_zig_string(global)?;
             // `ZigString::to_owned_slice` is infallible (global alloc aborts
             // on OOM).
             let slice = value_str.to_owned_slice();
+            if strings::index_of_char(&slice, 0).is_some() {
+                return Err(global
+                    .err(
+                        ErrorCode::INVALID_ARG_VALUE,
+                        format_args!(
+                            "env value for \"{}\" must be a string without null bytes. Received \"{}\"",
+                            key.to_zig_string(),
+                            value_str
+                        ),
+                    )
+                    .throw());
+            }
             let keyref = EnvStr::init_ref_counted(keyslice.into_boxed_slice());
             // defer keyref.deref() — done below (insert refs again).
             let valueref = EnvStr::init_ref_counted(slice.into_boxed_slice());

--- a/src/runtime/shell/ParsedShellScript.rs
+++ b/src/runtime/shell/ParsedShellScript.rs
@@ -2,7 +2,7 @@ use core::cell::Cell;
 use core::mem::size_of;
 use core::sync::atomic::Ordering;
 
-use bun_core::{strings, OwnedString, String as BunString};
+use bun_core::{OwnedString, String as BunString, strings};
 use bun_jsc::{
     CallFrame, ErrorCode, JSGlobalObject, JSPropertyIterator, JSPropertyIteratorOptions, JSValue,
     JsCell, JsRef, JsResult, MarkedArgumentBuffer, StringJsc as _,

--- a/test/js/bun/spawn/null-byte-injection.test.ts
+++ b/test/js/bun/spawn/null-byte-injection.test.ts
@@ -216,7 +216,10 @@ describe("null byte injection protection", () => {
     });
 
     test(".cwd() and .env() accept valid values", async () => {
-      const result = await $`echo ok`.cwd(process.cwd()).env({ ...process.env }).text();
+      const result = await $`echo ok`
+        .cwd(process.cwd())
+        .env({ ...process.env })
+        .text();
       expect(result.trim()).toBe("ok");
     });
   });

--- a/test/js/bun/spawn/null-byte-injection.test.ts
+++ b/test/js/bun/spawn/null-byte-injection.test.ts
@@ -172,5 +172,52 @@ describe("null byte injection protection", () => {
       const result = await $`echo ${name}`.text();
       expect(result.trim()).toBe("hello.txt");
     });
+
+    test("throws error when .cwd() option contains null byte", () => {
+      try {
+        $`echo hello`.cwd("/tmp\0/etc");
+        expect.unreachable();
+      } catch (e: any) {
+        expect(e.code).toBe("ERR_INVALID_ARG_VALUE");
+        expect(e.message).toMatch(/cwd must be a string without null bytes/);
+      }
+    });
+
+    test("throws error when .env() value contains null byte", () => {
+      try {
+        $`echo hello`.env({ X: "safe\0tail" });
+        expect.unreachable();
+      } catch (e: any) {
+        expect(e.code).toBe("ERR_INVALID_ARG_VALUE");
+        expect(e.message).toMatch(/must be a string without null bytes/);
+      }
+    });
+
+    test("throws error when .env() key contains null byte", () => {
+      try {
+        $`echo hello`.env({ "MY\0VAR": "value" });
+        expect.unreachable();
+      } catch (e: any) {
+        expect(e.code).toBe("ERR_INVALID_ARG_VALUE");
+        expect(e.message).toMatch(/must be a string without null bytes/);
+      }
+    });
+
+    test("throws error when $.cwd() default contains null byte", () => {
+      const sh = new $.Shell();
+      sh.cwd("/tmp\0/etc");
+      try {
+        sh`echo hello`;
+        expect.unreachable();
+      } catch (e: any) {
+        expect(e.code).toBe("ERR_INVALID_ARG_VALUE");
+        expect(e.message).toMatch(/cwd must be a string without null bytes/);
+      }
+    });
+
+    test(".cwd() and .env() accept valid values", async () => {
+      const result = await $`echo ok`.cwd(process.cwd()).env({ ...process.env }).text();
+      expect(result.trim()).toBe("ok");
+    });
   });
 });


### PR DESCRIPTION
## What does this PR do?

`$\`...\`.cwd()` and `$\`...\`.env()` accepted strings containing interior NUL bytes without validation, unlike every neighbouring JS-to-C-string boundary (`Bun.spawn` cwd/env/argv, `node:child_process`, `fs.*`, and *interpolated* shell arguments, which all throw `ERR_INVALID_ARG_VALUE` with "must be a string without null bytes").

### Repro

```ts
import { $ } from "bun";
import * as fs from "node:fs";

// env value truncation
const r = await $`printenv X`.env({ PATH: process.env.PATH!, X: "safe\x00tail" }).quiet().nothrow();
console.log("child sees:", JSON.stringify(r.stdout.toString().trim())); // "safe"

// cwd path confusion (release; debug-asserts build aborts here)
const base = fs.mkdtempSync("/tmp/shnul-");
fs.mkdirSync(`${base}/real/sub`, { recursive: true });
const hostile = `${base}/real\x00/sub`;
const w = await $`echo hi > marker`.cwd(hostile).quiet().nothrow();
console.log("rc:", w.exitCode,
  "wrote into truncated dir:", fs.existsSync(`${base}/real/marker`),      // true
  "wrote into claimed dir:", fs.existsSync(`${base}/real/sub/marker`));   // false
```

Before (release 1.4.0):
```
child sees: "safe"
rc: 0 wrote into truncated dir: true wrote into claimed dir: false
```

Before (debug/ASAN build): the `.cwd()` call panics in `ZStr::as_cstr` ("interior NUL would truncate the C view") via `openat`, SIGABRT.

### Cause

`ParsedShellScript::set_cwd` / `ParsedShellScript::set_env` (`src/runtime/shell/ParsedShellScript.rs`) take the JS string and stash it with no NUL scan. Every other option setter on the spawn surface already carries the same check.

### Fix

Add the same `index_of_ascii_char(0)` / `index_of_char(0)` guard `Bun.spawn` uses to `setCwd` and `setEnv`, throwing `ERR_INVALID_ARG_VALUE` synchronously. The cwd string is now wrapped in `OwnedString` so the ref is released on the error path.

After:
```
TypeError: env value for "X" must be a string without null bytes. Received "safetail"
 code: "ERR_INVALID_ARG_VALUE"
```

### How did you verify your code works?

Added 5 tests to `test/js/bun/spawn/null-byte-injection.test.ts` (the existing home of this check class) covering `.cwd()` NUL, `.env()` key NUL, `.env()` value NUL, the `$.Shell` default-cwd path, and a valid-values smoke test. All 25 tests in the file pass with `bun bd test`; the new ones fail with `USE_SYSTEM_BUN=1`. `test/js/bun/shell/bunshell.test.ts` (412 tests) passes unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/spawn/null-byte-injection.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (9cabbc78f)

test/js/bun/spawn/null-byte-injection.test.ts:
(pass) null byte injection protection > Bun.spawn > throws error when command contains null byte [5.63ms]
(pass) null byte injection protection > Bun.spawn > throws error when argument contains null byte [3.66ms]
(pass) null byte injection protection > Bun.spawn > throws error with ERR_INVALID_ARG_VALUE code for args with null byte [5.42ms]
(pass) null byte injection protection > Bun.spawn > throws error for null byte in env key [3.41ms]
(pass) null byte injection protection > Bun.spawn > throws error for null byte in env value [3.94ms]
(pass) null byte injection protection > Bun.spawn > throws error for null byte in argv0 [5.54ms]
(pass) null byte injection prot
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (d444133fd)

test/js/bun/spawn/null-byte-injection.test.ts:
(pass) null byte injection protection > Bun.spawn > throws error when command contains null byte [3.21ms]
(pass) null byte injection protection > Bun.spawn > throws error when argument contains null byte [1.28ms]
(pass) null byte injection protection > Bun.spawn > throws error with ERR_INVALID_ARG_VALUE code for args with null byte [0.85ms]
(pass) null byte injection protection > Bun.spawn > throws error for null byte in env key [0.08ms]
(pass) null byte injection protection > Bun.spawn > throws error for null byte in env value [0.05ms]
(pass) null byte injection protection > Bun.spawn > throws error for null byte in argv0 [0.08ms]
(pass) null byte injection protection > Bun.spawn > throws error for null byte in cwd [0.07ms]
(pass) null byte injection protection > Bun.spawn > works normally with valid arguments [14.16ms]
(pass) null byte injection protection > Bun.spawn > works with spread process.env [1.64ms]
(pass) null byte injection protection > Bun.spawnSync > throws error when command contains null byte [0.06ms]
(pass) null byte injection protection > Bun.spawnSync > throws er
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/spawn/null-byte-injection.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (9cabbc78f)

test/js/bun/spawn/null-byte-injection.test.ts:
(pass) null byte injection protection > Bun.spawn > throws error when command contains null byte [6.26ms]
(pass) null byte injection protection > Bun.spawn > throws error when argument contains null byte [3.68ms]
(pass) null byte injection protection > Bun.spawn > throws error with ERR_INVALID_ARG_VALUE code for args with null byte [6.15ms]
(pass) null byte injection protection > Bun.spawn > throws error for null byte in env key [3.62ms]
(pass) null byte injection protection > Bun.spawn > throws error for null byte in env value [4.03ms]
(pass) null byte injection protection > Bun.spawn > throws error for null byte in argv0 [5.97ms]
(pass) null byte injection prot
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 730ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/shell/ParsedShellScript.rs        | 47 ++++++++++++++++++++++---
 test/js/bun/spawn/null-byte-injection.test.ts | 50 +++++++++++++++++++++++++++
 2 files changed, 92 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/runtime/shell/ParsedShellScript.rs             3      8      0
test/js/bun/spawn/null-byte-injection.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->