### PR TITLE
cli: --heap-prof node parity, and fix absolute profile paths panicking (+2 tests)

### DIFF
--- a/docs/project/benchmarking.mdx
+++ b/docs/project/benchmarking.mdx
@@ -261,13 +261,19 @@ bun --cpu-prof --cpu-prof-dir ./profiles script.js
 
 ## Heap profiling
 
-Generate heap snapshots on exit to analyze memory usage and find memory leaks.
+Write a heap profile on exit to analyze memory usage and find memory leaks.
 
 ```sh terminal icon="terminal"
 bun --heap-prof script.js
 ```
 
-`--heap-prof` writes a V8 `.heapsnapshot` file you can load in Chrome DevTools (Memory tab → Load).
+`--heap-prof` writes a `.heapprofile` file using Node.js's filename format
+(`Heap.<yyyymmdd>.<hhmmss>.<pid>.<tid>.<seq>.heapprofile`). JavaScriptCore does not
+sample allocation call stacks, so the profile reports the live heap size on the
+`(root)` frame rather than a per-function allocation tree.
+
+For a full heap snapshot you can load in Chrome DevTools (Memory tab → Load), use
+`v8.writeHeapSnapshot()` or `Bun.generateHeapSnapshot("v8")` instead.
 
 ### Markdown output
 
@@ -282,13 +288,14 @@ bun --heap-prof-md script.js
 ### Options
 
 ```sh terminal icon="terminal"
-bun --heap-prof --heap-prof-name my-snapshot.heapsnapshot script.js
+bun --heap-prof --heap-prof-name my-profile.heapprofile script.js
 bun --heap-prof --heap-prof-dir ./profiles script.js
 ```
 
-| Flag                          | Description                                |
-| ----------------------------- | ------------------------------------------ |
-| `--heap-prof`                 | Generate a V8 `.heapsnapshot` file on exit |
-| `--heap-prof-md`              | Generate a markdown heap profile on exit   |
-| `--heap-prof-name <filename>` | Set output filename                        |
-| `--heap-prof-dir <dir>`       | Set output directory                       |
+| Flag                           | Description                                                  |
+| ------------------------------ | ------------------------------------------------------------ |
+| `--heap-prof`                  | Write a `.heapprofile` file on exit                          |
+| `--heap-prof-md`               | Generate a markdown heap profile on exit                     |
+| `--heap-prof-name <filename>`  | Set output filename                                          |
+| `--heap-prof-dir <dir>`        | Set output directory                                         |
+| `--heap-prof-interval <bytes>` | Accepted for Node.js compatibility (sampling is unsupported) |

--- a/src/jsc/BunCPUProfiler.rs
+++ b/src/jsc/BunCPUProfiler.rs
@@ -184,8 +184,9 @@ fn build_output_path(
         path.join(&[config.dir]).expect("unreachable");
     }
 
-    // Append filename
-    path.append(filename).expect("unreachable");
+    // Join filename; `join` resolves an absolute --cpu-prof-name where
+    // `append` asserts on it.
+    path.join(&[filename]).expect("unreachable");
 
     Ok(())
 }
@@ -220,7 +221,7 @@ fn generate_default_filename(
 }
 
 #[cfg(not(windows))]
-fn local_time_now() -> (i32, u32, u32, u32, u32, u32) {
+pub(crate) fn local_time_now() -> (i32, u32, u32, u32, u32, u32) {
     let secs = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_or(0, |d| d.as_secs()) as libc::time_t;
@@ -238,7 +239,7 @@ fn local_time_now() -> (i32, u32, u32, u32, u32, u32) {
 }
 
 #[cfg(windows)]
-fn local_time_now() -> (i32, u32, u32, u32, u32, u32) {
+pub(crate) fn local_time_now() -> (i32, u32, u32, u32, u32, u32) {
     #[repr(C)]
     #[derive(Default)]
     struct SystemTime {

--- a/src/jsc/BunHeapProfiler.rs
+++ b/src/jsc/BunHeapProfiler.rs
@@ -1,5 +1,5 @@
 use crate::CrateError as Error;
-use bun_core::{Output, Timespec, TimespecMockMode};
+use bun_core::Output;
 use bun_core::{OwnedString, String as BunString};
 use bun_paths::{AutoAbsPath, PathBuffer, resolve_path};
 use bun_sys::{self as sys, E, Fd, FdDirExt};
@@ -19,7 +19,7 @@ unsafe extern "C" {
     // safe: `VM` is an opaque `UnsafeCell`-backed ZST handle; `&mut VM` is ABI-identical
     // to a non-null `*mut VM` and C++ mutation is interior to the opaque cell.
     safe fn Bun__generateHeapProfile(vm: &mut VM) -> BunString;
-    safe fn Bun__generateHeapSnapshotV8(vm: &mut VM) -> BunString;
+    safe fn Bun__generateHeapProfileV8Sampling(vm: &mut VM) -> BunString;
 }
 
 pub fn generate_and_write_profile(vm: &mut VM, config: &HeapProfilerConfig) -> Result<(), Error> {
@@ -28,7 +28,7 @@ pub fn generate_and_write_profile(vm: &mut VM, config: &HeapProfilerConfig) -> R
     let profile_string = OwnedString::new(if config.text_format {
         Bun__generateHeapProfile(vm)
     } else {
-        Bun__generateHeapSnapshotV8(vm)
+        Bun__generateHeapProfileV8Sampling(vm)
     });
 
     if profile_string.is_empty() {
@@ -87,12 +87,15 @@ pub fn generate_and_write_profile(vm: &mut VM, config: &HeapProfilerConfig) -> R
         }
     }
 
-    // Print message to stderr to let user know where the profile was written
-    bun_core::pretty_errorln!(
-        "Heap profile written to: {}",
-        bstr::BStr::new(path_buf.slice())
-    );
-    Output::flush();
+    // Print where the markdown profile was written; node parity for the
+    // .heapprofile format is silence on success.
+    if config.text_format {
+        bun_core::pretty_errorln!(
+            "Heap profile written to: {}",
+            bstr::BStr::new(path_buf.slice())
+        );
+        Output::flush();
+    }
     Ok(())
 }
 
@@ -105,36 +108,30 @@ fn build_output_path(path: &mut AutoAbsPath, config: &HeapProfilerConfig) -> Res
         generate_default_filename(&mut filename_buf, config.text_format)?
     };
 
-    // Append directory if specified
+    // Join directory and filename; `join` resolves absolute segments where
+    // `append` asserts on them (node accepts absolute --heap-prof-dir/-name).
     if !config.dir.is_empty() {
-        path.append(config.dir)?;
+        path.join(&[config.dir])?;
     }
-
-    // Append filename
-    path.append(filename)?;
+    path.join(&[filename])?;
     Ok(())
 }
 
 fn generate_default_filename(buf: &mut PathBuffer, text_format: bool) -> Result<&[u8], Error> {
-    // Generate filename like:
-    // - Markdown format: Heap.{timestamp}.{pid}.md
-    // - V8 format: Heap.{timestamp}.{pid}.heapsnapshot
-    let timespec = Timespec::now(TimespecMockMode::ForceRealTime);
+    // Node's DiagnosticFilename format (local time, main-thread tid 0, 3-digit
+    // per-process sequence): Heap.<yyyymmdd>.<hhmmss>.<pid>.<tid>.<seq>.heapprofile
     #[cfg(windows)]
     let pid: core::ffi::c_uint = bun_sys::windows::GetCurrentProcessId();
     #[cfg(not(windows))]
     // SAFETY: getpid() is always safe to call.
     let pid: core::ffi::c_int = unsafe { libc::getpid() };
 
-    let epoch_microseconds: u64 = u64::try_from(
-        timespec
-            .sec
-            .wrapping_mul(1_000_000)
-            .wrapping_add(timespec.nsec / 1000),
-    )
-    .unwrap();
+    let (year, month, day, hour, minute, second) = crate::bun_cpu_profiler::local_time_now();
 
-    let extension: &str = if text_format { "md" } else { "heapsnapshot" };
+    static SEQ: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
+    let seq = SEQ.fetch_add(1, core::sync::atomic::Ordering::Relaxed) + 1;
+
+    let extension: &str = if text_format { ".md" } else { ".heapprofile" };
 
     // Write into the fixed buffer, then return the written slice
     use std::io::Write;
@@ -143,8 +140,7 @@ fn generate_default_filename(buf: &mut PathBuffer, text_format: bool) -> Result<
     let mut cursor: &mut [u8] = buf_slice;
     write!(
         &mut cursor,
-        "Heap.{}.{}.{}",
-        epoch_microseconds, pid, extension
+        "Heap.{year:04}{month:02}{day:02}.{hour:02}{minute:02}{second:02}.{pid}.0.{seq:03}{extension}"
     )
     .map_err(|_| crate::CrateError::Sys(bun_errno::SystemErrno::ENOSPC))?;
     let remaining = cursor.len();

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -469,10 +469,10 @@ impl VMHolder {
     }
 
     /// Node parity: `process.kill(self, sig)` with no JS handler for `sig`
-    /// flushes the CPU profile before sending the (likely fatal) signal,
-    /// mirroring node's `Kill` binding. Idempotent via `Option::take`.
+    /// flushes the CPU and heap profiles before sending the (likely fatal)
+    /// signal, mirroring node's `Kill` binding. Idempotent via `Option::take`.
     #[unsafe(no_mangle)]
-    pub(crate) extern "C" fn Bun__writeCPUProfileBeforeSelfKill() {
+    pub(crate) extern "C" fn Bun__writeProfilesBeforeSelfKill() {
         let Some(vm_ptr) = VM.get() else { return };
         // SAFETY: called on the JS thread that owns this VM (process._kill).
         let vm = unsafe { &mut *vm_ptr };
@@ -481,6 +481,13 @@ impl VMHolder {
                 crate::bun_cpu_profiler::stop_and_write_profile(vm.jsc_vm_mut(), &config)
             {
                 bun_core::Output::err(<&'static str>::from(e), "Failed to write CPU profile", ());
+            }
+        }
+        if let Some(config) = vm.heap_profiler_config.take() {
+            if let Err(e) =
+                crate::bun_heap_profiler::generate_and_write_profile(vm.jsc_vm_mut(), &config)
+            {
+                bun_core::Output::err(e, "Failed to write heap profile", ());
             }
         }
     }

--- a/src/jsc/bindings/BunHeapProfiler.cpp
+++ b/src/jsc/bindings/BunHeapProfiler.cpp
@@ -936,14 +936,16 @@ WTF::String generateHeapProfile(JSC::VM& vm)
     return output.toString();
 }
 
-WTF::String generateHeapSnapshotV8(JSC::VM& vm)
+WTF::String generateHeapProfileV8Sampling(JSC::VM& vm)
 {
-    vm.ensureHeapProfiler();
-    auto& heapProfiler = *vm.heapProfiler();
-    heapProfiler.clearSnapshots();
-
-    JSC::BunV8HeapSnapshotBuilder builder(heapProfiler);
-    return builder.json();
+    // JSC has no allocation-site sampling, so live bytes cannot be attributed
+    // to allocating call frames. Report the real live-heap size on the (root)
+    // frame — the node V8 uses for unattributable allocations — no samples.
+    WTF::StringBuilder output;
+    output.append("{\"head\":{\"callFrame\":{\"functionName\":\"(root)\",\"scriptId\":\"0\",\"url\":\"\",\"lineNumber\":-1,\"columnNumber\":-1},\"selfSize\":"_s);
+    output.append(WTF::String::number(vm.heap.size()));
+    output.append(",\"id\":1,\"children\":[]},\"samples\":[]}"_s);
+    return output.toString();
 }
 
 } // namespace Bun
@@ -954,8 +956,8 @@ extern "C" BunString Bun__generateHeapProfile(JSC::VM* vm)
     return Bun::toStringRef(result);
 }
 
-extern "C" BunString Bun__generateHeapSnapshotV8(JSC::VM* vm)
+extern "C" BunString Bun__generateHeapProfileV8Sampling(JSC::VM* vm)
 {
-    WTF::String result = Bun::generateHeapSnapshotV8(*vm);
+    WTF::String result = Bun::generateHeapProfileV8Sampling(*vm);
     return Bun::toStringRef(result);
 }

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -134,7 +134,7 @@ typedef int mode_t;
 extern "C" bool Bun__Node__ProcessNoDeprecation;
 extern "C" bool Bun__Node__ProcessThrowDeprecation;
 extern "C" bool Bun__Node__ProcessPendingDeprecation;
-extern "C" void Bun__writeCPUProfileBeforeSelfKill();
+extern "C" void Bun__writeProfilesBeforeSelfKill();
 extern "C" int32_t bun_stdio_tty[3];
 
 namespace Bun {
@@ -4302,11 +4302,11 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionReallyKill, (JSC::JSGlobalObject * glob
     int ownPid = uv_os_getpid();
 #endif
     // Node parity: a self-directed signal with no JS handler will most likely
-    // terminate this process, so flush the CPU profile first (node's Kill
-    // binding runs RunAtExit in this case).
+    // terminate this process, so flush the CPU/heap profiles first (node's
+    // Kill binding runs RunAtExit in this case).
     if (signal > 0 && (pid == 0 || pid == -1 || pid == ownPid || pid == -ownPid)
         && !(signalToContextIdsMap && signalToContextIdsMap->contains(signal))) {
-        Bun__writeCPUProfileBeforeSelfKill();
+        Bun__writeProfilesBeforeSelfKill();
     }
 
 #if !OS(WINDOWS)

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -220,7 +220,7 @@ pub(crate) const RUNTIME_PARAMS_: &[ParamType] = &[
         "--cpu-prof-interval <STR>         Specify the sampling interval in microseconds for CPU profiling (default: 1000)"
     ),
     parse_param!(
-        "--heap-prof                       Generate V8 heap snapshot on exit (.heapsnapshot)"
+        "--heap-prof                       Write a heap profile to disk on exit (.heapprofile)"
     ),
     parse_param!("--heap-prof-name <STR>            Specify the name of the heap profile file"),
     parse_param!(
@@ -228,6 +228,9 @@ pub(crate) const RUNTIME_PARAMS_: &[ParamType] = &[
     ),
     parse_param!(
         "--heap-prof-md                    Generate markdown heap profile on exit (for CLI analysis)"
+    ),
+    parse_param!(
+        "--heap-prof-interval <STR>        Specify the average sampling interval in bytes for heap profiling (default: 524288)"
     ),
     parse_param!(
         "--if-present                      Exit without an error if the entrypoint does not exist"
@@ -1290,6 +1293,8 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
                 ctx.runtime_options.heap_prof.dir = dir.into();
             }
         } else if heap_prof_v8 || heap_prof_md {
+            // --heap-prof-interval is accepted for node CLI parity but unused:
+            // JSC has no allocation-site sampler to configure.
             ctx.runtime_options.heap_prof.enabled = true;
             ctx.runtime_options.heap_prof.text_format = heap_prof_md;
             if let Some(name) = args.option(b"--heap-prof-name") {
@@ -1299,16 +1304,32 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
                 ctx.runtime_options.heap_prof.dir = dir.into();
             }
         } else {
-            // Warn if --heap-prof-name or --heap-prof-dir is used without --heap-prof or --heap-prof-md
+            // Node parity: heap-profiler-scoped options without a profiler flag
+            // exit 9, like the --cpu-prof block above. The default interval
+            // value (512 KiB) is a noop, like node.
+            let mut bad_flags: [Option<&str>; 3] = [None, None, None];
             if args.option(b"--heap-prof-name").is_some() {
-                bun_core::warn!(
-                    "--heap-prof-name requires --heap-prof or --heap-prof-md to be enabled",
-                );
+                bad_flags[0] = Some("--heap-prof-name");
             }
             if args.option(b"--heap-prof-dir").is_some() {
-                bun_core::warn!(
-                    "--heap-prof-dir requires --heap-prof or --heap-prof-md to be enabled",
-                );
+                bad_flags[1] = Some("--heap-prof-dir");
+            }
+            if let Some(interval_str) = args.option(b"--heap-prof-interval") {
+                if strings::parse_int::<u32>(interval_str, 10).unwrap_or(0) != 512 * 1024 {
+                    bad_flags[2] = Some("--heap-prof-interval");
+                }
+            }
+            if bad_flags.iter().any(Option::is_some) {
+                let argv0 = bun_core::argv().get(0).unwrap_or(bun_core::zstr!("bun"));
+                for flag in bad_flags.into_iter().flatten() {
+                    bun_core::pretty_errorln!(
+                        "{}: {} must be used with --heap-prof",
+                        BStr::new(argv0.as_bytes()),
+                        flag
+                    );
+                }
+                Output::flush();
+                Global::exit(9);
             }
         }
 

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -280,9 +280,7 @@ pub(crate) const RUNTIME_PARAMS_: &[ParamType] = &[
     parse_param!(
         "--throw-deprecation               Determine whether or not deprecation warnings result in errors."
     ),
-    parse_param!(
-        "--pending-deprecation             Emit pending deprecation warnings."
-    ),
+    parse_param!("--pending-deprecation             Emit pending deprecation warnings."),
     parse_param!("--title <STR>                     Set the process title"),
     parse_param!(
         "--zero-fill-buffers                Boolean to force Buffer.allocUnsafe(size) to be zero-filled."
@@ -1345,8 +1343,7 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
         if args.flag(b"--pending-deprecation")
             || env_var::NODE_PENDING_DEPRECATION.get() == Some(b"1" as &[u8])
         {
-            Bun__Node__ProcessPendingDeprecation
-                .store(true, core::sync::atomic::Ordering::Relaxed);
+            Bun__Node__ProcessPendingDeprecation.store(true, core::sync::atomic::Ordering::Relaxed);
         }
         if let Some(title) = args.option(b"--title") {
             // Static is `Mutex<Option<Box<[u8]>>>` so `process.title = "..."`

--- a/test/cli/heap-prof.test.ts
+++ b/test/cli/heap-prof.test.ts
@@ -4,7 +4,31 @@ import { join } from "path";
 
 const testScript = `const arr = []; for (let i = 0; i < 100; i++) arr.push({ x: i, y: "hello" + i }); console.log("done");`;
 
-test("--heap-prof generates V8 heap snapshot on exit", async () => {
+// Node's DiagnosticFilename format: Heap.<yyyymmdd>.<hhmmss>.<pid>.<tid>.<seq>.heapprofile
+const nodeFilenameRe = /^Heap\.\d{8}\.\d{6}\.\d+\.0\.\d{3}\.heapprofile$/;
+
+async function readProfile(dir: string, file: string) {
+  const content = await Bun.file(join(dir, file)).text();
+  return JSON.parse(content);
+}
+
+function expectV8SamplingProfileShape(profile: any) {
+  // V8 sampling heap profile: { head: { callFrame, selfSize, id, children }, samples }
+  expect(profile).toHaveProperty("head");
+  expect(profile).toHaveProperty("samples");
+  expect(profile.head.callFrame).toEqual({
+    functionName: "(root)",
+    scriptId: "0",
+    url: "",
+    lineNumber: -1,
+    columnNumber: -1,
+  });
+  expect(typeof profile.head.selfSize).toBe("number");
+  expect(Array.isArray(profile.head.children)).toBe(true);
+  expect(Array.isArray(profile.samples)).toBe(true);
+}
+
+test("--heap-prof writes a .heapprofile with node's filename format on exit", async () => {
   using dir = tempDir("heap-prof-v8-test", {});
 
   await using proc = Bun.spawn({
@@ -15,28 +39,67 @@ test("--heap-prof generates V8 heap snapshot on exit", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
   expect(stdout.trim()).toBe("done");
-  expect(stderr).toContain("Heap profile written to:");
   expect(exitCode).toBe(0);
 
-  // Find the heap snapshot file (V8 format)
-  const glob = new Bun.Glob("Heap.*.heapsnapshot");
+  const glob = new Bun.Glob("*.heapprofile");
   const files = Array.from(glob.scanSync({ cwd: String(dir) }));
-  expect(files.length).toBeGreaterThan(0);
+  expect(files.length).toBe(1);
+  expect(files[0]).toMatch(nodeFilenameRe);
 
-  // Read and validate the heap snapshot content (should be valid JSON in V8 format)
-  const profilePath = join(String(dir), files[0]);
-  const content = await Bun.file(profilePath).text();
-
-  // V8 heap snapshot format is JSON with specific structure
-  const snapshot = JSON.parse(content);
-  expect(snapshot).toHaveProperty("snapshot");
-  expect(snapshot).toHaveProperty("nodes");
-  expect(snapshot).toHaveProperty("edges");
-  expect(snapshot).toHaveProperty("strings");
+  const profile = await readProfile(String(dir), files[0]);
+  expectV8SamplingProfileShape(profile);
+  // The live-heap size is real, so it is never zero.
+  expect(profile.head.selfSize).toBeGreaterThan(0);
 });
+
+test("--heap-prof writes the profile when the script calls process.exit", async () => {
+  using dir = tempDir("heap-prof-exit-test", {});
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--heap-prof", "-e", `process.exit(55);`],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const exitCode = await proc.exited;
+  expect(exitCode).toBe(55);
+
+  const glob = new Bun.Glob("*.heapprofile");
+  const files = Array.from(glob.scanSync({ cwd: String(dir) }));
+  expect(files.length).toBe(1);
+  const profile = await readProfile(String(dir), files[0]);
+  expectV8SamplingProfileShape(profile);
+});
+
+test.skipIf(process.platform === "win32")(
+  "--heap-prof writes the profile on a self-directed SIGINT with no JS handler",
+  async () => {
+    using dir = tempDir("heap-prof-sigint-test", {});
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--heap-prof", "-e", `process.kill(process.pid, "SIGINT");`],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const exitCode = await proc.exited;
+    expect(proc.signalCode).toBe("SIGINT");
+    expect(exitCode).not.toBe(0);
+
+    const glob = new Bun.Glob("*.heapprofile");
+    const files = Array.from(glob.scanSync({ cwd: String(dir) }));
+    expect(files.length).toBe(1);
+    const profile = await readProfile(String(dir), files[0]);
+    expectV8SamplingProfileShape(profile);
+  },
+);
 
 test("--heap-prof-md generates markdown heap profile on exit", async () => {
   using dir = tempDir("heap-prof-md-test", {});
@@ -99,7 +162,7 @@ test("--heap-prof-md generates markdown heap profile on exit", async () => {
   expect(content).toContain("| Type | Count | Self Size | Retained Size | Largest ID |");
 });
 
-test("--heap-prof-dir specifies output directory for V8 format", async () => {
+test("--heap-prof-dir specifies the output directory", async () => {
   using dir = tempDir("heap-prof-dir-test", {
     "profiles": {},
   });
@@ -112,18 +175,15 @@ test("--heap-prof-dir specifies output directory for V8 format", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
   expect(stdout.trim()).toBe("hello");
-  expect(stderr).toContain("Heap profile written to:");
-  // Check for "profiles" directory in path (handles both / and \ separators)
-  expect(stderr).toMatch(/profiles[/\\]/);
   expect(exitCode).toBe(0);
 
-  // Check the profile is in the specified directory
-  const glob = new Bun.Glob("Heap.*.heapsnapshot");
+  const glob = new Bun.Glob("*.heapprofile");
   const files = Array.from(glob.scanSync({ cwd: join(String(dir), "profiles") }));
-  expect(files.length).toBeGreaterThan(0);
+  expect(files.length).toBe(1);
+  expect(files[0]).toMatch(nodeFilenameRe);
 });
 
 test("--heap-prof-dir specifies output directory for markdown format", async () => {
@@ -157,23 +217,20 @@ test("--heap-prof-name specifies output filename", async () => {
   using dir = tempDir("heap-prof-name-test", {});
 
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "--heap-prof", "--heap-prof-name", "my-profile.heapsnapshot", "-e", `console.log("hello");`],
+    cmd: [bunExe(), "--heap-prof", "--heap-prof-name", "my-profile.heapprofile", "-e", `console.log("hello");`],
     cwd: String(dir),
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
   expect(stdout.trim()).toBe("hello");
-  expect(stderr).toContain("Heap profile written to:");
-  expect(stderr).toContain("my-profile.heapsnapshot");
   expect(exitCode).toBe(0);
 
-  // Check the profile exists with the specified name
-  const profilePath = join(String(dir), "my-profile.heapsnapshot");
-  expect(Bun.file(profilePath).size).toBeGreaterThan(0);
+  const profile = await readProfile(String(dir), "my-profile.heapprofile");
+  expectV8SamplingProfileShape(profile);
 });
 
 test("--heap-prof-name and --heap-prof-dir work together", async () => {
@@ -188,7 +245,7 @@ test("--heap-prof-name and --heap-prof-dir work together", async () => {
       "--heap-prof-dir",
       "output",
       "--heap-prof-name",
-      "custom.heapsnapshot",
+      "custom.heapprofile",
       "-e",
       `console.log("hello");`,
     ],
@@ -198,36 +255,80 @@ test("--heap-prof-name and --heap-prof-dir work together", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
   expect(stdout.trim()).toBe("hello");
-  expect(stderr).toContain("Heap profile written to:");
   expect(exitCode).toBe(0);
 
-  // Check the profile exists in the specified location
-  const profilePath = join(String(dir), "output", "custom.heapsnapshot");
-  expect(Bun.file(profilePath).size).toBeGreaterThan(0);
+  const profile = await readProfile(join(String(dir), "output"), "custom.heapprofile");
+  expectV8SamplingProfileShape(profile);
 });
 
-test("--heap-prof-name without --heap-prof or --heap-prof-md shows warning", async () => {
-  using dir = tempDir("heap-prof-warn-test", {});
+// Node parity: heap-profiler-scoped flags without --heap-prof exit 9 with
+// "<execPath>: <flag> must be used with --heap-prof" on stderr.
+for (const [flag, value] of [
+  ["--heap-prof-name", "test.heapprofile"],
+  ["--heap-prof-dir", "prof"],
+  ["--heap-prof-interval", "128"],
+] as const) {
+  test(`${flag} without --heap-prof exits 9 with node's message`, async () => {
+    using dir = tempDir("heap-prof-invalid-test", {});
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), flag, value, "-e", `console.log("hello");`],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("");
+    expect(stderr.trim()).toBe(`${bunExe()}: ${flag} must be used with --heap-prof`);
+    expect(exitCode).toBe(9);
+
+    // No profile should be generated
+    const glob = new Bun.Glob("*.heap*");
+    const files = Array.from(glob.scanSync({ cwd: String(dir) }));
+    expect(files.length).toBe(0);
+  });
+}
+
+test("--heap-prof-interval equal to the default is a noop without --heap-prof, like node", async () => {
+  using dir = tempDir("heap-prof-interval-noop-test", {});
 
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "--heap-prof-name", "test.heapsnapshot", "-e", `console.log("hello");`],
+    cmd: [bunExe(), "--heap-prof-interval", "524288", "-e", `console.log("hello");`],
     cwd: String(dir),
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
   expect(stdout.trim()).toBe("hello");
-  expect(stderr).toContain("--heap-prof-name requires --heap-prof or --heap-prof-md to be enabled");
+  expect(exitCode).toBe(0);
+});
+
+test("--heap-prof --heap-prof-interval is accepted", async () => {
+  using dir = tempDir("heap-prof-interval-test", {});
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--heap-prof", "--heap-prof-interval", "128", "-e", `console.log("hello");`],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("hello");
   expect(exitCode).toBe(0);
 
-  // No profile should be generated
-  const glob = new Bun.Glob("*.heap*");
+  const glob = new Bun.Glob("*.heapprofile");
   const files = Array.from(glob.scanSync({ cwd: String(dir) }));
-  expect(files.length).toBe(0);
+  expect(files.length).toBe(1);
 });

--- a/test/js/node/test/parallel/test-heap-prof-basic.js
+++ b/test/js/node/test/parallel/test-heap-prof-basic.js
@@ -1,0 +1,37 @@
+'use strict';
+
+// Tests --heap-prof without --heap-prof-interval. Here we just verify that
+// we manage to generate a profile.
+
+const common = require('../common');
+
+const fixtures = require('../common/fixtures');
+common.skipIfInspectorDisabled();
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+const tmpdir = require('../common/tmpdir');
+
+const {
+  getHeapProfiles,
+  env
+} = require('../common/prof');
+
+{
+  tmpdir.refresh();
+  const output = spawnSync(process.execPath, [
+    '--heap-prof',
+    fixtures.path('workload', 'allocation.js'),
+  ], {
+    cwd: tmpdir.path,
+    env
+  });
+  if (output.status !== 0) {
+    console.log(output.stderr.toString());
+    console.log(output);
+  }
+  assert.strictEqual(output.status, 0);
+  const profiles = getHeapProfiles(tmpdir.path);
+  assert.strictEqual(profiles.length, 1);
+}

--- a/test/js/node/test/parallel/test-heap-prof-invalid-args.js
+++ b/test/js/node/test/parallel/test-heap-prof-invalid-args.js
@@ -1,0 +1,82 @@
+'use strict';
+
+// Tests invalid --heap-prof CLI arguments.
+
+const common = require('../common');
+
+const fixtures = require('../common/fixtures');
+common.skipIfInspectorDisabled();
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+const tmpdir = require('../common/tmpdir');
+
+const {
+  kHeapProfInterval,
+  env
+} = require('../common/prof');
+
+// Tests --heap-prof-name without --heap-prof.
+{
+  tmpdir.refresh();
+  const output = spawnSync(process.execPath, [
+    '--heap-prof-name',
+    'test.heapprofile',
+    fixtures.path('workload', 'allocation.js'),
+  ], {
+    cwd: tmpdir.path,
+    env
+  });
+  const stderr = output.stderr.toString().trim();
+  if (output.status !== 9) {
+    console.log(stderr);
+  }
+  assert.strictEqual(output.status, 9);
+  assert.strictEqual(
+    stderr,
+    `${process.execPath}: --heap-prof-name must be used with --heap-prof`);
+}
+
+// Tests --heap-prof-dir without --heap-prof.
+{
+  tmpdir.refresh();
+  const output = spawnSync(process.execPath, [
+    '--heap-prof-dir',
+    'prof',
+    fixtures.path('workload', 'allocation.js'),
+  ], {
+    cwd: tmpdir.path,
+    env
+  });
+  const stderr = output.stderr.toString().trim();
+  if (output.status !== 9) {
+    console.log(stderr);
+  }
+  assert.strictEqual(output.status, 9);
+  assert.strictEqual(
+    stderr,
+    `${process.execPath}: --heap-prof-dir must be used with --heap-prof`);
+}
+
+// Tests --heap-prof-interval without --heap-prof.
+{
+  tmpdir.refresh();
+  const output = spawnSync(process.execPath, [
+    '--heap-prof-interval',
+    kHeapProfInterval,
+    fixtures.path('workload', 'allocation.js'),
+  ], {
+    cwd: tmpdir.path,
+    env
+  });
+  const stderr = output.stderr.toString().trim();
+  if (output.status !== 9) {
+    console.log(stderr);
+  }
+  assert.strictEqual(output.status, 9);
+  assert.strictEqual(
+    stderr,
+    `${process.execPath}: ` +
+    '--heap-prof-interval must be used with --heap-prof');
+}


### PR DESCRIPTION
Extends the cpu-prof CLI parity on the base branch to `--heap-prof`, and fixes a real crash. Stacked on #34660.

## The honest ceiling, established first

JSC has **no allocation-sampling profiler**. `HeapProfiler.h` in the prebuilt WebKit is snapshots-only, `SamplingProfiler.h` is CPU stack sampling, and `nm libJavaScriptCore.a` exports no sampling-heap symbols. A generated bun heap snapshot carries `trace_function_infos: []` — zero allocation-site data exists anywhere.

Node's `.heapprofile` (measured on the v26.3.0 binary) has real V8-attributed call frames even for `-e '0'`, and **9 of the 11 upstream tests assert a `runAllocation` frame in the tree**. That cannot be produced honestly, so those 9 stay unconverted — the profile bun writes reports the real live-heap size on the `(root)` frame with no synthetic frames, which is V8's own shape for unattributed allocations.

## What's here

- `--heap-prof-interval` registered as value-taking (previously `128` parsed as the script name — verified); name/dir/interval without `--heap-prof` exit 9 with node's exact message, mirroring the base branch's cpu-prof block; default-interval noop like node.
- Node's `Heap.<yyyymmdd>.<hhmmss>.<pid>.0.<seq>.heapprofile` filename in local time — the old name had the same non-wall-clock `Timespec` bug the CPU side fixed (it produced `Heap.1540804227270…`).
- Flush on `process.exit` and self-directed fatal signals via the hook the cpu profiler already uses (`Bun__writeCPUProfileBeforeSelfKill` → `Bun__writeProfilesBeforeSelfKill`).
- `.heapsnapshot` capability preserved via `v8.writeHeapSnapshot` / `Bun.generateHeapSnapshot("v8")` (smoke-tested).

## Real crash fixed

An **absolute** `--heap-prof-dir`, `--heap-prof-name` — or `--cpu-prof-name`, already shipped on the base branch — hit `assertion failed: !is_input_absolute` in `AutoAbsPath::append` and died with exit 134. Both writers now join resolve-style. Verified: absolute paths write the profile and exit 0.

## Tests

`test-heap-prof-basic` and `test-heap-prof-invalid-args`, verbatim, node-ceiling-checked, 3× green, failing on system bun as control, tamper-checked. The 9 unconvertible files fail *only* on `verifyFrames('runAllocation')` — exit codes, dir creation, and SIGINT/exit-55 flush all work.

Regressions: `cpu-prof.test.ts` 9/9, the base branch's 6 vendored cpu-prof tests green, `test/js/node/process` unchanged, v8 heap-snapshot smoke OK. `cargo check` clean on windows-msvc and linux-gnu targets. Bun-side `test/cli/heap-prof.test.ts` rewritten for the new behavior (13 pass).
