### PR TITLE
Delete more dead porting-era type aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,6 @@ dependencies = [
  "allocator-api2",
  "bitflags",
  "bstr",
- "bumpalo",
  "bun_mimalloc_sys",
  "bun_opaque",
  "bun_wyhash",

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -3240,8 +3240,7 @@ pub use char_freq::CharFreq;
 pub use e as E;
 pub use e::CallUnwrap as CanBeUnwrapped;
 pub use expr::{
-    Data as ExprData, Expr, IntoExprData, IntoExprData as ExprInit,
-    PrimitiveType as KnownPrimitive, Tag as ExprTag,
+    Data as ExprData, Expr, IntoExprData, PrimitiveType as KnownPrimitive, Tag as ExprTag,
 };
 pub use g as G;
 pub use g::NamespaceAlias;

--- a/src/bun_alloc/Cargo.toml
+++ b/src/bun_alloc/Cargo.toml
@@ -25,5 +25,4 @@ allocator-api2.workspace = true
 
 bun_mimalloc_sys.workspace = true
 bun_wyhash.workspace = true
-bumpalo.workspace = true
 typed-arena.workspace = true

--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -114,8 +114,6 @@ pub struct StdAllocator {
     pub ptr: *mut core::ffi::c_void,
     pub vtable: &'static AllocatorVTable,
 }
-/// Legacy alias for `AllocatorVTable`.
-pub type VTable = AllocatorVTable;
 
 // SAFETY: `ptr` is an opaque tag/context handle; the vtable is `&'static`.
 // Thread-safety of dispatch is the implementor's concern (mimalloc is
@@ -185,14 +183,8 @@ impl StdAllocator {
 // (global mimalloc). `Arena` is the real per-heap `MimallocArena` — unlike
 // `bumpalo::Bump`, it supports per-allocation free + realloc, so `ArenaVec`
 // no longer leaks on grow.
-//
-// `bumpalo::Bump` is kept as `Bump` for genuinely bump-only scratch (parser
-// node stores that are never resized and where the no-op `deallocate` is the
-// point).
 pub use mimalloc_arena::MimallocArena;
 pub type Arena = MimallocArena;
-/// `bumpalo::Bump` — kept for genuinely bump-only scratch that's never resized.
-pub type Bump = bumpalo::Bump;
 mod baby_vec;
 pub use baby_vec::BabyVec;
 /// Arena-backed `Vec` with `u32` length/capacity.
@@ -2025,7 +2017,6 @@ impl core::hash::Hasher for IdentityU64Hasher {
 type IndexMapHasher = core::hash::BuildHasherDefault<IdentityU64Hasher>;
 
 pub type IndexMap = HashMap<HashKeyType, IndexType, IndexMapHasher>;
-pub type IndexMapManaged = HashMap<HashKeyType, IndexType, IndexMapHasher>;
 
 #[derive(Clone, Copy)]
 pub struct Result {

--- a/src/bun_core/deprecated.rs
+++ b/src/bun_core/deprecated.rs
@@ -12,5 +12,3 @@ pub struct BufferedReader<const BUFFER_SIZE: usize, R> {
     pub start: usize,
     pub end: usize,
 }
-
-

--- a/src/bun_core/deprecated.rs
+++ b/src/bun_core/deprecated.rs
@@ -13,21 +13,4 @@ pub struct BufferedReader<const BUFFER_SIZE: usize, R> {
     pub end: usize,
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// SinglyLinkedList
-// ──────────────────────────────────────────────────────────────────────────
-//
-// DEDUP(D050): the Rust port of `SinglyLinkedList` / `SinglyLinkedNode` was
-// removed — the canonical implementation lives at
-// `bun_collections::pool::{SinglyLinkedList, Node}`. The two had diverged
-// (`data: T` vs `data: MaybeUninit<T>`, `*mut`-null vs `Option<*mut>` returns)
-// and this copy had zero callers outside its own unit test. New consumers
-// should depend on `bun_collections::pool` directly.
 
-// ──────────────────────────────────────────────────────────────────────────
-// RapidHash
-// ──────────────────────────────────────────────────────────────────────────
-
-// Canonical impl lives in the leaf `bun_hash` crate; re-export so the
-// historical `crate::deprecated::RapidHash` path keeps resolving.
-pub use bun_hash::RapidHash;

--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -1466,11 +1466,8 @@ pub fn println(args: fmt::Arguments<'_>) {
 // Scoped debug logging
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Debug-only logs which should not appear in release mode.
-///
-/// To enable a specific log at runtime, set the environment variable
-///   `BUN_DEBUG_${TAG}` to 1.
-///
+/// Default visibility of a [`ScopedLogger`]: whether it emits without
+/// `BUN_DEBUG_${TAG}=1` set.
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum Visibility {
     /// Hide logs for this scope by default.

--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -1471,12 +1471,6 @@ pub fn println(args: fmt::Arguments<'_>) {
 /// To enable a specific log at runtime, set the environment variable
 ///   `BUN_DEBUG_${TAG}` to 1.
 ///
-/// For example, to enable the "foo" log, set the environment variable
-///   BUN_DEBUG_foo=1
-/// To enable all logs, set the environment variable
-///   BUN_DEBUG_ALL=1
-pub type LogFunction = fn(fmt::Arguments<'_>);
-
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum Visibility {
     /// Hide logs for this scope by default.

--- a/src/bun_core/string/wtf.rs
+++ b/src/bun_core/string/wtf.rs
@@ -13,15 +13,6 @@ pub use bun_alloc::{WTFStringImpl, WTFStringImplPtr, WTFStringImplStruct};
 /// the impl since the type is foreign — defined in `bun_alloc`).
 pub use crate::external_shared::WTFString;
 
-/// `WTF::RefPtr<T>` — a nullable owning reference into an externally-refcounted
-/// object. Generic re-export so callers can write `wtf::RefPtr<StringImpl>`
-/// (matching the C++ spelling) without reaching into `bun_ptr` directly.
-pub type RefPtr<T> = crate::external_shared::ExternalShared<T>;
-
-/// `WTF::StringImpl` — alias to the layout-mirroring struct so call sites can
-/// spell `wtf::StringImpl` (used by `wtf::RefPtr<StringImpl>`).
-pub type StringImpl = WTFStringImplStruct;
-
 /// Extension methods on [`WTFStringImplStruct`] that depend on
 /// `bun_string` types ([`ZigStringSlice`], `crate::ZBox`) or
 /// `crate::strings::*` transcoding. Kept as a trait because the struct is

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -3777,8 +3777,7 @@ pub fn fast_random() -> u64 {
 }
 
 // ── hash ──────────────────────────────────────────────────────────────────
-// `bun.hash` (Wyhash) lives in deprecated.rs as RapidHash; this module adds
-// the xxhash64 entry point that ETag/bundler need.
+// `bun.hash` one-shot Wyhash / XxHash64 wrappers over `bun_hash`.
 pub mod hash {
     pub use bun_hash::XxHash64;
     /// One-shot seeded XXH64 over `bytes`.

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -2693,8 +2693,6 @@ pub enum Pollable {
     NotReady,
     Hup,
 }
-/// Alias for [`Pollable`].
-pub type PollFlag = Pollable;
 
 impl Pollable {
     /// Lowercase tag name for the `[sys]` debug log.
@@ -3791,7 +3789,7 @@ pub mod hash {
     /// Wyhash one-shot (`bun.hash`).
     #[inline]
     pub fn wyhash(bytes: &[u8]) -> u64 {
-        crate::deprecated::RapidHash::hash(0, bytes)
+        bun_hash::RapidHash::hash(0, bytes)
     }
 }
 

--- a/src/bun_core/windows_sys.rs
+++ b/src/bun_core/windows_sys.rs
@@ -41,7 +41,6 @@ pub fn GetStdHandle(std_handle: DWORD) -> Option<HANDLE> {
 // `bun_windows_sys` leaf and are re-exported here for the
 // `crate::windows_sys::*` path used by callers.
 // ──────────────────────────────────────────────────────────────────────────
-pub use bun_windows_sys::UNICODE_STRING as UnicodeString;
 pub use bun_windows_sys::{
     CURDIR, Curdir, PEB, PebView, ProcessParameters, RTL_USER_PROCESS_PARAMETERS, TEB, peb, teb,
 };
@@ -53,10 +52,8 @@ pub use bun_windows_sys::{
 unsafe impl crate::ffi::Zeroable for CONSOLE_SCREEN_BUFFER_INFO {}
 
 // kernel32 externs are owned by the tier-0 leaf `bun_windows_sys`; re-export
-// so existing `crate::windows_sys::kernel32::*` / `c::*` callers resolve.
+// so existing `crate::windows_sys::kernel32::*` callers resolve.
 pub use bun_windows_sys::kernel32;
-// `c::` alias used by `output.rs`.
-pub use kernel32 as c;
 
 /// `bun.windows.libuv` — only `uv_disable_stdio_inheritance` is called from
 /// `bun_core`; declared directly to avoid a `bun_libuv_sys` dep at tier-0.

--- a/src/bun_core/wtf.rs
+++ b/src/bun_core/wtf.rs
@@ -56,6 +56,5 @@ pub fn parse_es5_date(buf: &[u8]) -> Result<f64, InvalidDate> {
 // `bun_core::wtf::parse_double` (formerly `bun_core::wtf::parse_double`)
 // resolves unchanged.
 pub use crate::string::wtf::{
-    InvalidCharacter, RefPtr, StringImpl, WTFString, WTFStringImpl, WTFStringImplExt,
-    WTFStringImplStruct, parse_double,
+    InvalidCharacter, WTFString, WTFStringImpl, WTFStringImplExt, WTFStringImplStruct, parse_double,
 };

--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -202,7 +202,6 @@ pub mod linker_context {
 // modules above.
 // ---------------------------------------------------------------------------
 
-pub use Graph::Graph as GraphStruct;
 /// See `bundle_v2`.
 pub use bundle_v2::BundleV2;
 /// See `chunk` module.
@@ -314,7 +313,6 @@ pub mod options {
 /// is canonical in `bun_js_parser`; the bundler-tier `disabled`/`set_disabled`
 /// live on `RuntimeTranspilerCacheExt`.
 pub use cache::RuntimeTranspilerCacheExt;
-pub use cache::Set as Cache;
 
 // ──────────────────────────────────────────────────────────────────────────
 // Re-export the canonical `bake_types` defs from

--- a/src/collections/bit_set.rs
+++ b/src/collections/bit_set.rs
@@ -104,19 +104,6 @@ fn set_range_value_masks(masks: &mut [usize], range: Range, value: bool) {
     }
 }
 
-// ───────────────────────────── StaticBitSet ─────────────────────────────
-
-/// Returns the optimal static bit set type for the specified number
-/// of elements.  The returned type will perform no allocations,
-/// can be copied by value, and does not require deinitialization.
-/// Both possible implementations fulfill the same interface.
-///
-// Stable Rust cannot select a struct definition from a const generic, so this
-// alias is the integer form and is only valid for `SIZE <= usize::BITS`
-// (enforced by `IntegerBitSet`'s debug asserts). Callers needing more bits
-// must use `ArrayBitSet<SIZE, { num_masks_for(SIZE) }>` directly.
-pub type StaticBitSet<const SIZE: usize> = IntegerBitSet<SIZE>;
-
 // ───────────────────────────── IntegerBitSet ─────────────────────────────
 
 /// A bit set with static size, which is backed by a single integer.

--- a/src/collections/bit_set.rs
+++ b/src/collections/bit_set.rs
@@ -6,7 +6,7 @@
 //! large and the number of actual items in a given set is usually
 //! small, they may be less memory efficient than an array set.
 //!
-//! There are five variants defined here:
+//! There are four variants defined here:
 //!
 //! IntegerBitSet:
 //!   A bit set with static size, which is backed by a single integer.
@@ -17,10 +17,6 @@
 //!   A bit set with static size, which is backed by an array of usize.
 //!   This set is good for sets with a larger size, but may use
 //!   more bytes than necessary if your set is small.
-//!
-//! StaticBitSet:
-//!   Picks either IntegerBitSet or ArrayBitSet depending on the requested
-//!   size.  The interfaces of these two types match exactly, except for fields.
 //!
 //! DynamicBitSet:
 //!   A bit set with runtime-known size, backed by an allocated slice

--- a/src/collections/lib.rs
+++ b/src/collections/lib.rs
@@ -42,7 +42,6 @@ pub use vec_ext::{ByteVecExt, OffsetByteList, VecExt, prepend_from};
 
 pub use bit_set::{
     AutoBitSet, DynamicBitSet, DynamicBitSetList, DynamicBitSetUnmanaged, IntegerBitSet,
-    StaticBitSet,
 };
 
 // Re-export for back-compat (`bun_jsc::host_fn`, `multi_array_list` import

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -77,19 +77,14 @@ pub use bun_uws::ssl_wrapper::SSLWrapper;
 // `NewHTTPContext`; alias all spellings to the canonical types so submodules
 // resolve without churn.
 pub use h2_client as h2;
-pub use h2_client as H2;
 pub use h3_client as h3;
 pub use h3_client as H3;
-pub use http_context as new_http_context;
 pub type NewHTTPContext<const SSL: bool> = http_context::HTTPContext<SSL>;
 pub type NewHttpContext<const SSL: bool> = http_context::HTTPContext<SSL>;
 pub type HttpsContext = http_context::HTTPContext<true>;
-pub type HttpContext = http_context::HTTPContext<false>;
 pub type HttpClient<'a> = HTTPClient<'a>;
-pub type HttpThread = HTTPThread;
 pub type AsyncHttp<'a> = AsyncHTTP<'a>;
 pub type ThreadlocalAsyncHttp<'a> = ThreadlocalAsyncHTTP<'a>;
-pub use HTTPClientResult as http_client_result;
 pub use bun_http_types::FetchRedirect::FetchRedirect;
 pub use bun_http_types::Method::Method;
 pub use bun_picohttp as picohttp;

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -961,9 +961,9 @@ use crate::internal_state::{RequestStage, ResponseStage, Stage};
 
 bun_core::declare_scope!(fetch, visible);
 
-/// Generic `HttpContext<const SSL>` alias — `crate::HttpContext` /
-/// `crate::HttpsContext` (above) are concrete-SSL aliases; the state machine
-/// needs a const-generic spelling for `get_ssl_ctx<IS_SSL>()`.
+/// Generic `HttpContext<const SSL>` alias — `crate::HttpsContext` (above) is
+/// the concrete-SSL alias; the state machine needs a const-generic spelling
+/// for `get_ssl_ctx<IS_SSL>()`.
 pub type GenHttpContext<const SSL: bool> = http_context::HTTPContext<SSL>;
 
 // ── header constants ────────────────────────────────────────────────────

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -150,12 +150,7 @@ pub mod lockfile {
     // Back-compat aliases for names the inline stub spelled differently.
     pub use crate::Origin;
     pub use crate::lockfile_real::LockfileFormat as Format;
-    pub use crate::lockfile_real::Serializer::SerializerLoadResult;
     pub use crate::lockfile_real::package_index::Entry as PackageIndexEntry;
-    /// Callers pass a `Resolution.Tag` literal when invoking
-    /// `Scripts.createList` for the root package; alias the tag enum here so
-    /// `lockfile::ScriptsListKind::Root` resolves.
-    pub use crate::resolution::Tag as ScriptsListKind;
     /// `MultiArrayList<Package>.append` row type — the real `PackageList`
     /// (`package::List<u64>`) takes a `Package` value, so alias the row type
     /// for callers (e.g. `migration.rs`) that spell it `PackageListEntry`.

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -137,8 +137,6 @@ bun_dispatch::link_interface! {
     }
 }
 
-pub type EventLoopKind = EventLoopCtxKind;
-
 impl EventLoopCtx {
     /// SAFETY: caller must not hold another live `&mut` to the same loop
     /// across this borrow (resolver-style accessor; the loop is per-thread).
@@ -481,9 +479,6 @@ pub use source::Source;
 pub enum Source {}
 
 pub use pipe_reader::{BufferedReader, BufferedReaderParent, PosixFlags};
-/// Downstream alias (`BufferedReader` is sometimes referenced as
-/// `PipeReader`).
-pub type PipeReader = BufferedReader;
 
 pub use open_for_writing_mod::{open_for_writing, open_for_writing_impl};
 

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -84,7 +84,7 @@ fn deregistration_already_gone(errno: sys::E) -> bool {
     matches!(errno, sys::E::ENOENT | sys::E::EBADF)
 }
 
-pub use crate::{EventLoopCtx, EventLoopCtxKind, EventLoopKind, OpaqueCallback};
+pub use crate::{EventLoopCtx, EventLoopCtxKind, OpaqueCallback};
 
 unsafe extern "Rust" {
     /// Defined `#[no_mangle]` in `bun_runtime::jsc_hooks`.

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1022,8 +1022,6 @@ impl Default for IntegerRange {
         }
     }
 }
-/// Back-compat alias — earlier ports spelled this `IntegerRangeOptions`.
-pub type IntegerRangeOptions = IntegerRange;
 
 // ──────────────────────────────────────────────────────────────────────────
 // ResolvedSource — `#[repr(C)]` mirror of the C struct in
@@ -1516,8 +1514,6 @@ pub mod module_loader;
 pub use self::module_loader as ModuleLoader;
 
 pub type ErrorableResolvedSource = Errorable<ResolvedSource>;
-pub type ErrorableZigString = Errorable<bun_core::ZigString>;
-pub type ErrorableJSValue = Errorable<JSValue>;
 pub type ErrorableString = Errorable<bun_core::String>;
 
 #[path = "hot_reloader.rs"]

--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -51,9 +51,8 @@ pub use bun_core_macros::{Anchored, CellRefCounted, RefCounted, ThreadSafeRefCou
 
 pub mod parent_ref;
 pub use parent_ref::{Anchored, LiveMarker, ParentRef};
-// Compat aliases for callers that use the pointer-typedef names.
+// Compat alias for callers that use the pointer-typedef name.
 pub type IntrusiveRc<T> = RefPtr<T>;
-pub type IntrusiveArc<T> = RefPtr<T>;
 
 pub use raw_ref_count::RawRefCount;
 pub use weak_ptr::WeakPtr;

--- a/src/ptr/weak_ptr.rs
+++ b/src/ptr/weak_ptr.rs
@@ -89,8 +89,6 @@ pub struct WeakPtr<T: HasWeakPtrData> {
     raw_ptr: Option<NonNull<T>>,
 }
 
-pub type Data = WeakPtrData;
-
 impl<T: HasWeakPtrData> WeakPtr<T> {
     pub const EMPTY: Self = Self { raw_ptr: None };
 

--- a/src/runtime/allocators/LinuxMemFdAllocator.rs
+++ b/src/runtime/allocators/LinuxMemFdAllocator.rs
@@ -29,7 +29,7 @@ use crate::webcore::blob::store::Bytes as BlobStoreBytes;
 
 /// Intrusive thread-safe ref-counted memfd allocator.
 ///
-/// `ref_count` must stay at this field offset for `bun_ptr::IntrusiveArc<Self>`.
+/// `ref_count` must stay at this field offset for `bun_ptr::RefPtr<Self>`.
 //
 // Intrusive *atomic* refcount. Blob stores (and thus this allocator, smuggled
 // through `StdAllocator.ptr`) cross threads, so the single-threaded `RefCount`
@@ -59,8 +59,8 @@ impl LinuxMemFdAllocator {
 static MEMFD_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 impl LinuxMemFdAllocator {
-    pub fn new(fd: Fd, size: usize) -> bun_ptr::IntrusiveArc<Self> {
-        bun_ptr::IntrusiveArc::new(Self {
+    pub fn new(fd: Fd, size: usize) -> bun_ptr::RefPtr<Self> {
+        bun_ptr::RefPtr::new(Self {
             ref_count: bun_ptr::ThreadSafeRefCount::init(),
             fd,
             size,

--- a/src/runtime/allocators/LinuxMemFdAllocator.rs
+++ b/src/runtime/allocators/LinuxMemFdAllocator.rs
@@ -46,7 +46,7 @@ impl LinuxMemFdAllocator {
     /// Close the fd, then free the allocation.
     ///
     /// # Safety
-    /// Refcount hit 0; `this` came from `heap::alloc` in `IntrusiveArc::new`.
+    /// Refcount hit 0; `this` came from `heap::alloc` in `RefPtr::new`.
     unsafe fn deinit(this: *mut Self) {
         // SAFETY: sole owner — close fd before reclaiming the Box.
         unsafe { (*this).fd.close() };
@@ -77,7 +77,7 @@ impl LinuxMemFdAllocator {
 
     /// # Safety
     /// `this` must point to a live, Box-allocated `Self` (as produced by
-    /// [`Self::new`] / `IntrusiveArc::new`), and the caller must own one
+    /// [`Self::new`] / `RefPtr::new`), and the caller must own one
     /// outstanding ref. After this call `this` may be dangling; the caller
     /// must not hold any live `&Self`/`&mut Self` derived from `this`.
     //
@@ -93,7 +93,7 @@ impl LinuxMemFdAllocator {
 
     /// # Safety
     /// `this` must be the `*mut Self` originally produced by `heap::alloc`
-    /// (via [`Self::new`] / `IntrusiveArc::new`) — the returned allocator's
+    /// (via [`Self::new`] / `RefPtr::new`) — the returned allocator's
     /// `free` will call [`Self::deref`] on it, which on the final ref drops
     /// the `Box`. A `*mut Self` derived from `&self` (SharedReadOnly
     /// provenance) would make that `heap::take` UB.
@@ -303,7 +303,7 @@ mod allocator_interface {
 
     /// # Safety
     /// `ptr` must be the `*mut LinuxMemFdAllocator` originally produced by
-    /// `heap::alloc` (via [`LinuxMemFdAllocator::new`] / `IntrusiveArc::new`)
+    /// `heap::alloc` (via [`LinuxMemFdAllocator::new`] / `RefPtr::new`)
     /// and the caller must own one outstanding ref on it. No `&Self`/`&mut Self`
     /// borrow of `*ptr` may be live across this call — when the refcount hits
     /// zero, `*ptr` is dropped and freed.

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -647,8 +647,6 @@ impl Config {
     }
 }
 
-// Legacy alias for backwards compatibility during migration
-
 // Mimalloc gets unstable if we try to move this to a different thread
 // threadlocal var transform_buffer: bun.MutableString = undefined;
 // threadlocal var transform_buffer_loaded: bool = false;

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -107,7 +107,7 @@ enum BunSocket {
     // shared-only deref safe at every read site (all `NewSocket` methods used
     // here take `&self`). LIFETIMES.tsv: SHARED — intrusive refcount, *T
     // crosses FFI; `NewSocket<SSL>` does not implement `bun_ptr::RefCounted`
-    // (hand-rolled `ref_()/deref()` on a `Cell<u32>`), so `IntrusiveArc` cannot
+    // (hand-rolled `ref_()/deref()` on a `Cell<u32>`), so `RefPtr` cannot
     // wrap it.
     Tls(bun_ptr::BackRef<TLSSocket>),
     TlsWriteonly(bun_ptr::BackRef<TLSSocket>),

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -1653,7 +1653,7 @@ impl WindowsNamedPipeListeningContext {
     /// Only ever invoked by libuv (coerces to the `uv_connection_cb` fn-pointer
     /// type at the `Pipe::listen_named_pipe` call site); body wraps its derefs
     /// explicitly — matches the `extern "C" fn` callback convention used in
-    /// `udp_socket.rs` / `bun_io::PipeReader`.
+    /// `udp_socket.rs` / `bun_io::BufferedReader`.
     extern "C" fn uv_on_client_connect(handle: *mut uv::uv_stream_t, status: uv::ReturnCode) {
         // SAFETY: `data` was set to `*mut Self` by `Pipe::listen` below.
         let this = unsafe { (*handle).data.cast::<WindowsNamedPipeListeningContext>() };

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -349,8 +349,6 @@ pub mod js_fns {
         hook!(on_test_finished, OnTestFinished);
     }
 }
-/// Compat alias for sibling drafts (jest.rs) that referenced `bun_test::HookKind`.
-pub use js_fns::GenericHookTag as HookKind;
 
 /// `Rc<BunTestCell>`: single-thread, weak-capable, interior-mutable shared handle.
 ///

--- a/src/runtime/valkey_jsc/mod.rs
+++ b/src/runtime/valkey_jsc/mod.rs
@@ -38,10 +38,8 @@ pub mod index;
 
 // ─── back-compat aliases ─────────────────────────────────────────────────────
 // Sibling files were written against `*_body` module names (`valkey.rs`
-// imports `super::js_valkey_body`, `js_valkey.rs` imports
-// `super::valkey_command_body`); keep the aliases so they don't need to churn.
+// imports `super::js_valkey_body`); keep the alias so it doesn't need to churn.
 pub use self::js_valkey as js_valkey_body;
-pub use self::valkey as valkey_body;
 
 // ─── public re-exports ───────────────────────────────────────────────────────
 pub use js_valkey::JSValkeyClient;

--- a/src/sourcemap/ParsedSourceMap.rs
+++ b/src/sourcemap/ParsedSourceMap.rs
@@ -15,7 +15,7 @@ use crate::{
 /// source map store (SavedSourceMap), so the reference count must be thread-safe.
 pub struct ParsedSourceMap {
     // bun.ptr.ThreadSafeRefCount → intrusive atomic count; managed via
-    // `bun_ptr::IntrusiveArc<ParsedSourceMap>`. `ref`/`deref` are methods on IntrusiveArc.
+    // `bun_ptr::RefPtr<ParsedSourceMap>`. `ref`/`deref` are methods on RefPtr.
     pub ref_count: AtomicU32,
 
     pub input_line_count: usize,

--- a/src/threading/guarded.rs
+++ b/src/threading/guarded.rs
@@ -17,9 +17,6 @@ pub type Guarded<Value> = GuardedBy<Value, Mutex>;
 /// [`crate::mutex::MutexGuard`] returned by `Mutex::lock_guard()`.
 pub type MutexGuard<'a, Value> = GuardedLock<'a, Value, Mutex>;
 
-/// Uses `bun_safety::ThreadLock`.
-pub type Debug<Value> = GuardedBy<Value, ThreadLock>;
-
 /// A wrapper around a mutex, and a value protected by the mutex.
 /// `M` should have `lock` and `unlock` methods.
 pub struct GuardedBy<Value, M: RawMutex> {

--- a/src/threading/guarded.rs
+++ b/src/threading/guarded.rs
@@ -3,7 +3,6 @@
 use core::cell::UnsafeCell;
 
 use crate::Mutex;
-use bun_safety::ThreadLock;
 
 /// A wrapper around a mutex, and a value protected by the mutex.
 /// This type uses `bun_threading::Mutex` internally.
@@ -162,16 +161,5 @@ impl RawMutex for Mutex {
     #[inline]
     fn unlock(&self) {
         Mutex::unlock(self)
-    }
-}
-
-impl RawMutex for ThreadLock {
-    #[inline]
-    fn lock(&self) {
-        ThreadLock::lock(self)
-    }
-    #[inline]
-    fn unlock(&self) {
-        ThreadLock::unlock(self)
     }
 }

--- a/src/threading/lib.rs
+++ b/src/threading/lib.rs
@@ -32,7 +32,6 @@ pub use condition::{Condition, Condvar};
 /// `Futex` re-exported as a capitalized module alias so callers can write
 /// `Futex::wait`, `Futex::wake`, `Futex::Deadline`.
 pub use futex as Futex;
-pub use guarded::Debug as DebugGuarded;
 pub use guarded::RawMutex;
 pub use guarded::{Guarded, GuardedBy, GuardedLock};
 pub use mutex::{Mutex, MutexGuard};

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -1269,9 +1269,8 @@ impl QueryStringMap {
     }
 }
 
-// Browsers typically limit URL lengths to around 64k
-// bun_collections::StaticBitSet currently aliases IntegerBitSet (≤64 bits), so
-// pick ArrayBitSet directly. 2048 / 64 == 32 masks.
+// Browsers typically limit URL lengths to around 64k.
+// IntegerBitSet caps at ≤64 bits, so pick ArrayBitSet directly. 2048 / 64 == 32 masks.
 /// Hard cap on parsed query-string parameters, enforced in `init` /
 /// `init_with_scanner` so the fixed-size `VisitedMap` bitset is never indexed
 /// out of bounds.


### PR DESCRIPTION
Follow-up to #34763 and #34767. Third pass removing zero-caller `pub type` / `pub use` aliases left over from the Zig port, this time reaching into mid-tier crates (jsc, http, io, install, ast, bundler, runtime) in addition to the foundation tier.

### Zero-caller aliases deleted

| Crate | Items |
|---|---|
| `bun_alloc` | `VTable`, `Bump`, `IndexMapManaged` |
| `bun_ptr` | `IntrusiveArc`, `weak_ptr::Data` |
| `bun_collections` | `StaticBitSet` |
| `bun_threading` | `guarded::Debug`, `DebugGuarded` |
| `bun_core` | `util::PollFlag`, `output::LogFunction`, `wtf::{RefPtr, StringImpl}`, `windows_sys::{UnicodeString, kernel32 as c}`, `deprecated::RapidHash` re-export + SinglyLinkedList tombstone comment |
| `bun_jsc` | `IntegerRangeOptions`, `ErrorableZigString`, `ErrorableJSValue` |
| `bun_http` | `H2`, `new_http_context`, `HttpContext`, `HttpThread`, `http_client_result` |
| `bun_io` | `EventLoopKind`, `PipeReader` |
| `bun_install` | `lockfile::{SerializerLoadResult, ScriptsListKind}` |
| `bun_ast` | `ExprInit` |
| `bun_bundler` | `GraphStruct`, `Cache` |
| `bun_runtime` | `valkey_jsc::valkey_body`, `test_runner::HookKind`, orphaned comment in JSTranspiler.rs |

### Caller rewrites (1 call site each)

- `runtime/allocators/LinuxMemFdAllocator.rs`: `bun_ptr::IntrusiveArc` → `bun_ptr::RefPtr` (IntrusiveArc was a type alias for RefPtr)
- `bun_core/util.rs`: `crate::deprecated::RapidHash` → `bun_hash::RapidHash` (direct path to canonical impl)

### Stale comment refs updated

- `url/lib.rs`: StaticBitSet → IntegerBitSet
- `runtime/socket/Listener.rs`: PipeReader → BufferedReader
- `runtime/allocators/LinuxMemFdAllocator.rs`: IntrusiveArc → RefPtr

### Verification

- `bun bd` builds
- `bun run rust:check-all` passes on all 10 targets

Net: +13 / -110.

No test added: every deleted item had zero callers (verified by workspace-wide `rg` per item); the two rewrites are to the type the alias already resolved to.