### PR TITLE
http: drop no-op Vec::clear and dead Option branches in client state

### DIFF
--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -249,9 +249,7 @@ impl RequestBodyBuffer {
         // A `Vec` cannot adopt a foreign allocator+buffer, so this
         // allocates a fresh Vec of the same capacity.
         // Callers that can should write into allocated_slice() directly instead.
-        let mut arraylist = Vec::with_capacity(self.allocated_slice().len());
-        arraylist.clear();
-        arraylist
+        Vec::with_capacity(self.allocated_slice().len())
     }
 }
 

--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -167,10 +167,6 @@ impl<'a> InternalState<'a> {
     }
 
     pub fn reset(&mut self) {
-        // allocator param dropped (global mimalloc).
-        self.compressed_body = MutableString::init_empty();
-        self.response_message_buffer = MutableString::init_empty();
-
         let body_msg = self.body_out_str;
         if let Some(body) = body_msg {
             crate::body_out::as_mut(body).reset();

--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -175,19 +175,9 @@ impl<'a> InternalState<'a> {
         if let Some(body) = body_msg {
             crate::body_out::as_mut(body).reset();
         }
-        // The boxed
-        // Zlib/Brotli/Zstd readers all impl Drop calling end()/destroy_instance
-        // (see the note in Decompressor.rs), so the `*self = ...` assignment below
-        // frees the FFI handle via drop glue — no explicit reset needed.
-
-        // just in case we check and free to avoid leaks
-        // (Option<HTTPResponseMetadata> drops on assignment; allocator param removed)
-        self.cloned_metadata = None;
-
-        // if exists we own this info
-        // (Option<CertificateInfo> drops on assignment; allocator param removed)
-        self.certificate_info = None;
-
+        // `*self = ...` below drops every field via drop glue. Only
+        // `original_request_body` needs an explicit `deinit()` because
+        // `HTTPRequestBody` deliberately has no `Drop` (see HTTPRequestBody.rs).
         self.original_request_body.deinit();
         *self = InternalState {
             body_out_str: body_msg,

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4641,29 +4641,26 @@ impl<'a> HTTPClient<'a> {
             self.state.cloned_metadata = None;
         }
 
-        let mut certificate_info: Option<CertificateInfo> = None;
-        if let Some(info) = self.state.certificate_info.take() {
-            // transfer owner ship of the certificate info here
-            certificate_info = Some(info);
-        } else if let Some(metadata) = self.state.cloned_metadata.take() {
-            // transfer owner ship of the metadata here
-            return HTTPClientResult {
-                metadata: Some(metadata),
-                body: body_out::opt_mut(self.state.body_out_str),
-                redirected: self.flags.redirected,
-                fail: self.state.fail,
-                dns_error: self.state.dns_error,
-                dns_hostname: self.state.dns_hostname.take(),
-                // check if we are reporting cert errors, do not have a fail state and we are not done
-                has_more: certificate_info.is_some()
-                    || (self.state.fail.is_none() && !self.state.is_done()),
-                body_size,
-                certificate_info: None,
-                can_stream: (self.state.request_stage == RequestStage::Body
-                    || self.state.request_stage == RequestStage::ProxyBody)
-                    && self.flags.is_streaming_request_body,
-                is_http2: self.flags.protocol != Protocol::Http1_1,
-            };
+        let certificate_info = self.state.certificate_info.take();
+        if certificate_info.is_none() {
+            if let Some(metadata) = self.state.cloned_metadata.take() {
+                // transfer ownership of the metadata here
+                return HTTPClientResult {
+                    metadata: Some(metadata),
+                    body: body_out::opt_mut(self.state.body_out_str),
+                    redirected: self.flags.redirected,
+                    fail: self.state.fail,
+                    dns_error: self.state.dns_error,
+                    dns_hostname: self.state.dns_hostname.take(),
+                    has_more: self.state.fail.is_none() && !self.state.is_done(),
+                    body_size,
+                    certificate_info: None,
+                    can_stream: (self.state.request_stage == RequestStage::Body
+                        || self.state.request_stage == RequestStage::ProxyBody)
+                        && self.flags.is_streaming_request_body,
+                    is_http2: self.flags.protocol != Protocol::Http1_1,
+                };
+            }
         }
         HTTPClientResult {
             body: body_out::opt_mut(self.state.body_out_str),


### PR DESCRIPTION
Drops Zig-port leftovers in `src/http/`. Each is either a no-op or a constant-folded branch; the diff is behavior-preserving by construction. Net -19 lines.

### Changes

- **`src/http/HTTPThread.rs` `RequestBodyBuffer::to_array_list`**: `Vec::with_capacity(n)` returns `len() == 0` by definition; the immediately following `.clear()` is a no-op. Collapse to `Vec::with_capacity(self.allocated_slice().len())`. (#32350 will supersede this by deleting the function entirely, but that PR has been open since June; this change is correct on its own and the conflict is trivial.)

- **`src/http/lib.rs` `HTTPClient::to_result`**: inside the `else if let Some(metadata) = ...` arm, `certificate_info` is the `None` initialised two lines above (the `if let` that would set it `Some` is the *other* arm of the same `if`/`else`), so `certificate_info.is_some()` is a constant `false` and `has_more` reduces to `self.state.fail.is_none() && !self.state.is_done()`. The surrounding `let mut x = None; if let Some(i) = y.take() { x = Some(i) } else ...` reduces to `let x = y.take(); if x.is_none() { ... }`.

- **`src/http/InternalState.rs` `reset`**: the explicit `self.compressed_body = init_empty()` / `self.response_message_buffer = init_empty()` / `self.cloned_metadata = None` / `self.certificate_info = None` assignments all immediately precede `*self = InternalState{...}`, whose drop glue drops every field of the old value (`InternalState` has no `Drop` impl; `MutableString` wraps a plain `Vec<u8>`, `Option<HTTPResponseMetadata>` and `Option<CertificateInfo>` drop via their fields' `Drop` glue). The removed code's own comments already acknowledged this. `original_request_body.deinit()` stays: `HTTPRequestBody` deliberately has no `Drop` (see `HTTPRequestBody.rs:51-54`), so its intrusive refcount release must be explicit.

### Verification

`cargo check -p bun_http` and `cargo clippy -p bun_http` are clean. Targeted test runs with the debug build:

- `test/js/web/fetch/fetch-redirect.test.ts` (12/12, exercises `InternalState::reset` on every hop)
- `test/js/web/fetch/fetch-gzip.test.ts` (60/60, exercises decompressor drop via `reset`)
- `test/js/web/fetch/fetch.tls.test.ts -t checkServerIdentity` (10/10, exercises both `certificate_info` arms of `to_result`)

`fetch.test.ts` / `fetch-leak.test.ts` have the same set of pre-existing failures with and without this diff.

No new test is added: each change is a boolean/drop identity, so no input can distinguish before from after.
