### PR TITLE
crash_handler: encode fault pc + GP registers from ucontext into the trace string (v3)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@lezer/common": "^1.2.3",
         "@lezer/cpp": "^1.1.3",
         "@types/bun": "workspace:*",
-        "bun-tracestrings": "github:oven-sh/bun.report#912ca63e26c51429d3e6799aa2a6ab079b188fd8",
+        "bun-tracestrings": "github:oven-sh/bun.report#1a48fb004e3f7d2fc36239c3589ca2a3429b8a89",
         "esbuild": "^0.21.5",
         "mitata": "^0.1.14",
         "oxlint": "1.70.0",
@@ -86,6 +86,10 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
+    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
 
     "@lezer/common": ["@lezer/common@1.3.0", "", {}, "sha512-L9X8uHCYU310o99L3/MpJKYxPzXPOS7S0NmBaM7UO/x2Kb2WbmMLSkfvdr1KxRIFYOpbY0Jhn7CfLSUDzL8arQ=="],
 
@@ -183,7 +187,11 @@
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.70.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ptOlKwCz7n4AKs5VweMqG6DAg677FmKOK+vBkkL9DMNgFATIQ+upqUYBTOEwRQyRAx1ncGlPlXleV2hIcm3z4g=="],
 
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
     "@sentry/types": ["@sentry/types@7.120.4", "", {}, "sha512-cUq2hSSe6/qrU6oZsEP4InMI5VVdD86aypE+ENrQ6eZEVLTCYm1w6XhW1NvIu3UuWh7gZec4a9J7AFpYxki88Q=="],
+
+    "@types/archiver": ["@types/archiver@6.0.4", "", { "dependencies": { "@types/readdir-glob": "*" } }, "sha512-ULdQpARQ3sz9WH4nb98mJDYA0ft2A8C4f4fovvUcFwINa1cgGjY36JCAYuP5YypRq4mco1lJp1/7jEMS2oR0Hg=="],
 
     "@types/aws-lambda": ["@types/aws-lambda@8.10.159", "", {}, "sha512-SAP22WSGNN12OQ8PlCzGzRCZ7QDCwI85dQZbmpz7+mAk+L7j+wI7qnvmdKh+o7A5LaOp6QnOZ2NJphAZQTTHQg=="],
 
@@ -197,17 +205,55 @@
 
     "@types/node": ["@types/node@25.0.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-rl78HwuZlaDIUSeUKkmogkhebA+8K1Hy7tddZuJ3D0xV8pZSfsYGTsliGUol1JPzu9EKnTxPC4L1fiWouStRew=="],
 
+    "@types/readdir-glob": ["@types/readdir-glob@1.1.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg=="],
+
+    "@types/tar": ["@types/tar@6.1.13", "", { "dependencies": { "@types/node": "*", "minipass": "^4.0.0" } }, "sha512-IznnlmU5f4WcGTh2ltRu/Ijpmk8wiWXfF0VA4s+HPjHZgvFggk1YaIkbo5krX/zUCzWF8N/l4+W/LNxnvAJ8nw=="],
+
+    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
+
     "aggregate-error": ["aggregate-error@3.1.0", "", { "dependencies": { "clean-stack": "^2.0.0", "indent-string": "^4.0.0" } }, "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "archiver": ["archiver@7.0.1", "", { "dependencies": { "archiver-utils": "^5.0.2", "async": "^3.2.4", "buffer-crc32": "^1.0.0", "readable-stream": "^4.0.0", "readdir-glob": "^1.1.2", "tar-stream": "^3.0.0", "zip-stream": "^6.0.1" } }, "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ=="],
+
+    "archiver-utils": ["archiver-utils@5.0.2", "", { "dependencies": { "glob": "^10.0.0", "graceful-fs": "^4.2.0", "is-stream": "^2.0.1", "lazystream": "^1.0.0", "lodash": "^4.17.15", "normalize-path": "^3.0.0", "readable-stream": "^4.0.0" } }, "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA=="],
+
+    "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
+
+    "b4a": ["b4a@1.8.1", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "bare-events": ["bare-events@2.9.1", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg=="],
+
+    "bare-fs": ["bare-fs@4.7.4", "", { "dependencies": { "bare-events": "^2.5.4", "bare-path": "^3.0.0", "bare-stream": "^2.6.4", "bare-url": "^2.2.2", "fast-fifo": "^1.3.2" }, "peerDependencies": { "bare-buffer": "*" }, "optionalPeers": ["bare-buffer"] }, "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ=="],
+
+    "bare-path": ["bare-path@3.1.1", "", {}, "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ=="],
+
+    "bare-stream": ["bare-stream@2.13.3", "", { "dependencies": { "b4a": "^1.8.1", "streamx": "^2.25.0", "teex": "^1.0.1" }, "peerDependencies": { "bare-abort-controller": "*", "bare-buffer": "*", "bare-events": "*" }, "optionalPeers": ["bare-abort-controller", "bare-buffer", "bare-events"] }, "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ=="],
+
+    "bare-url": ["bare-url@2.4.5", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "before-after-hook": ["before-after-hook@2.2.3", "", {}, "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="],
 
     "bottleneck": ["bottleneck@2.19.5", "", {}, "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="],
 
+    "brace-expansion": ["brace-expansion@2.1.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA=="],
+
     "btoa-lite": ["btoa-lite@1.0.0", "", {}, "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA=="],
+
+    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+
+    "buffer-crc32": ["buffer-crc32@1.0.0", "", {}, "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w=="],
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
-    "bun-tracestrings": ["bun-tracestrings@github:oven-sh/bun.report#912ca63", { "dependencies": { "@octokit/webhooks-methods": "^5.1.0", "@sentry/types": "^7.112.2", "@types/bun": "^1.2.6", "html-minifier": "^4.0.0", "lightningcss": "^1.24.1", "marked": "^12.0.1", "octokit": "^3.2.0", "prettier": "^3.2.5", "typescript": "^5.0.0" }, "bin": { "ci-remap-server": "./bin/ci-remap-server.ts" } }, "oven-sh-bun.report-912ca63"],
+    "bun-tracestrings": ["bun-tracestrings@github:oven-sh/bun.report#1a48fb0", { "dependencies": { "@octokit/webhooks-methods": "^5.1.0", "@sentry/types": "^7.112.2", "@types/archiver": "^6.0.3", "@types/bun": "^1.3.11", "@types/tar": "^6.1.13", "archiver": "^7.0.1", "html-minifier": "^4.0.0", "lightningcss": "^1.24.1", "marked": "^12.0.1", "octokit": "^3.2.0", "prettier": "^3.2.5", "tar": "^7.5.1", "typescript": "^5.0.0" }, "bin": { "ci-remap-server": "./bin/ci-remap-server.ts" } }, "oven-sh-bun.report-1a48fb0", "sha512-vLB/zUVaEcx1J14S12q2GDYtGUG7e75ZOomW1HYRBoANslRPTt1VyWj6M6gMJSAKXB3JAC5kYtEDr7NqwFtE/A=="],
 
     "bun-types": ["bun-types@workspace:packages/bun-types"],
 
@@ -217,13 +263,29 @@
 
     "change-case": ["change-case@4.1.2", "", { "dependencies": { "camel-case": "^4.1.2", "capital-case": "^1.0.4", "constant-case": "^3.0.4", "dot-case": "^3.0.4", "header-case": "^2.0.4", "no-case": "^3.0.4", "param-case": "^3.0.4", "pascal-case": "^3.1.2", "path-case": "^3.0.4", "sentence-case": "^3.0.4", "snake-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A=="],
 
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
+
     "clean-css": ["clean-css@4.2.4", "", { "dependencies": { "source-map": "~0.6.0" } }, "sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A=="],
 
     "clean-stack": ["clean-stack@2.2.0", "", {}, "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="],
 
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
     "commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
+    "compress-commons": ["compress-commons@6.0.2", "", { "dependencies": { "crc-32": "^1.2.0", "crc32-stream": "^6.0.0", "is-stream": "^2.0.1", "normalize-path": "^3.0.0", "readable-stream": "^4.0.0" } }, "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg=="],
+
     "constant-case": ["constant-case@3.0.4", "", { "dependencies": { "no-case": "^3.0.4", "tslib": "^2.0.3", "upper-case": "^2.0.2" } }, "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ=="],
+
+    "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
+
+    "crc-32": ["crc-32@1.2.2", "", { "bin": { "crc32": "bin/crc32.njs" } }, "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="],
+
+    "crc32-stream": ["crc32-stream@6.0.0", "", { "dependencies": { "crc-32": "^1.2.0", "readable-stream": "^4.0.0" } }, "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "deprecation": ["deprecation@2.3.1", "", {}, "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="],
 
@@ -231,9 +293,27 @@
 
     "dot-case": ["dot-case@3.0.4", "", { "dependencies": { "no-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w=="],
 
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
+    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
     "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
+    "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
+
+    "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
+
+    "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
+
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
+    "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
 
@@ -241,7 +321,21 @@
 
     "html-minifier": ["html-minifier@4.0.0", "", { "dependencies": { "camel-case": "^3.0.0", "clean-css": "^4.2.1", "commander": "^2.19.0", "he": "^1.2.0", "param-case": "^2.1.1", "relateurl": "^0.2.7", "uglify-js": "^3.5.1" }, "bin": { "html-minifier": "./cli.js" } }, "sha512-aoGxanpFPLg7MkIl/DDFYtb0iWz7jMFGqFhvEDZga6/4QTjneiD8I/NXL1x5aaoCp7FSIT6h/OhykDdPsbtMig=="],
 
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -250,6 +344,8 @@
     "jwa": ["jwa@1.4.2", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw=="],
 
     "jws": ["jws@3.2.2", "", { "dependencies": { "jwa": "^1.4.1", "safe-buffer": "^5.0.1" } }, "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA=="],
+
+    "lazystream": ["lazystream@1.0.1", "", { "dependencies": { "readable-stream": "^2.0.5" } }, "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw=="],
 
     "lightningcss": ["lightningcss@1.30.2", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.30.2", "lightningcss-darwin-arm64": "1.30.2", "lightningcss-darwin-x64": "1.30.2", "lightningcss-freebsd-x64": "1.30.2", "lightningcss-linux-arm-gnueabihf": "1.30.2", "lightningcss-linux-arm64-gnu": "1.30.2", "lightningcss-linux-arm64-musl": "1.30.2", "lightningcss-linux-x64-gnu": "1.30.2", "lightningcss-linux-x64-musl": "1.30.2", "lightningcss-win32-arm64-msvc": "1.30.2", "lightningcss-win32-x64-msvc": "1.30.2" } }, "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ=="],
 
@@ -275,6 +371,8 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.30.2", "", { "os": "win32", "cpu": "x64" }, "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw=="],
 
+    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
+
     "lodash.includes": ["lodash.includes@4.3.0", "", {}, "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="],
 
     "lodash.isboolean": ["lodash.isboolean@3.0.3", "", {}, "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="],
@@ -297,11 +395,19 @@
 
     "marked": ["marked@12.0.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q=="],
 
+    "minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
+
+    "minipass": ["minipass@4.2.8", "", {}, "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ=="],
+
+    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
+
     "mitata": ["mitata@0.1.14", "", {}, "sha512-8kRs0l636eT4jj68PFXOR2D5xl4m56T478g16SzUPOYgkzQU+xaw62guAQxzBPm+SXb15GQi1cCpDxJfkr4CSA=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "no-case": ["no-case@3.0.4", "", { "dependencies": { "lower-case": "^2.0.2", "tslib": "^2.0.3" } }, "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg=="],
+
+    "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
     "octokit": ["octokit@3.2.2", "", { "dependencies": { "@octokit/app": "^14.0.2", "@octokit/core": "^5.0.0", "@octokit/oauth-app": "^6.0.0", "@octokit/plugin-paginate-graphql": "^4.0.0", "@octokit/plugin-paginate-rest": "11.4.4-cjs.2", "@octokit/plugin-rest-endpoint-methods": "13.3.2-cjs.1", "@octokit/plugin-retry": "^6.0.0", "@octokit/plugin-throttling": "^8.0.0", "@octokit/request-error": "^5.0.0", "@octokit/types": "^13.0.0", "@octokit/webhooks": "^12.3.1" } }, "sha512-7Abo3nADdja8l/aglU6Y3lpnHSfv0tw7gFPiqzry/yCU+2gTAX7R1roJ8hJrxIK+S1j+7iqRJXtmuHJ/UDsBhQ=="],
 
@@ -309,11 +415,17 @@
 
     "oxlint": ["oxlint@1.70.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.70.0", "@oxlint/binding-android-arm64": "1.70.0", "@oxlint/binding-darwin-arm64": "1.70.0", "@oxlint/binding-darwin-x64": "1.70.0", "@oxlint/binding-freebsd-x64": "1.70.0", "@oxlint/binding-linux-arm-gnueabihf": "1.70.0", "@oxlint/binding-linux-arm-musleabihf": "1.70.0", "@oxlint/binding-linux-arm64-gnu": "1.70.0", "@oxlint/binding-linux-arm64-musl": "1.70.0", "@oxlint/binding-linux-ppc64-gnu": "1.70.0", "@oxlint/binding-linux-riscv64-gnu": "1.70.0", "@oxlint/binding-linux-riscv64-musl": "1.70.0", "@oxlint/binding-linux-s390x-gnu": "1.70.0", "@oxlint/binding-linux-x64-gnu": "1.70.0", "@oxlint/binding-linux-x64-musl": "1.70.0", "@oxlint/binding-openharmony-arm64": "1.70.0", "@oxlint/binding-win32-arm64-msvc": "1.70.0", "@oxlint/binding-win32-ia32-msvc": "1.70.0", "@oxlint/binding-win32-x64-msvc": "1.70.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-D6JgHtzkhRwvEC+A0Nw5AEc5bk8x5i1pHzvZIEf/a0C4hOzmAACNGtkDGPyFaxxX3ZVGxCPeig3P3rMM8XU3/g=="],
 
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
     "param-case": ["param-case@2.1.1", "", { "dependencies": { "no-case": "^2.2.0" } }, "sha512-eQE845L6ot89sk2N8liD8HAuH4ca6Vvr7VWAWwt7+kvvG5aBcPmmphQ68JsEG2qa9n1TykS2DLeMt363AAH8/w=="],
 
     "pascal-case": ["pascal-case@3.1.2", "", { "dependencies": { "no-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g=="],
 
     "path-case": ["path-case@3.0.4", "", { "dependencies": { "dot-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "peechy": ["peechy@0.4.34", "", { "dependencies": { "change-case": "^4.1.2" }, "bin": { "peechy": "cli.js" } }, "sha512-Cpke/cCqqZHhkyxz7mdqS8ZAGJFUi5icu3ZGqxm9GC7g2VrhH0tmjPhZoWHAN5ghw1m1wq5+2YvfbDSqgC4+Zg=="],
 
@@ -321,9 +433,17 @@
 
     "prettier-plugin-organize-imports": ["prettier-plugin-organize-imports@4.3.0", "", { "peerDependencies": { "prettier": ">=2.0", "typescript": ">=2.9", "vue-tsc": "^2.1.0 || 3" }, "optionalPeers": ["vue-tsc"] }, "sha512-FxFz0qFhyBsGdIsb697f/EkvHzi5SZOhWAjxcx2dLt+Q532bAlhswcXGYB1yzjZ69kW8UoadFBw7TyNwlq96Iw=="],
 
+    "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
+
+    "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
+
     "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
     "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
+
+    "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
+
+    "readdir-glob": ["readdir-glob@1.1.3", "", { "dependencies": { "minimatch": "^5.1.0" } }, "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA=="],
 
     "relateurl": ["relateurl@0.2.7", "", {}, "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog=="],
 
@@ -335,11 +455,37 @@
 
     "sentence-case": ["sentence-case@3.0.4", "", { "dependencies": { "no-case": "^3.0.4", "tslib": "^2.0.3", "upper-case-first": "^2.0.2" } }, "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg=="],
 
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
     "snake-case": ["snake-case@3.0.4", "", { "dependencies": { "dot-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "streamx": ["streamx@2.28.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw=="],
+
+    "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "tar": ["tar@7.5.20", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ=="],
+
+    "tar-stream": ["tar-stream@3.2.0", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg=="],
+
+    "teex": ["teex@1.0.1", "", { "dependencies": { "streamx": "^2.12.5" } }, "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg=="],
+
+    "text-decoder": ["text-decoder@1.2.7", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -357,7 +503,21 @@
 
     "upper-case-first": ["upper-case-first@2.0.2", "", { "dependencies": { "tslib": "^2.0.3" } }, "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg=="],
 
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
+
+    "zip-stream": ["zip-stream@6.0.1", "", { "dependencies": { "archiver-utils": "^5.0.0", "compress-commons": "^6.0.2", "readable-stream": "^4.0.0" } }, "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA=="],
+
+    "@isaacs/fs-minipass/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "@octokit/app/@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@9.2.2", "", { "dependencies": { "@octokit/types": "^12.6.0" }, "peerDependencies": { "@octokit/core": "5" } }, "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ=="],
 
@@ -379,7 +539,33 @@
 
     "constant-case/upper-case": ["upper-case@2.0.2", "", { "dependencies": { "tslib": "^2.0.3" } }, "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg=="],
 
+    "glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "glob/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "lazystream/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
+    "minizlib/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
     "param-case/no-case": ["no-case@2.3.2", "", { "dependencies": { "lower-case": "^1.1.1" } }, "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ=="],
+
+    "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "path-scurry/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "tar/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@octokit/app/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@20.0.0", "", {}, "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA=="],
 
@@ -389,6 +575,16 @@
 
     "camel-case/no-case/lower-case": ["lower-case@1.1.4", "", {}, "sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA=="],
 
+    "lazystream/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "lazystream/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
     "param-case/no-case/lower-case": ["lower-case@1.1.4", "", {}, "sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA=="],
+
+    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@lezer/common": "^1.2.3",
     "@lezer/cpp": "^1.1.3",
     "@types/bun": "workspace:*",
-    "bun-tracestrings": "github:oven-sh/bun.report#912ca63e26c51429d3e6799aa2a6ab079b188fd8",
+    "bun-tracestrings": "github:oven-sh/bun.report#1a48fb004e3f7d2fc36239c3589ca2a3429b8a89",
     "esbuild": "^0.21.5",
     "mitata": "^0.1.14",
     "oxlint": "1.70.0",

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -919,8 +919,9 @@ mod draft {
     pub enum TraceSeed<'a> {
         /// Signal/exception handler saved the fault register context: walk frame
         /// pointers from `fp` (POSIX) / RtlCapture and trim by `pc` (Windows). `pc`
-        /// becomes frame 0.
-        Fault(FaultRegisters),
+        /// becomes frame 0. Borrowed: the register file lives on the signal
+        /// handler's stack; boxing it would allocate inside a signal handler.
+        Fault(&'a FaultRegisters),
         /// A trace was already captured upstream.
         ErrorReturn(&'a StackTrace<'a>),
         /// Walk the current stack and trim the capture machinery above this PC.
@@ -1175,7 +1176,7 @@ mod draft {
 
                     let mut addr_buf: [usize; 20] = [0; 20];
                     let trace_buf: StackTrace;
-                    let mut fault_regs: Option<FaultRegisters> = None;
+                    let mut fault_regs: Option<&FaultRegisters> = None;
 
                     let trace: &StackTrace = 'blk: {
                         let idx: usize = match seed {
@@ -1222,7 +1223,7 @@ mod draft {
                                 trace,
                                 reason,
                                 action: TraceStringAction::ViewTrace,
-                                regs: fault_regs.as_ref(),
+                                regs: fault_regs,
                             }
                         )
                         .is_err()
@@ -1308,7 +1309,7 @@ mod draft {
                                 trace,
                                 reason,
                                 action: TraceStringAction::OpenIssue,
-                                regs: fault_regs.as_ref(),
+                                regs: fault_regs,
                             }
                         )
                         .is_err()
@@ -1884,6 +1885,7 @@ mod draft {
         // sigfault address field.
         let addr: usize = unsafe { (*info).si_addr() as usize };
 
+        let regs = fault_context_from_ucontext(ctx);
         crash_handler(
             match sig {
                 libc::SIGSEGV => CrashReason::SegmentationFault(addr),
@@ -1893,8 +1895,8 @@ mod draft {
                 // we do not register this handler for other signals
                 _ => unreachable!(),
             },
-            match fault_context_from_ucontext(ctx) {
-                Some(regs) => TraceSeed::Fault(regs),
+            match regs.as_ref() {
+                Some(r) => TraceSeed::Fault(r),
                 None => TraceSeed::None,
             },
         );
@@ -2286,7 +2288,7 @@ mod draft {
         // Windows: capture_from_context uses RtlCaptureStackBackTrace and trims
         // by `pc`; the frame-pointer slot is unused.
         let regs = fault_context_from_windows_context(info.ContextRecord, fallback_pc);
-        crash_handler(reason, TraceSeed::Fault(regs));
+        crash_handler(reason, TraceSeed::Fault(&regs));
     }
 
     #[cfg(all(target_os = "linux", target_env = "gnu"))]

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -673,7 +673,7 @@ mod draft {
 
         /// Hardware faults (reason codes '2'..'7'): the only variants with a
         /// `FaultRegisters` context and a self-delimiting reason payload, so
-        /// the v3/v4 register block is appended for them only.
+        /// the v3 register block is appended for them only.
         const fn is_fault(&self) -> bool {
             matches!(
                 self,
@@ -867,8 +867,8 @@ mod draft {
     }
 
     /// GP register snapshot at the fault, lifted from `ucontext_t` / `CONTEXT`
-    /// and encoded into the v3/v4 trace string so the remapper has register
-    /// state when the stack walk is short. Slot order: `NAMES` (bun.report).
+    /// and encoded into the v3 trace string so the remapper has register state
+    /// when the stack walk is short. Slot order: `NAMES` (bun.report).
     #[derive(Clone, Copy)]
     pub struct FaultRegisters {
         /// Faulting instruction pointer (raw, ASLR not removed). Becomes stack
@@ -913,7 +913,7 @@ mod draft {
         }
 
         /// Testing-only: synthesize a fault context so `bun:internal-for-testing`
-        /// can exercise the v3/v4 encoder without a real fault (ASAN owns the
+        /// can exercise the v3 encoder without a real fault (ASAN owns the
         /// SIGSEGV handler under debug builds).
         pub fn for_testing(pc: usize, values: &[u64]) -> Self {
             let mut r = Self::empty(pc, 0);
@@ -2601,11 +2601,21 @@ mod draft {
     ///
     /// '1' - original. uses 7 char hash with VLQ encoded stack-frames
     /// '2' - same as '1' but this build is known to be a canary build
-    /// '3' - '1' plus a trailing register block (StackLine pc, VLQ count,
-    ///       count * 2-VLQ regs) for fault reasons '2'..'7' only; other
-    ///       reasons are byte-identical to '1'.
-    /// '4' - same as '3' but this build is known to be a canary build
-    const VERSION_CHAR: &str = if Environment::IS_CANARY { "4" } else { "3" };
+    /// '3' - '1' plus a build-flags VLQ after the sha (bit0 = canary) and a
+    ///       trailing register block (StackLine pc, VLQ count, count * 2-VLQ
+    ///       regs) for fault reasons '2'..'7' only.
+    const VERSION_CHAR: &str = "3";
+
+    /// Build-variant flags written as one VLQ after the sha (v3+). The canary
+    /// bit replaces the '1'/'2' version-char split so future format bumps use
+    /// one version char instead of two.
+    const BUILD_FLAGS: i32 = {
+        let mut f = 0;
+        if Environment::IS_CANARY {
+            f |= 1 << 0;
+        }
+        f
+    };
 
     // The v1/v2 trace-string
     // format encodes exactly 7 hex chars. `Environment::GIT_SHA_SHORT` is 9 chars and would
@@ -2836,6 +2846,7 @@ mod draft {
 
         writer.write_all(VERSION_CHAR.as_bytes())?;
         writer.write_all(GIT_SHA.as_bytes())?;
+        writer.write_all(VLQ::encode(BUILD_FLAGS).slice())?;
 
         let packed_features: u64 = bun_analytics::packed_features().bits();
         write_u64_as_two_vlqs(writer, packed_features as usize)?;
@@ -2925,7 +2936,7 @@ mod draft {
             CrashReason::OutOfMemory => writer.write_byte(b'9')?,
         }
 
-        // v3/v4 register block: fault reasons only ('2'..'7', self-delimiting
+        // v3 register block: fault reasons only ('2'..'7', self-delimiting
         // payloads). '0'/'8' read payload to end-of-string so appending here
         // would make them ambiguous; '0'/'1'/'8'/'9' never carry a context.
         if opts.reason.is_fault() {

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1822,7 +1822,8 @@ mod draft {
         unsafe {
             let read = |off: usize| ctx.cast::<u8>().add(off).cast::<u64>().read_unaligned();
             // winnt.h _CONTEXT (x64): Rax at 0x78, then Rcx Rdx Rbx Rsp Rbp Rsi
-            // Rdi R8..R15 Rip, each DWORD64.
+            // Rdi R8..R15 Rip, each DWORD64. learn.microsoft.com ns-winnt-context;
+            // offsets are kernel/user ABI and cannot change.
             let rax = read(0x78);
             let rcx = read(0x80);
             let rdx = read(0x88);
@@ -1876,7 +1877,9 @@ mod draft {
         // SAFETY: the kernel provides a valid CONTEXT; offsets per winnt.h.
         unsafe {
             let read = |off: usize| ctx.cast::<u8>().add(off).cast::<u64>().read_unaligned();
-            // winnt.h _ARM64_NT_CONTEXT: X[31] at 0x8, Sp at 0x100, Pc at 0x108.
+            // winnt.h _ARM64_NT_CONTEXT: X[31] at 0x8, Sp at 0x100, Pc at 0x108
+            // (offsets are comment-annotated in the SDK header itself).
+            // learn.microsoft.com ns-winnt-arm64_nt_context.
             let pc = read(0x108);
             let fp = read(0x8 + 29 * 8);
             let mut r = FaultRegisters::empty(pc as usize, fp as usize);

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -868,9 +868,7 @@ mod draft {
 
     /// GP register snapshot at the fault, lifted from `ucontext_t` / `CONTEXT`
     /// and encoded into the v3/v4 trace string so the remapper has register
-    /// state when the stack walk is short. Slot order is shared with bun.report:
-    ///   x86_64:  rax rbx rcx rdx rdi rsi rbp rsp r8 r9 r10 r11 r12 r13 r14 r15 rip
-    ///   aarch64: x0..x28 fp lr sp pc
+    /// state when the stack walk is short. Slot order: `NAMES` (bun.report).
     #[derive(Clone, Copy)]
     pub struct FaultRegisters {
         /// Faulting instruction pointer (raw, ASLR not removed). Becomes stack
@@ -904,7 +902,6 @@ mod draft {
         pub const NAMES: &[&str] = &[];
 
         pub const COUNT: u8 = Self::NAMES.len() as u8;
-        const _CHECK: () = assert!(Self::NAMES.len() <= Self::MAX);
 
         const fn empty(pc: usize, fp: usize) -> Self {
             Self {
@@ -930,6 +927,10 @@ mod draft {
             &self.values[..self.count as usize]
         }
     }
+
+    // Free const: associated `impl` consts are lazy, so the bound check lives
+    // at module scope where it is always evaluated.
+    const _: () = assert!(FaultRegisters::NAMES.len() <= FaultRegisters::MAX);
 
     /// Where the crash trace is seeded from. Each call site has exactly one.
     #[derive(Clone, Copy)]

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -866,12 +866,9 @@ mod draft {
         ActionGuard(prev)
     }
 
-    /// General-purpose register snapshot at the faulting instruction, lifted
-    /// from `ucontext_t` (POSIX) / `CONTEXT` (Windows). Encoded into the trace
-    /// string (v3/v4) after the reason payload so the remapper can show the
-    /// register state even when the stack walk is short or corrupt.
-    ///
-    /// Slot order is fixed per arch and shared with the decoder:
+    /// GP register snapshot at the fault, lifted from `ucontext_t` / `CONTEXT`
+    /// and encoded into the v3/v4 trace string so the remapper has register
+    /// state when the stack walk is short. Slot order is shared with bun.report:
     ///   x86_64:  rax rbx rcx rdx rdi rsi rbp rsp r8 r9 r10 r11 r12 r13 r14 r15 rip
     ///   aarch64: x0..x28 fp lr sp pc
     #[derive(Clone, Copy)]
@@ -918,9 +915,8 @@ mod draft {
             }
         }
 
-        /// Testing-only constructor: seeds a fault context with caller-supplied
-        /// register values so the `bun:internal-for-testing` segfault hook can
-        /// exercise the v3/v4 encoding path without a real fault (ASAN owns the
+        /// Testing-only: synthesize a fault context so `bun:internal-for-testing`
+        /// can exercise the v3/v4 encoder without a real fault (ASAN owns the
         /// SIGSEGV handler under debug builds).
         pub fn for_testing(pc: usize, values: &[u64]) -> Self {
             let mut r = Self::empty(pc, 0);
@@ -938,10 +934,9 @@ mod draft {
     /// Where the crash trace is seeded from. Each call site has exactly one.
     #[derive(Clone, Copy)]
     pub enum TraceSeed<'a> {
-        /// Signal/exception handler saved the fault register context: walk frame
-        /// pointers from `fp` (POSIX) / RtlCapture and trim by `pc` (Windows). `pc`
-        /// becomes frame 0. Borrowed: the register file lives on the signal
-        /// handler's stack; boxing it would allocate inside a signal handler.
+        /// Signal/exception handler saved the fault context: walk frame pointers
+        /// from `fp` (POSIX) / trim by `pc` (Windows); `pc` is frame 0. Borrowed
+        /// so the signal handler does not allocate.
         Fault(&'a FaultRegisters),
         /// A trace was already captured upstream.
         ErrorReturn(&'a StackTrace<'a>),
@@ -1696,11 +1691,9 @@ mod draft {
         ARCH_DISPLAY_STRING,
     );
 
-    /// Lift `pc`, `fp` and the general-purpose register file from the
-    /// `ucontext_t` the kernel hands the signal handler. `pc`/`fp` seed the
-    /// frame-pointer walk; the full register set is encoded into the trace
-    /// string. Returns `None` on arch/OS combos we don't have layouts for
-    /// (the caller then falls back to a current-stack capture).
+    /// Lift `pc`, `fp` and the GP register file from the kernel-supplied
+    /// `ucontext_t`; `pc`/`fp` seed the frame walk, the rest is encoded into
+    /// the trace string. `None` for arch/OS combos without a known layout.
     #[cfg(unix)]
     fn fault_context_from_ucontext(ctx: *mut c_void) -> Option<FaultRegisters> {
         debug_assert!(!ctx.is_null());

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -885,8 +885,8 @@ mod draft {
         pub const MAX: usize = 34;
 
         /// Register names in encoding order. Source of truth for `COUNT`; the
-        /// per-target ucontext/CONTEXT readers assign `r.count = Self::COUNT`
-        /// so a drift between this table and the readers fails at compile time.
+        /// readers assign `r.count = Self::COUNT` so the encoded count tracks
+        /// this table. Keep each reader's slot writes in lockstep manually.
         #[cfg(target_arch = "x86_64")]
         pub const NAMES: &[&str] = &[
             "rax", "rbx", "rcx", "rdx", "rdi", "rsi", "rbp", "rsp", "r8", "r9", "r10", "r11",

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1189,7 +1189,11 @@ mod draft {
                             // strip the unwind tables a CFI-based capture would need.
                             TraceSeed::Fault(regs) => {
                                 fault_regs = Some(regs);
-                                bun_core::debug::capture_from_context(regs.pc, regs.fp, &mut addr_buf)
+                                bun_core::debug::capture_from_context(
+                                    regs.pc,
+                                    regs.fp,
+                                    &mut addr_buf,
+                                )
                             }
                             TraceSeed::BeginAddr(addr) => {
                                 debug::capture_stack_trace(addr, &mut addr_buf)
@@ -1689,12 +1693,27 @@ mod draft {
             let pc = g[libc::REG_RIP as usize] as usize;
             let mut r = FaultRegisters::empty(pc, g[libc::REG_RBP as usize] as usize);
             for (i, slot) in [
-                libc::REG_RAX, libc::REG_RBX, libc::REG_RCX, libc::REG_RDX,
-                libc::REG_RDI, libc::REG_RSI, libc::REG_RBP, libc::REG_RSP,
-                libc::REG_R8,  libc::REG_R9,  libc::REG_R10, libc::REG_R11,
-                libc::REG_R12, libc::REG_R13, libc::REG_R14, libc::REG_R15,
+                libc::REG_RAX,
+                libc::REG_RBX,
+                libc::REG_RCX,
+                libc::REG_RDX,
+                libc::REG_RDI,
+                libc::REG_RSI,
+                libc::REG_RBP,
+                libc::REG_RSP,
+                libc::REG_R8,
+                libc::REG_R9,
+                libc::REG_R10,
+                libc::REG_R11,
+                libc::REG_R12,
+                libc::REG_R13,
+                libc::REG_R14,
+                libc::REG_R15,
                 libc::REG_RIP,
-            ].into_iter().enumerate() {
+            ]
+            .into_iter()
+            .enumerate()
+            {
                 r.values[i] = g[slot as usize] as u64;
             }
             r.count = 17;
@@ -1729,9 +1748,8 @@ mod draft {
             let mut r = FaultRegisters::empty(ss.__rip as usize, ss.__rbp as usize);
             r.values = [
                 ss.__rax, ss.__rbx, ss.__rcx, ss.__rdx, ss.__rdi, ss.__rsi, ss.__rbp, ss.__rsp,
-                ss.__r8,  ss.__r9,  ss.__r10, ss.__r11, ss.__r12, ss.__r13, ss.__r14, ss.__r15,
-                ss.__rip,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                ss.__r8, ss.__r9, ss.__r10, ss.__r11, ss.__r12, ss.__r13, ss.__r14, ss.__r15,
+                ss.__rip, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             ];
             r.count = 17;
             Some(r)
@@ -1756,8 +1774,14 @@ mod draft {
             Some(r)
         }
         #[cfg(not(any(
-            all(any(target_os = "linux", target_os = "android"), target_arch = "x86_64"),
-            all(any(target_os = "linux", target_os = "android"), target_arch = "aarch64"),
+            all(
+                any(target_os = "linux", target_os = "android"),
+                target_arch = "x86_64"
+            ),
+            all(
+                any(target_os = "linux", target_os = "android"),
+                target_arch = "aarch64"
+            ),
             all(target_os = "macos", target_arch = "x86_64"),
             all(target_os = "macos", target_arch = "aarch64"),
         )))]
@@ -1770,10 +1794,7 @@ mod draft {
     /// Lift `pc`, `fp` and the general-purpose register file from the Windows
     /// `CONTEXT` record handed to a vectored exception handler.
     #[cfg(windows)]
-    fn fault_context_from_windows_context(
-        ctx: *mut c_void,
-        fallback_pc: usize,
-    ) -> FaultRegisters {
+    fn fault_context_from_windows_context(ctx: *mut c_void, fallback_pc: usize) -> FaultRegisters {
         if ctx.is_null() {
             return FaultRegisters::empty(fallback_pc, 0);
         }
@@ -1797,11 +1818,40 @@ mod draft {
             let rip = read(0xF8);
             let mut r = FaultRegisters::empty(rip as usize, rbp as usize);
             r.values = [
-                rax, rbx, rcx, rdx, rdi, rsi, rbp, rsp,
-                read(0xB8), read(0xC0), read(0xC8), read(0xD0),
-                read(0xD8), read(0xE0), read(0xE8), read(0xF0),
+                rax,
+                rbx,
+                rcx,
+                rdx,
+                rdi,
+                rsi,
+                rbp,
+                rsp,
+                read(0xB8),
+                read(0xC0),
+                read(0xC8),
+                read(0xD0),
+                read(0xD8),
+                read(0xE0),
+                read(0xE8),
+                read(0xF0),
                 rip,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
             ];
             r.count = 17;
             r

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -2620,9 +2620,9 @@ mod draft {
         f
     };
 
-    // The v1/v2 trace-string
-    // format encodes exactly 7 hex chars. `Environment::GIT_SHA_SHORT` is 9 chars and would
-    // shift every following VLQ byte, making bun.report unable to decode the URL.
+    // The trace-string format encodes exactly 7 hex chars. `Environment::GIT_SHA_SHORT`
+    // is 9 chars and would shift every following VLQ byte, making bun.report
+    // unable to decode the URL.
     const GIT_SHA: &str = {
         const fn sha7(s: &'static str) -> &'static str {
             let (head, _) = s.as_bytes().split_at(7);

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -670,6 +670,22 @@ mod draft {
                 | CrashReason::OutOfMemory => libc::SIGABRT,
             }
         }
+
+        /// True for hardware faults delivered via a signal/exception handler
+        /// (reason codes '2'..'7'). These are the only variants that ever carry
+        /// a `FaultRegisters` context and whose reason payload is
+        /// self-delimiting, so the v3/v4 register block is appended for them.
+        const fn is_fault(&self) -> bool {
+            matches!(
+                self,
+                CrashReason::SegmentationFault(_)
+                    | CrashReason::IllegalInstruction(_)
+                    | CrashReason::BusError(_)
+                    | CrashReason::FloatingPointError(_)
+                    | CrashReason::DatatypeMisalignment
+                    | CrashReason::StackOverflow
+            )
+        }
     }
 
     impl fmt::Display for CrashReason {
@@ -874,6 +890,9 @@ mod draft {
     impl FaultRegisters {
         pub const MAX: usize = 34;
 
+        /// Register names in encoding order. Source of truth for `COUNT`; the
+        /// per-target ucontext/CONTEXT readers assign `r.count = Self::COUNT`
+        /// so a drift between this table and the readers fails at compile time.
         #[cfg(target_arch = "x86_64")]
         pub const NAMES: &[&str] = &[
             "rax", "rbx", "rcx", "rdx", "rdi", "rsi", "rbp", "rsp", "r8", "r9", "r10", "r11",
@@ -887,6 +906,9 @@ mod draft {
         ];
         #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
         pub const NAMES: &[&str] = &[];
+
+        pub const COUNT: u8 = Self::NAMES.len() as u8;
+        const _CHECK: () = assert!(Self::NAMES.len() <= Self::MAX);
 
         const fn empty(pc: usize, fp: usize) -> Self {
             Self {
@@ -1717,7 +1739,7 @@ mod draft {
             {
                 r.values[i] = g[slot as usize] as u64;
             }
-            r.count = 17;
+            r.count = FaultRegisters::COUNT;
             Some(r)
         }
         #[cfg(all(
@@ -1735,7 +1757,7 @@ mod draft {
             r.values[30] = mc.regs[30] as u64; // lr
             r.values[31] = mc.sp as u64;
             r.values[32] = mc.pc as u64;
-            r.count = 33;
+            r.count = FaultRegisters::COUNT;
             Some(r)
         }
         #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
@@ -1752,7 +1774,7 @@ mod draft {
                 ss.__r8, ss.__r9, ss.__r10, ss.__r11, ss.__r12, ss.__r13, ss.__r14, ss.__r15,
                 ss.__rip, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             ];
-            r.count = 17;
+            r.count = FaultRegisters::COUNT;
             Some(r)
         }
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
@@ -1771,7 +1793,7 @@ mod draft {
             r.values[30] = ss.__lr;
             r.values[31] = ss.__sp;
             r.values[32] = ss.__pc;
-            r.count = 33;
+            r.count = FaultRegisters::COUNT;
             Some(r)
         }
         #[cfg(not(any(
@@ -1854,7 +1876,7 @@ mod draft {
                 0,
                 0,
             ];
-            r.count = 17;
+            r.count = FaultRegisters::COUNT;
             r
         }
         #[cfg(target_arch = "aarch64")]
@@ -1870,7 +1892,7 @@ mod draft {
             }
             r.values[31] = read(0x100); // sp
             r.values[32] = pc;
-            r.count = 33;
+            r.count = FaultRegisters::COUNT;
             r
         }
         #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
@@ -2586,11 +2608,14 @@ mod draft {
     ///
     /// '1' - original. uses 7 char hash with VLQ encoded stack-frames
     /// '2' - same as '1' but this build is known to be a canary build
-    /// '3' - same as '1' with a trailing fault-register block appended after the
-    ///       reason payload (see `encode_trace_string`): one `StackLine`-encoded
-    ///       fault pc, a VLQ register count, then count * 2-VLQ register values.
-    ///       A decoder that only knows '1'/'2' can treat '3' as '1' and stop at
-    ///       the end of the reason payload; everything after it is additive.
+    /// '3' - same as '1' plus, for hardware-fault reasons '2'..'7' only, a
+    ///       trailing register block after the reason payload: one
+    ///       `StackLine`-encoded fault pc, a VLQ register count, then
+    ///       count * 2-VLQ register values. Reasons '0'/'1'/'8'/'9' are
+    ///       byte-identical to v1, so a decoder that only knows '1'/'2' can
+    ///       treat '3' as '1': the fault reasons' payloads are self-delimiting
+    ///       and the appended block is additive; the non-fault reasons are
+    ///       unchanged.
     /// '4' - same as '3' but this build is known to be a canary build
     const VERSION_CHAR: &str = if Environment::IS_CANARY { "4" } else { "3" };
 
@@ -2912,22 +2937,29 @@ mod draft {
             CrashReason::OutOfMemory => writer.write_byte(b'9')?,
         }
 
-        // v3/v4 register block. Always present so the decoder does not have to
-        // branch on which reason codes carry one; `_A` (= no pc, 0 regs) marks
-        // "no fault context" (panic/OOM/unknown arch).
-        match opts.regs {
-            None => {
-                StackLine::write_encoded(None, writer)?;
-                writer.write_all(VLQ::ZERO.slice())?;
-            }
-            Some(regs) => {
-                let pc_line = StackLine::from_address(regs.pc, &mut name_bytes);
-                StackLine::write_encoded(pc_line.as_ref(), writer)?;
-                writer.write_all(VLQ::encode(regs.count as i32).slice())?;
-                for &v in regs.values() {
-                    write_u64_as_two_vlqs(writer, v as usize)?;
+        // v3/v4 register block. Only emitted for hardware-fault reasons
+        // ('2'..'7'), whose payloads are self-delimiting (fixed VLQ count or
+        // empty). Reasons '0' (Panic: base64 to end-of-string) and '8'
+        // (ZigError: identifier to end-of-string) are left byte-identical to
+        // v1/v2 so a decoder can still read the payload to end-of-string; they
+        // never carry a fault context anyway. '1'/'9' likewise never do.
+        if opts.reason.is_fault() {
+            match opts.regs {
+                None => {
+                    StackLine::write_encoded(None, writer)?;
+                    writer.write_all(VLQ::ZERO.slice())?;
+                }
+                Some(regs) => {
+                    let pc_line = StackLine::from_address(regs.pc, &mut name_bytes);
+                    StackLine::write_encoded(pc_line.as_ref(), writer)?;
+                    writer.write_all(VLQ::encode(regs.count as i32).slice())?;
+                    for &v in regs.values() {
+                        write_u64_as_two_vlqs(writer, v as usize)?;
+                    }
                 }
             }
+        } else {
+            debug_assert!(opts.regs.is_none());
         }
 
         if opts.action == TraceStringAction::ViewTrace {

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -671,10 +671,9 @@ mod draft {
             }
         }
 
-        /// True for hardware faults delivered via a signal/exception handler
-        /// (reason codes '2'..'7'). These are the only variants that ever carry
-        /// a `FaultRegisters` context and whose reason payload is
-        /// self-delimiting, so the v3/v4 register block is appended for them.
+        /// Hardware faults (reason codes '2'..'7'): the only variants with a
+        /// `FaultRegisters` context and a self-delimiting reason payload, so
+        /// the v3/v4 register block is appended for them only.
         const fn is_fault(&self) -> bool {
             matches!(
                 self,
@@ -2608,14 +2607,9 @@ mod draft {
     ///
     /// '1' - original. uses 7 char hash with VLQ encoded stack-frames
     /// '2' - same as '1' but this build is known to be a canary build
-    /// '3' - same as '1' plus, for hardware-fault reasons '2'..'7' only, a
-    ///       trailing register block after the reason payload: one
-    ///       `StackLine`-encoded fault pc, a VLQ register count, then
-    ///       count * 2-VLQ register values. Reasons '0'/'1'/'8'/'9' are
-    ///       byte-identical to v1, so a decoder that only knows '1'/'2' can
-    ///       treat '3' as '1': the fault reasons' payloads are self-delimiting
-    ///       and the appended block is additive; the non-fault reasons are
-    ///       unchanged.
+    /// '3' - '1' plus a trailing register block (StackLine pc, VLQ count,
+    ///       count * 2-VLQ regs) for fault reasons '2'..'7' only; other
+    ///       reasons are byte-identical to '1'.
     /// '4' - same as '3' but this build is known to be a canary build
     const VERSION_CHAR: &str = if Environment::IS_CANARY { "4" } else { "3" };
 
@@ -2937,12 +2931,9 @@ mod draft {
             CrashReason::OutOfMemory => writer.write_byte(b'9')?,
         }
 
-        // v3/v4 register block. Only emitted for hardware-fault reasons
-        // ('2'..'7'), whose payloads are self-delimiting (fixed VLQ count or
-        // empty). Reasons '0' (Panic: base64 to end-of-string) and '8'
-        // (ZigError: identifier to end-of-string) are left byte-identical to
-        // v1/v2 so a decoder can still read the payload to end-of-string; they
-        // never carry a fault context anyway. '1'/'9' likewise never do.
+        // v3/v4 register block: fault reasons only ('2'..'7', self-delimiting
+        // payloads). '0'/'8' read payload to end-of-string so appending here
+        // would make them ambiguous; '0'/'1'/'8'/'9' never carry a context.
         if opts.reason.is_fault() {
             match opts.regs {
                 None => {

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -2,12 +2,14 @@
 //! print backtraces that are mapped to source code. In release builds, we do
 //! not have debug symbols in the binary. Bun's solution to this is called
 //! a "trace string", a url with compressed encoding of the captured
-//! backtrace. Version 1 trace strings contain the following information:
+//! backtrace. Version 3 trace strings contain the following information:
 //!
 //! - What version and commit of Bun captured the backtrace.
 //! - The platform the backtrace was captured on.
 //! - The list of addresses with ASLR removed, ready to be remapped.
 //! - If panicking, the message that was panicked with.
+//! - For hardware faults, the faulting pc and general-purpose register values
+//!   captured from `ucontext_t` / `CONTEXT`.
 //!
 //! These can be demangled using Bun's remapping API, which has cached
 //! versions of all debug symbols for all versions of Bun. Hosting this keeps
@@ -849,13 +851,76 @@ mod draft {
         ActionGuard(prev)
     }
 
+    /// General-purpose register snapshot at the faulting instruction, lifted
+    /// from `ucontext_t` (POSIX) / `CONTEXT` (Windows). Encoded into the trace
+    /// string (v3/v4) after the reason payload so the remapper can show the
+    /// register state even when the stack walk is short or corrupt.
+    ///
+    /// Slot order is fixed per arch and shared with the decoder:
+    ///   x86_64:  rax rbx rcx rdx rdi rsi rbp rsp r8 r9 r10 r11 r12 r13 r14 r15 rip
+    ///   aarch64: x0..x28 fp lr sp pc
+    #[derive(Clone, Copy)]
+    pub struct FaultRegisters {
+        /// Faulting instruction pointer (raw, ASLR not removed). Becomes stack
+        /// frame 0 and is separately encoded as a `StackLine` so the remapper
+        /// has the exact fault site even if the frame walk produced nothing.
+        pub pc: usize,
+        /// Frame pointer for the frame walker. Not encoded.
+        pub fp: usize,
+        values: [u64; Self::MAX],
+        count: u8,
+    }
+
+    impl FaultRegisters {
+        pub const MAX: usize = 34;
+
+        #[cfg(target_arch = "x86_64")]
+        pub const NAMES: &[&str] = &[
+            "rax", "rbx", "rcx", "rdx", "rdi", "rsi", "rbp", "rsp", "r8", "r9", "r10", "r11",
+            "r12", "r13", "r14", "r15", "rip",
+        ];
+        #[cfg(target_arch = "aarch64")]
+        pub const NAMES: &[&str] = &[
+            "x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11", "x12", "x13",
+            "x14", "x15", "x16", "x17", "x18", "x19", "x20", "x21", "x22", "x23", "x24", "x25",
+            "x26", "x27", "x28", "fp", "lr", "sp", "pc",
+        ];
+        #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+        pub const NAMES: &[&str] = &[];
+
+        const fn empty(pc: usize, fp: usize) -> Self {
+            Self {
+                pc,
+                fp,
+                values: [0; Self::MAX],
+                count: 0,
+            }
+        }
+
+        /// Testing-only constructor: seeds a fault context with caller-supplied
+        /// register values so the `bun:internal-for-testing` segfault hook can
+        /// exercise the v3/v4 encoding path without a real fault (ASAN owns the
+        /// SIGSEGV handler under debug builds).
+        pub fn for_testing(pc: usize, values: &[u64]) -> Self {
+            let mut r = Self::empty(pc, 0);
+            let n = values.len().min(Self::MAX);
+            r.values[..n].copy_from_slice(&values[..n]);
+            r.count = n as u8;
+            r
+        }
+
+        pub fn values(&self) -> &[u64] {
+            &self.values[..self.count as usize]
+        }
+    }
+
     /// Where the crash trace is seeded from. Each call site has exactly one.
     #[derive(Clone, Copy)]
     pub enum TraceSeed<'a> {
         /// Signal/exception handler saved the fault register context: walk frame
         /// pointers from `fp` (POSIX) / RtlCapture and trim by `pc` (Windows). `pc`
         /// becomes frame 0.
-        Fault { pc: usize, fp: usize },
+        Fault(FaultRegisters),
         /// A trace was already captured upstream.
         ErrorReturn(&'a StackTrace<'a>),
         /// Walk the current stack and trim the capture machinery above this PC.
@@ -872,7 +937,7 @@ mod draft {
             Output::disable_scoped_debug_writer();
         }
 
-        let mut trace_str_buf = BoundedArray::<u8, 1024>::default();
+        let mut trace_str_buf = BoundedArray::<u8, 1536>::default();
 
         match PANIC_STAGE.with(|s| s.get()) {
             0 => {
@@ -1110,6 +1175,7 @@ mod draft {
 
                     let mut addr_buf: [usize; 20] = [0; 20];
                     let trace_buf: StackTrace;
+                    let mut fault_regs: Option<FaultRegisters> = None;
 
                     let trace: &StackTrace = 'blk: {
                         let idx: usize = match seed {
@@ -1121,8 +1187,9 @@ mod draft {
                             // `SA_ONSTACK` altstack, so its own frame chain is
                             // disjoint from the faulting thread's, and release builds
                             // strip the unwind tables a CFI-based capture would need.
-                            TraceSeed::Fault { pc, fp } => {
-                                bun_core::debug::capture_from_context(pc, fp, &mut addr_buf)
+                            TraceSeed::Fault(regs) => {
+                                fault_regs = Some(regs);
+                                bun_core::debug::capture_from_context(regs.pc, regs.fp, &mut addr_buf)
                             }
                             TraceSeed::BeginAddr(addr) => {
                                 debug::capture_stack_trace(addr, &mut addr_buf)
@@ -1151,6 +1218,7 @@ mod draft {
                                 trace,
                                 reason,
                                 action: TraceStringAction::ViewTrace,
+                                regs: fault_regs.as_ref(),
                             }
                         )
                         .is_err()
@@ -1236,6 +1304,7 @@ mod draft {
                                 trace,
                                 reason,
                                 action: TraceStringAction::OpenIssue,
+                                regs: fault_regs.as_ref(),
                             }
                         )
                         .is_err()
@@ -1601,27 +1670,53 @@ mod draft {
         ARCH_DISPLAY_STRING,
     );
 
-    /// Extract `(pc, fp)` from the `ucontext_t` the kernel hands the signal
-    /// handler. Seeds the frame-pointer walk from the faulting frame. Returns
-    /// `None` on arch/OS combos we don't have register offsets for (the caller
-    /// then falls back to a current-stack capture).
+    /// Lift `pc`, `fp` and the general-purpose register file from the
+    /// `ucontext_t` the kernel hands the signal handler. `pc`/`fp` seed the
+    /// frame-pointer walk; the full register set is encoded into the trace
+    /// string. Returns `None` on arch/OS combos we don't have layouts for
+    /// (the caller then falls back to a current-stack capture).
     #[cfg(unix)]
-    fn fault_context_from_ucontext(ctx: *mut c_void) -> Option<(usize, usize)> {
+    fn fault_context_from_ucontext(ctx: *mut c_void) -> Option<FaultRegisters> {
         debug_assert!(!ctx.is_null());
         let uc = ctx.cast::<libc::ucontext_t>().cast_const();
-        #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+        #[cfg(all(
+            any(target_os = "linux", target_os = "android"),
+            target_arch = "x86_64"
+        ))]
         // SAFETY: the kernel passes a valid ucontext_t as the handler's 3rd arg.
         unsafe {
-            let mc = &(*uc).uc_mcontext;
-            let pc = mc.gregs[libc::REG_RIP as usize] as usize;
-            let fp = mc.gregs[libc::REG_RBP as usize] as usize;
-            Some((pc, fp))
+            let g = &(*uc).uc_mcontext.gregs;
+            let pc = g[libc::REG_RIP as usize] as usize;
+            let mut r = FaultRegisters::empty(pc, g[libc::REG_RBP as usize] as usize);
+            for (i, slot) in [
+                libc::REG_RAX, libc::REG_RBX, libc::REG_RCX, libc::REG_RDX,
+                libc::REG_RDI, libc::REG_RSI, libc::REG_RBP, libc::REG_RSP,
+                libc::REG_R8,  libc::REG_R9,  libc::REG_R10, libc::REG_R11,
+                libc::REG_R12, libc::REG_R13, libc::REG_R14, libc::REG_R15,
+                libc::REG_RIP,
+            ].into_iter().enumerate() {
+                r.values[i] = g[slot as usize] as u64;
+            }
+            r.count = 17;
+            Some(r)
         }
-        #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+        #[cfg(all(
+            any(target_os = "linux", target_os = "android"),
+            target_arch = "aarch64"
+        ))]
         // SAFETY: the kernel passes a valid ucontext_t as the handler's 3rd arg.
         unsafe {
             let mc = &(*uc).uc_mcontext;
-            Some((mc.pc as usize, mc.regs[29] as usize))
+            let mut r = FaultRegisters::empty(mc.pc as usize, mc.regs[29] as usize);
+            for i in 0..29 {
+                r.values[i] = mc.regs[i] as u64;
+            }
+            r.values[29] = mc.regs[29] as u64; // fp
+            r.values[30] = mc.regs[30] as u64; // lr
+            r.values[31] = mc.sp as u64;
+            r.values[32] = mc.pc as u64;
+            r.count = 33;
+            Some(r)
         }
         #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
         // SAFETY: the kernel passes a valid ucontext_t as the handler's 3rd arg.
@@ -1630,7 +1725,16 @@ mod draft {
             if mc.is_null() {
                 return None;
             }
-            Some(((*mc).__ss.__rip as usize, (*mc).__ss.__rbp as usize))
+            let ss = &(*mc).__ss;
+            let mut r = FaultRegisters::empty(ss.__rip as usize, ss.__rbp as usize);
+            r.values = [
+                ss.__rax, ss.__rbx, ss.__rcx, ss.__rdx, ss.__rdi, ss.__rsi, ss.__rbp, ss.__rsp,
+                ss.__r8,  ss.__r9,  ss.__r10, ss.__r11, ss.__r12, ss.__r13, ss.__r14, ss.__r15,
+                ss.__rip,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ];
+            r.count = 17;
+            Some(r)
         }
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         // SAFETY: the kernel passes a valid ucontext_t as the handler's 3rd arg.
@@ -1639,17 +1743,88 @@ mod draft {
             if mc.is_null() {
                 return None;
             }
-            Some(((*mc).__ss.__pc as usize, (*mc).__ss.__fp as usize))
+            let ss = &(*mc).__ss;
+            let mut r = FaultRegisters::empty(ss.__pc as usize, ss.__fp as usize);
+            for i in 0..29 {
+                r.values[i] = ss.__x[i];
+            }
+            r.values[29] = ss.__fp;
+            r.values[30] = ss.__lr;
+            r.values[31] = ss.__sp;
+            r.values[32] = ss.__pc;
+            r.count = 33;
+            Some(r)
         }
         #[cfg(not(any(
-            all(target_os = "linux", target_arch = "x86_64"),
-            all(target_os = "linux", target_arch = "aarch64"),
+            all(any(target_os = "linux", target_os = "android"), target_arch = "x86_64"),
+            all(any(target_os = "linux", target_os = "android"), target_arch = "aarch64"),
             all(target_os = "macos", target_arch = "x86_64"),
             all(target_os = "macos", target_arch = "aarch64"),
         )))]
         {
             let _ = uc;
             None
+        }
+    }
+
+    /// Lift `pc`, `fp` and the general-purpose register file from the Windows
+    /// `CONTEXT` record handed to a vectored exception handler.
+    #[cfg(windows)]
+    fn fault_context_from_windows_context(
+        ctx: *mut c_void,
+        fallback_pc: usize,
+    ) -> FaultRegisters {
+        if ctx.is_null() {
+            return FaultRegisters::empty(fallback_pc, 0);
+        }
+        // `bun_sys::windows::CONTEXT` is an opaque aligned blob; read the GP
+        // register slots by their documented `winnt.h` byte offsets so this
+        // crate does not need the full arch-specific struct definition.
+        #[cfg(target_arch = "x86_64")]
+        // SAFETY: the kernel provides a valid CONTEXT; offsets per winnt.h.
+        unsafe {
+            let read = |off: usize| ctx.cast::<u8>().add(off).cast::<u64>().read_unaligned();
+            // winnt.h _CONTEXT (x64): Rax at 0x78, then Rcx Rdx Rbx Rsp Rbp Rsi
+            // Rdi R8..R15 Rip, each DWORD64.
+            let rax = read(0x78);
+            let rcx = read(0x80);
+            let rdx = read(0x88);
+            let rbx = read(0x90);
+            let rsp = read(0x98);
+            let rbp = read(0xA0);
+            let rsi = read(0xA8);
+            let rdi = read(0xB0);
+            let rip = read(0xF8);
+            let mut r = FaultRegisters::empty(rip as usize, rbp as usize);
+            r.values = [
+                rax, rbx, rcx, rdx, rdi, rsi, rbp, rsp,
+                read(0xB8), read(0xC0), read(0xC8), read(0xD0),
+                read(0xD8), read(0xE0), read(0xE8), read(0xF0),
+                rip,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ];
+            r.count = 17;
+            r
+        }
+        #[cfg(target_arch = "aarch64")]
+        // SAFETY: the kernel provides a valid CONTEXT; offsets per winnt.h.
+        unsafe {
+            let read = |off: usize| ctx.cast::<u8>().add(off).cast::<u64>().read_unaligned();
+            // winnt.h _ARM64_NT_CONTEXT: X[31] at 0x8, Sp at 0x100, Pc at 0x108.
+            let pc = read(0x108);
+            let fp = read(0x8 + 29 * 8);
+            let mut r = FaultRegisters::empty(pc as usize, fp as usize);
+            for i in 0..31 {
+                r.values[i] = read(0x8 + i * 8);
+            }
+            r.values[31] = read(0x100); // sp
+            r.values[32] = pc;
+            r.count = 33;
+            r
+        }
+        #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+        {
+            FaultRegisters::empty(fallback_pc, 0)
         }
     }
 
@@ -1669,7 +1844,7 @@ mod draft {
                 _ => unreachable!(),
             },
             match fault_context_from_ucontext(ctx) {
-                Some((pc, fp)) => TraceSeed::Fault { pc, fp },
+                Some(regs) => TraceSeed::Fault(regs),
                 None => TraceSeed::None,
             },
         );
@@ -1890,6 +2065,7 @@ mod draft {
                         trace: &trace,
                         reason,
                         action: TraceStringAction::ViewTrace,
+                        regs: None,
                     }
                 );
             } else {
@@ -1914,6 +2090,7 @@ mod draft {
                         trace: &trace,
                         reason,
                         action: TraceStringAction::OpenIssue,
+                        regs: None,
                     }
                 );
                 let _ = writer.write_all(trace_str_buf.const_slice());
@@ -1971,6 +2148,7 @@ mod draft {
                     action: TraceStringAction::ViewTrace,
                     reason: CrashReason::ZigError(b"DumpStackTrace"),
                     trace: &stack,
+                    regs: None,
                 }
             );
             return;
@@ -2054,10 +2232,11 @@ mod draft {
         };
         // SAFETY: kernel provides a valid EXCEPTION_RECORD; ExceptionAddress is
         // the faulting instruction.
-        let pc = unsafe { (*info.ExceptionRecord).ExceptionAddress } as usize;
+        let fallback_pc = unsafe { (*info.ExceptionRecord).ExceptionAddress } as usize;
         // Windows: capture_from_context uses RtlCaptureStackBackTrace and trims
         // by `pc`; the frame-pointer slot is unused.
-        crash_handler(reason, TraceSeed::Fault { pc, fp: 0 });
+        let regs = fault_context_from_windows_context(info.ContextRecord, fallback_pc);
+        crash_handler(reason, TraceSeed::Fault(regs));
     }
 
     #[cfg(all(target_os = "linux", target_env = "gnu"))]
@@ -2355,7 +2534,13 @@ mod draft {
     ///
     /// '1' - original. uses 7 char hash with VLQ encoded stack-frames
     /// '2' - same as '1' but this build is known to be a canary build
-    const VERSION_CHAR: &str = if Environment::IS_CANARY { "2" } else { "1" };
+    /// '3' - same as '1' with a trailing fault-register block appended after the
+    ///       reason payload (see `encode_trace_string`): one `StackLine`-encoded
+    ///       fault pc, a VLQ register count, then count * 2-VLQ register values.
+    ///       A decoder that only knows '1'/'2' can treat '3' as '1' and stop at
+    ///       the end of the reason payload; everything after it is additive.
+    /// '4' - same as '3' but this build is known to be a canary build
+    const VERSION_CHAR: &str = if Environment::IS_CANARY { "4" } else { "3" };
 
     // The v1/v2 trace-string
     // format encodes exactly 7 hex chars. `Environment::GIT_SHA_SHORT` is 9 chars and would
@@ -2557,6 +2742,7 @@ mod draft {
         trace: &'a StackTrace<'a>,
         reason: CrashReason,
         action: TraceStringAction,
+        regs: Option<&'a FaultRegisters>,
     }
 
     #[derive(Clone, Copy, PartialEq, Eq)]
@@ -2672,6 +2858,24 @@ mod draft {
             }
 
             CrashReason::OutOfMemory => writer.write_byte(b'9')?,
+        }
+
+        // v3/v4 register block. Always present so the decoder does not have to
+        // branch on which reason codes carry one; `_A` (= no pc, 0 regs) marks
+        // "no fault context" (panic/OOM/unknown arch).
+        match opts.regs {
+            None => {
+                StackLine::write_encoded(None, writer)?;
+                writer.write_all(VLQ::ZERO.slice())?;
+            }
+            Some(regs) => {
+                let pc_line = StackLine::from_address(regs.pc, &mut name_bytes);
+                StackLine::write_encoded(pc_line.as_ref(), writer)?;
+                writer.write_all(VLQ::encode(regs.count as i32).slice())?;
+                for &v in regs.values() {
+                    write_u64_as_two_vlqs(writer, v as usize)?;
+                }
+            }
         }
 
         if opts.action == TraceStringAction::ViewTrace {
@@ -3011,6 +3215,7 @@ mod draft {
                 trace,
                 reason,
                 action: TraceStringAction::ViewTrace,
+                regs: None,
             };
             if IS_ROOT {
                 bun_core::pretty_errorln!(
@@ -3065,6 +3270,7 @@ mod draft {
                     action: TraceStringAction::ViewTrace,
                     reason: CrashReason::ZigError(b"DumpStackTrace"),
                     trace,
+                    regs: None,
                 }
             );
             return;

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -100,6 +100,8 @@ export const cssInternals = {
 
 export const crash_handler = $rust("crash_handler.rs", "js_bindings.generate") as {
   getMachOImageZeroOffset: () => number;
+  getFeaturesAsVLQ: () => string;
+  getFeatureData: () => { is_canary: boolean; version: string; revision: string; features: string[]; generated_at: number };
   segfault: () => void;
   segfaultWithRegisters: () => void;
   panic: () => void;

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -101,7 +101,13 @@ export const cssInternals = {
 export const crash_handler = $rust("crash_handler.rs", "js_bindings.generate") as {
   getMachOImageZeroOffset: () => number;
   getFeaturesAsVLQ: () => string;
-  getFeatureData: () => { is_canary: boolean; version: string; revision: string; features: string[]; generated_at: number };
+  getFeatureData: () => {
+    is_canary: boolean;
+    version: string;
+    revision: string;
+    features: string[];
+    generated_at: number;
+  };
   segfault: () => void;
   segfaultWithRegisters: () => void;
   panic: () => void;

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -101,6 +101,7 @@ export const cssInternals = {
 export const crash_handler = $rust("crash_handler.rs", "js_bindings.generate") as {
   getMachOImageZeroOffset: () => number;
   segfault: () => void;
+  segfaultWithRegisters: () => void;
   panic: () => void;
   rootError: () => void;
   outOfMemory: () => void;

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -112,7 +112,7 @@ pub mod js_bindings {
         );
         crash_handler::crash_handler(
             crash_handler::CrashReason::SegmentationFault(0xDEADBEEF),
-            crash_handler::TraceSeed::Fault(regs),
+            crash_handler::TraceSeed::Fault(&regs),
         );
     }
 

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -12,7 +12,7 @@ pub mod js_bindings {
     use super::*;
 
     pub fn generate(global: &JSGlobalObject) -> JSValue {
-        let obj = JSValue::create_empty_object(global, 8);
+        let obj = JSValue::create_empty_object(global, 9);
         // `#[bun_jsc::host_fn]` emits an `extern "C"` shim named `__jsc_host_<fn>`; that
         // shim is the `JSHostFn` value passed to `JSFunction::create`.
         const ENTRIES: &[(&str, bun_jsc::JSHostFn)] = &[
@@ -23,6 +23,10 @@ pub mod js_bindings {
             ("getFeaturesAsVLQ", __jsc_host_js_get_features_as_vlq),
             ("getFeatureData", __jsc_host_js_get_feature_data),
             ("segfault", __jsc_host_js_segfault),
+            (
+                "segfaultWithRegisters",
+                __jsc_host_js_segfault_with_registers,
+            ),
             ("panic", __jsc_host_js_panic),
             ("rootError", __jsc_host_js_root_error),
             ("outOfMemory", __jsc_host_js_out_of_memory),
@@ -91,6 +95,25 @@ pub mod js_bindings {
             core::hint::black_box(ptr);
         }
         Ok(JSValue::UNDEFINED)
+    }
+
+    #[bun_jsc::host_fn]
+    pub(crate) fn js_segfault_with_registers(
+        _global: &JSGlobalObject,
+        _frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        crash_handler::suppress_core_dumps_if_necessary();
+        // Deterministic sentinel values so the test can assert on the encoded
+        // register block without depending on real CPU state.
+        let vals: [u64; 4] = [0x1111, 0x2222, 0x3333, 0xDEADBEEF00000000];
+        let regs = crash_handler::FaultRegisters::for_testing(
+            js_segfault_with_registers as *const () as usize,
+            &vals,
+        );
+        crash_handler::crash_handler(
+            crash_handler::CrashReason::SegmentationFault(0xDEADBEEF),
+            crash_handler::TraceSeed::Fault(regs),
+        );
     }
 
     #[bun_jsc::host_fn]

--- a/test/cli/run/fixture-crash.js
+++ b/test/cli/run/fixture-crash.js
@@ -11,5 +11,7 @@ const approach = process.argv[2];
 if (approach in crash_handler) {
   crash_handler[approach]();
 } else {
-  console.error("usage: bun fixture-crash.js <segfault|panic|rootError|outOfMemory|raiseIgnoringPanicHandler>");
+  console.error(
+    "usage: bun fixture-crash.js <segfault|segfaultWithRegisters|panic|rootError|outOfMemory|raiseIgnoringPanicHandler>",
+  );
 }

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -173,7 +173,7 @@ describe("trace string v3/v4 (fault pc + register block)", () => {
     expect(exitCode).not.toBe(0);
   });
 
-  test("non-fault crashes encode an empty register block (`_A` suffix)", async () => {
+  test("non-fault crashes are byte-identical to v1 (no register block)", async () => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
@@ -191,9 +191,12 @@ describe("trace string v3/v4 (fault pc + register block)", () => {
     expect(["3", "4"], `payload=${payload}`).toContain(payload[2]);
 
     const body = payload.replace(/\/view$/, "");
-    // OutOfMemory reason code is '9' with no trailing data in v1; v3 appends
-    // the empty register block: '_' (no pc) + 'A' (VLQ 0 = no registers).
-    expect(body.endsWith("9_A"), `payload=${body}`).toBe(true);
+    // OutOfMemory reason code is '9' with no trailing data. v3 leaves
+    // non-fault reasons byte-identical to v1 so Panic ('0', base64 to EOS)
+    // and ZigError ('8', identifier to EOS) stay decodable: the body must
+    // end exactly at '9', no `_A` suffix.
+    expect(body.endsWith("A9"), `payload=${body}`).toBe(true);
+    expect(body.endsWith("_A"), `payload=${body}`).toBe(false);
 
     expect(exitCode).not.toBe(0);
   });

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -166,10 +166,7 @@ describe("trace string v3/v4 (fault pc + register block)", () => {
     // Reason char '2' + write_u64_as_two_vlqs(0xDEADBEEF) is at most 9 bytes
     // ('2' + VLQ(0)=1 + VLQ(i32)<=7). v3 must have substantially more after
     // it: a StackLine (>=1 byte) + 'I' + 8 VLQs (>=8 bytes).
-    expect(
-      afterReason.length,
-      `v3 register block missing; tail=${afterReason}`,
-    ).toBeGreaterThanOrEqual(9 + 1 + 1 + 8);
+    expect(afterReason.length, `v3 register block missing; tail=${afterReason}`).toBeGreaterThanOrEqual(9 + 1 + 1 + 8);
     // Register count VLQ(4)='I' must appear in the tail.
     expect(afterReason).toContain("I");
 

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug, isLinux, isPosix, mergeWindowEnvs } from "harness";
 import path from "path";
 const { getMachOImageZeroOffset } = crash_handler;
-const is_canary: boolean = (crash_handler as any).getFeatureData().is_canary;
+const is_canary = crash_handler.getFeatureData().is_canary;
 
 // CI sets BUN_CRASH_REPORT_URL so unexpected crashes are captured; these
 // deliberate crashes must not upload there or the runner pins them on the

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -1,8 +1,9 @@
 import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, isLinux, isPosix, mergeWindowEnvs } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isLinux, isPosix, mergeWindowEnvs } from "harness";
 import path from "path";
 const { getMachOImageZeroOffset } = crash_handler;
+const is_canary: boolean = (crash_handler as any).getFeatureData().is_canary;
 
 // CI sets BUN_CRASH_REPORT_URL so unexpected crashes are captured; these
 // deliberate crashes must not upload there or the runner pins them on the
@@ -152,6 +153,18 @@ describe("trace string v3 (build flags + fault register block)", () => {
     const lo = Number(v & 0xffff_ffffn) | 0;
     return vlq(hi) + vlq(lo);
   }
+  function decodeVlq(s: string, i: number): [number, number] {
+    let shift = 0,
+      v = 0;
+    for (;;) {
+      const d = B64.indexOf(s[i++]);
+      v |= (d & 31) << shift;
+      shift += 5;
+      if ((d & 32) === 0) break;
+    }
+    const mag = v >>> 1;
+    return [v & 1 ? (mag === 0 ? -0x80000000 : -mag) : mag, i];
+  }
 
   test("version char is '3' and a fault context encodes pc + registers", async () => {
     await using proc = Bun.spawn({
@@ -172,8 +185,8 @@ describe("trace string v3 (build flags + fault register block)", () => {
     const payload = traceStringPayload(stderr);
     // payload = <platform><cmd><version><sha7><build_flags vlq>... ; version at index 2.
     expect(payload[2], `payload=${payload}`).toBe("3");
-    // build_flags VLQ(0|1) is one byte ('A' or 'C') right after the 7-char sha.
-    expect(["A", "C"], `payload=${payload}`).toContain(payload[10]);
+    // build_flags VLQ right after the 7-char sha: bit0 = canary.
+    expect(payload[10], `payload=${payload}`).toBe(is_canary ? "C" : "A");
 
     const body = payload.replace(/\/view$/, "");
 
@@ -190,6 +203,62 @@ describe("trace string v3 (build flags + fault register block)", () => {
     expect(before.lastIndexOf(reason), `reason '${reason}' not in payload=${body}`).toBeGreaterThan(0);
     const pcStackLine = before.slice(before.lastIndexOf(reason) + reason.length);
     expect(pcStackLine.length, `no pc StackLine; payload=${body}`).toBeGreaterThan(0);
+
+    expect(exitCode).not.toBe(0);
+  });
+
+  // Under ASAN the SIGSEGV handler is not installed (ASAN owns it), so the
+  // real ucontext/CONTEXT readers only run on non-ASAN builds.
+  test.skipIf(isASAN)("a real fault populates registers from ucontext/CONTEXT", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        path.join(import.meta.dir, "fixture-crash.js"),
+        "segfault",
+        "--debug-crash-handler-use-trace-string",
+      ],
+      env: noReportEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    void stdout;
+
+    expect(stderr).toContain("Segmentation fault at address 0xDEADBEEF");
+    const body = traceStringPayload(stderr).replace(/\/view$/, "");
+
+    // `segfault()` writes 0xDEADBEEF to *0xDEADBEEF, so at least one GP
+    // register must carry 0xDEADBEEF at the fault (address and/or value).
+    const expected_count = process.arch === "arm64" ? 33 : 17;
+
+    // Anchor on the frame terminator + reason byte + fault address. Frames
+    // precede the reason and the register block follows it, so the first
+    // occurrence is the real one.
+    const anchor = "A" + "2" + u64AsTwoVlqs(0xdead_beefn);
+    const anchorIdx = body.indexOf(anchor);
+    expect(anchorIdx, `anchor not found; payload=${body}`).toBeGreaterThan(0);
+    const afterReason = body.slice(anchorIdx + anchor.length);
+    // pc StackLine: a single VLQ (or '_' — never here since pc is in-image).
+    let i = 0;
+    if (afterReason[0] === "_") {
+      i = 1;
+    } else {
+      while (B64.indexOf(afterReason[i]) >= 32) i++;
+      i++;
+    }
+    const [count, ci] = decodeVlq(afterReason, i);
+    expect(count, `payload=${body}`).toBe(expected_count);
+    i = ci;
+    const regs: bigint[] = [];
+    for (let k = 0; k < count; k++) {
+      const [hi, j1] = decodeVlq(afterReason, i);
+      const [lo, j2] = decodeVlq(afterReason, j1);
+      regs.push((BigInt(hi >>> 0) << 32n) | BigInt(lo >>> 0));
+      i = j2;
+    }
+    expect(afterReason.slice(i), `trailing bytes after regs; payload=${body}`).toBe("");
+    expect(regs, `regs=${regs.map(r => r.toString(16))}`).toContain(0xdead_beefn);
+    // rip/pc (last slot) should be a plausible code address (non-zero).
+    expect(regs[expected_count - 1]).toBeGreaterThan(0n);
 
     expect(exitCode).not.toBe(0);
   });

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -213,7 +213,6 @@ describe("trace string v3/v4 (fault pc + register block)", () => {
     // Non-fault reasons stay byte-identical to v1 (so '0'/'8' remain
     // end-of-string terminated): body ends at reason '9', no `_A` suffix.
     expect(body.endsWith("A9"), `payload=${body}`).toBe(true);
-    expect(body.endsWith("_A"), `payload=${body}`).toBe(false);
 
     expect(exitCode).not.toBe(0);
   });

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -122,7 +122,7 @@ describe.if(isPosix)("terminal signal reflects the crash cause", () => {
   });
 });
 
-describe("trace string v3/v4 (fault pc + register block)", () => {
+describe("trace string v3 (build flags + fault register block)", () => {
   // `noReportEnv` sets BUN_CRASH_REPORT_URL="" so the base URL is empty; the
   // trace string is just `/<version>/<payload>` on its own line.
   function traceStringPayload(stderr: string): string {
@@ -153,7 +153,7 @@ describe("trace string v3/v4 (fault pc + register block)", () => {
     return vlq(hi) + vlq(lo);
   }
 
-  test("version char is '3'/'4' and a fault context encodes pc + registers", async () => {
+  test("version char is '3' and a fault context encodes pc + registers", async () => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
@@ -170,8 +170,10 @@ describe("trace string v3/v4 (fault pc + register block)", () => {
     expect(stderr).toContain("Segmentation fault at address 0xDEADBEEF");
 
     const payload = traceStringPayload(stderr);
-    // payload = <platform><cmd><version><sha7>... ; version char is at index 2.
-    expect(["3", "4"], `payload=${payload}`).toContain(payload[2]);
+    // payload = <platform><cmd><version><sha7><build_flags vlq>... ; version at index 2.
+    expect(payload[2], `payload=${payload}`).toBe("3");
+    // build_flags VLQ(0|1) is one byte ('A' or 'C') right after the 7-char sha.
+    expect(["A", "C"], `payload=${payload}`).toContain(payload[10]);
 
     const body = payload.replace(/\/view$/, "");
 
@@ -192,7 +194,7 @@ describe("trace string v3/v4 (fault pc + register block)", () => {
     expect(exitCode).not.toBe(0);
   });
 
-  test("non-fault crashes are byte-identical to v1 (no register block)", async () => {
+  test("non-fault crashes have no register block", async () => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
@@ -207,10 +209,10 @@ describe("trace string v3/v4 (fault pc + register block)", () => {
     void stdout;
 
     const payload = traceStringPayload(stderr);
-    expect(["3", "4"], `payload=${payload}`).toContain(payload[2]);
+    expect(payload[2], `payload=${payload}`).toBe("3");
 
     const body = payload.replace(/\/view$/, "");
-    // Non-fault reasons stay byte-identical to v1 (so '0'/'8' remain
+    // Non-fault reasons have no register block (so '0'/'8' remain
     // end-of-string terminated): body ends at reason '9', no `_A` suffix.
     expect(body.endsWith("A9"), `payload=${body}`).toBe(true);
 

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -131,6 +131,28 @@ describe("trace string v3/v4 (fault pc + register block)", () => {
     return m![1];
   }
 
+  // Source-map VLQ, matching bun_base64::VLQ::encode (standard base64 alphabet,
+  // low bit = sign, bit 5 = continuation).
+  const B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  function vlq(value: number): string {
+    let v = value >= 0 ? value << 1 : (Math.abs(value) << 1) | 1;
+    // coerce to u32 so the >>> below matches the Rust `u32` shift
+    v = v >>> 0;
+    let out = "";
+    do {
+      let digit = v & 31;
+      v >>>= 5;
+      if (v !== 0) digit |= 32;
+      out += B64[digit];
+    } while (v !== 0);
+    return out;
+  }
+  function u64AsTwoVlqs(v: bigint): string {
+    const hi = Number((v >> 32n) & 0xffff_ffffn) | 0;
+    const lo = Number(v & 0xffff_ffffn) | 0;
+    return vlq(hi) + vlq(lo);
+  }
+
   test("version char is '3'/'4' and a fault context encodes pc + registers", async () => {
     await using proc = Bun.spawn({
       cmd: [
@@ -151,24 +173,21 @@ describe("trace string v3/v4 (fault pc + register block)", () => {
     // payload = <platform><cmd><version><sha7>... ; version char is at index 2.
     expect(["3", "4"], `payload=${payload}`).toContain(payload[2]);
 
-    // Strip any trailing `/view` so the suffix assertions see only the
-    // encoded body.
     const body = payload.replace(/\/view$/, "");
 
-    // Reason code '2' (SegmentationFault) precedes the fault address. After
-    // the two-VLQ fault address the v3 block begins: one StackLine for the
-    // fault pc (always present, so never `_` here), then VLQ(4)='I' for the
-    // four synthetic registers, then eight VLQs of register halves.
-    // v1/v2 would end immediately after the fault-address VLQs.
-    const reasonIdx = body.lastIndexOf("2A");
-    expect(reasonIdx, `no segfault reason in payload=${body}`).toBeGreaterThan(0);
-    const afterReason = body.slice(reasonIdx);
-    // Reason char '2' + write_u64_as_two_vlqs(0xDEADBEEF) is at most 9 bytes
-    // ('2' + VLQ(0)=1 + VLQ(i32)<=7). v3 must have substantially more after
-    // it: a StackLine (>=1 byte) + 'I' + 8 VLQs (>=8 bytes).
-    expect(afterReason.length, `v3 register block missing; tail=${afterReason}`).toBeGreaterThanOrEqual(9 + 1 + 1 + 8);
-    // Register count VLQ(4)='I' must appear in the tail.
-    expect(afterReason).toContain("I");
+    // The fixture passes regs = [0x1111, 0x2222, 0x3333, 0xDEADBEEF00000000].
+    // Expected v3 tail: VLQ(4) count, then four 2-VLQ register values.
+    const sentinels = [0x1111n, 0x2222n, 0x3333n, 0xdead_beef_0000_0000n];
+    const regTail = vlq(sentinels.length) + sentinels.map(u64AsTwoVlqs).join("");
+    expect(body.endsWith(regTail), `want suffix ${regTail}, payload=${body}`).toBe(true);
+
+    // Between the reason payload and the register tail sits the
+    // StackLine-encoded pc (ASLR-adjusted), which the body must still carry.
+    const reason = "2" + u64AsTwoVlqs(0xdead_beefn);
+    const before = body.slice(0, -regTail.length);
+    expect(before.lastIndexOf(reason), `reason '${reason}' not in payload=${body}`).toBeGreaterThan(0);
+    const pcStackLine = before.slice(before.lastIndexOf(reason) + reason.length);
+    expect(pcStackLine.length, `no pc StackLine; payload=${body}`).toBeGreaterThan(0);
 
     expect(exitCode).not.toBe(0);
   });
@@ -191,10 +210,8 @@ describe("trace string v3/v4 (fault pc + register block)", () => {
     expect(["3", "4"], `payload=${payload}`).toContain(payload[2]);
 
     const body = payload.replace(/\/view$/, "");
-    // OutOfMemory reason code is '9' with no trailing data. v3 leaves
-    // non-fault reasons byte-identical to v1 so Panic ('0', base64 to EOS)
-    // and ZigError ('8', identifier to EOS) stay decodable: the body must
-    // end exactly at '9', no `_A` suffix.
+    // Non-fault reasons stay byte-identical to v1 (so '0'/'8' remain
+    // end-of-string terminated): body ends at reason '9', no `_A` suffix.
     expect(body.endsWith("A9"), `payload=${body}`).toBe(true);
     expect(body.endsWith("_A"), `payload=${body}`).toBe(false);
 

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -122,6 +122,86 @@ describe.if(isPosix)("terminal signal reflects the crash cause", () => {
   });
 });
 
+describe("trace string v3/v4 (fault pc + register block)", () => {
+  // `noReportEnv` sets BUN_CRASH_REPORT_URL="" so the base URL is empty; the
+  // trace string is just `/<version>/<payload>` on its own line.
+  function traceStringPayload(stderr: string): string {
+    const m = stderr.match(/^ \/[^/\s]+\/(\S+)/m);
+    expect(m, `no trace string in stderr:\n${stderr}`).not.toBeNull();
+    return m![1];
+  }
+
+  test("version char is '3'/'4' and a fault context encodes pc + registers", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        path.join(import.meta.dir, "fixture-crash.js"),
+        "segfaultWithRegisters",
+        "--debug-crash-handler-use-trace-string",
+      ],
+      env: noReportEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    void stdout;
+
+    expect(stderr).toContain("Segmentation fault at address 0xDEADBEEF");
+
+    const payload = traceStringPayload(stderr);
+    // payload = <platform><cmd><version><sha7>... ; version char is at index 2.
+    expect(["3", "4"], `payload=${payload}`).toContain(payload[2]);
+
+    // Strip any trailing `/view` so the suffix assertions see only the
+    // encoded body.
+    const body = payload.replace(/\/view$/, "");
+
+    // Reason code '2' (SegmentationFault) precedes the fault address. After
+    // the two-VLQ fault address the v3 block begins: one StackLine for the
+    // fault pc (always present, so never `_` here), then VLQ(4)='I' for the
+    // four synthetic registers, then eight VLQs of register halves.
+    // v1/v2 would end immediately after the fault-address VLQs.
+    const reasonIdx = body.lastIndexOf("2A");
+    expect(reasonIdx, `no segfault reason in payload=${body}`).toBeGreaterThan(0);
+    const afterReason = body.slice(reasonIdx);
+    // Reason char '2' + write_u64_as_two_vlqs(0xDEADBEEF) is at most 9 bytes
+    // ('2' + VLQ(0)=1 + VLQ(i32)<=7). v3 must have substantially more after
+    // it: a StackLine (>=1 byte) + 'I' + 8 VLQs (>=8 bytes).
+    expect(
+      afterReason.length,
+      `v3 register block missing; tail=${afterReason}`,
+    ).toBeGreaterThanOrEqual(9 + 1 + 1 + 8);
+    // Register count VLQ(4)='I' must appear in the tail.
+    expect(afterReason).toContain("I");
+
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("non-fault crashes encode an empty register block (`_A` suffix)", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        path.join(import.meta.dir, "fixture-crash.js"),
+        "outOfMemory",
+        "--debug-crash-handler-use-trace-string",
+      ],
+      env: noReportEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    void stdout;
+
+    const payload = traceStringPayload(stderr);
+    expect(["3", "4"], `payload=${payload}`).toContain(payload[2]);
+
+    const body = payload.replace(/\/view$/, "");
+    // OutOfMemory reason code is '9' with no trailing data in v1; v3 appends
+    // the empty register block: '_' (no pc) + 'A' (VLQ 0 = no registers).
+    expect(body.endsWith("9_A"), `payload=${body}`).toBe(true);
+
+    expect(exitCode).not.toBe(0);
+  });
+});
+
 test.if(process.platform === "darwin")("macOS has the assumed image offset", () => {
   // If this fails, then https://bun.report will be incorrect and the stack
   // trace remappings will stop working.


### PR DESCRIPTION
## What

Capture the faulting `pc` and general-purpose register file from `ucontext_t` (POSIX) / `CONTEXT` (Windows) in the fault signal handler and encode them into the crash-report trace string.

Decoder: oven-sh/bun.report#28.

## Why

For hardware faults (SIGSEGV/SIGILL/SIGBUS/SIGFPE, access violation) the register state at the fault is often the only way to reconstruct `this`, arguments, or the dereferenced pointer when the frame-pointer walk is short or corrupt. The handler was already reading `pc`/`fp` from `ucontext_t` to seed the walk, but none of it reached the trace string.

## How

- `FaultRegisters` holds `pc`, `fp`, and the GP register file in a fixed per-arch slot order (`FaultRegisters::NAMES` is the source of truth):
  - x86_64: `rax rbx rcx rdx rdi rsi rbp rsp r8..r15 rip` (17)
  - aarch64: `x0..x28 fp lr sp pc` (33)
- `fault_context_from_ucontext` fills it on linux/android (glibc + musl) and macOS, both arches.
- `fault_context_from_windows_context` reads `CONTEXT` by the documented `winnt.h` byte offsets on x64 and arm64.
- `TraceSeed::Fault` borrows `&FaultRegisters` (lives on the signal handler's altstack; boxing would allocate inside a signal handler).
- `encode_trace_string` appends a register block after the reason payload **for hardware-fault reasons `'2'`..`'7'` only**: one `StackLine`-encoded fault `pc` (ASLR removed, remappable), a VLQ register count, then count × two-VLQ register values. When the fault path has no saved context (unsupported arch) the block is `_A` (no pc, zero registers).

## Trace-string format (v3)

```
<bun_ver>/<platform><cmd>3<sha7><build_flags vlq><features 2-vlq><frames><A><reason>[<reg block>]
```

- `VERSION_CHAR` is now a single `'3'`. The even/odd split (`'1'`/`'2'` = release/canary) is replaced by a one-byte `build_flags` VLQ right after the 7-char sha; bit 0 = canary. Future build-variant flags pack into the same VLQ without a format bump.
- Reasons `'0'`/`'1'`/`'8'`/`'9'` have no register block.
- Reasons `'2'`..`'7'` are followed by the register block.
- `'1'`/`'2'` strings (older builds) remain decodable.

## Testing

`test/cli/run/run-crash-handler.test.ts` gains a `trace string v3` describe block:

- `segfaultWithRegisters` (new internal-for-testing hook) invokes the handler with a synthetic `FaultRegisters` so the encoding path is exercised deterministically, including under ASAN where our SIGSEGV handler is not installed. Asserts version char is `'3'`, the build-flags byte follows the sha, and the payload ends with the exact VLQ encoding of the sentinel register values.
- `outOfMemory` (non-fault reason `'9'`) asserts no register block is appended.

`cargo check -p bun_crash_handler` passes on all 10 supported targets (linux gnu/musl, macos, windows, android, freebsd × x64/aarch64) and `cargo clippy` is clean.

Verified end-to-end with real segfaults on linux-x64, macos-x64, macos-arm64, windows-x64, windows-arm64 (see comments below for decoded output).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 7 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/run-crash-handler.test.ts

<!-- robobun:evidence:end -->