### PR TITLE
process: boot from a deleted cwd, throw node's ENOENT from process.cwd() (+4 tests)

### DIFF
--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -4343,6 +4343,34 @@ pub fn intern_argv(v: Vec<&'static ZStr>) -> &'static [&'static ZStr] {
 /// Writes the current working directory into the caller's `PathBuffer` and
 /// returns the NUL-terminated slice on success.
 pub fn getcwd(buf: &mut PathBuffer) -> crate::CrateResult<&ZStr> {
+    let len = getcwd_len(buf)?;
+    Ok(ZStr::from_buf(&buf.0, len))
+}
+
+/// `getcwd` tolerating an unreachable cwd (e.g. deleted while we run): falls
+/// back to the executable's directory like Node's `Environment::GetCwd`, so
+/// startup proceeds and `process.cwd()` surfaces the real error later.
+pub fn getcwd_or_exe_dir(buf: &mut PathBuffer) -> &ZStr {
+    let len = match getcwd_len(buf) {
+        Ok(n) => n,
+        Err(_) => {
+            let dir: &[u8] = self_exe_path()
+                .ok()
+                .and_then(|p| dirname(p.as_bytes()))
+                // Reject a dir that can't fit with its NUL (paths from
+                // /proc/self/exe are not bounded by MAX_PATH_BYTES).
+                .filter(|d| d.len() < buf.0.len())
+                .unwrap_or(if cfg!(windows) { b"C:\\" } else { b"/" });
+            buf.0[..dir.len()].copy_from_slice(dir);
+            buf.0[dir.len()] = 0;
+            dir.len()
+        }
+    };
+    ZStr::from_buf(&buf.0, len)
+}
+
+/// Length-returning core of [`getcwd`]; `buf` holds the NUL-terminated path.
+fn getcwd_len(buf: &mut PathBuffer) -> crate::CrateResult<usize> {
     #[cfg(unix)]
     // SAFETY: `buf` provides `MAX_PATH_BYTES` writable bytes for `getcwd`; on
     // success the returned pointer aliases `buf` and is NUL-terminated, so
@@ -4352,8 +4380,7 @@ pub fn getcwd(buf: &mut PathBuffer) -> crate::CrateResult<&ZStr> {
         if p.is_null() {
             return Err(crate::CrateError::Unexpected);
         }
-        let len = libc::strlen(p);
-        Ok(ZStr::from_buf(&buf.0, len))
+        Ok(libc::strlen(p))
     }
     #[cfg(windows)]
     {
@@ -4389,7 +4416,7 @@ pub fn getcwd(buf: &mut PathBuffer) -> crate::CrateResult<&ZStr> {
             bi += nb;
         }
         out[bi] = 0;
-        Ok(ZStr::from_buf(&buf.0[..], bi))
+        Ok(bi)
     }
     #[cfg(not(any(unix, windows)))]
     {

--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -403,7 +403,10 @@ function WriteStream(this: FSStream, path: string | null, options?: any): void {
   if (fd == null) {
     this[kFs] = customFs || fs;
     this.fd = null;
-    this.path = getValidatedPath(path);
+    // Internal $fastPath callers (writableFromFileSink) discard .path; do not
+    // resolve it - path.resolve("") needs process.cwd(), which throws when
+    // the cwd has been deleted (Node still spawns children in that state).
+    this.path = fastPath ? path : getValidatedPath(path);
     const { flags, mode } = options;
     this.flags = flags === undefined ? "w" : flags;
     this.mode = mode === undefined ? 0o666 : mode;

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1002,7 +1002,9 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionChdir, (JSC::JSGlobalObject * globalObj
     RETURN_IF_EXCEPTION(scope, {});
 
     auto* processObject = defaultGlobalObject(globalObject)->processObject();
-    processObject->setCachedCwd(vm, result.toStringOrNull(globalObject));
+    // Node clears its cwd cache on chdir (does_own_process_state.js) and lets
+    // the next process.cwd() re-query the OS - do not re-populate it here.
+    processObject->clearCachedCwd();
     RELEASE_AND_RETURN(scope, JSC::JSValue::encode(result));
 }
 

--- a/src/jsc/bindings/BunProcess.h
+++ b/src/jsc/bindings/BunProcess.h
@@ -75,6 +75,7 @@ public:
 
     JSString* cachedCwd() { return m_cachedCwd.get(); }
     void setCachedCwd(JSC::VM& vm, JSString* cwd) { m_cachedCwd.set(vm, this, cwd); }
+    void clearCachedCwd() { m_cachedCwd.clear(); }
 
     JSValue getArgv(JSGlobalObject* globalObject);
     void setArgv(JSGlobalObject* globalObject, JSValue argv);

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -317,6 +317,9 @@ pub(crate) const RUNTIME_PARAMS_: &[ParamType] = &[
     parse_param!("--trace-exit"),
     parse_param!("--expose-internals"),
     parse_param!("--stack-trace-limit <STR>"),
+    // `node --interactive` compat: `Command::which()` routes it to the REPL;
+    // declared (hidden) so `Arguments.parse` under the run table accepts it.
+    parse_param!("--interactive"),
 ];
 
 pub(crate) const AUTO_OR_RUN_PARAMS: &[ParamType] = &[
@@ -771,8 +774,15 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
     // so we dupe into a plain `Box<[u8]>`.
     let cwd: Box<[u8]> = if let Some(cwd_arg) = args.option(b"--cwd") {
         let mut outbuf = PathBuffer::uninit();
-        let cwd_len = bun_sys::getcwd(&mut *outbuf)?;
-        let out = resolve_path::join_abs::<platform::Loose>(&outbuf[..cwd_len], cwd_arg);
+        // An absolute --cwd needs no base; a relative one still requires a
+        // live cwd (an exe-dir base would silently chdir somewhere else).
+        let base: &[u8] = if bun_paths::is_absolute(cwd_arg) {
+            b"/"
+        } else {
+            let len = bun_sys::getcwd(&mut *outbuf)?;
+            &outbuf[..len]
+        };
+        let out = resolve_path::join_abs::<platform::Loose>(base, cwd_arg);
         // `chdir` wants a NUL-terminated path; `join_abs` returns a borrowed
         // slice into a threadlocal buffer, so dupe-Z once and reuse for both
         // the `chdir` arg and the stored `absolute_working_dir`.
@@ -785,8 +795,24 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
             );
             Global::exit(1);
         }
-        Box::<[u8]>::from(out_z.as_bytes())
+        // Store the post-chdir physical path (mirrors process.chdir) so
+        // process.cwd(), path.resolve, and the resolver agree on one form.
+        let mut phys = PathBuffer::uninit();
+        match bun_core::getcwd(&mut phys) {
+            Ok(p) => Box::<[u8]>::from(p.as_bytes()),
+            Err(_) => Box::<[u8]>::from(out_z.as_bytes()),
+        }
+    } else if matches!(
+        cmd,
+        CommandTag::AutoCommand | CommandTag::RunCommand | CommandTag::RunAsNodeCommand
+    ) {
+        // A deleted cwd must not abort the runtime (Node boots and lets
+        // `process.cwd()` throw later); fall back to the executable's dir.
+        let mut temp = PathBuffer::uninit();
+        Box::<[u8]>::from(bun_core::getcwd_or_exe_dir(&mut temp).as_bytes())
     } else {
+        // Everything else (install/test/build/...) must not silently act on
+        // whatever project happens to live above the executable.
         let mut temp = PathBuffer::uninit();
         let len = bun_sys::getcwd(&mut *temp)?;
         Box::<[u8]>::from(&temp[..len])

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -961,13 +961,25 @@ pub mod command {
         let Some(mut first_arg_name) = iter.next() else {
             return Tag::AutoCommand;
         };
+        let mut interactive = false;
         while !first_arg_name.is_empty()
             && first_arg_name[0] == b'-'
             && !(first_arg_name.len() > 1 && first_arg_name[1] == b'e')
         {
+            // Node compat: `--interactive` opens the REPL, but only when no
+            // script follows (node runs the script and ignores the flag).
+            if first_arg_name == b"--interactive" {
+                interactive = true;
+            }
             match iter.next() {
                 Some(n) => first_arg_name = n,
-                None => return Tag::AutoCommand,
+                None => {
+                    return if interactive {
+                        Tag::ReplCommand
+                    } else {
+                        Tag::AutoCommand
+                    };
+                }
             }
         }
 

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1025,7 +1025,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
 
             // entry_path must end with /[eval] for the transpiler to use eval_source
             let mut cwd_buf = PathBuffer::uninit();
-            let cwd = bun_core::getcwd(&mut cwd_buf)?;
+            let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf);
             let cwd_bytes = cwd.as_bytes();
             let mut eval_path: Vec<u8> = Vec::with_capacity(cwd_bytes.len() + EVAL_TRIGGER.len());
             eval_path.extend_from_slice(cwd_bytes);
@@ -2924,7 +2924,7 @@ impl RunCommand {
 
         let mut entry_point_buf = [0u8; MAX_PATH_BYTES + STDIN_TRIGGER.len()];
         let mut cwd_buf = PathBuffer::uninit();
-        let cwd = bun_core::getcwd(&mut cwd_buf)?;
+        let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf);
         let cwd_bytes = cwd.as_bytes();
         let cwd_len = cwd_bytes.len();
         entry_point_buf[..cwd_len].copy_from_slice(cwd_bytes);
@@ -2968,7 +2968,7 @@ impl RunCommand {
 
         let mut entry_point_buf = [0u8; MAX_PATH_BYTES + EVAL_TRIGGER.len()];
         let mut cwd_buf = PathBuffer::uninit();
-        let cwd = bun_core::getcwd(&mut cwd_buf)?;
+        let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf);
         let cwd_bytes = cwd.as_bytes();
         let cwd_len = cwd_bytes.len();
         entry_point_buf[..cwd_len].copy_from_slice(cwd_bytes);
@@ -2989,7 +2989,7 @@ impl RunCommand {
             // synthetic `[eval]` path under cwd
             let mut entry_point_buf = [0u8; MAX_PATH_BYTES + EVAL_TRIGGER.len()];
             let mut cwd_buf = PathBuffer::uninit();
-            let cwd = bun_core::getcwd(&mut cwd_buf)?;
+            let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf);
             let cwd_bytes = cwd.as_bytes();
             let cwd_len = cwd_bytes.len();
             entry_point_buf[..cwd_len].copy_from_slice(cwd_bytes);
@@ -3016,7 +3016,7 @@ impl RunCommand {
             // platform separator) and then run the result through
             // `join_abs_string_buf::<Loose>` to collapse `.`/`..`.
             let mut cwd_buf = PathBuffer::uninit();
-            let cwd = bun_core::getcwd(&mut cwd_buf)?;
+            let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf);
             let cwd_len = cwd.as_bytes().len();
             cwd_buf[cwd_len] = b'/';
             let mut out_buf = PathBuffer::uninit();
@@ -3186,9 +3186,9 @@ impl RunCommand {
         let mut entry_point_buf = [0u8; MAX_PATH_BYTES + EVAL_TRIGGER.len()];
         // SAFETY: bun_paths::PathBuffer and bun_core::PathBuffer are
         // layout-identical newtypes over [u8; MAX_PATH_BYTES].
-        let cwd = bun_core::getcwd(unsafe {
+        let cwd = bun_core::getcwd_or_exe_dir(unsafe {
             &mut *entry_point_buf.as_mut_ptr().cast::<bun_core::PathBuffer>()
-        })?;
+        });
         let cwd_len = cwd.as_bytes().len();
         entry_point_buf[cwd_len..cwd_len + EVAL_TRIGGER.len()].copy_from_slice(EVAL_TRIGGER);
 

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -406,10 +406,34 @@ mod _impl {
     }
 
     fn get_cwd(global_object: &JSGlobalObject) -> JsResult<JSValue> {
+        // Real syscall (not the resolver's cached top_level_dir): Node's
+        // process.cwd() calls uv_cwd() so a deleted cwd must surface here.
         let mut buf = PathBuffer::uninit();
-        match crate::node::path::get_cwd(&mut buf) {
-            bun_sys::Result::Ok(r) => Ok(ZigString::init(r).with_encoding().to_js(global_object)),
-            bun_sys::Result::Err(e) => Err(global_object.throw_value(e.to_js(global_object))),
+        match Syscall::getcwd(&mut buf[..]) {
+            bun_sys::Result::Ok(len) => Ok(ZigString::init(&buf[..len])
+                .with_encoding()
+                .to_js(global_object)),
+            bun_sys::Result::Err(e) => {
+                // Node's UVException from `Cwd` (node_process_methods.cc):
+                // "CODE: process.cwd failed with error <uv_strerror>[, hint], uv_cwd"
+                let (code, label) = e.uv_code_label().unwrap_or(("UNKNOWN", "unknown error"));
+                let hint = if e.get_errno() == bun_sys::E::ENOENT {
+                    ", the current working directory was likely removed \
+                     without changing the working directory"
+                } else {
+                    ""
+                };
+                let message =
+                    format!("{code}: process.cwd failed with error {label}{hint}, uv_cwd");
+                let err = bun_jsc::SystemError {
+                    errno: core::ffi::c_int::from(e.errno).wrapping_neg(),
+                    code: BunString::static_(code),
+                    message: BunString::clone_utf8(message.as_bytes()),
+                    syscall: BunString::static_("uv_cwd"),
+                    ..Default::default()
+                };
+                Err(global_object.throw_value(err.to_error_instance(global_object)))
+            }
         }
     }
 

--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -325,7 +325,6 @@ pub(crate) fn get_cwd_t<T: PathCharCwd>(buf: &mut [T]) -> MaybeBuf<'_, T> {
     T::get_cwd(buf)
 }
 
-
 /// Based on Node v21.6.1 path.posix.basename:
 /// https://github.com/nodejs/node/blob/6ae20aa63de78294b18d5015481485b7cd8fbb60/lib/path.js#L1309
 pub fn basename_posix_t<'a, T: PathCharCwd>(path: &'a [T], suffix: Option<&[T]>) -> &'a [T] {

--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -325,8 +325,6 @@ pub(crate) fn get_cwd_t<T: PathCharCwd>(buf: &mut [T]) -> MaybeBuf<'_, T> {
     T::get_cwd(buf)
 }
 
-// Alias for naming consistency.
-pub use get_cwd_u8 as get_cwd;
 
 /// Based on Node v21.6.1 path.posix.basename:
 /// https://github.com/nodejs/node/blob/6ae20aa63de78294b18d5015481485b7cd8fbb60/lib/path.js#L1309

--- a/src/sys/Error.rs
+++ b/src/sys/Error.rs
@@ -331,6 +331,13 @@ impl Error {
         Some((<&'static str>::from(e), e))
     }
 
+    /// (code, uv_strerror label) pair, e.g. `("ENOENT", "no such file or
+    /// directory")` — the pieces of Node's `UVException` message.
+    pub fn uv_code_label(&self) -> Option<(&'static str, &'static str)> {
+        let (code, system_errno) = self.get_error_code_tag_name()?;
+        Some((code, libuv_error_map::LIBUV_ERROR_MAP[system_errno]))
+    }
+
     pub fn msg(&self) -> Option<&'static [u8]> {
         let (_code, system_errno) = self.get_error_code_tag_name()?;
         // Both error maps are total (`initFull("unknown error")`), so the

--- a/test/js/node/test/parallel/test-cwd-enoent-improved-message.js
+++ b/test/js/node/test/parallel/test-cwd-enoent-improved-message.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const common = require('../common');
+const { isMainThread } = require('worker_threads');
+const assert = require('assert');
+const fs = require('fs');
+
+if (!isMainThread) {
+  common.skip('process.chdir is not available in Workers');
+}
+
+// Fails with EINVAL on SmartOS, EBUSY on Windows, EBUSY on AIX.
+if (common.isSunOS || common.isWindows || common.isAIX || common.isIBMi) {
+  common.skip('cannot rmdir current working directory');
+}
+
+const tmpdir = require('../common/tmpdir');
+const dirname = `${tmpdir.path}/cwd-does-not-exist-${process.pid}`;
+
+tmpdir.refresh();
+fs.mkdirSync(dirname);
+process.chdir(dirname);
+fs.rmdirSync(dirname);
+
+assert.throws(
+  () => process.cwd(),
+  {
+    code: 'ENOENT',
+    message: 'ENOENT: process.cwd failed with error no such file or directory,' +
+      ' the current working directory was likely removed without changing the working directory, uv_cwd',
+  }
+);

--- a/test/js/node/test/parallel/test-cwd-enoent-preload.js
+++ b/test/js/node/test/parallel/test-cwd-enoent-preload.js
@@ -1,0 +1,35 @@
+'use strict';
+const common = require('../common');
+// Fails with EINVAL on SmartOS, EBUSY on Windows, EBUSY on AIX.
+if (common.isSunOS || common.isWindows || common.isAIX || common.isIBMi) {
+  common.skip('cannot rmdir current working directory');
+}
+
+const { isMainThread } = require('worker_threads');
+
+if (!isMainThread) {
+  common.skip('process.chdir is not available in Workers');
+}
+
+const assert = require('assert');
+const fs = require('fs');
+const spawn = require('child_process').spawn;
+const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
+
+const dirname = `${tmpdir.path}/cwd-does-not-exist-${process.pid}`;
+const abspathFile = fixtures.path('a.js');
+tmpdir.refresh();
+fs.mkdirSync(dirname);
+process.chdir(dirname);
+fs.rmdirSync(dirname);
+
+
+const proc = spawn(process.execPath, ['-r', abspathFile, '-e', '0']);
+proc.stdout.pipe(process.stdout);
+proc.stderr.pipe(process.stderr);
+
+proc.once('exit', common.mustCall(function(exitCode, signalCode) {
+  assert.strictEqual(exitCode, 0);
+  assert.strictEqual(signalCode, null);
+}));

--- a/test/js/node/test/parallel/test-cwd-enoent-repl.js
+++ b/test/js/node/test/parallel/test-cwd-enoent-repl.js
@@ -1,0 +1,35 @@
+'use strict';
+const common = require('../common');
+// Fails with EINVAL on SmartOS, EBUSY on Windows, EBUSY on AIX.
+if (common.isSunOS || common.isWindows || common.isAIX || common.isIBMi) {
+  common.skip('cannot rmdir current working directory');
+}
+
+const { isMainThread } = require('worker_threads');
+
+if (!isMainThread) {
+  common.skip('process.chdir is not available in Workers');
+}
+
+const assert = require('assert');
+const fs = require('fs');
+const spawn = require('child_process').spawn;
+
+const tmpdir = require('../common/tmpdir');
+
+const dirname = `${tmpdir.path}/cwd-does-not-exist-${process.pid}`;
+tmpdir.refresh();
+fs.mkdirSync(dirname);
+process.chdir(dirname);
+fs.rmdirSync(dirname);
+
+const proc = spawn(process.execPath, ['--interactive']);
+proc.stdout.pipe(process.stdout);
+proc.stderr.pipe(process.stderr);
+proc.stdin.write('require("path");\n');
+proc.stdin.write('process.exit(42);\n');
+
+proc.once('exit', common.mustCall(function(exitCode, signalCode) {
+  assert.strictEqual(exitCode, 42);
+  assert.strictEqual(signalCode, null);
+}));

--- a/test/js/node/test/parallel/test-cwd-enoent.js
+++ b/test/js/node/test/parallel/test-cwd-enoent.js
@@ -1,0 +1,33 @@
+'use strict';
+const common = require('../common');
+// Fails with EINVAL on SmartOS, EBUSY on Windows, EBUSY on AIX.
+if (common.isSunOS || common.isWindows || common.isAIX || common.isIBMi) {
+  common.skip('cannot rmdir current working directory');
+}
+
+const { isMainThread } = require('worker_threads');
+
+if (!isMainThread) {
+  common.skip('process.chdir is not available in Workers');
+}
+
+const assert = require('assert');
+const fs = require('fs');
+const spawn = require('child_process').spawn;
+
+const tmpdir = require('../common/tmpdir');
+
+const dirname = `${tmpdir.path}/cwd-does-not-exist-${process.pid}`;
+tmpdir.refresh();
+fs.mkdirSync(dirname);
+process.chdir(dirname);
+fs.rmdirSync(dirname);
+
+const proc = spawn(process.execPath, ['-e', '0']);
+proc.stdout.pipe(process.stdout);
+proc.stderr.pipe(process.stderr);
+
+proc.once('exit', common.mustCall(function(exitCode, signalCode) {
+  assert.strictEqual(exitCode, 0);
+  assert.strictEqual(signalCode, null);
+}));


### PR DESCRIPTION
Bun could not start from a deleted working directory, and `process.cwd()` served a cached value forever after the directory vanished. Node boots fine and throws its uv_cwd ENOENT on the call. Two signed commits.

## Startup from a deleted cwd

```
mkdir d && cd d && rmdir ../d
node -e '0'   # exit 0
bun  -e '0'   # was: "ENOENT: Bun could not find a file...", exit 1 — now exit 0
```

Root cause: `Arguments.parse` and every synthetic entry-path builder (`-e`, stdin, cron, node-emulation) did `getcwd(...)?` → hard abort. Node's `Environment::GetCwd` falls back to dirname(exec_path). Bun now does the same via a bounds-checked `getcwd_or_exe_dir` — **deliberately restricted to runtime commands** (`Auto|Run|RunAsNode`): `bun install`/`test`/`build` from a deleted cwd keep the hard error, because an early iteration of this fix silently ran `install` against the repo found *above the executable* — caught by re-driving the CLI, and exactly the failure a fallback must not create.

`--interactive` (bare) now routes to the REPL as node does; with a script, the script wins (node's behavior, checked on the binary).

## `process.cwd()` after the cwd vanishes

Byte-identical to node v26.3.0: message, `code: 'ENOENT'`, `errno: -2`, `syscall: 'uv_cwd'`, including the "was likely removed without changing the working directory" hint. Root cause was two caches: the C++ `m_cachedCwd` was *repopulated* on chdir where node clears it, and the Rust side read the resolver's `top_level_dir` instead of the OS.

**Perf, measured rather than assumed:** hot path unchanged — 2M cached calls: 8.1-8.7ms control vs 8.8-8.9ms fixed (~4.4ns/call both). Only the first call after startup/chdir pays one syscall, node's exact cost model.

Ride-along fix this exposed: `writableFromFileSink` built a `WriteStream("")` whose ctor `path.resolve("")`d — so `child_process` spawn from a deleted cwd threw. The internal fast path now skips resolution of a path it discards two lines later.

## Deliberately skipped: warning printer through `process.stderr`

Reported, not attempted: (a) bun's default warning printer is the native console inspector and there is no in-tree "format to string" hook, so formatting cannot be preserved through `process.stderr.write`; (b) node's default handler is a bootstrap-registered `'warning'` listener that prints *even when user listeners exist* — flipping bun to that silently changes stderr for every program with `expectWarning`-style listeners. Needs its own PR with node's format adopted deliberately.

## Verification

4 tests byte-identical to upstream, 3× green, failing on unfixed bun, 12 tampers all non-zero. Adversarial probes: `bun install`/`add`/`test` from deleted cwd still exit 1; relative `--cwd` from deleted cwd still errors; `--cwd <symlink>` now yields consistent physical paths; repeated chdir→rmdir→cwd() throws every iteration; cache identity preserved.

Regressions: fs 606/0, path 122/0, fs+path+child_process+run-eval 869 pass / 1 pre-existing network fail; process 209 pass with the control binary failing the same 3 **plus 2 more**; `bun run rust:check-all` 10/10 targets.

Known limitations (flag errored before, so these are strict improvements): `--interactive -e` evaluates and exits where node stays in the REPL; `-i` is not aliased (bun's `-i` = `--install=fallback`).
