### PR TITLE
napi: pass module.exports (not the module) to napi_module_register's init callback

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -750,7 +750,7 @@ void Napi::executePendingNapiModule(Zig::GlobalObject* globalObject)
     JSValue resultValue;
 
     if (mod.nm_register_func) {
-        resultValue = toJS(mod.nm_register_func(env.ptr(), toNapi(object, globalObject)));
+        resultValue = toJS(mod.nm_register_func(env.ptr(), toNapi(JSValue(strongExportsObject.get()), globalObject)));
     } else {
         JSValue errorInstance = createError(globalObject, makeString("Module has no declared entry point."_s));
         globalObject->m_pendingNapiModuleAndExports[0].set(vm, globalObject, errorInstance);

--- a/test/napi/napi-app/binding.gyp
+++ b/test/napi/napi-app/binding.gyp
@@ -132,6 +132,16 @@
             ],
         },
         {
+            "target_name": "exports_identity_addon",
+            "sources": ["exports_identity_addon.cpp"],
+            "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],
+            "libraries": [],
+            "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
+            "defines": [
+                "NAPI_DISABLE_CPP_EXCEPTIONS",
+            ],
+        },
+        {
             "target_name": "test_cleanup_hook_order",
             "sources": ["test_cleanup_hook_order.c"],
             "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],

--- a/test/napi/napi-app/exports_identity_addon.cpp
+++ b/test/napi/napi-app/exports_identity_addon.cpp
@@ -1,0 +1,40 @@
+#include <js_native_api.h>
+#include <node_api.h>
+#include <stdio.h>
+
+// This addon exercises napi_module_register (the deprecated static-ctor
+// registration path) and asserts that the `exports` argument passed to
+// nm_register_func is module.exports, not the module object itself.
+
+static napi_value register_cb(napi_env env, napi_value exports);
+
+static napi_module mod = {
+    1,                            // nm_version
+    0,                            // nm_flags
+    "exports_identity_addon.cpp", // nm_filename
+    register_cb,                  // nm_register_func
+    "exports_identity_addon",     // nm_modname
+    NULL,                         // nm_priv
+    {NULL}                        // reserved
+};
+
+class call_register {
+public:
+  call_register() { napi_module_register(&mod); }
+};
+
+static call_register constructor1;
+
+static napi_value register_cb(napi_env env, napi_value exports) {
+  napi_value key;
+  napi_create_string_utf8(env, "exports", NAPI_AUTO_LENGTH, &key);
+  bool has_own_exports = false;
+  napi_has_own_property(env, exports, key, &has_own_exports);
+  printf("exports_has_own_exports=%d\n", has_own_exports ? 1 : 0);
+  fflush(stdout);
+
+  napi_value marker;
+  napi_create_int32(env, 1, &marker);
+  napi_set_named_property(env, exports, "marker", marker);
+  return exports;
+}

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -1007,6 +1007,32 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     expect(exitCode).toBe(0);
   });
 
+  it("passes module.exports (not the module) to napi_module_register's init callback", async () => {
+    // Node.js passes module.exports as the `exports` argument to nm_register_func.
+    // Bun used to pass the JSCommonJSModule itself, so addons that wrote to
+    // `exports` and returned it produced a self-referential module object.
+    const addonPath = join(__dirname, "napi-app", "build", "Debug", "exports_identity_addon.node");
+    const script = `
+      const addon = require(${JSON.stringify(addonPath)});
+      console.log("own_names=" + Object.getOwnPropertyNames(addon).sort().join(","));
+      console.log("self_referential=" + (addon === addon.exports));
+    `;
+    const run = async (exe: string) => {
+      await using proc = spawn({ cmd: [exe, "-e", script], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout: stdout.split(/\r?\n/).filter(Boolean), stderr, exitCode };
+    };
+    const bunResult = await run(bunExe());
+    expect(bunResult.stderr).toBe("");
+    expect(bunResult.stdout).toEqual([
+      "exports_has_own_exports=0",
+      "own_names=marker",
+      "self_referential=false",
+    ]);
+    expect(bunResult.exitCode).toBe(0);
+    expect(await run(await nodeExeMatchingAbi())).toEqual(bunResult);
+  });
+
   it("behaves as expected when performing operations with an exception pending", async () => {
     await checkSameOutput("test_deferred_exceptions", []);
   });

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -1024,11 +1024,7 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     };
     const bunResult = await run(bunExe());
     expect(bunResult.stderr).toBe("");
-    expect(bunResult.stdout).toEqual([
-      "exports_has_own_exports=0",
-      "own_names=marker",
-      "self_referential=false",
-    ]);
+    expect(bunResult.stdout).toEqual(["exports_has_own_exports=0", "own_names=marker", "self_referential=false"]);
     expect(bunResult.exitCode).toBe(0);
     expect(await run(await nodeExeMatchingAbi())).toEqual(bunResult);
   });


### PR DESCRIPTION
## Summary

`Napi::executePendingNapiModule` passed the `JSCommonJSModule` wrapper to `nm_register_func` as its `exports` argument. Node.js passes `module.exports` here. An addon that writes to `exports` and then returns it (the common pattern) ended up mutating the module wrapper, and Bun then set `module.exports = <result>` (since the result did not equal the original exports object), leaving `require()` returning a self-referential object with a stray own `exports` property.

## Repro

```c
#include <node_api.h>
static napi_value Noop(napi_env e, napi_callback_info i) { return NULL; }
NAPI_MODULE_INIT() {
  napi_property_descriptor p = {"m", NULL, Noop, NULL, NULL, NULL, napi_default, NULL};
  napi_define_properties(env, exports, 1, &p);
  return exports;
}
```

Compiled against a `node_api.h` that still routes `NAPI_MODULE_INIT` through `napi_module_register` (older Node headers, or Bun's own `src/runtime/napi/node_api.h`):

```console
$ bun -e 'console.log(Object.getOwnPropertyNames(require("./addon.node")).sort())'
[ "exports", "m" ]
$ node -e 'console.log(Object.getOwnPropertyNames(require("./addon.node")).sort())'
[ 'm' ]
```

## Cause

In `src/jsc/bindings/napi.cpp`, `executePendingNapiModule` resolved `object` to the module wrapper and `strongExportsObject` to `module.exports`, then called:

```cpp
mod.nm_register_func(env.ptr(), toNapi(object, globalObject))
```

passing the wrapper instead of the exports. Node's `napi_module_register_by_symbol` passes `exports`:

```cpp
_exports = init(env, v8impl::JsValueFromV8LocalValue(exports));
```

The sibling `napi_register_module_v1` dlsym path in `BunProcess.cpp` and the V8 `node_module_register` path in `v8/node.cpp` already pass `exports`; only this path was wrong.

## Fix

Pass `strongExportsObject.get()` instead of `object`. The existing post-processing (set `module.exports = result` when the addon returns a different object) is unchanged and now matches Node's semantics.

## Test

New `exports_identity_addon` registers via a static constructor calling `napi_module_register` and asserts that the `exports` handed to the init callback has no own `exports` property. The test compares Bun's output against Node's on the same addon.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->