### PR TITLE
no-orphans: implement the Windows arm (Job Object + parent-process wait)

### DIFF
--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -860,9 +860,9 @@ elide-lines = 10
 
 ### `run.noOrphans` - don't leave orphan processes behind
 
-When `true`, Bun ensures nothing it spawned outlives it. Useful when Bun is launched by a supervisor (Electron, a CI runner, a thin shim) that may be force-killed.
+When `true`, Bun watches the process that spawned it and exits as soon as that parent goes away, even if the parent was force-killed and never got a chance to forward a signal. On its own exit, Bun also terminates every descendant process so nothing it spawned outlives it. Useful when Bun is launched by a supervisor (Electron, a CI runner, a thin shim) that may be force-killed.
 
-On Linux and macOS, Bun watches the process that spawned it and exits as soon as that parent goes away (even if the parent was `SIGKILL`ed and never got a chance to forward a signal), and on its own exit recursively `SIGKILL`s every descendant. On Windows, Bun assigns itself to a kill-on-close Job Object so the kernel terminates every descendant when Bun exits for any reason, including `TerminateProcess`; the parent-watch half is POSIX-only.
+On Linux this uses `prctl(PR_SET_PDEATHSIG)` and a `/proc` descendant walk; on macOS, `EVFILT_PROC`/`NOTE_EXIT` on the event loop's kqueue and a libproc descendant walk; on Windows, a thread-pool wait on the parent's process handle and a kill-on-close Job Object.
 
 Equivalent to the `--no-orphans` CLI flag or the `BUN_FEATURE_FLAG_NO_ORPHANS=1` environment variable.
 

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -860,9 +860,11 @@ elide-lines = 10
 
 ### `run.noOrphans` - don't leave orphan processes behind
 
-When `true`, Bun watches the process that spawned it and exits as soon as that parent goes away — even if the parent was `SIGKILL`ed and never got a chance to forward a signal. On its own exit, Bun also recursively `SIGKILL`s every descendant process so nothing it spawned outlives it. Useful when Bun is launched by a supervisor (Electron, a CI runner, a thin shim) that may be force-killed.
+When `true`, Bun ensures nothing it spawned outlives it. Useful when Bun is launched by a supervisor (Electron, a CI runner, a thin shim) that may be force-killed.
 
-Linux and macOS only (no-op on Windows and other platforms). Equivalent to the `--no-orphans` CLI flag or the `BUN_FEATURE_FLAG_NO_ORPHANS=1` environment variable.
+On Linux and macOS, Bun watches the process that spawned it and exits as soon as that parent goes away (even if the parent was `SIGKILL`ed and never got a chance to forward a signal), and on its own exit recursively `SIGKILL`s every descendant. On Windows, Bun assigns itself to a kill-on-close Job Object so the kernel terminates every descendant when Bun exits for any reason, including `TerminateProcess`; the parent-watch half is POSIX-only.
+
+Equivalent to the `--no-orphans` CLI flag or the `BUN_FEATURE_FLAG_NO_ORPHANS=1` environment variable.
 
 ```toml title="bunfig.toml" icon="settings"
 [run]

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -41,28 +41,83 @@ mod keep_alive;
 pub mod posix_event_loop;
 pub use keep_alive::KeepAlive;
 
-// ParentDeathWatchdog is POSIX-only (uses `libc::pid_t`, `getppid`, signals);
-// Windows handles orphan death via Job Objects in `spawn`. Downstream code
-// calls `install()` / `enable()` / `is_enabled()` unconditionally, so a
-// no-op Windows stub keeps the cross-platform call sites (main.rs, bunfig,
-// run_command, filter_run, dispatch) compiling.
+// ParentDeathWatchdog: POSIX uses `PR_SET_PDEATHSIG` / `EVFILT_PROC` plus an
+// exit-time descendant SIGKILL walk. Windows uses a kill-on-close Job Object
+// self-assigned at `enable()`; children inherit Job membership (nested jobs,
+// Win8+), so when this process exits for any reason, including
+// `TerminateProcess`, the kernel closes our Job handle and terminates every
+// descendant. Downstream code calls `install()` / `enable()` / `is_enabled()`
+// unconditionally, so both arms expose the same surface.
 #[cfg(not(windows))]
 #[path = "ParentDeathWatchdog.rs"]
 pub mod parent_death_watchdog;
 #[cfg(windows)]
 pub mod parent_death_watchdog {
+    use core::sync::atomic::{AtomicBool, Ordering};
+
     use crate::posix_event_loop::EventLoopCtx;
+
     /// Unit struct — `FilePoll.Owner` dispatch needs a real pointee type.
     pub struct ParentDeathWatchdog;
     pub const EXIT_CODE: u8 = 128 + 1;
+
+    static ENABLED: AtomicBool = AtomicBool::new(false);
+
     #[inline]
     pub fn is_enabled() -> bool {
-        false
+        ENABLED.load(Ordering::Relaxed)
     }
+
+    /// Called from `main()` before the CLI starts. Checks the env var and
+    /// enables the watchdog; `bunfig.toml`'s `[run] noOrphans` and the
+    /// `--no-orphans` flag call `enable()` directly later in startup.
     #[inline]
-    pub fn install() {}
-    #[inline]
-    pub fn enable() {}
+    pub fn install() {
+        if !bun_core::env_var::BUN_FEATURE_FLAG_NO_ORPHANS
+            .get()
+            .unwrap_or(false)
+        {
+            return;
+        }
+        enable();
+    }
+
+    /// Idempotent. Creates an anonymous kill-on-close Job Object and assigns
+    /// the current process to it. The handle is intentionally leaked: closing
+    /// it early would fire `KILL_ON_JOB_CLOSE` and terminate us. Best-effort;
+    /// on failure the flag stays set so `run_command` still propagates the env
+    /// var to nested Bun processes.
+    #[cold]
+    #[inline(never)]
+    pub fn enable() {
+        use bun_sys::windows;
+        if ENABLED.swap(true, Ordering::Relaxed) {
+            return;
+        }
+        // SAFETY: Win32 FFI; null args are documented-valid (anonymous Job).
+        unsafe {
+            let job = windows::CreateJobObjectA(core::ptr::null_mut(), core::ptr::null());
+            if job.is_null() {
+                return;
+            }
+            let mut jeli: windows::JOBOBJECT_EXTENDED_LIMIT_INFORMATION = bun_core::ffi::zeroed();
+            jeli.BasicLimitInformation.LimitFlags = windows::JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            if windows::SetInformationJobObject(
+                job,
+                windows::JobObjectExtendedLimitInformation,
+                core::ptr::from_mut(&mut jeli).cast(),
+                core::mem::size_of::<windows::JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            ) == 0
+            {
+                windows::CloseHandle(job);
+                return;
+            }
+            if windows::AssignProcessToJobObject(job, windows::GetCurrentProcess()) == 0 {
+                windows::CloseHandle(job);
+            }
+        }
+    }
+
     #[inline]
     pub fn install_on_event_loop(_handle: EventLoopCtx) {}
     #[inline]

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -42,18 +42,27 @@ pub mod posix_event_loop;
 pub use keep_alive::KeepAlive;
 
 // ParentDeathWatchdog: POSIX uses `PR_SET_PDEATHSIG` / `EVFILT_PROC` plus an
-// exit-time descendant SIGKILL walk. Windows uses a kill-on-close Job Object
-// self-assigned at `enable()`; children inherit Job membership (nested jobs,
-// Win8+), so when this process exits for any reason, including
-// `TerminateProcess`, the kernel closes our Job handle and terminates every
-// descendant. Downstream code calls `install()` / `enable()` / `is_enabled()`
+// exit-time descendant SIGKILL walk. Windows does both halves via Win32:
+//   descendants  — a kill-on-close Job Object self-assigned at `enable()`;
+//                  children inherit Job membership (nested jobs, Win8+), so
+//                  when this process exits for any reason, including
+//                  `TerminateProcess`, the kernel closes our Job handle and
+//                  terminates every descendant.
+//   parent watch — `RegisterWaitForSingleObject` on a `SYNCHRONIZE` handle to
+//                  the original parent; the system thread pool invokes
+//                  `on_parent_exit_cb` → `ExitProcess` when the parent's
+//                  process object is signaled (i.e. has terminated).
+// Downstream code calls `install()` / `enable()` / `is_enabled()`
 // unconditionally, so both arms expose the same surface.
 #[cfg(not(windows))]
 #[path = "ParentDeathWatchdog.rs"]
 pub mod parent_death_watchdog;
 #[cfg(windows)]
 pub mod parent_death_watchdog {
+    use core::ffi::c_void;
     use core::sync::atomic::{AtomicBool, Ordering};
+
+    use bun_sys::windows;
 
     use crate::posix_event_loop::EventLoopCtx;
 
@@ -83,46 +92,125 @@ pub mod parent_death_watchdog {
     }
 
     /// Idempotent. Creates an anonymous kill-on-close Job Object and assigns
-    /// the current process to it. The handle is intentionally leaked: closing
-    /// it early would fire `KILL_ON_JOB_CLOSE` and terminate us. Best-effort;
-    /// on failure the flag stays set so `run_command` still propagates the env
-    /// var to nested Bun processes.
+    /// the current process to it, then registers a thread-pool wait on the
+    /// original parent's process handle. Both handles are intentionally
+    /// leaked for the process lifetime. Best-effort; on any failure the flag
+    /// stays set so `run_command` still propagates the env var to nested Bun
+    /// processes.
     #[cold]
     #[inline(never)]
     pub fn enable() {
-        use bun_sys::windows;
         if ENABLED.swap(true, Ordering::Relaxed) {
             return;
         }
         // SAFETY: Win32 FFI; null args are documented-valid (anonymous Job).
         unsafe {
             let job = windows::CreateJobObjectA(core::ptr::null_mut(), core::ptr::null());
-            if job.is_null() {
-                return;
+            if !job.is_null() {
+                let mut jeli: windows::JOBOBJECT_EXTENDED_LIMIT_INFORMATION =
+                    bun_core::ffi::zeroed();
+                jeli.BasicLimitInformation.LimitFlags = windows::JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+                if windows::SetInformationJobObject(
+                    job,
+                    windows::JobObjectExtendedLimitInformation,
+                    core::ptr::from_mut(&mut jeli).cast(),
+                    core::mem::size_of::<windows::JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+                ) == 0
+                    || windows::AssignProcessToJobObject(job, windows::GetCurrentProcess()) == 0
+                {
+                    windows::CloseHandle(job);
+                }
             }
-            let mut jeli: windows::JOBOBJECT_EXTENDED_LIMIT_INFORMATION = bun_core::ffi::zeroed();
-            jeli.BasicLimitInformation.LimitFlags = windows::JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
-            if windows::SetInformationJobObject(
-                job,
-                windows::JobObjectExtendedLimitInformation,
-                core::ptr::from_mut(&mut jeli).cast(),
-                core::mem::size_of::<windows::JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
-            ) == 0
-            {
-                windows::CloseHandle(job);
-                return;
-            }
-            if windows::AssignProcessToJobObject(job, windows::GetCurrentProcess()) == 0 {
-                windows::CloseHandle(job);
-            }
+
+            arm_parent_watch();
         }
+    }
+
+    /// Open a `SYNCHRONIZE` handle on the creating process and register a
+    /// one-shot thread-pool wait on it. Skipped if the parent is already gone
+    /// or the ppid was recycled before we could open it.
+    unsafe fn arm_parent_watch() {
+        // SAFETY: pure FFI; libuv reads `InheritedFromUniqueProcessId` via
+        // `NtQueryInformationProcess`, no loop state required.
+        let ppid = unsafe { windows::libuv::uv_os_getppid() };
+        if ppid <= 0 {
+            return;
+        }
+        // SAFETY: Win32 FFI; by-value args, failure → NULL.
+        let parent = unsafe { windows::OpenProcess(windows::SYNCHRONIZE, 0, ppid as u32) };
+        if parent.is_null() {
+            return;
+        }
+        // PID-reuse guard: `InheritedFromUniqueProcessId` is frozen at our
+        // creation, so if the creator already exited and its PID was reused we
+        // just opened an unrelated process. A real parent's creation time is
+        // strictly earlier than ours; a reused PID's is not.
+        if !is_plausible_parent(parent) {
+            // SAFETY: `parent` is a valid handle we just opened.
+            unsafe { windows::CloseHandle(parent) };
+            return;
+        }
+        let mut wait: windows::HANDLE = core::ptr::null_mut();
+        // SAFETY: `&mut wait` is a valid out-param; `parent` is a valid
+        // waitable handle; `on_parent_exit_cb` has the `WAITORTIMERCALLBACK`
+        // ABI; `Context` is unused.
+        if unsafe {
+            windows::RegisterWaitForSingleObject(
+                &raw mut wait,
+                parent,
+                on_parent_exit_cb,
+                core::ptr::null_mut(),
+                windows::INFINITE,
+                windows::WT_EXECUTEONLYONCE,
+            )
+        } == 0
+        {
+            // SAFETY: `parent` is a valid handle we just opened.
+            unsafe { windows::CloseHandle(parent) };
+        }
+    }
+
+    fn is_plausible_parent(parent: windows::HANDLE) -> bool {
+        let Some(parent_created) = creation_time(parent) else {
+            return false;
+        };
+        let Some(self_created) = creation_time(windows::GetCurrentProcess()) else {
+            return true;
+        };
+        parent_created < self_created
+    }
+
+    fn creation_time(h: windows::HANDLE) -> Option<u64> {
+        let mut t: [windows::FILETIME; 4] = bun_core::ffi::zeroed();
+        // SAFETY: `h` is either the pseudo-handle or a handle we opened; out
+        // params are valid `FILETIME` slots.
+        if unsafe {
+            windows::GetProcessTimes(
+                h,
+                &raw mut t[0],
+                &raw mut t[1],
+                &raw mut t[2],
+                &raw mut t[3],
+            )
+        } == 0
+        {
+            return None;
+        }
+        Some((u64::from(t[0].dwHighDateTime) << 32) | u64::from(t[0].dwLowDateTime))
+    }
+
+    /// Thread-pool callback: the parent's process object signaled. Matches the
+    /// Linux `PR_SET_PDEATHSIG` SIGKILL path (hard exit, no Rust-side
+    /// unwinding); the Job Object reaps descendants when our handles close.
+    unsafe extern "system" fn on_parent_exit_cb(_ctx: *mut c_void, _timed_out: windows::BOOLEAN) {
+        windows::kernel32::ExitProcess(EXIT_CODE as u32);
     }
 
     #[inline]
     pub fn install_on_event_loop(_handle: EventLoopCtx) {}
     #[inline]
     pub fn on_parent_exit(_this: &mut ParentDeathWatchdog) {
-        debug_assert!(false, "ParentDeathWatchdog poll on Windows");
+        debug_assert!(false, "ParentDeathWatchdog FilePoll on Windows");
     }
 }
 pub use parent_death_watchdog as ParentDeathWatchdog;

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -105,6 +105,12 @@ pub mod parent_death_watchdog {
         }
         // SAFETY: Win32 FFI; null args are documented-valid (anonymous Job).
         unsafe {
+            // Export so a nested Bun spawned via `Bun.spawn([process.execPath,
+            // ...])` self-arms its own Job and parent-watch (POSIX parity).
+            let _ = windows::SetEnvironmentVariableA(
+                c"BUN_FEATURE_FLAG_NO_ORPHANS".as_ptr().cast(),
+                c"1".as_ptr().cast(),
+            );
             let job = windows::CreateJobObjectA(core::ptr::null_mut(), core::ptr::null());
             if !job.is_null() {
                 let mut jeli: windows::JOBOBJECT_EXTENDED_LIMIT_INFORMATION =

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -126,29 +126,35 @@ pub mod parent_death_watchdog {
         }
     }
 
-    /// Open a `SYNCHRONIZE` handle on the creating process and register a
-    /// one-shot thread-pool wait on it. Skipped if the parent is already gone
-    /// or the ppid was recycled before we could open it.
+    /// Open a handle on the creating process and register a one-shot
+    /// thread-pool wait on it. If the creator is already gone (OpenProcess
+    /// fails, or the PID was recycled), exit immediately, matching the POSIX
+    /// race branches in `ParentDeathWatchdog.rs`.
     unsafe fn arm_parent_watch() {
-        // SAFETY: pure FFI; libuv reads `InheritedFromUniqueProcessId` via
-        // `NtQueryInformationProcess`, no loop state required.
-        let ppid = unsafe { windows::libuv::uv_os_getppid() };
-        if ppid <= 0 {
+        let ppid = getppid();
+        if ppid == 0 {
             return;
         }
-        // SAFETY: Win32 FFI; by-value args, failure → NULL.
-        let parent = unsafe { windows::OpenProcess(windows::SYNCHRONIZE, 0, ppid as u32) };
-        if parent.is_null() {
-            return;
-        }
+        // SAFETY: Win32 FFI; by-value args, failure → NULL. SYNCHRONIZE for
+        // the wait, PROCESS_QUERY_LIMITED_INFORMATION for `GetProcessTimes`.
+        let parent = unsafe {
+            windows::OpenProcess(
+                windows::SYNCHRONIZE | windows::PROCESS_QUERY_LIMITED_INFORMATION,
+                0,
+                ppid,
+            )
+        };
         // PID-reuse guard: `InheritedFromUniqueProcessId` is frozen at our
         // creation, so if the creator already exited and its PID was reused we
-        // just opened an unrelated process. A real parent's creation time is
-        // strictly earlier than ours; a reused PID's is not.
-        if !is_plausible_parent(parent) {
-            // SAFETY: `parent` is a valid handle we just opened.
-            unsafe { windows::CloseHandle(parent) };
-            return;
+        // just opened an unrelated process. A real creator's creation time is
+        // no later than ours; a reused PID's is strictly later. Either outcome
+        // here means the original parent is gone.
+        if parent.is_null() || !is_original_parent(parent) {
+            if !parent.is_null() {
+                // SAFETY: `parent` is a valid handle we just opened.
+                unsafe { windows::CloseHandle(parent) };
+            }
+            windows::kernel32::ExitProcess(EXIT_CODE as u32);
         }
         let mut wait: windows::HANDLE = core::ptr::null_mut();
         // SAFETY: `&mut wait` is a valid out-param; `parent` is a valid
@@ -170,14 +176,36 @@ pub mod parent_death_watchdog {
         }
     }
 
-    fn is_plausible_parent(parent: windows::HANDLE) -> bool {
+    /// `InheritedFromUniqueProcessId` via direct ntdll call. Not
+    /// `uv_os_getppid`: libuv loads `NtQueryInformationProcess` lazily in
+    /// `uv__winapi_init`, and `enable()` runs from `main()` before that.
+    fn getppid() -> u32 {
+        // SAFETY: out-param is a valid `PROCESS_BASIC_INFORMATION`; the pseudo
+        // handle needs no access rights.
+        unsafe {
+            let mut pbi: windows::PROCESS_BASIC_INFORMATION = bun_core::ffi::zeroed_unchecked();
+            let rc = windows::ntdll::NtQueryInformationProcess(
+                windows::GetCurrentProcess(),
+                windows::ProcessBasicInformation,
+                core::ptr::from_mut(&mut pbi).cast(),
+                core::mem::size_of::<windows::PROCESS_BASIC_INFORMATION>() as u32,
+                core::ptr::null_mut(),
+            );
+            if !windows::NT_SUCCESS(rc) {
+                return 0;
+            }
+            pbi.InheritedFromUniqueProcessId as u32
+        }
+    }
+
+    fn is_original_parent(parent: windows::HANDLE) -> bool {
         let Some(parent_created) = creation_time(parent) else {
             return false;
         };
         let Some(self_created) = creation_time(windows::GetCurrentProcess()) else {
             return true;
         };
-        parent_created < self_created
+        parent_created <= self_created
     }
 
     fn creation_time(h: windows::HANDLE) -> Option<u64> {

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -134,9 +134,13 @@ pub mod parent_death_watchdog {
 
     /// Open a handle on the creating process and register a one-shot
     /// thread-pool wait on it. If the creator is already gone (OpenProcess
-    /// fails, or the PID was recycled), exit immediately, matching the POSIX
-    /// race branches in `ParentDeathWatchdog.rs`.
+    /// reports no such PID, or the PID was recycled), exit immediately,
+    /// matching the POSIX race branches in `ParentDeathWatchdog.rs`. If the
+    /// creator exists but its DACL denies us (e.g. a SYSTEM service spawned
+    /// us via `CreateProcessAsUser`), skip the parent watch best-effort; the
+    /// Job Object half already covers descendants.
     unsafe fn arm_parent_watch() {
+        const ERROR_INVALID_PARAMETER: u32 = 87;
         let ppid = getppid();
         if ppid == 0 {
             return;
@@ -150,16 +154,19 @@ pub mod parent_death_watchdog {
                 ppid,
             )
         };
+        if parent.is_null() {
+            if windows::GetLastError() == ERROR_INVALID_PARAMETER {
+                windows::kernel32::ExitProcess(EXIT_CODE as u32);
+            }
+            return;
+        }
         // PID-reuse guard: `InheritedFromUniqueProcessId` is frozen at our
         // creation, so if the creator already exited and its PID was reused we
         // just opened an unrelated process. A real creator's creation time is
-        // no later than ours; a reused PID's is strictly later. Either outcome
-        // here means the original parent is gone.
-        if parent.is_null() || !is_original_parent(parent) {
-            if !parent.is_null() {
-                // SAFETY: `parent` is a valid handle we just opened.
-                unsafe { windows::CloseHandle(parent) };
-            }
+        // no later than ours; a reused PID's is strictly later.
+        if !is_original_parent(parent) {
+            // SAFETY: `parent` is a valid handle we just opened.
+            unsafe { windows::CloseHandle(parent) };
             windows::kernel32::ExitProcess(EXIT_CODE as u32);
         }
         let mut wait: windows::HANDLE = core::ptr::null_mut();

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -107,9 +107,9 @@ pub mod parent_death_watchdog {
         unsafe {
             // Export so a nested Bun spawned via `Bun.spawn([process.execPath,
             // ...])` self-arms its own Job and parent-watch (POSIX parity).
-            let _ = windows::SetEnvironmentVariableA(
-                c"BUN_FEATURE_FLAG_NO_ORPHANS".as_ptr().cast(),
-                c"1".as_ptr().cast(),
+            let _ = windows::SetEnvironmentVariableW(
+                bun_core::w!("BUN_FEATURE_FLAG_NO_ORPHANS\0").as_ptr(),
+                bun_core::w!("1\0").as_ptr(),
             );
             let job = windows::CreateJobObjectA(core::ptr::null_mut(), core::ptr::null());
             if !job.is_null() {

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -327,7 +327,7 @@ pub(crate) const AUTO_OR_RUN_PARAMS: &[ParamType] = &[
         "-b, --bun                         Force a script or package to use Bun's runtime instead of Node.js (via symlinking node)"
     ),
     parse_param!(
-        "--no-orphans                      Kill every descendant when Bun exits; on POSIX also exit when the parent process dies."
+        "--no-orphans                      Exit when the parent process dies, and on exit kill every descendant."
     ),
     parse_param!(
         "--shell <STR>                     Control the shell used for package.json scripts. Supports either 'bun' or 'system'"
@@ -552,7 +552,7 @@ pub(crate) const BUILD_PARAMS: &[ParamType] =
 // TODO: update test completions
 pub(crate) const TEST_ONLY_PARAMS: &[ParamType] = &[
     parse_param!(
-        "--no-orphans                     Kill every descendant when Bun exits; on POSIX also exit when the parent process dies."
+        "--no-orphans                     Exit when the parent process dies, and on exit kill every descendant."
     ),
     parse_param!(
         "--timeout <NUMBER>               Set the per-test timeout in milliseconds, default is 5000."

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -327,7 +327,7 @@ pub(crate) const AUTO_OR_RUN_PARAMS: &[ParamType] = &[
         "-b, --bun                         Force a script or package to use Bun's runtime instead of Node.js (via symlinking node)"
     ),
     parse_param!(
-        "--no-orphans                      Exit when the parent process dies, and on exit SIGKILL every descendant. Linux/macOS only."
+        "--no-orphans                      Kill every descendant when Bun exits; on POSIX also exit when the parent process dies."
     ),
     parse_param!(
         "--shell <STR>                     Control the shell used for package.json scripts. Supports either 'bun' or 'system'"
@@ -552,7 +552,7 @@ pub(crate) const BUILD_PARAMS: &[ParamType] =
 // TODO: update test completions
 pub(crate) const TEST_ONLY_PARAMS: &[ParamType] = &[
     parse_param!(
-        "--no-orphans                     Exit when the parent process dies, and on exit SIGKILL every descendant. Linux/macOS only."
+        "--no-orphans                     Kill every descendant when Bun exits; on POSIX also exit when the parent process dies."
     ),
     parse_param!(
         "--timeout <NUMBER>               Set the per-test timeout in milliseconds, default is 5000."

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -3438,6 +3438,8 @@ pub use bun_windows_sys::externs::CreateJobObjectA;
 
 pub use bun_windows_sys::externs::AssignProcessToJobObject;
 
+pub use bun_windows_sys::externs::GetCurrentProcess;
+
 pub use bun_windows_sys::externs::ResumeThread;
 
 // Job Object structures + JOBOBJECTINFOCLASS consts — canonical definitions

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -3442,7 +3442,7 @@ pub use bun_windows_sys::externs::GetCurrentProcess;
 
 pub use bun_windows_sys::externs::{
     PROCESS_BASIC_INFORMATION, ProcessBasicInformation, RegisterWaitForSingleObject,
-    SetEnvironmentVariableA, WAITORTIMERCALLBACK, WT_EXECUTEONLYONCE,
+    SetEnvironmentVariableW, WAITORTIMERCALLBACK, WT_EXECUTEONLYONCE,
 };
 
 pub use bun_windows_sys::externs::ResumeThread;

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -3442,7 +3442,7 @@ pub use bun_windows_sys::externs::GetCurrentProcess;
 
 pub use bun_windows_sys::externs::{
     PROCESS_BASIC_INFORMATION, ProcessBasicInformation, RegisterWaitForSingleObject,
-    WAITORTIMERCALLBACK, WT_EXECUTEONLYONCE,
+    SetEnvironmentVariableA, WAITORTIMERCALLBACK, WT_EXECUTEONLYONCE,
 };
 
 pub use bun_windows_sys::externs::ResumeThread;

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -3441,7 +3441,8 @@ pub use bun_windows_sys::externs::AssignProcessToJobObject;
 pub use bun_windows_sys::externs::GetCurrentProcess;
 
 pub use bun_windows_sys::externs::{
-    RegisterWaitForSingleObject, WAITORTIMERCALLBACK, WT_EXECUTEONLYONCE,
+    PROCESS_BASIC_INFORMATION, ProcessBasicInformation, RegisterWaitForSingleObject,
+    WAITORTIMERCALLBACK, WT_EXECUTEONLYONCE,
 };
 
 pub use bun_windows_sys::externs::ResumeThread;

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -3440,6 +3440,10 @@ pub use bun_windows_sys::externs::AssignProcessToJobObject;
 
 pub use bun_windows_sys::externs::GetCurrentProcess;
 
+pub use bun_windows_sys::externs::{
+    RegisterWaitForSingleObject, WAITORTIMERCALLBACK, WT_EXECUTEONLYONCE,
+};
+
 pub use bun_windows_sys::externs::ResumeThread;
 
 // Job Object structures + JOBOBJECTINFOCLASS consts — canonical definitions

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -1468,6 +1468,8 @@ unsafe extern "system" {
 
     pub fn GetHostNameW(lpBuffer: PWSTR, nSize: c_int) -> BOOL;
 
+    pub fn SetEnvironmentVariableA(lpName: LPCSTR, lpValue: LPCSTR) -> BOOL;
+
     pub fn GetTempPathW(
         nBufferLength: DWORD, // [in]
         lpBuffer: LPCWSTR,    // [out]

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -636,6 +636,16 @@ pub mod ntdll {
         /// linking kernel32 in the standalone PE.
         pub fn RtlExitUserProcess(ExitStatus: u32) -> !;
 
+        /// `NtQueryInformationProcess` (`winternl.h`). With
+        /// `ProcessBasicInformation` (0), fills a [`PROCESS_BASIC_INFORMATION`].
+        pub fn NtQueryInformationProcess(
+            ProcessHandle: HANDLE,
+            ProcessInformationClass: ULONG,
+            ProcessInformation: *mut c_void,
+            ProcessInformationLength: ULONG,
+            ReturnLength: *mut ULONG,
+        ) -> NTSTATUS;
+
         pub fn NtReadFile(
             FileHandle: HANDLE,
             Event: HANDLE,
@@ -1514,6 +1524,20 @@ pub type WAITORTIMERCALLBACK =
     unsafe extern "system" fn(lpParameter: LPVOID, TimerOrWaitFired: BOOLEAN);
 /// `WT_EXECUTEONLYONCE` (`winnt.h`) — fire once; caller does not unregister.
 pub const WT_EXECUTEONLYONCE: ULONG = 0x0000_0008;
+
+/// `PROCESS_BASIC_INFORMATION` (`winternl.h`). Only
+/// `InheritedFromUniqueProcessId` is read; the rest are layout padding.
+#[repr(C)]
+pub struct PROCESS_BASIC_INFORMATION {
+    pub ExitStatus: NTSTATUS,
+    pub PebBaseAddress: *mut c_void,
+    pub AffinityMask: usize,
+    pub BasePriority: i32,
+    pub UniqueProcessId: usize,
+    pub InheritedFromUniqueProcessId: usize,
+}
+/// `PROCESSINFOCLASS::ProcessBasicInformation` (`winternl.h`).
+pub const ProcessBasicInformation: ULONG = 0;
 
 /// `JOBOBJECT_ASSOCIATE_COMPLETION_PORT` (`winnt.h`).
 #[repr(C)]

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -1508,6 +1508,13 @@ pub const JobObjectExtendedLimitInformation: DWORD = 9;
 /// last job handle closes.
 pub const JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE: DWORD = 0x0000_2000;
 
+/// `WAITORTIMERCALLBACK` (`winnt.h`) — thread-pool callback for
+/// `RegisterWaitForSingleObject`. `TimerOrWaitFired` is `TRUE` on timeout.
+pub type WAITORTIMERCALLBACK =
+    unsafe extern "system" fn(lpParameter: LPVOID, TimerOrWaitFired: BOOLEAN);
+/// `WT_EXECUTEONLYONCE` (`winnt.h`) — fire once; caller does not unregister.
+pub const WT_EXECUTEONLYONCE: ULONG = 0x0000_0008;
+
 /// `JOBOBJECT_ASSOCIATE_COMPLETION_PORT` (`winnt.h`).
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -1862,6 +1869,19 @@ unsafe extern "system" {
         out_lpExitTime: *mut FILETIME,
         out_lpKernelTime: *mut FILETIME,
         out_lpUserTime: *mut FILETIME,
+    ) -> BOOL;
+
+    /// `RegisterWaitForSingleObject` (`winbase.h`). Queues `Callback` to the
+    /// system thread pool once `hObject` is signaled (or `dwMilliseconds`
+    /// elapses). Returns non-zero on success; `*phNewWaitObject` receives the
+    /// wait handle.
+    pub fn RegisterWaitForSingleObject(
+        phNewWaitObject: *mut HANDLE,
+        hObject: HANDLE,
+        Callback: WAITORTIMERCALLBACK,
+        Context: LPVOID,
+        dwMilliseconds: ULONG,
+        dwFlags: ULONG,
     ) -> BOOL;
 
     pub fn GetFileAttributesExW(

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -1468,7 +1468,7 @@ unsafe extern "system" {
 
     pub fn GetHostNameW(lpBuffer: PWSTR, nSize: c_int) -> BOOL;
 
-    pub fn SetEnvironmentVariableA(lpName: LPCSTR, lpValue: LPCSTR) -> BOOL;
+    pub fn SetEnvironmentVariableW(lpName: LPCWSTR, lpValue: LPCWSTR) -> BOOL;
 
     pub fn GetTempPathW(
         nBufferLength: DWORD, // [in]

--- a/test/cli/run/no-orphans.test.ts
+++ b/test/cli/run/no-orphans.test.ts
@@ -1029,7 +1029,9 @@ async function spawnTreeWindows(argv: string[], extraEnv: Record<string, string>
     leafPid,
     async reap() {
       if (leafPid > 0 && isAlive(leafPid)) {
-        try { process.kill(leafPid, "SIGKILL"); } catch {}
+        try {
+          process.kill(leafPid, "SIGKILL");
+        } catch {}
         await waitUntilDead(leafPid, 2000);
       }
       dir[Symbol.dispose]();

--- a/test/cli/run/no-orphans.test.ts
+++ b/test/cli/run/no-orphans.test.ts
@@ -973,102 +973,103 @@ test.concurrent.skipIf(!isSupported || !hasPerl)(
 );
 
 // Windows: --no-orphans self-assigns to a kill-on-close Job Object. Children
-// inherit Job membership, so when Bun is TerminateProcess'd the kernel closes
-// the Job handle and terminates every descendant. No sh supervisor layer —
-// the test kills Bun directly and observes the grandchild.
-async function spawnTreeWindows(noOrphans: boolean) {
-  const env: Record<string, string> = { ...bunEnv };
-  delete env.BUN_FEATURE_FLAG_NO_ORPHANS;
+// inherit Job membership (nested jobs, Win8+), so when Bun is
+// TerminateProcess'd the kernel closes the Job handle and terminates every
+// descendant.
+//
+// libuv's uv_spawn already maintains its own kill-on-close job, but with
+// JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK so only processes libuv explicitly
+// assigns are covered — anything spawned *by* those children (cmd.exe →
+// tool, npm script → compiler, etc.) breaks away silently and survives. The
+// --no-orphans job omits SILENT_BREAKAWAY so membership is inherited
+// recursively.
+//
+// Tree under test: test → bun → cmd.exe → leaf bun. cmd.exe is the non-libuv
+// link: it spawns the leaf via plain CreateProcess, so the leaf escapes
+// libuv's job but not the --no-orphans job. The leaf writes its pid to a file
+// so the test can observe it after cmd.exe's stdout pipe is torn down.
+async function spawnTreeWindows(argv: string[], extraEnv: Record<string, string>) {
+  // No `cwd` anywhere in the chain: the leaf must not hold an open handle on
+  // the tempDir (CWD lock) or the negative test's cleanup races the rm.
+  const dir = tempDir("no-orphans-win", {
+    "leaf.js": `
+      require("fs").writeFileSync(process.env.PIDFILE, String(process.pid));
+      setInterval(()=>{}, 1000);
+    `,
+    "outer.js": `
+      Bun.spawn({
+        cmd: ["cmd.exe", "/d", "/c", process.env.BAT],
+        stdio: ["ignore", "ignore", "ignore"],
+      });
+      setInterval(()=>{}, 1000);
+    `,
+    // .bat avoids cmd /c's quote-stripping rules around a quoted exe + arg.
+    "run.bat": `@"${bunExe()}" "%~dp0leaf.js"\r\n`,
+  });
+  const pidfile = `${dir}\\leaf.pid`;
+  const env: Record<string, string> = { ...bunEnv, ...extraEnv, PIDFILE: pidfile, BAT: `${dir}\\run.bat` };
+  if (!("BUN_FEATURE_FLAG_NO_ORPHANS" in extraEnv)) delete env.BUN_FEATURE_FLAG_NO_ORPHANS;
   const bun = Bun.spawn({
-    cmd: [bunExe(), ...(noOrphans ? ["--no-orphans"] : []), `${String(fixture)}/child.js`],
+    cmd: [bunExe(), ...argv, `${dir}\\outer.js`],
     env,
-    cwd: String(fixture),
-    stdout: "pipe",
+    stdout: "ignore",
     stderr: "ignore",
   });
-  const reader = bun.stdout.getReader();
-  const decoder = new TextDecoder();
-  let line = "";
-  while (!line.includes("\n")) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    line += decoder.decode(value, { stream: true });
+  const deadline = Date.now() + 15000;
+  let leafPid = 0;
+  while (leafPid === 0 && Date.now() < deadline) {
+    try {
+      const t = await Bun.file(pidfile).text();
+      if (t.length > 0) leafPid = Number(t.trim());
+    } catch {}
+    if (leafPid === 0) await sleep(25);
   }
-  reader.releaseLock();
-  const [bunPid, , grandchildPid] = line.trim().split(" ").map(Number);
-  expect(bunPid).toBe(bun.pid);
-  expect(grandchildPid).toBeGreaterThan(0);
-  return { bun, grandchildPid };
+  return {
+    bun,
+    leafPid,
+    async reap() {
+      if (leafPid > 0 && isAlive(leafPid)) {
+        try { process.kill(leafPid, "SIGKILL"); } catch {}
+        await waitUntilDead(leafPid, 2000);
+      }
+      dir[Symbol.dispose]();
+    },
+  };
 }
 
 test.concurrent.skipIf(!isWindows)(
-  "windows: without --no-orphans, grandchild survives TerminateProcess on Bun",
+  "windows: without --no-orphans, a cmd.exe-spawned descendant survives TerminateProcess on Bun",
   async () => {
-    const { bun, grandchildPid } = await spawnTreeWindows(false);
-    expect(isAlive(grandchildPid)).toBe(true);
-    bun.kill("SIGKILL");
-    await bun.exited;
-    const died = await waitUntilDead(grandchildPid, 1000);
-    reap(grandchildPid);
-    expect(died).toBe(false);
-  },
-);
-
-test.concurrent.skipIf(!isWindows)(
-  "windows: --no-orphans reaps grandchild when Bun is TerminateProcess'd",
-  async () => {
-    const { bun, grandchildPid } = await spawnTreeWindows(true);
-    expect(isAlive(grandchildPid)).toBe(true);
-    bun.kill("SIGKILL");
-    await bun.exited;
-    const died = await waitUntilDead(grandchildPid, 10000);
-    reap(grandchildPid);
-    expect(died).toBe(true);
-  },
-);
-
-// The inner Bun and its child are both Bun (and so both self-assign to a Job
-// via env-var inheritance). This grandchild is a non-Bun process that never
-// creates its own Job — proves Job membership is inherited across spawn.
-test.concurrent.skipIf(!isWindows)(
-  "windows: --no-orphans reaps a non-Bun grandchild when Bun is TerminateProcess'd",
-  async () => {
-    using dir = tempDir("no-orphans-win-nonbun", {
-      "child.js": `
-        const gc = Bun.spawn({
-          cmd: ["cmd.exe", "/c", "echo r& ping -n 120 127.0.0.1 > NUL"],
-          stdio: ["ignore", "pipe", "ignore"],
-        });
-        await gc.stdout.getReader().read();
-        console.log(process.pid, process.ppid, gc.pid);
-        setInterval(()=>{}, 1000);
-      `,
-    });
-    const env: Record<string, string> = { ...bunEnv };
-    delete env.BUN_FEATURE_FLAG_NO_ORPHANS;
-    const bun = Bun.spawn({
-      cmd: [bunExe(), "--no-orphans", "child.js"],
-      env,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "ignore",
-    });
-    const reader = bun.stdout.getReader();
-    const decoder = new TextDecoder();
-    let line = "";
-    while (!line.includes("\n")) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      line += decoder.decode(value, { stream: true });
+    const { bun, leafPid, reap } = await spawnTreeWindows([], {});
+    try {
+      expect(leafPid).toBeGreaterThan(0);
+      expect(isAlive(leafPid)).toBe(true);
+      bun.kill("SIGKILL");
+      await bun.exited;
+      // Must NOT die: poll for death and expect the poll to time out.
+      const died = await waitUntilDead(leafPid, 1000);
+      expect(died).toBe(false);
+    } finally {
+      await reap();
     }
-    reader.releaseLock();
-    const [, , grandchildPid] = line.trim().split(" ").map(Number);
-    expect(grandchildPid).toBeGreaterThan(0);
-    expect(isAlive(grandchildPid)).toBe(true);
-    bun.kill("SIGKILL");
-    await bun.exited;
-    const died = await waitUntilDead(grandchildPid, 10000);
-    reap(grandchildPid);
-    expect(died).toBe(true);
   },
 );
+
+describe.concurrent.each([
+  { via: "--no-orphans", argv: ["--no-orphans"], env: {} },
+  { via: "BUN_FEATURE_FLAG_NO_ORPHANS=1", argv: [], env: { BUN_FEATURE_FLAG_NO_ORPHANS: "1" } },
+])("windows: $via reaps a cmd.exe-spawned descendant when Bun is TerminateProcess'd", ({ argv, env }) => {
+  test.concurrent.skipIf(!isWindows)("leaf dies", async () => {
+    const { bun, leafPid, reap } = await spawnTreeWindows(argv, env);
+    try {
+      expect(leafPid).toBeGreaterThan(0);
+      expect(isAlive(leafPid)).toBe(true);
+      bun.kill("SIGKILL");
+      await bun.exited;
+      const died = await waitUntilDead(leafPid, 10000);
+      expect(died).toBe(true);
+    } finally {
+      await reap();
+    }
+  });
+});

--- a/test/cli/run/no-orphans.test.ts
+++ b/test/cli/run/no-orphans.test.ts
@@ -988,10 +988,11 @@ test.concurrent.skipIf(!isSupported || !hasPerl)(
 // link: it spawns the leaf via plain CreateProcess, so the leaf escapes
 // libuv's job but not the --no-orphans job. The leaf writes its pid to a file
 // so the test can observe it after cmd.exe's stdout pipe is torn down.
-async function spawnTreeWindows(argv: string[], extraEnv: Record<string, string>) {
+async function spawnTreeWindows(argv: string[], extraEnv: Record<string, string>, bunfig = false) {
   // No `cwd` anywhere in the chain: the leaf must not hold an open handle on
   // the tempDir (CWD lock) or the negative test's cleanup races the rm.
   const dir = tempDir("no-orphans-win", {
+    ...(bunfig && { "bunfig.toml": "[run]\nnoOrphans = true\n" }),
     "leaf.js": `
       require("fs").writeFileSync(process.env.PIDFILE, String(process.pid));
       setInterval(()=>{}, 1000);
@@ -1010,7 +1011,7 @@ async function spawnTreeWindows(argv: string[], extraEnv: Record<string, string>
   const env: Record<string, string> = { ...bunEnv, ...extraEnv, PIDFILE: pidfile, BAT: `${dir}\\run.bat` };
   if (!("BUN_FEATURE_FLAG_NO_ORPHANS" in extraEnv)) delete env.BUN_FEATURE_FLAG_NO_ORPHANS;
   const bun = Bun.spawn({
-    cmd: [bunExe(), ...argv, `${dir}\\outer.js`],
+    cmd: [bunExe(), ...(bunfig ? ["-c", `${dir}\\bunfig.toml`] : []), ...argv, `${dir}\\outer.js`],
     env,
     stdout: "ignore",
     stderr: "ignore",
@@ -1060,11 +1061,12 @@ test.concurrent.skipIf(!isWindows)(
 );
 
 describe.concurrent.each([
-  { via: "--no-orphans", argv: ["--no-orphans"], env: {} },
-  { via: "BUN_FEATURE_FLAG_NO_ORPHANS=1", argv: [], env: { BUN_FEATURE_FLAG_NO_ORPHANS: "1" } },
-])("windows: $via reaps a cmd.exe-spawned descendant when Bun is TerminateProcess'd", ({ argv, env }) => {
+  { via: "--no-orphans", argv: ["--no-orphans"], env: {}, bunfig: false },
+  { via: "BUN_FEATURE_FLAG_NO_ORPHANS=1", argv: [], env: { BUN_FEATURE_FLAG_NO_ORPHANS: "1" }, bunfig: false },
+  { via: "bunfig [run] noOrphans = true", argv: [], env: {}, bunfig: true },
+])("windows: $via reaps a cmd.exe-spawned descendant when Bun is TerminateProcess'd", ({ argv, env, bunfig }) => {
   test.concurrent.skipIf(!isWindows)("leaf dies", async () => {
-    const { bun, leafPid, reap } = await spawnTreeWindows(argv, env);
+    const { bun, leafPid, reap } = await spawnTreeWindows(argv, env, bunfig);
     try {
       expect(leafPid).toBeGreaterThan(0);
       expect(isAlive(leafPid)).toBe(true);

--- a/test/cli/run/no-orphans.test.ts
+++ b/test/cli/run/no-orphans.test.ts
@@ -1079,3 +1079,104 @@ describe.concurrent.each([
     }
   });
 });
+
+// Parent watch: RegisterWaitForSingleObject on the original parent's process
+// handle. Tree: test → cmd.exe (supervisor) → bun → cmd.exe → leaf. Killing
+// the supervisor must bring down bun (parent watch) and transitively the leaf
+// (bun's Job Object). Without --no-orphans bun survives: it's behind libuv's
+// SILENT_BREAKAWAY, and nothing else ties it to the supervisor.
+async function spawnParentWatchTreeWindows(noOrphans: boolean) {
+  const dir = tempDir("no-orphans-win-parent", {
+    "leaf.js": `
+      require("fs").writeFileSync(process.env.PIDFILE, process.pid + " " + process.env.MID_PID);
+      setInterval(()=>{}, 1000);
+    `,
+    "middle.js": `
+      Bun.spawn({
+        cmd: ["cmd.exe", "/d", "/c", process.env.LEAF_BAT],
+        stdio: ["ignore", "ignore", "ignore"],
+        env: { ...process.env, MID_PID: String(process.pid) },
+      });
+      setInterval(()=>{}, 1000);
+    `,
+    "leaf.bat": `@"${bunExe()}" "%~dp0leaf.js"\r\n`,
+    "supervisor.bat": `@"${bunExe()}" ${noOrphans ? "--no-orphans " : ""}"%~dp0middle.js"\r\n`,
+  });
+  const pidfile = `${dir}\\pids.txt`;
+  const env: Record<string, string> = { ...bunEnv, PIDFILE: pidfile, LEAF_BAT: `${dir}\\leaf.bat` };
+  delete env.BUN_FEATURE_FLAG_NO_ORPHANS;
+  const supervisor = Bun.spawn({
+    cmd: ["cmd.exe", "/d", "/c", `${dir}\\supervisor.bat`],
+    env,
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  const deadline = Date.now() + 15000;
+  let leafPid = 0;
+  let bunPid = 0;
+  while (bunPid === 0 && Date.now() < deadline) {
+    try {
+      const t = (await Bun.file(pidfile).text()).trim().split(" ");
+      if (t.length === 2) {
+        leafPid = Number(t[0]);
+        bunPid = Number(t[1]);
+      }
+    } catch {}
+    if (bunPid === 0) await sleep(25);
+  }
+  return {
+    supervisor,
+    bunPid,
+    leafPid,
+    async reap() {
+      supervisor.kill("SIGKILL");
+      await supervisor.exited;
+      for (const pid of [bunPid, leafPid]) {
+        if (pid > 0 && isAlive(pid)) {
+          try {
+            process.kill(pid, "SIGKILL");
+          } catch {}
+          await waitUntilDead(pid, 2000);
+        }
+      }
+      dir[Symbol.dispose]();
+    },
+  };
+}
+
+test.concurrent.skipIf(!isWindows)(
+  "windows: without --no-orphans, Bun survives TerminateProcess on its parent",
+  async () => {
+    const { supervisor, bunPid, leafPid, reap } = await spawnParentWatchTreeWindows(false);
+    try {
+      expect(bunPid).toBeGreaterThan(0);
+      expect(isAlive(bunPid)).toBe(true);
+      supervisor.kill("SIGKILL");
+      await supervisor.exited;
+      const died = await waitUntilDead(bunPid, 1000);
+      expect({ bunDied: died, leafAlive: isAlive(leafPid) }).toEqual({ bunDied: false, leafAlive: true });
+    } finally {
+      await reap();
+    }
+  },
+);
+
+test.concurrent.skipIf(!isWindows)(
+  "windows: --no-orphans: Bun exits when its parent is TerminateProcess'd, and its descendants are reaped",
+  async () => {
+    const { supervisor, bunPid, leafPid, reap } = await spawnParentWatchTreeWindows(true);
+    try {
+      expect(bunPid).toBeGreaterThan(0);
+      expect(leafPid).toBeGreaterThan(0);
+      expect(isAlive(bunPid)).toBe(true);
+      expect(isAlive(leafPid)).toBe(true);
+      supervisor.kill("SIGKILL");
+      await supervisor.exited;
+      const bunDied = await waitUntilDead(bunPid, 10000);
+      const leafDied = await waitUntilDead(leafPid, 10000);
+      expect({ bunDied, leafDied }).toEqual({ bunDied: true, leafDied: true });
+    } finally {
+      await reap();
+    }
+  },
+);

--- a/test/cli/run/no-orphans.test.ts
+++ b/test/cli/run/no-orphans.test.ts
@@ -1028,6 +1028,8 @@ async function spawnTreeWindows(argv: string[], extraEnv: Record<string, string>
     bun,
     leafPid,
     async reap() {
+      bun.kill("SIGKILL");
+      await bun.exited;
       if (leafPid > 0 && isAlive(leafPid)) {
         try {
           process.kill(leafPid, "SIGKILL");

--- a/test/cli/run/no-orphans.test.ts
+++ b/test/cli/run/no-orphans.test.ts
@@ -1011,7 +1011,7 @@ async function spawnTreeWindows(argv: string[], extraEnv: Record<string, string>
   const env: Record<string, string> = { ...bunEnv, ...extraEnv, PIDFILE: pidfile, BAT: `${dir}\\run.bat` };
   if (!("BUN_FEATURE_FLAG_NO_ORPHANS" in extraEnv)) delete env.BUN_FEATURE_FLAG_NO_ORPHANS;
   const bun = Bun.spawn({
-    cmd: [bunExe(), ...(bunfig ? ["-c", `${dir}\\bunfig.toml`] : []), ...argv, `${dir}\\outer.js`],
+    cmd: [bunExe(), ...(bunfig ? [`--config=${dir}\\bunfig.toml`] : []), ...argv, `${dir}\\outer.js`],
     env,
     stdout: "ignore",
     stderr: "ignore",

--- a/test/cli/run/no-orphans.test.ts
+++ b/test/cli/run/no-orphans.test.ts
@@ -20,7 +20,8 @@ setDefaultTimeout(30_000);
 // Tree under test: test → sh (the "parent" we SIGKILL) → bun-debug → grandchild.
 // We SIGKILL sh and observe bun-debug and the grandchild.
 
-const isSupported = process.platform === "linux" || process.platform === "darwin";
+const isPosix = process.platform === "linux" || process.platform === "darwin";
+const isSupported = isPosix || isWindows;
 
 // Shared fixture dir — child.js spawns grandchild.js, prints
 // "<self> <ppid> <grandchild>", then idles. Kept on disk so we can pass it
@@ -46,6 +47,10 @@ const fixture = tempDir("no-orphans", {
     console.log(process.pid, process.ppid, gc.pid);
     setInterval(()=>{}, 1000);
   `,
+  // Windows supervisor — cmd.exe is the process we TerminateProcess in place
+  // of /bin/sh. A .bat avoids cmd /c's quote-stripping around a quoted exe +
+  // arg. %1 is the child script name.
+  "supervisor.bat": `@"${bunExe()}" "%~dp0%~1"\r\n`,
   // Same shape as child.js, but the grandchild is plain /bin/sh — never calls
   // prctl itself, so reaping it proves the spawn-side linux_pdeathsig (Linux)
   // and the libproc walk (macOS) cover non-Bun descendants.
@@ -82,9 +87,14 @@ async function spawnTree(noOrphans: string | undefined, childScript = "child.js"
   if (noOrphans !== undefined) env.BUN_FEATURE_FLAG_NO_ORPHANS = noOrphans;
 
   const sh = Bun.spawn({
-    // Trailing `wait` defeats sh's implicit-exec-of-last-command so sh stays a
-    // distinct pid we can SIGKILL independently of bun.
-    cmd: ["/bin/sh", "-c", `"${bunExe()}" "${String(fixture)}/${childScript}" & wait`],
+    // POSIX: trailing `wait` defeats sh's implicit-exec-of-last-command so sh
+    // stays a distinct pid we can SIGKILL independently of bun.
+    // Windows: cmd.exe always forks a child and waits; no trick needed. bun
+    // escapes the test's libuv job via SILENT_BREAKAWAY, so only the Windows
+    // parent-watch (RegisterWaitForSingleObject) ties it to cmd.exe.
+    cmd: isWindows
+      ? ["cmd.exe", "/d", "/c", `${fixture}\\supervisor.bat`, childScript]
+      : ["/bin/sh", "-c", `"${bunExe()}" "${String(fixture)}/${childScript}" & wait`],
     env,
     stdout: "pipe",
     stderr: "ignore",
@@ -191,7 +201,7 @@ test.concurrent.skipIf(!isSupported)(
 // Linux this is covered by Bun setting linux_pdeathsig on every spawn when
 // no-orphans mode is enabled (prctl in the vfork child before exec). On macOS
 // it's covered by the libproc descendant walk in the exit handler.
-test.concurrent.skipIf(!isSupported)(
+test.concurrent.skipIf(!isPosix)(
   "BUN_FEATURE_FLAG_NO_ORPHANS=1: non-Bun grandchildren are reaped when bun dies with its parent",
   async () => {
     const { sh, bunPid, grandchildPid } = await spawnTree("1", "child-nonbun.js");
@@ -209,7 +219,7 @@ test.concurrent.skipIf(!isSupported)(
 // Same as above but the grandchild is spawned with uid/gid. The credential
 // change clears the pdeathsig the spawn armed (prctl(2)), so this proves it
 // gets re-armed after setgid/setuid. Needs root to setuid.
-test.concurrent.skipIf(!isSupported || process.getuid?.() !== 0)(
+test.concurrent.skipIf(!isPosix || process.getuid?.() !== 0)(
   "BUN_FEATURE_FLAG_NO_ORPHANS=1: a non-Bun grandchild spawned with uid/gid is reaped",
   async () => {
     const { sh, bunPid, grandchildPid } = await spawnTree("1", "child-nonbun-uid.js");
@@ -256,7 +266,7 @@ describe.concurrent.each([
   { via: "--no-orphans", argv: ["--no-orphans"], bunfig: false, env: {} },
   { via: "bunfig [run] noOrphans = true", argv: [], bunfig: true, env: {} },
 ])("clean exit reaps descendants", ({ via, argv, bunfig, env: extraEnv }) => {
-  test.concurrent.skipIf(!isSupported)(via, async () => {
+  test.concurrent.skipIf(!isPosix)(via, async () => {
     using dir = tempDir("no-orphans-clean-exit", {
       ...(bunfig && { "bunfig.toml": "[run]\nnoOrphans = true\n" }),
       "grandchild.js": `process.stdout.write("r"); setInterval(()=>{}, 1000);`,
@@ -321,7 +331,7 @@ describe.concurrent.each([
     },
   },
 ])("bun run --no-orphans $label: supervisor SIGKILLed", ({ runArgs, files }) => {
-  test.concurrent.skipIf(!isSupported)("bun run and the script exit", async () => {
+  test.concurrent.skipIf(!isPosix)("bun run and the script exit", async () => {
     using dir = tempDir("no-orphans-run", files);
     const env: Record<string, string> = { ...bunEnv };
     delete env.BUN_FEATURE_FLAG_NO_ORPHANS;
@@ -377,7 +387,7 @@ describe.concurrent.each([
 // Linux: PR_SET_CHILD_SUBREAPER claims the orphan, procfs walk finds it.
 // macOS: NoOrphansTracker's p_puniqueid spawn-graph finds it.
 const hasPerl = Bun.which("perl") != null;
-test.concurrent.skipIf(!isSupported || !hasPerl)(
+test.concurrent.skipIf(!isPosix || !hasPerl)(
   "bun run --no-orphans: perl setsid+double-fork daemon (no Bun in chain) is reaped",
   async () => {
     using dir = tempDir("no-orphans-perl", {
@@ -446,7 +456,7 @@ test.concurrent.skipIf(!isSupported || !hasPerl)(
 // `bun run` may finish before the daemon writes its pidfile. Poll for the
 // file from the *test*; if it never appears the daemon was reaped before it
 // could write — also a pass. Only fail if the file appears AND the pid lives.
-test.concurrent.skipIf(!isSupported || !hasPerl)(
+test.concurrent.skipIf(!isPosix || !hasPerl)(
   "bun run --no-orphans (perl): fast-exit intermediate (no pidfile spin) — daemon still reaped",
   async () => {
     using dir = tempDir("no-orphans-fast-daemon", {
@@ -567,7 +577,7 @@ test.concurrent.skipIf(!isLinux || !hasPerl)(
 // the grandchild on its own clean exit. Uses a non-Bun grandchild so the test
 // doesn't depend on env-var inheritance — proves the descendant walk runs from
 // the `bun run` process itself.
-test.concurrent.skipIf(!isSupported)("bun run --no-orphans <script>: clean exit reaps descendants", async () => {
+test.concurrent.skipIf(!isPosix)("bun run --no-orphans <script>: clean exit reaps descendants", async () => {
   using dir = tempDir("no-orphans-run", {
     "package.json": JSON.stringify({
       name: "no-orphans-run",
@@ -778,7 +788,7 @@ test.concurrent.skipIf(!isLinux)(
 //      itself stopped.
 //   3. After perl `fg`s it (tcsetpgrp + SIGCONT), the script's SIGCONT
 //      handler fires — `onChildStopped` SIGCONT'd the whole script pgroup.
-test.concurrent.skipIf(!isSupported || !hasPerl)(
+test.concurrent.skipIf(!isPosix || !hasPerl)(
   "bun run --no-orphans on a TTY: Ctrl-Z stop observed by outer shell's waitpid(WUNTRACED), fg resumes script",
   async () => {
     // perl in the dev script so `getpgrp()` is trivially available; `$SIG{CONT}`
@@ -905,7 +915,7 @@ test.concurrent.skipIf(!isSupported || !hasPerl)(
 // Same perl-shell/pty rig as above, but perl never hands bun the foreground
 // (the `&` shape). After the script announces READY, perl re-reads
 // `tcgetpgrp(0)` and reports whether it's still perl's own pgroup.
-test.concurrent.skipIf(!isSupported || !hasPerl)(
+test.concurrent.skipIf(!isPosix || !hasPerl)(
   "bun run --no-orphans backgrounded on a TTY does not steal the foreground pgroup",
   async () => {
     using dir = tempDir("no-orphans-tty-bg", {
@@ -1079,104 +1089,3 @@ describe.concurrent.each([
     }
   });
 });
-
-// Parent watch: RegisterWaitForSingleObject on the original parent's process
-// handle. Tree: test → cmd.exe (supervisor) → bun → cmd.exe → leaf. Killing
-// the supervisor must bring down bun (parent watch) and transitively the leaf
-// (bun's Job Object). Without --no-orphans bun survives: it's behind libuv's
-// SILENT_BREAKAWAY, and nothing else ties it to the supervisor.
-async function spawnParentWatchTreeWindows(noOrphans: boolean) {
-  const dir = tempDir("no-orphans-win-parent", {
-    "leaf.js": `
-      require("fs").writeFileSync(process.env.PIDFILE, process.pid + " " + process.env.MID_PID);
-      setInterval(()=>{}, 1000);
-    `,
-    "middle.js": `
-      Bun.spawn({
-        cmd: ["cmd.exe", "/d", "/c", process.env.LEAF_BAT],
-        stdio: ["ignore", "ignore", "ignore"],
-        env: { ...process.env, MID_PID: String(process.pid) },
-      });
-      setInterval(()=>{}, 1000);
-    `,
-    "leaf.bat": `@"${bunExe()}" "%~dp0leaf.js"\r\n`,
-    "supervisor.bat": `@"${bunExe()}" ${noOrphans ? "--no-orphans " : ""}"%~dp0middle.js"\r\n`,
-  });
-  const pidfile = `${dir}\\pids.txt`;
-  const env: Record<string, string> = { ...bunEnv, PIDFILE: pidfile, LEAF_BAT: `${dir}\\leaf.bat` };
-  delete env.BUN_FEATURE_FLAG_NO_ORPHANS;
-  const supervisor = Bun.spawn({
-    cmd: ["cmd.exe", "/d", "/c", `${dir}\\supervisor.bat`],
-    env,
-    stdout: "ignore",
-    stderr: "ignore",
-  });
-  const deadline = Date.now() + 15000;
-  let leafPid = 0;
-  let bunPid = 0;
-  while (bunPid === 0 && Date.now() < deadline) {
-    try {
-      const t = (await Bun.file(pidfile).text()).trim().split(" ");
-      if (t.length === 2) {
-        leafPid = Number(t[0]);
-        bunPid = Number(t[1]);
-      }
-    } catch {}
-    if (bunPid === 0) await sleep(25);
-  }
-  return {
-    supervisor,
-    bunPid,
-    leafPid,
-    async reap() {
-      supervisor.kill("SIGKILL");
-      await supervisor.exited;
-      for (const pid of [bunPid, leafPid]) {
-        if (pid > 0 && isAlive(pid)) {
-          try {
-            process.kill(pid, "SIGKILL");
-          } catch {}
-          await waitUntilDead(pid, 2000);
-        }
-      }
-      dir[Symbol.dispose]();
-    },
-  };
-}
-
-test.concurrent.skipIf(!isWindows)(
-  "windows: without --no-orphans, Bun survives TerminateProcess on its parent",
-  async () => {
-    const { supervisor, bunPid, leafPid, reap } = await spawnParentWatchTreeWindows(false);
-    try {
-      expect(bunPid).toBeGreaterThan(0);
-      expect(isAlive(bunPid)).toBe(true);
-      supervisor.kill("SIGKILL");
-      await supervisor.exited;
-      const died = await waitUntilDead(bunPid, 1000);
-      expect({ bunDied: died, leafAlive: isAlive(leafPid) }).toEqual({ bunDied: false, leafAlive: true });
-    } finally {
-      await reap();
-    }
-  },
-);
-
-test.concurrent.skipIf(!isWindows)(
-  "windows: --no-orphans: Bun exits when its parent is TerminateProcess'd, and its descendants are reaped",
-  async () => {
-    const { supervisor, bunPid, leafPid, reap } = await spawnParentWatchTreeWindows(true);
-    try {
-      expect(bunPid).toBeGreaterThan(0);
-      expect(leafPid).toBeGreaterThan(0);
-      expect(isAlive(bunPid)).toBe(true);
-      expect(isAlive(leafPid)).toBe(true);
-      supervisor.kill("SIGKILL");
-      await supervisor.exited;
-      const bunDied = await waitUntilDead(bunPid, 10000);
-      const leafDied = await waitUntilDead(leafPid, 10000);
-      expect({ bunDied, leafDied }).toEqual({ bunDied: true, leafDied: true });
-    } finally {
-      await reap();
-    }
-  },
-);

--- a/test/cli/run/no-orphans.test.ts
+++ b/test/cli/run/no-orphans.test.ts
@@ -1,6 +1,6 @@
 import { dlopen, FFIType } from "bun:ffi";
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, isMusl, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isMusl, isWindows, tempDir } from "harness";
 import { chmodSync, readFileSync } from "node:fs";
 import { setTimeout as sleep } from "node:timers/promises";
 
@@ -969,5 +969,106 @@ test.concurrent.skipIf(!isSupported || !hasPerl)(
       await proc.exited;
       proc.terminal?.close();
     }
+  },
+);
+
+// Windows: --no-orphans self-assigns to a kill-on-close Job Object. Children
+// inherit Job membership, so when Bun is TerminateProcess'd the kernel closes
+// the Job handle and terminates every descendant. No sh supervisor layer —
+// the test kills Bun directly and observes the grandchild.
+async function spawnTreeWindows(noOrphans: boolean) {
+  const env: Record<string, string> = { ...bunEnv };
+  delete env.BUN_FEATURE_FLAG_NO_ORPHANS;
+  const bun = Bun.spawn({
+    cmd: [bunExe(), ...(noOrphans ? ["--no-orphans"] : []), `${String(fixture)}/child.js`],
+    env,
+    cwd: String(fixture),
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  const reader = bun.stdout.getReader();
+  const decoder = new TextDecoder();
+  let line = "";
+  while (!line.includes("\n")) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    line += decoder.decode(value, { stream: true });
+  }
+  reader.releaseLock();
+  const [bunPid, , grandchildPid] = line.trim().split(" ").map(Number);
+  expect(bunPid).toBe(bun.pid);
+  expect(grandchildPid).toBeGreaterThan(0);
+  return { bun, grandchildPid };
+}
+
+test.concurrent.skipIf(!isWindows)(
+  "windows: without --no-orphans, grandchild survives TerminateProcess on Bun",
+  async () => {
+    const { bun, grandchildPid } = await spawnTreeWindows(false);
+    expect(isAlive(grandchildPid)).toBe(true);
+    bun.kill("SIGKILL");
+    await bun.exited;
+    const died = await waitUntilDead(grandchildPid, 1000);
+    reap(grandchildPid);
+    expect(died).toBe(false);
+  },
+);
+
+test.concurrent.skipIf(!isWindows)(
+  "windows: --no-orphans reaps grandchild when Bun is TerminateProcess'd",
+  async () => {
+    const { bun, grandchildPid } = await spawnTreeWindows(true);
+    expect(isAlive(grandchildPid)).toBe(true);
+    bun.kill("SIGKILL");
+    await bun.exited;
+    const died = await waitUntilDead(grandchildPid, 10000);
+    reap(grandchildPid);
+    expect(died).toBe(true);
+  },
+);
+
+// The inner Bun and its child are both Bun (and so both self-assign to a Job
+// via env-var inheritance). This grandchild is a non-Bun process that never
+// creates its own Job — proves Job membership is inherited across spawn.
+test.concurrent.skipIf(!isWindows)(
+  "windows: --no-orphans reaps a non-Bun grandchild when Bun is TerminateProcess'd",
+  async () => {
+    using dir = tempDir("no-orphans-win-nonbun", {
+      "child.js": `
+        const gc = Bun.spawn({
+          cmd: ["cmd.exe", "/c", "echo r& ping -n 120 127.0.0.1 > NUL"],
+          stdio: ["ignore", "pipe", "ignore"],
+        });
+        await gc.stdout.getReader().read();
+        console.log(process.pid, process.ppid, gc.pid);
+        setInterval(()=>{}, 1000);
+      `,
+    });
+    const env: Record<string, string> = { ...bunEnv };
+    delete env.BUN_FEATURE_FLAG_NO_ORPHANS;
+    const bun = Bun.spawn({
+      cmd: [bunExe(), "--no-orphans", "child.js"],
+      env,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    const reader = bun.stdout.getReader();
+    const decoder = new TextDecoder();
+    let line = "";
+    while (!line.includes("\n")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      line += decoder.decode(value, { stream: true });
+    }
+    reader.releaseLock();
+    const [, , grandchildPid] = line.trim().split(" ").map(Number);
+    expect(grandchildPid).toBeGreaterThan(0);
+    expect(isAlive(grandchildPid)).toBe(true);
+    bun.kill("SIGKILL");
+    await bun.exited;
+    const died = await waitUntilDead(grandchildPid, 10000);
+    reap(grandchildPid);
+    expect(died).toBe(true);
   },
 );


### PR DESCRIPTION
## What

Implements `--no-orphans` / `BUN_FEATURE_FLAG_NO_ORPHANS` / `[run] noOrphans` on Windows. Previously `ParentDeathWatchdog` was a no-op stub there, so a `TerminateProcess` on Bun's parent left Bun running, and a `TerminateProcess` on Bun left its descendant tree running.

## How

`enable()` on Windows now does two things:

**Descendant cleanup.** Create an anonymous Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` and `AssignProcessToJobObject(job, GetCurrentProcess())`. The handle is leaked for the process lifetime. Children inherit Job membership via nested jobs (Win8+), so when Bun exits for any reason, including `TerminateProcess`, the kernel closes the Job handle and terminates every descendant. This is the same primitive already used in `test/parallel/Coordinator.rs` and the `--watch` manager, just applied to the current process instead of a specific child.

libuv's `uv_spawn` already maintains a per-process kill-on-close job for direct `Bun.spawn` children, but it sets `JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK` so membership is not inherited recursively: anything a `Bun.spawn`'d child itself spawns (cmd.exe -> tool, npm script -> compiler, a shell wrapper, etc.) breaks away silently and survives. The `--no-orphans` job omits `SILENT_BREAKAWAY_OK` so the whole tree is covered.

**Parent watch.** Read `InheritedFromUniqueProcessId` via `NtQueryInformationProcess(ProcessBasicInformation)`, `OpenProcess(SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION)` on it, and `RegisterWaitForSingleObject(..., WT_EXECUTEONLYONCE)`. When the parent's process object is signaled (i.e. has terminated) the system thread-pool callback calls `ExitProcess(129)`, which in turn closes the Job handle and reaps descendants.

`InheritedFromUniqueProcessId` is frozen at our creation (Windows has no reparenting), so a PID-reuse guard compares `GetProcessTimes` creation times: a real creator was created no later than us, a recycled PID strictly later. If the creator is already gone at `enable()` time we exit immediately, matching the Linux/macOS race branches.

## Tests

`test/cli/run/no-orphans.test.ts`:

- `spawnTree()` now uses cmd.exe as the supervisor on Windows, so the five core parent-watch tests ("bun exits when its parent is SIGKILLed", "grandchildren are reaped", "=0 is unset", "does not fire while parent is alive", and the negative control) run on all three platforms.
- New Windows-only tests for the recursive Job Object: test -> bun -> cmd.exe -> leaf, where cmd.exe is the non-libuv link that escapes libuv's `SILENT_BREAKAWAY` job but not the `--no-orphans` job. Covers `--no-orphans`, `BUN_FEATURE_FLAG_NO_ORPHANS=1`, and bunfig `[run] noOrphans`.
- POSIX-mechanism-specific tests (pdeathsig re-arm, subreaper, libproc walk, perl setsid daemons, TTY job control) stay `skipIf(!isPosix)`.

Verified on windows-x64: canary fails 6/9 (3 negative controls pass), this build passes 9/9. Linux: 18 pass, 4 Windows tests skip, one pre-existing root-only uid/gid failure unrelated to this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/no-orphans.test.ts

<!-- robobun:evidence:end -->