### PR TITLE
Remove dead code from shell_parser and ini

### DIFF
--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -201,16 +201,6 @@ bun_core::comptime_string_map! {
     };
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// ScopeError
-// ──────────────────────────────────────────────────────────────────────────
-
-#[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
-pub enum ScopeError {
-    #[error("no_value")]
-    NoValue,
-}
-
 pub use draft::{
     ConfigIterator, Parser, ScopeItem, ScopeIterator, ToStringFormatter, load_npmrc,
     load_npmrc_config,

--- a/src/runtime/shell/mod.rs
+++ b/src/runtime/shell/mod.rs
@@ -137,7 +137,7 @@ pub mod subproc;
 // ─── shell escaping (canonical impl lives in bun_shell_parser) ───────────────
 // Re-export so `crate::shell::*` callers resolve without duplicating the table.
 pub use bun_shell_parser::{
-    BACKSLASHABLE_CHARS, SPECIAL_CHARS, SPECIAL_CHARS_TABLE, assert_special_char, escape_8bit,
+    BACKSLASHABLE_CHARS, SPECIAL_CHARS, SPECIAL_CHARS_TABLE, escape_8bit,
     needs_escape_utf8_ascii_latin1, needs_escape_utf16,
 };
 

--- a/src/runtime/shell/shell_body.rs
+++ b/src/runtime/shell/shell_body.rs
@@ -43,8 +43,8 @@ pub use bun_shell_parser::parse::{
     JSValueRaw, LEX_JS_OBJREF_PREFIX, LEX_JS_STRING_PREFIX, LexError, LexResult, Lexer, LexerAscii,
     LexerError, LexerUnicode, ParseError, Parser, ParserError, SPECIAL_CHARS, SPECIAL_CHARS_TABLE,
     ShellCharIter, SmolList, Src, SrcAscii, SrcUnicode, StringEncoding, SubShellKind, SubshellKind,
-    TextRange, Token, TokenTag, assert_special_char, ast, escape_8bit, escape_bun_str,
-    escape_utf16, has_eq_sign, is_if_clause_keyword_bunstr, is_valid_var_name, needs_escape_bunstr,
+    TextRange, Token, TokenTag, ast, escape_8bit, escape_bun_str, escape_utf16, has_eq_sign,
+    is_if_clause_keyword_bunstr, is_valid_var_name, needs_escape_bunstr,
     needs_escape_utf8_ascii_latin1, needs_escape_utf16,
 };
 

--- a/src/shell_parser/braces.rs
+++ b/src/shell_parser/braces.rs
@@ -11,13 +11,11 @@ use smallvec::SmallVec;
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Moved from `bun_shell`:
-//   StringEncoding, SrcAscii, SrcUnicode, ShellCharIter, CharIter, has_eq_sign
+//   StringEncoding, SrcAscii, SrcUnicode, ShellCharIter, CharIter
 // These live here so `bun_shell` (higher tier) can depend on `shell_parser`
 // without a back-edge. `bun_shell` re-exports these under its old paths.
 // ═══════════════════════════════════════════════════════════════════════════
 
-use bun_core::strings;
-use bun_core::strings::CodePoint; // i32
 use bun_core::strings::{CodepointIterator, Cursor};
 
 /// Encoding of the shell input bytes being expanded.
@@ -350,26 +348,6 @@ impl<const E: StringEncoding> CharIter for ShellCharIter<E> {
             escaped: true,
         })
     }
-}
-
-// ─── has_eq_sign ───────────────────────────────────────────────────────────
-
-/// Returns the index of the first `=` in the string, if any
-/// (codepoint-aware for non-ASCII input).
-pub fn has_eq_sign(str_: &[u8]) -> Option<u32> {
-    if strings::is_all_ascii(str_) {
-        return bun_core::strings::index_of_char(str_, b'=');
-    }
-
-    // TODO actually i think that this can also use the simd stuff
-    let iter = CodepointIterator::init(str_);
-    let mut cursor = Cursor::default();
-    while CodepointIterator::next(&iter, &mut cursor) {
-        if cursor.c == b'=' as CodePoint {
-            return Some(cursor.i);
-        }
-    }
-    None
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/shell_parser/lib.rs
+++ b/src/shell_parser/lib.rs
@@ -10,9 +10,7 @@ pub use error::{Error, Result};
 pub mod braces;
 
 // Re-exports expected at crate root (callers do `use crate::{...}`).
-pub use braces::{
-    CharIter, InputChar, ShellCharIter, ShellCharIterState, StringEncoding, has_eq_sign,
-};
+pub use braces::{CharIter, InputChar, ShellCharIter, ShellCharIterState, StringEncoding};
 
 // ─── lexer / parser / AST ───────────────────────────────────────────────────
 // Shell lex/parse — moved down from `bun_runtime::shell::shell_body`
@@ -27,10 +25,10 @@ pub use parse::{
     BACKSLASHABLE_CHARS, EscapeUtf16Result, IfClauseTok, JSValueRaw, LEX_JS_OBJREF_PREFIX,
     LEX_JS_STRING_PREFIX, LexError, LexResult, Lexer, LexerAscii, LexerError, LexerUnicode,
     MemoryCost, ParseError, Parser, ParserError, SPECIAL_CHARS, SPECIAL_CHARS_TABLE, SmolList,
-    SubShellKind, SubshellKind, TextRange, Token, TokenTag, assert_special_char, ast, ast as AST,
-    escape_8bit, escape_bun_str, escape_utf16, is_valid_var_name, needs_escape_bunstr,
+    SubShellKind, SubshellKind, TextRange, Token, TokenTag, ast, ast as AST, escape_8bit,
+    escape_bun_str, escape_utf16, is_valid_var_name, needs_escape_bunstr,
     needs_escape_utf8_ascii_latin1, needs_escape_utf16,
 };
-// NOTE: `StringEncoding`/`ShellCharIter`/`InputChar`/`has_eq_sign` already
-// re-exported from `braces` above; `parse` defines its own (lexer-shaped)
-// copies which stay module-scoped to avoid crate-root ambiguity.
+// NOTE: `StringEncoding`/`ShellCharIter`/`InputChar` already re-exported from
+// `braces` above; `parse` defines its own (lexer-shaped) copies which stay
+// module-scoped to avoid crate-root ambiguity.

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -4200,10 +4200,6 @@ pub const SPECIAL_CHARS_TABLE: ByteTable = {
     ByteTable(table)
 };
 
-pub fn assert_special_char(c: u8) {
-    debug_assert!(SPECIAL_CHARS_TABLE.is_set(c as usize));
-}
-
 /// Characters that need to be backslashed inside double quotes
 pub const BACKSLASHABLE_CHARS: [u8; 4] = *b"$`\"\\";
 


### PR DESCRIPTION
Deletes three items with zero call sites anywhere in the tree (checked across `src/`, `build/debug/codegen/`, and `src/codegen/`):

- **`shell_parser::parse::assert_special_char`** (parse.rs): a `debug_assert!` wrapper that was never called, only re-exported from `shell_parser/lib.rs`, `runtime/shell/shell_body.rs`, and `runtime/shell/mod.rs`. The re-export entries are dropped along with it.
- **`shell_parser::braces::has_eq_sign`** (braces.rs): a verbatim duplicate of `parse::has_eq_sign`. The `parse` copy is the one actually called (parse.rs:1636) and re-exported through `shell_body`; the `braces` copy had no callers and its crate-root re-export was never imported. Two imports (`bun_core::strings`, `bun_core::strings::CodePoint`) become unused with it and are removed.
- **`ini::ScopeError`** (ini/lib.rs): a single-variant `thiserror` enum that is never constructed, matched, or returned.

Verification:
- `rg` for each symbol across `src/`, `build/debug/codegen/`, `src/codegen/`: only definitions and re-export lines.
- `bun bd` builds clean.
- `bun run rust:check-all` passes on all targets.
- `bun bd test test/js/bun/shell/{brace,parse,lex}.test.ts` and `test/js/bun/ini/ini.test.ts` pass.

Net: +10 / -48.