### PR TITLE
jsc/bindings: remove redundant null/type re-checks after guaranteed-nonnull guards

### DIFF
--- a/src/jsc/bindings/ErrorStackTrace.cpp
+++ b/src/jsc/bindings/ErrorStackTrace.cpp
@@ -580,17 +580,12 @@ String functionName(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::
         if (functionName.isEmpty()) {
             if (jstype == JSC::JSFunctionType) {
                 auto* function = uncheckedDowncast<JSC::JSFunction>(object);
-                if (function) {
-                    functionName = function->nameWithoutGC(vm);
-                    if (functionName.isEmpty() && !function->isHostFunction()) {
-                        functionName = function->jsExecutable()->ecmaName().string();
-                    }
+                functionName = function->nameWithoutGC(vm);
+                if (functionName.isEmpty() && !function->isHostFunction()) {
+                    functionName = function->jsExecutable()->ecmaName().string();
                 }
             } else if (jstype == JSC::InternalFunctionType) {
-                auto* function = uncheckedDowncast<JSC::InternalFunction>(object);
-                if (function) {
-                    functionName = function->name();
-                }
+                functionName = uncheckedDowncast<JSC::InternalFunction>(object)->name();
             }
         }
     }
@@ -651,22 +646,17 @@ String functionName(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, const
                 // Lastly, try type-specific properties.
                 if (jstype == JSC::JSFunctionType) {
                     auto* function = uncheckedDowncast<JSC::JSFunction>(object);
-                    if (function) {
-                        auto str = function->nameWithoutGC(vm);
-                        if (str.isEmpty() && !function->isHostFunction()) {
-                            setTypeFlagsIfNecessary();
-                            return function->jsExecutable()->ecmaName().string();
-                        }
+                    auto str = function->nameWithoutGC(vm);
+                    if (str.isEmpty() && !function->isHostFunction()) {
                         setTypeFlagsIfNecessary();
-                        return str;
+                        return function->jsExecutable()->ecmaName().string();
                     }
+                    setTypeFlagsIfNecessary();
+                    return str;
                 } else if (jstype == JSC::InternalFunctionType) {
-                    auto* function = uncheckedDowncast<JSC::InternalFunction>(object);
-                    if (function) {
-                        auto str = function->name();
-                        setTypeFlagsIfNecessary();
-                        return str;
-                    }
+                    auto str = uncheckedDowncast<JSC::InternalFunction>(object)->name();
+                    setTypeFlagsIfNecessary();
+                    return str;
                 }
             }
         }

--- a/src/jsc/bindings/ErrorStackTrace.cpp
+++ b/src/jsc/bindings/ErrorStackTrace.cpp
@@ -521,12 +521,7 @@ String sourceURL(JSC::VM& vm, JSC::JSFunction* function)
         return String();
     }
 
-    auto* jsExecutable = function->jsExecutable();
-    if (!jsExecutable) {
-        return String();
-    }
-
-    return Zig::sourceURL(jsExecutable->source());
+    return Zig::sourceURL(function->jsExecutable()->source());
 }
 
 String functionName(JSC::VM& vm, JSC::CodeBlock* codeBlock)
@@ -539,12 +534,7 @@ String functionName(JSC::VM& vm, JSC::CodeBlock* codeBlock)
     }
 
     if (codeType == JSC::FunctionCode) {
-        auto* jsExecutable = uncheckedDowncast<JSC::FunctionExecutable>(executable);
-        if (!jsExecutable) {
-            return String();
-        }
-
-        return jsExecutable->ecmaName().string();
+        return uncheckedDowncast<JSC::FunctionExecutable>(executable)->ecmaName().string();
     }
 
     return String();

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -457,12 +457,10 @@ AsymmetricMatcherResult matchAsymmetricMatcherAndGetFlags(JSGlobalObject* global
                 if (otherString.find(substring) != WTF::notFound) {
                     return AsymmetricMatcherResult::PASS;
                 }
-            } else if (expectedTestValue.isCell() and expectedTestValue.asCell()->type() == RegExpObjectType) {
-                if (auto* regex = dynamicDowncast<RegExpObject>(expectedTestValue)) {
-                    JSString* otherString = otherProp.toString(globalObject);
-                    if (regex->match(globalObject, otherString)) {
-                        return AsymmetricMatcherResult::PASS;
-                    }
+            } else if (auto* regex = dynamicDowncast<RegExpObject>(expectedTestValue)) {
+                JSString* otherString = otherProp.toString(globalObject);
+                if (regex->match(globalObject, otherString)) {
+                    return AsymmetricMatcherResult::PASS;
                 }
             }
         }

--- a/src/jsc/bindings/node/crypto/CryptoUtil.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoUtil.cpp
@@ -677,11 +677,6 @@ JSC::JSArrayBufferView* getArrayBufferOrView(JSGlobalObject* globalObject, Throw
         return view;
     }
 
-    if (!value.isCell() || !JSC::isTypedArrayTypeIncludingDataView(value.asCell()->type())) {
-        ERR::INVALID_ARG_TYPE_INSTANCE(scope, globalObject, argName, "string"_s, "Buffer, TypedArray, or DataView"_s, value);
-        return {};
-    }
-
     auto* view = dynamicDowncast<JSC::JSArrayBufferView>(value);
     if (!view) {
         ERR::INVALID_ARG_TYPE_INSTANCE(scope, globalObject, argName, "string"_s, "Buffer, TypedArray, or DataView"_s, value);

--- a/src/jsc/bindings/node/crypto/JSCipherPrototype.cpp
+++ b/src/jsc/bindings/node/crypto/JSCipherPrototype.cpp
@@ -234,10 +234,6 @@ JSC_DEFINE_HOST_FUNCTION(jsCipherGetAuthTag, (JSC::JSGlobalObject * lexicalGloba
 
     JSC::JSUint8Array* buf = JSC::JSUint8Array::createUninitialized(lexicalGlobalObject, globalObject->JSBufferSubclassStructure(), *cipher->m_authTagLen);
     RETURN_IF_EXCEPTION(scope, {});
-    if (!buf) {
-        throwOutOfMemoryError(lexicalGlobalObject, scope);
-        return {};
-    }
 
     memcpy(buf->vector(), cipher->m_authTag, *cipher->m_authTagLen);
 

--- a/src/jsc/bindings/node/crypto/JSHash.cpp
+++ b/src/jsc/bindings/node/crypto/JSHash.cpp
@@ -329,9 +329,8 @@ JSC_DEFINE_HOST_FUNCTION(constructHash, (JSC::JSGlobalObject * globalObject, JSC
     JSHash* original = nullptr;
     const EVP_MD* md = nullptr;
     ExternZigHash::Hasher* zigHasher = nullptr;
-    if (algorithmOrHashInstanceValue.inherits(JSHash::info())) {
-        original = dynamicDowncast<JSHash>(algorithmOrHashInstanceValue);
-        if (!original || original->m_finalized) {
+    if ((original = dynamicDowncast<JSHash>(algorithmOrHashInstanceValue))) {
+        if (original->m_finalized) {
             return Bun::ERR::CRYPTO_HASH_FINALIZED(scope, globalObject);
         }
 

--- a/src/jsc/bindings/node/crypto/JSKeyObjectConstructor.cpp
+++ b/src/jsc/bindings/node/crypto/JSKeyObjectConstructor.cpp
@@ -113,7 +113,6 @@ JSC_DEFINE_HOST_FUNCTION(jsKeyObjectConstructor_from, (JSGlobalObject * lexicalG
     if (keyObjectResult.hasException()) [[unlikely]] {
         WebCore::propagateException(*lexicalGlobalObject, scope, keyObjectResult.releaseException());
         RELEASE_AND_RETURN(scope, {});
-        return {};
     }
 
     // 2. Determine Key Type and Extract Material

--- a/src/jsc/bindings/node/crypto/JSSign.cpp
+++ b/src/jsc/bindings/node/crypto/JSSign.cpp
@@ -287,20 +287,15 @@ JSC_DEFINE_HOST_FUNCTION(jsSignProtoFuncUpdate, (JSC::JSGlobalObject * globalObj
         return JSValue::encode(wrappedSign);
     }
 
-    if (!data.isCell() || !JSC::isTypedArrayTypeIncludingDataView(data.asCell()->type())) {
+    auto* view = dynamicDowncast<JSC::JSArrayBufferView>(data);
+    if (!view) {
         return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "data"_s, "string or an instance of Buffer, TypedArray, or DataView"_s, data);
     }
 
-    // Handle ArrayBufferView input
-    if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(data)) {
+    updateWithBufferView(globalObject, thisObject, view);
+    RETURN_IF_EXCEPTION(scope, {});
 
-        updateWithBufferView(globalObject, thisObject, view);
-        RETURN_IF_EXCEPTION(scope, {});
-
-        return JSValue::encode(wrappedSign);
-    }
-
-    return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "data"_s, "string or an instance of Buffer, TypedArray, or DataView"_s, data);
+    return JSValue::encode(wrappedSign);
 }
 
 JSUint8Array* signWithKey(JSC::JSGlobalObject* lexicalGlobalObject, JSSign* thisObject, const ncrypto::EVPKeyPointer& pkey, DSASigEnc dsa_sig_enc, int padding, std::optional<int> salt_len)

--- a/src/jsc/bindings/node/crypto/JSVerify.cpp
+++ b/src/jsc/bindings/node/crypto/JSVerify.cpp
@@ -284,32 +284,28 @@ JSC_DEFINE_HOST_FUNCTION(jsVerifyProtoFuncUpdate, (JSGlobalObject * globalObject
         return JSValue::encode(wrappedVerify);
     }
 
-    if (!data.isCell() || !JSC::isTypedArrayTypeIncludingDataView(data.asCell()->type())) {
+    auto* view = dynamicDowncast<JSC::JSArrayBufferView>(data);
+    if (!view) {
         return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "data"_s, "string or an instance of Buffer, TypedArray, or DataView"_s, data);
     }
 
-    // Handle ArrayBufferView input
-    if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(data)) {
-        size_t byteLength = view->byteLength();
-        if (byteLength > INT_MAX) {
-            throwRangeError(globalObject, scope, "data is too long"_s);
-            return {};
-        }
-
-        auto buffer = ncrypto::Buffer<const void> {
-            .data = view->vector(),
-            .len = byteLength,
-        };
-
-        if (!thisObject->m_mdCtx.digestUpdate(buffer)) {
-            throwCryptoError(globalObject, scope, ERR_get_error(), "Failed to update digest");
-            return {};
-        }
-
-        return JSValue::encode(wrappedVerify);
+    size_t byteLength = view->byteLength();
+    if (byteLength > INT_MAX) {
+        throwRangeError(globalObject, scope, "data is too long"_s);
+        return {};
     }
 
-    return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "data"_s, "string or an instance of Buffer, TypedArray, or DataView"_s, data);
+    auto buffer = ncrypto::Buffer<const void> {
+        .data = view->vector(),
+        .len = byteLength,
+    };
+
+    if (!thisObject->m_mdCtx.digestUpdate(buffer)) {
+        throwCryptoError(globalObject, scope, ERR_get_error(), "Failed to update digest");
+        return {};
+    }
+
+    return JSValue::encode(wrappedVerify);
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsVerifyProtoFuncVerify, (JSGlobalObject * globalObject, CallFrame* callFrame))

--- a/src/jsc/bindings/webcore/JSCookie.cpp
+++ b/src/jsc/bindings/webcore/JSCookie.cpp
@@ -101,115 +101,114 @@ static std::optional<CookieInit> cookieInitFromJS(JSC::VM& vm, JSGlobalObject* l
     auto& names = builtinNames(vm);
 
     if (!options.isUndefinedOrNull()) {
-        if (!options.isObject()) {
+        auto* optionsObj = options.getObject();
+        if (!optionsObj) {
             throwVMTypeError(lexicalGlobalObject, throwScope, "Options must be an object"_s);
             return std::nullopt;
         }
 
-        if (auto* optionsObj = options.getObject()) {
-            if (checkName) {
-                auto nameValue = optionsObj->getIfPropertyExists(lexicalGlobalObject, vm.propertyNames->name);
-                RETURN_IF_EXCEPTION(throwScope, std::nullopt);
-                if (nameValue) {
-                    name = convert<IDLUSVString>(*lexicalGlobalObject, nameValue);
-                    RETURN_IF_EXCEPTION(throwScope, std::nullopt);
-                }
-
-                if (name.isEmpty()) {
-                    throwVMTypeError(lexicalGlobalObject, throwScope, "name is required"_s);
-                    return std::nullopt;
-                }
-
-                auto valueValue = optionsObj->getIfPropertyExists(lexicalGlobalObject, vm.propertyNames->value);
-                RETURN_IF_EXCEPTION(throwScope, std::nullopt);
-                if (valueValue) {
-                    value = convert<IDLUSVString>(*lexicalGlobalObject, valueValue);
-                    RETURN_IF_EXCEPTION(throwScope, std::nullopt);
-                }
-            }
-
-            // domain
-            auto domainValue = optionsObj->getIfPropertyExists(lexicalGlobalObject, names.domainPublicName());
+        if (checkName) {
+            auto nameValue = optionsObj->getIfPropertyExists(lexicalGlobalObject, vm.propertyNames->name);
             RETURN_IF_EXCEPTION(throwScope, std::nullopt);
-            if (domainValue) {
-                if (!domainValue.isUndefined() && !domainValue.isNull()) {
-                    domain = convert<IDLUSVString>(*lexicalGlobalObject, domainValue);
-                    RETURN_IF_EXCEPTION(throwScope, std::nullopt);
-                }
-            }
-
-            // path
-            auto pathValue = optionsObj->getIfPropertyExists(lexicalGlobalObject, names.pathPublicName());
-            RETURN_IF_EXCEPTION(throwScope, std::nullopt);
-            if (pathValue) {
-                if (!pathValue.isUndefined() && !pathValue.isNull()) {
-                    path = convert<IDLUSVString>(*lexicalGlobalObject, pathValue);
-                    RETURN_IF_EXCEPTION(throwScope, std::nullopt);
-                }
-            }
-
-            // expires
-            auto expiresValue = optionsObj->getIfPropertyExists(lexicalGlobalObject, names.expiresPublicName());
-            RETURN_IF_EXCEPTION(throwScope, std::nullopt);
-            if (expiresValue) {
-                expires = getExpiresValue(lexicalGlobalObject, throwScope, expiresValue);
+            if (nameValue) {
+                name = convert<IDLUSVString>(*lexicalGlobalObject, nameValue);
                 RETURN_IF_EXCEPTION(throwScope, std::nullopt);
             }
 
-            // maxAge
-            auto maxAgeValue = optionsObj->getIfPropertyExists(lexicalGlobalObject, names.maxAgePublicName());
-            RETURN_IF_EXCEPTION(throwScope, std::nullopt);
-            if (maxAgeValue) {
-                if (!maxAgeValue.isUndefined() && !maxAgeValue.isNull() && maxAgeValue.isNumber()) {
-                    maxAge = maxAgeValue.asNumber();
-                }
+            if (name.isEmpty()) {
+                throwVMTypeError(lexicalGlobalObject, throwScope, "name is required"_s);
+                return std::nullopt;
             }
 
-            // secure
-            auto secureValue = optionsObj->getIfPropertyExists(lexicalGlobalObject, names.securePublicName());
+            auto valueValue = optionsObj->getIfPropertyExists(lexicalGlobalObject, vm.propertyNames->value);
             RETURN_IF_EXCEPTION(throwScope, std::nullopt);
-            if (secureValue) {
-                if (!secureValue.isUndefined()) {
-                    secure = secureValue.toBoolean(lexicalGlobalObject);
-                }
+            if (valueValue) {
+                value = convert<IDLUSVString>(*lexicalGlobalObject, valueValue);
+                RETURN_IF_EXCEPTION(throwScope, std::nullopt);
             }
+        }
 
-            // httpOnly
-            auto httpOnlyValue = optionsObj->getIfPropertyExists(lexicalGlobalObject, names.httpOnlyPublicName());
-            RETURN_IF_EXCEPTION(throwScope, std::nullopt);
-            if (httpOnlyValue) {
-                if (!httpOnlyValue.isUndefined()) {
-                    httpOnly = httpOnlyValue.toBoolean(lexicalGlobalObject);
-                }
+        // domain
+        auto domainValue = optionsObj->getIfPropertyExists(lexicalGlobalObject, names.domainPublicName());
+        RETURN_IF_EXCEPTION(throwScope, std::nullopt);
+        if (domainValue) {
+            if (!domainValue.isUndefined() && !domainValue.isNull()) {
+                domain = convert<IDLUSVString>(*lexicalGlobalObject, domainValue);
+                RETURN_IF_EXCEPTION(throwScope, std::nullopt);
             }
+        }
 
-            // partitioned
-            auto partitionedValue = optionsObj->getIfPropertyExists(lexicalGlobalObject, names.partitionedPublicName());
-            RETURN_IF_EXCEPTION(throwScope, std::nullopt);
-            if (partitionedValue) {
-                if (!partitionedValue.isUndefined()) {
-                    partitioned = partitionedValue.toBoolean(lexicalGlobalObject);
-                }
+        // path
+        auto pathValue = optionsObj->getIfPropertyExists(lexicalGlobalObject, names.pathPublicName());
+        RETURN_IF_EXCEPTION(throwScope, std::nullopt);
+        if (pathValue) {
+            if (!pathValue.isUndefined() && !pathValue.isNull()) {
+                path = convert<IDLUSVString>(*lexicalGlobalObject, pathValue);
+                RETURN_IF_EXCEPTION(throwScope, std::nullopt);
             }
+        }
 
-            // sameSite
-            auto sameSiteValue = optionsObj->getIfPropertyExists(lexicalGlobalObject, names.sameSitePublicName());
+        // expires
+        auto expiresValue = optionsObj->getIfPropertyExists(lexicalGlobalObject, names.expiresPublicName());
+        RETURN_IF_EXCEPTION(throwScope, std::nullopt);
+        if (expiresValue) {
+            expires = getExpiresValue(lexicalGlobalObject, throwScope, expiresValue);
             RETURN_IF_EXCEPTION(throwScope, std::nullopt);
-            if (sameSiteValue) {
-                if (!sameSiteValue.isUndefined() && !sameSiteValue.isNull()) {
-                    String sameSiteStr = convert<IDLUSVString>(*lexicalGlobalObject, sameSiteValue);
-                    RETURN_IF_EXCEPTION(throwScope, std::nullopt);
+        }
 
-                    if (sameSiteStr == "strict"_s)
-                        sameSite = CookieSameSite::Strict;
-                    else if (sameSiteStr == "lax"_s)
-                        sameSite = CookieSameSite::Lax;
-                    else if (sameSiteStr == "none"_s)
-                        sameSite = CookieSameSite::None;
-                    else
-                        throwVMTypeError(lexicalGlobalObject, throwScope, "Invalid sameSite value. Must be 'strict', 'lax', or 'none'"_s);
-                    RETURN_IF_EXCEPTION(throwScope, std::nullopt);
-                }
+        // maxAge
+        auto maxAgeValue = optionsObj->getIfPropertyExists(lexicalGlobalObject, names.maxAgePublicName());
+        RETURN_IF_EXCEPTION(throwScope, std::nullopt);
+        if (maxAgeValue) {
+            if (!maxAgeValue.isUndefined() && !maxAgeValue.isNull() && maxAgeValue.isNumber()) {
+                maxAge = maxAgeValue.asNumber();
+            }
+        }
+
+        // secure
+        auto secureValue = optionsObj->getIfPropertyExists(lexicalGlobalObject, names.securePublicName());
+        RETURN_IF_EXCEPTION(throwScope, std::nullopt);
+        if (secureValue) {
+            if (!secureValue.isUndefined()) {
+                secure = secureValue.toBoolean(lexicalGlobalObject);
+            }
+        }
+
+        // httpOnly
+        auto httpOnlyValue = optionsObj->getIfPropertyExists(lexicalGlobalObject, names.httpOnlyPublicName());
+        RETURN_IF_EXCEPTION(throwScope, std::nullopt);
+        if (httpOnlyValue) {
+            if (!httpOnlyValue.isUndefined()) {
+                httpOnly = httpOnlyValue.toBoolean(lexicalGlobalObject);
+            }
+        }
+
+        // partitioned
+        auto partitionedValue = optionsObj->getIfPropertyExists(lexicalGlobalObject, names.partitionedPublicName());
+        RETURN_IF_EXCEPTION(throwScope, std::nullopt);
+        if (partitionedValue) {
+            if (!partitionedValue.isUndefined()) {
+                partitioned = partitionedValue.toBoolean(lexicalGlobalObject);
+            }
+        }
+
+        // sameSite
+        auto sameSiteValue = optionsObj->getIfPropertyExists(lexicalGlobalObject, names.sameSitePublicName());
+        RETURN_IF_EXCEPTION(throwScope, std::nullopt);
+        if (sameSiteValue) {
+            if (!sameSiteValue.isUndefined() && !sameSiteValue.isNull()) {
+                String sameSiteStr = convert<IDLUSVString>(*lexicalGlobalObject, sameSiteValue);
+                RETURN_IF_EXCEPTION(throwScope, std::nullopt);
+
+                if (sameSiteStr == "strict"_s)
+                    sameSite = CookieSameSite::Strict;
+                else if (sameSiteStr == "lax"_s)
+                    sameSite = CookieSameSite::Lax;
+                else if (sameSiteStr == "none"_s)
+                    sameSite = CookieSameSite::None;
+                else
+                    throwVMTypeError(lexicalGlobalObject, throwScope, "Invalid sameSite value. Must be 'strict', 'lax', or 'none'"_s);
+                RETURN_IF_EXCEPTION(throwScope, std::nullopt);
             }
         }
     }

--- a/src/jsc/bindings/webcore/JSMIMEParams.cpp
+++ b/src/jsc/bindings/webcore/JSMIMEParams.cpp
@@ -519,13 +519,7 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMEParamsProtoFuncToString, (JSGlobalObject * global
     StringBuilder builder;
     bool first = true;
 
-    JSValue iteratorValue = JSMapIterator::create(vm, globalObject->mapIteratorStructure(), map, IterationKind::Entries);
-    RETURN_IF_EXCEPTION(scope, encodedJSValue());
-    JSMapIterator* iterator = dynamicDowncast<JSMapIterator>(iteratorValue);
-    if (!iterator) { // Should not happen for JSMap.entries()
-        scope.release();
-        return Bun::ERR::INVALID_MIME_SYNTAX(scope, globalObject, "Internal error: Expected MapIterator"_s, "toString"_s, -1);
-    }
+    JSMapIterator* iterator = JSMapIterator::create(vm, globalObject->mapIteratorStructure(), map, IterationKind::Entries);
 
     while (true) {
         JSValue nextValue;

--- a/src/jsc/bindings/webcore/JSWebSocket.cpp
+++ b/src/jsc/bindings/webcore/JSWebSocket.cpp
@@ -260,12 +260,11 @@ static inline JSC::EncodedJSValue constructJSWebSocket3(JSGlobalObject* lexicalG
         RETURN_IF_EXCEPTION(throwScope, {});
         if (tlsOptionsValue && !tlsOptionsValue.isUndefinedOrNull() && tlsOptionsValue.isObject()) {
             // Also extract rejectUnauthorized for backwards compatibility
-            if (JSC::JSObject* tlsOptions = tlsOptionsValue.getObject()) {
-                auto rejectUnauthorizedValue = Bun::getOwnPropertyIfExists(globalObject, tlsOptions, PropertyName(Identifier::fromString(vm, "rejectUnauthorized"_s)));
-                RETURN_IF_EXCEPTION(throwScope, {});
-                if (rejectUnauthorizedValue && !rejectUnauthorizedValue.isUndefinedOrNull() && rejectUnauthorizedValue.isBoolean()) {
-                    rejectUnauthorized = rejectUnauthorizedValue.asBoolean() ? 1 : 0;
-                }
+            JSC::JSObject* tlsOptions = tlsOptionsValue.getObject();
+            auto rejectUnauthorizedValue = Bun::getOwnPropertyIfExists(globalObject, tlsOptions, PropertyName(Identifier::fromString(vm, "rejectUnauthorized"_s)));
+            RETURN_IF_EXCEPTION(throwScope, {});
+            if (rejectUnauthorizedValue && !rejectUnauthorizedValue.isUndefinedOrNull() && rejectUnauthorizedValue.isBoolean()) {
+                rejectUnauthorized = rejectUnauthorizedValue.asBoolean() ? 1 : 0;
             }
 
             // Parse full TLS options using the native SSLConfig parser
@@ -298,32 +297,31 @@ static inline JSC::EncodedJSValue constructJSWebSocket3(JSGlobalObject* lexicalG
                     proxyUrl = domUrl->wrapped().href().string();
                 } else if (proxyValue.isObject()) {
                     // proxy: { url: "http://proxy:8080", headers: {...} }
-                    if (JSC::JSObject* proxyOptions = proxyValue.getObject()) {
-                        auto proxyUrlValue = Bun::getOwnPropertyIfExists(globalObject, proxyOptions, PropertyName(Identifier::fromString(vm, "url"_s)));
+                    JSC::JSObject* proxyOptions = proxyValue.getObject();
+                    auto proxyUrlValue = Bun::getOwnPropertyIfExists(globalObject, proxyOptions, PropertyName(Identifier::fromString(vm, "url"_s)));
+                    RETURN_IF_EXCEPTION(throwScope, {});
+                    if (proxyUrlValue && !proxyUrlValue.isUndefinedOrNull()) {
+                        proxyUrl = convert<IDLUSVString>(*lexicalGlobalObject, proxyUrlValue);
                         RETURN_IF_EXCEPTION(throwScope, {});
-                        if (proxyUrlValue && !proxyUrlValue.isUndefinedOrNull()) {
-                            proxyUrl = convert<IDLUSVString>(*lexicalGlobalObject, proxyUrlValue);
-                            RETURN_IF_EXCEPTION(throwScope, {});
-                        }
+                    }
 
-                        auto proxyHeadersValue = Bun::getOwnPropertyIfExists(globalObject, proxyOptions, builtinnames.headersPublicName());
-                        RETURN_IF_EXCEPTION(throwScope, {});
-                        if (proxyHeadersValue && !proxyHeadersValue.isUndefinedOrNull()) {
-                            // Check if it's already a Headers instance (like fetch does)
-                            if (auto* jsHeaders = dynamicDowncast<JSFetchHeaders>(proxyHeadersValue)) {
-                                // Convert FetchHeaders to the Init variant
-                                auto& headers = jsHeaders->wrapped();
-                                Vector<KeyValuePair<String, String>> pairs;
-                                auto iterator = headers.createIterator(false);
-                                while (auto value = iterator.next()) {
-                                    pairs.append({ value->key, value->value });
-                                }
-                                proxyHeadersInit = WTF::move(pairs);
-                            } else {
-                                // Fall back to IDL conversion for plain objects/arrays
-                                proxyHeadersInit = convert<IDLUnion<IDLSequence<IDLSequence<IDLByteString>>, IDLRecord<IDLByteString, IDLByteString>>>(*lexicalGlobalObject, proxyHeadersValue);
-                                RETURN_IF_EXCEPTION(throwScope, {});
+                    auto proxyHeadersValue = Bun::getOwnPropertyIfExists(globalObject, proxyOptions, builtinnames.headersPublicName());
+                    RETURN_IF_EXCEPTION(throwScope, {});
+                    if (proxyHeadersValue && !proxyHeadersValue.isUndefinedOrNull()) {
+                        // Check if it's already a Headers instance (like fetch does)
+                        if (auto* jsHeaders = dynamicDowncast<JSFetchHeaders>(proxyHeadersValue)) {
+                            // Convert FetchHeaders to the Init variant
+                            auto& headers = jsHeaders->wrapped();
+                            Vector<KeyValuePair<String, String>> pairs;
+                            auto iterator = headers.createIterator(false);
+                            while (auto value = iterator.next()) {
+                                pairs.append({ value->key, value->value });
                             }
+                            proxyHeadersInit = WTF::move(pairs);
+                        } else {
+                            // Fall back to IDL conversion for plain objects/arrays
+                            proxyHeadersInit = convert<IDLUnion<IDLSequence<IDLSequence<IDLByteString>>, IDLRecord<IDLByteString, IDLByteString>>>(*lexicalGlobalObject, proxyHeadersValue);
+                            RETURN_IF_EXCEPTION(throwScope, {});
                         }
                     }
                 }


### PR DESCRIPTION
Removes seventeen redundant defensive checks in `src/jsc/bindings/` where a prior guard already proves the condition. Each removed branch is provably dead per the relevant JSC header; no observable behavior changes. Review with [`?w=1`](../../pull/34799/files?w=1) recommended since several sites (`JSCookie.cpp`, `JSWebSocket.cpp`, `JSVerify.cpp`, `JSSign.cpp`) lose an indent level.

## `getObject()` null-checked after `isObject()`

[`JSCell::getObject`](https://github.com/oven-sh/WebKit/blob/main/Source/JavaScriptCore/runtime/JSCell.cpp#L86-L89) is `return isObject() ? asObject(this) : nullptr;`, so after an `isObject()` guard the result is always non-null.

- `JSCookie.cpp` `cookieInitFromJS`: folded `!options.isObject()` / `if (auto* optionsObj = options.getObject())` into a single `getObject()` + null check
- `JSWebSocket.cpp` `constructJSWebSocket3`: `tls` and `proxy` option objects

## `JSType` / `inherits` check then null-checked `dynamicDowncast` of the same value

`jsDynamicCast<T*>` tests the same predicate as the preceding check, so the cast cannot fail.

- `bindings.cpp` `matchAsymmetricMatcherAndGetFlags`: `asCell()->type() == RegExpObjectType` then `dynamicDowncast<RegExpObject>`. `RegExpObject` is `final` with `JSTypeRange` `[RegExpObjectType, RegExpObjectType]` ([JSCast.h](https://github.com/oven-sh/WebKit/blob/main/Source/JavaScriptCore/runtime/JSCast.h)). Collapsed to a single `dynamicDowncast` in the `else if`.
- `JSHash.cpp` `constructHash`: `inherits(JSHash::info())` then `dynamicDowncast<JSHash>`; both walk the same `ClassInfo` chain. Collapsed to a single `dynamicDowncast`.
- `JSVerify.cpp` `jsVerifyProtoFuncUpdate`, `JSSign.cpp` `jsSignProtoFuncUpdate`, `CryptoUtil.cpp` `getArrayBufferOrView`: `isTypedArrayTypeIncludingDataView(type())` then `dynamicDowncast<JSArrayBufferView>`; `JSArrayBufferView`'s `JSTypeRange` is exactly `[FirstTypedArrayType, LastTypedArrayType]` = `[Int8ArrayType, DataViewType]`. Collapsed to a single `dynamicDowncast` and dropped the now-unreachable duplicate `ERR_INVALID_ARG_TYPE`.
- `JSMIMEParams.cpp` `jsMIMEParamsProtoFuncToString`: [`JSMapIterator::create`](https://github.com/oven-sh/WebKit/blob/main/Source/JavaScriptCore/runtime/JSMapIterator.h) is `new (NotNull, allocateCell<...>) ...`, never null, and takes `VM&` so cannot throw. Dropped the `JSValue` round-trip, `dynamicDowncast`, null check, and `RETURN_IF_EXCEPTION`.

## `uncheckedDowncast` / `static_cast` of a known-nonnull pointer

`uncheckedDowncast` is a [`static_cast`](https://github.com/oven-sh/WebKit/blob/main/Source/WTF/wtf/TypeCasts.h), so a non-null input yields a non-null result.

- `ErrorStackTrace.cpp` `sourceURL(VM&, JSFunction*)`: [`jsExecutable()`](https://github.com/oven-sh/WebKit/blob/main/Source/JavaScriptCore/runtime/JSFunctionInlines.h) is `static_cast<FunctionExecutable*>(executable())`; `executable()` was proven non-null three lines up.
- `ErrorStackTrace.cpp` `functionName(VM&, CodeBlock*)`: `executable` null-checked immediately before `uncheckedDowncast<FunctionExecutable>`.
- `ErrorStackTrace.cpp` `functionName(VM&, JSGlobalObject*, JSObject*)` and the `MustNotTriggerGC` branch of the `StackFrame` overload: `object` is dereferenced at entry / bound by `if (auto* object = ...)`, then `uncheckedDowncast<JSFunction>` / `uncheckedDowncast<InternalFunction>` null-checked.

## Other

- `JSCipherPrototype.cpp` `jsCipherGetAuthTag`: [`createUninitialized`](https://github.com/oven-sh/WebKit/blob/main/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h) returns `nullptr` only after `throwOutOfMemoryError`, so `RETURN_IF_EXCEPTION` on the preceding line has already returned.
- `JSKeyObjectConstructor.cpp` `jsKeyObjectConstructor_from`: `return {};` after `RELEASE_AND_RETURN(scope, {})`, which [expands to `scope.release(); return ...;`](https://github.com/oven-sh/WebKit/blob/main/Source/JavaScriptCore/runtime/ExceptionScope.h).

## Verification

Built and verified with `BUN_JSC_validateExceptionChecks=1` against the happy and error paths for every touched function, plus the existing test suites for `Bun.Cookie`, `node:util` MIME, `node:crypto`, `expect.stringMatching`, and `Error.captureStackTrace`.

No new tests: the removed branches cannot execute on any input, so there is no behavior difference for a test to observe.
