### PR TITLE
node:crypto: release throw scope before KeyObject asymmetric export

### DIFF
--- a/src/jsc/bindings/node/crypto/JSPrivateKeyObjectPrototype.cpp
+++ b/src/jsc/bindings/node/crypto/JSPrivateKeyObjectPrototype.cpp
@@ -47,7 +47,7 @@ JSC_DEFINE_HOST_FUNCTION(jsPrivateKeyObjectPrototype_export, (JSGlobalObject * g
 
     KeyObject& handle = privateKeyObject->handle();
     JSValue optionsValue = callFrame->argument(0);
-    return JSValue::encode(handle.exportAsymmetric(globalObject, scope, optionsValue, CryptoKeyType::Private));
+    RELEASE_AND_RETURN(scope, JSValue::encode(handle.exportAsymmetric(globalObject, scope, optionsValue, CryptoKeyType::Private)));
 }
 
 // JSC_DEFINE_HOST_FUNCTION(jsPrivateKeyObjectPrototype_toCryptoKey, (JSGlobalObject * globalObject, CallFrame* callFrame))

--- a/src/jsc/bindings/node/crypto/JSPublicKeyObjectPrototype.cpp
+++ b/src/jsc/bindings/node/crypto/JSPublicKeyObjectPrototype.cpp
@@ -47,7 +47,7 @@ JSC_DEFINE_HOST_FUNCTION(jsPublicKeyObjectPrototype_export, (JSGlobalObject * gl
 
     KeyObject& handle = publicKeyObject->handle();
     JSValue optionsValue = callFrame->argument(0);
-    return JSValue::encode(handle.exportAsymmetric(globalObject, scope, optionsValue, CryptoKeyType::Public));
+    RELEASE_AND_RETURN(scope, JSValue::encode(handle.exportAsymmetric(globalObject, scope, optionsValue, CryptoKeyType::Public)));
 }
 
 // JSC_DEFINE_HOST_FUNCTION(jsPublicKeyObjectPrototype_toCryptoKey, (JSGlobalObject * globalObject, CallFrame* callFrame))

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -1130,6 +1130,33 @@ describe("KeyObject raw-public / raw-private / raw-seed formats", () => {
     ).toThrow(expect.objectContaining({ code: "ERR_CRYPTO_INCOMPATIBLE_KEY_OPTIONS" }));
   });
 
+  // The raw-* export path allocates the output Buffer through JSUint8Array::create, which can
+  // throw. validateExceptionChecks=1 aborts the child if the throw scope isn't released before
+  // the allocation.
+  it("raw key export checks for a pending exception after Buffer allocation", async () => {
+    const src = `
+      const crypto = require("node:crypto");
+      const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
+      const pub = publicKey.export({ format: "raw-public" });
+      const priv = privateKey.export({ format: "raw-private" });
+      const fromPriv = privateKey.export({ format: "raw-public" });
+      console.log(pub.length, priv.length, fromPriv.length);
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "32 32 32\n",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
   it("publicEncrypt is not confused by a buffer detached from an oaepLabel getter", () => {
     const { publicKey, privateKey } = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
     const label = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -129,7 +129,6 @@ test/napi/node-napi-tests/test/node-api/test_general/do.test.ts
 # normalizeCryptoAlgorithmParameters
 test/js/bun/crypto/wpt-webcrypto.generateKey.test.ts
 test/js/deno/crypto/webcrypto.test.ts
-test/js/node/crypto/node-crypto.test.js
 test/js/node/test/parallel/test-crypto-oaep-zero-length.js
 test/js/node/test/parallel/test-crypto-psychic-signatures.js
 test/js/node/test/parallel/test-crypto-subtle-zero-length.js


### PR DESCRIPTION
## What does this PR do?

`PublicKeyObject.prototype.export` and `PrivateKeyObject.prototype.export` were returning the result of `KeyObject::exportAsymmetric` without releasing their `ThrowScope`. On the `format: "raw-public"` / `"raw-private"` path (added in #32623), `exportAsymmetric` → `exportRaw` → `dataPointerToBuffer` ends in a `JSUint8Array::create` call that declares its own `ThrowScope`, so the caller's scope has to be released first. Under `BUN_JSC_validateExceptionChecks=1` this aborts with:

```
ERROR: Unchecked JS exception:
    This scope can throw a JS exception: create @ JavaScriptCore/JSGenericTypedArrayViewInlines.h:109
    But the exception was unchecked as of this scope: jsPublicKeyObjectPrototype_export @ src/jsc/bindings/node/crypto/JSPublicKeyObjectPrototype.cpp:40
```

`SecretKeyObject.prototype.export` already wraps its helper call in `RELEASE_AND_RETURN`; this change brings the public and private variants in line. `PrivateKeyObject.prototype.export` hits the same unchecked path for `raw-private` and is fixed the same way.

`test/js/node/crypto/node-crypto.test.js` is now clean 3/3 under `BUN_JSC_validateExceptionChecks=1` and is removed from `test/no-validate-exceptions.txt` (it was listed under the `normalizeCryptoAlgorithmParameters` section but was actually tripping on this signature; its one `crypto.subtle.digest` call does not hit that path).

## How did you verify your code works?

New test in `node-crypto.test.js` spawns a child with `BUN_JSC_validateExceptionChecks=1` that exports ed25519 keys via `raw-public` and `raw-private`.

Without the fix (`src/` stashed, `bun bd`): child aborts with `SIGABRT` and the unchecked-exception report above.
With the fix: child prints `32 32 32` and exits 0.

Full `node-crypto.test.js` (203 tests) passes 3/3 under `BUN_JSC_validateExceptionChecks=1 bun bd test`.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/crypto/node-crypto.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f23d992f3)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [5.66ms]
(pass) crypto.randomInt should return a number [4.04ms]
(pass) crypto.randomInt with no arguments [6.22ms]
(pass) crypto.randomInt with one argument [4.35ms]
(pass) crypto.randomInt with a callback [68.95ms]
(pass) createHash > rsa-md5 - "Hello World" [8.42ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [5.38ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [1.39ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [1.62ms]
(pass) createHash > rsa-sha1 - "Hello World" [15.43ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [2.33ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [1.40ms
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (f23d992f3)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [0.15ms]
(pass) crypto.randomInt should return a number [0.05ms]
(pass) crypto.randomInt with no arguments [0.09ms]
(pass) crypto.randomInt with one argument [0.04ms]
(pass) crypto.randomInt with a callback [1.08ms]
(pass) createHash > rsa-md5 - "Hello World" [0.20ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [0.10ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [0.01ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [0.01ms]
(pass) createHash > rsa-sha1 - "Hello World" [0.17ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [0.03ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.01ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary [0.01ms]
(pass) createHash > rsa-sha224 - "Hello World" [0.03ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [0.02ms]
(pass) createHash > rsa-sha256 - "Hello World" [0.02ms]
(pass) createHash > rsa-sha256 - "Hello World" -> binary
(pass) createHash > rsa-sha3-224 - "Hello World"
(pass) createHash > rsa-sha3-224 - "Hello World" -> binary [0.01ms]
(pas
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/crypto/node-crypto.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f23d992f3)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [4.50ms]
(pass) crypto.randomInt should return a number [2.31ms]
(pass) crypto.randomInt with no arguments [3.64ms]
(pass) crypto.randomInt with one argument [2.43ms]
(pass) crypto.randomInt with a callback [69.91ms]
(pass) createHash > rsa-md5 - "Hello World" [11.96ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [4.78ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [0.95ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [1.03ms]
(pass) createHash > rsa-sha1 - "Hello World" [8.41ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [1.29ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.81ms
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 933ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_crypto-1.cpp.o
[2/7] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[3/7] gen cpp.rs (cppbind)
[3/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../node/crypto/JSPrivateKeyObjectPrototype.cpp    |  2 +-
 .../node/crypto/JSPublicKeyObjectPrototype.cpp     |  2 +-
 test/js/node/crypto/node-crypto.test.js            | 27 ++++++++++++++++++++++
 test/no-validate-exceptions.txt                    |  1 -
 4 files changed, 29 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…sc/bindings/node/crypto/JSPrivateKeyObjectPrototype.cpp      1      1      0
…jsc/bindings/node/crypto/JSPublicKeyObjectPrototype.cpp      1      1      0
test/js/node/crypto/node-crypto.test.js                       1      2      0
test/no-validate-exceptions.txt                               1      1      0
```

</details>

<!-- robobun:evidence:end -->