### PR TITLE
core: drop redundant defensive guards across 7 sites

### DIFF
--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -1498,10 +1498,7 @@ impl ZigString {
             // string death. `heap::release` is the hand-off-to-foreign-owner
             // spelling.
             let leaked: &'static mut [u16] = crate::heap::release(utf16.into_boxed_slice());
-            let mut out = ZigString::init_utf16(leaked);
-            out.mark_global();
-            out.mark_utf16();
-            Ok(out)
+            Ok(ZigString::from16_slice(leaked))
         } else {
             // Same hand-off: JSC owns the bytes, freed via `mi_free` on string death.
             let duped: &'static mut [u8] = crate::heap::release(Box::<[u8]>::from(utf8));

--- a/src/collections/zig_hash_map.rs
+++ b/src/collections/zig_hash_map.rs
@@ -340,7 +340,7 @@ impl<K, V, C: HashContext<K>> HashMap<K, V, C> {
         Q: ?Sized,
     {
         self.get_index(key)
-            .and_then(|i| self.slots[i].as_ref().map(|(_, v)| v))
+            .map(|i| &self.slots[i].as_ref().unwrap().1)
     }
 
     pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
@@ -350,7 +350,7 @@ impl<K, V, C: HashContext<K>> HashMap<K, V, C> {
         Q: ?Sized,
     {
         self.get_index(key)
-            .and_then(move |i| self.slots[i].as_mut().map(|(_, v)| v))
+            .map(move |i| &mut self.slots[i].as_mut().unwrap().1)
     }
 
     pub fn get_key_value<Q>(&self, key: &Q) -> Option<(&K, &V)>
@@ -359,8 +359,10 @@ impl<K, V, C: HashContext<K>> HashMap<K, V, C> {
         C: HashContext<Q>,
         Q: ?Sized,
     {
-        self.get_index(key)
-            .and_then(|i| self.slots[i].as_ref().map(|(k, v)| (k, v)))
+        self.get_index(key).map(|i| {
+            let (k, v) = self.slots[i].as_ref().unwrap();
+            (k, v)
+        })
     }
 
     #[inline]
@@ -477,9 +479,9 @@ impl<K, V, C: HashContext<K>> HashMap<K, V, C> {
         Ok(())
     }
 
-    fn remove_by_index(&mut self, idx: usize) -> Option<(K, V)> {
+    fn remove_by_index(&mut self, idx: usize) -> (K, V) {
         self.metadata[idx] = SLOT_TOMBSTONE;
-        let kv = self.slots[idx].take();
+        let kv = self.slots[idx].take().unwrap();
         self.size -= 1;
         self.available += 1;
         kv
@@ -492,8 +494,7 @@ impl<K, V, C: HashContext<K>> HashMap<K, V, C> {
         C: HashContext<Q>,
         Q: ?Sized,
     {
-        self.get_index(key)
-            .and_then(|i| self.remove_by_index(i).map(|(_, v)| v))
+        self.get_index(key).map(|i| self.remove_by_index(i).1)
     }
 
     /// std `remove_entry`.
@@ -503,7 +504,7 @@ impl<K, V, C: HashContext<K>> HashMap<K, V, C> {
         C: HashContext<Q>,
         Q: ?Sized,
     {
-        self.get_index(key).and_then(|i| self.remove_by_index(i))
+        self.get_index(key).map(|i| self.remove_by_index(i))
     }
 
     /// Remove and return the owned `{key, value}` pair.

--- a/src/event_loop/MiniEventLoop.rs
+++ b/src/event_loop/MiniEventLoop.rs
@@ -177,7 +177,7 @@ pub fn init_global(
     if let Some(dir) = cwd {
         // Dupe to keep Box<[u8]> ownership uniform.
         global.top_level_dir = Box::<[u8]>::from(dir);
-    } else if global.top_level_dir.is_empty() {
+    } else {
         let mut buf = bun_paths::PathBuffer::uninit();
         match sys::getcwd(&mut buf[..]) {
             Ok(len) => {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1177,10 +1177,6 @@ impl<'a> Resolver<'a> {
         }
 
         if self.log_ref().level == bun_ast::Level::Verbose {
-            if self.debug_logs.is_some() {
-                // deinit → drop
-                self.debug_logs = None;
-            }
             self.debug_logs = Some(DebugLogs::init().expect("unreachable"));
         }
 

--- a/src/sys/copy_file.rs
+++ b/src/sys/copy_file.rs
@@ -433,9 +433,6 @@ pub fn copy_file_read_write_loop(in_: fd_t, out: fd_t, len: usize) -> crate::Res
                     amt_written += wrote;
                 }
             }
-            if amt_read == 0 {
-                return Ok(0);
-            }
             Ok(amt_read)
         }
         Err(err) => Err(err),

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -1174,7 +1174,7 @@ pub mod ssl_wrapper {
         /// re-checked between pops and nothing else of `self` is borrowed
         /// across a dispatch.
         fn flush_pending_events(this: *mut Self, buffer: &mut [u8; BUFFER_SIZE]) {
-            if Self::r(this).handlers.on_session.is_some() {
+            if let Some(on_session) = Self::r(this).handlers.on_session {
                 loop {
                     let Some(ssl) = Self::r(this).ssl else { return };
                     // SAFETY: ssl is live (checked above); buffer is writable
@@ -1189,12 +1189,10 @@ pub mod ssl_wrapper {
                     if len <= 0 {
                         break;
                     }
-                    if let Some(on_session) = Self::r(this).handlers.on_session {
-                        on_session(Self::r(this).handlers.ctx, &buffer[..len as usize]);
-                    }
+                    on_session(Self::r(this).handlers.ctx, &buffer[..len as usize]);
                 }
             }
-            if Self::r(this).handlers.on_keylog.is_some() {
+            if let Some(on_keylog) = Self::r(this).handlers.on_keylog {
                 loop {
                     let Some(ssl) = Self::r(this).ssl else { return };
                     // SAFETY: same as the session pop above; keylog entries
@@ -1209,9 +1207,7 @@ pub mod ssl_wrapper {
                     if len <= 0 {
                         break;
                     }
-                    if let Some(on_keylog) = Self::r(this).handlers.on_keylog {
-                        on_keylog(Self::r(this).handlers.ctx, &buffer[..len as usize]);
-                    }
+                    on_keylog(Self::r(this).handlers.ctx, &buffer[..len as usize]);
                 }
             }
         }

--- a/src/valkey/valkey_protocol.rs
+++ b/src/valkey/valkey_protocol.rs
@@ -355,7 +355,8 @@ impl<'a> ValkeyReader<'a> {
     /// server amplify a few KB of nested aggregate headers carrying huge
     /// declared lengths into gigabytes of reserved capacity.
     fn take_prealloc_budget(&mut self, len: usize, element_size: usize) -> usize {
-        let cap = len.min(self.prealloc_budget / element_size.max(1));
+        debug_assert_ne!(element_size, 0);
+        let cap = len.min(self.prealloc_budget / element_size);
         self.prealloc_budget -= cap * element_size;
         cap
     }


### PR DESCRIPTION
Drops seven redundant defensive branches in core crates. Each is either provably dead or provably always-taken; the diff is behavior-preserving by construction. Net -12 lines.

### Changes

- **`src/bun_core/string/mod.rs` `dupe_for_js`**: `init_utf16` already sets the 16-bit pointer tag (it calls `mark_utf16` internally, `bun_alloc/lib.rs:966`), and `mark_global` is OR-only so the bit survives. The subsequent `mark_utf16()` re-sets a bit that is already set. Collapse the three lines to `from16_slice(leaked)`, which sets both the 16-bit and global bits.

- **`src/collections/zig_hash_map.rs` `get`/`get_mut`/`get_key_value`/`remove`/`remove_entry`**: `get_index` returns `Some(idx)` only from inside `if let Some((k, _)) = &self.slots[idx]` (line 324), so `slots[idx]` is `Some` at every returned index. Replace the `.and_then(|i| slots[i].as_ref().map(..))` re-check with `.map(|i| ..unwrap()..)`, matching the pattern already used by `get_or_put` (line 433), `insert` (line 458), and `OccupiedEntry::get`/`get_mut` in the same file. `remove_by_index` (private, only called with `get_index` results) now returns `(K, V)` instead of `Option<(K, V)>`.

- **`src/event_loop/MiniEventLoop.rs` `init_global`**: `global` is a fresh `MiniEventLoop::init()` value, which sets `top_level_dir: Box::default()`. Nothing between construction and the check writes that field, so `is_empty()` is always true in the `else if`.

- **`src/resolver/resolver.rs`**: the `if is_some { = None }` before `= Some(new)` is a leftover from the Zig port (the `deinit → drop` comment says as much). Rust's assignment drop glue already drops the old value.

- **`src/sys/copy_file.rs` `copy_file_read_write_loop`**: the second `if amt_read == 0 { return Ok(0) }` is unreachable; `amt_read` is the immutable `Ok` binding from `read()` and is checked for zero at line 421 before the write loop.

- **`src/uws/lib.rs` `flush_pending_events`**: `handlers.on_session` / `handlers.on_keylog` are `Option<fn(T, &[u8])>`, set once at construction (`init_with_ctx`, line 493) and never written again anywhere in the tree. Hoist the `if let Some(cb)` out of the loop and drop the inner re-check. The fn pointers are `Copy`, so capturing them once is safe across re-entrancy; the per-iteration `ssl` liveness check is unchanged. `test/js/node/tls/node-tls-connect.test.ts` covers both the normal case and the "handler destroys the socket immediately" re-entrancy case.

- **`src/valkey/valkey_protocol.rs` `take_prealloc_budget`**: the private fn's five call sites (lines 418, 471, 494, 514, 564) all pass `size_of::<RESPValue>()` or `size_of::<MapEntry>()`, which are compile-time nonzero. Replace the `.max(1)` div-by-zero guard with a `debug_assert_ne!` so the invariant is still documented.

### Not changed

The originating audit also flagged `src/sys/Error.rs:306-312` (the `errno > 0 && errno < MAX` range check before `SystemErrno::init`). That guard is **not** redundant: `errno` is a `u16`, and `SystemErrno::init(0)` returns `Some(SUCCESS)` rather than `None`, so dropping the `> 0` check would change behavior for `errno == 0`. Left as-is.

### Verification

- `cargo check` and `cargo clippy` clean across `bun_core`, `bun_collections`, `bun_sys`, `bun_uws`, `bun_valkey`, `bun_event_loop`, `bun_resolver`
- `cargo fmt --check` clean
- `cargo test -p bun_collections` (41 pass)
- `bun bd` builds
- `bun bd test test/js/node/fs/fs.test.ts -t copyFile` (7 pass, exercises the read/write fallback loop)
- `bun bd test test/js/node/tls/node-tls-connect.test.ts -t session` (2 pass, exercises `flush_pending_events` including the destroy-in-handler path)
- `bun bd test test/js/bun/resolve/resolve.test.ts` (45 pass)

There is no fail-before state for these changes; the removed branches were never taken (or always taken), so existing tests pass identically before and after.
