### PR TITLE
sourcemap: drop three redundant conditions

### DIFF
--- a/src/sourcemap/Chunk.rs
+++ b/src/sourcemap/Chunk.rs
@@ -591,9 +591,7 @@ impl NewBuilder<VLQSourceMap> {
                     // This new line doesn't have a mapping yet
                     self.line_starts_with_mapping = false;
 
-                    needs_mapping = self.cover_lines_without_mappings
-                        && !self.line_starts_with_mapping
-                        && self.has_prev_state;
+                    needs_mapping = self.cover_lines_without_mappings && self.has_prev_state;
                 }
 
                 _ => {

--- a/src/sourcemap/InternalSourceMap.rs
+++ b/src/sourcemap/InternalSourceMap.rs
@@ -1410,7 +1410,5 @@ pub fn from_vlq(vlq: &[u8], input_line_count_hint: u32) -> Result<Box<[u8]>, Fro
     blob[8..16].copy_from_slice(&mapping_count.to_ne_bytes());
     blob[16..24].copy_from_slice(&input_lines.to_ne_bytes());
 
-    let owned = core::mem::take(&mut out.list).into_boxed_slice();
-    builder.finalized = None;
-    Ok(owned)
+    Ok(core::mem::take(&mut out.list).into_boxed_slice())
 }

--- a/src/sourcemap/lib.rs
+++ b/src/sourcemap/lib.rs
@@ -1085,10 +1085,7 @@ pub fn parse_json(source: &[u8], hint: ParseUrlResultHint) -> crate::Result<Pars
     };
 
     let content_slice: Option<Box<[u8]>> = match source_index {
-        Some(idx)
-            if !matches!(hint, ParseUrlResultHint::MappingsOnly)
-                && (idx as usize) < sources_content.items().len() =>
-        'content: {
+        Some(idx) if (idx as usize) < sources_content.items().len() => 'content: {
             let item = &sources_content.items()[idx as usize];
             let Some(str) = item.as_str() else {
                 break 'content None;


### PR DESCRIPTION
Three conditions in `src/sourcemap/` that always evaluate the same way, found during a code audit. Each is behavior-preserving: the simplified expression computes the identical value as before.

## `Chunk.rs` `update_generated_line_and_column_slow`

```rust
self.line_starts_with_mapping = false;

needs_mapping = self.cover_lines_without_mappings
    && !self.line_starts_with_mapping   // always true: set to false one line above
    && self.has_prev_state;
```

Nothing between the assignment and the read mutates the field (the intervening `append_line_separator` call is on `self.source_map`, a different struct). The initial computation at the top of the function (line 523) keeps the term because at entry `line_starts_with_mapping` reflects caller state; only this in-loop reassignment is a tautology.

## `InternalSourceMap.rs` `from_vlq`

```rust
let owned = core::mem::take(&mut out.list).into_boxed_slice();
builder.finalized = None;   // builder drops on the next line; out.list already taken
Ok(owned)
```

`out` is `&mut MutableString` borrowed from `builder.finalized`. After `take(&mut out.list)` the inner `Vec` is empty, `MutableString` has no `Drop` impl, and `builder` itself is dropped at the closing brace. Assigning `None` early does nothing.

## `lib.rs` `parse_json`

```rust
let (found_mapping, source_index) = match hint {
    ParseUrlResultHint::SourceOnly(index) => (None, Some(index)),
    ParseUrlResultHint::All { .. } => /* (Some(m), idx) or (None, None) */,
    ParseUrlResultHint::MappingsOnly => (None, None),
};

match source_index {
    Some(idx)
        if !matches!(hint, ParseUrlResultHint::MappingsOnly)   // unreachable guard
            && (idx as usize) < sources_content.items().len() =>
```

The preceding `match` is exhaustive and yields `source_index = None` for `MappingsOnly`, so the `Some(idx)` arm can only be reached for `SourceOnly` or `All`. The `MappingsOnly` guard is always true where it is evaluated.

## Verification

`cargo check -p bun_sourcemap` and `cargo clippy -p bun_sourcemap` pass. Existing sourcemap tests pass under the debug build:

- `test/js/bun/sourcemap/internal-sourcemap.test.ts`
- `test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts`
- `test/bundler/compile-sourcemap-internal.test.ts`
- `test/bundler/bun-build-compile-sourcemap.test.ts`
- `test/bundler/bundler_comments.test.ts`
- `test/js/node/module/sourcemap.test.js`
- `test/js/node/module/module-sourcemap.test.js`
- `test/js/node/module/sourcemap-simd.test.ts`

No new test is added: each removal is an algebraic identity (dropping an always-true conjunct, or dropping an assignment to a local about to drop), so there is no input for which the before/after code paths diverge.