### PR TITLE
semver: drop redundant store and two dead guards in the parser

### DIFF
--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -329,7 +329,6 @@ impl List {
             range: *range,
             next: None,
         });
-        tail.range = *range;
 
         let tail_ptr = NonNull::from(&mut *tail);
 
@@ -988,7 +987,7 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                         break 'possibly_hyphenate false;
                     }
 
-                    if !(i < input.len() && matches!(input[i], b'0'..=b'9' | b'X' | b'x' | b'*')) {
+                    if !matches!(input[i], b'0'..=b'9' | b'X' | b'x' | b'*') {
                         break 'possibly_hyphenate false;
                     }
 

--- a/src/semver/Version.rs
+++ b/src/semver/Version.rs
@@ -579,9 +579,6 @@ impl<T: VersionInt> VersionType<T> {
                     }
 
                     part_start_i = i;
-                    while i < input.len() && matches!(input[i], b' ') {
-                        i += 1;
-                    }
                     let tag_result = Tag::parse(sliced_string.sub(&input[part_start_i..]));
                     result.version.tag = tag_result.tag;
                     i += tag_result.len as usize;


### PR DESCRIPTION
Three no-op statements left over from the Zig port, all provably unreachable or redundant. No behavior change.

### `List::and_range` (`SemverQuery.rs`)

```rust
let mut tail = Box::new(Query { range: *range, next: None });
tail.range = *range;
```

`range: &Range` is an immutable reference and `Range` is `Copy`, so the second store writes the same value it already holds.

### `query::parse` hyphen lookahead (`SemverQuery.rs`)

```rust
i += strings::length_of_leading_whitespace_ascii(&input[i..]);
if i == input.len() { break 'possibly_hyphenate false; }
if !(i < input.len() && matches!(input[i], b'0'..=b'9' | b'X' | b'x' | b'*')) { ... }
```

`length_of_leading_whitespace_ascii` returns at most its slice's length, so after the addition `i <= input.len()`. The preceding `i == input.len()` check then leaves `i < input.len()` as the only remaining case, so the guard in the next condition is always true.

### `Version::parse` tag arm (`Version.rs`)

```rust
b'-' | b'+' => {
    ...
    part_start_i = i;
    while i < input.len() && matches!(input[i], b' ') { i += 1; }
```

This arm is entered via `match input[i]` with `i` unchanged between dispatch and the loop, so `input[i]` is `-` or `+` and the loop condition is false on the first iteration. `Tag::parse` reads from `part_start_i` (set before the loop) regardless.

### Why no new test

These are identity transformations on the compiled function: the dropped store writes the value already present, and the dropped guards evaluate to the branch already taken on every input. There is no input that can distinguish before from after. Regression coverage is the existing `test/cli/install/semver.test.ts`, which exercises `List::and_range` (multi-comparator ranges), the hyphen-range lookahead, and version tag parsing.

### Verification

```
$ cargo clippy -p bun_semver
    Finished `dev` profile
$ bun bd test test/cli/install/semver.test.ts
 28 pass
 0 fail
 1946 expect() calls
```