### PR TITLE
bundler: drop unreachable NonNull checks and duplicate lookup

### DIFF
--- a/src/bundler/AstBuilder.rs
+++ b/src/bundler/AstBuilder.rs
@@ -125,20 +125,18 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
     pub fn push_scope(&mut self, kind: ScopeKind) -> Result<*mut Scope, OOM> {
         self.scopes.reserve(1);
         self.current_scope_mut().children.ensure_unused_capacity(1);
-        let scope: *mut Scope = self.bump.alloc(Scope {
+        let scope = NonNull::from(self.bump.alloc(Scope {
             kind,
             label_ref: Ref::NONE,
             parent: NonNull::new(self.current_scope).map(bun_ast::StoreRef::from),
             ..Default::default()
-        });
-        // `scope` came from `bump.alloc`, so it is non-null and distinct from
-        // `current_scope` (fresh allocation).
+        }));
         self.current_scope_mut()
             .children
-            .append_assume_capacity(NonNull::new(scope).expect("bump alloc non-null").into());
+            .append_assume_capacity(scope.into());
         self.scopes.push(self.current_scope);
-        self.current_scope = scope;
-        Ok(scope)
+        self.current_scope = scope.as_ptr();
+        Ok(scope.as_ptr())
     }
 
     pub fn pop_scope(&mut self) {

--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -137,7 +137,9 @@ mod io_thread_pool {
                     // null. REF_COUNT != 0 ⇒ THREAD_POOL is initialized (set
                     // under MUTEX below).
                     return unsafe {
-                        NonNull::new_unchecked(THREAD_POOL.get().cast::<ThreadPoolLib::ThreadPool>())
+                        NonNull::new_unchecked(
+                            THREAD_POOL.get().cast::<ThreadPoolLib::ThreadPool>(),
+                        )
                     };
                 }
                 Err(actual) => count = actual,

--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -133,10 +133,12 @@ mod io_thread_pool {
                 Ordering::Relaxed,
             ) {
                 Ok(_) => {
-                    // REF_COUNT != 0 ⇒ THREAD_POOL is initialized (set under MUTEX below).
-                    // `UnsafeCell::get` never returns null.
-                    return NonNull::new(THREAD_POOL.get().cast::<ThreadPoolLib::ThreadPool>())
-                        .expect("UnsafeCell::get is non-null");
+                    // SAFETY: `RacyCell::get` is derived from `&self` and never
+                    // null. REF_COUNT != 0 ⇒ THREAD_POOL is initialized (set
+                    // under MUTEX below).
+                    return unsafe {
+                        NonNull::new_unchecked(THREAD_POOL.get().cast::<ThreadPoolLib::ThreadPool>())
+                    };
                 }
                 Err(actual) => count = actual,
             }
@@ -163,9 +165,9 @@ mod io_thread_pool {
             // NOTE: a racing acquirer that reaches here does not bump the ref
             // count — a latent under-count, preserved intentionally.
         }
-        // Just initialized (or observed initialized) above. `UnsafeCell::get` never returns null.
-        NonNull::new(THREAD_POOL.get().cast::<ThreadPoolLib::ThreadPool>())
-            .expect("UnsafeCell::get is non-null")
+        // SAFETY: `RacyCell::get` is derived from `&self` and never null;
+        // THREAD_POOL was just initialized (or observed initialized) above.
+        unsafe { NonNull::new_unchecked(THREAD_POOL.get().cast::<ThreadPoolLib::ThreadPool>()) }
     }
 
     pub(super) fn release() {

--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -133,14 +133,10 @@ mod io_thread_pool {
                 Ordering::Relaxed,
             ) {
                 Ok(_) => {
-                    // SAFETY: `RacyCell::get` is derived from `&self` and never
-                    // null. REF_COUNT != 0 ⇒ THREAD_POOL is initialized (set
-                    // under MUTEX below).
-                    return unsafe {
-                        NonNull::new_unchecked(
-                            THREAD_POOL.get().cast::<ThreadPoolLib::ThreadPool>(),
-                        )
-                    };
+                    // REF_COUNT != 0 ⇒ THREAD_POOL is initialized (set under MUTEX below).
+                    // `UnsafeCell::get` never returns null.
+                    return NonNull::new(THREAD_POOL.get().cast::<ThreadPoolLib::ThreadPool>())
+                        .expect("UnsafeCell::get is non-null");
                 }
                 Err(actual) => count = actual,
             }
@@ -167,9 +163,9 @@ mod io_thread_pool {
             // NOTE: a racing acquirer that reaches here does not bump the ref
             // count — a latent under-count, preserved intentionally.
         }
-        // SAFETY: `RacyCell::get` is derived from `&self` and never null;
-        // THREAD_POOL was just initialized (or observed initialized) above.
-        unsafe { NonNull::new_unchecked(THREAD_POOL.get().cast::<ThreadPoolLib::ThreadPool>()) }
+        // Just initialized (or observed initialized) above. `UnsafeCell::get` never returns null.
+        NonNull::new(THREAD_POOL.get().cast::<ThreadPoolLib::ThreadPool>())
+            .expect("UnsafeCell::get is non-null")
     }
 
     pub(super) fn release() {

--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -81,21 +81,6 @@ unsafe impl Send for ThreadPool {}
 // raw-pointer targets (`ThreadPoolLib::ThreadPool`, `BundleV2`) are `Sync`.
 unsafe impl Sync for ThreadPool {}
 
-impl Default for ThreadPool {
-    /// Placeholder so `bundle_v2` can `arena().alloc(ThreadPool::default())`
-    /// before overwriting with [`ThreadPool::init`].
-    fn default() -> Self {
-        Self {
-            io_pool: None,
-            worker_pool: ptr::null_mut(),
-            worker_pool_is_owned: false,
-            workers_assignments: bun_threading::Guarded::new(ArrayHashMap::default()),
-            generation: POOL_GENERATION.fetch_add(1, Ordering::Relaxed),
-            v2: ptr::null(),
-        }
-    }
-}
-
 mod io_thread_pool {
     use super::*;
 

--- a/src/bundler/barrel_imports.rs
+++ b/src/bundler/barrel_imports.rs
@@ -146,12 +146,11 @@ fn apply_barrel_optimization_impl(
     // files parsed before this barrel. scheduleBarrelDeferredImports records
     // requests eagerly as each file is processed, so we don't need to scan
     // the graph.
-    if let Some(existing) = RequestedExports::lookup(&this.requested_exports, source_index) {
-        match existing {
-            RequestedExports::All => return Ok(()), // import * already seen — load everything
-            RequestedExports::Partial(_) => {}
-        }
-    }
+    let requested = match RequestedExports::lookup(&this.requested_exports, source_index) {
+        Some(RequestedExports::All) => return Ok(()), // import * already seen — load everything
+        Some(RequestedExports::Partial(partial)) => Some(partial),
+        None => None,
+    };
 
     // Build the set of needed import_record_indices from already-requested
     // export names. Export * records are always needed.
@@ -161,17 +160,12 @@ fn apply_barrel_optimization_impl(
         needed_records.put(*record_idx, ())?;
     }
 
-    if let Some(existing) = RequestedExports::lookup(&this.requested_exports, source_index) {
-        match existing {
-            RequestedExports::All => unreachable!(), // handled above
-            RequestedExports::Partial(partial) => {
-                for key in partial.keys() {
-                    if let Some(resolution) =
-                        resolve_barrel_export(key, &ast.named_exports, &ast.named_imports)
-                    {
-                        needed_records.put(resolution.import_record_index, ())?;
-                    }
-                }
+    if let Some(partial) = requested {
+        for key in partial.keys() {
+            if let Some(resolution) =
+                resolve_barrel_export(key, &ast.named_exports, &ast.named_imports)
+            {
+                needed_records.put(resolution.import_record_index, ())?;
             }
         }
     }

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2892,20 +2892,18 @@ pub mod bv2_impl {
 
             this.linker.dev_server = this.dev_server;
 
-            // Arena-owned. Coerce to `*mut`
-            // immediately so the `&this` borrow from `arena()` ends before
-            // `ThreadPool::init` takes `&mut this`.
-            let pool: *mut ThreadPool =
-                std::ptr::from_mut(this.arena().alloc(ThreadPool::default()));
+            // Arena-owned. Erase the `&mut` lifetime so later `&mut this`
+            // borrows (`this.graph.pool = ...`, `from_mut(&mut *this)`) don't
+            // conflict.
+            let pool = NonNull::from(this.arena().alloc(ThreadPool::default()));
             // errdefer this.graph.heap.deinit() — Drop handles arena teardown.
 
             // SAFETY: arena slot is live for the bundle pass; the default value
             // written above has no Drop, so overwriting via `*pool = ...` is fine.
             unsafe {
-                *pool = ThreadPool::init(&*this, thread_pool)?;
+                *pool.as_ptr() = ThreadPool::init(&*this, thread_pool)?;
             }
-            this.graph.pool =
-                bun_ptr::BackRef::from(NonNull::new(pool).expect("arena allocation is non-null"));
+            this.graph.pool = bun_ptr::BackRef::from(pool);
             // Install the watcher only after `ThreadPool::init()` has succeeded —
             // the `?` above is the last early-return in this fn, so the watcher's
             // raw `*mut BundleV2` can't outlive the box it points at (the caller

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2892,18 +2892,9 @@ pub mod bv2_impl {
 
             this.linker.dev_server = this.dev_server;
 
-            // Arena-owned. Erase the `&mut` lifetime so later `&mut this`
-            // borrows (`this.graph.pool = ...`, `from_mut(&mut *this)`) don't
-            // conflict.
-            let pool = NonNull::from(this.arena().alloc(ThreadPool::default()));
+            let tp = ThreadPool::init(&*this, thread_pool)?;
             // errdefer this.graph.heap.deinit() — Drop handles arena teardown.
-
-            // SAFETY: arena slot is live for the bundle pass; the default value
-            // written above has no Drop, so overwriting via `*pool = ...` is fine.
-            unsafe {
-                *pool.as_ptr() = ThreadPool::init(&*this, thread_pool)?;
-            }
-            this.graph.pool = bun_ptr::BackRef::from(pool);
+            this.graph.pool = bun_ptr::BackRef::from(NonNull::from(this.arena().alloc(tp)));
             // Install the watcher only after `ThreadPool::init()` has succeeded —
             // the `?` above is the last early-return in this fn, so the watcher's
             // raw `*mut BundleV2` can't outlive the box it points at (the caller


### PR DESCRIPTION
Small no-behavior-change cleanup in `src/bundler/` that removes three dead defensive checks, one `unsafe` block, and a now-unused `Default` impl. No new `unsafe`.

### What changed

- **`AstBuilder.rs` (`push_scope`)**: `bump.alloc(...)` returns `&mut Scope`; the `&mut`-to-raw coercion followed by `NonNull::new(scope).expect("bump alloc non-null")` checked a value that is non-null by type. Now builds the `NonNull` directly with `NonNull::from` on the `&mut`.
- **`bundle_v2.rs`**: `arena()` returns `&'a Arena` decoupled from `&self`, so the `&mut ThreadPool` from `alloc()` never borrowed `this` and the coerce-to-raw + `NonNull::new(pool).expect("arena allocation is non-null")` dance was never needed. `ThreadPool::init` also only reads `v2` to store a raw backref and never touches `v2.graph.pool`, so seating a default first was not load-bearing. Call `init`, then `alloc` the result directly: drops the `unsafe { *pool = ... }` block, its SAFETY comment, and a stale comment about a borrow conflict that did not exist. The `?` stays the last early-return, so the watcher-install ordering invariant below still holds.
- **`ThreadPool.rs`**: deletes `impl Default for ThreadPool`, whose only caller was the seat-then-overwrite removed above (its doc comment said exactly that). `init_with_pool` fills every field explicitly; nothing bounds `ThreadPool: Default`. The impl also burned a `POOL_GENERATION` stamp on every call, so leaving it around uncalled was a footgun.
- **`barrel_imports.rs` (`apply_barrel_optimization_impl`)**: `RequestedExports::lookup` was called twice on the same `(map, idx)`. The first call early-returned on `All`; the second had `All => unreachable!()`. Nothing between the two calls (only a fresh local map and iteration over `ast.export_star_import_records`) touches `this.requested_exports`. Now binds the `Partial` result from the single lookup and drops the second call and the `unreachable!()` arm.

The `NonNull::new(RacyCell::get()).expect(...)` sites in `io_thread_pool::acquire` were considered and left alone: removing those would need `unsafe { new_unchecked }`, which is a net loss.

### Why

These checks are unreachable by construction: `&mut T` is never null, and the duplicate lookup is on immutable state. Removing them makes the invariants explicit in the types rather than in panic strings and drops one redundant vec-index per barrel file.

### Verification

No behavior change; covered by existing tests.

```
cargo check --workspace               # clean
cargo clippy -p bun_bundler           # clean
bun bd test bundler_barrel.test.ts    # 49 pass, 0 fail
bun bd test bundler_edgecase.test.ts  # 116 pass, 0 fail
```

There is no fail-before test for this change: the removed branches are provably dead on every input, so no test can distinguish before/after.
