### PR TITLE
bun:test: check exception after isArray() in expect.any(Array), toMatchObject, toHaveProperty

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -390,7 +390,9 @@ AsymmetricMatcherResult matchAsymmetricMatcherAndGetFlags(JSGlobalObject* global
         }
 
         case AsymmetricMatcherConstructorType::Array: {
-            if (JSC::isArray(globalObject, otherProp)) {
+            bool otherIsArray = JSC::isArray(globalObject, otherProp);
+            RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
+            if (otherIsArray) {
                 return AsymmetricMatcherResult::PASS;
             }
             break;
@@ -1648,8 +1650,13 @@ bool Bun__deepMatch(
     // - two "simple" arrays
     // similar to what is done in deepEquals (canPerformFastPropertyEnumerationForIterationBun)
 
+    bool objIsArray = isArray(globalObject, objValue);
+    RETURN_IF_EXCEPTION(throwScope, false);
+    bool subsetIsArray = isArray(globalObject, subsetValue);
+    RETURN_IF_EXCEPTION(throwScope, false);
+
     // arrays should match exactly
-    if (isArray(globalObject, objValue) && isArray(globalObject, subsetValue)) {
+    if (objIsArray && subsetIsArray) {
         if (obj->getArrayLength() != subsetObj->getArrayLength()) {
             return false;
         }
@@ -4369,7 +4376,9 @@ JSC::EncodedJSValue JSC__JSValue__getIfPropertyExistsFromPath(JSC::EncodedJSValu
         return JSValue::encode(currProp);
     }
 
-    if (isArray(globalObject, path)) {
+    bool pathIsArray = isArray(globalObject, path);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (pathIsArray) {
         // each item in array is property name, ignore dot/bracket notation
         JSValue currProp = value;
         auto* pathObject = path.toObject(globalObject);

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -677,6 +677,38 @@ describe("expect()", () => {
         expect(p1).toStrictEqual(p2);
       }
     });
+
+    // JSC::isArray() declares a throw scope on the Proxy path. expect.any(Array),
+    // toMatchObject, and toHaveProperty called it without checking, which aborts
+    // under BUN_JSC_validateExceptionChecks=1 (a no-op on release builds).
+    test("expect.any(Array)/toMatchObject/toHaveProperty check the isArray() exception for Proxy values", async () => {
+      const { bunEnv, bunExe } = require("harness");
+      const src = `
+        const { expect } = require("bun:test");
+        try { expect(new Proxy({}, {})).toEqual(expect.any(Array)); } catch {}
+        try { expect(new Proxy([], {})).toEqual(expect.any(Array)); } catch {}
+        try { expect(new Proxy([], {})).toMatchObject([]); } catch {}
+        try { expect([]).toMatchObject(new Proxy([], {})); } catch {}
+        try { expect(new Proxy([], {})).toMatchObject(new Proxy([], {})); } catch {}
+        try { expect({ a: 1 }).toHaveProperty(new Proxy(["a"], {})); } catch {}
+        try { expect({ a: 1 }).toHaveProperty(new Proxy(new Set(["a"]), {})); } catch {}
+        const rp = Proxy.revocable({}, {}); rp.revoke();
+        try { expect(rp.proxy).toEqual(expect.any(Array)); } catch {}
+        console.log("ok");
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", src],
+        env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toMatchObject({
+        stdout: "ok\n",
+        exitCode: 0,
+        signalCode: null,
+      });
+    });
   }
 
   test("deepEquals works with sets/maps/dates/strings", () => {


### PR DESCRIPTION
## Repro

Under `BUN_JSC_validateExceptionChecks=1` on a debug build:

```js
const { expect } = require('bun:test');
expect(new Proxy({}, {})).toEqual(expect.any(Array));
// or:
expect(new Proxy([], {})).toMatchObject([]);
// or:
expect({ a: 1 }).toHaveProperty(new Proxy(new Set(['a']), {}));
```

```
ERROR: Unchecked JS exception:
    This scope can throw a JS exception: isArraySlowInline @ JavaScriptCore/runtime/ArrayConstructor.cpp:128
    But the exception was unchecked as of this scope: hasInstance @ JavaScriptCore/runtime/JSObject.cpp:2678
ASSERTION FAILED: exception check validation failed
```

## Cause

`JSC::isArray()` declares a throw scope on its Proxy path (`isArraySlowInline`, for the revoked-Proxy case). Three call sites in `src/jsc/bindings/bindings.cpp` used it inside an `if` condition and then either entered another throw-scope-declaring call, or returned with the scope's `m_needExceptionCheck` still set:

- `matchAsymmetricMatcherAndGetFlags` (`AsymmetricMatcherConstructorType::Array`): `isArray()` then falls through to `constructorObject->hasInstance()`.
- `Bun__deepMatch`: `isArray(globalObject, objValue) && isArray(globalObject, subsetValue)` chains two throw-scope calls, then `getPropertyNames()`.
- `JSC__JSValue__getIfPropertyExistsFromPath` (the `toHaveProperty` path lookup): when `isArray()` returns false for a Proxy over an iterable non-array (Set, Map, generator), the body is skipped and the function returns `{}` with the outer `ThrowScope` still unsatisfied.

The `Bun__deepEquals` sites (`v1Array`/`v2Array`) already had the check.

## Fix

Hoist each `isArray()` result out of the condition and `RETURN_IF_EXCEPTION` immediately after it. Same pattern as #34747 for the `NodeVM.cpp` instances.

Release behavior is effectively unchanged for `expect.any(Array)` and `toHaveProperty` (the `isArray` revocation error already reached the caller via a later check). For `toMatchObject` with a revoked-Proxy receiver, the thrown `TypeError` message changes from the generic revocation message to `Array.isArray cannot be called on a Proxy that has been revoked`, matching the operation that actually failed.

## Verification

New subprocess test in `test/js/bun/test/expect.test.js` spawns with `BUN_JSC_validateExceptionChecks=1` and runs every affected matcher shape with transparent and revoked Proxies. On builds without exception-scope verification the option is a no-op and the child exits 0 either way.

```
# fail-before (src/ stashed, bun bd):
(fail) expect.any(Array)/toMatchObject/toHaveProperty check the isArray() exception for Proxy values
  exitCode: 134, signalCode: SIGABRT
  ERROR: Unchecked JS exception: isArraySlowInline ... hasInstance

# pass-after (bun bd):
(pass) expect.any(Array)/toMatchObject/toHaveProperty check the isArray() exception for Proxy values
```

`expect.test.js` (408 pass), `jest-extended.test.js` (57 pass), `test/js/node/assert/deep-equal.test.ts` (260 pass) all pass.

## Related

#32948 applies the same `Bun__deepMatch` split as part of a larger Proxy-transparency change and composes with this one; it does not touch the `expect.any(Array)` or `toHaveProperty` sites.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 10 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (4b23b02ae)

test/js/bun/test/expect.test.js:
(pass) expect() > () [615.76ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [2.91ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.62ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.38ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.38ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.37ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.37ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.40ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.37ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.41ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.36ms]
(pass) ex
... (truncated)

release without fix: 10 skipped
bun test v1.4.0-canary.1 (4b23b02ae)

test/js/bun/test/expect.test.js:
(pass) expect() > () [0.70ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.03ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(-0).toBe(-0) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true
(pass) expect() > toBe() > expect({}).toBe({}) == true
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true
(pass) expect() > toBe() > expect(0).toBe(false) == false [0.02ms]
(pass) expect() > toBe() > expect(0).toBe("") == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(1).toBe(2) == false
(pass) expect() > toBe() > expect(1).toBe(true) == false
(pass) expect() > toBe() > expect(1).toBe("1") == false
(pass) expect() > toBe() > expect(Infinity).toBe(-Infinity) == false
(pass) expect() > toBe() > expect("foo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 10 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (4b23b02ae)

test/js/bun/test/expect.test.js:
(pass) expect() > () [586.95ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [2.83ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.57ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.45ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.37ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.44ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.37ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.44ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.37ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.43ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.36ms]
(pass) ex
... (truncated)

release with fix: 10 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 734ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cxx obj/src/jsc/bindings/bindings.cpp.o
[2/6] gen cpp.rs (cppbind)
[2/5] link bun-profile
[3/5] bun-profile --revision
1.4.0-canary.1+4b23b02ae
[5/5] strip bun
[build] done
bun test v1.4.0-canary.1 (4b23b02ae)

test/js/bun/test/expect.test.js:
(pass) expect() > () [0.70ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.03ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(-0).toBe(-0) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true
(pass) expect() > toBe() > exp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/bindings.cpp   | 15 ++++++++++++---
 test/js/bun/test/expect.test.js | 32 ++++++++++++++++++++++++++++++++
 2 files changed, 44 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                             reads  edits  tests
src/jsc/bindings/bindings.cpp        6      3      0
test/js/bun/test/expect.test.js      2      2      0
```

</details>

<!-- robobun:evidence:end -->