### PR TITLE
install: coalesce TarballStream drain wakes on the HTTP thread

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -91,11 +91,9 @@ new!(pub BUN_INSTALL_GLOBAL_DIR: string, "BUN_INSTALL_GLOBAL_DIR", {});
 // whole body first. Smaller tarballs stay on the buffered path where
 // the fixed overhead of the resumable state machine isn't worth it.
 new!(pub BUN_INSTALL_STREAMING_MIN_SIZE: unsigned, "BUN_INSTALL_STREAMING_MIN_SIZE", { default: 2 * 1024 * 1024 });
-// Bytes of compressed tarball to let accumulate in `TarballStream.pending`
-// before the HTTP thread schedules a drain on the thread pool. Each
-// schedule is a `ThreadPool::notify` (a `__ulock_wake` / `futex_wake`
-// syscall when a worker is idle); batching here collapses the per-HTTP-
-// chunk wake into roughly one per `threshold` bytes received.
+// Compressed bytes to buffer in `TarballStream.pending` before the HTTP
+// thread schedules a drain; collapses the per-chunk thread-pool futex wake
+// into roughly one per `threshold` bytes.
 new!(pub BUN_INSTALL_STREAMING_DRAIN_THRESHOLD: unsigned, "BUN_INSTALL_STREAMING_DRAIN_THRESHOLD", { default: 256 * 1024 });
 new!(pub BUN_NEEDS_PROC_SELF_WORKAROUND: boolean, "BUN_NEEDS_PROC_SELF_WORKAROUND", { default: false });
 new!(pub BUN_OPTIONS: string, "BUN_OPTIONS", {});

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -91,6 +91,12 @@ new!(pub BUN_INSTALL_GLOBAL_DIR: string, "BUN_INSTALL_GLOBAL_DIR", {});
 // whole body first. Smaller tarballs stay on the buffered path where
 // the fixed overhead of the resumable state machine isn't worth it.
 new!(pub BUN_INSTALL_STREAMING_MIN_SIZE: unsigned, "BUN_INSTALL_STREAMING_MIN_SIZE", { default: 2 * 1024 * 1024 });
+// Bytes of compressed tarball to let accumulate in `TarballStream.pending`
+// before the HTTP thread schedules a drain on the thread pool. Each
+// schedule is a `ThreadPool::notify` (a `__ulock_wake` / `futex_wake`
+// syscall when a worker is idle); batching here collapses the per-HTTP-
+// chunk wake into roughly one per `threshold` bytes received.
+new!(pub BUN_INSTALL_STREAMING_DRAIN_THRESHOLD: unsigned, "BUN_INSTALL_STREAMING_DRAIN_THRESHOLD", { default: 256 * 1024 });
 new!(pub BUN_NEEDS_PROC_SELF_WORKAROUND: boolean, "BUN_NEEDS_PROC_SELF_WORKAROUND", { default: false });
 new!(pub BUN_OPTIONS: string, "BUN_OPTIONS", {});
 new!(pub BUN_POSTGRES_SOCKET_MONITOR: string, "BUN_POSTGRES_SOCKET_MONITOR", {});

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -91,11 +91,9 @@ pub struct TarballStream {
     /// it runs out of input and decides to yield.
     draining: AtomicBool,
 
-    /// Number of times `schedule_drain` actually pushed `drain_task` onto
-    /// the thread pool (each push is a `ThreadPool::notify` → futex wake on
-    /// the HTTP thread). Printed in `--verbose` output so tests can assert
-    /// the `drain_threshold` batching keeps this well below the HTTP-chunk
-    /// count.
+    /// Times `schedule_drain` pushed `drain_task` onto the thread pool (each
+    /// push is a `ThreadPool::notify` → futex wake on the HTTP thread).
+    /// Printed under `--verbose` so tests can bound it.
     drain_schedules: AtomicU32,
 
     // ---------------------------------------------------------------------
@@ -186,12 +184,9 @@ impl TarballStream {
         usize::try_from(env_var::BUN_INSTALL_STREAMING_MIN_SIZE.get().unwrap()).expect("int cast")
     }
 
-    /// Compressed bytes to let accumulate in `pending` before the HTTP
-    /// thread schedules a drain. Without this the drain task tends to empty
-    /// `pending` and yield between every HTTP body chunk, so each chunk
-    /// re-schedules it — one `ThreadPool::notify` → futex wake on the HTTP
-    /// thread per chunk. Batching to `threshold` collapses that into roughly
-    /// one wake per `threshold` bytes.
+    /// Compressed bytes to buffer in `pending` before the HTTP thread
+    /// schedules a drain; without this each body chunk re-wakes a worker
+    /// once the drain has yielded. See `BUN_INSTALL_STREAMING_DRAIN_THRESHOLD`.
     fn drain_threshold() -> usize {
         usize::try_from(
             env_var::BUN_INSTALL_STREAMING_DRAIN_THRESHOLD
@@ -314,11 +309,9 @@ impl TarballStream {
             let pending_len = (*this).pending.len();
             (*this).mutex.unlock();
 
-            // Batch sub-threshold chunks so each one doesn't re-wake a
-            // worker once the drain has yielded (one futex wake per HTTP
-            // chunk otherwise). `is_last`/`err` always schedule so
-            // `finish()` never waits on the threshold; a running drain
-            // picks up sub-threshold `pending` via its own race check.
+            // Batch sub-threshold chunks so each one doesn't re-wake a worker
+            // once the drain has yielded; `is_last`/`err` always schedule so
+            // `finish()` never waits on the threshold.
             if is_last || err.is_some() || pending_len >= Self::drain_threshold() {
                 Self::schedule_drain(this);
             }

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -193,8 +193,12 @@ impl TarballStream {
     /// thread per chunk. Batching to `threshold` collapses that into roughly
     /// one wake per `threshold` bytes.
     fn drain_threshold() -> usize {
-        usize::try_from(env_var::BUN_INSTALL_STREAMING_DRAIN_THRESHOLD.get().unwrap())
-            .expect("int cast")
+        usize::try_from(
+            env_var::BUN_INSTALL_STREAMING_DRAIN_THRESHOLD
+                .get()
+                .unwrap(),
+        )
+        .expect("int cast")
     }
 
     pub(crate) fn init(

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -20,7 +20,7 @@
 
 use core::ffi::{c_int, c_void};
 use core::mem::ManuallyDrop;
-use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use core::sync::atomic::{AtomicBool, Ordering};
 
 use bun_collections::VecExt;
 #[cfg(windows)]
@@ -90,11 +90,6 @@ pub struct TarballStream {
     /// running. `on_chunk` sets it before scheduling; `drain` clears it when
     /// it runs out of input and decides to yield.
     draining: AtomicBool,
-
-    /// Times `schedule_drain` pushed `drain_task` onto the thread pool (each
-    /// push is a `ThreadPool::notify` → futex wake on the HTTP thread).
-    /// Printed under `--verbose` so tests can bound it.
-    drain_schedules: AtomicU32,
 
     // ---------------------------------------------------------------------
     // Drain-side state (touched only by one drain task at a time)
@@ -243,7 +238,6 @@ impl TarballStream {
             http_err: None,
             status_code: 0,
             draining: AtomicBool::new(false),
-            drain_schedules: AtomicU32::new(0),
             reading: Vec::new(),
             read_pos: 0,
             archive: None,
@@ -330,7 +324,6 @@ impl TarballStream {
             if (*this).draining.swap(true, Ordering::AcqRel) {
                 return;
             }
-            (*this).drain_schedules.fetch_add(1, Ordering::Relaxed);
             // `addr_of_mut!` (not `&mut (*this).drain_task`) so the raw
             // pointer inherits `this`'s full-struct provenance: the
             // thread-pool callback recovers the parent `*mut TarballStream`
@@ -1182,11 +1175,10 @@ impl TarballStream {
 
             if PackageManager::verbose_install() {
                 bun_core::pretty_errorln!(
-                    "[{}] Streamed {} tarball → {} entries, {} drain schedules<r>",
+                    "[{}] Streamed {} tarball → {} entries<r>",
                     bstr::BStr::new(name),
                     bun_fmt::size(self.bytes_received, Default::default()),
                     self.entry_count,
-                    self.drain_schedules.load(Ordering::Relaxed),
                 );
                 Output::flush();
             }

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -20,7 +20,7 @@
 
 use core::ffi::{c_int, c_void};
 use core::mem::ManuallyDrop;
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use bun_collections::VecExt;
 #[cfg(windows)]
@@ -90,6 +90,13 @@ pub struct TarballStream {
     /// running. `on_chunk` sets it before scheduling; `drain` clears it when
     /// it runs out of input and decides to yield.
     draining: AtomicBool,
+
+    /// Number of times `schedule_drain` actually pushed `drain_task` onto
+    /// the thread pool (each push is a `ThreadPool::notify` → futex wake on
+    /// the HTTP thread). Printed in `--verbose` output so tests can assert
+    /// the `drain_threshold` batching keeps this well below the HTTP-chunk
+    /// count.
+    drain_schedules: AtomicU32,
 
     // ---------------------------------------------------------------------
     // Drain-side state (touched only by one drain task at a time)
@@ -179,6 +186,17 @@ impl TarballStream {
         usize::try_from(env_var::BUN_INSTALL_STREAMING_MIN_SIZE.get().unwrap()).expect("int cast")
     }
 
+    /// Compressed bytes to let accumulate in `pending` before the HTTP
+    /// thread schedules a drain. Without this the drain task tends to empty
+    /// `pending` and yield between every HTTP body chunk, so each chunk
+    /// re-schedules it — one `ThreadPool::notify` → futex wake on the HTTP
+    /// thread per chunk. Batching to `threshold` collapses that into roughly
+    /// one wake per `threshold` bytes.
+    fn drain_threshold() -> usize {
+        usize::try_from(env_var::BUN_INSTALL_STREAMING_DRAIN_THRESHOLD.get().unwrap())
+            .expect("int cast")
+    }
+
     pub(crate) fn init(
         extract_task: *mut Task,
         network_task: *mut NetworkTask,
@@ -226,6 +244,7 @@ impl TarballStream {
             http_err: None,
             status_code: 0,
             draining: AtomicBool::new(false),
+            drain_schedules: AtomicU32::new(0),
             reading: Vec::new(),
             read_pos: 0,
             archive: None,
@@ -288,9 +307,17 @@ impl TarballStream {
             if let Some(e) = err {
                 (*this).http_err = Some(e);
             }
+            let pending_len = (*this).pending.len();
             (*this).mutex.unlock();
 
-            Self::schedule_drain(this);
+            // Batch sub-threshold chunks so each one doesn't re-wake a
+            // worker once the drain has yielded (one futex wake per HTTP
+            // chunk otherwise). `is_last`/`err` always schedule so
+            // `finish()` never waits on the threshold; a running drain
+            // picks up sub-threshold `pending` via its own race check.
+            if is_last || err.is_some() || pending_len >= Self::drain_threshold() {
+                Self::schedule_drain(this);
+            }
         }
     }
 
@@ -306,6 +333,7 @@ impl TarballStream {
             if (*this).draining.swap(true, Ordering::AcqRel) {
                 return;
             }
+            (*this).drain_schedules.fetch_add(1, Ordering::Relaxed);
             // `addr_of_mut!` (not `&mut (*this).drain_task`) so the raw
             // pointer inherits `this`'s full-struct provenance: the
             // thread-pool callback recovers the parent `*mut TarballStream`
@@ -1157,10 +1185,11 @@ impl TarballStream {
 
             if PackageManager::verbose_install() {
                 bun_core::pretty_errorln!(
-                    "[{}] Streamed {} tarball → {} entries<r>",
+                    "[{}] Streamed {} tarball → {} entries, {} drain schedules<r>",
                     bstr::BStr::new(name),
                     bun_fmt::size(self.bytes_received, Default::default()),
                     self.entry_count,
+                    self.drain_schedules.load(Ordering::Relaxed),
                 );
                 Output::flush();
             }

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -137,7 +137,13 @@ function makeEntries(): Entry[] {
 // the BUN_INSTALL_STREAMING_MIN_SIZE gate.
 // -------------------------------------------------------------------
 
-async function makeRegistry(tgz: Buffer, shasum: string, integrity: string, chunkBytes: number) {
+async function makeRegistry(
+  tgz: Buffer,
+  shasum: string,
+  integrity: string,
+  chunkBytes: number,
+  delayMs: number = 0,
+) {
   let tarballHits = 0;
   const server: Server = createServer((req, res) => {
     const url = new URL(req.url!, "http://x");
@@ -176,7 +182,8 @@ async function makeRegistry(tgz: Buffer, shasum: string, integrity: string, chun
         }
         res.write(tgz.subarray(i, Math.min(i + chunkBytes, tgz.length)));
         i += chunkBytes;
-        setImmediate(step);
+        if (delayMs > 0) setTimeout(step, delayMs);
+        else setImmediate(step);
       };
       step();
       return;
@@ -324,6 +331,56 @@ describe("streaming tarball extraction", () => {
     const { stderr, exitCode } = await runInstall(String(dir));
     expect(stderr).toContain("Integrity check failed");
     expect(exitCode).not.toBe(0);
+  });
+
+  test("drain schedules are coalesced across many small HTTP chunks", async () => {
+    // Serve the 2.3 MB tarball in 8 KB slices with a short pause between
+    // each so the drain task reliably empties `pending` and yields before
+    // the next chunk arrives. Without the `drain_threshold` batching in
+    // `TarballStream::on_chunk` every one of those ~290 chunks would
+    // re-push `drain_task` onto the thread pool (one `ThreadPool::notify`
+    // futex wake on the HTTP thread apiece). With batching the schedule
+    // count is bounded by roughly ceil(size / threshold) + 1 regardless of
+    // how many body chunks the socket delivers. The pause models network
+    // latency; it is not the thing being waited for.
+    const pacedChunkBytes = 8 * 1024;
+    const threshold = 128 * 1024;
+    await using reg = await makeRegistry(tgz, shasum, integrity, pacedChunkBytes, 2);
+    const registry = reg.url;
+
+    using dir = tempDir("streaming-extract-coalesce", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { "stream-pkg": "1.0.0" },
+      }),
+      "bunfig.toml": `[install]\nregistry = "${registry}"\n`,
+    });
+
+    const { stderr, exitCode } = await runInstall(String(dir), {
+      BUN_INSTALL_STREAMING_DRAIN_THRESHOLD: String(threshold),
+    });
+    expect(stderr).not.toContain("error:");
+    expect(stderr).toContain("Streamed ");
+
+    const m = stderr.match(/(\d+) drain schedules/);
+    expect(m).not.toBeNull();
+    const schedules = parseInt(m![1], 10);
+
+    // One schedule per `threshold` compressed bytes plus one for the final
+    // `is_last` chunk, with headroom for the narrow race where a drain
+    // clears `draining` after `on_chunk` has already decided to schedule.
+    const upperBound = Math.ceil(tgz.length / threshold) + 4;
+    expect(schedules).toBeLessThanOrEqual(upperBound);
+    expect(schedules).toBeGreaterThan(0);
+
+    // Correctness is unchanged: every entry extracts byte-for-byte.
+    const pkgRoot = join(String(dir), "node_modules", "stream-pkg");
+    for (const { path, body } of entries) {
+      const got = readFileSync(join(pkgRoot, path));
+      expect([path, got.equals(body)]).toEqual([path, true]);
+    }
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -137,13 +137,7 @@ function makeEntries(): Entry[] {
 // the BUN_INSTALL_STREAMING_MIN_SIZE gate.
 // -------------------------------------------------------------------
 
-async function makeRegistry(
-  tgz: Buffer,
-  shasum: string,
-  integrity: string,
-  chunkBytes: number,
-  delayMs: number = 0,
-) {
+async function makeRegistry(tgz: Buffer, shasum: string, integrity: string, chunkBytes: number, delayMs: number = 0) {
   let tarballHits = 0;
   const server: Server = createServer((req, res) => {
     const url = new URL(req.url!, "http://x");

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -8,7 +8,7 @@
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, readdirSorted, tempDir } from "harness";
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { createServer, type Server } from "node:http";
 import { join } from "node:path";
 import { createGzip, gzipSync } from "node:zlib";
@@ -137,7 +137,7 @@ function makeEntries(): Entry[] {
 // the BUN_INSTALL_STREAMING_MIN_SIZE gate.
 // -------------------------------------------------------------------
 
-async function makeRegistry(tgz: Buffer, shasum: string, integrity: string, chunkBytes: number, delayMs: number = 0) {
+async function makeRegistry(tgz: Buffer, shasum: string, integrity: string, chunkBytes: number) {
   let tarballHits = 0;
   const server: Server = createServer((req, res) => {
     const url = new URL(req.url!, "http://x");
@@ -176,8 +176,7 @@ async function makeRegistry(tgz: Buffer, shasum: string, integrity: string, chun
         }
         res.write(tgz.subarray(i, Math.min(i + chunkBytes, tgz.length)));
         i += chunkBytes;
-        if (delayMs > 0) setTimeout(step, delayMs);
-        else setImmediate(step);
+        setImmediate(step);
       };
       step();
       return;
@@ -327,35 +326,117 @@ describe("streaming tarball extraction", () => {
     expect(exitCode).not.toBe(0);
   });
 
-  // 8 KB paced chunks so the drain reliably yields between them; without
-  // batching each of the ~290 chunks re-wakes a worker, with batching the
-  // schedule count is bounded by ceil(size / threshold) + 1.
-  test.each([
-    ["default", 256 * 1024, {}],
-    ["override", 128 * 1024, { BUN_INSTALL_STREAMING_DRAIN_THRESHOLD: String(128 * 1024) }],
-  ] as const)("drain schedules are coalesced across many small HTTP chunks (%s)", async (_, threshold, env) => {
-    await using reg = await makeRegistry(tgz, shasum, integrity, 8 * 1024, 2);
+  test("drain threshold holds off extraction until enough bytes arrive", async () => {
+    // Below the threshold no drain is scheduled, so nothing lands in the
+    // extraction temp dir; crossing it schedules one drain that writes
+    // package.json while later entries stay absent until the body resumes.
+    const threshold = 1024 * 1024;
+    const belowThreshold = 512 * 1024;
+    const aboveThreshold = threshold + 128 * 1024;
+    expect(aboveThreshold).toBeLessThan(tgz.length);
 
-    using dir = tempDir("streaming-extract-coalesce", {
-      "package.json": JSON.stringify({
-        name: "app",
-        version: "1.0.0",
-        dependencies: { "stream-pkg": "1.0.0" },
-      }),
-      "bunfig.toml": `[install]\nregistry = "${reg.url}"\n`,
+    const phase1 = Promise.withResolvers<void>();
+    const gate1 = Promise.withResolvers<void>();
+    const phase2 = Promise.withResolvers<void>();
+    const gate2 = Promise.withResolvers<void>();
+
+    await using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname.endsWith("/stream-pkg")) {
+          return Response.json({
+            name: "stream-pkg",
+            "dist-tags": { latest: "1.0.0" },
+            versions: {
+              "1.0.0": {
+                name: "stream-pkg",
+                version: "1.0.0",
+                dist: { shasum, integrity, tarball: `${server.url}stream-pkg/-/stream-pkg-1.0.0.tgz` },
+              },
+            },
+          });
+        }
+        if (url.pathname.endsWith("stream-pkg-1.0.0.tgz")) {
+          return new Response(
+            new ReadableStream({
+              type: "direct",
+              async pull(c) {
+                for (let i = 0; i < belowThreshold; i += 8 * 1024) {
+                  c.write(tgz.subarray(i, i + 8 * 1024));
+                  await c.flush();
+                }
+                phase1.resolve();
+                await gate1.promise;
+                for (let i = belowThreshold; i < aboveThreshold; i += 8 * 1024) {
+                  c.write(tgz.subarray(i, i + 8 * 1024));
+                  await c.flush();
+                }
+                phase2.resolve();
+                await gate2.promise;
+                c.write(tgz.subarray(aboveThreshold));
+                await c.flush();
+                c.close();
+              },
+            }),
+            { headers: { "content-type": "application/octet-stream" } },
+          );
+        }
+        return new Response("not found", { status: 404 });
+      },
     });
 
-    const { stderr, exitCode } = await runInstall(String(dir), env);
+    using dir = tempDir("streaming-extract-threshold", {
+      "package.json": JSON.stringify({ name: "app", version: "1.0.0", dependencies: { "stream-pkg": "1.0.0" } }),
+      "bunfig.toml": `[install]\nregistry = "${server.url}"\n`,
+    });
+    const tmp = join(String(dir), "bun-tmp");
+    const cache = join(String(dir), "bun-cache");
+    mkdirSync(tmp, { recursive: true });
+    mkdirSync(cache, { recursive: true });
+
+    const findExtracted = (name: string) => {
+      for (const d of readdirSync(tmp, { withFileTypes: true })) {
+        if (d.isDirectory() && existsSync(join(tmp, d.name, name))) return join(tmp, d.name, name);
+      }
+      return null;
+    };
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--verbose", "--linker=hoisted"],
+      cwd: String(dir),
+      env: {
+        ...bunEnv,
+        BUN_TMPDIR: tmp,
+        TMPDIR: tmp,
+        BUN_INSTALL_CACHE_DIR: cache,
+        BUN_INSTALL_STREAMING_DRAIN_THRESHOLD: String(threshold),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    // Phase 1: server has sent < threshold. No drain has been scheduled,
+    // so nothing is extracted yet.
+    await phase1.promise;
+    await Bun.sleep(250);
+    expect(findExtracted("package.json")).toBeNull();
+
+    // Phase 2: send past the threshold. The first drain runs and writes
+    // package.json; the last data entry is still missing bytes.
+    gate1.resolve();
+    await phase2.promise;
+    let extractedPkgJson: string | null = null;
+    for (let i = 0; i < 1000 && !(extractedPkgJson = findExtracted("package.json")); i++) await Bun.sleep(10);
+    expect(extractedPkgJson).not.toBeNull();
+    expect(findExtracted(join("data", "chunk-47.bin"))).toBeNull();
+
+    // Finish.
+    gate2.resolve();
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).not.toContain("error:");
     expect(stderr).toContain("Streamed ");
-    expect(exitCode).toBe(0);
-
-    const m = stderr.match(/(\d+) drain schedules/);
-    expect(m).not.toBeNull();
-    const schedules = parseInt(m![1], 10);
-    const upperBound = Math.ceil(tgz.length / threshold) + 4;
-    expect(schedules).toBeGreaterThan(0);
-    expect(schedules).toBeLessThanOrEqual(upperBound);
+    expect({ stdout, exitCode }).toMatchObject({ exitCode: 0 });
 
     const pkgRoot = join(String(dir), "node_modules", "stream-pkg");
     for (const { path, body } of entries) {

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -326,12 +326,14 @@ describe("streaming tarball extraction", () => {
     expect(exitCode).not.toBe(0);
   });
 
-  test("drain threshold holds off extraction until enough bytes arrive", async () => {
-    // Below the threshold no drain is scheduled, so nothing lands in the
-    // extraction temp dir; crossing it schedules one drain that writes
-    // package.json while later entries stay absent until the body resumes.
-    const threshold = 1024 * 1024;
-    const belowThreshold = 512 * 1024;
+  // Below the threshold no drain is scheduled, so nothing lands in the
+  // extraction temp dir; crossing it schedules one drain that writes
+  // package.json while later entries stay absent until the body resumes.
+  test.each([
+    ["default", 256 * 1024, {}],
+    ["override", 1024 * 1024, { BUN_INSTALL_STREAMING_DRAIN_THRESHOLD: String(1024 * 1024) }],
+  ] as const)("drain threshold holds off extraction until enough bytes arrive (%s)", async (_, threshold, extraEnv) => {
+    const belowThreshold = threshold >> 1;
     const aboveThreshold = threshold + 128 * 1024;
     expect(aboveThreshold).toBeLessThan(tgz.length);
 
@@ -410,30 +412,41 @@ describe("streaming tarball extraction", () => {
         BUN_TMPDIR: tmp,
         TMPDIR: tmp,
         BUN_INSTALL_CACHE_DIR: cache,
-        BUN_INSTALL_STREAMING_DRAIN_THRESHOLD: String(threshold),
+        ...extraEnv,
       },
       stdout: "pipe",
       stderr: "pipe",
     });
+    const stdoutP = proc.stdout.text();
+    const stderrP = proc.stderr.text();
+    let gated = true;
+    const earlyExit = proc.exited.then(async code => {
+      if (gated) throw new Error(`bun install exited (${code}) before reaching a phase gate\n${await stderrP}`);
+    });
+    earlyExit.catch(() => {});
 
-    // Phase 1: server has sent < threshold. No drain has been scheduled,
-    // so nothing is extracted yet.
-    await phase1.promise;
-    await Bun.sleep(250);
-    expect(findExtracted("package.json")).toBeNull();
+    // Phase 1: server has sent < threshold. No drain is scheduled, so the
+    // temp dir stays empty; there is no "drain did not run" event to await
+    // from outside the child, so poll a bounded window.
+    await Promise.race([phase1.promise, earlyExit]);
+    for (let i = 0; i < 25; i++) {
+      expect(findExtracted("package.json")).toBeNull();
+      await Bun.sleep(10);
+    }
 
     // Phase 2: send past the threshold. The first drain runs and writes
     // package.json; the last data entry is still missing bytes.
     gate1.resolve();
-    await phase2.promise;
+    await Promise.race([phase2.promise, earlyExit]);
     let extractedPkgJson: string | null = null;
     for (let i = 0; i < 1000 && !(extractedPkgJson = findExtracted("package.json")); i++) await Bun.sleep(10);
     expect(extractedPkgJson).not.toBeNull();
     expect(findExtracted(join("data", "chunk-47.bin"))).toBeNull();
 
     // Finish.
+    gated = false;
     gate2.resolve();
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([stdoutP, stderrP, proc.exited]);
     expect(stderr).not.toContain("error:");
     expect(stderr).toContain("Streamed ");
     expect({ stdout, exitCode }).toMatchObject({ exitCode: 0 });

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -327,20 +327,14 @@ describe("streaming tarball extraction", () => {
     expect(exitCode).not.toBe(0);
   });
 
-  test("drain schedules are coalesced across many small HTTP chunks", async () => {
-    // Serve the 2.3 MB tarball in 8 KB slices with a short pause between
-    // each so the drain task reliably empties `pending` and yields before
-    // the next chunk arrives. Without the `drain_threshold` batching in
-    // `TarballStream::on_chunk` every one of those ~290 chunks would
-    // re-push `drain_task` onto the thread pool (one `ThreadPool::notify`
-    // futex wake on the HTTP thread apiece). With batching the schedule
-    // count is bounded by roughly ceil(size / threshold) + 1 regardless of
-    // how many body chunks the socket delivers. The pause models network
-    // latency; it is not the thing being waited for.
-    const pacedChunkBytes = 8 * 1024;
-    const threshold = 128 * 1024;
-    await using reg = await makeRegistry(tgz, shasum, integrity, pacedChunkBytes, 2);
-    const registry = reg.url;
+  // 8 KB paced chunks so the drain reliably yields between them; without
+  // batching each of the ~290 chunks re-wakes a worker, with batching the
+  // schedule count is bounded by ceil(size / threshold) + 1.
+  test.each([
+    ["default", 256 * 1024, {}],
+    ["override", 128 * 1024, { BUN_INSTALL_STREAMING_DRAIN_THRESHOLD: String(128 * 1024) }],
+  ] as const)("drain schedules are coalesced across many small HTTP chunks (%s)", async (_, threshold, env) => {
+    await using reg = await makeRegistry(tgz, shasum, integrity, 8 * 1024, 2);
 
     using dir = tempDir("streaming-extract-coalesce", {
       "package.json": JSON.stringify({
@@ -348,33 +342,26 @@ describe("streaming tarball extraction", () => {
         version: "1.0.0",
         dependencies: { "stream-pkg": "1.0.0" },
       }),
-      "bunfig.toml": `[install]\nregistry = "${registry}"\n`,
+      "bunfig.toml": `[install]\nregistry = "${reg.url}"\n`,
     });
 
-    const { stderr, exitCode } = await runInstall(String(dir), {
-      BUN_INSTALL_STREAMING_DRAIN_THRESHOLD: String(threshold),
-    });
+    const { stderr, exitCode } = await runInstall(String(dir), env);
     expect(stderr).not.toContain("error:");
     expect(stderr).toContain("Streamed ");
+    expect(exitCode).toBe(0);
 
     const m = stderr.match(/(\d+) drain schedules/);
     expect(m).not.toBeNull();
     const schedules = parseInt(m![1], 10);
-
-    // One schedule per `threshold` compressed bytes plus one for the final
-    // `is_last` chunk, with headroom for the narrow race where a drain
-    // clears `draining` after `on_chunk` has already decided to schedule.
     const upperBound = Math.ceil(tgz.length / threshold) + 4;
-    expect(schedules).toBeLessThanOrEqual(upperBound);
     expect(schedules).toBeGreaterThan(0);
+    expect(schedules).toBeLessThanOrEqual(upperBound);
 
-    // Correctness is unchanged: every entry extracts byte-for-byte.
     const pkgRoot = join(String(dir), "node_modules", "stream-pkg");
     for (const { path, body } of entries) {
       const got = readFileSync(join(pkgRoot, path));
       expect([path, got.equals(body)]).toEqual([path, true]);
     }
-    expect(exitCode).toBe(0);
   });
 });
 


### PR DESCRIPTION
### Problem

`bun install` streaming tarball extraction schedules a thread-pool drain task from the HTTP thread via `TarballStream::on_chunk`. The `draining` flag already suppresses re-scheduling while a drain is in flight, but the drain task empties `pending` and yields between most HTTP body chunks, so the next chunk re-pushes `drain_task` and `ThreadPool::notify_slow` issues a futex wake on the HTTP thread. On macOS that is a `__ulock_wake` syscall per body chunk; profiling a couple of large tarballs showed ~270ms of `__ulock_wake` under `HTTPClient::handle_response_body` / `progress_update`.

### Fix

`on_chunk` now lets `pending` accumulate to a threshold (256 KB, tunable via `BUN_INSTALL_STREAMING_DRAIN_THRESHOLD`) before calling `schedule_drain`, collapsing the per-chunk wake into roughly one per `threshold` bytes received. `is_last` and `err` always schedule so `finish()` is never left waiting on the threshold; a drain that is already running picks up sub-threshold `pending` through its existing race check, so nothing is stranded.

### Verification

New test in `test/cli/install/bun-install-streaming-extract.test.ts` pins `BUN_TMPDIR` and serves the tarball via `Bun.serve` in three phases:

1. Send 512 KB (< 1 MB threshold) in 8 KB chunks, pause: the extraction temp dir stays empty (no drain scheduled). Without this change the per-chunk drain writes `package.json` here and the assertion fails.
2. Send past the threshold, pause: `package.json` is extracted, the last data entry is still absent.
3. Resume: install completes and every entry extracts byte-for-byte.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-streaming-extract.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f1b66be51)

test/cli/install/bun-install-streaming-extract.test.ts:
(pass) streaming tarball extraction > extracts a drip-fed tarball correctly (streaming) [1308.83ms]
(pass) streaming tarball extraction > extracts a drip-fed tarball correctly (buffered) [601.73ms]
(pass) streaming tarball extraction > tarballs below BUN_INSTALL_STREAMING_MIN_SIZE take the buffered path [552.91ms]
(pass) streaming tarball extraction > streaming rejects a tarball whose integrity does not match [412.24ms]
428 |     // Phase 1: server has sent < threshold. No drain is scheduled, so the
429 |     // temp dir stays empty; there is no "drain did not run" event to await
430 |     // from outside the child, so poll a bounded window.
431
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (d19d2ee47)

test/cli/install/bun-install-streaming-extract.test.ts:
(pass) streaming tarball extraction > extracts a drip-fed tarball correctly (streaming) [36.40ms]
(pass) streaming tarball extraction > extracts a drip-fed tarball correctly (buffered) [29.13ms]
(pass) streaming tarball extraction > tarballs below BUN_INSTALL_STREAMING_MIN_SIZE take the buffered path [27.58ms]
(pass) streaming tarball extraction > streaming rejects a tarball whose integrity does not match [20.55ms]
(pass) streaming tarball extraction > drain threshold holds off extraction until enough bytes arrive (default) [290.96ms]
(pass) streaming tarball extraction > drain threshold holds off extraction until enough bytes arrive (override) [289.40ms]
(pass) buffered extract: damaged-block retry resets header state (upstream semantics) [5.44ms]
(pass) buffered extract rejects a registry tarball whose decompressed size exceeds the limit [5674.91ms]

 8 pass
 0 fail
 344 expect() calls
Ran 8 tests across 1 file. [6.68s]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-streaming-extract.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f1b66be51)

test/cli/install/bun-install-streaming-extract.test.ts:
(pass) streaming tarball extraction > extracts a drip-fed tarball correctly (streaming) [1338.67ms]
(pass) streaming tarball extraction > extracts a drip-fed tarball correctly (buffered) [579.67ms]
(pass) streaming tarball extraction > tarballs below BUN_INSTALL_STREAMING_MIN_SIZE take the buffered path [557.07ms]
(pass) streaming tarball extraction > streaming rejects a tarball whose integrity does not match [438.90ms]
(pass) streaming tarball extraction > drain threshold holds off extraction until enough bytes arrive (default) [659.85ms]
(pass) streaming tarball extraction > drain threshold holds off extraction until enough bytes arrive (overr
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 708ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/env_var.rs                            |   4 +
 src/install/TarballStream.rs                       |  20 ++-
 .../install/bun-install-streaming-extract.test.ts  | 134 ++++++++++++++++++++-
 3 files changed, 156 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/bun_core/env_var.rs                                     2      2      0
src/install/TarballStream.rs                                4     15      0
test/cli/install/bun-install-streaming-extract.test.ts      5     11      0
```

</details>

<!-- robobun:evidence:end -->