### PR TITLE
node:fs: snapshot resizable ArrayBuffer inputs for async write/writev

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -10,6 +10,7 @@ use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use crate::api::bun::process::event_loop_handle_to_ctx;
 use crate::webcore;
 use bun_core::Environment;
+use bun_core::zig_string::Slice as ZigStringSlice;
 use bun_core::{String as BunString, ZStr, ZigString};
 use bun_event_loop::AnyTaskWithExtraContext::AnyTaskWithExtraContext;
 use bun_event_loop::MiniEventLoop::MiniEventLoop;
@@ -1087,6 +1088,7 @@ mod _async_tasks {
         args::Rename,
         args::Truncate,
         args::FdVectorIo,
+        args::Writev,
         args::FTruncate,
         args::Chown,
         args::Lutimes,
@@ -2817,11 +2819,10 @@ pub mod args {
         }
     }
 
-    /// Shared layout for `fs.writev` / `fs.readv` arguments. One concrete
-    /// struct; we re-export both
-    /// names as type aliases so every `args::Writev` / `args::Readv` caller
-    /// (UVFSRequest params, `readv`/`writev`/`preadv_inner`/`pwritev_inner`,
-    /// uv dispatch arms) is untouched.
+    /// Shared layout for `fs.writev` / `fs.readv` arguments. `args::Readv` is
+    /// a direct alias; `args::Writev` newtypes it so its `from_js` can snapshot
+    /// resizable inputs on the async path while every
+    /// `.fd`/`.buffers`/`.position` consumer stays unchanged via `Deref`.
     pub struct FdVectorIo {
         pub fd: FD,
         pub buffers: VectorArrayBuffer,
@@ -2873,8 +2874,44 @@ pub mod args {
             })
         }
     }
-    pub type Writev = FdVectorIo;
     pub type Readv = FdVectorIo;
+
+    /// Transparent so the `args_as!` identity cast in the Windows
+    /// `UVFSRequest` dispatch stays a pure reinterpretation.
+    #[repr(transparent)]
+    pub struct Writev(pub FdVectorIo);
+    impl core::ops::Deref for Writev {
+        type Target = FdVectorIo;
+        #[inline]
+        fn deref(&self) -> &FdVectorIo {
+            &self.0
+        }
+    }
+    impl core::ops::DerefMut for Writev {
+        #[inline]
+        fn deref_mut(&mut self) -> &mut FdVectorIo {
+            &mut self.0
+        }
+    }
+    impl Unprotect for Writev {
+        #[inline]
+        fn unprotect(&mut self) {
+            self.0.unprotect();
+        }
+    }
+    impl Writev {
+        #[inline]
+        pub fn to_thread_safe(&mut self) {
+            self.0.to_thread_safe();
+        }
+        pub fn from_js(ctx: &JSGlobalObject, arguments: &mut ArgumentsSlice) -> JsResult<Self> {
+            let mut inner = FdVectorIo::from_js(ctx, arguments)?;
+            if arguments.will_be_async {
+                inner.buffers.snapshot_resizable_inputs(ctx);
+            }
+            Ok(Self(inner))
+        }
+    }
 
     pub struct FTruncate {
         pub fd: FD,
@@ -3885,11 +3922,23 @@ pub mod args {
             }
             if arguments.will_be_async && matches!(args.buffer, StringOrBuffer::Buffer(_)) {
                 if let Some(pinned) = bv.as_pinned_arraybuffer(ctx) {
-                    args.buffer = StringOrBuffer::Buffer(Buffer {
-                        buffer: pinned,
-                        owns_buffer: false,
-                        pinned: true,
-                    });
+                    if pinned.resizable && !pinned.shared {
+                        // pin() blocks transfer(), not resize(); a shrink
+                        // decommits pages the threadpool hands to write(2),
+                        // which then returns EFAULT. Snapshot the call-time
+                        // bytes instead.
+                        let owned = pinned.byte_slice().to_vec();
+                        pinned.unpin();
+                        ctx.vm().report_extra_memory(owned.len());
+                        args.buffer =
+                            StringOrBuffer::EncodedSlice(ZigStringSlice::init_owned(owned));
+                    } else {
+                        args.buffer = StringOrBuffer::Buffer(Buffer {
+                            buffer: pinned,
+                            owns_buffer: false,
+                            pinned: true,
+                        });
+                    }
                 }
             }
             Ok(args)

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -2876,8 +2876,8 @@ pub mod args {
     }
     pub type Readv = FdVectorIo;
 
-    /// Transparent so the `args_as!` identity cast in the Windows
-    /// `UVFSRequest` dispatch stays a pure reinterpretation.
+    /// Newtype over [`FdVectorIo`] so writev's `from_js` can snapshot resizable
+    /// inputs on the async path; `Readv` stays the plain alias.
     #[repr(transparent)]
     pub struct Writev(pub FdVectorIo);
     impl core::ops::Deref for Writev {
@@ -3924,12 +3924,16 @@ pub mod args {
                 if let Some(pinned) = bv.as_pinned_arraybuffer(ctx) {
                     if pinned.resizable && !pinned.shared {
                         // pin() blocks transfer(), not resize(); a shrink
-                        // decommits pages the threadpool hands to write(2),
-                        // which then returns EFAULT. Snapshot the call-time
-                        // bytes instead.
-                        let owned = pinned.byte_slice().to_vec();
+                        // decommits pages the threadpool hands to write(2) and
+                        // returns EFAULT. Snapshot the call-time bytes instead.
+                        let view = pinned.byte_slice();
+                        let off = (args.offset as usize).min(view.len());
+                        let len = (args.length as usize).min(view.len() - off);
+                        let owned = view[off..off + len].to_vec();
                         pinned.unpin();
                         ctx.vm().report_extra_memory(owned.len());
+                        args.offset = 0;
+                        args.length = owned.len() as u64;
                         args.buffer =
                             StringOrBuffer::EncodedSlice(ZigStringSlice::init_owned(owned));
                     } else {

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -1441,6 +1441,10 @@ pub struct VectorArrayBuffer {
     /// The collected elements, in order. Rooted (and their backing stores
     /// pinned) for the lifetime of an async operation; see [`Self::release`].
     pub views: Vec<JSValue>,
+    /// Owned snapshots of any resizable-backed inputs; the matching
+    /// `buffers[i]` points in here. Populated by
+    /// [`Self::snapshot_resizable_inputs`]; freed by `Drop`.
+    owned: Vec<Box<[u8]>>,
     pinned: bool,
 }
 
@@ -1459,6 +1463,33 @@ impl VectorArrayBuffer {
         for view in self.views.drain(..) {
             view.unpin_array_buffer();
             view.unprotect();
+        }
+    }
+
+    /// For async writev: copy any element backed by a resizable non-shared
+    /// ArrayBuffer into owned storage and repoint its iovec. `pin()` blocks
+    /// `transfer()` but not `ArrayBuffer.prototype.resize`; a shrink decommits
+    /// pages the threadpool hands to `pwritev(2)`, which then returns EFAULT.
+    /// Fixed-length and growable-shared backings stay zero-copy.
+    pub fn snapshot_resizable_inputs(&mut self, global: &JSGlobalObject) {
+        if !self.pinned {
+            return;
+        }
+        debug_assert_eq!(self.views.len(), self.buffers.len());
+        let mut extra: usize = 0;
+        for (i, view) in self.views.iter().enumerate() {
+            let Some(buf) = view.as_array_buffer(global) else {
+                continue;
+            };
+            if buf.resizable && !buf.shared {
+                let mut owned: Box<[u8]> = Box::from(buf.byte_slice());
+                extra += owned.len();
+                self.buffers[i] = bun_sys::platform_iovec_create(&mut owned[..]);
+                self.owned.push(owned);
+            }
+        }
+        if extra > 0 {
+            global.vm().report_extra_memory(extra);
         }
     }
 }
@@ -1517,6 +1548,7 @@ impl VectorArrayBuffer {
             value: val,
             buffers: Vec::new(),
             views: Vec::new(),
+            owned: Vec::new(),
             pinned: false,
         };
         bun_jsc::validation_scope!(scope, global_object);

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5512,6 +5512,102 @@ it("fs.promises.writeFile keeps a buffer path argument attached while options ar
   expect(readFileSync(file, "utf8")).toBe("hello world");
 });
 
+// pin() blocks transfer(), not ArrayBuffer.prototype.resize: a shrink decommits
+// pages the threadpool passes to write(2)/pwritev(2), which then returns EFAULT
+// (or, if the buffer is regrown before the syscall runs, writes zeroed bytes).
+// Async fs.write/fs.writev now snapshot resizable non-shared inputs at call
+// time so the written content is the call-time bytes.
+describe.concurrent.each(["write", "writev"] as const)(
+  "async fs.%s snapshots a resizable ArrayBuffer input at call time",
+  op => {
+    const fixture = /* js */ `
+      import fs from "node:fs";
+      import { open, readFile, writeFile } from "node:fs/promises";
+      import { join } from "node:path";
+
+      const dir = process.env.FIXTURE_DIR;
+      const SIZE = 256 * 1024;
+      const heavy = join(dir, "heavy");
+      await writeFile(heavy, Buffer.alloc(2 * 1024 * 1024));
+      const saturate = () =>
+        Promise.all(Array.from({ length: 32 }, () => fs.promises.readFile(heavy).catch(() => {})));
+
+      const enqueue = ${
+        op === "write"
+          ? `(fd, ab) => new Promise(r => fs.write(fd, new Uint8Array(ab), 0, SIZE, 0, (e, n) => r({ e, n })))`
+          : `(fd, ab) => new Promise(r => fs.writev(fd, [new Uint8Array(ab, 0, SIZE / 2), new Uint8Array(ab, SIZE / 2)], 0, (e, n) => r({ e, n })))`
+      };
+
+      const out = join(dir, "out");
+      const failures = [];
+      for (let i = 0; i < 6; i++) {
+        const fh = await open(out, "w");
+        const ab = new ArrayBuffer(SIZE, { maxByteLength: SIZE * 2 });
+        new Uint8Array(ab).fill(0x41);
+        const blockers = saturate();
+        const p = enqueue(fh.fd, ab);
+        // Shrink then regrow: zeroes the bytes without leaving PROT_NONE pages,
+        // so a write that races the resize succeeds with wrong content instead
+        // of EFAULT. The snapshot taken at call time must write the 0x41 bytes.
+        ab.resize(0);
+        ab.resize(SIZE);
+        const { e, n } = await p;
+        await blockers;
+        await fh.close();
+        if (e) { failures.push(e.code); continue; }
+        if (n !== SIZE) { failures.push("short=" + n); continue; }
+        const content = await readFile(out);
+        if (content.indexOf(0) !== -1) failures.push("zeroed");
+      }
+      if (failures.length) {
+        console.error(JSON.stringify(failures));
+        process.exit(1);
+      }
+      console.log("ok");
+    `;
+
+    it("writes the call-time bytes", async () => {
+      using dir = tempDir(`fs-${op}-resizable-ab`, {});
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: { ...bunEnv, FIXTURE_DIR: String(dir) },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("ok");
+      expect(exitCode).toBe(0);
+    });
+
+    it("leaves a growable SharedArrayBuffer zero-copy", async () => {
+      using dir = tempDir(`fs-${op}-growable-sab`, {});
+      const out = join(String(dir), "out");
+      const fh = await fs.promises.open(out, "w");
+      const sab = new SharedArrayBuffer(4096, { maxByteLength: 8192 });
+      new Uint8Array(sab).fill(0x41);
+      const p: Promise<{ e: any; n: number }> =
+        op === "write"
+          ? new Promise(r => fs.write(fh.fd, new Uint8Array(sab), 0, 4096, 0, (e, n) => r({ e, n })))
+          : new Promise(r =>
+              fs.writev(fh.fd, [new Uint8Array(sab, 0, 2048), new Uint8Array(sab, 2048)], 0, (e, n) =>
+                r({ e, n }),
+              ),
+            );
+      sab.grow(8192);
+      const { e, n } = await p;
+      await fh.close();
+      expect(e).toBeNull();
+      expect(n).toBe(4096);
+      expect(readFileSync(out).every(b => b === 0x41)).toBe(true);
+    });
+  },
+);
+
 describe("fs.close on stdio descriptors", () => {
   it.skipIf(isWindows)("closeSync(2) actually closes fd 2 and allows redirect", async () => {
     using dir = tempDir("fs-close-stdio", {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5513,10 +5513,8 @@ it("fs.promises.writeFile keeps a buffer path argument attached while options ar
 });
 
 // pin() blocks transfer(), not ArrayBuffer.prototype.resize: a shrink decommits
-// pages the threadpool passes to write(2)/pwritev(2), which then returns EFAULT
-// (or, if the buffer is regrown before the syscall runs, writes zeroed bytes).
-// Async fs.write/fs.writev now snapshot resizable non-shared inputs at call
-// time so the written content is the call-time bytes.
+// pages the threadpool hands to write(2)/pwritev(2). Async write/writev now
+// snapshot resizable non-shared inputs at call time.
 describe.concurrent.each(["write", "writev"] as const)(
   "async fs.%s snapshots a resizable ArrayBuffer input at call time",
   op => {
@@ -5575,29 +5573,48 @@ describe.concurrent.each(["write", "writev"] as const)(
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
-      expect(stdout.trim()).toBe("ok");
-      expect(exitCode).toBe(0);
+      expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+        stdout: "ok",
+        stderr: expect.any(String),
+        exitCode: 0,
+      });
     });
 
-    it("leaves a growable SharedArrayBuffer zero-copy", async () => {
+    if (op === "write") {
+      it("snapshots only the [offset, offset+length) window", async () => {
+        using dir = tempDir("fs-write-resizable-offset", {});
+        const out = join(String(dir), "out");
+        const fh = await fs.promises.open(out, "w");
+        const ab = new ArrayBuffer(64, { maxByteLength: 128 });
+        const view = new Uint8Array(ab);
+        view.fill(0x42);
+        view.fill(0x41, 16, 48);
+        const p = new Promise<{ e: any; n: number }>(r =>
+          fs.write(fh.fd, view, 16, 32, 0, (e, n) => r({ e, n })),
+        );
+        ab.resize(0);
+        const { e, n } = await p;
+        await fh.close();
+        expect({ e, n, out: readFileSync(out) }).toEqual({ e: null, n: 32, out: Buffer.alloc(32, 0x41) });
+      });
+    }
+
+    it("accepts a growable SharedArrayBuffer input", async () => {
       using dir = tempDir(`fs-${op}-growable-sab`, {});
       const out = join(String(dir), "out");
       const fh = await fs.promises.open(out, "w");
       const sab = new SharedArrayBuffer(4096, { maxByteLength: 8192 });
       new Uint8Array(sab).fill(0x41);
-      const p: Promise<{ e: any; n: number }> =
+      const { e, n } =
         op === "write"
-          ? new Promise(r => fs.write(fh.fd, new Uint8Array(sab), 0, 4096, 0, (e, n) => r({ e, n })))
-          : new Promise(r =>
+          ? await new Promise<{ e: any; n: number }>(r =>
+              fs.write(fh.fd, new Uint8Array(sab), 0, 4096, 0, (e, n) => r({ e, n })),
+            )
+          : await new Promise<{ e: any; n: number }>(r =>
               fs.writev(fh.fd, [new Uint8Array(sab, 0, 2048), new Uint8Array(sab, 2048)], 0, (e, n) => r({ e, n })),
             );
-      sab.grow(8192);
-      const { e, n } = await p;
       await fh.close();
-      expect(e).toBeNull();
-      expect(n).toBe(4096);
-      expect(readFileSync(out).every(b => b === 0x41)).toBe(true);
+      expect({ e, n, out: readFileSync(out) }).toEqual({ e: null, n: 4096, out: Buffer.alloc(4096, 0x41) });
     });
   },
 );

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5574,11 +5574,7 @@ describe.concurrent.each(["write", "writev"] as const)(
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toBe("");
       expect(stdout.trim()).toBe("ok");
       expect(exitCode).toBe(0);
@@ -5594,9 +5590,7 @@ describe.concurrent.each(["write", "writev"] as const)(
         op === "write"
           ? new Promise(r => fs.write(fh.fd, new Uint8Array(sab), 0, 4096, 0, (e, n) => r({ e, n })))
           : new Promise(r =>
-              fs.writev(fh.fd, [new Uint8Array(sab, 0, 2048), new Uint8Array(sab, 2048)], 0, (e, n) =>
-                r({ e, n }),
-              ),
+              fs.writev(fh.fd, [new Uint8Array(sab, 0, 2048), new Uint8Array(sab, 2048)], 0, (e, n) => r({ e, n })),
             );
       sab.grow(8192);
       const { e, n } = await p;

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5589,9 +5589,7 @@ describe.concurrent.each(["write", "writev"] as const)(
         const view = new Uint8Array(ab);
         view.fill(0x42);
         view.fill(0x41, 16, 48);
-        const p = new Promise<{ e: any; n: number }>(r =>
-          fs.write(fh.fd, view, 16, 32, 0, (e, n) => r({ e, n })),
-        );
+        const p = new Promise<{ e: any; n: number }>(r => fs.write(fh.fd, view, 16, 32, 0, (e, n) => r({ e, n })));
         ab.resize(0);
         const { e, n } = await p;
         await fh.close();


### PR DESCRIPTION
## Repro

```js
import fs from "node:fs";
import { open } from "node:fs/promises";
const fh = await open("/tmp/out", "w");
const ab = new ArrayBuffer(256 * 1024, { maxByteLength: 1 << 21 });
new Uint8Array(ab).fill(0x41);
const p = new Promise((res, rej) =>
  fs.writev(fh.fd, [new Uint8Array(ab)], 0, (e, n) => (e ? rej(e) : res(n))));
ab.resize(0);
await p;
```

```
EFAULT: bad address in system call argument, pwritev
```

`fs.write` fails the same way (syscall `write`). Node.js itself has the same race for `fs.write`/`fs.writev` (V8's `BackingStore::ResizeInPlace` also `mprotect`s the shrunk tail to `PROT_NONE`, and `node_file.cc` snapshots a raw `Buffer::Data()`/`Length()` into the libuv request); Bun's threadpool just loses the race more often.

## Cause

Async `fs.write` (`args::Write::from_js`) and `fs.writev` (`VectorArrayBuffer::from_js` via `FdVectorIo`) pin the backing ArrayBuffer and hand a `(ptr, len)` snapshot to the threadpool. `pin()` blocks `transfer()`/detach but `ArrayBuffer.prototype.resize` never consults the pin count: JSC's `ArrayBuffer::resize` shrink path calls `OSAllocator::protect(.., readable=false, writable=false)` on the tail, so the kernel's `write(2)`/`pwritev(2)` sees decommitted pages and returns `EFAULT`.

## Fix

When an input buffer's backing is a resizable non-shared ArrayBuffer, copy the bytes into the job on the async path instead of borrowing:

- `args::Write`: the async repin branch now returns an owned `EncodedSlice` for resizable non-shared inputs; the existing pinned borrow is kept for fixed-length and growable-shared backings.
- `VectorArrayBuffer` gains an `owned` vector and `snapshot_resizable_inputs()`, which copies any resizable non-shared element into owned storage and repoints its iovec at the copy.
- `args::Writev` is now a `#[repr(transparent)]` newtype over `FdVectorIo` whose `from_js` runs the snapshot on the async path. `args::Readv` stays the plain `FdVectorIo` alias, so output buffers are never copied (shrinking an output buffer mid-read is a caller error, and copying would discard the read bytes). All consumers keep accessing `.fd`/`.buffers`/`.position` through `Deref`.

Fixed-length ArrayBuffer (the overwhelmingly common case) stays zero-copy. Growable SharedArrayBuffer also stays zero-copy: `grow()` only commits additional tail pages in place, so the original extent remains valid.

This is the same approach #34751 takes for the crypto/zlib input funnels and #32189 takes for path buffers. Those PRs do not cover `args::Write`'s repin branch or the writev collector; this one does, and it does not overlap their diffs. `fs.writeFile`/`appendFile` route their data argument through `StringOrBuffer::from_js_maybe_async`, which #34751 already patches.

## Verification

`test/js/node/fs/fs.test.ts` gains, for each of `write` and `writev`:

- a subprocess that saturates the threadpool with concurrent `readFile`, queues the operation on a resizable ArrayBuffer filled with `0x41`, shrinks and regrows the backing (which zeroes it), and asserts the file contents are the call-time `0x41` bytes. On the unfixed build the subprocess reports `["zeroed", ...]` (and occasionally `"EFAULT"`); with this change it prints `ok`.
- a growable-SharedArrayBuffer case that exercises the `resizable && !shared` guard: `grow()` mid-flight must not copy and must still write the original bytes.

Existing `writev`/`readv`/`write` coverage in `fs.test.ts` and the Node `test/parallel` `test-fs-write*`/`test-fs-writev*`/`test-fs-readv*` suite pass unchanged; `rust:check-all` compiles on every target.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->