### PR TITLE
test(net): measure mongodb-pattern RSS at steady state, not during JIT tier-up

### DIFF
--- a/test/js/node/net/net-mongodb-pattern-leak.test.ts
+++ b/test/js/node/net/net-mongodb-pattern-leak.test.ts
@@ -150,9 +150,11 @@ async function command(sock: net.Socket, messages: Transform, body: Buffer) {
 
 function snapshot() {
   Bun.gc(true);
-  const t = heapStats().objectTypeCounts;
+  const hs = heapStats();
+  const t = hs.objectTypeCounts;
   return {
     rss: process.memoryUsage.rss(),
+    heapSize: hs.heapSize,
     Timeout: t.Timeout || 0,
     Promise: t.Promise || 0,
     AsyncGenerator: t.AsyncGenerator || 0,
@@ -172,10 +174,10 @@ describe.each([
 
     try {
       const body = Buffer.alloc(256, 0x61);
-      const ITER = isDebug || isASAN ? 2_000 : 5_000;
+      const ITER = isDebug || isASAN ? 1_500 : 5_000;
 
-      // Run the workload twice. Round 1 absorbs JIT, root-CA load and allocator
-      // pool growth; round 2 is steady-state. We assert on round-2 vs round-1.
+      // Round 0 absorbs JIT tier-up, root-CA load and allocator pool growth;
+      // rounds 1 and 2 are steady-state. We assert on round-2 vs round-1.
       const round = async () => {
         for (let i = 0; i < ITER; i++) {
           const reply = await command(sock, messages, body);
@@ -185,6 +187,7 @@ describe.each([
         return snapshot();
       };
 
+      await round(); // warmup; JIT tier-up is not reliably done after one round
       const after1 = await round();
       const after2 = await round();
 
@@ -196,14 +199,16 @@ describe.each([
       expect(after2.AsyncGenerator - after1.AsyncGenerator).toBeLessThanOrEqual(2);
       expect(after2.Promise - after1.Promise).toBeLessThanOrEqual(10);
       expect(after2.Function - after1.Function).toBeLessThanOrEqual(20);
+      // JS heap must be flat once warm. ±1 MB covers scavenger jitter.
+      expect(after2.heapSize - after1.heapSize).toBeLessThan(1024 * 1024);
 
       // The Transform must not have accumulated listeners (onData removes its
       // pair on .return(); a missed cleanup would grow this by ITER).
       expect(messages.listenerCount("data")).toBe(0);
       expect(messages.listenerCount("error")).toBeLessThanOrEqual(1);
 
-      // RSS round-2 vs round-1: weak signal (mimalloc segment noise) but
-      // catches anything egregious that heapStats can't see.
+      // RSS at steady state: weak signal (mimalloc segment noise) but catches
+      // anything egregious that heapStats can't see.
       const rssBound = isASAN || isDebug ? 32 * 1024 * 1024 : 8 * 1024 * 1024;
       expect(after2.rss - after1.rss).toBeLessThan(rssBound);
     } finally {

--- a/test/js/node/net/net-mongodb-pattern-leak.test.ts
+++ b/test/js/node/net/net-mongodb-pattern-leak.test.ts
@@ -199,8 +199,9 @@ describe.each([
       expect(after2.AsyncGenerator - after1.AsyncGenerator).toBeLessThanOrEqual(2);
       expect(after2.Promise - after1.Promise).toBeLessThanOrEqual(10);
       expect(after2.Function - after1.Function).toBeLessThanOrEqual(20);
-      // JS heap must be flat once warm. ±1 MB covers scavenger jitter.
-      expect(after2.heapSize - after1.heapSize).toBeLessThan(1024 * 1024);
+      // vm.heap.size() after a sync full GC: live-cell bytes, not affected by
+      // allocator/JIT. Observed r2-r1 range -38..+8 KB; a listener leak is ~56 MB.
+      expect(after2.heapSize - after1.heapSize).toBeLessThan(256 * 1024);
 
       // The Transform must not have accumulated listeners (onData removes its
       // pair on .return(); a missed cleanup would grow this by ITER).


### PR DESCRIPTION
## What

`net-mongodb-pattern-leak.test.ts` started failing its 8 MB release RSS delta check on ~40% of PR builds after #33133 (WebKit upgrade, merged July 1). Sampling Buildkite annotations: 1/29 builds flaked in the week before #33133, 15/37 in the days after. Observed deltas 8.4-12.3 MB.

## Why this is not a memory regression

Five-round instrumented runs on current main:

| metric | r1 | r2 | r3 | r4 | r5 |
|---|---|---|---|---|---|
| heapSize | 2.06 MB | 2.06 MB | 2.06 MB | 2.06 MB | 2.06 MB |
| Timeout / Promise / AsyncGenerator / Function delta | 0 | 0 | 0 | 0 | 0 |
| RSS (one run) | 68.3 MB | 69.1 MB | 66.9 MB | 63.6 MB | 64.6 MB |

`heapSize` and every tracked object count are flat; RSS in rounds 3-5 goes **down**. With `BUN_JSC_useJIT=0` total RSS drops from ~65 MB to ~33 MB and the r2-r1 delta is <2 MB on every run. The extra RSS is JIT code pages: the newer JSC's tier-up thresholds put more DFG/FTL compilation into round 2, where the old build had finished it in round 1.

Over 30 local release runs the r2-r1 delta ranged **-0.0..+11.0 MB** (one would have failed the 8 MB bound), while r3-r2 ranged **-2.2..+2.0 MB**.

## Change

- Run one unmeasured warmup round before the two measured rounds, so the RSS comparison happens at steady state. The 8 MB release bound is **unchanged**.
- Add a `heapSize` delta assertion (<1 MB), which is the precise signal for JS-heap retention.
- Drop debug/ASAN `ITER` 2000 -> 1500 so total work (3x1500) stays near the previous 2x2000 under the existing 60 s timeout.

## Verification

- Release: 0/50 runs failed locally (was ~1/10 on the unmodified test under load).
- Debug+ASAN: 3/3 passed, 28-45 s per case.
- Simulated leak (listeners not removed in `onData.close`): Function count 15000 > 20, both cases fail as expected.

## vs #33725

\#33725 widens the release bound 8 MB -> 24 MB. That also stops the flake, but loosens the native-leak backstop. This keeps the bound where it was by measuring after JIT tier-up has settled, and adds the heapSize check the original test was missing. The `node-net.test.ts` await fix in #33725 is independent and still worth taking.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/net/net-mongodb-pattern-leak.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/net/net-mongodb-pattern-leak.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (e038b51dd)

test/js/node/net/net-mongodb-pattern-leak.test.ts:
(pass) mongodb driver pattern over tcp does not leak > long-lived connection: framed command round-trips [31949.62ms]
(pass) mongodb driver pattern over tls does not leak > long-lived connection: framed command round-trips [34195.90ms]

 2 pass
 0 fail
 22 expect() calls
Ran 2 tests across 1 file. [68.61s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/node/net/net-mongodb-pattern-leak.test.ts | 18 ++++++++++++------
 1 file changed, 12 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
test/js/node/net/net-mongodb-pattern-leak.test.ts      4      6      0
```

</details>

<!-- robobun:evidence:end -->