### PR TITLE
napi: check exceptions between NapiClass::create and defineOwnProperty

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -357,10 +357,12 @@ napi_status Napi::defineProperty(napi_env env, JSC::JSObject* to, const napi_pro
         if (property.getter) {
             auto name = makeString("get "_s, propertyName.isSymbol() ? String() : propertyName.string());
             descriptor.setGetter(NapiClass::create(vm, env, name, property.getter, dataPtr, 0, nullptr));
+            RETURN_IF_EXCEPTION(scope, napi_pending_exception);
         }
         if (property.setter) {
             auto name = makeString("set "_s, propertyName.isSymbol() ? String() : propertyName.string());
             descriptor.setSetter(NapiClass::create(vm, env, name, property.setter, dataPtr, 0, nullptr));
+            RETURN_IF_EXCEPTION(scope, napi_pending_exception);
         }
     } else if (property.method != nullptr) {
         WTF::String name;
@@ -368,6 +370,7 @@ napi_status Napi::defineProperty(napi_env env, JSC::JSObject* to, const napi_pro
             name = propertyName.string();
         }
         descriptor.setValue(NapiClass::create(vm, env, name, property.method, dataPtr, 0, nullptr));
+        RETURN_IF_EXCEPTION(scope, napi_pending_exception);
         descriptor.setWritable(writable);
         failureStatus = napi_generic_failure;
     } else {

--- a/test/napi/napi-define-property-exception-check.test.ts
+++ b/test/napi/napi-define-property-exception-check.test.ts
@@ -103,8 +103,12 @@ test.concurrent.skipIf(isWindows || !cc)(
     await loadAddonWithValidator(
       "napi-define-properties-exception-check",
       definePropertiesSource,
-      `const m = require("./addon.node");\nconsole.log("loaded", Object.getOwnPropertyNames(m).sort().join(","));\n`,
-      "loaded a,exports,g,m,s\n",
+      // Assert only what the addon defined; the exports object may carry loader-added own
+      // properties (Bun currently passes the module object here, Node passes module.exports).
+      `const m = require("./addon.node");\n` +
+        `const own = Object.getOwnPropertyNames(m);\n` +
+        `console.log("loaded", ["a","g","m","s"].filter(k => own.includes(k)).join(","));\n`,
+      "loaded a,g,m,s\n",
     );
   },
 );

--- a/test/napi/napi-define-property-exception-check.test.ts
+++ b/test/napi/napi-define-property-exception-check.test.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isMacOS, isWindows, tempDir } from "harness";
+import { join } from "path";
+
+// In-repo N-API headers (node_api.h / js_native_api.h) so we don't depend on node-gyp.
+const napiHeaderDir = join(import.meta.dir, "..", "..", "src", "runtime", "napi");
+
+const cc = Bun.which("cc") ?? Bun.which("clang") ?? Bun.which("gcc");
+
+// napi_define_class with method/getter/setter/accessor properties. Each of these descriptor
+// kinds makes Napi::defineProperty call NapiClass::create (which opens and closes its own
+// ThrowScope) immediately before defineOwnProperty. The validator requires the exception
+// state to be observed between those two calls.
+const defineClassSource = /* c */ `
+#include <node_api.h>
+#include <stddef.h>
+
+static napi_value Noop(napi_env env, napi_callback_info info) { return NULL; }
+
+NAPI_MODULE_INIT() {
+  napi_property_descriptor props[] = {
+    {"m", NULL, Noop, NULL, NULL, NULL, napi_default, NULL},
+    {"g", NULL, NULL, Noop, NULL, NULL, napi_default, NULL},
+    {"s", NULL, NULL, NULL, Noop, NULL, napi_default, NULL},
+    {"a", NULL, NULL, Noop, Noop, NULL, napi_default, NULL},
+  };
+  napi_value cls;
+  napi_define_class(env, "Thing", NAPI_AUTO_LENGTH, Noop, NULL, 4, props, &cls);
+  return cls;
+}
+`;
+
+// Same property descriptor shapes via napi_define_properties (the other Napi::defineProperty caller).
+const definePropertiesSource = /* c */ `
+#include <node_api.h>
+#include <stddef.h>
+
+static napi_value Noop(napi_env env, napi_callback_info info) { return NULL; }
+
+NAPI_MODULE_INIT() {
+  napi_property_descriptor props[] = {
+    {"m", NULL, Noop, NULL, NULL, NULL, napi_default, NULL},
+    {"g", NULL, NULL, Noop, NULL, NULL, napi_default, NULL},
+    {"s", NULL, NULL, NULL, Noop, NULL, napi_default, NULL},
+    {"a", NULL, NULL, Noop, Noop, NULL, napi_default, NULL},
+  };
+  napi_define_properties(env, exports, 4, props);
+  return exports;
+}
+`;
+
+async function loadAddonWithValidator(tag: string, addonSource: string, loadJs: string, expectedStdout: string) {
+  using dir = tempDir(tag, { "addon.c": addonSource, "load.js": loadJs });
+
+  await using compile = Bun.spawn({
+    cmd: [
+      cc!,
+      "-shared",
+      "-fPIC",
+      ...(isMacOS ? ["-undefined", "dynamic_lookup"] : []),
+      `-I${napiHeaderDir}`,
+      "-o",
+      "addon.node",
+      "addon.c",
+    ],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+  const [compileStderr, compileExit] = await Promise.all([compile.stderr.text(), compile.exited]);
+  expect({ exitCode: compileExit, stderr: compileStderr }).toMatchObject({ exitCode: 0 });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "load.js"],
+    cwd: String(dir),
+    env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Keep stderr in the received object so the abort report shows up in the failure diff,
+  // but don't assert it exactly (debug builds emit unrelated noise).
+  expect({ stdout, stderr, exitCode }).toMatchObject({ stdout: expectedStdout, exitCode: 0 });
+}
+
+test.concurrent.skipIf(isWindows || !cc)(
+  "napi_define_class with method/getter/setter runs under BUN_JSC_validateExceptionChecks",
+  async () => {
+    await loadAddonWithValidator(
+      "napi-define-class-exception-check",
+      defineClassSource,
+      `const Thing = require("./addon.node");\nconsole.log("loaded", typeof Thing, Thing.name);\n`,
+      "loaded function Thing\n",
+    );
+  },
+);
+
+test.concurrent.skipIf(isWindows || !cc)(
+  "napi_define_properties with method/getter/setter runs under BUN_JSC_validateExceptionChecks",
+  async () => {
+    await loadAddonWithValidator(
+      "napi-define-properties-exception-check",
+      definePropertiesSource,
+      `const m = require("./addon.node");\nconsole.log("loaded", Object.getOwnPropertyNames(m).sort().join(","));\n`,
+      "loaded a,exports,g,m,s\n",
+    );
+  },
+);


### PR DESCRIPTION
### Repro

Any N-API addon whose `Init` calls `napi_define_class` or `napi_define_properties` with a method, getter, or setter descriptor aborts under `BUN_JSC_validateExceptionChecks=1`:

```c
NAPI_MODULE_INIT() {
  napi_property_descriptor prop = {"m", NULL, Method, NULL, NULL, NULL, napi_default, NULL};
  napi_value cls;
  napi_define_class(env, "Thing", NAPI_AUTO_LENGTH, Ctor, NULL, 1, &prop, &cls);
  return cls;
}
```

```
ERROR: Unchecked JS exception:
    This scope can throw a JS exception: finishCreation @ src/jsc/bindings/NapiClass.cpp:120
        (ExceptionScope::m_recursionDepth was 12)
    But the exception was unchecked as of this scope: defineOwnNonIndexProperty @ JavaScriptCore/runtime/JSObject.cpp:4062
        (ExceptionScope::m_recursionDepth was 12)
ASSERTION FAILED: exception check validation failed
```

Hit by every `test/napi/node-napi-tests/test/js-native-api/*` suite that defines a class or a function property (33 entries in the `# 3rd party napi` section of `test/no-validate-exceptions.txt`).

### Cause

`Napi::defineProperty` (shared by `napi_define_class` and `napi_define_properties`) builds method/getter/setter descriptors by calling `NapiClass::create`, which opens and closes its own `ThrowScope` in `finishCreation`. On return that scope's destructor simulates a throw. The very next call is `defineOwnProperty`, which enters `defineOwnNonIndexProperty` and constructs a new `ThrowScope`; its constructor finds the unsatisfied check and `RELEASE_ASSERT`s. This surfaced after #34134 routed every descriptor kind through `defineOwnProperty`.

### Fix

Add `RETURN_IF_EXCEPTION(scope, napi_pending_exception)` after each of the three `NapiClass::create` calls in `Napi::defineProperty` (getter, setter, method), so the exception state is observed before `defineOwnProperty`. The same pattern is already used after `toPropertyKey` and after `defineOwnProperty` in the same function.

### Verification

`test/napi/napi-define-property-exception-check.test.ts` compiles two tiny C addons with the system `cc` against the in-repo headers (no node-gyp) and `require()`s each in a child process with `BUN_JSC_validateExceptionChecks=1`: one exercising `napi_define_class` with method/getter/setter/accessor properties, one exercising `napi_define_properties` with the same shapes. Without the fix both abort (exit 134) with the `finishCreation`/`defineOwnNonIndexProperty` report above; with it, both load cleanly. On release builds the validator is compiled out, so the option is a no-op and the tests pass trivially; the gate runs a debug build.

Also ran against the fixed debug build: `test/napi/node-napi-tests/test/js-native-api/{6_object_wrap,test_constructor,test_properties}/do.test.ts` (9 pass) and `test/napi/napi.test.ts -t napi_define` (the `[[DefineOwnProperty]]` test from #34134 still passes).

### Relationship to #32911

\#32911 (open) addresses the broader question of addon C code not being able to satisfy JSC's exception-check discipline between consecutive `napi_*` calls, via a `NapiBoundaryScope` at the preamble level, and as a secondary fix adds the getter/setter checks here (but not the method one). This PR is the narrow `Napi::defineProperty` half of that and stands on its own: a single `napi_define_class` call is enough to abort, regardless of what the addon does before or after it. The `no-validate-exceptions.txt` entries are intentionally left in place since most of them still need the preamble-side fix from #32911 (or the `dlopen` path fix it mentions) before the validator can be enabled for them.