### PR TITLE
test(HTMLRewriter): measure kernel peak RSS, not a point sample that straddles a segment decommit

### DIFF
--- a/test/js/workerd/html-rewriter-leak.test.ts
+++ b/test/js/workerd/html-rewriter-leak.test.ts
@@ -47,13 +47,13 @@ test("onEndTag callbacks are released after the rewrite", () => {
 // LOLHTMLContext.deinit() must destroy those allocations. Previously it only
 // unprotected the held JSValues and leaked the struct memory.
 //
-// RSS is a high-water mark across the allocator's committed segments. mimalloc
-// hands a ~30 MB segment back to the OS on its own schedule, so a single
-// `Bun.gc(true); rss()` sample lands on either side of that release — the
-// 4-vCPU Windows CI lane saw `after` at the peak and `before` in the trough
-// for a +31 MB "delta" with nothing retained. Per-window *peak* RSS is the
-// stable observable: a leak raises it every pass (~50 MB over 3), while freed
-// memory leaves it flat regardless of when the decommit fires.
+// `process.memoryUsage.rss()` is a point sample; mimalloc hands a ~30 MB
+// segment back to the OS on its own cadence between passes, so two point
+// samples can straddle that release and read as a +31 MB "delta" with nothing
+// retained (observed on the 4-vCPU Windows lane). `resourceUsage().maxRSS` is
+// the kernel's monotone peak (VmHWM / PeakWorkingSetSize), so it never dips:
+// flat when freed memory is reused, strictly rising (~50 MB over 3 passes)
+// when it leaks.
 //
 // Skipped in debug: at this N a debug pass is ~40s and the extra debug-build
 // allocation tracking adds enough RSS noise to drown the signal. CI has no
@@ -72,23 +72,23 @@ test.skipIf(isDebug)(
       }
 
       const N = 4000;
+      const samples = [];
       function pass() {
         for (let i = 0; i < N; i++) once();
         Bun.gc(true);
-        return process.memoryUsage.rss();
+        samples.push(process.memoryUsage.rss());
       }
 
-      function peakOver(passes) {
-        let peak = 0;
-        for (let i = 0; i < passes; i++) peak = Math.max(peak, pass());
-        return peak;
-      }
+      // ru_maxrss is KB on Linux/Windows, bytes on macOS; normalize to bytes.
+      const maxRSS = () => process.resourceUsage().maxRSS * (process.platform === "darwin" ? 1 : 1024);
 
-      const before = peakOver(3);
-      const after = peakOver(3);
+      for (let i = 0; i < 3; i++) pass();
+      const before = maxRSS();
+      for (let i = 0; i < 3; i++) pass();
+      const after = maxRSS();
 
       process.stdout.write(
-        JSON.stringify({ before, after, deltaMB: (after - before) / 1024 / 1024 }) + "\\n",
+        JSON.stringify({ samples, before, after, deltaMB: (after - before) / 1024 / 1024 }) + "\\n",
       );
     `;
 
@@ -117,6 +117,8 @@ test.skipIf(isDebug)(
       .trim();
     expect(filteredStderr).toBe("");
 
+    // Logged so a future red carries the per-pass trace without a repro.
+    console.log(stdout.trim());
     const { deltaMB } = JSON.parse(stdout.trim());
 
     // Unfixed: ~50 MB over 3 measured passes. Fixed: <1 MB.

--- a/test/js/workerd/html-rewriter-leak.test.ts
+++ b/test/js/workerd/html-rewriter-leak.test.ts
@@ -47,11 +47,13 @@ test("onEndTag callbacks are released after the rewrite", () => {
 // LOLHTMLContext.deinit() must destroy those allocations. Previously it only
 // unprotected the held JSValues and leaked the struct memory.
 //
-// RSS is a high-water mark — Bun.gc(true) collects every wrapper and its
-// lol-html builder, but the allocators don't promptly hand pages back to the
-// OS. So warmup runs the *same* workload as the measured phase: the allocator
-// footprint is established before the baseline, and any growth past that is
-// what's actually retained.
+// RSS is a high-water mark across the allocator's committed segments. mimalloc
+// hands a ~30 MB segment back to the OS on its own schedule, so a single
+// `Bun.gc(true); rss()` sample lands on either side of that release — the
+// 4-vCPU Windows CI lane saw `after` at the peak and `before` in the trough
+// for a +31 MB "delta" with nothing retained. Per-window *peak* RSS is the
+// stable observable: a leak raises it every pass (~50 MB over 3), while freed
+// memory leaves it flat regardless of when the decommit fires.
 //
 // Skipped in debug: at this N a debug pass is ~40s and the extra debug-build
 // allocation tracking adds enough RSS noise to drown the signal. CI has no
@@ -76,10 +78,14 @@ test.skipIf(isDebug)(
         return process.memoryUsage.rss();
       }
 
-      pass(); pass();
-      const before = pass();
-      pass(); pass();
-      const after = pass();
+      function peakOver(passes) {
+        let peak = 0;
+        for (let i = 0; i < passes; i++) peak = Math.max(peak, pass());
+        return peak;
+      }
+
+      const before = peakOver(3);
+      const after = peakOver(3);
 
       process.stdout.write(
         JSON.stringify({ before, after, deltaMB: (after - before) / 1024 / 1024 }) + "\\n",
@@ -113,7 +119,7 @@ test.skipIf(isDebug)(
 
     const { deltaMB } = JSON.parse(stdout.trim());
 
-    // Unfixed: ~50 MB over 3 measured passes. Fixed: ±1 MB plateau.
+    // Unfixed: ~50 MB over 3 measured passes. Fixed: <1 MB.
     // Threshold sits at ~half the unfixed signal.
     expect(deltaMB).toBeLessThan(25);
     expect(exitCode).toBe(0);


### PR DESCRIPTION
Fixes `test/js/workerd/html-rewriter-leak.test.ts` red on the Windows x64 / x64-baseline lanes since ~2026-07-19 (9 failures across builds 75679, 75790, 75881, 75934, 75972, 75974, 75988, 75996, 76026; zero in the 280 builds before that).

### Failure

```
error: expect(received).toBeLessThan(expected)
Expected: < 25
Received: 30.6171875
```

All four retries on build 76026: 30.6 / 30.99 / 31.0 / 31.18 MB. Same ~31 MB on build 75996.

### Cause

Not a leak. The fixture sampled `process.memoryUsage.rss()` once after pass 3 (`before`) and once after pass 6 (`after`), but RSS is bimodal between passes: mimalloc periodically hands a ~30 MB segment back to the OS, so each sample lands on either the ~60 MB peak or the ~30-47 MB trough. Ten consecutive passes on Windows release:

```
59.6, 60.1, 47.0, 60.1, 60.1, 48.0, 60.2, 60.2, 48.4, 60.2
59.6, 60.1, 46.5, 60.1, 60.2, 32.4, 60.2, 60.2, 33.8, 60.2
59.6, 34.5, 60.1, 60.1, 47.7, 60.1, 60.2, 34.5, 60.2, 60.2
```

`after - before` can therefore be anywhere in [-30, +30] MB with nothing retained. On the 4-vCPU D4ds_v6 Windows runners the decommit consistently lands between passes 2 and 3, so `before` catches the trough and `after` catches the peak; on larger boxes the phase happens to favour pass 3 ≈ pass 6 and the test passed.

No code in `src/runtime/api/html_rewriter.rs` or `vendor/lolhtml` changed since the test was added in #33048; the `.on()`/`.onDocument()` allocations are all released through `Drop` when the rewriter is collected.

### Fix

Read `process.resourceUsage().maxRSS` (the kernel's monotone peak: `VmHWM` on Linux, `PeakWorkingSetSize` on Windows, `ru_maxrss` on macOS) after each 3-pass window instead of point-sampling `rss()`. The kernel tracks the peak continuously, so it cannot miss one between sample points regardless of when the decommit fires. A real leak raises it every pass; freed memory leaves it flat.

Same six passes, same 25 MB bound, same ~1 s runtime. The fixture now also emits the per-pass `rss()` trace and the test logs it before asserting, so a future red carries the diagnostic in the CI log.

### Verification

```
Windows x64 release, 20 runs:   maxRSS delta 0.03 MB every run, 40/40 assertions pass
Linux   x64 release, 10 runs:   maxRSS delta 0 MB every run,    20/20 assertions pass
bun bd (debug+ASAN):            1 pass, 1 skip (unchanged; RSS test is skipIf(isDebug))
```

Leak still caught: simulating retention (push every rewriter into an array) gives a 98.9 MB maxRSS delta on Windows release.

Test-only change (the regression it guards lives entirely in `LOLHTMLContext`'s `Drop`, which has not changed), so there is no src/ diff for fail-before.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->