### PR TITLE
usockets: round epoll_pwait fallback timeout up and subtract elapsed time on EINTR retry

### DIFF
--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -188,6 +188,36 @@ static int bun_epoll_pwait2(int epfd, struct epoll_event *events, int maxevents,
 
 extern int Bun__isEpollPwait2SupportedOnLinuxKernel();
 
+#else
+
+/* kevent(2) returns EINTR when a signal is caught (XNU kqueue_scan returns
+ * EINTR on THREAD_INTERRUPTED; FreeBSD kqueue_scan maps ERESTART->EINTR), so
+ * retry with the remaining time against an absolute monotonic deadline. */
+static int bun_kevent64_wait(int kqfd, struct kevent64_s *eventlist, int nevents, unsigned int flags, const struct timespec *timeout) {
+    int ret;
+    uint64_t deadline_ns = 0;
+    const int has_deadline = timeout && (timeout->tv_sec | timeout->tv_nsec);
+    if (has_deadline) {
+        deadline_ns = us_internal_monotonic_ns()
+                    + (uint64_t) timeout->tv_sec * 1000000000ULL
+                    + (uint64_t) timeout->tv_nsec;
+    }
+
+    struct timespec remaining_ts;
+    const struct timespec *remaining = timeout;
+    for (;;) {
+        ret = kevent64(kqfd, NULL, 0, eventlist, nevents, flags, remaining);
+        if (!IS_EINTR(ret)) return ret;
+        if (!has_deadline) continue;
+        uint64_t now = us_internal_monotonic_ns();
+        if (now >= deadline_ns) return 0;
+        uint64_t left = deadline_ns - now;
+        remaining_ts.tv_sec  = (time_t) (left / 1000000000ULL);
+        remaining_ts.tv_nsec = (long)   (left % 1000000000ULL);
+        remaining = &remaining_ts;
+    }
+}
+
 #endif
 
 /* Loop */
@@ -376,9 +406,7 @@ void us_loop_run(struct us_loop_t *loop) {
 #ifdef LIBUS_USE_EPOLL
         loop->num_ready_polls = bun_epoll_pwait2(loop->fd, loop->ready_polls, LIBUS_MAX_READY_POLLS, timeout);
 #else
-        do {
-            loop->num_ready_polls = kevent64(loop->fd, NULL, 0, loop->ready_polls, LIBUS_MAX_READY_POLLS, 0, timeout);
-        } while (IS_EINTR(loop->num_ready_polls));
+        loop->num_ready_polls = bun_kevent64_wait(loop->fd, loop->ready_polls, LIBUS_MAX_READY_POLLS, 0, timeout);
 #endif
 
         us_internal_dispatch_ready_polls(loop);
@@ -451,17 +479,15 @@ void us_loop_run_bun_tick(struct us_loop_t *loop, const struct timespec* timeout
      * interaction (line 1975). No equivalent of KEVENT_FLAG_IMMEDIATE needed. */
     loop->num_ready_polls = bun_epoll_pwait2(loop->fd, loop->ready_polls, LIBUS_MAX_READY_POLLS, timeout);
 #else
-    do {
-        loop->num_ready_polls = kevent64(loop->fd, NULL, 0, loop->ready_polls, LIBUS_MAX_READY_POLLS,
-            /* When we won't idle (pending wakeups or zero timeout), use KEVENT_FLAG_IMMEDIATE.
-             * In XNU's kqueue_scan (bsd/kern/kern_event.c):
-             *  - KEVENT_FLAG_IMMEDIATE: returns immediately after kqueue_process() (line 8031)
-             *  - Zero timespec without the flag: falls through to assert_wait_deadline (line 8039)
-             *    and thread_block (line 8048), doing a full context switch cycle (~14us) even
-             *    though the deadline is already in the past. */
-            will_idle_inside_event_loop ? 0 : KEVENT_FLAG_IMMEDIATE,
-            timeout);
-    } while (IS_EINTR(loop->num_ready_polls));
+    loop->num_ready_polls = bun_kevent64_wait(loop->fd, loop->ready_polls, LIBUS_MAX_READY_POLLS,
+        /* When we won't idle (pending wakeups or zero timeout), use KEVENT_FLAG_IMMEDIATE.
+         * In XNU's kqueue_scan (bsd/kern/kern_event.c):
+         *  - KEVENT_FLAG_IMMEDIATE: returns immediately after kqueue_process() (line 8031)
+         *  - Zero timespec without the flag: falls through to assert_wait_deadline (line 8039)
+         *    and thread_block (line 8048), doing a full context switch cycle (~14us) even
+         *    though the deadline is already in the past. */
+        will_idle_inside_event_loop ? 0 : KEVENT_FLAG_IMMEDIATE,
+        timeout);
 #endif
 
     /* Before anything can allocate again. */

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -107,6 +107,7 @@ void us_internal_poll_set_type(struct us_poll_t *p, int poll_type) {
 #include <sys/syscall.h>
 #include <signal.h>
 #include <errno.h>
+#include <limits.h>
 
 static int has_epoll_pwait2 = -1;
 
@@ -126,10 +127,31 @@ static int bun_epoll_pwait2(int epfd, struct epoll_event *events, int maxevents,
     sigset_t mask;
     sigemptyset(&mask);
 
+    /* For a finite non-zero timeout, track an absolute monotonic deadline so
+     * EINTR retries wait for the remaining time (signal(7): epoll_*wait is
+     * never restarted by SA_RESTART). NULL and {0,0} are idempotent on retry. */
+    uint64_t deadline_ns = 0;
+    const int has_deadline = timeout && (timeout->tv_sec | timeout->tv_nsec);
+    if (has_deadline) {
+        deadline_ns = us_internal_monotonic_ns()
+                    + (uint64_t) timeout->tv_sec * 1000000000ULL
+                    + (uint64_t) timeout->tv_nsec;
+    }
+
     if (has_epoll_pwait2 != 0) {
-        do {
-            ret = sys_epoll_pwait2(epfd, events, maxevents, timeout, &mask);
-        } while (ret == -EINTR);
+        struct timespec remaining_ts;
+        const struct timespec *remaining = timeout;
+        for (;;) {
+            ret = sys_epoll_pwait2(epfd, events, maxevents, remaining, &mask);
+            if (LIKELY(ret != -EINTR)) break;
+            if (!has_deadline) continue;
+            uint64_t now = us_internal_monotonic_ns();
+            if (now >= deadline_ns) return 0;
+            uint64_t left = deadline_ns - now;
+            remaining_ts.tv_sec  = (time_t) (left / 1000000000ULL);
+            remaining_ts.tv_nsec = (long)   (left % 1000000000ULL);
+            remaining = &remaining_ts;
+        }
 
         if (LIKELY(ret != -ENOSYS && ret != -EPERM && ret != -EOPNOTSUPP && ret != -EACCES && ret != -EFAULT)) {
             return ret;
@@ -138,14 +160,28 @@ static int bun_epoll_pwait2(int epfd, struct epoll_event *events, int maxevents,
         has_epoll_pwait2 = 0;
     }
 
-    int timeoutMs = -1;
-    if (timeout) {
-        timeoutMs = timeout->tv_sec * 1000 + timeout->tv_nsec / 1000000;
+    /* epoll_pwait(2) takes an int millisecond timeout; epoll_pwait2(2) takes a
+     * timespec (since Linux 5.11). Round the ns remainder UP so a sub-ms delta
+     * waits 1 ms instead of truncating to 0 and busy-spinning. */
+    int timeoutMs;
+    if (!timeout) {
+        timeoutMs = -1;
+    } else {
+        uint64_t ns = (uint64_t) timeout->tv_sec * 1000000000ULL + (uint64_t) timeout->tv_nsec;
+        uint64_t ms = (ns + 999999ULL) / 1000000ULL;
+        timeoutMs = ms > (uint64_t) INT_MAX ? INT_MAX : (int) ms;
     }
 
-    do {
+    for (;;) {
         ret = epoll_pwait(epfd, events, maxevents, timeoutMs, &mask);
-    } while (IS_EINTR(ret));
+        if (!IS_EINTR(ret)) break;
+        if (!has_deadline) continue;
+        uint64_t now = us_internal_monotonic_ns();
+        if (now >= deadline_ns) return 0;
+        uint64_t left_ns = deadline_ns - now;
+        uint64_t left_ms = (left_ns + 999999ULL) / 1000000ULL;
+        timeoutMs = left_ms > (uint64_t) INT_MAX ? INT_MAX : (int) left_ms;
+    }
 
     return ret;
 }

--- a/test/js/web/timers/setTimeout.test.js
+++ b/test/js/web/timers/setTimeout.test.js
@@ -433,7 +433,11 @@ it.skipIf(!isLinux)("epoll_pwait fallback does not busy-spin on sub-ms timers", 
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
+  const filteredStderr = stderr
+    .split("\n")
+    .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
+  expect(filteredStderr).toBe("");
   const { ticks, cpuUs, wallUs } = JSON.parse(stdout);
   const cpuPercent = (cpuUs / wallUs) * 100;
   // Busy-spinning puts cpuUs ~= wallUs (100%). Sleeping properly it is a
@@ -500,7 +504,11 @@ __attribute__((constructor)) static void arm(void) {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
+    const filteredStderr = stderr
+      .split("\n")
+      .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+      .join("\n");
+    expect(filteredStderr).toBe("");
     const { ms } = JSON.parse(stdout);
     // Without the fix this lands ~900-1000 ms; with it, ~200-210 ms.
     expect(ms).toBeWithin(200, 500);

--- a/test/js/web/timers/setTimeout.test.js
+++ b/test/js/web/timers/setTimeout.test.js
@@ -1,7 +1,7 @@
 import { spawnSync } from "bun";
 import { heapStats } from "bun:jsc";
-import { expect, it } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe, isLinux, isWindows, tempDirWithFiles } from "harness";
 import path from "node:path";
 
 it("setTimeout", async () => {
@@ -401,6 +401,111 @@ it("setTimeout CPU usage #7790", async () => {
   expect(code).toBe(0);
   const stats = process.resourceUsage();
   expect(stats.cpuTime.total / BigInt(1e6)).toBeLessThan(1);
+});
+
+// The epoll_pwait(2) fallback (kernels <5.11, gVisor, seccomp-blocked
+// environments) used to truncate the ns-resolution timespec to ms, so any
+// sub-ms timer deadline became a 0 ms timeout and the loop busy-spun at
+// 100% CPU until the deadline passed. Force the fallback and assert
+// setInterval(1) spends most of the window asleep.
+// https://man7.org/linux/man-pages/man2/epoll_wait.2.html
+it.skipIf(!isLinux)("epoll_pwait fallback does not busy-spin on sub-ms timers", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const wall0 = process.hrtime.bigint();
+       const cpu0 = process.cpuUsage();
+       let ticks = 0;
+       const id = setInterval(() => {
+         ticks++;
+         if (process.hrtime.bigint() - wall0 >= 300_000_000n) {
+           clearInterval(id);
+           const cpu = process.cpuUsage(cpu0);
+           const cpuUs = cpu.user + cpu.system;
+           const wallUs = Number((process.hrtime.bigint() - wall0) / 1000n);
+           console.log(JSON.stringify({ ticks, cpuUs, wallUs }));
+         }
+       }, 1);`,
+    ],
+    env: { ...bunEnv, BUN_FEATURE_FLAG_DISABLE_EPOLL_PWAIT2: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const { ticks, cpuUs, wallUs } = JSON.parse(stdout);
+  const cpuPercent = (cpuUs / wallUs) * 100;
+  // Busy-spinning puts cpuUs ~= wallUs (100%). Sleeping properly it is a
+  // small fraction (~5% release). 50% gives wide headroom for ASAN/debug.
+  expect(cpuPercent, `ticks=${ticks} cpuUs=${cpuUs} wallUs=${wallUs}`).toBeLessThan(50);
+  expect(ticks).toBeGreaterThan(0);
+  expect(exitCode).toBe(0);
+});
+
+// EINTR retry used to re-issue the full timeout (on both epoll_pwait and
+// epoll_pwait2), so a signal stream faster than the timer period could
+// delay the timer far past its deadline. We LD_PRELOAD a constructor that
+// installs a no-op SIGALRM handler and a 20 ms ITIMER_REAL (not via
+// process.on(), which wakes the loop via eventfd and masks the bug), and
+// assert a 200 ms setTimeout still fires roughly on time.
+// https://man7.org/linux/man-pages/man7/signal.7.html (epoll_*wait is never
+// restarted by SA_RESTART)
+describe.skipIf(!isLinux)("epoll EINTR retry accounts for elapsed time", () => {
+  const src = `
+#include <signal.h>
+#include <string.h>
+#include <sys/time.h>
+static void noop(int s) { (void) s; }
+__attribute__((constructor)) static void arm(void) {
+    struct sigaction sa; memset(&sa, 0, sizeof sa);
+    sa.sa_handler = noop; sigemptyset(&sa.sa_mask); sa.sa_flags = 0;
+    sigaction(SIGALRM, &sa, 0);
+    struct itimerval itv;
+    itv.it_interval.tv_sec = 0; itv.it_interval.tv_usec = 20000;
+    itv.it_value = itv.it_interval;
+    setitimer(ITIMER_REAL, &itv, 0);
+}`;
+  let soPath = "";
+  let built = false;
+  if (isLinux) {
+    const dir = tempDirWithFiles("epoll-eintr", { "itimer.c": src });
+    soPath = path.join(dir, "itimer.so");
+    try {
+      const cc = spawnSync({
+        cmd: ["cc", "-shared", "-fPIC", "-O0", "-o", soPath, path.join(dir, "itimer.c")],
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      built = cc.exitCode === 0;
+    } catch {}
+  }
+
+  it.skipIf(!built).each([
+    ["epoll_pwait2", {}],
+    ["epoll_pwait fallback", { BUN_FEATURE_FLAG_DISABLE_EPOLL_PWAIT2: "1" }],
+  ])("%s: setTimeout fires on time under signal storm", async (_name, extraEnv) => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const s = process.hrtime.bigint();
+         setTimeout(() => {
+           console.log(JSON.stringify({ ms: Number((process.hrtime.bigint() - s) / 1_000_000n) }));
+           process.exit(0);
+         }, 200);`,
+      ],
+      env: { ...bunEnv, ...extraEnv, LD_PRELOAD: soPath },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const { ms } = JSON.parse(stdout);
+    // Without the fix this lands ~900-1000 ms; with it, ~200-210 ms.
+    expect(ms).toBeWithin(200, 500);
+    expect(exitCode).toBe(0);
+  });
 });
 
 it("Returning a Promise in setTimeout doesnt keep the event loop alive forever", async () => {


### PR DESCRIPTION
## What

Two fixes in the event-loop wait helpers (packages/bun-usockets/src/eventing/epoll_kqueue.c):

1. **epoll_pwait fallback busy-spin.** When `epoll_pwait2(2)` is unavailable (Linux <5.11, RHEL 8's 4.18, gVisor, some seccomp/Android sandboxes) we fall back to `epoll_pwait(2)`, which takes an `int` **millisecond** timeout. The ns->ms conversion truncated (`tv_sec*1000 + tv_nsec/1000000`), so the sub-ms deltas that `timer::All::get_timeout` produces for `setInterval(1)` / fast timers became `epoll_pwait(..., 0)` and the loop busy-spun at 100% CPU until the deadline passed. Now rounds **up** so a sub-ms remainder sleeps for 1 ms, and is capped to `INT_MAX`.

2. **EINTR retry over-waits.** The retry loops on `epoll_pwait2`, the `epoll_pwait` fallback, and both blocking `kevent64` sites re-issued the *original* timeout on `EINTR` with no elapsed-time subtraction. A signal arriving faster than the timer period (a 1 kHz `SIGPROF` profiler, `SIGCHLD` storms) could push a timer far past its deadline. We now convert a finite non-zero timeout to an absolute `CLOCK_MONOTONIC` deadline once and recompute the remaining time on each retry; `NULL` (infinite) and `{0,0}` (non-blocking) remain idempotent on retry with no extra clock read. The non-blocking drain/change kevent64 sites are unchanged.

## Why these are the correct semantics

- [`epoll_wait(2)`](https://man7.org/linux/man-pages/man2/epoll_wait.2.html): "The *timeout* argument specifies the number of **milliseconds** that `epoll_wait()` will block." and, for `epoll_pwait2()`, "The *timeout* argument is a pointer to a `timespec` structure" (nanosecond resolution). HISTORY: "`epoll_pwait2()` was added in Linux **5.11**."
- [`signal(7)`](https://man7.org/linux/man-pages/man7/signal.7.html), *Interruption of system calls and library functions by signal handlers*: `epoll_wait(2)` and `epoll_pwait(2)` are listed under "The following interfaces are **never restarted** after being interrupted by a signal handler, regardless of the use of `SA_RESTART`". So every caught signal yields `EINTR` and we must account for elapsed time ourselves.
- [`kevent(2)`](https://man.freebsd.org/cgi/man.cgi?query=kevent&sektion=2) (FreeBSD) and XNU's `kqueue_scan` both return `EINTR` when interrupted by a caught signal; XNU on `THREAD_INTERRUPTED`, FreeBSD maps `ERESTART`->`EINTR` in `kqueue_scan`.
- The `>=5.11` gate already lives in `Bun__isEpollPwait2SupportedOnLinuxKernel` (src/analytics/lib.rs) which cites [epoll_pwait2(2) HISTORY](https://man.archlinux.org/man/epoll_pwait2.2.en#HISTORY).

## Repro / verification

Fallback busy-spin (`BUN_FEATURE_FLAG_DISABLE_EPOLL_PWAIT2=1` forces the fallback):

```
$ BUN_FEATURE_FLAG_DISABLE_EPOLL_PWAIT2=1 bun -e '
  const w0=process.hrtime.bigint(), c0=process.cpuUsage();
  const id=setInterval(()=>{
    if(process.hrtime.bigint()-w0>=300_000_000n){
      clearInterval(id);
      const c=process.cpuUsage(c0);
      console.log(((c.user+c.system)/Number((process.hrtime.bigint()-w0)/1000n)*100).toFixed(0)+"%");
    }}, 1);'
# before: 100%
# after:   5%
```

EINTR over-wait: an `LD_PRELOAD` constructor installs a no-op `SIGALRM` handler + 20 ms `ITIMER_REAL` (a raw C handler, not `process.on`, whose eventfd wakeup would mask the bug), then a 200 ms `setTimeout`. Before: fires at ~985 ms on both Linux paths. After: ~207 ms.

Tests added to `test/js/web/timers/setTimeout.test.js` (Linux-only, gracefully skip when `cc` is unavailable):

- `epoll_pwait fallback does not busy-spin on sub-ms timers`
- `epoll EINTR retry accounts for elapsed time` (parameterized over `epoll_pwait2` and the fallback)

No test is added for the kqueue path as `LD_PRELOAD` and `setitimer` inheritance behave differently on macOS; CI will exercise the code path via the existing timer suite there.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/timers/setTimeout.test.js

<!-- robobun:evidence:end -->