### PR TITLE
docs: fix off-by-one in HTTP range request example

### DIFF
--- a/docs/runtime/http/routing.mdx
+++ b/docs/runtime/http/routing.mdx
@@ -218,14 +218,13 @@ To send part of a file, use the [`slice(start, end)`](https://developer.mozilla.
 ```ts
 Bun.serve({
   fetch(req) {
-    // parse `Range` (this example handles "start-end" and open-ended "start-", not suffix "-N" ranges)
+    // parse `Range` header
     const [start = 0, end = Infinity] = req.headers
       .get("Range") // "bytes=0-100"
       .split("=") // ["bytes", "0-100"]
       .at(-1) // "0-100"
       .split("-") // ["0", "100"]
-      // an open-ended range like "bytes=100-" has an empty end; keep it as Infinity
-      .map((value, index) => (index === 1 && value === "" ? Infinity : Number(value))); // [0, 100]
+      .map(Number); // [0, 100]
 
     // return a slice of the file.
     // `Range` is end-inclusive, but `slice`'s end is exclusive, so add 1.

--- a/docs/runtime/http/routing.mdx
+++ b/docs/runtime/http/routing.mdx
@@ -224,7 +224,8 @@ Bun.serve({
       .split("=") // ["bytes", "0-100"]
       .at(-1) // "0-100"
       .split("-") // ["0", "100"]
-      .map(Number); // [0, 100]
+      // an open-ended range like "bytes=100-" has an empty end; keep it as Infinity
+      .map((value, index) => (index === 1 && value === "" ? Infinity : Number(value))); // [0, 100]
 
     // return a slice of the file.
     // `Range` is end-inclusive, but `slice`'s end is exclusive, so add 1.

--- a/docs/runtime/http/routing.mdx
+++ b/docs/runtime/http/routing.mdx
@@ -220,15 +220,16 @@ Bun.serve({
   fetch(req) {
     // parse `Range` header
     const [start = 0, end = Infinity] = req.headers
-      .get("Range") // Range: bytes=0-100
-      .split("=") // ["Range: bytes", "0-100"]
+      .get("Range") // "bytes=0-100"
+      .split("=") // ["bytes", "0-100"]
       .at(-1) // "0-100"
       .split("-") // ["0", "100"]
       .map(Number); // [0, 100]
 
-    // return a slice of the file
+    // return a slice of the file.
+    // `Range` is end-inclusive, but `slice`'s end is exclusive, so add 1.
     const bigFile = Bun.file("./big-video.mp4");
-    return new Response(bigFile.slice(start, end));
+    return new Response(bigFile.slice(start, end + 1));
   },
 });
 ```

--- a/docs/runtime/http/routing.mdx
+++ b/docs/runtime/http/routing.mdx
@@ -218,7 +218,7 @@ To send part of a file, use the [`slice(start, end)`](https://developer.mozilla.
 ```ts
 Bun.serve({
   fetch(req) {
-    // parse `Range` header
+    // parse `Range` (this example handles "start-end" and open-ended "start-", not suffix "-N" ranges)
     const [start = 0, end = Infinity] = req.headers
       .get("Range") // "bytes=0-100"
       .split("=") // ["bytes", "0-100"]


### PR DESCRIPTION
### What does this PR do?

Fixes #28030. The HTTP range-request example in `docs/runtime/http/routing.mdx` had two problems:

1. **Off-by-one.** The `Range` header is *end-inclusive* (`bytes=0-100` means bytes 0 through 100 → 101 bytes), but `Blob.prototype.slice(start, end)` treats `end` as *exclusive*. So `slice(start, end)` dropped the last byte of every requested range. Changed to `slice(start, end + 1)`, which is also correct for the open-ended `end = Infinity` default (`Infinity + 1 === Infinity`).

2. **Misleading comments.** `req.headers.get("Range")` returns the header *value* `"bytes=0-100"` (not `"Range: bytes=0-100"`), so `.split("=")` yields `["bytes", "0-100"]`. The old comments showed `["Range: bytes", "0-100"]`. Updated the step-by-step comments to show the real intermediate values, and added a one-line note on why `+ 1` is needed.

This exact off-by-one was previously reported in #3087 (closed) but the docs were never actually corrected — the example still shipped `slice(start, end)` — so it's still live today.

### How did you verify your code works?

Verified each claim against the runtime with `bun -e` (Bun 1.3.14):

```
get("Range")                         -> "bytes=0-100"
.split("=")                          -> ["bytes","0-100"]
new Blob([Uint8Array(200)]).slice(0,100).size -> 100   // old example: drops the last byte
new Blob([Uint8Array(200)]).slice(0,101).size -> 101   // end + 1: bytes 0..100 inclusive
new Blob([Uint8Array(200)]).slice(0,Infinity).size -> 200 // open-ended still works
```

Docs-only change; no code paths affected.
