### PR TITLE
node:v8: heap statistics shape, cachedDataVersionTag, ERR_NOT_BUILDING_SNAPSHOT (+4 tests)

### DIFF
--- a/src/js/node/v8.ts
+++ b/src/js/node/v8.ts
@@ -2,6 +2,7 @@
 
 // This is a stub! None of this is actually implemented yet.
 const { hideFromStack, throwNotImplemented } = require("internal/shared");
+const { validateString, validateOneOf } = require("internal/validators");
 const jsc: typeof import("bun:jsc") = require("bun:jsc");
 
 function notimpl(message) {
@@ -26,8 +27,14 @@ class GCProfiler {
   }
 }
 
+// Node derives this tag from the V8 version, command-line flags, and CPU
+// features; Bun mirrors that with its own version plus the flags recorded by
+// setFlagsFromString, so the tag is stable until the flags change.
+let versionTagFlags = "";
+let versionTag: number | undefined;
 function cachedDataVersionTag() {
-  notimpl("cachedDataVersionTag");
+  versionTag ??= Bun.hash.crc32(`bun ${Bun.version}-${Bun.revision}${versionTagFlags}`);
+  return versionTag;
 }
 var HeapSnapshotReadable_;
 function getHeapSnapshot() {
@@ -70,6 +77,7 @@ function getHeapStatistics() {
     total_physical_size: memory.peak,
     total_available_size: totalmem() - stats.heapSize,
     used_heap_size: stats.heapSize,
+    total_allocated_bytes: stats.heapCapacity,
     heap_size_limit: Math.min(memory.peak * 10, totalmem()),
     malloced_memory: stats.heapSize,
     peak_malloced_memory: memory.peak,
@@ -85,14 +93,72 @@ function getHeapStatistics() {
     external_memory: stats.extraMemorySize,
   };
 }
+// V8 divides its heap into fixed spaces; JSC manages one undivided heap, so
+// the JSC totals are reported under "old_space" and the other V8 space names
+// exist for shape compatibility.
+const kHeapSpaces = [
+  "read_only_space",
+  "new_space",
+  "old_space",
+  "code_space",
+  "shared_space",
+  "trusted_space",
+  "new_large_object_space",
+  "large_object_space",
+  "code_large_object_space",
+  "shared_large_object_space",
+  "shared_trusted_space",
+  "shared_trusted_large_object_space",
+  "trusted_large_object_space",
+];
 function getHeapSpaceStatistics() {
-  notimpl("getHeapSpaceStatistics");
+  const stats = jsc.heapStats();
+  const spaces = [];
+  for (let i = 0; i < kHeapSpaces.length; i++) {
+    const space_name = kHeapSpaces[i];
+    const isHeap = space_name === "old_space";
+    const used = isHeap ? stats.heapSize : 0;
+    const size = isHeap ? stats.heapCapacity : 0;
+    $arrayPush(spaces, {
+      space_name,
+      space_size: size,
+      space_used_size: used,
+      space_available_size: size > used ? size - used : 0,
+      physical_space_size: size,
+    });
+  }
+  return spaces;
 }
+// JSC does not expose a per-category code size breakdown; report zeros rather
+// than invented numbers, like node does for counters V8 is not tracking
+// (e.g. cpu_profiler_metadata_size).
 function getHeapCodeStatistics() {
-  notimpl("getHeapCodeStatistics");
+  return {
+    code_and_metadata_size: 0,
+    bytecode_and_metadata_size: 0,
+    external_script_source_size: 0,
+    cpu_profiler_metadata_size: 0,
+  };
 }
-function setFlagsFromString() {
-  notimpl("setFlagsFromString");
+function setFlagsFromString(flags) {
+  validateString(flags, "flags");
+  // V8 flags have no JSC equivalent; record them so cachedDataVersionTag
+  // changes like node's does, and otherwise ignore them.
+  versionTagFlags += ` ${flags}`;
+  versionTag = undefined;
+}
+// Bun has no cppgc (Oilpan) C++ heap, so the statistics are always empty;
+// this matches node's shape with nothing allocated through cppgc.
+function getCppHeapStatistics(type = "detailed") {
+  validateOneOf(type, "type", ["brief", "detailed"]);
+  return {
+    committed_size_bytes: 0,
+    resident_size_bytes: 0,
+    used_size_bytes: 0,
+    space_statistics: [],
+    type_names: [],
+    detail_level: type,
+  };
 }
 function deserialize(value) {
   return jsc.deserialize(value);
@@ -149,6 +215,10 @@ function writeHeapSnapshot(path, _options) {
 function setHeapSnapshotNearHeapLimit() {
   notimpl("setHeapSnapshotNearHeapLimit");
 }
+function throwNotBuildingSnapshot() {
+  throw $ERR_NOT_BUILDING_SNAPSHOT("Operation cannot be invoked when not building startup snapshot");
+}
+
 const promiseHooks = {
     createHook: () => {
       notimpl("createHook");
@@ -167,9 +237,9 @@ const promiseHooks = {
     },
   },
   startupSnapshot = {
-    addDeserializeCallback: () => notimpl("addDeserializeCallback"),
-    addSerializeCallback: () => notimpl("addSerializeCallback"),
-    setDeserializeMainFunction: () => notimpl("setDeserializeMainFunction"),
+    addDeserializeCallback: throwNotBuildingSnapshot,
+    addSerializeCallback: throwNotBuildingSnapshot,
+    setDeserializeMainFunction: throwNotBuildingSnapshot,
     // Bun never builds a V8 startup snapshot, so this is always false, matching
     // Node's behavior during normal execution.
     isBuildingSnapshot: () => false,
@@ -181,6 +251,7 @@ export default {
   getHeapStatistics,
   getHeapSpaceStatistics,
   getHeapCodeStatistics,
+  getCppHeapStatistics,
   setFlagsFromString,
   deserialize,
   takeCoverage,
@@ -198,11 +269,13 @@ export default {
 
 hideFromStack(
   notimpl,
+  throwNotBuildingSnapshot,
   cachedDataVersionTag,
   getHeapSnapshot,
   getHeapStatistics,
   getHeapSpaceStatistics,
   getHeapCodeStatistics,
+  getCppHeapStatistics,
   setFlagsFromString,
   deserialize,
   takeCoverage,

--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -360,5 +360,6 @@ const errors: ErrorCodeMapping = [
   // llhttp reports a missing CRLF after a chunk's data as HPE_STRICT,
   // distinct from a malformed chunk-size line (HPE_INVALID_CHUNK_SIZE).
   ["HPE_STRICT", Error],
+  ["ERR_NOT_BUILDING_SNAPSHOT", Error],
 ];
 export default errors;

--- a/test/js/node/test/parallel/test-cppheap-stats.js
+++ b/test/js/node/test/parallel/test-cppheap-stats.js
@@ -1,0 +1,125 @@
+'use strict';
+// Tests that v8.getCppHeapStatistics() returns an object with an expected shape.
+
+require('../common');
+const assert = require('assert');
+const v8 = require('v8');
+
+// Detailed heap statistics
+const heapStatsDetailed = v8.getCppHeapStatistics('detailed');
+assert.strictEqual(heapStatsDetailed.detail_level, 'detailed');
+const expectedTopLevelKeys = [
+  'committed_size_bytes',
+  'resident_size_bytes',
+  'used_size_bytes',
+  'detail_level',
+  'space_statistics',
+  'type_names',
+].sort();
+
+// Check top level properties
+const actualTopLevelKeys = Object.keys(heapStatsDetailed).sort();
+assert.deepStrictEqual(actualTopLevelKeys, expectedTopLevelKeys);
+
+// Check types of top level properties
+assert.strictEqual(typeof heapStatsDetailed.committed_size_bytes, 'number');
+assert.strictEqual(typeof heapStatsDetailed.resident_size_bytes, 'number');
+assert.strictEqual(typeof heapStatsDetailed.used_size_bytes, 'number');
+assert.strictEqual(typeof heapStatsDetailed.detail_level, 'string');
+assert.strictEqual(Array.isArray(heapStatsDetailed.space_statistics), true);
+assert.strictEqual(Array.isArray(heapStatsDetailed.type_names), true);
+
+
+// Check space statistics array
+const expectedSpaceKeys = [
+  'name',
+  'committed_size_bytes',
+  'resident_size_bytes',
+  'used_size_bytes',
+  'page_stats',
+  'free_list_stats',
+].sort();
+
+for (const space of heapStatsDetailed.space_statistics) {
+  const actualSpaceKeys = Object.keys(space).sort();
+  assert.deepStrictEqual(actualSpaceKeys, expectedSpaceKeys);
+  assert.strictEqual(typeof space.name, 'string');
+  assert.strictEqual(typeof space.committed_size_bytes, 'number');
+  assert.strictEqual(typeof space.resident_size_bytes, 'number');
+  assert.strictEqual(typeof space.used_size_bytes, 'number');
+  assert.strictEqual(Array.isArray(space.page_stats), true);
+  assert.strictEqual(typeof space.free_list_stats, 'object');
+}
+
+// Check page statistics array
+const expectedPageKeys = [
+  'committed_size_bytes',
+  'resident_size_bytes',
+  'used_size_bytes',
+  'object_statistics',
+].sort();
+
+for (const space of heapStatsDetailed.space_statistics) {
+  for (const page of space.page_stats) {
+    const actualPageKeys = Object.keys(page).sort();
+    assert.deepStrictEqual(actualPageKeys, expectedPageKeys);
+    assert.strictEqual(typeof page.committed_size_bytes, 'number');
+    assert.strictEqual(typeof page.resident_size_bytes, 'number');
+    assert.strictEqual(typeof page.used_size_bytes, 'number');
+    assert.strictEqual(Array.isArray(page.object_statistics), true);
+  }
+}
+
+// Check free list statistics
+const expectedFreeListKeys = ['bucket_size', 'free_count', 'free_size'].sort();
+
+for (const space of heapStatsDetailed.space_statistics) {
+  const actualFreeListKeys = Object.keys(space.free_list_stats).sort();
+  assert.deepStrictEqual(actualFreeListKeys, expectedFreeListKeys);
+  assert.strictEqual(Array.isArray(space.free_list_stats.bucket_size), true);
+  assert.strictEqual(Array.isArray(space.free_list_stats.free_count), true);
+  assert.strictEqual(Array.isArray(space.free_list_stats.free_size), true);
+}
+
+// Check object statistics
+const expectedObjectStatsKeys = ['allocated_bytes', 'object_count'].sort();
+
+for (const space of heapStatsDetailed.space_statistics) {
+  for (const page of space.page_stats) {
+    for (const objectStats of page.object_statistics) {
+      const actualObjectStatsKeys = Object.keys(objectStats).sort();
+      assert.deepStrictEqual(actualObjectStatsKeys, expectedObjectStatsKeys);
+      assert.strictEqual(typeof objectStats.allocated_bytes, 'number');
+      assert.strictEqual(typeof objectStats.object_count, 'number');
+    }
+  }
+}
+
+// Check type names
+for (const typeName of heapStatsDetailed.type_names) {
+  assert.strictEqual(typeof typeName, 'string');
+}
+
+// Brief heap statistics
+const heapStatsBrief = v8.getCppHeapStatistics('brief');
+const expectedBriefKeys = [
+  'committed_size_bytes',
+  'resident_size_bytes',
+  'used_size_bytes',
+  'detail_level',
+  'space_statistics',
+  'type_names',
+].sort();
+
+// Check top level properties
+const actualBriefKeys = Object.keys(heapStatsBrief).sort();
+assert.strictEqual(heapStatsBrief.detail_level, 'brief');
+assert.deepStrictEqual(actualBriefKeys, expectedBriefKeys);
+
+// Check types of top level properties
+assert.strictEqual(typeof heapStatsBrief.committed_size_bytes, 'number');
+assert.strictEqual(typeof heapStatsBrief.resident_size_bytes, 'number');
+assert.strictEqual(typeof heapStatsBrief.used_size_bytes, 'number');
+assert.strictEqual(typeof heapStatsBrief.detail_level, 'string');
+assert.strictEqual(Array.isArray(heapStatsBrief.space_statistics), true);
+assert.strictEqual(Array.isArray(heapStatsBrief.type_names), true);

--- a/test/js/node/test/parallel/test-v8-startup-snapshot-api.js
+++ b/test/js/node/test/parallel/test-v8-startup-snapshot-api.js
@@ -1,0 +1,26 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+const {
+  isBuildingSnapshot,
+  addSerializeCallback,
+  addDeserializeCallback,
+  setDeserializeMainFunction
+} = require('v8').startupSnapshot;
+
+// This test verifies that the v8.startupSnapshot APIs are not available when
+// it is not building snapshot.
+
+assert(!isBuildingSnapshot());
+
+assert.throws(() => addSerializeCallback(() => {}), {
+  code: 'ERR_NOT_BUILDING_SNAPSHOT',
+});
+assert.throws(() => addDeserializeCallback(() => {}), {
+  code: 'ERR_NOT_BUILDING_SNAPSHOT',
+});
+assert.throws(() => setDeserializeMainFunction(() => {}), {
+  code: 'ERR_NOT_BUILDING_SNAPSHOT',
+});

--- a/test/js/node/test/parallel/test-v8-stats.js
+++ b/test/js/node/test/parallel/test-v8-stats.js
@@ -1,0 +1,66 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const v8 = require('v8');
+
+const s = v8.getHeapStatistics();
+const keys = [
+  'does_zap_garbage',
+  'external_memory',
+  'heap_size_limit',
+  'malloced_memory',
+  'number_of_detached_contexts',
+  'number_of_native_contexts',
+  'peak_malloced_memory',
+  'total_allocated_bytes',
+  'total_available_size',
+  'total_global_handles_size',
+  'total_heap_size',
+  'total_heap_size_executable',
+  'total_physical_size',
+  'used_global_handles_size',
+  'used_heap_size'];
+assert.deepStrictEqual(Object.keys(s).sort(), keys);
+keys.forEach(function(key) {
+  assert.strictEqual(typeof s[key], 'number');
+});
+
+
+const heapCodeStatistics = v8.getHeapCodeStatistics();
+const heapCodeStatisticsKeys = [
+  'bytecode_and_metadata_size',
+  'code_and_metadata_size',
+  'cpu_profiler_metadata_size',
+  'external_script_source_size'];
+assert.deepStrictEqual(Object.keys(heapCodeStatistics).sort(),
+                       heapCodeStatisticsKeys);
+heapCodeStatisticsKeys.forEach(function(key) {
+  assert.strictEqual(typeof heapCodeStatistics[key], 'number');
+});
+
+
+const expectedHeapSpaces = [
+  'code_large_object_space',
+  'code_space',
+  'large_object_space',
+  'new_large_object_space',
+  'new_space',
+  'old_space',
+  'read_only_space',
+  'shared_large_object_space',
+  'shared_space',
+  'shared_trusted_large_object_space',
+  'shared_trusted_space',
+  'trusted_large_object_space',
+  'trusted_space',
+];
+const heapSpaceStatistics = v8.getHeapSpaceStatistics();
+const actualHeapSpaceNames = heapSpaceStatistics.map((s) => s.space_name);
+assert.deepStrictEqual(actualHeapSpaceNames.sort(), expectedHeapSpaces.sort());
+heapSpaceStatistics.forEach((heapSpace) => {
+  assert.strictEqual(typeof heapSpace.space_name, 'string');
+  assert.strictEqual(typeof heapSpace.space_size, 'number');
+  assert.strictEqual(typeof heapSpace.space_used_size, 'number');
+  assert.strictEqual(typeof heapSpace.space_available_size, 'number');
+  assert.strictEqual(typeof heapSpace.physical_space_size, 'number');
+});

--- a/test/js/node/test/parallel/test-v8-version-tag.js
+++ b/test/js/node/test/parallel/test-v8-version-tag.js
@@ -1,0 +1,19 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const v8 = require('v8');
+
+const versionTag1 = v8.cachedDataVersionTag();
+assert.strictEqual(typeof versionTag1, 'number');
+assert.strictEqual(v8.cachedDataVersionTag(), versionTag1);
+
+// The value returned by v8.cachedDataVersionTag() is derived from the V8
+// version, command-line flags, and detected CPU features. Test that the value
+// does indeed update when flags are toggled.
+v8.setFlagsFromString('--allow_natives_syntax');
+
+const versionTag2 = v8.cachedDataVersionTag();
+assert.strictEqual(typeof versionTag2, 'number');
+assert.strictEqual(v8.cachedDataVersionTag(), versionTag2);
+
+assert.notStrictEqual(versionTag1, versionTag2);


### PR DESCRIPTION
Four small `node:v8` API gaps, each verified against the node v26.3.0 binary before implementation.

| API | before | now |
|---|---|---|
| `getHeapStatistics()` | 14 keys | node's exact 15 (`total_allocated_bytes` = JSC heapCapacity, a real number) |
| `getHeapSpaceStatistics()` / `getHeapCodeStatistics()` | threw | node's shape with JSC's real totals — see the judgment call below |
| `getCppHeapStatistics()` | missing | validated arg (node's exact `ERR_INVALID_ARG_VALUE` message), empty statistics — node itself reports empty when cppgc holds nothing |
| `cachedDataVersionTag()` | missing | stable uint32 from runtime version + recorded flags; **changes across `setFlagsFromString`**, which the test asserts |
| `setFlagsFromString()` | validate-then-throw | validate-and-record no-op (feeds the version tag) |
| `startupSnapshot` callbacks | NotImplemented | node's exact `ERR_NOT_BUILDING_SNAPSHOT` |

**The one judgment call:** `getHeapSpaceStatistics` must return exactly V8's 13 space names (the test and shape-dependent consumers require them), but JSC has one undivided heap. JSC's real used/capacity numbers are reported under `old_space`; the other twelve names carry zeros. The names are shape, the numbers are real — nothing is fabricated.

**Deliberately skipped:** `writeHeapSnapshot` Buffer/URL paths (PR #34084 already fixes exactly this — duplicating would conflict), `queryObjects` (needs real heap iteration by prototype chain, which JSC doesn't expose — an honest implementation is a new native heap-walk binding), `test-v8-flags` (`%IsSmi` natives syntax) and `test-v8-serdes` (native V8 Serializer classes).

**No overlap** with #34550 (GCProfiler untouched) or #34523 (its `test-v8-flag-type-check.js` passes against this implementation; one trivial import-line adjacency whenever the second lands).

## Verification

All 4 tests byte-identical to upstream, pass on node (ceiling), fail on unpatched bun (control), pass 3× each on this build with the CI invocation. 12 tamper mutations (3 per file), every one fails. Regressions: `test/js/node/v8/` 48/48, `stubs.test.js` 378/378, `v8-heap-snapshot.test.ts` 7/7, all pre-existing vendored v8/worker heap tests green. tsc clean in touched files.
