### PR TITLE
mimalloc: fold every thread's theap into the subproc stats aggregate

### DIFF
--- a/patches/mimalloc/stats-aggregate-all-theaps.patch
+++ b/patches/mimalloc/stats-aggregate-all-theaps.patch
@@ -1,0 +1,20 @@
+--- a/src/stats.c
++++ b/src/stats.c
+@@ -619,6 +619,17 @@
+ static bool mi_cdecl mi_heap_aggregate_visitor(mi_heap_t* heap, void* arg) {
+   mi_stats_t* stats = (mi_stats_t*)arg;
+   mi_stats_add_into(stats, mi_heap_get_stats(heap));
++  // Fold in every thread's theap, not just the caller's: the NULL-theap path in
++  // `_mi_arenas_page_free` decrements `heap->stats.pages` for a page whose +1 may still
++  // sit in another thread's unmerged theap, so summing only `heap->stats` underreports.
++  // `mi_heap_get_stats` above already merged (and zeroed) the caller's theap, so including
++  // it again is a no-op. Lock order `subproc->heaps_lock` -> `heap->theaps_lock` matches
++  // `mi_prof_set_all_theaps` and the fork-prepare path.
++  mi_lock(&heap->theaps_lock) {
++    for (mi_theap_t* t = heap->theaps; t != NULL; t = t->hnext) {
++      mi_stats_add_into(stats, &t->stats);
++    }
++  }
+   return true;
+ }
+ 

--- a/patches/mimalloc/stats-aggregate-all-theaps.patch
+++ b/patches/mimalloc/stats-aggregate-all-theaps.patch
@@ -1,16 +1,17 @@
 --- a/src/stats.c
 +++ b/src/stats.c
-@@ -619,6 +619,17 @@
+@@ -618,7 +618,17 @@
+ 
  static bool mi_cdecl mi_heap_aggregate_visitor(mi_heap_t* heap, void* arg) {
    mi_stats_t* stats = (mi_stats_t*)arg;
-   mi_stats_add_into(stats, mi_heap_get_stats(heap));
-+  // Fold in every thread's theap, not just the caller's: the NULL-theap path in
-+  // `_mi_arenas_page_free` decrements `heap->stats.pages` for a page whose +1 may still
-+  // sit in another thread's unmerged theap, so summing only `heap->stats` underreports.
-+  // `mi_heap_get_stats` above already merged (and zeroed) the caller's theap, so including
-+  // it again is a no-op. Lock order `subproc->heaps_lock` -> `heap->theaps_lock` matches
-+  // `mi_prof_set_all_theaps` and the fork-prepare path.
+-  mi_stats_add_into(stats, mi_heap_get_stats(heap));
++  // Fold in `heap->stats` plus every thread's theap, not just the caller's: the NULL-theap
++  // path in `_mi_arenas_page_free` decrements `heap->stats.pages` for a page whose +1 may
++  // still sit in another thread's unmerged theap, so summing only `heap->stats` underreports.
++  // Pure read (no merge-and-zero) so the aggregate is a side-effect-free snapshot. Lock order
++  // `subproc->heaps_lock` -> `heap->theaps_lock` matches `mi_prof_set_all_theaps`.
 +  mi_lock(&heap->theaps_lock) {
++    mi_stats_add_into(stats, &heap->stats);
 +    for (mi_theap_t* t = heap->theaps; t != NULL; t = t->hnext) {
 +      mi_stats_add_into(stats, &t->stats);
 +    }

--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -24,6 +24,8 @@ export const mimalloc: Dependency = {
     commit: MIMALLOC_COMMIT,
   }),
 
+  patches: ["patches/mimalloc/stats-aggregate-all-theaps.patch"],
+
   build: cfg => {
     // ─── Override behavior (global malloc replacement) ───
     //   ASAN:    OFF — ASAN interceptors must see the real malloc.

--- a/test/js/bun/jsc/heapStats-mimalloc.test.ts
+++ b/test/js/bun/jsc/heapStats-mimalloc.test.ts
@@ -54,6 +54,7 @@ describe("heapStats() mimalloc integration", () => {
     using dir = tempDir("heapStats-mimalloc-pages", {
       "check.js": `
         import { heapStats } from "bun:jsc";
+        const theapsBefore = heapStats().mimalloc.theaps?.current ?? 0;
         const code = \`
           const hold = [];
           for (let i = 0; i < 50000; i++) hold.push({ a: i, b: "str_" + i });
@@ -69,7 +70,7 @@ describe("heapStats() mimalloc integration", () => {
         const stat = s.mimalloc.pages.current;
         const binSum = s.mimalloc.page_bins.reduce((a, b) => a + b.current, 0);
         const theaps = s.mimalloc.theaps?.current ?? 0;
-        console.log(JSON.stringify({ stat, dump, binSum, theaps }));
+        console.log(JSON.stringify({ stat, dump, binSum, theapsBefore, theaps }));
         w.terminate();
       `,
     });
@@ -81,17 +82,17 @@ describe("heapStats() mimalloc integration", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    const { stat, dump, binSum, theaps } = JSON.parse(stdout);
-    // A Worker allocates on its own thread and must create at least one theap; without that
-    // precondition the assertion below would be vacuous.
-    expect(theaps).toBeGreaterThan(0);
+    const { stat, dump, binSum, theapsBefore, theaps } = JSON.parse(stdout);
+    // The Worker allocates on its own thread; if that didn't create a new theap the assertion
+    // below would be vacuous (only the caller's theap exists, which the old aggregate already
+    // folded in). The static main theap is not counted, so before is 0 in practice.
+    expect({ theapsBefore, theaps }).toSatisfy(v => v.theaps > v.theapsBefore);
     // The live heap walk is ground truth. A small slack covers the few pages that can change
     // between the two reads; before the fix the counter sat tens of pages below the walk here.
     expect(stat).toBeGreaterThanOrEqual(0);
     expect({ stat, dump }).toSatisfy(v => v.stat >= v.dump - 5);
     expect({ binSum, dump }).toSatisfy(v => v.binSum >= v.dump - 5);
-    expect(exitCode).toBe(0);
+    expect({ stderr, exitCode }).toEqual({ stderr: expect.any(String), exitCode: 0 });
   });
 
   test("dump reflects new heaps and allocations", () => {

--- a/test/js/bun/jsc/heapStats-mimalloc.test.ts
+++ b/test/js/bun/jsc/heapStats-mimalloc.test.ts
@@ -82,17 +82,23 @@ describe("heapStats() mimalloc integration", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // Surface stderr/exitCode before parsing so a subprocess crash reports the real diagnostic
+    // instead of a bare JSON SyntaxError.
+    expect({ stdout: stdout.trim() || null, stderr, exitCode }).toMatchObject({
+      stdout: expect.any(String),
+      exitCode: 0,
+    });
     const { stat, dump, binSum, theapsBefore, theaps } = JSON.parse(stdout);
     // The Worker allocates on its own thread; if that didn't create a new theap the assertion
     // below would be vacuous (only the caller's theap exists, which the old aggregate already
     // folded in). The static main theap is not counted, so before is 0 in practice.
     expect({ theapsBefore, theaps }).toSatisfy(v => v.theaps > v.theapsBefore);
-    // The live heap walk is ground truth. A small slack covers the few pages that can change
-    // between the two reads; before the fix the counter sat tens of pages below the walk here.
+    // The live heap walk is ground truth. Bracket the counter: the lower bound catches the
+    // pre-fix underreport (~-36 here), the upper bound catches a double-fold. Slack covers the
+    // few pages that can change between the two reads plus a concurrent merge-and-zero.
     expect(stat).toBeGreaterThanOrEqual(0);
-    expect({ stat, dump }).toSatisfy(v => v.stat >= v.dump - 5);
-    expect({ binSum, dump }).toSatisfy(v => v.binSum >= v.dump - 5);
-    expect({ stderr, exitCode }).toEqual({ stderr: expect.any(String), exitCode: 0 });
+    expect({ stat, dump }).toSatisfy(v => v.stat >= v.dump - 5 && v.stat <= v.dump + 10);
+    expect({ binSum, dump }).toSatisfy(v => v.binSum >= v.dump - 5 && v.binSum <= v.dump + 10);
   });
 
   test("dump reflects new heaps and allocations", () => {

--- a/test/js/bun/jsc/heapStats-mimalloc.test.ts
+++ b/test/js/bun/jsc/heapStats-mimalloc.test.ts
@@ -1,5 +1,6 @@
 import { heapStats } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("heapStats() mimalloc integration", () => {
   test("mimalloc aggregate stats are present", () => {
@@ -43,6 +44,54 @@ describe("heapStats() mimalloc integration", () => {
     for (const [, sz] of main.blocks.slice(0, 50)) {
       expect(pageSizes.has(sz)).toBe(true);
     }
+  });
+
+  // `pages.current` must account for pages allocated by every thread's theap, not just the
+  // caller's: the increment lands in the allocating thread's theap, while a cross-thread free
+  // of an abandoned page decrements heap->stats directly. Summing only the caller's theap
+  // underreports by the pages other threads allocated (and can go negative under churn).
+  test("pages.current agrees with the live heap dump across threads", async () => {
+    using dir = tempDir("heapStats-mimalloc-pages", {
+      "check.js": `
+        import { heapStats } from "bun:jsc";
+        const code = \`
+          const hold = [];
+          for (let i = 0; i < 50000; i++) hold.push({ a: i, b: "str_" + i });
+          self.postMessage("ready");
+          self.onmessage = () => {};
+        \`;
+        const url = URL.createObjectURL(new Blob([code], { type: "application/javascript" }));
+        const w = new Worker(url);
+        await new Promise(r => { w.onmessage = r; });
+        const s = heapStats({ dump: true });
+        let dump = 0;
+        for (const h of s.mimallocDump.heaps) dump += h.pages.length;
+        const stat = s.mimalloc.pages.current;
+        const binSum = s.mimalloc.page_bins.reduce((a, b) => a + b.current, 0);
+        const theaps = s.mimalloc.theaps?.current ?? 0;
+        console.log(JSON.stringify({ stat, dump, binSum, theaps }));
+        w.terminate();
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "check.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const { stat, dump, binSum, theaps } = JSON.parse(stdout);
+    // A Worker allocates on its own thread and must create at least one theap; without that
+    // precondition the assertion below would be vacuous.
+    expect(theaps).toBeGreaterThan(0);
+    // The live heap walk is ground truth. A small slack covers the few pages that can change
+    // between the two reads; before the fix the counter sat tens of pages below the walk here.
+    expect(stat).toBeGreaterThanOrEqual(0);
+    expect({ stat, dump }).toSatisfy(v => v.stat >= v.dump - 5);
+    expect({ binSum, dump }).toSatisfy(v => v.binSum >= v.dump - 5);
+    expect(exitCode).toBe(0);
   });
 
   test("dump reflects new heaps and allocations", () => {


### PR DESCRIPTION
Since #34009 moved JSC onto mimalloc, `heapStats().mimalloc.pages.current` (and `page_bins[].current`) can drift negative under an import-and-bust loop. First seen on macOS arm64 `--smol` (`45 → 72 → -125 → -534` over 1000 iterations) and noted in #34159's side note; #34359 and #34686 work around the same drift in `node-net.test.ts`.

### Repro

```js
// start a Worker so another thread allocates mimalloc pages
const w = new Worker(URL.createObjectURL(new Blob([`
  const hold = [];
  for (let i = 0; i < 50000; i++) hold.push({ a: i, b: "str_" + i });
  self.postMessage("ready"); self.onmessage = () => {};
`], { type: "application/javascript" })));
await new Promise(r => { w.onmessage = r; });
const s = require("bun:jsc").heapStats({ dump: true });
let dump = 0; for (const h of s.mimallocDump.heaps) dump += h.pages.length;
console.log({ stat: s.mimalloc.pages.current, dump });  // { stat: 46, dump: 82 }
```

The live heap walk (`mimallocDump`, ground truth) counts 82 pages; the stat counter reports 46. The 36 missing pages are the Worker thread's.

### Cause

`mi_subproc_stats_get` summed `subproc->stats` plus each `heap->stats`, after merging only the **calling** thread's theap into its heap (`mi_heap_get_stats` → `_mi_heap_theap_peek`). The `pages` counter is incremented in the **allocating** thread's theap (`arena.c:986`), while a cross-thread or scavenger free of an abandoned page decrements `heap->stats.pages` directly via the NULL-theap branch of `_mi_arenas_page_free` (`arena.c:1171`, reached from `free.c:271` and the abandoned-holes sweep at `arena.c:1350/1356`). Threads that never call `mi_collect`/`mi_on_thread_idle` (JSC helper threads, Worker VMs, the transpiler pool while busy) leave their +1s in an unmerged theap the aggregate never read, so every page they allocated is invisible while its eventual `-1` is visible. Under churn the visible side outruns the invisible side and `pages.current` goes negative.

### Fix

`mi_heap_aggregate_visitor` now reads `heap->stats` plus every theap on `heap->theaps`, under `heap->theaps_lock`, as a pure snapshot with no merge-and-zero side effect. Lock order `subproc->heaps_lock → heap->theaps_lock` matches `mi_prof_set_all_theaps` and the fork-prepare path in `init.c`. Reads of another thread's `theap->stats` are racy with that thread's non-atomic writes, which is fine for an advisory snapshot (aligned `int64_t` reads on every target Bun supports); a concurrent `mi_theap_merge_stats` (add then memzero, without `theaps_lock`) can transiently over-count by one merging theap's pending delta, which the test's upper bound tolerates.

Applied as a patch because I can't push to oven-sh/mimalloc; the same change belongs upstream there.

### Why this is the right level

The alternative is to move the `pages` increment to `heap->stats` (atomic) at page-alloc time so both sides always target the same counter. That adds an atomic RMW on every fresh page alloc and still leaves the other theap-local counters (`page_committed`, `pages_abandoned`, `page_bins`) under-reported for the same reason. Folding all theaps into the read-side aggregate fixes every counter with no hot-path change.

### Verification

```
# USE_SYSTEM_BUN=1 (5 runs, identical):
expect(received).toSatisfy(expected)
Received: { stat: 46, dump: 81 }
(fail) pages.current agrees with the live heap dump across threads

# bun bd test (3 runs):
(pass) pages.current agrees with the live heap dump across threads
```

The test brackets the counter against the live walk (`dump - 5 ≤ stat ≤ dump + 10`) so it catches both the pre-fix underreport and any future double-fold. All five tests in `test/js/bun/jsc/heapStats-mimalloc.test.ts` pass on the debug build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · The fix is a vendored-dep patch (`patches/mimalloc/` + `scripts/build/deps/mimalloc.ts`); neither is under `src/` or `packages/`, so the fail-before stash is a no-op and both builds have the patch applied. Fail-before/pass-after shown above with `USE_SYSTEM_BUN=1` vs `bun bd`.

<!-- robobun:evidence:end -->