### PR TITLE
Treat two Invalid Dates as equal in deepEquals and fix their failure-message rendering

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1180,7 +1180,10 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
         JSC::DateInstance* left = uncheckedDowncast<DateInstance>(c1);
         JSC::DateInstance* right = uncheckedDowncast<DateInstance>(c2);
 
-        return left->internalNumber() == right->internalNumber();
+        double leftTime = left->internalNumber();
+        double rightTime = right->internalNumber();
+        // Two Invalid Dates (NaN time values) are equal, matching Node.js.
+        return leftTime == rightTime || (std::isnan(leftTime) && std::isnan(rightTime));
     }
     case RegExpObjectType: {
         if (c2Type != RegExpObjectType) {

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -1937,7 +1937,10 @@ impl<'a> Formatter<'a> {
                                 Err(_) => b"",
                             }
                         };
-                        if out_buf.len() > 2 {
+                        if out_buf == b"null" {
+                            // JSON.stringify(new Date(NaN)) is `null` (unquoted)
+                            out_buf = b"Invalid Date";
+                        } else if out_buf.len() > 2 {
                             // trim the quotes
                             out_buf = &out_buf[1..out_buf.len() - 1];
                         }

--- a/test/js/bun/bun-object/deep-equals.spec.ts
+++ b/test/js/bun/bun-object/deep-equals.spec.ts
@@ -14,6 +14,7 @@ describe.each([true, false])("Bun.deepEquals(a, b, strict: %p)", strict => {
     [new Set(), new Set()],
     [Symbol.for("foo"), Symbol.for("foo")],
     [NaN, NaN],
+    [new Date(NaN), new Date(NaN)],
   ])("Bun.deepEquals(%p, %p) === true, regardless of strict modee", (a, b) => {
     expect(Bun.deepEquals(a, b, true)).toBe(true);
     expect(Bun.deepEquals(a, b, false)).toBe(true);
@@ -24,6 +25,7 @@ describe.each([true, false])("Bun.deepEquals(a, b, strict: %p)", strict => {
     [-0, +0], //
     [{ a: 1 }, { a: 2 }],
     ["foo", "bar"],
+    [new Date(NaN), new Date(0)],
   ])("Bun.deepEquals(%p, %p) !== true, regardless of strict modee", (a, b) => {
     expect(Bun.deepEquals(a, b, true)).toBe(false);
     expect(Bun.deepEquals(a, b, false)).toBe(false);

--- a/test/js/bun/test/expect-invalid-date-message.test.ts
+++ b/test/js/bun/test/expect-invalid-date-message.test.ts
@@ -1,0 +1,29 @@
+// Failure messages for Invalid Date must print "Invalid Date".
+// JSON.stringify(new Date(NaN)) is `null` (unquoted), and the quote-trimming
+// pass used to slice it down to the garbage string "ul".
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("expect() failure messages render Invalid Date, not a sliced 'null'", async () => {
+  using dir = tempDir("expect-invalid-date", {
+    "invalid-date.test.ts": `
+      import { test, expect } from "bun:test";
+      test("invalid date vs valid date", () => {
+        expect(new Date(NaN)).toEqual(new Date(0));
+      });
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "invalid-date.test.ts"],
+    env: { ...bunEnv, NO_COLOR: "1", FORCE_COLOR: undefined },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("Expected: 1970-01-01T00:00:00.000Z");
+  expect(stderr).toContain("Received: Invalid Date");
+  expect(exitCode).toBe(1);
+});

--- a/test/js/bun/test/expect-invalid-date-message.test.ts
+++ b/test/js/bun/test/expect-invalid-date-message.test.ts
@@ -21,7 +21,7 @@ test("expect() failure messages render Invalid Date, not a sliced 'null'", async
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toContain("Expected: 1970-01-01T00:00:00.000Z");
   expect(stderr).toContain("Received: Invalid Date");

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -727,7 +727,9 @@ describe("expect()", () => {
       expect(new Date(NaN)).toEqual(new Date(NaN));
       expect(new Date(NaN)).toStrictEqual(new Date(NaN));
       expect(new Date(NaN)).not.toEqual(new Date(0));
+      expect(new Date(NaN)).not.toStrictEqual(new Date(0));
       expect(new Date(0)).not.toEqual(new Date(NaN));
+      expect(new Date(0)).not.toStrictEqual(new Date(NaN));
     }
 
     class Date2 extends Date {

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -722,6 +722,14 @@ describe("expect()", () => {
     expect(d).toEqual(e);
     expect(e).toEqual(d);
 
+    if (isBun) {
+      // Two Invalid Dates are equal, matching Node.js (jest disagrees).
+      expect(new Date(NaN)).toEqual(new Date(NaN));
+      expect(new Date(NaN)).toStrictEqual(new Date(NaN));
+      expect(new Date(NaN)).not.toEqual(new Date(0));
+      expect(new Date(0)).not.toEqual(new Date(NaN));
+    }
+
     class Date2 extends Date {
       constructor() {
         // @ts-ignore

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -287,6 +287,8 @@ const cases: Case[] = [
   // Date.
   { name: "two equal dates", a: () => new Date(0), b: () => new Date(0), strict: true, loose: true },
   { name: "two different dates", a: () => new Date(0), b: () => new Date(1), strict: false, loose: false },
+  { name: "two invalid dates", a: () => new Date(NaN), b: () => new Date(NaN), strict: true, loose: true },
+  { name: "an invalid and a valid date", a: () => new Date(NaN), b: () => new Date(0), strict: false, loose: false },
   {
     name: "a date with an extra own property",
     a: () => withExtraProperty(new Date(0)),


### PR DESCRIPTION
Fixes #34816

### Repro

```js
import { test, expect } from "bun:test";
test("invalid date", () => {
  expect(new Date(NaN)).toEqual(new Date(NaN)); // fails
});
```

```
error: expect(received).toEqual(expected)

Expected: ul
Received: ul
```

Also affected the Node compat surface: `util.isDeepStrictEqual(new Date(NaN), new Date(NaN))` returned `false` (Node returns `true`), and `assert.deepStrictEqual` threw.

### Cause

Two bugs:

1. `specialObjectsDequal` in bindings.cpp compared Dates with `left->internalNumber() == right->internalNumber()`, which is `NaN == NaN` for Invalid Dates, so they never compared equal. Node compares Dates with `Object.is(getTime(), getTime())` semantics, under which two NaN time values are equal.
2. The test runner's failure diff renders Dates by JSON-stringifying and trimming the surrounding quotes. `JSON.stringify(new Date(NaN))` is the unquoted `null`, so trimming produced the garbage `ul`. The console formatter already special-cases this and prints `Invalid Date`; the test runner's copy was missing that branch.

### Fix

- Dates in deepEquals compare equal when both time values are NaN. This covers `toEqual`, `toStrictEqual`, `Bun.deepEquals`, `assert.deepStrictEqual`/`deepEqual`, and `util.isDeepStrictEqual` (they share the same comparison). This matches Node; jest's `expect` disagrees (it also fails this case), but Node parity plus `expect(NaN).toEqual(NaN)` passing makes equal the consistent answer.
- The test runner's diff now prints `Invalid Date` for a NaN Date, matching `console.log`.

### Verification

New tests fail on the released build and pass with this change:

- `test/js/bun/bun-object/deep-equals.spec.ts`: `Bun.deepEquals(new Date(NaN), new Date(NaN))` in both strict modes, plus invalid-vs-valid inequality
- `test/js/node/assert/deep-equal.test.ts`: matrix entries for two invalid dates (strict and loose) and invalid vs valid
- `test/js/bun/test/expect.test.js`: `toEqual`/`toStrictEqual` on Invalid Dates (Bun-only branch, since jest diverges)
- `test/js/bun/test/expect-invalid-date-message.test.ts`: failure message renders `Received: Invalid Date`, not `ul`

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 failed, 10 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect-invalid-date-message.test.ts test/js/bun/test/expect.test.js test/js/node/assert/deep-equal.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (3cc58c633)

test/js/bun/test/expect.test.js:
(pass) expect() > () [594.80ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [2.51ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.57ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.38ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.37ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.40ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.37ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.46ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.38ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.4
... (truncated)

release without fix: 12 failed, 10 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/test/expect.test.js:
(pass) expect() > () [0.69ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.03ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(-0).toBe(-0) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true
(pass) expect() > toBe() > expect({}).toBe({}) == true
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true
(pass) expect() > toBe() > expect(0).toBe(false) == false [0.02ms]
(pass) expect() > toBe() > expect(0).toBe("") == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(1).toBe(2) == false
(pass) expect() > toBe() > expect(1).toBe(true) == false
(pass) expect() > toBe() > expect(1).toBe("1") == false
(pass) expect() > toBe() > expect(Infinity).toBe(-Infinity) == false
(pass) expect() > toBe() > expect("foo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 10 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect-invalid-date-message.test.ts test/js/bun/test/expect.test.js test/js/node/assert/deep-equal.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (3cc58c633)

test/js/bun/test/expect.test.js:
(pass) expect() > () [590.80ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [2.58ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.63ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.43ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.42ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.41ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.43ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.40ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.42ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.4
... (truncated)

release with fix: 10 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     3cc58c6333
  features     (none)

22 deps, 106 codegen, 1169 objects in 786ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1232] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [12.00ms]
[2/1232] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1232] gen ErrorCode+*.h
[4/1232] gen bindgenv2
[5/1232] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [10.00ms]
[6/1232] fetch zlib
[zlib] up to date
[7/1232] gen .bind.ts → GeneratedBindings.cpp
[8/1232] fetch tinycc
[tinyc
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/bindings.cpp                      |  5 +++-
 src/runtime/test_runner/pretty_format.rs           |  5 +++-
 test/js/bun/bun-object/deep-equals.spec.ts         |  2 ++
 .../bun/test/expect-invalid-date-message.test.ts   | 29 ++++++++++++++++++++++
 test/js/bun/test/expect.test.js                    |  8 ++++++
 test/js/node/assert/deep-equal.test.ts             |  2 ++
 6 files changed, 49 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/jsc/bindings/bindings.cpp                             2      1      0
src/runtime/test_runner/pretty_format.rs                  1      1      0
test/js/bun/bun-object/deep-equals.spec.ts                1      1      0
test/js/bun/test/expect-invalid-date-message.test.ts      0      2      0
test/js/bun/test/expect.test.js                           1      1      0
test/js/node/assert/deep-equal.test.ts                    1      2      0
```

</details>

**root cause** · written by the author bot

Deep equality compared two Date objects by checking their internal time values with a plain numeric equality, which fails when both dates are invalid because an invalid date's time value is NaN and NaN never equals itself. The fix updates the Date branch of the native deep-equality routine to treat two NaN time values as equal, matching Node's Object.is semantics, so that `expect(new Date(NaN)).toEqual(new Date(NaN))` and the related assert and Bun.deepEquals surfaces now pass while invalid versus valid dates still compare unequal. A companion change in the test runner's pretty formatter ma…

<!-- robobun:evidence:end -->