### PR TITLE
Drop dead bumpalo dep and consolidate duplicate type-alias re-exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,6 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "bstr",
- "bumpalo",
  "bun_alloc",
  "bun_collections",
  "bun_core",
@@ -241,7 +240,6 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "bstr",
- "bumpalo",
  "bun_alloc",
  "bun_collections",
  "bun_core",
@@ -347,7 +345,6 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "bstr",
- "bumpalo",
  "bun_alloc",
  "bun_analytics",
  "bun_ast",
@@ -607,7 +604,6 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "bstr",
- "bumpalo",
  "bun_alloc",
  "bun_ast",
  "bun_base64",
@@ -1078,7 +1074,6 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "bstr",
- "bumpalo",
  "bun_alloc",
  "bun_ast",
  "bun_base64",
@@ -1143,7 +1138,6 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "bstr",
- "bumpalo",
  "bun_alloc",
  "bun_ast",
  "bun_collections",
@@ -1375,7 +1369,6 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "bstr",
- "bumpalo",
  "bun_alloc",
  "bun_ast",
  "bun_collections",
@@ -1561,7 +1554,6 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "bstr",
- "bumpalo",
  "bun_alloc",
  "bun_analytics",
  "bun_ast",
@@ -1827,7 +1819,6 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "bstr",
- "bumpalo",
  "bun_alloc",
  "bun_collections",
  "bun_core",
@@ -1871,7 +1862,6 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "bstr",
- "bumpalo",
  "bun_alloc",
  "bun_ast",
  "bun_base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -344,7 +344,6 @@ rustix = { version = "0.38", default-features = false, features = ["std", "fs", 
 bitflags = "2"
 thiserror = "2"
 smallvec = "1"
-bumpalo = { version = "3", features = ["collections", "boxed"] }
 typed-arena = "2"
 itoa = "1"
 # Vendored, not crates.io — see the `exclude = ["vendor"]` note above.

--- a/src/ast/Cargo.toml
+++ b/src/ast/Cargo.toml
@@ -20,7 +20,6 @@ enum-map.workspace = true
 enumset.workspace = true
 libc.workspace = true
 bitflags.workspace = true
-bumpalo.workspace = true
 typed-arena.workspace = true
 bun_alloc.workspace = true
 bun_dispatch.workspace = true

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -3141,10 +3141,6 @@ pub struct ToSourceOptions {
     pub convert_bom: bool,
 }
 
-/// Downstream-compat alias: some callers (`ini::load_npmrc_config`) spell the
-/// option-struct as `bun_ast::ToSourceOpts { convert_bom: true }`.
-pub type ToSourceOpts = ToSourceOptions;
-
 /// Read `path` (rooted at cwd) into memory and wrap it in a `Source`.
 ///
 /// MOVE_DOWN from `bun_sys::File::to_source` (T1 cannot name T2).

--- a/src/base64/Cargo.toml
+++ b/src/base64/Cargo.toml
@@ -27,5 +27,4 @@ bun_collections.workspace = true
 # `wyhash_url_safe` (CSS-modules / dependency placeholder hasher) — leaf crates,
 # no cycle.
 bun_wyhash.workspace = true
-bumpalo.workspace = true
 bun_alloc.workspace = true

--- a/src/bundler/Cargo.toml
+++ b/src/bundler/Cargo.toml
@@ -22,7 +22,6 @@ enumset.workspace = true
 libc.workspace = true
 bitflags.workspace = true
 thiserror.workspace = true
-bumpalo.workspace = true
 typed-arena.workspace = true
 bun_base64.workspace = true
 bun_alloc.workspace = true

--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -246,7 +246,6 @@ pub mod options {
     /// `OutputFile.init` argument struct.
     pub use super::output_file::Options as OutputFileInit;
     pub use super::output_file::OptionsData as OutputFileData;
-    pub use super::output_file::Value as OutputValue;
     pub use super::output_file::Value as OutputFileValue;
     /// `options.Format` — many ported call-sites spell this `OutputFormat`.
     pub use bun_options_types::Format as OutputFormat;

--- a/src/collections/lib.rs
+++ b/src/collections/lib.rs
@@ -174,7 +174,7 @@ pub use string_map::StringMap;
 
 // Re-export from bun_ptr so callers can name it as `bun_collections::TaggedPtrUnion`
 // (PORTING.md groups it under Collections; the impl lives in src/ptr/).
-pub use bun_ptr::tagged_pointer::{TaggedPtr as TaggedPointer, TaggedPtrUnion};
+pub use bun_ptr::tagged_pointer::{TaggedPtr, TaggedPtrUnion};
 // Lifetime-erasure helpers (RUST_PATTERNS.md §6/§18) — re-exported here so
 // crates that already depend on `bun_collections` (logger, css, js_parser,
 // crash_handler, watcher, http_types) can route the borrowck-dodge through

--- a/src/css/Cargo.toml
+++ b/src/css/Cargo.toml
@@ -19,7 +19,6 @@ enum-map.workspace = true
 enumset.workspace = true
 libc.workspace = true
 bitflags.workspace = true
-bumpalo.workspace = true
 typed-arena.workspace = true
 bun_base64.workspace = true
 bun_alloc.workspace = true

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -1278,7 +1278,7 @@ mod draft {
         for &npmrc_path in npmrc_paths {
             let source = match bun_ast::source_from_file(
                 npmrc_path,
-                bun_ast::ToSourceOpts { convert_bom: true },
+                bun_ast::ToSourceOptions { convert_bom: true },
             ) {
                 Ok(s) => s,
                 Err(err) => {

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -1521,7 +1521,7 @@ impl Store {
 #[derive(Copy, Clone)]
 #[allow(dead_code)]
 pub(crate) struct Pollable {
-    repr: bun_collections::TaggedPointer,
+    repr: bun_collections::TaggedPtr,
 }
 
 impl Pollable {
@@ -1533,7 +1533,7 @@ impl Pollable {
     #[allow(dead_code)]
     pub(crate) fn init(ptr: *const crate::FilePoll) -> Self {
         Self {
-            repr: bun_collections::TaggedPointer::init(ptr, Self::FILE_POLL_TAG),
+            repr: bun_collections::TaggedPtr::init(ptr, Self::FILE_POLL_TAG),
         }
     }
 
@@ -1541,7 +1541,7 @@ impl Pollable {
     #[allow(dead_code)]
     pub(crate) fn from(val: *mut c_void) -> Self {
         Self {
-            repr: bun_collections::TaggedPointer::from(val),
+            repr: bun_collections::TaggedPtr::from(val),
         }
     }
 

--- a/src/js_parser/Cargo.toml
+++ b/src/js_parser/Cargo.toml
@@ -22,7 +22,6 @@ enum-map.workspace = true
 enumset.workspace = true
 libc.workspace = true
 bitflags.workspace = true
-bumpalo.workspace = true
 typed-arena.workspace = true
 bun_base64.workspace = true
 bun_alloc.workspace = true

--- a/src/js_printer/Cargo.toml
+++ b/src/js_printer/Cargo.toml
@@ -20,7 +20,6 @@ enum-map.workspace = true
 enumset.workspace = true
 libc.workspace = true
 bitflags.workspace = true
-bumpalo.workspace = true
 typed-arena.workspace = true
 bun_alloc.workspace = true
 bun_core.workspace = true

--- a/src/parsers/Cargo.toml
+++ b/src/parsers/Cargo.toml
@@ -21,7 +21,6 @@ enum-map.workspace = true
 enumset.workspace = true
 libc.workspace = true
 bitflags.workspace = true
-bumpalo.workspace = true
 typed-arena.workspace = true
 bun_alloc.workspace = true
 bun_core.workspace = true

--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -35,9 +35,7 @@ pub mod raw_ref_count;
 pub mod weak_ptr;
 
 pub mod tagged_pointer;
-// Compat alias — `tagged_pointer` exports the short name; some downstream code
-// uses the long one.
-pub use tagged_pointer::TaggedPtr as TaggedPointer;
+pub use tagged_pointer::TaggedPtr;
 
 pub mod ref_count;
 pub use ref_count::{

--- a/src/resolver/Cargo.toml
+++ b/src/resolver/Cargo.toml
@@ -49,4 +49,3 @@ bun_url.workspace = true
 bun_wyhash.workspace = true
 bun_hash.workspace = true
 bun_zstd.workspace = true
-bumpalo.workspace = true

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -336,7 +336,7 @@ extern "C" fn on_auto_flush_trampoline(ctx: *mut c_void) -> bool {
 /// to `AnyServerTag` here.
 #[inline]
 fn any_server_from_packed(packed: u64) -> AnyServer {
-    let repr = bun_ptr::TaggedPointer::from(packed);
+    let repr = bun_ptr::TaggedPtr::from(packed);
     let tag = match repr.data() {
         1024 => AnyServerTag::HTTPServer,
         1023 => AnyServerTag::HTTPSServer,

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2078,7 +2078,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // The packed `AnyServer` is a pure function of the (now-stable) heap
         // address and the const variant tag; cache it so the per-request
         // `node:http` prologue is a plain field load instead of a tag match +
-        // `TaggedPointer::init`.
+        // `TaggedPtr::init`.
         // SAFETY: `server` is the freshly-boxed `*mut Self`; uniquely owned here.
         unsafe {
             (*server).any_server_packed = AnyServer::from(server.cast_const()).to_packed() as usize;
@@ -3688,7 +3688,7 @@ impl AnyServer {
             AnyServerTag::DebugHTTPSServer => 1021,
         };
         // `TaggedPtr::to()` bit-casts the full packed word through `*mut c_void`.
-        bun_ptr::TaggedPointer::init(self.ptr, tag).to() as u64
+        bun_ptr::TaggedPtr::init(self.ptr, tag).to() as u64
     }
 
     /// Shared borrow of the process-static VM. Routes through

--- a/src/shell_parser/Cargo.toml
+++ b/src/shell_parser/Cargo.toml
@@ -18,7 +18,6 @@ enum-map.workspace = true
 enumset.workspace = true
 libc.workspace = true
 bitflags.workspace = true
-bumpalo.workspace = true
 typed-arena.workspace = true
 smallvec.workspace = true
 thiserror.workspace = true

--- a/src/sourcemap/Cargo.toml
+++ b/src/sourcemap/Cargo.toml
@@ -23,7 +23,6 @@ enum-map.workspace = true
 enumset.workspace = true
 libc.workspace = true
 bitflags.workspace = true
-bumpalo.workspace = true
 smallvec = { workspace = true, features = ["const_generics", "union"] }
 typed-arena.workspace = true
 bun_alloc.workspace = true

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -719,7 +719,7 @@ pub(crate) fn to_bytes(
     for output_file in output_files {
         string_builder.count_z(&output_file.dest_path);
         string_builder.count_z(prefix);
-        if let options::OutputValue::Buffer { bytes } = &output_file.value {
+        if let options::OutputFileValue::Buffer { bytes } = &output_file.value {
             if output_file.output_kind == options::OutputKind::Sourcemap {
                 // This is an over-estimation to ensure that we allocate
                 // enough memory for the source-map contents. Calculating
@@ -769,7 +769,7 @@ pub(crate) fn to_bytes(
             continue;
         }
 
-        let options::OutputValue::Buffer { bytes: buf_bytes } = &output_file.value else {
+        let options::OutputFileValue::Buffer { bytes: buf_bytes } = &output_file.value else {
             continue;
         };
 


### PR DESCRIPTION
Follow-up to #34763, #34767, #34778.

### bumpalo dependency removed

`bumpalo` is dropped from the workspace root and 10 member crates (ast, base64, bundler, css, js_parser, js_printer, parsers, resolver, shell_parser, sourcemap). The last code-level use was the `pub type Bump = bumpalo::Bump` alias deleted in #34778; every remaining `bumpalo` reference in `src/` is in a comment (verified: `rg 'bumpalo' --type rust src/ | grep -v '//'` returns nothing).

### TaggedPointer → TaggedPtr

The long-name `TaggedPointer` alias existed in both `bun_ptr` and `bun_collections`, both resolving to `tagged_pointer::TaggedPtr`. Rewrote the 5 call sites to use `TaggedPtr` directly and replaced both aliases with plain re-exports of the canonical name:
- `io/posix_event_loop.rs` (3 sites, via `bun_collections::`)
- `runtime/server/mod.rs`, `runtime/server/NodeHTTPResponse.rs` (2 sites, via `bun_ptr::`)

### Duplicate/compat aliases consolidated

- `bun_ast::ToSourceOpts` → `ToSourceOptions` (1 caller in `ini/lib.rs`)
- `bundler::options::OutputValue` → `OutputFileValue` (2 callers in `StandaloneModuleGraph.rs`; both names aliased the same `output_file::Value` on adjacent lines)

### Verification

- `bun bd` builds
- `bun run rust:check-all` passes on all 10 targets

Net: +11 / -39 (including Cargo.lock regen).

No test added: bumpalo was already unreferenced in code (dead dep removal has no fail-before state); the alias rewrites are identity substitutions to the type each alias already resolved to.