### PR TITLE
redis: encapsulate EventLoopTimer keep-alive refs in RefCountedTimer

### DIFF
--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -363,9 +363,97 @@ pub struct JSValkeyClient {
     /// `RareData.defaultClientSslCtx()` instead; `tls: false` leaves this null.
     pub _secure: Cell<Option<*mut uws::SslCtx>>,
 
-    pub timer: JsCell<Timer::EventLoopTimer>,
-    pub reconnect_timer: JsCell<Timer::EventLoopTimer>,
+    pub timer: RefCountedTimer,
+    pub reconnect_timer: RefCountedTimer,
     pub ref_count: bun_ptr::RefCount<JSValkeyClient>,
+}
+
+/// Intrusive [`EventLoopTimer`] slot that owns one strong ref on
+/// [`JSValkeyClient`] while armed. `ref_held` mirrors the `ref_()` taken in
+/// [`arm`] so [`disarm`] and [`take_fire_ref`] release it exactly once even
+/// when the fire/close/reconnect paths re-enter each other.
+///
+/// [`EventLoopTimer`]: Timer::EventLoopTimer
+/// [`arm`]: Self::arm
+/// [`disarm`]: Self::disarm
+/// [`take_fire_ref`]: Self::take_fire_ref
+#[repr(C)]
+pub struct RefCountedTimer {
+    // Must be first (offset 0): `dispatch.rs` recovers `*mut JSValkeyClient`
+    // from the fired `*const EventLoopTimer` via `offset_of!(.., timer)`.
+    event_loop_timer: JsCell<Timer::EventLoopTimer>,
+    ref_held: Cell<bool>,
+}
+
+const _: () = assert!(core::mem::offset_of!(RefCountedTimer, event_loop_timer) == 0);
+
+impl RefCountedTimer {
+    fn new(tag: Timer::Tag) -> Self {
+        Self {
+            event_loop_timer: JsCell::new(Timer::EventLoopTimer::init_paused(tag)),
+            ref_held: Cell::new(false),
+        }
+    }
+
+    #[inline]
+    fn state(&self) -> Timer::State {
+        self.event_loop_timer.get().state
+    }
+
+    /// Insert into the VM timer heap to fire after `ms`, taking the keep-alive
+    /// ref if not already held. Disarms first if currently active.
+    fn arm(&self, owner: &JSValkeyClient, ms: u32) {
+        let _guard = owner.ref_scope();
+        if self.state() == Timer::State::ACTIVE {
+            self.disarm(owner);
+        }
+        if ms == 0 {
+            return;
+        }
+        let now = bun_core::Timespec::ms_from_now(
+            bun_core::TimespecMockMode::AllowMockedTime,
+            i64::from(ms),
+        );
+        self.event_loop_timer.with_mut(|t| {
+            t.next = Timer::Timespec {
+                sec: now.sec,
+                nsec: now.nsec,
+            }
+        });
+        let vm = std::ptr::from_ref::<VirtualMachine>(owner.client.get().vm).cast_mut();
+        // SAFETY: `vm` is the live per-thread VM; the timer is an unlinked
+        // field of the boxed `JSValkeyClient` (stable address until disarmed).
+        unsafe { VirtualMachine::timer_insert(vm, self.event_loop_timer.as_ptr()) };
+        if !self.ref_held.replace(true) {
+            owner.ref_();
+        }
+    }
+
+    /// Remove from the VM timer heap and release the keep-alive ref if held.
+    fn disarm(&self, owner: &JSValkeyClient) {
+        if self.state() == Timer::State::ACTIVE {
+            let vm = std::ptr::from_ref::<VirtualMachine>(owner.client.get().vm).cast_mut();
+            // SAFETY: `vm` is the live per-thread VM; the timer is currently
+            // linked into the heap (state == ACTIVE checked above).
+            unsafe { VirtualMachine::timer_remove(vm, self.event_loop_timer.as_ptr()) };
+        }
+        if self.ref_held.replace(false) {
+            // SAFETY: balanced with `arm`'s `ref_()`; `_guard`/caller's ref
+            // keeps `owner` live past this call.
+            unsafe { JSValkeyClient::deref(std::ptr::from_ref(owner).cast_mut()) };
+        }
+    }
+
+    /// Mark fired and hand the keep-alive ref (if held) to the callback scope.
+    /// Returns `None` when no ref was held, so a stray fire cannot over-release.
+    fn take_fire_ref(&self, owner: &JSValkeyClient) -> Option<ScopedRef<JSValkeyClient>> {
+        self.event_loop_timer
+            .with_mut(|t| t.state = Timer::State::FIRED);
+        self.ref_held.replace(false).then(|| {
+            // SAFETY: `arm`'s `ref_()` set `ref_held`; this scope consumes it.
+            unsafe { ScopedRef::adopt(owner.as_ctx_ptr()) }
+        })
+    }
 }
 
 bun_event_loop::impl_timer_owner!(JSValkeyClient;
@@ -734,12 +822,8 @@ impl JSValkeyClient {
             this_value: JsCell::new(JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::default()),
             _secure: Cell::new(None),
-            timer: JsCell::new(Timer::EventLoopTimer::init_paused(
-                Timer::Tag::ValkeyConnectionTimeout,
-            )),
-            reconnect_timer: JsCell::new(Timer::EventLoopTimer::init_paused(
-                Timer::Tag::ValkeyConnectionReconnect,
-            )),
+            timer: RefCountedTimer::new(Timer::Tag::ValkeyConnectionTimeout),
+            reconnect_timer: RefCountedTimer::new(Timer::Tag::ValkeyConnectionReconnect),
         }))
     }
 
@@ -858,12 +942,8 @@ impl JSValkeyClient {
             this_value: JsCell::new(JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::default()),
             _secure: Cell::new(None),
-            timer: JsCell::new(Timer::EventLoopTimer::init_paused(
-                Timer::Tag::ValkeyConnectionTimeout,
-            )),
-            reconnect_timer: JsCell::new(Timer::EventLoopTimer::init_paused(
-                Timer::Tag::ValkeyConnectionReconnect,
-            )),
+            timer: RefCountedTimer::new(Timer::Tag::ValkeyConnectionTimeout),
+            reconnect_timer: RefCountedTimer::new(Timer::Tag::ValkeyConnectionReconnect),
         }))
     }
 
@@ -1063,93 +1143,22 @@ impl JSValkeyClient {
         (get_on_close,   set_on_close   => onclose_get_cached, onclose_set_cached),
     }
 
-    /// Safely add a timer with proper reference counting and event loop keepalive
-    fn add_timer(&self, timer: &JsCell<Timer::EventLoopTimer>, next_timeout_ms: u32) {
-        // `timer` is `&self.timer` or `&self.reconnect_timer`; `JsCell` gives
-        // us closure-scoped `&mut` without an open-coded raw deref.
-        let _guard = self.ref_scope();
-
-        // If the timer is already active, we need to remove it first
-        if timer.get().state == Timer::State::ACTIVE {
-            self.remove_timer(timer);
-        }
-
-        // Skip if timeout is zero
-        if next_timeout_ms == 0 {
-            return;
-        }
-
-        // Set up timer and add to event loop
-        let now = bun_core::Timespec::ms_from_now(
-            bun_core::TimespecMockMode::AllowMockedTime,
-            i64::from(next_timeout_ms),
-        );
-        // `bun_event_loop::Timespec` is a local stub distinct from
-        // `bun_core::Timespec`; convert by fields until they are unified.
-        timer.with_mut(|t| {
-            t.next = Timer::Timespec {
-                sec: now.sec,
-                nsec: now.nsec,
-            }
-        });
-        // `vm.timer.insert(timer)` — `Timer::All` lives in `bun_runtime`;
-        // dispatched through `RuntimeHooks` (see VirtualMachine::timer_insert).
-        let vm = std::ptr::from_ref::<VirtualMachine>(self.client.get().vm).cast_mut();
-        // SAFETY: `vm` is the live per-thread VM; `timer` is an unlinked
-        // `EventLoopTimer` field of the boxed `JSValkeyClient` (stable address
-        // until `remove_timer`/`stop_timers` unlinks it).
-        unsafe { VirtualMachine::timer_insert(vm, timer.as_ptr()) };
-        self.ref_();
-    }
-
-    /// Safely remove a timer with proper reference counting and event loop keepalive
-    fn remove_timer(&self, timer: &JsCell<Timer::EventLoopTimer>) {
-        if timer.get().state == Timer::State::ACTIVE {
-            // Remove the timer from the event loop
-            let vm = std::ptr::from_ref::<VirtualMachine>(self.client.get().vm).cast_mut();
-            // SAFETY: `vm` is the live per-thread VM; `timer` is currently
-            // linked into the heap (state == ACTIVE checked above).
-            unsafe { VirtualMachine::timer_remove(vm, timer.as_ptr()) };
-
-            // self.add_timer() adds a reference to 'self' when the timer is
-            // alive which is balanced here.
-            // SAFETY: balanced with add_timer's ref_(); count stays > 0 so
-            // `&self` remains valid past this call.
-            unsafe { JSValkeyClient::deref(std::ptr::from_ref(self).cast_mut()) };
-        }
-    }
-
     fn reset_connection_timeout(&self) {
-        let interval = self.client.get().get_timeout_interval();
-
-        // First remove existing timer if active
-        if self.timer.get().state == Timer::State::ACTIVE {
-            self.remove_timer(&self.timer);
-        }
-
-        // Add new timer if interval is non-zero
-        if interval > 0 {
-            self.add_timer(&self.timer, interval);
-        }
+        self.timer.arm(self, self.client.get().get_timeout_interval());
     }
 
     pub fn disable_connection_timeout(&self) {
-        if self.timer.get().state == Timer::State::ACTIVE {
-            self.remove_timer(&self.timer);
-        }
-        self.timer.with_mut(|t| t.state = Timer::State::CANCELLED);
+        self.timer.disarm(self);
+        self.timer
+            .event_loop_timer
+            .with_mut(|t| t.state = Timer::State::CANCELLED);
     }
 
     pub fn on_connection_timeout(&self) {
         debug!("onConnectionTimeout");
 
-        // Mark timer as fired
-        self.timer.with_mut(|t| t.state = Timer::State::FIRED);
-
         let _guard = self.ref_scope();
-        // SAFETY: adopts add_timer's keep-alive ref (remove_timer/stop_timers
-        // skip FIRED timers, so this scope is the only releaser).
-        let _timer_ref = unsafe { ScopedRef::adopt(self.as_ctx_ptr()) };
+        let _timer_ref = self.timer.take_fire_ref(self);
         if self.client.get().flags.failed {
             return;
         }
@@ -1197,14 +1206,8 @@ impl JSValkeyClient {
     pub fn on_reconnect_timer(&self) {
         debug!("Reconnect timer fired, attempting to reconnect");
 
-        // Mark timer as fired and store important values before doing any derefs
-        self.reconnect_timer
-            .with_mut(|t| t.state = Timer::State::FIRED);
-
         let _guard = self.ref_scope();
-        // SAFETY: adopts add_timer's keep-alive ref (remove_timer/stop_timers
-        // skip FIRED timers, so this scope is the only releaser).
-        let _timer_ref = unsafe { ScopedRef::adopt(self.as_ctx_ptr()) };
+        let _timer_ref = self.reconnect_timer.take_fire_ref(self);
 
         // Execute reconnection logic
         self.reconnect();
@@ -1387,15 +1390,8 @@ impl JSValkeyClient {
         // sole releaser. The caller holds its own scoped ref, so count > 0.
         let _socket_ref = unsafe { ScopedRef::adopt(self.as_ctx_ptr()) };
 
-        // Schedule reconnection using our safe timer methods
-        if self.reconnect_timer.get().state == Timer::State::ACTIVE {
-            self.remove_timer(&self.reconnect_timer);
-        }
-
-        let delay_ms = self.client.get().get_reconnect_delay();
-        if delay_ms > 0 {
-            self.add_timer(&self.reconnect_timer, delay_ms);
-        }
+        self.reconnect_timer
+            .arm(self, self.client.get().get_reconnect_delay());
     }
 
     // Callback for when Valkey client closes
@@ -1542,13 +1538,8 @@ impl JSValkeyClient {
     }
 
     pub fn stop_timers(&self) {
-        // Use safe timer removal methods to ensure proper reference counting
-        if self.timer.get().state == Timer::State::ACTIVE {
-            self.remove_timer(&self.timer);
-        }
-        if self.reconnect_timer.get().state == Timer::State::ACTIVE {
-            self.remove_timer(&self.reconnect_timer);
-        }
+        self.timer.disarm(self);
+        self.reconnect_timer.disarm(self);
     }
 
     fn connect(&self) -> Result<(), crate::Error> {
@@ -1721,6 +1712,8 @@ impl JSValkeyClient {
             // SAFETY: last ref dropped — sole owner of `*this` (see above).
             let this_ref = unsafe { &*this };
             debug_assert!(this_ref.client.get().socket.is_closed());
+            debug_assert!(!this_ref.timer.ref_held.get());
+            debug_assert!(!this_ref.reconnect_timer.ref_held.get());
             if let Some(s) = this_ref._secure.get() {
                 // SAFETY: SSL_CTX is C-refcounted; this releases our ref.
                 unsafe { boringssl::c::SSL_CTX_free(s) };

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1144,7 +1144,8 @@ impl JSValkeyClient {
     }
 
     fn reset_connection_timeout(&self) {
-        self.timer.arm(self, self.client.get().get_timeout_interval());
+        self.timer
+            .arm(self, self.client.get().get_timeout_interval());
     }
 
     pub fn disable_connection_timeout(&self) {

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isASAN } from "harness";
 import net from "node:net";
 
 // Fuzzer found a heap-use-after-free: connect()'s tls_ctx_failed branch
@@ -41,6 +41,86 @@ test.concurrent("RedisClient survives a failed custom-TLS context without freein
   expect(proc.signalCode).toBeNull();
   expect(exitCode).toBe(0);
 });
+
+// Fuzzer found a heap-use-after-free that survived the ScopedRef refactor:
+// on_connection_timeout's unconditional `ScopedRef::adopt` released a ref the
+// timer no longer held, so the ScopedRef drop at scope end brought the
+// intrusive count to 0 and freed the Box<JSValkeyClient> while the JS wrapper
+// (and the other armed timer) still pointed at it; GC finalize -> stop_timers
+// then read the freed allocation. Repro: server answers HELLO then stops
+// replying, so the connection/idle-timeout and reconnect timers churn against
+// each other under subscribe/close/connect re-entry.
+test.concurrent(
+  "RedisClient survives connection-timeout + reconnect churn against an under-replying server",
+  async () => {
+    const src = `
+    const CRLF = "\\r\\n";
+    const blk = s => "$" + s.length + CRLF + s + CRLF;
+    const HELLO = "%1" + CRLF + blk("proto") + ":3" + CRLF;
+    const sockets = [];
+    const server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        open(s) { s.data = { buf: "" }; sockets.push(s); },
+        data(s, d) {
+          s.data.buf += d.toString("latin1");
+          if (s.data.buf.includes("HELLO")) {
+            s.write(HELLO);
+            s.data.buf = "";
+          }
+          // anything else is ignored (under-replying)
+        },
+        close() {},
+      },
+    });
+    const url = "redis://127.0.0.1:" + server.port;
+    for (let round = 0; round < ${isASAN ? 40 : 120}; round++) {
+      const c = new Bun.RedisClient(url, {
+        autoReconnect: true,
+        connectionTimeout: 1 + (round % 4),
+        idleTimeout: 1 + (round % 5),
+        maxRetries: 2,
+      });
+      c.onconnect = () => {}; c.onclose = () => {};
+      try { await c.connect(); } catch {}
+      try { c.subscribe("ch", () => {}).catch(() => {}); } catch {}
+      try { c.get("k").catch(() => {}); } catch {}
+      await new Promise(r => setTimeout(r, round % 7));
+      if (round % 2) while (sockets.length) try { sockets.pop()?.terminate?.(); } catch {}
+      await new Promise(r => setTimeout(r, round % 5));
+      try { c.close(); } catch {}
+      try { c.connect().catch(() => {}); } catch {}
+      await new Promise(r => setImmediate(r));
+      try { c.close(); } catch {}
+      // Before the fix the backing allocation could already be freed here;
+      // ASAN reports heap-use-after-free on the status read inside this getter.
+      if (typeof c.connected !== "boolean") throw new Error("expected boolean");
+      if (round % 3 === 0) Bun.gc(true);
+    }
+    for (const s of sockets) try { s.terminate?.(); } catch {}
+    server.stop(true);
+    Bun.gc(true);
+    await 1;
+    Bun.gc(true);
+    console.log("OK");
+    process.exit(0);
+  `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+    expect(stdout.trim()).toBe("OK");
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(0);
+  },
+);
 
 // Fuzzer found the same over-release reachable from subscribe() when the
 // socket dies mid-call: upsert_receive_handler's exit guard re-enters


### PR DESCRIPTION
Follow-up to #34714, which fixed the TLS-context over-release path but left the timer path with an unconditional `ScopedRef::adopt`.

## Problem

The fuzzer still produces heap-use-after-free on 99fc2f892c23: `on_connection_timeout`'s `ScopedRef::adopt` drops as the final deref, freeing the `Box<JSValkeyClient>` while the JS wrapper and the other armed `EventLoopTimer` still point at it; GC finalize then reaches `stop_timers` on freed memory.

```
freed by:
    ScopedRef::<JSValkeyClient>::drop
    JSValkeyClient::on_connection_timeout js_valkey.rs:1195
    ...
accessed by:
    <State as PartialEq>::eq
    JSValkeyClient::stop_timers
    JSValkeyClient::finalize
```

The fire callbacks adopt what they assume is `add_timer`'s +1 unconditionally. When the close/reconnect/fail paths re-enter each other and the timer's ref has already been released (or was never taken for that arm), the adopt spends a phantom ref and the count reaches zero under live references.

## Fix

Wrap each timer in a `RefCountedTimer` that tracks whether its keep-alive ref is currently held:

- `arm()` inserts into the timer heap and `ref_()`s the owner iff `ref_held` was false.
- `disarm()` unlinks and `deref()`s iff `ref_held` was true.
- `take_fire_ref()` marks the timer `FIRED` and returns `Some(ScopedRef::adopt(..))` iff `ref_held` was true, otherwise `None`.

So a fire (or stop) path can never release a ref that was not taken, regardless of how the connect/close/timeout callbacks interleave. `deinit()` asserts both flags are clear at count==0. The wrapper is `#[repr(C)]` with the `EventLoopTimer` first so the `from_field_ptr!` container-of recovery in `dispatch.rs` is unchanged (`offset_of` const-asserted).

This also folds away the open-coded `state == ACTIVE` checks and the separate remove-then-add at every call site, so the net diff is -115/+188 with most of the addition being the wrapper itself.

## Verification

```
$ bun bd test test/js/valkey/valkey-gc.test.ts
 8 pass
 0 fail
```

The new test ("connection-timeout + reconnect churn against an under-replying server") exercises the fire/disarm/re-arm interleaving under ASAN but does not reproduce the fuzzer crash deterministically; I could not construct a local sequence that over-releases on the parent commit. The fix is structural: the flag makes phantom release impossible by construction, so fuzzer re-verification against this branch is the intended proof.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey-gc.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (cddda957a)

test/js/valkey/valkey-gc.test.ts:
(pass) RedisClient survives a failed custom-TLS context without freeing the live client [522.76ms]
(pass) custom setter with a foreign receiver throws instead of corrupting the heap [493.89ms]
(pass) RedisClient survives GC after a command throws during argument validation [640.52ms]
(pass) rejects a RESP simple-string reply whose line terminator never arrives [497.23ms]
(pass) RedisClient survives GC across many short-lived instances [738.72ms]
(pass) RedisClient survives connection-timeout + reconnect churn against an under-replying server [1406.40ms]
(pass) RedisClient survives subscribe() + close() against a server that resets the connection [2589.52ms]
(pass) getBuffer replies surviv
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/valkey/valkey-gc.test.ts:
(pass) RedisClient survives a failed custom-TLS context without freeing the live client [16.40ms]
352 |       });
353 |       try {
354 |         await client.send("PING", []);
355 |         expect.unreachable();
356 |       } catch (error: any) {
357 |         expect(error.code).toBe("ERR_REDIS_CONNECTION_CLOSED");
                                 ^
error: expect(received).toBe(expected)

Expected: "ERR_REDIS_CONNECTION_CLOSED"
Received: "ERR_REDIS_INVALID_RESPONSE"

      at <anonymous> (/workspace/bun/test/js/valkey/valkey-gc.test.ts:357:28)
(fail) rejects a RESP simple-string reply whose line terminator never arrives [12.75ms]
(pass) RedisClient survives GC after a command throws during argument validation [15.55ms]
(pass) custom setter with a foreign receiver throws instead of corrupting the heap [14.95ms]
(pass) RedisClient survives GC across many short-lived instances [14.96ms]
(pass) getBuffer replies survive GC with adopted backing stores intact [53.11ms]
(pass) RedisClient survives subscribe() + close() against a server that resets the connection [436.48ms]
(pass) RedisClient survives 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey-gc.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (cddda957a)

test/js/valkey/valkey-gc.test.ts:
(pass) RedisClient survives a failed custom-TLS context without freeing the live client [516.07ms]
(pass) custom setter with a foreign receiver throws instead of corrupting the heap [500.60ms]
(pass) RedisClient survives GC after a command throws during argument validation [645.94ms]
(pass) rejects a RESP simple-string reply whose line terminator never arrives [483.82ms]
(pass) RedisClient survives GC across many short-lived instances [735.06ms]
(pass) RedisClient survives connection-timeout + reconnect churn against an under-replying server [1383.79ms]
(pass) RedisClient survives subscribe() + close() against a server that resets the connection [2606.69ms]
(pass) getBuffer replies surviv
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 711ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/valkey_jsc/js_valkey.rs | 222 ++++++++++++++++++------------------
 test/js/valkey/valkey-gc.test.ts    |  82 ++++++++++++-
 2 files changed, 189 insertions(+), 115 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/runtime/valkey_jsc/js_valkey.rs     14     15      0
test/js/valkey/valkey-gc.test.ts         1      2      0
```

</details>

<!-- robobun:evidence:end -->