### PR TITLE
node:http2: reject request header blocks that fail RFC 9113 8.3.1 (empty/missing :path, :method, :scheme; CONNECT shape)

### DIFF
--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -13,6 +13,18 @@ use super::stream::{self, State};
 use super::wire::{self, ErrorCode, FrameHeader, FrameType, SettingId};
 use bun_collections::HashMap;
 
+/// Pseudo-header presence bits shared by the per-field decode loop and the RFC 9113 §8.3.1
+/// request checks in `finish_header_block` (nghttp2's NGHTTP2_HTTP_FLAG__* equivalents).
+mod pseudo {
+    pub(super) const METHOD: u8 = 1;
+    pub(super) const SCHEME: u8 = 2;
+    pub(super) const AUTHORITY: u8 = 4;
+    pub(super) const PATH: u8 = 8;
+    pub(super) const STATUS: u8 = 16;
+    pub(super) const PROTOCOL: u8 = 32;
+    pub(super) const UNKNOWN: u8 = 64;
+}
+
 /// Snapshot of the local-settings values carried by one sent-but-unACKed SETTINGS frame, so an
 /// inbound ACK is attributed to the submission it actually acknowledges (RFC 9113 §6.5.3) rather
 /// than to the latest submission.
@@ -235,6 +247,11 @@ pub struct Connection {
     header_target: u32,
     /// 0 for a normal HEADERS block; the parent stream id when assembling a PUSH_PROMISE block.
     header_push_parent: u32,
+    /// The assembling block opens a new inbound stream (a request block on the server, a
+    /// PUSH_PROMISE request block on the client). False for a later HEADERS on the same stream
+    /// (a trailer section), which RFC 9113 §8.1 forbids from carrying pseudo-headers and which
+    /// must not be held to the request pseudo-header requirements of §8.3.1.
+    header_is_request: bool,
     /// HEADERS arrived on a closed/half-closed-remote stream: the block is still decoded so the
     /// connection-scoped HPACK table stays in sync (§4.3), then refused with RST_STREAM
     /// (STREAM_CLOSED) instead of being dispatched.
@@ -286,6 +303,7 @@ impl Connection {
             header_flags: 0,
             header_target: 0,
             header_push_parent: 0,
+            header_is_request: false,
             header_stream_closed: false,
             header_stream_refused: false,
             terminated: false,
@@ -986,6 +1004,10 @@ impl Connection {
         self.header_flags = hdr.flags;
         self.header_target = hdr.stream_id;
         self.header_push_parent = 0;
+        // Only a server receives request blocks via HEADERS; on a client every response block
+        // looks "new" (the engine only tracks inbound-created streams), so without this gate it
+        // would be misclassified as a request. PUSH_PROMISE sets the flag itself.
+        self.header_is_request = self.is_server && is_new;
         self.header_stream_closed = stream_closed;
         self.header_stream_refused = refused;
         if !end_headers {
@@ -1056,9 +1078,14 @@ impl Connection {
         let mut malformed = is_trailer && !self.header_end_stream;
         let mut seen_regular = false;
         let mut seen_pseudo: u8 = 0;
+        // Request-block state for the RFC 9113 §8.3.1 checks below (nghttp2's
+        // nghttp2_http_on_request_headers): only an initial HEADERS block (or a PUSH_PROMISE
+        // block) is a request; a later HEADERS on the same stream is a trailer section.
+        let is_request = self.header_is_request;
+        let mut saw_connect = false;
+        let mut saw_host = false;
         let mut informational = false;
         let mut content_length: Option<u64> = None;
-        let mut connect = false;
         while off < block.len() {
             match self.hpack.decode(&block[off..]) {
                 Ok(h) => {
@@ -1090,13 +1117,13 @@ impl Connection {
                             malformed = true;
                         } else if let Some(rest) = name_b.strip_prefix(b":") {
                             let bit: u8 = match rest {
-                                b"method" => 1,
-                                b"scheme" => 2,
-                                b"authority" => 4,
-                                b"path" => 8,
-                                b"status" => 16,
-                                b"protocol" => 32,
-                                _ => 64,
+                                b"method" => pseudo::METHOD,
+                                b"scheme" => pseudo::SCHEME,
+                                b"authority" => pseudo::AUTHORITY,
+                                b"path" => pseudo::PATH,
+                                b"status" => pseudo::STATUS,
+                                b"protocol" => pseudo::PROTOCOL,
+                                _ => pseudo::UNKNOWN,
                             };
                             // 8.3.1: requests never carry :status - a server seeing it inbound is
                             // a malformed block. (The client direction also constrains pseudo
@@ -1112,12 +1139,16 @@ impl Connection {
                             let protocol_disabled = self.is_server
                                 && rest == b"protocol"
                                 && self.local_settings.enable_connect_protocol == 0;
+                            // nghttp2 (check_pseudo_header) treats an empty pseudo-header value as
+                            // malformed, so `:path: ""` never counts as a present :path (§8.3.1:
+                            // `:path` "MUST NOT be empty" for http/https).
                             if seen_regular
-                                || bit == 64
+                                || bit == pseudo::UNKNOWN
                                 || (seen_pseudo & bit) != 0
                                 || wrong_direction
                                 || protocol_disabled
                                 || is_trailer
+                                || value_b.is_empty()
                             {
                                 malformed = true;
                             }
@@ -1126,13 +1157,14 @@ impl Connection {
                             }
                             seen_pseudo |= bit;
                             if rest == b"method" && value_b == b"CONNECT" {
-                                connect = true;
+                                saw_connect = true;
                             }
                         } else {
                             seen_regular = true;
                             match name_b {
                                 b"connection" | b"keep-alive" | b"proxy-connection"
                                 | b"transfer-encoding" | b"upgrade" => malformed = true,
+                                b"host" if is_request => saw_host = true,
                                 b"te" => {
                                     // RFC 9110 10.1.4: field values are case-insensitive.
                                     if !value_b.eq_ignore_ascii_case(b"trailers") {
@@ -1186,9 +1218,25 @@ impl Connection {
             sink.on_stream_reset(target, ErrorCode::StreamClosed.as_u32());
             return false;
         }
+        // RFC 9113 §8.3.1 (nghttp2_http_on_request_headers): a request block needs exactly one
+        // non-empty :method, :scheme and :path plus an :authority or Host; plain CONNECT omits
+        // :scheme/:path and carries :authority; extended CONNECT (:protocol, RFC 8441) requires
+        // :method CONNECT and :authority. Without this a block with an empty or missing :path
+        // reaches JS as a request with an empty url (no compliant peer can produce that shape).
+        if is_request && !rejected && !malformed {
+            use pseudo::{AUTHORITY, METHOD, PATH, PROTOCOL, SCHEME};
+            let extended_connect = (seen_pseudo & PROTOCOL) != 0;
+            malformed = if saw_connect && !extended_connect {
+                (seen_pseudo & (SCHEME | PATH)) != 0 || (seen_pseudo & AUTHORITY) == 0
+            } else {
+                (seen_pseudo & (METHOD | SCHEME | PATH)) != (METHOD | SCHEME | PATH)
+                    || ((seen_pseudo & AUTHORITY) == 0 && !saw_host)
+                    || (extended_connect && (!saw_connect || (seen_pseudo & AUTHORITY) == 0))
+            };
+        }
         if push_parent == 0 && self.is_server && !malformed && !rejected {
             if let Some(s) = self.streams.get_mut(&target) {
-                if !connect && s.content_length.is_none() {
+                if !saw_connect && s.content_length.is_none() {
                     s.content_length = content_length;
                 }
                 if self.header_end_stream
@@ -1654,6 +1702,7 @@ impl Connection {
         self.header_flags = 0;
         self.header_target = promised;
         self.header_push_parent = hdr.stream_id;
+        self.header_is_request = true;
         self.header_stream_closed = false;
         self.header_stream_refused = false;
         if !end_headers {
@@ -2072,7 +2121,12 @@ mod tests {
         let sink = CaptureSink::default();
         let mut c = Connection::new(true, Settings::default());
         c.preface_received = wire::CONNECTION_PREFACE.len();
-        let block = encode_block(&[(b":method", b"GET"), (b":path", b"/")]);
+        let block = encode_block(&[
+            (b":method", b"GET"),
+            (b":scheme", b"http"),
+            (b":path", b"/"),
+            (b":authority", b"localhost"),
+        ]);
         let flags = wire::flags::END_HEADERS | wire::flags::END_STREAM;
         let f = frame(FrameType::Headers, flags, 1, &block);
         let fed = c.receive(&sink, &f);
@@ -2104,7 +2158,12 @@ mod tests {
         let sink = CaptureSink::default();
         let mut c = Connection::new(true, Settings::default());
         c.preface_received = wire::CONNECTION_PREFACE.len();
-        let block = encode_block(&[(b":method", b"POST"), (b":path", b"/")]);
+        let block = encode_block(&[
+            (b":method", b"POST"),
+            (b":scheme", b"http"),
+            (b":path", b"/"),
+            (b":authority", b"localhost"),
+        ]);
         // HEADERS without END_STREAM -> stream stays open for DATA.
         let h = frame(FrameType::Headers, wire::flags::END_HEADERS, 1, &block);
         c.receive(&sink, &h);
@@ -2144,7 +2203,9 @@ mod tests {
         let mut client = Connection::new(false, Settings::default());
         client.begin_header_block();
         assert!(client.encode_header(b":method", b"GET", false));
+        assert!(client.encode_header(b":scheme", b"http", false));
         assert!(client.encode_header(b":path", b"/x", false));
+        assert!(client.encode_header(b":authority", b"localhost", false));
         client.send_header_block(&csink, 1, true);
         let wire_bytes = csink.out.borrow().clone();
         assert_eq!(
@@ -2183,7 +2244,9 @@ mod tests {
         let mut server = Connection::new(true, Settings::default());
         server.begin_header_block();
         assert!(server.encode_header(b":method", b"GET", false));
+        assert!(server.encode_header(b":scheme", b"http", false));
         assert!(server.encode_header(b":path", b"/pushed", false));
+        assert!(server.encode_header(b":authority", b"localhost", false));
         server.send_push_promise(&ssink, 1, 2);
         let bytes = ssink.out.borrow().clone();
         assert_eq!(

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -799,6 +799,130 @@ describe("request header and body framing (RFC 9113 §8.1)", () => {
   });
 });
 
+describe("request pseudo-header requirements (RFC 9113 §8.3.1)", () => {
+  // HPACK "literal never indexed, new name" (0x10) so the wire shape is exactly what is written
+  // and no client library normalizes it away.
+  function hpackBlock(pairs: [string, string][]): Buffer {
+    return Buffer.concat(pairs.flatMap(([n, v]) => [Buffer.from([0x10]), hpackLiteral(n), hpackLiteral(v)]));
+  }
+
+  async function probe(
+    headers: [string, string][],
+    opts?: http2.ServerOptions,
+  ): Promise<{ dispatched: boolean; frames: Frame[] }> {
+    const srv = http2.createServer(opts ?? {});
+    srv.on("sessionError", () => {});
+    let dispatched = false;
+    srv.on("stream", stream => {
+      dispatched = true;
+      stream.on("error", () => {});
+      try {
+        stream.respond({ ":status": 200 });
+        stream.end();
+      } catch {}
+    });
+    srv.listen(0, "127.0.0.1");
+    await once(srv, "listening");
+    const srvPort = (srv.address() as net.AddressInfo).port;
+    const c = await RawH2.connect(srvPort);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      c.sendFrame(FrameType.HEADERS, 0x5, 1, hpackBlock(headers));
+      // PING as a barrier: by the time the ACK (or a GOAWAY/close) arrives, the server has
+      // fully processed the HEADERS above.
+      c.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(8));
+      await Promise.race([
+        c.waitFor(f => (f.type === FrameType.PING && (f.flags & 1) !== 0) || f.type === FrameType.GOAWAY),
+        c.waitClosed(),
+      ]);
+      return { dispatched, frames: c.frames.slice() };
+    } finally {
+      c.destroy();
+      srv.close();
+    }
+  }
+
+  function expectStreamProtocolError({ dispatched, frames }: { dispatched: boolean; frames: Frame[] }) {
+    expect(dispatched).toBe(false);
+    const rst = frames.find(f => f.type === FrameType.RST_STREAM && f.streamId === 1);
+    expect(rst?.payload.readUInt32BE(0)).toBe(ErrorCode.PROTOCOL_ERROR);
+    expect(frames.find(f => f.type === FrameType.HEADERS && f.streamId === 1)).toBeUndefined();
+  }
+
+  test.each([
+    ["empty :path", [[":method", "GET"], [":scheme", "http"], [":path", ""], [":authority", "localhost"]]],
+    ["empty :method", [[":method", ""], [":scheme", "http"], [":path", "/"], [":authority", "localhost"]]],
+    ["empty :scheme", [[":method", "GET"], [":scheme", ""], [":path", "/"], [":authority", "localhost"]]],
+    ["empty :authority", [[":method", "GET"], [":scheme", "http"], [":path", "/"], [":authority", ""]]],
+    ["missing :path", [[":method", "GET"], [":scheme", "http"], [":authority", "localhost"]]],
+    ["missing :method", [[":scheme", "http"], [":path", "/"], [":authority", "localhost"]]],
+    ["missing :scheme", [[":method", "GET"], [":path", "/"], [":authority", "localhost"]]],
+    ["no :authority or host", [[":method", "GET"], [":scheme", "http"], [":path", "/"]]],
+    ["CONNECT with :path", [[":method", "CONNECT"], [":authority", "localhost"], [":path", "/"]]],
+    ["CONNECT with :scheme", [[":method", "CONNECT"], [":authority", "localhost"], [":scheme", "http"]]],
+    ["CONNECT without :authority", [[":method", "CONNECT"]]],
+  ] as const)("a request with %s is RST with PROTOCOL_ERROR and never dispatched", async (_, headers) => {
+    expectStreamProtocolError(await probe(headers as [string, string][]));
+  });
+
+  test.each([
+    [":protocol on non-CONNECT", [[":method", "GET"], [":scheme", "http"], [":path", "/"], [":authority", "localhost"], [":protocol", "websocket"]]],
+    ["extended CONNECT without :scheme", [[":method", "CONNECT"], [":protocol", "websocket"], [":path", "/"], [":authority", "localhost"]]],
+    ["extended CONNECT without :path", [[":method", "CONNECT"], [":protocol", "websocket"], [":scheme", "http"], [":authority", "localhost"]]],
+    ["extended CONNECT without :authority", [[":method", "CONNECT"], [":protocol", "websocket"], [":scheme", "http"], [":path", "/"]]],
+    ["extended CONNECT with empty :path", [[":method", "CONNECT"], [":protocol", "websocket"], [":scheme", "http"], [":path", ""], [":authority", "localhost"]]],
+  ] as const)("with enableConnectProtocol: %s is RST with PROTOCOL_ERROR and never dispatched", async (_, headers) => {
+    expectStreamProtocolError(await probe(headers as [string, string][], { settings: { enableConnectProtocol: true } }));
+  });
+
+  test("a valid request block is dispatched", async () => {
+    const { dispatched, frames } = await probe([
+      [":method", "GET"],
+      [":scheme", "http"],
+      [":path", "/"],
+      [":authority", "localhost"],
+    ]);
+    expect(dispatched).toBe(true);
+    expect(frames.find(f => f.type === FrameType.RST_STREAM && f.streamId === 1)).toBeUndefined();
+  });
+
+  test("a request with a host header in place of :authority is dispatched", async () => {
+    const { dispatched, frames } = await probe([
+      [":method", "GET"],
+      [":scheme", "http"],
+      [":path", "/"],
+      ["host", "localhost"],
+    ]);
+    expect(dispatched).toBe(true);
+    expect(frames.find(f => f.type === FrameType.RST_STREAM && f.streamId === 1)).toBeUndefined();
+  });
+
+  test("a plain CONNECT with only :authority is dispatched", async () => {
+    const { dispatched, frames } = await probe([
+      [":method", "CONNECT"],
+      [":authority", "localhost"],
+    ]);
+    expect(dispatched).toBe(true);
+    expect(frames.find(f => f.type === FrameType.RST_STREAM && f.streamId === 1)).toBeUndefined();
+  });
+
+  test("an extended CONNECT (:protocol) with :scheme/:path/:authority is dispatched", async () => {
+    const { dispatched, frames } = await probe(
+      [
+        [":method", "CONNECT"],
+        [":protocol", "websocket"],
+        [":scheme", "http"],
+        [":path", "/"],
+        [":authority", "localhost"],
+      ],
+      { settings: { enableConnectProtocol: true } },
+    );
+    expect(dispatched).toBe(true);
+    expect(frames.find(f => f.type === FrameType.RST_STREAM && f.streamId === 1)).toBeUndefined();
+  });
+});
+
 describe("inbound stream lifecycle", () => {
   test("releases server stream objects once the peer resets their streams", async () => {
     const total = 32;

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -851,29 +851,147 @@ describe("request pseudo-header requirements (RFC 9113 §8.3.1)", () => {
   }
 
   test.each([
-    ["empty :path", [[":method", "GET"], [":scheme", "http"], [":path", ""], [":authority", "localhost"]]],
-    ["empty :method", [[":method", ""], [":scheme", "http"], [":path", "/"], [":authority", "localhost"]]],
-    ["empty :scheme", [[":method", "GET"], [":scheme", ""], [":path", "/"], [":authority", "localhost"]]],
-    ["empty :authority", [[":method", "GET"], [":scheme", "http"], [":path", "/"], [":authority", ""]]],
-    ["missing :path", [[":method", "GET"], [":scheme", "http"], [":authority", "localhost"]]],
-    ["missing :method", [[":scheme", "http"], [":path", "/"], [":authority", "localhost"]]],
-    ["missing :scheme", [[":method", "GET"], [":path", "/"], [":authority", "localhost"]]],
-    ["no :authority or host", [[":method", "GET"], [":scheme", "http"], [":path", "/"]]],
-    ["CONNECT with :path", [[":method", "CONNECT"], [":authority", "localhost"], [":path", "/"]]],
-    ["CONNECT with :scheme", [[":method", "CONNECT"], [":authority", "localhost"], [":scheme", "http"]]],
+    [
+      "empty :path",
+      [
+        [":method", "GET"],
+        [":scheme", "http"],
+        [":path", ""],
+        [":authority", "localhost"],
+      ],
+    ],
+    [
+      "empty :method",
+      [
+        [":method", ""],
+        [":scheme", "http"],
+        [":path", "/"],
+        [":authority", "localhost"],
+      ],
+    ],
+    [
+      "empty :scheme",
+      [
+        [":method", "GET"],
+        [":scheme", ""],
+        [":path", "/"],
+        [":authority", "localhost"],
+      ],
+    ],
+    [
+      "empty :authority",
+      [
+        [":method", "GET"],
+        [":scheme", "http"],
+        [":path", "/"],
+        [":authority", ""],
+      ],
+    ],
+    [
+      "missing :path",
+      [
+        [":method", "GET"],
+        [":scheme", "http"],
+        [":authority", "localhost"],
+      ],
+    ],
+    [
+      "missing :method",
+      [
+        [":scheme", "http"],
+        [":path", "/"],
+        [":authority", "localhost"],
+      ],
+    ],
+    [
+      "missing :scheme",
+      [
+        [":method", "GET"],
+        [":path", "/"],
+        [":authority", "localhost"],
+      ],
+    ],
+    [
+      "no :authority or host",
+      [
+        [":method", "GET"],
+        [":scheme", "http"],
+        [":path", "/"],
+      ],
+    ],
+    [
+      "CONNECT with :path",
+      [
+        [":method", "CONNECT"],
+        [":authority", "localhost"],
+        [":path", "/"],
+      ],
+    ],
+    [
+      "CONNECT with :scheme",
+      [
+        [":method", "CONNECT"],
+        [":authority", "localhost"],
+        [":scheme", "http"],
+      ],
+    ],
     ["CONNECT without :authority", [[":method", "CONNECT"]]],
   ] as const)("a request with %s is RST with PROTOCOL_ERROR and never dispatched", async (_, headers) => {
     expectStreamProtocolError(await probe(headers as [string, string][]));
   });
 
   test.each([
-    [":protocol on non-CONNECT", [[":method", "GET"], [":scheme", "http"], [":path", "/"], [":authority", "localhost"], [":protocol", "websocket"]]],
-    ["extended CONNECT without :scheme", [[":method", "CONNECT"], [":protocol", "websocket"], [":path", "/"], [":authority", "localhost"]]],
-    ["extended CONNECT without :path", [[":method", "CONNECT"], [":protocol", "websocket"], [":scheme", "http"], [":authority", "localhost"]]],
-    ["extended CONNECT without :authority", [[":method", "CONNECT"], [":protocol", "websocket"], [":scheme", "http"], [":path", "/"]]],
-    ["extended CONNECT with empty :path", [[":method", "CONNECT"], [":protocol", "websocket"], [":scheme", "http"], [":path", ""], [":authority", "localhost"]]],
+    [
+      ":protocol on non-CONNECT",
+      [
+        [":method", "GET"],
+        [":scheme", "http"],
+        [":path", "/"],
+        [":authority", "localhost"],
+        [":protocol", "websocket"],
+      ],
+    ],
+    [
+      "extended CONNECT without :scheme",
+      [
+        [":method", "CONNECT"],
+        [":protocol", "websocket"],
+        [":path", "/"],
+        [":authority", "localhost"],
+      ],
+    ],
+    [
+      "extended CONNECT without :path",
+      [
+        [":method", "CONNECT"],
+        [":protocol", "websocket"],
+        [":scheme", "http"],
+        [":authority", "localhost"],
+      ],
+    ],
+    [
+      "extended CONNECT without :authority",
+      [
+        [":method", "CONNECT"],
+        [":protocol", "websocket"],
+        [":scheme", "http"],
+        [":path", "/"],
+      ],
+    ],
+    [
+      "extended CONNECT with empty :path",
+      [
+        [":method", "CONNECT"],
+        [":protocol", "websocket"],
+        [":scheme", "http"],
+        [":path", ""],
+        [":authority", "localhost"],
+      ],
+    ],
   ] as const)("with enableConnectProtocol: %s is RST with PROTOCOL_ERROR and never dispatched", async (_, headers) => {
-    expectStreamProtocolError(await probe(headers as [string, string][], { settings: { enableConnectProtocol: true } }));
+    expectStreamProtocolError(
+      await probe(headers as [string, string][], { settings: { enableConnectProtocol: true } }),
+    );
   });
 
   test("a valid request block is dispatched", async () => {


### PR DESCRIPTION
## What

A raw-frame h2 client that sends a request with `:path` set to the empty string reaches the `'stream'` handler with `headers[':path'] === ''` (and `req.url === ''` in the compat layer). RFC 9113 8.3.1 says `:path` "MUST NOT be empty" for http/https and that every non-CONNECT request must carry exactly one non-empty `:method`, `:scheme` and `:path`; node (via nghttp2's `nghttp2_http_on_request_headers`) answers with `RST_STREAM(PROTOCOL_ERROR)` and never dispatches.

Repro (node RSTs, Bun on main dispatches):

```js
import http2 from 'node:http2'; import net from 'node:net';
const hs = s => { const b = Buffer.from(s); return Buffer.concat([Buffer.from([b.length]), b]); };
const hp = ps => Buffer.concat(ps.flatMap(([n,v]) => [Buffer.from([0x10]), hs(n), hs(v)]));
const fr = (t,f,sid,pl) => { const h = Buffer.alloc(9); h.writeUIntBE(pl.length,0,3); h[3]=t; h[4]=f; h.writeUInt32BE(sid,5); return Buffer.concat([h,pl]); };
const srv = http2.createServer();
srv.on('stream', (st, h) => { console.log('DISPATCHED', JSON.stringify(h)); st.respond({':status':200}); st.end(); });
srv.listen(0, '127.0.0.1', () => {
  const s = net.connect(srv.address().port, '127.0.0.1');
  s.on('connect', () => s.write(Buffer.concat([
    Buffer.from('PRI * HTTP/2.0\\r\\n\\r\\nSM\\r\\n\\r\\n'),
    fr(4,0,0,Buffer.alloc(0)),
    fr(1,0x5,1,hp([[':method','GET'],[':path',''],[':scheme','http'],[':authority','h']])),
  ])));
});
// bun main: DISPATCHED {":method":"GET",":path":"",":scheme":"http",":authority":"h"}
// node v26: (no dispatch, RST_STREAM PROTOCOL_ERROR on stream 1)
```

The same validator gap meant requests with `:method`/`:scheme`/`:path` missing entirely, a plain `CONNECT` carrying `:scheme`/`:path`, a `CONNECT` without `:authority`, or `:protocol` on a non-CONNECT all reached the handler too. All are rejected by node as a stream `PROTOCOL_ERROR`.

## Cause

`finish_header_block` in the h2 engine (`src/runtime/api/bun/h2/connection.rs`) tracks which pseudo-headers were seen (for the duplicate check) but never checks that the required ones are present, and never checks for empty values. The decode loop validated per-field shape (duplicate, unknown, late, connection-specific, CR/LF/NUL) but not the per-block 8.3.1 requirements.

## Fix

nghttp2-equivalent, one block in `finish_header_block`:

- An empty pseudo-header value is malformed inline (`check_pseudo_header` semantics), so `":path": ""` never counts as present.
- After the decode loop, a request block (a server-received initial `HEADERS` or a client-received `PUSH_PROMISE`) is held to the 8.3.1 requirements: `:method`, `:scheme`, `:path` and `:authority`-or-`Host` for ordinary requests; `:authority` and no `:scheme`/`:path` for plain `CONNECT`; `:method CONNECT` + `:authority` for extended CONNECT (`:protocol`, RFC 8441).

A `header_is_request` flag distinguishes a request block from a trailer section (which 8.1 already forbids from carrying pseudo-headers) and from a client-received response block (which the 8.3.1 rules do not apply to).

The rejection takes the existing malformed-block path (`RST_STREAM(PROTOCOL_ERROR)`, counted against `maxSessionInvalidFrames`, never surfaced to `'stream'`), so the JS-visible behavior matches node exactly.

## Verification

16 new rejection cases plus 4 positive cases (valid block, `host` in place of `:authority`, plain `CONNECT`, extended `CONNECT`) in `test/js/node/http2/h2-conformance.test.ts`. All 16 rejection cases fail on the unfixed build (the request is dispatched) and pass with the fix; all 4 positive cases pass on both. The full `h2-conformance` suite (58 tests), `node-http2.test.js` (305 tests) and node's upstream `test-http2-connect-method*`/`test-http2-misused-pseudoheaders` pass on the fixed build.

## Related

#33191 carries a broader version of this validation (including nghttp2's `check_path()` `:path`-starts-with-`/` rule, `Host` empty/repeated handling, and `PUSH_PROMISE` connection-error semantics) as item 1 of a larger hardening round. This PR is the minimal, standalone carve-out of the 8.3.1 presence/emptiness rules against current main, shaped so #33191 rebases cleanly over it.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 16 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/h2-conformance.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (26eb1c855)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [429.38ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [145.80ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [117.38ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [87.99ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§
... (truncated)

release without fix: 29 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [8.02ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [2.39ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [1.39ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [0.92ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [0.86ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [2.33ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [0.82ms]
(pass) PING (checklist §3.7) > a PING on a non-zero stream id is a PROTOCOL_ERROR [0.72ms]
(pass) WINDOW_UPDATE (checklist §6) > a connection-level WINDOW_UPDATE with a 0 increment is a PROTOCOL_ERROR [0.71ms]
(pass) WINDOW_UPDATE
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/h2-conformance.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (26eb1c855)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [451.77ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [148.56ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [133.99ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [90.24ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 750ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/h2/connection.rs      |  89 +++++++++--
 test/js/node/http2/h2-conformance.test.ts | 242 ++++++++++++++++++++++++++++++
 2 files changed, 318 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/runtime/api/bun/h2/connection.rs           6     13      0
test/js/node/http2/h2-conformance.test.ts      5      1      0
```

</details>

<!-- robobun:evidence:end -->