### PR TITLE
Replace bytemuck with in-tree bun_core::cast module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,6 @@ dependencies = [
  "bun_ptr",
  "bun_sys",
  "bun_wyhash",
- "bytemuck",
  "const_format",
  "enum-map",
  "enumset",
@@ -383,7 +382,6 @@ dependencies = [
  "bun_url",
  "bun_watcher",
  "bun_wyhash",
- "bytemuck",
  "const_format",
  "enum-map",
  "enumset",
@@ -535,7 +533,6 @@ dependencies = [
  "bun_simdutf_sys",
  "bun_windows_sys",
  "bun_wyhash",
- "bytemuck",
  "const_format",
  "itoa",
  "libc",
@@ -768,7 +765,6 @@ dependencies = [
  "bun_core",
  "bun_sha_hmac",
  "bun_sys",
- "bytemuck",
  "const_format",
  "enum-map",
  "enumset",
@@ -850,7 +846,6 @@ dependencies = [
  "bun_wyhash",
  "bun_zlib",
  "bun_zstd",
- "bytemuck",
  "const_format",
  "enum-map",
  "enumset",
@@ -904,7 +899,6 @@ dependencies = [
  "bun_collections",
  "bun_core",
  "bun_url",
- "bytemuck",
  "const_format",
  "enum-map",
  "enumset",
@@ -989,7 +983,6 @@ dependencies = [
  "bun_which",
  "bun_wyhash",
  "bun_zlib",
- "bytemuck",
  "const_format",
  "enum-map",
  "enumset",
@@ -1095,7 +1088,6 @@ dependencies = [
  "bun_react_compiler",
  "bun_url",
  "bun_wyhash",
- "bytemuck",
  "const_format",
  "criterion",
  "enum-map",
@@ -1157,7 +1149,6 @@ dependencies = [
  "bun_sourcemap",
  "bun_sys",
  "bun_wyhash",
- "bytemuck",
  "const_format",
  "enum-map",
  "enumset",
@@ -1215,7 +1206,6 @@ dependencies = [
  "bun_uws",
  "bun_watcher",
  "bun_wyhash",
- "bytemuck",
  "const_format",
  "enum-map",
  "enumset",
@@ -1248,7 +1238,6 @@ dependencies = [
  "bun_paths",
  "bun_sys",
  "bun_wyhash",
- "bytemuck",
  "const_format",
  "enum-map",
  "enumset",
@@ -1384,7 +1373,6 @@ dependencies = [
  "bun_highway",
  "bun_simdutf_sys",
  "bun_wyhash",
- "bytemuck",
  "const_format",
  "criterion",
  "enum-map",
@@ -1447,7 +1435,6 @@ dependencies = [
  "bun_core",
  "bun_errno",
  "bun_simdutf_sys",
- "bytemuck",
  "const_format",
  "enum-map",
  "enumset",
@@ -1714,7 +1701,6 @@ dependencies = [
  "bun_wyhash",
  "bun_zlib",
  "bun_zstd",
- "bytemuck",
  "const_format",
  "enum-map",
  "enumset",
@@ -1849,7 +1835,6 @@ version = "0.0.0"
 dependencies = [
  "bun_opaque",
  "bun_windows_sys",
- "bytemuck",
 ]
 
 [[package]]
@@ -2073,7 +2058,6 @@ dependencies = [
  "bun_paths",
  "bun_windows_sys",
  "bun_wyhash",
- "bytemuck",
  "const_format",
  "enum-map",
  "enumset",
@@ -2336,12 +2320,6 @@ dependencies = [
  "scopeguard",
  "strum",
 ]
-
-[[package]]
-name = "bytemuck"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"

--- a/src/ast/Cargo.toml
+++ b/src/ast/Cargo.toml
@@ -10,7 +10,6 @@ path = "lib.rs"
 workspace = true
 
 [dependencies]
-bytemuck = "1"
 thiserror.workspace = true
 strum.workspace = true
 bstr.workspace = true

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -1667,7 +1667,7 @@ impl EString {
         // as `*const u8` for storage only) and `data.len` deliberately stores the
         // **u16 element count**, not a byte count — so the backing allocation is
         // `2 * data.len` bytes and reading `data.len` u16s is in-bounds. Can't be
-        // `bytemuck::cast_slice(self.data.slice())` because that would yield
+        // `bun_core::cast::cast_slice(self.data.slice())` because that would yield
         // `len/2` u16s; the lying-length encoding is load-bearing for `len()`/
         // `javascript_length()`/`has_prefix_comptime()` and changing it is a
         // cross-crate refactor (see TODO above).
@@ -1712,7 +1712,7 @@ impl EString {
         // pointer/length pair as the old raw-slice construction, without an
         // `unsafe` block. Consumers must check `is_utf16` and re-slice via
         // `slice16`.
-        let bytes = &bytemuck::cast_slice::<u16, u8>(data)[..data.len()];
+        let bytes = &bun_core::cast::cast_slice::<u16, u8>(data)[..data.len()];
         Self {
             data: Str::new(bytes),
             is_utf16: true,
@@ -1863,7 +1863,7 @@ impl EString {
         if self.is_utf8() {
             bun_wyhash::hash(&self.data)
         } else {
-            bun_wyhash::hash(bytemuck::cast_slice::<u16, u8>(self.slice16()))
+            bun_wyhash::hash(bun_core::cast::cast_slice::<u16, u8>(self.slice16()))
         }
     }
 }

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -2753,10 +2753,10 @@ impl Data {
         // Local mirror of `bun.writeAnyToHasher` for padding-free POD —
         // `bun_core::write_any_to_hasher` is bound by `AsBytes` (ints only) and
         // we cannot extend that trait from this crate-file scope. `NoUninit`
-        // bound lets `bytemuck::bytes_of` view the value's bytes safely.
+        // bound lets `bun_core::cast::bytes_of` view the value's bytes safely.
         #[inline(always)]
-        fn raw<H: bun_core::Hasher + ?Sized, T: bytemuck::NoUninit>(h: &mut H, v: T) {
-            h.update(bytemuck::bytes_of(&v));
+        fn raw<H: bun_core::Hasher + ?Sized, T: bun_core::cast::NoUninit>(h: &mut H, v: T) {
+            h.update(bun_core::cast::bytes_of(&v));
         }
         #[inline(always)]
         fn name_of<H: bun_core::Hasher + ?Sized, S: crate::base::SymbolTable + ?Sized>(
@@ -2878,7 +2878,7 @@ impl Data {
                 if current.is_utf8() {
                     hasher.update(&current.data);
                 } else {
-                    hasher.update(bytemuck::cast_slice::<u16, u8>(current.slice16()));
+                    hasher.update(bun_core::cast::cast_slice::<u16, u8>(current.slice16()));
                 }
                 hasher.update(b"\x00");
             }

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -3522,7 +3522,7 @@ pub fn data_store_dupe_str(bytes: &[u8]) -> &'static [u8] {
         // slice is borrowed from that arena; its lifetime is widened to
         // `'static` per the `StoreStr` convention (arena ownership, bulk-freed
         // on scope drop — callers must not hold it past that boundary). This is
-        // lifetime erasure, not a value cast, so no safe `bytemuck`/`as`
+        // lifetime erasure, not a value cast, so no safe `cast`/`as`
         // equivalent exists.
         return unsafe {
             let dup: *const [u8] = (*ov).alloc_slice_copy(bytes);

--- a/src/bun_core/Cargo.toml
+++ b/src/bun_core/Cargo.toml
@@ -10,7 +10,6 @@ path = "lib.rs"
 workspace = true
 
 [dependencies]
-bytemuck = "1"
 itoa.workspace = true
 bun_opaque.workspace = true
 strum.workspace = true

--- a/src/bun_core/atomic_cell.rs
+++ b/src/bun_core/atomic_cell.rs
@@ -190,7 +190,7 @@ impl<T: Atom + core::fmt::Debug> core::fmt::Debug for AtomicCell<T> {
 ///   reinterpreting as `uN` reads only initialized bits).
 /// - Round-tripping `Self → uN → Self` (where every `uN` value observed was
 ///   produced from a valid `Self`) yields the original value. This is weaker
-///   than `bytemuck::AnyBitPattern` — `#[repr(u8)]` enums qualify because the
+///   than [`crate::cast::AnyBitPattern`] — `#[repr(u8)]` enums qualify because the
 ///   cell only ever stores valid discriminants.
 /// - `Self` is safe to transport across threads when stored in an
 ///   `AtomicCell` — i.e. it has no thread affinity beyond what the atomic op

--- a/src/bun_core/cast.rs
+++ b/src/bun_core/cast.rs
@@ -356,25 +356,28 @@ mod tests {
         assert_eq!(v, u32::from_ne_bytes([1, 2, 3, 4]));
     }
 
+    // `#[repr(align(2))]` guarantees an even base address so the alignment
+    // branch of `try_cast_slice` is deterministic in both tests below.
+    #[repr(align(2))]
+    struct Aligned2<const N: usize>([u8; N]);
+
     #[test]
     fn try_cast_rejects_slop() {
-        let bytes = [0u8; 3];
+        let a = Aligned2([0u8; 3]);
         assert_eq!(
-            try_cast_slice::<u8, u16>(&bytes).unwrap_err(),
+            try_cast_slice::<u8, u16>(&a.0).unwrap_err(),
             PodCastError::OutputSliceWouldHaveSlop
         );
     }
 
     #[test]
     fn try_cast_rejects_misalign() {
-        let bytes = [0u8; 5];
-        let odd = &bytes[1..5];
-        if (odd.as_ptr() as usize) % 2 != 0 {
-            assert_eq!(
-                try_cast_slice::<u8, u16>(odd).unwrap_err(),
-                PodCastError::TargetAlignmentGreaterAndInputNotAligned
-            );
-        }
+        let a = Aligned2([0u8; 6]);
+        let odd = &a.0[1..5];
+        assert_eq!(
+            try_cast_slice::<u8, u16>(odd).unwrap_err(),
+            PodCastError::TargetAlignmentGreaterAndInputNotAligned
+        );
     }
 
     #[test]

--- a/src/bun_core/cast.rs
+++ b/src/bun_core/cast.rs
@@ -1,0 +1,399 @@
+//! Safe zero-cost reinterpretation between plain-data types.
+//!
+//! In-tree replacement for the subset of the `bytemuck` crate Bun uses: four
+//! marker traits plus a handful of slice/value casts. Everything here is
+//! `core`-only so the freestanding `#![no_std]` Windows shim can reuse the
+//! same source via its local `bun_core` stand-in.
+//!
+//! The trait hierarchy matches upstream so existing `unsafe impl` sites keep
+//! their documented safety contracts unchanged:
+//!
+//! ```text
+//!   Zeroable            NoUninit
+//!       ^                   ^
+//!       |                   |
+//!   AnyBitPattern <──────── Pod
+//! ```
+
+use core::mem::{align_of, size_of};
+
+// ── Marker traits ───────────────────────────────────────────────────────────
+
+/// Marker: the all-zero bit pattern is a valid value of `Self`.
+///
+/// # Safety
+/// `Self` must be inhabited at the all-zero bit pattern: no `NonNull`/
+/// `NonZero*`/references/fn pointers, no niche-optimised enums.
+pub unsafe trait Zeroable: Sized {
+    /// All-bits-zero value of `Self`. Do not override.
+    #[inline(always)]
+    fn zeroed() -> Self {
+        // SAFETY: trait contract guarantees all-zero is a valid `Self`.
+        unsafe { core::mem::zeroed() }
+    }
+}
+
+/// Marker: every bit pattern is a valid `Self` (padding bytes permitted).
+///
+/// # Safety
+/// `Self` must be inhabited for *every* bit pattern of its backing storage,
+/// contain no interior mutability, and be `Copy + 'static`. `#[repr(C)]`
+/// structs with padding qualify; enums do not.
+pub unsafe trait AnyBitPattern: Zeroable + Copy + 'static {}
+
+/// Marker: `Self` has no uninitialized (padding) bytes.
+///
+/// # Safety
+/// Every byte of `Self`'s storage must be initialized: no padding, no
+/// `MaybeUninit`. `#[repr(Int)]` enums and padding-free `#[repr(C)]` structs
+/// qualify. Interior mutability is forbidden.
+pub unsafe trait NoUninit: Copy + Sized + 'static {}
+
+/// Marker: plain old data. Implies both [`NoUninit`] and [`AnyBitPattern`].
+///
+/// # Safety
+/// The union of the [`NoUninit`] and [`AnyBitPattern`] contracts: `Self` must
+/// be `Copy + 'static`, have no padding, allow every bit pattern, and contain
+/// no interior mutability.
+pub unsafe trait Pod: Zeroable + Copy + 'static {}
+
+// SAFETY: `Pod`'s contract is a superset of `NoUninit`'s.
+unsafe impl<T: Pod> NoUninit for T {}
+// SAFETY: `Pod`'s contract is a superset of `AnyBitPattern`'s.
+unsafe impl<T: Pod> AnyBitPattern for T {}
+
+/// Marker: `Self` is `#[repr(transparent)]` over `Inner`.
+///
+/// # Safety
+/// `Self` must be `#[repr(transparent)]` with `Inner` as its single non-ZST
+/// field, so the two have identical size, alignment, and ABI.
+pub unsafe trait TransparentWrapper<Inner: ?Sized> {
+    /// View `&[Self]` as `&[Inner]`.
+    #[inline]
+    fn peel_slice(s: &[Self]) -> &[Inner]
+    where
+        Self: Sized,
+        Inner: Sized,
+    {
+        assert!(size_of::<Self>() == size_of::<Inner>());
+        assert!(align_of::<Self>() == align_of::<Inner>());
+        // SAFETY: `#[repr(transparent)]` per trait contract ⇒ identical layout.
+        unsafe { core::slice::from_raw_parts(s.as_ptr().cast::<Inner>(), s.len()) }
+    }
+}
+
+// ── Primitive impls ─────────────────────────────────────────────────────────
+
+macro_rules! impl_pod {
+    ($($t:ty),* $(,)?) => { $(
+        // SAFETY: primitive numeric/unit type — zero is valid.
+        unsafe impl Zeroable for $t {}
+        // SAFETY: primitive numeric/unit type — no padding, every bit pattern valid.
+        unsafe impl Pod for $t {}
+    )* };
+}
+impl_pod!(
+    (),
+    u8,
+    u16,
+    u32,
+    u64,
+    u128,
+    usize,
+    i8,
+    i16,
+    i32,
+    i64,
+    i128,
+    isize,
+    f32,
+    f64
+);
+
+// SAFETY: array of `Zeroable` is `Zeroable`.
+unsafe impl<T: Zeroable, const N: usize> Zeroable for [T; N] {}
+// SAFETY: array of `Pod` has no padding between elements and every bit pattern is valid.
+unsafe impl<T: Pod, const N: usize> Pod for [T; N] {}
+
+// SAFETY: `Wrapping` is `#[repr(transparent)]` over `T`.
+unsafe impl<T: Zeroable> Zeroable for core::num::Wrapping<T> {}
+// SAFETY: `Wrapping` is `#[repr(transparent)]` over `T`.
+unsafe impl<T: Pod> Pod for core::num::Wrapping<T> {}
+
+// SAFETY: `PhantomData` is a ZST; trivially zero-valid.
+unsafe impl<T: ?Sized> Zeroable for core::marker::PhantomData<T> {}
+// SAFETY: `PhantomData` is a ZST; trivially `Pod`.
+unsafe impl<T: ?Sized + 'static> Pod for core::marker::PhantomData<T> {}
+
+// `bool` / `char` / `NonZero*`: every byte is initialized, but not every bit
+// pattern is valid ⇒ `NoUninit` only.
+macro_rules! impl_nouninit {
+    ($($t:ty),* $(,)?) => { $(
+        // SAFETY: type has no padding bytes; every byte is initialized.
+        unsafe impl NoUninit for $t {}
+    )* };
+}
+impl_nouninit!(
+    bool,
+    char,
+    core::num::NonZeroU8,
+    core::num::NonZeroU16,
+    core::num::NonZeroU32,
+    core::num::NonZeroU64,
+    core::num::NonZeroU128,
+    core::num::NonZeroUsize,
+    core::num::NonZeroI8,
+    core::num::NonZeroI16,
+    core::num::NonZeroI32,
+    core::num::NonZeroI64,
+    core::num::NonZeroI128,
+    core::num::NonZeroIsize,
+);
+
+// ── Error type ──────────────────────────────────────────────────────────────
+
+/// Reason a checked cast was rejected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PodCastError {
+    /// Target alignment exceeds source alignment and the input pointer is misaligned.
+    TargetAlignmentGreaterAndInputNotAligned,
+    /// Input byte length is not a multiple of the target element size.
+    OutputSliceWouldHaveSlop,
+    /// Source and target sizes differ for a `&T`/`T` cast.
+    SizeMismatch,
+}
+
+impl core::fmt::Display for PodCastError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(self, f)
+    }
+}
+
+#[cold]
+#[inline(never)]
+#[track_caller]
+fn cast_panic(which: &str, e: PodCastError) -> ! {
+    panic!("cast::{which}: {e:?}")
+}
+
+#[inline(always)]
+fn is_aligned_to(p: *const (), align: usize) -> bool {
+    (p as usize).is_multiple_of(align)
+}
+
+// ── Value / reference casts ─────────────────────────────────────────────────
+
+/// View `&T` as `&[u8]`. Never panics (`align_of::<u8>() == 1`).
+#[inline(always)]
+#[track_caller]
+pub fn bytes_of<T: NoUninit>(t: &T) -> &[u8] {
+    // SAFETY: `NoUninit` ⇒ every byte initialized; `u8` has align 1.
+    unsafe { core::slice::from_raw_parts(core::ptr::from_ref(t).cast::<u8>(), size_of::<T>()) }
+}
+
+/// View `&mut T` as `&mut [u8]`. Never panics.
+#[inline(always)]
+#[track_caller]
+pub fn bytes_of_mut<T: Pod>(t: &mut T) -> &mut [u8] {
+    // SAFETY: `Pod` ⇒ no padding and every bit pattern valid; `u8` has align 1.
+    unsafe { core::slice::from_raw_parts_mut(core::ptr::from_mut(t).cast::<u8>(), size_of::<T>()) }
+}
+
+/// View `&A` as `&B`. Panics if sizes differ or `a` is misaligned for `B`.
+#[inline]
+#[track_caller]
+pub fn cast_ref<A: NoUninit, B: AnyBitPattern>(a: &A) -> &B {
+    if size_of::<A>() != size_of::<B>() {
+        cast_panic("cast_ref", PodCastError::SizeMismatch)
+    }
+    let p = core::ptr::from_ref(a);
+    if align_of::<B>() > align_of::<A>() && !is_aligned_to(p.cast::<()>(), align_of::<B>()) {
+        cast_panic(
+            "cast_ref",
+            PodCastError::TargetAlignmentGreaterAndInputNotAligned,
+        )
+    }
+    // SAFETY: size matches, alignment verified, `NoUninit` source ⇒ every byte
+    // initialized, `AnyBitPattern` target ⇒ every byte pattern valid.
+    unsafe { &*p.cast::<B>() }
+}
+
+/// Copy a `T` out of a byte slice without requiring alignment.
+/// Panics if `bytes.len() != size_of::<T>()`.
+#[inline]
+#[track_caller]
+pub fn pod_read_unaligned<T: AnyBitPattern>(bytes: &[u8]) -> T {
+    if bytes.len() != size_of::<T>() {
+        cast_panic("pod_read_unaligned", PodCastError::SizeMismatch)
+    }
+    // SAFETY: length checked; `AnyBitPattern` ⇒ every byte pattern valid;
+    // `read_unaligned` has no alignment requirement.
+    unsafe { bytes.as_ptr().cast::<T>().read_unaligned() }
+}
+
+// ── Slice casts ─────────────────────────────────────────────────────────────
+
+/// Try to view `&[A]` as `&[B]` (length recomputed from byte size).
+#[inline]
+pub fn try_cast_slice<A: NoUninit, B: AnyBitPattern>(a: &[A]) -> Result<&[B], PodCastError> {
+    let input_bytes = core::mem::size_of_val(a);
+    if align_of::<B>() > align_of::<A>() && !is_aligned_to(a.as_ptr().cast::<()>(), align_of::<B>())
+    {
+        Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned)
+    } else if size_of::<B>() == size_of::<A>() {
+        // SAFETY: same element size ⇒ same length; alignment verified above;
+        // `NoUninit`/`AnyBitPattern` discharge the value-validity obligations.
+        Ok(unsafe { core::slice::from_raw_parts(a.as_ptr().cast::<B>(), a.len()) })
+    } else if size_of::<B>() == 0 {
+        if input_bytes == 0 {
+            // SAFETY: empty ZST slice; dangling pointer is valid for ZSTs.
+            Ok(unsafe { core::slice::from_raw_parts(core::ptr::NonNull::dangling().as_ptr(), 0) })
+        } else {
+            Err(PodCastError::OutputSliceWouldHaveSlop)
+        }
+    } else if input_bytes.is_multiple_of(size_of::<B>()) {
+        let new_len = input_bytes / size_of::<B>();
+        // SAFETY: byte length divides evenly; alignment verified; trait bounds
+        // discharge value-validity.
+        Ok(unsafe { core::slice::from_raw_parts(a.as_ptr().cast::<B>(), new_len) })
+    } else {
+        Err(PodCastError::OutputSliceWouldHaveSlop)
+    }
+}
+
+/// View `&[A]` as `&[B]`. Panics on misalignment or size slop.
+#[inline]
+#[track_caller]
+pub fn cast_slice<A: NoUninit, B: AnyBitPattern>(a: &[A]) -> &[B] {
+    match try_cast_slice(a) {
+        Ok(b) => b,
+        Err(e) => cast_panic("cast_slice", e),
+    }
+}
+
+/// View `&mut [A]` as `&mut [B]`. Panics on misalignment or size slop.
+///
+/// Both bounds are `NoUninit + AnyBitPattern` (i.e. effectively `Pod`): the
+/// mutable view lets bytes flow either way, so both directions must be valid.
+#[inline]
+#[track_caller]
+pub fn cast_slice_mut<A: NoUninit + AnyBitPattern, B: NoUninit + AnyBitPattern>(
+    a: &mut [A],
+) -> &mut [B] {
+    let input_bytes = core::mem::size_of_val::<[A]>(a);
+    if align_of::<B>() > align_of::<A>() && !is_aligned_to(a.as_ptr().cast::<()>(), align_of::<B>())
+    {
+        cast_panic(
+            "cast_slice_mut",
+            PodCastError::TargetAlignmentGreaterAndInputNotAligned,
+        )
+    }
+    if size_of::<B>() == size_of::<A>() {
+        // SAFETY: same element size; alignment verified; `Pod`-equivalent bounds.
+        return unsafe { core::slice::from_raw_parts_mut(a.as_mut_ptr().cast::<B>(), a.len()) };
+    }
+    if size_of::<B>() == 0 {
+        if input_bytes == 0 {
+            // SAFETY: empty ZST slice.
+            return unsafe {
+                core::slice::from_raw_parts_mut(core::ptr::NonNull::dangling().as_ptr(), 0)
+            };
+        }
+        cast_panic("cast_slice_mut", PodCastError::OutputSliceWouldHaveSlop)
+    }
+    if !input_bytes.is_multiple_of(size_of::<B>()) {
+        cast_panic("cast_slice_mut", PodCastError::OutputSliceWouldHaveSlop)
+    }
+    let new_len = input_bytes / size_of::<B>();
+    // SAFETY: byte length divides evenly; alignment verified; `Pod`-equivalent bounds.
+    unsafe { core::slice::from_raw_parts_mut(a.as_mut_ptr().cast::<B>(), new_len) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slice_u16_to_u8_roundtrip() {
+        let src: [u16; 3] = [0x0201, 0x0403, 0x0605];
+        let bytes: &[u8] = cast_slice(&src);
+        assert_eq!(bytes, &[1, 2, 3, 4, 5, 6]);
+        let back: &[u16] = cast_slice(bytes);
+        assert_eq!(back, &src);
+    }
+
+    #[test]
+    fn bytes_of_struct() {
+        #[repr(C)]
+        #[derive(Clone, Copy)]
+        struct P {
+            a: u16,
+            b: u16,
+        }
+        // SAFETY: two `u16` fields, `#[repr(C)]`, no padding.
+        unsafe impl Zeroable for P {}
+        // SAFETY: two `u16` fields, `#[repr(C)]`, no padding.
+        unsafe impl Pod for P {}
+        let p = P {
+            a: 0x0201,
+            b: 0x0403,
+        };
+        assert_eq!(bytes_of(&p), &[1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn cast_ref_array() {
+        let a: [u64; 2] = [1, 2];
+        let b: &[u8; 16] = cast_ref(&a);
+        assert_eq!(b[0], 1);
+        assert_eq!(b[8], 2);
+    }
+
+    #[test]
+    fn read_unaligned() {
+        let bytes = [0u8, 1, 2, 3, 4];
+        let v: u32 = pod_read_unaligned(&bytes[1..5]);
+        assert_eq!(v, u32::from_ne_bytes([1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn try_cast_rejects_slop() {
+        let bytes = [0u8; 3];
+        assert_eq!(
+            try_cast_slice::<u8, u16>(&bytes).unwrap_err(),
+            PodCastError::OutputSliceWouldHaveSlop
+        );
+    }
+
+    #[test]
+    fn try_cast_rejects_misalign() {
+        let bytes = [0u8; 5];
+        let odd = &bytes[1..5];
+        if (odd.as_ptr() as usize) % 2 != 0 {
+            assert_eq!(
+                try_cast_slice::<u8, u16>(odd).unwrap_err(),
+                PodCastError::TargetAlignmentGreaterAndInputNotAligned
+            );
+        }
+    }
+
+    #[test]
+    fn empty_slices() {
+        let e: &[u32] = &[];
+        let b: &[u8] = cast_slice(e);
+        assert!(b.is_empty());
+        let back: &[u32] = cast_slice(b);
+        assert!(back.is_empty());
+    }
+
+    #[test]
+    fn transparent_peel() {
+        #[repr(transparent)]
+        struct W(u32);
+        // SAFETY: `#[repr(transparent)]` over `u32`.
+        unsafe impl TransparentWrapper<u32> for W {}
+        let ws = [W(1), W(2), W(3)];
+        let inner: &[u32] = W::peel_slice(&ws);
+        assert_eq!(inner, &[1, 2, 3]);
+    }
+}

--- a/src/bun_core/cast.rs
+++ b/src/bun_core/cast.rs
@@ -356,9 +356,10 @@ mod tests {
         assert_eq!(v, u32::from_ne_bytes([1, 2, 3, 4]));
     }
 
-    // `#[repr(align(2))]` guarantees an even base address so the alignment
-    // branch of `try_cast_slice` is deterministic in both tests below.
-    #[repr(align(2))]
+    // `#[repr(C, align(2))]` guarantees an even base address *and* field offset
+    // 0, so `&a.0` is spec-2-aligned and the alignment branch of
+    // `try_cast_slice` is deterministic in both tests below.
+    #[repr(C, align(2))]
     struct Aligned2<const N: usize>([u8; N]);
 
     #[test]

--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -2883,7 +2883,7 @@ pub fn parse_hex_prefix(input: &[u8], max_digits: usize) -> (u32, usize) {
 /// `[0-9a-fA-F]`. `T` is capped at 16 bytes (u128) since stable Rust can't size
 /// a stack array by a generic without `generic_const_exprs`.
 #[inline]
-pub fn parse_hex_to_int<T: bytemuck::Pod>(slice: &[u8]) -> Option<T> {
+pub fn parse_hex_to_int<T: crate::cast::AnyBitPattern>(slice: &[u8]) -> Option<T> {
     let n = core::mem::size_of::<T>();
     debug_assert!(n <= 16);
     if slice.len() != n * 2 {
@@ -2893,7 +2893,7 @@ pub fn parse_hex_to_int<T: bytemuck::Pod>(slice: &[u8]) -> Option<T> {
     for i in 0..n {
         buf[i] = hex_pair_value(slice[i * 2], slice[i * 2 + 1])?;
     }
-    Some(bytemuck::pod_read_unaligned(&buf[..n]))
+    Some(crate::cast::pod_read_unaligned(&buf[..n]))
 }
 
 /// Map the low 4 bits of `n` to a lowercase ASCII hex digit (`0-9`, `a-f`).

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod Global;
 pub mod atomic_cell;
+pub mod cast;
 pub mod comptime_string_map;
 pub mod error;
 pub mod hint;
@@ -2502,9 +2503,9 @@ pub mod ffi {
     /// of [`cstr_bytes`] for inline arrays like `utsname::release`.
     #[inline]
     pub fn c_field_bytes(s: &[core::ffi::c_char]) -> &[u8] {
-        // `c_char` is a type alias for `i8`/`u8`; both are `bytemuck::Pod`, so
-        // the byte-sized reinterpretation is a safe `cast_slice`.
-        let b: &[u8] = bytemuck::cast_slice(s);
+        // `c_char` is a type alias for `i8`/`u8`; both are `Pod`, so the
+        // byte-sized reinterpretation is a safe `cast_slice`.
+        let b: &[u8] = crate::cast::cast_slice(s);
         &b[..b.iter().position(|&c| c == 0).unwrap_or(b.len())]
     }
 
@@ -2530,9 +2531,9 @@ pub mod ffi {
 
     /// Marker: the all-zero bit pattern is a valid value of `Self`.
     ///
-    /// Local re-spelling of `bytemuck::Zeroable` so we can blanket-`impl` it
-    /// for foreign `libc` POD (orphan rule blocks impl-ing the upstream trait
-    /// on `libc::sigaction` et al.). Once a type carries this marker,
+    /// Kept separate from [`crate::cast::Zeroable`] so this module can
+    /// blanket-`impl` it for foreign `libc` POD without dragging the cast
+    /// trait hierarchy into every FFI init site. Once a type carries this marker,
     /// [`zeroed`] is a *safe* call — the audit happens once at the `unsafe
     /// impl`, not at every out-param init site.
     ///
@@ -2560,7 +2561,7 @@ pub mod ffi {
     }
 
     // ── Zeroable impls ──────────────────────────────────────────────────────
-    // Primitives, raw pointers, arrays — match `bytemuck::Zeroable` blankets.
+    // Primitives, raw pointers, arrays.
     macro_rules! zeroable_prim {
         ($($t:ty),* $(,)?) => { $(
             // SAFETY: primitive numeric/unit type — the all-zero bit pattern is

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -1202,7 +1202,7 @@ pub fn eql(self_: &[u8], other: &[u8]) -> bool {
 pub fn eql_comptime_t<T: crate::NoUninit + Eq>(self_: &[T], alt: &'static [u8]) -> bool {
     // Branch on size_of (const-folded): 2-byte T → eql_comptime_utf16.
     if core::mem::size_of::<T>() == 2 {
-        // `NoUninit` + size_of::<T>()==2 lets bytemuck prove the &[T]→&[u16]
+        // `NoUninit` + size_of::<T>()==2 lets `cast_slice` prove the &[T]→&[u16]
         // reinterpret is sound (align checked at runtime; T is u16 in practice).
         let s16: &[u16] = crate::cast_slice(self_);
         return eql_comptime_utf16(s16, alt);

--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -1292,12 +1292,12 @@ impl OwnedString {
     /// slice afterwards.
     #[inline]
     pub fn as_raw_slice(owned: &[OwnedString]) -> &[String] {
-        // `#[repr(transparent)]` over `String` ⇒ bytemuck's safe slice peel.
-        <Self as bytemuck::TransparentWrapper<String>>::peel_slice(owned)
+        // `#[repr(transparent)]` over `String` ⇒ safe slice peel.
+        <Self as crate::cast::TransparentWrapper<String>>::peel_slice(owned)
     }
 }
 // SAFETY: `OwnedString` is `#[repr(transparent)]` with a single `String` field.
-unsafe impl bytemuck::TransparentWrapper<String> for OwnedString {}
+unsafe impl crate::cast::TransparentWrapper<String> for OwnedString {}
 impl core::ops::Deref for OwnedString {
     type Target = String;
     #[inline]

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -3261,33 +3261,15 @@ impl<H: core::hash::Hasher> Hasher for H {
     }
 }
 
-/// Re-export so downstream crates can write `T: bun_core::NoUninit` without a
-/// direct `bytemuck` dep.
-pub use bytemuck::NoUninit;
-
-/// Reinterpret a value's storage as a borrowed byte slice.
-///
-/// Safe: the [`bytemuck::NoUninit`] bound statically guarantees `T` is `Copy`,
-/// `'static`, and contains no uninitialized (padding) bytes, so every byte of
-/// the returned slice is initialized and reading it is defined behaviour.
-#[inline]
-pub fn bytes_of<T: bytemuck::NoUninit>(v: &T) -> &[u8] {
-    bytemuck::bytes_of(v)
-}
-
-/// Mutable counterpart of [`bytes_of`]: reinterpret `&mut T` as `&mut [u8]`.
-///
-/// Safe: the [`bytemuck::Pod`] bound guarantees `T` has no padding bytes and
-/// every bit pattern is a valid `T`, so writing arbitrary bytes through the
-/// returned slice cannot produce an invalid value.
-#[inline]
-pub fn bytes_of_mut<T: bytemuck::Pod>(v: &mut T) -> &mut [u8] {
-    bytemuck::bytes_of_mut(v)
-}
+/// Re-exports so downstream crates can write `T: bun_core::NoUninit` etc. and
+/// call `bun_core::cast_slice(..)` without reaching into [`crate::cast`].
+pub use crate::cast::{
+    AnyBitPattern, NoUninit, Pod, bytes_of, bytes_of_mut, cast_slice, cast_slice_mut,
+};
 
 // ─── Slice reinterpretation (canonical) ───────────────────────────────────────
 // Split by mutability, with two safety surfaces:
-//   - `cast_slice` / `cast_slice_mut`  → SAFE, bytemuck-bounded, panics on
+//   - `cast_slice` / `cast_slice_mut`  → SAFE, trait-bounded, panics on
 //     misalign or `len % size_of::<B>() != 0`. Use for Pod↔Pod (u8↔u16 etc.).
 //   - `bytes_as_slice_mut`             → UNSAFE escape hatch, unbounded `T`,
 //     TRUNCATES trailing bytes. Use only when `T` is not
@@ -3295,34 +3277,15 @@ pub fn bytes_of_mut<T: bytemuck::Pod>(v: &mut T) -> &mut [u8] {
 // Every current caller targets `u16` over an even-length buffer, so the safe
 // path is the default.
 
-/// Read-only `&[A]` → `&[B]` reinterpretation. Safe: the [`bytemuck::NoUninit`] bound
-/// on `A` guarantees every source byte is initialized, and
-/// [`bytemuck::AnyBitPattern`] on `B` guarantees every byte pattern is a valid
-/// `B`. Panics if size/alignment don't divide evenly (same as `bytemuck`).
-#[inline]
-pub fn cast_slice<A: bytemuck::NoUninit, B: bytemuck::AnyBitPattern>(a: &[A]) -> &[B] {
-    bytemuck::cast_slice(a)
-}
-
-/// Mutable counterpart of [`cast_slice`]: reinterpret `&mut [A]` as `&mut [B]`.
-/// Safe: both [`bytemuck::Pod`] bounds guarantee every byte pattern is valid in
-/// both directions and there are no uninitialized bytes. Panics on misalignment
-/// or if `a.len() * size_of::<A>() % size_of::<B>() != 0` (same as `bytemuck`).
-#[inline]
-pub fn cast_slice_mut<A: bytemuck::Pod, B: bytemuck::Pod>(a: &mut [A]) -> &mut [B] {
-    bytemuck::cast_slice_mut(a)
-}
-
 /// Reinterpret `&[T]` as `&[u8]`.
 ///
 /// This is [`cast_slice`] with the output type fixed to `u8`, so callers never
-/// need a `::<_, u8>` turbofish. Safe: [`bytemuck::NoUninit`] guarantees every
-/// byte of `T` is initialized; `align_of::<u8>() == 1` and
-/// `size_of::<T>() % 1 == 0` mean the bytemuck size/align checks are trivially
-/// satisfied and this never panics.
+/// need a `::<_, u8>` turbofish. Safe: [`NoUninit`] guarantees every byte of
+/// `T` is initialized; `align_of::<u8>() == 1` and `size_of::<T>() % 1 == 0`
+/// mean the size/align checks are trivially satisfied and this never panics.
 #[inline]
-pub fn slice_as_bytes<T: bytemuck::NoUninit>(s: &[T]) -> &[u8] {
-    bytemuck::cast_slice(s)
+pub fn slice_as_bytes<T: NoUninit>(s: &[T]) -> &[u8] {
+    crate::cast::cast_slice(s)
 }
 
 // ─── extern_union_accessors! ──────────────────────────────────────────────────
@@ -3414,7 +3377,7 @@ macro_rules! extern_union_accessors {
 }
 
 /// Feed a value's raw bytes to a hasher. Taking a generic by-value-as-bytes
-/// safely requires a `bytemuck` bound, so this
+/// safely requires a [`NoUninit`] bound, so this
 /// accepts anything that is itself viewable as bytes (covers the actual call
 /// sites: `u8` tags, `usize` lengths, `Index` newtypes).
 #[inline]
@@ -3431,7 +3394,7 @@ macro_rules! as_bytes_pod {
     ($($t:ty),* $(,)?) => { $(
         impl AsBytes for $t {
             #[inline] fn as_bytes_for_hash(&self) -> &[u8] {
-                bytemuck::bytes_of(self)
+                crate::cast::bytes_of(self)
             }
         }
     )* }
@@ -5107,7 +5070,7 @@ pub struct Timespec {
 unsafe impl crate::ffi::Zeroable for Timespec {}
 // SAFETY: `#[repr(C)]` with two `i64` fields → size 16, align 8, no padding,
 // no interior mutability, `Copy + 'static`. Every byte is initialized.
-unsafe impl bytemuck::NoUninit for Timespec {}
+unsafe impl crate::cast::NoUninit for Timespec {}
 
 /// Lowercase alias (`bun.timespec`).
 #[allow(non_camel_case_types)]
@@ -5434,12 +5397,12 @@ impl From<f16> for f32 {
     }
 }
 // SAFETY: `#[repr(transparent)]` over `u16` — every bit pattern is a valid
-// `f16`, no padding, `Copy + 'static`. Enables safe `bytemuck::cast_slice`
-// from `&[u8]` for Float16Array printing (ConsoleObject).
-unsafe impl bytemuck::Zeroable for f16 {}
+// `f16`, no padding, `Copy + 'static`. Enables safe `cast_slice` from `&[u8]`
+// for Float16Array printing (ConsoleObject).
+unsafe impl crate::cast::Zeroable for f16 {}
 // SAFETY: `#[repr(transparent)]` over `u16` — no padding, every bit pattern is
-// valid, `Copy + Zeroable + 'static`; satisfies all `bytemuck::Pod` invariants.
-unsafe impl bytemuck::Pod for f16 {}
+// valid, `Copy + Zeroable + 'static`; satisfies all `Pod` invariants.
+unsafe impl crate::cast::Pod for f16 {}
 impl core::fmt::Display for f16 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.to_f64().fmt(f)

--- a/src/bundler/Cargo.toml
+++ b/src/bundler/Cargo.toml
@@ -10,7 +10,6 @@ path = "lib.rs"
 workspace = true
 
 [dependencies]
-bytemuck = "1"
 bun_opaque.workspace = true
 bun_dispatch.workspace = true
 strum.workspace = true

--- a/src/bundler/analyze_transpiled_module.rs
+++ b/src/bundler/analyze_transpiled_module.rs
@@ -42,12 +42,12 @@ pub(crate) type ImportAttributes = FetchParameters;
 pub struct RecordKind(pub u8);
 // SAFETY: `#[repr(transparent)]` over `u8` — no padding, every bit pattern is
 // a valid `u8`. `Pod` lets
-// `bytemuck::{cast_slice,try_cast_slice}` reinterpret byte buffers and the
+// `bun_core::cast::{cast_slice,try_cast_slice}` reinterpret byte buffers and the
 // printer-crate `#[repr(u8)]` enum into `&[RecordKind]` without `unsafe`.
-unsafe impl bytemuck::Zeroable for RecordKind {}
+unsafe impl bun_core::cast::Zeroable for RecordKind {}
 // SAFETY: see above — `#[repr(transparent)]` over `u8`, so no padding and every
 // bit pattern is valid; `RecordKind` is `Copy + 'static` with no interior refs.
-unsafe impl bytemuck::Pod for RecordKind {}
+unsafe impl bun_core::cast::Pod for RecordKind {}
 
 impl RecordKind {
     /// var_name
@@ -430,10 +430,10 @@ unsafe fn free_aligned_dup(slice: *mut [u8]) {
 /// or its length is not a multiple of `size_of::<T>()` (i.e. the format's
 /// internal padding was violated).
 ///
-/// (`bytemuck::try_cast_slice` checks both alignment and size.)
+/// (`bun_core::cast::try_cast_slice` checks both alignment and size.)
 #[inline]
-fn bytes_as_slice<T: bytemuck::AnyBitPattern>(bytes: &[u8]) -> Result<&[T], ModuleInfoError> {
-    bytemuck::try_cast_slice(bytes).map_err(|_| ModuleInfoError::BadModuleInfo)
+fn bytes_as_slice<T: bun_core::cast::AnyBitPattern>(bytes: &[u8]) -> Result<&[T], ModuleInfoError> {
+    bun_core::cast::try_cast_slice(bytes).map_err(|_| ModuleInfoError::BadModuleInfo)
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -487,15 +487,16 @@ impl ModuleInfoExt for ModuleInfo {
             rm_keys = bun_ptr::RawSlice::new(view.requested_modules_keys);
             rm_values = bun_ptr::RawSlice::new(view.requested_modules_values);
             // Printer's `ModulePhase` is `#[repr(u8)] NoUninit` — safe to view as `&[u8]`.
-            rm_phases = bun_ptr::RawSlice::new(bytemuck::cast_slice::<_, u8>(
+            rm_phases = bun_ptr::RawSlice::new(bun_core::cast::cast_slice::<_, u8>(
                 view.requested_modules_phases,
             ));
             buffer = bun_ptr::RawSlice::new(view.buffer);
             // Printer's `RecordKind` is `#[repr(u8)] NoUninit` with the same
             // discriminant layout as this crate's `#[repr(transparent)] u8`
-            // `RecordKind` (Pod) — `bytemuck::cast_slice` is the safe reinterpret.
-            record_kinds =
-                bun_ptr::RawSlice::new(bytemuck::cast_slice::<_, RecordKind>(view.record_kinds));
+            // `RecordKind` (Pod) — `bun_core::cast::cast_slice` is the safe reinterpret.
+            record_kinds = bun_ptr::RawSlice::new(bun_core::cast::cast_slice::<_, RecordKind>(
+                view.record_kinds,
+            ));
             let mut f = Flags::empty();
             f.set(Flags::CONTAINS_IMPORT_META, view.flags.contains_import_meta);
             f.set(Flags::IS_TYPESCRIPT, view.flags.is_typescript);

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -7523,7 +7523,7 @@ pub mod bv2_impl {
         }
         pub(crate) fn write_ints(&mut self, i: &[u32]) {
             bun_core::scoped_log!(ContentHasher, "HASH_UPDATE: {:?}\n", i);
-            self.hasher.update(bytemuck::cast_slice::<u32, u8>(i));
+            self.hasher.update(bun_core::cast::cast_slice::<u32, u8>(i));
         }
         pub(crate) fn digest(&self) -> u64 {
             self.hasher.digest()

--- a/src/exe_format/Cargo.toml
+++ b/src/exe_format/Cargo.toml
@@ -10,7 +10,6 @@ path = "lib.rs"
 workspace = true
 
 [dependencies]
-bytemuck = "1"
 thiserror.workspace = true
 strum.workspace = true
 bstr.workspace = true

--- a/src/exe_format/macho_types.rs
+++ b/src/exe_format/macho_types.rs
@@ -184,11 +184,11 @@ pub struct SuperBlob {
 // that order → offsets 0..36, 36..40, 40..56, 56..88. Every field boundary is
 // naturally aligned with no inserted padding; size 88, align 8. `Copy + 'static`,
 // no interior mutability, every byte initialized.
-unsafe impl bytemuck::NoUninit for CodeDirectory {}
+unsafe impl bun_core::cast::NoUninit for CodeDirectory {}
 // SAFETY: `#[repr(C)]` 2×u32 → size 8, align 4, no padding. `Copy + 'static`.
-unsafe impl bytemuck::NoUninit for BlobIndex {}
+unsafe impl bun_core::cast::NoUninit for BlobIndex {}
 // SAFETY: `#[repr(C)]` 3×u32 → size 12, align 4, no padding. `Copy + 'static`.
-unsafe impl bytemuck::NoUninit for SuperBlob {}
+unsafe impl bun_core::cast::NoUninit for SuperBlob {}
 
 // ── load-command iterator ─────────────────────────────────────────────────
 // Canonical impl lives in `bun_sys::macho` (raw-ptr storage; see module-level

--- a/src/http/Cargo.toml
+++ b/src/http/Cargo.toml
@@ -20,7 +20,6 @@ enum-map.workspace = true
 enumset.workspace = true
 libc.workspace = true
 bitflags.workspace = true
-bytemuck = "1"
 bun_analytics.workspace = true
 bun_base64.workspace = true
 bun_boringssl.workspace = true

--- a/src/http_types/Cargo.toml
+++ b/src/http_types/Cargo.toml
@@ -10,7 +10,6 @@ path = "lib.rs"
 workspace = true
 
 [dependencies]
-bytemuck = "1"
 strum.workspace = true
 bstr.workspace = true
 scopeguard.workspace = true

--- a/src/http_types/h2.rs
+++ b/src/http_types/h2.rs
@@ -165,8 +165,8 @@ impl UInt31WithReserved {
 //
 // `StreamPriority`, `SettingsPayloadUnit` and `FullSettingsPayload` are
 // `#[repr(C, packed)]` with integer-only fields and therefore have no padding
-// bytes and no niches. They implement `bytemuck::Pod`, so the per-`from()`
-// byte-view is the safe `bytemuck::bytes_of_mut`.
+// bytes and no niches. They implement `bun_core::cast::Pod`, so the per-`from()`
+// byte-view is the safe `bun_core::cast::bytes_of_mut`.
 
 /// 5-byte PRIORITY payload: BE stream identifier + weight.
 #[repr(C, packed)]
@@ -177,9 +177,9 @@ pub struct StreamPriority {
 }
 // SAFETY: `#[repr(C, packed)]` with `u32 + u8` fields — no padding, no niches,
 // every 5-byte pattern is a valid value.
-unsafe impl bytemuck::Zeroable for StreamPriority {}
+unsafe impl bun_core::cast::Zeroable for StreamPriority {}
 // SAFETY: see `Zeroable` impl above; additionally `Copy + 'static`.
-unsafe impl bytemuck::Pod for StreamPriority {}
+unsafe impl bun_core::cast::Pod for StreamPriority {}
 const _: () = assert!(core::mem::size_of::<StreamPriority>() == StreamPriority::BYTE_SIZE);
 
 impl StreamPriority {
@@ -187,7 +187,7 @@ impl StreamPriority {
 
     #[inline]
     pub fn from(dst: &mut StreamPriority, src: &[u8]) {
-        bytemuck::bytes_of_mut(dst).copy_from_slice(src);
+        bun_core::cast::bytes_of_mut(dst).copy_from_slice(src);
         // Byte-swap each field; `weight: u8` is a no-op.
         // Brace-expr `{packed.field}` performs an unaligned copy;
         // assignment to a packed field is an unaligned store. No `unsafe`.
@@ -198,7 +198,7 @@ impl StreamPriority {
     pub fn encode_into(self, dst: &mut [u8; Self::BYTE_SIZE]) {
         let mut swap = self;
         swap.stream_identifier = u32::swap_bytes(swap.stream_identifier);
-        dst.copy_from_slice(bytemuck::bytes_of(&swap));
+        dst.copy_from_slice(bun_core::cast::bytes_of(&swap));
     }
 }
 
@@ -259,9 +259,9 @@ pub struct SettingsPayloadUnit {
 }
 // SAFETY: `#[repr(C, packed)]` with `u16 + u32` fields — no padding, no
 // niches, every 6-byte pattern is a valid value.
-unsafe impl bytemuck::Zeroable for SettingsPayloadUnit {}
+unsafe impl bun_core::cast::Zeroable for SettingsPayloadUnit {}
 // SAFETY: see `Zeroable` impl above; additionally `Copy + 'static`.
-unsafe impl bytemuck::Pod for SettingsPayloadUnit {}
+unsafe impl bun_core::cast::Pod for SettingsPayloadUnit {}
 const _: () =
     assert!(core::mem::size_of::<SettingsPayloadUnit>() == SettingsPayloadUnit::BYTE_SIZE);
 
@@ -270,7 +270,7 @@ impl SettingsPayloadUnit {
 
     #[inline]
     pub fn from<const END: bool>(dst: &mut SettingsPayloadUnit, src: &[u8], offset: usize) {
-        let bytes = bytemuck::bytes_of_mut(dst);
+        let bytes = bun_core::cast::bytes_of_mut(dst);
         bytes[offset..src.len() + offset].copy_from_slice(src);
         if END {
             // Byte-swap each field.
@@ -307,9 +307,9 @@ pub(crate) struct FullSettingsPayload {
 }
 // SAFETY: `#[repr(C, packed)]` with only `u16`/`u32` fields — no padding, no
 // niches, every 42-byte pattern is a valid value.
-unsafe impl bytemuck::Zeroable for FullSettingsPayload {}
+unsafe impl bun_core::cast::Zeroable for FullSettingsPayload {}
 // SAFETY: see `Zeroable` impl above; additionally `Copy + 'static`.
-unsafe impl bytemuck::Pod for FullSettingsPayload {}
+unsafe impl bun_core::cast::Pod for FullSettingsPayload {}
 const _: () =
     assert!(core::mem::size_of::<FullSettingsPayload>() == FullSettingsPayload::BYTE_SIZE);
 

--- a/src/install/Cargo.toml
+++ b/src/install/Cargo.toml
@@ -17,7 +17,6 @@ shim_standalone = []
 workspace = true
 
 [dependencies]
-bytemuck = "1"
 strum.workspace = true
 thiserror.workspace = true
 bstr.workspace = true

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -123,9 +123,9 @@ impl Id {
     pub fn for_bin_link(package_id: PackageID) -> Id {
         let mut hasher = Wyhash11::init(0);
         hasher.update(b"bin-link:");
-        // `PackageID` is `u32`: `bytemuck::bytes_of` gives the
+        // `PackageID` is `u32`: `bun_core::cast::bytes_of` gives the
         // native-endian byte view.
-        hasher.update(bytemuck::bytes_of(&package_id));
+        hasher.update(bun_core::cast::bytes_of(&package_id));
         Id(hasher.final_())
     }
 

--- a/src/install/integrity.rs
+++ b/src/install/integrity.rs
@@ -20,7 +20,7 @@ pub struct Integrity {
 }
 // SAFETY: `#[repr(C)]` with a `#[repr(transparent)] u8` tag + `[u8; 64]` →
 // size 65, align 1, no padding bytes, `Copy + 'static`. Every byte initialized.
-unsafe impl bytemuck::NoUninit for Integrity {}
+unsafe impl bun_core::cast::NoUninit for Integrity {}
 
 impl Default for Integrity {
     fn default() -> Self {
@@ -275,7 +275,7 @@ impl fmt::Display for Integrity {
 pub struct Tag(pub u8);
 // SAFETY: `#[repr(transparent)]` newtype over `u8` — same layout as `u8`,
 // no padding, `Copy + 'static`.
-unsafe impl bytemuck::NoUninit for Tag {}
+unsafe impl bun_core::cast::NoUninit for Tag {}
 
 impl Tag {
     pub const UNKNOWN: Tag = Tag(0);

--- a/src/install/lockfile/Buffers.rs
+++ b/src/install/lockfile/Buffers.rs
@@ -188,9 +188,9 @@ where
         stream.write_all(bytes)?;
         let real_end_pos = stream.get_pos()? as u64;
         let positioned: [u64; 2] = [real_start_pos, real_end_pos];
-        // `[u64; 2]` and `[u8; 16]` are both `Pod` of equal size — `bytemuck`
+        // `[u64; 2]` and `[u8; 16]` are both `Pod` of equal size — `cast_ref`
         // gives the byte view without `unsafe`.
-        let positioned_bytes: &[u8; 16] = bytemuck::cast_ref(&positioned);
+        let positioned_bytes: &[u8; 16] = bun_core::cast::cast_ref(&positioned);
         let mut written: usize = 0;
         while written < 16 {
             written += stream.pwrite(&positioned_bytes[written..], start_pos + written);
@@ -198,9 +198,9 @@ where
     } else {
         let real_end_pos = stream.get_pos()? as u64;
         let positioned: [u64; 2] = [real_end_pos, real_end_pos];
-        // `[u64; 2]` and `[u8; 16]` are both `Pod` of equal size — `bytemuck`
+        // `[u64; 2]` and `[u8; 16]` are both `Pod` of equal size — `cast_ref`
         // gives the byte view without `unsafe`.
-        let positioned_bytes: &[u8; 16] = bytemuck::cast_ref(&positioned);
+        let positioned_bytes: &[u8; 16] = bun_core::cast::cast_ref(&positioned);
         let mut written: usize = 0;
         while written < 16 {
             written += stream.pwrite(&positioned_bytes[written..], start_pos + written);

--- a/src/install/windows-shim/BinLinkingShim.rs
+++ b/src/install/windows-shim/BinLinkingShim.rs
@@ -368,12 +368,12 @@ mod host {
             debug_assert!(buf.len() == self.encoded_length());
             debug_assert!(self.bin_path[0] != b'/' as u16);
 
-            // `bytemuck::cast_slice_mut` performs a runtime alignment +
+            // `bun_core::cast::cast_slice_mut` performs a runtime alignment +
             // size-multiple check and panics on mismatch — no
             // `unsafe` needed. (The sole caller, `bin.rs`, passes a stack `[u8; 65536]`
             // whose Rust-guaranteed alignment is 1; it should be changed to a `[u16; N]`
             // buffer to make alignment a compile-time guarantee — tracked separately.)
-            let mut wbuf: &mut [u16] = bytemuck::cast_slice_mut(buf);
+            let mut wbuf: &mut [u16] = bun_core::cast::cast_slice_mut(buf);
 
             wbuf[0..self.bin_path.len()].copy_from_slice(self.bin_path);
             wbuf = &mut wbuf[self.bin_path.len()..];
@@ -451,7 +451,7 @@ mod host {
         // Bounds checked above so the trailing 2-byte slice is in range.
         // `pod_read_unaligned` is the safe equivalent of
         // `ptr.cast::<u16>().read_unaligned()` over a `&[u8]`.
-        let flags = Flags::from_bits(bytemuck::pod_read_unaligned::<u16>(
+        let flags = Flags::from_bits(bun_core::cast::pod_read_unaligned::<u16>(
             &input[input.len() - FLAGS_SIZE..],
         ));
         if !flags.is_valid() {
@@ -460,10 +460,10 @@ mod host {
 
         let bin_path_u8: &[u8] = if flags.has_shebang() {
             'bin_path_u8: {
-                // Bounds checked above; unaligned u32 read via safe `bytemuck`.
+                // Bounds checked above; unaligned u32 read via safe `cast`.
                 let off = input.len() - FLAGS_SIZE - 2 * size_of::<u32>();
                 let bin_path_byte_len =
-                    bytemuck::pod_read_unaligned::<u32>(&input[off..off + size_of::<u32>()])
+                    bun_core::cast::pod_read_unaligned::<u32>(&input[off..off + size_of::<u32>()])
                         as usize;
                 if !bin_path_byte_len.is_multiple_of(2) {
                     return None;

--- a/src/install/windows-shim/Cargo.toml
+++ b/src/install/windows-shim/Cargo.toml
@@ -48,16 +48,11 @@ required-features = ["shim_standalone"]
 [features]
 shim_standalone = []
 
-# Almost no crates.io dependencies: `bstr` / `strum` would defeat `#![no_std]`
+# No crates.io dependencies: `bstr` / `strum` would defeat `#![no_std]`
 # (they pull `alloc`/`std` into the link). The shared source's two former uses
 # of them — `strum::IntoStaticStr` on `FailReason` (never consumed) and
 # `bstr::BStr` for byte-slice display — are handled with `core`-only code
 # under `cfg(feature = "shim_standalone")`.
-#
-# `bytemuck` is the one exception: it is `#![no_std]` with no `alloc`, exports
-# no `#[no_mangle]` symbols, and inlines to the same (ptr, len*2) arithmetic
-# the hand-written `from_raw_parts` casts compiled to — so it adds zero link
-# roots and lets the shared source's `&[u16] → &[u8]` views stay safe.
 
 [lints]
 workspace = true
@@ -67,4 +62,3 @@ workspace = true
 [target.'cfg(windows)'.dependencies]
 bun_windows_sys.workspace = true
 bun_opaque.workspace = true
-bytemuck = { version = "1", default-features = false }

--- a/src/install/windows-shim/bun_shim_impl.rs
+++ b/src/install/windows-shim/bun_shim_impl.rs
@@ -523,14 +523,14 @@ fn launcher<const MODE: LauncherMode, Ctx: BunCtx>(bun_ctx: Ctx) -> LauncherRet 
     let image_path_u16: &[u16] =
         unsafe { bun_core::ffi::slice(image_path_ptr, image_path_b_len / 2) };
     // Byte view of the same buffer — `&[u16]` → `&[u8]` is a total, panic-free
-    // `bytemuck` cast (align 1, size always divides).
-    let image_path_u8: &[u8] = bytemuck::cast_slice(image_path_u16);
+    // `cast_slice` (align 1, size always divides).
+    let image_path_u8: &[u8] = bun_core::cast::cast_slice(image_path_u16);
 
     let cmd_line_b_len = command_line.Length as usize;
     // SAFETY: CommandLine.Buffer is valid for Length bytes.
     let cmd_line_u16: &[u16] =
         unsafe { bun_core::ffi::slice(command_line.Buffer, cmd_line_b_len / 2) };
-    let cmd_line_u8: &[u8] = bytemuck::cast_slice(cmd_line_u16);
+    let cmd_line_u8: &[u8] = bun_core::cast::cast_slice(cmd_line_u16);
 
     debug_assert!((cmd_line_u16.as_ptr() as usize) % 2 == 0); // alignment assumption
 
@@ -682,8 +682,8 @@ fn launcher<const MODE: LauncherMode, Ctx: BunCtx>(bun_ctx: Ctx) -> LauncherRet 
     // `from_raw_parts` from the byte view.
     let (user_arguments_u16, user_arguments_u8): (&[u16], &[u8]) = if !IS_STANDALONE {
         let a = bun_ctx.arguments();
-        // `&[u16]` → `&[u8]` reinterpretation: total, panic-free `bytemuck` cast.
-        (a, bytemuck::cast_slice(a))
+        // `&[u16]` → `&[u8]` reinterpretation: total, panic-free `cast_slice`.
+        (a, bun_core::cast::cast_slice(a))
     } else {
         'find_args: {
             // Windows command line quotes are really silly. This post explains it better than I can:
@@ -1045,7 +1045,7 @@ fn launcher<const MODE: LauncherMode, Ctx: BunCtx>(bun_ctx: Ctx) -> LauncherRet 
             // BinLinkingShim.rs and must be even. An odd value (corrupt or
             // tampered shim) would later misalign `write_ptr` (used to store a
             // u16 NUL terminator) and break the even-length invariant relied on
-            // by `bytemuck::cast_slice`. Reject up front.
+            // by `bun_core::cast::cast_slice`. Reject up front.
             if shebang_arg_len_u8 == 0
                 || (shebang_arg_len_u8 & 1) != 0
                 || (shebang_bin_path_len_bytes & 1) != 0
@@ -1160,8 +1160,8 @@ fn launcher<const MODE: LauncherMode, Ctx: BunCtx>(bun_ctx: Ctx) -> LauncherRet 
             // `filename` is a UTF-16 byte view: its base is `buf1_u8 + 2*NT_OBJECT_PREFIX.len()`
             // (even offset from a `*mut u16`-derived pointer ⇒ 2-aligned) and its length is the
             // difference of two `*mut u16`-derived addresses minus an even constant ⇒ even.
-            // `bytemuck::cast_slice` checks both invariants at runtime, so no `unsafe` needed.
-            let filename_u16: &[u16] = bytemuck::cast_slice(filename);
+            // `bun_core::cast::cast_slice` checks both invariants at runtime, so no `unsafe` needed.
+            let filename_u16: &[u16] = bun_core::cast::cast_slice(filename);
             if DBG {
                 debug!("filename and quote: '{}'", fmt16(filename_u16));
                 if !filename_u16.is_empty() {

--- a/src/install/windows-shim/main.rs
+++ b/src/install/windows-shim/main.rs
@@ -198,6 +198,45 @@ macro_rules! w_lit {
 pub mod bun_core {
     // Re-export under the path the shared source uses (`bun_core::w!`).
     pub use crate::w_lit as w;
+
+    /// Mirrors `bun_core::cast` (src/bun_core/cast.rs). The shared source only
+    /// calls `cast_slice` for `&[u16]` ↔ `&[u8]`, so a `u8`/`u16`-only subset
+    /// is enough; the real module is `core`-only but defining the handful of
+    /// needed impls locally keeps the trait surface out of this freestanding PE.
+    pub mod cast {
+        use core::mem::{align_of, size_of};
+
+        /// # Safety
+        /// See `bun_core::cast::NoUninit`.
+        pub unsafe trait NoUninit: Copy + 'static {}
+        /// # Safety
+        /// See `bun_core::cast::AnyBitPattern`.
+        pub unsafe trait AnyBitPattern: Copy + 'static {}
+        // SAFETY: primitive integers — no padding, every bit pattern valid.
+        unsafe impl NoUninit for u8 {}
+        // SAFETY: see above.
+        unsafe impl NoUninit for u16 {}
+        // SAFETY: see above.
+        unsafe impl AnyBitPattern for u8 {}
+        // SAFETY: see above.
+        unsafe impl AnyBitPattern for u16 {}
+
+        /// Mirrors `bun_core::cast::cast_slice`. Panics on misalignment or slop.
+        #[inline]
+        #[track_caller]
+        pub fn cast_slice<A: NoUninit, B: AnyBitPattern>(a: &[A]) -> &[B] {
+            let bytes = core::mem::size_of_val(a);
+            assert!(
+                align_of::<B>() <= align_of::<A>()
+                    || (a.as_ptr() as usize).is_multiple_of(align_of::<B>())
+            );
+            assert!(size_of::<B>() != 0 && bytes.is_multiple_of(size_of::<B>()));
+            // SAFETY: alignment + even division checked; trait bounds discharge
+            // value-validity in both directions.
+            unsafe { core::slice::from_raw_parts(a.as_ptr().cast::<B>(), bytes / size_of::<B>()) }
+        }
+    }
+
     /// Mirrors `bun_core::RacyCell` (src/bun_core/util.rs) — `static`-safe
     /// interior-mutability cell with no synchronization. The shim is
     /// single-threaded (it never spawns a thread), so the

--- a/src/js_parser/Cargo.toml
+++ b/src/js_parser/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 
 [dependencies]
 thiserror.workspace = true
-bytemuck = "1"
 bun_dispatch.workspace = true
 strum.workspace = true
 bstr.workspace = true

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -2769,7 +2769,7 @@ lexer_impl_header! {
                 // It was created via `cast_slice::<u16, u8>` from an arena `[u16]` dupe,
                 // so the pointer is u16-aligned and `cast_slice` back is sound (panics
                 // if that invariant is ever broken — strictly safer than the raw cast).
-                let utf16: &[u16] = bytemuck::cast_slice::<u8, u16>(self.string_literal_raw_content);
+                let utf16: &[u16] = bun_core::cast::cast_slice::<u8, u16>(self.string_literal_raw_content);
                 Ok(js_ast::E::String::init_utf16(utf16))
             }
             StringLiteralRawFormat::NeedsDecode => {
@@ -3164,7 +3164,7 @@ lexer_impl_header! {
 
             let dup = self.arena.alloc_slice_copy(&tmp);
             // Reinterpret &[u16] as &[u8] — `u16: Pod`, so `cast_slice` is safe.
-            self.string_literal_raw_content = bytemuck::cast_slice::<u16, u8>(dup);
+            self.string_literal_raw_content = bun_core::cast::cast_slice::<u16, u8>(dup);
             self.string_literal_raw_format = StringLiteralRawFormat::Utf16;
             tmp.clear();
             self.temp_buffer_u16 = tmp;
@@ -3250,7 +3250,7 @@ lexer_impl_header! {
                         }
                         let dup = self.arena.alloc_slice_copy(&tmp);
                         // Reinterpret arena-owned &[u16] as &[u8] — `u16: Pod`.
-                        self.string_literal_raw_content = bytemuck::cast_slice::<u16, u8>(dup);
+                        self.string_literal_raw_content = bun_core::cast::cast_slice::<u16, u8>(dup);
                         self.string_literal_raw_format = StringLiteralRawFormat::Utf16;
 
                         let was_empty = tmp.is_empty();

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -243,7 +243,7 @@ impl<'a> Options<'a> {
                 // as the optimizations break newer versions of react, see https://github.com/oven-sh/bun/issues/11025
                 let jsx_optimizations: [bool; 2] = [false, false];
                 // `bool: NoUninit`, `u8: AnyBitPattern`.
-                hasher.update(bytemuck::cast_slice::<bool, u8>(&jsx_optimizations));
+                hasher.update(bun_core::cast::cast_slice::<bool, u8>(&jsx_optimizations));
             } else {
                 hasher.update(b"NO_JSX");
             }

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -414,7 +414,7 @@ pub mod Runtime {
 
             // `[bool; N]` is N bytes of 0x00/0x01.
             // `bool: NoUninit`, `u8: AnyBitPattern` → `cast_slice` is statically sound.
-            hasher.update(bytemuck::cast_slice::<bool, u8>(&bools));
+            hasher.update(bun_core::cast::cast_slice::<bool, u8>(&bools));
             hasher.update(&[self.react_compiler as u8]);
 
             // Hash --feature flags. These directly affect transpiled output via

--- a/src/js_printer/Cargo.toml
+++ b/src/js_printer/Cargo.toml
@@ -10,7 +10,6 @@ path = "lib.rs"
 workspace = true
 
 [dependencies]
-bytemuck = "1"
 thiserror.workspace = true
 strum.workspace = true
 bstr.workspace = true

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -167,16 +167,16 @@ pub mod analyze_transpiled_module {
     }
 
     // SAFETY: `#[repr(u8)]` enum with no fields → single initialized byte, no padding.
-    unsafe impl bytemuck::NoUninit for RecordKind {}
+    unsafe impl bun_core::cast::NoUninit for RecordKind {}
 
     /// Index into `ModuleInfo`'s interned-string table. Two reserved sentinels.
     #[repr(transparent)]
     #[derive(Clone, Copy, PartialEq, Eq, Hash)]
     pub struct StringID(pub u32);
     // SAFETY: `#[repr(transparent)]` over `u32`.
-    unsafe impl bytemuck::Zeroable for StringID {}
+    unsafe impl bun_core::cast::Zeroable for StringID {}
     // SAFETY: `#[repr(transparent)]` over `u32` (Pod).
-    unsafe impl bytemuck::Pod for StringID {}
+    unsafe impl bun_core::cast::Pod for StringID {}
     impl StringID {
         pub const STAR_DEFAULT: Self = Self(u32::MAX);
         pub const STAR_NAMESPACE: Self = Self(u32::MAX - 1);
@@ -187,9 +187,9 @@ pub mod analyze_transpiled_module {
     #[derive(Clone, Copy, PartialEq, Eq)]
     pub struct FetchParameters(pub u32);
     // SAFETY: `#[repr(transparent)]` over `u32`.
-    unsafe impl bytemuck::Zeroable for FetchParameters {}
+    unsafe impl bun_core::cast::Zeroable for FetchParameters {}
     // SAFETY: `#[repr(transparent)]` over `u32` (Pod).
-    unsafe impl bytemuck::Pod for FetchParameters {}
+    unsafe impl bun_core::cast::Pod for FetchParameters {}
     #[allow(non_upper_case_globals)]
     impl FetchParameters {
         pub const None: Self = Self(u32::MAX);
@@ -218,7 +218,7 @@ pub mod analyze_transpiled_module {
         Defer = 1,
     }
     // SAFETY: `#[repr(u8)]` enum with no fields → single initialized byte, no padding.
-    unsafe impl bytemuck::NoUninit for ModulePhase {}
+    unsafe impl bun_core::cast::NoUninit for ModulePhase {}
 
     /// Borrowing view over a finalized/serialized `ModuleInfo`.
     /// Built on demand
@@ -277,7 +277,7 @@ pub mod analyze_transpiled_module {
     /// Heap byte buffer with guaranteed 4-byte alignment.
     ///
     /// `as_ref()` below reinterprets interior ranges as `&[u32]` / `&[StringID]` /
-    /// `&[FetchParameters]` via `bytemuck::cast_slice`. A plain `Box<[u8]>` only
+    /// `&[FetchParameters]` via `bun_core::cast::cast_slice`. A plain `Box<[u8]>` only
     /// guarantees `align(1)`, so forming an aligned `&[u32]` from it is UB. We
     /// instead over-align the allocation by storing `Box<[u32]>` and viewing it as
     /// bytes — no raw alloc/dealloc, and `Send`/`Sync` are auto-derived.
@@ -290,7 +290,7 @@ pub mod analyze_transpiled_module {
     impl AlignedBytes {
         fn copy_from(src: &[u8]) -> Self {
             let mut words = vec![0u32; src.len().div_ceil(4)].into_boxed_slice();
-            bytemuck::cast_slice_mut::<u32, u8>(&mut words)[..src.len()].copy_from_slice(src);
+            bun_core::cast::cast_slice_mut::<u32, u8>(&mut words)[..src.len()].copy_from_slice(src);
             Self {
                 words,
                 len: src.len(),
@@ -301,7 +301,7 @@ pub mod analyze_transpiled_module {
         type Target = [u8];
         #[inline]
         fn deref(&self) -> &[u8] {
-            &bytemuck::cast_slice::<u32, u8>(&self.words)[..self.len]
+            &bun_core::cast::cast_slice::<u32, u8>(&self.words)[..self.len]
         }
     }
 
@@ -412,11 +412,11 @@ pub mod analyze_transpiled_module {
         pub fn as_ref(&self) -> ModuleInfoDeserialized<'_> {
             let bytes: &[u8] = &self.backing;
             #[inline(always)]
-            fn sub<T: bytemuck::Pod>(bytes: &[u8], (off, len): (usize, usize)) -> &[T] {
+            fn sub<T: bun_core::cast::Pod>(bytes: &[u8], (off, len): (usize, usize)) -> &[T] {
                 // `create` derives every (off, len) from `count * size_of::<T>()`
                 // and pads to 4-byte boundaries; `AlignedBytes` guarantees a
                 // 4-aligned base — so `cast_slice`'s align/size checks pass.
-                bytemuck::cast_slice(&bytes[off..off + len])
+                bun_core::cast::cast_slice(&bytes[off..off + len])
             }
             ModuleInfoDeserialized {
                 record_kinds: &self.record_kinds,
@@ -2648,7 +2648,7 @@ pub mod __gated_printer {
 
         pub fn print_string_characters_utf16(&mut self, text: &[u16], quote: u8) {
             debug_assert!(matches!(quote, b'\'' | b'"' | b'`'));
-            let slice: &[u8] = bytemuck::cast_slice(text);
+            let slice: &[u8] = bun_core::cast::cast_slice(text);
             let mut writer = self.writer.std_writer();
             let _ = write_pre_quoted_string_inner::<_, { Encoding::Utf16 }>(
                 slice,

--- a/src/jsc/Cargo.toml
+++ b/src/jsc/Cargo.toml
@@ -21,7 +21,6 @@ enum-map.workspace = true
 enumset.workspace = true
 libc.workspace = true
 bitflags.workspace = true
-bytemuck = "1"
 bun_analytics.workspace = true
 bun_api.workspace = true
 bun_base64.workspace = true

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -5699,8 +5699,8 @@ pub mod formatter {
             // `slice` comes from a typed array whose backing storage is aligned for its
             // element type (JS spec: typed-array byteOffset is always a multiple of
             // element size, and ArrayBuffer storage is mimalloc-aligned), so the safe
-            // `bytemuck::cast_slice` alignment/size checks always pass.
-            use bytemuck::cast_slice;
+            // `bun_core::cast::cast_slice` alignment/size checks always pass.
+            use bun_core::cast::cast_slice;
             match js_type {
                 T::Int8Array => Self::write_typed_array::<i8, C>(&mut writer, cast_slice(slice)),
                 T::Int16Array => Self::write_typed_array::<i16, C>(&mut writer, cast_slice(slice)),

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -532,7 +532,7 @@ impl Entry {
                     // `chars` is `&mut [u16; char_len]` backed by contiguous
                     // WTFString storage; reinterpret as bytes for pread via the
                     // safe POD cast (`u16` → `u8` always satisfies size/align).
-                    let chars_bytes: &mut [u8] = bytemuck::cast_slice_mut(chars);
+                    let chars_bytes: &mut [u8] = bun_core::cast::cast_slice_mut(chars);
                     let read_bytes =
                         file.pread_all(chars_bytes, self.metadata.output_byte_offset)?;
                     if read_bytes as u64 != self.metadata.output_byte_length {
@@ -540,7 +540,7 @@ impl Entry {
                     }
 
                     if self.metadata.output_hash != 0 {
-                        let utf16_bytes: &[u8] = bytemuck::cast_slice(string.utf16());
+                        let utf16_bytes: &[u8] = bun_core::cast::cast_slice(string.utf16());
                         if hash(utf16_bytes) != self.metadata.output_hash {
                             return Err(crate::CrateError::InvalidHash);
                         }

--- a/src/jsc/ipc.rs
+++ b/src/jsc/ipc.rs
@@ -302,7 +302,7 @@ mod advanced {
     }
     // SAFETY: `#[repr(u8)]` fieldless enum → size 1, align 1, no padding,
     // `Copy + 'static`; the single byte is always an initialized discriminant.
-    unsafe impl bytemuck::NoUninit for IPCMessageType {}
+    unsafe impl bun_core::cast::NoUninit for IPCMessageType {}
 
     impl IPCMessageType {
         fn tag_name(raw: u8) -> &'static str {

--- a/src/libarchive/Cargo.toml
+++ b/src/libarchive/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 
 [dependencies]
 thiserror.workspace = true
-bytemuck = "1"
 bun_opaque.workspace = true
 strum.workspace = true
 bstr.workspace = true

--- a/src/parsers/Cargo.toml
+++ b/src/parsers/Cargo.toml
@@ -11,7 +11,6 @@ path = "lib.rs"
 workspace = true
 
 [dependencies]
-bytemuck = "1"
 thiserror.workspace = true
 strum.workspace = true
 bstr.workspace = true

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -576,7 +576,7 @@ impl Encoding for Utf16 {
         // Reinterpret `&[u16]` as `&[u8]` of `len * 2` for byte-keyed hashing.
         // Uniqueness is preserved (equal u16 slices ⇔ equal byte slices). Same
         // pattern as `bun_ast::E::EString::hash()` for the utf16 arm.
-        bytemuck::cast_slice(s)
+        bun_core::cast::cast_slice(s)
     }
     #[inline]
     fn unit_from_u16(u: u16) -> u16 {

--- a/src/paths/Cargo.toml
+++ b/src/paths/Cargo.toml
@@ -18,7 +18,6 @@ enum-map.workspace = true
 enumset.workspace = true
 libc.workspace = true
 bitflags.workspace = true
-bytemuck = "1"
 bun_alloc.workspace = true
 bun_core.workspace = true
 bun_errno.workspace = true

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -18,7 +18,6 @@ getrandom.workspace = true
 # docs/PORTING.md, prefer a vetted crates.io impl over hand-porting Keccak/Blake2.
 sha3 = { version = "0.10", default-features = false }
 blake2 = { version = "0.10", default-features = false }
-bytemuck = "1"
 thiserror.workspace = true
 strum.workspace = true
 bstr.workspace = true

--- a/src/runtime/api/UnsafeObject.rs
+++ b/src/runtime/api/UnsafeObject.rs
@@ -51,8 +51,8 @@ pub(crate) fn array_buffer_to_string(
     match array_buffer.typed_array_type {
         JSType::Uint16Array | JSType::Int16Array => {
             // Uint16Array/Int16Array storage is u16-aligned with even byte length;
-            // bytemuck checks both at runtime.
-            let utf16: &[u16] = bytemuck::cast_slice(array_buffer.byte_slice());
+            // `cast_slice` checks both at runtime.
+            let utf16: &[u16] = bun_core::cast::cast_slice(array_buffer.byte_slice());
             let zig_str = ZigString::init_utf16(utf16);
             Ok(zig_str.to_js(global))
         }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -369,9 +369,9 @@ struct StreamPriority {
 }
 // SAFETY: `#[repr(C, packed)]` with `u32 + u8` fields — no padding, no niches,
 // every 5-byte pattern is a valid value.
-unsafe impl bytemuck::Zeroable for StreamPriority {}
+unsafe impl bun_core::cast::Zeroable for StreamPriority {}
 // SAFETY: see `Zeroable` impl above; additionally `Copy + 'static`.
-unsafe impl bytemuck::Pod for StreamPriority {}
+unsafe impl bun_core::cast::Pod for StreamPriority {}
 const _: () = assert!(core::mem::size_of::<StreamPriority>() == StreamPriority::BYTE_SIZE);
 impl StreamPriority {
     pub(crate) const BYTE_SIZE: usize = 5;
@@ -379,7 +379,7 @@ impl StreamPriority {
     fn write(self, writer: &mut impl WireWriter) -> bool {
         let mut swap = self;
         swap.stream_identifier = swap.stream_identifier.swap_bytes();
-        writer.write_all(bytemuck::bytes_of(&swap)).is_ok()
+        writer.write_all(bun_core::cast::bytes_of(&swap)).is_ok()
     }
     #[inline]
     fn from(dst: &mut StreamPriority, src: &[u8]) {
@@ -494,9 +494,9 @@ pub(crate) struct FullSettingsPayload {
 }
 // SAFETY: `#[repr(C, packed)]` with only `u16`/`u32` fields — no padding, no
 // niches, every 42-byte pattern is a valid value.
-unsafe impl bytemuck::Zeroable for FullSettingsPayload {}
+unsafe impl bun_core::cast::Zeroable for FullSettingsPayload {}
 // SAFETY: see `Zeroable` impl above; additionally `Copy + 'static`.
-unsafe impl bytemuck::Pod for FullSettingsPayload {}
+unsafe impl bun_core::cast::Pod for FullSettingsPayload {}
 const _: () =
     assert!(core::mem::size_of::<FullSettingsPayload>() == FullSettingsPayload::BYTE_SIZE);
 impl Default for FullSettingsPayload {
@@ -616,7 +616,7 @@ impl FullSettingsPayload {
         swap.max_header_list_size = swap.max_header_list_size.swap_bytes();
         swap._enable_connect_protocol_type = swap._enable_connect_protocol_type.swap_bytes();
         swap.enable_connect_protocol = swap.enable_connect_protocol.swap_bytes();
-        writer.write_all(bytemuck::bytes_of(&swap)).is_ok()
+        writer.write_all(bun_core::cast::bytes_of(&swap)).is_ok()
     }
 }
 

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5778,7 +5778,7 @@ impl DevServer {
         let cost = self.memory_cost_detailed();
         let system_total = crate::node::os::totalmem();
         // Wire format: 10 contiguous native-endian u32s. `[u32; 10]` has no
-        // padding and is `bytemuck::Pod`, so the byte view is safe.
+        // padding and is `bun_core::cast::Pod`, so the byte view is safe.
         let fields: [u32; 10] = [
             /* incremental_graph_client */ cost.incremental_graph_client as u32,
             /* incremental_graph_server */ cost.incremental_graph_server as u32,
@@ -5793,7 +5793,7 @@ impl DevServer {
             /* system_used */ system_total.saturating_sub(crate::node::os::freemem()) as u32,
             /* system_total */ system_total as u32,
         ];
-        payload.extend_from_slice(bytemuck::bytes_of(&fields));
+        payload.extend_from_slice(bun_core::cast::bytes_of(&fields));
 
         // SourceMapStore is easy to leak refs in.
         {

--- a/src/runtime/node/dir_iterator.rs
+++ b/src/runtime/node/dir_iterator.rs
@@ -719,8 +719,8 @@ mod platform {
                 // `buf` follows the 8-byte `Fd` in a `repr(C, align(8))` struct so
                 // it is itself 8-byte aligned, and per MS docs each record (and
                 // thus its FileName at offset 64) lands on an 8-byte boundary —
-                // bytemuck checks the u8→u16 alignment at runtime.
-                let dir_info_name: &[u16] = bytemuck::cast_slice(
+                // `cast_slice` checks the u8→u16 alignment at runtime.
+                let dir_info_name: &[u16] = bun_core::cast::cast_slice(
                     &self.buf[name_byte_offset..name_byte_offset + name_len_u16 * 2],
                 );
 

--- a/src/runtime/node/fs_events.rs
+++ b/src/runtime/node/fs_events.rs
@@ -109,8 +109,8 @@ fn dlsym<T>(handle: *mut c_void, symbol: &core::ffi::CStr) -> Option<T> {
     // as the symbol's true type. Callers monomorphise T to the matching `extern "C" fn`
     // (or pointer-sized data symbol) declared by CoreFoundation/CoreServices; the const
     // assert above enforces size parity, and the null check rules out the absent-symbol
-    // case so the resulting fn pointer is always non-null. Not expressible via
-    // bytemuck/as: fn pointers are not Pod and `as` can't cast data→fn pointers.
+    // case so the resulting fn pointer is always non-null. Not expressible via a
+    // safe cast: fn pointers are not Pod and `as` can't cast data→fn pointers.
     Some(unsafe { core::mem::transmute_copy::<*mut c_void, T>(&ptr) })
 }
 #[cfg(not(unix))]

--- a/src/runtime/node/node_os.rs
+++ b/src/runtime/node/node_os.rs
@@ -1169,8 +1169,8 @@ mod _impl {
                         // reinterpret as bytes — same width, same provenance.
                         let dl = unsafe { &*ll_addr.cast::<c::sockaddr_dl>() };
                         let raw = &dl.sdl_data[dl.sdl_nlen as usize..];
-                        // c_char and u8 are both Pod; bytemuck statically checks the layout.
-                        bytemuck::cast_slice::<_, u8>(raw)
+                        // c_char and u8 are both Pod; `cast_slice` statically checks the layout.
+                        bun_core::cast::cast_slice::<_, u8>(raw)
                     };
                     if addr_data.len() < 6 {
                         let mac = b"00:00:00:00:00:00";

--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -19,15 +19,15 @@ use bun_sys;
 fn create_js_string_t<T: PathCharCwd>(global: &JSGlobalObject, s: &[T]) -> JsResult<JSValue> {
     use crate::jsc::{StringJsc as _, bun_string_jsc};
     if T::IS_U16 {
-        // T == u16 when IS_U16; bytemuck statically checks the layout.
-        let s16: &[u16] = bytemuck::cast_slice::<T, u16>(s);
+        // T == u16 when IS_U16; `cast_slice` statically checks the layout.
+        let s16: &[u16] = bun_core::cast::cast_slice::<T, u16>(s);
         let bs = bun_core::String::clone_utf16(s16);
         let r = bs.to_js(global);
         bs.deref();
         r
     } else {
-        // T == u8 when !IS_U16; bytemuck statically checks the layout.
-        let s8: &[u8] = bytemuck::cast_slice::<T, u8>(s);
+        // T == u8 when !IS_U16; `cast_slice` statically checks the layout.
+        let s8: &[u8] = bun_core::cast::cast_slice::<T, u8>(s);
         bun_string_jsc::create_utf8_for_js(global, s8)
     }
 }
@@ -68,14 +68,14 @@ impl<'a, T: PathCharCwd> PathScratch<'a, T> {
     fn new(pool: &'a mut RarePathBuf, len: usize) -> Self {
         if !T::IS_U16 && len <= Self::POOL_MAX {
             // SAFETY-adjacent: `!IS_U16` ⇒ `T == u8`; `cast_slice_mut::<u8, u8>`
-            // is the bytemuck identity cast — never panics, no alignment hazard.
+            // is the identity cast — never panics, no alignment hazard.
             let bytes = &mut pool.get(len)[..len];
-            Self::Pooled(bytemuck::cast_slice_mut::<u8, T>(bytes))
+            Self::Pooled(bun_core::cast::cast_slice_mut::<u8, T>(bytes))
         } else {
             // `T: Pod` ⇒ `T: Zeroable + Copy`. Spill is rare (u8 only when
             // >128 KB) or path-sized (u16), so the zero-fill is negligible and
             // buys a safe `&mut [T]` in `slice()`.
-            Self::Spill(vec![<T as bytemuck::Zeroable>::zeroed(); len].into_boxed_slice())
+            Self::Spill(vec![<T as bun_core::cast::Zeroable>::zeroed(); len].into_boxed_slice())
         }
     }
 
@@ -95,10 +95,10 @@ const PATH_MIN_WIDE: usize = 4096; // 4 KB
 pub use bun_paths::PathChar;
 
 /// Runtime-only extension over [`PathChar`]: adds the `bun_sys`-coupled
-/// per-width `get_cwd` plus the `bytemuck::Pod`/`Default` bounds this module
+/// per-width `get_cwd` plus the `bun_core::cast::Pod`/`Default` bounds this module
 /// needs for `PathScratch`'s `cast_slice` and zero-init. Every generic `_t`
 /// fn here bounds on `PathCharCwd` (only `u8`/`u16` ever instantiate it).
-pub trait PathCharCwd: PathChar + Default + bytemuck::Pod {
+pub trait PathCharCwd: PathChar + Default + bun_core::cast::Pod {
     /// Per-width `get_cwd` — replaces the `IS_U16` runtime dispatch in `get_cwd_t`.
     fn get_cwd(buf: &mut [Self]) -> bun_sys::Result<&mut [Self]>;
 }
@@ -124,9 +124,9 @@ fn l<T: PathCharCwd>(s: &'static [u8]) -> &'static [T] {
 /// Compares ASCII values case-insensitively, non-ASCII values are compared directly
 fn eql_ignore_case_t<T: PathCharCwd>(a: &[T], b: &[T]) -> bool {
     if !T::IS_U16 {
-        // T == u8 when !IS_U16; bytemuck statically checks the layout.
-        let a8: &[u8] = bytemuck::cast_slice::<T, u8>(a);
-        let b8: &[u8] = bytemuck::cast_slice::<T, u8>(b);
+        // T == u8 when !IS_U16; `cast_slice` statically checks the layout.
+        let a8: &[u8] = bun_core::cast::cast_slice::<T, u8>(a);
+        let b8: &[u8] = bun_core::cast::cast_slice::<T, u8>(b);
         return strings::eql_case_insensitive_ascii(a8, b8, true);
     }
     // In practice the only callers instantiate with `T == u8`; provide a sound
@@ -3030,11 +3030,11 @@ pub(crate) fn resolve_windows_t<'a, T: PathCharCwd>(
                         // reused arena buffer with arbitrary prior contents past
                         // `buf_size`, so write the terminator explicitly.
                         buf2[buf_size] = T::from_u8(0);
-                        // T == u16 when IS_U16; bytemuck statically checks the layout.
-                        break 'brk bytemuck::cast_slice::<T, u16>(&buf2[..=buf_size]);
+                        // T == u16 when IS_U16; `cast_slice` statically checks the layout.
+                        break 'brk bun_core::cast::cast_slice::<T, u16>(&buf2[..=buf_size]);
                     }
-                    // T == u8 when !IS_U16; bytemuck statically checks the layout.
-                    let key8: &[u8] = bytemuck::cast_slice::<T, u8>(&buf2[..buf_size]);
+                    // T == u8 when !IS_U16; `cast_slice` statically checks the layout.
+                    let key8: &[u8] = bun_core::cast::cast_slice::<T, u8>(&buf2[..buf_size]);
                     // Write the NUL after widening so the LPCWSTR is properly
                     // terminated regardless of `WPathBuffer::uninit()`'s init
                     // state — don't rely on `uninit()` happening to zero-fill
@@ -3048,14 +3048,14 @@ pub(crate) fn resolve_windows_t<'a, T: PathCharCwd>(
                 if let Some(r) = bun_sys::windows::getenv_w(key_w) {
                     if T::IS_U16 {
                         buf_size = r.len();
-                        // T == u16 when IS_U16; bytemuck checks the layout at runtime.
+                        // T == u16 when IS_U16; `cast_slice` checks the layout at runtime.
                         let dst: &mut [u16] =
-                            bytemuck::cast_slice_mut::<T, u16>(&mut buf2[..buf_size]);
+                            bun_core::cast::cast_slice_mut::<T, u16>(&mut buf2[..buf_size]);
                         memmove(dst, &r);
                     } else {
                         // Reuse buf2 because it's used for path.
-                        // T == u8 when !IS_U16; bytemuck statically checks the layout.
-                        let dst: &mut [u8] = bytemuck::cast_slice_mut::<T, u8>(&mut buf2[..]);
+                        // T == u8 when !IS_U16; `cast_slice` statically checks the layout.
+                        let dst: &mut [u8] = bun_core::cast::cast_slice_mut::<T, u8>(&mut buf2[..]);
                         buf_size = strings::convert_utf16_to_utf8_in_buffer(dst, &r).len();
                     }
                     env_path_len = Some(buf_size);

--- a/src/runtime/test_runner/diff/diff_match_patch.rs
+++ b/src/runtime/test_runner/diff/diff_match_patch.rs
@@ -70,8 +70,8 @@ impl Default for Config {
 
 /// Marker trait for the element type a diff operates over (`u8` or `usize`).
 /// `Pod` lets the `Unit == u8` fast paths reinterpret `&[Unit]` as `&[u8]`
-/// via `bytemuck::cast_slice` instead of raw `from_raw_parts`.
-pub(crate) trait DiffUnit: Copy + Eq + bytemuck::Pod + 'static {}
+/// via `bun_core::cast::cast_slice` instead of raw `from_raw_parts`.
+pub(crate) trait DiffUnit: Copy + Eq + bun_core::cast::Pod + 'static {}
 impl DiffUnit for u8 {}
 impl DiffUnit for usize {}
 
@@ -779,8 +779,8 @@ fn diff_lines_to_chars_munge<'a, Unit: DiffUnit>(
     if TypeId::of::<Unit>() != TypeId::of::<u8>() {
         panic!("Unit must be u8");
     }
-    // Unit == u8 verified above; bytemuck statically checks the layout.
-    let text_u8: &[u8] = bytemuck::cast_slice::<Unit, u8>(text);
+    // Unit == u8 verified above; `cast_slice` statically checks the layout.
+    let text_u8: &[u8] = bun_core::cast::cast_slice::<Unit, u8>(text);
 
     let mut line_start: isize = 0;
     let mut line_end: isize = -1;
@@ -796,8 +796,8 @@ fn diff_lines_to_chars_munge<'a, Unit: DiffUnit>(
         };
         let mut line = &text[usize::try_from(line_start).unwrap()
             ..usize::try_from(line_start + (line_end + 1 - line_start)).unwrap()];
-        // Unit == u8 verified above; bytemuck statically checks the layout.
-        let line_u8: &[u8] = bytemuck::cast_slice::<Unit, u8>(line);
+        // Unit == u8 verified above; `cast_slice` statically checks the layout.
+        let line_u8: &[u8] = bun_core::cast::cast_slice::<Unit, u8>(line);
 
         if let Some(&value) = line_hash.get(line_u8) {
             chars.push(value);
@@ -807,8 +807,8 @@ fn diff_lines_to_chars_munge<'a, Unit: DiffUnit>(
                 line_end = isize::try_from(text.len()).unwrap();
             }
             line_array.push(line);
-            // Unit == u8 verified above; bytemuck statically checks the layout.
-            let line_u8: &[u8] = bytemuck::cast_slice::<Unit, u8>(line);
+            // Unit == u8 verified above; `cast_slice` statically checks the layout.
+            let line_u8: &[u8] = bun_core::cast::cast_slice::<Unit, u8>(line);
             // `put_assume_capacity` copies the key into an owned `Box<[u8]>`.
             line_hash.put_assume_capacity(line_u8, line_array.len() - 1);
             chars.push(line_array.len() - 1);
@@ -1271,9 +1271,9 @@ fn diff_cleanup_semantic_score<Unit: DiffUnit>(one: &[Unit], two: &[Unit]) -> us
     if TypeId::of::<Unit>() != TypeId::of::<u8>() {
         return 5;
     }
-    // Unit == u8 verified above; bytemuck statically checks the layout.
-    let one: &[u8] = bytemuck::cast_slice::<Unit, u8>(one);
-    let two: &[u8] = bytemuck::cast_slice::<Unit, u8>(two);
+    // Unit == u8 verified above; `cast_slice` statically checks the layout.
+    let one: &[u8] = bun_core::cast::cast_slice::<Unit, u8>(one);
+    let two: &[u8] = bun_core::cast::cast_slice::<Unit, u8>(two);
 
     // Each port of this function behaves slightly differently due to
     // subtle differences in each language's definition of things like

--- a/src/runtime/webcore/ArrayBufferSink.rs
+++ b/src/runtime/webcore/ArrayBufferSink.rs
@@ -155,9 +155,9 @@ impl ArrayBufferSink {
         }
         let bytes = data.slice();
         // The caller guarantees the byte slice is u16-aligned and has even
-        // length when the stream encoding is UTF-16. bytemuck checks both at
+        // length when the stream encoding is UTF-16. `cast_slice` checks both at
         // runtime.
-        let utf16: &[u16] = bytemuck::cast_slice(bytes);
+        let utf16: &[u16] = bun_core::cast::cast_slice(bytes);
         let len = match self.bytes.write_utf16(utf16) {
             Ok(len) => len,
             Err(_) => return streams::result::Writable::Err(syscall::Error::oom()),

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2670,7 +2670,7 @@ impl BlobExt for Blob {
             // This branch intentionally does NOT `self.detach()` for
             // `Lifetime::Transfer`, unlike the toJSON path.
             let buf = &buf[..buf.len() & !1];
-            let out = match bytemuck::try_cast_slice::<u8, u16>(buf) {
+            let out = match bun_core::cast::try_cast_slice::<u8, u16>(buf) {
                 Ok(units) => OwnedString::new(BunString::clone_utf16(units)),
                 Err(_) => {
                     let units: Vec<u16> = buf
@@ -2904,7 +2904,7 @@ impl BlobExt for Blob {
             // Reinterpret as u16: drop a trailing odd byte.
             // +1 WTF ref; `OwnedString` releases it on scope exit.
             let buf = &buf[..buf.len() & !1];
-            let mut out = match bytemuck::try_cast_slice::<u8, u16>(buf) {
+            let mut out = match bun_core::cast::try_cast_slice::<u8, u16>(buf) {
                 Ok(units) => OwnedString::new(BunString::clone_utf16(units)),
                 Err(_) => {
                     let units: Vec<u16> = buf

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -240,8 +240,8 @@ impl UTF8Fallback {
     ) -> streams::result::Writable {
         let bytes = input.slice();
         // input.slice() is guaranteed by caller to be u16-aligned UTF-16 bytes;
-        // bytemuck checks alignment + even length at runtime.
-        let str_: &[u16] = bytemuck::cast_slice(bytes);
+        // `cast_slice` checks alignment + even length at runtime.
+        let str_: &[u16] = bun_core::cast::cast_slice(bytes);
 
         if Self::STACK_SIZE >= str_.len() * 2 {
             let mut buf = [0u8; Self::STACK_SIZE];
@@ -914,7 +914,7 @@ impl<T: JsSinkType + JsSinkAbi> JSSink<T> {
         let _keep_str = bun_jsc::EnsureStillAlive(str_.to_js());
         if view.is_16bit() {
             let utf16 = view.utf16_slice_aligned();
-            let bytes: &[u8] = bytemuck::cast_slice(utf16);
+            let bytes: &[u8] = bun_core::cast::cast_slice(utf16);
             // Borrowed view over GC-kept JSString.
             let data = bun_ptr::RawSlice::new(bytes);
             return Ok(this

--- a/src/runtime/webcore/encoding.rs
+++ b/src/runtime/webcore/encoding.rs
@@ -318,7 +318,7 @@ pub(crate) fn to_bun_string_from_owned_slice(input: Vec<u8>, encoding: Encoding)
             // `construct_from_u16`'s utf16le arm, which avoids the same
             // reinterpret for the same reason.
             let mut as_u16 = vec![0u16; usable_len / 2];
-            let dst: &mut [u8] = bytemuck::cast_slice_mut(&mut as_u16);
+            let dst: &mut [u8] = bun_core::cast::cast_slice_mut(&mut as_u16);
             dst.copy_from_slice(&input[..usable_len]);
             create_external_globally_allocated_utf16(as_u16)
         }
@@ -428,7 +428,7 @@ pub(crate) fn to_bun_string_comptime<const ENCODING: u8>(input: &[u8]) -> BunStr
                 return str;
             }
             // chars is a freshly-allocated [u16] buffer; reinterpret as bytes.
-            let output_bytes: &mut [u8] = bytemuck::cast_slice_mut(chars);
+            let output_bytes: &mut [u8] = bun_core::cast::cast_slice_mut(chars);
             let out_len = output_bytes.len();
             output_bytes[out_len - 1] = 0;
 
@@ -570,12 +570,13 @@ pub(crate) unsafe fn write_u8<const ENCODING: u8, const ALLOW_PARTIAL_WRITE: boo
             let buf = input_slice;
             let out_units = to_len / 2;
             // `to_slice` already covers `to_ptr[..to_len]`; for the aligned fast
-            // path, `bytemuck` gives a safe `&mut [u8] → &mut [u16]` view (it
+            // path, `cast_slice_mut` gives a safe `&mut [u8] → &mut [u16]` view (it
             // re-checks alignment + even length, both proven here).
             let mut written = if out_units == 0 {
                 0
             } else if (to_slice.as_ptr() as usize).is_multiple_of(core::mem::align_of::<u16>()) {
-                let output: &mut [u16] = bytemuck::cast_slice_mut(&mut to_slice[..out_units * 2]);
+                let output: &mut [u16] =
+                    bun_core::cast::cast_slice_mut(&mut to_slice[..out_units * 2]);
                 strings::copy_latin1_into_utf16(output, buf).written as usize * 2
             } else {
                 // Rust `&mut [u16]` requires natural alignment, so inline the
@@ -888,7 +889,7 @@ pub(crate) unsafe fn construct_from_u16<const ENCODING: u8>(
             // `input_slice: &[u16]` is the source bytes verbatim — copy them
             // out into a fresh u8 Vec (a `Vec<u16>` header reinterpret would be
             // allocator-layout-dependent).
-            bytemuck::cast_slice::<u16, u8>(input_slice).to_vec()
+            bun_core::cast::cast_slice::<u16, u8>(input_slice).to_vec()
         }
 
         Encoding::Hex => {

--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -1111,8 +1111,8 @@ impl MultiPartUpload {
                     WriteEncoding::Bytes => self.buffered.write(chunk)?,
                     WriteEncoding::Latin1 => self.buffered.write_latin1::<true>(chunk)?,
                     WriteEncoding::Utf16 => {
-                        // @alignCast — caller guarantees chunk is u16-aligned; bytemuck checks at runtime.
-                        let utf16: &[u16] = bytemuck::cast_slice(chunk);
+                        // @alignCast — caller guarantees chunk is u16-aligned; `cast_slice` checks at runtime.
+                        let utf16: &[u16] = bun_core::cast::cast_slice(chunk);
                         self.buffered.write_utf16(utf16)?
                     }
                 }
@@ -1131,8 +1131,8 @@ impl MultiPartUpload {
                 WriteEncoding::Bytes => self.buffered.write(chunk)?,
                 WriteEncoding::Latin1 => self.buffered.write_latin1::<true>(chunk)?,
                 WriteEncoding::Utf16 => {
-                    // @alignCast — caller guarantees chunk is u16-aligned; bytemuck checks at runtime.
-                    let utf16: &[u16] = bytemuck::cast_slice(chunk);
+                    // @alignCast — caller guarantees chunk is u16-aligned; `cast_slice` checks at runtime.
+                    let utf16: &[u16] = bun_core::cast::cast_slice(chunk);
                     self.buffered.write_utf16(utf16)?
                 }
             }

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -374,8 +374,8 @@ pub enum ResultTag {
 impl StreamResult {
     pub fn slice16(&self) -> &[u16] {
         // Caller guarantees bytes are u16-aligned and even length;
-        // bytemuck checks both at runtime.
-        bytemuck::cast_slice(self.slice())
+        // `cast_slice` checks both at runtime.
+        bun_core::cast::cast_slice(self.slice())
     }
 
     pub fn slice(&self) -> &[u8] {
@@ -1778,8 +1778,8 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
 
         // we must always buffer UTF-16
         // we assume the case of all-ascii UTF-16 string is pretty uncommon
-        // bytes are u16-aligned per Result.slice16 invariant; bytemuck checks at runtime.
-        let utf16: &[u16] = bytemuck::cast_slice(bytes);
+        // bytes are u16-aligned per Result.slice16 invariant; `cast_slice` checks at runtime.
+        let utf16: &[u16] = bun_core::cast::cast_slice(bytes);
         let written = match self.buffer.write_utf16(utf16) {
             Ok(n) => n,
             Err(_) => return Writable::Err(SysError::from_code(sys::E::ENOMEM, sys::Tag::write)),

--- a/src/sql/postgres/protocol/ParameterDescription.rs
+++ b/src/sql/postgres/protocol/ParameterDescription.rs
@@ -46,9 +46,9 @@ impl ParameterDescription {
 // Rust cannot form an unaligned `&[i32]`, so we reinterpret as `&[[u8; 4]]`
 // (align 1) and let the caller `from_ne_bytes` each element.
 fn to_int32_slice(slice: &[u8]) -> &[[u8; core::mem::size_of::<Int4>()]] {
-    // `[u8; 4]` has align 1 and is `AnyBitPattern`, so this is a safe cast
-    // cast. Truncate any trailing `len % 4` bytes first (cast_slice would
-    // panic on a remainder).
+    // `[u8; 4]` has align 1 and is `AnyBitPattern`, so this is a safe
+    // `cast_slice`. Truncate any trailing `len % 4` bytes first (cast_slice
+    // would panic on a remainder).
     let n = core::mem::size_of::<Int4>();
     bun_core::cast_slice(&slice[..slice.len() - slice.len() % n])
 }

--- a/src/sql/postgres/protocol/ParameterDescription.rs
+++ b/src/sql/postgres/protocol/ParameterDescription.rs
@@ -46,7 +46,7 @@ impl ParameterDescription {
 // Rust cannot form an unaligned `&[i32]`, so we reinterpret as `&[[u8; 4]]`
 // (align 1) and let the caller `from_ne_bytes` each element.
 fn to_int32_slice(slice: &[u8]) -> &[[u8; core::mem::size_of::<Int4>()]] {
-    // `[u8; 4]` has align 1 and is `AnyBitPattern`, so this is a safe bytemuck
+    // `[u8; 4]` has align 1 and is `AnyBitPattern`, so this is a safe cast
     // cast. Truncate any trailing `len % 4` bytes first (cast_slice would
     // panic on a remainder).
     let n = core::mem::size_of::<Int4>();

--- a/src/sys/Cargo.toml
+++ b/src/sys/Cargo.toml
@@ -10,7 +10,6 @@ path = "lib.rs"
 workspace = true
 
 [dependencies]
-bytemuck = "1"
 bun_opaque.workspace = true
 strum.workspace = true
 bstr.workspace = true

--- a/src/sys/SignalCode.rs
+++ b/src/sys/SignalCode.rs
@@ -80,13 +80,13 @@ impl SignalCode {
         }
     }
 
-    pub fn from<T: bytemuck::NoUninit>(value: T) -> SignalCode {
+    pub fn from<T: bun_core::cast::NoUninit>(value: T) -> SignalCode {
         // View `value` as bytes and read the
         // first one. `NoUninit` guarantees `T` is `Copy` with no padding/uninit
-        // bytes, so `bytemuck::bytes_of` is the safe equivalent of the raw
+        // bytes, so `bun_core::cast::bytes_of` is the safe equivalent of the raw
         // `*(&raw const value).cast::<u8>()` reinterpret. A ZST `T` panics on
         // the `[0]` index; all callers pass integer types.
-        SignalCode(bytemuck::bytes_of(&value)[0])
+        SignalCode(bun_core::cast::bytes_of(&value)[0])
     }
 
     pub fn fmt(self, enable_ansi_colors: bool) -> Fmt {

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -720,7 +720,7 @@ pub mod dir_iterator {
                 // name_byte_offset + name_len_u16*2 ≤ BUF_SIZE by clamp above.
                 // `AlignedBuf` is align(8) and `entry_offset`/`NAME_OFFSET` are
                 // both multiples of 4, so the u8→u16 cast is always aligned.
-                let dir_info_name: &[u16] = bytemuck::cast_slice(
+                let dir_info_name: &[u16] = bun_core::cast::cast_slice(
                     &buf[name_byte_offset..name_byte_offset + name_len_u16 * 2],
                 );
 
@@ -6256,7 +6256,7 @@ impl DynLib {
         // SAFETY: irreducible — `dlsym` yields an untyped symbol address as
         // `*mut c_void`; the caller asserts `T` is a pointer-sized fn pointer
         // (or `*mut c_void`) whose ABI matches the resolved symbol. fn pointers
-        // are not `bytemuck::Pod` (not zeroable), so no safe cast exists.
+        // are not `bun_core::cast::Pod` (not zeroable), so no safe cast exists.
         // `transmute_copy` is used over `transmute` because `T` is generic and
         // its size cannot be checked at the definition site; the `const` assert
         // above enforces `size_of::<T>() == size_of::<*mut c_void>()` at
@@ -6372,7 +6372,7 @@ macro_rules! dlsym_with_handle {
             )
         };
         // SAFETY: irreducible — `$T` is a fn-pointer type (caller contract);
-        // fn pointers are not `bytemuck::Pod`, so the `*mut c_void` → `$T`
+        // fn pointers are not `bun_core::cast::Pod`, so the `*mut c_void` → `$T`
         // reinterpretation cannot be expressed safely. `p` is non-null (checked
         // below) and was obtained from `dlsym`, so it is a valid code address;
         // `Once` provides happens-before for the store. The `const` assert above

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -3512,7 +3512,7 @@ pub fn user_unique_id() -> u32 {
         "username: {}",
         bun_core::fmt::utf16(name)
     );
-    bun_wyhash::hash32(bytemuck::cast_slice::<u16, u8>(name))
+    bun_wyhash::hash32(bun_core::cast::cast_slice::<u16, u8>(name))
 }
 
 pub fn win_sock_error_to_zig_error(err: win32::ws2_32::WinsockError) -> Result<(), SystemErrno> {

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -178,7 +178,7 @@ impl EventIterator {
         // The variable-length filename begins at the `FileName` field of the
         // record; `FileNameLength` (kernel-set) bounds the trailing UTF-16
         // bytes which lie wholly inside `buf`. Safe bounds-checked sub-slice of
-        // the owned `[u8; 64K]` buffer, then a `bytemuck`-checked u8→u16 view
+        // the owned `[u8; 64K]` buffer, then a `cast_slice`-checked u8→u16 view
         // (alignment holds: `buf` is DWORD-aligned per the static assert above,
         // `self.offset` advances by kernel `NextEntryOffset` which is DWORD-
         // aligned, and `name_offset` == 12). Wrap in `RawSlice` so callers

--- a/test/js/bun/util/cast-paths.test.ts
+++ b/test/js/bun/util/cast-paths.test.ts
@@ -33,10 +33,6 @@ test("Float16Array inspection reads element values through the u8/f16 slice cast
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  expect(stdout).toContain("Float16Array(4)");
-  expect(stdout).toContain(" 1");
-  expect(stdout).toContain(" 2");
-  expect(stdout).toContain(" -3");
-  expect(stdout).toContain(" 1.5");
+  expect(stdout).toBe("Float16Array(4) [ 1, 2, -3, 1.5 ]");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/util/cast-paths.test.ts
+++ b/test/js/bun/util/cast-paths.test.ts
@@ -2,7 +2,7 @@
 // safe-transmute helpers). Each case exercises a distinct cast shape so a
 // regression in the slice-reinterpretation logic surfaces as a concrete value
 // mismatch rather than a hard-to-localize downstream failure.
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 // `&[u16]` ↔ `&[u8]` via `cast_slice` / `cast_slice_mut` (encoding.rs).

--- a/test/js/bun/util/cast-paths.test.ts
+++ b/test/js/bun/util/cast-paths.test.ts
@@ -1,7 +1,9 @@
 // Smoke coverage for runtime paths backed by `bun_core::cast` (the in-tree
-// safe-transmute helpers). Each case exercises a distinct cast shape so a
+// safe-transmute helpers). Each case exercises a `cast_slice` call site so a
 // regression in the slice-reinterpretation logic surfaces as a concrete value
-// mismatch rather than a hard-to-localize downstream failure.
+// mismatch rather than a hard-to-localize downstream failure. `bytes_of`,
+// `cast_ref`, and `pod_read_unaligned` are covered by the cargo unit tests in
+// `src/bun_core/cast.rs`.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
@@ -37,24 +39,4 @@ test("Float16Array inspection reads element values through the u8/f16 slice cast
   expect(stdout).toContain(" -3");
   expect(stdout).toContain(" 1.5");
   expect(exitCode).toBe(0);
-});
-
-// Unaligned integer read via `pod_read_unaligned` (fmt.rs `parse_hex_to_int`,
-// used by `bun pm hash` / lockfile digests).
-test("hex digest parsing reads unaligned integers correctly", () => {
-  const h = new Bun.CryptoHasher("sha1");
-  h.update("abc");
-  expect(h.digest("hex")).toBe("a9993e364706816aba3e25717850c26c9cd0d89d");
-});
-
-// `bytes_of` on a `#[repr(C)]` struct for hashing (SocketContext.rs /
-// PackageManagerTask.rs pattern): `Bun.hash` of a typed array views the
-// backing bytes and must produce a stable, length-sensitive result.
-test("Bun.hash over typed-array bytes is stable and length-sensitive", () => {
-  const a = new Uint32Array([1, 2, 3, 4]);
-  const b = new Uint32Array([1, 2, 3, 4]);
-  const c = new Uint32Array([1, 2, 3, 5]);
-  expect(Bun.hash(a)).toBe(Bun.hash(b));
-  expect(Bun.hash(a)).not.toBe(Bun.hash(c));
-  expect(Bun.hash(new Uint8Array(a.buffer))).toBe(Bun.hash(a));
 });

--- a/test/js/bun/util/cast-paths.test.ts
+++ b/test/js/bun/util/cast-paths.test.ts
@@ -1,0 +1,60 @@
+// Smoke coverage for runtime paths backed by `bun_core::cast` (the in-tree
+// safe-transmute helpers). Each case exercises a distinct cast shape so a
+// regression in the slice-reinterpretation logic surfaces as a concrete value
+// mismatch rather than a hard-to-localize downstream failure.
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// `&[u16]` ↔ `&[u8]` via `cast_slice` / `cast_slice_mut` (encoding.rs).
+test("utf16le Buffer encoding round-trips through the u16/u8 slice cast", () => {
+  const s = "aé中𝌆"; // 1-byte, 2-byte, 3-byte, surrogate pair
+  const buf = Buffer.from(s, "utf16le");
+  expect([...buf]).toEqual([0x61, 0x00, 0xe9, 0x00, 0x2d, 0x4e, 0x34, 0xd8, 0x06, 0xdf]);
+  expect(buf.toString("utf16le")).toBe(s);
+});
+
+// `&[u8]` → `&[f16]` via `cast_slice` with the local `f16: Pod` impl
+// (util.rs / ConsoleObject.rs). A bad length recomputation would print the
+// wrong element count; a bad bit-reinterpretation would print wrong values.
+test("Float16Array inspection reads element values through the u8/f16 slice cast", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      // 0x3c00 = 1.0, 0x4000 = 2.0, 0xc200 = -3.0, 0x3e00 = 1.5 (IEEE-754 binary16)
+      `const b = new Uint16Array([0x3c00, 0x4000, 0xc200, 0x3e00]);
+       const f = new Float16Array(b.buffer);
+       process.stdout.write(Bun.inspect(f));`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toContain("Float16Array(4)");
+  expect(stdout).toContain(" 1");
+  expect(stdout).toContain(" 2");
+  expect(stdout).toContain(" -3");
+  expect(stdout).toContain(" 1.5");
+  expect(exitCode).toBe(0);
+});
+
+// Unaligned integer read via `pod_read_unaligned` (fmt.rs `parse_hex_to_int`,
+// used by `bun pm hash` / lockfile digests).
+test("hex digest parsing reads unaligned integers correctly", () => {
+  const h = new Bun.CryptoHasher("sha1");
+  h.update("abc");
+  expect(h.digest("hex")).toBe("a9993e364706816aba3e25717850c26c9cd0d89d");
+});
+
+// `bytes_of` on a `#[repr(C)]` struct for hashing (SocketContext.rs /
+// PackageManagerTask.rs pattern): `Bun.hash` of a typed array views the
+// backing bytes and must produce a stable, length-sensitive result.
+test("Bun.hash over typed-array bytes is stable and length-sensitive", () => {
+  const a = new Uint32Array([1, 2, 3, 4]);
+  const b = new Uint32Array([1, 2, 3, 4]);
+  const c = new Uint32Array([1, 2, 3, 5]);
+  expect(Bun.hash(a)).toBe(Bun.hash(b));
+  expect(Bun.hash(a)).not.toBe(Bun.hash(c));
+  expect(Bun.hash(new Uint8Array(a.buffer))).toBe(Bun.hash(a));
+});


### PR DESCRIPTION
## What

Inlines the subset of `bytemuck` that Bun uses into a new `src/bun_core/cast.rs` (~300 lines) and drops the external dependency from all 16 crates that pulled it in.

## Why

`bytemuck` was used at ~190 call sites for safe byte-level reinterpretation (`&[u16]` ↔ `&[u8]`, struct-as-bytes for hashing and wire formats, unaligned reads). Only 5 traits and 7 functions out of its 4,100 lines were reached. Bringing that subset in-tree removes a crates.io dependency with no change in safety guarantees or generated code.

## Scope

- **New**: `src/bun_core/cast.rs` with `Zeroable` / `AnyBitPattern` / `NoUninit` / `Pod` / `TransparentWrapper` and `cast_slice` / `cast_slice_mut` / `try_cast_slice` / `bytes_of` / `bytes_of_mut` / `cast_ref` / `pod_read_unaligned`. `core`-only, `#[track_caller]` on panicking paths, same runtime alignment/size checks as upstream.
- **Mechanical**: `bytemuck::` → `bun_core::cast::` across 45 `.rs` files.
- **Re-exports**: `bun_core::util`'s existing `cast_slice` / `bytes_of` / `NoUninit` wrappers now forward to `crate::cast`, so the top-level `bun_core::cast_slice(..)` API is unchanged.
- **Windows shim**: the freestanding `#![no_std]` `bun_shim_impl` binary can't link `bun_core`, so its local `bun_core` stand-in gains a minimal `cast` module (u8/u16 `cast_slice` only, which is all the shared source uses un-gated).
- **Removed**: `bytemuck` from 16 `Cargo.toml` files and `Cargo.lock`.

## Verification

- `bun bd` builds clean
- `bun run rust:check-all` passes on all 10 targets (linux/macos/windows × x64/aarch64, android)
- `cargo check -p bun_shim_impl --features shim_standalone --target x86_64-pc-windows-msvc` passes
- Smoke tests on cast-heavy paths pass: `node:path`, `text-encoder`, `node-http2`, `transpiler`, `inspect`
- `cargo clippy -p bun_core` clean