### PR TITLE
node:vm: release throw scope before returning from moduleLoaderImportModuleInner

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1691,9 +1691,10 @@ static JSPromise* moduleLoaderImportModuleInner(NodeVMGlobalObject* globalObject
 
     if (sourceOrigin.fetcher() == nullptr && sourceOrigin.url().isEmpty()) {
         if (globalObject->dynamicImportCallback().isCallable()) {
-            return NodeVM::importModuleInner(globalObject, moduleName, WTF::move(parameters), sourceOrigin, globalObject->dynamicImportCallback(), JSValue {});
+            RELEASE_AND_RETURN(scope, NodeVM::importModuleInner(globalObject, moduleName, WTF::move(parameters), sourceOrigin, globalObject->dynamicImportCallback(), JSValue {}));
         }
 
+        scope.release();
         promise->reject(vm, createError(globalObject, ErrorCode::ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING, "A dynamic import callback was not specified."_s));
         return promise;
     }

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
+import { bunEnv, bunExe, isASAN, normalizeBunSnapshot } from "harness";
 import {
   compileFunction,
   constants,
@@ -1236,3 +1236,54 @@ describe("node:vm SourceTextModule cyclic graph linking", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+test.skipIf(!isASAN)(
+  "indirect-eval dynamic import in a contextified realm passes JSC exception-scope validation",
+  async () => {
+    const fixture = `
+      import { Script, SourceTextModule, createContext } from "node:vm";
+
+      const foo = new SourceTextModule("export const a = 1;");
+      await foo.link(() => {});
+      await foo.evaluate();
+
+      // Indirect eval has no ScriptFetcher and no source URL, so the module
+      // loader falls back to the context-level importModuleDynamically hook.
+      const ctx = createContext({}, { importModuleDynamically: () => foo });
+      const s = new Script("Promise.resolve(\\"import('foo')\\").then(eval)", {
+        importModuleDynamically: () => { throw new Error("must not call"); },
+      });
+      const ns = await s.runInContext(ctx);
+      if (ns.a !== 1) throw new Error("unexpected namespace");
+
+      // Same path but with no context-level hook: the loader rejects with
+      // ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING.
+      const ctx2 = createContext({});
+      const s2 = new Script("Promise.resolve(\\"import('foo')\\").then(eval)", {
+        importModuleDynamically: () => { throw new Error("must not call"); },
+      });
+      let code;
+      try {
+        await s2.runInContext(ctx2);
+      } catch (e) {
+        code = e.code;
+      }
+      if (code !== "ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING") throw new Error("unexpected code: " + code);
+
+      console.log("OK");
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("OK");
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -41,7 +41,6 @@ test/js/bun/util/BunObject.test.ts
 test/js/bun/util/fuzzy-wuzzy.test.ts
 test/js/third_party/pg-gateway/pglite.test.ts
 test/js/web/websocket/websocket.test.js
-test/js/node/test/parallel/test-vm-module-referrer-realm.mjs
 test/js/bun/resolve/resolve.test.ts
 test/cli/install/bunx.test.ts
 test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js


### PR DESCRIPTION
## Repro

```sh
BUN_JSC_validateExceptionChecks=1 bun-debug --config=bunfig.node-test.toml \
  test/js/node/test/parallel/test-vm-module-referrer-realm.mjs
```

```
ERROR: Unchecked JS exception:
    This scope can throw a JS exception: importModuleInner @ src/jsc/bindings/NodeVM.cpp:303
    But the exception was unchecked as of this scope: moduleLoaderImportModuleInner @ src/jsc/bindings/NodeVM.cpp:1688
ASSERTION FAILED: exception check validation failed
```

## Cause

`moduleLoaderImportModuleInner` declares a `DECLARE_THROW_SCOPE` and then, on the no-fetcher / no-source-URL path (indirect `eval` of `import()` inside a vm context), tail-calls `NodeVM::importModuleInner` with a plain `return`. `importModuleInner` declares its own throw scope and can throw (it invokes the user's `importModuleDynamically` hook). Returning without releasing the outer scope leaves that potential exception un-acknowledged, which JSC's exception-scope validator flags and aborts on.

The sibling `promise->reject(...)` branch for `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING` had the same shape; the fall-through reject a few lines below already releases first.

## Fix

Release the scope on both exits: `RELEASE_AND_RETURN(scope, ...)` around the `importModuleInner` tail call, and `scope.release()` before the missing-callback reject. This matches the pattern used by every other caller of `importModuleInner` in the same file.

## Verification

New `test.skipIf(!isASAN)` case in `test/js/node/vm/vm.test.ts` spawns a child with `BUN_JSC_validateExceptionChecks=1` and drives both branches (context with and without an `importModuleDynamically` hook) via indirect-eval `import()`. It aborts on main and passes with this change.

`test-vm-module-referrer-realm.mjs` now passes under exception-scope validation and is removed from `test/no-validate-exceptions.txt`. The full `vm.test.ts` suite and `test-vm-module-dynamic-import.js` still pass.