### PR TITLE
standalone: route madvise hint logging through a scoped logger

### DIFF
--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -23,6 +23,8 @@ use bun_paths::{OSPathBuffer, WPathBuffer};
 use bun_sourcemap as SourceMap;
 use bun_sys::{self as Syscall, Fd, FdExt as _, Stat};
 
+bun_core::declare_scope!(StandaloneModuleGraph, hidden);
+
 // `bun_webcore::Blob` lives in a higher tier and `cached_blob` is only ever
 // set from `bun_runtime`, so it is modeled as an opaque erased pointer here.
 bun_opaque::opaque_ffi! {
@@ -2115,13 +2117,15 @@ impl StandaloneModuleGraph {
                     )
                 };
                 if rc != 0 {
-                    bun_core::debug_warn!(
+                    bun_core::scoped_log!(
+                        StandaloneModuleGraph,
                         "hintSourcePagesDontNeed: madvise failed errno={}",
                         bun_sys::last_errno()
                     );
                     return;
                 }
-                bun_core::debug_warn!(
+                bun_core::scoped_log!(
+                    StandaloneModuleGraph,
                     "hintSourcePagesDontNeed: MADV_DONTNEED {} bytes",
                     end - start
                 );

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -451,14 +451,14 @@ if (isLinux) {
       expect(bunAddr % 128n).toBe(0n);
 
       // Sanity: the binary still runs and produces the expected output.
-      // (Ignore stderr — a debug-ASAN bun may log `hintSourcePagesDontNeed`
-      // advisory warnings from the compiled binary's mmap'd .bun segment.)
       await using proc = Bun.spawn({
         cmd: [result.outputs[0].path],
+        env: bunEnv,
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
       expect(stdout).toContain("wsl1-regression-20000");
       expect(exitCode).toBe(0);
     }, 60_000);

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -20,7 +20,7 @@ describe("bundler", () => {
         console.log("Hello, world!");
       `,
     },
-    run: { stdout: "Hello, world!" },
+    run: { stdout: "Hello, world!", stderr: "" },
   });
   // --footer/--banner are concatenated verbatim (UTF-8). Guard against the
   // standalone module graph treating those bytes as Latin-1, which would

--- a/test/js/bun/compile/standalone-madvise-tla.test.ts
+++ b/test/js/bun/compile/standalone-madvise-tla.test.ts
@@ -8,58 +8,62 @@ import path from "node:path";
 
 // Relies on the StandaloneModuleGraph scoped logger which is compiled out in
 // release builds.
-test.skipIf(isWindows || !isDebug)("standalone madvise hint fires with top-level await entrypoint", async () => {
-  using dir = tempDir("standalone-madvise-tla", {
-    "entry.ts": `
+test.skipIf(isWindows || !isDebug)(
+  "standalone madvise hint fires with top-level await entrypoint",
+  async () => {
+    using dir = tempDir("standalone-madvise-tla", {
+      "entry.ts": `
       console.log("before-await");
       await new Promise<void>(r => setTimeout(r, 0));
       console.log("after-await");
     `,
-  });
-
-  const out = path.join(String(dir), "compiled");
-  const build = Bun.spawnSync({
-    cmd: [bunExe(), "build", "--compile", path.join(String(dir), "entry.ts"), "--outfile", out],
-    env: bunEnv,
-    stderr: "pipe",
-    stdout: "pipe",
-  });
-  expect(build.stderr.toString()).not.toContain("error:");
-  expect(build.exitCode).toBe(0);
-
-  {
-    await using proc = Bun.spawn({
-      cmd: [out],
-      env: { ...bunEnv, BUN_DEBUG_StandaloneModuleGraph: "1" },
-      stdout: "pipe",
-      stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stdout).toContain("before-await");
-    expect(stdout).toContain("after-await");
-    // Scoped loggers write to the debug-writer stream (stdout by default).
-    // Either the success or failure variant proves the call site is reached.
-    expect(stdout).toContain("hintSourcePagesDontNeed:");
-    expect(stderr).toBe("");
-    expect(exitCode).toBe(0);
-  }
-
-  // The scope is declared hidden, so without opting in the log must not
-  // appear even when BUN_DEBUG_QUIET_LOGS is unset.
-  {
-    await using proc = Bun.spawn({
-      cmd: [out],
-      env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: undefined },
-      stdout: "pipe",
+    const out = path.join(String(dir), "compiled");
+    const build = Bun.spawnSync({
+      cmd: [bunExe(), "build", "--compile", path.join(String(dir), "entry.ts"), "--outfile", out],
+      env: bunEnv,
       stderr: "pipe",
+      stdout: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(build.stderr.toString()).not.toContain("error:");
+    expect(build.exitCode).toBe(0);
 
-    expect(stdout).not.toContain("hintSourcePagesDontNeed:");
-    expect(stdout).toContain("before-await");
-    expect(stdout).toContain("after-await");
-    expect(stderr).not.toContain("hintSourcePagesDontNeed:");
-    expect(exitCode).toBe(0);
-  }
-}, 30_000);
+    {
+      await using proc = Bun.spawn({
+        cmd: [out],
+        env: { ...bunEnv, BUN_DEBUG_StandaloneModuleGraph: "1" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stdout).toContain("before-await");
+      expect(stdout).toContain("after-await");
+      // Scoped loggers write to the debug-writer stream (stdout by default).
+      // Either the success or failure variant proves the call site is reached.
+      expect(stdout).toContain("hintSourcePagesDontNeed:");
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    }
+
+    // The scope is declared hidden, so without opting in the log must not
+    // appear even when BUN_DEBUG_QUIET_LOGS is unset.
+    {
+      await using proc = Bun.spawn({
+        cmd: [out],
+        env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: undefined },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stdout).not.toContain("hintSourcePagesDontNeed:");
+      expect(stdout).toContain("before-await");
+      expect(stdout).toContain("after-await");
+      expect(stderr).not.toContain("hintSourcePagesDontNeed:");
+      expect(exitCode).toBe(0);
+    }
+  },
+  30_000,
+);

--- a/test/js/bun/compile/standalone-madvise-tla.test.ts
+++ b/test/js/bun/compile/standalone-madvise-tla.test.ts
@@ -6,7 +6,8 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isDebug, isWindows, tempDir } from "harness";
 import path from "node:path";
 
-// Relies on Output.debugWarn which is compiled out in release builds.
+// Relies on the StandaloneModuleGraph scoped logger which is compiled out in
+// release builds.
 test.skipIf(isWindows || !isDebug)("standalone madvise hint fires with top-level await entrypoint", async () => {
   using dir = tempDir("standalone-madvise-tla", {
     "entry.ts": `
@@ -26,18 +27,39 @@ test.skipIf(isWindows || !isDebug)("standalone madvise hint fires with top-level
   expect(build.stderr.toString()).not.toContain("error:");
   expect(build.exitCode).toBe(0);
 
-  await using proc = Bun.spawn({
-    cmd: [out],
-    env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: undefined },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  {
+    await using proc = Bun.spawn({
+      cmd: [out],
+      env: { ...bunEnv, BUN_DEBUG_StandaloneModuleGraph: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stdout).toContain("before-await");
-  expect(stdout).toContain("after-await");
-  // Output.debugWarn is debug-build-only; either the success or failure
-  // variant proves the call site is reached.
-  expect(stderr).toContain("hintSourcePagesDontNeed:");
-  expect(exitCode).toBe(0);
-});
+    expect(stdout).toContain("before-await");
+    expect(stdout).toContain("after-await");
+    // Scoped loggers write to the debug-writer stream (stdout by default).
+    // Either the success or failure variant proves the call site is reached.
+    expect(stdout).toContain("hintSourcePagesDontNeed:");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  }
+
+  // The scope is declared hidden, so without opting in the log must not
+  // appear even when BUN_DEBUG_QUIET_LOGS is unset.
+  {
+    await using proc = Bun.spawn({
+      cmd: [out],
+      env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: undefined },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).not.toContain("hintSourcePagesDontNeed:");
+    expect(stdout).toContain("before-await");
+    expect(stdout).toContain("after-await");
+    expect(stderr).not.toContain("hintSourcePagesDontNeed:");
+    expect(exitCode).toBe(0);
+  }
+}, 30_000);


### PR DESCRIPTION
## Repro

```
$ bun bd test test/bundler/bundler_compile.test.ts -t HelloWorldBytecode
...
- [Disk Cache] Cache miss for sourceCode"
+ [Disk Cache] Cache miss for sourceCode
+ debug warn: hintSourcePagesDontNeed: MADV_DONTNEED 4096 bytes"
```

Every standalone executable produced by a debug build prints that line on startup, so every exact-`stderr` assertion in `bundler_compile.test.ts` (`HelloWorldBytecode`, the three `ReactSSR+bytecode` variants) fails under `bun bd`. CI doesn't see it because the test lanes run a release build. Several open PRs (#33337, #33316, #29066) have had to call it out as pre-existing debug noise in their verification sections, and `bun-build-compile.test.ts` grew a workaround comment that discards stderr.

## Cause

`hint_source_pages_dont_need()` logs the `madvise(MADV_DONTNEED)` outcome with `debug_warn!`, which writes to stderr unconditionally in debug builds and is not silenced by `BUN_DEBUG_QUIET_LOGS`. The success path is purely informational, and the failure path is documented as a best-effort hint, so neither is a warning.

## Fix

Declare a hidden `StandaloneModuleGraph` scope and route both log sites through `scoped_log!`. The information is still available via `BUN_DEBUG_StandaloneModuleGraph=1`; by default a compiled binary's stderr is clean again. Release builds are unaffected either way since both macros compile out.

Test changes:

- `compile/HelloWorld` now asserts `stderr: ""` so the regression is covered directly rather than only as a side effect of the bytecode cache tests.
- `standalone-madvise-tla.test.ts` was asserting the hint on stderr via the old `debug_warn!` path; it now opts in with `BUN_DEBUG_StandaloneModuleGraph=1` and reads the scoped log from stdout (scoped loggers write to the debug stream, which is stdout by default). A second run without the env var asserts the scope stays hidden even with `BUN_DEBUG_QUIET_LOGS` unset.
- The workaround comment and discarded stderr in the `#29963` PT_GNU_STACK test in `bun-build-compile.test.ts` are replaced with `expect(stderr).toBe("")`.

## Verification

```
$ bun bd test test/bundler/bundler_compile.test.ts -t "compile/HelloWorld$|HelloWorldBytecode|ImportDeferBytecode|ReactSSR\+bytecode"
 7 pass, 0 fail
$ bun bd test test/js/bun/compile/standalone-madvise-tla.test.ts
 1 pass, 0 fail
$ bun bd test test/bundler/bun-build-compile.test.ts -t "preserves PT_GNU_STACK"
 1 pass, 0 fail

# opt-in still works
$ BUN_DEBUG_StandaloneModuleGraph=1 ./compiled-out
hi
[standalonemodulegraph] hintSourcePagesDontNeed: MADV_DONTNEED 4096 bytes
```

`cargo check -p bun_standalone_graph` and `--target x86_64-pc-windows-msvc` both clean; `cargo clippy -p bun_standalone_graph --no-deps` clean.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-compile.test.ts test/bundler/bundler_compile.test.ts test/js/bun/compile/standalone-madvise-tla.test.ts

<!-- robobun:evidence:end -->