### PR TITLE
URLPattern: release throw scope in convertURLPatternInputToJS

### DIFF
--- a/src/jsc/bindings/webcore/JSURLPatternResult.cpp
+++ b/src/jsc/bindings/webcore/JSURLPatternResult.cpp
@@ -88,7 +88,7 @@ static JSC::JSValue convertURLPatternInputToJS(JSC::JSGlobalObject& lexicalGloba
     auto& vm = JSC::getVM(&lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    return WTF::switchOn(input, [&](const String& str) -> JSValue { return toJS<IDLUSVString>(lexicalGlobalObject, throwScope, str); }, [&](const URLPatternInit& init) -> JSValue { return convertDictionaryToJS(lexicalGlobalObject, globalObject, init); });
+    RELEASE_AND_RETURN(throwScope, WTF::switchOn(input, [&](const String& str) -> JSValue { return toJS<IDLUSVString>(lexicalGlobalObject, throwScope, str); }, [&](const URLPatternInit& init) -> JSValue { return convertDictionaryToJS(lexicalGlobalObject, globalObject, init); }));
 }
 
 JSC::JSObject* convertDictionaryToJS(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, const URLPatternComponentResult& dictionary)

--- a/test/js/web/urlpattern/urlpattern.test.ts
+++ b/test/js/web/urlpattern/urlpattern.test.ts
@@ -1,6 +1,7 @@
 // Test data from Web Platform Tests
 // https://github.com/web-platform-tests/wpt/blob/master/LICENSE.md
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import testData from "./urlpatterntestdata.json";
 
 const kComponents = ["protocol", "username", "password", "hostname", "port", "pathname", "search", "hash"] as const;
@@ -204,6 +205,30 @@ describe("URLPattern", () => {
 
     test("complex pathname with regexp", () => {
       expect(new URLPattern({ pathname: "/a/:foo/:baz([a-z]+)?/b/*" }).hasRegExpGroups).toBe(true);
+    });
+  });
+
+  // convertURLPatternInputToJS calls convertDictionaryToJS (which has its own throw scope) when the
+  // exec() input is a dictionary, and must release its scope so the caller owns the check.
+  // BUN_JSC_validateExceptionChecks=1 aborts the child if the scope is left unchecked.
+  test("exec() with a dictionary input under validateExceptionChecks", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const r = new URLPattern({ pathname: "/foo" }).exec({ pathname: "/foo" }); console.log(JSON.stringify(r.inputs));`,
+      ],
+      env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // Combined assertion so the JSC exception-check failure on stderr appears in the diff.
+    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: '[{"pathname":"/foo"}]\n',
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
     });
   });
 });

--- a/test/js/web/urlpattern/urlpattern.test.ts
+++ b/test/js/web/urlpattern/urlpattern.test.ts
@@ -224,9 +224,8 @@ describe("URLPattern", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     // Combined assertion so the JSC exception-check failure on stderr appears in the diff.
-    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toMatchObject({
       stdout: '[{"pathname":"/foo"}]\n',
-      stderr: "",
       exitCode: 0,
       signalCode: null,
     });

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -156,9 +156,6 @@ vendor/elysia/test/ws/message.test.ts
 
 test/js/node/test/parallel/test-worker-abort-on-uncaught-exception.js
 
-# TODO: WebCore fixes
-test/js/web/urlpattern/urlpattern.test.ts
-
 # TODO: jsc
 test/js/bun/jsonl/jsonl-parse.test.ts
 test/regression/issue/isArray-proxy-crash.test.ts


### PR DESCRIPTION
Under `BUN_JSC_validateExceptionChecks=1`, any `URLPattern#exec()` with a dictionary input aborted:

```
ERROR: Unchecked JS exception:
    This scope can throw a JS exception: convertDictionaryToJS @ src/jsc/bindings/webcore/JSURLPatternInit.cpp:148
    But the exception was unchecked as of this scope: convertURLPatternInputToJS @ src/jsc/bindings/webcore/JSURLPatternResult.cpp:89
```

Repro:

```sh
BUN_JSC_validateExceptionChecks=1 bun-debug -e 'new URLPattern({pathname:"/foo"}).exec({pathname:"/foo"})'
```

### Cause

`convertURLPatternInputToJS` declares a `ThrowScope` and returns the result of a `WTF::switchOn` whose `URLPatternInit` arm calls `convertDictionaryToJS`, which declares its own scope. Returning without releasing leaves the outer scope unchecked.

### Fix

`RELEASE_AND_RETURN(throwScope, ...)`. The only caller already has `RETURN_IF_EXCEPTION` immediately after the call, so releasing here hands the check to it.

### Verification

New test spawns a child under `BUN_JSC_validateExceptionChecks=1` and asserts it exits cleanly; aborts with SIGABRT on main. The full `urlpattern.test.ts` (409 tests) now passes under the validator, so the file is removed from `test/no-validate-exceptions.txt`.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/urlpattern/urlpattern.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (217834b86)

test/js/web/urlpattern/urlpattern.test.ts:
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] [34.41ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] [7.74ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] [7.60ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] [8.01ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] [13.73ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] [9.21m
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (3816c5ff3)

test/js/web/urlpattern/urlpattern.test.ts:
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] [3.04ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] [0.05ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] [0.03ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] [0.04ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] [0.26ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] [0.66ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] [0.09ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] [0.03ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] [0.06ms]
(pass) 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/urlpattern/urlpattern.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (217834b86)

test/js/web/urlpattern/urlpattern.test.ts:
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] [35.03ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] [7.99ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] [7.39ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] [8.36ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] [13.83ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] [9.14m
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 721ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[2/8] gen cpp.rs (cppbind)
[2/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/wor
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/JSURLPatternResult.cpp |  2 +-
 test/js/web/urlpattern/urlpattern.test.ts       | 24 ++++++++++++++++++++++++
 test/no-validate-exceptions.txt                 |  3 ---
 3 files changed, 25 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/jsc/bindings/webcore/JSURLPatternResult.cpp      1      1      0
test/js/web/urlpattern/urlpattern.test.ts            4      3      0
test/no-validate-exceptions.txt                      1      1      0
```

</details>

<!-- robobun:evidence:end -->