### PR TITLE
jsc: pick a/an in throw_invalid_argument_type error messages

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -81,6 +81,16 @@ impl core::fmt::Debug for GlobalRef {
     }
 }
 
+/// "a" or "an" for the given noun. Deliberately treats only a/e/i/o as vowel
+/// onsets: "u"-initial type names seen here ("Uint8Array", "URL") take "a".
+#[inline]
+const fn indefinite_article_for(noun: &str) -> &'static str {
+    match noun.as_bytes() {
+        [b'a' | b'A' | b'e' | b'E' | b'i' | b'I' | b'o' | b'O', ..] => "an",
+        _ => "a",
+    }
+}
+
 impl JSGlobalObject {
     /// Alias of the macro-provided [`as_mut_ptr`](Self::as_mut_ptr) kept for
     /// call-site readability where mutation is not the intent.
@@ -282,7 +292,7 @@ impl JSGlobalObject {
         }
     }
 
-    /// "Expected {field} to be a {typename} for '{name}'."
+    /// "Expected {field} to be a/an {typename} for '{name}'."
     pub fn create_invalid_argument_type(
         &self,
         name_: &'static str,
@@ -291,7 +301,13 @@ impl JSGlobalObject {
     ) -> JSValue {
         self.err(
             JscError::INVALID_ARG_TYPE,
-            format_args!("Expected {} to be a {} for '{}'.", field, typename, name_),
+            format_args!(
+                "Expected {} to be {} {} for '{}'.",
+                field,
+                indefinite_article_for(typename),
+                typename,
+                name_
+            ),
         )
         .to_js()
     }
@@ -300,7 +316,7 @@ impl JSGlobalObject {
         Ok(value.into())
     }
 
-    /// "Expected {field} to be a {typename} for '{name}'."
+    /// "Expected {field} to be a/an {typename} for '{name}'."
     pub fn throw_invalid_argument_type(
         &self,
         name_: &'static str,

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -90,6 +90,20 @@ const fn indefinite_article_for(noun: &str) -> &'static str {
         _ => "a",
     }
 }
+const _: () = {
+    assert!(indefinite_article_for("array").len() == 2);
+    assert!(indefinite_article_for("element").len() == 2);
+    assert!(indefinite_article_for("integer").len() == 2);
+    assert!(indefinite_article_for("object").len() == 2);
+    assert!(indefinite_article_for("Array").len() == 2);
+    assert!(indefinite_article_for("Error").len() == 2);
+    assert!(indefinite_article_for("Iterable").len() == 2);
+    assert!(indefinite_article_for("Object").len() == 2);
+    assert!(indefinite_article_for("string").len() == 1);
+    assert!(indefinite_article_for("Uint8Array").len() == 1);
+    assert!(indefinite_article_for("URL").len() == 1);
+    assert!(indefinite_article_for("").len() == 1);
+};
 
 impl JSGlobalObject {
     /// Alias of the macro-provided [`as_mut_ptr`](Self::as_mut_ptr) kept for

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -82,7 +82,7 @@ impl core::fmt::Debug for GlobalRef {
 }
 
 /// "a" or "an" for the given noun. Deliberately treats only a/e/i/o as vowel
-/// onsets: "u"-initial type names seen here ("Uint8Array", "URL") take "a".
+/// onsets so that "u"-initial type names like "Uint8Array"/"URL" take "a".
 #[inline]
 const fn indefinite_article_for(noun: &str) -> &'static str {
     match noun.as_bytes() {
@@ -90,6 +90,8 @@ const fn indefinite_article_for(noun: &str) -> &'static str {
         _ => "a",
     }
 }
+// The function returns one of exactly two literals, so len() distinguishes them
+// (`&str == &str` is not const-evaluable without `feature(const_trait_impl)`).
 const _: () = {
     assert!(indefinite_article_for("array").len() == 2);
     assert!(indefinite_article_for("element").len() == 2);

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -796,13 +796,13 @@ pub fn js_assert_settings(
 ) -> JsResult<JSValue> {
     let args_list = callframe.arguments_old::<1>();
     if args_list.len < 1 {
-        return Err(global_object.throw(format_args!("Expected settings to be a object")));
+        return Err(global_object.throw(format_args!("Expected settings to be an object")));
     }
 
     if args_list.len > 0 && !args_list.ptr[0].is_empty_or_undefined_or_null() {
         let options = args_list.ptr[0];
         if !options.is_object() {
-            return Err(global_object.throw(format_args!("Expected settings to be a object")));
+            return Err(global_object.throw(format_args!("Expected settings to be an object")));
         }
 
         if let Some(header_table_size) = options.get(global_object, "headerTableSize")? {
@@ -942,7 +942,7 @@ pub fn js_get_packed_settings(
         let options = args_list.ptr[0];
 
         if !options.is_object() {
-            return Err(global_object.throw(format_args!("Expected settings to be a object")));
+            return Err(global_object.throw(format_args!("Expected settings to be an object")));
         }
 
         if let Some(header_table_size) = options.get(global_object, "headerTableSize")? {
@@ -6347,7 +6347,7 @@ impl H2FrameParser {
         options: JSValue,
     ) -> JsResult<()> {
         if options.is_empty_or_undefined_or_null() || !options.is_object() {
-            return Err(global_object.throw(format_args!("Expected settings to be a object")));
+            return Err(global_object.throw(format_args!("Expected settings to be an object")));
         }
 
         // R-2: read-modify-write the `Cell<FullSettingsPayload>` via a local copy.

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -2569,7 +2569,7 @@ impl ExpectArrayContaining {
         if args.is_empty() || !args[0].js_type().is_array() {
             return Err(crate::throw_pretty_static!(
                 global_this,
-                "<d>expect.<r>arrayContaining<d>(<r>array<d>)<r>\n\nExpected a array\n",
+                "<d>expect.<r>arrayContaining<d>(<r>array<d>)<r>\n\nExpected an array\n",
             ));
         }
 

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -196,9 +196,7 @@ describe("ERR_INVALID_ARG_TYPE message uses the right indefinite article", () =>
   });
   test("an object", () => {
     // options validation throws before the destination path is ever touched.
-    expect(() => Bun.write("unused-path", "x", "nope" as any)).toThrow(
-      "Expected options to be an object for 'write'.",
-    );
+    expect(() => Bun.write("unused-path", "x", "nope" as any)).toThrow("Expected options to be an object for 'write'.");
   });
   test("a string (consonant onset unchanged)", () => {
     expect(() => color("red", 123 as any)).toThrow("Expected format to be a string for 'color'.");

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -183,6 +183,28 @@ test.each(bad)("color(%s, 'css') === null", input => {
   expect(color(input)).toBeNull();
 });
 
+describe("ERR_INVALID_ARG_TYPE message uses the right indefinite article", () => {
+  // These all flow through JSGlobalObject::create_invalid_argument_type, which
+  // used to hardcode "a" and emit "a integer" / "a array" / "a object".
+  test("an integer", () => {
+    expect(() => color({ r: "x" as any, g: 0, b: 0 })).toThrow("Expected r to be an integer for 'color'.");
+  });
+  test("an array", () => {
+    expect(() => expect({}).toContainAllKeys("nope" as any)).toThrow(
+      "Expected expected to be an array for 'toContainAllKeys'.",
+    );
+  });
+  test("an object", () => {
+    // options validation throws before the destination path is ever touched.
+    expect(() => Bun.write("unused-path", "x", "nope" as any)).toThrow(
+      "Expected options to be an object for 'write'.",
+    );
+  });
+  test("a string (consonant onset unchanged)", () => {
+    expect(() => color("red", 123 as any)).toThrow("Expected format to be a string for 'color'.");
+  });
+});
+
 test("invalid format string lists the accepted values", () => {
   let message!: string;
   try {

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -184,8 +184,7 @@ test.each(bad)("color(%s, 'css') === null", input => {
 });
 
 describe("ERR_INVALID_ARG_TYPE message uses the right indefinite article", () => {
-  // These all flow through JSGlobalObject::create_invalid_argument_type, which
-  // used to hardcode "a" and emit "a integer" / "a array" / "a object".
+  // All four flow through the shared JSGlobalObject::create_invalid_argument_type helper.
   test("an integer", () => {
     expect(() => color({ r: "x" as any, g: 0, b: 0 })).toThrow("Expected r to be an integer for 'color'.");
   });


### PR DESCRIPTION
## What

`JSGlobalObject::create_invalid_argument_type` formats its message as `"Expected {field} to be a {typename} for '{name}'."` with a hardcoded `"a"`, so vowel-initial typenames come out ungrammatical:

```js
> Bun.color({ r: "x", g: 0, b: 0 })
TypeError: Expected r to be a integer for 'color'.

> Bun.write("out", "x", "nope")
TypeError: Expected options to be a object for 'write'.

> Bun.dns.setServers("nope")
TypeError: Expected servers to be a array for 'setServers'.
```

This reaches about a dozen user-visible paths today (`Bun.color`, `Bun.write`, `Bun.dns.setServers`, `Bun.udpSocket().sendMany`, `expect().toContainAllKeys`, the valkey `hmset`/`hset` object overload, socket `byteOffset`/`byteLength`, `Bun.sql` query construction, and more).

## Fix

Pick `"a"`/`"an"` from the first byte of the typename. Only `a/e/i/o` onsets map to `"an"`; `"u"` is deliberately excluded so `"Uint8Array"` and `"URL"` keep `"a"` if they ever show up here. Consonant-initial typenames (every existing inline snapshot in the tree) are byte-identical to before.

Also fixes four inline `"Expected settings to be a object"` literals in `h2_frame_parser.rs` that had the same bug outside the helper.

## Why this fix and not a reword

The sibling helper `throw_invalid_argument_type_value` already uses Node's `"must be of type {typename}"` phrasing, so rewording this one to match would be defensible. But that changes the message for ~70 call sites including 30+ inline snapshots in `test/js/valkey/` that are already correct. Picking the article fixes exactly the call sites that were wrong and touches nothing else.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/css/color.test.ts -t "indefinite article"
 1 pass
 3 fail   # "a integer", "a array", "a object"

$ bun bd test test/js/bun/css/color.test.ts -t "indefinite article"
 4 pass
 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/color.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (579f11f05)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [3.40ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [1.38ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [1.19ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [1.98ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [12.98ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [1.71ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [1.71ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit")) [0.30ms]
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g
... (truncated)

release without fix: 146 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [0.09ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [0.02ms]
[38;5;	m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [0.01ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [0.04ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [0.49ms]
122 |     test(`color(${JSON.stringify(input)}, "ansi-24bit")`, () => {
123 |       expect(color(input, "ansi-24bit")).toMatchSnapshot();
124 |     });
125 | 
126 |     test(`color(${JSON.stringify(input)}, "ansi-16")`, () => {
127 |       expect(color(input, "ansi-16")).toMatchSnapshot();
                                            ^
error: expect(received).toMatchSnapshot(expected)

Expected: "[91m"
Received: "[38;5;	m"

      at <anonymous> (/workspace/bun/test/js/bun/css/color.test.ts:127:39)
(fail) color({"r":255,"g":0,"b":0}, "ansi-16") [0.17ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [0.03ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":2
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/color.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (579f11f05)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [3.78ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [1.39ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [1.16ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [2.00ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [13.04ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [1.74ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [1.77ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit")) [0.33ms]
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     579f11f050
  features     (none)

22 deps, 106 codegen, 1169 objects in 773ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1232] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [10.00ms]
[2/1232] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1232] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [5.00ms]
[4/1232] gen ErrorCode+*.h
[5/1232] gen bindgenv2
[6/1232] fetch picohttpparser
[picohttpparser] up to date
[7/1232] fetch tinycc
[tinycc] up to date
[8/1232] fetch 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/JSGlobalObject.rs              | 38 +++++++++++++++++++++++++++++++---
 src/runtime/api/bun/h2_frame_parser.rs |  8 +++----
 src/runtime/test_runner/expect.rs      |  2 +-
 test/js/bun/css/color.test.ts          | 19 +++++++++++++++++
 4 files changed, 59 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/jsc/JSGlobalObject.rs                   5      6      0
src/runtime/api/bun/h2_frame_parser.rs      2      1      0
src/runtime/test_runner/expect.rs           1      1      0
test/js/bun/css/color.test.ts               2      3      0
```

</details>

<!-- robobun:evidence:end -->