### PR TITLE
strings: call highway_memmem directly on all platforms

### DIFF
--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -377,29 +377,8 @@ pub use crate::strings_impl::{
     to_utf8_from_latin1_z, u16_lead, u16_trail,
 };
 
-/// memmem — libc on posix, scalar fallback on windows.
-#[cfg(not(windows))]
-pub fn memmem(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    if needle.is_empty() {
-        return Some(0);
-    }
-    // SAFETY: `&[u8]` guarantees both (ptr,len) pairs are valid for reads;
-    // libc memmem only reads within those bounds.
-    let p = unsafe {
-        libc::memmem(
-            haystack.as_ptr().cast(),
-            haystack.len(),
-            needle.as_ptr().cast(),
-            needle.len(),
-        )
-    };
-    if p.is_null() {
-        None
-    } else {
-        Some(p as usize - haystack.as_ptr() as usize)
-    }
-}
-#[cfg(windows)]
+/// memmem — `memchr::memmem` (via bstr): SIMD, guaranteed-linear, same on all platforms.
+#[inline]
 pub fn memmem(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     bstr::ByteSlice::find(haystack, needle)
 }

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -377,10 +377,10 @@ pub use crate::strings_impl::{
     to_utf8_from_latin1_z, u16_lead, u16_trail,
 };
 
-/// memmem — `memchr::memmem` (via bstr): SIMD, guaranteed-linear, same on all platforms.
+/// memmem — `highway_memmem` (HWY_DYNAMIC_DISPATCH MemMemImpl), same on all platforms.
 #[inline]
 pub fn memmem(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    bstr::ByteSlice::find(haystack, needle)
+    highway::memmem(haystack, needle)
 }
 
 /// `bun.reinterpretSlice` — `&[T]` → `&[u8]` view (T must be u8/u16 in practice).

--- a/src/highway/lib.rs
+++ b/src/highway/lib.rs
@@ -6,6 +6,13 @@ unsafe extern "C" {
 
     fn highway_index_of_char(haystack: *const u8, haystack_len: usize, needle: u8) -> usize;
 
+    fn highway_memmem(
+        haystack: *const u8,
+        haystack_len: usize,
+        needle: *const u8,
+        needle_len: usize,
+    ) -> *const u8;
+
     fn highway_index_of_interesting_character_in_string_literal(
         text: *const u8,
         text_len: usize,
@@ -138,6 +145,31 @@ pub fn index_of_char(haystack: &[u8], needle: u8) -> Option<usize> {
     debug_assert!(haystack[result] == needle);
 
     Some(result)
+}
+
+#[inline(always)]
+pub fn memmem(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() {
+        return Some(0);
+    }
+    if haystack.len() < needle.len() {
+        return None;
+    }
+    // SAFETY: both (ptr,len) pairs are valid readable ranges.
+    let p = unsafe {
+        highway_memmem(
+            haystack.as_ptr(),
+            haystack.len(),
+            needle.as_ptr(),
+            needle.len(),
+        )
+    };
+    if p.is_null() {
+        None
+    } else {
+        // SAFETY: highway_memmem returns a pointer within `haystack` on success.
+        Some(unsafe { p.offset_from(haystack.as_ptr()) } as usize)
+    }
 }
 
 #[inline(always)]


### PR DESCRIPTION
## What

`bun_core::strings::memmem` previously split on `#[cfg]`: POSIX called `libc::memmem` (which resolved to `highway_memmem` via the link-time symbol override in `highway_strings.cpp:2236-2252`), Windows called `bstr::ByteSlice::find` (memchr). The doc comment claimed "libc on posix, scalar fallback on windows", both halves of which were wrong.

This adds a `bun_highway::memmem` wrapper around the existing `highway_memmem` C entrypoint and calls it from `strings::memmem` on all platforms, matching how `strings::index_of_char_usize` already calls `bun_highway::index_of_char`.

## Why

- Makes the highway dependency explicit instead of relying on libc symbol interposition
- Unifies Windows with POSIX (both now use `highway_memmem`)
- Drops the `#[cfg]` split and the misleading doc comment

## Semantics

Behavior is identical to the previous POSIX path (same `MemMemImpl` backend). Empty needle → `Some(0)`, needle longer than haystack → `None`; both guarded in the Rust wrapper before the FFI call. `index_of` (the primary caller) additionally guards these itself and is unchanged.

`cargo check -p bun_core` and `cargo clippy` pass on linux-x64 and x86_64-pc-windows-msvc. Full `bun bd` links and smoke tests pass locally.

This is a behavior-preserving refactor; no fail-before test is constructible.