### PR TITLE
js_parser: skip constant folding of radix BigInt literals

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -860,6 +860,26 @@ impl BigInt {
     pub const EMPTY: BigInt = BigInt { value: Str::EMPTY };
 
     // `toJS` alias deleted — lives in `js_parser_jsc` extension trait.
+
+    /// `value` may carry a `0x`/`0o`/`0b` prefix. A leading zero is otherwise
+    /// a syntax error, so any literal that starts with `0` and has more than
+    /// one character is a radix literal.
+    #[inline]
+    pub fn has_radix(v: &[u8]) -> bool {
+        v.len() >= 2 && v[0] == b'0'
+    }
+
+    /// `Some(equal)` when the comparison is decidable from the source text, or
+    /// `None` when either side has a radix prefix and the values differ.
+    pub fn check_equality(a: &[u8], b: &[u8]) -> Option<bool> {
+        if a == b {
+            return Some(true);
+        }
+        if !Self::has_radix(a) && !Self::has_radix(b) {
+            return Some(false);
+        }
+        None
+    }
 }
 
 // ── immutable JSON nodes ───────────────────────────────────────────────────
@@ -2213,7 +2233,9 @@ impl Template {
                     part.value = Expr::init(EString::init(b"undefined"), part.value.loc);
                 }
                 crate::expr::Data::EBigInt(value) => {
-                    part.value = Expr::init(EString::init(&value.value), part.value.loc);
+                    if !BigInt::has_radix(&value.value) {
+                        part.value = Expr::init(EString::init(&value.value), part.value.loc);
+                    }
                 }
                 _ => {}
             }

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1593,9 +1593,9 @@ impl Expr {
                 }));
             }
             Data::EBigInt(b) => {
-                return Some(expr.at(E::Boolean {
-                    value: b.value == b"0",
-                }));
+                if let Some(equal) = E::BigInt::check_equality(&b.value, b"0") {
+                    return Some(expr.at(E::Boolean { value: equal }));
+                }
             }
             Data::EFunction(_) | Data::EArrow(_) | Data::ERegExp(_) => {
                 return Some(expr.at(E::Boolean { value: false }));
@@ -1665,7 +1665,13 @@ impl Expr {
             Data::EBoolean(data) | Data::EBranchBoolean(data) => {
                 Some(if data.value { b"true" } else { b"false" })
             }
-            Data::EBigInt(bigint) => Some(bigint.value.slice()),
+            Data::EBigInt(bigint) => {
+                if E::BigInt::has_radix(&bigint.value) {
+                    None
+                } else {
+                    Some(bigint.value.slice())
+                }
+            }
             Data::ENumber(num) => num.to_string(bump).map(|s| s.slice()),
             Data::ERegExp(regexp) => Some(regexp.value.slice()),
             Data::EDot(dot) => 'brk: {
@@ -3407,13 +3413,16 @@ impl Data {
             },
             Data::EBigInt(l) => {
                 if let Data::EBigInt(r) = right {
-                    if bun_core::strings::eql_long(&l.value, &r.value, true) {
-                        return Equality::TRUE;
-                    }
-                    // 0x0000n == 0n is true
-                    return Equality {
-                        ok: false,
-                        ..Default::default()
+                    return match E::BigInt::check_equality(&l.value, &r.value) {
+                        Some(equal) => Equality {
+                            ok: true,
+                            equal,
+                            ..Default::default()
+                        },
+                        None => Equality {
+                            ok: false,
+                            ..Default::default()
+                        },
                     };
                 } else {
                     return Equality {

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -3692,7 +3692,7 @@ lexer_impl_header! {
 
             // Slow path: do we need to re-scan the input as text?
             if is_big_integer_literal || is_invalid_legacy_octal_literal {
-                let text = self.raw();
+                let mut text = self.raw();
 
                 // Can't use a leading zero for bigint literals;
                 if is_big_integer_literal && self.is_legacy_octal_literal {
@@ -3711,6 +3711,7 @@ lexer_impl_header! {
                             i += 1;
                         }
                     }
+                    text = bytes;
                 }
 
                 // Store bigints as text to avoid precision loss;

--- a/src/js_parser/scan/scan_side_effects.rs
+++ b/src/js_parser/scan/scan_side_effects.rs
@@ -912,11 +912,11 @@ impl SideEffects {
                 ok: true,
             },
             ExprData::EBigInt(e) => {
-                let v = e.value.slice();
+                let equal = E::BigInt::check_equality(&e.value, b"0");
                 Result {
-                    value: !bun_core::eql_comptime(v, b"0"),
+                    value: equal == Some(false),
                     side_effects: SideEffects::NoSideEffects,
-                    ok: true,
+                    ok: equal.is_some(),
                 }
             }
             ExprData::EString(e) => Result {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3999,8 +3999,19 @@ console.log(foo, array);
       expectPrinted('"" == 0', "!0");
       expectPrinted("1n == 1n", "!0");
       expectPrinted("1234n == 1234n", "!0");
+      expectPrinted("1n == 2n", "!1");
+      expectPrinted("!0n", "!0");
+      expectPrinted("!1n", "!1");
+      // Radix BigInt literals keep their source text, so folds that need a
+      // decimal string bail out instead of producing a wrong constant.
       expectPrinted("0x00n == 0n", "0x00n == 0n");
-      expectPrinted("1n == 2n", "1n == 2n");
+      expectPrinted("0x10n == 16n", "0x10n == 16n");
+      expectPrinted("0x10n == 0x10n", "!0");
+      expectPrinted("!0x0n", "!0x0n");
+      expectPrinted("!0x1n", "!0x1n");
+      expectPrinted("`${0x10n}`", "`${0x10n}`");
+      expectPrinted("`${0b1_0n}`", "`${0b10n}`");
+      expectPrinted("`${10n}`", '"10"');
 
       expectPrinted("'a' === '\\x61'", "!0");
       expectPrinted("'a' === '\\x62'", "!1");

--- a/test/js/bun/transpiler/transpiler-radix-bigint.test.ts
+++ b/test/js/bun/transpiler/transpiler-radix-bigint.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Constant folding previously treated E::BigInt::value as decimal, so `${0x10n}`
+// produced "0x10" and `!0x0n` produced false. Folds now bail out on a radix prefix.
+test("radix BigInt literals are not constant-folded using their source text", async () => {
+  const src = `
+    const out = [];
+    out.push(\`\${0x10n}\`);
+    out.push(\`\${0o10n}\`);
+    out.push(\`\${0b10n}\`);
+    out.push(\`\${0b1_0n}\`);
+    out.push(\`\${0xFF_FFn}\`);
+    out.push(\`\${0x0n}\`);
+    out.push(\`\${0X00n}\`);
+    out.push(\`\${0xffffffffffffffffffffffffffffffffn}\`);
+    out.push(String(!0x0n));
+    out.push(String(!0o0n));
+    out.push(String(!0b0n));
+    out.push(String(!0x1n));
+    out.push(0x0n ? "taken" : "not-taken");
+    out.push(0x1n ? "taken" : "not-taken");
+    out.push(String("" + 0x10n));
+    console.log(JSON.stringify(out));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ out: JSON.parse(stdout.trim()), stderr, exitCode }).toEqual({
+    out: [
+      "16",
+      "8",
+      "2",
+      "2",
+      "65535",
+      "0",
+      "0",
+      "340282366920938463463374607431768211455",
+      "true",
+      "true",
+      "true",
+      "false",
+      "not-taken",
+      "taken",
+      "16",
+    ],
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+test("radix BigInt literals round-trip through the printer", () => {
+  const t = new Bun.Transpiler({ loader: "js" });
+  // The literal is printed as written (underscores stripped); the folds bail
+  // out for radix BigInt literals instead of producing a wrong constant.
+  expect(t.transformSync("var x = 0x10n;").trim()).toBe("var x = 0x10n;");
+  expect(t.transformSync("var x = 0b1_0n;").trim()).toBe("var x = 0b10n;");
+  expect(t.transformSync("var x = 0xFF_FFn;").trim()).toBe("var x = 0xFFFFn;");
+  expect(t.transformSync("var x = `${0x10n}`;").trim()).toBe("var x = `${0x10n}`;");
+});


### PR DESCRIPTION
## Problem

Radix BigInt literals (`0x`/`0o`/`0b` prefix) were constant-folded using their raw source text instead of their numeric value. Reproduces in plain `bun run` with no flags:

```js
console.log(`${0x10n}`);   // "0x10", should be "16"
console.log(`${0b1_0n}`);  // "0b1_0", should be "2"
console.log(!0x0n);        // false, should be true
if (0x0n) console.log("taken"); // taken, should not be
```

## Cause

`parse_numeric_literal_or_dot` in `src/js_parser/lexer.rs` stores the raw token (including the radix prefix) in `E::BigInt::value`, and the underscore-filtering loop built a stripped buffer without assigning it back. Constant folding in `src/ast/e.rs` (template inlining), `src/ast/expr.rs` (`maybe_simplify_not`, `to_string_expr_without_side_effects`, BigInt equality), and `scan_side_effects.rs` (truthiness) all treated `E::BigInt::value` as the decimal stringification.

## Fix

Match esbuild: keep the radix prefix in the stored literal and guard each fold with a has-radix check. A BigInt literal that starts with `0` and is longer than one character is always a radix literal (a leading zero is otherwise a syntax error), so `E::BigInt::has_radix` / `E::BigInt::check_equality` are enough for every fold to either prove the result or bail out. The lexer now also assigns the underscore-stripped buffer.

Folding `1n == 2n` now succeeds (both sides are canonical decimal), matching esbuild; `0x00n == 0n` stays unfolded because one side has a radix.

## Verification

```
$ bun bd test test/js/bun/transpiler/transpiler-radix-bigint.test.ts    # passes
$ bun bd test test/bundler/transpiler/transpiler.test.js                # 182 pass
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js test/js/bun/transpiler/transpiler-radix-bigint.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (8d9512995)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.62ms]
(pass) Bun.Transpiler > normalizes \r\n [7.98ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [3.82ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [6.99ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.21ms]
(pass) Bun.Transpiler > property access inlining > works [2.47ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.43ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [20.75ms]
(pass) Bun.Transpiler 
... (truncated)

release without fix: 22 skipped
bun test v1.4.0-canary.1 (e2867e8a3)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.09ms]
(pass) Bun.Transpiler > normalizes \r\n [0.17ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.08ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.15ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.04ms]
(pass) Bun.Transpiler > property access inlining > works [0.05ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.03ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [0.28ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.04ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [0.04ms]
(pass) Bun.Transpiler > TypeScript > reports Expected ":" for a conditional expression missing its colon [0.17ms]
(pass) Bun.Transpiler > TypeScript > contextual keywords used as plain identifiers keep their statements [0.27ms]
(pass) Bun.Transpiler > TypeScript > contextual keywords followed by a newline apply ASI instead of a
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js test/js/bun/transpiler/transpiler-radix-bigint.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (8d9512995)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [7.30ms]
(pass) Bun.Transpiler > normalizes \r\n [5.94ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [3.74ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [10.34ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.32ms]
(pass) Bun.Transpiler > property access inlining > works [2.45ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.39ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [19.60ms]
(pass) Bun.Transpiler
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 873ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/e.rs                                       | 24 +++++++-
 src/ast/expr.rs                                    | 31 ++++++----
 src/js_parser/lexer.rs                             |  3 +-
 src/js_parser/scan/scan_side_effects.rs            |  6 +-
 test/bundler/transpiler/transpiler.test.js         | 13 ++++-
 .../bun/transpiler/transpiler-radix-bigint.test.ts | 66 ++++++++++++++++++++++
 6 files changed, 126 insertions(+), 17 deletions(-)
```

</details>

**gate history** · 1 passed · 2 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/ast/e.rs                                                5      4      0
src/ast/expr.rs                                             6      5      0
src/js_parser/lexer.rs                                      9     10      0
src/js_parser/scan/scan_side_effects.rs                     4      3      0
test/bundler/transpiler/transpiler.test.js                  2      2      0
test/js/bun/transpiler/transpiler-radix-bigint.test.ts      0      5      0
```

</details>

<!-- robobun:evidence:end -->