### PR TITLE
js_parser: drop Result from infallible new_symbol/store_name_in_ref/forbid_lexical_decl

### DIFF
--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -148,9 +148,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 Some(loc_ref) => loc_ref.ref_,
                                 None => {
                                     // Generate a new import item symbol in the module scope
-                                    let new_ref = p
-                                        .new_symbol(js_ast::symbol::Kind::Import, name)
-                                        .expect("unreachable");
+                                    let new_ref = p.new_symbol(js_ast::symbol::Kind::Import, name);
                                     let new_item = LocRef {
                                         loc: name_loc,
                                         ref_: new_ref,
@@ -393,9 +391,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                         format!("${}", bun_core::fmt::fmt_identifier(name))
                                             .as_bytes(),
                                     );
-                                    let new_ref = p
-                                        .new_symbol(js_ast::symbol::Kind::Other, sym_name)
-                                        .expect("unreachable");
+                                    let new_ref =
+                                        p.new_symbol(js_ast::symbol::Kind::Other, sym_name);
                                     // SAFETY: module_scope is arena-owned and valid for 'a.
                                     VecExt::append(&mut p.module_scope_mut().generated, new_ref);
                                     p.commonjs_named_exports
@@ -622,9 +619,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                             format!("${}", bun_core::fmt::fmt_identifier(name))
                                                 .as_bytes(),
                                         );
-                                        let new_ref = p
-                                            .new_symbol(js_ast::symbol::Kind::Other, sym_name)
-                                            .expect("unreachable");
+                                        let new_ref =
+                                            p.new_symbol(js_ast::symbol::Kind::Other, sym_name);
                                         // SAFETY: module_scope is arena-owned and valid for 'a.
                                         VecExt::append(
                                             &mut p.module_scope_mut().generated,

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -167,7 +167,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     /// newSymbol + scope.generated.append in one call.
     fn new_sym(&mut self, kind: js_ast::symbol::Kind, name: &'a [u8]) -> Ref {
-        let ref_ = self.new_symbol(kind, name).expect("unreachable");
+        let ref_ = self.new_symbol(kind, name);
         VecExt::append(&mut self.current_scope_mut().generated, ref_);
         ref_
     }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -53,7 +53,7 @@ pub(crate) trait ParserLike<'a> {
     fn bump(&self) -> &'a Bump;
     fn source(&self) -> &'a bun_ast::Source;
     fn new_expr<T: js_ast::expr::IntoExprData>(&mut self, t: T, loc: bun_ast::Loc) -> Expr;
-    fn store_name_in_ref(&mut self, name: &'a [u8]) -> Result<Ref, crate::Error>;
+    fn store_name_in_ref(&mut self, name: &'a [u8]) -> Ref;
 }
 // Trait + impl defined so Expr methods can bound on it. Method bodies
 // forward to the inherent impls.
@@ -79,7 +79,7 @@ impl<'a, const TS: bool, const SCAN: bool> ParserLike<'a> for P<'a, TS, SCAN> {
         P::new_expr(self, t, loc)
     }
     #[inline]
-    fn store_name_in_ref(&mut self, name: &'a [u8]) -> Result<Ref, crate::Error> {
+    fn store_name_in_ref(&mut self, name: &'a [u8]) -> Ref {
         P::store_name_in_ref(self, name)
     }
 }
@@ -1275,9 +1275,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         .expect("unreachable");
                         buf.into_bump_str().as_bytes()
                     };
-                    let namespace_ref = self
-                        .new_symbol(js_ast::symbol::Kind::Other, name)
-                        .expect("oom");
+                    let namespace_ref = self.new_symbol(js_ast::symbol::Kind::Other, name);
 
                     self.imports_to_convert_from_require
                         .push(DeferredImportNamespace {
@@ -2141,7 +2139,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut declared_symbols = bun_ast::DeclaredSymbolList::default();
         declared_symbols.ensure_total_capacity(imports.len() + 1)?;
 
-        let namespace_ref = self.new_symbol(js_ast::symbol::Kind::Other, namespace_identifier)?;
+        let namespace_ref = self.new_symbol(js_ast::symbol::Kind::Other, namespace_identifier);
         declared_symbols.append_assume_capacity(DeclaredSymbol {
             ref_: namespace_ref,
             is_top_level: true,
@@ -2275,7 +2273,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut declared_symbols = bun_ast::DeclaredSymbolList::default();
         declared_symbols.ensure_total_capacity(len)?;
 
-        let namespace_ref = self.new_symbol(js_ast::symbol::Kind::Other, b"RefreshRuntime")?;
+        let namespace_ref = self.new_symbol(js_ast::symbol::Kind::Other, b"RefreshRuntime");
         declared_symbols.append_assume_capacity(DeclaredSymbol {
             ref_: namespace_ref,
             is_top_level: true,
@@ -3188,9 +3186,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         if self.options.features.react_fast_refresh {
             self.react_refresh.create_signature_ref =
-                self.declare_generated_symbol(js_ast::symbol::Kind::Other, b"$RefreshSig$")?;
+                self.declare_generated_symbol(js_ast::symbol::Kind::Other, b"$RefreshSig$");
             self.react_refresh.register_ref =
-                self.declare_generated_symbol(js_ast::symbol::Kind::Other, b"$RefreshReg$")?;
+                self.declare_generated_symbol(js_ast::symbol::Kind::Other, b"$RefreshReg$");
         }
 
         {
@@ -3200,7 +3198,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     self.server_components_wrap_ref = self.declare_generated_symbol(
                         js_ast::symbol::Kind::Other,
                         b"registerClientReference",
-                    )?;
+                    );
                 }
                 // TODO: these wrapping modes.
                 options::ServerComponents::WrapAnonServerFunctions => {}
@@ -3215,7 +3213,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     self.response_ref =
                         self.declare_common_js_symbol(js_ast::symbol::Kind::Import, b"Response")?;
                     self.bun_app_namespace_ref =
-                        self.new_symbol(js_ast::symbol::Kind::Other, b"import_bun_app")?;
+                        self.new_symbol(js_ast::symbol::Kind::Other, b"import_bun_app");
                     let symbol = &mut self.symbols[self.response_ref.inner_index() as usize];
                     symbol.namespace_alias = Some(bun_alloc::ast_box(js_ast::NamespaceAlias {
                         namespace_ref: self.bun_app_namespace_ref,
@@ -3238,9 +3236,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if !self.runtime_imports.__require.is_empty() {
             return;
         }
-        let ref_ = self
-            .declare_generated_symbol(js_ast::symbol::Kind::Other, b"__require")
-            .expect("oom");
+        let ref_ = self.declare_generated_symbol(js_ast::symbol::Kind::Other, b"__require");
         self.runtime_imports.__require = ref_;
         self.runtime_imports.put(b"__require", ref_);
     }
@@ -3357,9 +3353,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             // `Symbol.original_name` is an arena-owned `StoreStr` valid for 'a.
                             let original_name: &'a [u8] =
                                 self.symbols[symbol_idx].original_name.slice();
-                            let hoisted_ref = self
-                                .new_symbol(js_ast::symbol::Kind::Hoisted, original_name)
-                                .expect("unreachable");
+                            let hoisted_ref =
+                                self.new_symbol(js_ast::symbol::Kind::Hoisted, original_name);
                             // No live `&` borrow of `scope` exists here (the members
                             // snapshot was taken by value); `StoreRef` `DerefMut`.
                             VecExt::append(&mut scope.generated, hoisted_ref);
@@ -3854,13 +3849,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     #[cold]
     #[inline(never)]
-    pub fn forbid_lexical_decl(&mut self, loc: bun_ast::Loc) -> Result<(), crate::Error> {
+    pub fn forbid_lexical_decl(&mut self, loc: bun_ast::Loc) {
         self.log().add_error(
             Some(self.source),
             loc,
             b"Cannot use a declaration in a single-statement context",
         );
-        Ok(())
     }
 
     /// If we attempt to parse TypeScript syntax outside of a TypeScript file
@@ -4087,7 +4081,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             )
             .into_bump_str()
             .as_bytes();
-            stmt.namespace_ref = self.new_symbol(js_ast::symbol::Kind::Other, name)?;
+            stmt.namespace_ref = self.new_symbol(js_ast::symbol::Kind::Other, name);
             VecExt::append(&mut self.current_scope_mut().generated, stmt.namespace_ref);
         }
 
@@ -4340,10 +4334,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(())
     }
 
-    pub fn create_default_name(
-        &mut self,
-        loc: bun_ast::Loc,
-    ) -> Result<js_ast::LocRef, crate::Error> {
+    pub fn create_default_name(&mut self, loc: bun_ast::Loc) -> js_ast::LocRef {
         let identifier: &'a [u8] = {
             let s = format!("{}_default", self.source.path.name().fmt_identifier());
             self.arena.alloc_slice_copy(s.as_bytes())
@@ -4351,19 +4342,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let name = js_ast::LocRef {
             loc,
-            ref_: self.new_symbol(js_ast::symbol::Kind::Other, identifier)?,
+            ref_: self.new_symbol(js_ast::symbol::Kind::Other, identifier),
         };
 
         VecExt::append(&mut self.current_scope_mut().generated, name.ref_);
 
-        Ok(name)
+        name
     }
 
-    pub fn new_symbol(
-        &mut self,
-        kind: js_ast::symbol::Kind,
-        identifier: &'a [u8],
-    ) -> Result<Ref, crate::Error> {
+    pub fn new_symbol(&mut self, kind: js_ast::symbol::Kind, identifier: &'a [u8]) -> Ref {
         let inner_index = self.symbols.len() as js_ast::base::RefInt; // @truncate
         self.symbols.push(Symbol {
             kind,
@@ -4375,11 +4362,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             self.ts_use_counts.push(0);
         }
 
-        Ok(Ref::new(
+        Ref::new(
             inner_index,
             self.source.index.0 as js_ast::base::RefInt,
             js_ast::base::RefTag::Symbol,
-        ))
+        )
     }
 
     pub fn default_name_for_expr(&mut self, expr: Expr, loc: bun_ast::Loc) -> LocRef {
@@ -4417,7 +4404,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             _ => {}
         }
 
-        self.create_default_name(loc).expect("unreachable")
+        self.create_default_name(loc)
     }
 
     pub fn discard_scopes_up_to(&mut self, scope_index: usize) {
@@ -4796,7 +4783,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         // Create a new symbol if we didn't merge with an existing one above
-        let ref_ = self.new_symbol(kind, name)?;
+        let ref_ = self.new_symbol(kind, name);
 
         if member.is_none() {
             self.module_scope_mut().members.put(
@@ -4854,15 +4841,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         &mut self,
         kind: js_ast::symbol::Kind,
         name: &'static [u8],
-    ) -> Result<Ref, crate::Error> {
+    ) -> Ref {
         let ref_ = if self.will_use_renamer() {
-            self.new_symbol(kind, name)?
+            self.new_symbol(kind, name)
         } else {
             let hashed = self.hash_generated_name(name);
-            self.new_symbol(kind, hashed)?
+            self.new_symbol(kind, hashed)
         };
         VecExt::append(&mut self.module_scope_mut().generated, ref_);
-        Ok(ref_)
+        ref_
     }
 
     pub fn declare_symbol(
@@ -4886,7 +4873,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         // Allocate a new symbol
-        let mut ref_ = self.new_symbol(kind, name)?;
+        let mut ref_ = self.new_symbol(kind, name);
 
         // Single-probe `getOrPut`. The previous two-probe shape
         // (`members.get` then `members.put_borrowed`) existed only because the
@@ -5017,7 +5004,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(())
     }
 
-    pub fn store_name_in_ref(&mut self, name: &'a [u8]) -> Result<Ref, crate::Error> {
+    pub fn store_name_in_ref(&mut self, name: &'a [u8]) -> Ref {
         if Self::TRACK_SYMBOL_USAGE_DURING_PARSE_PASS {
             if let Some(uses) = &mut self.parse_pass_symbol_uses {
                 if let Some(res) = uses.get_mut(name) {
@@ -5037,18 +5024,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // safety check without the per-identifier branch in release.
             let off = name_ptr - contents_ptr;
             debug_assert!(off <= u32::MAX as usize && name.len() <= u32::MAX as usize);
-            Ok(Ref::new(
+            Ref::new(
                 name.len() as u32,
                 off as u32,
                 js_ast::base::RefTag::SourceContentsSlice,
-            ))
+            )
         } else {
             // `allocated_names.len()` is bounded by the
             // symbol budget (asserted by Ref::pack's INNER_INDEX_BITS check).
             let inner_index = self.allocated_names.len();
             debug_assert!(inner_index <= u32::MAX as usize);
             self.allocated_names.push(name);
-            Ok(Ref::init(inner_index as u32, self.source.index.0, false))
+            Ref::init(inner_index as u32, self.source.index.0, false)
         }
     }
 
@@ -6151,9 +6138,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             Some(existing) => existing,
             None => {
                 let symbol_name = kind.tag_name();
-                let new_ref = self
-                    .declare_generated_symbol(js_ast::symbol::Kind::Other, symbol_name)
-                    .expect("unreachable");
+                let new_ref =
+                    self.declare_generated_symbol(js_ast::symbol::Kind::Other, symbol_name);
                 let loc_ref = LocRef { loc, ref_: new_ref };
                 self.is_import_item.insert(new_ref, ());
                 self.jsx_imports.set(kind, loc_ref);
@@ -6612,9 +6598,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.has_called_runtime = true;
 
         if !self.runtime_imports.contains(name) {
-            let ref_ = self
-                .declare_generated_symbol(js_ast::symbol::Kind::Other, name)
-                .expect("unreachable");
+            let ref_ = self.declare_generated_symbol(js_ast::symbol::Kind::Other, name);
             self.runtime_imports.put(name, ref_);
             ref_
         } else {
@@ -7060,9 +7044,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                         if s_class.class.extends.is_some() {
                             let target = self.new_expr(E::Super {}, stmt.loc);
-                            let arguments_ref = self
-                                .new_symbol(js_ast::symbol::Kind::Unbound, arguments_str)
-                                .expect("unreachable");
+                            let arguments_ref =
+                                self.new_symbol(js_ast::symbol::Kind::Unbound, arguments_str);
                             VecExt::append(&mut self.current_scope_mut().generated, arguments_ref);
 
                             let spread_inner =
@@ -7647,12 +7630,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         );
 
         // Allocate an "unbound" symbol
-        let r#ref = self
-            .new_symbol(
-                js_ast::symbol::Kind::Unbound,
-                self.arena.alloc_slice_copy(name),
-            )
-            .expect("unreachable");
+        let r#ref = self.new_symbol(
+            js_ast::symbol::Kind::Unbound,
+            self.arena.alloc_slice_copy(name),
+        );
 
         // Track how many times we've referenced this symbol
         self.record_usage(r#ref);
@@ -7768,9 +7749,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .into_bump_str()
                 .as_bytes()
         };
-        let r#ref = self
-            .new_symbol(js_ast::symbol::Kind::Other, name)
-            .expect("oom");
+        let r#ref = self.new_symbol(js_ast::symbol::Kind::Other, name);
 
         self.temp_refs_to_declare.push(TempRef {
             r#ref,
@@ -8523,9 +8502,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 ..Default::default()
             };
             if self.has_import_meta {
-                self.import_meta_ref = self
-                    .new_symbol(js_ast::symbol::Kind::Other, b"$Bun_import_meta")
-                    .expect("oom");
+                self.import_meta_ref =
+                    self.new_symbol(js_ast::symbol::Kind::Other, b"$Bun_import_meta");
                 args[5] = Arg {
                     binding: self.b(
                         B::Identifier {
@@ -8673,8 +8651,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 let mut buf = bun_alloc::ArenaString::new_in(arena);
                 let _ = write!(&mut buf, "require_{}", self.source.fmt_identifier());
                 break 'brk self
-                    .new_symbol(js_ast::symbol::Kind::Other, buf.into_bump_str().as_bytes())
-                    .expect("oom");
+                    .new_symbol(js_ast::symbol::Kind::Other, buf.into_bump_str().as_bytes());
             }
 
             Ref::NONE

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -596,7 +596,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // Are these arguments for a call to a function named "async"?
         if opts.is_async {
             p.log_expr_errors(&mut errors);
-            let async_ref = p.store_name_in_ref(b"async")?;
+            let async_ref = p.store_name_in_ref(b"async");
             let async_expr = p.new_expr(
                 E::Identifier {
                     ref_: async_ref,
@@ -641,7 +641,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let name = LocRef {
             loc: p.lexer.loc(),
-            ref_: p.store_name_in_ref(p.lexer.identifier)?,
+            ref_: p.store_name_in_ref(p.lexer.identifier),
         };
         p.lexer.next()?;
         Ok(Some(name))
@@ -797,7 +797,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         || p.lexer.token == T::TOpenBracket
                     {
                         if opts.lexical_decl != LexicalDecl::AllowAll {
-                            p.forbid_lexical_decl(token_range.loc)?;
+                            p.forbid_lexical_decl(token_range.loc);
                         }
 
                         let decls = p.parse_and_declare_decls(js_ast::symbol::Kind::Other, opts)?;
@@ -832,7 +832,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             if p.lexer.token == T::TIdentifier && !p.lexer.has_newline_before {
                 if opts.lexical_decl != LexicalDecl::AllowAll {
-                    p.forbid_lexical_decl(token_range.loc)?;
+                    p.forbid_lexical_decl(token_range.loc);
                 }
                 // p.markSyntaxFeature(.using, token_range.loc);
                 opts.is_using_statement = true;
@@ -891,7 +891,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     if p.lexer.token == T::TIdentifier && !p.lexer.has_newline_before {
                         // It's an "await using" declaration if we get here
                         if opts.lexical_decl != LexicalDecl::AllowAll {
-                            p.forbid_lexical_decl(using_range.loc)?;
+                            p.forbid_lexical_decl(using_range.loc);
                         }
                         // p.markSyntaxFeature(.using, using_range.loc);
                         opts.is_using_statement = true;
@@ -920,7 +920,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             decls: decls_slice,
                         });
                     }
-                    let r = p.store_name_in_ref(raw2)?;
+                    let r = p.store_name_in_ref(raw2);
                     break 'value p.new_expr(
                         E::Identifier {
                             ref_: r,
@@ -952,7 +952,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         // Parse the remainder of this expression that starts with an identifier
-        let ref_ = p.store_name_in_ref(raw)?;
+        let ref_ = p.store_name_in_ref(raw);
         let mut result = ExprOrLetStmt {
             stmt_or_expr: js_ast::StmtOrExpr::Expr(p.new_expr(
                 E::Identifier {
@@ -992,7 +992,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     );
                 }
 
-                let ref_ = p.store_name_in_ref(name).expect("unreachable");
+                let ref_ = p.store_name_in_ref(name);
                 p.lexer.next()?;
                 return Ok(p.b(B::Identifier { r#ref: ref_ }, loc));
             }
@@ -1157,9 +1157,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         match p.lexer.token {
             T::TDotDotDot => {
                 p.lexer.next()?;
-                let ident_ref = p
-                    .store_name_in_ref(p.lexer.identifier)
-                    .expect("unreachable");
+                let ident_ref = p.store_name_in_ref(p.lexer.identifier);
                 let value = p.b(B::Identifier { r#ref: ident_ref }, p.lexer.loc());
                 p.lexer.expect(T::TIdentifier)?;
                 return Ok(B::Property {
@@ -1212,7 +1210,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 );
 
                 if p.lexer.token != T::TColon && p.lexer.token != T::TOpenParen {
-                    let ref_ = p.store_name_in_ref(name).expect("unreachable");
+                    let ref_ = p.store_name_in_ref(name);
                     let value = p.b(B::Identifier { r#ref: ref_ }, loc);
                     let mut default_value: Option<Expr> = None;
                     if p.lexer.token == T::TEquals {
@@ -1578,7 +1576,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // "async => {}"
                 T::TEqualsGreaterThan => {
                     if level.lte(Level::Assign) {
-                        let async_ref = p.store_name_in_ref(b"async")?;
+                        let async_ref = p.store_name_in_ref(b"async");
                         let arg_binding = p.b(B::Identifier { r#ref: async_ref }, async_range.loc);
                         let args: &'a mut [G::Arg] = p.arena.alloc_slice_fill_with(1, |_| G::Arg {
                             binding: arg_binding,
@@ -1611,7 +1609,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             || p.check_for_arrow_after_the_current_token();
 
                         if is_arrow_fn {
-                            let ref_ = p.store_name_in_ref(p.lexer.identifier)?;
+                            let ref_ = p.store_name_in_ref(p.lexer.identifier);
                             let arg_loc = p.lexer.loc();
                             let arg_binding = p.b(B::Identifier { r#ref: ref_ }, arg_loc);
                             let args: &'a mut [G::Arg] =
@@ -1695,7 +1693,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // "async"
         // "async + 1"
-        let async_ref = p.store_name_in_ref(b"async")?;
+        let async_ref = p.store_name_in_ref(b"async");
         Ok(p.new_expr(
             E::Identifier {
                 ref_: async_ref,

--- a/src/js_parser/parse/parse_fn.rs
+++ b/src/js_parser/parse/parse_fn.rs
@@ -35,13 +35,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         match opts.lexical_decl {
             LexicalDecl::Forbid => {
-                p.forbid_lexical_decl(loc)?;
+                p.forbid_lexical_decl(loc);
             }
 
             // Allow certain function statements in certain single-statement contexts
             LexicalDecl::AllowFnInsideIf | LexicalDecl::AllowFnInsideLabel => {
                 if opts.is_typescript_declare || is_generator || is_async {
-                    p.forbid_lexical_decl(loc)?;
+                    p.forbid_lexical_decl(loc);
                 }
             }
             _ => {}
@@ -56,7 +56,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             name_text = p.lexer.identifier;
             p.lexer.expect(T::TIdentifier)?;
             // Difference
-            let ref_ = p.new_symbol(js_ast::symbol::Kind::Other, name_text)?;
+            let ref_ = p.new_symbol(js_ast::symbol::Kind::Other, name_text);
             name = Some(js_ast::LocRef {
                 loc: name_loc,
                 ref_,
@@ -448,7 +448,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let ref_ = if !text.is_empty() && text != arguments_str {
                 p.declare_symbol(js_ast::symbol::Kind::HoistedFunction, name_loc, text)?
             } else {
-                p.new_symbol(js_ast::symbol::Kind::HoistedFunction, text)?
+                p.new_symbol(js_ast::symbol::Kind::HoistedFunction, text)
             };
             name = Some(js_ast::LocRef {
                 loc: name_loc,

--- a/src/js_parser/parse/parse_import_export.rs
+++ b/src/js_parser/parse/parse_import_export.rs
@@ -123,7 +123,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let alias = p.parse_clause_alias(b"import")?;
             let mut name = LocRef {
                 loc: alias_loc,
-                ref_: p.store_name_in_ref(alias)?,
+                ref_: p.store_name_in_ref(alias),
             };
             let mut original_name = alias;
             p.lexer.next()?;
@@ -147,7 +147,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         original_name = p.lexer.identifier;
                         name = LocRef {
                             loc: p.lexer.loc(),
-                            ref_: p.store_name_in_ref(original_name)?,
+                            ref_: p.store_name_in_ref(original_name),
                         };
                         p.lexer.next()?;
 
@@ -173,7 +173,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         original_name = p.lexer.identifier;
                         name = LocRef {
                             loc: p.lexer.loc(),
-                            ref_: p.store_name_in_ref(original_name)?,
+                            ref_: p.store_name_in_ref(original_name),
                         };
                         p.lexer.expect(T::TIdentifier)?;
 
@@ -222,7 +222,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     original_name = p.lexer.identifier;
                     name = LocRef {
                         loc: alias_loc,
-                        ref_: p.store_name_in_ref(original_name)?,
+                        ref_: p.store_name_in_ref(original_name),
                     };
                     p.lexer.expect(T::TIdentifier)?;
                 } else if !is_identifier {
@@ -296,7 +296,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             let name = LocRef {
                 loc: alias_loc,
-                ref_: p.store_name_in_ref(alias).expect("unreachable"),
+                ref_: p.store_name_in_ref(alias),
             };
             let original_name = alias;
 

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -115,7 +115,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.lexer.expected(T::TIn)?;
         }
 
-        let ref_ = p.store_name_in_ref(name)?;
+        let ref_ = p.store_name_in_ref(name);
         Ok(p.new_expr(E::PrivateIdentifier { ref_ }, loc))
     }
 
@@ -252,7 +252,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // Handle the start of an arrow expression
         if p.lexer.token == T::TEqualsGreaterThan && level.lte(Level::Assign) {
-            let ref_ = p.store_name_in_ref(name).expect("unreachable");
+            let ref_ = p.store_name_in_ref(name);
             // reshaped for borrowck — build binding before borrowing arena.
             // `Arg` is non-Copy (owns Vec) → use fill_iter instead of alloc_slice_copy.
             let binding = p.b(B::Identifier { r#ref: ref_ }, loc);
@@ -274,7 +274,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return Ok(p.new_expr(arrow_result?, loc));
         }
 
-        let ref_ = p.store_name_in_ref(name).expect("unreachable");
+        let ref_ = p.store_name_in_ref(name);
 
         Ok(Expr::init_identifier(ref_, loc))
     }
@@ -560,9 +560,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                 name = Some(js_ast::LocRef {
                     loc: p.lexer.loc(),
-                    ref_: p
-                        .new_symbol(symbol::Kind::Other, name_text)
-                        .expect("unreachable"),
+                    ref_: p.new_symbol(symbol::Kind::Other, name_text),
                 });
                 p.lexer.next()?;
             }
@@ -625,9 +623,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                 name = Some(js_ast::LocRef {
                     loc: p.lexer.loc(),
-                    ref_: p
-                        .new_symbol(symbol::Kind::Other, name_text)
-                        .expect("unreachable"),
+                    ref_: p.new_symbol(symbol::Kind::Other, name_text),
                 });
                 p.lexer.next()?;
             }

--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -287,7 +287,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
 
                     let ident = p.lexer.identifier;
-                    let ref_ = p.store_name_in_ref(ident).expect("unreachable");
+                    let ref_ = p.store_name_in_ref(ident);
                     key = p.new_expr(E::PrivateIdentifier { ref_ }, p.lexer.loc());
                     p.lexer.next()?;
                 }
@@ -577,7 +577,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             }
                         }
 
-                        let ref_ = p.store_name_in_ref(name).expect("unreachable");
+                        let ref_ = p.store_name_in_ref(name);
                         let value = p.new_expr(E::Identifier::init(ref_), key.loc);
 
                         // Destructuring patterns have an optional default value

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -135,7 +135,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         loc: bun_ast::Loc,
     ) -> Result<Stmt> {
         if opts.lexical_decl != LexicalDecl::AllowAll {
-            p.forbid_lexical_decl(loc)?;
+            p.forbid_lexical_decl(loc);
         }
 
         p.parse_class_stmt(loc, opts)
@@ -168,7 +168,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         loc: bun_ast::Loc,
     ) -> Result<Stmt> {
         if opts.lexical_decl != LexicalDecl::AllowAll {
-            p.forbid_lexical_decl(loc)?;
+            p.forbid_lexical_decl(loc);
         }
         // p.markSyntaxFeature(compat.Const, p.lexer.Range())
 
@@ -1007,10 +1007,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     ref_: name.ref_,
                                 }
                             } else {
-                                p.create_default_name(default_loc)?
+                                p.create_default_name(default_loc)
                             }
                         } else {
-                            p.create_default_name(default_loc)?
+                            p.create_default_name(default_loc)
                         };
 
                         let value = js_ast::StmtOrExpr::Stmt(stmt);
@@ -1023,7 +1023,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         ));
                     }
 
-                    let default_name = p.create_default_name(loc)?;
+                    let default_name = p.create_default_name(loc);
 
                     let mut expr = p.parse_async_prefix_expr(async_range, Level::Comma)?;
                     p.parse_suffix(&mut expr, Level::Comma, None, EFlags::None)?;
@@ -1096,7 +1096,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             }
                         }
 
-                        p.create_default_name(default_loc).expect("unreachable")
+                        p.create_default_name(default_loc)
                     };
                     p.has_export_default = true;
                     p.has_es_module_syntax = true;
@@ -1155,7 +1155,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             _ => {}
                         }
 
-                        p.create_default_name(default_loc).expect("unreachable")
+                        p.create_default_name(default_loc)
                     };
                     p.has_export_default = true;
                     return Ok(p.s(
@@ -1214,7 +1214,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     // "export * as ns from 'path'"
                     p.lexer.next()?;
                     let name = p.parse_clause_alias(b"export")?;
-                    namespace_ref = p.store_name_in_ref(name)?;
+                    namespace_ref = p.store_name_in_ref(name);
                     alias = Some(G::ExportStarAlias {
                         loc: p.lexer.loc(),
                         original_name: bun_ast::StoreStr::new(name),
@@ -1235,7 +1235,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             .expect("unreachable");
                         p.arena.alloc_slice_copy(&buf)
                     };
-                    namespace_ref = p.store_name_in_ref(name)?;
+                    namespace_ref = p.store_name_in_ref(name);
                 }
 
                 let import_record_index = p.add_import_record(
@@ -1329,7 +1329,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             bun_core::fmt::fmt_identifier(path_name.non_unique_name_string_base())
                         )
                         .expect("unreachable");
-                        p.store_name_in_ref(p.arena.alloc_slice_copy(&buf))?
+                        p.store_name_in_ref(p.arena.alloc_slice_copy(&buf))
                     };
 
                     if Self::TRACK_SYMBOL_USAGE_DURING_PARSE_PASS {
@@ -1455,7 +1455,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 p.lexer.next()?;
                 p.lexer.expect_contextual_keyword(b"as")?;
                 stmt = S::Import {
-                    namespace_ref: p.store_name_in_ref(p.lexer.identifier)?,
+                    namespace_ref: p.store_name_in_ref(p.lexer.identifier),
                     star_name_loc: p.lexer.loc(),
                     import_record_index: u32::MAX,
                     ..Default::default()
@@ -1507,7 +1507,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     import_record_index: u32::MAX,
                     default_name: Some(LocRef {
                         loc: p.lexer.loc(),
-                        ref_: p.store_name_in_ref(default_name)?,
+                        ref_: p.store_name_in_ref(default_name),
                     }),
                     ..Default::default()
                 };
@@ -1541,7 +1541,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     p.lexer.next()?;
                     p.lexer.expect_contextual_keyword(b"as")?;
                     stmt = S::Import {
-                        namespace_ref: p.store_name_in_ref(p.lexer.identifier)?,
+                        namespace_ref: p.store_name_in_ref(p.lexer.identifier),
                         star_name_loc: p.lexer.loc(),
                         import_record_index: u32::MAX,
                         phase_defer: true,
@@ -1630,7 +1630,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         T::TAsterisk => {
                             p.lexer.next()?;
                             p.lexer.expect_contextual_keyword(b"as")?;
-                            stmt.namespace_ref = p.store_name_in_ref(p.lexer.identifier)?;
+                            stmt.namespace_ref = p.store_name_in_ref(p.lexer.identifier);
                             stmt.star_name_loc = p.lexer.loc();
                             p.lexer.expect(T::TIdentifier)?;
                         }

--- a/src/js_parser/parse/parse_suffix.rs
+++ b/src/js_parser/parse/parse_suffix.rs
@@ -79,7 +79,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let name = p.lexer.identifier;
             let name_loc = p.lexer.loc();
             p.lexer.next()?;
-            let ref_ = p.store_name_in_ref(name).expect("unreachable");
+            let ref_ = p.store_name_in_ref(name);
             let loc = left.loc;
             let index = p.new_expr(E::PrivateIdentifier { ref_ }, name_loc);
             *left = p.new_expr(
@@ -218,7 +218,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     let name = p.lexer.identifier;
                     let name_loc = p.lexer.loc();
                     p.lexer.next()?;
-                    let ref_ = p.store_name_in_ref(name).expect("unreachable");
+                    let ref_ = p.store_name_in_ref(name);
                     let loc = left.loc;
                     let target = *left;
                     let index = p.new_expr(E::PrivateIdentifier { ref_ }, name_loc);

--- a/src/js_parser/parse/parse_typescript.rs
+++ b/src/js_parser/parse/parse_typescript.rs
@@ -93,7 +93,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let loc = p.lexer.loc();
         let ident = p.lexer.identifier;
-        let ref_ = p.store_name_in_ref(ident)?;
+        let ref_ = p.store_name_in_ref(ident);
         let mut expr = p.new_expr(
             E::Identifier {
                 ref_,
@@ -132,7 +132,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         let name = p.lexer.identifier;
                         let name_loc = p.lexer.loc();
                         p.lexer.next()?;
-                        let ref_ = p.store_name_in_ref(name)?;
+                        let ref_ = p.store_name_in_ref(name);
                         let index = p.new_expr(E::PrivateIdentifier { ref_ }, name_loc);
                         expr = p.new_expr(
                             E::Index {
@@ -447,15 +447,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                     underscores += 1;
                 };
-                arg_ref = p
-                    .new_symbol(SymbolKind::Hoisted, prefixed)
-                    .expect("unreachable");
+                arg_ref = p.new_symbol(SymbolKind::Hoisted, prefixed);
                 // SAFETY: see above.
                 VecExt::append(&mut p.current_scope_mut().generated, arg_ref);
             } else {
-                arg_ref = p
-                    .new_symbol(SymbolKind::Hoisted, name_text)
-                    .expect("unreachable");
+                arg_ref = p.new_symbol(SymbolKind::Hoisted, name_text);
             }
             ts_namespace.arg_ref = arg_ref;
         }
@@ -492,7 +488,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let kind = js_ast::LocalKind::KConst;
         let name = p.lexer.identifier;
-        let target_ref = p.store_name_in_ref(name).expect("unreachable");
+        let target_ref = p.store_name_in_ref(name);
         let target_loc = p.lexer.loc();
         let target = p.new_expr(
             E::Identifier {
@@ -722,9 +718,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // PERF: strings::cat heap-allocates — could allocate into p.arena.
                 let prefixed = strings::cat(b"_", name_text).expect("unreachable");
                 let prefixed: &'a [u8] = p.arena.alloc_slice_copy(&prefixed);
-                arg_ref = p
-                    .new_symbol(SymbolKind::Hoisted, prefixed)
-                    .expect("unreachable");
+                arg_ref = p.new_symbol(SymbolKind::Hoisted, prefixed);
                 // SAFETY: see above.
                 VecExt::append(&mut p.current_scope_mut().generated, arg_ref);
             } else {

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -996,7 +996,7 @@ impl<'a> JSXTag<'a> {
 
         // Otherwise, this is an identifier
         // <Button>
-        let ref_ = p.store_name_in_ref(name)?;
+        let ref_ = p.store_name_in_ref(name);
         let mut tag = p.new_expr(
             E::Identifier {
                 ref_,

--- a/src/js_parser/react_compiler_host.rs
+++ b/src/js_parser/react_compiler_host.rs
@@ -67,9 +67,8 @@ impl<'a, const TS: bool, const SCAN_ONLY: bool> bun_react_compiler::Host
         match p.jsx_imports.get_with_tag(kind) {
             Some(existing) => existing,
             None => {
-                let new_ref = p
-                    .declare_generated_symbol(js_ast::symbol::Kind::Other, kind.tag_name())
-                    .expect("oom");
+                let new_ref =
+                    p.declare_generated_symbol(js_ast::symbol::Kind::Other, kind.tag_name());
                 let loc_ref = js_ast::LocRef {
                     loc: bun_ast::Loc::EMPTY,
                     ref_: new_ref,
@@ -84,9 +83,7 @@ impl<'a, const TS: bool, const SCAN_ONLY: bool> bun_react_compiler::Host
     fn new_generated(&mut self, name: &[u8]) -> js_ast::Ref {
         let p = &mut *self.p;
         let name = p.arena.alloc_slice_copy(name);
-        let ref_ = p
-            .new_symbol(js_ast::symbol::Kind::Other, name)
-            .expect("oom");
+        let ref_ = p.new_symbol(js_ast::symbol::Kind::Other, name);
         VecExt::append(&mut p.module_scope_mut().generated, ref_);
         ref_
     }
@@ -94,9 +91,7 @@ impl<'a, const TS: bool, const SCAN_ONLY: bool> bun_react_compiler::Host
     fn new_import_item(&mut self, name: &[u8]) -> js_ast::Ref {
         let p = &mut *self.p;
         let name = p.arena.alloc_slice_copy(name);
-        let ref_ = p
-            .new_symbol(js_ast::symbol::Kind::Import, name)
-            .expect("oom");
+        let ref_ = p.new_symbol(js_ast::symbol::Kind::Import, name);
         VecExt::append(&mut p.module_scope_mut().generated, ref_);
         p.is_import_item.insert(ref_, ());
         ref_
@@ -128,9 +123,7 @@ impl<'a, const TS: bool, const SCAN_ONLY: bool> bun_react_compiler::Host
         let p = &mut *self.p;
         let path = p.arena.alloc_slice_copy(path);
         let index = p.add_import_record_by_range(kind, bun_ast::Range::NONE, path);
-        let namespace_ref = p
-            .new_symbol(js_ast::symbol::Kind::Other, path)
-            .expect("oom");
+        let namespace_ref = p.new_symbol(js_ast::symbol::Kind::Other, path);
         VecExt::append(&mut p.module_scope_mut().generated, namespace_ref);
         (index, namespace_ref)
     }

--- a/src/js_parser/scan/scan_symbols.rs
+++ b/src/js_parser/scan/scan_symbols.rs
@@ -77,7 +77,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     break 'brk *existing;
                                 }
                                 let arg_ref = ts.arg_ref;
-                                let new_ref = self.new_symbol(js_ast::symbol::Kind::Other, name)?;
+                                let new_ref = self.new_symbol(js_ast::symbol::Kind::Other, name);
                                 // Re-borrow ts_namespace mutably after &mut self.
                                 let ts_mut = &mut *ts_namespace;
                                 ts_mut.property_accesses.insert(name, new_ref);
@@ -119,9 +119,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             // gpe borrows self.module_scope while self.new_symbol needs &mut self.
             // Drop gpe, allocate, then re-insert.
-            let new_ref = self
-                .new_symbol(js_ast::symbol::Kind::Unbound, name)
-                .expect("unreachable");
+            let new_ref = self.new_symbol(js_ast::symbol::Kind::Unbound, name);
 
             *self
                 .module_scope_mut()

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -847,9 +847,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             } else {
                 b"_default"
             };
-            let new_ref = self
-                .new_symbol(SymbolKind::Constant, name_str)
-                .expect("unreachable");
+            let new_ref = self.new_symbol(SymbolKind::Constant, name_str);
             shadow_ref.set(new_ref);
         }
 

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -273,7 +273,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // "export {foo} from 'path'"
         let name = p.load_name_from_ref(data.namespace_ref);
 
-        data.namespace_ref = p.new_symbol(js_ast::symbol::Kind::Other, name)?;
+        data.namespace_ref = p.new_symbol(js_ast::symbol::Kind::Other, name);
         VecExt::append(&mut p.cur_scope().generated, data.namespace_ref);
         p.record_declared_symbol(data.namespace_ref);
 
@@ -294,7 +294,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
 
                 let _name = p.load_name_from_ref(old_ref);
-                let ref_ = p.new_symbol(js_ast::symbol::Kind::Import, _name)?;
+                let ref_ = p.new_symbol(js_ast::symbol::Kind::Import, _name);
                 VecExt::append(&mut p.cur_scope().generated, ref_);
                 p.record_declared_symbol(ref_);
                 // Compaction: items[..j] is the kept prefix; items[i] is dead
@@ -310,7 +310,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // This is a re-export and the symbols created here are used to reference
             for item in items.iter_mut() {
                 let _name = p.load_name_from_ref(item.name.ref_);
-                let ref_ = p.new_symbol(js_ast::symbol::Kind::Import, _name)?;
+                let ref_ = p.new_symbol(js_ast::symbol::Kind::Import, _name);
                 VecExt::append(&mut p.cur_scope().generated, ref_);
                 p.record_declared_symbol(ref_);
                 item.name.ref_ = ref_;
@@ -329,7 +329,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     ) -> Result<(), Error> {
         // "export * from 'path'"
         let name = p.load_name_from_ref(data.namespace_ref);
-        data.namespace_ref = p.new_symbol(js_ast::symbol::Kind::Other, name)?;
+        data.namespace_ref = p.new_symbol(js_ast::symbol::Kind::Other, name);
         VecExt::append(&mut p.cur_scope().generated, data.namespace_ref);
         p.record_declared_symbol(data.namespace_ref);
 
@@ -458,7 +458,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
 
                 if !data.default_name.ref_.is_symbol() {
-                    data.default_name = p.create_default_name(expr.loc).expect("unreachable");
+                    data.default_name = p.create_default_name(expr.loc);
                 }
 
                 let should_emit_temp_var = p.options.features.react_fast_refresh
@@ -614,8 +614,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         }
 
                         if !data.default_name.ref_.is_symbol() {
-                            data.default_name =
-                                p.create_default_name(stmt.loc).expect("unreachable");
+                            data.default_name = p.create_default_name(stmt.loc);
                         }
 
                         // Capture the original function name before any `mem::take` below resets
@@ -809,8 +808,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         }
 
                         if !data.default_name.ref_.is_symbol() {
-                            data.default_name =
-                                p.create_default_name(stmt.loc).expect("unreachable");
+                            data.default_name = p.create_default_name(stmt.loc);
                         }
 
                         // We only inject a name into classes when decorator lowering
@@ -1333,9 +1331,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.push_scope_for_visit_pass(js_ast::scope::Kind::Label, stmt.loc)
             .expect("unreachable");
         let name = p.load_name_from_ref(data.name.ref_);
-        let ref_ = p
-            .new_symbol(js_ast::symbol::Kind::Label, name)
-            .expect("unreachable");
+        let ref_ = p.new_symbol(js_ast::symbol::Kind::Label, name);
         data.name.ref_ = ref_;
         p.cur_scope().label_ref = ref_;
         match data.stmt.data {


### PR DESCRIPTION
## What

Five helpers on `P<'a, ...>` returned `Result<T, crate::Error>` with no reachable `Err` path. This changes them to return `T` directly and deletes the `?` / `.expect("unreachable")` / `.expect("oom")` noise at ~95 call sites across 16 files.

| function | was | now | why it cannot fail |
|---|---|---|---|
| `new_symbol` | `Result<Ref, Error>` | `Ref` | arena-Vec `push` (infallible) + `Ref::new` |
| `store_name_in_ref` | `Result<Ref, Error>` | `Ref` | pointer-range check + arena-Vec `push` |
| `forbid_lexical_decl` | `Result<(), Error>` | `()` | `Log::add_error` returns `()` |
| `create_default_name` | `Result<LocRef, Error>` | `LocRef` | only fallible step was `new_symbol` |
| `declare_generated_symbol` | `Result<Ref, Error>` | `Ref` | only fallible step was `new_symbol` |

The `ParserLike::store_name_in_ref` trait method is updated to match.

## Why

Every single caller already treated failure as impossible: either `?` threading an error that never materializes, or `.expect("unreachable")` / `.expect("oom")` encoding the invariant as a runtime panic string. This moves the invariant to the type system where the compiler enforces it, and deletes ~50 lines of ceremony.

This is the parser's `P::new_symbol`; `AstBuilder::new_symbol` in the bundler is a different function that can return `OOM` and is unchanged.

`mark_strict_mode_feature` has the same shape (logs and returns `Ok(())`) but unwrapping it cascades through `declare_symbol` and `declare_binding` into a much larger diff; left for a follow-up.

## Verification

No behavior change is possible here: the removed `Err` arms were dead. `cargo check -p bun_js_parser -p bun_bundler` is clean, and the existing suites pass unchanged under the debug build:

- `test/bundler/transpiler/transpiler.test.js` (182 pass)
- `test/bundler/transpiler/{decorators,export-default,react-compiler}.test.*` (57 pass)
- `test/bundler/esbuild/ts.test.ts` (57 pass)

Because there is no observable runtime delta, a fail-before/pass-after test is not constructible; the compiler is the proof.