### PR TITLE
node:path: fix win32.resolve buffer aliasing for drive-relative paths on Windows

### DIFF
--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -3046,23 +3046,31 @@ pub(crate) fn resolve_windows_t<'a, T: PathCharCwd>(
                 // TODO: Enable test once spawnResult.stdout works on Windows.
                 // test/js/node/path/resolve.test.js
                 if let Some(r) = bun_sys::windows::getenv_w(key_w) {
+                    // Store the env path in tmp_buf AFTER the resolved device.
+                    // buf2[0..resolved_tail_len] already holds the accumulated
+                    // tail; writing the value there (as before) clobbered it,
+                    // which is why `resolve("C:foo")` produced corrupted output
+                    // on Windows. tmp_buf past the device is scratch here.
                     if T::IS_U16 {
-                        buf_size = r.len();
+                        buf_size = r.len().min(tmp_buf.len() - resolved_device_len);
                         // T == u16 when IS_U16; bytemuck checks the layout at runtime.
-                        let dst: &mut [u16] =
-                            bytemuck::cast_slice_mut::<T, u16>(&mut buf2[..buf_size]);
-                        memmove(dst, &r);
+                        let dst: &mut [u16] = bytemuck::cast_slice_mut::<T, u16>(
+                            &mut tmp_buf[resolved_device_len..resolved_device_len + buf_size],
+                        );
+                        memmove(dst, &r[..buf_size]);
                     } else {
-                        // Reuse buf2 because it's used for path.
                         // T == u8 when !IS_U16; bytemuck statically checks the layout.
-                        let dst: &mut [u8] = bytemuck::cast_slice_mut::<T, u8>(&mut buf2[..]);
+                        let dst: &mut [u8] = bytemuck::cast_slice_mut::<T, u8>(
+                            &mut tmp_buf[resolved_device_len..],
+                        );
                         buf_size = strings::convert_utf16_to_utf8_in_buffer(dst, &r).len();
                     }
                     env_path_len = Some(buf_size);
                 }
             }
             if let Some(ep_len) = env_path_len {
-                path_ptr = buf2.as_ptr();
+                // SAFETY: offset is within tmp_buf (resolved_device_len == 2 here).
+                path_ptr = unsafe { tmp_buf.as_ptr().add(resolved_device_len) };
                 path_len = ep_len;
             } else {
                 // cwd is limited to MAX_PATH_BYTES.

--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -3273,7 +3273,7 @@ pub(crate) fn resolve_windows_t<'a, T: PathCharCwd>(
             }
             buf_size = slice_len;
             if slice_len > 0 {
-                // path may alias buf2 (env path branch); use ptr::copy.
+                // path may alias buf2 (drive-mismatch fallback); use ptr::copy.
                 // SAFETY: handles overlap.
                 unsafe {
                     core::ptr::copy(path_ptr.add(root_end), buf2.as_mut_ptr(), slice_len);

--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -3057,9 +3057,8 @@ pub(crate) fn resolve_windows_t<'a, T: PathCharCwd>(
                         memmove(dst, &r[..buf_size]);
                     } else {
                         // T == u8 when !IS_U16; bytemuck statically checks the layout.
-                        let dst: &mut [u8] = bytemuck::cast_slice_mut::<T, u8>(
-                            &mut tmp_buf[resolved_device_len..],
-                        );
+                        let dst: &mut [u8] =
+                            bytemuck::cast_slice_mut::<T, u8>(&mut tmp_buf[resolved_device_len..]);
                         buf_size = strings::convert_utf16_to_utf8_in_buffer(dst, &r).len();
                     }
                     env_path_len = Some(buf_size);

--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -3046,11 +3046,8 @@ pub(crate) fn resolve_windows_t<'a, T: PathCharCwd>(
                 // TODO: Enable test once spawnResult.stdout works on Windows.
                 // test/js/node/path/resolve.test.js
                 if let Some(r) = bun_sys::windows::getenv_w(key_w) {
-                    // Store the env path in tmp_buf AFTER the resolved device.
-                    // buf2[0..resolved_tail_len] already holds the accumulated
-                    // tail; writing the value there (as before) clobbered it,
-                    // which is why `resolve("C:foo")` produced corrupted output
-                    // on Windows. tmp_buf past the device is scratch here.
+                    // Store in tmp_buf AFTER the device: buf2[0..resolved_tail_len]
+                    // already backs the accumulated tail, so writing there clobbers it.
                     if T::IS_U16 {
                         buf_size = r.len().min(tmp_buf.len() - resolved_device_len);
                         // T == u16 when IS_U16; bytemuck checks the layout at runtime.

--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -3065,8 +3065,7 @@ pub(crate) fn resolve_windows_t<'a, T: PathCharCwd>(
                 }
             }
             if let Some(ep_len) = env_path_len {
-                // SAFETY: offset is within tmp_buf (resolved_device_len == 2 here).
-                path_ptr = unsafe { tmp_buf.as_ptr().add(resolved_device_len) };
+                path_ptr = tmp_buf[resolved_device_len..].as_ptr();
                 path_len = ep_len;
             } else {
                 // cwd is limited to MAX_PATH_BYTES.

--- a/test/js/node/path/resolve.test.js
+++ b/test/js/node/path/resolve.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isWindows } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 import assert from "node:assert";
 // import child from "node:child_process";
 import path from "node:path";
@@ -109,6 +109,42 @@ describe("path.resolve", () => {
     expect(path.win32.resolve("//server/share", "C:relative")).toBe(path.win32.resolve("C:relative"));
     expect(path.win32.resolve("//server/share", "C:")).toBe(path.win32.resolve("C:"));
     expect(path.win32.resolve("//a/b", "//c/d", "C:foo")).toBe(path.win32.resolve("C:foo"));
+  });
+
+  // On Windows, a drive-relative path like "C:foo" is resolved against the
+  // per-drive cwd stored in the `=C:` environment variable. The env value was
+  // being written into the same buffer region that already held the
+  // accumulated tail ("foo"), corrupting the result. Spawn a child with a
+  // known `=C:` so the expected output is deterministic.
+  test.skipIf(!isWindows)("win32 drive-relative input resolves against the per-drive cwd (=X: env var)", async () => {
+    const script = `const p = require("path");
+      console.log(JSON.stringify([
+        p.resolve("C:foo"),
+        p.resolve("C:"),
+        p.resolve("C:", "foo"),
+        p.resolve("C:foo/bar"),
+        p.resolve("c:foo"),
+        p.win32.resolve("C:foo"),
+        p.toNamespacedPath("C:foo"),
+      ]));`;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...bunEnv, "=C:": "C:\\known\\dir" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual([
+      "C:\\known\\dir\\foo",
+      "C:\\known\\dir",
+      "C:\\known\\dir\\foo",
+      "C:\\known\\dir\\foo\\bar",
+      "c:\\known\\dir\\foo",
+      "C:\\known\\dir\\foo",
+      "\\\\?\\C:\\known\\dir\\foo",
+    ]);
+    expect(exitCode).toBe(0);
   });
 
   test("undefined argument are ignored if absolute path comes first (reverse loop through args)", () => {

--- a/test/js/node/path/resolve.test.js
+++ b/test/js/node/path/resolve.test.js
@@ -111,11 +111,8 @@ describe("path.resolve", () => {
     expect(path.win32.resolve("//a/b", "//c/d", "C:foo")).toBe(path.win32.resolve("C:foo"));
   });
 
-  // On Windows, a drive-relative path like "C:foo" is resolved against the
-  // per-drive cwd stored in the `=C:` environment variable. The env value was
-  // being written into the same buffer region that already held the
-  // accumulated tail ("foo"), corrupting the result. Spawn a child with a
-  // known `=C:` so the expected output is deterministic.
+  // Drive-relative paths ("C:foo") resolve against the per-drive cwd in `=C:`.
+  // Spawn a child with a known `=C:` so the expected output is deterministic.
   test.skipIf(!isWindows)("win32 drive-relative input resolves against the per-drive cwd (=X: env var)", async () => {
     const script = `const p = require("path");
       console.log(JSON.stringify([
@@ -134,17 +131,19 @@ describe("path.resolve", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(JSON.parse(stdout.trim())).toEqual([
-      "C:\\known\\dir\\foo",
-      "C:\\known\\dir",
-      "C:\\known\\dir\\foo",
-      "C:\\known\\dir\\foo\\bar",
-      "c:\\known\\dir\\foo",
-      "C:\\known\\dir\\foo",
-      "\\\\?\\C:\\known\\dir\\foo",
-    ]);
-    expect(exitCode).toBe(0);
+    expect({ stdout: JSON.parse(stdout.trim()), stderr, exitCode }).toEqual({
+      stdout: [
+        "C:\\known\\dir\\foo",
+        "C:\\known\\dir",
+        "C:\\known\\dir\\foo",
+        "C:\\known\\dir\\foo\\bar",
+        "c:\\known\\dir\\foo",
+        "C:\\known\\dir\\foo",
+        "\\\\?\\C:\\known\\dir\\foo",
+      ],
+      stderr: "",
+      exitCode: 0,
+    });
   });
 
   test("undefined argument are ignored if absolute path comes first (reverse loop through args)", () => {


### PR DESCRIPTION
On Windows, `path.resolve("C:foo")` returns corrupted output instead of resolving against the per-drive cwd stored in the `=C:` environment variable.

## Repro (Windows, pwsh)

```
> bun -e 'console.log(require("path").resolve("C:foo"))'
C:\Users\azureusC:\C:\U
> node -e 'console.log(require("path").resolve("C:foo"))'
C:\Users\azureuser\foo
```

## Cause

`resolve_windows_t` in `src/runtime/node/path.rs` keeps the accumulated path tail in `buf2[0..resolved_tail_len]`. When a drive-relative input has been seen (`resolvedDevice == "C:"`, `resolvedTail == "foo\\"`, `resolvedAbsolute == false`), the final loop iteration reads the `=C:` env var via `GetEnvironmentVariableW` and writes the value into `buf2` starting at index 0, clobbering the tail that was already there. The subsequent `resolvedTail = ${path.slice(rootEnd)}\\${resolvedTail}` step then splices fragments of the env value into itself.

In Node's JS implementation this is a fresh string so it can never alias; the Rust port reuses caller-provided buffers and picked the one already occupied.

## Fix

Write the env value into `tmp_buf` after the resolved device prefix (`tmp_buf[resolved_device_len..]`) instead of `buf2`. That region is scratch at this point: the device occupies `tmp_buf[0..2]`, and nothing reads past it until the UNC builder (which is guarded away when a device is already set). `path_ptr` is adjusted to point there. The later tail-prepend copies from `tmp_buf` into `buf2` with no overlap.

## Verification

Fail-before on Windows with the released binary:

```
USE_SYSTEM_BUN=1 bun test test/js/node/path/resolve.test.js
...
(fail) path.resolve > win32 drive-relative input resolves against the per-drive cwd (=X: env var)
  Expected: ["C:\\known\\dir\\foo", ...]
  Received: ["C:\\known\\dC:\\C:\\k", ...]
```

Pass-after with the debug build: `bun bd test test/js/node/path/` on Windows, 122 pass / 0 fail. Full `test/js/node/path/` on Linux also 122 pass / 0 fail (new test skipped there). `cargo check -p bun_runtime --target x86_64-pc-windows-msvc` clean.

The new test is `skipIf(!isWindows)` because the env-lookup branch is inside `#[cfg(windows)]`; on a non-Windows host `resolve_windows_t` takes the cwd fallback instead, so this code path does not exist. The Linux gate cannot observe a fail-before for a `#[cfg(windows)]`-only code path; the Windows fail-before/pass-after above is the evidence.

Related: #31735 fixes the adjacent non-Windows cwd fallback and the drive-mismatch fallback (different branches of the same else-block); this PR does not overlap with it.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/path/resolve.test.js

<!-- robobun:evidence:end -->