### PR TITLE
fix(sql): don't crash in debug builds when bun:sql module load throws

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -319,9 +319,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -331,9 +328,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/test/js/sql/sql-lazy-load-throw.test.ts
+++ b/test/js/sql/sql-lazy-load-throw.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 test("Bun.SQL lazy getter propagates module load errors without crashing", async () => {

--- a/test/js/sql/sql-lazy-load-throw.test.ts
+++ b/test/js/sql/sql-lazy-load-throw.test.ts
@@ -1,0 +1,31 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("Bun.SQL lazy getter propagates module load errors without crashing", async () => {
+  // The bun:sql internal module reads global `Symbol` at top level. If user
+  // code has clobbered the global before the first access, evaluating the
+  // module throws. That exception must propagate back to the caller as a
+  // normal JS error rather than crashing the process.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        globalThis.Symbol = "i";
+        let caught = 0;
+        try { Bun.sql; } catch { caught++; }
+        try { Bun.SQL; } catch { caught++; }
+        console.log("caught=" + caught);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("caught=2");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fuzzilli found a crash (fingerprint `281fcb3ecf3202d4`) where accessing `Bun.SQL` or `Bun.sql` after `globalThis.Symbol` was replaced with a non-function would crash the process in debug/ASAN builds instead of throwing.

## What

The `Bun.sql` / `Bun.SQL` lazy property callbacks in `BunObject.cpp` call `requireId()` to load the `bun:sql` internal module. In debug builds, if that evaluation threw, a `#if BUN_DEBUG` block called `reportUncaughtExceptionAtEventLoop()` before the `RETURN_IF_EXCEPTION` check.

`reportUncaughtExceptionAtEventLoop` routes through `Bun__reportUnhandledError` -> `uncaught_exception` -> `Bun__handleUncaughtException`, which can clear the pending VM exception (via `tryClearException` on the `_fatalException` lookup). With the exception cleared, `RETURN_IF_EXCEPTION` doesn't fire and `sqlValue.getObject()->get(...)` dereferences a null pointer.

Release builds were unaffected since the block is `#if BUN_DEBUG` only.

## How

Remove the debug-only `reportUncaughtExceptionAtEventLoop` calls. The exception now propagates to the caller the same way in debug and release builds.

## Repro

```js
globalThis.Symbol = "i";
try { Bun.SQL; } catch (e) { console.log(e.message); }
```

Before: `member call on null pointer of type 'JSC::JSCell'` (UBSAN) or `assertNoException` (exception scope check)
After: throws `TypeError: Symbol is not a function` which is catchable