### PR TITLE
crypto: drop unreachable has_exception() guards in Bun.password verify and pbkdf2

### DIFF
--- a/src/runtime/crypto/PBKDF2.rs
+++ b/src/runtime/crypto/PBKDF2.rs
@@ -159,8 +159,8 @@ impl PBKDF2 {
                 );
             }
 
+            let slice = arg4.to_slice(global_this)?;
             'invalid: {
-                let slice = arg4.to_slice(global_this)?;
                 match evp::lookup_ignore_case(slice.slice()) {
                     Some(alg) => match alg {
                         Algorithm::Shake128 | Algorithm::Shake256 => break 'invalid,
@@ -171,18 +171,12 @@ impl PBKDF2 {
                 }
             }
 
-            if !global_this.has_exception() {
-                let slice = arg4.to_slice(global_this)?;
-                let name = slice.slice();
-                return Err(global_this
-                    .err(
-                        bun_jsc::ErrorCode::CRYPTO_INVALID_DIGEST,
-                        format_args!("Invalid digest: {}", bstr::BStr::new(name)),
-                    )
-                    .throw());
-                // `slice` drops here.
-            }
-            return Err(bun_jsc::JsError::Thrown);
+            return Err(global_this
+                .err(
+                    bun_jsc::ErrorCode::CRYPTO_INVALID_DIGEST,
+                    format_args!("Invalid digest: {}", bstr::BStr::new(slice.slice())),
+                )
+                .throw());
         };
 
         let mut out = PBKDF2 {

--- a/src/runtime/crypto/PasswordObject.rs
+++ b/src/runtime/crypto/PasswordObject.rs
@@ -5,7 +5,7 @@ use std::io::Write as _;
 use bun_core::ZigString;
 use bun_io::KeepAlive;
 use bun_jsc::{
-    self as jsc, CallFrame, JSFunction, JSGlobalObject, JSValue, JsError, JsResult, WorkPoolTask,
+    self as jsc, CallFrame, JSFunction, JSGlobalObject, JSValue, JsResult, WorkPoolTask,
 };
 // `bun_jsc::{AnyTask, ConcurrentTask, EventLoop}` are *modules* (re-exported from
 // `bun_event_loop`); pull the concrete types out by name.
@@ -836,14 +836,11 @@ pub(crate) fn js_password_object_verify(
         algorithm = match algorithm_from_zig_string(&algorithm_string) {
             Some(a) => Some(a),
             None => {
-                if !global_object.has_exception() {
-                    return Err(global_object.throw_invalid_argument_type(
-                        "verify",
-                        "algorithm",
-                        UNKNOWN_PASSWORD_ALGORITHM_MESSAGE,
-                    ));
-                }
-                return Err(JsError::Thrown);
+                return Err(global_object.throw_invalid_argument_type(
+                    "verify",
+                    "algorithm",
+                    UNKNOWN_PASSWORD_ALGORITHM_MESSAGE,
+                ));
             }
         };
     }
@@ -917,14 +914,11 @@ pub(crate) fn js_password_object_verify_sync(
         algorithm = match algorithm_from_zig_string(&algorithm_string) {
             Some(a) => Some(a),
             None => {
-                if !global_object.has_exception() {
-                    return Err(global_object.throw_invalid_argument_type(
-                        "verify",
-                        "algorithm",
-                        UNKNOWN_PASSWORD_ALGORITHM_MESSAGE,
-                    ));
-                }
-                return Ok(JSValue::ZERO);
+                return Err(global_object.throw_invalid_argument_type(
+                    "verify",
+                    "algorithm",
+                    UNKNOWN_PASSWORD_ALGORITHM_MESSAGE,
+                ));
             }
         };
     }


### PR DESCRIPTION
## What

Removes three `!global.has_exception()` guards whose else-branches are provably unreachable:

- `js_password_object_verify` / `js_password_object_verify_sync` (PasswordObject.rs): the preceding `arguments[2].get_zig_string(global_object)?` propagates any exception via `?`, and `algorithm_from_zig_string` is a sequence of `ZigString::eql_comptime` byte compares with no JS entry. `has_exception()` is always false at the guard, so the `Err(JsError::Thrown)` / `Ok(JSValue::ZERO)` fallthroughs are dead. The `JsError` import had no other use in the file.
- `PBKDF2::from_js` (PBKDF2.rs): the preceding `arg4.to_slice(global_this)?` propagates any exception via `?`; `evp::lookup_ignore_case` is a `ComptimeStringMap` probe and `Algorithm::md()` returns a static BoringSSL singleton pointer. `has_exception()` is always false and `return Err(JsError::Thrown)` is dead. The digest `slice` is hoisted one scope out so the error message reuses it instead of calling `to_slice()` a second time.

## Why

These guards are leftovers from the pattern where a fallible helper returned an in-band sentinel (`None`/`.zero`) with the exception left pending for the caller to check. In the Rust bindings, `?` on `JsResult` already propagates the exception, so the explicit `has_exception()` check always observes `false` and the alternate branch is unreachable. Keeping them suggests a pending-exception state that cannot exist and invites readers to audit for one.

## Verification

No behavior change. Existing coverage exercises every touched path:

- `test/js/bun/util/password.test.ts` "invalid algorithm throws" passes `"scrpyt"` to both `verify` and `verifySync`, hitting the `None` arm of `algorithm_from_zig_string`.
- `test/js/node/crypto/pbkdf2.test.ts` "invalid inputs > digest" passes `"md55"`, hitting the `'invalid` fallthrough and asserting `Invalid digest: md55`.

Both suites pass on this branch (106 pass, 0 fail). Ran the password suite under `BUN_JSC_validateExceptionChecks=1` as well.

Because the removed branches are dead, there is no input that distinguishes before from after, so this change cannot produce a fail-before/pass-after test. Related items from the same audit (the redundant `& 0x3F` mask on bcrypt cost, and the explicit `drop()` calls in async `verify`) are left out here since #33865 and #33702 already rewrite those lines as part of behavioral fixes.