### PR TITLE
runtime: drop redundant guards and double-cleanups across api/bake/timer/test_runner

### DIFF
--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -174,59 +174,53 @@ impl Config {
         }
 
         if let Some(define) = object.get_truthy(global, "define")? {
-            'define: {
-                if define.is_undefined_or_null() {
-                    break 'define;
+            let Some(define_obj) = define.get_object() else {
+                return Err(
+                    global.throw_invalid_arguments(format_args!("define must be an object"))
+                );
+            };
+
+            // SAFETY: `define_obj` is a non-null *mut JSObject (just returned by get_object()).
+            let define_obj_ref = unsafe { &*define_obj };
+            let mut define_iter =
+                JSPropertyIterator::init(global, define_obj_ref, PROP_ITER_OPTS)?;
+            // `defer define_iter.deinit()` → Drop
+
+            // `define_iter.i` is the property position, not a dense index of yielded
+            // entries. With `skip_empty_name = true` (or a skipped property getter),
+            // writing at `define_iter.i` would leave earlier slots uninitialized.
+            // Use Vecs so the stored slice is always exactly what was appended.
+            let mut names: Vec<Box<[u8]>> = Vec::new();
+            let mut values: Vec<Box<[u8]>> = Vec::new();
+            names.reserve_exact(define_iter.len);
+            values.reserve_exact(define_iter.len);
+
+            while let Some(prop) = define_iter.next()? {
+                let property_value = define_iter.value;
+                let value_type = property_value.js_type();
+
+                if !value_type.is_string_like() {
+                    return Err(global.throw_invalid_arguments(format_args!(
+                        "define \"{}\" must be a JSON string",
+                        prop
+                    )));
                 }
 
-                let Some(define_obj) = define.get_object() else {
-                    return Err(
-                        global.throw_invalid_arguments(format_args!("define must be an object"))
-                    );
-                };
-
-                // SAFETY: `define_obj` is a non-null *mut JSObject (just returned by get_object()).
-                let define_obj_ref = unsafe { &*define_obj };
-                let mut define_iter =
-                    JSPropertyIterator::init(global, define_obj_ref, PROP_ITER_OPTS)?;
-                // `defer define_iter.deinit()` → Drop
-
-                // `define_iter.i` is the property position, not a dense index of yielded
-                // entries. With `skip_empty_name = true` (or a skipped property getter),
-                // writing at `define_iter.i` would leave earlier slots uninitialized.
-                // Use Vecs so the stored slice is always exactly what was appended.
-                let mut names: Vec<Box<[u8]>> = Vec::new();
-                let mut values: Vec<Box<[u8]>> = Vec::new();
-                names.reserve_exact(define_iter.len);
-                values.reserve_exact(define_iter.len);
-
-                while let Some(prop) = define_iter.next()? {
-                    let property_value = define_iter.value;
-                    let value_type = property_value.js_type();
-
-                    if !value_type.is_string_like() {
-                        return Err(global.throw_invalid_arguments(format_args!(
-                            "define \"{}\" must be a JSON string",
-                            prop
-                        )));
-                    }
-
-                    names.push(prop.to_owned_slice().into());
-                    let mut val = ZigString::init(b"");
-                    property_value.to_zig_string(&mut val, global)?;
-                    if val.len == 0 {
-                        val = ZigString::init(b"\"\"");
-                    }
-                    let mut buf = Vec::new();
-                    write!(&mut buf, "{}", val).expect("unreachable");
-                    values.push(buf.into_boxed_slice());
+                names.push(prop.to_owned_slice().into());
+                let mut val = ZigString::init(b"");
+                property_value.to_zig_string(&mut val, global)?;
+                if val.len == 0 {
+                    val = ZigString::init(b"\"\"");
                 }
-
-                self.transform.define = Some(api::StringMap {
-                    keys: names,
-                    values,
-                });
+                let mut buf = Vec::new();
+                write!(&mut buf, "{}", val).expect("unreachable");
+                values.push(buf.into_boxed_slice());
             }
+
+            self.transform.define = Some(api::StringMap {
+                keys: names,
+                values,
+            });
         }
 
         if let Some(external) = object.get(global, "external")? {
@@ -342,9 +336,6 @@ impl Config {
 
         if let Some(macros) = object.get_truthy(global, "macro")? {
             'macros: {
-                if macros.is_undefined_or_null() {
-                    break 'macros;
-                }
                 if macros.is_boolean() {
                     self.no_macros = !macros.as_boolean();
                     break 'macros;

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -182,8 +182,7 @@ impl Config {
 
             // SAFETY: `define_obj` is a non-null *mut JSObject (just returned by get_object()).
             let define_obj_ref = unsafe { &*define_obj };
-            let mut define_iter =
-                JSPropertyIterator::init(global, define_obj_ref, PROP_ITER_OPTS)?;
+            let mut define_iter = JSPropertyIterator::init(global, define_obj_ref, PROP_ITER_OPTS)?;
             // `defer define_iter.deinit()` → Drop
 
             // `define_iter.i` is the property position, not a dense index of yielded

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -317,11 +317,7 @@ fn get_argv(
         arg_index += 1;
     }
 
-    if argv.is_empty() {
-        return Err(
-            global_this.throw_invalid_arguments(format_args!("cmd must be an array of strings"))
-        );
-    }
+    debug_assert!(!argv.is_empty()); // unconditional push at `argv.push(argv0_result.arg0..)` above
     Ok(())
 }
 

--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -1101,7 +1101,7 @@ impl FrameworkRouter {
                         route_index = current;
                         continue 'outer;
                     }
-                    next = match self.route_ptr(next.unwrap()).next_sibling {
+                    next = match self.route_ptr(current).next_sibling {
                         Some(s) => Some(s),
                         None => break,
                     };

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -864,15 +864,9 @@ pub(super) fn build_with_vm(
 
         let server_file = router_type.server_file;
         let server_entry_point = pt.load_bundled_module(server_file)?;
-        let server_render_func = 'brk: {
-            let Some(raw) = bake_get_on_module_namespace(global, server_entry_point, b"prerender")
-            else {
-                break 'brk None;
-            };
-            if !raw.is_callable() {
-                break 'brk None;
-            }
-            break 'brk Some(raw);
+        let server_render_func = {
+            let raw = bake_get_on_module_namespace(global, server_entry_point, b"prerender");
+            raw.is_callable().then_some(raw)
         };
         let Some(server_render_func) = server_render_func else {
             bun_core::err_generic!("Framework does not support static site generation");
@@ -887,16 +881,9 @@ pub(super) fn build_with_vm(
         };
 
         let server_param_func = if router.dynamic_routes.count() > 0 {
-            let f = 'brk: {
-                let Some(raw) =
-                    bake_get_on_module_namespace(global, server_entry_point, b"getParams")
-                else {
-                    break 'brk None;
-                };
-                if !raw.is_callable() {
-                    break 'brk None;
-                }
-                break 'brk Some(raw);
+            let f = {
+                let raw = bake_get_on_module_namespace(global, server_entry_point, b"getParams");
+                raw.is_callable().then_some(raw)
             };
             match f {
                 Some(f) => f,
@@ -1287,7 +1274,7 @@ fn bake_get_on_module_namespace(
     global: &JSGlobalObject,
     module: JSValue,
     property: &[u8],
-) -> Option<JSValue> {
+) -> JSValue {
     unsafe extern "C" {
         // PRECONDITION: `ptr` must be readable for `len` bytes (C++ builds an
         // `Identifier` from the slice). Cannot be `safe fn` — raw ptr+len pair
@@ -1301,7 +1288,7 @@ fn bake_get_on_module_namespace(
     // `&[u8]` for the call duration — discharges the ptr+len precondition above.
     let result: JSValue = unsafe { f(global, module, property.as_ptr(), property.len()) };
     debug_assert!(!result.is_empty());
-    Some(result)
+    result
 }
 
 // Renders all routes for static site generation by calling the JavaScript implementation.

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -1821,7 +1821,6 @@ pub(super) fn generate_symbol_for_function(
     }
 
     *function = Function::default();
-    function.base_name = None;
     function.arg_types = abi_types;
     function.return_type = return_type;
     function.threadsafe = threadsafe;

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -1502,8 +1502,7 @@ pub(super) extern "C" fn napi_is_dataview(
     if value.is_empty() {
         return env.invalid_arg();
     }
-    *result =
-        !value.is_empty_or_undefined_or_null() && value.js_type_loose() == jsc::JSType::DataView;
+    *result = !value.is_undefined_or_null() && value.js_type_loose() == jsc::JSType::DataView;
     env.ok()
 }
 

--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -85,7 +85,7 @@ use crate::jsc_hooks::timer_all_mut as timer_all;
 /// into the owning `JSTLSSocket` wrapper's visited `values:` slot (the GC
 /// root). All four `get_js_handlers` slots follow the identical
 /// `NewFunctionWithData(global, null, 0, fn, self)` → `ensureStillAlive` →
-/// `setFunctionData(self)` → store pattern.
+/// store pattern.
 #[inline]
 fn lazy_js_handler(
     shadow: &mut JSValue,
@@ -100,7 +100,6 @@ fn lazy_js_handler(
     }
     let callback = host_fn::new_function_with_data(global, None, 0, func, this_ptr);
     callback.ensure_still_alive();
-    host_fn::set_function_data(callback, Some(this_ptr));
     set_slot(js_wrapper, global, callback);
     *shadow = callback;
     callback

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -308,11 +308,11 @@ fn filter_names<R: WriteEnd>(rem: &mut R, description: Option<&[u8]>, parent_in:
         // per-use reborrow.
         // SAFETY: parent backrefs are stable for the lifetime of the collection tree.
         parent = scope.base.parent.map(|p| unsafe { &*p });
-        if scope.base.name.is_none() {
+        let Some(name) = scope.base.name.as_deref() else {
             continue;
-        }
+        };
         rem.write_end(SEP);
-        rem.write_end(scope.base.name.as_deref().unwrap_or(b""));
+        rem.write_end(name);
     }
 }
 

--- a/src/runtime/test_runner/expect/toContain.rs
+++ b/src/runtime/test_runner/expect/toContain.rs
@@ -55,9 +55,6 @@ impl Expect {
                 pass = true;
             } else if strings::contains(value_string.slice(), expected_string.slice()) {
                 pass = true;
-            } else if value_string.slice().is_empty() && expected_string.slice().is_empty() {
-                // edge case two empty strings are true
-                pass = true;
             }
         } else if value.is_iterable(global)? {
             let mut expected_entry = ExpectedEntry {

--- a/src/runtime/timer/timer_object_internals.rs
+++ b/src/runtime/timer/timer_object_internals.rs
@@ -767,17 +767,14 @@ impl TimerObjectInternals {
 
         let now = Timespec::now(TimespecMockMode::AllowMockedTime);
         let scheduled_time = now.add_ms(i64::from(self.interval.get()));
-        let was_active = self.event_loop_timer_state() == EventLoopTimerState::ACTIVE;
-        if was_active {
-            // SAFETY: `state` is the boxed per-thread `RuntimeState`; fresh
-            // `&mut` to `.timer` for this call only.
-            unsafe { (*state).timer.remove(self.event_loop_timer()) };
-        } else {
+        if self.event_loop_timer_state() != EventLoopTimerState::ACTIVE {
             self.ref_();
         }
 
-        // SAFETY: as above — `event_loop_timer()` derives a fresh raw ptr (no
-        // `&mut` aliasing across `update`).
+        // SAFETY: `state` is the boxed per-thread `RuntimeState`; fresh `&mut`
+        // to `.timer` for this call only. `event_loop_timer()` derives a fresh
+        // raw ptr (no `&mut` aliasing across `update`). `update()` removes the
+        // timer from the heap if it is still ACTIVE.
         unsafe {
             (*state)
                 .timer
@@ -938,11 +935,8 @@ impl TimerObjectInternals {
         // `refresh` method
         debug_assert!(self.flags.get().kind() != Kind::SetImmediate);
 
-        // setImmediate does not support refreshing and we do not support refreshing after cleanup
-        if self.id == -1
-            || self.flags.get().kind() == Kind::SetImmediate
-            || self.flags.get().has_cleared_timer()
-        {
+        // we do not support refreshing after cleanup
+        if self.id == -1 || self.flags.get().has_cleared_timer() {
             return Ok(this_value);
         }
 

--- a/src/runtime/webcore/ByteStream.rs
+++ b/src/runtime/webcore/ByteStream.rs
@@ -217,7 +217,6 @@ impl ByteStream {
                     p.result.release();
                     p.result = streams::Result::Done;
                 });
-                self.buffer_action.set(None);
 
                 return res;
             }
@@ -502,7 +501,6 @@ impl ByteStream {
                 global,
                 &streams::StreamError::AbortReason(jsc::CommonAbortReason::UserAbort),
             );
-            self.buffer_action.set(None);
         }
     }
 

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -555,7 +555,6 @@ pub(crate) fn writable_stream(
     // explicitly set it to a dead pointer
     // we use this memory address to disable signals being sent
     sink.signal.clear();
-    assert!(sink.signal.is_dead());
     Ok(sink.to_js(global_this))
 }
 


### PR DESCRIPTION
Removes 14 provably-dead checks and stores across `src/runtime/` left behind by the Zig port. Each site is a guard that cannot fire or a store that repeats an immediately preceding one. Net: 12 files, -41 lines, no behavior change.

## Sites

| File | What | Why it is dead |
| --- | --- | --- |
| `api/JSTranspiler.rs` (`define`, `macro`) | `is_undefined_or_null()` re-check on a `get_truthy()` result | `get_truthy` already filters `is_empty_or_undefined_or_null()` (`src/jsc/JSValue.rs:1183`); the now-unused `'define:` block label is flattened too |
| `api/bun/js_bun_spawn_bindings.rs` | `if argv.is_empty()` throw | `argv.push(argv0_result.arg0..)` at line 278 runs on every non-error path before this check; reduced to `debug_assert!` |
| `bake/FrameworkRouter.rs` | `next.unwrap()` inside `while let Some(current) = next` | `next` is proven `Some(current)` by the loop head and not reassigned between 1095 and 1104; use `current` directly |
| `bake/production.rs` | `bake_get_on_module_namespace` returns `Option<JSValue>` | Only exit is `Some(result)`; returns `JSValue` now and both call sites collapse to `raw.is_callable().then_some(raw)` |
| `ffi/ffi_body.rs` | `function.base_name = None` | Line above is `*function = Function::default()` whose `Default` impl sets `base_name: None` |
| `napi/napi_body.rs` (`napi_is_dataview`) | `is_empty_or_undefined_or_null()` | Two lines earlier is `if value.is_empty() { return }`; the helper is `is_empty() \|\| is_undefined_or_null()`, so the `is_empty` half is already handled |
| `socket/UpgradedDuplex.rs` | `set_function_data(callback, Some(this_ptr))` | `new_function_with_data(.., this_ptr)` calls `Bun__CreateFFIFunctionWithData` which already writes `function->dataPtr = data` (`JSFFIFunction.cpp:85`); `set_function_data` rewrites the same field with the same value |
| `test_runner/expect/toContain.rs` | `else if value.is_empty() && expected.is_empty()` | Reaches here only via the `else` of `if expected.is_empty()`, so `expected.is_empty()` is false and the conjunction is always false |
| `test_runner/ScopeFunctions.rs` | `.unwrap_or(b"")` after `if name.is_none() { continue }` | Folded into a single `let Some(name) = .. else { continue }` |
| `timer/timer_object_internals.rs` (`reschedule`) | explicit `if ACTIVE { remove(timer) }` before `All::update` | `All::update` begins with the identical `if state == ACTIVE { self.remove(timer) }` (`src/runtime/timer/mod.rs:816`); kept only the `ref_()` arm |
| `timer/timer_object_internals.rs` (`do_refresh`) | `\|\| kind() == SetImmediate` runtime guard | `do_refresh` is bound only on `TimeoutObject` (`node.classes.ts:147`, `TimeoutObject.rs:46`) via `host_fn(method)`, which type-checks `this`; a `TimeoutObject`'s kind is only ever `SetTimeout`/`SetInterval`. The preceding `debug_assert!` already documents the invariant, and `reschedule()` early-returns on `SetImmediate` regardless |
| `webcore/s3/client.rs` | `assert!(sink.signal.is_dead())` | Immediately follows `sink.signal.clear()`; `clear()` is `self.ptr = None`, `is_dead()` is `self.ptr.is_none()` |
| `webcore/ByteStream.rs` (two sites) | `self.buffer_action.set(None)` | Immediately follows `self.buffer_action.replace(None)` on the same cell; a leftover from translating Zig's `defer { .. = null }` |

## Why this is correct to have

Each removed path is either unreachable given the immediately-preceding guard or a no-op store. The two non-trivial cases:

* **`reschedule`**: `ref_()` only bumps a refcount and does not touch `event_loop_timer_state()`, so moving the heap removal into `All::update` is an order-preserving no-op.
* **`ByteStream`**: `replace(None)` already leaves the cell `None`. If `action.reject()` ever re-entered and installed a fresh `buffer_action`, the removed `set(None)` would have clobbered it; that reentrancy does not occur today (promise rejection schedules microtasks), but removing the store can only be equal-or-better.

## Verification

Builds clean on debug+ASAN. Existing suites for the touched areas pass: `test/js/node/timers/node-timers.test.ts`, `test/js/web/timers/setTimeout.test.js` (modulo three pre-existing leak-threshold failures on `bun-debug` that also reproduce on `main`; the fixture's `isASAN` probe checks `execPath.includes("bun-asan")`), `test/bundler/transpiler/transpiler.test.js -t define/macro`, `test/js/bun/test/expect.test.js -t toContain`, `test/cli/test/test-filter-lifecycle-snapshot.test.ts`, and `test/js/bun/spawn/spawn.test.ts -t argv`.

No new test: the diff changes no observable behavior, so nothing fails before and passes after.