### PR TITLE
test: quarantine test-http2-reset-flood.js on ASAN

### DIFF
--- a/test/expectations.txt
+++ b/test/expectations.txt
@@ -103,6 +103,14 @@ test/js/bun/spawn/spawn-maxbuf.test.ts [ FLAKY ]
 # stdio builders have completed"). Tracked separately in #34690; this entry
 # is NOT removable with the one above.
 [ ASAN ] test/js/node/worker_threads/worker-transfer-terminate-stress.test.ts [ CRASH ] # #34690: ExceptionScope::assertNoException during worker terminate bootstrap
+# Same ExceptionScope::assertNoException at ExceptionScope.h:61 as #34690:
+# the http2 server runs inside a Worker and the main thread calls
+# worker.terminate() on conn error, so terminate() races with a socket
+# handler on the worker's VM. Seen on debian-13 x64-asan across unrelated
+# branches (builds 75493/75670/75930/75949/75996/75998/76117/76129/76248/
+# 76250/76342). Tracked in #34846; root-cause fix is #34414. Remove with
+# #34690/#34414.
+[ ASAN ] test/js/node/test/parallel/test-http2-reset-flood.js [ CRASH ] # #34846/#34690: ExceptionScope::assertNoException during worker.terminate()
 
 # Tests failed due to ASAN: use-after-poison
 [ ASAN ] test/js/node/test/parallel/test-worker-unref-from-message-during-exit.js [ CRASH ]


### PR DESCRIPTION
Fixes #34846.

## Failure

`test/js/node/test/parallel/test-http2-reset-flood.js` intermittently dies with SIGABRT on debian-13 x64-asan:

```
ASSERTION FAILED: (null)
!exception()
vendor/WebKit/Source/JavaScriptCore/runtime/ExceptionScope.h(61) : void JSC::ExceptionScope::assertNoException()
```

Seen across 11+ unrelated branches (builds 75493, 75670, 75930, 75949, 75996, 75998, 76117, 76129, 76248, 76250, 76342), including a pure deps-bot bump, so not branch-specific.

## Cause

The issue body says "with no worker involvement", but that's not the case: this test runs the http2 server inside a `Worker` and the main thread calls `worker.terminate()` when the client connection errors:

```js
const worker = new Worker(__filename).on('message', common.mustCall((port) => {
  // ...
  conn.once('error', common.mustCall(() => {
    gotError = true;
    worker.terminate();   // races with a socket handler on the worker's VM
    conn.destroy();
  }));
}));
```

So this is the same `ExceptionScope::assertNoException` during-worker-terminate race as #34690, triggered via a different test. Root-cause fix is #34414 (socket/websocket error-handler dispatch guarding against re-entering JS with a pending termination exception).

## Change

Adds an `[ ASAN ] ... [ CRASH ]` entry next to the existing #34095/#34690 entries. The test continues to run on all non-ASAN lanes. Entry verified to parse as `{modifiers: ['ASAN'], filename: 'test/js/node/test/parallel/test-http2-reset-flood.js', expectations: ['CRASH']}` via the `getTestExpectations` logic in `scripts/runner.node.mjs`.

Remove with #34690 / #34414.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->