### PR TITLE
crash_handler: classify guard-page SIGSEGV/SIGBUS as StackOverflow on POSIX

### DIFF
--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1588,8 +1588,7 @@ mod draft {
         }
     }
 
-    /// A fault this close to the faulting SP is a guard-page hit, not a stray
-    /// dereference. Same heuristic as the sanitizers' stack-overflow detector.
+    /// A fault this close to SP is a guard-page hit (same heuristic as the sanitizers).
     #[cfg(unix)]
     const STACK_OVERFLOW_SP_SLOP: usize = 0x10000;
 

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -652,14 +652,11 @@ mod draft {
         #[cfg(unix)]
         fn terminal_signal(&self) -> c_int {
             match self {
-                CrashReason::SegmentationFault(_) => libc::SIGSEGV,
+                CrashReason::SegmentationFault(_) | CrashReason::StackOverflow => libc::SIGSEGV,
                 CrashReason::IllegalInstruction(_) => libc::SIGILL,
                 CrashReason::BusError(_) => libc::SIGBUS,
                 CrashReason::FloatingPointError(_) => libc::SIGFPE,
                 CrashReason::Trap(_) => libc::SIGTRAP,
-                // On POSIX a stack overflow arrives as SIGSEGV on the guard
-                // page; re-raise as SIGSEGV so the parent sees the real fault.
-                CrashReason::StackOverflow => libc::SIGSEGV,
                 CrashReason::Abort
                 | CrashReason::Panic(_)
                 | CrashReason::Unreachable
@@ -1591,12 +1588,8 @@ mod draft {
         }
     }
 
-    /// `si_addr` within this distance of the faulting thread's stack pointer
-    /// is classified as a stack overflow rather than a stray dereference.
-    /// x86 exceptions are precise, so `push`/`call` fault with SP still at its
-    /// pre-decrement value and `addr == sp - 8`; explicit `sub rsp, N` runs
-    /// before the faulting store so `addr` is near the already-lowered SP
-    /// regardless of frame size.
+    /// A fault this close to the faulting SP is a guard-page hit, not a stray
+    /// dereference. Same heuristic as the sanitizers' stack-overflow detector.
     #[cfg(unix)]
     const STACK_OVERFLOW_SP_SLOP: usize = 0x10000;
 

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -635,7 +635,6 @@ mod draft {
         Trap(usize),
         /// Windows-only
         DatatypeMisalignment,
-        /// Windows-only
         StackOverflow,
 
         /// Either `main` returned an error, or somewhere else in the code a trace string is printed.
@@ -658,11 +657,13 @@ mod draft {
                 CrashReason::BusError(_) => libc::SIGBUS,
                 CrashReason::FloatingPointError(_) => libc::SIGFPE,
                 CrashReason::Trap(_) => libc::SIGTRAP,
+                // On POSIX a stack overflow arrives as SIGSEGV on the guard
+                // page; re-raise as SIGSEGV so the parent sees the real fault.
+                CrashReason::StackOverflow => libc::SIGSEGV,
                 CrashReason::Abort
                 | CrashReason::Panic(_)
                 | CrashReason::Unreachable
                 | CrashReason::DatatypeMisalignment
-                | CrashReason::StackOverflow
                 | CrashReason::ZigError(_)
                 | CrashReason::OutOfMemory => libc::SIGABRT,
             }
@@ -1516,27 +1517,41 @@ mod draft {
         ARCH_DISPLAY_STRING,
     );
 
-    /// Extract `(pc, fp)` from the `ucontext_t` the kernel hands the signal
+    #[cfg(unix)]
+    #[derive(Clone, Copy)]
+    struct FaultRegs {
+        pc: usize,
+        fp: usize,
+        sp: usize,
+    }
+
+    /// Extract `pc`/`fp`/`sp` from the `ucontext_t` the kernel hands the signal
     /// handler. Seeds the frame-pointer walk from the faulting frame. Returns
     /// `None` on arch/OS combos we don't have register offsets for (the caller
     /// then falls back to a current-stack capture).
     #[cfg(unix)]
-    fn fault_context_from_ucontext(ctx: *mut c_void) -> Option<(usize, usize)> {
+    fn fault_context_from_ucontext(ctx: *mut c_void) -> Option<FaultRegs> {
         debug_assert!(!ctx.is_null());
         let uc = ctx.cast::<libc::ucontext_t>().cast_const();
         #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
         // SAFETY: the kernel passes a valid ucontext_t as the handler's 3rd arg.
         unsafe {
             let mc = &(*uc).uc_mcontext;
-            let pc = mc.gregs[libc::REG_RIP as usize] as usize;
-            let fp = mc.gregs[libc::REG_RBP as usize] as usize;
-            Some((pc, fp))
+            Some(FaultRegs {
+                pc: mc.gregs[libc::REG_RIP as usize] as usize,
+                fp: mc.gregs[libc::REG_RBP as usize] as usize,
+                sp: mc.gregs[libc::REG_RSP as usize] as usize,
+            })
         }
         #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
         // SAFETY: the kernel passes a valid ucontext_t as the handler's 3rd arg.
         unsafe {
             let mc = &(*uc).uc_mcontext;
-            Some((mc.pc as usize, mc.regs[29] as usize))
+            Some(FaultRegs {
+                pc: mc.pc as usize,
+                fp: mc.regs[29] as usize,
+                sp: mc.sp as usize,
+            })
         }
         #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
         // SAFETY: the kernel passes a valid ucontext_t as the handler's 3rd arg.
@@ -1545,7 +1560,11 @@ mod draft {
             if mc.is_null() {
                 return None;
             }
-            Some(((*mc).__ss.__rip as usize, (*mc).__ss.__rbp as usize))
+            Some(FaultRegs {
+                pc: (*mc).__ss.__rip as usize,
+                fp: (*mc).__ss.__rbp as usize,
+                sp: (*mc).__ss.__rsp as usize,
+            })
         }
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         // SAFETY: the kernel passes a valid ucontext_t as the handler's 3rd arg.
@@ -1554,7 +1573,11 @@ mod draft {
             if mc.is_null() {
                 return None;
             }
-            Some(((*mc).__ss.__pc as usize, (*mc).__ss.__fp as usize))
+            Some(FaultRegs {
+                pc: (*mc).__ss.__pc as usize,
+                fp: (*mc).__ss.__fp as usize,
+                sp: (*mc).__ss.__sp as usize,
+            })
         }
         #[cfg(not(any(
             all(target_os = "linux", target_arch = "x86_64"),
@@ -1568,25 +1591,46 @@ mod draft {
         }
     }
 
+    /// `si_addr` within this distance of the faulting thread's stack pointer
+    /// is classified as a stack overflow rather than a stray dereference.
+    /// x86 exceptions are precise, so `push`/`call` fault with SP still at its
+    /// pre-decrement value and `addr == sp - 8`; explicit `sub rsp, N` runs
+    /// before the faulting store so `addr` is near the already-lowered SP
+    /// regardless of frame size.
+    #[cfg(unix)]
+    const STACK_OVERFLOW_SP_SLOP: usize = 0x10000;
+
+    /// Async-signal-safe: reads only the kernel-provided `si_addr` and `sp`.
+    #[cfg(unix)]
+    pub fn posix_fault_reason(sig: c_int, addr: usize, sp: usize) -> CrashReason {
+        match sig {
+            libc::SIGSEGV | libc::SIGBUS
+                if addr != 0 && sp != 0 && addr.abs_diff(sp) < STACK_OVERFLOW_SP_SLOP =>
+            {
+                CrashReason::StackOverflow
+            }
+            libc::SIGSEGV => CrashReason::SegmentationFault(addr),
+            libc::SIGILL => CrashReason::IllegalInstruction(addr),
+            libc::SIGBUS => CrashReason::BusError(addr),
+            libc::SIGFPE => CrashReason::FloatingPointError(addr),
+            libc::SIGABRT => CrashReason::Abort,
+            libc::SIGTRAP => CrashReason::Trap(addr),
+            // we do not register this handler for other signals
+            _ => unreachable!(),
+        }
+    }
+
     #[cfg(unix)]
     extern "C" fn handle_segfault_posix(sig: c_int, info: *mut libc::siginfo_t, ctx: *mut c_void) {
         // SAFETY: kernel provides a valid siginfo_t; `si_addr` reads the per-platform
         // sigfault address field.
         let addr: usize = unsafe { (*info).si_addr() as usize };
+        let regs = fault_context_from_ucontext(ctx);
 
         crash_handler(
-            match sig {
-                libc::SIGSEGV => CrashReason::SegmentationFault(addr),
-                libc::SIGILL => CrashReason::IllegalInstruction(addr),
-                libc::SIGBUS => CrashReason::BusError(addr),
-                libc::SIGFPE => CrashReason::FloatingPointError(addr),
-                libc::SIGABRT => CrashReason::Abort,
-                libc::SIGTRAP => CrashReason::Trap(addr),
-                // we do not register this handler for other signals
-                _ => unreachable!(),
-            },
-            match fault_context_from_ucontext(ctx) {
-                Some((pc, fp)) => TraceSeed::Fault { pc, fp },
+            posix_fault_reason(sig, addr, regs.map_or(0, |r| r.sp)),
+            match regs {
+                Some(r) => TraceSeed::Fault { pc: r.pc, fp: r.fp },
                 None => TraceSeed::None,
             },
         );
@@ -1622,10 +1666,12 @@ mod draft {
 
                 // SAFETY: stack points to a valid static buffer
                 if unsafe { libc::sigaltstack(&raw const stack, core::ptr::null_mut()) } == 0 {
-                    act_.sa_flags |= libc::SA_ONSTACK;
                     // SAFETY: single global; only mutated during signal-handler setup
                     DID_REGISTER_SIGALTSTACK.store(true, Ordering::Relaxed);
                 }
+            }
+            if DID_REGISTER_SIGALTSTACK.load(Ordering::Relaxed) {
+                act_.sa_flags |= libc::SA_ONSTACK;
             }
         }
 

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -121,6 +121,7 @@ export const cssInternals = {
 export const crash_handler = $rust("crash_handler.rs", "js_bindings.generate") as {
   getMachOImageZeroOffset: () => number;
   segfault: () => void;
+  stackOverflow: () => void;
   panic: () => void;
   rootError: () => void;
   outOfMemory: () => void;

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -132,9 +132,7 @@ pub(crate) mod js_bindings {
         crash_handler::suppress_core_dumps_if_necessary();
         #[cfg(unix)]
         {
-            // Under ASAN the POSIX handler is not installed (`reset_on_posix`
-            // early-returns so ASAN keeps SIGSEGV): exercise the classifier
-            // directly with a fault address just below the current SP.
+            // ASAN owns SIGSEGV (see `js_segfault`); call the classifier directly.
             if Environment::ENABLE_ASAN {
                 let probe = 0u8;
                 let sp = core::hint::black_box(&probe) as *const u8 as usize;
@@ -144,16 +142,11 @@ pub(crate) mod js_bindings {
                     crash_handler::TraceSeed::BeginAddr(crash_handler::debug::return_address()),
                 );
             }
-            // JSC's wasm-fault `jscSignalHandler` is installed over Bun's at VM
-            // init without `SA_ONSTACK`, so a guard-page SIGSEGV can't be
-            // delivered on the exhausted stack and the process dies before any
-            // handler runs. Re-arm Bun's handler (now with `SA_ONSTACK` on a
-            // second call) so the real signal path is what the test observes.
+            // JSC's wasm-fault handler replaced Bun's at VM init without
+            // `SA_ONSTACK`; re-arm so the guard-page fault is deliverable.
             crash_handler::reset_on_posix();
-            // CI runs with `ulimit -s unlimited`; cap the main-thread stack so
-            // recursion faults on the guard page instead of exhausting RAM.
-            // SAFETY: get/setrlimit take valid pointers; the process is about
-            // to crash so lowering limits in the test hook is harmless.
+            // `ulimit -s unlimited` on CI: cap so recursion hits a guard page.
+            // SAFETY: get/setrlimit take valid pointers.
             unsafe {
                 let mut lim: libc::rlimit = core::mem::zeroed();
                 if libc::getrlimit(libc::RLIMIT_STACK, &raw mut lim) == 0 {

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -23,6 +23,7 @@ pub(crate) mod js_bindings {
             ("getFeatureData", __jsc_host_js_get_feature_data),
             ("segfault", __jsc_host_js_segfault),
             ("segfaultInDll", __jsc_host_js_segfault_in_dll),
+            ("stackOverflow", __jsc_host_js_stack_overflow),
             ("panic", __jsc_host_js_panic),
             ("rootError", __jsc_host_js_root_error),
             ("outOfMemory", __jsc_host_js_out_of_memory),
@@ -123,6 +124,55 @@ pub(crate) mod js_bindings {
             return js_segfault(_global, _frame);
         }
         #[allow(unreachable_code)]
+        Ok(JSValue::UNDEFINED)
+    }
+
+    #[bun_jsc::host_fn]
+    fn js_stack_overflow(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
+        crash_handler::suppress_core_dumps_if_necessary();
+        #[cfg(unix)]
+        {
+            // Under ASAN the POSIX handler is not installed (`reset_on_posix`
+            // early-returns so ASAN keeps SIGSEGV): exercise the classifier
+            // directly with a fault address just below the current SP.
+            if Environment::ENABLE_ASAN {
+                let probe = 0u8;
+                let sp = core::hint::black_box(&probe) as *const u8 as usize;
+                let addr = sp.saturating_sub(128);
+                crash_handler::crash_handler(
+                    crash_handler::posix_fault_reason(libc::SIGSEGV, addr, sp),
+                    crash_handler::TraceSeed::BeginAddr(crash_handler::debug::return_address()),
+                );
+            }
+            // JSC's wasm-fault `jscSignalHandler` is installed over Bun's at VM
+            // init without `SA_ONSTACK`, so a guard-page SIGSEGV can't be
+            // delivered on the exhausted stack and the process dies before any
+            // handler runs. Re-arm Bun's handler (now with `SA_ONSTACK` on a
+            // second call) so the real signal path is what the test observes.
+            crash_handler::reset_on_posix();
+            // CI runs with `ulimit -s unlimited`; cap the main-thread stack so
+            // recursion faults on the guard page instead of exhausting RAM.
+            // SAFETY: get/setrlimit take valid pointers; the process is about
+            // to crash so lowering limits in the test hook is harmless.
+            unsafe {
+                let mut lim: libc::rlimit = core::mem::zeroed();
+                if libc::getrlimit(libc::RLIMIT_STACK, &raw mut lim) == 0 {
+                    const CAP: libc::rlim_t = 16 << 20;
+                    if lim.rlim_cur == libc::RLIM_INFINITY || lim.rlim_cur > CAP {
+                        lim.rlim_cur = CAP.min(lim.rlim_max);
+                        let _ = libc::setrlimit(libc::RLIMIT_STACK, &raw const lim);
+                    }
+                }
+            }
+        }
+        #[inline(never)]
+        #[allow(unconditional_recursion)]
+        fn recurse(n: usize) -> usize {
+            let frame = [n; 64];
+            core::hint::black_box(&frame);
+            core::hint::black_box(recurse(core::hint::black_box(n).wrapping_add(1)))
+        }
+        core::hint::black_box(recurse(0));
         Ok(JSValue::UNDEFINED)
     }
 

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -142,8 +142,7 @@ pub(crate) mod js_bindings {
                     crash_handler::TraceSeed::BeginAddr(crash_handler::debug::return_address()),
                 );
             }
-            // JSC's wasm-fault handler replaced Bun's at VM init without
-            // `SA_ONSTACK`; re-arm so the guard-page fault is deliverable.
+            // Re-arm over JSC's wasm-fault handler, which lacks `SA_ONSTACK`.
             crash_handler::reset_on_posix();
             // `ulimit -s unlimited` on CI: cap so recursion hits a guard page.
             // SAFETY: get/setrlimit take valid pointers.

--- a/test/cli/run/fixture-crash.js
+++ b/test/cli/run/fixture-crash.js
@@ -12,6 +12,6 @@ if (approach in crash_handler) {
   crash_handler[approach]();
 } else {
   console.error(
-    "usage: bun fixture-crash.js <segfault|segfaultInDll|panic|rootError|outOfMemory|abort|trap|raiseIgnoringPanicHandler>",
+    "usage: bun fixture-crash.js <segfault|segfaultInDll|stackOverflow|panic|rootError|outOfMemory|abort|trap|raiseIgnoringPanicHandler>",
   );
 }

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -1,6 +1,6 @@
 import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, isLinux, isMacOS, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
 import { rmSync } from "node:fs";
 import { constants as osConstants } from "node:os";
 import path from "path";
@@ -95,7 +95,10 @@ test.if(isPosix)(
 // "Segmentation fault at 0x<guard page>", or bun.report buckets every deep
 // recursion in native code as an arbitrary wild-pointer crash. Windows gets
 // `EXCEPTION_STACK_OVERFLOW` from the kernel and never needed this detection.
-test.if(isPosix)("native stack overflow is reported as StackOverflow, not SegmentationFault", async () => {
+// Linux and macOS only: those are the targets `fault_context_from_ucontext`
+// has register offsets for; elsewhere SP is unavailable and the fault still
+// reports as a plain segfault.
+test.if(isLinux || isMacOS)("native stack overflow is reported as StackOverflow, not SegmentationFault", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -89,6 +89,32 @@ test.if(isPosix)(
   20_000,
 );
 
+// On POSIX a native stack overflow faults on the thread's guard page and the
+// kernel delivers SIGSEGV. The handler must recognise that address and report
+// `StackOverflow` (trace-string reason byte '7') rather than a generic
+// "Segmentation fault at 0x<guard page>", or bun.report buckets every deep
+// recursion in native code as an arbitrary wild-pointer crash. Windows gets
+// `EXCEPTION_STACK_OVERFLOW` from the kernel and never needed this detection.
+test.if(isPosix)("native stack overflow is reported as StackOverflow, not SegmentationFault", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      path.join(import.meta.dir, "fixture-crash.js"),
+      "stackOverflow",
+      "--debug-crash-handler-use-trace-string",
+    ],
+    env: noReportEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("Stack overflow");
+  expect(stderr).not.toContain("Segmentation fault at address");
+  expect(proc.signalCode).toBe("SIGSEGV");
+  expect(exitCode).not.toBe(0);
+  void stdout;
+});
+
 // After printing the crash report the handler must terminate with a signal
 // that reflects the crash cause: panics abort (SIGABRT), a caught fault is
 // re-raised as the original signal. Previously the handler ended in a trap


### PR DESCRIPTION
## What

`CrashReason::StackOverflow` was only ever produced on Windows from `EXCEPTION_STACK_OVERFLOW`. On Linux/macOS a native stack overflow arrives as `SIGSEGV` (or `SIGBUS` on darwin) on the thread's guard page, and `handle_segfault_posix` mapped every `SIGSEGV` to `SegmentationFault(addr)`. Result: a Rust/C++ deep-recursion crash reported as `Segmentation fault at address 0x<guard page>`, the trace-string reason byte `7` was never emitted on POSIX, bun.report could not bucket stack overflows, and users got the wrong "how to fix" hint.

## Fix

`handle_segfault_posix` now routes through `posix_fault_reason(sig, addr, sp)`, which returns `StackOverflow` when `si_addr` is within 64KB of the faulting stack pointer read from `ucontext_t`. This is the same heuristic the sanitizers use: it reads only kernel-provided register state so it is async-signal-safe (no `pthread_getattr_np`, which on glibc `fopen`s `/proc/self/maps` and would deadlock a heap-corruption fault that arrives while an allocator lock is held), and it works on every thread without pre-registration. `fault_context_from_ucontext` is extended to also extract SP on linux/macos x64/arm64. On targets where it has no register offsets (FreeBSD, Android) SP is 0 and the classifier falls back to `SegmentationFault`, unchanged from before; the test is gated to Linux and macOS accordingly.

`terminal_signal()` now re-raises `StackOverflow` as `SIGSEGV` on POSIX so the parent process and core-dump analyzers still see the real fault.

Also fixes a latent bug in `update_posix_segfault_handler`: it only OR'd `SA_ONSTACK` into `sa_flags` on the first call, so any subsequent re-install (including the existing one in `SignalForwarding::drop()`) silently dropped `SA_ONSTACK` and a guard-page SIGSEGV could not be delivered on the exhausted stack. It now sets `SA_ONSTACK` whenever the altstack is already registered.

## Test

Adds a `stackOverflow` deep-recursion hook to `bun:internal-for-testing` and a POSIX test that asserts the report says `Stack overflow`, not `Segmentation fault at address`, with terminal signal `SIGSEGV`. The hook re-arms Bun's handler before recursing (JSC's wasm-fault `jscSignalHandler` installs over it at VM init without `SA_ONSTACK`, so without the re-arm the kernel cannot deliver the guard-page fault at all); under ASAN, where Bun's handler is not installed, it feeds an address one page below the current SP through `posix_fault_reason` directly. Verified on both `bun bd` (ASAN) and a local release build.

```
panic(main thread): Stack overflow
```

Note: on release builds a stack overflow that occurs while JSC's handler is the active one still dies without a crash report, because `WTF::SignalHandlers::finalize()` installs with `sa_flags = SA_SIGINFO` only. That is a pre-existing WebKit limitation and is out of scope here.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/run-crash-handler.test.ts

<!-- robobun:evidence:end -->
