### PR TITLE
Remove dead code from bun_router

### DIFF
--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -708,8 +708,7 @@ impl<'a> RouteLoader<'a> {
                 index_id = Some(i);
             }
 
-            let (filepath, match_name) =
-                (route.abs_path.as_bytes(), route.match_name.as_bytes());
+            let (filepath, match_name) = (route.abs_path.as_bytes(), route.match_name.as_bytes());
             route_list.push(RouteIndex {
                 name: route.name,
                 filepath,
@@ -1033,44 +1032,43 @@ impl Route {
             // DirnameStore (process-lifetime arena → `&'static`), so the
             // post-if bindings are 'static and the route_file_buf borrow is
             // dropped before the abs-path block below needs it mutably.
-            let (name, match_name): (&'static [u8], &'static [u8]) =
-                if !name.is_empty() {
-                    validation_result = match Pattern::validate(&name[1..], log) {
-                        Some(v) => v,
-                        None => return None,
-                    };
-
-                    let mut name_i: usize = 0;
-                    while !has_uppercase && name_i < public_path.len() {
-                        has_uppercase = public_path[name_i] >= b'A' && public_path[name_i] <= b'Z';
-                        name_i += 1;
-                    }
-
-                    let name_offset = name.as_ptr() as usize - public_path.as_ptr() as usize;
-                    let name_len = name.len();
-
-                    // NOTE: DirnameStore::append returns `&'static [u8]` (process-
-                    // lifetime arena), so rebinding here drops the borrow on
-                    // `route_file_buf` and avoids needing lifetime transmutes
-                    // below.
-                    let dirname_store = FileSystem::instance().dirname_store();
-                    let public_path: &'static [u8] =
-                        dirname_store.append(public_path).expect("unreachable");
-                    let name: &'static [u8] = &public_path[name_offset..][0..name_len];
-                    let match_name: &'static [u8] = if has_uppercase {
-                        dirname_store
-                            .append_lower_case(&name[1..])
-                            .expect("unreachable")
-                    } else {
-                        &name[1..]
-                    };
-
-                    debug_assert!(match_name[0] != b'/');
-                    debug_assert!(name[0] == b'/');
-                    (name, match_name)
-                } else {
-                    (Route::INDEX_ROUTE_NAME, Route::INDEX_ROUTE_NAME)
+            let (name, match_name): (&'static [u8], &'static [u8]) = if !name.is_empty() {
+                validation_result = match Pattern::validate(&name[1..], log) {
+                    Some(v) => v,
+                    None => return None,
                 };
+
+                let mut name_i: usize = 0;
+                while !has_uppercase && name_i < public_path.len() {
+                    has_uppercase = public_path[name_i] >= b'A' && public_path[name_i] <= b'Z';
+                    name_i += 1;
+                }
+
+                let name_offset = name.as_ptr() as usize - public_path.as_ptr() as usize;
+                let name_len = name.len();
+
+                // NOTE: DirnameStore::append returns `&'static [u8]` (process-
+                // lifetime arena), so rebinding here drops the borrow on
+                // `route_file_buf` and avoids needing lifetime transmutes
+                // below.
+                let dirname_store = FileSystem::instance().dirname_store();
+                let public_path: &'static [u8] =
+                    dirname_store.append(public_path).expect("unreachable");
+                let name: &'static [u8] = &public_path[name_offset..][0..name_len];
+                let match_name: &'static [u8] = if has_uppercase {
+                    dirname_store
+                        .append_lower_case(&name[1..])
+                        .expect("unreachable")
+                } else {
+                    &name[1..]
+                };
+
+                debug_assert!(match_name[0] != b'/');
+                debug_assert!(name[0] == b'/');
+                (name, match_name)
+            } else {
+                (Route::INDEX_ROUTE_NAME, Route::INDEX_ROUTE_NAME)
+            };
 
             if abs_path_str.is_empty() {
                 // The reads of `cache().fd` and the `set_abs_path` write below

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -1028,10 +1028,9 @@ impl Route {
             let is_index = name.is_empty();
 
             let mut has_uppercase = false;
-            // NOTE: reshaped for borrowck — the non-index arm interns via
-            // DirnameStore (process-lifetime arena → `&'static`), so the
-            // post-if bindings are 'static and the route_file_buf borrow is
-            // dropped before the abs-path block below needs it mutably.
+            // NOTE: the non-index arm interns via DirnameStore (process-lifetime
+            // arena → `&'static`), so the post-if bindings drop the
+            // route_file_buf borrow before the abs-path block reborrows it.
             let (name, match_name): (&'static [u8], &'static [u8]) = if !name.is_empty() {
                 validation_result = match Pattern::validate(&name[1..], log) {
                     Some(v) => v,
@@ -1044,10 +1043,9 @@ impl Route {
                     name_i += 1;
                 }
 
-                // NOTE: DirnameStore::append returns `&'static [u8]` (process-
-                // lifetime arena), so rebinding here drops the borrow on
-                // `route_file_buf` and avoids needing lifetime transmutes
-                // below.
+                // NOTE: DirnameStore::append returns `&'static [u8]`, so
+                // rebinding drops the route_file_buf borrow without a
+                // lifetime transmute.
                 let dirname_store = FileSystem::instance().dirname_store();
                 let name: &'static [u8] = dirname_store.append(name).expect("unreachable");
                 let match_name: &'static [u8] = if has_uppercase {

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -1044,17 +1044,12 @@ impl Route {
                     name_i += 1;
                 }
 
-                let name_offset = name.as_ptr() as usize - public_path.as_ptr() as usize;
-                let name_len = name.len();
-
                 // NOTE: DirnameStore::append returns `&'static [u8]` (process-
                 // lifetime arena), so rebinding here drops the borrow on
                 // `route_file_buf` and avoids needing lifetime transmutes
                 // below.
                 let dirname_store = FileSystem::instance().dirname_store();
-                let public_path: &'static [u8] =
-                    dirname_store.append(public_path).expect("unreachable");
-                let name: &'static [u8] = &public_path[name_offset..][0..name_len];
+                let name: &'static [u8] = dirname_store.append(name).expect("unreachable");
                 let match_name: &'static [u8] = if has_uppercase {
                     dirname_store
                         .append_lower_case(&name[1..])

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -16,7 +16,6 @@ use bun_collections::{ArrayHashMap, StringHashMap};
 use bun_core::strings;
 use bun_paths::{self, PathBuffer, SEP, SEP_STR};
 use bun_sys::Fd;
-use bun_url::PathnameScanner;
 
 use bun_http_types::URLPath::URLPath;
 
@@ -38,10 +37,7 @@ use bun_resolver::DirInfoRef;
 use bun_resolver::fs as Fs;
 use bun_resolver::fs::FileSystem;
 
-// peechy schema types: `StringPointer` lives in `bun_core::schema::api` (T0);
-// the route-config pair lives in `bun_options_types::schema::api`.
 mod api {
-    pub(crate) use bun_core::schema::api::StringPointer;
     pub(crate) use bun_options_types::schema::api::{LoadedRouteConfig, RouteConfig};
 }
 
@@ -111,18 +107,6 @@ impl RouteConfig {
             static_dir: Box::from(Self::DEFAULT_STATIC_DIR),
             routes_enabled: false,
             ..Default::default()
-        }
-    }
-
-    pub fn from_loaded_routes(loaded: api::LoadedRouteConfig) -> RouteConfig {
-        RouteConfig {
-            extensions: loaded.extensions,
-            routes_enabled: !loaded.dir.is_empty(),
-            static_dir_enabled: !loaded.static_dir.is_empty(),
-            dir: loaded.dir,
-            asset_prefix_path: loaded.asset_prefix,
-            static_dir: loaded.static_dir,
-            possible_dirs: Box::default(),
         }
     }
 
@@ -228,22 +212,6 @@ impl<'a> Router<'a> {
 
     pub fn get_entry_points(&self) -> &[&'static [u8]] {
         self.routes.list.items_filepath()
-    }
-
-    pub fn get_public_paths(&self) -> &[&'static [u8]] {
-        self.routes.list.items_public_path()
-    }
-
-    pub fn route_index_by_hash(&self, hash: u32) -> Option<usize> {
-        if hash == INDEX_ROUTE_HASH {
-            return self.routes.index_id;
-        }
-
-        self.routes
-            .list
-            .items_hash()
-            .iter()
-            .position(|&h| h == hash)
     }
 
     pub fn get_names(&self) -> &[&'static [u8]] {
@@ -391,10 +359,6 @@ impl RouteIndexList {
     #[inline]
     pub fn items_filepath(&self) -> &[&'static [u8]] {
         &self.filepath
-    }
-    #[inline]
-    pub fn items_public_path(&self) -> &[&'static [u8]] {
-        &self.public_path
     }
     #[inline]
     pub fn items_hash(&self) -> &[u32] {
@@ -940,14 +904,6 @@ impl TinyPtr {
     }
 
     #[inline]
-    pub fn to_string_pointer(self) -> api::StringPointer {
-        api::StringPointer {
-            offset: self.offset() as u32,
-            length: self.len() as u32,
-        }
-    }
-
-    #[inline]
     pub fn eql(a: TinyPtr, b: TinyPtr) -> bool {
         a == b
     }
@@ -1003,9 +959,6 @@ pub struct Route {
 
     pub has_uppercase: bool,
 }
-
-// TODO(b1): inherent assoc types unstable; module-level alias instead.
-pub type RoutePtr = TinyPtr;
 
 impl Route {
     pub const INDEX_ROUTE_NAME: &'static [u8] = b"/";
@@ -1471,20 +1424,6 @@ impl<'a> Match<'a> {
         // SAFETY: producers (`Routes::match_page*`) always set `params` to a
         // live caller-provided list that outlives the `Match`.
         unsafe { (*self.params).len() > 0 }
-    }
-
-    pub fn params_iterator(&self) -> PathnameScanner<'_> {
-        // SAFETY: see `has_params`.
-        PathnameScanner::init(self.pathname, self.name, unsafe { &*self.params })
-    }
-
-    pub fn name_with_basename<'s>(file_path: &'s [u8], dir: &[u8]) -> &'s [u8] {
-        let mut name = file_path;
-        if let Some(i) = strings::index_of(name, dir) {
-            name = &name[i + dir.len()..];
-        }
-
-        &name[0..name.len() - bun_paths::extension(name).len()]
     }
 
     pub fn pathname_without_leading_slash(&self) -> &[u8] {

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -301,8 +301,6 @@ struct RouteIndex {
     name: &'static [u8],
     match_name: &'static [u8],
     filepath: &'static [u8],
-    public_path: &'static [u8],
-    hash: u32,
 }
 
 // TODO(b2-blocked): bun_collections::MultiArrayElement derive — proc-macro not
@@ -318,8 +316,6 @@ pub struct RouteIndexList {
     name: Vec<&'static [u8]>,
     match_name: Vec<&'static [u8]>,
     filepath: Vec<&'static [u8]>,
-    public_path: Vec<&'static [u8]>,
-    hash: Vec<u32>,
 }
 
 impl RouteIndexList {
@@ -328,8 +324,6 @@ impl RouteIndexList {
         self.name.reserve_exact(cap);
         self.match_name.reserve_exact(cap);
         self.filepath.reserve_exact(cap);
-        self.public_path.reserve_exact(cap);
-        self.hash.reserve_exact(cap);
         Ok(())
     }
     pub(crate) fn push(&mut self, item: RouteIndex) {
@@ -337,8 +331,6 @@ impl RouteIndexList {
         self.name.push(item.name);
         self.match_name.push(item.match_name);
         self.filepath.push(item.filepath);
-        self.public_path.push(item.public_path);
-        self.hash.push(item.hash);
     }
     #[inline]
     pub fn len(&self) -> usize {
@@ -359,10 +351,6 @@ impl RouteIndexList {
     #[inline]
     pub fn items_filepath(&self) -> &[&'static [u8]] {
         &self.filepath
-    }
-    #[inline]
-    pub fn items_hash(&self) -> &[u32] {
-        &self.hash
     }
 }
 
@@ -386,7 +374,6 @@ pub struct Routes {
     /// `list.route`). Stored as `NonNull` (not `&'a Route`) so `Routes` claims
     /// no borrow it doesn't actually take; matches `static_` above.
     pub index: Option<NonNull<Route>>,
-    pub index_id: Option<usize>,
 
     // allocator dropped — global mimalloc
     pub config: RouteConfig,
@@ -404,7 +391,6 @@ impl Default for Routes {
             dynamic_len: 0,
             static_: StringHashMap::new(),
             index: None,
-            index_id: Some(0),
             config: RouteConfig::default(),
             client_framework_enabled: false,
         }
@@ -722,17 +708,12 @@ impl<'a> RouteLoader<'a> {
                 index_id = Some(i);
             }
 
-            let (filepath, match_name, public_path) = (
-                route.abs_path.as_bytes(),
-                route.match_name.as_bytes(),
-                route.public_path.as_bytes(),
-            );
+            let (filepath, match_name) =
+                (route.abs_path.as_bytes(), route.match_name.as_bytes());
             route_list.push(RouteIndex {
                 name: route.name,
                 filepath,
                 match_name,
-                public_path,
-                hash: route.full_hash,
                 route,
             });
         }
@@ -758,7 +739,6 @@ impl<'a> RouteLoader<'a> {
             // pointer.
             index: this.index,
             config,
-            index_id,
             client_framework_enabled: false,
         }
     }
@@ -950,11 +930,6 @@ pub struct Route {
 
     pub abs_path: AbsPath,
 
-    /// URL-safe path for the route's transpiled script relative to project's top level directory
-    /// - It might not share a prefix with the absolute path due to symlinks.
-    /// - It has a leading slash
-    pub public_path: Interned,
-
     pub kind: pattern::Tag,
 
     pub has_uppercase: bool,
@@ -1054,11 +1029,11 @@ impl Route {
             let is_index = name.is_empty();
 
             let mut has_uppercase = false;
-            // NOTE: reshaped for borrowck — both arms intern via DirnameStore
-            // (process-lifetime arena → `&'static`), so the post-if bindings are
-            // 'static and the route_file_buf borrow is dropped before the
-            // abs-path block below needs it mutably.
-            let (public_path, name, match_name): (&'static [u8], &'static [u8], &'static [u8]) =
+            // NOTE: reshaped for borrowck — the non-index arm interns via
+            // DirnameStore (process-lifetime arena → `&'static`), so the
+            // post-if bindings are 'static and the route_file_buf borrow is
+            // dropped before the abs-path block below needs it mutably.
+            let (name, match_name): (&'static [u8], &'static [u8]) =
                 if !name.is_empty() {
                     validation_result = match Pattern::validate(&name[1..], log) {
                         Some(v) => v,
@@ -1092,16 +1067,9 @@ impl Route {
 
                     debug_assert!(match_name[0] != b'/');
                     debug_assert!(name[0] == b'/');
-                    (public_path, name, match_name)
+                    (name, match_name)
                 } else {
-                    let dirname_store = FileSystem::instance().dirname_store();
-                    let public_path: &'static [u8] =
-                        dirname_store.append(public_path).expect("unreachable");
-                    (
-                        public_path,
-                        Route::INDEX_ROUTE_NAME,
-                        Route::INDEX_ROUTE_NAME,
-                    )
+                    (Route::INDEX_ROUTE_NAME, Route::INDEX_ROUTE_NAME)
                 };
 
             if abs_path_str.is_empty() {
@@ -1212,14 +1180,13 @@ impl Route {
             #[cfg(all(debug_assertions, windows))]
             {
                 debug_assert!(!strings::index_of_char(name, b'\\').is_some());
-                debug_assert!(!strings::index_of_char(public_path, b'\\').is_some());
                 debug_assert!(!strings::index_of_char(match_name, b'\\').is_some());
                 debug_assert!(!strings::index_of_char(abs_path.as_bytes(), b'\\').is_some());
                 // SAFETY: read-only reborrow; the `&mut` write above is dead.
                 debug_assert!(!strings::index_of_char(unsafe { &*entry }.base(), b'\\').is_some());
             }
 
-            // NOTE: name/match_name/public_path are already `&'static` via
+            // NOTE: name/match_name are already `&'static` via
             // DirnameStore::append above. `entry.base()` borrows the entry (it
             // may be inline-stored for ≤31-byte names); intern it
             // explicitly to get `&'static` without a lifetime transmute.
@@ -1232,7 +1199,6 @@ impl Route {
             Some(Route {
                 name,
                 basename,
-                public_path: Interned::from_static(public_path),
                 match_name: Interned::from_static(match_name),
                 full_hash: if is_index {
                     INDEX_ROUTE_HASH


### PR DESCRIPTION
Dead-code sweep of `src/router/lib.rs`. Each removed item has zero references across `src/`, `build/debug/codegen/`, `src/codegen/`, `src/js/`, and `packages/` (verified with `rg -w`). None are `#[no_mangle]`/`extern "C"`, none appear in any `.classes.ts`, and none are referenced by string name.

| Item | Why it's dead |
|---|---|
| `RouteConfig::from_loaded_routes` | Zig `fromLoadedRoutes`; its only caller was the old dev-server config loader which goes through `from_api` in Rust |
| `Router::get_public_paths` | Zig `getPublicPaths`; no Rust caller |
| `Router::route_index_by_hash` | Zig `routeIndexByHash`; no Rust caller |
| `TinyPtr::to_string_pointer` | Zig `toStringPointer`; no Rust caller |
| `type RoutePtr = TinyPtr` | unused alias (`Route.Ptr` in Zig, moved to module level for the port, never referenced) |
| `Match::params_iterator` | Zig `paramsIterator`; Rust `filesystem_router.rs` builds params via `PathnameScanner` directly |
| `Match::name_with_basename` | Zig `nameWithBasename`; no Rust caller |
| `RouteIndexList::items_public_path` | cascade: only caller was `get_public_paths` |
| `RouteIndexList::items_hash` | cascade: only caller was `route_index_by_hash` (the other `items_hash` hits in the tree are on the watcher's unrelated SoA types) |
| `RouteIndexList.public_path` / `.hash` columns, `RouteIndex.public_path` / `.hash` fields | cascade: write-only once both accessors are gone |
| `Routes.index_id` field | cascade: only reader was `route_index_by_hash`'s `INDEX_ROUTE_HASH` fast path (the `load_all` local of the same name stays; it feeds `dynamic_len`) |
| `Route.public_path` field | cascade: only reader was the `RouteIndex` push in `load_all`; the index-route arm's `DirnameStore` append existed only to populate it |
| `api::StringPointer` re-export, `PathnameScanner` import | cascade: orphaned by `to_string_pointer` / `params_iterator` |

## Verification

- `rg -w <symbol>` across the full repo returns only the definition for each primary item
- `cargo check -p bun_router` and `cargo check -p bun_bundler` pass, including `--target x86_64-pc-windows-msvc` (a `#[cfg(windows)]` debug_assert block was touched)
- `bun run rust:check-all`: `bun_router` checks clean on all 10 targets (the `bun_jsc` build-script failure there is pre-existing on main, unrelated to this change)
- `bun bd` builds
- `bun bd test test/js/bun/util/filesystem_router.test.ts`: 29 pass
- `bun bd test test/bake/framework-router.test.ts`: 35 pass

No test added: this is pure dead-code removal with no observable behavior change, so there is no fail-before case a regression test could cover. The existing router suites above exercise every surviving code path.

Net: -102 lines.

