### PR TITLE
server: drop unreachable None re-checks after is_aborted_or_ended() and a redundant state store

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -739,10 +739,6 @@ where
             return;
         }
 
-        if ctx.server.is_none() {
-            ctx.render_missing_invalid_response(value);
-            return;
-        }
         if value.is_empty_or_undefined_or_null() || !value.is_cell() {
             ctx.render_missing_invalid_response(value);
             return;
@@ -1747,9 +1743,6 @@ where
             return;
         }
 
-        if self.resp.is_none() || self.server.is_none() {
-            return;
-        }
         // SAFETY: BACKREF
         let global_this = self.server().global_this();
         let resp = self.resp.expect("infallible: resp bound");

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1139,8 +1139,6 @@ impl ServePlugins {
         drop(plugin); // pending.plugin.deinit()
         drop(promise); // Drop on JscStrong releases the slot.
 
-        self.state = ServePluginsState::Err;
-
         for route in html_bundle_routes {
             // BACKREF: route was ref'd when stored (intrusive +1 keeps it alive
             // for this call). R-2: `on_plugins_rejected` takes `&self`.


### PR DESCRIPTION
Three dead branches in `src/runtime/server/`, all carried over from the Zig port.

## What

### `RequestContext::handle_resolve` (was line 742)

```rust
if ctx.is_aborted_or_ended() || ctx.did_upgrade_web_socket() {
    return;
}
if ctx.server.is_none() {            // unreachable
    ctx.render_missing_invalid_response(value);
    return;
}
```

### `RequestContext::do_sendfile` (was line 1750)

```rust
if self.is_aborted_or_ended() { return; }
if self.flags.has_sendfile_ctx() { return; }
if self.resp.is_none() || self.server.is_none() {   // unreachable
    return;
}
let global_this = self.server().global_this();
let resp = self.resp.expect("infallible: resp bound");
```

### `ServePlugins::handle_on_reject` (was line 1142)

```rust
let ServePluginsState::Pending { .. } =
    mem::replace(&mut self.state, ServePluginsState::Err)  // stores Err
else { unreachable!() };
drop(plugin);
drop(promise);
self.state = ServePluginsState::Err;   // redundant: already Err
```

## Why these are provably dead

`is_aborted_or_ended()` is:

```rust
self.resp.is_none()
    || self.flags.aborted()
    || self.server.is_none()
    || self.server().terminated()
```

so once it returns `false`, both `resp` and `server` are `Some`. Between the guard and the removed check the only calls are `did_upgrade_web_socket()` (pure read of `self.upgrade_context`) and `flags.has_sendfile_ctx()` (bitflag getter via `flag_accessor!`); neither mutates `resp`/`server` and neither yields to JS, the event loop, or any callback that could reach `detach_response()` / `clear_server()`. The `.expect("infallible: ...")` lines that immediately follow already encode the same invariant and would have panicked first had it ever been violated.

For `handle_on_reject`, `mem::replace` writes `ServePluginsState::Err` into `self.state` and returns the old value. The intervening `drop(plugin)` / `drop(promise)` operate on owned values moved out of that old state (their `Drop` impls release a GC slot and free the plugin, with no path back into `ServePlugins`). The Zig original mutated the union in place and then assigned `.err`, which is why the second store appeared in the port; the sibling `handle_on_resolve` uses the same `mem::replace` pattern but reassigns to `Loaded(..)`, so only the reject path ended up redundant.

## Verification

No observable behaviour changes, so there is nothing a regression test can distinguish. Existing coverage that runs through these paths still passes with the debug build:

- `test/js/bun/http/bun-serve-file.test.ts` (sendfile path): 83 pass / 0 fail
- `test/bake/serve-plugins-dev-server.test.ts` (`handle_on_reject`/`handle_on_resolve`): 2 pass / 0 fail
- `test/js/bun/http/serve.test.ts` (`handle_resolve`): 255 pass; the 4 remaining failures reproduce identically on `main` and on the installed release build (container networking / egress proxy, unrelated)
