### PR TITLE
node:tls: make rootCertificates non-configurable

### DIFF
--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -398,6 +398,7 @@ const ArrayPrototypeSome = Array.prototype.some;
 const ArrayPrototypeReduce = Array.prototype.reduce;
 
 const ObjectFreeze = Object.freeze;
+const ObjectDefineProperty = Object.defineProperty;
 
 function parseCertString() {
   // Removed since JAN 2022 Node v18.0.0+ https://github.com/nodejs/node/pull/41479
@@ -1686,7 +1687,7 @@ function getDefaultCiphers() {
   return `TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256${ciphers ? ":" + ciphers : ""}`;
 }
 
-export default {
+const tls_exports = {
   CLIENT_RENEG_LIMIT,
   CLIENT_RENEG_WINDOW,
   connect,
@@ -1728,8 +1729,16 @@ export default {
   Server,
   TLSSocket,
   checkServerIdentity,
-  get rootCertificates() {
-    return cacheBundledRootCertificates();
-  },
   getCACertificates,
-} as any as typeof import("node:tls");
+};
+
+// Node.js defines this with configurable: false so the bundled trust
+// store cannot be swapped out via Object.defineProperty.
+ObjectDefineProperty(tls_exports, "rootCertificates", {
+  __proto__: null,
+  configurable: false,
+  enumerable: true,
+  get: cacheBundledRootCertificates,
+});
+
+export default tls_exports as any as typeof import("node:tls");

--- a/test/js/node/tls/node-tls-rootcertificates-immutable.test.ts
+++ b/test/js/node/tls/node-tls-rootcertificates-immutable.test.ts
@@ -64,4 +64,34 @@ describe("tls", () => {
     // Check if the array is actually frozen
     expect(Object.isFrozen(tls.rootCertificates)).toBe(true);
   });
+
+  test("rootCertificates property is non-configurable", () => {
+    const tls = require("tls");
+
+    const descriptor = Object.getOwnPropertyDescriptor(tls, "rootCertificates")!;
+    expect(descriptor.configurable).toBe(false);
+    expect(descriptor.enumerable).toBe(true);
+    expect(typeof descriptor.get).toBe("function");
+    expect(descriptor.set).toBeUndefined();
+
+    const originalLength = tls.rootCertificates.length;
+
+    expect(() => {
+      Object.defineProperty(tls, "rootCertificates", {
+        value: ["-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----"],
+      });
+    }).toThrow(TypeError);
+
+    expect(() => {
+      Object.defineProperty(tls, "rootCertificates", {
+        configurable: true,
+        get() {
+          return ["injected"];
+        },
+      });
+    }).toThrow(TypeError);
+
+    expect(tls.rootCertificates.length).toBe(originalLength);
+    expect(tls.rootCertificates[0]).toStartWith("-----BEGIN CERTIFICATE-----");
+  });
 });


### PR DESCRIPTION
## Problem

Node.js defines `tls.rootCertificates` as a non-configurable accessor. In Bun it was a plain object-literal getter, which is configurable: `Object.defineProperty(tls, 'rootCertificates', { value: [...] })` could silently replace the bundled trust store at runtime. The existing immutability test only covered simple assignment and array mutation, both of which were already blocked by the getter-only accessor and the frozen array.

## Repro

```js
const tls = require('node:tls');
Object.defineProperty(tls, 'rootCertificates', { value: ['FAKE'] });
console.log(tls.rootCertificates[0]);
// node:  TypeError: Cannot redefine property: rootCertificates
// bun:   FAKE
```

Descriptor comparison:

```
node: { configurable: false, enumerable: true, get: [Function], set: undefined }
bun:  { configurable: true,  enumerable: true, get: [Function], set: undefined }
```

## Fix

Define the accessor with `Object.defineProperty` and `configurable: false`, matching Node's `lib/tls.js`:

```js
ObjectDefineProperty(exports, 'rootCertificates', {
  __proto__: null,
  configurable: false,
  enumerable: true,
  get: cacheRootCertificates,
});
```

## Verification

New test in `test/js/node/tls/node-tls-rootcertificates-immutable.test.ts` asserts the descriptor shape and that both value-replacement and getter-replacement via `Object.defineProperty` throw `TypeError`. Fails on main (`configurable` is `true`), passes with this change. Named ESM import `import { rootCertificates } from 'tls'` continues to work (verified via `node-tls-internals.test.ts`).