### PR TITLE
yaml: reject NUL byte (U+0000) instead of silently truncating input

### DIFF
--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -4441,6 +4441,9 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         loop {
             match __c {
                 0 => {
+                    if !self.is_eof() {
+                        return Err(ParseError::UnexpectedCharacter);
+                    }
                     return Ok(ctx.done(self));
                 }
 
@@ -4785,6 +4788,9 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         loop {
             match __c {
                 0 => {
+                    if !self.is_eof() {
+                        return Err(ParseError::UnexpectedCharacter);
+                    }
                     return Ok((
                         indent_indicator.unwrap_or(IndentIndicator::DEFAULT),
                         chomp.unwrap_or(Chomp::DEFAULT),
@@ -5008,6 +5014,9 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             let __c = Enc::wide(self.next());
             match __c {
                 0 => {
+                    if !self.is_eof() {
+                        return Err(ParseError::UnexpectedCharacter);
+                    }
                     // Official yaml-test-suite JEF9/02: trailing indentation
                     // at EOF without a final break counts as one trailing
                     // empty line for chomping (matches eemeli/yaml + js-yaml).
@@ -5098,7 +5107,12 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         let mut __c = first;
         loop {
             match __c {
-                0 => return Ok(ctx.done()?),
+                0 => {
+                    if !self.is_eof() {
+                        return Err(ParseError::UnexpectedCharacter);
+                    }
+                    return Ok(ctx.done()?);
+                }
                 0x0D => {
                     if Enc::wide(self.peek(1)) == 0x0A {
                         self.inc(1);
@@ -5698,6 +5712,12 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             let c = Enc::wide(self.next());
             match c {
                 0 => {
+                    // [1] c-printable excludes U+0000. `next()` returns NUL as
+                    // the EOF sentinel, so a literal NUL in the input must be
+                    // rejected here rather than silently ending the stream.
+                    if !self.is_eof() {
+                        return Err(ParseError::UnexpectedCharacter);
+                    }
                     let start = self.pos;
                     break 'next Token::eof(self.token_init(start));
                 }

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -4829,6 +4829,9 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     if Enc::wide(self.next()) == 0x23 /* '#' */ {
                         self.inc(1);
                         while !self.is_b_char_or_eof() {
+                            if Enc::wide(self.next()) == 0 {
+                                return Err(ParseError::UnexpectedCharacter);
+                            }
                             self.inc(1);
                         }
                     }
@@ -5862,6 +5865,9 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     }
                     self.inc(1);
                     while !self.is_b_char_or_eof() {
+                        if Enc::wide(self.next()) == 0 {
+                            return Err(ParseError::UnexpectedCharacter);
+                        }
                         self.inc(1);
                     }
                     continue;
@@ -6152,6 +6158,9 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             }
             self.inc(1);
             while !self.is_b_char_or_eof() {
+                if Enc::wide(self.next()) == 0 {
+                    return Err(ParseError::UnexpectedCharacter);
+                }
                 self.inc(1);
             }
         }

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -2385,32 +2385,36 @@ my_config:
       expect(YAML.parse(input2)).toMatchSnapshot();
     });
 
-    test("handles YAML bombs", () => {
-      function buildTest(depth) {
-        const lines: string[] = [];
-        lines.push(`a0: &a0\n  k0: 0`);
-        for (let i = 1; i <= depth; i++) {
-          const refs = Array.from({ length: i }, (_, j) => `*a${j}`).join(", ");
-          lines.push(`a${i}: &a${i}\n  <<: [${refs}]\n  k${i}: ${i}`);
+    test(
+      "handles YAML bombs",
+      () => {
+        function buildTest(depth) {
+          const lines: string[] = [];
+          lines.push(`a0: &a0\n  k0: 0`);
+          for (let i = 1; i <= depth; i++) {
+            const refs = Array.from({ length: i }, (_, j) => `*a${j}`).join(", ");
+            lines.push(`a${i}: &a${i}\n  <<: [${refs}]\n  k${i}: ${i}`);
+          }
+          lines.push(`root:\n  <<: *a${depth}`);
+          const input = lines.join("\n");
+
+          const expected: any = {};
+          for (let i = 0; i <= depth; i++) {
+            const record = {};
+            for (let j = 0; j <= i; j++) record[`k${j}`] = j;
+            expected[`a${i}`] = record;
+          }
+          expected.root = { ...expected[`a${depth}`] };
+
+          return { input, expected };
         }
-        lines.push(`root:\n  <<: *a${depth}`);
-        const input = lines.join("\n");
 
-        const expected: any = {};
-        for (let i = 0; i <= depth; i++) {
-          const record = {};
-          for (let j = 0; j <= i; j++) record[`k${j}`] = j;
-          expected[`a${i}`] = record;
-        }
-        expected.root = { ...expected[`a${depth}`] };
+        const { input, expected } = buildTest(24);
 
-        return { input, expected };
-      }
-
-      const { input, expected } = buildTest(24);
-
-      expect(YAML.parse(input)).toEqual(expected);
-    }, isDebug || isASAN ? 2000 : 100);
+        expect(YAML.parse(input)).toEqual(expected);
+      },
+      isDebug || isASAN ? 2000 : 100,
+    );
 
     describe("merge keys", () => {
       test("merge overrides", () => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -63,9 +63,9 @@ describe("Bun.YAML", () => {
         const str = "value: 42";
         const encoder = new TextEncoder();
         const bytes = encoder.encode(str);
-        // Ensure buffer is aligned for Int32Array
+        // Ensure buffer is aligned for Int32Array; pad with LF (NUL is not c-printable)
         const alignedBuffer = new ArrayBuffer(Math.ceil(bytes.length / 4) * 4);
-        new Uint8Array(alignedBuffer).set(bytes);
+        new Uint8Array(alignedBuffer).fill(0x0a).set(bytes);
         const int32Array = new Int32Array(alignedBuffer);
         expect(YAML.parse(int32Array)).toEqual({ value: 42 });
       });
@@ -74,9 +74,9 @@ describe("Bun.YAML", () => {
         const str = "test: pass";
         const encoder = new TextEncoder();
         const bytes = encoder.encode(str);
-        // Ensure buffer is aligned for Uint32Array
+        // Ensure buffer is aligned for Uint32Array; pad with LF (NUL is not c-printable)
         const alignedBuffer = new ArrayBuffer(Math.ceil(bytes.length / 4) * 4);
-        new Uint8Array(alignedBuffer).set(bytes);
+        new Uint8Array(alignedBuffer).fill(0x0a).set(bytes);
         const uint32Array = new Uint32Array(alignedBuffer);
         expect(YAML.parse(uint32Array)).toEqual({ test: "pass" });
       });
@@ -118,9 +118,9 @@ describe("Bun.YAML", () => {
         const str = "huge: 1000";
         const encoder = new TextEncoder();
         const bytes = encoder.encode(str);
-        // Ensure buffer is aligned for BigUint64Array
+        // Ensure buffer is aligned for BigUint64Array; pad with LF (NUL is not c-printable)
         const alignedBuffer = new ArrayBuffer(Math.ceil(bytes.length / 8) * 8);
-        new Uint8Array(alignedBuffer).set(bytes);
+        new Uint8Array(alignedBuffer).fill(0x0a).set(bytes);
         const bigUint64Array = new BigUint64Array(alignedBuffer);
         expect(YAML.parse(bigUint64Array)).toEqual({ huge: 1000 });
       });
@@ -171,9 +171,9 @@ database:
         const yaml = "[1, 2, 3, 4, 5]";
         const encoder = new TextEncoder();
         const bytes = encoder.encode(yaml);
-        // Ensure buffer is aligned for Uint32Array
+        // Ensure buffer is aligned for Uint32Array; pad with LF (NUL is not c-printable)
         const alignedBuffer = new ArrayBuffer(Math.ceil(bytes.length / 4) * 4);
-        new Uint8Array(alignedBuffer).set(bytes);
+        new Uint8Array(alignedBuffer).fill(0x0a).set(bytes);
         const uint32Array = new Uint32Array(alignedBuffer);
         expect(YAML.parse(uint32Array)).toEqual([1, 2, 3, 4, 5]);
       });
@@ -1833,11 +1833,34 @@ folded: >
       // Bugs surfaced by the multi-modal bughunt (12 finder lenses × 3 rounds).
       // Each todo asserts the spec-correct result.
       describe("bughunt findings", () => {
-        test.todo("NUL byte (U+0000) is not c-printable — should error, not truncate", () => {
-          // [1] c-printable excludes NUL. Currently NUL is the EOF sentinel, so
-          // input is silently truncated. Data loss / security-adjacent.
-          expect(() => YAML.parse("a: 1\x00b: 2")).toThrow();
-          expect(() => YAML.parse("key: foo\x00bar")).toThrow();
+        describe("NUL byte (U+0000) is not c-printable — should error, not truncate", () => {
+          // [1] c-printable excludes NUL. NUL is the peek()/next() EOF sentinel,
+          // so a literal NUL in the input must be distinguished from real EOF.
+          test.each([
+            ["between mappings", "a: 1\x00b: 2"],
+            ["inside a plain scalar value", "key: foo\x00bar"],
+            ["at start of input", "\x00a: 1"],
+            ["as the only byte", "\x00"],
+            ["inside a block sequence", "- a\n- b\x00- c"],
+            ["inside a literal block scalar", "x: |\n  foo\x00bar"],
+            ["inside a folded block scalar", "x: >\n  foo\x00bar"],
+            ["in a block scalar header", "x: |\x00"],
+            ["inside a plain scalar (utf16 input)", "😀: foo\x00bar"],
+            ["from a Buffer", Buffer.from("a: 1\x00b: 2")],
+          ] as const)("%s", (_name, input) => {
+            expect(() => YAML.parse(input as string)).toThrow(SyntaxError);
+          });
+          test("flow collections still error (not truncate) on NUL", () => {
+            expect(() => YAML.parse("[a, b\x00, c]")).toThrow(SyntaxError);
+            expect(() => YAML.parse("{a: 1\x00, b: 2}")).toThrow(SyntaxError);
+          });
+          test("quoted scalars still error on NUL", () => {
+            expect(() => YAML.parse('"foo\x00bar"')).toThrow(SyntaxError);
+            expect(() => YAML.parse("'foo\x00bar'")).toThrow(SyntaxError);
+          });
+          test('escaped NUL ("\\0") remains valid', () => {
+            expect(YAML.parse('"a\\0b"')).toBe("a\x00b");
+          });
         });
 
         test.todo("C0/C1/DEL control characters are not c-printable — should error", () => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1845,6 +1845,9 @@ folded: >
             ["inside a literal block scalar", "x: |\n  foo\x00bar"],
             ["inside a folded block scalar", "x: >\n  foo\x00bar"],
             ["in a block scalar header", "x: |\x00"],
+            ["inside a comment", "# foo\x00bar\nkey: 1"],
+            ["inside a block-scalar header comment", "x: | # foo\x00bar\n  body"],
+            ["inside a directive trailing comment", "%YAML 1.2 # c\x00mt\n---\nkey: 1"],
             ["inside a plain scalar (utf16 input)", "😀: foo\x00bar"],
             ["from a Buffer", Buffer.from("a: 1\x00b: 2")],
           ] as const)("%s", (_name, input) => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -2410,7 +2410,7 @@ my_config:
       const { input, expected } = buildTest(24);
 
       expect(YAML.parse(input)).toEqual(expected);
-    }, 100);
+    }, isDebug || isASAN ? 2000 : 100);
 
     describe("merge keys", () => {
       test("merge overrides", () => {


### PR DESCRIPTION
## What

`Bun.YAML.parse` was silently truncating the document at the first NUL byte instead of raising a parse error.

```js
Bun.YAML.parse("a: 1\x00b: 2")     // {"a":1}        (b: 2 dropped, no error)
Bun.YAML.parse("key: foo\x00bar")  // {"key":"foo"}  (value truncated, no error)
```

YAML 1.2 [1] `c-printable` excludes U+0000, so a NUL byte anywhere in the stream is a syntax error and must never produce a partial result.

## Why

`peek()` / `next()` return `Enc::NUL` (0) as the end-of-input sentinel. The scanner state machines dispatch on `Enc::wide(self.next())` and match `0 =>` to mean "EOF, finish cleanly". A literal NUL byte in the input is indistinguishable from real EOF there, so `scan()` emitted `Token::Eof` and `scan_plain_scalar()` / the block-scalar scanners returned `ctx.done()`, yielding a successfully-parsed prefix of the input.

Quoted-scalar scanning already rejected `0` with `UnexpectedCharacter`, which is why a NUL inside a double-quoted string threw while the same byte in block context truncated.

## Fix

Each `0 =>` arm that treated NUL as successful EOF now checks `self.is_eof()` first and returns `ParseError::UnexpectedCharacter` when the position is still inside the input (i.e. the 0 is a literal byte, not the sentinel). Five sites: `scan()`, `scan_plain_scalar()`, `scan_block_header()`, and both phases of the literal/folded block-scalar scanner.

The `test.todo` in `yaml.test.ts` is promoted to a `describe` block covering NUL in plain scalars, block sequences, literal/folded block scalars, block-scalar headers, UTF-16 input, Buffer input, and start-of-input, plus regression guards for the contexts that already errored (quoted scalars, flow collections) and for the `"\0"` escape sequence, which remains valid.

Four existing TypedArray input tests were incidentally relying on the truncation bug: their alignment padding left trailing NUL bytes in the buffer, which the old parser treated as EOF. Those now pad with LF instead.

## Verification

- `bun bd test test/js/bun/yaml/yaml.test.ts`: 622 pass / 0 fail / 21 todo
- `bun bd test test/js/bun/yaml/yaml-test-suite.test.ts`: 402 pass / 0 fail
- `bun bd test test/js/bun/yaml/yaml-block-scalar-matrix.test.ts`: all pass
- fail-before: with `src/` reverted, the new NUL tests fail 10/13 (the 3 passes are the already-correct quoted/flow/escape guards)