### PR TITLE
node:module: check exceptions from jsString/jsSubstring in Module.wrap and new Module()

### DIFF
--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -178,6 +178,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeModuleModuleConstructor,
 
         if (index != WTF::notFound) {
             dirname = JSC::jsSubstring(globalObject, idString, 0, index);
+            RETURN_IF_EXCEPTION(scope, {});
         }
     }
 
@@ -230,7 +231,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionWrap, (JSC::JSGlobalObject * globalObject, JS
             "(function (exports, require, module, __filename, __dirname) { "_s));
     JSString* suffix = jsString(vm, String("\n});"_s));
 
-    return JSValue::encode(jsString(globalObject, prefix, code, suffix));
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsString(globalObject, prefix, code, suffix)));
 }
 extern "C" void Bun__Node__Path_joinWTF(BunString* lhs, const char* rhs,
     size_t len, BunString* result);

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -130,6 +130,29 @@ describe.concurrent("node-module-module", () => {
     expect(wrap()).toBe("(function (exports, require, module, __filename, __dirname) { undefined\n});");
   });
 
+  // Module.wrap's rope concatenation and new Module()'s dirname jsSubstring
+  // both allocate and can throw; JSC's exception-check validator aborts the
+  // process when the result is used without a check.
+  test("Module.wrap / new Module() satisfy JSC exception-check validation", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const M = require("module"); M.wrap("x"); const m = new M("a/b"); if (m.id !== "a/b") throw new Error(m.id); console.log("ok");`,
+      ],
+      env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "ok\n",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
   test("Overwriting _resolveFilename", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "run", path.join(import.meta.dir, "resolveFilenameOverwrite.cjs")],

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -26,7 +26,6 @@ test/js/node/test/parallel/test-worker.mjs
 test/js/node/test/system-ca/test-native-root-certs.test.mjs
 test/js/node/events/event-emitter.test.ts
 test/js/node/module/node-module-module.test.js
-test/js/node/module/module-resolve-filename-paths.test.js
 test/js/node/process/call-constructor.test.js
 test/js/node/stubs.test.js
 test/js/node/timers/node-timers.test.ts


### PR DESCRIPTION
Two host functions in `src/jsc/modules/NodeModuleModule.cpp` used the result of a potentially-throwing JSC call without an exception check, which trips JSC's exception-scope validator and aborts the process under `BUN_JSC_validateExceptionChecks=1`.

## Repro

```console
$ BUN_JSC_validateExceptionChecks=1 bun-debug -e \
    'const M = require("module"); M.wrap("x"); new M("a/b")'
ERROR: Unchecked JS exception:
    This scope can throw a JS exception: jsString @ JavaScriptCore/OperationsInlines.h:167
    But the exception was unchecked as of this scope: jsFunctionWrap @ src/jsc/modules/NodeModuleModule.cpp:220
ASSERTION FAILED: exception check validation failed
```

With the `M.wrap` call removed, `new M("a/b")` alone produces the same abort from `jsSubstring @ JSString.h:1112` in `jsFunctionNodeModuleModuleConstructor`.

## Cause

- `jsFunctionWrap` builds the wrapped source via the three-string rope `jsString(globalObject, prefix, code, suffix)`. That overload allocates a `JSRopeString` and can throw (rope-length overflow or OOM), so the scope needs to be released before returning the result.
- `jsFunctionNodeModuleModuleConstructor` derives `dirname` from the id via `JSC::jsSubstring(globalObject, idString, 0, index)` when the id contains a `/`. `jsSubstring` can throw (OOM), and the result was passed on to `JSCommonJSModule::create` without a check.

## Fix

- `jsFunctionWrap`: wrap the tail call in `RELEASE_AND_RETURN(scope, ...)`.
- `jsFunctionNodeModuleModuleConstructor`: add `RETURN_IF_EXCEPTION(scope, {})` after `jsSubstring`.

## Verification

New test in `test/js/node/module/node-module-module.test.js` spawns a subprocess with `BUN_JSC_validateExceptionChecks=1` that calls both `Module.wrap("x")` and `new Module("a/b")`. On the unfixed debug build the child aborts with the unchecked-exception report above; with the fix it prints `ok` and exits 0. The env var is a no-op on release JSC builds, so the test is harmless on non-ASAN lanes.

`test/js/node/module/module-resolve-filename-paths.test.js` (which constructs `new Module("/some/other/directory/file.js")`) is now clean under `BUN_JSC_validateExceptionChecks=1` (3/3 runs) and is removed from `test/no-validate-exceptions.txt`. `node-module-module.test.js` stays in that list: two of its subprocess tests still hit unrelated unchecked scopes in `Interpreter.cpp` / `VirtualMachine.rs`.

The `jsFunctionWrap` hunk overlaps with #34099 at the same return statement; whichever lands second will need a trivial rebase.