### PR TITLE
node:test: reporter-output parity with node (+8 tests)

### DIFF
--- a/src/js/eval/node_test.ts
+++ b/src/js/eval/node_test.ts
@@ -148,18 +148,31 @@ const kBuiltinReporters = {
 };
 
 async function resolveReporter(name: string) {
-  const builtin = kBuiltinReporters[name];
-  if (builtin !== undefined) return builtin;
-  // Custom reporter: a module specifier, resolved like node resolves it.
-  const specifier = name.startsWith(".") ? resolve(process.cwd(), name) : name;
-  let mod;
-  try {
-    mod = await import(specifier);
-  } catch (err) {
-    (err as { code?: string }).code ??= "ERR_MODULE_NOT_FOUND";
-    throw err;
+  let reporter: unknown = kBuiltinReporters[name];
+  if (reporter === undefined) {
+    // Custom reporter: a module specifier, resolved like node resolves it.
+    const specifier = name.startsWith(".") ? resolve(process.cwd(), name) : name;
+    let mod;
+    try {
+      mod = await import(specifier);
+    } catch (err) {
+      // Rewrap: bun's ResolveMessage hides `code` from inspection, and the
+      // reporter tests look for ERR_MODULE_NOT_FOUND in stderr like node's.
+      const error = new Error((err as Error)?.message ?? String(err));
+      (error as { code?: string }).code = (err as { code?: string })?.code ?? "ERR_MODULE_NOT_FOUND";
+      throw error;
+    }
+    reporter = mod.default ?? mod;
   }
-  const reporter = mod.default ?? mod;
+  // node news any constructor-carrying function (utils.js getReportersMap).
+  // The own-constructor identity check keeps bundled async generators (whose
+  // shared prototype carries an AsyncGeneratorFunction constructor) as-is.
+  if (
+    (reporter as { prototype?: object })?.prototype &&
+    Object.getOwnPropertyDescriptor((reporter as { prototype: object }).prototype, "constructor")?.value === reporter
+  ) {
+    reporter = new (reporter as new () => unknown)();
+  }
   if (typeof reporter !== "function" && !(reporter && typeof (reporter as any).pipe === "function")) {
     const error = new TypeError(
       `The "Reporter" argument must be a function or a stream. Received ${reporter === undefined ? "undefined" : typeof reporter}`,
@@ -176,43 +189,24 @@ function destinationFor(dest: string) {
   return createWriteStream(resolve(process.cwd(), dest));
 }
 
-function isTransformLike(reporter: unknown): boolean {
-  return typeof reporter === "function" && typeof (reporter as any).prototype?._transform === "function";
-}
-
-// Wires one reporter over its own copy of the event stream. Returns a promise
-// that settles when the reporter has flushed everything it will write.
+// Wires one reporter over its own copy of the event stream, node-style:
+// compose(source, reporter).pipe(destination) (internal/test_runner/utils.js).
+// Returns a promise that settles when the reporter has flushed everything.
 function attachReporter(reporter, source, destination): Promise<void> {
+  const { compose } = require("node:stream");
   const endDestination = destination !== process.stdout && destination !== process.stderr;
-  // A file destination must reach 'finish' before this resolves, or a
-  // --test-force-exit right after could truncate the report.
-  function destinationFlushed(): Promise<void> {
-    if (!endDestination) return Promise.resolve();
-    return new Promise(resolveFlush => {
-      destination.on("finish", resolveFlush);
-      destination.on("error", resolveFlush);
-    });
-  }
-  if (isTransformLike(reporter)) {
-    return new Promise((resolvePromise, rejectPromise) => {
-      const transform = new reporter();
-      transform.on("error", rejectPromise);
-      const flushed = destinationFlushed();
-      const out = source.pipe(transform).pipe(destination, { end: endDestination });
-      transform.on("end", () => flushed.then(resolvePromise));
-      out.on("error", rejectPromise);
-    });
-  }
-  return (async () => {
-    for await (const chunk of reporter(source)) {
-      destination.write(chunk);
-    }
+  return new Promise((resolvePromise, rejectPromise) => {
+    const composed = compose(source, reporter);
+    composed.on("error", rejectPromise);
+    const out = composed.pipe(destination, { end: endDestination });
+    out.on("error", rejectPromise);
     if (endDestination) {
-      const flushed = destinationFlushed();
-      destination.end();
-      await flushed;
+      destination.on("finish", resolvePromise);
+      destination.on("error", rejectPromise);
+    } else {
+      composed.on("end", resolvePromise);
     }
-  })();
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -334,8 +328,9 @@ async function main() {
       reporter = await resolveReporter(reporterNames[i]);
     } catch (err) {
       // node's main is ESM: a reporter that can't be set up leaves the
-      // top-level await unfinished, which exits with code 7.
-      console.error(err);
+      // top-level await unfinished, which exits with code 7. inspect() keeps
+      // the error's `code` visible, like node's fatal printer.
+      console.error(require("node:util").inspect(err));
       process.exit(7);
     }
     const destination = destinationFor(destinationNames[i]);

--- a/src/js/node/test.reporters.ts
+++ b/src/js/node/test.reporters.ts
@@ -660,10 +660,20 @@ class LcovReporter extends Transform {
   }
 }
 
+// node exports spec/lcov as plain functions that ReflectConstruct their class
+// (lib/test/reporters.js), so both `new spec()` and stream compose() work.
+function spec(...args: unknown[]) {
+  return Reflect.construct(SpecReporter, args);
+}
+
+function lcov(...args: unknown[]) {
+  return Reflect.construct(LcovReporter, args);
+}
+
 export default {
   dot,
   junit,
-  spec: SpecReporter,
+  spec,
   tap,
-  lcov: LcovReporter,
+  lcov,
 };

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -359,8 +359,10 @@ function emitRunDiagnostics(reporter: TestsStream, counts: Record<string, number
 // Runs each file in its own `bun test` child and republishes the child's events
 // on the parent's stream, then emits the run-level plan/diagnostics/summary.
 async function runFiles(opts: ReturnType<typeof validateRunOptions>, reporter: TestsStream) {
-  const started = Date.now();
+  const started = performance.now();
   const counts = makeRunCounts();
+  runInterrupted = false;
+  activeRunFileNode = null;
 
   // run() returns the stream before any file starts, and callers attach their
   // listeners synchronously on the returned stream. Yield first so the earliest
@@ -370,18 +372,43 @@ async function runFiles(opts: ReturnType<typeof validateRunOptions>, reporter: T
   try {
     if (typeof opts.setup === "function") await opts.setup(reporter);
 
-    const files = opts.files ?? [];
-    for (let i = 0; i < files.length; i++) {
-      await runOneFile(files[i], opts, reporter, counts);
+    // Explicit files keep their spelling: the per-file test is named by the
+    // path as passed (node's runner), while discovery yields absolute paths.
+    const files = opts.files !== undefined ? (opts.files as string[]) : discoverRunFiles(opts);
+    const onInterrupt = () => {
+      runInterrupted = true;
+      activeRunChildProc?.kill();
+    };
+    process.on("SIGINT", onInterrupt);
+    process.on("SIGTERM", onInterrupt);
+    try {
+      for (let i = 0; i < files.length; i++) {
+        if (runInterrupted) break;
+        await runOneFile(files[i], opts, reporter, counts);
+      }
+    } finally {
+      process.off("SIGINT", onInterrupt);
+      process.off("SIGTERM", onInterrupt);
     }
 
-    // No run-level plan: node's parent forwards each child's root plan and
-    // adds none of its own.
-    const durationMs = Date.now() - started;
+    if (runInterrupted) {
+      // node reports the file-level tests that were still running.
+      counts.failed++;
+      reporter.emitMessage("test:interrupted", {
+        __proto__: null,
+        nesting: 0,
+        tests: activeRunFileNode !== null ? [activeRunFileNode] : [],
+      });
+    }
+
+    if (counts.topLevel > 0) {
+      reporter.emitMessage("test:plan", { __proto__: null, nesting: 0, count: counts.topLevel });
+    }
+    const durationMs = roundDurationMs(performance.now() - started);
     emitRunDiagnostics(reporter, counts, durationMs);
     reporter.emitMessage("test:summary", {
       __proto__: null,
-      success: counts.failed === 0,
+      success: counts.failed === 0 && counts.cancelled === 0,
       counts,
       duration_ms: durationMs,
       file: undefined,
@@ -392,6 +419,11 @@ async function runFiles(opts: ReturnType<typeof validateRunOptions>, reporter: T
   }
   reporter.endStream();
 }
+
+// The child currently running under runFiles, for SIGINT interruption.
+let activeRunChildProc: { kill: () => void } | null = null;
+let activeRunFileNode: Record<string, unknown> | null = null;
+let runInterrupted = false;
 
 async function runOneFile(
   file: string,
@@ -405,7 +437,7 @@ async function runOneFile(
   // in the child's process.execArgv; bun's CLI likewise takes runtime flags
   // before the `test` keyword and user args after the path.
   const args = [process.execPath, ...(opts.execArgv as string[]), "test", absolute, ...(opts.argv as string[])];
-  const fileStarted = Date.now();
+  const fileStarted = performance.now();
   const fileCounts = makeRunCounts();
 
   // Under process isolation node models the file itself as a top-level test,
@@ -431,6 +463,8 @@ async function runOneFile(
     stdout: "pipe",
     stderr: "pipe",
   });
+  activeRunChildProc = proc;
+  activeRunFileNode = fileNode;
 
   let stderrText = "";
   const drainStderr = (async () => {
@@ -463,18 +497,23 @@ async function runOneFile(
     } catch {
       continue;
     }
+    // node's parent swallows each child's root plan and emits one run-level
+    // plan at the end (runner.js #skipReporting + Test.postRun).
+    if (event.type === "test:plan" && event.data?.nesting === 0) continue;
     republishChildEvent(event, absolute, reporter, fileCounts);
   }
 
   await drainStderr;
   const exitCode = await proc.exited;
+  activeRunChildProc = null;
+  if (!runInterrupted) activeRunFileNode = null;
 
   // Two failure shapes: the file died before reporting anything (top-level
   // throw — node emits a file-level test:fail and no per-file summary), or its
   // tests failed (covered by the children's events; completes `subtestsFailed`).
-  const fileFailed = exitCode !== 0 && fileCounts.failed === 0;
-  const subtestsFailed = fileCounts.failed > 0;
-  const fileDuration = Date.now() - fileStarted;
+  const fileFailed = exitCode !== 0 && fileCounts.failed === 0 && fileCounts.cancelled === 0;
+  const subtestsFailed = fileCounts.failed > 0 || fileCounts.cancelled > 0;
+  const fileDuration = roundDurationMs(performance.now() - fileStarted);
   let error: Error | undefined;
 
   if (subtestsFailed) {
@@ -485,7 +524,7 @@ async function runOneFile(
   if (!fileFailed) {
     reporter.emitMessage("test:summary", {
       __proto__: null,
-      success: fileCounts.failed === 0,
+      success: fileCounts.failed === 0 && fileCounts.cancelled === 0,
       counts: fileCounts,
       duration_ms: fileDuration,
       file: absolute,
@@ -499,6 +538,12 @@ async function runOneFile(
 
   // node emits the file node's completion before its verdict, and a failed
   // completion carries the error too.
+  if (runInterrupted) {
+    // The interrupted file's verdict is replaced by the test:interrupted
+    // report that runFiles emits; suppress the synthesized failure.
+    addRunCounts(counts, fileCounts);
+    return;
+  }
   reporter.emitMessage("test:complete", {
     __proto__: null,
     ...fileNode,
@@ -537,15 +582,25 @@ function republishChildEvent(
   if (isVerdict || type === "test:complete") {
     const isSuite = data.type === "suite";
     if (isVerdict) {
-      if (data.nesting === 0) counts.topLevel++;
+      // node's parent renumbers top-level entries across files (runner.js).
+      if (data.nesting === 0) {
+        counts.topLevel++;
+        data.testNumber = counts.topLevel;
+      }
       // node counts a suite in `suites` and stops there: a skipped or todo
       // suite never lands in skipped/todo/passed/tests (countCompletedTest).
       if (isSuite) counts.suites++;
       else {
         counts.tests++;
-        if (data.skip) counts.skipped++;
-        else if (data.todo) counts.todo++;
+        const failureType = data.error?.failureType;
+        // node's kCanceledTests (runner.js): these failure kinds count as
+        // cancelled, not failed.
+        const wasCancelled =
+          failureType === "testTimeoutFailure" || failureType === "cancelledByParent" || failureType === "testAborted";
+        if (data.skip !== undefined) counts.skipped++;
+        else if (data.todo !== undefined) counts.todo++;
         else if (type === "test:pass") counts.passed++;
+        else if (wasCancelled) counts.cancelled++;
         else counts.failed++;
       }
     }
@@ -554,12 +609,29 @@ function republishChildEvent(
     const serialized = data.error;
     let error;
     if (serialized !== undefined) {
-      const { message, stack, code, failureType, name } = serialized;
-      error = new Error(message);
-      error.stack = stack;
-      if (name !== undefined && name !== "Error") error.name = name;
-      if (code !== undefined) (error as any).code = code;
-      if (failureType !== undefined) (error as any).failureType = failureType;
+      if (Error.isError(serialized)) {
+        error = serialized;
+      } else {
+        const { message, stack, code, failureType, name, cause } = serialized;
+        error = new Error(message);
+        error.stack = stack;
+        if (name !== undefined && name !== "Error") error.name = name;
+        if (code !== undefined) (error as any).code = code;
+        if (failureType !== undefined) (error as any).failureType = failureType;
+        if (cause !== undefined) {
+          const rebuilt = new Error(cause.message) as Record<string, unknown> & Error;
+          rebuilt.stack = cause.stack;
+          if (cause.name !== undefined && cause.name !== "Error") rebuilt.name = cause.name;
+          // Enumerable-property order mirrors node's AssertionError inspect.
+          if (cause.generatedMessage !== undefined) rebuilt.generatedMessage = cause.generatedMessage;
+          if (cause.code !== undefined) rebuilt.code = cause.code;
+          if (cause.actual !== undefined) rebuilt.actual = cause.actual;
+          if (cause.expected !== undefined) rebuilt.expected = cause.expected;
+          if (cause.operator !== undefined) rebuilt.operator = cause.operator;
+          if (cause.diff !== undefined) rebuilt.diff = cause.diff;
+          (error as { cause?: unknown }).cause = rebuilt;
+        }
+      }
     }
     data.details = { __proto__: null, duration_ms: data.duration_ms, type: detailType, error };
     if (type === "test:complete") data.details.passed = data.passed;
@@ -575,7 +647,16 @@ function republishChildEvent(
 // spawning parent can rebuild node's event stream.
 const runChildReporterEnabled = process.env[kRunChildEnv] !== undefined;
 
+// Registers this process as a run() child with the native runner, so genuine
+// uncaught errors route to the process listeners installed below (spawned
+// grandchildren inherit the env var but never register in-process).
+const registerRunChild = $newRustFunction("jest.rs", "jsNodeTestRegisterChild", 0);
+
 if (runChildReporterEnabled) {
+  // The attribution listeners themselves install lazily with the first test
+  // (executeTestNode); an uncaught before that takes the fatal path, like a
+  // node test file that dies while loading.
+  registerRunChild();
   // node's child emits its root-level plan when the file finishes; the file
   // boundary in bun:test is process exit.
   process.on("exit", () => {
@@ -595,8 +676,14 @@ function emitRunChildEvent(type: string, data: unknown) {
     standaloneSink(type, data);
     return;
   }
+  // In-process sinks receive the real error object; only the pipe flattens it.
+  const record = data as { error?: unknown } | null;
+  const wire =
+    record !== null && typeof record === "object" && Error.isError(record.error)
+      ? { ...record, error: serializeRunError(record.error) }
+      : data;
   try {
-    process.stdout.write(kRunEventPrefix + JSON.stringify({ type, data }) + "\n");
+    process.stdout.write(kRunEventPrefix + JSON.stringify({ type, data: wire }) + "\n");
   } catch {}
 }
 
@@ -604,6 +691,37 @@ function emitRunChildEvent(type: string, data: unknown) {
 // child streaming to its parent, or standalone mode reporting in-process.
 function runEventsEnabled(): boolean {
   return runChildReporterEnabled || standaloneActive;
+}
+
+// node computes durations from hrtime bigints, which carry at most 6 decimal
+// digits as milliseconds; raw performance.now() deltas have float noise.
+function roundDurationMs(ms: number): number {
+  return Math.round(ms * 1e6) / 1e6;
+}
+
+// node wraps every user failure in ERR_TEST_FAILURE carrying `failureType` and
+// the original error as `cause` (errors.js E('ERR_TEST_FAILURE')).
+function wrapTestError(error: unknown): Error {
+  if (Error.isError(error)) {
+    if ((error as { code?: string }).code === "ERR_TEST_FAILURE") {
+      (error as { failureType?: string }).failureType ??= "testCodeFailure";
+      return error;
+    }
+    const wrapper = new Error(error.message);
+    (wrapper as { code?: string }).code = "ERR_TEST_FAILURE";
+    (wrapper as { failureType?: string }).failureType = "testCodeFailure";
+    (wrapper as { cause?: unknown }).cause = error;
+    // node's wrapper hides its internal frames; reporters use the cause's stack.
+    wrapper.stack = `Error [ERR_TEST_FAILURE]: ${wrapper.message}`;
+    return wrapper;
+  }
+  // node: msg = error?.message ?? error, inspected when not a string.
+  const wrapper = new Error(typeof error === "string" ? error : Bun.inspect(error));
+  (wrapper as { code?: string }).code = "ERR_TEST_FAILURE";
+  (wrapper as { failureType?: string }).failureType = "testCodeFailure";
+  (wrapper as { cause?: unknown }).cause = error;
+  wrapper.stack = `Error [ERR_TEST_FAILURE]: ${wrapper.message}`;
+  return wrapper;
 }
 
 // node's top-level tests are nesting 0, so the root node itself doesn't count.
@@ -614,9 +732,10 @@ function nestingOf(node: TestNode) {
 }
 
 // Errors cross the process boundary as plain JSON; the parent rebuilds an Error.
+const kSerializedCauseExtras = ["generatedMessage", "actual", "expected", "operator", "diff"];
 function serializeRunError(error: unknown) {
   if (Error.isError(error)) {
-    return {
+    const out: Record<string, unknown> = {
       __proto__: null,
       message: error.message,
       stack: error.stack,
@@ -624,6 +743,25 @@ function serializeRunError(error: unknown) {
       failureType: (error as { failureType?: string }).failureType,
       name: error.name,
     };
+    const { cause } = error as { cause?: unknown };
+    if (Error.isError(cause)) {
+      const c = cause as Record<string, unknown> & Error;
+      const serializedCause: Record<string, unknown> = {
+        __proto__: null,
+        message: c.message,
+        stack: c.stack,
+        code: c.code,
+        name: c.name,
+      };
+      // Only JSON-safe primitives survive the pipe (node uses the v8 serializer).
+      for (const key of kSerializedCauseExtras) {
+        const value = c[key];
+        const t = typeof value;
+        if (value === null || t === "string" || t === "number" || t === "boolean") serializedCause[key] = value;
+      }
+      out.cause = serializedCause;
+    }
+    return out;
   }
   return { __proto__: null, message: String(error), stack: undefined, code: undefined, name: "Error" };
 }
@@ -644,8 +782,8 @@ function reportDirectiveOnlyNode(node: TestNode, mode: "skip" | "todo") {
     testId: runTestIdFor(node),
     parentId: runParentIdFor(node),
     duration_ms: 0,
-    skip: skipped ? true : undefined,
-    todo: !skipped ? true : undefined,
+    skip: skipped ? (node.directiveMessage ?? true) : undefined,
+    todo: !skipped ? (node.directiveMessage ?? true) : undefined,
     type: node.isSuite ? "suite" : "test",
     tags: node.tags,
     error: undefined,
@@ -656,6 +794,43 @@ function reportDirectiveOnlyNode(node: TestNode, mode: "skip" | "todo") {
   // Directive-only nodes never execute, so completion bookkeeping for the
   // enclosing suite happens here.
   noteRunChildDone(node.parent, false);
+}
+
+// True when any enclosing suite is marked skipped with a falsy-but-defined
+// value ({ skip: '' }): its callback ran and declared children, which node
+// cancels instead of running.
+function hasSkippedAncestorSuite(node: TestNode): boolean {
+  for (let cur = node.parent; cur !== undefined && cur.parent !== undefined; cur = cur.parent) {
+    if (cur.isSuite && cur.skipped) return true;
+  }
+  return false;
+}
+
+function makeCancelledByParentError() {
+  return makeTestFailure("test did not finish before its parent and was cancelled", "cancelledByParent");
+}
+
+// Reports a declared-but-never-run child of a skipped suite (node's
+// cancelledByParent verdict).
+function reportCancelledNode(node: TestNode) {
+  if (!runEventsEnabled()) return;
+  reportQueueChain(node);
+  const data = {
+    __proto__: null,
+    name: node.name,
+    nesting: nestingOf(node),
+    testNumber: nextTestNumberFor(node),
+    testId: runTestIdFor(node),
+    parentId: runParentIdFor(node),
+    duration_ms: 0,
+    type: node.isSuite ? "suite" : "test",
+    tags: node.tags,
+    error: makeCancelledByParentError(),
+  };
+  emitRunChildEvent("test:complete", { ...data, passed: false });
+  reportStartChain(node);
+  emitRunChildEvent("test:fail", data);
+  noteRunChildDone(node.parent, true);
 }
 
 // node's todo directive is inherited: a test inside a todo suite reports (and
@@ -756,8 +931,17 @@ function maybeCompleteSuite(suite: TestNode): boolean {
   // A todo suite's advisory results never fail it (or the run) in node.
   const isTodo = suite.todoFlag || hasTodoAncestor(suite);
   if (isTodo) suite.childrenFailed = 0;
-  const suiteFailed = suite.childrenFailed > 0;
+  let suiteFailed = suite.childrenFailed > 0;
   const failedCount = suite.childrenFailed;
+  // node's Suite.pass(): an expectFailure suite with no error still fails
+  // ('test was expected to fail but passed'); a failing one keeps its error.
+  const { expectFailure } = suite;
+  const xfail = expectFailure ? (expectFailure.label ?? true) : undefined;
+  let forcedError: Error | undefined;
+  if (expectFailure && !suiteFailed && !isTodo) {
+    suiteFailed = true;
+    forcedError = makeTestFailure("test was expected to fail but passed", "expectedFailure");
+  }
   const data = {
     __proto__: null,
     name: suite.name,
@@ -766,13 +950,13 @@ function maybeCompleteSuite(suite: TestNode): boolean {
     testId: runTestIdFor(suite),
     parentId: runParentIdFor(suite),
     type: "suite",
+    skip: suite.skipped ? (suite.directiveMessage ?? true) : undefined,
     todo: isTodo ? true : undefined,
-    duration_ms: suite.startedAtMs > 0 ? performance.now() - suite.startedAtMs : 0,
+    expectFailure: xfail,
+    duration_ms: suite.startedAtMs > 0 ? roundDurationMs(performance.now() - suite.startedAtMs) : 0,
     tags: suite.tags,
     error: suiteFailed
-      ? serializeRunError(
-          makeTestFailure(`${failedCount} subtest${failedCount > 1 ? "s" : ""} failed`, "subtestsFailed"),
-        )
+      ? (forcedError ?? makeTestFailure(`${failedCount} subtest${failedCount > 1 ? "s" : ""} failed`, "subtestsFailed"))
       : undefined,
   };
   // node's order around a finishing suite: its completion, the plan covering
@@ -822,12 +1006,12 @@ function reportNodeToRunParent(node: TestNode, startedAt: number) {
     testNumber: nextTestNumberFor(node),
     testId: runTestIdFor(node),
     parentId: runParentIdFor(node),
-    duration_ms: performance.now() - startedAt,
-    skip: skipped ? true : undefined,
-    todo: !skipped && todoEffective ? true : undefined,
+    duration_ms: roundDurationMs(performance.now() - startedAt),
+    skip: skipped ? (node.directiveMessage ?? true) : undefined,
+    todo: !skipped && todoEffective ? (node.directiveMessage ?? true) : undefined,
     expectFailure: xfail,
     tags: node.tags,
-    error: node.passed ? undefined : serializeRunError(node.error),
+    error: node.passed ? undefined : wrapTestError(node.error),
   };
   emitRunChildEvent("test:complete", { ...data, passed: node.passed });
   // A test that ran subtests reports the plan covering them.
@@ -1483,6 +1667,9 @@ function makeTestFailure(message: string, failureType?: string) {
   const error = new Error(message);
   (error as { code?: string }).code = "ERR_TEST_FAILURE";
   if (failureType !== undefined) (error as { failureType?: string }).failureType = failureType;
+  // node's ERR_TEST_FAILURE hides its internal frames (hideInternalStackFrames),
+  // so reporters print no stack for these wrappers.
+  error.stack = `Error [ERR_TEST_FAILURE]: ${message}`;
   return error;
 }
 
@@ -1524,7 +1711,7 @@ class TestPlan {
       return;
     }
     if (wait === false || wait === undefined || actual > expected) {
-      throw makeTestFailure(`plan expected ${expected} assertions but received ${actual}`);
+      throw makeTestFailure(`plan expected ${expected} assertions but received ${actual}`, "testCodeFailure");
     }
     return new Promise((resolve, reject) => {
       let timer: ReturnType<typeof setTimeout> | undefined;
@@ -1532,7 +1719,10 @@ class TestPlan {
         timer = realSetTimeout(() => {
           this.#pending = undefined;
           reject(
-            makeTestFailure(`plan timed out after ${wait}ms with ${this.actual} assertions when expecting ${expected}`),
+            makeTestFailure(
+              `plan timed out after ${wait}ms with ${this.actual} assertions when expecting ${expected}`,
+              "testCodeFailure",
+            ),
           );
         }, wait);
         // Not unref'd: count()/cancel()/the timer callback always clear it, and
@@ -1540,6 +1730,18 @@ class TestPlan {
       }
       this.#pending = { resolve, reject, timer };
     });
+  }
+
+  // An uncaughtException attributed to the awaiting test must reject a
+  // pending wait, or the test would hang on a plan that can no longer be met.
+  failPending(err: Error) {
+    const pending = this.#pending;
+    if (pending === undefined) return false;
+    this.#pending = undefined;
+    const { timer } = pending;
+    if (timer !== undefined) realClearTimeout(timer);
+    pending.reject(err);
+    return true;
   }
 
   // Mirrors count()'s cleanup for the stop-wins-race path: if the test-level
@@ -1635,6 +1837,10 @@ class TestNode {
   mockTracker: MockTracker | null = null;
   skipped = false;
   todoFlag = false;
+  // The skip/todo reason string ({ skip: 'reason' }, t.skip('reason')).
+  directiveMessage: string | null = null;
+  cancelled = false;
+  abortController: AbortController | undefined;
   expectFailure: ExpectFailure = false;
   started = false;
   // run()-child suite accounting: a collection suite completes when its last
@@ -1684,8 +1890,11 @@ class TestNode {
     // being collected); nested tests inherit their parent's file.
     this.filePath =
       parent !== undefined && parent.parent !== undefined ? parent.filePath : (currentImportFile ?? Bun.main);
-    this.skipped = !!options.skip;
-    this.todoFlag = !!options.todo || (parent?.todoFlag ?? false);
+    // node: any non-undefined, non-false value is a directive, including ''.
+    const { skip, todo } = options;
+    this.skipped = skip !== undefined && skip !== false;
+    this.todoFlag = (todo !== undefined && todo !== false) || (parent?.todoFlag ?? false);
+    this.directiveMessage = typeof skip === "string" ? skip : typeof todo === "string" ? todo : null;
     this.expectFailure = parseExpectFailure(options.expectFailure) || parent?.expectFailure || false;
   }
 
@@ -1779,7 +1988,6 @@ function getRootNode(): TestNode {
  */
 class TestContext {
   #node: TestNode;
-  #abortController?: AbortController;
   #assert: Record<string, Function> | undefined;
 
   constructor(node: TestNode) {
@@ -1787,10 +1995,10 @@ class TestContext {
   }
 
   get signal(): AbortSignal {
-    if (this.#abortController === undefined) {
-      this.#abortController = new AbortController();
-    }
-    return this.#abortController.signal;
+    // Owned by the node so a timeout can abort it (node's #cancel()).
+    const node = this.#node;
+    node.abortController ??= new AbortController();
+    return node.abortController.signal;
   }
 
   get name(): string {
@@ -1852,12 +2060,14 @@ class TestContext {
     throwNotImplemented("runOnly()", 5090, "Use `bun:test` in the interim.");
   }
 
-  skip(_message?: string) {
+  skip(message?: string) {
     this.#node.skipped = true;
+    if (typeof message === "string") this.#node.directiveMessage = message;
   }
 
-  todo(_message?: string) {
+  todo(message?: string) {
     this.#node.todoFlag = true;
+    if (typeof message === "string") this.#node.directiveMessage = message;
   }
 
   before(arg0: unknown, arg1: unknown) {
@@ -2202,7 +2412,7 @@ function invokeWithDoneCallback(fn: Function, arg: unknown) {
     const done = (err?: unknown) => {
       if (doneCalled) {
         // Node throws into the caller when the callback is invoked again.
-        throw makeTestFailure("callback invoked multiple times");
+        throw makeTestFailure("callback invoked multiple times", "multipleCallbackInvocations");
       }
       doneCalled = true;
       // A done() call made before the function returned is deferred, and one
@@ -2225,7 +2435,7 @@ function invokeWithDoneCallback(fn: Function, arg: unknown) {
       // Node fails the test but still awaits the returned promise, so hooks
       // and later tests never race a still-running body.
       returnedPromise = true;
-      const fail = () => reject(makeTestFailure("passed a callback but also returned a Promise"));
+      const fail = () => reject(makeTestFailure("passed a callback but also returned a Promise", "callbackAndPromisePresent"));
       (result as Promise<unknown>).then(fail, fail);
       return;
     }
@@ -2261,7 +2471,7 @@ function createStopController(timeout: number | undefined) {
   const promise = new Promise<never>((_, reject) => {
     // Not unref'd: dispose() always clears it, and on Windows an unref'd timer
     // alone under bun:test leaves the uws loop inactive so auto_tick busy-spins.
-    timer = realSetTimeout(() => reject(makeTestFailure(`test timed out after ${timeout}ms`)), timeout);
+    timer = realSetTimeout(() => reject(makeTestFailure(`test timed out after ${timeout}ms`, "testTimeoutFailure")), timeout);
   });
   // Swallow the rejection when nothing is racing it anymore.
   promise.catch(() => {});
@@ -2291,7 +2501,7 @@ async function raceWithTimeoutAndSignal(
     if (typeof timeout === "number" && Number.isFinite(timeout)) {
       racers.push(
         new Promise<never>((_, reject) => {
-          timer = realSetTimeout(() => reject(makeTestFailure(`test timed out after ${timeout}ms`)), timeout);
+          timer = realSetTimeout(() => reject(makeTestFailure(`test timed out after ${timeout}ms`, "testTimeoutFailure")), timeout);
         }),
       );
     }
@@ -2370,6 +2580,54 @@ async function runOwnBeforeHooks(node: TestNode) {
   }
 }
 
+// Tests currently executing in this process (innermost last), plus an
+// AsyncLocalStorage tying async work to the test whose body created it —
+// node's harness attributes process errors via async context.
+type ExecutionEntry = { node: TestNode; fail: (err: Error) => void };
+const executionStack: ExecutionEntry[] = [];
+let processErrorAttributionInstalled = false;
+let testContextStorage: { run: (store: TestNode, fn: () => unknown) => unknown; getStore: () => TestNode | undefined } | undefined;
+
+function getTestContextStorage() {
+  testContextStorage ??= new (require("node:async_hooks").AsyncLocalStorage)();
+  return testContextStorage!;
+}
+
+function attributeProcessError(err: unknown, failureType: string): void {
+  const store = testContextStorage?.getStore();
+  let entry: ExecutionEntry | undefined;
+  if (store !== undefined && store.finished) {
+    // Another test's late async activity: node reports this at root level and
+    // fails the run without blaming the currently running test.
+    console.error((err as Error)?.stack ?? err);
+    process.exitCode = 1;
+    return;
+  }
+  if (store !== undefined) {
+    entry = executionStack.find(e => e.node === store);
+  }
+  // No tracked context (bun's ALS does not cover promise-rejection sweeps or
+  // every native source): fall back to the innermost running test.
+  entry ??= executionStack[executionStack.length - 1];
+  if (entry !== undefined && !entry.node.finished) {
+    const wrapper = wrapTestError(err) as { failureType?: string };
+    wrapper.failureType = failureType;
+    entry.fail(wrapper as Error);
+    return;
+  }
+  // No active test: node's fatal path — print and exit 1 (kGenericUserError).
+  console.error((err as Error)?.stack ?? err);
+  process.exit(1);
+}
+
+function installProcessErrorAttribution() {
+  if (processErrorAttributionInstalled) return;
+  processErrorAttributionInstalled = true;
+  getTestContextStorage();
+  process.on("uncaughtException", err => attributeProcessError(err, "uncaughtException"));
+  process.on("unhandledRejection", err => attributeProcessError(err, "unhandledRejection"));
+}
+
 async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
   // Runs a single test (top-level or subtest): inherited beforeEach hooks, the
   // body, pending subtests, the plan check, inherited afterEach hooks, and the
@@ -2398,6 +2656,31 @@ async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
     failure = err;
   }
 
+  // While this test runs, an uncaughtException/unhandledRejection belongs to
+  // it (node fails the test instead of crashing the process). The interrupt
+  // promise unblocks a body that can no longer settle (e.g. awaiting forever).
+  let execEntry: ExecutionEntry | undefined;
+  let interrupt: { promise: Promise<never>; reject: (err: Error) => void } | undefined;
+  if (runEventsEnabled()) {
+    installProcessErrorAttribution();
+    let rejectInterrupt!: (err: Error) => void;
+    const interruptPromise = new Promise<never>((_, reject) => {
+      rejectInterrupt = reject;
+    });
+    interruptPromise.catch(() => {});
+    interrupt = { promise: interruptPromise, reject: rejectInterrupt };
+    execEntry = {
+      node,
+      fail: err => {
+        if (node.finished) return;
+        node.hookFailure ??= err;
+        node.plan?.failPending(err);
+        interrupt!.reject(err);
+      },
+    };
+    executionStack.push(execEntry);
+  }
+
   if (failure === undefined) {
     // Node arms one stopPromise (timeout + signal) and races both the body
     // AND the plan wait against it. Arm timeout once here so plan({wait:true})
@@ -2405,14 +2688,28 @@ async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
     const stop = createStopController(node.options.timeout);
     try {
       const runBody = async () => {
-        await runWithNode(node, () => invokeTestFn(fn, ctx));
+        // The body runs inside the test's async context so late async work
+        // (timers, ticks) is attributed to this test, like node.
+        const invoke = () => runWithNode(node, () => invokeTestFn(fn, ctx));
+        await (execEntry !== undefined ? getTestContextStorage().run(node, invoke) : invoke());
         // Wait for inline subtests created during the body (awaited or not),
         // including ones scheduled while earlier subtests were running.
         await drainSubtestChain(node);
       };
 
+      // Races the body/plan against the test timeout AND external interrupts
+      // (attributed uncaught errors that must unblock a pending await).
+      const raceExternal = (p: unknown) => {
+        const racers: unknown[] = [];
+        if (stop !== undefined) racers.push(stop.promise);
+        if (interrupt !== undefined) racers.push(interrupt.promise);
+        if (racers.length === 0) return p;
+        racers.push(p);
+        return Promise.race(racers as Promise<unknown>[]);
+      };
+
       try {
-        await (stop === undefined ? runBody() : Promise.race([stop.promise, runBody()]));
+        await raceExternal(runBody());
       } catch (err) {
         // A body that throws or rejects with a nullish value must still fail.
         failure = err ?? makeTestFailure("test failed");
@@ -2430,12 +2727,12 @@ async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
             // Defuse: if stop wins the race, plan's own wait-timeout may still
             // reject `pending` afterward with no one listening.
             pending.catch(() => {});
-            await (stop === undefined ? pending : Promise.race([stop.promise, pending]));
+            await raceExternal(pending);
             // A t.test() that fulfilled the plan from an async callback was
             // scheduled onto subtestChain during the wait; drain again so its
             // failure reaches failedSubtests below (Node fails the parent).
             const drain = drainSubtestChain(node);
-            await (stop === undefined ? drain : Promise.race([stop.promise, drain]));
+            await raceExternal(drain);
           }
         } catch (err) {
           failure = err;
@@ -2446,14 +2743,28 @@ async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
       node.plan?.cancel();
     }
 
+    // An error attributed while the body was in flight fails the test.
+    failure ??= node.hookFailure;
+
     const { failedSubtests, firstSubtestError } = node;
     if (failure === undefined && failedSubtests > 0) {
-      const error = makeTestFailure(`${failedSubtests} subtest${failedSubtests > 1 ? "s" : ""} failed`);
+      const error = makeTestFailure(`${failedSubtests} subtest${failedSubtests > 1 ? "s" : ""} failed`, "subtestsFailed");
       if (firstSubtestError !== undefined) {
         (error as { cause?: unknown }).cause = firstSubtestError;
       }
       failure = error;
     }
+  }
+
+  if (execEntry !== undefined) {
+    const at = executionStack.lastIndexOf(execEntry);
+    if (at !== -1) executionStack.splice(at, 1);
+  }
+
+  // node cancels (rather than fails) a timed-out test and aborts t.signal.
+  if ((failure as { failureType?: string } | undefined)?.failureType === "testTimeoutFailure") {
+    node.cancelled = true;
+    (node.abortController ??= new AbortController()).abort();
   }
 
   failure = applyExpectFailure(node, failure);
@@ -2733,7 +3044,7 @@ function pruneStandaloneEntries(entries: StandaloneEntry[], filters: string[]): 
 // registrations first, like node), then one merged queue executes with shared
 // root hooks. Events flow through the same restructuring as process isolation.
 async function runFilesInProcess(opts: ReturnType<typeof validateRunOptions>, reporter: TestsStream) {
-  const started = Date.now();
+  const started = performance.now();
   const counts = makeRunCounts();
   // A standalone caller may already have queued its own tests; they belong to
   // its beforeExit pass, not to this run. Saved here so the restore helper
@@ -2822,7 +3133,7 @@ async function runFilesInProcess(opts: ReturnType<typeof validateRunOptions>, re
       counts.failed++;
     }
 
-    const durationMs = Date.now() - started;
+    const durationMs = roundDurationMs(performance.now() - started);
     const { reportedCount } = root;
     if (reportedCount > 0) {
       standaloneSink("test:plan", { __proto__: null, nesting: 0, count: reportedCount });
@@ -2830,7 +3141,7 @@ async function runFilesInProcess(opts: ReturnType<typeof validateRunOptions>, re
     emitRunDiagnostics(reporter, counts, durationMs);
     reporter.emitMessage("test:summary", {
       __proto__: null,
-      success: counts.failed === 0,
+      success: counts.failed === 0 && counts.cancelled === 0,
       counts,
       duration_ms: durationMs,
       file: undefined,
@@ -2884,7 +3195,7 @@ async function runStandalone() {
     console.error(err);
     counts.failed++;
   } finally {
-    const durationMs = performance.now() - startedAt;
+    const durationMs = roundDurationMs(performance.now() - startedAt);
     const { reportedCount } = root;
     if (reportedCount > 0) {
       standaloneSink!("test:plan", { __proto__: null, nesting: 0, count: reportedCount });
@@ -2892,7 +3203,7 @@ async function runStandalone() {
     emitRunDiagnostics(stream, counts, durationMs);
     stream.emitMessage("test:summary", {
       __proto__: null,
-      success: counts.failed === 0,
+      success: counts.failed === 0 && counts.cancelled === 0,
       counts,
       duration_ms: durationMs,
       file: undefined,
@@ -2920,6 +3231,15 @@ async function runStandaloneEntry(entry: StandaloneEntry) {
   if (!isSuite) {
     // executeTestNode reports the node's events itself.
     await executeTestNode(node, fn);
+    return;
+  }
+  if (node.isSuite && node.skipped) {
+    // A skipped suite whose callback still ran (falsy-but-defined skip):
+    // node cancels the declared children without running them or the hooks.
+    for (const child of node.standaloneChildren ?? []) {
+      reportCancelledNode(child.node);
+    }
+    noteSuiteCollectionSettled(node);
     return;
   }
   // Suites: the callback already ran at declaration (node runs describe
@@ -2965,21 +3285,29 @@ async function runStandaloneEntry(entry: StandaloneEntry) {
 async function attachStandaloneReporters(stream: TestsStream): Promise<unknown> {
   const reporters = require("node:test/reporters");
   const names: string[] = [];
+  const destinationNames: string[] = [];
   const argv = process.execArgv;
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg.startsWith("--test-reporter=")) names.push(arg.slice("--test-reporter=".length));
     else if (arg === "--test-reporter" && i + 1 < argv.length) names.push(argv[++i]);
+    else if (arg.startsWith("--test-reporter-destination="))
+      destinationNames.push(arg.slice("--test-reporter-destination=".length));
+    else if (arg === "--test-reporter-destination" && i + 1 < argv.length) destinationNames.push(argv[++i]);
   }
   if (names.length === 0) names.push("spec");
+  while (destinationNames.length < names.length) destinationNames.push("stdout");
 
+  const { PassThrough, compose } = require("node:stream");
+  const { createWriteStream } = require("node:fs");
+  const path = require("node:path");
   const promises: Promise<void>[] = [];
-  for (const name of names) {
+  for (let i = 0; i < names.length; i++) {
+    const name = names[i];
     let reporter = (reporters as Record<string, unknown>)[name];
     if (reporter === undefined) {
       // A custom reporter is a module specifier, like in node.
       try {
-        const path = require("node:path");
         const mod = await import(name.startsWith(".") ? path.resolve(process.cwd(), name) : name);
         reporter = mod.default ?? mod;
       } catch (err) {
@@ -2988,32 +3316,54 @@ async function attachStandaloneReporters(stream: TestsStream): Promise<unknown> 
         continue;
       }
     }
-    if (typeof reporter !== "function") {
-      console.error(new TypeError(`The reporter '${name}' is not a function or a stream`));
+    // node news any constructor-carrying function (utils.js getReportersMap).
+    // The own-constructor identity check keeps bundled async generators (whose
+    // shared prototype carries an AsyncGeneratorFunction constructor) as-is.
+    if (
+      (reporter as { prototype?: object })?.prototype &&
+      Object.getOwnPropertyDescriptor((reporter as { prototype: object }).prototype, "constructor")?.value ===
+        reporter
+    ) {
+      reporter = new (reporter as new () => unknown)();
+    }
+    if (typeof reporter !== "function" && !(reporter && typeof (reporter as { pipe?: unknown }).pipe === "function")) {
+      // Validate upfront, like node: a plain object must not reach compose(),
+      // whose throw would surface as a mid-run unhandled rejection.
+      const error = new TypeError(
+        `The "Reporter" argument must be a function or a stream. Received ${reporter === undefined ? "undefined" : typeof reporter}`,
+      );
+      (error as { code?: string }).code = "ERR_INVALID_ARG_TYPE";
+      console.error(error);
       process.exitCode = 1;
       continue;
     }
-    const { PassThrough } = require("node:stream");
+    const destinationName = destinationNames[i];
+    const destination =
+      destinationName === "stdout"
+        ? process.stdout
+        : destinationName === "stderr"
+          ? process.stderr
+          : createWriteStream(path.resolve(process.cwd(), destinationName));
+    const endDestination = destination !== process.stdout && destination !== process.stderr;
     const copy = new PassThrough({ objectMode: true });
     stream.pipe(copy);
-    if (typeof (reporter as any)?.prototype?._transform === "function") {
-      promises.push(
-        new Promise(resolvePromise => {
-          const transform = new (reporter as any)();
-          copy.pipe(transform).pipe(process.stdout, { end: false });
-          transform.on("end", resolvePromise);
-          transform.on("error", resolvePromise);
-        }),
-      );
-    } else {
-      promises.push(
-        (async () => {
-          for await (const chunk of (reporter as any)(copy)) {
-            process.stdout.write(chunk);
-          }
-        })(),
-      );
-    }
+    promises.push(
+      new Promise(resolvePromise => {
+        const composed = compose(copy, reporter);
+        composed.on("error", (err: Error) => {
+          console.error(err?.stack ?? err);
+          process.exitCode = 1;
+          resolvePromise();
+        });
+        composed.pipe(destination, { end: endDestination });
+        if (endDestination) {
+          destination.on("finish", resolvePromise);
+          destination.on("error", resolvePromise);
+        } else {
+          composed.on("end", resolvePromise);
+        }
+      }),
+    );
   }
   return Promise.all(promises);
 }
@@ -3106,6 +3456,8 @@ function addTest(
   node.ownTags = ownTags;
 
   // Node checks `skip` before `todo`, so `{ skip: true, todo: true }` is a skip.
+  // Execution routing is by truthiness: node runs the body for falsy-but-
+  // defined skip/todo ({ skip: '' }) and only reports the directive.
   const effectiveMode = mode ?? (options.skip ? "skip" : options.todo ? "todo" : undefined);
 
   if (inStandaloneMode()) {
@@ -3124,6 +3476,17 @@ function addTest(
   const { test } = bunTest();
   const passOptions = bunTestOptions(options);
 
+  if (hasSkippedAncestorSuite(node)) {
+    // Declared inside a skipped suite whose callback still ran: node cancels
+    // the child without running it, and the cancellation fails the run.
+    const cancelledRunner = (done: (error?: unknown) => void) => {
+      reportCancelledNode(node);
+      done(makeCancelledByParentError());
+    };
+    test(name, cancelledRunner);
+    return Promise.resolve(undefined);
+  }
+
   if (effectiveMode === "todo" || effectiveMode === "skip") {
     // Node runs a todo body, so `t.skip()` inside one still changes the
     // directive it reports. bun:test only runs todo bodies under --todo, so a
@@ -3136,6 +3499,18 @@ function addTest(
       const runner = createTopLevelTestRunner(node, fn);
       if (passOptions !== undefined) test(name, runner, passOptions);
       else test(name, runner);
+      return Promise.resolve(undefined);
+    }
+    if (runChildReporterEnabled) {
+      // Report at the node's execution turn so the event stream keeps
+      // declaration order (node reports skipped tests with the queued ones).
+      const directiveRunner = (done: (error?: unknown) => void) => {
+        reportDirectiveOnlyNode(node, effectiveMode);
+        markCurrentResult(false, done);
+        done(undefined);
+      };
+      if (passOptions !== undefined) test(name, directiveRunner, passOptions);
+      else test(name, directiveRunner);
       return Promise.resolve(undefined);
     }
     // A skipped body never runs — in node either — so nothing would report it.
@@ -3226,6 +3601,8 @@ function addSuite(
   noteRunChildRegistered(parent);
 
   // Node checks `skip` before `todo`, so `{ skip: true, todo: true }` is a skip.
+  // Execution routing is by truthiness: node runs the body for falsy-but-
+  // defined skip/todo ({ skip: '' }) and only reports the directive.
   const effectiveMode = mode ?? (options.skip ? "skip" : options.todo ? "todo" : undefined);
 
   if (inStandaloneMode()) {
@@ -3285,6 +3662,19 @@ function addSuite(
     } else {
       register = describe.todo;
     }
+  }
+  if (effectiveMode === "skip" && runChildReporterEnabled) {
+    // Report at execution turn so the event stream keeps declaration order.
+    suiteNode.suiteReported = true;
+    const { test } = bunTest();
+    const directiveRunner = (done: (error?: unknown) => void) => {
+      reportDirectiveOnlyNode(suiteNode, "skip");
+      markCurrentResult(false, done);
+      done(undefined);
+    };
+    if (passOptions !== undefined) test(name, directiveRunner, passOptions);
+    else test(name, directiveRunner);
+    return Promise.resolve(undefined);
   }
   if (effectiveMode === "skip" || (effectiveMode === "todo" && !runChildReporterEnabled)) {
     // A skipped suite reports as a leaf: its directive event is its completion

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -2435,7 +2435,8 @@ function invokeWithDoneCallback(fn: Function, arg: unknown) {
       // Node fails the test but still awaits the returned promise, so hooks
       // and later tests never race a still-running body.
       returnedPromise = true;
-      const fail = () => reject(makeTestFailure("passed a callback but also returned a Promise", "callbackAndPromisePresent"));
+      const fail = () =>
+        reject(makeTestFailure("passed a callback but also returned a Promise", "callbackAndPromisePresent"));
       (result as Promise<unknown>).then(fail, fail);
       return;
     }
@@ -2471,7 +2472,10 @@ function createStopController(timeout: number | undefined) {
   const promise = new Promise<never>((_, reject) => {
     // Not unref'd: dispose() always clears it, and on Windows an unref'd timer
     // alone under bun:test leaves the uws loop inactive so auto_tick busy-spins.
-    timer = realSetTimeout(() => reject(makeTestFailure(`test timed out after ${timeout}ms`, "testTimeoutFailure")), timeout);
+    timer = realSetTimeout(
+      () => reject(makeTestFailure(`test timed out after ${timeout}ms`, "testTimeoutFailure")),
+      timeout,
+    );
   });
   // Swallow the rejection when nothing is racing it anymore.
   promise.catch(() => {});
@@ -2501,7 +2505,10 @@ async function raceWithTimeoutAndSignal(
     if (typeof timeout === "number" && Number.isFinite(timeout)) {
       racers.push(
         new Promise<never>((_, reject) => {
-          timer = realSetTimeout(() => reject(makeTestFailure(`test timed out after ${timeout}ms`, "testTimeoutFailure")), timeout);
+          timer = realSetTimeout(
+            () => reject(makeTestFailure(`test timed out after ${timeout}ms`, "testTimeoutFailure")),
+            timeout,
+          );
         }),
       );
     }
@@ -2586,7 +2593,9 @@ async function runOwnBeforeHooks(node: TestNode) {
 type ExecutionEntry = { node: TestNode; fail: (err: Error) => void };
 const executionStack: ExecutionEntry[] = [];
 let processErrorAttributionInstalled = false;
-let testContextStorage: { run: (store: TestNode, fn: () => unknown) => unknown; getStore: () => TestNode | undefined } | undefined;
+let testContextStorage:
+  | { run: (store: TestNode, fn: () => unknown) => unknown; getStore: () => TestNode | undefined }
+  | undefined;
 
 function getTestContextStorage() {
   testContextStorage ??= new (require("node:async_hooks").AsyncLocalStorage)();
@@ -2748,7 +2757,10 @@ async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
 
     const { failedSubtests, firstSubtestError } = node;
     if (failure === undefined && failedSubtests > 0) {
-      const error = makeTestFailure(`${failedSubtests} subtest${failedSubtests > 1 ? "s" : ""} failed`, "subtestsFailed");
+      const error = makeTestFailure(
+        `${failedSubtests} subtest${failedSubtests > 1 ? "s" : ""} failed`,
+        "subtestsFailed",
+      );
       if (firstSubtestError !== undefined) {
         (error as { cause?: unknown }).cause = firstSubtestError;
       }
@@ -3321,8 +3333,7 @@ async function attachStandaloneReporters(stream: TestsStream): Promise<unknown> 
     // shared prototype carries an AsyncGeneratorFunction constructor) as-is.
     if (
       (reporter as { prototype?: object })?.prototype &&
-      Object.getOwnPropertyDescriptor((reporter as { prototype: object }).prototype, "constructor")?.value ===
-        reporter
+      Object.getOwnPropertyDescriptor((reporter as { prototype: object }).prototype, "constructor")?.value === reporter
     ) {
       reporter = new (reporter as new () => unknown)();
     }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -37,6 +37,10 @@ pub(crate) static has_bun_garbage_collector_flag_enabled: core::sync::atomic::At
     core::sync::atomic::AtomicBool::new(false);
 #[unsafe(no_mangle)]
 pub static isBunTest: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+// Set by the node:test shim when it loads inside a run() child (jest.rs
+// js_node_test_register_child); gates uncaught routing to process listeners.
+pub static IS_NODE_TEST_RUN_CHILD: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
 #[unsafe(no_mangle)]
 pub(crate) static Bun__defaultRemainingRunsUntilSkipReleaseAccess: core::sync::atomic::AtomicI32 =
     core::sync::atomic::AtomicI32::new(10);
@@ -1388,7 +1392,11 @@ impl VirtualMachine {
             return true;
         }
 
-        if isBunTest.load(core::sync::atomic::Ordering::Relaxed) {
+        // A registered node:test run() child takes the vanilla path below so
+        // the shim's process listeners can attribute uncaught errors to the
+        // running test; in-process registration doesn't leak to grandchildren.
+        let is_node_test_child = IS_NODE_TEST_RUN_CHILD.load(core::sync::atomic::Ordering::Relaxed);
+        if isBunTest.load(core::sync::atomic::Ordering::Relaxed) && !is_node_test_child {
             self.unhandled_error_counter += 1;
             (self.on_unhandled_rejection)(self, global_object, err);
             return true;
@@ -3361,7 +3369,11 @@ impl VirtualMachine {
             return;
         }
 
-        if isBunTest.load(core::sync::atomic::Ordering::Relaxed) {
+        // Mirrors uncaught_exception: a registered node:test run() child routes
+        // rejections through the vanilla path so the shim can attribute them.
+        if isBunTest.load(core::sync::atomic::Ordering::Relaxed)
+            && !IS_NODE_TEST_RUN_CHILD.load(core::sync::atomic::Ordering::Relaxed)
+        {
             self.unhandled_error_counter += 1;
             (self.on_unhandled_rejection)(self, global_object, reason);
             return;

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -833,9 +833,15 @@ impl BunTest {
             // in Jest, this is "Expected done to be called once, but it was called multiple times."
             // Vitest does not support done callbacks
         } else {
-            // error is only reported for the first done() call
+            // Error is only reported for the first done() call. Routed through
+            // bun:test's collector, not `uncaught_exception`: in a node:test
+            // child the latter dispatches genuine uncaughts to process listeners.
             if was_error {
-                let _ = global_this.bun_vm().as_mut().uncaught_exception(global_this, value, false);
+                let vm = global_this.bun_vm().as_mut();
+                if !vm.is_shutting_down() {
+                    vm.unhandled_error_counter += 1;
+                    (vm.on_unhandled_rejection)(vm, global_this, value);
+                }
             }
         }
         // SAFETY: see above — `this` is a live `*mut DoneCallback`.

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -556,6 +556,17 @@ pub(crate) fn js_file_generation(
     Ok(JSValue::from(generation))
 }
 
+/// Reached from node:test at module load in a run() child: registers this
+/// process so genuine uncaught errors route to the process listeners the shim
+/// installs (VirtualMachine::uncaught_exception / unhandled_rejection gates).
+pub(crate) fn js_node_test_register_child(
+    _global: &JSGlobalObject,
+    _callframe: &CallFrame,
+) -> JsResult<JSValue> {
+    jsc::virtual_machine::IS_NODE_TEST_RUN_CHILD.store(true, core::sync::atomic::Ordering::Relaxed);
+    Ok(JSValue::UNDEFINED)
+}
+
 /// Reached only from `node:test` (`t.skip()` / `t.todo()` at runtime): overrides
 /// the running sequence's result so bun:test reports skip/todo instead of pass.
 /// `done`'s bound `DoneCallback.r#ref.phase` names the intended sequence so a

--- a/test/js/node/test/.gitignore
+++ b/test/js/node/test/.gitignore
@@ -20,3 +20,13 @@ fixtures/test-runner/coverage/*
 !fixtures/test-runner/no-isolation
 !fixtures/test-runner/no-isolation/**
 !fixtures/test-runner/test-id-fixture.js
+!fixtures/test-runner/describe_error.js
+!fixtures/test-runner/never_ending_async.js
+!fixtures/test-runner/never_ending_sync.js
+!fixtures/test-runner/todo_exit_code.js
+!fixtures/test-runner/throws_sync_and_async.js
+!fixtures/test-runner/reporters.js
+!fixtures/test-runner/plan
+!fixtures/test-runner/plan/**
+!fixtures/test-runner/error-reporter-fail-fast
+!fixtures/test-runner/error-reporter-fail-fast/**

--- a/test/js/node/test/common/test-error-reporter.js
+++ b/test/js/node/test/common/test-error-reporter.js
@@ -1,0 +1,41 @@
+'use strict';
+const { relative } = require('node:path');
+const { inspect } = require('node:util');
+const cwd = process.cwd();
+
+module.exports = async function* errorReporter(source) {
+  for await (const event of source) {
+    if (event.type === 'test:fail') {
+      const { name, details, line, column, file } = event.data;
+      let { error } = details;
+
+      if (error?.failureType === 'subtestsFailed') {
+        // In the interest of keeping things concise, skip failures that are
+        // only due to nested failures.
+        continue;
+      }
+
+      if (error?.code === 'ERR_TEST_FAILURE') {
+        error = error.cause;
+      }
+
+      const output = [
+        `Test failure: '${name}'`,
+      ];
+
+      if (file) {
+        output.push(`Location: ${relative(cwd, file)}:${line}:${column}`);
+      }
+
+      output.push(inspect(error));
+      output.push('\n');
+      yield output.join('\n');
+
+      if (process.env.FAIL_FAST) {
+        yield `\nBailing on failed test: ${event.data.name}\n`;
+        process.exitCode = 1;
+        process.emit('SIGINT');
+      }
+    }
+  }
+};

--- a/test/js/node/test/fixtures/test-runner/describe_error.js
+++ b/test/js/node/test/fixtures/test-runner/describe_error.js
@@ -1,0 +1,10 @@
+'use strict';
+const { describe, it } = require('node:test');
+
+describe('should fail', () => {
+  throw new Error('error in describe');
+});
+
+describe('should pass', () => {
+  it('ok', () => {});
+});

--- a/test/js/node/test/fixtures/test-runner/error-reporter-fail-fast/a.mjs
+++ b/test/js/node/test/fixtures/test-runner/error-reporter-fail-fast/a.mjs
@@ -1,0 +1,6 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+test('fail', () => {
+  assert.fail('a.mjs fail');
+});

--- a/test/js/node/test/fixtures/test-runner/error-reporter-fail-fast/b.mjs
+++ b/test/js/node/test/fixtures/test-runner/error-reporter-fail-fast/b.mjs
@@ -1,0 +1,6 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+test('fail', () => {
+  assert.fail('b.mjs fail');
+});

--- a/test/js/node/test/fixtures/test-runner/never_ending_async.js
+++ b/test/js/node/test/fixtures/test-runner/never_ending_async.js
@@ -1,0 +1,6 @@
+const test = require('node:test');
+const { setTimeout } = require('timers/promises');
+
+// We are using a very large timeout value to ensure that the parent process
+// will have time to send a SIGINT signal to cancel the test.
+test('never ending test', () => setTimeout(100_000_000));

--- a/test/js/node/test/fixtures/test-runner/never_ending_sync.js
+++ b/test/js/node/test/fixtures/test-runner/never_ending_sync.js
@@ -1,0 +1,5 @@
+const test = require('node:test');
+
+test('never ending test', () => {
+  while (true);
+});

--- a/test/js/node/test/fixtures/test-runner/plan/less.mjs
+++ b/test/js/node/test/fixtures/test-runner/plan/less.mjs
@@ -1,0 +1,7 @@
+import test from 'node:test';
+
+test('less assertions than planned', (t) => {
+  t.plan(2);
+  t.assert.ok(true, 'only one assertion');
+  // Missing second assertion
+});

--- a/test/js/node/test/fixtures/test-runner/plan/match.mjs
+++ b/test/js/node/test/fixtures/test-runner/plan/match.mjs
@@ -1,0 +1,7 @@
+import test from 'node:test';
+
+test('matching assertions', (t) => {
+  t.plan(2);
+  t.assert.ok(true, 'first assertion');
+  t.assert.ok(true, 'second assertion');
+});

--- a/test/js/node/test/fixtures/test-runner/plan/more.mjs
+++ b/test/js/node/test/fixtures/test-runner/plan/more.mjs
@@ -1,0 +1,7 @@
+import test from 'node:test';
+
+test('more assertions than planned', (t) => {
+  t.plan(1);
+  t.assert.ok(true, 'first assertion');
+  t.assert.ok(true, 'extra assertion'); // This should cause failure
+});

--- a/test/js/node/test/fixtures/test-runner/plan/nested-subtests.mjs
+++ b/test/js/node/test/fixtures/test-runner/plan/nested-subtests.mjs
@@ -1,0 +1,14 @@
+import test from 'node:test';
+
+test('deeply nested tests', async (t) => {
+  t.plan(1);
+
+  await t.test('level 1', async (t) => {
+    t.plan(1);
+
+    await t.test('level 2', (t) => {
+      t.plan(1);
+      t.assert.ok(true, 'deepest assertion');
+    });
+  });
+});

--- a/test/js/node/test/fixtures/test-runner/plan/plan-via-options.mjs
+++ b/test/js/node/test/fixtures/test-runner/plan/plan-via-options.mjs
@@ -1,0 +1,9 @@
+import test from 'node:test';
+
+test('failing planning by options', { plan: 1 }, () => {
+  // Should fail - no assertions
+});
+
+test('passing planning by options', { plan: 1 }, (t) => {
+  t.assert.ok(true);
+});

--- a/test/js/node/test/fixtures/test-runner/plan/streaming.mjs
+++ b/test/js/node/test/fixtures/test-runner/plan/streaming.mjs
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import { Readable } from 'node:stream';
+
+test('planning with streams', (t, done) => {
+  function* generate() {
+    yield 'a';
+    yield 'b';
+    yield 'c';
+  }
+  const expected = ['a', 'b', 'c'];
+  t.plan(expected.length);
+  const stream = Readable.from(generate());
+  stream.on('data', (chunk) => {
+    t.assert.strictEqual(chunk, expected.shift());
+  });
+
+  stream.on('end', () => {
+    done();
+  });
+});

--- a/test/js/node/test/fixtures/test-runner/plan/subtest.mjs
+++ b/test/js/node/test/fixtures/test-runner/plan/subtest.mjs
@@ -1,0 +1,9 @@
+import test from 'node:test';
+
+test('parent test', async (t) => {
+  t.plan(1);
+  await t.test('child test', (t) => {
+    t.plan(1);
+    t.assert.ok(true, 'child assertion');
+  });
+});

--- a/test/js/node/test/fixtures/test-runner/plan/timeout-basic.mjs
+++ b/test/js/node/test/fixtures/test-runner/plan/timeout-basic.mjs
@@ -1,0 +1,15 @@
+import test from 'node:test';
+
+test('planning with wait should PASS within timeout', async (t) => {
+  t.plan(1, { wait: 5000 });
+  setTimeout(() => {
+    t.assert.ok(true);
+  }, 250);
+});
+
+test('planning with wait should FAIL within timeout', async (t) => {
+  t.plan(1, { wait: 5000 });
+  setTimeout(() => {
+    t.assert.ok(false);
+  }, 250);
+});

--- a/test/js/node/test/fixtures/test-runner/plan/timeout-expired.mjs
+++ b/test/js/node/test/fixtures/test-runner/plan/timeout-expired.mjs
@@ -1,0 +1,8 @@
+import test from 'node:test';
+
+test('planning should FAIL when wait time expires before plan is met', (t) => {
+  t.plan(2, { wait: 500 });
+  setTimeout(() => {
+    t.assert.ok(true);
+  }, 30_000).unref();
+});

--- a/test/js/node/test/fixtures/test-runner/plan/timeout-wait-false.mjs
+++ b/test/js/node/test/fixtures/test-runner/plan/timeout-wait-false.mjs
@@ -1,0 +1,11 @@
+import test from 'node:test';
+
+test('should not wait for assertions and fail immediately', async (t) => {
+  t.plan(1, { wait: false });
+
+  // Set up an async operation that won't complete before the test finishes
+  // Since wait:false, the test should fail immediately without waiting
+  setTimeout(() => {
+    t.assert.ok(true);
+  }, 1000).unref();
+});

--- a/test/js/node/test/fixtures/test-runner/plan/timeout-wait-true.mjs
+++ b/test/js/node/test/fixtures/test-runner/plan/timeout-wait-true.mjs
@@ -1,0 +1,17 @@
+import test from 'node:test';
+
+test('should pass when assertions are eventually met', async (t) => {
+  t.plan(1, { wait: true });
+
+  setTimeout(() => {
+    t.assert.ok(true);
+  }, 250);
+});
+
+test('should fail when assertions fail', async (t) => {
+  t.plan(1, { wait: true });
+
+  setTimeout(() => {
+    t.assert.ok(false);
+  }, 250).unref();
+});

--- a/test/js/node/test/fixtures/test-runner/reporters.js
+++ b/test/js/node/test/fixtures/test-runner/reporters.js
@@ -1,0 +1,11 @@
+'use strict';
+const test = require('node:test');
+
+test('nested', { concurrency: 4 }, async (t) => {
+  t.test('ok', () => {});
+  t.test('failing', () => {
+    throw new Error('error');
+  });
+});
+
+test('top level', () => {});

--- a/test/js/node/test/fixtures/test-runner/throws_sync_and_async.js
+++ b/test/js/node/test/fixtures/test-runner/throws_sync_and_async.js
@@ -1,0 +1,10 @@
+'use strict';
+const { test } = require('node:test');
+
+test('fails and schedules more work', () => {
+  setTimeout(() => {
+    throw new Error('this should not have a chance to be thrown');
+  }, 1000);
+
+  throw new Error('fails');
+});

--- a/test/js/node/test/fixtures/test-runner/todo_exit_code.js
+++ b/test/js/node/test/fixtures/test-runner/todo_exit_code.js
@@ -1,0 +1,21 @@
+const { describe, test } = require('node:test');
+
+describe('suite should pass', () => {
+  test.todo('should fail without harming suite', () => {
+    throw new Error('Fail but not badly')
+  });
+});
+
+test.todo('should fail without effecting exit code', () => {
+  throw new Error('Fail but not badly')
+});
+
+test('empty string todo', { todo: '' }, () => {
+  throw new Error('Fail but not badly')
+});
+
+describe.todo('should inherit todo', () => {
+  test('should fail without harming suite', () => {
+    throw new Error('Fail but not badly');
+  });
+});

--- a/test/js/node/test/parallel/test-runner-error-reporter.js
+++ b/test/js/node/test/parallel/test-runner-error-reporter.js
@@ -1,0 +1,32 @@
+'use strict';
+
+require('../common');
+const fixtures = require('../common/fixtures');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const { test } = require('node:test');
+const cwd = fixtures.path('test-runner', 'error-reporter-fail-fast');
+
+test('all tests failures reported without FAIL_FAST flag', async () => {
+  const args = [
+    `--test-reporter=${require.resolve('../common/test-error-reporter.js')}`,
+    '--test-concurrency=1',
+    '--test',
+    `${cwd}/*.mjs`,
+  ];
+  const cp = spawnSync(process.execPath, args);
+  const failureCount = (cp.stdout.toString().match(/Test failure:/g) || []).length;
+  assert.strictEqual(failureCount, 2);
+});
+
+test('FAIL_FAST stops test execution after first failure', async () => {
+  const args = [
+    `--test-reporter=${require.resolve('../common/test-error-reporter.js')}`,
+    '--test-concurrency=1',
+    '--test',
+    `${cwd}/*.mjs`,
+  ];
+  const cp = spawnSync(process.execPath, args, { env: { ...process.env, FAIL_FAST: 'true' } });
+  const failureCount = (cp.stdout.toString().match(/Test failure:/g) || []).length;
+  assert.strictEqual(failureCount, 1);
+});

--- a/test/js/node/test/parallel/test-runner-exit-code.js
+++ b/test/js/node/test/parallel/test-runner-exit-code.js
@@ -1,0 +1,87 @@
+'use strict';
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+const assert = require('assert');
+const { spawnSync, spawn } = require('child_process');
+const { once } = require('events');
+const { finished } = require('stream/promises');
+
+async function runAndKill(file, expectedTestName) {
+  if (common.isWindows) {
+    common.printSkipMessage(`signals are not supported in windows, skipping ${file}`);
+    return;
+  }
+  let stdout = '';
+  const child = spawn(process.execPath, ['--test', '--test-reporter=tap', file]);
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (chunk) => {
+    if (!stdout.length) child.kill('SIGINT');
+    stdout += chunk;
+  });
+  const [code, signal] = await once(child, 'exit');
+  await finished(child.stdout);
+  assert(stdout.startsWith('TAP version 13\n'));
+  // Verify interrupted test message
+  assert(stdout.includes(`Interrupted while running: ${expectedTestName}`),
+         `Expected output to contain interrupted test name`);
+  assert.strictEqual(signal, null);
+  assert.strictEqual(code, 1);
+}
+
+if (process.argv[2] === 'child') {
+  const test = require('node:test');
+
+  if (process.argv[3] === 'pass') {
+    test('passing test', () => {
+      assert.strictEqual(true, true);
+    });
+  } else if (process.argv[3] === 'fail') {
+    assert.strictEqual(process.argv[3], 'fail');
+    test('failing test', () => {
+      assert.strictEqual(true, false);
+    });
+  } else assert.fail('unreachable');
+} else {
+  let child = spawnSync(process.execPath, [__filename, 'child', 'pass']);
+  assert.strictEqual(child.status, 0);
+  assert.strictEqual(child.signal, null);
+
+  child = spawnSync(process.execPath, [
+    '--test',
+    fixtures.path('test-runner', 'default-behavior', 'subdir', 'subdir_test.js'),
+  ]);
+  assert.strictEqual(child.status, 0);
+  assert.strictEqual(child.signal, null);
+
+
+  child = spawnSync(process.execPath, [
+    '--test',
+    fixtures.path('test-runner', 'todo_exit_code.js'),
+  ]);
+  assert.strictEqual(child.status, 0);
+  assert.strictEqual(child.signal, null);
+  const stdout = child.stdout.toString();
+  assert.match(stdout, /tests 4/);
+  assert.match(stdout, /pass 0/);
+  assert.match(stdout, /fail 0/);
+  assert.match(stdout, /todo 4/);
+
+  child = spawnSync(process.execPath, [__filename, 'child', 'fail']);
+  assert.strictEqual(child.status, 1);
+  assert.strictEqual(child.signal, null);
+
+  // An error thrown inside describe() should cause a non-zero exit code.
+  child = spawnSync(process.execPath, [
+    '--test',
+    fixtures.path('test-runner', 'describe_error.js'),
+  ]);
+  assert.strictEqual(child.status, 1);
+  assert.strictEqual(child.signal, null);
+
+  // With process isolation (default), the test name shown is the file path
+  // because the parent runner only knows about file-level tests
+  const neverEndingSync = fixtures.path('test-runner', 'never_ending_sync.js');
+  const neverEndingAsync = fixtures.path('test-runner', 'never_ending_async.js');
+  runAndKill(neverEndingSync, neverEndingSync).then(common.mustCall());
+  runAndKill(neverEndingAsync, neverEndingAsync).then(common.mustCall());
+}

--- a/test/js/node/test/parallel/test-runner-force-exit-failure.js
+++ b/test/js/node/test/parallel/test-runner-force-exit-failure.js
@@ -1,0 +1,25 @@
+'use strict';
+require('../common');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const fixtures = require('../common/fixtures');
+const fixture = fixtures.path('test-runner/throws_sync_and_async.js');
+
+for (const isolation of ['none', 'process']) {
+  const args = [
+    '--test',
+    '--test-reporter=spec',
+    '--test-force-exit',
+    `--test-isolation=${isolation}`,
+    fixture,
+  ];
+  const r = spawnSync(process.execPath, args);
+
+  assert.strictEqual(r.status, 1);
+  assert.strictEqual(r.signal, null);
+  assert.strictEqual(r.stderr.toString(), '');
+
+  const stdout = r.stdout.toString();
+  assert.match(stdout, /Error: fails/);
+  assert.doesNotMatch(stdout, /this should not have a chance to be thrown/);
+}

--- a/test/js/node/test/parallel/test-runner-force-exit-flush.js
+++ b/test/js/node/test/parallel/test-runner-force-exit-flush.js
@@ -1,0 +1,49 @@
+'use strict';
+require('../common');
+const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const { readFileSync } = require('node:fs');
+const { test } = require('node:test');
+
+function runWithReporter(reporter) {
+  const destination = tmpdir.resolve(`${reporter}.out`);
+  const args = [
+    '--test-force-exit',
+    `--test-reporter=${reporter}`,
+    `--test-reporter-destination=${destination}`,
+    fixtures.path('test-runner', 'reporters.js'),
+  ];
+  const child = spawnSync(process.execPath, args);
+  assert.strictEqual(child.stdout.toString(), '');
+  assert.strictEqual(child.stderr.toString(), '');
+  assert.strictEqual(child.status, 1);
+  return destination;
+}
+
+tmpdir.refresh();
+
+test('junit reporter', () => {
+  const output = readFileSync(runWithReporter('junit'), 'utf8');
+  assert.match(output, /<!-- tests 4 -->/);
+  assert.match(output, /<!-- pass 2 -->/);
+  assert.match(output, /<!-- fail 2 -->/);
+  assert.match(output, /<!-- duration_ms/);
+  assert.match(output, /<\/testsuites>/);
+});
+
+test('spec reporter', () => {
+  const output = readFileSync(runWithReporter('spec'), 'utf8');
+  assert.match(output, /tests 4/);
+  assert.match(output, /pass 2/);
+  assert.match(output, /fail 2/);
+});
+
+test('tap reporter', () => {
+  const output = readFileSync(runWithReporter('tap'), 'utf8');
+  assert.match(output, /# tests 4/);
+  assert.match(output, /# pass 2/);
+  assert.match(output, /# fail 2/);
+  assert.match(output, /# duration_ms/);
+});

--- a/test/js/node/test/parallel/test-runner-misc.js
+++ b/test/js/node/test/parallel/test-runner-misc.js
@@ -1,0 +1,41 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const { setTimeout } = require('timers/promises');
+
+if (process.argv[2] === 'child') {
+  const test = require('node:test');
+
+  if (process.argv[3] === 'abortSignal') {
+    assert.throws(() => test({ signal: {} }), {
+      code: 'ERR_INVALID_ARG_TYPE',
+      name: 'TypeError'
+    });
+
+    let testSignal;
+    test({ timeout: 10 }, common.mustCall(async ({ signal }) => {
+      assert.strictEqual(signal.aborted, false);
+      testSignal = signal;
+      await setTimeout(50);
+    })).finally(common.mustCall(() => {
+      test(() => assert.strictEqual(testSignal.aborted, true));
+    }));
+
+    // TODO(benjamingr) add more tests to describe + AbortSignal
+    // this just tests the parameter is passed
+    test.describe('Abort Signal in describe', common.mustCall(({ signal }) => {
+      test.it('Supports AbortSignal', common.mustCall(() => {
+        assert.strictEqual(signal.aborted, false);
+      }));
+    }));
+  } else assert.fail('unreachable');
+} else {
+  const child = spawnSync(process.execPath, [__filename, 'child', 'abortSignal']);
+  const stdout = child.stdout.toString();
+  assert.match(stdout, /pass 2$/m);
+  assert.match(stdout, /fail 0$/m);
+  assert.match(stdout, /cancelled 1$/m);
+  assert.strictEqual(child.status, 1);
+  assert.strictEqual(child.signal, null);
+}

--- a/test/js/node/test/parallel/test-runner-plan.mjs
+++ b/test/js/node/test/parallel/test-runner-plan.mjs
@@ -1,0 +1,171 @@
+import * as common from '../common/index.mjs';
+import * as fixtures from '../common/fixtures.mjs';
+import { describe, it, run } from 'node:test';
+import { join } from 'node:path';
+
+const testFixtures = fixtures.path('test-runner', 'plan');
+
+describe('input validation', () => {
+  it('throws if options is not an object', (t) => {
+    t.assert.throws(() => {
+      t.plan(1, null);
+    }, {
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: /The "options" argument must be of type object/,
+    });
+  });
+
+  it('throws if options.wait is not a number or a boolean', (t) => {
+    t.assert.throws(() => {
+      t.plan(1, { wait: 'foo' });
+    }, {
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: /The "options\.wait" property must be one of type boolean or number\. Received type string/,
+    });
+  });
+
+  it('throws if count is not a number', (t) => {
+    t.assert.throws(() => {
+      t.plan('foo');
+    }, {
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: /The "count" argument must be of type number/,
+    });
+  });
+});
+
+describe('test planning', () => {
+  it('should pass when assertions match plan', async () => {
+    const stream = run({
+      files: [join(testFixtures, 'match.mjs')]
+    });
+
+    stream.on('test:fail', common.mustNotCall());
+    stream.on('test:pass', common.mustCall(1));
+
+    // eslint-disable-next-line no-unused-vars
+    for await (const _ of stream);
+  });
+
+  it('should fail when less assertions than planned', async () => {
+    const stream = run({
+      files: [join(testFixtures, 'less.mjs')]
+    });
+
+    stream.on('test:fail', common.mustCall(1));
+    stream.on('test:pass', common.mustNotCall());
+
+    // eslint-disable-next-line no-unused-vars
+    for await (const _ of stream);
+  });
+
+  it('should fail when more assertions than planned', async () => {
+    const stream = run({
+      files: [join(testFixtures, 'more.mjs')]
+    });
+
+    stream.on('test:fail', common.mustCall(1));
+    stream.on('test:pass', common.mustNotCall());
+
+    // eslint-disable-next-line no-unused-vars
+    for await (const _ of stream);
+  });
+
+  it('should handle plan with subtests correctly', async () => {
+    const stream = run({
+      files: [join(testFixtures, 'subtest.mjs')]
+    });
+
+    stream.on('test:fail', common.mustNotCall());
+    stream.on('test:pass', common.mustCall(2)); // Parent + child test
+
+    // eslint-disable-next-line no-unused-vars
+    for await (const _ of stream);
+  });
+
+  it('should handle plan via options', async () => {
+    const stream = run({
+      files: [join(testFixtures, 'plan-via-options.mjs')]
+    });
+
+    stream.on('test:fail', common.mustCall(1));
+    stream.on('test:pass', common.mustCall(1));
+
+    // eslint-disable-next-line no-unused-vars
+    for await (const _ of stream);
+  });
+
+  it('should handle streaming with plan', async () => {
+    const stream = run({
+      files: [join(testFixtures, 'streaming.mjs')]
+    });
+
+    stream.on('test:fail', common.mustNotCall());
+    stream.on('test:pass', common.mustCall(1));
+
+    // eslint-disable-next-line no-unused-vars
+    for await (const _ of stream);
+  });
+
+  it('should handle nested subtests with plan', async () => {
+    const stream = run({
+      files: [join(testFixtures, 'nested-subtests.mjs')]
+    });
+
+    stream.on('test:fail', common.mustNotCall());
+    stream.on('test:pass', common.mustCall(3)); // Parent + 2 levels of nesting
+
+    // eslint-disable-next-line no-unused-vars
+    for await (const _ of stream);
+  });
+
+  describe('with timeout', () => {
+    it('should handle basic timeout scenarios', async () => {
+      const stream = run({
+        files: [join(testFixtures, 'timeout-basic.mjs')]
+      });
+
+      stream.on('test:fail', common.mustCall(1));
+      stream.on('test:pass', common.mustCall(1));
+
+      // eslint-disable-next-line no-unused-vars
+      for await (const _ of stream);
+    });
+
+    it('should fail when timeout expires before plan is met', async (t) => {
+      const stream = run({
+        files: [join(testFixtures, 'timeout-expired.mjs')]
+      });
+
+      stream.on('test:fail', common.mustCall(1));
+      stream.on('test:pass', common.mustNotCall());
+
+      // eslint-disable-next-line no-unused-vars
+      for await (const _ of stream);
+    });
+
+    it('should handle wait:true option specifically', async () => {
+      const stream = run({
+        files: [join(testFixtures, 'timeout-wait-true.mjs')]
+      });
+
+      stream.on('test:fail', common.mustCall(1));
+      stream.on('test:pass', common.mustCall(1));
+
+      // eslint-disable-next-line no-unused-vars
+      for await (const _ of stream);
+    });
+
+    it('should handle wait:false option (should not wait)', async () => {
+      const stream = run({
+        files: [join(testFixtures, 'timeout-wait-false.mjs')]
+      });
+
+      stream.on('test:fail', common.mustCall(1)); // Fails because plan is not met immediately
+      stream.on('test:pass', common.mustNotCall());
+
+      // eslint-disable-next-line no-unused-vars
+      for await (const _ of stream);
+    });
+  });
+});

--- a/test/js/node/test/parallel/test-runner-run-files-undefined.mjs
+++ b/test/js/node/test/parallel/test-runner-run-files-undefined.mjs
@@ -1,0 +1,31 @@
+import '../common/index.mjs';
+import tmpdir from '../common/tmpdir.js';
+import { spawnSyncAndExitWithoutError } from '../common/child_process.js';
+
+async function runTests(run, reporters) {
+  for (const reporterName of Object.keys(reporters)) {
+    if (reporterName === 'default') continue;
+    console.log({ reporterName });
+
+    const stream = run({
+      files: undefined
+    }).compose(reporters[reporterName]);
+    stream.on('test:fail', () => {
+      throw new Error('Received test:fail with ' + reporterName);
+    });
+    stream.on('test:pass', () => {
+      throw new Error('Received test:pass with ' + reporterName);
+    });
+
+    // eslint-disable-next-line no-unused-vars
+    for await (const _ of stream);
+  }
+}
+
+tmpdir.refresh();
+spawnSyncAndExitWithoutError(process.execPath, ['--input-type=module', '-e', `
+  import { run } from 'node:test';
+  import * as reporters from 'node:test/reporters';
+
+  await (${runTests})(run, reporters);
+`], { cwd: tmpdir.path });

--- a/test/js/node/test/parallel/test-runner-xfail.js
+++ b/test/js/node/test/parallel/test-runner-xfail.js
@@ -1,0 +1,259 @@
+'use strict';
+const common = require('../common');
+const { test, suite } = require('node:test');
+const { spawn } = require('child_process');
+const assert = require('node:assert');
+
+if (process.env.CHILD_PROCESS === 'true') {
+  test('fail with message string', { expectFailure: 'reason string' }, () => {
+    assert.fail('boom');
+  });
+
+  test('fail with label object', { expectFailure: { label: 'reason object' } }, () => {
+    assert.fail('boom');
+  });
+
+  test('fail with match regex', { expectFailure: { match: /boom/ } }, () => {
+    assert.fail('boom');
+  });
+
+  test('fail with match object', { expectFailure: { match: { message: 'boom' } } }, () => {
+    assert.fail('boom');
+  });
+
+  test('fail with match class', { expectFailure: { match: assert.AssertionError } }, () => {
+    assert.fail('boom');
+  });
+
+  test('fail with match error (wrong error)', { expectFailure: { match: /bang/ } }, () => {
+    assert.fail('boom'); // Should result in real failure because error doesn't match
+  });
+
+  test('unexpected pass', { expectFailure: true }, () => {
+    // Should result in real failure because it didn't fail
+  });
+
+  test('fail with empty string', { expectFailure: '' }, () => {
+    assert.fail('boom');
+  });
+
+  // 1. Matcher: RegExp
+  test('fails with regex matcher', { expectFailure: /expected error/ }, () => {
+    throw new Error('this is the expected error');
+  });
+
+  test('fails with regex matcher (mismatch)', { expectFailure: /expected error/ }, () => {
+    throw new Error('wrong error'); // Should fail the test
+  });
+
+  // 2. Matcher: Class
+  test('fails with class matcher', { expectFailure: RangeError }, () => {
+    throw new RangeError('out of bounds');
+  });
+
+  test('fails with class matcher (mismatch)', { expectFailure: RangeError }, () => {
+    throw new TypeError('wrong type'); // Should fail the test
+  });
+
+  // 3. Matcher: Function
+  test('fails with function matcher', {
+    expectFailure: (err) => err.code === 'ERR_FUNCTION',
+  }, () => {
+    const err = new Error('boom');
+    err.code = 'ERR_FUNCTION';
+    throw err;
+  });
+
+  test('fails with function matcher (mismatch)', {
+    expectFailure: (err) => err.code === 'ERR_FUNCTION',
+  }, () => {
+    const err = new Error('boom');
+    err.code = 'ERR_WRONG';
+    throw err; // Should fail
+  });
+
+  // 4. Matcher: Object (Properties)
+  test('fails with object matcher', { expectFailure: { code: 'ERR_TEST' } }, () => {
+    const err = new Error('boom');
+    err.code = 'ERR_TEST';
+    throw err;
+  });
+
+  test('fails with object matcher (mismatch)', { expectFailure: { code: 'ERR_TEST' } }, () => {
+    const err = new Error('boom');
+    err.code = 'ERR_WRONG';
+    throw err; // Should fail
+  });
+
+  // 5. Configuration Object: Reason + Validation
+  test('fails with config object (label + match)', {
+    expectFailure: {
+      label: 'Bug #124',
+      match: /boom/
+    }
+  }, () => {
+    throw new Error('boom');
+  });
+
+  test('fails with config object (label only)', {
+    expectFailure: { label: 'Bug #125' }
+  }, () => {
+    throw new Error('boom');
+  });
+
+  test('fails with config object (match only)', {
+    expectFailure: { match: /boom/ }
+  }, () => {
+    throw new Error('boom');
+  });
+
+  // 6. Edge Case: Empty Object (Should throw ERR_INVALID_ARG_VALUE during creation)
+  test('invalid empty object throws', () => {
+    // eslint-disable-next-line no-restricted-syntax
+    assert.throws(() => test('invalid empty object', { expectFailure: {} }, () => {}));
+  });
+
+  // 7. Primitives and Truthiness
+  test('fails with boolean true', { expectFailure: true }, () => {
+    throw new Error('any error');
+  });
+
+  // 8. Unexpected Pass (Enhanced)
+  test('unexpected pass (reason string)', { expectFailure: 'should fail' }, () => {
+    // Pass
+  });
+
+  test('unexpected pass (matcher)', { expectFailure: /boom/ }, () => {
+    // Pass
+  });
+
+  // 9. Test level expectFailure with subtests
+  test('test level expectFailure with subtests', { expectFailure: true }, async (t) => {
+    await t.test('subtest should pass if it throws', () => {
+      throw new Error('fail');
+    });
+
+    await t.test('subtest should fail if it does not throw', () => {
+      // This should fail the test because the suite expects failure,
+      // and this subtest inherited that expectation but didn't throw.
+    });
+  });
+
+  test('test level expectFailure with subtests and matcher', { expectFailure: /suite error/ }, async (t) => {
+    await t.test('subtest match suite expectation', () => {
+      throw new Error('suite error');
+    });
+  });
+
+  // 10. Suite level expectFailure
+  suite('suite level expectFailure', { expectFailure: true }, () => {
+    test('suite subtest should pass if it throws', () => {
+      throw new Error('fail');
+    });
+
+    test('suite subtest should fail if it does not throw', () => {
+      // This should fail the test because the suite expects failure,
+      // and this subtest inherited that expectation but didn't throw.
+    });
+  });
+
+  suite('suite level expectFailure with matcher', { expectFailure: /suite error/ }, () => {
+    test('suite subtest match suite expectation', () => {
+      throw new Error('suite error');
+    });
+  });
+
+  test('correct config with label and match object', {
+    expectFailure: {
+      label: 'Bug #124',
+      match: { code: 'ERR_TEST' }
+    }
+  }, () => {
+    const err = new Error('boom');
+    err.code = 'ERR_TEST';
+    throw err;
+  });
+
+  test('fails with ambiguous config (mixed props)', {
+    expectFailure: {
+      code: 'ERR_TEST',
+      label: 'Bug #124',
+    }
+  }, () => {
+    const err = new Error('boom');
+    err.code = 'ERR_TEST';
+    throw err;
+  });
+
+  test('fails with ambiguous config (mixed props with match)', {
+    expectFailure: {
+      code: 'ERR_TEST',
+      match: /message/
+    }
+  }, () => {
+    const err = new Error('message');
+    err.code = 'ERR_TEST';
+    throw err;
+  });
+
+} else {
+  const child = spawn(process.execPath, ['--test-reporter', 'tap', __filename], {
+    env: { ...process.env, CHILD_PROCESS: 'true' },
+    stdio: 'pipe',
+  });
+
+  let stdout = '';
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (chunk) => { stdout += chunk; });
+
+  child.on('close', common.mustCall((code) => {
+    // We expect exit code 1 because 'unexpected pass' and 'wrong error' should fail the test run
+    assert.strictEqual(code, 1);
+
+    assert.match(stdout, /ok \d+ - fail with message string # EXPECTED FAILURE reason string/);
+    assert.match(stdout, /ok \d+ - fail with label object # EXPECTED FAILURE reason object/);
+    assert.match(stdout, /ok \d+ - fail with match regex # EXPECTED FAILURE/);
+    assert.match(stdout, /ok \d+ - fail with match object # EXPECTED FAILURE/);
+    assert.match(stdout, /ok \d+ - fail with match class # EXPECTED FAILURE/);
+    assert.match(stdout, /not ok \d+ - fail with match error \(wrong error\) # EXPECTED FAILURE/);
+    assert.match(stdout, /not ok \d+ - unexpected pass # EXPECTED FAILURE/);
+    assert.match(stdout, /ok \d+ - fail with empty string # EXPECTED FAILURE/);
+
+    // New tests verification
+    assert.match(stdout, /ok \d+ - fails with regex matcher # EXPECTED FAILURE/);
+    assert.match(stdout, /not ok \d+ - fails with regex matcher \(mismatch\) # EXPECTED FAILURE/);
+    assert.match(stdout, /ok \d+ - fails with class matcher # EXPECTED FAILURE/);
+    assert.match(stdout, /not ok \d+ - fails with class matcher \(mismatch\) # EXPECTED FAILURE/);
+    assert.match(stdout, /ok \d+ - fails with function matcher # EXPECTED FAILURE/);
+    assert.match(stdout, /not ok \d+ - fails with function matcher \(mismatch\) # EXPECTED FAILURE/);
+    assert.match(stdout, /ok \d+ - fails with object matcher # EXPECTED FAILURE/);
+    assert.match(stdout, /not ok \d+ - fails with object matcher \(mismatch\) # EXPECTED FAILURE/);
+    assert.match(stdout, /ok \d+ - fails with config object \(label \+ match\) # EXPECTED FAILURE Bug \\#124/);
+    assert.match(stdout, /ok \d+ - fails with config object \(label only\) # EXPECTED FAILURE Bug \\#125/);
+    assert.match(stdout, /ok \d+ - fails with config object \(match only\) # EXPECTED FAILURE/);
+    assert.match(stdout, /ok \d+ - fails with boolean true # EXPECTED FAILURE/);
+    assert.match(stdout, /not ok \d+ - unexpected pass \(reason string\) # EXPECTED FAILURE should fail/);
+    assert.match(stdout, /not ok \d+ - unexpected pass \(matcher\) # EXPECTED FAILURE/);
+
+    // Suite inheritance verification
+    assert.match(stdout, /ok \d+ - test level expectFailure with subtests # EXPECTED FAILURE/);
+    assert.match(stdout, /ok \d+ - subtest should pass if it throws # EXPECTED FAILURE/);
+    assert.match(stdout, /not ok \d+ - subtest should fail if it does not throw # EXPECTED FAILURE/);
+    assert.match(stdout, /ok \d+ - test level expectFailure with subtests and matcher # EXPECTED FAILURE/);
+    assert.match(stdout, /ok \d+ - subtest match suite expectation # EXPECTED FAILURE/);
+
+    // Suite level expectFailure verification
+    assert.match(stdout, /ok \d+ - suite level expectFailure # EXPECTED FAILURE/);
+    assert.match(stdout, /ok \d+ - suite subtest should pass if it throws # EXPECTED FAILURE/);
+    assert.match(stdout, /not ok \d+ - suite subtest should fail if it does not throw # EXPECTED FAILURE/);
+    assert.match(stdout, /ok \d+ - suite level expectFailure with matcher # EXPECTED FAILURE/);
+    assert.match(stdout, /ok \d+ - suite subtest match suite expectation # EXPECTED FAILURE/);
+
+    // Empty object error
+    assert.match(stdout, /ok \d+ - invalid empty object throws/);
+    assert.match(stdout, /ok \d+ - correct config with label and match object # EXPECTED FAILURE Bug \\#124/);
+    assert.match(stdout, /not ok \d+ - fails with ambiguous config \(mixed props\) # EXPECTED FAILURE/);
+    assert.match(stdout, /not ok \d+ - fails with ambiguous config \(mixed props with match\) # EXPECTED FAILURE/);
+
+  }));
+}

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "node:path";
 
 describe("node:test", () => {
@@ -505,4 +505,82 @@ test("mock.property/mock.method survive a polluted Object.prototype", async () =
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stdout: stdout.trim(), stderr, exitCode }).toMatchObject({ stdout: "ok", exitCode: 0 });
+});
+
+test("run(): an uncaught exception during a pending body fails that test instead of hanging", async () => {
+  using dir = tempDir("node-test-uncaught-body", {
+    "fixture.test.mjs": `
+      import test from 'node:test';
+      test('pending body uncaught', async () => {
+        setTimeout(() => { throw new Error('late boom'); }, 20);
+        await new Promise(() => {});
+      });
+    `,
+    "driver.mjs": `
+      import { run } from 'node:test';
+      const stream = run({ files: [new URL('./fixture.test.mjs', import.meta.url).pathname] });
+      const fails = [];
+      stream.on('test:fail', d => fails.push({ name: d.name, failureType: d.details?.error?.failureType }));
+      for await (const _ of stream);
+      console.log(JSON.stringify(fails));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", join(String(dir), "driver.mjs")],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  // Well under bun:test's own 5s watchdog: the shim must fail the test as
+  // soon as the error is attributed, not wait for a timeout rescue.
+  const exited = await Promise.race([proc.exited, Bun.sleep(4000).then(() => "timeout" as const)]);
+  if (exited === "timeout") proc.kill();
+  const stdout = await proc.stdout.text();
+  expect(exited).not.toBe("timeout");
+  const fails = JSON.parse(stdout.trim() || "[]");
+  expect(fails).toContainEqual({ name: "pending body uncaught", failureType: "uncaughtException" });
+});
+
+test("NODE_TEST_CONTEXT does not leak node:test uncaught handling into spawned grandchildren", async () => {
+  using dir = tempDir("node-test-env-leak", {
+    "inner.test.js": `
+      process.on("uncaughtException", () => {});
+      const { test } = require("bun:test");
+      test("swallow attempt", async () => {
+        setTimeout(() => { throw new Error("boom"); }, 10);
+        await new Promise(r => setTimeout(r, 50));
+      });
+    `,
+    "outer.test.mjs": `
+      import test from 'node:test';
+      import assert from 'node:assert';
+      import { spawnSync } from 'node:child_process';
+      test('grandchild records the uncaught', () => {
+        const r = spawnSync(process.execPath, ['test', process.env.INNER_FIXTURE], { env: { ...process.env } });
+        assert.strictEqual(r.status, 1);
+      });
+    `,
+    "driver.mjs": `
+      import { run } from 'node:test';
+      const stream = run({ files: [new URL('./outer.test.mjs', import.meta.url).pathname] });
+      let passed = 0, failed = 0;
+      stream.on('test:pass', () => passed++);
+      stream.on('test:fail', () => failed++);
+      for await (const _ of stream);
+      console.log(JSON.stringify({ passed, failed }));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", join(String(dir), "driver.mjs")],
+    env: { ...bunEnv, INNER_FIXTURE: join(String(dir), "inner.test.js") },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const counts = JSON.parse(stdout.trim());
+  expect(counts.failed).toBe(0);
+  expect(counts.passed).toBeGreaterThanOrEqual(1);
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
Makes node:test's default reporter output match node's, byte-for-byte in structure. Stacked on #34515 (which supplies `--test` CLI mode, `node:test/reporters`, and standalone execution — this PR is why those tests were still red: the *output* didn't match).

## Before/after

The full byte-diff catalogue vs node v26.3.0 drove every change: directive reasons dropped (`# SKIP` without reason), skips reported at registration (breaking declaration order and TAP numbering), float-noise durations, missing `failureType`/`expected`/`actual`/`operator` YAML, raw errors instead of ERR_TEST_FAILURE wrapping, timeouts counted as `fail` instead of `cancelled`, no run-level plan in multi-file mode, no `test:interrupted`, reporters exported as raw classes so `.compose(reporters.lcov)` crashed.

After: TAP/spec output is structurally identical to node except `location:` fields (declaration capture not implemented), engine stack-frame naming, and actual timing values. Counts, ordering, numbering, directives, YAML field set/order, and exit codes all match.

## The part review earned its keep on

Six findings from review, all fixed with regression tests that fail on the pre-fix build:

- **Two hang classes**: an uncaught during a pending body now settles the body await (node fails immediately and moves on; bun previously awaited a never-resolving promise forever), and `unhandledRejection` is gated like `uncaughtException` so a `t.plan({wait})` test whose only failure is a floating rejection can't stall the child.
- **A fail→pass flip**: the native gate was keyed on the inheritable `NODE_TEST_CONTEXT` env var, so a grandchild `bun test` spawned with `{env: process.env}` got node-test semantics and a user `uncaughtException` listener swallowed throws that used to be recorded. The shim now **registers itself in-process** via a native call; grandchildren keep collector semantics by construction.
- Bystander attribution: test bodies run in an `AsyncLocalStorage` context carrying their TestNode, so a finished test's late `setTimeout` throw reports at root level (node's "generated asynchronous activity" semantics) instead of failing whichever test happens to be running.
- Falsy-but-defined `skip:''`/`skip:0` still *runs* the body (verified: node executes it, side effects and all, while reporting `# SKIP`), and reporter validation is back upfront with node's error.

## Tests

8 vendored upstream test-runner files (exit-code, misc, force-exit ×2, xfail, error-reporter, plan, run-files-undefined), verified **through `scripts/runner.node.mjs` itself** so the branch's dispatch heuristic and env applied verbatim: 45/45 vendored runner files pass, 0 flaky. Two new regression tests for the hang and the grandchild leak. bun:test machinery green: `bun_test`, `done-async`, `describe`, `concurrent*`, `dots`, `test_runner` suite 103/0.

Remaining from the 37-test cluster, by blocker: coverage (6), watch (2), globalSetup (2), name-pattern (2), randomize (2), snapshots (2), module-mocking, and a handful of structural ones (V8 frame-naming assertions, parser-message text, `{concurrency:true}` subtest scheduling) — each needs a second feature, as the original census predicted.
