### PR TITLE
test: audit ASAN quarantine lists; remove 77 stale entries

### DIFF
--- a/test/expectations.txt
+++ b/test/expectations.txt
@@ -76,12 +76,9 @@ test/js/node/test/parallel/test-set-http-max-http-headers.js [ FAIL ] # spawns t
 test/js/bun/spawn/spawn-maxbuf.test.ts [ FLAKY ]
 
 # Tests failed due to ASAN: attempting free on address which was not malloc()-ed
-[ ASAN ] test/js/node/worker_threads/worker_threads.test.ts [ CRASH ] # After: threadId module and worker property is consistent
-[ ASAN ] test/js/node/worker_threads/worker_destruction.test.ts [ CRASH ] # After: bun closes cleanly when Bun.connect is used in a Worker that is terminating
 [ ASAN ] test/integration/next-pages/test/dev-server-ssr-100.test.ts [ CRASH ]
 [ ASAN ] test/integration/next-pages/test/next-build.test.ts [ CRASH ]
 [ ASAN ] test/js/third_party/next-auth/next-auth.test.ts [ CRASH ]
-[ ASAN ] test/js/node/watch/fs.watch.test.ts [ CRASH ]
 
 # Tests failed due to ASAN: SEGV on unknown address
 [ ASAN ] test/integration/next-pages/test/dev-server.test.ts [ CRASH ]
@@ -105,11 +102,7 @@ test/js/bun/spawn/spawn-maxbuf.test.ts [ FLAKY ]
 [ ASAN ] test/js/node/worker_threads/worker-transfer-terminate-stress.test.ts [ CRASH ] # #34690: ExceptionScope::assertNoException during worker terminate bootstrap
 
 # Tests failed due to ASAN: use-after-poison
-[ ASAN ] test/js/node/test/parallel/test-worker-unref-from-message-during-exit.js [ CRASH ]
 [ ASAN ] test/napi/napi.test.ts [ CRASH ] # can throw an exception from an async_complete_callback
-[ ASAN ] test/js/node/test/parallel/test-fs-watch.js [ CRASH ]
-[ ASAN ] test/js/node/test/parallel/test-fs-watch-recursive-watch-file.js [ CRASH ]
-[ ASAN ] test/js/node/test/parallel/test-fs-promises-watch.js [ CRASH ]
 
 # Tests failed due to ASAN: unknown-crash
 [ ASAN ] test/js/sql/tls-sql.test.ts [ CRASH ] # After: Throws on illegal transactions
@@ -117,8 +110,6 @@ test/js/bun/spawn/spawn-maxbuf.test.ts [ FLAKY ]
 # Tests timed out due to ASAN
 [ ASAN ] test/js/bun/spawn/spawn.test.ts [ TIMEOUT ]
 [ ASAN ] test/cli/inspect/inspect.test.ts [ TIMEOUT ]
-[ ASAN ] test/cli/test/parallel.test.ts [ TIMEOUT ] # 24 spawns × N workers each × LSAN exit overhead
-[ ASAN ] test/cli/test/isolation.test.ts [ TIMEOUT ] # 14 spawns × LSAN exit overhead
 [ ASAN ] test/js/bun/typescript/type-export.test.ts [ TIMEOUT ] # bun build --compile is slow under ASAN
 
 # Tests failed due to memory leaks
@@ -126,7 +117,6 @@ test/js/bun/spawn/spawn-maxbuf.test.ts [ FLAKY ]
 [ ASAN ] test/js/node/fs/abort-signal-leak-read-write-file.test.ts [ LEAK ] # should not leak memory with already aborted signals
 [ ASAN ] test/js/web/streams/streams-leak.test.ts [ LEAK ] # Absolute memory usage remains relatively constant when reading and writing to a pipe
 [ ASAN ] test/cli/run/require-cache.test.ts [ LEAK ] # files transpiled and loaded don't leak file paths > via require()
-[ ASAN ] test/js/bun/io/bun-write-leak.test.ts [ LEAK ] # Bun.write should not leak the output data
 
 # Windows-only gaps in named-pipe / socket teardown for ported Node net tests
 # (these pass on Linux and macOS): half-close (FIN) handling on named pipes,
@@ -142,10 +132,6 @@ test/js/bun/spawn/spawn-maxbuf.test.ts [ FLAKY ]
 # readable side on Windows, so the accepted connection never ends and
 # server.close() (via `await using`) waits forever. The assertion itself passes;
 # only the teardown hangs. Passes on Linux and macOS.
-
-# The 10 MB socket write in this test is an order of magnitude slower under
-# AddressSanitizer and exceeds the per-test timeout; it passes on regular builds.
-[ ASAN ] test/js/node/test/parallel/test-net-error-twice.js [ SKIP ] # ASAN-instrumented 10 MB write exceeds the timeout
 
 # The localAddress/localPort bind-before-connect and the SO_ERROR read on a
 # connecting socket that was reset during establishment are implemented in the

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -1,72 +1,25 @@
 # List of tests for which we do NOT set validateExceptionChecks=1 when running in ASAN CI
 
 # List of tests that potentially throw inside of reifyStaticProperties
-test/js/node/test/parallel/test-stream-some-find-every.mjs
-test/js/node/test/parallel/test-stream-iterator-helpers-test262-tests.mjs
-test/js/node/test/parallel/test-fs-stat-date.mjs
-test/js/node/test/parallel/test-fs-readSync-position-validation.mjs
-test/js/node/test/parallel/test-fs-read-promises-position-validation.mjs
-test/js/node/test/parallel/test-fs-read-position-validation.mjs
-test/js/node/test/parallel/test-net-server-async-dispose.mjs
-test/js/node/test/parallel/test-net-connect-custom-lookup-non-string-address.mjs
-test/js/node/test/parallel/test-abortsignal-any.mjs
-test/js/node/test/parallel/test-child-process-fork-url.mjs
-test/js/node/test/parallel/test-debugger-invalid-json.mjs
-test/js/node/test/parallel/test-dgram-async-dispose.mjs
-test/js/node/test/parallel/test-events-add-abort-listener.mjs
-test/js/node/test/parallel/test-fetch.mjs
-test/js/node/test/parallel/test-module-globalpaths-nodepath.js
-test/js/node/test/parallel/test-parse-args.mjs
-test/js/node/test/parallel/test-process-default.js
-test/js/node/test/parallel/test-readline-promises-csi.mjs
-test/js/node/test/parallel/test-require-dot.js
-test/js/node/test/parallel/test-util-promisify-custom-names.mjs
-test/js/node/test/parallel/test-whatwg-readablestream.mjs
-test/js/node/test/parallel/test-worker.mjs
-test/js/node/test/system-ca/test-native-root-certs.test.mjs
-test/js/node/events/event-emitter.test.ts
 test/js/node/module/node-module-module.test.js
 test/js/node/module/module-resolve-filename-paths.test.js
-test/js/node/process/call-constructor.test.js
-test/js/node/stubs.test.js
-test/js/node/timers/node-timers.test.ts
-test/bake/dev/vfile.test.ts
-test/bake/dev/import-meta-inline.test.ts
 test/bake/dev/production.test.ts
-test/cli/run/run-eval.test.ts
-test/cli/run/self-reference.test.ts
-test/js/bun/resolve/import-meta-resolve.test.mjs
 test/js/bun/resolve/import-meta.test.js
 test/js/bun/util/BunObject.test.ts
 test/js/bun/util/fuzzy-wuzzy.test.ts
-test/js/third_party/pg-gateway/pglite.test.ts
 test/js/web/websocket/websocket.test.js
 test/js/node/test/parallel/test-vm-module-referrer-realm.mjs
 test/js/bun/resolve/resolve.test.ts
-test/cli/install/bunx.test.ts
-test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
 test/integration/vite-build/vite-build.test.ts
-test/bundler/esbuild/default.test.ts
-test/cli/install/bun-repl.test.ts
 test/js/third_party/astro/astro-post.test.js
 test/regression/issue/ctrl-c.test.ts
-test/bundler/bundler_comments.test.ts
-test/js/node/test/parallel/test-fs-promises-file-handle-readLines.mjs
-test/js/bun/test/parallel/test-require-builtins.ts
 test/cli/install/bun-install-lifecycle-scripts.test.ts
 test/js/bun/test/parallel/test-integration-rspack.ts
 
-# trips asan on my macos test machine
-test/js/node/test/parallel/test-fs-watch.js
-test/js/node/test/parallel/test-fs-watch-recursive-watch-file.js
 # hit a debug assert
 test/bundler/bundler_compile.test.ts
 
-# try again later
-test/js/node/test/parallel/test-worker-nested-uncaught.js
-
 # 3rd party napi
-test/regression/issue/30205.test.ts
 test/integration/sharp/sharp.test.ts
 test/js/third_party/@napi-rs/canvas/napi-rs-canvas.test.ts
 test/js/third_party/prisma/prisma.test.ts
@@ -116,10 +69,7 @@ test/napi/node-napi-tests/test/node-api/test_exception/do.test.ts
 test/napi/node-napi-tests/test/node-api/test_fatal/do.test.ts
 test/napi/node-napi-tests/test/node-api/test_fatal_exception/do.test.ts
 test/napi/node-napi-tests/test/node-api/test_general/do.test.ts
-test/napi/node-napi-tests/test/node-api/test_init_order/do.test.ts
-test/napi/node-napi-tests/test/node-api/test_instance_data/do.test.ts
 test/napi/node-napi-tests/test/node-api/test_make_callback/do.test.ts
-test/napi/node-napi-tests/test/node-api/test_make_callback_recurse/do.test.ts
 test/napi/node-napi-tests/test/node-api/test_threadsafe_function/do.test.ts
 test/napi/node-napi-tests/test/node-api/test_worker_terminate_finalization/do.test.ts
 test/napi/node-napi-tests/test/node-api/test_reference_by_node_api_version/do.test.ts
@@ -130,22 +80,10 @@ test/napi/node-napi-tests/test/node-api/test_general/do.test.ts
 test/js/bun/crypto/wpt-webcrypto.generateKey.test.ts
 test/js/deno/crypto/webcrypto.test.ts
 test/js/node/crypto/node-crypto.test.js
-test/js/node/test/parallel/test-crypto-oaep-zero-length.js
-test/js/node/test/parallel/test-crypto-psychic-signatures.js
-test/js/node/test/parallel/test-crypto-subtle-zero-length.js
 test/js/node/test/parallel/test-crypto-webcrypto-aes-decrypt-tag-too-small.js
-test/js/node/test/parallel/test-crypto-worker-thread.js
-test/js/node/test/parallel/test-webcrypto-cryptokey-workers.js
-test/js/node/test/parallel/test-webcrypto-derivekey.js
-test/js/node/test/parallel/test-webcrypto-digest.js
 test/js/node/test/parallel/test-webcrypto-encrypt-decrypt-aes.js
-test/js/node/test/parallel/test-webcrypto-encrypt-decrypt.js
-test/js/node/test/parallel/test-webcrypto-sign-verify.js
 test/js/third_party/pg/pg.test.ts
 test/js/web/crypto/web-crypto.test.ts
-test/regression/issue/01466.test.ts
-test/regression/issue/21311.test.ts
-test/regression/issue/24399.test.ts
 vendor/elysia/test/aot/response.test.ts
 vendor/elysia/test/cookie/response.test.ts
 vendor/elysia/test/cookie/signature.test.ts
@@ -154,7 +92,6 @@ vendor/elysia/test/lifecycle/error.test.ts
 vendor/elysia/test/validator/body.test.ts
 vendor/elysia/test/ws/message.test.ts
 
-test/js/node/test/parallel/test-worker-abort-on-uncaught-exception.js
 
 # TODO: WebCore fixes
 test/js/web/urlpattern/urlpattern.test.ts

--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -61,6 +61,9 @@ test/js/node/test/parallel/test-worker-workerdata-sharedarraybuffer.js
 test/js/node/test/parallel/test-worker.js
 test/js/node/test/parallel/test-worker.mjs
 test/js/node/worker_threads/worker_destruction.test.ts
+# Two tests hit their 5s timeout under BUN_DESTRUCT_VM_ON_EXIT; passes without
+# LSAN and no sanitizer report, just slow VM teardown.
+test/js/node/watch/fs.watch.test.ts
 test/js/web/broadcastchannel/broadcast-channel.test.ts
 test/js/web/broadcastchannel/broadcast-channel-worker-gc.test.ts
 
@@ -158,11 +161,8 @@ test/cli/install/minimum-release-age.test.ts
 
 
 # crash for reasons not related to LSAN
-test/js/node/test/parallel/test-fs-watch-recursive-watch-file.js
 test/js/node/test/parallel/test-dgram-send-address-types.js
-test/js/node/test/parallel/test-fs-watch.js
 test/js/node/test/parallel/test-dgram-unref.js
-test/js/node/test/parallel/test-fs-promises-watch.js
 test/bake/dev/ecosystem.test.ts
 test/bake/dev/html.test.ts
 test/bake/dev/plugins.test.ts


### PR DESCRIPTION
Audited every `[ ASAN ]` entry in `test/expectations.txt` and every entry in `test/no-validate-exceptions.txt` against a release-asan build at 9dc6c37fe. Each test was run under four configs (bare ASAN / +validateExceptionChecks / +LeakSanitizer / full CI), and every removal candidate was re-verified 3x.

### `test/expectations.txt` (11 `[ ASAN ]` entries removed)

No test in this file reproduces an AddressSanitizer heap error anymore. Removed entries:

| Test | Was | Now |
|---|---|---|
| `worker_threads/worker_threads.test.ts` | CRASH (bad free) | bare clean; flaky LSAN leak 1/4 → stays in `no-validate-leaksan.txt` |
| `worker_threads/worker_destruction.test.ts` | CRASH (bad free) | bare clean; test-body timeout under `BUN_DESTRUCT_VM_ON_EXIT` → stays in `no-validate-leaksan.txt` |
| `node/watch/fs.watch.test.ts` | CRASH (bad free) | bare clean; test-body timeout under `BUN_DESTRUCT_VM_ON_EXIT` → added to `no-validate-leaksan.txt` |
| `test-worker-unref-from-message-during-exit.js` | CRASH (use-after-poison) | stable clean 3/3 under full CI config |
| `test-fs-watch.js` | CRASH (use-after-poison) | stable clean 5/5 |
| `test-fs-watch-recursive-watch-file.js` | CRASH (use-after-poison) | stable clean 5/5 |
| `test-fs-promises-watch.js` | CRASH (use-after-poison) | stable clean 5/5 |
| `cli/test/parallel.test.ts` | TIMEOUT | stable clean 3/3, ~22s under full config |
| `cli/test/isolation.test.ts` | TIMEOUT | stable clean 3/3, ~6s under full config |
| `bun/io/bun-write-leak.test.ts` | LEAK | stable clean 3/3, ~2s |
| `test-net-error-twice.js` | SKIP (slow write) | stable clean 3/3, ~0.5s |

Left in place: the two `transfer-terminate` entries added earlier today (#34686, known ~1/4000 flake); the next-pages / next-auth / napi / inspect / tls-sql / spawn / type-export entries (still fail under at least one config or could not be verified locally); the four `[ LEAK ]` entries that hit their 5s test-body timeout under ASAN.

### `test/no-validate-exceptions.txt` (63 lines removed)

60 entries now pass 3x under `BUN_JSC_validateExceptionChecks=1` on a release-asan build, plus 2 entries for files that no longer exist (`cli/install/bun-repl.test.ts` removed in fa3a30f075, `node/test/system-ca/test-native-root-certs.test.mjs`), plus one orphaned section header.

The `vendor/elysia/*` entries are left as-is (repo is cloned in CI via `test/vendor.json`, not present locally).

### `test/no-validate-leaksan.txt`

Added `test/js/node/watch/fs.watch.test.ts` (test-body timeout under `BUN_DESTRUCT_VM_ON_EXIT`, no sanitizer report). Removed `test-fs-watch.js`, `test-fs-watch-recursive-watch-file.js`, and `test-fs-promises-watch.js` (stable clean 5/5 under LSAN).

### Remaining unchecked-exception sites in Bun code

The still-failing entries in `no-validate-exceptions.txt` cluster around these throw → unchecked pairs in `src/jsc/`:

| Throw | Unchecked at | Repro |
|---|---|---|
| `NapiClass.cpp:120` finishCreation | `JSObject::defineOwnNonIndexProperty` | 33× napi tests, `require-cache.test.ts` |
| `napi_create_function` napi.cpp:954 | `napi_set_named_property` :598 etc. | addon Init() pattern (#32911) |
| `defaultBunSQLObject` BunObject.cpp:319 | itself | `BunObject.test.ts`, `import-meta.test.js`, `resolve.test.ts` |
| `JSObject::putInlineSlow` | `Process_functionDlopen` BunProcess.cpp:397 | napi `4_object_factory`, `5_function_factory` |
| `jsString` | `jsFunctionWrap` NodeModuleModule.cpp:220 | `node-module-module.test.js` |
| `jsSubstring` | `jsFunctionNodeModuleModuleConstructor` NodeModuleModule.cpp:172 | `module-resolve-filename-paths.test.js` |
| `isArraySlowInline` | `determineSpecificType` ErrorCode.cpp:348 | `isArray-proxy-crash.test.ts` |
| `importModuleInner` NodeVM.cpp:303 | `moduleLoaderImportModuleInner` NodeVM.cpp:1688 | `test-vm-module-referrer-realm.mjs` |
| `JSGenericTypedArrayView::create` | `jsPublicKeyObjectPrototype_export` :40 | `node-crypto.test.js` |
| `convertDictionaryToJS` JSURLPatternInit.cpp:148 | `convertURLPatternInputToJS` JSURLPatternResult.cpp:89 | `urlpattern.test.ts` |
| `normalizeCryptoAlgorithmParameters` SubtleCrypto.cpp:135 | `JSDOMPromiseDeferred::reject` :194/:159 | webcrypto tests |
| `evaluateWithScopeExtension` JSInjectedScriptHost.cpp:120 | `...PrototypeFunctionEvaluateWithScopeExtension` :275 | `inspect.test.ts` (WebKit) |
| `JSOrderedHashTable::getImpl` | `executeBoundCall` Interpreter.cpp:1223 | next-pages tests (WebKit) |
