### PR TITLE
bun create: stop busy-waiting on the git futex

### DIFF
--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -2795,7 +2795,7 @@ impl GitHandler {
 
     pub(crate) fn wait() -> bool {
         while SUCCESS.load(Ordering::Acquire) == 0 {
-            let _ = Futex::wait(&SUCCESS, 0, Some(1000));
+            Futex::wait_forever(&SUCCESS, 0);
         }
 
         let outcome = SUCCESS.load(Ordering::Acquire) == 1;

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -1,7 +1,8 @@
 import { spawn, spawnSync } from "bun";
 import { beforeEach, describe, expect, it } from "bun:test";
+import { chmodSync } from "fs";
 import { exists, stat } from "fs/promises";
-import { bunExe, bunEnv as env, tls, tmpdirSync } from "harness";
+import { bunExe, bunEnv as env, isPosix, tempDir, tls, tmpdirSync } from "harness";
 import { once } from "node:events";
 import * as nodetls from "node:tls";
 import { join } from "path";
@@ -170,6 +171,42 @@ it("handles a close-delimited GitHub tarball body split across packets", async (
     for (const s of sockets) s.destroy();
     await new Promise<void>(r => server.close(() => r()));
   }
+});
+
+// GitHandler::wait() used Futex::wait(.., Some(1000)) (1us timeout) in a loop,
+// issuing ~18k futex syscalls/sec while the git thread ran. POSIX-only: stub
+// `git` is a shell script and ru_nvcsw is always 0 on Windows.
+it.skipIf(!isPosix)("does not busy-wait on the futex while git runs", async () => {
+  using dir = tempDir("create-git-futex", {
+    "bin/git": "#!/bin/sh\nsleep 0.5\nexit 0\n",
+    "bun-create/tmpl/index.js": "// hi\n",
+    "bun-create/tmpl/package.json": JSON.stringify({
+      name: "tmpl",
+      version: "1.0.0",
+      dependencies: { localdep: "file:./localdep" },
+    }),
+    "bun-create/tmpl/localdep/package.json": JSON.stringify({ name: "localdep", version: "1.0.0" }),
+  });
+  chmodSync(join(String(dir), "bin", "git"), 0o755);
+
+  const proc = spawnSync({
+    cmd: [bunExe(), "create", "tmpl", join(String(dir), "dest")],
+    cwd: String(dir),
+    env: {
+      ...env,
+      PATH: join(String(dir), "bin") + ":" + process.env.PATH,
+      BUN_CREATE_DIR: join(String(dir), "bun-create"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const stderr = proc.stderr.toString();
+  expect(stderr).not.toContain("error:");
+  expect(stderr).toContain("] git");
+  expect(proc.exitCode).toBe(0);
+  // Before the fix this was ~27,000 over the ~1.5s git wait; after, a few dozen.
+  expect(proc.resourceUsage!.contextSwitches.voluntary).toBeLessThan(2000);
 });
 
 it("should create template from local folder", async () => {


### PR DESCRIPTION
`GitHandler::wait()` in `src/runtime/cli/create_command.rs` was calling `Futex::wait(&SUCCESS, 0, Some(1000))` in a loop. `Futex::wait`'s timeout is in nanoseconds, so this re-armed a 1 microsecond wait for the entire duration of the background `git init`/`add`/`commit`, generating roughly 18k futex syscalls per second on the main thread once `bun install` had returned.

The git thread already stores the result and calls `Futex::wake(&SUCCESS, 1)`, so no timeout is needed; switch to `Futex::wait_forever` and keep the surrounding `while` loop to tolerate spurious wakeups.

### Verification

Local template with a `file:` dependency (so `bun install` returns in ~20 ms) and a stub `git` on `PATH` that does `sleep 0.5`, so the main thread spends ~1.5 s in `GitHandler::wait()`:

| | wall | `ru_nvcsw` |
|---|---|---|
| before | 1509 ms | 27,013 |
| after | 1636 ms (debug+ASAN) | 36 |

The new test asserts `resourceUsage().contextSwitches.voluntary < 2000` for this scenario (POSIX only; the stub `git` is a shell script and `ru_nvcsw` is always 0 on Windows).

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-create.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (653760d58)

test/cli/install/bun-create.test.ts:
(pass) should not crash > ["create"] [110.29ms]
(pass) should not crash > ["create",""] [100.94ms]
(pass) should not crash > ["create","--"] [94.18ms]
(pass) should not crash > ["create","--",""] [100.68ms]
(pass) should not crash > ["create","--help"] [99.58ms]
(pass) should create selected template with @ prefix [491.10ms]
(pass) should create selected template with @ prefix implicit `/create` [485.04ms]
(pass) should create selected template with @ prefix implicit `/create` with version [414.43ms]
(pass) handles a close-delimited GitHub tarball body split across packets [796.53ms]
204 |   const stderr = proc.stderr.toString();
205 |   expect(stderr).not.toContain("error:");
206 |
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (f5781d88b)

test/cli/install/bun-create.test.ts:
(pass) should not crash > ["create"] [4.05ms]
(pass) should not crash > ["create",""] [2.05ms]
(pass) should not crash > ["create","--"] [1.90ms]
(pass) should not crash > ["create","--",""] [1.96ms]
(pass) should not crash > ["create","--help"] [2.23ms]
(pass) should create selected template with @ prefix [88.33ms]
(pass) should create selected template with @ prefix implicit `/create` [52.33ms]
(pass) should create selected template with @ prefix implicit `/create` with version [42.99ms]
(pass) handles a close-delimited GitHub tarball body split across packets [39.92ms]
(pass) does not busy-wait on the futex while git runs [1513.85ms]
Copying files... 

[17.00ms] git

[18.00ms] bun create /tmp/cr8-10WJUPSC/bun-create/test-template

Come hang out in bun's Discord: https://bun.com/discord

Created test-template project successfully

# To get started, run:

  cd test-template
  bun dev

(pass) should create template from local folder [22.83ms]
(pass) should name GitHub in the error when the tarball request gets 503 [18.83ms]
(pass) should name GitHub in the error when the tarball request gets 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-create.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (653760d58)

test/cli/install/bun-create.test.ts:
(pass) should not crash > ["create"] [117.21ms]
(pass) should not crash > ["create",""] [100.06ms]
(pass) should not crash > ["create","--"] [102.36ms]
(pass) should not crash > ["create","--",""] [104.29ms]
(pass) should not crash > ["create","--help"] [107.74ms]
(pass) should create selected template with @ prefix [416.20ms]
(pass) should create selected template with @ prefix implicit `/create` [412.45ms]
(pass) should create selected template with @ prefix implicit `/create` with version [414.28ms]
(pass) handles a close-delimited GitHub tarball body split across packets [788.37ms]
(pass) does not busy-wait on the futex while git runs [1665.16ms]
Copying files... 

[16.00ms] git
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 701ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_alloc v0.0.0 (/workspace/bun/src/bun_alloc)

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/create_command.rs   |  2 +-
 test/cli/install/bun-create.test.ts | 39 ++++++++++++++++++++++++++++++++++++-
 2 files changed, 39 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/runtime/cli/create_command.rs        2      1      0
test/cli/install/bun-create.test.ts      1      5      0
```

</details>

<!-- robobun:evidence:end -->