### PR TITLE
boringssl: route OPENSSL_malloc to mimalloc on macOS and Windows

### DIFF
--- a/patches/boringssl/require-memory-hooks.patch
+++ b/patches/boringssl/require-memory-hooks.patch
@@ -1,14 +1,13 @@
 --- a/crypto/mem.cc
 +++ b/crypto/mem.cc
-@@ -100,9 +100,21 @@
+@@ -100,9 +100,20 @@
  // primitives used must tolerate every other synchronization primitive linked
  // into the process, including pthreads locks. Failing to meet these constraints
  // may result in deadlocks, crashes, or memory corruption.
 +#if defined(BORINGSSL_REQUIRE_MEMORY_HOOKS)
-+// Bun: the embedder guarantees these three are always defined, so declare them
-+// as ordinary externs. WEAK_SYMBOL_FUNC above is gated on __ELF__, so on Mach-O
-+// and COFF it would expand to a static null pointer and the hook path would be
-+// folded away at compile time.
++// Bun: the embedder guarantees these three are always defined. WEAK_SYMBOL_FUNC
++// is gated on __ELF__, so on Mach-O and COFF it would expand to a static null
++// pointer and the hook path would be folded away at compile time.
 +extern "C" {
 +void *OPENSSL_memory_alloc(size_t size);
 +void OPENSSL_memory_free(void *ptr);
@@ -22,7 +21,7 @@
  
  #if defined(BORINGSSL_MALLOC_FAILURE_TESTING)
  static StaticMutex malloc_failure_lock;
-@@ -186,6 +198,15 @@
+@@ -186,6 +197,15 @@
      goto err;
    }
  
@@ -38,7 +37,7 @@
    if (OPENSSL_memory_alloc != nullptr) {
      assert(OPENSSL_memory_free != nullptr);
      assert(OPENSSL_memory_get_size != nullptr);
-@@ -195,6 +216,7 @@
+@@ -195,6 +215,7 @@
      }
      return ptr2;
    }
@@ -46,7 +45,7 @@
  
    if (size + OPENSSL_MALLOC_PREFIX < size) {
      goto err;
-@@ -238,10 +260,15 @@
+@@ -238,10 +259,15 @@
      return;
    }
  
@@ -62,7 +61,7 @@
  
    void *ptr = ((uint8_t *)orig_ptr) - OPENSSL_MALLOC_PREFIX;
    __asan_unpoison_memory_region(ptr, OPENSSL_MALLOC_PREFIX);
-@@ -268,6 +295,9 @@
+@@ -268,6 +294,9 @@
    }
  
    size_t old_size;
@@ -72,7 +71,7 @@
    if (OPENSSL_memory_get_size != nullptr) {
      old_size = OPENSSL_memory_get_size(orig_ptr);
    } else {
-@@ -276,6 +306,7 @@
+@@ -276,6 +305,7 @@
      old_size = *(size_t *)ptr;
      __asan_poison_memory_region(ptr, OPENSSL_MALLOC_PREFIX);
    }

--- a/patches/boringssl/require-memory-hooks.patch
+++ b/patches/boringssl/require-memory-hooks.patch
@@ -1,0 +1,82 @@
+--- a/crypto/mem.cc
++++ b/crypto/mem.cc
+@@ -100,9 +100,21 @@
+ // primitives used must tolerate every other synchronization primitive linked
+ // into the process, including pthreads locks. Failing to meet these constraints
+ // may result in deadlocks, crashes, or memory corruption.
++#if defined(BORINGSSL_REQUIRE_MEMORY_HOOKS)
++// Bun: the embedder guarantees these three are always defined, so declare them
++// as ordinary externs. WEAK_SYMBOL_FUNC above is gated on __ELF__, so on Mach-O
++// and COFF it would expand to a static null pointer and the hook path would be
++// folded away at compile time.
++extern "C" {
++void *OPENSSL_memory_alloc(size_t size);
++void OPENSSL_memory_free(void *ptr);
++size_t OPENSSL_memory_get_size(void *ptr);
++}
++#else
+ WEAK_SYMBOL_FUNC(void *, OPENSSL_memory_alloc, (size_t size))
+ WEAK_SYMBOL_FUNC(void, OPENSSL_memory_free, (void *ptr))
+ WEAK_SYMBOL_FUNC(size_t, OPENSSL_memory_get_size, (void *ptr))
++#endif
+ 
+ #if defined(BORINGSSL_MALLOC_FAILURE_TESTING)
+ static StaticMutex malloc_failure_lock;
+@@ -186,6 +198,15 @@
+     goto err;
+   }
+ 
++#if defined(BORINGSSL_REQUIRE_MEMORY_HOOKS)
++  {
++    void *ptr2 = OPENSSL_memory_alloc(size);
++    if (ptr2 == nullptr && size != 0) {
++      goto err;
++    }
++    return ptr2;
++  }
++#else
+   if (OPENSSL_memory_alloc != nullptr) {
+     assert(OPENSSL_memory_free != nullptr);
+     assert(OPENSSL_memory_get_size != nullptr);
+@@ -195,6 +216,7 @@
+     }
+     return ptr2;
+   }
++#endif
+ 
+   if (size + OPENSSL_MALLOC_PREFIX < size) {
+     goto err;
+@@ -238,10 +260,15 @@
+     return;
+   }
+ 
++#if defined(BORINGSSL_REQUIRE_MEMORY_HOOKS)
++  OPENSSL_memory_free(orig_ptr);
++  return;
++#else
+   if (OPENSSL_memory_free != nullptr) {
+     OPENSSL_memory_free(orig_ptr);
+     return;
+   }
++#endif
+ 
+   void *ptr = ((uint8_t *)orig_ptr) - OPENSSL_MALLOC_PREFIX;
+   __asan_unpoison_memory_region(ptr, OPENSSL_MALLOC_PREFIX);
+@@ -268,6 +295,9 @@
+   }
+ 
+   size_t old_size;
++#if defined(BORINGSSL_REQUIRE_MEMORY_HOOKS)
++  old_size = OPENSSL_memory_get_size(orig_ptr);
++#else
+   if (OPENSSL_memory_get_size != nullptr) {
+     old_size = OPENSSL_memory_get_size(orig_ptr);
+   } else {
+@@ -276,6 +306,7 @@
+     old_size = *(size_t *)ptr;
+     __asan_poison_memory_region(ptr, OPENSSL_MALLOC_PREFIX);
+   }
++#endif
+ 
+   void *ret = OPENSSL_malloc(new_size);
+   if (ret == nullptr) {

--- a/scripts/build/deps/boringssl.ts
+++ b/scripts/build/deps/boringssl.ts
@@ -36,6 +36,11 @@ export const boringssl: Dependency = {
     commit: BORINGSSL_COMMIT,
   }),
 
+  // Upstream mem.cc gates OPENSSL_memory_* weak-symbol overrides on __ELF__;
+  // on Mach-O/COFF the hooks compile to static nullptr and OPENSSL_malloc goes
+  // straight to libc. Declare them as plain externs so lib.rs binds everywhere.
+  patches: ["patches/boringssl/require-memory-hooks.patch"],
+
   build: cfg => {
     // win-x64 uses NASM-syntax .asm; everything else (including win-aarch64)
     // uses gas .S that clang assembles.
@@ -48,6 +53,8 @@ export const boringssl: Dependency = {
       includes: ["include"],
       defines: {
         BORINGSSL_IMPLEMENTATION: true,
+        // See `patches:` above. Bun always defines the three hooks.
+        BORINGSSL_REQUIRE_MEMORY_HOOKS: true,
         ...(cfg.windows && {
           _HAS_EXCEPTIONS: 0,
           WIN32_LEAN_AND_MEAN: true,

--- a/scripts/build/deps/boringssl.ts
+++ b/scripts/build/deps/boringssl.ts
@@ -53,8 +53,9 @@ export const boringssl: Dependency = {
       includes: ["include"],
       defines: {
         BORINGSSL_IMPLEMENTATION: true,
-        // See `patches:` above. Bun always defines the three hooks.
-        BORINGSSL_REQUIRE_MEMORY_HOOKS: true,
+        // See `patches:` above. Off under ASAN so BoringSSL allocs stay on the
+        // intercepted libc heap on Mach-O/COFF instead of routing to mimalloc.
+        ...(!cfg.asan && { BORINGSSL_REQUIRE_MEMORY_HOOKS: true }),
         ...(cfg.windows && {
           _HAS_EXCEPTIONS: 0,
           WIN32_LEAN_AND_MEAN: true,

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -965,18 +965,6 @@ export const linkerFlags: Flag[] = [
     desc: "Windows cross-compile: MSVC CRT + Windows SDK library search root (xwin splat)",
   },
   {
-    // BoringSSL's allocator hooks (defined in src/boringssl/lib.rs, routing
-    // OPENSSL_malloc to mimalloc) are referenced by BoringSSL only as COFF
-    // weak externals, which never pull the defining archive member on their
-    // own — so on Windows the hooks silently stayed unbound and every
-    // BoringSSL allocation (TLS handshakes, parsed certificates) landed on
-    // the CRT's NT heap instead of mimalloc. Force the symbols in so the
-    // weak externals bind, like they already do on ELF/Mach-O.
-    flag: ["/INCLUDE:OPENSSL_memory_alloc", "/INCLUDE:OPENSSL_memory_free", "/INCLUDE:OPENSSL_memory_get_size"],
-    when: c => c.windows,
-    desc: "Bind BoringSSL's mimalloc-backed allocator hooks (COFF weak externals don't pull archive members)",
-  },
-  {
     flag: ["/STACK:0x1200000,0x200000", "/errorlimit:0"],
     when: c => c.windows,
     desc: "18MB stack reserve (JSC uses deep recursion), no error limit",


### PR DESCRIPTION
## Problem

`vendor/boringssl/crypto/mem.cc` declares the `OPENSSL_memory_alloc` / `OPENSSL_memory_free` / `OPENSSL_memory_get_size` override hooks as weak externs only under `#if defined(__ELF__)`. On Mach-O and COFF the macro expands to `static ... = nullptr`, so the `if (OPENSSL_memory_alloc != nullptr)` branch is folded away at compile time and `OPENSSL_malloc` compiles to a direct call to libc `malloc`. The mimalloc-backed definitions in `src/boringssl/lib.rs` were dead code on those two platforms, and every TLS record read / handshake allocation hit the system allocator.

The Windows `/INCLUDE:OPENSSL_memory_*` linker flags in `scripts/build/flags.ts` didn't help either: they forced the Rust symbols into the image, but the call sites in `mem.cc` had already been compiled out. The comment claiming the hooks "already bind on ELF/Mach-O" was wrong for Mach-O.

## Fix

Patch `crypto/mem.cc` to honor a new `BORINGSSL_REQUIRE_MEMORY_HOOKS` define that declares the three hooks as ordinary `extern "C"` functions and calls them unconditionally. Bun always defines the hooks, so the runtime null check is unnecessary. Pass the define from `scripts/build/deps/boringssl.ts` on all platforms.

`mem.cc.o` now carries strong undefined references on every target, which pull the defining archive member at link time on ELF, Mach-O and COFF alike. The Windows `/INCLUDE:` flags are removed since the strong refs make the link fail if the hooks ever go missing.

The patch lives in `patches/boringssl/` (same mechanism as libarchive/zlib/etc.); it can be folded into the `oven-sh/boringssl` fork on the next bump.

## Verification

Simulating the non-ELF path without the fix (unpatched `mem.cc`, `-U__ELF__`):

```
$ nm mem.cc.o | grep -E 'OPENSSL_memory|OPENSSL_malloc| malloc$'
0000000000000000 T OPENSSL_malloc
                 U malloc
```

`OPENSSL_memory_*` are completely absent; `OPENSSL_malloc` calls `malloc` directly.

With the fix (`-DBORINGSSL_REQUIRE_MEMORY_HOOKS`):

```
$ nm mem.cc.o | grep -E 'OPENSSL_memory|OPENSSL_malloc'
0000000000000000 T OPENSSL_malloc
                 U OPENSSL_memory_alloc
                 U OPENSSL_memory_free
                 U OPENSSL_memory_get_size

$ objdump -d -r mem.cc.o   # OPENSSL_malloc
   0: push   %rbx
   1: mov    %rdi,%rbx
   4: call   9 <OPENSSL_malloc+0x9>
        R_X86_64_PLT32  OPENSSL_memory_alloc-0x4
   ...

$ objdump -d -r mem.cc.o   # OPENSSL_free
 150: test   %rdi,%rdi
 153: jne    159 <OPENSSL_free+0x9>
        R_X86_64_PLT32  OPENSSL_memory_free-0x4
 159: ret
```

The libc fallback is dead-stripped; `OPENSSL_free` is a tail call to the hook.

Linux `bun bd` build succeeds and `test/js/node/tls/node-tls-connect.test.ts` + `test/js/node/crypto/node-crypto.test.js` (202 tests) pass. ELF codegen is also slightly tighter now since the weak-symbol null checks are gone.

### Darwin arm64 (Apple clang 16, `-O2 -mcpu=apple-m1`)

Without `-DBORINGSSL_REQUIRE_MEMORY_HOOKS`:

```
$ nm mem.cc.o | grep -E 'OPENSSL_memory|OPENSSL_malloc| _malloc$'
0000000000000000 T _OPENSSL_malloc
                 U _malloc
```

With `-DBORINGSSL_REQUIRE_MEMORY_HOOKS`:

```
$ nm mem.cc.o | grep -E 'OPENSSL_memory|OPENSSL_malloc'
0000000000000000 T _OPENSSL_malloc
                 U _OPENSSL_memory_alloc
                 U _OPENSSL_memory_free
                 U _OPENSSL_memory_get_size

$ otool -tV mem.cc.o    # _OPENSSL_free
_OPENSSL_free:
014c  cbz  x0, 0x154
0150  b    _OPENSSL_memory_free
0154  ret
```

`_OPENSSL_malloc` no longer has a `bl _malloc`; the only branch targets in its body are `_OPENSSL_memory_alloc` and `_ERR_put_error`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->