### PR TITLE
runtime/cli: drop redundant guards already implied by the enclosing branch

### DIFF
--- a/src/runtime/cli/shell_completions.rs
+++ b/src/runtime/cli/shell_completions.rs
@@ -74,22 +74,20 @@ impl ShellCompletions {
             }
         }
 
-        if self.commands.len() > 1 {
-            for (i, cmd) in self.commands[1..].iter().enumerate() {
-                if writer.write_all(delimiter).is_err() {
-                    return;
-                }
+        for (i, cmd) in self.commands[1..].iter().enumerate() {
+            if writer.write_all(delimiter).is_err() {
+                return;
+            }
 
-                if writer.write_all(cmd).is_err() {
+            if writer.write_all(cmd).is_err() {
+                return;
+            }
+            if !self.descriptions.is_empty() {
+                if writer.write_all(b"\t").is_err() {
                     return;
                 }
-                if !self.descriptions.is_empty() {
-                    if writer.write_all(b"\t").is_err() {
-                        return;
-                    }
-                    if writer.write_all(self.descriptions[i]).is_err() {
-                        return;
-                    }
+                if writer.write_all(self.descriptions[i]).is_err() {
+                    return;
                 }
             }
         }

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -1311,11 +1311,7 @@ impl UpdateInteractiveCommand {
         } else if state.cursor >= state.viewport_start + state.viewport_height {
             // Cursor is below viewport - put it at the end of viewport
             if !state.packages.is_empty() {
-                let max_cursor = if state.packages.len() > 1 {
-                    state.packages.len() - 1
-                } else {
-                    0
-                };
+                let max_cursor = state.packages.len() - 1;
                 let viewport_end = state.viewport_start + state.viewport_height;
                 state.cursor = (viewport_end - 1).min(max_cursor);
             }
@@ -1368,11 +1364,7 @@ impl UpdateInteractiveCommand {
             } else {
                 0
             };
-            let desired_start = if state.viewport_height > context_below {
-                state.cursor - (state.viewport_height - context_below)
-            } else {
-                state.cursor
-            };
+            let desired_start = state.cursor - (state.viewport_height - context_below);
             state.viewport_start = desired_start.min(max_start);
         }
         // If cursor is near top of viewport, adjust to maintain context


### PR DESCRIPTION
Three small simplifications in `src/runtime/cli/` where an inner condition re-checks something the enclosing branch already guarantees. No behavior change.

### `shell_completions.rs`

`ShellCompletions::print` returns early when `commands.is_empty()`, so at the point of the loop `commands.len() >= 1` and `&commands[1..]` is always in bounds (an empty slice when `len() == 1`, which the `for` loop handles). The `len() > 1` wrapper adds nothing.

### `update_interactive_command.rs`, `ensure_cursor_in_viewport`

Inside `if !state.packages.is_empty()` the length is at least 1, so `len() - 1` cannot underflow. When `len() == 1` the expression is `0`, which is exactly what the removed `else` branch returned.

### `update_interactive_command.rs`, `update_viewport`

The third `else if` arm is guarded by `state.viewport_height > context_below && ...`. Neither `viewport_height` nor `context_below` is mutated inside the arm, so re-testing `viewport_height > context_below` before computing `desired_start` always takes the true branch. Both subtractions remain safe: `viewport_height - context_below` is covered by the outer guard, and `cursor - (viewport_height - context_below)` is covered by the second conjunct (`cursor > viewport_start + viewport_height - context_below` with `viewport_start: usize >= 0`).

### Verification

`cargo clippy -p bun_runtime` is clean and the existing `getcompletes` and `update --interactive` snapshot tests pass unchanged with the debug build. Because the change preserves behavior exactly, there is no input that distinguishes before from after, so no new regression test is added.