### PR TITLE
sys: hint POSIX_FADV_SEQUENTIAL on the copy-file read/write fallback

### DIFF
--- a/bench/copyfile/fallback-rw-loop.mjs
+++ b/bench/copyfile/fallback-rw-loop.mjs
@@ -1,0 +1,73 @@
+// Benchmark the read/write fallback copy loop (the path taken when the
+// kernel-side fast paths are unavailable). On Linux, setting
+// BUN_CONFIG_DISABLE_COPY_FILE_RANGE=1 makes Bun.write(file, file) go
+// straight to NodeFS::copy_file_using_read_write_loop.
+//
+// Cold-cache measurement: each iteration evicts the source from the page
+// cache via posix_fadvise(DONTNEED) so readahead behaviour is observable.
+//
+//   BUN_CONFIG_DISABLE_COPY_FILE_RANGE=1 bun bench/copyfile/fallback-rw-loop.mjs
+import fs from "node:fs";
+import { dlopen, FFIType } from "bun:ffi";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const libc = dlopen(process.platform === "darwin" ? "libc.dylib" : "libc.so.6", {
+  posix_fadvise: {
+    args: [FFIType.i32, FFIType.i64, FFIType.i64, FFIType.i32],
+    returns: FFIType.i32,
+  },
+  fdatasync: { args: [FFIType.i32], returns: FFIType.i32 },
+});
+const POSIX_FADV_DONTNEED = 4;
+
+function evict(path) {
+  let fd;
+  try {
+    fd = fs.openSync(path, "r+");
+  } catch {
+    return;
+  }
+  libc.symbols.fdatasync(fd);
+  libc.symbols.posix_fadvise(fd, 0n, 0n, POSIX_FADV_DONTNEED);
+  fs.closeSync(fd);
+}
+
+if (!process.env.BUN_CONFIG_DISABLE_COPY_FILE_RANGE) {
+  console.error("note: BUN_CONFIG_DISABLE_COPY_FILE_RANGE not set; fast paths will be used");
+}
+
+for (const mb of [1, 64, 512]) {
+  const src = join(tmpdir(), `cp-fallback-src-${mb}m.bin`);
+  const dst = join(tmpdir(), `cp-fallback-dst-${mb}m.bin`);
+  if (!fs.existsSync(src) || fs.statSync(src).size !== mb * 1048576) {
+    const chunk = Buffer.allocUnsafe(1048576);
+    for (let i = 0; i < chunk.length; i++) chunk[i] = i & 0xff;
+    const fd = fs.openSync(src, "w");
+    for (let i = 0; i < mb; i++) fs.writeSync(fd, chunk);
+    fs.closeSync(fd);
+  }
+
+  const iters = 8;
+  const times = [];
+  for (let i = 0; i < iters; i++) {
+    evict(src);
+    evict(dst);
+    try {
+      fs.unlinkSync(dst);
+    } catch {}
+    const t0 = performance.now();
+    await Bun.write(Bun.file(dst), Bun.file(src));
+    const t1 = performance.now();
+    times.push(t1 - t0);
+  }
+  times.sort((a, b) => a - b);
+  const min = times[0];
+  const med = times[iters >> 1];
+  console.log(
+    `${mb} MiB: min=${min.toFixed(2)}ms med=${med.toFixed(2)}ms (${(mb / (min / 1000)).toFixed(0)} MiB/s peak)`,
+  );
+  try {
+    fs.unlinkSync(dst);
+  } catch {}
+}

--- a/bench/copyfile/fallback-rw-loop.mjs
+++ b/bench/copyfile/fallback-rw-loop.mjs
@@ -1,11 +1,5 @@
-// Benchmark the read/write fallback copy loop (the path taken when the
-// kernel-side fast paths are unavailable). On Linux, setting
-// BUN_CONFIG_DISABLE_COPY_FILE_RANGE=1 makes Bun.write(file, file) go
-// straight to NodeFS::copy_file_using_read_write_loop.
-//
-// Cold-cache measurement: each iteration evicts the source from the page
-// cache via posix_fadvise(DONTNEED) so readahead behaviour is observable.
-//
+// Cold-cache benchmark of NodeFS::copy_file_using_read_write_loop via Bun.write(file, file).
+// blob/copy_file.rs routes there directly when BUN_CONFIG_DISABLE_COPY_FILE_RANGE=1; usage:
 //   BUN_CONFIG_DISABLE_COPY_FILE_RANGE=1 bun bench/copyfile/fallback-rw-loop.mjs
 import fs from "node:fs";
 import { dlopen, FFIType } from "bun:ffi";
@@ -28,9 +22,13 @@ function evict(path) {
   } catch {
     return;
   }
-  libc.symbols.fdatasync(fd);
-  libc.symbols.posix_fadvise(fd, 0n, 0n, POSIX_FADV_DONTNEED);
-  fs.closeSync(fd);
+  try {
+    if (libc.symbols.fdatasync(fd) !== 0 || libc.symbols.posix_fadvise(fd, 0n, 0n, POSIX_FADV_DONTNEED) !== 0) {
+      throw new Error(`page-cache eviction failed for ${path}; results would be warm-cache`);
+    }
+  } finally {
+    fs.closeSync(fd);
+  }
 }
 
 if (!process.env.BUN_CONFIG_DISABLE_COPY_FILE_RANGE) {
@@ -40,34 +38,34 @@ if (!process.env.BUN_CONFIG_DISABLE_COPY_FILE_RANGE) {
 for (const mb of [1, 64, 512]) {
   const src = join(tmpdir(), `cp-fallback-src-${mb}m.bin`);
   const dst = join(tmpdir(), `cp-fallback-dst-${mb}m.bin`);
-  if (!fs.existsSync(src) || fs.statSync(src).size !== mb * 1048576) {
-    const chunk = Buffer.allocUnsafe(1048576);
-    for (let i = 0; i < chunk.length; i++) chunk[i] = i & 0xff;
-    const fd = fs.openSync(src, "w");
-    for (let i = 0; i < mb; i++) fs.writeSync(fd, chunk);
-    fs.closeSync(fd);
-  }
-
-  const iters = 8;
-  const times = [];
-  for (let i = 0; i < iters; i++) {
-    evict(src);
-    evict(dst);
-    try {
-      fs.unlinkSync(dst);
-    } catch {}
-    const t0 = performance.now();
-    await Bun.write(Bun.file(dst), Bun.file(src));
-    const t1 = performance.now();
-    times.push(t1 - t0);
-  }
-  times.sort((a, b) => a - b);
-  const min = times[0];
-  const med = times[iters >> 1];
-  console.log(
-    `${mb} MiB: min=${min.toFixed(2)}ms med=${med.toFixed(2)}ms (${(mb / (min / 1000)).toFixed(0)} MiB/s peak)`,
-  );
   try {
-    fs.unlinkSync(dst);
-  } catch {}
+    {
+      const chunk = Buffer.allocUnsafe(1048576);
+      for (let i = 0; i < chunk.length; i++) chunk[i] = i & 0xff;
+      const fd = fs.openSync(src, "w");
+      for (let i = 0; i < mb; i++) fs.writeSync(fd, chunk);
+      fs.closeSync(fd);
+    }
+
+    const iters = 8;
+    const times = [];
+    for (let i = 0; i < iters; i++) {
+      evict(src);
+      evict(dst);
+      fs.rmSync(dst, { force: true });
+      const t0 = performance.now();
+      await Bun.write(Bun.file(dst), Bun.file(src));
+      const t1 = performance.now();
+      times.push(t1 - t0);
+    }
+    times.sort((a, b) => a - b);
+    const min = times[0];
+    const med = times[iters >> 1];
+    console.log(
+      `${mb} MiB: min=${min.toFixed(2)}ms med=${med.toFixed(2)}ms (${(mb / (min / 1000)).toFixed(0)} MiB/s peak)`,
+    );
+  } finally {
+    fs.rmSync(src, { force: true });
+    fs.rmSync(dst, { force: true });
+  }
 }

--- a/bench/copyfile/fallback-rw-loop.mjs
+++ b/bench/copyfile/fallback-rw-loop.mjs
@@ -6,7 +6,12 @@ import { dlopen, FFIType } from "bun:ffi";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-const libc = dlopen(process.platform === "darwin" ? "libc.dylib" : "libc.so.6", {
+if (process.platform !== "linux") {
+  console.error("this bench targets the Linux read/write fallback; skipping");
+  process.exit(0);
+}
+
+const libc = dlopen("libc.so.6", {
   posix_fadvise: {
     args: [FFIType.i32, FFIType.i64, FFIType.i64, FFIType.i32],
     returns: FFIType.i32,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4930,9 +4930,8 @@ impl NodeFS {
         #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
         {
             // SAFETY: `src_fd` is a valid open fd; `posix_fadvise` only reads it.
-            let _ = unsafe {
-                libc::posix_fadvise(src_fd.native(), 0, 0, libc::POSIX_FADV_SEQUENTIAL)
-            };
+            let _ =
+                unsafe { libc::posix_fadvise(src_fd.native(), 0, 0, libc::POSIX_FADV_SEQUENTIAL) };
         }
 
         let mut stack_buf = [0u8; 64 * 1024];

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4924,6 +4924,17 @@ impl NodeFS {
         stat_size: usize,
         wrote: &mut u64,
     ) -> Maybe<ret::CopyFile> {
+        // We only reach this loop after the kernel-side fast paths have bailed.
+        // Doubling the readahead window is a measurable win (~1.35x on a
+        // cold-cache 512 MiB copy with the 64 KiB buffer); ignore failures.
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+        {
+            // SAFETY: `src_fd` is a valid open fd; `posix_fadvise` only reads it.
+            let _ = unsafe {
+                libc::posix_fadvise(src_fd.native(), 0, 0, libc::POSIX_FADV_SEQUENTIAL)
+            };
+        }
+
         let mut stack_buf = [0u8; 64 * 1024];
         let stack_buf_len = stack_buf.len();
         let mut buf_to_free: Vec<u8> = Vec::new();

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4924,9 +4924,8 @@ impl NodeFS {
         stat_size: usize,
         wrote: &mut u64,
     ) -> Maybe<ret::CopyFile> {
-        // We only reach this loop after the kernel-side fast paths have bailed.
-        // Doubling the readahead window is a measurable win (~1.35x on a
-        // cold-cache 512 MiB copy with the 64 KiB buffer); ignore failures.
+        // Kernel-side fast paths have already bailed; double the readahead
+        // window for the sequential read()s below. Best-effort.
         #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
         {
             // SAFETY: `src_fd` is a valid open fd; `posix_fadvise` only reads it.

--- a/src/sys/copy_file.rs
+++ b/src/sys/copy_file.rs
@@ -222,6 +222,11 @@ pub fn copy_file_with_state(
 
     #[cfg(not(any(target_os = "linux", target_os = "android", windows)))]
     {
+        // macOS has no posix_fadvise; FreeBSD's matches Linux semantics.
+        #[cfg(target_os = "freebsd")]
+        // SAFETY: `in_` is a valid open fd; `posix_fadvise` only reads it.
+        let _ = unsafe { libc::posix_fadvise(in_.native(), 0, 0, libc::POSIX_FADV_SEQUENTIAL) };
+
         loop {
             {
                 let amt =

--- a/src/sys/copy_file.rs
+++ b/src/sys/copy_file.rs
@@ -58,7 +58,9 @@ bitflags::bitflags! {
         const HAS_IOCTL_FICLONE_FAILED     = 1 << 1;
         const HAS_COPY_FILE_RANGE_FAILED   = 1 << 2;
         const HAS_SENDFILE_FAILED          = 1 << 3;
-        // _: u4 padding
+        /// Per-fd, not per-tree: cleared on entry to `copy_file_with_state`.
+        const HAS_HINTED_SEQUENTIAL        = 1 << 4;
+        // _: u3 padding
     }
 }
 impl Default for LinuxCopyFileState {
@@ -111,6 +113,9 @@ pub fn copy_file_with_state(
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
     {
+        // Per-fd bit; the other bits persist across files in a tree walk.
+        copy_file_state.remove(LinuxCopyFileState::HAS_HINTED_SEQUENTIAL);
+
         if can_use_ioctl_ficlone()
             && !copy_file_state.contains(LinuxCopyFileState::HAS_SEEN_EXDEV)
             && !copy_file_state.contains(LinuxCopyFileState::HAS_IOCTL_FICLONE_FAILED)
@@ -406,6 +411,14 @@ pub fn copy_file_range(
             }
         }
         break;
+    }
+
+    if !copy_file_state.contains(LinuxCopyFileState::HAS_HINTED_SEQUENTIAL) {
+        copy_file_state.insert(LinuxCopyFileState::HAS_HINTED_SEQUENTIAL);
+        // The read/write loop below is called once per 32 KiB chunk; hint once
+        // up front so the kernel doubles its readahead window. Best-effort.
+        // SAFETY: `in_` is a valid open fd; `posix_fadvise` only reads it.
+        let _ = unsafe { libc::posix_fadvise(in_, 0, 0, libc::POSIX_FADV_SEQUENTIAL) };
     }
 
     copy_file_read_write_loop(in_, out, len)

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -515,8 +515,8 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
           stderr: expect.stringMatching(/\[fadvise\] fd=\d+ advice=2/),
           stdout: "",
         });
-        expect(exitCode).toBe(0);
         expect(fs.readFileSync(join(String(dir), "dst.bin"))).toEqual(Buffer.alloc(128 * 1024, 0x41));
+        expect(exitCode).toBe(0);
       },
     );
   }

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -465,6 +465,60 @@ const IS_UV_FS_COPYFILE_DISABLED =
         }
       });
     });
+
+    it.skipIf(!(Bun.which("cc") || Bun.which("gcc") || Bun.which("clang")))(
+      "read/write fallback hints POSIX_FADV_SEQUENTIAL on the source fd",
+      async () => {
+        const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+        using dir = tempDir("bun-write-fadvise", {
+          "shim.c": `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <stdio.h>
+#include <sys/types.h>
+static int (*real)(int, off_t, off_t, int);
+int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
+  if (!real) real = dlsym(RTLD_NEXT, "posix_fadvise");
+  fprintf(stderr, "[fadvise] fd=%d advice=%d\\n", fd, advice);
+  return real(fd, offset, len, advice);
+}
+`,
+          "src.bin": Buffer.alloc(128 * 1024, 0x41).toString(),
+        });
+        const shim = join(String(dir), "shim.so");
+        await using ccProc = Bun.spawn({
+          cmd: [cc, "-shared", "-fPIC", "-o", shim, join(String(dir), "shim.c"), "-ldl"],
+          env: bunEnv,
+          stderr: "pipe",
+        });
+        const [ccErr, ccExit] = await Promise.all([ccProc.stderr.text(), ccProc.exited]);
+        if (ccExit !== 0) throw new Error(`shim compile failed: ${ccErr}`);
+
+        const existing = bunEnv.LD_PRELOAD;
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            join(import.meta.dir, "./bun-write-exdev-fixture.js"),
+            join(String(dir), "src.bin"),
+            join(String(dir), "dst.bin"),
+          ],
+          env: {
+            ...bunEnv,
+            BUN_CONFIG_DISABLE_COPY_FILE_RANGE: "1",
+            LD_PRELOAD: existing ? `${shim}:${existing}` : shim,
+          },
+          stderr: "pipe",
+          stdout: "pipe",
+        });
+        const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+        expect({ stderr, stdout }).toEqual({
+          stderr: expect.stringMatching(/\[fadvise\] fd=\d+ advice=2/),
+          stdout: "",
+        });
+        expect(exitCode).toBe(0);
+        expect(fs.readFileSync(join(String(dir), "dst.bin"))).toEqual(Buffer.alloc(128 * 1024, 0x41));
+      },
+    );
   }
 
   describe("ENOENT", () => {


### PR DESCRIPTION
When `clonefile`/`copy_file_range`/`sendfile` all bail and we fall back to a manual `read()`/`write()` loop, tell the kernel up front that the source will be read sequentially so it doubles its readahead window.

### What changed

- **`NodeFS::copy_file_using_read_write_loop`** (node_fs.rs): one `posix_fadvise(src_fd, 0, 0, POSIX_FADV_SEQUENTIAL)` at the top, gated to Linux/Android/FreeBSD. Failures are ignored.
- **`bun_sys::copy_file_range`** (sys/copy_file.rs): a new `HAS_HINTED_SEQUENTIAL` bit on `LinuxCopyFileState`, cleared on entry to `copy_file_with_state` and set the first time we fall through to `copy_file_read_write_loop`. This gives exactly one hint per source fd even though the outer loop re-enters the 32 KiB read/write helper once per chunk, and even when `bun install` reuses the state across a whole directory tree.
- **`bench/copyfile/fallback-rw-loop.mjs`**: reproducible cold-cache benchmark (uses `POSIX_FADV_DONTNEED` to evict the source between iterations).

### Benchmarks

All on overlayfs/NVMe, kernel 6.17, 128 KiB default readahead.

**Isolated read/write loop** (standalone C, 512 MiB file, cold cache, 10 iters alternating order; this is the shape of both fallback loops with their respective buffer sizes):

| buffer | no hint | with hint | speedup |
|-------:|--------:|----------:|--------:|
| 32 KiB | 2387 ms | 1715 ms   | 1.39x   |
| 64 KiB | 2352 ms | 1748 ms   | 1.35x   |
| 8 MiB  | 1813 ms | 1809 ms   | ~1.00x  |

**End-to-end `Bun.write(file, file)` with `BUN_CONFIG_DISABLE_COPY_FILE_RANGE=1`** (debug build, cold cache, interleaved 6x10 iters):

| file size | path          | before (min) | after (min) | speedup |
|----------:|:--------------|-------------:|------------:|--------:|
| 1 MiB     | 64 KiB buffer | 6.5-7.3 ms   | 5.4-5.9 ms  | ~1.2x   |
| 512 MiB   | 8 MiB slab    | 1810 ms      | 1810 ms     | 1.00x   |
| 64 MiB warm cache |       | 46.2 ms med  | 46.6 ms med | no regression |

### Why the 8 MiB slab case is flat

`copy_file_using_read_write_loop` allocates an 8 MiB heap slab for files > 1 MiB. An 8 MiB `read()` already dwarfs the 128/256 KiB readahead window, and the kernel's adaptive readahead ramps to its ceiling after the first couple of reads with or without the hint. So for large files through this path the hint is a no-op (one extra syscall, ~2 us). The measurable win is on the fixed 32 KiB loop in `sys/copy_file.rs` (always) and the 64 KiB stack-buffer branch of `node_fs.rs` (files <= 1 MiB).

### Windows

Not touched. On Windows `fs.copyFile`/`fs.cp` and `bun_sys::copy_file` all go through `CopyFileW`, so the read/write fallback in `node_fs.rs`/`sys/copy_file.rs` is never reached. The only Windows-side read/write loop is `CopyFileWindows::ReadWriteLoop` in `blob/copy_file.rs` (libuv-async, 64 KiB, used when `Bun.write` can't get a source path); adding `FILE_FLAG_SEQUENTIAL_SCAN` there would mean reopening a handle we were handed, which is a larger change than this PR attempts.

### Correctness

Existing coverage exercises the fallback path directly:
- `test/js/bun/io/bun-write.test.js` "should work when copyFileRange is not available" (large + small)
- `test/js/node/fs/fs.test.ts` "copyFileSync > should work when copyFileRange is not available"
- `test/js/node/fs/cp.test.ts` (all passing with this change)

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->