### PR TITLE
types: FormData values()/entries() yield File | string, add [Symbol.iterator]

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1698,9 +1698,10 @@ interface FormData {
   set(name: string, value: string): void;
   set(name: string, blobValue: Blob, filename?: string): void;
   forEach(callbackfn: (value: Bun.FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void;
+  [Symbol.iterator](): IterableIterator<[string, Bun.FormDataEntryValue]>;
   keys(): IterableIterator<string>;
-  values(): IterableIterator<string>;
-  entries(): IterableIterator<[string, string]>;
+  values(): IterableIterator<Bun.FormDataEntryValue>;
+  entries(): IterableIterator<[string, Bun.FormDataEntryValue]>;
 }
 declare var FormData: Bun.__internal.UseLibDomIfAvailable<"FormData", { prototype: FormData; new (): FormData }>;
 

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -556,6 +556,45 @@ describe("@types/bun integration test", () => {
     });
   });
 
+  describe("FormData iteration", () => {
+    typeTest("values()/entries() yield File | string and FormData is iterable (#27194)", {
+      files: {
+        "formdata-27194.ts": `
+          // https://github.com/oven-sh/bun/issues/27194
+          type Equals<A, B> =
+            (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+          type Assert<T extends true> = T;
+
+          const fd = new FormData();
+          fd.append("field", new Blob(["data"]), "file.txt");
+
+          // FormData is iterable (must expose [Symbol.iterator])
+          const asIterable: Iterable<[string, File | string]> = fd;
+          void asIterable;
+
+          // values()/entries() yield File | string, matching get()/getAll()/forEach(); keys() yields string
+          type _values = Assert<Equals<ReturnType<FormData["values"]>, IterableIterator<File | string>>>;
+          type _entries = Assert<Equals<ReturnType<FormData["entries"]>, IterableIterator<[string, File | string]>>>;
+          type _keys = Assert<Equals<ReturnType<FormData["keys"]>, IterableIterator<string>>>;
+
+          for (const [key, value] of fd) {
+            const k: string = key;
+            const v: File | string = value;
+            void k;
+            void v;
+          }
+
+          export {};
+        `,
+      },
+      emptyInterfaces: expectedEmptyInterfacesWhenNoDOM,
+      diagnostics: diagnostics => {
+        const relevantDiagnostics = diagnostics.filter(d => d.line?.startsWith("formdata-27194.ts"));
+        expect(relevantDiagnostics).toEqual([]);
+      },
+    });
+  });
+
   describe("Bunland reaching for JSX", () => {
     typeTest("Bun.markdown.react() returns type compatible with React.ReactElement", {
       packages: ["@types/react", "@types/react-dom"],


### PR DESCRIPTION
### What does this PR do?

Fixes #27194.

Bun's global `FormData` interface typed `values()` and `entries()` to yield only `string`, and was missing `[Symbol.iterator]`:

```ts
keys(): IterableIterator<string>;
values(): IterableIterator<string>;
entries(): IterableIterator<[string, string]>;
```

But a `FormData` value can be a `File` — `append()`/`set()` accept a `Blob`, and the sibling accessors on the same interface already reflect that:

- `get(): Bun.FormDataEntryValue | null` &nbsp;(`File | string`)
- `getAll(): Bun.FormDataEntryValue[]`
- `forEach((value: Bun.FormDataEntryValue, …) => …)`

So typing the iterators as `string`-only was inconsistent with the rest of the interface, and `for (const [k, v] of formData)` failed to type-check without `lib.dom` because `[Symbol.iterator]` was absent. This change aligns the three iterator methods (and adds `[Symbol.iterator]`) with `Bun.FormDataEntryValue`, matching `lib.dom`'s `FormData` and the [reference docs](https://bun.com/reference/globals/FormData/entries).

`keys()` is unchanged — keys are always `string`.

### How did you verify your code works?

- Confirmed the runtime with `bun -e`: `FormData` is iterable (`fd[Symbol.iterator] === fd.entries`) and iterating yields `Blob`/`File` values, not just strings.
- Added a regression case to `test/integration/bun-types/bun-types.test.ts` (`FormData iteration`) that checks the `values()`/`entries()`/`keys()` return types, that `FormData` is assignable to `Iterable`, and that `for..of` destructuring types are `[string, File | string]`.
  - It **passes** with this change and **fails** without it: reverting the `.d.ts` produces `[Symbol.iterator]' is missing … Iterable` (2741) and `must have a '[Symbol.iterator]()' method` (2488) for the iterability checks, and `Assert<false>` (2344) for `values()`/`entries()`; `keys()` is correctly unaffected.
- Ran the full `bun test test/integration/bun-types/bun-types.test.ts` suite: the existing `checks with lib.dom.d.ts` case still passes, confirming the declaration merge with `lib.dom`'s `FormData` stays clean.
