### PR TITLE
node:http: deliver a pipelined POST's body when the previous response is still in flight

### DIFF
--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
@@ -703,11 +703,9 @@ static WebCore::JSNodeHTTPResponse* getNodeHTTPResponse(us_socket_t* socket, voi
     if (!ctx || (current && current->m_ctx == ctx)) {
         return current;
     }
-    /* A pipelined request's NodeHTTPResponse is not the connection's
-     * currentResponseObject yet (the in-flight response still owns that slot),
-     * so look it up in the queued list by its native ctx. Returning the wrong
-     * wrapper here would read cached slots (ondata, onabort) off the in-flight
-     * response and drop the pipelined request's body. */
+    /* A pipelined request isn't currentResponseObject yet; find it in the
+     * queued list by native ctx so cached ondata/onabort slots are read off
+     * its own wrapper, not the in-flight response's. */
     Locker locker { serverSocket->m_pipelinedResponsesLock };
     for (auto& entry : serverSocket->m_pipelinedResponses) {
         auto* res = entry.get();

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
@@ -693,21 +693,37 @@ static JSNodeHTTPServerSocket* getNodeHTTPServerSocket(us_socket_t* socket)
 }
 
 template<bool SSL>
-static WebCore::JSNodeHTTPResponse* getNodeHTTPResponse(us_socket_t* socket)
+static WebCore::JSNodeHTTPResponse* getNodeHTTPResponse(us_socket_t* socket, void* ctx)
 {
     auto* serverSocket = getNodeHTTPServerSocket<SSL>(socket);
     if (!serverSocket) {
         return nullptr;
     }
-    return serverSocket->currentResponseObject.get();
+    auto* current = serverSocket->currentResponseObject.get();
+    if (!ctx || (current && current->m_ctx == ctx)) {
+        return current;
+    }
+    /* A pipelined request's NodeHTTPResponse is not the connection's
+     * currentResponseObject yet (the in-flight response still owns that slot),
+     * so look it up in the queued list by its native ctx. Returning the wrong
+     * wrapper here would read cached slots (ondata, onabort) off the in-flight
+     * response and drop the pipelined request's body. */
+    Locker locker { serverSocket->m_pipelinedResponsesLock };
+    for (auto& entry : serverSocket->m_pipelinedResponses) {
+        auto* res = entry.get();
+        if (res && res->m_ctx == ctx) {
+            return res;
+        }
+    }
+    return current;
 }
 
-extern "C" JSC::EncodedJSValue Bun__getNodeHTTPResponseThisValue(bool is_ssl, us_socket_t* socket)
+extern "C" JSC::EncodedJSValue Bun__getNodeHTTPResponseThisValue(bool is_ssl, us_socket_t* socket, void* ctx)
 {
     if (is_ssl) {
-        return JSValue::encode(getNodeHTTPResponse<true>(socket));
+        return JSValue::encode(getNodeHTTPResponse<true>(socket, ctx));
     }
-    return JSValue::encode(getNodeHTTPResponse<false>(socket));
+    return JSValue::encode(getNodeHTTPResponse<false>(socket, ctx));
 }
 
 extern "C" JSC::EncodedJSValue Bun__getNodeHTTPServerSocketThisValue(bool is_ssl, us_socket_t* socket)

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -657,7 +657,10 @@ impl NodeHTTPResponse {
         // mark_request_as_done's clear_and_free does not drop user data).
         let body_pending = self.body_read_state.get() == BodyReadState::Pending
             && !(flags.contains(Flags::IS_DATA_BUFFERED_DURING_PAUSE_LAST)
-                && self.buffered_request_body_data_during_pause.get().is_empty());
+                && self
+                    .buffered_request_body_data_during_pause
+                    .get()
+                    .is_empty());
 
         // A raw 'upgrade'/'connect' tunnel handoff ends the HTTP exchange the
         // same way, except an Upgrade carrying a body keeps parsing as HTTP

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -652,11 +652,12 @@ impl NodeHTTPResponse {
             return false;
         }
 
-        // The body is fully received once either body_read_state left Pending
-        // or its fin was captured during a pause (the LAST flag is set without
-        // transitioning body_read_state).
+        // The body is fully received once body_read_state left Pending, or fin
+        // was captured during a pause and nothing is left in that buffer (so
+        // mark_request_as_done's clear_and_free does not drop user data).
         let body_pending = self.body_read_state.get() == BodyReadState::Pending
-            && !flags.contains(Flags::IS_DATA_BUFFERED_DURING_PAUSE_LAST);
+            && !(flags.contains(Flags::IS_DATA_BUFFERED_DURING_PAUSE_LAST)
+                && self.buffered_request_body_data_during_pause.get().is_empty());
 
         // A raw 'upgrade'/'connect' tunnel handoff ends the HTTP exchange the
         // same way, except an Upgrade carrying a body keeps parsing as HTTP

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -649,15 +649,21 @@ impl NodeHTTPResponse {
             return false;
         }
 
+        // The body is fully received once either body_read_state left Pending
+        // or its fin was captured during a pause (the LAST flag is set without
+        // transitioning body_read_state).
+        let body_pending = self.body_read_state.get() == BodyReadState::Pending
+            && !flags.contains(Flags::IS_DATA_BUFFERED_DURING_PAUSE_LAST);
+
         // A raw 'upgrade'/'connect' tunnel handoff ends the HTTP exchange the
         // same way, except an Upgrade carrying a body keeps parsing as HTTP
         // until the body's fin chunk (the actual tunnel start).
         if flags.contains(Flags::TUNNELED) {
-            return self.body_read_state.get() == BodyReadState::Pending;
+            return body_pending;
         }
 
         if flags.contains(Flags::ENDED) {
-            return self.body_read_state.get() == BodyReadState::Pending;
+            return body_pending;
         }
 
         true

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -188,9 +188,15 @@ pub enum BodyReadState {
 
 unsafe extern "C" {
     // `socket` is the opaque uSockets handle from `AnyResponse::socket()`; C++
-    // only reads its ext slot. Module-private — the sole callers below pass a
-    // live handle, so no caller-side precondition remains.
-    safe fn Bun__getNodeHTTPResponseThisValue(is_ssl: bool, socket: *mut c_void) -> JSValue;
+    // only reads its ext slot. `ctx` is this NodeHTTPResponse's own heap address
+    // so a pipelined response resolves to its own JS wrapper (not the
+    // connection's in-flight `currentResponseObject`). Module-private — the sole
+    // callers below pass a live handle, so no caller-side precondition remains.
+    safe fn Bun__getNodeHTTPResponseThisValue(
+        is_ssl: bool,
+        socket: *mut c_void,
+        ctx: *mut c_void,
+    ) -> JSValue;
     safe fn Bun__getNodeHTTPServerSocketThisValue(is_ssl: bool, socket: *mut c_void) -> JSValue;
 
     // Moves the connection's captured node:http request-trailer section out.
@@ -423,7 +429,11 @@ impl NodeHTTPResponse {
         if flags.contains(Flags::SOCKET_CLOSED) || flags.contains(Flags::UPGRADED) {
             return JSValue::ZERO;
         }
-        Bun__getNodeHTTPResponseThisValue(any_response_is_ssl(&raw), raw.socket().cast())
+        Bun__getNodeHTTPResponseThisValue(
+            any_response_is_ssl(&raw),
+            raw.socket().cast(),
+            (self as *const Self).cast_mut().cast(),
+        )
     }
 
     pub(crate) fn get_server_socket_value(&self) -> JSValue {
@@ -1351,6 +1361,10 @@ impl NodeHTTPResponse {
             || flags.contains(Flags::SOCKET_CLOSED)
             || flags.contains(Flags::ENDED)
             || flags.contains(Flags::UPGRADED)
+            // This request's body is already fully delivered: re-arming onData
+            // would overwrite a pipelined request's userData on the shared
+            // HttpResponseData and route that request's body chunks here.
+            || self.body_read_state.get() != BodyReadState::Pending
         {
             return Ok(JSValue::FALSE);
         }
@@ -1416,6 +1430,10 @@ impl NodeHTTPResponse {
             || flags.contains(Flags::SOCKET_CLOSED)
             || flags.contains(Flags::ENDED)
             || flags.contains(Flags::UPGRADED)
+            // This request's body is already fully delivered: re-arming onData /
+            // onTimeout would overwrite a pipelined request's userData on the
+            // shared HttpResponseData and route that request's body chunks here.
+            || self.body_read_state.get() != BodyReadState::Pending
         {
             return JSValue::FALSE;
         }

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -622,7 +622,10 @@ impl NodeHTTPResponse {
                 || js::on_data_get_cached(this_value).is_none())
         {
             let had_ref = self.body_read_ref.get().has;
-            if !flags.contains(Flags::UPGRADED) && !flags.contains(Flags::SOCKET_CLOSED) {
+            if !flags.contains(Flags::UPGRADED)
+                && !flags.contains(Flags::SOCKET_CLOSED)
+                && !flags.contains(Flags::IS_DATA_BUFFERED_DURING_PAUSE_LAST)
+            {
                 scoped_log!(NodeHTTPResponse, "clearOnData");
                 if let Some(raw_response) = self.raw_response.get() {
                     raw_response.clear_on_data();
@@ -2223,9 +2226,11 @@ impl NodeHTTPResponse {
                 js::on_data_set_cached(this_value, global_object, JSValue::UNDEFINED);
             }
             let flags = self.flags.get();
-            // Only clear the uWS slot while still Pending: once Done, uWS nulled
-            // inStream after fin, so a set slot belongs to a pipelined request.
+            // Only clear the uWS slot while the body is still arriving: once fin
+            // was seen (Done, or buffered-LAST) a set slot is a pipelined
+            // request's. The state is forced to Done below regardless.
             if state == BodyReadState::Pending
+                && !flags.contains(Flags::IS_DATA_BUFFERED_DURING_PAUSE_LAST)
                 && !flags.contains(Flags::SOCKET_CLOSED)
                 && !flags.contains(Flags::UPGRADED)
             {
@@ -2261,7 +2266,8 @@ impl NodeHTTPResponse {
             // defer { if body_read_ref.has { unref } } — moved to tail of this branch.
             match self.body_read_state.get() {
                 BodyReadState::Pending => {
-                    if !flags.contains(Flags::REQUEST_HAS_COMPLETED)
+                    if !flags.contains(Flags::IS_DATA_BUFFERED_DURING_PAUSE_LAST)
+                        && !flags.contains(Flags::REQUEST_HAS_COMPLETED)
                         && !flags.contains(Flags::SOCKET_CLOSED)
                         && !flags.contains(Flags::UPGRADED)
                     {

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -1359,21 +1359,24 @@ impl NodeHTTPResponse {
             || flags.contains(Flags::SOCKET_CLOSED)
             || flags.contains(Flags::ENDED)
             || flags.contains(Flags::UPGRADED)
-            // This request's body is already fully delivered: re-arming onData
-            // would overwrite a pipelined request's userData on the shared
-            // HttpResponseData and route that request's body chunks here.
-            || self.body_read_state.get() != BodyReadState::Pending
         {
             return Ok(JSValue::FALSE);
         }
-        self.update_flags(|f| f.insert(Flags::IS_DATA_BUFFERED_DURING_PAUSE));
-        raw.on_data(on_buffer_paused_shim, self.as_ctx_ptr());
-
         // TODO: figure out why windows is not emitting EOF with UV_DISCONNECT
         #[cfg(not(windows))]
         {
             self.pause_socket();
         }
+        // Only re-arm onData while this request's body is still arriving: once
+        // it is done (or there is none) the write would overwrite a pipelined
+        // request's userData on the shared HttpResponseData.
+        if self.body_read_state.get() != BodyReadState::Pending
+            || flags.contains(Flags::IS_DATA_BUFFERED_DURING_PAUSE_LAST)
+        {
+            return Ok(JSValue::TRUE);
+        }
+        self.update_flags(|f| f.insert(Flags::IS_DATA_BUFFERED_DURING_PAUSE));
+        raw.on_data(on_buffer_paused_shim, self.as_ctx_ptr());
         Ok(JSValue::TRUE)
     }
 
@@ -1428,16 +1431,19 @@ impl NodeHTTPResponse {
             || flags.contains(Flags::SOCKET_CLOSED)
             || flags.contains(Flags::ENDED)
             || flags.contains(Flags::UPGRADED)
-            // This request's body is already fully delivered: re-arming onData /
-            // onTimeout would overwrite a pipelined request's userData on the
-            // shared HttpResponseData and route that request's body chunks here.
-            || self.body_read_state.get() != BodyReadState::Pending
         {
             return JSValue::FALSE;
         }
-        self.set_on_aborted_handler();
-        raw.on_data(on_data_shim, self.as_ctx_ptr());
         self.update_flags(|f| f.remove(Flags::IS_DATA_BUFFERED_DURING_PAUSE));
+        // Only re-arm onData/onTimeout while this body is still arriving: once
+        // done (or fin was buffered) the write would overwrite a pipelined
+        // request's userData on the shared HttpResponseData.
+        if self.body_read_state.get() == BodyReadState::Pending
+            && !flags.contains(Flags::IS_DATA_BUFFERED_DURING_PAUSE_LAST)
+        {
+            self.set_on_aborted_handler();
+            raw.on_data(on_data_shim, self.as_ctx_ptr());
+        }
         let mut result: JSValue = JSValue::TRUE;
 
         if let Some(buffered_data) = self.drain_buffered_request_body_from_pause(global_object) {
@@ -2205,18 +2211,24 @@ impl NodeHTTPResponse {
 
     fn clear_on_data_callback(&self, this_value: JSValue, global_object: &JSGlobalObject) {
         scoped_log!(NodeHTTPResponse, "clearOnDataCallback");
-        if self.body_read_state.get() != BodyReadState::None {
+        let state = self.body_read_state.get();
+        if state != BodyReadState::None {
             if !this_value.is_empty() {
                 js::on_data_set_cached(this_value, global_object, JSValue::UNDEFINED);
             }
             let flags = self.flags.get();
-            if !flags.contains(Flags::SOCKET_CLOSED) && !flags.contains(Flags::UPGRADED) {
+            // Only clear the uWS slot while still Pending: once Done, uWS nulled
+            // inStream after fin, so a set slot belongs to a pipelined request.
+            if state == BodyReadState::Pending
+                && !flags.contains(Flags::SOCKET_CLOSED)
+                && !flags.contains(Flags::UPGRADED)
+            {
                 scoped_log!(NodeHTTPResponse, "clearOnData");
                 if let Some(raw_response) = self.raw_response.get() {
                     raw_response.clear_on_data();
                 }
             }
-            if self.body_read_state.get() != BodyReadState::Done {
+            if state != BodyReadState::Done {
                 self.body_read_state.set(BodyReadState::Done);
             }
         }
@@ -2242,7 +2254,7 @@ impl NodeHTTPResponse {
             js::on_data_set_cached(this_value, global_object, JSValue::UNDEFINED);
             // defer { if body_read_ref.has { unref } } — moved to tail of this branch.
             match self.body_read_state.get() {
-                BodyReadState::Pending | BodyReadState::Done => {
+                BodyReadState::Pending => {
                     if !flags.contains(Flags::REQUEST_HAS_COMPLETED)
                         && !flags.contains(Flags::SOCKET_CLOSED)
                         && !flags.contains(Flags::UPGRADED)
@@ -2254,7 +2266,9 @@ impl NodeHTTPResponse {
                     }
                     self.body_read_state.set(BodyReadState::Done);
                 }
-                BodyReadState::None => {}
+                // Done: uWS nulled inStream after fin; a set slot now belongs
+                // to a pipelined request, so leave it alone.
+                BodyReadState::Done | BodyReadState::None => {}
             }
             if self.body_read_ref.get().has {
                 self.body_read_ref

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -187,11 +187,9 @@ pub enum BodyReadState {
 }
 
 unsafe extern "C" {
-    // `socket` is the opaque uSockets handle from `AnyResponse::socket()`; C++
-    // only reads its ext slot. `ctx` is this NodeHTTPResponse's own heap address
-    // so a pipelined response resolves to its own JS wrapper (not the
-    // connection's in-flight `currentResponseObject`). Module-private — the sole
-    // callers below pass a live handle, so no caller-side precondition remains.
+    // `socket` is the uSockets handle (ext slot read only); `ctx` is this
+    // NodeHTTPResponse's heap address so a pipelined response resolves to its
+    // own wrapper, not the connection's in-flight `currentResponseObject`.
     safe fn Bun__getNodeHTTPResponseThisValue(
         is_ssl: bool,
         socket: *mut c_void,
@@ -432,7 +430,7 @@ impl NodeHTTPResponse {
         Bun__getNodeHTTPResponseThisValue(
             any_response_is_ssl(&raw),
             raw.socket().cast(),
-            (self as *const Self).cast_mut().cast(),
+            self.as_ctx_ptr().cast(),
         )
     }
 

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2798,10 +2798,10 @@ describe("pipelined POST bodies behind an async handler", () => {
   });
 
   it("GET then POST", async () => {
-    await check(
-      "GET /a HTTP/1.1\r\nHost: x\r\n\r\n" + "POST /b HTTP/1.1\r\nHost: x\r\nContent-Length: 3\r\n\r\nxyz",
-      { "/a": "", "/b": "xyz" },
-    );
+    await check("GET /a HTTP/1.1\r\nHost: x\r\n\r\n" + "POST /b HTTP/1.1\r\nHost: x\r\nContent-Length: 3\r\n\r\nxyz", {
+      "/a": "",
+      "/b": "xyz",
+    });
   });
 });
 

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2727,28 +2727,27 @@ it("pipelined responses buffered past the high water mark pause reads on the con
 });
 
 describe("pipelined POST bodies behind an async handler", () => {
-  // Two POSTs arrive in one TCP segment; the first handler defers res.end() so
-  // the second is dispatched while the first response is still in flight. The
-  // second request's 'data'/'end' must still fire, matching Node.
+  // Two POSTs in one TCP segment; the first response is held so the second
+  // is dispatched pipelined. Its 'data'/'end' must still fire, matching Node.
   async function check(payload: string, expected: Record<string, string>) {
     const results: Record<string, string> = {};
     const urls = Object.keys(expected);
     const last = urls[urls.length - 1];
     const { promise, resolve, reject } = Promise.withResolvers<void>();
+    const held: http.ServerResponse[] = [];
     const server = createServer((req, res) => {
       let body = "";
       req.on("data", c => (body += c));
       req.on("end", () => {
         results[req.url!] = body;
+        res.setHeader("Content-Length", "1");
         if (req.url === last) {
-          res.setHeader("Content-Length", "1");
           res.end("x");
           resolve();
         } else {
-          setTimeout(() => {
-            res.setHeader("Content-Length", "1");
-            res.end("x");
-          }, 20);
+          // Held: the response stays in flight so every later request is
+          // dispatched with isPipelinedDispatch = true.
+          held.push(res);
         }
       });
     });
@@ -2761,10 +2760,12 @@ describe("pipelined POST bodies behind an async handler", () => {
       await once(server, "listening");
       const { port } = server.address() as AddressInfo;
       const socket = connect(port, "127.0.0.1", () => socket.write(payload));
-      socket.on("error", () => {});
+      socket.on("error", reject);
       socket.resume();
       await promise;
       expect(results).toEqual(expected);
+      for (const res of held) res.end("x");
+      socket.removeAllListeners("error");
       socket.destroy();
     } finally {
       server.closeAllConnections();

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2726,6 +2726,85 @@ it("pipelined responses buffered past the high water mark pause reads on the con
   }
 });
 
+describe("pipelined POST bodies behind an async handler", () => {
+  // Two POSTs arrive in one TCP segment; the first handler defers res.end() so
+  // the second is dispatched while the first response is still in flight. The
+  // second request's 'data'/'end' must still fire, matching Node.
+  async function check(payload: string, expected: Record<string, string>) {
+    const results: Record<string, string> = {};
+    const urls = Object.keys(expected);
+    const last = urls[urls.length - 1];
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", c => (body += c));
+      req.on("end", () => {
+        results[req.url!] = body;
+        if (req.url === last) {
+          res.setHeader("Content-Length", "1");
+          res.end("x");
+          resolve();
+        } else {
+          setTimeout(() => {
+            res.setHeader("Content-Length", "1");
+            res.end("x");
+          }, 20);
+        }
+      });
+    });
+    server.on("clientError", (err, sock) => {
+      sock.destroy();
+      reject(err);
+    });
+    try {
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const { port } = server.address() as AddressInfo;
+      const socket = connect(port, "127.0.0.1", () => socket.write(payload));
+      socket.on("error", () => {});
+      socket.resume();
+      await promise;
+      expect(results).toEqual(expected);
+      socket.destroy();
+    } finally {
+      server.closeAllConnections();
+      server.close();
+    }
+  }
+
+  it("Content-Length bodies", async () => {
+    await check(
+      "POST /a HTTP/1.1\r\nHost: x\r\nContent-Length: 3\r\n\r\nabc" +
+        "POST /b HTTP/1.1\r\nHost: x\r\nContent-Length: 3\r\n\r\nxyz",
+      { "/a": "abc", "/b": "xyz" },
+    );
+  });
+
+  it("chunked bodies", async () => {
+    await check(
+      "POST /a HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n3\r\nabc\r\n0\r\n\r\n" +
+        "POST /b HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n3\r\nxyz\r\n0\r\n\r\n",
+      { "/a": "abc", "/b": "xyz" },
+    );
+  });
+
+  it("three pipelined POSTs", async () => {
+    await check(
+      "POST /a HTTP/1.1\r\nHost: x\r\nContent-Length: 3\r\n\r\naaa" +
+        "POST /b HTTP/1.1\r\nHost: x\r\nContent-Length: 3\r\n\r\nbbb" +
+        "POST /c HTTP/1.1\r\nHost: x\r\nContent-Length: 3\r\n\r\nccc",
+      { "/a": "aaa", "/b": "bbb", "/c": "ccc" },
+    );
+  });
+
+  it("GET then POST", async () => {
+    await check(
+      "GET /a HTTP/1.1\r\nHost: x\r\n\r\n" + "POST /b HTTP/1.1\r\nHost: x\r\nContent-Length: 3\r\n\r\nxyz",
+      { "/a": "", "/b": "xyz" },
+    );
+  });
+});
+
 it("requireHostHeader still rejects Upgrade-carrying requests that dispatch as normal requests", async () => {
   // The native parser exempts Upgrade requests from the Host check so genuine
   // upgrades can reach the 'upgrade' event, but a request that falls through

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2804,6 +2804,61 @@ describe("pipelined POST bodies behind an async handler", () => {
       "/b": "xyz",
     });
   });
+
+  it("resuming the first request after its fin was buffered during pause", async () => {
+    // /a pauses on its data chunk; its fin is buffered while paused. Resuming
+    // /a after /b is dispatched must not re-arm onData with /a's ctx.
+    const results: Record<string, string> = {};
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    const held: http.ServerResponse[] = [];
+    let resumeA: () => void;
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", c => {
+        body += c;
+        if (req.url === "/a") {
+          req.pause();
+          resumeA = () => req.resume();
+        }
+      });
+      req.on("end", () => {
+        results[req.url!] = body;
+        res.setHeader("Content-Length", "1");
+        if (req.url === "/b") {
+          res.end("x");
+          resolve();
+        } else {
+          held.push(res);
+        }
+      });
+      if (req.url === "/b") queueMicrotask(() => resumeA?.());
+    });
+    server.on("clientError", (err, sock) => {
+      sock.destroy();
+      reject(err);
+    });
+    try {
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const { port } = server.address() as AddressInfo;
+      const socket = connect(port, "127.0.0.1", () =>
+        socket.write(
+          "POST /a HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n3\r\nabc\r\n0\r\n\r\n" +
+            "POST /b HTTP/1.1\r\nHost: x\r\nContent-Length: 3\r\n\r\nxyz",
+        ),
+      );
+      socket.on("error", reject);
+      socket.resume();
+      await promise;
+      expect(results).toEqual({ "/a": "abc", "/b": "xyz" });
+      for (const res of held) res.end("x");
+      socket.removeAllListeners("error");
+      socket.destroy();
+    } finally {
+      server.closeAllConnections();
+      server.close();
+    }
+  });
 });
 
 it("requireHostHeader still rejects Upgrade-carrying requests that dispatch as normal requests", async () => {


### PR DESCRIPTION
A `node:http` server handling two pipelined POSTs in one TCP segment never delivered the second request's body when the first handler deferred `res.end()`:

```js
const server = http.createServer((req, res) => {
  let got = 0;
  req.on('data', c => (got += c.length));
  req.on('end', () => {
    if (req.url === '/a') setTimeout(() => res.end('a'), 50);
    else { res.end('b'); console.log(got); }   // never reached
  });
});
// client writes, in one segment:
// POST /a HTTP/1.1\r\n...Content-Length: 3\r\n\r\nabcPOST /b HTTP/1.1\r\n...Content-Length: 3\r\n\r\nxyz
```

Node v26.3.0 delivers `'data'`/`'end'` for both requests. Bun never fired them for `/b` and the handler hung.

### Cause

uWS has one `HttpResponseData` per connection, so every `inStream`/`userData`/`onTimeout` registration is shared across every request on that connection. Two consequences:

1. `NodeHTTPResponse::get_this_value()` resolved the Rust handle's JS wrapper via the connection's `currentResponseObject`. For a pipelined dispatch that slot still holds the in-flight response's wrapper, so `/b`'s body chunk arriving at `on_data_or_aborted` looked up `ondata` on `/a`'s wrapper (already cleared by `/a`'s `IncomingMessage` auto-destroy) and dropped the bytes.
2. Several teardown and flow-control sites on `/a` re-armed or cleared the shared `inStream`/`userData` after `/a`'s body had left `Pending`: `do_pause`/`do_resume` (reached from `socket.resume()` -> `#resumeSocket`), `set_on_data(undefined)` (from `IncomingMessage._destroy`), and `clear_on_data_callback` (from `mark_request_as_done`). Each would overwrite `/b`'s registration between `/b`'s data chunk and its fin (chunked bodies) or wipe it entirely.

### Fix

- `Bun__getNodeHTTPResponseThisValue` takes the native ctx and matches it against `currentResponseObject` first (the fast path, unchanged for non-pipelined requests) and the `m_pipelinedResponses` queue otherwise.
- `do_pause` / `do_resume` / `set_on_data` / `clear_on_data_callback` only touch the shared `inStream`/`userData` slot while this request's body is still `Pending` (and its fin was not buffered during pause). Once the body is done, uWS already nulled `inStream` after fin, so a set slot belongs to a later request. `pause_socket()` / `resume_socket()` still run so `pausePipelineReads` and the deferred-EOF path are unaffected.

### Verification

New `describe("pipelined POST bodies behind an async handler")` in `node-http.test.ts` covers Content-Length, chunked, three-deep, GET-then-POST, and pause/resume-after-pipelined-dispatch variants. All five time out on `main` and pass with this change; Node v26.3.0 passes them identically.

Also ran `node-http.test.ts` (full), `node-http-transfer-encoding.test.ts`, `node-http-backpressure.test.ts`, `request-smuggling.test.ts`, `http-server-chunking.test.ts`, `hspec.test.ts`, `express.json.test.ts`, `express-body-parser-test.test.ts`, and the upstream `test-http-get-pipeline-problem.js` / `test-http-incoming-pipelined-socket-destroy.js` / `test-http-keep-alive-pipeline-max-requests.js` / `test-http-keep-alive-drop-requests.js` / `test-http-1.0-keep-alive.js` / `test-http-pause.js`. No new failures.

The `do_pause`/`do_resume` guard overlaps with #34740, which needs the same guard for its eager-push model; whichever merges second resolves trivially.