### PR TITLE
node:http: reject Content-Length / Transfer-Encoding in request trailer section

### DIFF
--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -102,6 +102,10 @@ struct HttpResponseData;
          * llhttp reports this as HPE_STRICT "Expected LF after chunk data",
          * distinct from a malformed chunk-size line (HPE_INVALID_CHUNK_SIZE). */
         HTTP_PARSER_ERROR_CHUNK_TERMINATOR_EXPECTED = 16,
+        /* A Content-Length field appeared in the trailer section of a chunked
+         * body. llhttp reports HPE_INVALID_CONTENT_LENGTH ("Content-Length can't
+         * be present with Transfer-Encoding"). node:http compat only. */
+        HTTP_PARSER_ERROR_TRAILER_CONTENT_LENGTH = 17,
     };
 
 
@@ -545,21 +549,40 @@ struct HttpResponseData;
          * message is completed. Node's llhttp fails the message on a malformed trailer
          * field line (clientError HPE_INVALID_HEADER_TOKEN) instead of completing it
          * with req.trailers silently dropped; a CTL byte in a value is only accepted
-         * under insecureHTTPParser, exactly like a header value. An empty section
-         * (bare CRLF, no trailers) is valid.
+         * under insecureHTTPParser, exactly like a header value. A Content-Length or
+         * Transfer-Encoding field in the trailer section is rejected exactly like
+         * llhttp does (it runs trailers through the same header state machine, so
+         * the already-set F_CHUNKED collides), unless insecureHTTPParser is set
+         * (llhttp's LENIENT_CHUNKED_LENGTH / LENIENT_TRANSFER_ENCODING). An empty
+         * section (bare CRLF, no trailers) is valid.
          *
          * Known bound: parseTrailerFields stops at MAX_TRAILER_FIELDS, so a section with
          * more valid fields than that followed by a malformed line is accepted where node
          * still errors; reaching it requires a deliberately padded (but size-capped)
          * section, and rejecting it would need a second scanning mode. */
-        static bool validNodeTrailerSection(const std::string *section, bool useInsecureHTTPParser) {
+        static HttpParserError validateNodeTrailerSection(const std::string *section, bool useInsecureHTTPParser) {
             if (!section || section->size() <= 2) {
-                return true;
+                return HTTP_PARSER_ERROR_NONE;
             }
             /* parseTrailerFields consumes (post-pads) its input, so validate a copy. */
             std::string copy(*section);
             std::pair<std::string_view, std::string_view> scratch[MAX_TRAILER_FIELDS];
-            return parseTrailerFields(copy, scratch, useInsecureHTTPParser) > 0;
+            unsigned count = parseTrailerFields(copy, scratch, useInsecureHTTPParser);
+            if (count == 0) {
+                return HTTP_PARSER_ERROR_INVALID_HEADER_TOKEN;
+            }
+            if (!useInsecureHTTPParser) {
+                for (unsigned i = 0; i < count; i++) {
+                    std::string_view name = scratch[i].first;
+                    if (name.length() == 14 && !strncasecmp(name.data(), "content-length", 14)) {
+                        return HTTP_PARSER_ERROR_TRAILER_CONTENT_LENGTH;
+                    }
+                    if (name.length() == 17 && !strncasecmp(name.data(), "transfer-encoding", 17)) {
+                        return HTTP_PARSER_ERROR_INVALID_TRANSFER_ENCODING;
+                    }
+                }
+            }
+            return HTTP_PARSER_ERROR_NONE;
         }
 
     private:
@@ -1278,10 +1301,12 @@ struct HttpResponseData;
                         if (*chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
                             return HttpParserResult::error(HTTP_ERROR_413_PAYLOAD_TOO_LARGE, HTTP_PARSER_ERROR_CHUNK_EXTENSIONS_OVERFLOW);
                         }
-                        /* The fin dispatch completes the message: a malformed trailer field
-                         * line must fail it first (node: HPE_INVALID_HEADER_TOKEN). */
-                        if (IsNodeHttp && chunk.length() == 0 && !validNodeTrailerSection(nodeHttpRequestTrailers, useInsecureHTTPParser)) [[unlikely]] {
-                            return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, HTTP_PARSER_ERROR_INVALID_HEADER_TOKEN);
+                        /* The fin dispatch completes the message: a malformed or
+                         * framing-field trailer must fail it first (node: HPE_*). */
+                        if (IsNodeHttp && chunk.length() == 0) {
+                            if (HttpParserError trailerError = validateNodeTrailerSection(nodeHttpRequestTrailers, useInsecureHTTPParser)) [[unlikely]] {
+                                return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, trailerError);
+                            }
                         }
                         void *returnedUser = dataHandler(user, chunk, chunk.length() == 0);
                         if (returnedUser != user) {
@@ -1359,10 +1384,12 @@ public:
                     if (*chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
                         return HttpParserResult::error(HTTP_ERROR_413_PAYLOAD_TOO_LARGE, HTTP_PARSER_ERROR_CHUNK_EXTENSIONS_OVERFLOW);
                     }
-                    /* The fin dispatch completes the message: a malformed trailer field
-                     * line must fail it first (node: HPE_INVALID_HEADER_TOKEN). */
-                    if (IsNodeHttp && chunk.length() == 0 && !validNodeTrailerSection(nodeHttpRequestTrailers, useInsecureHTTPParser)) [[unlikely]] {
-                        return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, HTTP_PARSER_ERROR_INVALID_HEADER_TOKEN);
+                    /* The fin dispatch completes the message: a malformed or
+                     * framing-field trailer must fail it first (node: HPE_*). */
+                    if (IsNodeHttp && chunk.length() == 0) {
+                        if (HttpParserError trailerError = validateNodeTrailerSection(nodeHttpRequestTrailers, useInsecureHTTPParser)) [[unlikely]] {
+                            return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, trailerError);
+                        }
                     }
                     void *returnedUser = dataHandler(user, chunk, chunk.length() == 0);
                     if (returnedUser != user) {
@@ -1442,10 +1469,12 @@ public:
                             if (*chunkedExtensionsByteCount > MAX_CHUNK_EXTENSION_SIZE) [[unlikely]] {
                                 return HttpParserResult::error(HTTP_ERROR_413_PAYLOAD_TOO_LARGE, HTTP_PARSER_ERROR_CHUNK_EXTENSIONS_OVERFLOW);
                             }
-                            /* The fin dispatch completes the message: a malformed trailer field
-                             * line must fail it first (node: HPE_INVALID_HEADER_TOKEN). */
-                            if (IsNodeHttp && chunk.length() == 0 && !validNodeTrailerSection(nodeHttpRequestTrailers, useInsecureHTTPParser)) [[unlikely]] {
-                                return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, HTTP_PARSER_ERROR_INVALID_HEADER_TOKEN);
+                            /* The fin dispatch completes the message: a malformed or
+                             * framing-field trailer must fail it first (node: HPE_*). */
+                            if (IsNodeHttp && chunk.length() == 0) {
+                                if (HttpParserError trailerError = validateNodeTrailerSection(nodeHttpRequestTrailers, useInsecureHTTPParser)) [[unlikely]] {
+                                    return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, trailerError);
+                                }
                             }
                             void *returnedUser = dataHandler(user, chunk, chunk.length() == 0);
                             if (returnedUser != user) {

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1267,6 +1267,7 @@ enum HttpParserError {
   HTTP_PARSER_ERROR_CLOSED_CONNECTION = 14,
   HTTP_PARSER_ERROR_TRAILER_FIELDS_TOO_LARGE = 15,
   HTTP_PARSER_ERROR_CHUNK_TERMINATOR_EXPECTED = 16,
+  HTTP_PARSER_ERROR_TRAILER_CONTENT_LENGTH = 17,
 }
 // Native callback fired when the HTTP parser rejects incoming bytes. Builds
 // the same error object Node's parser produces and routes it through
@@ -1302,6 +1303,9 @@ function onServerClientError(ssl: boolean, socket: unknown, errorCode: number, r
       break;
     case HttpParserError.HTTP_PARSER_ERROR_INVALID_TRANSFER_ENCODING:
       err = $HPE_INVALID_TRANSFER_ENCODING("Parse Error: Request has invalid `Transfer-Encoding`");
+      break;
+    case HttpParserError.HTTP_PARSER_ERROR_TRAILER_CONTENT_LENGTH:
+      err = $HPE_INVALID_CONTENT_LENGTH("Parse Error: Content-Length can't be present with Transfer-Encoding");
       break;
     case HttpParserError.HTTP_PARSER_ERROR_INVALID_REQUEST:
       err = $HPE_INVALID_CONSTANT("Parse Error: Expected HTTP/");

--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -307,6 +307,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_REDIS_TLS_NOT_AVAILABLE", Error, "RedisError"],
   ["ERR_REDIS_TLS_UPGRADE_FAILED", Error, "RedisError"],
   ["HPE_UNEXPECTED_CONTENT_LENGTH", Error],
+  ["HPE_INVALID_CONTENT_LENGTH", Error],
   ["HPE_INVALID_TRANSFER_ENCODING", Error],
   ["HPE_INVALID_EOF_STATE", Error],
   ["HPE_INVALID_METHOD", Error],

--- a/test/js/node/http/node-http-transfer-encoding.test.ts
+++ b/test/js/node/http/node-http-transfer-encoding.test.ts
@@ -306,7 +306,7 @@ test("framing field in trailers is rejected before a pipelined follow-up is serv
   socket.on("close", () => resolve(wire));
   const response = await promise;
   expect(response).toContain("x-cerr: HPE_INVALID_CONTENT_LENGTH");
-  expect(response).not.toContain("content-length\":\"5\"");
+  expect(response).not.toContain('content-length":"5"');
   expect(response).not.toContain("u=/after");
   expect(paths).toEqual(["/a"]);
 });

--- a/test/js/node/http/node-http-transfer-encoding.test.ts
+++ b/test/js/node/http/node-http-transfer-encoding.test.ts
@@ -237,6 +237,113 @@ test("insecureHTTPParser accepts a CTL byte in a trailer value like node", async
   expect(result).toEqual({ trailers: { "x-t": "a\bb" }, raw: ["X-T", "a\bb"] });
 });
 
+// RFC 9110 6.5.1: framing fields (Content-Length, Transfer-Encoding) are forbidden
+// in trailers. llhttp runs trailers through the same header state machine and the
+// already-set F_CHUNKED collides, so node rejects both before the body completes.
+for (const { field, value, code } of [
+  { field: "Content-Length", value: "5", code: "HPE_INVALID_CONTENT_LENGTH" },
+  { field: "content-length", value: "5", code: "HPE_INVALID_CONTENT_LENGTH" },
+  { field: "Transfer-Encoding", value: "chunked", code: "HPE_INVALID_TRANSFER_ENCODING" },
+  { field: "Transfer-Encoding", value: "gzip", code: "HPE_INVALID_TRANSFER_ENCODING" },
+  { field: "transfer-encoding", value: "chunked", code: "HPE_INVALID_TRANSFER_ENCODING" },
+]) {
+  test(`${field}: ${value} in trailer section fires clientError ${code}`, async () => {
+    const { promise, resolve } = Promise.withResolvers<{ err?: any; trailers?: any }>();
+    await using server = createServer((req, res) => {
+      req.resume();
+      req.on("end", () => {
+        resolve({ trailers: { ...req.trailers } });
+        res.end("ok");
+      });
+    });
+    server.on("clientError", (err, socket) => {
+      socket.destroy();
+      resolve({ err });
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const socket = connect(port, "127.0.0.1", () => {
+      socket.write(
+        "POST /a HTTP/1.1\r\nHost: h\r\nTransfer-Encoding: chunked\r\n\r\n" +
+          `5\r\nHELLO\r\n0\r\n${field}: ${value}\r\n\r\n`,
+      );
+    });
+    socket.on("error", () => {});
+    const result = await promise;
+    socket.destroy();
+    expect(result.err?.code).toBe(code);
+    expect(result.trailers).toBeUndefined();
+  });
+}
+
+test("framing field in trailers is rejected before a pipelined follow-up is served", async () => {
+  const paths: string[] = [];
+  await using server = createServer((req, res) => {
+    paths.push(req.url!);
+    req.resume();
+    req.on("end", () => res.end(`u=${req.url} trailers=${JSON.stringify(req.trailers)}`));
+  });
+  server.on("clientError", (err, socket) => {
+    try {
+      socket.end(`HTTP/1.1 400 x\r\nx-cerr: ${(err as any).code}\r\nconnection: close\r\n\r\n`);
+    } catch {}
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const { promise, resolve } = Promise.withResolvers<string>();
+  const socket = connect(port, "127.0.0.1", () => {
+    socket.write(
+      "POST /a HTTP/1.1\r\nHost: h\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5\r\nHELLO\r\n0\r\nContent-Length: 5\r\n\r\n" +
+        "GET /after HTTP/1.1\r\nHost: h\r\nConnection: close\r\n\r\n",
+    );
+  });
+  let wire = "";
+  socket.on("data", d => (wire += d));
+  socket.on("error", () => {});
+  socket.on("close", () => resolve(wire));
+  const response = await promise;
+  expect(response).toContain("x-cerr: HPE_INVALID_CONTENT_LENGTH");
+  expect(response).not.toContain("content-length\":\"5\"");
+  expect(response).not.toContain("u=/after");
+  expect(paths).toEqual(["/a"]);
+});
+
+test("insecureHTTPParser accepts Content-Length / Transfer-Encoding in trailers like node", async () => {
+  for (const { field, value } of [
+    { field: "Content-Length", value: "5" },
+    { field: "Transfer-Encoding", value: "chunked" },
+  ]) {
+    const { promise, resolve, reject } = Promise.withResolvers<{ trailers: any; raw: string[] }>();
+    await using server = createServer({ insecureHTTPParser: true }, (req, res) => {
+      req.resume();
+      req.on("end", () => {
+        resolve({ trailers: { ...req.trailers }, raw: [...req.rawTrailers] });
+        res.end("ok");
+      });
+    });
+    server.on("clientError", (err, socket) => {
+      socket.destroy();
+      reject(err);
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const socket = connect(port, "127.0.0.1", () => {
+      socket.write(
+        "POST / HTTP/1.1\r\nHost: h\r\nTransfer-Encoding: chunked\r\n\r\n" +
+          `5\r\nHELLO\r\n0\r\n${field}: ${value}\r\n\r\n`,
+      );
+    });
+    socket.on("error", reject);
+    const result = await promise;
+    socket.destroy();
+    expect(result).toEqual({ trailers: { [field.toLowerCase()]: value }, raw: [field, value] });
+  }
+});
+
 test("createServer({maxHeaderSize:0}) still bounds trailer section", async () => {
   const { promise, resolve, reject } = Promise.withResolvers<any>();
   await using server = createServer({ maxHeaderSize: 0 }, (req, res) => {


### PR DESCRIPTION
## Problem

A `node:http` server on current main accepts a chunked request whose trailer section carries `Content-Length` or `Transfer-Encoding`: the request completes (200), the forbidden field lands in `req.trailers`, and the connection stays keep-alive so a pipelined follow-up is served. Node.js (llhttp) hard-rejects both with 400 + `clientError` (`HPE_INVALID_CONTENT_LENGTH` / `HPE_INVALID_TRANSFER_ENCODING`), and so did bun 1.4.0's pre-rewrite parser. RFC 9110 6.5.1 forbids framing fields in trailers.

Framing itself is not altered (the body already terminated by the zero-chunk), so this is not a desync on bun itself. The risk is (a) any middleware that merges `req.trailers` into headers or forwards them gets header pollution with a framing field, and (b) strictness skew vs every llhttp-based peer.

### Reproduction

```js
import http from "node:http"; import net from "node:net";
const srv = http.createServer((req, res) => {
  req.on("data", () => {});
  req.on("end", () => res.end(`u=${req.url} trailers=${JSON.stringify(req.trailers)}`));
});
srv.on("clientError", (e, s) => s.end(`HTTP/1.1 400 x\r\nx-cerr: ${e.code}\r\nconnection: close\r\n\r\n`));
srv.listen(0, "127.0.0.1", () => {
  const s = net.connect(srv.address().port, "127.0.0.1");
  s.on("connect", () => s.write(
    "POST /a HTTP/1.1\r\nHost: h\r\nTransfer-Encoding: chunked\r\n\r\n" +
    "5\r\nHELLO\r\n0\r\nContent-Length: 5\r\n\r\n" +
    "GET /after HTTP/1.1\r\nHost: h\r\nConnection: close\r\n\r\n"));
  let w = ""; s.on("data", d => w += d); s.on("close", () => { console.log(w); process.exit(); });
});
```

node v26.3.0: `400 x-cerr: HPE_INVALID_CONTENT_LENGTH`, connection closed.
bun main before: `200 u=/a trailers={"content-length":"5"}` followed by `200 u=/after`.

## Cause

`validNodeTrailerSection` in `packages/bun-uws/src/HttpParser.h` validated only the field-line syntax of a captured trailer section (reuse of the header scanner); it had no framing-field deny list. llhttp runs trailers through the same header state machine, so a `Content-Length` there collides with the already-set `F_CHUNKED` ("Content-Length can't be present with Transfer-Encoding", `HPE_INVALID_CONTENT_LENGTH`) and a `Transfer-Encoding` there is rejected as a duplicate/invalid chunked token (`HPE_INVALID_TRANSFER_ENCODING`). The rewritten trailer path did not reproduce that collision.

## Fix

`validNodeTrailerSection` becomes `validateNodeTrailerSection` returning a specific `HttpParserError` instead of `bool`. After the existing syntax scan it flags `content-length` / `transfer-encoding` field names (case-insensitive), returning `HTTP_PARSER_ERROR_TRAILER_CONTENT_LENGTH` (new; maps to Node's `HPE_INVALID_CONTENT_LENGTH`) or the existing `HTTP_PARSER_ERROR_INVALID_TRANSFER_ENCODING`. The three call sites pass the returned code through. `insecureHTTPParser` bypasses the check, matching llhttp's `LENIENT_CHUNKED_LENGTH` / `LENIENT_TRANSFER_ENCODING`.

Other fields (Host, Upgrade, Connection) are not rejected: verified against node v26.3.0, llhttp accepts them in trailers. Connection in trailers has a side effect in node (it sets F_CONNECTION_CLOSE so a pipelined follow-up then fails with `HPE_CLOSED_CONNECTION`), but the trailered message itself still completes 200; that side effect is a separate accidental consequence of llhttp reusing the header state machine and is not in scope here.

`Bun.serve`'s native parser is untouched (the check is gated on `IsNodeHttp`), and it already rejects any trailer section.

## Verification

New tests in `test/js/node/http/node-http-transfer-encoding.test.ts`:

- `Content-Length` / `content-length` in trailers fire `clientError` with `HPE_INVALID_CONTENT_LENGTH` and the request body does not complete.
- `Transfer-Encoding: chunked` / `gzip` / lowercase variant in trailers fire `clientError` with `HPE_INVALID_TRANSFER_ENCODING`.
- The pipelined `GET /after` is never served and the framing field never reaches `req.trailers` (wire-level check matching the repro above).
- `insecureHTTPParser: true` accepts both CL and TE in trailers and surfaces them on `req.trailers` / `req.rawTrailers`, matching Node.

```
bun bd test test/js/node/http/node-http-transfer-encoding.test.ts   # 23 pass
bun bd test test/js/bun/http/request-smuggling.test.ts               # 75 pass
bun bd test test/js/bun/http/http-server-chunking.test.ts            # 13 pass
```

<details><summary>fail-before (src/ + packages/ stashed)</summary>

```
(fail) Content-Length: 5 in trailer section fires clientError HPE_INVALID_CONTENT_LENGTH
  Expected: "HPE_INVALID_CONTENT_LENGTH"  Received: undefined
(fail) content-length: 5 in trailer section fires clientError HPE_INVALID_CONTENT_LENGTH
(fail) Transfer-Encoding: chunked in trailer section fires clientError HPE_INVALID_TRANSFER_ENCODING
(fail) Transfer-Encoding: gzip in trailer section fires clientError HPE_INVALID_TRANSFER_ENCODING
(fail) transfer-encoding: chunked in trailer section fires clientError HPE_INVALID_TRANSFER_ENCODING
(fail) framing field in trailers is rejected before a pipelined follow-up is served
  Received: "HTTP/1.1 200 OK ... u=/a trailers={\"content-length\":\"5\"} ... u=/after trailers={}"
 17 pass  6 fail
```
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-transfer-encoding.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (60a7310cb)

test/js/node/http/node-http-transfer-encoding.test.ts:
(pass) should not duplicate transfer-encoding header in request [796.34ms]
(pass) should not duplicate transfer-encoding header in response when explicitly set [529.58ms]
(pass) chunked request trailers parse at every field-value scan boundary [560.91ms]
(pass) bare-LF in trailer section fires clientError instead of hanging [127.07ms]
(pass) bare-LF between trailer fields is rejected, not silently accepted [123.16ms]
(pass) CTL byte in a trailer value fires clientError HPE_INVALID_HEADER_TOKEN [103.39ms]
(pass) insecureHTTPParser accepts a CTL byte in a trailer value like node [130.82ms]
270 |       );
271 |     });
272 |     socket.on("error", ()
... (truncated)

release without fix: 20 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/http/node-http-transfer-encoding.test.ts:
(pass) should not duplicate transfer-encoding header in request [16.18ms]
(pass) should not duplicate transfer-encoding header in response when explicitly set [10.30ms]
129 |     socket.on("end", () => resolve(rawResponse));
130 |     socket.on("error", reject);
131 |     expect((await promise).split("\r\n\r\n").at(-1)).toBe("ok");
132 |   }
133 | 
134 |   expect(seen).toEqual(values.map(value => ({ trailers: { "x-boundary": value }, raw: ["X-Boundary", value] })));
                     ^
error: expect(received).toEqual(expected)

  [
    {
-     "raw": [
-       "X-Boundary",
-       "vvvvvvv",
-     ],
-     "trailers": {
-       "x-boundary": "vvvvvvv",
-     },
+     "raw": [],
+     "trailers": {},
    },
    {
-     "raw": [
-       "X-Boundary",
-       "vvvvvvvv",
-     ],
-     "trailers": {
-       "x-boundary": "vvvvvvvv",
-     },
+     "raw": [],
+     "trailers": {},
    },
    {
-     "raw": [
-       "X-Boundary",
-       "vvvvvvvvvvvvvvv",
-     ],
-     "trailers": {
-       "x-boundary": "vvvvvvvvvvvvvvv",
-     },
+     "raw": [],
+     "trailers": {},
  
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-transfer-encoding.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (60a7310cb)

test/js/node/http/node-http-transfer-encoding.test.ts:
(pass) should not duplicate transfer-encoding header in request [831.27ms]
(pass) should not duplicate transfer-encoding header in response when explicitly set [557.67ms]
(pass) chunked request trailers parse at every field-value scan boundary [587.96ms]
(pass) bare-LF in trailer section fires clientError instead of hanging [155.30ms]
(pass) bare-LF between trailer fields is rejected, not silently accepted [121.80ms]
(pass) CTL byte in a trailer value fires clientError HPE_INVALID_HEADER_TOKEN [169.41ms]
(pass) insecureHTTPParser accepts a CTL byte in a trailer value like node [143.08ms]
(pass) Content-Length: 5 in trailer section fires clientErro
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     60a7310cb6
  features     (none)

22 deps, 106 codegen, 1169 objects in 933ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1232] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [21.00ms]
[2/1232] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [6.00ms]
[3/1232] gen bindgenv2
[4/1232] gen ErrorCode+*.h
[5/1232] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [9.00ms]
[6/1232] fetch zlib
[zlib] up to date
[7/1232] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1232] fetch picoht
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-uws/src/HttpParser.h                  |  63 ++++++++----
 src/js/node/_http_server.ts                        |   4 +
 src/jsc/bindings/ErrorCode.ts                      |   1 +
 .../node/http/node-http-transfer-encoding.test.ts  | 107 +++++++++++++++++++++
 4 files changed, 158 insertions(+), 17 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
packages/bun-uws/src/HttpParser.h                          5      5      0
src/js/node/_http_server.ts                                2      2      0
src/jsc/bindings/ErrorCode.ts                              1      1      0
test/js/node/http/node-http-transfer-encoding.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->