### PR TITLE
standalone_graph: treat embedded bytecode as read-only

### DIFF
--- a/src/jsc/ResolvedSource.rs
+++ b/src/jsc/ResolvedSource.rs
@@ -43,7 +43,7 @@ pub struct ResolvedSource {
     pub already_bundled: bool,
 
     // -- Bytecode cache fields --
-    pub bytecode_cache: *mut u8,
+    pub bytecode_cache: *const u8,
     pub bytecode_cache_size: usize,
     pub module_info: *mut c_void,
     /// The file path used as the source origin for bytecode cache validation.
@@ -66,7 +66,7 @@ impl Default for ResolvedSource {
             tag: Tag::Javascript,
             source_code_needs_deref: true,
             already_bundled: false,
-            bytecode_cache: core::ptr::null_mut(),
+            bytecode_cache: core::ptr::null(),
             bytecode_cache_size: 0,
             module_info: core::ptr::null_mut(),
             bytecode_origin_path: BunString::empty(),

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -1028,7 +1028,10 @@ impl TranspilerJob {
                     if len == 0 {
                         (ptr::null(), 0)
                     } else {
-                        (bun_core::heap::into_raw(bytes).cast::<u8>().cast_const(), len)
+                        (
+                            bun_core::heap::into_raw(bytes).cast::<u8>().cast_const(),
+                            len,
+                        )
                     }
                 }
                 _ => (ptr::null(), 0),

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -1026,12 +1026,12 @@ impl TranspilerJob {
                 AlreadyBundled::Bytecode(bytes) | AlreadyBundled::BytecodeCjs(bytes) => {
                     let len = bytes.len();
                     if len == 0 {
-                        (ptr::null_mut(), 0)
+                        (ptr::null(), 0)
                     } else {
-                        (bun_core::heap::into_raw(bytes).cast::<u8>(), len)
+                        (bun_core::heap::into_raw(bytes).cast::<u8>().cast_const(), len)
                     }
                 }
-                _ => (ptr::null_mut(), 0),
+                _ => (ptr::null(), 0),
             };
             self.resolved_source = OwnedResolvedSource::from(ResolvedSource {
                 source_code: String::clone_latin1(&parse_result.source.contents),

--- a/src/jsc/bindings/ZigSourceProvider.cpp
+++ b/src/jsc/bindings/ZigSourceProvider.cpp
@@ -128,7 +128,9 @@ Ref<SourceProvider> SourceProvider::create(
 
             auto origin = getSourceOrigin();
 
-            Ref<JSC::CachedBytecode> bytecode = JSC::CachedBytecode::create(std::span<uint8_t>(resolvedSource.bytecode_cache, resolvedSource.bytecode_cache_size), destructor, {});
+            // CachedBytecode::create takes span<uint8_t> but JSC only ever reads it
+            // (span() returns span<const uint8_t>; Decoder caches into a side map).
+            Ref<JSC::CachedBytecode> bytecode = JSC::CachedBytecode::create(std::span<uint8_t>(const_cast<uint8_t*>(resolvedSource.bytecode_cache), resolvedSource.bytecode_cache_size), destructor, {});
             auto provider = adoptRef(*new SourceProvider(
                 globalObject->bunVM(),
                 resolvedSource,

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -128,7 +128,7 @@ typedef struct ResolvedSource {
     bool needsDeref;
     bool already_bundled;
     // -- Bytecode cache fields --
-    uint8_t* bytecode_cache;
+    const uint8_t* bytecode_cache;
     size_t bytecode_cache_size;
     void* module_info;
     // File path used as source origin for bytecode cache validation.

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2750,13 +2750,13 @@ fn transpile_source_code_inner(
                         AlreadyBundled::Bytecode(bytes) | AlreadyBundled::BytecodeCjs(bytes) => {
                             let len = bytes.len();
                             if len == 0 {
-                                (core::ptr::null_mut(), 0)
+                                (core::ptr::null(), 0)
                             } else {
                                 // C++ side becomes the owner.
-                                (bun_core::heap::into_raw(bytes).cast::<u8>(), len)
+                                (bun_core::heap::into_raw(bytes).cast::<u8>().cast_const(), len)
                             }
                         }
-                        _ => (core::ptr::null_mut(), 0),
+                        _ => (core::ptr::null(), 0),
                     };
                     return Ok(OwnedResolvedSource::from(ResolvedSource {
                         source_code: bun_core::String::clone_latin1(&source.contents),
@@ -3768,14 +3768,14 @@ export default db;
                     },
                     source_code_needs_deref: false,
                     bytecode_cache: if bytecode_len > 0 {
-                        file.bytecode.cast::<u8>()
+                        file.bytecode.as_ptr()
                     } else {
-                        core::ptr::null_mut()
+                        core::ptr::null()
                     },
                     bytecode_cache_size: bytecode_len,
                     module_info: if module_info_len > 0 {
                         bun_bundler::analyze_transpiled_module::ModuleInfoDeserialized
-                            ::create_from_cached_record(&*file.module_info)
+                            ::create_from_cached_record(file.module_info)
                             .map(bun_core::heap::into_raw)
                             .unwrap_or(core::ptr::null_mut())
                             .cast::<c_void>()

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2753,7 +2753,10 @@ fn transpile_source_code_inner(
                                 (core::ptr::null(), 0)
                             } else {
                                 // C++ side becomes the owner.
-                                (bun_core::heap::into_raw(bytes).cast::<u8>().cast_const(), len)
+                                (
+                                    bun_core::heap::into_raw(bytes).cast::<u8>().cast_const(),
+                                    len,
+                                )
                             }
                         }
                         _ => (core::ptr::null(), 0),

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -31,12 +31,8 @@ bun_opaque::opaque_ffi! {
 }
 
 pub struct StandaloneModuleGraph {
-    /// Raw view over the serialized graph (`[0, offsets.byte_count)`). Stored as a
-    /// raw fat pointer — NOT `&'static [u8]` — because `byte_count` covers the
-    /// bytecode/module_info subranges that JSC mutates in place via
-    /// `File.bytecode`. Holding a `&'static [u8]` over those bytes would freeze
-    /// them under Stacked/Tree Borrows and make the later foreign write UB.
-    pub bytes: *const [u8],
+    /// Immutable view over the serialized graph (`[0, offsets.byte_count)`).
+    pub bytes: &'static [u8],
     pub files: StringArrayHashMap<File>,
     pub entry_point_id: u32,
     pub compile_exec_argv: &'static [u8],
@@ -280,11 +276,8 @@ mod macho {
         pub(super) fn Bun__getStandaloneModuleGraphMachoLength() -> *mut u64; // possibly unaligned
     }
 
-    /// Returns `(base, len)` for the embedded `__BUN` section data. Kept as a
-    /// raw `*mut u8` so the FFI write-provenance is preserved end-to-end —
-    /// collapsing to `&[u8]` here would freeze it to read-only and make the
-    /// later `from_bytes` writable subslices UB under Stacked Borrows.
-    pub(super) fn get_data() -> Option<(*mut u8, usize)> {
+    /// Returns `(base, len)` for the embedded `__BUN` section data.
+    pub(super) fn get_data() -> Option<(*const u8, usize)> {
         // SAFETY: FFI call returns pointer to embedded section header or null.
         let length_ptr = unsafe { Bun__getStandaloneModuleGraphMachoLength() };
         if length_ptr.is_null() {
@@ -309,11 +302,8 @@ mod pe {
         Bun__getStandaloneModuleGraphPEData, Bun__getStandaloneModuleGraphPELength,
     };
 
-    /// Returns `(base, len)` for the embedded `.bun` PE section data. Kept as a
-    /// raw `*mut u8` so the FFI write-provenance is preserved end-to-end —
-    /// collapsing to `&[u8]` here would freeze it to read-only and make the
-    /// later `from_bytes` writable subslices UB under Stacked Borrows.
-    pub(super) fn get_data() -> Option<(*mut u8, usize)> {
+    /// Returns `(base, len)` for the embedded `.bun` PE section data.
+    pub(super) fn get_data() -> Option<(*const u8, usize)> {
         // SAFETY: FFI calls.
         let length = unsafe { Bun__getStandaloneModuleGraphPELength() };
         if length == 0 {
@@ -337,11 +327,8 @@ mod elf {
         pub(super) fn Bun__getStandaloneModuleGraphELFVaddr() -> *mut u64; // align(1)
     }
 
-    /// Returns `(base, len)` for the embedded ELF segment data. Kept as a raw
-    /// `*mut u8` so write-provenance is preserved end-to-end — collapsing to
-    /// `&[u8]` here would freeze it to read-only and make the later
-    /// `from_bytes` writable subslices UB under Stacked Borrows.
-    pub(super) fn get_data() -> Option<(*mut u8, usize)> {
+    /// Returns `(base, len)` for the embedded ELF segment data.
+    pub(super) fn get_data() -> Option<(*const u8, usize)> {
         // SAFETY: FFI call.
         let vaddr_ptr = unsafe { Bun__getStandaloneModuleGraphELFVaddr() };
         if vaddr_ptr.is_null() {
@@ -355,9 +342,7 @@ mod elf {
         // BUN_COMPILED.size holds the virtual address of the appended data.
         // The kernel mapped it via PT_LOAD, so we can dereference directly.
         // Format at target: [u64 payload_len][payload bytes]
-        // Synthesize a `*mut u8` directly so the provenance carries write
-        // permission for the in-place bytecode mutation done by JSC.
-        let target = vaddr as *mut u8;
+        let target = vaddr as *const u8;
         // SAFETY: target points to 8-byte little-endian length prefix.
         let payload_len =
             u64::from_le_bytes(unsafe { core::ptr::read_unaligned(target.cast::<[u8; 8]>()) });
@@ -377,9 +362,8 @@ pub struct File {
     pub cached_blob: Option<NonNull<Blob>>,
     pub encoding: Encoding,
     pub wtf_string: BunString,
-    // BACKREF into the embedded section; JSC mutates the bytecode buffer in place.
-    pub bytecode: *mut [u8],
-    pub module_info: *mut [u8],
+    pub bytecode: &'static [u8],
+    pub module_info: &'static [u8],
     /// The file path used when generating bytecode (e.g., "B:/~BUN/root/app.js").
     /// Must match exactly at runtime for bytecode cache hits.
     pub bytecode_origin_path: &'static [u8],
@@ -467,9 +451,8 @@ impl LazySourceMap {
                         .take(source_files_count)
                         .collect();
                 for i in 0..source_files_count {
-                    // SAFETY: `serialized.bytes` is a 'static read-only sourcemap subrange
-                    // (disjoint from bytecode); StringPointer offsets were serialized by
-                    // `to_bytes` and are in-bounds.
+                    // SAFETY: `serialized.bytes` is a 'static read-only sourcemap subrange;
+                    // StringPointer offsets were serialized by `to_bytes` and are in-bounds.
                     file_names.push(Box::from(unsafe {
                         slice_to(
                             serialized.bytes.as_ptr(),
@@ -531,13 +514,13 @@ const TRAILER: &[u8] = b"\n---- Bun! ----\n";
 
 impl StandaloneModuleGraph {
     fn from_bytes(
-        raw_ptr: *mut u8,
+        raw_ptr: *const u8,
         raw_len: usize,
         offsets: Offsets,
     ) -> crate::Result<StandaloneModuleGraph> {
         if raw_len == 0 {
             return Ok(StandaloneModuleGraph {
-                bytes: core::ptr::slice_from_raw_parts(NonNull::<u8>::dangling().as_ptr(), 0),
+                bytes: b"",
                 files: StringArrayHashMap::new(),
                 entry_point_id: 0,
                 compile_exec_argv: b"",
@@ -545,19 +528,9 @@ impl StandaloneModuleGraph {
             });
         }
 
-        // This function hands out read-only subslices
-        // (name/contents/sourcemap) AND writable subslices (bytecode/module_info, which JSC
-        // mutates in place) into the same allocation. We must not derive the writable
-        // ones from a `&[u8]` reborrow (writing through const-derived provenance is UB), and we
-        // must not hold a long-lived `&[u8]` that *spans* a writable subrange (a foreign write
-        // would invalidate it under Stacked/Tree Borrows). Keep `(raw_ptr, raw_len)` raw and
-        // derive every read-only `&'static [u8]` per-call over its own disjoint subrange only;
-        // the bytecode/module_info regions never have a shared reference formed over them.
-        let raw_const: *const u8 = raw_ptr;
-
-        // SAFETY: modules metadata blob is a read-only subrange of `[0, raw_len)` disjoint
-        // from bytecode/module_info, serialized by `to_bytes`.
-        let modules_list_bytes = unsafe { slice_to(raw_const, raw_len, offsets.modules_ptr) };
+        // SAFETY: modules metadata blob is a read-only subrange of `[0, raw_len)`,
+        // serialized by `to_bytes`.
+        let modules_list_bytes = unsafe { slice_to(raw_ptr, raw_len, offsets.modules_ptr) };
         // Note: the modules blob sits at an arbitrary byte offset in the section, and
         // `&[CompiledModuleGraphFile]` would require natural alignment (StringPointer's u32 fields
         // → 4-byte). We instead iterate by index and `read_unaligned` each fixed-size record into a
@@ -581,15 +554,14 @@ impl StandaloneModuleGraph {
                 )
             };
             let module = &module;
-            // SAFETY: each name/contents/sourcemap/bytecode_origin_path subrange is in-bounds
-            // (serialized by `to_bytes`) and disjoint from the writable bytecode/module_info
-            // subranges; section bytes are a live 'static allocation.
+            // SAFETY: each subrange is in-bounds (serialized by `to_bytes`);
+            // section bytes are a live 'static read-only allocation.
             let (name, contents, sourcemap_bytes, bytecode_origin) = unsafe {
                 (
-                    slice_to_z(raw_const, raw_len, module.name),
-                    slice_to_z(raw_const, raw_len, module.contents),
-                    slice_to(raw_const, raw_len, module.sourcemap),
-                    slice_to_z(raw_const, raw_len, module.bytecode_origin_path),
+                    slice_to_z(raw_ptr, raw_len, module.name),
+                    slice_to_z(raw_ptr, raw_len, module.contents),
+                    slice_to(raw_ptr, raw_len, module.sourcemap),
+                    slice_to_z(raw_ptr, raw_len, module.bytecode_origin_path),
                 )
             };
             let _ = modules.put(
@@ -608,21 +580,10 @@ impl StandaloneModuleGraph {
                     } else {
                         LazySourceMap::None
                     },
-                    bytecode: if module.bytecode.length > 0 {
-                        // SAFETY: section bytes are a writable 'static allocation; JSC mutates
-                        // bytecode in place. Subrange is in-bounds (serialized by to_bytes) and
-                        // disjoint from every read-only subslice handed out above — no
-                        // `&[u8]` is ever formed over this range.
-                        unsafe { slice_to_mut(raw_ptr, raw_len, module.bytecode) }
-                    } else {
-                        std::ptr::from_mut::<[u8]>(&mut [])
-                    },
-                    module_info: if module.module_info.length > 0 {
-                        // SAFETY: see bytecode above.
-                        unsafe { slice_to_mut(raw_ptr, raw_len, module.module_info) }
-                    } else {
-                        std::ptr::from_mut::<[u8]>(&mut [])
-                    },
+                    // SAFETY: in-bounds subrange (serialized by `to_bytes`).
+                    bytecode: unsafe { slice_to(raw_ptr, raw_len, module.bytecode) },
+                    // SAFETY: in-bounds subrange (serialized by `to_bytes`).
+                    module_info: unsafe { slice_to(raw_ptr, raw_len, module.module_info) },
                     bytecode_origin_path: if module.bytecode_origin_path.length > 0 {
                         bytecode_origin.as_bytes()
                     } else {
@@ -640,14 +601,13 @@ impl StandaloneModuleGraph {
         modules.lock_pointers(); // make the pointers stable forever
 
         Ok(StandaloneModuleGraph {
-            // Stored as a raw fat pointer — `byte_count` covers the writable
-            // bytecode/module_info regions, so a `&'static [u8]` here would alias them.
-            bytes: core::ptr::slice_from_raw_parts(raw_const, offsets.byte_count),
+            // SAFETY: `[0, byte_count)` is in-bounds of the live 'static read-only section.
+            bytes: unsafe { core::slice::from_raw_parts(raw_ptr, offsets.byte_count) },
             files: modules,
             entry_point_id: offsets.entry_point_id,
-            // SAFETY: read-only argv string subrange, disjoint from writable regions.
+            // SAFETY: in-bounds read-only subrange.
             compile_exec_argv: unsafe {
-                slice_to_z(raw_const, raw_len, offsets.compile_exec_argv_ptr)
+                slice_to_z(raw_ptr, raw_len, offsets.compile_exec_argv_ptr)
             }
             .as_bytes(),
             flags: offsets.flags,
@@ -655,13 +615,8 @@ impl StandaloneModuleGraph {
     }
 }
 
-/// Read-only subslice helper. Builds a `&'static [u8]` over the *subrange only* so no
-/// shared reference ever spans the writable bytecode/module_info regions of the same
-/// allocation (which would be invalidated by JSC's in-place writes).
-///
-/// SAFETY: caller guarantees `base[..len]` is a live 'static allocation and
-/// `[ptr.offset, ptr.offset + ptr.length)` is in-bounds and never written through a
-/// `*mut` alias for the lifetime of the returned reference.
+/// SAFETY: caller guarantees `base[..len]` is a live 'static read-only allocation
+/// and `[ptr.offset, ptr.offset + ptr.length)` is in-bounds.
 unsafe fn slice_to(base: *const u8, len: usize, ptr: StringPointer) -> &'static [u8] {
     if ptr.length == 0 {
         return b"";
@@ -672,21 +627,6 @@ unsafe fn slice_to(base: *const u8, len: usize, ptr: StringPointer) -> &'static 
     let _ = len;
     // SAFETY: caller contract — `[off, off+n)` lies within a live 'static read-only allocation.
     unsafe { core::slice::from_raw_parts(base.add(off), n) }
-}
-
-/// Mutable-subslice helper for `from_bytes`. Derives a `*mut [u8]` directly from the raw
-/// section base so the result carries write provenance — going through `slice_to` (which
-/// returns `&[u8]`) and casting `*const [u8] as *mut [u8]` would be UB on write.
-///
-/// SAFETY: caller guarantees `base[..len]` is a live allocation with write permission and
-/// that `[ptr.offset, ptr.offset + ptr.length)` is in-bounds.
-unsafe fn slice_to_mut(base: *mut u8, len: usize, ptr: StringPointer) -> *mut [u8] {
-    let off = ptr.offset as usize;
-    let n = ptr.length as usize;
-    debug_assert!(off.checked_add(n).is_some_and(|end| end <= len));
-    let _ = len;
-    // SAFETY: caller contract — `off` is in-bounds of the writable allocation at `base`.
-    core::ptr::slice_from_raw_parts_mut(unsafe { base.add(off) }, n)
 }
 
 /// SAFETY: as `slice_to`, plus `base[ptr.offset + ptr.length] == 0` (written by
@@ -790,31 +730,16 @@ pub(crate) fn to_bytes(
                 // Bytecode alignment for JSC bytecode cache deserialization.
                 // Not aligning correctly causes a runtime assertion error or segfault.
                 //
-                // PLATFORM-SPECIFIC ALIGNMENT:
-                // - PE (Windows) and Mach-O (macOS): The module graph data is embedded in
-                //   a dedicated section with an 8-byte size header. At runtime, the section
-                //   is memory-mapped at a page-aligned address (hence 128-byte aligned).
-                //   The data buffer starts 8 bytes after the section start.
-                //   For bytecode at offset O to be 128-byte aligned:
-                //     (section_va + 8 + O) % 128 == 0
-                //     => O % 128 == 120
-                //
-                // - ELF (Linux): The module graph data is appended to the executable and
-                //   read into a heap-allocated buffer at runtime. The allocator provides
-                //   natural alignment, and there's no 8-byte section header offset.
-                //   However, using target_mod=120 is still safe because:
-                //   - If the buffer is 128-aligned: bytecode at offset 120 is at (128n + 120),
-                //     which when loaded at a 128-aligned address gives proper alignment.
-                //   - The extra 120 bytes of padding is acceptable overhead.
-                //
-                // This alignment strategy (target_mod=120) works for all platforms because
-                // it's the worst-case offset needed for the 8-byte header scenario.
+                // On every platform the payload lives in a dedicated section mapped at a
+                // page-aligned address (PE `.bun`, Mach-O `__BUN,__bun`, ELF `.bun` via
+                // PT_LOAD) with an 8-byte u64 length prefix. The data buffer thus starts
+                // 8 bytes after a page boundary, so for bytecode at offset O to be
+                // 128-byte aligned: (section_va + 8 + O) % 128 == 0 => O % 128 == 120.
                 let bytecode = output_files[output_file.bytecode_index as usize]
                     .value
                     .as_slice();
                 let current_offset = string_builder.len;
                 // Calculate padding so that (current_offset + padding) % 128 == 120
-                // This accounts for the 8-byte section header on PE/Mach-O platforms.
                 let target_mod: usize = 128 - size_of::<u64>(); // 120 = accounts for 8-byte header
                 let current_mod = current_offset % 128;
                 let padding = if current_mod <= target_mod {
@@ -1974,9 +1899,7 @@ impl StandaloneModuleGraph {
                 bun_core::debug_warn!("bun standalone module graph is too small to be valid");
                 return Ok(None);
             }
-            // SAFETY: `[len - Offsets - TRAILER, len)` is in-bounds (checked above) and
-            // read-only; build short-lived views via raw `read_unaligned` so no `&[u8]`
-            // ever spans the writable bytecode region carried in `base`'s provenance.
+            // SAFETY: `[len - Offsets - TRAILER, len)` is in-bounds (checked above).
             let offsets_ptr = unsafe { base.add(len - size_of::<Offsets>() - TRAILER.len()) };
             // SAFETY: `[len - TRAILER.len(), len)` is in-bounds (length checked above) and read-only.
             let trailer_bytes = unsafe {
@@ -2001,9 +1924,7 @@ impl StandaloneModuleGraph {
                 bun_core::debug_warn!("bun standalone module graph is too small to be valid");
                 return Ok(None);
             }
-            // SAFETY: `[len - Offsets - TRAILER, len)` is in-bounds (checked above) and
-            // read-only; build short-lived views via raw `read_unaligned` so no `&[u8]`
-            // ever spans the writable bytecode region carried in `base`'s provenance.
+            // SAFETY: `[len - Offsets - TRAILER, len)` is in-bounds (checked above).
             let offsets_ptr = unsafe { base.add(len - size_of::<Offsets>() - TRAILER.len()) };
             // SAFETY: `[len - TRAILER.len(), len)` is in-bounds (length checked above) and read-only.
             let trailer_bytes = unsafe {
@@ -2028,9 +1949,7 @@ impl StandaloneModuleGraph {
                 bun_core::debug_warn!("bun standalone module graph is too small to be valid");
                 return Ok(None);
             }
-            // SAFETY: `[len - Offsets - TRAILER, len)` is in-bounds (checked above) and
-            // read-only; build short-lived views via raw `read_unaligned` so no `&[u8]`
-            // ever spans the writable bytecode region carried in `base`'s provenance.
+            // SAFETY: `[len - Offsets - TRAILER, len)` is in-bounds (checked above).
             let offsets_ptr = unsafe { base.add(len - size_of::<Offsets>() - TRAILER.len()) };
             // SAFETY: `[len - TRAILER.len(), len)` is in-bounds (length checked above) and read-only.
             let trailer_bytes = unsafe {
@@ -2072,7 +1991,7 @@ impl StandaloneModuleGraph {
 
         #[cfg(not(windows))]
         {
-            let (base, len): (*mut u8, usize) = {
+            let (base, len): (*const u8, usize) = {
                 #[cfg(target_os = "macos")]
                 {
                     match macho::get_data() {
@@ -2133,7 +2052,7 @@ impl StandaloneModuleGraph {
 /// Allocates a StandaloneModuleGraph in the process-static `INSTANCE`,
 /// populates it from bytes, sets it globally, and returns the pointer.
 fn from_bytes_alloc(
-    raw_ptr: *mut u8,
+    raw_ptr: *const u8,
     raw_len: usize,
     offsets: Offsets,
 ) -> crate::Result<*mut StandaloneModuleGraph> {

--- a/test/regression/issue/pe-codesigning-integrity.test.ts
+++ b/test/regression/issue/pe-codesigning-integrity.test.ts
@@ -369,7 +369,72 @@ console.log("Large data length:", JSON.stringify(largeData).length);
     const IMAGE_SCN_MEM_EXECUTE = 0x20000000;
     expect(bunSection.characteristics & IMAGE_SCN_MEM_EXECUTE).toBe(0);
 
+    // Should NOT be writable: StandaloneModuleGraph hands the embedded
+    // bytecode to JSC as a read-only span; JSC never mutates it.
+    const IMAGE_SCN_MEM_WRITE = 0x80000000;
+    expect(bunSection.characteristics & IMAGE_SCN_MEM_WRITE).toBe(0);
+
     // Cleanup
+    unlinkSync(testFile);
+    unlinkSync(exePath);
+  });
+
+  it("should run embedded bytecode from a read-only .bun section", async () => {
+    // StandaloneModuleGraph treats the embedded bytecode as immutable
+    // (`&'static [u8]`), and the PE writer marks `.bun` without
+    // IMAGE_SCN_MEM_WRITE, so the loader maps it PAGE_READONLY. Any in-place
+    // write by the JSC decoder would fault; running this binary to completion
+    // proves the decoder is read-only.
+    const testFile = join(tempDir, "test-pe-bytecode-ro.js");
+    await Bun.write(
+      testFile,
+      `
+function outer(a) {
+  function mid(b) {
+    function inner(c) { return a + b + c; }
+    return inner;
+  }
+  return mid;
+}
+let s = 0;
+for (let i = 0; i < 50; i++) s += outer(i)(i * 2)(i * 3);
+console.log("SUM", s);
+    `.trim(),
+    );
+
+    const exePath = join(tempDir, "test-pe-bytecode-ro.exe");
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", "--bytecode", "--outfile", exePath, testFile],
+      env: bunEnv,
+      cwd: tempDir,
+      stderr: "pipe",
+    });
+    const [, buildErr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    expect(buildErr).not.toContain("error:");
+    expect(buildExit).toBe(0);
+
+    // Verify the .bun section carries bytecode (not just source) and is read-only.
+    const peData = readFileSync(exePath);
+    const parser = new PEParser(peData);
+    const validation = parser.validatePE();
+    const bunSection = validation.bunSection!.section;
+    const IMAGE_SCN_MEM_WRITE = 0x80000000;
+    expect(bunSection.characteristics & IMAGE_SCN_MEM_WRITE).toBe(0);
+    // With --bytecode the section is at least several KB.
+    expect(validation.bunSection!.dataSize).toBeGreaterThan(4096);
+
+    // Running against PAGE_READONLY pages: any in-place write would crash here.
+    await using proc = Bun.spawn({
+      cmd: [exePath],
+      env: bunEnv,
+      cwd: tempDir,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim()).toBe("SUM 7350");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
     unlinkSync(testFile);
     unlinkSync(exePath);
   });

--- a/test/regression/issue/pe-codesigning-integrity.test.ts
+++ b/test/regression/issue/pe-codesigning-integrity.test.ts
@@ -430,10 +430,8 @@ console.log("SUM", s);
       cwd: tempDir,
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout.trim()).toBe("SUM 7350");
-    expect(stderr).toBe("");
-    expect(exitCode).toBe(0);
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "SUM 7350", exitCode: 0 });
 
     unlinkSync(testFile);
     unlinkSync(exePath);


### PR DESCRIPTION
## What

Removes the "JSC mutates the bytecode buffer in place" claim and the `*mut [u8]` write-provenance plumbing it justified in `StandaloneModuleGraph`. Also corrects the stale ELF alignment comment.

## Why

There was a contradiction in the `--compile` code: the PE writer emits `.bun` as `IMAGE_SCN_CNT_INITIALIZED_DATA | IMAGE_SCN_MEM_READ` only (`src/exe_format/pe.rs:647`), and on Windows the payload is read straight out of the loaded image (`src/jsc/bindings/c-bindings.cpp:1123-1130`). Yet `StandaloneModuleGraph` insisted JSC mutates the buffer in place and carried `*mut [u8]` write-provenance end to end, while ELF/Mach-O map RW. Only one could be right.

### Verification

Built a `--compile --bytecode` executable on Windows (released bun 1.4.0-canary) and ran it:

```
PE_SECTION .bun VA=0x4d4b000 size=28097 char=0x40000040 MEM_READ=true MEM_WRITE=false
VIRTUALQUERY Protect=0x2 PAGE_READONLY AllocProtect=0x80
RESULT 23 610
DONE
```

The section is `PAGE_READONLY` at runtime, bytecode is embedded (28 KB with `--bytecode` vs 3 KB without), and the program runs to completion (exit 0) for both `--format=cjs` and `--format=esm`. Any in-place write would have faulted with `0xC0000005`; none does.

From JSC source:
- `CachedBytecode::span()` returns `std::span<const uint8_t>` (`vendor/WebKit/Source/JavaScriptCore/runtime/CachedBytecode.h:72`)
- `Decoder::ptrForOffsetFromBase()` returns `const void*`; decoded pointers are cached in a side `m_offsetToPtrMap` HashMap (`CachedTypes.h:94-108`), never written into the buffer
- Bun's `SourceProvider::updateCache` / `cacheBytecode` / `commitCachedBytecode` are early-`return;` no-ops (`ZigSourceProvider.cpp:294-322`)
- `module_info` is consumed via `create_from_cached_record(&*file.module_info)` which only reads and copies out

The mutation claim first appeared in the Rust rewrite (#30412); it was never in the Zig source and was never observed behavior.

## Changes

- `File.bytecode` / `File.module_info`: `*mut [u8]` -> `&'static [u8]`
- `StandaloneModuleGraph.bytes`: `*const [u8]` -> `&'static [u8]`
- `get_data()` (macho/pe/elf): `*mut u8` -> `*const u8`
- `ResolvedSource.bytecode_cache`: `*mut u8` -> `*const u8` (Rust + `headers-handwritten.h`)
- `ZigSourceProvider.cpp`: `const_cast` at the `CachedBytecode::create` boundary (its signature takes `span<uint8_t>` but the payload is only ever exposed as `span<const>`)
- Drops `slice_to_mut` and the write-provenance commentary (net -79 lines)
- Rewrites the ELF alignment comment: the payload is PT_LOAD-mapped from the executable with the same 8-byte `u64` length prefix as PE/Mach-O (verified via `/proc/self/maps` + `readelf -l`), so `target_mod = 120` is required on ELF for the same reason, not incidental overhead

Mach-O `PROT::WRITE` (`macho.rs:142-143`) and the ELF RW PT_LOAD extension (`elf.rs:402-424`) are left as-is; they are not needed for this reason but changing segment permissions is a separate concern.

## Tests

`bun bd test test/bundler/bundler_compile.test.ts -t Bytecode`: 16/16 bytecode tests pass. `cargo check` clean on all targets (linux/macos/windows x x64/aarch64).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/regression/issue/pe-codesigning-integrity.test.ts

<!-- robobun:evidence:end -->