### PR TITLE
shell_parser: drop six redundant/tautological predicates

### DIFF
--- a/src/shell_parser/braces.rs
+++ b/src/shell_parser/braces.rs
@@ -982,9 +982,6 @@ impl<'a> Parser<'a> {
     fn parse_expansion(&mut self) -> Result<ast::Expansion, ParserError> {
         let mut variants: BumpVec<'a, ast::Group> = BumpVec::new_in(self.bump);
         while !self.match_any(&[TokenTag::Close, TokenTag::Eof]) {
-            if self.r#match(TokenTag::Eof) {
-                break;
-            }
             let mut group: BumpVec<'a, ast::Atom> = BumpVec::new_in(self.bump);
             let mut close = false;
             while !self.r#match(TokenTag::Eof) {

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -4560,14 +4560,12 @@ impl<T, const INLINED_MAX: usize> SmolList<T, INLINED_MAX> {
     {
         debug_assert!(vals.len() <= u32::MAX as usize);
         if vals.len() <= INLINED_MAX {
-            let mut this = Self::zeroes();
-            if let SmolList::Inlined(inlined) = &mut this {
-                for (i, v) in vals.iter().enumerate() {
-                    inlined.items[i].write(v.clone());
-                }
-                inlined.len += u32::try_from(vals.len()).expect("int cast");
+            let mut inlined = SmolListInlined::<T, INLINED_MAX>::default();
+            for (i, v) in vals.iter().enumerate() {
+                inlined.items[i].write(v.clone());
             }
-            return this;
+            inlined.len = u32::try_from(vals.len()).expect("int cast");
+            return SmolList::Inlined(inlined);
         }
         let mut heap = Vec::with_capacity_in(vals.len(), SmolListAlloc::new(bump));
         heap.extend_from_slice(vals);

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -3006,7 +3006,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                             }
                             if next.escaped || next.char != u32::from(b'|') {
                                 self.tokens.push(Token::Pipe);
-                            } else if next.char == u32::from(b'|') {
+                            } else {
                                 self.eat().expect("unreachable");
                                 self.tokens.push(Token::DoublePipe);
                             }

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -1958,7 +1958,6 @@ impl<'bump> Parser<'bump> {
         let tag = tok.tag();
         tag == TokenTag::Delimit
             || tag == TokenTag::Semicolon
-            || tag == TokenTag::Semicolon
             || tag == TokenTag::Eof
             || tag == TokenTag::Newline
             || (self.inside_subshell.is_some()
@@ -3066,13 +3065,9 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                                 self.tokens.push(Token::Redirect(inner));
                             } else if next.escaped || next.char != u32::from(b'&') {
                                 self.tokens.push(Token::Ampersand);
-                            } else if next.char == u32::from(b'&') {
+                            } else {
                                 self.eat().expect("unreachable");
                                 self.tokens.push(Token::DoubleAmpersand);
-                            } else {
-                                self.tokens.push(Token::Ampersand);
-                                fell_through = true;
-                                break 'escaped;
                             }
                             fell_through = true;
                         }
@@ -4532,12 +4527,10 @@ impl<T, const INLINED_MAX: usize> SmolList<T, INLINED_MAX> {
     }
 
     pub fn init_with(val: T) -> Self {
-        let mut this = Self::zeroes();
-        if let SmolList::Inlined(inlined) = &mut this {
-            inlined.items[0].write(val);
-            inlined.len += 1;
-        }
-        this
+        let mut inlined = SmolListInlined::<T, INLINED_MAX>::default();
+        inlined.items[0].write(val);
+        inlined.len = 1;
+        SmolList::Inlined(inlined)
     }
 
     pub fn memory_cost(&self) -> usize


### PR DESCRIPTION
Six dead-by-construction predicates in the shell parser, all carried over from the original Zig source. No behavior change.

### `Parser::delimits` (parse.rs)

```rust
tag == TokenTag::Delimit
    || tag == TokenTag::Semicolon
    || tag == TokenTag::Semicolon   // same comparison twice
    || tag == TokenTag::Eof
```

The duplicate is not a placeholder for a missing tag: the sibling `expect_delimit` (which `debug_assert!`s on `delimits`) checks exactly `{Delimit, Semicolon, Newline, Eof, subshell-closer}` once each.

### `|` and `&` lexer arms (parse.rs)

```rust
} else if next.escaped || next.char != u32::from(b'&') {
    self.tokens.push(Token::Ampersand);
} else if next.char == u32::from(b'&') {   // already implied by negating the line above
    ...
} else {                                    // unreachable
```

Reaching the third arm means `!(next.escaped || next.char != b'&')`, i.e. `!next.escaped && next.char == b'&'`, so the guard is always true and the trailing `else` is dead. Collapsed to a plain `else`. The `|` arm ~55 lines above has the byte-identical `else if next.char == b'|'` shape (without the trailing dead `else`) and is collapsed the same way.

### `SmolList::init_with` / `init_with_slice` (parse.rs)

```rust
let mut this = Self::zeroes();                      // always SmolList::Inlined(..)
if let SmolList::Inlined(inlined) = &mut this { ... }
```

`zeroes()` unconditionally returns the `Inlined` variant, so the `if let` is always taken and reads as though the value(s) could be silently dropped. Both constructors now build the `SmolListInlined` directly and wrap it. (`zeroes()` itself stays: it has other callers.)

### `parse_expansion` loop (braces.rs)

```rust
while !self.match_any(&[TokenTag::Close, TokenTag::Eof]) {
    if self.r#match(TokenTag::Eof) { break; }       // peek() is already known not to be Eof here
```

`match_any` peeks, advances only on a match, and returns `false` without advancing otherwise. Entering the body therefore guarantees `peek()` is neither `Close` nor `Eof`, so the inner `Eof` check can never fire.

### Verification

`cargo clippy -p bun_shell_parser` is clean. `test/js/bun/shell/{parse,lex,brace,bunshell}.test.ts` pass on the debug build. There is no fail-before test to add: none of these branches are observable from JS (the conditions are tautologies, not mis-evaluations), so any test exercising them passes identically before and after.
