### PR TITLE
tls: make rootCertificates property non-configurable

### DIFF
--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -1686,7 +1686,7 @@ function getDefaultCiphers() {
   return `TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256${ciphers ? ":" + ciphers : ""}`;
 }
 
-export default {
+const tls_exports = {
   CLIENT_RENEG_LIMIT,
   CLIENT_RENEG_WINDOW,
   connect,
@@ -1728,8 +1728,15 @@ export default {
   Server,
   TLSSocket,
   checkServerIdentity,
-  get rootCertificates() {
-    return cacheBundledRootCertificates();
-  },
   getCACertificates,
 } as any as typeof import("node:tls");
+
+// Non-configurable so it cannot be deleted and replaced (matches Node.js).
+Object.defineProperty(tls_exports, "rootCertificates", {
+  __proto__: null,
+  configurable: false,
+  enumerable: true,
+  get: cacheBundledRootCertificates,
+});
+
+export default tls_exports;

--- a/test/js/node/tls/node-tls-rootcertificates-immutable.test.ts
+++ b/test/js/node/tls/node-tls-rootcertificates-immutable.test.ts
@@ -64,4 +64,39 @@ describe("tls", () => {
     // Check if the array is actually frozen
     expect(Object.isFrozen(tls.rootCertificates)).toBe(true);
   });
+
+  test("rootCertificates property descriptor is non-configurable", () => {
+    const tls = require("tls");
+
+    const desc = Object.getOwnPropertyDescriptor(tls, "rootCertificates");
+    expect({
+      hasGet: typeof desc!.get === "function",
+      set: desc!.set,
+      enumerable: desc!.enumerable,
+      configurable: desc!.configurable,
+    }).toEqual({
+      hasGet: true,
+      set: undefined,
+      enumerable: true,
+      configurable: false,
+    });
+
+    const originalLength = tls.rootCertificates.length;
+    const originalFirstCert = tls.rootCertificates[0];
+
+    expect(() => {
+      "use strict";
+      // @ts-expect-error
+      delete tls.rootCertificates;
+    }).toThrow(TypeError);
+
+    expect(() => {
+      Object.defineProperty(tls, "rootCertificates", {
+        value: ["-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----"],
+      });
+    }).toThrow(TypeError);
+
+    expect(tls.rootCertificates.length).toBe(originalLength);
+    expect(tls.rootCertificates[0]).toBe(originalFirstCert);
+  });
 });


### PR DESCRIPTION
## What does this PR do?

Makes `tls.rootCertificates` non-configurable to match Node.js.

### Repro

```js
const tls = require("tls");
delete tls.rootCertificates;
tls.rootCertificates = ["-----BEGIN CERTIFICATE-----\nATTACKER CA\n-----END CERTIFICATE-----"];
console.log(tls.rootCertificates); // => ["...ATTACKER CA..."]
```

Before: succeeds, `tls.rootCertificates` is replaced process-wide.
After: `delete` throws `TypeError` (matches Node.js).

### Cause

The `rootCertificates` getter was defined in the `export default { ... }` object literal. Accessors in object literals default to `configurable: true`, so the property could be deleted and redefined. Node.js defines it with `ObjectDefineProperty(exports, 'rootCertificates', { __proto__: null, configurable: false, enumerable: true, get: cacheRootCertificates })`.

### Fix

Define `rootCertificates` on the exports object via `Object.defineProperty` with `configurable: false`.

### Verification

```
# before (system bun)
$ bun -e 'const d = Object.getOwnPropertyDescriptor(require("tls"), "rootCertificates"); console.log(d.configurable)'
true

# after (this PR)
$ bun-debug -e 'const d = Object.getOwnPropertyDescriptor(require("tls"), "rootCertificates"); console.log(d.configurable)'
false

# node
$ node -e 'const d = Object.getOwnPropertyDescriptor(require("tls"), "rootCertificates"); console.log(d.configurable)'
false
```

Added a test to `node-tls-rootcertificates-immutable.test.ts` that asserts the descriptor shape (`{ get, set: undefined, enumerable: true, configurable: false }`) and that `delete` / `Object.defineProperty` both throw.