### PR TITLE
rust: drop redundant cfg!(debug_assertions) wrappers around debug_assert!

### DIFF
--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -820,19 +820,17 @@ impl InlinedEnumValue {
                 }
             },
         };
-        if cfg!(debug_assertions) {
-            debug_assert!(match encoded.decode() {
-                InlinedEnumValueDecoded::String(str_) => match decoded {
-                    InlinedEnumValueDecoded::String(orig) => core::ptr::eq(str_, orig),
-                    _ => false,
-                },
-                InlinedEnumValueDecoded::Number(num) => match decoded {
-                    InlinedEnumValueDecoded::Number(orig) =>
-                        num.to_bits() == Self::purify_nan(orig).to_bits(),
-                    _ => false,
-                },
-            });
-        }
+        debug_assert!(match encoded.decode() {
+            InlinedEnumValueDecoded::String(str_) => match decoded {
+                InlinedEnumValueDecoded::String(orig) => core::ptr::eq(str_, orig),
+                _ => false,
+            },
+            InlinedEnumValueDecoded::Number(num) => match decoded {
+                InlinedEnumValueDecoded::Number(orig) =>
+                    num.to_bits() == Self::purify_nan(orig).to_bits(),
+                _ => false,
+            },
+        });
         encoded
     }
 

--- a/src/bun_core/string/MutableString.rs
+++ b/src/bun_core/string/MutableString.rs
@@ -226,9 +226,7 @@ impl MutableString {
 
             let _ = has_needed_gap;
 
-            if cfg!(debug_assertions) {
-                debug_assert!(js_lexer::is_identifier(&mutable.list));
-            }
+            debug_assert!(js_lexer::is_identifier(&mutable.list));
 
             return Ok(mutable.to_owned_slice());
         }

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -1847,10 +1847,8 @@ fn _decode_hex_to_bytes<Char: HexChar, const TRUNCATE: bool>(
 }
 
 pub fn encode_bytes_to_hex(destination: &mut [u8], source: &[u8]) -> usize {
-    if cfg!(debug_assertions) {
-        debug_assert!(!destination.is_empty());
-        debug_assert!(!source.is_empty());
-    }
+    debug_assert!(!destination.is_empty());
+    debug_assert!(!source.is_empty());
     let to_write = if destination.len() < source.len() * 2 {
         destination.len() - destination.len() % 2
     } else {
@@ -2309,22 +2307,18 @@ pub fn move_all_slices<'a, T: MoveSlices<'a> + ?Sized>(
 }
 
 pub fn move_slice<'a>(slice: &[u8], from: &[u8], to: &'a [u8]) -> &'a [u8] {
-    if cfg!(debug_assertions) {
-        debug_assert!(from.len() <= to.len() && from.len() >= slice.len());
-        // assert we are in bounds
-        debug_assert!(
-            (from.as_ptr() as usize + from.len()) >= slice.as_ptr() as usize + slice.len()
-                && (from.as_ptr() as usize <= slice.as_ptr() as usize)
-        );
-        debug_assert!(eql_long(from, &to[0..from.len()], false)); // data should be identical
-    }
+    debug_assert!(from.len() <= to.len() && from.len() >= slice.len());
+    // assert we are in bounds
+    debug_assert!(
+        (from.as_ptr() as usize + from.len()) >= slice.as_ptr() as usize + slice.len()
+            && (from.as_ptr() as usize <= slice.as_ptr() as usize)
+    );
+    debug_assert!(eql_long(from, &to[0..from.len()], false)); // data should be identical
 
     let ptr_offset = slice.as_ptr() as usize - from.as_ptr() as usize;
     let result = &to[ptr_offset..][0..slice.len()];
 
-    if cfg!(debug_assertions) {
-        debug_assert!(eql_long(slice, result, false)); // data should be identical
-    }
+    debug_assert!(eql_long(slice, result, false)); // data should be identical
 
     result
 }

--- a/src/bun_core/string/wtf.rs
+++ b/src/bun_core/string/wtf.rs
@@ -165,9 +165,7 @@ impl WTFStringImplExt for WTFStringImplStruct {
     /// Caller must ensure that the string is 8-bit and ASCII.
     #[inline]
     fn utf8_slice(&self) -> &[u8] {
-        if cfg!(debug_assertions) {
-            debug_assert!(self.can_use_as_utf8());
-        }
+        debug_assert!(self.can_use_as_utf8());
         self.raw_bytes(self.length() as usize)
     }
 }

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -698,9 +698,7 @@ impl<'a> LinkerGraph<'a> {
                 .zip(source_indices.iter_mut())
             {
                 let source = &sources[i.get() as usize];
-                if cfg!(debug_assertions) {
-                    debug_assert!(source.index.0 == i.get());
-                }
+                debug_assert!(source.index.0 == i.get());
                 entry_point_kinds[source.index.0 as usize] = entry_point::Kind::UserSpecified;
 
                 // Check if this entry point has an original name (from virtual entry resolution)

--- a/src/bundler/linker.rs
+++ b/src/bundler/linker.rs
@@ -693,9 +693,7 @@ impl Linker {
 
             ImportPathFormat::AbsoluteUrl => {
                 if namespace == b"node" {
-                    if cfg!(debug_assertions) {
-                        debug_assert!(&source_path[0..5] == b"node:");
-                    }
+                    debug_assert!(&source_path[0..5] == b"node:");
 
                     let mut buf: Vec<u8> = Vec::new();
                     // assumption: already starts with "node:"

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -924,9 +924,7 @@ pub fn defines_from_transform_options(
             break 'load_env;
         };
 
-        if cfg!(debug_assertions) {
-            debug_assert!(framework.behavior != api::DotEnvBehavior::None);
-        }
+        debug_assert!(framework.behavior != api::DotEnvBehavior::None);
 
         behavior = framework.behavior;
         if behavior == api::DotEnvBehavior::LoadAllWithoutInlining

--- a/src/collections/pool.rs
+++ b/src/collections/pool.rs
@@ -359,9 +359,7 @@ where
     }
 
     pub fn push(pooled: T) {
-        if cfg!(debug_assertions) {
-            debug_assert!(!Self::full());
-        }
+        debug_assert!(!Self::full());
 
         let new_node = bun_core::heap::into_raw(Box::new(Node::<T> {
             next: ptr::null_mut(),

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -3401,10 +3401,8 @@ impl<'a> Parser<'a> {
         // don't call this if css modules is not enabled!
         debug_assert!(self.flags.css_modules());
         debug_assert!(self.extra.is_some());
-        if cfg!(debug_assertions) {
-            // tag should only have one bit set, or none
-            debug_assert!(tag.bits().count_ones() <= 1);
-        }
+        // tag should only have one bit set, or none
+        debug_assert!(tag.bits().count_ones() <= 1);
 
         let extra = self.extra.as_deref_mut().unwrap();
         // Split borrows so the miss arm can grow `symbols` while

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -1064,9 +1064,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_quoted<const QUOTE: u8>(&mut self) -> Result<Option<&[u8]>, AllocError> {
-        if cfg!(debug_assertions) {
-            debug_assert!(self.src[self.pos] == QUOTE);
-        }
+        debug_assert!(self.src[self.pos] == QUOTE);
         let start = self.pos;
         self.value_buffer.clear(); // Reset the buffer
         let mut end = start + 1;
@@ -1084,9 +1082,7 @@ impl<'a> Parser<'a> {
                         match self.src[i] {
                             b'\\' => {
                                 if QUOTE == b'"' {
-                                    if cfg!(debug_assertions) {
-                                        debug_assert!(i + 1 < end);
-                                    }
+                                    debug_assert!(i + 1 < end);
                                     match self.src[i + 1] {
                                         b'n' => {
                                             self.value_buffer.push(b'\n');

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -595,11 +595,9 @@ impl<const SSL: bool> HTTPContext<SSL> {
     ) {
         // log("releaseSocket(0x{f})", .{bun.fmt.hexIntUpper(@intFromPtr(socket.socket))});
 
-        if cfg!(debug_assertions) {
-            debug_assert!(!socket.is_closed());
-            debug_assert!(!socket.is_shutdown());
-            debug_assert!(socket.is_established());
-        }
+        debug_assert!(!socket.is_closed());
+        debug_assert!(!socket.is_shutdown());
+        debug_assert!(socket.is_established());
         debug_assert!(!hostname.is_empty());
         debug_assert!(port > 0);
 

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4735,14 +4735,12 @@ impl<'a> HTTPClient<'a> {
             }
 
             if self.state.response_message_buffer.owns(incoming_data) {
-                if cfg!(debug_assertions) {
-                    // i'm not sure why this would happen and i haven't seen it happen
-                    // but we should check
-                    debug_assert!(
-                        self.state.get_body_buffer().list.as_ptr()
-                            != self.state.response_message_buffer.list.as_ptr()
-                    );
-                }
+                // i'm not sure why this would happen and i haven't seen it happen
+                // but we should check
+                debug_assert!(
+                    self.state.get_body_buffer().list.as_ptr()
+                        != self.state.response_message_buffer.list.as_ptr()
+                );
                 self.state.response_message_buffer = MutableString::default();
             }
         }
@@ -5294,9 +5292,7 @@ impl<'a> HTTPClient<'a> {
 
                                 let _ = string_builder.append(location);
 
-                                if cfg!(debug_assertions) {
-                                    debug_assert!(string_builder.cap == string_builder.len);
-                                }
+                                debug_assert!(string_builder.cap == string_builder.len);
 
                                 let input =
                                     BunString::borrow_utf8(string_builder.allocated_slice());
@@ -5355,9 +5351,7 @@ impl<'a> HTTPClient<'a> {
 
                                 let _ = string_builder.append(location);
 
-                                if cfg!(debug_assertions) {
-                                    debug_assert!(string_builder.cap == string_builder.len);
-                                }
+                                debug_assert!(string_builder.cap == string_builder.len);
 
                                 let input =
                                     BunString::borrow_utf8(string_builder.allocated_slice());

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -885,7 +885,6 @@ impl<const SSL: bool> HTTPClient<SSL> {
 
         debug_assert!(this.is_same_socket(socket));
 
-        #[cfg(debug_assertions)]
         debug_assert!(!socket.is_shutdown());
 
         // Handle proxy handshake response

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -2360,12 +2360,10 @@ impl<'a> PackageInstall<'a> {
                                     .as_mut_slice()
                             };
 
-                            if cfg!(debug_assertions) {
-                                debug_assert!(bun_core::is_slice_in_buffer(
-                                    self.cache_dir_subpath.as_bytes(),
-                                    buf
-                                ));
-                            }
+                            debug_assert!(bun_core::is_slice_in_buffer(
+                                self.cache_dir_subpath.as_bytes(),
+                                buf
+                            ));
 
                             let subpath_len =
                                 strings::without_trailing_slash(self.cache_dir_subpath.as_bytes())

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -433,9 +433,7 @@ impl<'a> PackageInstaller<'a> {
         tree_id: lockfile::tree::Id,
         log_level: Options::LogLevel,
     ) {
-        if cfg!(debug_assertions) {
-            debug_assert!(tree_id != lockfile::tree::INVALID_ID);
-        }
+        debug_assert!(tree_id != lockfile::tree::INVALID_ID);
 
         let tree = &mut self.trees[tree_id as usize];
         let current_count = tree.install_count;
@@ -1090,11 +1088,9 @@ impl<'a> PackageInstaller<'a> {
         folder_path: &mut bun_paths::AutoAbsPath,
         log_level: Options::LogLevel,
     ) -> usize {
-        if cfg!(debug_assertions) {
-            debug_assert!(resolution_tag != resolution::Tag::Root);
-            debug_assert!(resolution_tag != resolution::Tag::Workspace);
-            debug_assert!(package_id != 0);
-        }
+        debug_assert!(resolution_tag != resolution::Tag::Root);
+        debug_assert!(resolution_tag != resolution::Tag::Workspace);
+        debug_assert!(package_id != 0);
         let mut count: usize = 0;
         let scripts = 'brk: {
             let scripts = self.lockfile().packages.items_scripts()[package_id as usize];
@@ -1125,9 +1121,7 @@ impl<'a> PackageInstaller<'a> {
             break 'brk temp;
         };
 
-        if cfg!(debug_assertions) {
-            debug_assert!(scripts.filled);
-        }
+        debug_assert!(scripts.filled);
 
         match resolution_tag {
             resolution::Tag::Git | resolution::Tag::Github | resolution::Tag::Root => {
@@ -1507,9 +1501,7 @@ impl<'a> PackageInstaller<'a> {
                     resolution.tag,
                 )
             {
-                if cfg!(debug_assertions) {
-                    debug_assert!(resolution.can_enqueue_install_task());
-                }
+                debug_assert!(resolution.can_enqueue_install_task());
 
                 let context =
                     TaskCallbackContext::DependencyInstallContext(DependencyInstallContext {
@@ -1980,13 +1972,11 @@ impl<'a> PackageInstaller<'a> {
                     );
                 }
                 package_install::InstallResult::Failure(cause) => {
-                    if cfg!(debug_assertions) {
-                        debug_assert!(
-                            !cause.is_package_missing_from_cache()
-                                || (resolution.tag != resolution::Tag::Symlink
-                                    && resolution.tag != resolution::Tag::Workspace)
-                        );
-                    }
+                    debug_assert!(
+                        !cause.is_package_missing_from_cache()
+                            || (resolution.tag != resolution::Tag::Symlink
+                                && resolution.tag != resolution::Tag::Workspace)
+                    );
 
                     // even if the package failed to install, we still need to increment the install
                     // counter for this tree

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -879,7 +879,6 @@ pub(crate) fn edit(
             // paths between the top of this `for` body and here, so a plain post-loop assert
             // suffices (and avoids a `scopeguard` borrow conflict on
             // `request.e_string`).
-            #[cfg(debug_assertions)]
             debug_assert!(request.e_string.is_some());
         }
 

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -923,9 +923,7 @@ pub fn path_for_cached_npm_path<'a>(
     let cache_path_len = cache_path.as_bytes().len();
     // reshaped for borrowck — drop borrow before mutating buffer
 
-    if cfg!(debug_assertions) {
-        debug_assert!(cache_path_buf[package_name.len()] == b'@');
-    }
+    debug_assert!(cache_path_buf[package_name.len()] == b'@');
 
     cache_path_buf[package_name.len()] = SEP;
 

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -486,9 +486,7 @@ pub fn enqueue_dependency_to_root(
         let index = lf.dependencies.len();
         lf.dependencies.push(dep);
         lf.resolutions.push(invalid_package_id);
-        if cfg!(debug_assertions) {
-            debug_assert!(lf.dependencies.len() == lf.resolutions.len());
-        }
+        debug_assert!(lf.dependencies.len() == lf.resolutions.len());
         break 'brk index;
     } as DependencyID;
 
@@ -1011,9 +1009,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                         let name_str: Vec<u8> = this.lockfile.str(&name).to_vec();
                         let task_id = Task::Id::for_manifest(&name_str);
 
-                        if cfg!(debug_assertions) {
-                            debug_assert!(task_id.get() != 0);
-                        }
+                        debug_assert!(task_id.get() != 0);
 
                         if cfg!(debug_assertions) {
                             bun_output::scoped_log!(
@@ -1432,9 +1428,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 }
 
                 // should not trigger a network call
-                if cfg!(debug_assertions) {
-                    debug_assert!(result.task.is_none());
-                }
+                debug_assert!(result.task.is_none());
 
                 if cfg!(debug_assertions) {
                     bun_output::scoped_log!(
@@ -2079,9 +2073,7 @@ fn get_or_put_resolved_package_with_find_result(
         Features::NPM,
     )?)?;
 
-    if cfg!(debug_assertions) {
-        debug_assert!(package.meta.id != invalid_package_id);
-    }
+    debug_assert!(package.meta.id != invalid_package_id);
     // Record exact-version pins so `Lockfile::get_package_id`'s
     // order-independence guard can tell them apart from range-resolved
     // entries (which it treats as network-order artefacts).

--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -298,13 +298,11 @@ impl PackageManager {
 
     pub fn assign_resolution(&mut self, dependency_id: DependencyID, package_id: PackageID) {
         // reshaped for borrowck — capture lengths before mutable borrows.
-        if cfg!(debug_assertions) {
-            debug_assert!(
-                (dependency_id as usize) < self.lockfile.buffers.resolutions.as_slice().len()
-            );
-            debug_assert!((package_id as usize) < self.lockfile.packages.len());
-            // debug_assert!(self.lockfile.buffers.resolutions.as_slice()[dependency_id as usize] == invalid_package_id);
-        }
+        debug_assert!(
+            (dependency_id as usize) < self.lockfile.buffers.resolutions.as_slice().len()
+        );
+        debug_assert!((package_id as usize) < self.lockfile.packages.len());
+        // debug_assert!(self.lockfile.buffers.resolutions.as_slice()[dependency_id as usize] == invalid_package_id);
         let buffers = &mut self.lockfile.buffers;
         buffers.resolutions.as_mut_slice()[dependency_id as usize] = package_id;
         let string_buf = buffers.string_bytes.as_slice();
@@ -319,16 +317,14 @@ impl PackageManager {
 
     pub fn assign_root_resolution(&mut self, dependency_id: DependencyID, package_id: PackageID) {
         // reshaped for borrowck — capture lengths before mutable borrows.
-        if cfg!(debug_assertions) {
-            debug_assert!(
-                (dependency_id as usize) < self.lockfile.buffers.resolutions.as_slice().len()
-            );
-            debug_assert!((package_id as usize) < self.lockfile.packages.len());
-            debug_assert!(
-                self.lockfile.buffers.resolutions.as_slice()[dependency_id as usize]
-                    == invalid_package_id
-            );
-        }
+        debug_assert!(
+            (dependency_id as usize) < self.lockfile.buffers.resolutions.as_slice().len()
+        );
+        debug_assert!((package_id as usize) < self.lockfile.packages.len());
+        debug_assert!(
+            self.lockfile.buffers.resolutions.as_slice()[dependency_id as usize]
+                == invalid_package_id
+        );
         let buffers = &mut self.lockfile.buffers;
         buffers.resolutions.as_mut_slice()[dependency_id as usize] = package_id;
         let string_buf = buffers.string_bytes.as_slice();

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -682,9 +682,7 @@ pub fn install_with_manager(
             let (first_index, _, entries) =
                 scripts.get_script_entries(string_bytes, ResolutionTag::Workspace, add_node_gyp);
 
-            if cfg!(debug_assertions) {
-                debug_assert!(first_index != -1);
-            }
+            debug_assert!(first_index != -1);
 
             // In the `add_node_gyp` arm the assert already guarantees
             // `first_index != -1`, so a single guarded loop covers
@@ -1233,12 +1231,10 @@ fn print_blocked_packages_info(summary: &PackageInstallSummary, global: bool) {
         scripts_count += *count;
     }
 
-    if cfg!(debug_assertions) {
-        // if packages_count is greater than 0, scripts_count must also be greater than 0.
-        debug_assert!(packages_count == 0 || scripts_count > 0);
-        // if scripts_count is 1, it's only possible for packages_count to be 1.
-        debug_assert!(scripts_count != 1 || packages_count == 1);
-    }
+    // if packages_count is greater than 0, scripts_count must also be greater than 0.
+    debug_assert!(packages_count == 0 || scripts_count > 0);
+    // if scripts_count is 1, it's only possible for packages_count to be 1.
+    debug_assert!(scripts_count != 1 || packages_count == 1);
 
     if packages_count > 0 {
         bun_core::prettyln!(
@@ -1822,9 +1818,7 @@ fn run_root_lifecycle_scripts(
     log_level: Options::LogLevel,
 ) -> crate::Result<()> {
     if let Some(scripts) = manager.root_lifecycle_scripts.take() {
-        if cfg!(debug_assertions) {
-            debug_assert!(scripts.total > 0);
-        }
+        debug_assert!(scripts.total > 0);
 
         if log_level != Options::LogLevel::Silent {
             Output::print_error(format_args!("\n"));

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -203,9 +203,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
         // — reclaim ownership exactly once here so the `Box` drops at end of
         // iteration on every path.
         let mut ptask = unsafe { bun_core::heap::take(ptask_ptr) };
-        if cfg!(debug_assertions) {
-            debug_assert!(manager.pending_task_count() > 0);
-        }
+        debug_assert!(manager.pending_task_count() > 0);
         manager.decrement_pending_tasks();
         ptask.run_from_main_thread(manager, log_level)?;
         if let PatchTaskCallback::Apply(apply) = &mut ptask.callback {
@@ -335,9 +333,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
         }
         // SAFETY: `next()` returned non-null; node is exclusively owned by this batch.
         let task = unsafe { &mut *task_ptr };
-        if cfg!(debug_assertions) {
-            debug_assert!(manager.pending_task_count() > 0);
-        }
+        debug_assert!(manager.pending_task_count() > 0);
         manager.decrement_pending_tasks();
         // We cannot free the network task at the end of this scope.
         // It may continue to be referenced in a future task.
@@ -911,9 +907,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
         if task_ptr.is_null() {
             break;
         }
-        if cfg!(debug_assertions) {
-            debug_assert!(manager.pending_task_count() > 0);
-        }
+        debug_assert!(manager.pending_task_count() > 0);
         // raw-ptr capture — borrowck would reject overlapping `&mut`
         // with the loop body. Guard runs on every `continue`/`?`/fallthrough.
         // Phase B: have the iterator yield a pool guard that puts back on Drop.

--- a/src/install/hoisted_install.rs
+++ b/src/install/hoisted_install.rs
@@ -560,9 +560,7 @@ pub(crate) fn install_hoisted_packages(
         // Index instead of `.iter()` so the immutable borrow of
         // `installer.trees` doesn't overlap `&mut self`.
         for tree_idx in 0..installer.trees.len() {
-            if cfg!(debug_assertions) {
-                debug_assert!(installer.trees[tree_idx].pending_installs.len() == 0);
-            }
+            debug_assert!(installer.trees[tree_idx].pending_installs.len() == 0);
             // force = true
             installer.install_available_packages::<true>(log_level);
         }

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -1072,9 +1072,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
     }
 
     pub fn reset_polls(&mut self) {
-        if cfg!(debug_assertions) {
-            debug_assert!(self.remaining_fds == 0);
-        }
+        debug_assert!(self.remaining_fds == 0);
 
         let process = core::mem::replace(&mut self.process, core::ptr::null_mut());
         if !process.is_null() {

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -2237,9 +2237,7 @@ impl Lockfile {
 
         match entry {
             PackageIndexEntry::Id(id) => {
-                if cfg!(debug_assertions) {
-                    debug_assert!((*id as usize) < resolutions.len());
-                }
+                debug_assert!((*id as usize) < resolutions.len());
 
                 if resolutions[*id as usize].eql(resolution, buf, buf) {
                     return Some(*id);
@@ -2251,9 +2249,7 @@ impl Lockfile {
             }
             PackageIndexEntry::Ids(ids) => {
                 for &id in ids.iter() {
-                    if cfg!(debug_assertions) {
-                        debug_assert!((id as usize) < resolutions.len());
-                    }
+                    debug_assert!((id as usize) < resolutions.len());
 
                     if resolutions[id as usize].eql(resolution, buf, buf) {
                         return Some(id);
@@ -2434,9 +2430,7 @@ impl Lockfile {
         self.packages.append(package)?;
         self.get_or_put_id(id, name_hash)?;
 
-        if cfg!(debug_assertions) {
-            debug_assert!(self.get_package_id(name_hash, None, &resolution).is_some());
-        }
+        debug_assert!(self.get_package_id(name_hash, None, &resolution).is_some());
 
         Ok(package)
     }
@@ -2653,11 +2647,9 @@ impl<'a> StringBuilder<'a> {
     }
 
     pub fn clamp(&mut self) {
-        if cfg!(debug_assertions) {
-            debug_assert!(self.cap >= self.len);
-            // assert that no other builder was allocated while this builder was being used
-            debug_assert!(self.string_bytes.len() == self.off + self.cap);
-        }
+        debug_assert!(self.cap >= self.len);
+        // assert that no other builder was allocated while this builder was being used
+        debug_assert!(self.string_bytes.len() == self.off + self.cap);
 
         let excess = self.cap - self.len;
 
@@ -2693,10 +2685,8 @@ impl<'a> StringBuilder<'a> {
         if SemverString::can_inline(slice) {
             return T::from_init(self.string_bytes.as_slice(), slice, hash);
         }
-        if cfg!(debug_assertions) {
-            debug_assert!(self.len <= self.cap); // didn't count everything
-            debug_assert!(self.ptr.is_some()); // must call allocate first
-        }
+        debug_assert!(self.len <= self.cap); // didn't count everything
+        debug_assert!(self.ptr.is_some()); // must call allocate first
 
         // `allocate()` resized `string_bytes` to `off + cap`; write via safe
         // indexing instead of the cached raw `ptr` + `copy_nonoverlapping`.
@@ -2706,9 +2696,7 @@ impl<'a> StringBuilder<'a> {
         let final_slice = &self.string_bytes[start..end];
         self.len += slice.len();
 
-        if cfg!(debug_assertions) {
-            debug_assert!(self.len <= self.cap);
-        }
+        debug_assert!(self.len <= self.cap);
 
         T::from_init(self.string_bytes.as_slice(), final_slice, hash)
     }
@@ -2718,10 +2706,8 @@ impl<'a> StringBuilder<'a> {
             return T::from_init(self.string_bytes.as_slice(), slice, hash);
         }
 
-        if cfg!(debug_assertions) {
-            debug_assert!(self.len <= self.cap); // didn't count everything
-            debug_assert!(self.ptr.is_some()); // must call allocate first
-        }
+        debug_assert!(self.len <= self.cap); // didn't count everything
+        debug_assert!(self.ptr.is_some()); // must call allocate first
 
         let string_entry = self.string_pool.get_or_put(hash).expect("unreachable");
         if !string_entry.found_existing {
@@ -2736,9 +2722,7 @@ impl<'a> StringBuilder<'a> {
             *string_entry.value_ptr = SemverString::init(self.string_bytes.as_slice(), final_slice);
         }
 
-        if cfg!(debug_assertions) {
-            debug_assert!(self.len <= self.cap);
-        }
+        debug_assert!(self.len <= self.cap);
 
         T::from_pooled(*string_entry.value_ptr, hash)
     }
@@ -3203,9 +3187,7 @@ impl Lockfile {
                     PackageIndexEntry::Id(id) => {
                         let resolutions = self.packages.items_resolution();
 
-                        if cfg!(debug_assertions) {
-                            debug_assert!((*id as usize) < resolutions.len());
-                        }
+                        debug_assert!((*id as usize) < resolutions.len());
                         if satisfies(&resolutions[*id as usize]) {
                             return Some(*id);
                         }
@@ -3214,9 +3196,7 @@ impl Lockfile {
                         let resolutions = self.packages.items_resolution();
 
                         for &id in ids.iter() {
-                            if cfg!(debug_assertions) {
-                                debug_assert!((id as usize) < resolutions.len());
-                            }
+                            debug_assert!((id as usize) < resolutions.len());
                             if satisfies(&resolutions[id as usize]) {
                                 return Some(id);
                             }

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -680,9 +680,7 @@ impl Package<u64> {
             package.resolution = Resolution::<u64>::init(TaggedValue::Root);
 
             let total_len = dependencies_list.len() + total_dependencies_count as usize;
-            if cfg!(debug_assertions) {
-                debug_assert!(dependencies_list.len() == resolutions_list.len());
-            }
+            debug_assert!(dependencies_list.len() == resolutions_list.len());
 
             let dep_start = dependencies_list.len();
             bun_core::vec::extend_from_fn(
@@ -788,9 +786,7 @@ impl Package<u64> {
                 let version_strings = map.value.get(&manifest.external_strings_for_versions);
                 total_dependencies_count += map.value.len;
 
-                if cfg!(debug_assertions) {
-                    debug_assert!(keys.len() == version_strings.len());
-                }
+                debug_assert!(keys.len() == version_strings.len());
 
                 debug_assert_eq!(keys.len(), version_strings.len());
                 for (key, ver) in keys.iter().zip(version_strings.iter()) {
@@ -835,9 +831,7 @@ impl Package<u64> {
                 }));
 
             let total_len = dependencies_list.len() + total_dependencies_count as usize;
-            if cfg!(debug_assertions) {
-                debug_assert!(dependencies_list.len() == resolutions_list.len());
-            }
+            debug_assert!(dependencies_list.len() == resolutions_list.len());
 
             let dep_start = dependencies_list.len();
             bun_core::vec::extend_from_fn(
@@ -854,9 +848,7 @@ impl Package<u64> {
                 let keys = map.name.get(&manifest.external_strings);
                 let version_strings = map.value.get(&manifest.external_strings_for_versions);
 
-                if cfg!(debug_assertions) {
-                    debug_assert!(keys.len() == version_strings.len());
-                }
+                debug_assert!(keys.len() == version_strings.len());
                 let is_peer = group.field == b"peer_dependencies";
 
                 debug_assert_eq!(keys.len(), version_strings.len());
@@ -2008,10 +2000,8 @@ impl Package<u64> {
                                 break 'brk rel;
                             }
                         });
-                    if cfg!(debug_assertions) {
-                        debug_assert!(path.len() > 0);
-                        debug_assert!(!bun_paths::is_absolute(path.slice(buf)));
-                    }
+                    debug_assert!(path.len() > 0);
+                    debug_assert!(!bun_paths::is_absolute(path.slice(buf)));
                     dependency_version.value.workspace = path;
 
                     let workspace_entry = workspace_paths.get_or_put(name_hash)?;
@@ -2511,11 +2501,7 @@ impl Package<u64> {
 
         let off = lockfile.buffers.dependencies.len();
         let total_len = off + total_dependencies_count as usize;
-        if cfg!(debug_assertions) {
-            debug_assert!(
-                lockfile.buffers.dependencies.len() == lockfile.buffers.resolutions.len()
-            );
-        }
+        debug_assert!(lockfile.buffers.dependencies.len() == lockfile.buffers.resolutions.len());
 
         // `parse_dependency` can return early with an error
         // (e.g. `InstallFailed` for a non-matching `workspace:` range), and the caller
@@ -2629,9 +2615,7 @@ impl Package<u64> {
                                 extern_strings[i] = string_builder.append::<ExternalString>(v);
                                 i += 1;
                             }
-                            if cfg!(debug_assertions) {
-                                debug_assert!(i == extern_strings.len());
-                            }
+                            debug_assert!(i == extern_strings.len());
                             self.bin = Bin {
                                 tag: bin::Tag::Map,
                                 value: bin::Value {

--- a/src/install/lockfile/Package/Scripts.rs
+++ b/src/install/lockfile/Package/Scripts.rs
@@ -468,9 +468,7 @@ impl List {
     }
 
     pub fn first(&self) -> &[u8] {
-        if cfg!(debug_assertions) {
-            debug_assert!(self.items[self.first_index as usize].is_some());
-        }
+        debug_assert!(self.items[self.first_index as usize].is_some());
         self.items[self.first_index as usize].as_ref().unwrap()
     }
 

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -854,13 +854,11 @@ impl Tree {
                     debug_assert!(pkg_id == invalid_package_id);
                     debug_assert!(res_id != invalid_package_id);
                     builder.resolutions[dep_id as usize] = res_id;
-                    if cfg!(debug_assertions) {
-                        debug_assert!(
-                            !builder
-                                .pending_optional_peers
-                                .contains_key(&dependency.name_hash)
-                        );
-                    }
+                    debug_assert!(
+                        !builder
+                            .pending_optional_peers
+                            .contains_key(&dependency.name_hash)
+                    );
 
                     if let Some(entry) = builder
                         .pending_optional_peers
@@ -957,9 +955,7 @@ impl Tree {
         // reshaped for borrowck — re-read `next` via index.
         let next: Tree = builder.list.items_tree()[next_id as usize];
         if next.dependencies.len == 0 {
-            if cfg!(debug_assertions) {
-                debug_assert!(builder.list.len() == (next.id as usize) + 1);
-            }
+            debug_assert!(builder.list.len() == (next.id as usize) + 1);
             let _ = builder.list.pop();
         }
 

--- a/src/install/lockfile/bun.lockb.rs
+++ b/src/install/lockfile/bun.lockb.rs
@@ -791,9 +791,7 @@ pub(crate) fn load(
         }
     }
 
-    if cfg!(debug_assertions) {
-        debug_assert!(stream.pos as u64 == total_buffer_size);
-    }
+    debug_assert!(stream.pos as u64 == total_buffer_size);
 
     Ok(res)
 }

--- a/src/install/lockfile/printer/Yarn.rs
+++ b/src/install/lockfile/printer/Yarn.rs
@@ -252,9 +252,7 @@ fn packages(this: &mut Printer, writer: &mut impl bun_io::Write) -> Result<(), c
 
                         // assert its sorted. debug only because of a bug saving incorrect ordering
                         // of optional dependencies to lockfiles
-                        if cfg!(debug_assertions) {
-                            debug_assert!(dependency_behavior_change_count < 3);
-                        }
+                        debug_assert!(dependency_behavior_change_count < 3);
                     }
 
                     writer.write_all(b"    ")?;

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -2081,9 +2081,7 @@ impl PackageManifest {
                 let sliced_version = SlicedString::init(version_name, version_name);
                 let parsed_version = Semver::Version::parse(sliced_version);
 
-                if cfg!(debug_assertions) {
-                    debug_assert!(parsed_version.valid);
-                }
+                debug_assert!(parsed_version.valid);
                 if !parsed_version.valid {
                     log.add_error_fmt(
                         Some(&source),
@@ -2365,21 +2363,17 @@ impl PackageManifest {
                 let mut sliced_version = SlicedString::init(version_name, version_name);
                 let mut parsed_version = Semver::Version::parse(sliced_version);
 
-                if cfg!(debug_assertions) {
-                    debug_assert!(parsed_version.valid);
-                }
+                debug_assert!(parsed_version.valid);
                 // We only need to copy the version tags if it contains pre and/or build
                 if parsed_version.version.tag.has_build() || parsed_version.version.tag.has_pre() {
                     let version_string = string_builder.append::<SemverString>(version_name);
                     sliced_version = version_string.sliced(string_builder.allocated_slice());
                     parsed_version = Semver::Version::parse(sliced_version);
-                    if cfg!(debug_assertions) {
-                        debug_assert!(parsed_version.valid);
-                        debug_assert!(
-                            parsed_version.version.tag.has_build()
-                                || parsed_version.version.tag.has_pre()
-                        );
-                    }
+                    debug_assert!(parsed_version.valid);
+                    debug_assert!(
+                        parsed_version.version.tag.has_build()
+                            || parsed_version.version.tag.has_pre()
+                    );
                 }
                 if !parsed_version.valid {
                     continue;

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -1067,7 +1067,6 @@ pub struct Formatter<'a> {
 
 impl<'a> fmt::Display for Formatter<'a> {
     fn fmt(&self, writer: &mut fmt::Formatter<'_>) -> fmt::Result {
-        #[cfg(debug_assertions)]
         debug_assert!(!self.label.is_empty());
         writer.write_str(self.label)?;
 

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -992,7 +992,6 @@ impl FilePoll {
         fd: Fd,
         force_unregister: bool,
     ) -> sys::Result<()> {
-        #[cfg(debug_assertions)]
         debug_assert!(fd.native() >= 0 && fd != INVALID_FD);
 
         if !(self.flags.contains(Flags::PollReadable)

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1752,9 +1752,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // during minification. These counts shouldn't include references inside dead
         // code regions since those will be culled.
         if !self.is_control_flow_dead {
-            if cfg!(debug_assertions) {
-                debug_assert!(self.symbols.len() > ref_.inner_index() as usize);
-            }
+            debug_assert!(self.symbols.len() > ref_.inner_index() as usize);
             self.symbols[ref_.inner_index() as usize].use_count_estimate += 1;
             // `get_or_put` zero-initializes the slot on insert (`Use::default()`).
             self.symbol_uses

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -313,9 +313,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 p.lexer.next()?;
                 break 'parse_template_part;
             }
-            if cfg!(debug_assertions) {
-                debug_assert!(p.lexer.token != T::TEndOfFile);
-            }
+            debug_assert!(p.lexer.token != T::TEndOfFile);
         }
 
         p.allow_in = old_allow_in;

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -840,9 +840,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     &mut property_opts,
                     Some(&mut self_errors),
                 )? {
-                    if cfg!(debug_assertions) {
-                        debug_assert!(prop.key.is_some() || prop.value.is_some());
-                    }
+                    debug_assert!(prop.key.is_some() || prop.value.is_some());
                     properties.push(prop);
                 }
             }

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1083,9 +1083,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 .e_number()
                                 .expect("infallible: variant checked")
                                 .to_usize();
-                            if cfg!(debug_assertions) {
-                                debug_assert!(strings::is_all_ascii(&literal));
-                            }
+                            debug_assert!(strings::is_all_ascii(&literal));
                             if num < literal.len() {
                                 *e = p.new_expr(
                                     E::String {
@@ -1118,9 +1116,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 *e = p.new_expr(E::Undefined {}, inlined.loc);
                                 return;
                             }
-                            if cfg!(debug_assertions) {
-                                debug_assert!(inlined.can_be_inlined_from_property_access());
-                            }
+                            debug_assert!(inlined.can_be_inlined_from_property_access());
                             *e = inlined;
                             return;
                         }

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -823,7 +823,6 @@ pub(crate) enum NameUse {
 impl NameUse {
     pub(crate) fn find(this: &NumberScope, name: &[u8]) -> NameUse {
         // This version doesn't allocate
-        #[cfg(debug_assertions)]
         debug_assert!(js_lexer::is_identifier(name));
 
         // Hash `name` once and probe each scope in the parent chain with the

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -909,9 +909,7 @@ impl JSGlobalObject {
         message: BunString,
         error_array: JSValue,
     ) -> JsResult<JSValue> {
-        if cfg!(debug_assertions) {
-            debug_assert!(error_array.is_array());
-        }
+        debug_assert!(error_array.is_array());
         crate::from_js_host_call(self, || {
             JSC__JSGlobalObject__createAggregateErrorWithArray(
                 self,

--- a/src/paths/string_paths.rs
+++ b/src/paths/string_paths.rs
@@ -414,9 +414,7 @@ pub fn clone_normalizing_separators(input: &[u8]) -> Vec<u8> {
     // remove duplicate slashes in the file path
     let base = without_trailing_slash(input);
     let mut buf = vec![0u8; base.len() + 2];
-    if cfg!(debug_assertions) {
-        debug_assert!(!base.is_empty());
-    }
+    debug_assert!(!base.is_empty());
     if base[0] == crate::SEP {
         buf[0] = crate::SEP;
     }
@@ -475,11 +473,9 @@ pub fn without_trailing_slash_windows_path(input: &[u8]) -> &[u8] {
         path = &path[..path.len() - 1];
     }
 
-    if cfg!(debug_assertions) {
-        debug_assert!(
-            !crate::is_absolute(path) || !is_windows_absolute_path_missing_drive_letter::<u8>(path)
-        );
-    }
+    debug_assert!(
+        !crate::is_absolute(path) || !is_windows_absolute_path_missing_drive_letter::<u8>(path)
+    );
 
     path
 }

--- a/src/resolver/data_url.rs
+++ b/src/resolver/data_url.rs
@@ -62,9 +62,7 @@ impl From<EncodeError> for DecodeDataError {
 impl PercentEncoding {
     /// returns true if str starts with a valid path character or a percent encoded octet
     pub(crate) fn is_pchar(str: &[u8]) -> bool {
-        if cfg!(debug_assertions) {
-            debug_assert!(!str.is_empty());
-        }
+        debug_assert!(!str.is_empty());
         match str[0] {
             b'a'..=b'z'
             | b'A'..=b'Z'

--- a/src/resolver/node_fallbacks.rs
+++ b/src/resolver/node_fallbacks.rs
@@ -172,9 +172,7 @@ pub(crate) fn map() -> &'static bun_collections::StringHashMap<FallbackModule> {
 }
 
 pub fn contents_from_path(path: &[u8]) -> Option<&'static [u8]> {
-    if cfg!(debug_assertions) {
-        debug_assert!(path.starts_with(IMPORT_PATH));
-    }
+    debug_assert!(path.starts_with(IMPORT_PATH));
 
     let module_name = &path[IMPORT_PATH.len()..];
     let module_name = &module_name[..module_name

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2272,9 +2272,7 @@ impl<'a> Resolver<'a> {
                 //
                 // [1]: https://github.com/oven-sh/bun/issues/16705
                 // [2]: https://github.com/nodejs/node/blob/e346323109b49fa6b9a4705f4e3816fc3a30c151/lib/internal/modules/cjs/loader.js#L1934
-                if cfg!(debug_assertions) {
-                    debug_assert!(is_package_path(import_path));
-                }
+                debug_assert!(is_package_path(import_path));
                 let mut closest_dir = source_dir;
                 // `dirname` returns `None` once the entire directory tree
                 // has been visited. `None` is theoretically impossible since
@@ -4351,9 +4349,7 @@ impl<'a> Resolver<'a> {
         }
 
         let mut queue_slice_len = i;
-        if cfg!(debug_assertions) {
-            debug_assert!(queue_slice_len > 0);
-        }
+        debug_assert!(queue_slice_len > 0);
         let open_dir_count = core::cell::Cell::new(0usize);
 
         // When this function halts, any item not processed means it's not found.
@@ -5459,9 +5455,7 @@ impl<'a> Resolver<'a> {
                 }
             }
 
-            if cfg!(debug_assertions) {
-                debug_assert!(bun_paths::is_absolute(file.path));
-            }
+            debug_assert!(bun_paths::is_absolute(file.path));
 
             *out = MatchResult {
                 path_pair: PathPair {

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -959,9 +959,7 @@ impl TinyPtr {
 
         let right = in_.as_ptr() as usize + in_.len();
         let end = parent.as_ptr() as usize + parent.len();
-        if cfg!(debug_assertions) {
-            debug_assert!(end < right);
-        }
+        debug_assert!(end < right);
 
         let length = end.max(right) - right;
         let offset =

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -3670,9 +3670,7 @@ impl DevServer {
             route_bundle.data,
             route_bundle::Data::Framework(_)
         ));
-        if cfg!(debug_assertions) {
-            debug_assert!(!route_bundle.data.framework().cached_css_file_array.has());
-        }
+        debug_assert!(!route_bundle.data.framework().cached_css_file_array.has());
         debug_assert!(route_bundle.server_state == route_bundle::State::Loaded);
 
         let _lock = self.graph_safety_lock.guard();

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -710,12 +710,10 @@ pub(super) fn build_with_vm(
             // wrapper functions like `__esm`) is marked as server side, but it is
             // also used by client
             if file.bake_extra.bake_is_runtime {
-                if cfg!(debug_assertions) {
-                    debug_assert!(
-                        maybe_runtime_file_index.is_none(),
-                        "Runtime file should only be in one chunk."
-                    );
-                }
+                debug_assert!(
+                    maybe_runtime_file_index.is_none(),
+                    "Runtime file should only be in one chunk."
+                );
                 maybe_runtime_file_index = Some(u32::try_from(i).expect("int cast"));
             }
 
@@ -1380,9 +1378,7 @@ pub(super) extern "C" fn BakeProdResolve(
         return BunString::dead();
     }
 
-    if cfg!(debug_assertions) {
-        debug_assert!(strings::has_prefix(referrer.slice(), b"bake:"));
-    }
+    debug_assert!(strings::has_prefix(referrer.slice(), b"bake:"));
 
     // dirname semantics: returns None for the root / no-parent.
     let after_scheme = &referrer.slice()[5..];

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -577,7 +577,6 @@ impl TrustCommand {
         };
 
         // now add the package names to lockfile.trustedDependencies and package.json `trustedDependencies`
-        #[cfg(debug_assertions)]
         debug_assert!(!package_names_to_add.keys().is_empty());
 
         // could be null if these are the first packages to be trusted
@@ -679,7 +678,6 @@ impl TrustCommand {
         let _ = bun_sys::ftruncate(root_file.handle, new_package_json_contents.len() as i64);
         let _ = root_file.close();
 
-        #[cfg(debug_assertions)]
         debug_assert!(total_scripts_ran > 0);
 
         bun_core::pretty!(

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -375,11 +375,7 @@ impl<'a> Scanner<'a> {
                     return;
                 }
 
-                if cfg!(debug_assertions) {
-                    debug_assert!(
-                        strings::index_of(name, bun_paths::NODE_MODULES_NEEDLE).is_none()
-                    );
-                }
+                debug_assert!(strings::index_of(name, bun_paths::NODE_MODULES_NEEDLE).is_none());
 
                 for exclude_name in self.exclusion_names {
                     if strings::eql(exclude_name, name) {

--- a/src/runtime/ffi/FFIObject.rs
+++ b/src/runtime/ffi/FFIObject.rs
@@ -477,9 +477,7 @@ fn ptr_(global_this: &JSGlobalObject, value: JSValue, byte_offset: Option<JSValu
         ));
     }
 
-    if cfg!(debug_assertions) {
-        debug_assert!(JSValue::from_ptr_address(addr).as_ptr_address() == addr);
-    }
+    debug_assert!(JSValue::from_ptr_address(addr).as_ptr_address() == addr);
 
     JSValue::from_ptr_address(addr)
 }

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2191,9 +2191,7 @@ pub(super) extern "C" fn napi_delete_async_work(
     let Some(work) = (unsafe { work_.as_mut() }) else {
         return env.invalid_arg();
     };
-    if cfg!(debug_assertions) {
-        debug_assert!(core::ptr::eq(env.to_js(), work.global.as_ptr()));
-    }
+    debug_assert!(core::ptr::eq(env.to_js(), work.global.as_ptr()));
     napi_async_work::destroy(work_);
     env.ok()
 }
@@ -2209,9 +2207,7 @@ pub(super) extern "C" fn napi_queue_async_work(
     let Some(work) = (unsafe { work_.as_mut() }) else {
         return env.invalid_arg();
     };
-    if cfg!(debug_assertions) {
-        debug_assert!(core::ptr::eq(env.to_js(), work.global.as_ptr()));
-    }
+    debug_assert!(core::ptr::eq(env.to_js(), work.global.as_ptr()));
     work.schedule();
     env.ok()
 }
@@ -2227,9 +2223,7 @@ pub(super) extern "C" fn napi_cancel_async_work(
     let Some(work) = (unsafe { work_.as_mut() }) else {
         return env.invalid_arg();
     };
-    if cfg!(debug_assertions) {
-        debug_assert!(core::ptr::eq(env.to_js(), work.global.as_ptr()));
-    }
+    debug_assert!(core::ptr::eq(env.to_js(), work.global.as_ptr()));
     if work.cancel() {
         return env.ok();
     }

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -865,9 +865,7 @@ where
         }
 
         ctx_log!("deinit<d> ({:p})<r>", self);
-        if cfg!(debug_assertions) {
-            debug_assert!(self.flags.has_finalized());
-        }
+        debug_assert!(self.flags.has_finalized());
 
         // A response body stream suspended inside its `pull()` never settles the promise
         // whose reactions consume the sink (`handleResolveStream` / `handleRejectStream`),

--- a/src/runtime/socket/SocketAddress.rs
+++ b/src/runtime/socket/SocketAddress.rs
@@ -549,9 +549,7 @@ impl SocketAddress {
         port_: u16,
         is_ipv6: bool,
     ) -> JsResult<JSValue> {
-        if cfg!(debug_assertions) {
-            debug_assert!(!addr_.is_empty());
-        }
+        debug_assert!(!addr_.is_empty());
 
         Ok(JSSocketAddressDTO__create(
             global_object,
@@ -976,9 +974,7 @@ impl sockaddr {
                 .len();
         // SAFETY: buf[len] == 0 written by ares_inet_ntop above
         let formatted = ZStr::from_buf(&buf[..], len);
-        if cfg!(debug_assertions) {
-            debug_assert!(bun_core::is_all_ascii(formatted.as_bytes()));
-        }
+        debug_assert!(bun_core::is_all_ascii(formatted.as_bytes()));
         formatted
     }
 

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -1557,9 +1557,7 @@ impl Expect {
         } else if message.is_string() {
             bun_core::OwnedString::new(message.to_bun_string(global_this)?)
         } else {
-            if cfg!(debug_assertions) {
-                debug_assert!(message.is_callable()); // checked above
-            }
+            debug_assert!(message.is_callable()); // checked above
 
             // Pass the global object itself as `this`.
             let message_result = message.call_with_global_this(global_this, &[])?;

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -167,9 +167,7 @@ impl SubscriptionCtx {
         }
 
         // Existing is guaranteed to be an array of callbacks.
-        if cfg!(debug_assertions) {
-            debug_assert!(existing.is_array());
-        }
+        debug_assert!(existing.is_array());
 
         // TODO(markovejnovic): I can't find a better way to do this... I generate a new array,
         // filtering out the callback we want to remove. This is woefully inefficient for large
@@ -277,9 +275,7 @@ impl SubscriptionCtx {
             return Ok(());
         };
 
-        if cfg!(debug_assertions) {
-            debug_assert!(callbacks.is_array());
-        }
+        debug_assert!(callbacks.is_array());
 
         // Callback runs on the JS thread; VM is alive for the duration.
         let vm = VirtualMachine::get();
@@ -295,9 +291,7 @@ impl SubscriptionCtx {
         // If callbacks is an array, iterate and call each one
         let mut iter = callbacks.array_iterator(global_object)?;
         while let Some(callback) = iter.next()? {
-            if cfg!(debug_assertions) {
-                debug_assert!(callback.is_callable());
-            }
+            debug_assert!(callback.is_callable());
             // `event_loop_mut()` is the safe accessor for the VM-owned
             // event-loop self-pointer (see `VirtualMachine::event_loop_mut`).
             vm.event_loop_mut()

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4732,12 +4732,10 @@ pub fn write_file_with_source_destination(
     let destination_type = destination_store.data.tag();
 
     // TODO: make sure this invariant isn't being broken elsewhere, then upgrade to allow_assert
-    if cfg!(debug_assertions) {
-        debug_assert!(
-            destination_type != store::DataTag::Bytes,
-            "Cannot write to a Blob backed by a Buffer or TypedArray. This is a bug in the caller."
-        );
-    }
+    debug_assert!(
+        destination_type != store::DataTag::Bytes,
+        "Cannot write to a Blob backed by a Buffer or TypedArray. This is a bug in the caller."
+    );
 
     let Some(source_store) = source_blob.store.get().clone() else {
         return write_file_with_empty_source_to_destination(ctx, destination_blob, options);

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -972,9 +972,7 @@ impl FileReader {
     pub fn drain(&self) -> Vec<u8> {
         if !self.buffered.get().is_empty() {
             let out = Vec::<u8>::move_from_list(self.buffered.replace(Vec::new()));
-            if cfg!(debug_assertions) {
-                debug_assert!(self.reader().buffer().as_ptr() != out.as_ptr());
-            }
+            debug_assert!(self.reader().buffer().as_ptr() != out.as_ptr());
             return out;
         }
 

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -979,7 +979,6 @@ impl Request {
                     let protocol = self.get_protocol();
                     let url_bytelength = protocol.len() + host.len() + req_url.len();
 
-                    #[cfg(debug_assertions)]
                     debug_assert!(self.size_of_url() == url_bytelength);
 
                     if url_bytelength < 128 {
@@ -995,7 +994,6 @@ impl Request {
                             &buffer[..at]
                         };
 
-                        #[cfg(debug_assertions)]
                         debug_assert!(self.size_of_url() == url.len());
 
                         let href = bun_url::href_from_string(&BunString::from_bytes(url));
@@ -1044,7 +1042,6 @@ impl Request {
                 }
             }
 
-            #[cfg(debug_assertions)]
             debug_assert!(self.size_of_url() == req_url.len());
             self.url.set(BunString::clone_utf8(&req_url));
         }

--- a/src/runtime/webcore/TextEncoderStreamEncoder.rs
+++ b/src/runtime/webcore/TextEncoderStreamEncoder.rs
@@ -96,14 +96,9 @@ impl TextEncoderStreamEncoder {
                 buffer.ensure_total_capacity(buffer.len() + remain.len() + 1);
             }
         }
-
-        if cfg!(debug_assertions) {
-            // guarded so simdutf isn't called in a release build here.
-            debug_assert!(
-                buffer.len()
-                    == (simdutf::length::utf8::from::latin1(input) + prepend_replacement_len)
-            );
-        }
+        debug_assert!(
+            buffer.len() == (simdutf::length::utf8::from::latin1(input) + prepend_replacement_len)
+        );
 
         JSUint8Array::from_bytes(global, buffer.into())
     }

--- a/src/runtime/webcore/prompt.rs
+++ b/src/runtime/webcore/prompt.rs
@@ -383,10 +383,8 @@ pub mod prompt {
             input.truncate(input.len() - 1);
         }
 
-        if cfg!(debug_assertions) {
-            debug_assert!(!input.is_empty());
-            debug_assert!(input[input.len() - 1] != b'\r');
-        }
+        debug_assert!(!input.is_empty());
+        debug_assert!(input[input.len() - 1] != b'\r');
 
         // 8. Let result be null if the user aborts, or otherwise the string
         //    that the user responded with.

--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -138,9 +138,7 @@ impl Query {
         version_buf: &[u8],
         pre_matched: &mut bool,
     ) -> bool {
-        if cfg!(debug_assertions) {
-            debug_assert!(version.tag.has_pre());
-        }
+        debug_assert!(version.tag.has_pre());
         let mut node = self;
         loop {
             if !node
@@ -271,9 +269,7 @@ impl List {
     }
 
     pub fn satisfies_pre(&self, version: Version, list_buf: &[u8], version_buf: &[u8]) -> bool {
-        if cfg!(debug_assertions) {
-            debug_assert!(version.tag.has_pre());
-        }
+        debug_assert!(version.tag.has_pre());
 
         // `version` has a prerelease tag:
         // - needs to satisfy each comparator in the query (<comparator> AND <comparator> AND ...) like normal comparison
@@ -466,9 +462,7 @@ impl Group {
             && range.left.op == RangeOp::Eql
             && !range.has_right()
         {
-            if cfg!(debug_assertions) {
-                debug_assert!(self.tail.is_none());
-            }
+            debug_assert!(self.tail.is_none());
             return Some(range.left.version);
         }
 

--- a/src/semver/SemverRange.rs
+++ b/src/semver/SemverRange.rs
@@ -146,9 +146,7 @@ impl Range {
         version_buf: &[u8],
         pre_matched: &mut bool,
     ) -> bool {
-        if cfg!(debug_assertions) {
-            debug_assert!(version.tag.has_pre());
-        }
+        debug_assert!(version.tag.has_pre());
         let has_left = self.has_left();
         let has_right = self.has_right();
 

--- a/src/semver/Version.rs
+++ b/src/semver/Version.rs
@@ -1156,12 +1156,10 @@ impl Tag {
                         }
                         State::Build => {
                             result.tag.build = sliced_string.sub(&input[start..i]).external();
-                            if cfg!(debug_assertions) {
-                                debug_assert!(!strings::contains_char(
-                                    result.tag.build.slice(sliced_string.buf),
-                                    b'-'
-                                ));
-                            }
+                            debug_assert!(!strings::contains_char(
+                                result.tag.build.slice(sliced_string.buf),
+                                b'-'
+                            ));
                             state = State::None;
                         }
                     }

--- a/src/semver/lib.rs
+++ b/src/semver/lib.rs
@@ -809,9 +809,7 @@ pub mod semver_string {
     impl Pointer {
         #[inline]
         pub fn init(buf: &[u8], in_: &[u8]) -> Pointer {
-            if cfg!(debug_assertions) {
-                debug_assert!(bun_alloc::is_slice_in_buffer(in_, buf));
-            }
+            debug_assert!(bun_alloc::is_slice_in_buffer(in_, buf));
 
             Pointer {
                 off: (in_.as_ptr() as usize - buf.as_ptr() as usize) as u32,
@@ -969,10 +967,8 @@ pub mod semver_string {
                 }
             }
 
-            if cfg!(debug_assertions) {
-                debug_assert!(self.len <= self.cap); // didn't count everything
-                debug_assert!(self.ptr.is_some()); // must call allocate first
-            }
+            debug_assert!(self.len <= self.cap); // didn't count everything
+            debug_assert!(self.ptr.is_some()); // must call allocate first
 
             // reshaped for borrowck — compute final slice range, then borrow once.
             let start = self.len;
@@ -983,9 +979,7 @@ pub mod semver_string {
             }
             self.len += slice_.len();
 
-            if cfg!(debug_assertions) {
-                debug_assert!(self.len <= self.cap);
-            }
+            debug_assert!(self.len <= self.cap);
 
             let allocated = &self.ptr.as_ref().unwrap()[0..self.cap];
             let final_slice = &allocated[start..start + slice_.len()];
@@ -997,10 +991,8 @@ pub mod semver_string {
             if slice_.len() <= String::MAX_INLINE_LEN {
                 return T::from_init(self.allocated_slice(), slice_, hash);
             }
-            if cfg!(debug_assertions) {
-                debug_assert!(self.len <= self.cap); // didn't count everything
-                debug_assert!(self.ptr.is_some()); // must call allocate first
-            }
+            debug_assert!(self.len <= self.cap); // didn't count everything
+            debug_assert!(self.ptr.is_some()); // must call allocate first
 
             // reshaped for borrowck
             let start = self.len;
@@ -1011,9 +1003,7 @@ pub mod semver_string {
             }
             self.len += slice_.len();
 
-            if cfg!(debug_assertions) {
-                debug_assert!(self.len <= self.cap);
-            }
+            debug_assert!(self.len <= self.cap);
 
             let allocated = &self.ptr.as_ref().unwrap()[0..self.cap];
             let final_slice = &allocated[start..start + slice_.len()];
@@ -1025,10 +1015,8 @@ pub mod semver_string {
                 return T::from_init(self.allocated_slice(), slice_, hash);
             }
 
-            if cfg!(debug_assertions) {
-                debug_assert!(self.len <= self.cap); // didn't count everything
-                debug_assert!(self.ptr.is_some()); // must call allocate first
-            }
+            debug_assert!(self.len <= self.cap); // didn't count everything
+            debug_assert!(self.ptr.is_some()); // must call allocate first
 
             // reshaped for borrowck — get_or_put borrows self.string_pool while we also need
             // &mut self.ptr; capture scalars first, then re-borrow.
@@ -1052,9 +1040,7 @@ pub mod semver_string {
                 *string_entry.value_ptr = String::init(allocated, final_slice);
             }
 
-            if cfg!(debug_assertions) {
-                debug_assert!(self.len <= self.cap);
-            }
+            debug_assert!(self.len <= self.cap);
 
             T::from_pooled(*string_entry.value_ptr, hash)
         }

--- a/src/shell_parser/braces.rs
+++ b/src/shell_parser/braces.rs
@@ -873,9 +873,7 @@ fn expand_flat(
             }
             Token::Open(expansion_variants) => {
                 depth += 1;
-                if cfg!(debug_assertions) {
-                    debug_assert!(expansion_variants.end - expansion_variants.idx >= 1);
-                }
+                debug_assert!(expansion_variants.end - expansion_variants.idx >= 1);
 
                 let variants = &expansion_table
                     [usize::from(expansion_variants.idx)..usize::from(expansion_variants.end)];

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -1157,9 +1157,7 @@ impl<'bump> Parser<'bump> {
 
     fn expect_if_clause_text_token(&mut self, if_clause_token: IfClauseTok) -> Token {
         let tagname = Self::extract_if_clause_text_token(if_clause_token);
-        if cfg!(debug_assertions) {
-            debug_assert!(self.peek().tag() == TokenTag::Text);
-        }
+        debug_assert!(self.peek().tag() == TokenTag::Text);
         if let Token::Text(range) = self.peek() {
             if self.delimits(self.peek_n(1)) && self.text(range) == tagname {
                 let tok = self.advance();

--- a/src/sourcemap/lib.rs
+++ b/src/sourcemap/lib.rs
@@ -247,11 +247,9 @@ impl LineColumnOffset {
 
         let remain = &input[offset as usize..];
 
-        if cfg!(debug_assertions) {
-            debug_assert!(strings::is_all_ascii(remain));
-            debug_assert!(strings::index_of_char(remain, b'\n').is_none());
-            debug_assert!(strings::index_of_char(remain, b'\r').is_none());
-        }
+        debug_assert!(strings::is_all_ascii(remain));
+        debug_assert!(strings::index_of_char(remain, b'\n').is_none());
+        debug_assert!(strings::index_of_char(remain, b'\r').is_none());
 
         this.columns = this
             .columns

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -2121,9 +2121,7 @@ mod spawn_process_body {
         // defer dup_fds cleanup — handled below at each exit
         let cleanup_dup = |failed: bool| {
             if dup_src.is_some() {
-                if cfg!(debug_assertions) {
-                    debug_assert!(dup_src.is_some() && dup_tgt.is_some());
-                }
+                debug_assert!(dup_src.is_some() && dup_tgt.is_some());
             }
             if failed && dup_fds[0] != -1 {
                 Fd::from_uv(dup_fds[0]).close();

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -4642,9 +4642,7 @@ pub fn move_opened_file_at(
     // and therefore having different behavior when the Windows version is >= rs1 but < rs5.
     // Bun's minimum supported Windows version is >= win10_rs5.
 
-    if cfg!(debug_assertions) {
-        debug_assert!(!new_file_name.contains(&(b'/' as u16))); // Call moveOpenedFileAtLoose
-    }
+    debug_assert!(!new_file_name.contains(&(b'/' as u16))); // Call moveOpenedFileAtLoose
 
     // The FileName tail here is UTF-16, so the correct cap is
     // `PATH_MAX_WIDE * 2` bytes — sizing against the UTF-8 worst case

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -785,13 +785,11 @@ impl<'a> URL<'a> {
                 b'@' => {
                     // we found a password, everything before this point in the slice is a password
                     self.password = &str[0..i];
-                    if cfg!(debug_assertions) {
-                        debug_assert!(
-                            str[i..].len() < 2
-                                || u16::from_le_bytes([str[i], str[i + 1]])
-                                    != u16::from_le_bytes(*b"//")
-                        );
-                    }
+                    debug_assert!(
+                        str[i..].len() < 2
+                            || u16::from_le_bytes([str[i], str[i + 1]])
+                                != u16::from_le_bytes(*b"//")
+                    );
                     return Some(u32::try_from(i + 1).expect("int cast"));
                 }
                 // if we reach a slash or "?", there's no password
@@ -1331,9 +1329,7 @@ impl<'a> Iterator<'a> {
             .position(|p| p.name_hash == hash)
         {
             let real_i = current_i + next_index + self.i;
-            if cfg!(debug_assertions) {
-                debug_assert!(!self.visited.is_set(real_i));
-            }
+            debug_assert!(!self.visited.is_set(real_i));
 
             self.visited.set(real_i);
             target[target_i] = self.map.str(remainder[current_i + next_index].value);

--- a/src/watcher/INotifyWatcher.rs
+++ b/src/watcher/INotifyWatcher.rs
@@ -103,7 +103,6 @@ impl Event {
     // + read_unaligned.
 
     pub fn name(&self) -> &ZStr {
-        #[cfg(debug_assertions)]
         debug_assert!(
             self.name_len > 0,
             "INotifyWatcher.Event.name() called with name_len == 0, you should check it before calling this function."


### PR DESCRIPTION
### What

`debug_assert!(x)` expands to `if cfg!(debug_assertions) { assert!(x) }`, so
wrapping it in another `if cfg!(debug_assertions) { ... }` is a no-op
double-gate: the inner macro already short-circuits in release, and the outer
`if` adds nothing in debug. This PR unwraps those to a bare `debug_assert!`.

126 sites across 69 files, net -248 lines. No behavior change in debug or
release builds.

### Why this is correct

For `if cfg!(debug_assertions) { debug_assert!(x) }` the argument `x` is already
type-checked in release builds with or without the outer `if` (the body of an
`if false { ... }` is compiled, not evaluated), so dropping the outer `if` is a
pure deletion of dead control flow. 115 of the 126 sites are this shape.

The remaining 11 are `#[cfg(debug_assertions)]` attributes directly on a
`debug_assert!`. Those *do* change whether `x` is type-checked in release, so
only the ones whose expression references no `#[cfg(debug_assertions)]`-gated
field or function were touched. Each was checked individually:
`posix_event_loop.rs` (`fd.native()`, `INVALID_FD`), `INotifyWatcher.rs`
(`name_len`), `Request.rs` (`size_of_url()`), `WebSocketUpgradeClient.rs`
(`socket.is_shutdown()`), `repository.rs` (`Formatter::label`),
`pm_trusted_command.rs` (locals), `renamer.rs` (`js_lexer::is_identifier`),
`PackageJSONEditor.rs` (`request.e_string`).

Left alone on purpose:

- `#[cfg(debug_assertions)]` attributes guarding a `debug_assert!` that reads a
  debug-only field: `HotReloadEvent::debug_mutex`, `Ipc::has_written_version`,
  `DeferredBatchTask::running`, `GlobWalker::Iterator::fds_open`. Removing the
  attribute there would break the release build.
- `if cfg!(debug_assertions) { ... }` blocks that contain anything besides
  `debug_assert!` (loops, `let` bindings, `debug_warn!`/`scoped_log!`, compound
  `&&` conditions, `else` branches). Those are not redundant.

Also removed one now-stale comment in `TextEncoderStreamEncoder.rs` that
claimed the outer guard was needed to keep simdutf out of release; the inner
`debug_assert!` already guarantees that.

### Verification

- `bun bd` (debug + ASAN) builds clean.
- `cargo check --workspace --release` passes (confirms the attribute-variant
  expressions compile without `debug_assertions`).
- `cargo check --workspace --target {x86_64-pc-windows-msvc, aarch64-apple-darwin, x86_64-unknown-linux-gnu}`
  passes in both dev and release profiles.
- `cargo fmt --all -- --check` passes.
- `cargo clippy --workspace --no-deps` reports nothing new in the touched files.
- Smoke-tested `test/js/bun/resolve/resolve.test.ts` and
  `test/bundler/esbuild/default.test.ts` with the debug build; both pass.

This is a mechanical no-behavior-change cleanup, so there is no test that fails
before and passes after.
