### PR TITLE
sql: drop redundant clamps and a zero-fill of a zero-initialized buffer

### DIFF
--- a/src/sql/mysql/protocol/HandshakeV10.rs
+++ b/src/sql/mysql/protocol/HandshakeV10.rs
@@ -76,16 +76,13 @@ impl HandshakeV10 {
         );
 
         // Length of auth plugin data
-        let mut auth_plugin_data_len = reader.int::<u8>()?;
-        if auth_plugin_data_len < 21 {
-            auth_plugin_data_len = 21;
-        }
+        let auth_plugin_data_len = reader.int::<u8>()?.max(21);
 
         // Skip reserved bytes
         reader.skip(10);
 
         // Auth plugin data part 2
-        let remaining_auth_len = (auth_plugin_data_len - 8).max(13);
+        let remaining_auth_len = auth_plugin_data_len - 8;
         let auth_data_2 = reader.read(remaining_auth_len as usize)?;
         self.auth_plugin_data_part_2 = Box::<[u8]>::from(auth_data_2.slice());
 

--- a/src/sql/mysql/protocol/PreparedStatement.rs
+++ b/src/sql/mysql/protocol/PreparedStatement.rs
@@ -53,7 +53,6 @@ impl<'a> Execute<'a> {
         let mut null_bitmap_buf = [0u8; MYSQL_MAX_PARAMS];
         let bitmap_bytes = self.params.len.div_ceil(8);
         let null_bitmap = &mut null_bitmap_buf[0..bitmap_bytes];
-        null_bitmap.fill(0);
 
         for i in 0..self.params.len {
             if (self.params.is_null)(self.params.ctx, i) {

--- a/src/sql/postgres/CommandTag.rs
+++ b/src/sql/postgres/CommandTag.rs
@@ -82,12 +82,12 @@ impl<'a> CommandTag<'a> {
         let number: u64 = 'brk: {
             match cmd {
                 KnownCommand::Insert => {
-                    let mut remaining = &tag[(first_space_index + 1).min(tag.len())..];
+                    let mut remaining = &tag[first_space_index + 1..];
                     let Some(second_space) = strings::index_of_char(remaining, b' ') else {
                         return CommandTag::Other(tag);
                     };
                     let second_space = second_space as usize;
-                    remaining = &remaining[(second_space + 1).min(remaining.len())..];
+                    remaining = &remaining[second_space + 1..];
                     // Postgres wire is pure base-10 ASCII so radix-0/`_`/sign
                     // widening is unreachable.
                     match bun_core::fmt::parse_int::<u64>(remaining, 0) {
@@ -103,7 +103,7 @@ impl<'a> CommandTag<'a> {
                     }
                 }
                 _ => {
-                    let after_tag = &tag[(first_space_index + 1).min(tag.len())..];
+                    let after_tag = &tag[first_space_index + 1..];
                     match bun_core::fmt::parse_int::<u64>(after_tag, 0) {
                         Ok(n) => break 'brk n,
                         Err(err) => {

--- a/src/sql/postgres/protocol/NewReader.rs
+++ b/src/sql/postgres/protocol/NewReader.rs
@@ -9,6 +9,9 @@ pub trait ReaderContext {
     fn peek(&self) -> &[u8];
     fn skip(&mut self, count: usize);
     fn ensure_length(&mut self, count: usize) -> bool;
+    /// On `Ok`, the returned slice is exactly `count` bytes; otherwise
+    /// `Err(ShortRead)`. Callers rely on this: `int<Int>()` passes the
+    /// result straight to `from_be_slice` without re-checking length.
     fn read(&mut self, count: usize) -> Result<Data, AnyPostgresError>;
     fn read_z(&mut self) -> Result<Data, AnyPostgresError>;
 }

--- a/src/sql/postgres/protocol/NewReader.rs
+++ b/src/sql/postgres/protocol/NewReader.rs
@@ -126,11 +126,7 @@ impl<Context: ReaderContext> NewReaderWrap<Context> {
 
     pub fn int<Int: ProtocolInt>(&mut self) -> Result<Int, AnyPostgresError> {
         let data = self.read(Int::SIZE)?;
-        let slice = data.slice();
-        if slice.len() < Int::SIZE {
-            return Err(AnyPostgresError::ShortRead);
-        }
-        Ok(Int::from_be_slice(&slice[0..Int::SIZE]))
+        Ok(Int::from_be_slice(data.slice()))
     }
 
     pub fn peek_int<Int: ProtocolInt>(&self) -> Option<Int> {


### PR DESCRIPTION
## What

Removes four dead guards in `src/sql/` that are porting artifacts from the Zig rewrite (#30412). In Zig the original code initialized buffers with `undefined` and had different slice-length contracts; in Rust these checks are provably unreachable.

No behaviour change.

## Why each one is dead

**`src/sql/mysql/protocol/PreparedStatement.rs` `write_null_bitmap`:** `[0u8; MYSQL_MAX_PARAMS]` is zero-initialized by the language, so the subsequent `.fill(0)` on a sub-slice writes zeros over zeros. The sibling `NewWriter::write_null_bitmap` (src/sql/mysql/protocol/NewWriter.rs:104) already omits the fill.

**`src/sql/mysql/protocol/HandshakeV10.rs`:** `auth_plugin_data_len` is floored to 21 before the subtraction, so `auth_plugin_data_len - 8 >= 13` and `.max(13)` is a no-op. Collapsed the `if` clamp and the later `.max(13)` into a single `.max(21)`, which also lets the binding lose `mut`.

**`src/sql/postgres/CommandTag.rs`:** `strings::index_of_char` wraps `highway::index_of_char`, which returns `None` when the byte is absent and otherwise an index strictly inside the slice (the implementation `debug_assert!`s `haystack[result] == needle`). So `idx + 1 <= len` and `.min(len)` on `idx + 1` is a no-op. Three call sites.

**`src/sql/postgres/protocol/NewReader.rs` `int<Int>`:** both concrete postgres `ReaderContext::read` implementations, the shared `StackReader::read` (src/sql/shared/StackReader.rs:94) and the live-socket `Reader::read` (src/sql_jsc/postgres/PostgresSQLConnection.rs:1743), either return `Err(ShortRead)` or a slice of exactly `count` bytes. The `slice.len() < Int::SIZE` re-check is unreachable under every extant impl, and `from_be_slice` already slices `[..SIZE]` internally so an undersized input from a future implementation would still fail loudly rather than silently. Added a doc comment on the trait method stating the contract.

## Verification

`cargo check -p bun_sql` and `cargo clippy -p bun_sql` are clean. The existing fault-injection protocol tests that exercise `HandshakeV10` decoding and `NewReaderWrap::int` still pass under `bun bd`:

```
test/js/sql/sql-mysql-auth-short-nonce.test.ts        2 pass
test/js/sql/postgres-invalid-message-length.test.ts  10 pass
```

This is a pure refactor with no observable difference on any input, so there is no test that can fail on the released binary and pass on this branch; the justification is the analysis above plus the existing coverage.
