### PR TITLE
webcore: decode Content-Transfer-Encoding: base64 parts in Response.formData()

### DIFF
--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -9,6 +9,7 @@ use bun_jsc::{
 };
 use bun_semver::{self, SlicedString};
 use core::ffi::c_void;
+use std::borrow::Cow;
 
 use crate::webcore::Blob;
 use crate::webcore::BlobExt as _;
@@ -83,8 +84,9 @@ impl AsyncFormDataExt for AsyncFormData {
 /// file bodies are binary data that can contain null bytes, which
 /// Semver.String's inline storage treats as terminators.
 pub struct Field<'a> {
-    /// Borrows into the caller-owned input buffer (binary body slice).
-    pub value: &'a [u8],
+    /// Borrows into the caller-owned input buffer, or owns a decoded copy when
+    /// the part carried `Content-Transfer-Encoding: base64`.
+    pub value: Cow<'a, [u8]>,
     pub filename: bun_semver::String,
     pub content_type: bun_semver::String,
     pub is_file: bool,
@@ -94,7 +96,7 @@ pub struct Field<'a> {
 impl Default for Field<'_> {
     fn default() -> Self {
         Field {
-            value: b"",
+            value: Cow::Borrowed(b""),
             filename: bun_semver::String::default(),
             content_type: bun_semver::String::default(),
             is_file: false,
@@ -217,7 +219,7 @@ pub fn to_js_from_multipart_data(
 
     impl<'a> Wrapper<'a> {
         fn on_entry(wrap: &mut Self, name: bun_semver::String, field: &Field<'_>, buf: &[u8]) {
-            let value_str: &[u8] = field.value;
+            let value_str: &[u8] = &field.value;
             let key = ZigString::init_utf8(name.slice(buf));
 
             if field.is_file {
@@ -339,7 +341,8 @@ pub fn for_each_multipart_entry<C>(
         let mut filename: Option<bun_semver::String> = None;
         let mut header_chunk = header;
         let mut is_file = false;
-        while !header_chunk.is_empty() && (filename.is_none() || name.len() == 0) {
+        let mut is_base64 = false;
+        while !header_chunk.is_empty() {
             let line_end = strings::index_of(header_chunk, b"\r\n")
                 .ok_or(crate::Error::IsMissingHeaderLineEnd)?;
             let line = &header_chunk[..line_end];
@@ -407,6 +410,15 @@ pub fn for_each_multipart_entry<C>(
                         break;
                     }
                 }
+            } else if strings::eql_case_insensitive_ascii(key, b"content-transfer-encoding", true) {
+                // RFC 7578 §4.7 deprecates Content-Transfer-Encoding in
+                // multipart/form-data, but undici decodes base64 parts and
+                // Bun matches that for compatibility.
+                is_base64 = strings::eql_case_insensitive_ascii(
+                    strings::trim(value, b" \t"),
+                    b"base64",
+                    true,
+                );
             } else if !value.is_empty()
                 && field.content_type.is_empty()
                 && strings::eql_case_insensitive_ascii(key, b"content-type", true)
@@ -435,7 +447,14 @@ pub fn for_each_multipart_entry<C>(
         if body.ends_with(b"\r\n") {
             body = &body[..body.len() - 2];
         }
-        field.value = body;
+        field.value = if is_base64 {
+            let mut out = vec![0u8; bun_base64::decode_lenient_len(body.len())];
+            let wrote = bun_base64::decode_lenient(&mut out, body, false);
+            out.truncate(wrote);
+            Cow::Owned(out)
+        } else {
+            Cow::Borrowed(body)
+        };
         field.filename = filename.unwrap_or_default();
         field.is_file = is_file;
 

--- a/test/js/web/fetch/client-fetch.test.ts
+++ b/test/js/web/fetch/client-fetch.test.ts
@@ -148,7 +148,7 @@ test("multipart formdata not base64", async () => {
   expect(text).toBe("example\ntext file");
 });
 
-test.todo("multipart formdata base64", async () => {
+test("multipart formdata base64", async () => {
   // Example form data with base64 encoding
   const data = randomFillSync(Buffer.alloc(256));
   const formRaw =

--- a/test/js/web/html/FormData-multipart-serialization.test.ts
+++ b/test/js/web/html/FormData-multipart-serialization.test.ts
@@ -136,7 +136,7 @@ describe("multipart serialization (new Response(formData))", () => {
       ["dup", "first"],
       ["dup", "second"],
       ["unicode name ☺", "ünïcode välue 😊"],
-      ["blob", { file: true, name: undefined, type: "", text: "blob-bytes" }],
+      ["blob", { file: true, name: undefined, type: "application/octet-stream", text: "blob-bytes" }],
       ["file", { file: true, name: "日本語ファイル名.html", type: "text/html;charset=utf-8", text: "<p>hi</p>" }],
     ]);
   });

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -241,6 +241,38 @@ describe("FormData", () => {
     }
   }
 
+  it("decodes a part with Content-Transfer-Encoding: base64", async () => {
+    const raw = crypto.getRandomValues(new Uint8Array(256));
+    const body =
+      "--X\r\n" +
+      'Content-Disposition: form-data; name="file"; filename="test.txt"\r\n' +
+      "Content-Type: application/octet-stream\r\n" +
+      "Content-Transfer-Encoding: base64\r\n" +
+      "\r\n" +
+      Buffer.from(raw).toString("base64") +
+      "\r\n--X--\r\n";
+    const form = await new Response(body, {
+      headers: { "Content-Type": "multipart/form-data; boundary=X" },
+    }).formData();
+    const file = form.get("file") as File;
+    expect(file.type).toBe("application/octet-stream");
+    expect(Buffer.from(await file.arrayBuffer()).equals(Buffer.from(raw))).toBe(true);
+  });
+
+  it("decodes a base64 part without a filename as a string value", async () => {
+    const body =
+      "--X\r\n" +
+      'Content-Disposition: form-data; name="greeting"\r\n' +
+      "content-transfer-encoding: Base64\r\n" +
+      "\r\n" +
+      Buffer.from("hello world").toString("base64") +
+      "\r\n--X--\r\n";
+    const form = await new Response(body, {
+      headers: { "Content-Type": "multipart/form-data; boundary=X" },
+    }).formData();
+    expect(form.get("greeting")).toBe("hello world");
+  });
+
   it("should throw on missing final boundary", async () => {
     const response = new Response('-foo\r\nContent-Disposition: form-data; name="foo"\r\n\r\nbar\r\n', {
       headers: {

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -241,6 +241,44 @@ describe("FormData", () => {
     }
   }
 
+  // https://github.com/oven-sh/bun/issues/33012
+  describe("multipart file part honors an explicit Content-Type", () => {
+    const boundary = "----formdataboundary";
+    const headers = { "Content-Type": `multipart/form-data; boundary=${boundary}` };
+    // "RIFF" + 4-byte size + "WEBPVP8 ": no entry in the magic-byte sniff table.
+    const webp = Buffer.concat([Buffer.from("RIFF"), Buffer.from([0, 0, 0, 0]), Buffer.from("WEBPVP8 ")]);
+
+    function buildBody(contentType: string | null, filename: string, content: Uint8Array): Uint8Array {
+      const head =
+        `--${boundary}\r\n` +
+        `Content-Disposition: form-data; name="file"; filename="${filename}"\r\n` +
+        (contentType === null ? "" : `Content-Type: ${contentType}\r\n`) +
+        `\r\n`;
+      return Buffer.concat([Buffer.from(head, "latin1"), content, Buffer.from(`\r\n--${boundary}--\r\n`, "latin1")]);
+    }
+
+    function parse(C: typeof Response | typeof Request, body: Uint8Array) {
+      const source =
+        C === Response ? new Response(body, { headers }) : new Request("http://x/", { method: "POST", body, headers });
+      return source.formData();
+    }
+
+    for (const C of [Response, Request] as const) {
+      it(`keeps the declared type for an extensionless filename (${C.name})`, async () => {
+        const form = await parse(C, buildBody("image/webp", "banner", webp));
+        const file = form.get("file");
+        expect(file).toBeInstanceOf(File);
+        expect((file as File).name).toBe("banner");
+        expect((file as File).type).toBe("image/webp");
+      });
+
+      it(`prefers the declared type over the filename extension (${C.name})`, async () => {
+        const form = await parse(C, buildBody("image/webp", "banner.txt", webp));
+        expect((form.get("file") as File).type).toBe("image/webp");
+      });
+    }
+  });
+
   it("decodes a part with Content-Transfer-Encoding: base64", async () => {
     const raw = crypto.getRandomValues(new Uint8Array(256));
     const body =


### PR DESCRIPTION
## What does this PR do?

`Response.formData()` / `Request.formData()` now decodes a multipart part whose headers include `Content-Transfer-Encoding: base64`, matching Node/undici.

```js
const raw = crypto.getRandomValues(new Uint8Array(256));
const body = "--X\r\nContent-Disposition: form-data; name=\"file\"; filename=\"test.txt\"\r\n" +
  "Content-Type: application/octet-stream\r\nContent-Transfer-Encoding: base64\r\n\r\n" +
  Buffer.from(raw).toString("base64") + "\r\n--X--";
const res = new Response(body, { headers: { "content-type": "multipart/form-data; boundary=X" } });
const f = await (await res.formData()).get("file").bytes();
console.log(f.length);
// node:   256 (decoded)
// before: 344 (raw base64 text)
// after:  256
```

RFC 7578 section 4.7 deprecates `Content-Transfer-Encoding` in `multipart/form-data`, so ignoring it is spec-permissible; this is booked as an undici-compat fix (undici's own suite asserts decoding, ported as `test/js/web/fetch/client-fetch.test.ts` `"multipart formdata base64"`, previously `test.todo`).

## Cause

`for_each_multipart_entry` stopped scanning a part's header lines as soon as both `name` and `filename` had been parsed from `Content-Disposition`, so any following header line was never read for file parts. That skipped `Content-Transfer-Encoding` entirely, and also meant `Content-Type` fell back to filename-extension sniffing instead of the value on the wire.

## Fix

* Walk every header line.
* Capture `Content-Transfer-Encoding`; when it equals `base64` (case-insensitive, OWS-trimmed), decode the part body via `bun_base64::decode_lenient`, the same forgiving decoder Node's `Buffer.from(str, "base64")` uses (which is what undici calls).
* `Field.value` becomes `Cow<[u8]>` so a decoded body can be owned while the common path still borrows.

The header-loop change also makes a file part's `Content-Type` come from the wire header instead of extension sniffing, which matches Node's round-trip behaviour. That:

* updates one expectation in `FormData-multipart-serialization.test.ts` (untyped `Blob` round-trip now yields `application/octet-stream`, as Node does),
* fixes #33012 (WebP `Content-Type` was dropped because the sniff table has no WebP magic and the header was never read),
* fixes the `Request.formData()` half of #34717 (`text/plain` on the wire came back as `text/plain;charset=utf-8` via the `.txt` extension fallback; the `Blob`/`File` constructor half is #33605).

Supersedes #33013 (same early-exit removal, without the base64 decoding).

Fixes #33012

## How did you verify your code works?

* `bun bd test test/js/web/html/FormData.test.ts` (155 pass, 6 new)
* `bun bd test test/js/web/fetch/client-fetch.test.ts -t "multipart formdata"` (un-todo'd undici port passes)
* `bun bd test test/js/web/html/FormData-multipart-serialization.test.ts` (6 pass)
* New tests fail under `USE_SYSTEM_BUN=1`:
  * base64 file part: body length 344 vs 256
  * base64 string part: `Expected: "hello world"  Received: "aGVsbG8gd29ybGQ="`
  * explicit `Content-Type` (webp, extensionless): `Expected: "image/webp"  Received: ""`
  * explicit `Content-Type` over extension: `Expected: "image/webp"  Received: "text/plain;charset=utf-8"`

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/html/FormData-multipart-serialization.test.ts

<!-- robobun:evidence:end -->