### PR TITLE
install: reject non-URL-friendly npm package names before registry routing

### DIFF
--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1185,13 +1185,13 @@ pub use crate::string::immutable::{
     has_prefix, has_prefix_case_insensitive, has_prefix_comptime, has_prefix_comptime_utf16,
     has_suffix_comptime, index_of, index_of_scalar, index_of_t, is_all_whitespace, is_ip_address,
     is_npm_package_name, is_npm_package_name_ignore_length, is_on_char_boundary,
-    is_url_safe_package_name,
-    is_utf8_char_boundary, is_valid_utf8, join, last_index_of, last_index_of_t,
-    length_of_leading_whitespace_ascii, memmem, order, order_t, percent_encode_write, sort_asc,
-    sort_desc, split, starts_with_case_insensitive_ascii, starts_with_char, str_utf8,
-    to_ascii_hex_value, to_utf16_alloc, trim_leading_char, trim_prefix, trim_prefix_comptime,
-    trim_spaces, trim_suffix, trim_suffix_comptime, utf8_byte_sequence_length, utf16_eql_string,
-    without_prefix, without_prefix_comptime, without_suffix_comptime, without_utf8_bom,
+    is_url_safe_package_name, is_utf8_char_boundary, is_valid_utf8, join, last_index_of,
+    last_index_of_t, length_of_leading_whitespace_ascii, memmem, order, order_t,
+    percent_encode_write, sort_asc, sort_desc, split, starts_with_case_insensitive_ascii,
+    starts_with_char, str_utf8, to_ascii_hex_value, to_utf16_alloc, trim_leading_char, trim_prefix,
+    trim_prefix_comptime, trim_spaces, trim_suffix, trim_suffix_comptime,
+    utf8_byte_sequence_length, utf16_eql_string, without_prefix, without_prefix_comptime,
+    without_suffix_comptime, without_utf8_bom,
 };
 
 #[allow(deprecated)]

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1185,6 +1185,7 @@ pub use crate::string::immutable::{
     has_prefix, has_prefix_case_insensitive, has_prefix_comptime, has_prefix_comptime_utf16,
     has_suffix_comptime, index_of, index_of_scalar, index_of_t, is_all_whitespace, is_ip_address,
     is_npm_package_name, is_npm_package_name_ignore_length, is_on_char_boundary,
+    is_url_safe_package_name,
     is_utf8_char_boundary, is_valid_utf8, join, last_index_of, last_index_of_t,
     length_of_leading_whitespace_ascii, memmem, order, order_t, percent_encode_write, sort_asc,
     sort_desc, split, starts_with_case_insensitive_ascii, starts_with_char, str_utf8,

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -611,6 +611,30 @@ pub fn is_npm_package_name_ignore_length(target: &[u8]) -> bool {
     !scoped || (slash_index > 0 && slash_index + 1 < target.len())
 }
 
+/// npm's `validForOldPackages` error gate: every byte must pass
+/// `encodeURIComponent` unchanged, except for the leading `@` and the single
+/// `/` of a scoped name. Anything else (`%`, `?`, `#`, `\`, space, non-ASCII)
+/// would change the URL path the registry resolves.
+pub fn is_url_safe_package_name(target: &[u8]) -> bool {
+    #[inline]
+    fn is_uri_component_char(c: u8) -> bool {
+        matches!(c, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9'
+            | b'-' | b'_' | b'.' | b'!' | b'~' | b'*' | b'\'' | b'(' | b')')
+    }
+    if target.is_empty() {
+        return false;
+    }
+    if target[0] == b'@' {
+        let Some(slash) = index_of_char(target, b'/') else {
+            return false;
+        };
+        let slash = slash as usize;
+        return target[1..slash].iter().all(|&c| is_uri_component_char(c))
+            && target[slash + 1..].iter().all(|&c| is_uri_component_char(c));
+    }
+    target.iter().all(|&c| is_uri_component_char(c))
+}
+
 // Secret-redaction scanners are canonical in crate::strings_impl (only callers
 // live in bun_core/fmt.rs). Re-exported here to preserve the bun.strings.* path.
 pub use crate::strings_impl::{

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -621,7 +621,7 @@ pub fn is_url_safe_package_name(target: &[u8]) -> bool {
         matches!(c, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9'
             | b'-' | b'_' | b'.' | b'!' | b'~' | b'*' | b'\'' | b'(' | b')')
     }
-    if target.is_empty() {
+    if target.is_empty() || matches!(target[0], b'.' | b'_') {
         return false;
     }
     if target[0] == b'@' {

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -629,6 +629,9 @@ pub fn is_url_safe_package_name(target: &[u8]) -> bool {
             return false;
         };
         let slash = slash as usize;
+        if slash < 2 || slash + 1 >= target.len() {
+            return false;
+        }
         return target[1..slash].iter().all(|&c| is_uri_component_char(c))
             && target[slash + 1..]
                 .iter()

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -630,7 +630,9 @@ pub fn is_url_safe_package_name(target: &[u8]) -> bool {
         };
         let slash = slash as usize;
         return target[1..slash].iter().all(|&c| is_uri_component_char(c))
-            && target[slash + 1..].iter().all(|&c| is_uri_component_char(c));
+            && target[slash + 1..]
+                .iter()
+                .all(|&c| is_uri_component_char(c));
     }
     target.iter().all(|&c| is_uri_component_char(c))
 }

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -424,6 +424,10 @@ impl NetworkTask {
         is_optional: bool,
         needs_extended: bool,
     ) -> Result<(), ForManifestError> {
+        // Every producer must validate `name` before `scope_for_package_name`;
+        // see `is_url_safe_package_name` in PackageManagerEnqueue.rs and
+        // PopulateManifestCache.rs.
+        debug_assert!(strings::is_url_safe_package_name(name));
         let pm = self.pm_mut();
         // SAFETY: `pm.log` is the long-lived `*mut Log` the package manager
         // was constructed with.

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1022,8 +1022,8 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                         None,
                                         bun_ast::Loc::EMPTY,
                                         format_args!(
-                                            "Invalid package name \"{}\" (package names may only contain URL-friendly characters)",
-                                            bstr::BStr::new(&name_str),
+                                            "Invalid package name {} (package names may only contain URL-friendly characters)",
+                                            bun_fmt::quote(&name_str),
                                         ),
                                     );
                                 }

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -782,6 +782,29 @@ pub fn enqueue_dependency_with_main_and_success_fn(
     };
     let mut loaded_manifest: Option<Npm::PackageManifest> = None;
 
+    // Reject non-URL-friendly names before any registry routing. npm rejects
+    // these at parse time (validate-npm-package-name); accepting them lets a
+    // percent-encoded `/` bypass `[install.scopes]` and reach the default
+    // registry while the server decodes it back to the scoped name.
+    if version.tag.is_npm() {
+        let name_str = this.lockfile.str(&name);
+        if !strings::is_npm_package_name_ignore_length(name_str) {
+            if let Some(fail) = fail_fn {
+                fail(this, dependency, id, crate::Error::InvalidPackageName);
+            } else {
+                this.log_mut().add_error_fmt(
+                    None,
+                    bun_ast::Loc::EMPTY,
+                    format_args!(
+                        "Invalid package name \"{}\" (package names may only contain URL-friendly characters)",
+                        bstr::BStr::new(name_str),
+                    ),
+                );
+            }
+            return Ok(());
+        }
+    }
+
     match version.tag {
         dependency::version::Tag::DistTag
         | dependency::version::Tag::Folder

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -782,29 +782,6 @@ pub fn enqueue_dependency_with_main_and_success_fn(
     };
     let mut loaded_manifest: Option<Npm::PackageManifest> = None;
 
-    // Reject non-URL-friendly names before any registry routing. npm rejects
-    // these at parse time (validate-npm-package-name); accepting them lets a
-    // percent-encoded `/` bypass `[install.scopes]` and reach the default
-    // registry while the server decodes it back to the scoped name.
-    if version.tag.is_npm() {
-        let name_str = this.lockfile.str(&name);
-        if !strings::is_npm_package_name_ignore_length(name_str) {
-            if let Some(fail) = fail_fn {
-                fail(this, dependency, id, crate::Error::InvalidPackageName);
-            } else {
-                this.log_mut().add_error_fmt(
-                    None,
-                    bun_ast::Loc::EMPTY,
-                    format_args!(
-                        "Invalid package name \"{}\" (package names may only contain URL-friendly characters)",
-                        bstr::BStr::new(name_str),
-                    ),
-                );
-            }
-            return Ok(());
-        }
-    }
-
     match version.tag {
         dependency::version::Tag::DistTag
         | dependency::version::Tag::Folder
@@ -1032,6 +1009,28 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                         // and `name_str` is still read afterwards on the
                         // fall-through path.
                         let name_str: Vec<u8> = this.lockfile.str(&name).to_vec();
+
+                        // Non-URL-safe bytes (`%`, `?`, `#`, `\`, ...) let the
+                        // registry resolve a different path than scope routing
+                        // saw (e.g. `@priv%2fx` bypasses `[install.scopes]`).
+                        if !strings::is_url_safe_package_name(&name_str) {
+                            if dependency.behavior.is_required() {
+                                if let Some(fail) = fail_fn {
+                                    fail(this, dependency, id, crate::Error::InvalidPackageName);
+                                } else {
+                                    this.log_mut().add_error_fmt(
+                                        None,
+                                        bun_ast::Loc::EMPTY,
+                                        format_args!(
+                                            "Invalid package name \"{}\" (package names may only contain URL-friendly characters)",
+                                            bstr::BStr::new(&name_str),
+                                        ),
+                                    );
+                                }
+                            }
+                            return Ok(());
+                        }
+
                         let task_id = Task::Id::for_manifest(&name_str);
 
                         if cfg!(debug_assertions) {

--- a/src/install/PackageManager/PopulateManifestCache.rs
+++ b/src/install/PackageManager/PopulateManifestCache.rs
@@ -54,7 +54,7 @@ fn start_manifest_task(
     // before `scope_for_package_name` so a crafted lockfile name like
     // `@priv%2fx` can't bypass `[install.scopes]`.
     if !bun_core::strings::is_url_safe_package_name(pkg_name) {
-        if dep.behavior.is_required() {
+        if !dep.behavior.contains(Behavior::OPTIONAL) {
             manager.log_mut().add_error_fmt(
                 None,
                 bun_ast::Loc::EMPTY,

--- a/src/install/PackageManager/PopulateManifestCache.rs
+++ b/src/install/PackageManager/PopulateManifestCache.rs
@@ -50,6 +50,22 @@ fn start_manifest_task(
     dep: &Dependency,
     needs_extended_manifest: bool,
 ) -> Result<(), StartManifestTaskError> {
+    // Same guard as `enqueue_dependency_with_main_and_success_fn`: reject
+    // before `scope_for_package_name` so a crafted lockfile name like
+    // `@priv%2fx` can't bypass `[install.scopes]`.
+    if !bun_core::strings::is_url_safe_package_name(pkg_name) {
+        if dep.behavior.is_required() {
+            manager.log_mut().add_error_fmt(
+                None,
+                bun_ast::Loc::EMPTY,
+                format_args!(
+                    "Invalid package name \"{}\" (package names may only contain URL-friendly characters)",
+                    bstr::BStr::new(pkg_name),
+                ),
+            );
+        }
+        return Ok(());
+    }
     let task_id = Task::Id::for_manifest(pkg_name);
     // Read the *raw* OPTIONAL bit
     // — not `Behavior.isOptional()` (which is `optional && !peer`). For

--- a/src/install/PackageManager/PopulateManifestCache.rs
+++ b/src/install/PackageManager/PopulateManifestCache.rs
@@ -59,8 +59,8 @@ fn start_manifest_task(
                 None,
                 bun_ast::Loc::EMPTY,
                 format_args!(
-                    "Invalid package name \"{}\" (package names may only contain URL-friendly characters)",
-                    bstr::BStr::new(pkg_name),
+                    "Invalid package name {} (package names may only contain URL-friendly characters)",
+                    bun_core::fmt::quote(pkg_name),
                 ),
             );
         }

--- a/src/install/error.rs
+++ b/src/install/error.rs
@@ -192,6 +192,8 @@ pub enum Error {
     LockfileIsMissingResolutionData,
     #[error("MissingPackageName")]
     MissingPackageName,
+    #[error("InvalidPackageName")]
+    InvalidPackageName,
     #[error("GlobError")]
     GlobError,
     #[error("Invalid")]
@@ -375,6 +377,7 @@ impl Error {
             Self::CorruptLockfile => "CorruptLockfile",
             Self::LockfileIsMissingResolutionData => "Lockfile is missing resolution data",
             Self::MissingPackageName => "MissingPackageName",
+            Self::InvalidPackageName => "InvalidPackageName",
             Self::GlobError => "GlobError",
             Self::Invalid => "Invalid",
             Self::LockfileValidationFailedListIsImpossiblyLong => {

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -8969,6 +8969,131 @@ registry = { url = "http://localhost:${port}/", token = "${token}" }
   expect(await exited).not.toBe(0);
 });
 
+describe("rejects percent-encoded dependency names that would bypass [install.scopes]", () => {
+  // A dependency named `@priv%2fx` has no literal `/`, so scope routing would
+  // match it against no `[install.scopes]` entry and fall through to the
+  // default registry. That registry receives `GET /@priv%2fx`, which the npm
+  // namespace decodes back to `@priv/x`, so the default registry serves the
+  // scoped packument for a name the scope pin was meant to redirect. npm's
+  // validate-npm-package-name rejects non-URL-friendly names at parse time;
+  // bun must do the same before any registry request.
+  for (const [label, depName, alias] of [
+    ["root dependency key", "@priv%2fx", "@priv%2fx"],
+    ["npm: alias target", "npm:@priv%2fx@*", "innocent"],
+    // uppercase %2F and the raw `?` URL metacharacter must be rejected too.
+    ["uppercase %2F", "@priv%2Fx", "@priv%2Fx"],
+    ["raw ? metacharacter", "@priv/x?", "@priv/x?"],
+  ] as const) {
+    test(label, async () => {
+      const defaultHits: string[] = [];
+      using defaultReg = Bun.serve({
+        port: 0,
+        fetch(req) {
+          defaultHits.push(new URL(req.url).pathname);
+          return new Response("{}", { status: 404 });
+        },
+      });
+      const scopedHits: string[] = [];
+      using scopedReg = Bun.serve({
+        port: 0,
+        fetch(req) {
+          scopedHits.push(new URL(req.url).pathname);
+          return new Response("{}", { status: 404 });
+        },
+      });
+
+      await Promise.all([
+        write(
+          join(packageDir, "bunfig.toml"),
+          `
+[install]
+cache = false
+registry = "http://localhost:${defaultReg.port}/"
+[install.scopes]
+"@priv" = { url = "http://localhost:${scopedReg.port}/" }
+`,
+        ),
+        write(
+          packageJson,
+          JSON.stringify({
+            name: "foo",
+            version: "1.0.0",
+            dependencies: { [alias]: alias === depName ? "*" : depName },
+          }),
+        ),
+      ]);
+
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+
+      const err = await stderr.text();
+      await stdout.text();
+
+      expect(err.toLowerCase()).toContain("invalid package name");
+      expect({ defaultHits, scopedHits }).toEqual({ defaultHits: [], scopedHits: [] });
+      expect(await exited).not.toBe(0);
+      expect(await exists(join(packageDir, "node_modules", alias))).toBe(false);
+    });
+  }
+
+  test("literal @scope/name still routes to the pinned registry", async () => {
+    const defaultHits: string[] = [];
+    using defaultReg = Bun.serve({
+      port: 0,
+      fetch(req) {
+        defaultHits.push(new URL(req.url).pathname);
+        return new Response("{}", { status: 404 });
+      },
+    });
+
+    await Promise.all([
+      write(
+        join(packageDir, "bunfig.toml"),
+        `
+[install]
+cache = false
+registry = "http://localhost:${defaultReg.port}/"
+[install.scopes]
+"@priv" = { url = "http://localhost:${port}/" }
+`,
+      ),
+      write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          version: "1.0.0",
+          dependencies: { "@priv/x": "*" },
+        }),
+      ),
+    ]);
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+
+    const err = await stderr.text();
+    await stdout.text();
+    await exited;
+
+    // Control: a well-formed scoped name must not be rejected by the new
+    // validator; it is routed to the pinned registry (which 404s here because
+    // verdaccio has no @priv/x) and must never touch the default registry.
+    expect(err).not.toContain("Invalid package name");
+    expect(defaultHits).toEqual([]);
+  });
+});
+
 test("registry override from a project .env only keeps the saved token when the host matches and the scheme is not downgraded", async () => {
   // `bun install` loads the project's `.env` before computing installer
   // options, so a repo-committed `.env` can point BUN_CONFIG_REGISTRY at a

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -8961,8 +8961,9 @@ registry = { url = "http://localhost:${port}/", token = "${token}" }
   const err = await stderr.text();
   await stdout.text();
 
-  // The manifest request must be refused with a clear error...
-  expect(err).toContain("is not on registry");
+  // The manifest request must be refused with a clear error (the name is
+  // rejected as non-URL-safe before the URL join)...
+  expect(err).toContain("Invalid package name");
   // ...and no request (carrying the registry Authorization header) may reach
   // a host other than the configured registry.
   expect(received).toEqual([]);
@@ -8970,19 +8971,16 @@ registry = { url = "http://localhost:${port}/", token = "${token}" }
 });
 
 describe("rejects percent-encoded dependency names that would bypass [install.scopes]", () => {
-  // A dependency named `@priv%2fx` has no literal `/`, so scope routing would
-  // match it against no `[install.scopes]` entry and fall through to the
-  // default registry. That registry receives `GET /@priv%2fx`, which the npm
-  // namespace decodes back to `@priv/x`, so the default registry serves the
-  // scoped packument for a name the scope pin was meant to redirect. npm's
-  // validate-npm-package-name rejects non-URL-friendly names at parse time;
-  // bun must do the same before any registry request.
+  // `@priv%2fx` has no literal `/`, so scope routing would fall through to the
+  // default registry, which decodes it back to `@priv/x`. Match npm's
+  // validate-npm-package-name error gate and reject before any request.
   for (const [label, depName, alias] of [
     ["root dependency key", "@priv%2fx", "@priv%2fx"],
     ["npm: alias target", "npm:@priv%2fx@*", "innocent"],
-    // uppercase %2F and the raw `?` URL metacharacter must be rejected too.
     ["uppercase %2F", "@priv%2Fx", "@priv%2Fx"],
     ["raw ? metacharacter", "@priv/x?", "@priv/x?"],
+    ["raw # metacharacter", "@priv/x#y", "@priv/x#y"],
+    ["backslash", "@priv\\x", "@priv\\x"],
   ] as const) {
     test(label, async () => {
       const defaultHits: string[] = [];
@@ -9042,12 +9040,20 @@ registry = "http://localhost:${defaultReg.port}/"
     });
   }
 
-  test("literal @scope/name still routes to the pinned registry", async () => {
+  test("literal @scope/name and legacy npm chars still route to the pinned registry", async () => {
     const defaultHits: string[] = [];
     using defaultReg = Bun.serve({
       port: 0,
       fetch(req) {
         defaultHits.push(new URL(req.url).pathname);
+        return new Response("{}", { status: 404 });
+      },
+    });
+    const scopedHits: string[] = [];
+    using scopedReg = Bun.serve({
+      port: 0,
+      fetch(req) {
+        scopedHits.push(new URL(req.url).pathname);
         return new Response("{}", { status: 404 });
       },
     });
@@ -9060,7 +9066,7 @@ registry = "http://localhost:${defaultReg.port}/"
 cache = false
 registry = "http://localhost:${defaultReg.port}/"
 [install.scopes]
-"@priv" = { url = "http://localhost:${port}/" }
+"@priv" = { url = "http://localhost:${scopedReg.port}/" }
 `,
       ),
       write(
@@ -9068,7 +9074,7 @@ registry = "http://localhost:${defaultReg.port}/"
         JSON.stringify({
           name: "foo",
           version: "1.0.0",
-          dependencies: { "@priv/x": "*" },
+          dependencies: { "@priv/x": "*", "@priv/pkg~1": "*" },
         }),
       ),
     ]);
@@ -9086,11 +9092,12 @@ registry = "http://localhost:${defaultReg.port}/"
     await stdout.text();
     await exited;
 
-    // Control: a well-formed scoped name must not be rejected by the new
-    // validator; it is routed to the pinned registry (which 404s here because
-    // verdaccio has no @priv/x) and must never touch the default registry.
+    // Control: well-formed scoped names, including legacy chars npm only
+    // warns about (`~`), must not be rejected and must route to the pinned
+    // registry only.
     expect(err).not.toContain("Invalid package name");
     expect(defaultHits).toEqual([]);
+    expect(scopedHits.sort()).toEqual(["/@priv%2fpkg~1", "/@priv%2fx"]);
   });
 });
 

--- a/test/regression/issue/31652.test.ts
+++ b/test/regression/issue/31652.test.ts
@@ -117,7 +117,7 @@ test("install does not abort on an unresolved optional dependency with an empty 
   expect(stderr).not.toContain('Invalid dependency name ""');
   // An invalid (empty) package name is now dropped before any manifest
   // request; for an optional dependency that must be silent.
-  expect(stderr).not.toContain('Invalid package name');
+  expect(stderr).not.toContain("Invalid package name");
   expect(emptyNameManifestRequested).toBe(false);
   // The requested package must still be installed.
   expect(await Bun.file(join(String(dir), "node_modules", "top", "package.json")).exists()).toBe(true);

--- a/test/regression/issue/31652.test.ts
+++ b/test/regression/issue/31652.test.ts
@@ -115,10 +115,12 @@ test("install does not abort on an unresolved optional dependency with an empty 
 
   // The empty-name optional dependency must not abort the install.
   expect(stderr).not.toContain('Invalid dependency name ""');
+  // An invalid (empty) package name is now dropped before any manifest
+  // request; for an optional dependency that must be silent.
+  expect(stderr).not.toContain('Invalid package name');
+  expect(emptyNameManifestRequested).toBe(false);
   // The requested package must still be installed.
   expect(await Bun.file(join(String(dir), "node_modules", "top", "package.json")).exists()).toBe(true);
-  // Sanity check that we actually exercised the empty-name resolution path.
-  expect(emptyNameManifestRequested).toBe(true);
   // Assert the exit code last for a more useful message if a behavioral check fails.
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Repro

```toml
# bunfig.toml
[install]
registry = "http://default-registry/"
[install.scopes]
"@priv" = { url = "http://internal-registry/" }
```
```json
{ "dependencies": { "@priv%2fx": "*" } }
```

Before: `bun install` sends `GET /@priv%2fx` to the **default** registry (0 requests to the pinned one). The npm registry namespace decodes `%2f`, so the default registry serves the `@priv/x` packument and bun installs it under `node_modules/@priv%2fx` with exit 0. The scope pin is bypassed. Same shape works from any transitive dependency's manifest and from `npm:@priv%2fx@*` aliases.

npm rejects the name at parse time: `validate-npm-package-name` returns "name can only contain URL-friendly characters".

## Cause

`Scope::get_name` (src/install/npm.rs) splits on the first literal `/` to extract the scope. `@priv%2fx` has none, so `scope_for_package_name` hashes `priv%2fx`, misses the `[install.scopes]` map, and falls back to the default registry. `NetworkTask::for_manifest` then sends the name verbatim in the URL path, where the server decodes it back to the scoped name. No layer validated that a dependency name destined for a registry lookup is URL-safe.

## Fix

Add `strings::is_url_safe_package_name`, which implements npm's `validForOldPackages` error gate: every byte must pass `encodeURIComponent` unchanged except the leading `@` and the single `/` of a scoped name. Characters npm only warns about (`~ ' ! ( ) *`) remain accepted.

Apply it at both `NetworkTask::for_manifest` producers, before `scope_for_package_name`:

- `enqueue_dependency_with_main_and_success_fn`: at the point a manifest request is about to be enqueued, after workspace and folder resolution have already had their chance to claim the name. A required dependency with an unsafe name logs `Invalid package name "..." (package names may only contain URL-friendly characters)` and the install fails; an optional one is skipped silently. This covers root `package.json` dependency keys, transitive dependencies from fetched packuments, `npm:` alias targets, and override/catalog replacements.
- `start_manifest_task` (`bun outdated`, `bun update -i`, yarn/pnpm lockfile migration): same guard, so a crafted lockfile entry cannot bypass the scope pin on those paths either.

A `debug_assert!` in `NetworkTask::for_manifest` enforces the invariant so any future producer that forgets the check trips in debug builds.

## Verification

`test/cli/install/bun-install-registry.test.ts` adds a describe block with two in-process registries (default + `@priv`-pinned) and asserts that `@priv%2fx`, `@priv%2Fx`, `@priv/x?`, `@priv/x#y`, `@priv\x`, and `npm:@priv%2fx@*` are each rejected with the new error before any request reaches either registry, plus a control leg that `@priv/x` and `@priv/pkg~1` are still accepted and routed to the pinned registry only.

On the released binary the six rejection tests fail: the error output shows `GET http://localhost:<defaultReg>/@priv%2fx - 404`, demonstrating the request reached the default registry. With the fix all seven pass.

The existing cross-origin `npm:` alias test now hits the name validator before the URL-join origin check (its assertion is updated to match), and the #31652 empty-name optional dependency regression test now observes the invalid name being dropped before any manifest request (previously it was sent and 404'd).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-registry.test.ts

<!-- robobun:evidence:end -->