### PR TITLE
ci: annotate steps that fail before the runner/build reporter completes

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -28,12 +28,15 @@ status="${BUILDKITE_COMMAND_EXIT_STATUS:-0}"
 # build annotating every running job is noise, not signal. The agent's
 # Executor.Cancel() sets BUILDKITE_JOB_CANCELLED=true in the shell env
 # (buildkite/agent@3ab8ab31, v3.94.0+), and additionally
-# BUILDKITE_JOB_TIMED_OUT=true when the cancel was a job-level timeout. The
-# exit-code fallback covers agents still on v3.87.0 (the linux queue=ci image
-# at the time of writing): -1 is the posix agent-killed code, 3221225786 is
-# Windows STATUS_CONTROL_C_EXIT, both observed on cancel in build 76127.
-# Drop the fallback once every agent is v3.94.0+.
+# BUILDKITE_JOB_TIMED_OUT=true when the cancel was a job-level timeout.
 if [ "${BUILDKITE_JOB_CANCELLED:-}" = "true" ]; then exit 0; fi
+# TODO(ci): the exit-code fallback below is only needed while agents older than
+# v3.94.0 remain in the fleet (as of 2026-07: the linux queue=ci image is still
+# on v3.87.0 and several bare-metal darwin boxes are on v3.87.0/v3.94.0;
+# scripts/bootstrap.sh already pins 3.114.0, those images just need rebaking).
+# -1 is the posix agent-killed code, 3221225786 is Windows STATUS_CONTROL_C_EXIT,
+# both observed on cancel in build 76127. Delete this `case` once every agent is
+# v3.94.0+.
 case "$status" in -1|3221225786) exit 0 ;; esac
 
 if buildkite-agent meta-data exists "reported-${BUILDKITE_JOB_ID}" 2>/dev/null; then

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -25,7 +25,9 @@ set -uo pipefail
 error=""
 for log in "/tmp/bk-${BUILDKITE_JOB_ID:-}.log" "/tmp/sc-${BUILDKITE_JOB_ID:-}.log"; do
   [ -s "$log" ] || continue
-  body=$(grep -v '^Stopping VM\.\.\.' "$log" 2>/dev/null || true)
+  # Cap per-log output so a pathological tart dump cannot push the shared
+  # `--append`ed annotation past Buildkite's 1 MiB body limit.
+  body=$(grep -v '^Stopping VM\.\.\.' "$log" 2>/dev/null | head -c 2048 || true)
   [ -n "$body" ] && error+="${error:+$'\n'}${log##*/}: ${body}"
 done
 
@@ -33,9 +35,12 @@ done
 
 label="${BUILDKITE_LABEL:-${BUILDKITE_STEP_KEY:-job}}"
 job_url="${BUILDKITE_BUILD_URL:-}#${BUILDKITE_JOB_ID:-}"
+# Match escapeCodeBlock() in scripts/runner.node.mjs: the body renders inside a
+# ```terminal fence, so only backticks need escaping.
+preview=$(printf '%s' "$error" | sed 's/`/\\`/g')
 
 printf '<details><summary><code>tart guest boot</code> failed on <a href="%s">%s</a></summary>\n\n```terminal\n%s\n```\n\n</details>\n\n' \
-  "$job_url" "$label" "$error" \
+  "$job_url" "$label" "$preview" \
   | buildkite-agent annotate --append --style error --context tart-guest-boot --priority 5 2>&1 \
   || echo "pre-exit: buildkite-agent annotate failed (non-fatal)"
 

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Surface darwin tart-host infra failures as Buildkite annotations.
+#
+# darwin arm64 test agents (agent tag tart=true) wrap jobs in an agent-level
+# `command` hook that boots an ephemeral tart guest and runs runner.node.mjs
+# inside it over SSH. If the guest fails to boot (macOS 2-VM-per-host cap hit,
+# tart clone race, vmnet bring-up hang), the hook exits 1 before the runner
+# starts, so no annotation is posted and the red job is only discoverable by
+# opening the raw log.
+#
+# This repository pre-exit hook runs on the host after the command hook and
+# inspects the `tart run` log(s) the hook leaves in /tmp. A guest that booted
+# and was cleanly stopped writes only `Stopping VM...`; anything else is tart
+# reporting why it exited, which is the infra error to surface.
+#
+# Repository hooks run on every agent, so early-exit unless the agent is
+# tagged tart=true and the command failed. Windows agents look for
+# pre-exit.{bat,ps1} and ignore this file. Never exits non-zero.
+
+set -uo pipefail
+
+[ "${BUILDKITE_AGENT_META_DATA_TART:-}" = "true" ] || exit 0
+[ "${BUILDKITE_COMMAND_EXIT_STATUS:-0}" = "0" ] && exit 0
+
+error=""
+for log in "/tmp/bk-${BUILDKITE_JOB_ID:-}.log" "/tmp/sc-${BUILDKITE_JOB_ID:-}.log"; do
+  [ -s "$log" ] || continue
+  body=$(grep -v '^Stopping VM\.\.\.' "$log" 2>/dev/null || true)
+  [ -n "$body" ] && error+="${error:+$'\n'}${log##*/}: ${body}"
+done
+
+[ -n "$error" ] || exit 0
+
+label="${BUILDKITE_LABEL:-${BUILDKITE_STEP_KEY:-job}}"
+job_url="${BUILDKITE_BUILD_URL:-}#${BUILDKITE_JOB_ID:-}"
+
+printf '<details><summary><code>tart guest boot</code> failed on <a href="%s">%s</a></summary>\n\n```terminal\n%s\n```\n\n</details>\n\n' \
+  "$job_url" "$label" "$error" \
+  | buildkite-agent annotate --append --style error --context tart-guest-boot --priority 5 2>&1 \
+  || echo "pre-exit: buildkite-agent annotate failed (non-fatal)"
+
+exit 0

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -1,47 +1,55 @@
 #!/usr/bin/env bash
-# Surface darwin tart-host infra failures as Buildkite annotations.
+# Fallback Buildkite annotation for infra failures.
 #
-# darwin arm64 test agents (agent tag tart=true) wrap jobs in an agent-level
-# `command` hook that boots an ephemeral tart guest and runs runner.node.mjs
-# inside it over SSH. If the guest fails to boot (macOS 2-VM-per-host cap hit,
-# tart clone race, vmnet bring-up hang), the hook exits 1 before the runner
-# starts, so no annotation is posted and the red job is only discoverable by
-# opening the raw log.
+# `scripts/runner.node.mjs` (test steps) and `scripts/build/ci.ts` (build steps)
+# post their own failure annotations, then set build meta-data key
+# `reported-$BUILDKITE_JOB_ID` via markBuildkiteStepReported() just before
+# exiting. Anything that kills the step before that marker is written (agent
+# command-hook failures such as a tart guest that never boots, artifact
+# download failures, `node` missing, the runner/build script itself crashing)
+# leaves the job red with nothing in the build's annotation list, so the
+# failure is only discoverable by opening the raw log. This repository pre-exit
+# hook posts a generic annotation for any such job so it shows up alongside
+# test/build failures.
 #
-# This repository pre-exit hook runs on the host after the command hook and
-# inspects the `tart run` log(s) the hook leaves in /tmp. A guest that booted
-# and was cleanly stopped writes only `Stopping VM...`; anything else is tart
-# reporting why it exited, which is the infra error to surface.
-#
-# Repository hooks run on every agent, so early-exit unless the agent is
-# tagged tart=true and the command failed. Windows agents look for
-# pre-exit.{bat,ps1} and ignore this file. Never exits non-zero.
+# The marker is build meta-data, which is server-side and so remains visible
+# here even when the reporter ran inside an ephemeral VM (the darwin tart
+# agents forward the Job API socket into the guest). Repository hooks run on
+# every posix agent; Windows agents look for pre-exit.{bat,ps1} and ignore this
+# file. Never exits non-zero.
 
 set -uo pipefail
 
-[ "${BUILDKITE_AGENT_META_DATA_TART:-}" = "true" ] || exit 0
 [ "${BUILDKITE_COMMAND_EXIT_STATUS:-0}" = "0" ] && exit 0
+[ -n "${BUILDKITE_JOB_ID:-}" ] || exit 0
 
-error=""
-for log in "/tmp/bk-${BUILDKITE_JOB_ID:-}.log" "/tmp/sc-${BUILDKITE_JOB_ID:-}.log"; do
+if buildkite-agent meta-data exists "reported-${BUILDKITE_JOB_ID}" 2>/dev/null; then
+  exit 0
+fi
+
+label="${BUILDKITE_LABEL:-${BUILDKITE_STEP_KEY:-job}}"
+job_url="${BUILDKITE_BUILD_URL:-}#${BUILDKITE_JOB_ID}"
+
+# darwin tart agents redirect `tart run` to /tmp/{bk,sc}-<job-id>.log on the
+# host. A guest that booted and was cleanly stopped writes only
+# `Stopping VM...`; anything else is tart reporting why it exited.
+detail=""
+for log in "/tmp/bk-${BUILDKITE_JOB_ID}.log" "/tmp/sc-${BUILDKITE_JOB_ID}.log"; do
   [ -s "$log" ] || continue
   # Cap per-log output so a pathological tart dump cannot push the shared
   # `--append`ed annotation past Buildkite's 1 MiB body limit.
   body=$(grep -v '^Stopping VM\.\.\.' "$log" 2>/dev/null | head -c 2048 || true)
-  [ -n "$body" ] && error+="${error:+$'\n'}${log##*/}: ${body}"
+  [ -n "$body" ] && detail+="${detail:+$'\n'}${log##*/}: ${body}"
 done
+[ -n "$detail" ] || detail="see the job log for output"
 
-[ -n "$error" ] || exit 0
-
-label="${BUILDKITE_LABEL:-${BUILDKITE_STEP_KEY:-job}}"
-job_url="${BUILDKITE_BUILD_URL:-}#${BUILDKITE_JOB_ID:-}"
 # Match escapeCodeBlock() in scripts/runner.node.mjs: the body renders inside a
 # ```terminal fence, so only backticks need escaping.
-preview=$(printf '%s' "$error" | sed 's/`/\\`/g')
+preview=$(printf '%s' "$detail" | sed 's/`/\\`/g')
 
-printf '<details><summary><code>tart guest boot</code> failed on <a href="%s">%s</a></summary>\n\n```terminal\n%s\n```\n\n</details>\n\n' \
-  "$job_url" "$label" "$preview" \
-  | buildkite-agent annotate --append --style error --context tart-guest-boot --priority 5 2>&1 \
+printf '<details><summary><a><code>step failed outside runner</code></a> - exit %s on <a href="%s">%s</a></summary>\n\n```terminal\n%s\n```\n\n</details>\n\n' \
+  "${BUILDKITE_COMMAND_EXIT_STATUS}" "$job_url" "$label" "$preview" \
+  | buildkite-agent annotate --append --style error --context step-failed-outside-runner --priority 5 2>&1 \
   || echo "pre-exit: buildkite-agent annotate failed (non-fatal)"
 
 exit 0

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -23,15 +23,18 @@ status="${BUILDKITE_COMMAND_EXIT_STATUS:-0}"
 [ "$status" = "0" ] && exit 0
 [ -n "${BUILDKITE_JOB_ID:-}" ] || exit 0
 
-# Skip cancel/timeout kills: the agent SIGKILLs the command after its grace
-# period (or on build cancel), which reports as exit -1 on posix and
-# 3221225786 (STATUS_CONTROL_C_EXIT) / 15 (SIGTERM passthrough) on Windows.
-# The reporter had no chance to set the marker, and a canceled build annotating
-# 30 "step failed outside runner" entries is noise, not signal. Real infra
-# failures exit with ordinary codes (1, 2, 127, ...).
-case "$status" in
-  -1|255|3221225786|15) exit 0 ;;
-esac
+# Skip canceled/timed-out jobs: on cancel the agent SIGTERMs then SIGKILLs the
+# command, so the reporter had no chance to set the marker, and a canceled
+# build annotating every running job is noise, not signal. The agent's
+# Executor.Cancel() sets BUILDKITE_JOB_CANCELLED=true in the shell env
+# (buildkite/agent@3ab8ab31, v3.94.0+), and additionally
+# BUILDKITE_JOB_TIMED_OUT=true when the cancel was a job-level timeout. The
+# exit-code fallback covers agents still on v3.87.0 (the linux queue=ci image
+# at the time of writing): -1 is the posix agent-killed code, 3221225786 is
+# Windows STATUS_CONTROL_C_EXIT, both observed on cancel in build 76127.
+# Drop the fallback once every agent is v3.94.0+.
+if [ "${BUILDKITE_JOB_CANCELLED:-}" = "true" ]; then exit 0; fi
+case "$status" in -1|3221225786) exit 0 ;; esac
 
 if buildkite-agent meta-data exists "reported-${BUILDKITE_JOB_ID}" 2>/dev/null; then
   exit 0

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -15,13 +15,23 @@
 # The marker is build meta-data, which is server-side and so remains visible
 # here even when the reporter ran inside an ephemeral VM (the darwin tart
 # agents forward the Job API socket into the guest). Repository hooks run on
-# every posix agent; Windows agents look for pre-exit.{bat,ps1} and ignore this
-# file. Never exits non-zero.
+# every posix agent, and on Windows via Git Bash. Never exits non-zero.
 
 set -uo pipefail
 
-[ "${BUILDKITE_COMMAND_EXIT_STATUS:-0}" = "0" ] && exit 0
+status="${BUILDKITE_COMMAND_EXIT_STATUS:-0}"
+[ "$status" = "0" ] && exit 0
 [ -n "${BUILDKITE_JOB_ID:-}" ] || exit 0
+
+# Skip cancel/timeout kills: the agent SIGKILLs the command after its grace
+# period (or on build cancel), which reports as exit -1 on posix and
+# 3221225786 (STATUS_CONTROL_C_EXIT) / 15 (SIGTERM passthrough) on Windows.
+# The reporter had no chance to set the marker, and a canceled build annotating
+# 30 "step failed outside runner" entries is noise, not signal. Real infra
+# failures exit with ordinary codes (1, 2, 127, ...).
+case "$status" in
+  -1|255|3221225786|15) exit 0 ;;
+esac
 
 if buildkite-agent meta-data exists "reported-${BUILDKITE_JOB_ID}" 2>/dev/null; then
   exit 0
@@ -48,7 +58,7 @@ done
 preview=$(printf '%s' "$detail" | sed 's/`/\\`/g')
 
 printf '<details><summary><a><code>step failed outside runner</code></a> - exit %s on <a href="%s">%s</a></summary>\n\n```terminal\n%s\n```\n\n</details>\n\n' \
-  "${BUILDKITE_COMMAND_EXIT_STATUS}" "$job_url" "$label" "$preview" \
+  "$status" "$job_url" "$label" "$preview" \
   | buildkite-agent annotate --append --style error --context step-failed-outside-runner --priority 5 2>&1 \
   || echo "pre-exit: buildkite-agent annotate failed (non-fatal)"
 

--- a/scripts/binary-size.ts
+++ b/scripts/binary-size.ts
@@ -236,6 +236,9 @@ for (const r of rows) {
 
 if (failed) {
   console.error(`\nerror: ${overThreshold.length} target(s) exceeded ${limit} vs ${buildKind}`);
+  // Suppress the generic fallback in .buildkite/hooks/pre-exit; this script
+  // owns its failure annotation.
+  Bun.spawnSync(["buildkite-agent", "meta-data", "set", `reported-${process.env.BUILDKITE_JOB_ID}`, "1"]);
   process.exit(1);
 }
 

--- a/scripts/binary-size.ts
+++ b/scripts/binary-size.ts
@@ -22,6 +22,8 @@
 
 import { mkdirSync, rmSync } from "node:fs";
 import { parseArgs } from "node:util";
+// @ts-ignore — utils.mjs has JSDoc types but no .d.ts
+import { markBuildkiteStepReported } from "./utils.mjs";
 
 type Target = { triplet: string };
 type Sizes = Record<string, number>;
@@ -238,7 +240,7 @@ if (failed) {
   console.error(`\nerror: ${overThreshold.length} target(s) exceeded ${limit} vs ${buildKind}`);
   // Suppress the generic fallback in .buildkite/hooks/pre-exit; this script
   // owns its failure annotation.
-  Bun.spawnSync(["buildkite-agent", "meta-data", "set", `reported-${process.env.BUILDKITE_JOB_ID}`, "1"]);
+  markBuildkiteStepReported();
   process.exit(1);
 }
 

--- a/scripts/build/ci.ts
+++ b/scripts/build/ci.ts
@@ -194,6 +194,7 @@ export async function spawnWithAnnotations(
     console.error(`Command exited: code ${exitCode}`);
   }
 
+  utils.markBuildkiteStepReported();
   process.exit(exitCode ?? 1);
 }
 

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -61,6 +61,7 @@ import {
   isMacOS,
   isWindows,
   isX64,
+  markBuildkiteStepReported,
   printEnvironment,
   reportAnnotationToBuildKite,
   startGroup,
@@ -692,6 +693,7 @@ async function runTests() {
     }
 
     if (options["bail"]) {
+      markBuildkiteStepReported();
       process.exit(getExitCode("fail"));
     }
 
@@ -2654,6 +2656,7 @@ function isAlwaysFailure(error) {
 function onExit(signal) {
   const label = `${getAnsi("red")}Received ${signal}, exiting...${getAnsi("reset")}`;
   startGroup(label, () => {
+    markBuildkiteStepReported();
     process.exit(getExitCode("cancel"));
   });
 }
@@ -3008,6 +3011,7 @@ export async function main() {
     await new Promise(resolve => setTimeout(resolve, 60_000));
   }
 
+  markBuildkiteStepReported();
   process.exit(getExitCode(ok ? "pass" : "fail"));
 }
 

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -2787,6 +2787,31 @@ export function reportAnnotationToBuildKite({ context, label, content, style = "
 }
 
 /**
+ * Mark this Buildkite job as having handled its own failure reporting.
+ *
+ * The repository `.buildkite/hooks/pre-exit` hook posts a generic fallback
+ * annotation for any step that exits non-zero without this marker set, so
+ * infra failures that happen before (or crash) the runner/build scripts are
+ * still surfaced in the build's annotation list instead of being visible only
+ * in the raw job log. Call this from every controlled exit path that has
+ * already posted (or had nothing to post) so the fallback stays quiet. The
+ * marker is build meta-data, which is server-side and so remains visible to
+ * the host pre-exit hook even when the reporter ran inside an ephemeral VM.
+ */
+export function markBuildkiteStepReported() {
+  if (!isBuildkite) return;
+  const jobId = getEnv("BUILDKITE_JOB_ID", false);
+  if (!jobId) return;
+  const { status } = nodeSpawnSync("buildkite-agent", ["meta-data", "set", `reported-${jobId}`, "1"], {
+    stdio: "ignore",
+    timeout: 30_000,
+  });
+  if (status !== 0) {
+    console.error(`buildkite-agent meta-data set reported-${jobId} failed (non-fatal)`);
+  }
+}
+
+/**
  * @param {object} obj
  * @param {number} indent
  * @returns {string}

--- a/scripts/verify-baseline.ts
+++ b/scripts/verify-baseline.ts
@@ -280,6 +280,9 @@ function annotate(html: string) {
   Bun.spawnSync(["buildkite-agent", "annotate", "--append", "--style", "error", "--context", "verify-baseline"], {
     stdin: new Blob([html]),
   });
+  // Suppress the generic fallback in .buildkite/hooks/pre-exit; this script
+  // owns its failure annotation.
+  Bun.spawnSync(["buildkite-agent", "meta-data", "set", `reported-${process.env.BUILDKITE_JOB_ID}`, "1"]);
 }
 
 if (instructionFailures > 0) {

--- a/scripts/verify-baseline.ts
+++ b/scripts/verify-baseline.ts
@@ -11,6 +11,8 @@
 
 import { readdirSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
+// @ts-ignore — utils.mjs has JSDoc types but no .d.ts
+import { markBuildkiteStepReported } from "./utils.mjs";
 
 const { parseArgs } = require("node:util");
 
@@ -282,7 +284,7 @@ function annotate(html: string) {
   });
   // Suppress the generic fallback in .buildkite/hooks/pre-exit; this script
   // owns its failure annotation.
-  Bun.spawnSync(["buildkite-agent", "meta-data", "set", `reported-${process.env.BUILDKITE_JOB_ID}`, "1"]);
+  markBuildkiteStepReported();
 }
 
 if (instructionFailures > 0) {


### PR DESCRIPTION
## What

Posts a fallback Buildkite error annotation for any step that exits non-zero without having reported its own failure, so infra failures show up in the build's annotation list instead of only in the raw job log.

## Why

`scripts/runner.node.mjs` (test steps) and `scripts/build/ci.ts` (build steps) post failure annotations themselves. Anything that kills the step before they get that far (agent command-hook failures such as a tart guest that never boots, artifact download failures, `node` missing, or the reporter script itself crashing) leaves the job red with nothing in the annotation list.

Example: https://buildkite.com/bun/bun/builds/76001#019f7df3-f093-4bdd-b34d-f332071e98ae failed with

```
guest never up after retry
The number of VMs exceeds the system limit (other running VMs: warmkeeper, sc-019f7df3-f094-4e69-9dac-02bf41b9f3bb, bk-019f7df3-f094-4e69-9dac-02bf41b9f3bb)
```

but the build's annotation list showed nothing for that lane.

## How

- `scripts/utils.mjs`: new `markBuildkiteStepReported()` sets build meta-data `reported-<job-id>=1`. Meta-data is server-side, so it survives the tart host/guest boundary (the darwin tart agents forward the Job API socket into the guest).
- `scripts/runner.node.mjs`, `scripts/build/ci.ts`, `scripts/verify-baseline.ts`, `scripts/binary-size.ts`: call it at their controlled exit points, after posting their own annotations.
- `.buildkite/hooks/pre-exit` (repository hook, runs on every posix agent): if `BUILDKITE_COMMAND_EXIT_STATUS != 0` and the `reported-<job-id>` marker is missing, post a `step failed outside runner` error annotation. On tart hosts it also includes the tail of `/tmp/{bk,sc}-<job-id>.log` (the `tart run` output) when that contains anything other than `Stopping VM...`. Always exits 0. Windows agents look for `pre-exit.{bat,ps1}` and ignore this file.

## Verification

Hook picked up and run on a real tart job from this branch's build 76102 (the log shows `~~~ Running local pre-exit hook` / `$ .buildkite/hooks/pre-exit`); the job passed so the hook correctly did nothing.

Hook logic tested locally and on a tart host under bash 3.2 against the real failed-job log above, a clean-stop log, a missing log, and with/without the `reported-` marker set.

`bunx tsc --noEmit -p scripts/build/tsconfig.json` output unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->