### PR TITLE
fetch: add record/replay store (dir + memory backends)

### DIFF
--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -150,6 +150,15 @@ depth = 3
 
 Higher values show more nested properties but may produce verbose output for complex objects. The `--console-depth` CLI flag overrides this setting.
 
+### `fetch.cache`
+
+Enable a process-wide record/replay store for `fetch()`. Pass `"memory"` for an in-process cache, or a directory path to write one JSON file per unique request. The `--fetch-cache` CLI flag overrides this setting, and a per-call `store` option on `fetch()` overrides both.
+
+```toml title="bunfig.toml" icon="settings"
+[fetch]
+cache = "./.bun-fetch-cache"
+```
+
 ## Serve
 
 The `[serve]` section configures `Bun.serve` and `bun run` when serving HTTP.

--- a/docs/runtime/networking/fetch.mdx
+++ b/docs/runtime/networking/fetch.mdx
@@ -461,7 +461,7 @@ const res2 = await fetch(url, { store: { type: "memory", ttl: 60_000, max: 1000 
 
 Two requests share a cache entry when their method, URL, request headers and (buffered) request body are identical. For the `dir` backend, each entry is a standalone JSON file containing the full request and response; bodies that are not valid UTF-8 text are base64-encoded.
 
-The store is bypassed when the request body is a `ReadableStream` (the body bytes are not available to hash upfront) and for `s3://` URLs. A `Bun.file()` request body is read into memory so it can participate. Responses are recorded once the body has been fully consumed, whether you read it via `.text()`/`.json()`/`.bytes()` or as a stream.
+The store is bypassed when the request body is a `ReadableStream` (the body bytes are not available to hash upfront), when the body is a `FormData` (its multipart boundary is random per call), and for `s3://` URLs. A `Bun.file()` request body is read into memory so it can participate. The `unix` socket path is included in the cache key. Responses are recorded once the body has been fully consumed, whether you read it via `.text()`/`.json()`/`.bytes()` or as a stream.
 
 To enable the store for every `fetch()` in a process, use `bun --fetch-cache=<path>` (or `--fetch-cache=memory`), or set `cache` under `[fetch]` in `bunfig.toml`.
 

--- a/docs/runtime/networking/fetch.mdx
+++ b/docs/runtime/networking/fetch.mdx
@@ -459,11 +459,11 @@ const res = await fetch("https://api.example.com/users/1", {
 const res2 = await fetch(url, { store: { type: "memory", ttl: 60_000, max: 1000 } });
 ```
 
-Two requests share a cache entry when their method, URL, request headers and (buffered) request body are identical. For the `dir` backend, each entry is a standalone JSON file containing the full request and response; bodies that are not valid UTF-8 text are base64-encoded.
+Two requests share a cache entry when their method, URL, request headers and (buffered) request body are identical. The `unix` socket path, `proxy` URL, `redirect` mode and `decompress` setting are also included in the cache key. For the `dir` backend, each entry is a standalone JSON file containing the full request and response; bodies that are not valid UTF-8 text are base64-encoded.
 
-The store is bypassed when the request body is a `ReadableStream` (the body bytes are not available to hash upfront), when the body is a `FormData` (its multipart boundary is random per call), and for `s3://` URLs. A `Bun.file()` request body is read into memory so it can participate. The `unix` socket path is included in the cache key. Responses are recorded once the body has been fully consumed, whether you read it via `.text()`/`.json()`/`.bytes()` or as a stream.
+The store is bypassed for `s3://` URLs, when the request body is a `ReadableStream` or `FormData`, and when a per-call `tls`, `protocol`, or `proxy.headers` option is set (these transport overrides aren't part of the key). A `Bun.file()` request body is read into memory so it can participate. Responses are recorded once the body has been fully consumed, whether you read it via `.text()`/`.json()`/`.bytes()` or as a stream.
 
-To enable the store for every `fetch()` in a process, use `bun --fetch-cache=<path>` (or `--fetch-cache=memory`), or set `cache` under `[fetch]` in `bunfig.toml`.
+To enable the store for every `fetch()` in a process, use `bun --fetch-cache=<path>` (or `--fetch-cache=memory`), or set `cache` under `[fetch]` in `bunfig.toml`. Pass `store: null` or `store: false` on an individual call to bypass the process-wide store for that request.
 
 ### Response buffering
 

--- a/docs/runtime/networking/fetch.mdx
+++ b/docs/runtime/networking/fetch.mdx
@@ -461,7 +461,7 @@ const res2 = await fetch(url, { store: { type: "memory", ttl: 60_000, max: 1000 
 
 Two requests share a cache entry when their method, URL, request headers and (buffered) request body are identical. For the `dir` backend, each entry is a standalone JSON file containing the full request and response; bodies that are not valid UTF-8 text are base64-encoded.
 
-The store is bypassed when the request body is a `ReadableStream` (the body bytes are not available to hash) and for `s3://` URLs. A response is recorded once its body has been fully buffered, which happens automatically when you call `response.text()`, `.json()`, `.bytes()`, `.arrayBuffer()` or `.blob()`; a response whose body you read as a stream is not recorded.
+The store is bypassed when the request body is a `ReadableStream` (the body bytes are not available to hash upfront) and for `s3://` URLs. A `Bun.file()` request body is read into memory so it can participate. Responses are recorded once the body has been fully consumed, whether you read it via `.text()`/`.json()`/`.bytes()` or as a stream.
 
 To enable the store for every `fetch()` in a process, use `bun --fetch-cache=<path>` (or `--fetch-cache=memory`), or set `cache` under `[fetch]` in `bunfig.toml`.
 

--- a/docs/runtime/networking/fetch.mdx
+++ b/docs/runtime/networking/fetch.mdx
@@ -459,7 +459,7 @@ const res = await fetch("https://api.example.com/users/1", {
 const res2 = await fetch(url, { store: { type: "memory", ttl: 60_000, max: 1000 } });
 ```
 
-Two requests share a cache entry when their method, URL, request headers and (buffered) request body are identical. The `unix` socket path, `proxy` URL, `redirect` mode and `decompress` setting are also included in the cache key. For the `dir` backend, each entry is a standalone JSON file containing the full request and response; bodies that are not valid UTF-8 text are base64-encoded.
+Two requests share a cache entry when their method, URL, request headers and (buffered) request body are identical. The `unix` socket path, `proxy` URL, `redirect` mode, `maxRedirects` and `decompress` setting are also included in the cache key. For the `dir` backend, each entry is a standalone JSON file containing the full request and response; bodies that are not valid UTF-8 text are base64-encoded.
 
 The store is bypassed for `s3://` URLs, when the request body is a `ReadableStream` or `FormData`, and when a per-call `tls`, `protocol`, or `proxy.headers` option is set (these transport overrides aren't part of the key). A `Bun.file()` request body is read into memory so it can participate. Responses are recorded once the body has been fully consumed, whether you read it via `.text()`/`.json()`/`.bytes()` or as a stream.
 

--- a/docs/runtime/networking/fetch.mdx
+++ b/docs/runtime/networking/fetch.mdx
@@ -461,6 +461,8 @@ const res2 = await fetch(url, { store: { type: "memory", ttl: 60_000, max: 1000 
 
 Two requests share a cache entry when their method, URL, request headers and (buffered) request body are identical. For the `dir` backend, each entry is a standalone JSON file containing the full request and response; bodies that are not valid UTF-8 text are base64-encoded.
 
+The store is bypassed when the request body is a `ReadableStream` (the body bytes are not available to hash) and for `s3://` URLs. A response is recorded once its body has been fully buffered, which happens automatically when you call `response.text()`, `.json()`, `.bytes()`, `.arrayBuffer()` or `.blob()`; a response whose body you read as a stream is not recorded.
+
 To enable the store for every `fetch()` in a process, use `bun --fetch-cache=<path>` (or `--fetch-cache=memory`), or set `cache` under `[fetch]` in `bunfig.toml`.
 
 ### Response buffering

--- a/docs/runtime/networking/fetch.mdx
+++ b/docs/runtime/networking/fetch.mdx
@@ -445,6 +445,24 @@ BUN_CONFIG_MAX_HTTP_REQUESTS=512 bun ./my-script.ts
 
 The max value for this limit is 65,535. The maximum port number is 65,535, so it's quite difficult for any one computer to exceed this limit.
 
+### Recording & replaying requests
+
+Bun can record every `fetch()` request/response pair and replay the recorded response on the next identical request, skipping the network entirely. This is designed for writing tests against third-party APIs and for agents that need deterministic traffic.
+
+```ts
+// Per request: write one JSON file per unique request under ./fixtures
+const res = await fetch("https://api.example.com/users/1", {
+  store: { type: "dir", path: "./fixtures" },
+});
+
+// Per request: in-memory, with optional TTL (ms) and max entries
+const res2 = await fetch(url, { store: { type: "memory", ttl: 60_000, max: 1000 } });
+```
+
+Two requests share a cache entry when their method, URL, request headers and (buffered) request body are identical. For the `dir` backend, each entry is a standalone JSON file containing the full request and response; bodies that are not valid UTF-8 text are base64-encoded.
+
+To enable the store for every `fetch()` in a process, use `bun --fetch-cache=<path>` (or `--fetch-cache=memory`), or set `cache` under `[fetch]` in `bunfig.toml`.
+
 ### Response buffering
 
 The fastest way to read the response body is to use one of these methods:

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -2022,9 +2022,7 @@ interface BunFetchRequestInit extends RequestInit {
    * Not part of the Fetch API specification.
    * @experimental
    */
-  store?:
-    | { type: "dir"; path: string }
-    | { type: "memory"; ttl?: number; max?: number };
+  store?: { type: "dir"; path: string } | { type: "memory"; ttl?: number; max?: number };
 
   /**
    * Force the underlying HTTP version. `"http2"` advertises only `h2` in

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -2006,6 +2006,27 @@ interface BunFetchRequestInit extends RequestInit {
   unix?: string;
 
   /**
+   * Record & replay this request through a persistent store. When a request
+   * with the same method, URL, headers and body has been recorded before, the
+   * recorded Response is returned without touching the network.
+   *
+   * - `{ type: "dir", path }` writes one JSON file per unique request under
+   *   `path`. Non-text bodies are base64-encoded. Designed for committing
+   *   fixtures alongside tests and for agents to inspect traffic.
+   * - `{ type: "memory", ttl?, max? }` keeps entries in a process-global
+   *   hash map. `ttl` is in milliseconds; `max` bounds the entry count.
+   *
+   * The process-wide default can be set with `--fetch-cache=<path|memory>`
+   * or `[fetch] cache` in `bunfig.toml`; this per-call option overrides it.
+   *
+   * Not part of the Fetch API specification.
+   * @experimental
+   */
+  store?:
+    | { type: "dir"; path: string }
+    | { type: "memory"; ttl?: number; max?: number };
+
+  /**
    * Force the underlying HTTP version. `"http2"` advertises only `h2` in
    * the TLS ALPN list and the request fails with `HTTP2Unsupported` if the
    * server doesn't select it. `"http1.1"` pins the request to HTTP/1.1,

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -2018,11 +2018,12 @@ interface BunFetchRequestInit extends RequestInit {
    *
    * The process-wide default can be set with `--fetch-cache=<path|memory>`
    * or `[fetch] cache` in `bunfig.toml`; this per-call option overrides it.
+   * Pass `null` or `false` to bypass the process-wide store for this call.
    *
    * Not part of the Fetch API specification.
    * @experimental
    */
-  store?: { type: "dir"; path: string } | { type: "memory"; ttl?: number; max?: number };
+  store?: { type: "dir"; path: string } | { type: "memory"; ttl?: number; max?: number } | null | false;
 
   /**
    * Force the underlying HTTP version. `"http2"` advertises only `h2` in

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -826,20 +826,25 @@ impl<'a> Parser<'a> {
                 }
             }
 
-            if let Some(fetch_expr) = json.get(b"fetch") {
-                if let Some(cache) = fetch_expr.get(b"cache") {
-                    if let Some(value) = cache.as_string(self.bump) {
-                        self.ctx.runtime_options.fetch_store =
-                            bun_options_types::context::FetchStoreConfig::parse(value);
-                    } else if let Some(path) =
-                        cache.get(b"path").and_then(|e| e.as_string(self.bump))
-                    {
-                        self.ctx.runtime_options.fetch_store =
-                            bun_options_types::context::FetchStoreConfig::Dir {
-                                path: path.to_vec().into_boxed_slice(),
-                            };
-                    } else {
-                        self.add_error(cache.loc, b"Expected string or { path }")?;
+            if matches!(
+                self.ctx.runtime_options.fetch_store,
+                bun_options_types::context::FetchStoreConfig::None
+            ) {
+                if let Some(fetch_expr) = json.get(b"fetch") {
+                    if let Some(cache) = fetch_expr.get(b"cache") {
+                        if let Some(value) = cache.as_string(self.bump) {
+                            self.ctx.runtime_options.fetch_store =
+                                bun_options_types::context::FetchStoreConfig::parse(value);
+                        } else if let Some(path) =
+                            cache.get(b"path").and_then(|e| e.as_string(self.bump))
+                        {
+                            self.ctx.runtime_options.fetch_store =
+                                bun_options_types::context::FetchStoreConfig::Dir {
+                                    path: path.to_vec().into_boxed_slice(),
+                                };
+                        } else {
+                            self.add_error(cache.loc, b"Expected string or { path }")?;
+                        }
                     }
                 }
             }

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -826,6 +826,24 @@ impl<'a> Parser<'a> {
                 }
             }
 
+            if let Some(fetch_expr) = json.get(b"fetch") {
+                if let Some(cache) = fetch_expr.get(b"cache") {
+                    if let Some(value) = cache.as_string(self.bump) {
+                        self.ctx.runtime_options.fetch_store =
+                            bun_options_types::context::FetchStoreConfig::parse(value);
+                    } else if let Some(path) =
+                        cache.get(b"path").and_then(|e| e.as_string(self.bump))
+                    {
+                        self.ctx.runtime_options.fetch_store =
+                            bun_options_types::context::FetchStoreConfig::Dir {
+                                path: path.to_vec().into_boxed_slice(),
+                            };
+                    } else {
+                        self.add_error(cache.loc, b"Expected string or { path }")?;
+                    }
+                }
+            }
+
             if let Some(console_expr) = json.get(b"console") {
                 if let Some(depth) = console_expr.get(b"depth") {
                     if let Some(n) = depth.as_number() {

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -832,16 +832,12 @@ impl<'a> Parser<'a> {
             ) {
                 if let Some(fetch_expr) = json.get(b"fetch") {
                     if let Some(cache) = fetch_expr.get(b"cache") {
-                        if let Some(value) = cache.as_string(self.bump) {
+                        let value = cache
+                            .as_string(self.bump)
+                            .or_else(|| cache.get(b"path").and_then(|e| e.as_string(self.bump)));
+                        if let Some(value) = value {
                             self.ctx.runtime_options.fetch_store =
                                 bun_options_types::context::FetchStoreConfig::parse(value);
-                        } else if let Some(path) =
-                            cache.get(b"path").and_then(|e| e.as_string(self.bump))
-                        {
-                            self.ctx.runtime_options.fetch_store =
-                                bun_options_types::context::FetchStoreConfig::Dir {
-                                    path: path.to_vec().into_boxed_slice(),
-                                };
                         } else {
                             self.add_error(cache.loc, b"Expected string or { path }")?;
                         }

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -557,26 +557,28 @@ impl FetchStoreConfig {
         if value == b"memory" {
             return FetchStoreConfig::Memory { ttl_ms: 0, max: 0 };
         }
-        let path = if bun_paths::is_absolute(value) {
-            value.to_vec().into_boxed_slice()
-        } else {
-            let mut cwd_buf = bun_paths::path_buffer_pool::get();
-            match bun_sys::getcwd(&mut cwd_buf) {
-                Ok(len) => {
-                    let mut out = bun_paths::path_buffer_pool::get();
-                    bun_paths::resolve_path::join_abs_string_buf::<bun_paths::platform::Auto>(
-                        &cwd_buf[..len],
-                        &mut out,
-                        &[value],
-                    )
-                    .to_vec()
-                    .into_boxed_slice()
-                }
-                Err(_) => value.to_vec().into_boxed_slice(),
-            }
-        };
-        FetchStoreConfig::Dir { path }
+        FetchStoreConfig::Dir {
+            path: resolve_against_cwd(value),
+        }
     }
+}
+
+/// Resolve `path` to absolute against the process cwd. Shared by the CLI /
+/// bunfig parser and the per-call `store: { path }` option so both freeze the
+/// directory at the moment the user names it.
+pub fn resolve_against_cwd(path: &[u8]) -> Box<[u8]> {
+    if bun_paths::is_absolute(path) {
+        return path.to_vec().into_boxed_slice();
+    }
+    let mut cwd_buf = bun_paths::path_buffer_pool::get();
+    let cwd = match bun_sys::getcwd(&mut cwd_buf) {
+        Ok(len) => &cwd_buf[..len],
+        Err(_) => return path.to_vec().into_boxed_slice(),
+    };
+    let mut out = bun_paths::path_buffer_pool::get();
+    bun_paths::resolve_path::join_abs_string_buf::<bun_paths::platform::Auto>(cwd, &mut out, &[path])
+        .to_vec()
+        .into_boxed_slice()
 }
 
 pub struct RuntimeOptions {

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -547,7 +547,9 @@ pub enum FetchStoreConfig {
 
 impl FetchStoreConfig {
     /// Parse the `--fetch-cache=` value / bunfig string form:
-    /// `"memory"` or a directory path.
+    /// `"memory"` or a directory path. Relative paths are resolved against
+    /// the current cwd here (startup time) so a later `process.chdir()` does
+    /// not retarget the store.
     pub fn parse(value: &[u8]) -> Self {
         if value.is_empty() {
             return FetchStoreConfig::None;
@@ -555,9 +557,25 @@ impl FetchStoreConfig {
         if value == b"memory" {
             return FetchStoreConfig::Memory { ttl_ms: 0, max: 0 };
         }
-        FetchStoreConfig::Dir {
-            path: value.to_vec().into_boxed_slice(),
-        }
+        let path = if bun_paths::is_absolute(value) {
+            value.to_vec().into_boxed_slice()
+        } else {
+            let mut cwd_buf = bun_paths::path_buffer_pool::get();
+            match bun_sys::getcwd(&mut cwd_buf) {
+                Ok(len) => {
+                    let mut out = bun_paths::path_buffer_pool::get();
+                    bun_paths::resolve_path::join_abs_string_buf::<bun_paths::platform::Auto>(
+                        &cwd_buf[..len],
+                        &mut out,
+                        &[value],
+                    )
+                    .to_vec()
+                    .into_boxed_slice()
+                }
+                Err(_) => value.to_vec().into_boxed_slice(),
+            }
+        };
+        FetchStoreConfig::Dir { path }
     }
 }
 

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -576,9 +576,13 @@ pub fn resolve_against_cwd(path: &[u8]) -> Box<[u8]> {
         Err(_) => return path.to_vec().into_boxed_slice(),
     };
     let mut out = bun_paths::path_buffer_pool::get();
-    bun_paths::resolve_path::join_abs_string_buf::<bun_paths::platform::Auto>(cwd, &mut out, &[path])
-        .to_vec()
-        .into_boxed_slice()
+    bun_paths::resolve_path::join_abs_string_buf::<bun_paths::platform::Auto>(
+        cwd,
+        &mut out,
+        &[path],
+    )
+    .to_vec()
+    .into_boxed_slice()
 }
 
 pub struct RuntimeOptions {

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -529,6 +529,38 @@ pub struct DebuggerEnable {
     pub set_breakpoint_on_first_line: bool,
 }
 
+/// Process-wide default for `fetch()`'s record/replay store. Set by
+/// `--fetch-cache` / `[fetch] cache` in bunfig; a per-call `store` option
+/// overrides it.
+#[derive(Clone, Default)]
+pub enum FetchStoreConfig {
+    #[default]
+    None,
+    Dir {
+        path: Box<[u8]>,
+    },
+    Memory {
+        ttl_ms: u32,
+        max: u32,
+    },
+}
+
+impl FetchStoreConfig {
+    /// Parse the `--fetch-cache=` value / bunfig string form:
+    /// `"memory"` or a directory path.
+    pub fn parse(value: &[u8]) -> Self {
+        if value.is_empty() {
+            return FetchStoreConfig::None;
+        }
+        if value == b"memory" {
+            return FetchStoreConfig::Memory { ttl_ms: 0, max: 0 };
+        }
+        FetchStoreConfig::Dir {
+            path: value.to_vec().into_boxed_slice(),
+        }
+    }
+}
+
 pub struct RuntimeOptions {
     pub smol: bool,
     pub debugger: Debugger,
@@ -539,6 +571,7 @@ pub struct RuntimeOptions {
     pub preconnect: Vec<Box<[u8]>>,
     pub experimental_http2_fetch: bool,
     pub experimental_http3_fetch: bool,
+    pub fetch_store: FetchStoreConfig,
     pub dns_result_order: Box<[u8]>,
     /// `--expose-gc` makes `globalThis.gc()` available. Added for Node
     /// compatibility.
@@ -603,6 +636,7 @@ impl Default for RuntimeOptions {
             preconnect: Vec::new(),
             experimental_http2_fetch: false,
             experimental_http3_fetch: false,
+            fetch_store: FetchStoreConfig::None,
             dns_result_order: Box::from(&b"verbatim"[..]),
             expose_gc: false,
             preserve_symlinks_main: false,

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -254,6 +254,9 @@ pub(crate) const RUNTIME_PARAMS_: &[ParamType] = &[
     parse_param!("--conditions <STR>...             Pass custom conditions to resolve"),
     parse_param!("--fetch-preconnect <STR>...       Preconnect to a URL while code is loading"),
     parse_param!(
+        "--fetch-cache <STR>               Record & replay fetch() responses. Pass \"memory\" or a directory path"
+    ),
+    parse_param!(
         "--experimental-http2-fetch        Offer h2 in fetch() TLS ALPN. Same as BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT=1"
     ),
     parse_param!(
@@ -1102,6 +1105,10 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
         ctx.runtime_options.if_present = args.flag(b"--if-present");
         ctx.runtime_options.smol = args.flag(b"--smol");
         ctx.runtime_options.preconnect = slice_to_owned(args.options(b"--fetch-preconnect"));
+        if let Some(value) = args.option(b"--fetch-cache") {
+            ctx.runtime_options.fetch_store =
+                bun_options_types::context::FetchStoreConfig::parse(value);
+        }
         ctx.runtime_options.experimental_http2_fetch = args.flag(b"--experimental-http2-fetch");
         ctx.runtime_options.experimental_http3_fetch = args.flag(b"--experimental-http3-fetch");
         ctx.runtime_options.expose_gc = args.flag(b"--expose-gc");

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1003,7 +1003,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         break 'extract_verbose verbose;
     };
 
-    // store: { type: "dir" | "memory", ... } | undefined
+    // store: { type: "dir" | "memory", ... } | null | false | undefined
     let fetch_store: Option<FetchStore> = 'extract_store: {
         let objects_to_try = [
             options_object.unwrap_or(JSValue::ZERO),
@@ -1012,7 +1012,10 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         for obj in objects_to_try {
             if !obj.is_empty() {
                 if let Some(store_val) = obj.get(global_this, "store")? {
-                    if !store_val.is_undefined_or_null() {
+                    if store_val.is_null() || store_val == JSValue::FALSE {
+                        break 'extract_store None;
+                    }
+                    if !store_val.is_undefined() {
                         break 'extract_store FetchStore::from_js(global_this, store_val)?;
                     }
                 }
@@ -2097,10 +2100,14 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             let body_bytes = if s.is_empty() { None } else { Some(s) };
             let empty_headers;
             let req = store::build_request(
-                method,
-                url.href,
-                unix_socket_path.slice(),
-                proxy.as_ref().map(|p| p.href).unwrap_or(b""),
+                &store::KeyInputs {
+                    method,
+                    url: url.href,
+                    unix_socket_path: unix_socket_path.slice(),
+                    proxy_href: proxy.as_ref().map(|p| p.href).unwrap_or(b""),
+                    redirect: redirect_type,
+                    decompress: !disable_decompression,
+                },
                 match headers.as_ref() {
                     Some(h) => h,
                     None => {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -2075,15 +2075,12 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     // Record/replay store: key the request now that method/url/headers/body
     // are finalised, and either short-circuit on a hit or carry the key into
     // the tasklet so the response can be persisted once fully buffered.
+    // Streamed / sendfile bodies are unhashable, so the store is bypassed for
+    // them entirely (a false hit would replay the wrong body's response).
     let store_request: Option<(FetchStore, store::StoredRequest)> = match fetch_store {
-        Some(store_) if !url.is_s3() => {
-            let body_bytes: Option<&[u8]> = match &body {
-                HTTPRequestBody::AnyBlob(_) => {
-                    let s = body.slice();
-                    if s.is_empty() { None } else { Some(s) }
-                }
-                _ => None,
-            };
+        Some(store_) if !url.is_s3() && matches!(&body, HTTPRequestBody::AnyBlob(_)) => {
+            let s = body.slice();
+            let body_bytes = if s.is_empty() { None } else { Some(s) };
             let empty_headers;
             let req = store::build_request(
                 method,

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1759,7 +1759,13 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             // An explicit `compress` request always wins over the sendfile
             // heuristic — otherwise the same `Bun.file()` body would compress
             // over https/proxy/<32 KiB/Windows but silently not over plain http.
-            if proxy.is_none() && compress.is_none() && http::SendFile::is_eligible(&url) {
+            // A configured record/replay store likewise forces the buffered
+            // path so the body bytes are available for the cache key.
+            if proxy.is_none()
+                && compress.is_none()
+                && fetch_store.is_none()
+                && http::SendFile::is_eligible(&url)
+            {
                 'use_sendfile: {
                     let stat: bun_sys::Stat = match bun_sys::fstat(opened_fd) {
                         Ok(result) => result,

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -2100,6 +2100,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 method,
                 url.href,
                 unix_socket_path.slice(),
+                proxy.as_ref().map(|p| p.href).unwrap_or(b""),
                 match headers.as_ref() {
                     Some(h) => h,
                     None => {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -2090,10 +2090,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             if !is_s3
                 && matches!(&body, HTTPRequestBody::AnyBlob(_))
                 && !body.get_any_blob().is_some_and(|b| {
-                    bun_core::strings::has_prefix_comptime(
-                        b.content_type(),
-                        b"multipart/form-data",
-                    )
+                    bun_core::strings::has_prefix_comptime(b.content_type(), b"multipart/form-data")
                 }) =>
         {
             let s = body.slice();

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -2082,17 +2082,27 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     // Record/replay store: key the request now that method/url/headers/body
     // are finalised, and either short-circuit on a hit or carry the key into
     // the tasklet so the response can be persisted once fully buffered.
-    // s3:// is bypassed (the signing block above has already rewritten `url`
-    // to https:// and installed per-second SigV4 headers, which would give a
-    // fresh key on every call). Streamed bodies are bypassed too (unhashable).
+    // Bypassed for s3:// (SigV4 installs per-second headers), streamed bodies
+    // (unhashable), and multipart/form-data (FormData serialises with a fresh
+    // random boundary in both the body bytes and Content-Type on every call).
     let store_request: Option<(FetchStore, store::StoredRequest)> = match fetch_store {
-        Some(store_) if !is_s3 && matches!(&body, HTTPRequestBody::AnyBlob(_)) => {
+        Some(store_)
+            if !is_s3
+                && matches!(&body, HTTPRequestBody::AnyBlob(_))
+                && !body.get_any_blob().is_some_and(|b| {
+                    bun_core::strings::has_prefix_comptime(
+                        b.content_type(),
+                        b"multipart/form-data",
+                    )
+                }) =>
+        {
             let s = body.slice();
             let body_bytes = if s.is_empty() { None } else { Some(s) };
             let empty_headers;
             let req = store::build_request(
                 method,
                 url.href,
+                unix_socket_path.slice(),
                 match headers.as_ref() {
                     Some(h) => h,
                     None => {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -2114,6 +2114,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                     proxy_href: proxy.as_ref().map(|p| p.href).unwrap_or(b""),
                     redirect: redirect_type,
                     decompress: !disable_decompression,
+                    max_redirects,
                 },
                 match headers.as_ref() {
                     Some(h) => h,

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -2094,6 +2094,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             if !is_s3
                 && proxy_headers.is_none()
                 && ssl_config.is_none()
+                && check_server_identity.is_empty_or_undefined_or_null()
                 && !force_http1
                 && !force_http2
                 && !force_http3

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -2085,12 +2085,18 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     // Record/replay store: key the request now that method/url/headers/body
     // are finalised, and either short-circuit on a hit or carry the key into
     // the tasklet so the response can be persisted once fully buffered.
-    // Bypassed for s3:// (SigV4 installs per-second headers), streamed bodies
-    // (unhashable), and multipart/form-data (FormData serialises with a fresh
-    // random boundary in both the body bytes and Content-Type on every call).
+    // Bypassed for s3:// (per-second SigV4 headers), streamed bodies
+    // (unhashable), multipart/form-data (random per-call boundary), and
+    // per-call transport overrides not covered by KeyInputs (proxy headers,
+    // custom TLS, forced protocol) to avoid false hits across those axes.
     let store_request: Option<(FetchStore, store::StoredRequest)> = match fetch_store {
         Some(store_)
             if !is_s3
+                && proxy_headers.is_none()
+                && ssl_config.is_none()
+                && !force_http1
+                && !force_http2
+                && !force_http3
                 && matches!(&body, HTTPRequestBody::AnyBlob(_))
                 && !body.get_any_blob().is_some_and(|b| {
                     bun_core::strings::has_prefix_comptime(b.content_type(), b"multipart/form-data")

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -38,6 +38,9 @@ pub mod fetch_tasklet;
 #[path = "fetch/compress_body.rs"]
 pub mod compress_body;
 
+#[path = "fetch/store.rs"]
+pub mod store;
+
 // ──────────────────────────────────────────────────────────────────────────
 // fetch() implementation
 // ──────────────────────────────────────────────────────────────────────────
@@ -81,6 +84,7 @@ use bun_url::URL as ZigURL;
 
 pub use self::fetch_tasklet::FetchTasklet;
 use self::fetch_tasklet::{FetchOptions, HTTPRequestBody};
+use self::store::FetchStore;
 
 // ──────────────────────────────────────────────────────────────────────────
 // Local extension shims (upstream methods not yet ported / not in scope)
@@ -998,6 +1002,34 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         }
         break 'extract_verbose verbose;
     };
+
+    // store: { type: "dir" | "memory", ... } | undefined
+    let fetch_store: Option<FetchStore> = 'extract_store: {
+        let objects_to_try = [
+            options_object.unwrap_or(JSValue::ZERO),
+            request_init_object.unwrap_or(JSValue::ZERO),
+        ];
+        for obj in objects_to_try {
+            if !obj.is_empty() {
+                if let Some(store_val) = obj.get(global_this, "store")? {
+                    if !store_val.is_undefined_or_null() {
+                        break 'extract_store FetchStore::from_js(global_this, store_val)?;
+                    }
+                }
+                if global_this.has_exception() {
+                    return Ok(JSValue::ZERO);
+                }
+            }
+        }
+        // No per-call store: fall back to the process-wide --fetch-cache /
+        // bunfig [fetch] cache setting.
+        bun_options_types::context::try_get()
+            .and_then(|ctx| FetchStore::from_config(&ctx.runtime_options.fetch_store))
+    };
+
+    if global_this.has_exception() {
+        return Ok(JSValue::ZERO);
+    }
 
     // proxy: string | { url: string, headers?: Headers } | undefined;
     let mut proxy_headers: Option<Headers> = None;
@@ -2040,6 +2072,40 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         }
     }
 
+    // Record/replay store: key the request now that method/url/headers/body
+    // are finalised, and either short-circuit on a hit or carry the key into
+    // the tasklet so the response can be persisted once fully buffered.
+    let store_request: Option<(FetchStore, store::StoredRequest)> = match fetch_store {
+        Some(store_) if !url.is_s3() => {
+            let body_bytes: Option<&[u8]> = match &body {
+                HTTPRequestBody::AnyBlob(_) => {
+                    let s = body.slice();
+                    if s.is_empty() { None } else { Some(s) }
+                }
+                _ => None,
+            };
+            let empty_headers;
+            let req = store::build_request(
+                method,
+                url.href,
+                match headers.as_ref() {
+                    Some(h) => h,
+                    None => {
+                        empty_headers = Headers::default();
+                        &empty_headers
+                    }
+                },
+                body_bytes,
+            );
+            if let Some(hit) = store_.lookup(req.key) {
+                body.detach();
+                return Ok(store::response_from_hit(global_this, hit));
+            }
+            Some((store_, req))
+        }
+        _ => None,
+    };
+
     // Only create this after we have validated all the input.
     // or else we will leak it
     let promise = jsc::JSPromiseStrong::init(global_this);
@@ -2097,6 +2163,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         force_http1,
         is_node_http_client: ALLOW_GET_BODY,
         compress,
+        store_request,
         check_server_identity: if check_server_identity.is_empty_or_undefined_or_null() {
             jsc::strong::Optional::empty()
         } else {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1898,7 +1898,8 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         compress = None;
     }
 
-    if url.is_s3() {
+    let is_s3 = url.is_s3();
+    if is_s3 {
         // get ENV config — `Transpiler::env_mut` is the safe accessor for the
         // process-singleton dotenv loader (set during init).
         let env_creds = s3_credentials_from_env(
@@ -2081,10 +2082,11 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     // Record/replay store: key the request now that method/url/headers/body
     // are finalised, and either short-circuit on a hit or carry the key into
     // the tasklet so the response can be persisted once fully buffered.
-    // Streamed / sendfile bodies are unhashable, so the store is bypassed for
-    // them entirely (a false hit would replay the wrong body's response).
+    // s3:// is bypassed (the signing block above has already rewritten `url`
+    // to https:// and installed per-second SigV4 headers, which would give a
+    // fresh key on every call). Streamed bodies are bypassed too (unhashable).
     let store_request: Option<(FetchStore, store::StoredRequest)> = match fetch_store {
-        Some(store_) if !url.is_s3() && matches!(&body, HTTPRequestBody::AnyBlob(_)) => {
+        Some(store_) if !is_s3 && matches!(&body, HTTPRequestBody::AnyBlob(_)) => {
             let s = body.slice();
             let body_bytes = if s.is_empty() { None } else { Some(s) };
             let empty_headers;

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -124,6 +124,10 @@ pub struct FetchTasklet {
 
     pub tracker: AsyncTaskTracker,
 
+    /// Record/replay store carried from `fetch()`; consumed once the body is
+    /// fully buffered (`on_body_received` with `!has_more`).
+    pub store_request: Option<(super::store::FetchStore, super::store::StoredRequest)>,
+
     pub ref_count: bun_ptr::ThreadSafeRefCount<FetchTasklet>,
 }
 
@@ -487,6 +491,7 @@ impl FetchTasklet {
 
         self.abort_reason.deinit();
         self.check_server_identity.deinit();
+        self.store_request = None;
         self.clear_abort_signal();
         // Clear the sink only after the requested ended otherwise we would potentialy lose the last chunk
         self.clear_sink();
@@ -755,6 +760,7 @@ impl FetchTasklet {
             // we will reach here when not streaming, this is also the only case we dont wanna to reset the buffer
             buffer_reset.set(false);
             if !self.result.has_more {
+                self.persist_to_store();
                 let scheduled_response_buffer =
                     core::mem::take(&mut self.scheduled_response_buffer.list);
                 // `body` (&mut response.body.value) and `get_fetch_headers()`
@@ -1736,6 +1742,7 @@ impl FetchTasklet {
             return BodyValue::Locked(pending);
         }
 
+        self.persist_to_store();
         let scheduled_response_buffer = core::mem::take(&mut self.scheduled_response_buffer);
         let response = BodyValue::InternalBlob(InternalBlob {
             bytes: scheduled_response_buffer.list,
@@ -1744,6 +1751,24 @@ impl FetchTasklet {
         self.scheduled_response_buffer = MutableString::default();
 
         response
+    }
+
+    /// Commit the record/replay store entry once a full buffered body is
+    /// available. Called from both fast-path (`to_body_value`, body arrived
+    /// with headers) and slow-path (`on_body_received`, body streamed in).
+    fn persist_to_store(&mut self) {
+        let Some((store_, req)) = self.store_request.take() else {
+            return;
+        };
+        let Some(metadata) = self.metadata.as_ref() else {
+            return;
+        };
+        let mut resp = super::store::capture_response(
+            metadata,
+            self.scheduled_response_buffer.list.as_slice(),
+        );
+        resp.redirected = self.result.redirected;
+        store_.persist(&req, resp);
     }
 
     fn to_response(&mut self) -> Response {
@@ -1914,6 +1939,7 @@ impl FetchTasklet {
             // SAFETY: jsc_vm derived from FFI ptr above; AsyncTaskTracker::init only
             // bumps a counter on the VM.
             tracker: AsyncTaskTracker::init(global_this.bun_vm().as_mut()),
+            store_request: fetch_options.store_request,
             ref_count: bun_ptr::ThreadSafeRefCount::init(),
         });
 
@@ -2578,6 +2604,7 @@ pub struct FetchOptions {
     pub force_http1: bool,
     pub is_node_http_client: bool,
     pub compress: Option<http::compress_body::CompressOption>,
+    pub store_request: Option<(super::store::FetchStore, super::store::StoredRequest)>,
 }
 
 impl Default for FetchOptions {
@@ -2614,6 +2641,7 @@ impl Default for FetchOptions {
             force_http1: false,
             is_node_http_client: false,
             compress: None,
+            store_request: None,
         }
     }
 }

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -124,9 +124,12 @@ pub struct FetchTasklet {
 
     pub tracker: AsyncTaskTracker,
 
-    /// Record/replay store carried from `fetch()`; consumed once the body is
-    /// fully buffered (`on_body_received` with `!has_more`).
+    /// Record/replay store carried from `fetch()`; consumed once the full
+    /// body has been observed (buffered or streamed).
     pub store_request: Option<(super::store::FetchStore, super::store::StoredRequest)>,
+    /// Response bytes teed while delivering to a JS ReadableStream consumer,
+    /// so a streamed body can still be persisted to `store_request`.
+    pub store_body_accumulator: Vec<u8>,
 
     pub ref_count: bun_ptr::ThreadSafeRefCount<FetchTasklet>,
 }
@@ -492,6 +495,7 @@ impl FetchTasklet {
         self.abort_reason.deinit();
         self.check_server_identity.deinit();
         self.store_request = None;
+        self.store_body_accumulator = Vec::new();
         self.clear_abort_signal();
         // Clear the sink only after the requested ended otherwise we would potentialy lose the last chunk
         self.clear_sink();
@@ -716,6 +720,7 @@ impl FetchTasklet {
                 bytes.size_hint.set(self.get_size_hint());
                 // body can be marked as used but we still need to pipe the data
                 if self.result.has_more {
+                    self.tee_stream_chunk_for_store(false);
                     let chunk = self.scheduled_response_buffer.list.as_slice();
                     bytes.on_data(Self::temporary_chunk(chunk, false))?;
                     self.drop_backpressure_if_unobserved(&readable, &bytes);
@@ -724,6 +729,7 @@ impl FetchTasklet {
                     let prev = core::mem::take(&mut self.readable_stream_ref);
                     buffer_reset.set(false);
 
+                    self.tee_stream_chunk_for_store(true);
                     let chunk = self.scheduled_response_buffer.list.as_slice();
                     bytes.on_data(Self::temporary_chunk(chunk, true))?;
                     drop(prev);
@@ -742,6 +748,8 @@ impl FetchTasklet {
                     "onBodyReceived CurrentResponse BodyReadableStream"
                 );
                 if let Some(bytes) = readable.ptr.bytes() {
+                    let done = !self.result.has_more;
+                    self.tee_stream_chunk_for_store(done);
                     let chunk = self.scheduled_response_buffer.list.as_slice();
 
                     if self.result.has_more {
@@ -1622,6 +1630,10 @@ impl FetchTasklet {
 
         // This means we have received part of the body but not the whole thing
         if !this.scheduled_response_buffer.list.is_empty() {
+            if this.store_request.is_some() {
+                this.store_body_accumulator
+                    .extend_from_slice(this.scheduled_response_buffer.list.as_slice());
+            }
             let scheduled_response_buffer = core::mem::take(&mut this.scheduled_response_buffer);
             this.mutex.unlock();
 
@@ -1753,20 +1765,39 @@ impl FetchTasklet {
         response
     }
 
-    /// Commit the record/replay store entry once a full buffered body is
-    /// available. Called from both fast-path (`to_body_value`, body arrived
-    /// with headers) and slow-path (`on_body_received`, body streamed in).
+    /// Tee the current streaming chunk into the store accumulator (when a
+    /// store is configured), and on the terminal chunk persist from it.
+    fn tee_stream_chunk_for_store(&mut self, done: bool) {
+        if self.store_request.is_none() {
+            return;
+        }
+        self.store_body_accumulator
+            .extend_from_slice(self.scheduled_response_buffer.list.as_slice());
+        if done {
+            let body = core::mem::take(&mut self.store_body_accumulator);
+            self.persist_to_store_with(&body);
+        }
+    }
+
+    /// Buffered-body path: the whole body is already in
+    /// `scheduled_response_buffer`.
     fn persist_to_store(&mut self) {
+        if self.store_request.is_none() {
+            return;
+        }
+        let mut body = core::mem::take(&mut self.store_body_accumulator);
+        body.extend_from_slice(self.scheduled_response_buffer.list.as_slice());
+        self.persist_to_store_with(&body);
+    }
+
+    fn persist_to_store_with(&mut self, body: &[u8]) {
         let Some((store_, req)) = self.store_request.take() else {
             return;
         };
         let Some(metadata) = self.metadata.as_ref() else {
             return;
         };
-        let mut resp = super::store::capture_response(
-            metadata,
-            self.scheduled_response_buffer.list.as_slice(),
-        );
+        let mut resp = super::store::capture_response(metadata, body);
         resp.redirected = self.result.redirected;
         store_.persist(&req, resp);
     }
@@ -1940,6 +1971,7 @@ impl FetchTasklet {
             // bumps a counter on the VM.
             tracker: AsyncTaskTracker::init(global_this.bun_vm().as_mut()),
             store_request: fetch_options.store_request,
+            store_body_accumulator: Vec::new(),
             ref_count: bun_ptr::ThreadSafeRefCount::init(),
         });
 

--- a/src/runtime/webcore/fetch/store.rs
+++ b/src/runtime/webcore/fetch/store.rs
@@ -97,6 +97,7 @@ pub fn build_request(
     method: Method,
     url: &[u8],
     unix_socket_path: &[u8],
+    proxy_href: &[u8],
     headers: &Headers,
     body: Option<&[u8]>,
 ) -> StoredRequest {
@@ -125,6 +126,11 @@ pub fn build_request(
         buf.extend_from_slice(unix_socket_path);
         buf.push(b'\n');
     }
+    if !proxy_href.is_empty() {
+        buf.extend_from_slice(b"\0proxy:");
+        buf.extend_from_slice(proxy_href);
+        buf.push(b'\n');
+    }
     for (n, v) in &hv {
         buf.extend_from_slice(n);
         buf.push(b':');
@@ -151,11 +157,34 @@ pub fn build_request(
 
 // ─── config resolution ────────────────────────────────────────────────────
 
+/// Resolve a store directory path to absolute against the current cwd so a
+/// later `process.chdir()` does not silently retarget the dir backend.
+fn to_abs_path(path: &[u8]) -> Box<[u8]> {
+    if bun_paths::is_absolute(path) {
+        return path.to_vec().into_boxed_slice();
+    }
+    let mut cwd_buf = bun_paths::path_buffer_pool::get();
+    let cwd = match bun_sys::getcwd(&mut cwd_buf) {
+        Ok(len) => &cwd_buf[..len],
+        Err(_) => return path.to_vec().into_boxed_slice(),
+    };
+    let mut out_buf = bun_paths::path_buffer_pool::get();
+    bun_paths::resolve_path::join_abs_string_buf::<bun_paths::platform::Auto>(
+        cwd,
+        &mut out_buf,
+        &[path],
+    )
+    .to_vec()
+    .into_boxed_slice()
+}
+
 impl FetchStore {
     pub fn from_config(cfg: &FetchStoreConfig) -> Option<Self> {
         match cfg {
             FetchStoreConfig::None => None,
-            FetchStoreConfig::Dir { path } => Some(FetchStore::Dir { path: path.clone() }),
+            FetchStoreConfig::Dir { path } => Some(FetchStore::Dir {
+                path: to_abs_path(path),
+            }),
             FetchStoreConfig::Memory { ttl_ms, max } => Some(FetchStore::Memory {
                 ttl_ms: *ttl_ms,
                 max: *max,
@@ -194,8 +223,9 @@ impl FetchStore {
                 )));
             }
             let path = path.to_slice_clone(global)?;
-            let path = path.slice().to_vec().into_boxed_slice();
-            return Ok(Some(FetchStore::Dir { path }));
+            return Ok(Some(FetchStore::Dir {
+                path: to_abs_path(path.slice()),
+            }));
         }
         if ty.eql_comptime(b"memory") {
             let clamp_u32 = |v: JSValue| -> u32 {

--- a/src/runtime/webcore/fetch/store.rs
+++ b/src/runtime/webcore/fetch/store.rs
@@ -1,0 +1,519 @@
+//! fetch() record/replay store.
+//!
+//! Not an RFC 9111 HTTP cache: this is a deterministic record/replay layer
+//! keyed on `(method, url, sorted request headers, request body)`. A hit
+//! short-circuits the network entirely and returns the recorded Response.
+//!
+//! Backends:
+//! - `dir`: one JSON file per unique request under a directory. Non-UTF-8
+//!   bodies are base64-encoded. Optimised for humans/agents to read, diff,
+//!   and commit alongside tests.
+//! - `memory`: process-global hash table with optional TTL and bounded entry
+//!   count (FIFO eviction). Cheap and fast; survives only the process.
+//! - SQLite: follow-up.
+
+use std::io::Write as _;
+use std::time::Instant;
+
+use bun_collections::HashMap;
+use bun_core::Mutex;
+use bun_core::fmt::{JSONFormatterUTF8Options, format_json_string_utf8};
+use bun_core::{String as BunString, strings};
+use bun_http::{HTTPResponseMetadata, Headers};
+use bun_http_types::ETag::HeaderEntryColumns;
+use bun_http_types::Method::Method;
+use bun_jsc::{JSGlobalObject, JSValue, JsResult};
+use bun_options_types::context::FetchStoreConfig;
+use bun_sys::{Fd, O};
+
+use crate::webcore::body::{Body, Value as BodyValue};
+use crate::webcore::jsc::JSPromise;
+use crate::webcore::response::HeadersRef;
+use crate::webcore::{FetchHeaders, InternalBlob, Response};
+
+bun_core::declare_scope!(fetch_store, hidden);
+
+/// Resolved per-request store handle. Cloned from either the `fetch()` options
+/// object or (when that is absent) the process-global `--fetch-cache` /
+/// `[fetch] cache` setting. Owned by `FetchTasklet` until the body is fully
+/// received.
+#[derive(Clone)]
+pub enum FetchStore {
+    Dir { path: Box<[u8]> },
+    Memory { ttl_ms: u32, max: u32 },
+}
+
+/// What we need from the request to compute a key and serialise the JSON
+/// `"request"` half. All fields are owned copies so the tasklet can outlive
+/// the parse scope.
+pub struct StoredRequest {
+    pub key: u64,
+    pub method: Method,
+    pub url: Box<[u8]>,
+    pub headers: Vec<(Box<[u8]>, Box<[u8]>)>,
+    pub body: Option<Box<[u8]>>,
+}
+
+/// What a hit yields / what we persist.
+pub struct StoredResponse {
+    pub status: u16,
+    pub status_text: Box<[u8]>,
+    pub url: Box<[u8]>,
+    pub redirected: bool,
+    pub headers: Vec<(Box<[u8]>, Box<[u8]>)>,
+    pub body: Vec<u8>,
+}
+
+// ─── memory backend ───────────────────────────────────────────────────────
+
+struct MemoryEntry {
+    inserted: Instant,
+    response: StoredResponse,
+}
+
+// Process-global. fetch() is JS-thread-only so a std `Mutex` suffices; the
+// lock is held only for the map lookup/insert, never across I/O.
+static MEMORY_STORE: Mutex<Option<HashMap<u64, MemoryEntry>>> = Mutex::new(None);
+
+impl StoredResponse {
+    fn clone_for_hit(&self) -> StoredResponse {
+        StoredResponse {
+            status: self.status,
+            status_text: self.status_text.clone(),
+            url: self.url.clone(),
+            redirected: self.redirected,
+            headers: self.headers.clone(),
+            body: self.body.clone(),
+        }
+    }
+}
+
+// ─── key derivation ───────────────────────────────────────────────────────
+
+/// Derive the store key and the owned request snapshot in one pass.
+/// `body` is `None` for GET/HEAD or when the body is a stream (streams are
+/// unhashable; a streamed request is never cached).
+pub fn build_request(
+    method: Method,
+    url: &[u8],
+    headers: &Headers,
+    body: Option<&[u8]>,
+) -> StoredRequest {
+    let entries = headers.entries.slice();
+    let names = entries.items_name();
+    let values = entries.items_value();
+    let mut hv: Vec<(Box<[u8]>, Box<[u8]>)> = Vec::with_capacity(names.len());
+    for i in 0..names.len() {
+        let name = headers.as_str(names[i]);
+        let value = headers.as_str(values[i]);
+        let mut name_lc = name.to_vec().into_boxed_slice();
+        name_lc.make_ascii_lowercase();
+        hv.push((name_lc, value.to_vec().into_boxed_slice()));
+    }
+    // Canonical order so header iteration order doesn't perturb the key.
+    hv.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+
+    let mut buf: Vec<u8> = Vec::with_capacity(url.len() + 32);
+    buf.extend_from_slice(method.as_str().as_bytes());
+    buf.push(b'\n');
+    buf.extend_from_slice(url);
+    buf.push(b'\n');
+    for (n, v) in &hv {
+        buf.extend_from_slice(n);
+        buf.push(b':');
+        buf.extend_from_slice(v);
+        buf.push(b'\n');
+    }
+    if let Some(b) = body {
+        buf.extend_from_slice(b);
+    }
+    let key = bun_wyhash::hash(&buf);
+
+    StoredRequest {
+        key,
+        method,
+        url: url.to_vec().into_boxed_slice(),
+        headers: hv,
+        body: body.map(|b| b.to_vec().into_boxed_slice()),
+    }
+}
+
+// ─── config resolution ────────────────────────────────────────────────────
+
+impl FetchStore {
+    pub fn from_config(cfg: &FetchStoreConfig) -> Option<Self> {
+        match cfg {
+            FetchStoreConfig::None => None,
+            FetchStoreConfig::Dir { path } => Some(FetchStore::Dir { path: path.clone() }),
+            FetchStoreConfig::Memory { ttl_ms, max } => Some(FetchStore::Memory {
+                ttl_ms: *ttl_ms,
+                max: *max,
+            }),
+        }
+    }
+
+    /// Read `{ type: "dir" | "memory", ... }` from a JS options value.
+    pub fn from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<Self>> {
+        if value.is_undefined_or_null() || !value.is_object() {
+            return Ok(None);
+        }
+        let Some(ty) = value.get(global, "type")? else {
+            return Ok(None);
+        };
+        if !ty.is_string() {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "fetch: 'store.type' must be \"dir\" or \"memory\""
+            )));
+        }
+        let ty = bun_core::OwnedString::new(ty.to_bun_string(global)?);
+        if ty.eql_comptime(b"dir") {
+            let Some(path) = value.get(global, "path")? else {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "fetch: 'store.path' is required when store.type is \"dir\""
+                )));
+            };
+            if !path.is_string() {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "fetch: 'store.path' must be a string"
+                )));
+            }
+            let path = path.to_slice_clone(global)?;
+            let path = path.slice().to_vec().into_boxed_slice();
+            return Ok(Some(FetchStore::Dir { path }));
+        }
+        if ty.eql_comptime(b"memory") {
+            let max = match value.get(global, "max")? {
+                Some(v) if v.is_number() => v.to_int32().max(0) as u32,
+                _ => 0,
+            };
+            let ttl_ms = match value.get(global, "ttl")? {
+                Some(v) if v.is_number() => {
+                    let ms = v.as_number();
+                    if ms.is_finite() && ms > 0.0 {
+                        ms.min(u32::MAX as f64) as u32
+                    } else {
+                        0
+                    }
+                }
+                _ => 0,
+            };
+            return Ok(Some(FetchStore::Memory { ttl_ms, max }));
+        }
+        Err(global.throw_invalid_arguments(format_args!(
+            "fetch: 'store.type' must be \"dir\" or \"memory\""
+        )))
+    }
+}
+
+// ─── lookup / persist ─────────────────────────────────────────────────────
+
+impl FetchStore {
+    pub fn lookup(&self, key: u64) -> Option<StoredResponse> {
+        match self {
+            FetchStore::Memory { ttl_ms, .. } => {
+                let mut guard = MEMORY_STORE.lock();
+                let map = guard.as_mut()?;
+                let entry = map.get(&key)?;
+                if *ttl_ms > 0 {
+                    let age = entry.inserted.elapsed().as_millis();
+                    if age > u128::from(*ttl_ms) {
+                        map.remove(&key);
+                        return None;
+                    }
+                }
+                Some(entry.response.clone_for_hit())
+            }
+            FetchStore::Dir { path } => {
+                let file_path = dir_entry_path(path, key);
+                let bytes = match bun_sys::File::openat(Fd::cwd(), &file_path, O::RDONLY, 0)
+                    .and_then(|f| f.read_to_end())
+                {
+                    Ok(b) => b,
+                    Err(_) => return None,
+                };
+                match parse_stored_json(&bytes) {
+                    Some(resp) => Some(resp),
+                    None => {
+                        bun_core::scoped_log!(
+                            fetch_store,
+                            "dir: malformed entry at {:?}",
+                            bstr::BStr::new(&file_path)
+                        );
+                        None
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn persist(&self, req: &StoredRequest, resp: StoredResponse) {
+        match self {
+            FetchStore::Memory { max, .. } => {
+                let mut guard = MEMORY_STORE.lock();
+                let map = guard.get_or_insert_with(HashMap::new);
+                if *max > 0 && map.len() as u32 >= *max && !map.contains(&req.key) {
+                    // FIFO-ish eviction: drop one arbitrary older entry. Memory
+                    // store is a test/dev convenience, not a production LRU.
+                    if let Some(victim) = map.keys().next().copied() {
+                        map.remove(&victim);
+                    }
+                }
+                map.insert(
+                    req.key,
+                    MemoryEntry {
+                        inserted: Instant::now(),
+                        response: resp,
+                    },
+                );
+            }
+            FetchStore::Dir { path } => {
+                if let Err(err) = write_dir_entry(path, req, &resp) {
+                    bun_core::scoped_log!(
+                        fetch_store,
+                        "dir: write failed key={:016x}: {:?}",
+                        req.key,
+                        err
+                    );
+                }
+            }
+        }
+    }
+}
+
+// ─── dir backend: paths + JSON ────────────────────────────────────────────
+
+fn dir_entry_path(dir: &[u8], key: u64) -> Vec<u8> {
+    let mut out = Vec::with_capacity(dir.len() + 1 + 16 + 5);
+    out.extend_from_slice(dir);
+    if !dir.is_empty() && *dir.last().unwrap() != b'/' && *dir.last().unwrap() != b'\\' {
+        out.push(if cfg!(windows) { b'\\' } else { b'/' });
+    }
+    let _ = write!(&mut out, "{key:016x}.json");
+    out
+}
+
+fn body_is_text(bytes: &[u8]) -> bool {
+    // Require valid UTF-8 and no embedded NULs; anything else round-trips
+    // through base64 so the JSON stays hand-editable.
+    !bytes.is_empty()
+        && strings::index_of_char(bytes, 0).is_none()
+        && strings::is_valid_utf8(bytes)
+}
+
+fn write_json_body(out: &mut Vec<u8>, bytes: Option<&[u8]>) {
+    match bytes {
+        None | Some([]) => out.extend_from_slice(b"null"),
+        Some(b) if body_is_text(b) => {
+            let _ = write!(
+                out,
+                "{}",
+                format_json_string_utf8(b, JSONFormatterUTF8Options::default())
+            );
+        }
+        Some(b) => {
+            out.extend_from_slice(br#"{"encoding":"base64","data":""#);
+            let enc = bun_base64::encode_alloc(b);
+            out.extend_from_slice(&enc);
+            out.extend_from_slice(br#""}"#);
+        }
+    }
+}
+
+fn write_json_headers(out: &mut Vec<u8>, headers: &[(Box<[u8]>, Box<[u8]>)]) {
+    out.push(b'{');
+    for (i, (name, value)) in headers.iter().enumerate() {
+        if i > 0 {
+            out.push(b',');
+        }
+        let _ = write!(
+            out,
+            "{}",
+            format_json_string_utf8(name, JSONFormatterUTF8Options::default())
+        );
+        out.push(b':');
+        let _ = write!(
+            out,
+            "{}",
+            format_json_string_utf8(value, JSONFormatterUTF8Options::default())
+        );
+    }
+    out.push(b'}');
+}
+
+fn write_dir_entry(dir: &[u8], req: &StoredRequest, resp: &StoredResponse) -> bun_sys::Result<()> {
+    bun_sys::Dir::borrow(&Fd::cwd()).make_path(dir)?;
+    let path = dir_entry_path(dir, req.key);
+
+    let mut out: Vec<u8> = Vec::with_capacity(512 + resp.body.len());
+    out.extend_from_slice(br#"{"request":{"method":""#);
+    out.extend_from_slice(req.method.as_str().as_bytes());
+    out.extend_from_slice(br#"","url":"#);
+    let _ = write!(
+        &mut out,
+        "{}",
+        format_json_string_utf8(&req.url, JSONFormatterUTF8Options::default())
+    );
+    out.extend_from_slice(br#","headers":"#);
+    write_json_headers(&mut out, &req.headers);
+    out.extend_from_slice(br#","body":"#);
+    write_json_body(&mut out, req.body.as_deref());
+    out.extend_from_slice(br#"},"response":{"status":"#);
+    let _ = write!(&mut out, "{}", resp.status);
+    out.extend_from_slice(br#","statusText":"#);
+    let _ = write!(
+        &mut out,
+        "{}",
+        format_json_string_utf8(&resp.status_text, JSONFormatterUTF8Options::default())
+    );
+    out.extend_from_slice(br#","url":"#);
+    let _ = write!(
+        &mut out,
+        "{}",
+        format_json_string_utf8(&resp.url, JSONFormatterUTF8Options::default())
+    );
+    out.extend_from_slice(br#","redirected":"#);
+    out.extend_from_slice(if resp.redirected { b"true" } else { b"false" });
+    out.extend_from_slice(br#","headers":"#);
+    write_json_headers(&mut out, &resp.headers);
+    out.extend_from_slice(br#","body":"#);
+    write_json_body(&mut out, Some(&resp.body));
+    out.extend_from_slice(br#"},"time":"#);
+    let _ = write!(&mut out, "{}", bun_core::time::milli_timestamp());
+    out.extend_from_slice(b"}\n");
+
+    let file = bun_sys::File::openat(
+        Fd::cwd(),
+        &path,
+        O::WRONLY | O::CREAT | O::TRUNC,
+        0o644,
+    )?;
+    file.write_all(&out)?;
+    Ok(())
+}
+
+// ─── dir backend: read-back JSON parse ────────────────────────────────────
+
+fn parse_stored_json(bytes: &[u8]) -> Option<StoredResponse> {
+    let bump = bun_alloc::MimallocArena::new();
+    let source = bun_ast::Source::init_path_string(b"fetch-store.json", bytes);
+    let mut log = bun_ast::Log::init();
+    let parsed = bun_parsers::json::parse_utf8(&source, &mut log, &bump).ok()?;
+    let root = parsed;
+    let response = root.get(b"response")?;
+
+    let status = response.get(b"status")?.as_number()? as u16;
+    let status_text = response
+        .get(b"statusText")
+        .and_then(|e| e.as_string(&bump))
+        .unwrap_or(b"")
+        .to_vec()
+        .into_boxed_slice();
+    let url = response
+        .get(b"url")
+        .and_then(|e| e.as_string(&bump))
+        .unwrap_or(b"")
+        .to_vec()
+        .into_boxed_slice();
+    let redirected = response
+        .get(b"redirected")
+        .and_then(|e| e.as_bool())
+        .unwrap_or(false);
+
+    let mut headers: Vec<(Box<[u8]>, Box<[u8]>)> = Vec::new();
+    if let Some(h) = response.get(b"headers") {
+        h.for_each_property(|k, _loc, v| {
+            let k = k.to_vec().into_boxed_slice();
+            let v = v
+                .as_string(&bump)
+                .unwrap_or(b"")
+                .to_vec()
+                .into_boxed_slice();
+            headers.push((k, v));
+        });
+    }
+
+    let body: Vec<u8> = match response.get(b"body") {
+        None => Vec::new(),
+        Some(b) => {
+            if let Some(s) = b.as_string(&bump) {
+                s.to_vec()
+            } else if let Some(data) = b.get(b"data").and_then(|d| d.as_string(&bump)) {
+                bun_base64::decode_alloc(data).ok()?
+            } else {
+                Vec::new()
+            }
+        }
+    };
+
+    Some(StoredResponse {
+        status,
+        status_text,
+        url,
+        redirected,
+        headers,
+        body,
+    })
+}
+
+// ─── build a JS Response from a cache hit ─────────────────────────────────
+
+pub fn response_from_hit(global: &JSGlobalObject, hit: StoredResponse) -> JSValue {
+    let headers = FetchHeaders::create_from_pico_headers(&build_pico_headers(&hit.headers));
+    let status_text = if hit.status_text.is_empty() {
+        crate::server::http_status_text::get(hit.status)
+            .map(|t| BunString::static_(&t[4..]))
+            .unwrap_or_else(BunString::empty)
+    } else {
+        BunString::clone_utf8(&hit.status_text)
+    };
+    let url = BunString::clone_utf8(&hit.url);
+
+    let response = bun_core::heap::into_raw(Box::new(Response::init(
+        crate::webcore::response::Init {
+            // SAFETY: create_from_pico_headers returns a fresh refcount=1 FetchHeaders*.
+            headers: Some(unsafe { HeadersRef::adopt(headers) }),
+            status_code: hit.status,
+            status_text: status_text.into(),
+            ..Default::default()
+        },
+        Body::new(BodyValue::InternalBlob(InternalBlob {
+            bytes: hit.body,
+            was_string: false,
+        })),
+        url,
+        hit.redirected,
+    )));
+
+    JSPromise::resolved_promise_value(global, Response::make_maybe_pooled(global, response))
+}
+
+/// `FetchHeaders::create_from_pico_headers` needs a slice of `picohttp::Header`,
+/// which borrows its name/value; keep the owned `(name, value)` boxes alive in
+/// the caller's `hit.headers` while this Vec borrows them.
+fn build_pico_headers(headers: &[(Box<[u8]>, Box<[u8]>)]) -> Vec<bun_picohttp::Header> {
+    headers
+        .iter()
+        .map(|(n, v)| bun_picohttp::Header::new(n, v))
+        .collect()
+}
+
+/// Snapshot response metadata + body into an owned `StoredResponse`. Called on
+/// the JS thread once the full body has been buffered.
+pub fn capture_response(metadata: &HTTPResponseMetadata, body: &[u8]) -> StoredResponse {
+    let http_response = &metadata.response;
+    let mut headers: Vec<(Box<[u8]>, Box<[u8]>)> =
+        Vec::with_capacity(http_response.headers.list.len());
+    for h in http_response.headers.list {
+        let mut name = h.name().to_vec().into_boxed_slice();
+        name.make_ascii_lowercase();
+        headers.push((name, h.value().to_vec().into_boxed_slice()));
+    }
+    StoredResponse {
+        status: http_response.status_code as u16,
+        status_text: http_response.status.to_vec().into_boxed_slice(),
+        url: metadata.url.slice().to_vec().into_boxed_slice(),
+        redirected: false,
+        headers,
+        body: body.to_vec(),
+    }
+}

--- a/src/runtime/webcore/fetch/store.rs
+++ b/src/runtime/webcore/fetch/store.rs
@@ -169,9 +169,9 @@ impl FetchStore {
             return Ok(None);
         }
         if !value.is_object() {
-            return Err(global.throw_invalid_arguments(format_args!(
-                "fetch: 'store' must be an object"
-            )));
+            return Err(
+                global.throw_invalid_arguments(format_args!("fetch: 'store' must be an object"))
+            );
         }
         let Some(ty) = value.get(global, "type")? else {
             return Ok(None);

--- a/src/runtime/webcore/fetch/store.rs
+++ b/src/runtime/webcore/fetch/store.rs
@@ -96,6 +96,7 @@ impl StoredResponse {
 pub fn build_request(
     method: Method,
     url: &[u8],
+    unix_socket_path: &[u8],
     headers: &Headers,
     body: Option<&[u8]>,
 ) -> StoredRequest {
@@ -118,6 +119,12 @@ pub fn build_request(
     buf.push(b'\n');
     buf.extend_from_slice(url);
     buf.push(b'\n');
+    if !unix_socket_path.is_empty() {
+        // Leading NUL so this line cannot alias a header (names can't be NUL).
+        buf.extend_from_slice(b"\0unix:");
+        buf.extend_from_slice(unix_socket_path);
+        buf.push(b'\n');
+    }
     for (n, v) in &hv {
         buf.extend_from_slice(n);
         buf.push(b':');
@@ -397,8 +404,25 @@ fn write_dir_entry(dir: &[u8], req: &StoredRequest, resp: &StoredResponse) -> bu
     let _ = write!(&mut out, "{}", bun_core::time::milli_timestamp());
     out.extend_from_slice(b"}\n");
 
-    let file = bun_sys::File::openat(Fd::cwd(), &path, O::WRONLY | O::CREAT | O::TRUNC, 0o644)?;
-    file.write_all(&out)?;
+    // Write to a sibling temp file and rename over the target so concurrent
+    // readers (Workers, `bun test --parallel`) and crash-interrupted writes
+    // never observe a truncated entry.
+    let mut tmp_path = path.clone();
+    tmp_path.extend_from_slice(b".tmp");
+    {
+        let file =
+            bun_sys::File::openat(Fd::cwd(), &tmp_path, O::WRONLY | O::CREAT | O::TRUNC, 0o644)?;
+        file.write_all(&out)?;
+    }
+    tmp_path.push(0);
+    let mut path = path;
+    path.push(0);
+    bun_sys::renameat(
+        Fd::cwd(),
+        bun_core::ZStr::from_slice_with_nul(&tmp_path),
+        Fd::cwd(),
+        bun_core::ZStr::from_slice_with_nul(&path),
+    )?;
     Ok(())
 }
 

--- a/src/runtime/webcore/fetch/store.rs
+++ b/src/runtime/webcore/fetch/store.rs
@@ -124,6 +124,10 @@ pub fn build_request(
         buf.extend_from_slice(v);
         buf.push(b'\n');
     }
+    // Self-delimit the header block from the body so a body that happens to
+    // look like `name:value\n` cannot alias a header (header names can't be
+    // empty, so `\n\n` only occurs here).
+    buf.push(b'\n');
     if let Some(b) = body {
         buf.extend_from_slice(b);
     }

--- a/src/runtime/webcore/fetch/store.rs
+++ b/src/runtime/webcore/fetch/store.rs
@@ -165,8 +165,13 @@ impl FetchStore {
 
     /// Read `{ type: "dir" | "memory", ... }` from a JS options value.
     pub fn from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<Self>> {
-        if value.is_undefined_or_null() || !value.is_object() {
+        if value.is_undefined_or_null() {
             return Ok(None);
+        }
+        if !value.is_object() {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "fetch: 'store' must be an object"
+            )));
         }
         let Some(ty) = value.get(global, "type")? else {
             return Ok(None);
@@ -193,19 +198,20 @@ impl FetchStore {
             return Ok(Some(FetchStore::Dir { path }));
         }
         if ty.eql_comptime(b"memory") {
+            let clamp_u32 = |v: JSValue| -> u32 {
+                let n = v.as_number();
+                if n.is_finite() && n > 0.0 {
+                    n.min(u32::MAX as f64) as u32
+                } else {
+                    0
+                }
+            };
             let max = match value.get(global, "max")? {
-                Some(v) if v.is_number() => v.to_int32().max(0) as u32,
+                Some(v) if v.is_number() => clamp_u32(v),
                 _ => 0,
             };
             let ttl_ms = match value.get(global, "ttl")? {
-                Some(v) if v.is_number() => {
-                    let ms = v.as_number();
-                    if ms.is_finite() && ms > 0.0 {
-                        ms.min(u32::MAX as f64) as u32
-                    } else {
-                        0
-                    }
-                }
+                Some(v) if v.is_number() => clamp_u32(v),
                 _ => 0,
             };
             return Ok(Some(FetchStore::Memory { ttl_ms, max }));
@@ -404,26 +410,38 @@ fn write_dir_entry(dir: &[u8], req: &StoredRequest, resp: &StoredResponse) -> bu
     let _ = write!(&mut out, "{}", bun_core::time::milli_timestamp());
     out.extend_from_slice(b"}\n");
 
-    // Write to a sibling temp file and rename over the target so concurrent
-    // readers (Workers, `bun test --parallel`) and crash-interrupted writes
-    // never observe a truncated entry.
+    // Write to a per-writer temp sibling and rename over the target so
+    // concurrent readers and crash-interrupted writes never see a partial
+    // file. 0o600 because request headers/bodies can carry credentials.
+    static TMP_SEQ: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
+    let seq = TMP_SEQ.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     let mut tmp_path = path.clone();
-    tmp_path.extend_from_slice(b".tmp");
-    {
-        let file =
-            bun_sys::File::openat(Fd::cwd(), &tmp_path, O::WRONLY | O::CREAT | O::TRUNC, 0o644)?;
-        file.write_all(&out)?;
-    }
+    let _ = write!(&mut tmp_path, ".{}.{seq}.tmp", std::process::id());
     tmp_path.push(0);
-    let mut path = path;
-    path.push(0);
-    bun_sys::renameat(
-        Fd::cwd(),
-        bun_core::ZStr::from_slice_with_nul(&tmp_path),
-        Fd::cwd(),
-        bun_core::ZStr::from_slice_with_nul(&path),
-    )?;
-    Ok(())
+    let tmp_z = bun_core::ZStr::from_slice_with_nul(&tmp_path);
+    let write = || -> bun_sys::Result<()> {
+        let file = bun_sys::File::openat(
+            Fd::cwd(),
+            &tmp_path[..tmp_path.len() - 1],
+            O::WRONLY | O::CREAT | O::TRUNC,
+            0o600,
+        )?;
+        file.write_all(&out)?;
+        drop(file);
+        let mut path = path;
+        path.push(0);
+        bun_sys::renameat(
+            Fd::cwd(),
+            tmp_z,
+            Fd::cwd(),
+            bun_core::ZStr::from_slice_with_nul(&path),
+        )
+    };
+    let result = write();
+    if result.is_err() {
+        let _ = bun_sys::unlink(tmp_z);
+    }
+    result
 }
 
 // ─── dir backend: read-back JSON parse ────────────────────────────────────

--- a/src/runtime/webcore/fetch/store.rs
+++ b/src/runtime/webcore/fetch/store.rs
@@ -188,34 +188,14 @@ pub fn build_request(
 
 // ─── config resolution ────────────────────────────────────────────────────
 
-/// Resolve a store directory path to absolute against the current cwd so a
-/// later `process.chdir()` does not silently retarget the dir backend.
-fn to_abs_path(path: &[u8]) -> Box<[u8]> {
-    if bun_paths::is_absolute(path) {
-        return path.to_vec().into_boxed_slice();
-    }
-    let mut cwd_buf = bun_paths::path_buffer_pool::get();
-    let cwd = match bun_sys::getcwd(&mut cwd_buf) {
-        Ok(len) => &cwd_buf[..len],
-        Err(_) => return path.to_vec().into_boxed_slice(),
-    };
-    let mut out_buf = bun_paths::path_buffer_pool::get();
-    bun_paths::resolve_path::join_abs_string_buf::<bun_paths::platform::Auto>(
-        cwd,
-        &mut out_buf,
-        &[path],
-    )
-    .to_vec()
-    .into_boxed_slice()
-}
+use bun_options_types::context::resolve_against_cwd;
 
 impl FetchStore {
     pub fn from_config(cfg: &FetchStoreConfig) -> Option<Self> {
         match cfg {
             FetchStoreConfig::None => None,
-            FetchStoreConfig::Dir { path } => Some(FetchStore::Dir {
-                path: to_abs_path(path),
-            }),
+            // `FetchStoreConfig::parse` has already absolutised the path.
+            FetchStoreConfig::Dir { path } => Some(FetchStore::Dir { path: path.clone() }),
             FetchStoreConfig::Memory { ttl_ms, max } => Some(FetchStore::Memory {
                 ttl_ms: *ttl_ms,
                 max: *max,
@@ -262,7 +242,7 @@ impl FetchStore {
                 )));
             }
             return Ok(Some(FetchStore::Dir {
-                path: to_abs_path(path.slice()),
+                path: resolve_against_cwd(path.slice()),
             }));
         }
         if ty.eql_comptime(b"memory") {

--- a/src/runtime/webcore/fetch/store.rs
+++ b/src/runtime/webcore/fetch/store.rs
@@ -318,24 +318,28 @@ fn write_json_body(out: &mut Vec<u8>, bytes: Option<&[u8]>) {
 }
 
 fn write_json_headers(out: &mut Vec<u8>, headers: &[(Box<[u8]>, Box<[u8]>)]) {
-    out.push(b'{');
+    // Array of [name, value] pairs (same shape as `new Headers([...])`) so
+    // repeated names like Set-Cookie survive JSON.parse / jq / formatters.
+    out.push(b'[');
     for (i, (name, value)) in headers.iter().enumerate() {
         if i > 0 {
             out.push(b',');
         }
+        out.push(b'[');
         let _ = write!(
             out,
             "{}",
             format_json_string_utf8(name, JSONFormatterUTF8Options::default())
         );
-        out.push(b':');
+        out.push(b',');
         let _ = write!(
             out,
             "{}",
             format_json_string_utf8(value, JSONFormatterUTF8Options::default())
         );
+        out.push(b']');
     }
-    out.push(b'}');
+    out.push(b']');
 }
 
 fn write_dir_entry(dir: &[u8], req: &StoredRequest, resp: &StoredResponse) -> bun_sys::Result<()> {
@@ -414,15 +418,33 @@ fn parse_stored_json(bytes: &[u8]) -> Option<StoredResponse> {
 
     let mut headers: Vec<(Box<[u8]>, Box<[u8]>)> = Vec::new();
     if let Some(h) = response.get(b"headers") {
-        h.for_each_property(|k, _loc, v| {
-            let k = k.to_vec().into_boxed_slice();
-            let v = v
-                .as_string(&bump)
-                .unwrap_or(b"")
-                .to_vec()
-                .into_boxed_slice();
-            headers.push((k, v));
-        });
+        if let Some(mut arr) = h.as_array() {
+            while let Some(pair) = arr.next() {
+                let Some(mut it) = pair.as_array() else {
+                    continue;
+                };
+                let k = it
+                    .next()
+                    .and_then(|e| e.as_string(&bump))
+                    .unwrap_or(b"")
+                    .to_vec()
+                    .into_boxed_slice();
+                let v = it
+                    .next()
+                    .and_then(|e| e.as_string(&bump))
+                    .unwrap_or(b"")
+                    .to_vec()
+                    .into_boxed_slice();
+                headers.push((k, v));
+            }
+        } else {
+            h.for_each_property(|k, _loc, v| {
+                headers.push((
+                    k.to_vec().into_boxed_slice(),
+                    v.as_string(&bump).unwrap_or(b"").to_vec().into_boxed_slice(),
+                ));
+            });
+        }
     }
 
     let body: Vec<u8> = match response.get(b"body") {

--- a/src/runtime/webcore/fetch/store.rs
+++ b/src/runtime/webcore/fetch/store.rs
@@ -229,7 +229,9 @@ impl FetchStore {
             );
         }
         let Some(ty) = value.get(global, "type")? else {
-            return Ok(None);
+            return Err(global.throw_invalid_arguments(format_args!(
+                "fetch: 'store.type' must be \"dir\" or \"memory\""
+            )));
         };
         if !ty.is_string() {
             return Err(global.throw_invalid_arguments(format_args!(
@@ -249,6 +251,11 @@ impl FetchStore {
                 )));
             }
             let path = path.to_slice_clone(global)?;
+            if path.slice().is_empty() {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "fetch: 'store.path' is required when store.type is \"dir\""
+                )));
+            }
             return Ok(Some(FetchStore::Dir {
                 path: to_abs_path(path.slice()),
             }));

--- a/src/runtime/webcore/fetch/store.rs
+++ b/src/runtime/webcore/fetch/store.rs
@@ -381,6 +381,22 @@ fn body_is_text(bytes: &[u8]) -> bool {
     !bytes.is_empty() && strings::index_of_char(bytes, 0).is_none() && strings::is_valid_utf8(bytes)
 }
 
+/// JSON-escape a network-sourced byte string. Header values and reason
+/// phrases are RFC 7230 field-values (opaque octets, historically Latin-1),
+/// so route non-UTF-8 through the Latin-1 encoder instead of handing invalid
+/// bytes to the UTF-8 path's `from_utf8_unchecked`.
+fn write_json_string(out: &mut Vec<u8>, bytes: &[u8]) {
+    if strings::is_valid_utf8(bytes) {
+        let _ = write!(
+            out,
+            "{}",
+            format_json_string_utf8(bytes, JSONFormatterUTF8Options::default())
+        );
+    } else {
+        let _ = write!(out, "{}", bun_core::fmt::format_json_string_latin1(bytes));
+    }
+}
+
 fn write_json_body(out: &mut Vec<u8>, bytes: Option<&[u8]>) {
     match bytes {
         None | Some([]) => out.extend_from_slice(b"null"),
@@ -409,17 +425,9 @@ fn write_json_headers(out: &mut Vec<u8>, headers: &[(Box<[u8]>, Box<[u8]>)]) {
             out.push(b',');
         }
         out.push(b'[');
-        let _ = write!(
-            out,
-            "{}",
-            format_json_string_utf8(name, JSONFormatterUTF8Options::default())
-        );
+        write_json_string(out, name);
         out.push(b',');
-        let _ = write!(
-            out,
-            "{}",
-            format_json_string_utf8(value, JSONFormatterUTF8Options::default())
-        );
+        write_json_string(out, value);
         out.push(b']');
     }
     out.push(b']');
@@ -433,11 +441,7 @@ fn write_dir_entry(dir: &[u8], req: &StoredRequest, resp: &StoredResponse) -> bu
     out.extend_from_slice(br#"{"request":{"method":""#);
     out.extend_from_slice(req.method.as_str().as_bytes());
     out.extend_from_slice(br#"","url":"#);
-    let _ = write!(
-        &mut out,
-        "{}",
-        format_json_string_utf8(&req.url, JSONFormatterUTF8Options::default())
-    );
+    write_json_string(&mut out, &req.url);
     out.extend_from_slice(br#","headers":"#);
     write_json_headers(&mut out, &req.headers);
     out.extend_from_slice(br#","body":"#);
@@ -445,17 +449,9 @@ fn write_dir_entry(dir: &[u8], req: &StoredRequest, resp: &StoredResponse) -> bu
     out.extend_from_slice(br#"},"response":{"status":"#);
     let _ = write!(&mut out, "{}", resp.status);
     out.extend_from_slice(br#","statusText":"#);
-    let _ = write!(
-        &mut out,
-        "{}",
-        format_json_string_utf8(&resp.status_text, JSONFormatterUTF8Options::default())
-    );
+    write_json_string(&mut out, &resp.status_text);
     out.extend_from_slice(br#","url":"#);
-    let _ = write!(
-        &mut out,
-        "{}",
-        format_json_string_utf8(&resp.url, JSONFormatterUTF8Options::default())
-    );
+    write_json_string(&mut out, &resp.url);
     out.extend_from_slice(br#","redirected":"#);
     out.extend_from_slice(if resp.redirected { b"true" } else { b"false" });
     out.extend_from_slice(br#","headers":"#);

--- a/src/runtime/webcore/fetch/store.rs
+++ b/src/runtime/webcore/fetch/store.rs
@@ -268,16 +268,26 @@ impl FetchStore {
             }
             FetchStore::Dir { path } => {
                 if let Err(err) = write_dir_entry(path, req, &resp) {
-                    bun_core::scoped_log!(
-                        fetch_store,
-                        "dir: write failed key={:016x}: {:?}",
-                        req.key,
-                        err
-                    );
+                    warn_write_failed_once(path, &err);
                 }
             }
         }
     }
+}
+
+/// Surface a dir-write failure to stderr once per process; the fetch itself
+/// has already succeeded, so we don't fail it, but the user opted into
+/// recording and should learn it isn't happening.
+fn warn_write_failed_once(path: &[u8], err: &bun_sys::Error) {
+    static WARNED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+    if WARNED.swap(true, core::sync::atomic::Ordering::Relaxed) {
+        return;
+    }
+    bun_core::warn!(
+        "fetch: failed to record response to {}: {}",
+        bstr::BStr::new(path),
+        err
+    );
 }
 
 // ─── dir backend: paths + JSON ────────────────────────────────────────────

--- a/src/runtime/webcore/fetch/store.rs
+++ b/src/runtime/webcore/fetch/store.rs
@@ -101,6 +101,7 @@ pub struct KeyInputs<'a> {
     pub proxy_href: &'a [u8],
     pub redirect: bun_http::FetchRedirect,
     pub decompress: bool,
+    pub max_redirects: Option<u8>,
 }
 
 /// Derive the store key and the owned request snapshot in one pass.
@@ -118,6 +119,7 @@ pub fn build_request(
         proxy_href,
         redirect,
         decompress,
+        max_redirects,
     } = *inputs;
     let entries = headers.entries.slice();
     let names = entries.items_name();
@@ -156,6 +158,9 @@ pub fn build_request(
     }
     if !decompress {
         buf.extend_from_slice(b"\0decompress:false\n");
+    }
+    if let Some(n) = max_redirects {
+        let _ = writeln!(&mut buf, "\0maxRedirects:{n}");
     }
     for (n, v) in &hv {
         buf.extend_from_slice(n);

--- a/src/runtime/webcore/fetch/store.rs
+++ b/src/runtime/webcore/fetch/store.rs
@@ -295,9 +295,7 @@ fn dir_entry_path(dir: &[u8], key: u64) -> Vec<u8> {
 fn body_is_text(bytes: &[u8]) -> bool {
     // Require valid UTF-8 and no embedded NULs; anything else round-trips
     // through base64 so the JSON stays hand-editable.
-    !bytes.is_empty()
-        && strings::index_of_char(bytes, 0).is_none()
-        && strings::is_valid_utf8(bytes)
+    !bytes.is_empty() && strings::index_of_char(bytes, 0).is_none() && strings::is_valid_utf8(bytes)
 }
 
 fn write_json_body(out: &mut Vec<u8>, bytes: Option<&[u8]>) {
@@ -381,12 +379,7 @@ fn write_dir_entry(dir: &[u8], req: &StoredRequest, resp: &StoredResponse) -> bu
     let _ = write!(&mut out, "{}", bun_core::time::milli_timestamp());
     out.extend_from_slice(b"}\n");
 
-    let file = bun_sys::File::openat(
-        Fd::cwd(),
-        &path,
-        O::WRONLY | O::CREAT | O::TRUNC,
-        0o644,
-    )?;
+    let file = bun_sys::File::openat(Fd::cwd(), &path, O::WRONLY | O::CREAT | O::TRUNC, 0o644)?;
     file.write_all(&out)?;
     Ok(())
 }

--- a/src/runtime/webcore/fetch/store.rs
+++ b/src/runtime/webcore/fetch/store.rs
@@ -90,17 +90,35 @@ impl StoredResponse {
 
 // ─── key derivation ───────────────────────────────────────────────────────
 
+/// Inputs that select the transport or shape the response and so must feed
+/// the cache key. Non-default values are emitted into the preimage so the
+/// common case (no unix/proxy, follow redirects, decompress) keeps the same
+/// key as earlier versions.
+pub struct KeyInputs<'a> {
+    pub method: Method,
+    pub url: &'a [u8],
+    pub unix_socket_path: &'a [u8],
+    pub proxy_href: &'a [u8],
+    pub redirect: bun_http::FetchRedirect,
+    pub decompress: bool,
+}
+
 /// Derive the store key and the owned request snapshot in one pass.
 /// `body` is `None` for GET/HEAD or when the body is a stream (streams are
 /// unhashable; a streamed request is never cached).
 pub fn build_request(
-    method: Method,
-    url: &[u8],
-    unix_socket_path: &[u8],
-    proxy_href: &[u8],
+    inputs: &KeyInputs<'_>,
     headers: &Headers,
     body: Option<&[u8]>,
 ) -> StoredRequest {
+    let KeyInputs {
+        method,
+        url,
+        unix_socket_path,
+        proxy_href,
+        redirect,
+        decompress,
+    } = *inputs;
     let entries = headers.entries.slice();
     let names = entries.items_name();
     let values = entries.items_value();
@@ -130,6 +148,14 @@ pub fn build_request(
         buf.extend_from_slice(b"\0proxy:");
         buf.extend_from_slice(proxy_href);
         buf.push(b'\n');
+    }
+    match redirect {
+        bun_http::FetchRedirect::Follow => {}
+        bun_http::FetchRedirect::Manual => buf.extend_from_slice(b"\0redirect:manual\n"),
+        bun_http::FetchRedirect::Error => buf.extend_from_slice(b"\0redirect:error\n"),
+    }
+    if !decompress {
+        buf.extend_from_slice(b"\0decompress:false\n");
     }
     for (n, v) in &hv {
         buf.extend_from_slice(n);

--- a/src/runtime/webcore/fetch/store.rs
+++ b/src/runtime/webcore/fetch/store.rs
@@ -441,7 +441,10 @@ fn parse_stored_json(bytes: &[u8]) -> Option<StoredResponse> {
             h.for_each_property(|k, _loc, v| {
                 headers.push((
                     k.to_vec().into_boxed_slice(),
-                    v.as_string(&bump).unwrap_or(b"").to_vec().into_boxed_slice(),
+                    v.as_string(&bump)
+                        .unwrap_or(b"")
+                        .to_vec()
+                        .into_boxed_slice(),
                 ));
             });
         }

--- a/test/js/bun/fetch/fetch-store.test.ts
+++ b/test/js/bun/fetch/fetch-store.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -163,11 +163,7 @@ describe("fetch store", () => {
       cwd: String(srcDir),
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     const out = JSON.parse(stdout.trim());
     expect(out).toEqual({ a: "ok1", b: "ok1", hits: 1 });
@@ -195,11 +191,7 @@ describe("fetch store", () => {
       cwd: String(srcDir),
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(JSON.parse(stdout.trim())).toEqual({ a: "m1", b: "m1", hits: 1 });
     expect(exitCode).toBe(0);
@@ -227,11 +219,7 @@ describe("fetch store", () => {
       cwd: String(srcDir),
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(JSON.parse(stdout.trim())).toEqual({ a: "bf1", b: "bf1", hits: 1 });
     expect(exitCode).toBe(0);

--- a/test/js/bun/fetch/fetch-store.test.ts
+++ b/test/js/bun/fetch/fetch-store.test.ts
@@ -218,8 +218,11 @@ describe("fetch store", () => {
   test("store type validation", async () => {
     // @ts-expect-error invalid type
     await expect(fetch("http://example.com", { store: { type: "nope" } })).rejects.toThrow(/store\.type/);
+    // @ts-expect-error missing type
+    await expect(fetch("http://example.com", { store: { path: "./x" } })).rejects.toThrow(/store\.type/);
     // @ts-expect-error missing path
     await expect(fetch("http://example.com", { store: { type: "dir" } })).rejects.toThrow(/store\.path/);
+    await expect(fetch("http://example.com", { store: { type: "dir", path: "" } })).rejects.toThrow(/store\.path/);
     // @ts-expect-error not an object
     await expect(fetch("http://example.com", { store: 123 })).rejects.toThrow(/'store' must be an object/);
   });

--- a/test/js/bun/fetch/fetch-store.test.ts
+++ b/test/js/bun/fetch/fetch-store.test.ts
@@ -190,7 +190,80 @@ describe("fetch store", () => {
     await expect(fetch("http://example.com", { store: { type: "dir" } })).rejects.toThrow(/store\.path/);
   });
 
-  test("streamed request bodies bypass the store", async () => {
+  test("Bun.file() request bodies are buffered and persist into the store", async () => {
+    using cacheDir = tempDir("fetch-store-bunfile", {});
+    using dataDir = tempDir("fetch-store-bunfile-src", {
+      "a.bin": Buffer.alloc(40 * 1024, "A").toString(),
+      "b.bin": Buffer.alloc(40 * 1024, "B").toString(),
+    });
+    let hits = 0;
+    await using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        hits++;
+        const first = (await req.bytes())[0];
+        return new Response(String.fromCharCode(first) + hits);
+      },
+    });
+    const store = { type: "dir", path: String(cacheDir) } as const;
+    const url = `http://localhost:${server.port}/file`;
+
+    const a1 = await (
+      await fetch(url, { method: "POST", body: Bun.file(join(String(dataDir), "a.bin")), store })
+    ).text();
+    const b1 = await (
+      await fetch(url, { method: "POST", body: Bun.file(join(String(dataDir), "b.bin")), store })
+    ).text();
+    expect(hits).toBe(2);
+    const a2 = await (
+      await fetch(url, { method: "POST", body: Bun.file(join(String(dataDir), "a.bin")), store })
+    ).text();
+    const b2 = await (
+      await fetch(url, { method: "POST", body: Bun.file(join(String(dataDir), "b.bin")), store })
+    ).text();
+    expect({ a1, b1, a2, b2, hits }).toEqual({ a1: "A1", b1: "B2", a2: "A1", b2: "B2", hits: 2 });
+    expect(readdirSync(String(cacheDir)).filter(f => f.endsWith(".json")).length).toBe(2);
+  });
+
+  test("response bodies read as a stream still persist", async () => {
+    using cacheDir = tempDir("fetch-store-resp-stream", {});
+    let hits = 0;
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        hits++;
+        const body = Buffer.alloc(8000, "x").toString() + hits;
+        return new Response(
+          new ReadableStream({
+            async start(c) {
+              c.enqueue(new TextEncoder().encode(body.slice(0, 4000)));
+              await Bun.sleep(0);
+              c.enqueue(new TextEncoder().encode(body.slice(4000)));
+              c.close();
+            },
+          }),
+        );
+      },
+    });
+    const store = { type: "dir", path: String(cacheDir) } as const;
+    const url = `http://localhost:${server.port}/stream-resp`;
+
+    const r1 = await fetch(url, { store });
+    let got = "";
+    for await (const chunk of r1.body!) got += new TextDecoder().decode(chunk);
+    expect(got.length).toBe(8001);
+    expect(got.endsWith("1")).toBe(true);
+    expect(hits).toBe(1);
+
+    const r2 = await fetch(url, { store });
+    expect(await r2.text()).toBe(got);
+    expect(hits).toBe(1);
+
+    const files = readdirSync(String(cacheDir)).filter(f => f.endsWith(".json"));
+    expect(files.length).toBe(1);
+  });
+
+  test("ReadableStream request bodies bypass the store", async () => {
     using cacheDir = tempDir("fetch-store-stream", {});
     let hits = 0;
     const bodies: string[] = [];

--- a/test/js/bun/fetch/fetch-store.test.ts
+++ b/test/js/bun/fetch/fetch-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { test, expect, describe } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -137,9 +137,35 @@ describe("fetch store", () => {
 
   test("store type validation", async () => {
     // @ts-expect-error invalid type
-    expect(fetch("http://example.com", { store: { type: "nope" } })).rejects.toThrow(/store\.type/);
+    await expect(fetch("http://example.com", { store: { type: "nope" } })).rejects.toThrow(/store\.type/);
     // @ts-expect-error missing path
-    expect(fetch("http://example.com", { store: { type: "dir" } })).rejects.toThrow(/store\.path/);
+    await expect(fetch("http://example.com", { store: { type: "dir" } })).rejects.toThrow(/store\.path/);
+  });
+
+  test("streamed request bodies bypass the store", async () => {
+    using cacheDir = tempDir("fetch-store-stream", {});
+    let hits = 0;
+    const bodies: string[] = [];
+    await using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        hits++;
+        bodies.push(await req.text());
+        return new Response(String(hits));
+      },
+    });
+    const store = { type: "dir", path: String(cacheDir) } as const;
+    const mk = (s: string) =>
+      new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode(s));
+          c.close();
+        },
+      });
+    const a = await (await fetch(`http://localhost:${server.port}/s`, { method: "POST", body: mk("A"), store })).text();
+    const b = await (await fetch(`http://localhost:${server.port}/s`, { method: "POST", body: mk("B"), store })).text();
+    expect({ a, b, hits, bodies }).toEqual({ a: "1", b: "2", hits: 2, bodies: ["A", "B"] });
+    expect(readdirSync(String(cacheDir))).toEqual([]);
   });
 
   test.concurrent("--fetch-cache=<dir> applies to all fetch() calls", async () => {
@@ -164,10 +190,11 @@ describe("fetch store", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    const out = JSON.parse(stdout.trim());
-    expect(out).toEqual({ a: "ok1", b: "ok1", hits: 1 });
-    expect(exitCode).toBe(0);
+    expect({ out: JSON.parse(stdout.trim()), stderr, exitCode }).toEqual({
+      out: { a: "ok1", b: "ok1", hits: 1 },
+      stderr: "",
+      exitCode: 0,
+    });
     expect(readdirSync(String(cacheDir)).filter(f => f.endsWith(".json")).length).toBe(1);
   });
 
@@ -192,9 +219,11 @@ describe("fetch store", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(JSON.parse(stdout.trim())).toEqual({ a: "m1", b: "m1", hits: 1 });
-    expect(exitCode).toBe(0);
+    expect({ out: JSON.parse(stdout.trim()), stderr, exitCode }).toEqual({
+      out: { a: "m1", b: "m1", hits: 1 },
+      stderr: "",
+      exitCode: 0,
+    });
   });
 
   test.concurrent("bunfig [fetch] cache = <dir>", async () => {
@@ -220,9 +249,11 @@ describe("fetch store", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(JSON.parse(stdout.trim())).toEqual({ a: "bf1", b: "bf1", hits: 1 });
-    expect(exitCode).toBe(0);
+    expect({ out: JSON.parse(stdout.trim()), stderr, exitCode }).toEqual({
+      out: { a: "bf1", b: "bf1", hits: 1 },
+      stderr: "",
+      exitCode: 0,
+    });
     expect(readdirSync(String(cacheDir)).filter(f => f.endsWith(".json")).length).toBe(1);
   });
 });

--- a/test/js/bun/fetch/fetch-store.test.ts
+++ b/test/js/bun/fetch/fetch-store.test.ts
@@ -36,7 +36,7 @@ describe("fetch store", () => {
     expect(data.request.method).toBe("GET");
     expect(data.request.url).toContain("/hello");
     expect(data.response.status).toBe(200);
-    expect(data.response.headers["content-type"]).toBe("application/json");
+    expect(data.response.headers).toContainEqual(["content-type", "application/json"]);
     expect(typeof data.response.body).toBe("string");
     expect(JSON.parse(data.response.body)).toEqual({ n: 1, path: "/hello" });
   });
@@ -105,6 +105,38 @@ describe("fetch store", () => {
       })
     ).text();
     expect({ a, b, hits }).toEqual({ a: "1", b: "1", hits: 1 });
+  });
+
+  test("dir: repeated response headers (Set-Cookie) survive JSON round-trip", async () => {
+    using cacheDir = tempDir("fetch-store-setcookie", {});
+    let hits = 0;
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        hits++;
+        return new Response("ok", {
+          headers: [
+            ["set-cookie", "a=1"],
+            ["set-cookie", "b=2"],
+          ],
+        });
+      },
+    });
+    const store = { type: "dir", path: String(cacheDir) } as const;
+    const url = `http://localhost:${server.port}/cookies`;
+
+    await (await fetch(url, { store })).text();
+    const r2 = await fetch(url, { store });
+    expect(r2.headers.getSetCookie()).toEqual(["a=1", "b=2"]);
+    expect(hits).toBe(1);
+
+    const files = readdirSync(String(cacheDir)).filter(f => f.endsWith(".json"));
+    const data = JSON.parse(readFileSync(join(String(cacheDir), files[0]), "utf8"));
+    const cookies = data.response.headers.filter((h: [string, string]) => h[0] === "set-cookie");
+    expect(cookies).toEqual([
+      ["set-cookie", "a=1"],
+      ["set-cookie", "b=2"],
+    ]);
   });
 
   test("dir: binary body is base64 encoded", async () => {

--- a/test/js/bun/fetch/fetch-store.test.ts
+++ b/test/js/bun/fetch/fetch-store.test.ts
@@ -1,0 +1,240 @@
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("fetch store", () => {
+  test("dir: records response to disk and replays on second call", async () => {
+    using cacheDir = tempDir("fetch-store-dir", {});
+    let hits = 0;
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        hits++;
+        return new Response(JSON.stringify({ n: hits, path: new URL(req.url).pathname }), {
+          headers: { "content-type": "application/json", "x-hit": String(hits) },
+        });
+      },
+    });
+    const store = { type: "dir", path: String(cacheDir) } as const;
+
+    // miss → records
+    const r1 = await fetch(`http://localhost:${server.port}/hello`, { store });
+    expect(r1.status).toBe(200);
+    expect(await r1.json()).toEqual({ n: 1, path: "/hello" });
+    expect(hits).toBe(1);
+
+    // hit → replays, server not contacted
+    const r2 = await fetch(`http://localhost:${server.port}/hello`, { store });
+    expect(r2.status).toBe(200);
+    expect(r2.headers.get("content-type")).toBe("application/json");
+    expect(r2.headers.get("x-hit")).toBe("1");
+    expect(await r2.json()).toEqual({ n: 1, path: "/hello" });
+    expect(hits).toBe(1);
+
+    // one file on disk, valid JSON with the expected shape
+    const files = readdirSync(String(cacheDir)).filter(f => f.endsWith(".json"));
+    expect(files.length).toBe(1);
+    const data = JSON.parse(readFileSync(join(String(cacheDir), files[0]), "utf8"));
+    expect(data.request.method).toBe("GET");
+    expect(data.request.url).toContain("/hello");
+    expect(data.response.status).toBe(200);
+    expect(data.response.headers["content-type"]).toBe("application/json");
+    expect(typeof data.response.body).toBe("string");
+    expect(JSON.parse(data.response.body)).toEqual({ n: 1, path: "/hello" });
+  });
+
+  test("dir: different method/url/body get different keys", async () => {
+    using cacheDir = tempDir("fetch-store-keys", {});
+    let hits = 0;
+    await using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        hits++;
+        return new Response(String(hits));
+      },
+    });
+    const store = { type: "dir", path: String(cacheDir) } as const;
+    const base = `http://localhost:${server.port}`;
+
+    await (await fetch(`${base}/a`, { store })).text();
+    await (await fetch(`${base}/b`, { store })).text();
+    await (await fetch(`${base}/a`, { method: "POST", body: "x", store })).text();
+    await (await fetch(`${base}/a`, { method: "POST", body: "y", store })).text();
+    expect(hits).toBe(4);
+
+    // all four should now hit
+    await (await fetch(`${base}/a`, { store })).text();
+    await (await fetch(`${base}/b`, { store })).text();
+    await (await fetch(`${base}/a`, { method: "POST", body: "x", store })).text();
+    await (await fetch(`${base}/a`, { method: "POST", body: "y", store })).text();
+    expect(hits).toBe(4);
+
+    expect(readdirSync(String(cacheDir)).filter(f => f.endsWith(".json")).length).toBe(4);
+  });
+
+  test("dir: binary body is base64 encoded", async () => {
+    using cacheDir = tempDir("fetch-store-binary", {});
+    const payload = new Uint8Array([0, 1, 2, 255, 128, 0]);
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(payload, { headers: { "content-type": "application/octet-stream" } });
+      },
+    });
+    const store = { type: "dir", path: String(cacheDir) } as const;
+
+    const r1 = await fetch(`http://localhost:${server.port}/bin`, { store });
+    expect(new Uint8Array(await r1.arrayBuffer())).toEqual(payload);
+
+    const r2 = await fetch(`http://localhost:${server.port}/bin`, { store });
+    expect(new Uint8Array(await r2.arrayBuffer())).toEqual(payload);
+
+    const files = readdirSync(String(cacheDir)).filter(f => f.endsWith(".json"));
+    const data = JSON.parse(readFileSync(join(String(cacheDir), files[0]), "utf8"));
+    expect(data.response.body).toEqual({
+      encoding: "base64",
+      data: Buffer.from(payload).toString("base64"),
+    });
+  });
+
+  test("memory: records and replays within process", async () => {
+    let hits = 0;
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        hits++;
+        return new Response("v" + hits);
+      },
+    });
+    const store = { type: "memory" } as const;
+
+    expect(await (await fetch(`http://localhost:${server.port}/mem`, { store })).text()).toBe("v1");
+    expect(await (await fetch(`http://localhost:${server.port}/mem`, { store })).text()).toBe("v1");
+    expect(hits).toBe(1);
+  });
+
+  test("memory: max evicts when full", async () => {
+    let hits = 0;
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        hits++;
+        return new Response(new URL(req.url).pathname);
+      },
+    });
+    const store = { type: "memory", max: 2 } as const;
+    const base = `http://localhost:${server.port}`;
+
+    await (await fetch(`${base}/m1`, { store })).text();
+    await (await fetch(`${base}/m2`, { store })).text();
+    await (await fetch(`${base}/m3`, { store })).text();
+    // 3 misses; map holds 2 entries. m3 is definitely cached.
+    expect(hits).toBe(3);
+    await (await fetch(`${base}/m3`, { store })).text();
+    expect(hits).toBe(3);
+  });
+
+  test("store type validation", async () => {
+    // @ts-expect-error invalid type
+    expect(fetch("http://example.com", { store: { type: "nope" } })).rejects.toThrow(/store\.type/);
+    // @ts-expect-error missing path
+    expect(fetch("http://example.com", { store: { type: "dir" } })).rejects.toThrow(/store\.path/);
+  });
+
+  test.concurrent("--fetch-cache=<dir> applies to all fetch() calls", async () => {
+    using cacheDir = tempDir("fetch-store-cli", {});
+    using srcDir = tempDir("fetch-store-cli-src", {
+      "script.ts": `
+        let hits = 0;
+        await using server = Bun.serve({
+          port: 0,
+          fetch() { hits++; return new Response("ok" + hits); },
+        });
+        const url = "http://localhost:" + server.port + "/cli";
+        const a = await (await fetch(url)).text();
+        const b = await (await fetch(url)).text();
+        console.log(JSON.stringify({ a, b, hits }));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--fetch-cache", String(cacheDir), "script.ts"],
+      env: bunEnv,
+      cwd: String(srcDir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    const out = JSON.parse(stdout.trim());
+    expect(out).toEqual({ a: "ok1", b: "ok1", hits: 1 });
+    expect(exitCode).toBe(0);
+    expect(readdirSync(String(cacheDir)).filter(f => f.endsWith(".json")).length).toBe(1);
+  });
+
+  test.concurrent("--fetch-cache=memory", async () => {
+    using srcDir = tempDir("fetch-store-cli-mem", {
+      "script.ts": `
+        let hits = 0;
+        await using server = Bun.serve({
+          port: 0,
+          fetch() { hits++; return new Response("m" + hits); },
+        });
+        const url = "http://localhost:" + server.port + "/climem";
+        const a = await (await fetch(url)).text();
+        const b = await (await fetch(url)).text();
+        console.log(JSON.stringify({ a, b, hits }));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--fetch-cache", "memory", "script.ts"],
+      env: bunEnv,
+      cwd: String(srcDir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ a: "m1", b: "m1", hits: 1 });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("bunfig [fetch] cache = <dir>", async () => {
+    using cacheDir = tempDir("fetch-store-bunfig-cache", {});
+    using srcDir = tempDir("fetch-store-bunfig", {
+      "bunfig.toml": `[fetch]\ncache = ${JSON.stringify(String(cacheDir))}\n`,
+      "script.ts": `
+        let hits = 0;
+        await using server = Bun.serve({
+          port: 0,
+          fetch() { hits++; return new Response("bf" + hits); },
+        });
+        const url = "http://localhost:" + server.port + "/bunfig";
+        const a = await (await fetch(url)).text();
+        const b = await (await fetch(url)).text();
+        console.log(JSON.stringify({ a, b, hits }));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "script.ts"],
+      env: bunEnv,
+      cwd: String(srcDir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ a: "bf1", b: "bf1", hits: 1 });
+    expect(exitCode).toBe(0);
+    expect(readdirSync(String(cacheDir)).filter(f => f.endsWith(".json")).length).toBe(1);
+  });
+});

--- a/test/js/bun/fetch/fetch-store.test.ts
+++ b/test/js/bun/fetch/fetch-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -293,6 +293,55 @@ describe("fetch store", () => {
 
     const files = readdirSync(String(cacheDir)).filter(f => f.endsWith(".json"));
     expect(files.length).toBe(1);
+  });
+
+  test("FormData request bodies bypass the store", async () => {
+    using cacheDir = tempDir("fetch-store-formdata", {});
+    let hits = 0;
+    await using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        hits++;
+        return new Response(String(hits));
+      },
+    });
+    const store = { type: "dir", path: String(cacheDir) } as const;
+    const fd = new FormData();
+    fd.set("q", "hello");
+    const a = await (await fetch(`http://localhost:${server.port}/fd`, { method: "POST", body: fd, store })).text();
+    const b = await (await fetch(`http://localhost:${server.port}/fd`, { method: "POST", body: fd, store })).text();
+    expect({ a, b, hits }).toEqual({ a: "1", b: "2", hits: 2 });
+    expect(readdirSync(String(cacheDir))).toEqual([]);
+  });
+
+  test.skipIf(isWindows)("unix socket path is part of the cache key", async () => {
+    using dir = tempDir("fetch-store-unix", {});
+    using cacheDir = tempDir("fetch-store-unix-cache", {});
+    let hitsA = 0;
+    let hitsB = 0;
+    await using serverA = Bun.serve({
+      unix: join(String(dir), "a.sock"),
+      fetch() {
+        hitsA++;
+        return new Response("A");
+      },
+    });
+    await using serverB = Bun.serve({
+      unix: join(String(dir), "b.sock"),
+      fetch() {
+        hitsB++;
+        return new Response("B");
+      },
+    });
+    const store = { type: "dir", path: String(cacheDir) } as const;
+    const url = "http://localhost/x";
+    const a1 = await (await fetch(url, { unix: join(String(dir), "a.sock"), store })).text();
+    const b1 = await (await fetch(url, { unix: join(String(dir), "b.sock"), store })).text();
+    expect({ a1, b1, hitsA, hitsB }).toEqual({ a1: "A", b1: "B", hitsA: 1, hitsB: 1 });
+    const a2 = await (await fetch(url, { unix: join(String(dir), "a.sock"), store })).text();
+    const b2 = await (await fetch(url, { unix: join(String(dir), "b.sock"), store })).text();
+    expect({ a2, b2, hitsA, hitsB }).toEqual({ a2: "A", b2: "B", hitsA: 1, hitsB: 1 });
+    expect(readdirSync(String(cacheDir)).filter(f => f.endsWith(".json")).length).toBe(2);
   });
 
   test("ReadableStream request bodies bypass the store", async () => {

--- a/test/js/bun/fetch/fetch-store.test.ts
+++ b/test/js/bun/fetch/fetch-store.test.ts
@@ -220,6 +220,8 @@ describe("fetch store", () => {
     await expect(fetch("http://example.com", { store: { type: "nope" } })).rejects.toThrow(/store\.type/);
     // @ts-expect-error missing path
     await expect(fetch("http://example.com", { store: { type: "dir" } })).rejects.toThrow(/store\.path/);
+    // @ts-expect-error not an object
+    await expect(fetch("http://example.com", { store: 123 })).rejects.toThrow(/'store' must be an object/);
   });
 
   test("Bun.file() request bodies are buffered and persist into the store", async () => {

--- a/test/js/bun/fetch/fetch-store.test.ts
+++ b/test/js/bun/fetch/fetch-store.test.ts
@@ -346,6 +346,68 @@ describe("fetch store", () => {
     expect(readdirSync(String(cacheDir)).filter(f => f.endsWith(".json")).length).toBe(2);
   });
 
+  test("redirect mode is part of the cache key", async () => {
+    using cacheDir = tempDir("fetch-store-redirect", {});
+    await using target = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("final");
+      },
+    });
+    await using origin = Bun.serve({
+      port: 0,
+      fetch() {
+        return Response.redirect(`http://localhost:${target.port}/final`, 302);
+      },
+    });
+    const store = { type: "dir", path: String(cacheDir) } as const;
+    const url = `http://localhost:${origin.port}/r`;
+
+    const follow1 = await fetch(url, { store });
+    expect(follow1.status).toBe(200);
+    expect(await follow1.text()).toBe("final");
+
+    const manual1 = await fetch(url, { redirect: "manual", store });
+    expect(manual1.status).toBe(302);
+
+    const follow2 = await fetch(url, { store });
+    expect(follow2.status).toBe(200);
+    const manual2 = await fetch(url, { redirect: "manual", store });
+    expect(manual2.status).toBe(302);
+
+    expect(readdirSync(String(cacheDir)).filter(f => f.endsWith(".json")).length).toBe(2);
+  });
+
+  test.concurrent("store: null opts out of a process-wide --fetch-cache", async () => {
+    using cacheDir = tempDir("fetch-store-null", {});
+    using srcDir = tempDir("fetch-store-null-src", {
+      "script.ts": `
+        let hits = 0;
+        await using server = Bun.serve({
+          port: 0,
+          fetch() { hits++; return new Response("n" + hits); },
+        });
+        const url = "http://localhost:" + server.port + "/null";
+        const a = await (await fetch(url)).text();
+        const b = await (await fetch(url, { store: null })).text();
+        const c = await (await fetch(url, { store: false })).text();
+        console.log(JSON.stringify({ a, b, c, hits }));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--fetch-cache", String(cacheDir), "script.ts"],
+      env: bunEnv,
+      cwd: String(srcDir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ out: JSON.parse(stdout.trim()), stderr, exitCode }).toEqual({
+      out: { a: "n1", b: "n2", c: "n3", hits: 3 },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
   test("ReadableStream request bodies bypass the store", async () => {
     using cacheDir = tempDir("fetch-store-stream", {});
     let hits = 0;

--- a/test/js/bun/fetch/fetch-store.test.ts
+++ b/test/js/bun/fetch/fetch-store.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";

--- a/test/js/bun/fetch/fetch-store.test.ts
+++ b/test/js/bun/fetch/fetch-store.test.ts
@@ -18,13 +18,11 @@ describe("fetch store", () => {
     });
     const store = { type: "dir", path: String(cacheDir) } as const;
 
-    // miss → records
     const r1 = await fetch(`http://localhost:${server.port}/hello`, { store });
     expect(r1.status).toBe(200);
     expect(await r1.json()).toEqual({ n: 1, path: "/hello" });
     expect(hits).toBe(1);
 
-    // hit → replays, server not contacted
     const r2 = await fetch(`http://localhost:${server.port}/hello`, { store });
     expect(r2.status).toBe(200);
     expect(r2.headers.get("content-type")).toBe("application/json");
@@ -32,7 +30,6 @@ describe("fetch store", () => {
     expect(await r2.json()).toEqual({ n: 1, path: "/hello" });
     expect(hits).toBe(1);
 
-    // one file on disk, valid JSON with the expected shape
     const files = readdirSync(String(cacheDir)).filter(f => f.endsWith(".json"));
     expect(files.length).toBe(1);
     const data = JSON.parse(readFileSync(join(String(cacheDir), files[0]), "utf8"));
@@ -44,7 +41,7 @@ describe("fetch store", () => {
     expect(JSON.parse(data.response.body)).toEqual({ n: 1, path: "/hello" });
   });
 
-  test("dir: different method/url/body get different keys", async () => {
+  test("dir: different method/url/body/headers get different keys", async () => {
     using cacheDir = tempDir("fetch-store-keys", {});
     let hits = 0;
     await using server = Bun.serve({
@@ -61,16 +58,53 @@ describe("fetch store", () => {
     await (await fetch(`${base}/b`, { store })).text();
     await (await fetch(`${base}/a`, { method: "POST", body: "x", store })).text();
     await (await fetch(`${base}/a`, { method: "POST", body: "y", store })).text();
-    expect(hits).toBe(4);
+    await (await fetch(`${base}/a`, { headers: { "x-k": "1" }, store })).text();
+    await (await fetch(`${base}/a`, { headers: { "x-k": "2" }, store })).text();
+    expect(hits).toBe(6);
 
-    // all four should now hit
     await (await fetch(`${base}/a`, { store })).text();
     await (await fetch(`${base}/b`, { store })).text();
     await (await fetch(`${base}/a`, { method: "POST", body: "x", store })).text();
     await (await fetch(`${base}/a`, { method: "POST", body: "y", store })).text();
-    expect(hits).toBe(4);
+    await (await fetch(`${base}/a`, { headers: { "x-k": "1" }, store })).text();
+    await (await fetch(`${base}/a`, { headers: { "x-k": "2" }, store })).text();
+    expect(hits).toBe(6);
 
-    expect(readdirSync(String(cacheDir)).filter(f => f.endsWith(".json")).length).toBe(4);
+    expect(readdirSync(String(cacheDir)).filter(f => f.endsWith(".json")).length).toBe(6);
+  });
+
+  test("dir: header order and case do not perturb the key", async () => {
+    using cacheDir = tempDir("fetch-store-hdr-order", {});
+    let hits = 0;
+    await using server = Bun.serve({
+      port: 0,
+      async fetch() {
+        hits++;
+        return new Response(String(hits));
+      },
+    });
+    const store = { type: "dir", path: String(cacheDir) } as const;
+    const base = `http://localhost:${server.port}`;
+
+    const a = await (
+      await fetch(`${base}/h`, {
+        headers: [
+          ["X-A", "1"],
+          ["x-b", "2"],
+        ] as [string, string][],
+        store,
+      })
+    ).text();
+    const b = await (
+      await fetch(`${base}/h`, {
+        headers: [
+          ["x-b", "2"],
+          ["x-a", "1"],
+        ] as [string, string][],
+        store,
+      })
+    ).text();
+    expect({ a, b, hits }).toEqual({ a: "1", b: "1", hits: 1 });
   });
 
   test("dir: binary body is base64 encoded", async () => {
@@ -114,25 +148,39 @@ describe("fetch store", () => {
     expect(hits).toBe(1);
   });
 
-  test("memory: max evicts when full", async () => {
-    let hits = 0;
-    await using server = Bun.serve({
-      port: 0,
-      fetch(req) {
-        hits++;
-        return new Response(new URL(req.url).pathname);
-      },
+  test.concurrent("memory: max bounds entry count", async () => {
+    // Subprocess gives an isolated memory store. With max=1 each insert
+    // evicts the prior key, so re-fetching both keys misses both times;
+    // an unbounded store would leave `after` at 2.
+    using srcDir = tempDir("fetch-store-mem-max", {
+      "script.ts": `
+        let hits = 0;
+        await using server = Bun.serve({
+          port: 0,
+          fetch(req) { hits++; return new Response(new URL(req.url).pathname); },
+        });
+        const store = { type: "memory", max: 1 } as const;
+        const base = "http://localhost:" + server.port;
+        await (await fetch(base + "/m1", { store })).text();
+        await (await fetch(base + "/m2", { store })).text();
+        const before = hits;
+        await (await fetch(base + "/m1", { store })).text();
+        await (await fetch(base + "/m2", { store })).text();
+        console.log(JSON.stringify({ before, after: hits }));
+      `,
     });
-    const store = { type: "memory", max: 2 } as const;
-    const base = `http://localhost:${server.port}`;
-
-    await (await fetch(`${base}/m1`, { store })).text();
-    await (await fetch(`${base}/m2`, { store })).text();
-    await (await fetch(`${base}/m3`, { store })).text();
-    // 3 misses; map holds 2 entries. m3 is definitely cached.
-    expect(hits).toBe(3);
-    await (await fetch(`${base}/m3`, { store })).text();
-    expect(hits).toBe(3);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "script.ts"],
+      env: bunEnv,
+      cwd: String(srcDir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ out: JSON.parse(stdout.trim()), stderr, exitCode }).toEqual({
+      out: { before: 2, after: 4 },
+      stderr: "",
+      exitCode: 0,
+    });
   });
 
   test("store type validation", async () => {


### PR DESCRIPTION
Adds an on-disk and in-memory record/replay store for `fetch()`, designed for testing and agent workflows: record real traffic once, replay it deterministically afterwards without touching the network.

### What this adds

A `fetch()` call with a `store` configured hashes `(method, URL, sorted request headers, buffered body)` into a key. A hit returns the recorded `Response` immediately; a miss goes to the network and persists the response once the body is fully buffered.

**Backends** (in this PR):

- `{ type: "dir", path }`: one JSON file per unique request under `path`. Each file contains the full request and response; non-text bodies are base64-encoded. Intended to be committed alongside tests, diffed, and edited by hand or by agents.
- `{ type: "memory", ttl?, max? }`: process-global hash map with optional TTL (ms) and bounded entry count.

A SQLite backend (WAL, production-grade) is planned as a follow-up.

**Configuration** (all three land here):

```ts
// Per call
await fetch(url, { store: { type: "dir", path: "./fixtures" } });
await fetch(url, { store: { type: "memory", ttl: 60_000, max: 1000 } });
```
```sh
# Process-wide default
bun --fetch-cache=./fixtures script.ts
bun --fetch-cache=memory script.ts
```
```toml
# bunfig.toml
[fetch]
cache = "./fixtures"
```

A per-call `store` overrides `--fetch-cache`, which overrides bunfig.

### How it hooks in

- `src/runtime/webcore/fetch/store.rs` (new): `FetchStore` enum, key derivation, JSON (de)serialization via `bun_core::fmt::format_json_string_utf8` / `bun_parsers::json`, memory-backend global map, `response_from_hit` that builds a `Response` with an `InternalBlob` body.
- `fetch.rs::fetch_impl`: parses `store` from the options object (or falls back to the process-wide default via `bun_options_types::context::try_get()`); after method/url/headers/body are finalised, checks for a hit and either returns a resolved promise or threads `(FetchStore, StoredRequest)` into `FetchOptions`.
- `FetchTasklet::persist_to_store`: called from both `to_body_value` (body arrived with headers in a single packet) and `on_body_received` (body streamed in later) right before `scheduled_response_buffer` is consumed.
- `options_types::context::FetchStoreConfig` + `--fetch-cache` in `Arguments.rs` + `[fetch] cache` in `bunfig.rs`.

### Example `dir` entry

```json
{"request":{"method":"GET","url":"http://localhost:42165/hello","headers":[],"body":null},"response":{"status":200,"statusText":"OK","url":"http://localhost:42165/hello","redirected":false,"headers":[["x-hit","1"],["content-type","text/plain;charset=utf-8"],["date","Mon, 20 Jul 2026 01:57:07 GMT"],["content-length","6"]],"body":"hello1"},"time":1784512627079}
```

### Scope notes

- The store is bypassed for `s3://` and for requests whose body is a `ReadableStream` (unhashable).
- Response bodies consumed as a stream are persisted once fully read.
- This is not an RFC 9111 HTTP cache: `Cache-Control` / `Vary` / revalidation are ignored by design.

### Tests

`test/js/bun/fetch/fetch-store.test.ts` covers: dir record+replay, key separation by method/url/body, base64 encoding for binary bodies, memory backend with eviction, option validation, `--fetch-cache=<dir>`, `--fetch-cache=memory`, and `[fetch] cache` in bunfig.

```
 9 pass
 0 fail
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 11 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/fetch/fetch-store.test.ts

<!-- robobun:evidence:end -->

Part of #27523 (the fetch-level record/replay store; the `test.recorded` API and update-recordings flag are follow-ups).