### PR TITLE
dns: drop unreachable Result<_, AllocError> from to_list/address_to_string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,7 +676,6 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "bstr",
- "bun_alloc",
  "bun_cares_sys",
  "bun_core",
  "bun_sys",

--- a/src/dns/Cargo.toml
+++ b/src/dns/Cargo.toml
@@ -18,7 +18,6 @@ enum-map.workspace = true
 enumset.workspace = true
 libc.workspace = true
 bitflags.workspace = true
-bun_alloc.workspace = true
 bun_core.workspace = true
 bun_sys.workspace = true
 bun_cares_sys.workspace = true

--- a/src/dns/lib.rs
+++ b/src/dns/lib.rs
@@ -3,7 +3,6 @@
 use core::ffi::c_int;
 use std::io::Write as _;
 
-use bun_alloc::AllocError;
 use bun_core::String as BunString;
 // `bun_wyhash` exports `Wyhash11` (iterative init/update/final_ surface).
 // Hash is in-memory dedupe only — algorithm identity is not load-bearing.
@@ -329,7 +328,7 @@ impl Drop for ResultAny {
 }
 
 impl GetAddrInfoResult {
-    pub fn to_list(addrinfo: &sock::addrinfo) -> Result<ResultList, AllocError> {
+    pub fn to_list(addrinfo: &sock::addrinfo) -> ResultList {
         let mut list = ResultList::with_capacity(addr_info_count(addrinfo) as usize);
 
         let mut addr: *const sock::addrinfo = addrinfo;
@@ -342,7 +341,7 @@ impl GetAddrInfoResult {
             addr = a.ai_next;
         }
 
-        Ok(list)
+        list
     }
 
     pub fn from_addr_info(addrinfo: &sock::addrinfo) -> Option<GetAddrInfoResult> {
@@ -363,17 +362,17 @@ impl GetAddrInfoResult {
     }
 }
 
-pub fn address_to_string(address: &Address) -> Result<BunString, AllocError> {
+pub fn address_to_string(address: &Address) -> BunString {
     // Reshaped — bun_sys::net::Address exposes family()/as_in4()/
     // as_in6() rather than .in/.in6/.un union views.
     match address.family() {
         sock::AF_INET => {
             let v4 = address.as_in4().unwrap(); // family() just checked
             let bytes: [u8; 4] = v4.sin_addr.s_addr.to_ne_bytes();
-            Ok(BunString::create_format(format_args!(
+            BunString::create_format(format_args!(
                 "{}.{}.{}.{}",
                 bytes[0], bytes[1], bytes[2], bytes[3]
-            )))
+            ))
         }
         sock::AF_INET6 => {
             let v6 = address.as_in6().unwrap(); // family() just checked
@@ -387,7 +386,7 @@ pub fn address_to_string(address: &Address) -> Result<BunString, AllocError> {
                 bun_cares_sys::ntop(sock::AF_INET6, (&raw const v6.sin6_addr).cast(), &mut buf)
             } {
                 Some(s) => s.len(),
-                None => return Ok(BunString::EMPTY),
+                None => return BunString::EMPTY,
             };
             let len = if v6.sin6_scope_id != 0 {
                 let mut cursor = &mut buf[n..];
@@ -398,7 +397,7 @@ pub fn address_to_string(address: &Address) -> Result<BunString, AllocError> {
             } else {
                 n
             };
-            Ok(BunString::clone_latin1(&buf[..len]))
+            BunString::clone_latin1(&buf[..len])
         }
         sock::AF_UNIX => {
             // Unix sockets exist on every target Bun ships (Windows 10 rs4+
@@ -409,9 +408,9 @@ pub fn address_to_string(address: &Address) -> Result<BunString, AllocError> {
             let path: &[u8] = unsafe {
                 core::slice::from_raw_parts(un.sun_path.as_ptr().cast::<u8>(), un.sun_path.len())
             };
-            Ok(BunString::clone_latin1(path))
+            BunString::clone_latin1(path)
         }
-        _ => Ok(BunString::EMPTY),
+        _ => BunString::EMPTY,
     }
 }
 

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -1284,10 +1284,7 @@ pub mod get_addr_info_request {
             });
 
             // SAFETY: addrinfo is non-null (checked above); freed by `_free` guard after copy.
-            *self =
-                LibcBackend::Success(bun_core::handle_oom(GetAddrInfoResult::to_list(unsafe {
-                    &*addrinfo
-                })));
+            *self = LibcBackend::Success(GetAddrInfoResult::to_list(unsafe { &*addrinfo }));
         }
     }
 
@@ -1600,7 +1597,7 @@ impl GetAddrInfoRequest {
             let result_any = if addrinfo.is_null() {
                 GetAddrInfoResultAny::Addrinfo(ptr::null_mut())
             } else {
-                let list = GetAddrInfoResult::to_list(&*addrinfo).unwrap_or_default();
+                let list = GetAddrInfoResult::to_list(&*addrinfo);
                 libuv::uv_freeaddrinfo(addrinfo.cast());
                 GetAddrInfoResultAny::List(list)
             };

--- a/src/runtime/dns_jsc/options_jsc.rs
+++ b/src/runtime/dns_jsc/options_jsc.rs
@@ -247,11 +247,7 @@ pub(crate) fn address_to_js(
     address: &bun_dns::Address,
     global: &JSGlobalObject,
 ) -> JsResult<JSValue> {
-    let mut str = match address_to_string(address) {
-        Ok(s) => s,
-        Err(_) => return Err(global.throw_out_of_memory()),
-    };
-    str.transfer_to_js(global)
+    address_to_string(address).transfer_to_js(global)
 }
 
 pub(crate) fn addr_info_to_js_array(


### PR DESCRIPTION
## What

Two functions in `src/dns/lib.rs` declared `Result<_, AllocError>` return types but the `Err` variant was provably unreachable. Change them to return the value directly and drop the dead error-handling at call sites.

- `GetAddrInfoResult::to_list` (lib.rs:331): body only calls `Vec::with_capacity` / `push`, which abort on OOM; no `?` or `return Err` anywhere.
- `address_to_string` (lib.rs:364): every match arm returned `Ok(...)`; `BunString::create_format` / `clone_latin1` / `EMPTY` all yield `BunString` directly, not `Result`.

Call sites carried dead handling:
- `dns_jsc/dns.rs:1287`: `bun_core::handle_oom(GetAddrInfoResult::to_list(...))` on a function that cannot return `Err`
- `dns_jsc/dns.rs:1600` (Windows): `.unwrap_or_default()`, which would have silently swallowed a real error into an empty list had one ever been introduced
- `dns_jsc/options_jsc.rs:250`: a dead `Err(_) => throw_out_of_memory()` match arm

Also drops `bun_alloc` as a direct dependency of the `bun_dns` crate (`AllocError` was its only use).

## Why

The signature lied about fallibility. `Vec::push` in Rust never returns `Err` on OOM; it aborts via the global allocator's error hook. Declaring `Result<_, AllocError>` on top of infallible operations forces callers to write error branches that can never execute, and the `.unwrap_or_default()` at the Windows call site was a quiet footgun: if this function ever became genuinely fallible, OOM would produce an empty result list instead of a crash.

## Verification

Behavior-preserving refactor; no runtime change. Verified:
- `cargo check -p bun_dns` and `cargo check -p bun_runtime` clean on both `x86_64-unknown-linux-gnu` and `x86_64-pc-windows-msvc`
- `cargo clippy -p bun_dns --no-deps` clean
- `bun bd test test/js/bun/dns/resolve-dns.test.ts -t localhost` (exercises `to_list` via the libc/system backends and `address_to_string` via `address_to_js`): 27 pass / 0 fail
- `bun bd test test/js/node/dns/node-dns.test.js -t localhost`: 3 pass / 0 fail

Net: +12 / -22.