### PR TITLE
process.dlopen: check for exception after writing replaced exports

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -786,6 +786,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionDlopen, (JSC::JSGlobalObject * globalOb
     if (!resultValue.isEmpty() && !scope.exception() && (!strongExports || resultValue != strongExports.get())) {
         PutPropertySlot slot(strongModule.get(), false);
         strongModule->put(strongModule.get(), globalObject, builtinNames(vm).exportsPublicName(), resultValue, slot);
+        RETURN_IF_EXCEPTION(scope, {});
     }
 
     return JSValue::encode(resultValue);

--- a/test/napi/dlopen-replace-exports-exception-check.test.ts
+++ b/test/napi/dlopen-replace-exports-exception-check.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isMacOS, isWindows, tempDir } from "harness";
+import { join } from "path";
+
+// Path to the in-repo copies of node_api.h / js_native_api.h.
+const napiHeaderDir = join(import.meta.dir, "..", "..", "src", "runtime", "napi");
+
+// A plain C compiler is enough: the addon below only needs the N-API C ABI.
+const cc = Bun.which("cc") ?? Bun.which("clang") ?? Bun.which("gcc");
+
+// Returns a value other than `exports`, so dlopen writes it to module.exports via
+// JSObject::put, which must be exception-checked. Exports napi_register_module_v1
+// directly (no NAPI_MODULE ctor) so dlopen takes the dlsym path, not self-registration.
+const replaceExportsSource = /* c */ `
+#include <node_api.h>
+
+static napi_value Method(napi_env env, napi_callback_info info) {
+  napi_value result;
+  napi_create_int32(env, 42, &result);
+  return result;
+}
+
+NAPI_MODULE_EXPORT napi_value napi_register_module_v1(napi_env env, napi_value exports) {
+  napi_value fn;
+  napi_create_function(env, "exports", NAPI_AUTO_LENGTH, Method, NULL, &fn);
+  return fn;
+}
+`;
+
+test.skipIf(isWindows || !cc)(
+  "process.dlopen writes a replaced exports value under BUN_JSC_validateExceptionChecks",
+  async () => {
+    using dir = tempDir("dlopen-replace-exports", {
+      "addon.c": replaceExportsSource,
+      "load.js": `const addon = require("./addon.node");\nconsole.log("loaded", addon());\n`,
+    });
+
+    await using compile = Bun.spawn({
+      cmd: [
+        cc!,
+        "-shared",
+        "-fPIC",
+        // The napi_* symbols are resolved from the host process at dlopen time.
+        ...(isMacOS ? ["-undefined", "dynamic_lookup"] : []),
+        `-I${napiHeaderDir}`,
+        "-o",
+        "addon.node",
+        "addon.c",
+      ],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [compileStderr, compileExitCode] = await Promise.all([compile.stderr.text(), compile.exited]);
+    expect({ exitCode: compileExitCode, stderr: compileStderr }).toMatchObject({ exitCode: 0 });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "load.js"],
+      cwd: String(dir),
+      env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // stderr is in the received object so the abort report shows up in the
+    // failure diff, but its contents are not asserted (debug builds write noise).
+    expect({ stdout, stderr, exitCode }).toMatchObject({ stdout: "loaded 42\n", exitCode: 0 });
+  },
+);


### PR DESCRIPTION
### Repro

With `BUN_JSC_validateExceptionChecks=1` on an assert-enabled build, requiring any N-API addon whose `napi_register_module_v1` returns a value other than the original `exports` object aborts at module load:

```
ERROR: Unchecked JS exception:
    This scope can throw a JS exception: putInlineSlow @ vendor/WebKit/Source/JavaScriptCore/runtime/JSObject.cpp:836
        (ExceptionScope::m_recursionDepth was 9)
    But the exception was unchecked as of this scope: Process_functionDlopen @ ../../src/jsc/bindings/BunProcess.cpp:397
        (ExceptionScope::m_recursionDepth was 8)
ASSERTION FAILED: exception check validation failed
```

This is the shape of every "module exports a single function/class" addon (Node's own `js-native-api/4_object_factory` and `5_function_factory` conformance tests included), and is why those two entries are in `test/no-validate-exceptions.txt`. #32911 fixes the N-API entry-point side of the validator failures and explicitly leaves this one, which is in the `process.dlopen` wrapper itself, for a separate change.

### Cause

When `napi_register_module_v1` returns a replacement exports value, `Process_functionDlopen` writes it back to `module.exports` via `JSObject::put`. `put` can run a user-defined setter and opens its own `ThrowScope` inside `putInlineSlow`; the function then returned without observing that write's exception state, so the outer scope's destructor tripped `verifyExceptionCheckNeedIsSatisfied`. The parallel call site in `Napi::executePendingNapiModule` (the self-registration path) already has the matching check.

### Fix

Add the missing `RETURN_IF_EXCEPTION(scope, {})` after the `put`, matching `executePendingNapiModule`. If the setter throws, the exception now propagates to the `require()` call instead of being left pending past an unchecked scope; on release builds (where the verifier is compiled out) the observable behaviour is unchanged for non-throwing setters.

### Verification

`test/napi/dlopen-replace-exports-exception-check.test.ts` compiles a minimal addon with the system C compiler against the in-repo N-API headers (no node-gyp) that exports `napi_register_module_v1` directly (no static-constructor `NAPI_MODULE` registration, so the `dlsym` path in `Process_functionDlopen` is taken) and returns a new function as its exports. It is `require()`d in a child process under `BUN_JSC_validateExceptionChecks=1`.

```
git stash push -- src/ && bun bd test test/napi/dlopen-replace-exports-exception-check.test.ts
  # exit 134, SIGABRT with the putInlineSlow / Process_functionDlopen report above
git stash pop && bun bd test test/napi/dlopen-replace-exports-exception-check.test.ts
  # 1 pass, stdout 'loaded 42'
```

On release builds the validator is compiled out, so the env var is a no-op and the test still passes.