### PR TITLE
install: drop back-to-back identical predicate and dead bounds checks

### DIFF
--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -624,9 +624,7 @@ pub fn install_with_manager(
 
     if manager.lockfile.packages.len() > 0 {
         root = *manager.lockfile.packages.get(0);
-    }
 
-    if manager.lockfile.packages.len() > 0 {
         for request in &manager.update_requests {
             // prevent redundant errors
             if request.failed {

--- a/src/install/yarn.rs
+++ b/src/install/yarn.rs
@@ -154,29 +154,13 @@ impl<'a> Entry<'a> {
             }
             return None;
         } else if let Some(url_idx) = strings::index_of(unquoted, b"@https://") {
-            let after_at = url_idx + 1;
-            if after_at < unquoted.len() {
-                return Some(&unquoted[after_at..]);
-            }
-            return None;
+            return Some(&unquoted[url_idx + 1..]);
         } else if let Some(git_idx) = strings::index_of(unquoted, b"@git+") {
-            let after_at = git_idx + 1;
-            if after_at < unquoted.len() {
-                return Some(&unquoted[after_at..]);
-            }
-            return None;
+            return Some(&unquoted[git_idx + 1..]);
         } else if let Some(gh_idx) = strings::index_of(unquoted, b"@github:") {
-            let after_at = gh_idx + 1;
-            if after_at < unquoted.len() {
-                return Some(&unquoted[after_at..]);
-            }
-            return None;
+            return Some(&unquoted[gh_idx + 1..]);
         } else if let Some(file_idx) = strings::index_of(unquoted, b"@file:") {
-            let after_at = file_idx + 1;
-            if after_at < unquoted.len() {
-                return Some(&unquoted[after_at..]);
-            }
-            return None;
+            return Some(&unquoted[file_idx + 1..]);
         } else if let Some(idx) = strings::index_of(unquoted, b"@") {
             let after_at = idx + 1;
             if after_at < unquoted.len() {


### PR DESCRIPTION
Two pieces of porting cruft carried over unchanged from the pre-rewrite Zig sources.

### `install_with_manager.rs`

```rust
if manager.lockfile.packages.len() > 0 {
    root = *manager.lockfile.packages.get(0);
}

if manager.lockfile.packages.len() > 0 {
    ...
}
```

`MultiArrayList::get` takes `&self` and returns `ManuallyDrop<T>`; nothing between the two predicates can change `packages.len()`. Merged into one block.

### `yarn.rs` `get_version_from_spec`

```rust
} else if let Some(url_idx) = strings::index_of(unquoted, b"@https://") {
    let after_at = url_idx + 1;
    if after_at < unquoted.len() {
        return Some(&unquoted[after_at..]);
    }
    return None;
}
```

When `strings::index_of` returns `Some(idx)` the match lies entirely inside the haystack, so `idx + needle.len() <= haystack.len()`. For the `@https://` (9), `@git+` (5), `@github:` (8) and `@file:` (6) branches the `idx + 1 < len` guard is therefore always true and the `return None` is unreachable. The `@npm:` branch (offset is `idx + 5`, needle is 5 bytes) and the bare-`@` branch (offset is `idx + 1`, needle is 1 byte) can legitimately reach the end of the input when the version part is empty, so their guards stay.

No behavior change. `cargo check -p bun_install` clean; `bun bd` links; existing `test/cli/install/migration/yarn-lock-migration.test.ts` and `test/cli/install/bun-install-cpu-os.test.ts` pass.