### PR TITLE
yaml: resolve self-referential anchors so cyclic objects round-trip

### DIFF
--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -3893,10 +3893,13 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             return Ok(None);
         };
         let name = Enc::key_bytes(anchor.slice(self.input));
-        if self.anchors.get(name).is_some() {
-            // Redefinition: an alias inside this body keeps resolving to the
-            // previous definition; the post-body put overwrites afterwards.
-            return Ok(None);
+        if let Some(prev) = self.anchors.get(name) {
+            // Sibling redefinition: keep resolving to the previous closed
+            // node. Nested redefinition (prev still open) shadows instead so
+            // *name binds to the inner anchor, not the enclosing placeholder.
+            if Self::collection_ptr(prev).is_none_or(|p| !self.open_anchors.contains(&p)) {
+                return Ok(None);
+            }
         }
         let placeholder = match kind {
             AnchorPlaceholder::Array => Expr::init(E::Array::default(), loc),

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -23,14 +23,40 @@ use bun_core::{self, StackCheck};
 pub struct YAML;
 
 impl YAML {
+    /// Parse a YAML document. Self-referential anchors (`&a {self: *a}`) are
+    /// rejected with `Unresolved alias` so the returned `Expr` graph is
+    /// acyclic; callers that walk it without a seen-set (bundler printer,
+    /// `Expr::deep_clone`) stay safe.
     pub fn parse(
         source: &bun_ast::Source,
         log: &mut bun_ast::Log,
         bump: &bun_alloc::Arena,
     ) -> Result<Expr, YamlParseError> {
+        Self::parse_impl(source, log, bump, false)
+    }
+
+    /// Parse a YAML document with self-referential anchors resolved. The
+    /// returned `Expr` graph may contain cycles; the caller must be able to
+    /// walk a cyclic graph (as `Bun.YAML.parse`'s `to_js` does via
+    /// `seen_objects`).
+    pub fn parse_allowing_self_references(
+        source: &bun_ast::Source,
+        log: &mut bun_ast::Log,
+        bump: &bun_alloc::Arena,
+    ) -> Result<Expr, YamlParseError> {
+        Self::parse_impl(source, log, bump, true)
+    }
+
+    fn parse_impl(
+        source: &bun_ast::Source,
+        log: &mut bun_ast::Log,
+        bump: &bun_alloc::Arena,
+        allow_self_referential_aliases: bool,
+    ) -> Result<Expr, YamlParseError> {
         bun_core::analytics::Features::yaml_parse_inc();
 
         let mut parser: Parser<Utf8> = Parser::init(bump, source.contents());
+        parser.allow_self_referential_aliases = allow_self_referential_aliases;
 
         let stream = match parser.parse() {
             Ok(s) => s,
@@ -2353,6 +2379,10 @@ pub struct Parser<'i, Enc: Encoding> {
     pub merge_props_budget: usize,
     pub alias_expansion_budget: usize,
 
+    /// When false (the default), self-referential anchors are not
+    /// pre-registered and `*a` inside `&a {...}` keeps failing with
+    /// `UnresolvedAlias`, guaranteeing an acyclic `Expr` graph.
+    pub allow_self_referential_aliases: bool,
     /// Collection nodes whose anchor is registered but whose body is still
     /// being parsed. An alias that resolves to one of these is a
     /// self-reference (`&a {self: *a}`). A merge key that resolves to one is
@@ -2397,6 +2427,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             stack_check: StackCheck::init(),
             merge_props_budget: MappingProps::MAX_MERGED_PROPERTIES,
             alias_expansion_budget: Self::MAX_ALIAS_EXPANSION,
+            allow_self_referential_aliases: false,
             open_anchors: Vec::new(),
             self_referential: Vec::new(),
         }
@@ -3859,6 +3890,9 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         kind: AnchorPlaceholder,
         loc: Loc,
     ) -> Result<Option<Expr>, ParseError> {
+        if !self.allow_self_referential_aliases {
+            return Ok(None);
+        }
         let Some(anchor) = anchor else {
             return Ok(None);
         };

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -13,7 +13,7 @@ use core::fmt;
 use bun_alloc::AllocError;
 use bun_ast::{self, E, Expr, G};
 use bun_ast::{self as ast, Loc};
-use bun_collections::{StringHashMap, VecExt};
+use bun_collections::{HashMap, StringHashMap, VecExt};
 use bun_core::{self, StackCheck};
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -2389,8 +2389,10 @@ pub struct Parser<'i, Enc: Encoding> {
     /// rejected because the placeholder is still empty at merge time.
     pub open_anchors: Vec<*const ()>,
     /// Collection nodes known to be on a cycle. `charge_alias_expansion`
-    /// must not descend into these.
-    pub self_referential: Vec<*const ()>,
+    /// must not descend into these. O(1) membership keeps the per-node work
+    /// in `charge_alias_expansion` constant regardless of how many
+    /// self-referential anchors the document declares.
+    pub self_referential: HashMap<*const (), ()>,
 }
 
 impl<'i, Enc: Encoding> Parser<'i, Enc> {
@@ -2429,7 +2431,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             alias_expansion_budget: Self::MAX_ALIAS_EXPANSION,
             allow_self_referential_aliases: false,
             open_anchors: Vec::new(),
-            self_referential: Vec::new(),
+            self_referential: HashMap::default(),
         }
     }
 
@@ -4045,9 +4047,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                             // parsed. Mark it so later alias charges don't walk
                             // the cycle; the placeholder is empty here so there
                             // is nothing to charge for its body yet.
-                            if !self.self_referential.contains(&ptr) {
-                                self.self_referential.push(ptr);
-                            }
+                            self.self_referential.put(ptr, ())?;
                         }
                     }
                     self.charge_alias_expansion(copy)?;

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -2355,7 +2355,8 @@ pub struct Parser<'i, Enc: Encoding> {
 
     /// Collection nodes whose anchor is registered but whose body is still
     /// being parsed. An alias that resolves to one of these is a
-    /// self-reference (`&a {self: *a}`).
+    /// self-reference (`&a {self: *a}`). A merge key that resolves to one is
+    /// rejected because the placeholder is still empty at merge time.
     pub open_anchors: Vec<*const ()>,
     /// Collection nodes known to be on a cycle. `charge_alias_expansion`
     /// must not descend into these.
@@ -2789,7 +2790,12 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         Expr::init(E::Null {}, self.token.start.loc())
                     };
                     let mut props = MappingProps::init();
-                    props.append_maybe_merge(key, value, &mut self.merge_props_budget)?;
+                    props.append_maybe_merge(
+                        key,
+                        value,
+                        &mut self.merge_props_budget,
+                        &self.open_anchors,
+                    )?;
                     Expr::init(
                         E::Object {
                             properties: props.move_list(),
@@ -2922,7 +2928,12 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         current_mapping_indent: Some(self.token.indent),
                         ..Default::default()
                     })?;
-                    props.append_maybe_merge(key, value, &mut self.merge_props_budget)?;
+                    props.append_maybe_merge(
+                        key,
+                        value,
+                        &mut self.merge_props_budget,
+                        &self.open_anchors,
+                    )?;
                 }
 
                 // [140] ns-s-flow-map-entries: after an entry, only `,` or `}`.
@@ -3112,7 +3123,12 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     _ => Expr::init(E::Null {}, mapping_value_start.loc()),
                 };
 
-                props.append_maybe_merge(first_key, value, &mut self.merge_props_budget)?;
+                props.append_maybe_merge(
+                    first_key,
+                    value,
+                    &mut self.merge_props_budget,
+                    &self.open_anchors,
+                )?;
             }
 
             if self.context.get() == Context::FlowIn {
@@ -3244,7 +3260,12 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         }
                     };
 
-                    props.append_maybe_merge(key, value, &mut self.merge_props_budget)?;
+                    props.append_maybe_merge(
+                        key,
+                        value,
+                        &mut self.merge_props_budget,
+                        &self.open_anchors,
+                    )?;
                 }
 
                 Ok(Expr::init(
@@ -3349,37 +3370,49 @@ impl MappingProps {
         key: Expr,
         value: Expr,
         budget: &mut usize,
-    ) -> Result<(), AllocError> {
+        open_anchors: &[*const ()],
+    ) -> Result<(), ParseError> {
         let is_merge_key = match &key.data {
             ast::ExprData::EString(key_str) => key_str.eql_comptime(b"<<"),
             _ => false,
         };
 
         if !is_merge_key {
-            return self.append(G::Property {
+            return Ok(self.append(G::Property {
                 key: Some(key),
                 value: Some(value),
                 ..Default::default()
-            });
+            })?);
         }
 
         match &value.data {
-            ast::ExprData::EObject(value_obj) => self.merge(value_obj.properties.slice(), budget),
+            ast::ExprData::EObject(value_obj) => {
+                if open_anchors.contains(&(value_obj.as_ptr() as *const ())) {
+                    return Err(ParseError::UnresolvedAlias);
+                }
+                Ok(self.merge(value_obj.properties.slice(), budget)?)
+            }
             ast::ExprData::EArray(value_arr) => {
+                if open_anchors.contains(&(value_arr.as_ptr() as *const ())) {
+                    return Err(ParseError::UnresolvedAlias);
+                }
                 for item in value_arr.items.slice() {
                     let item_obj = match &item.data {
                         ast::ExprData::EObject(obj) => obj,
                         _ => continue,
                     };
+                    if open_anchors.contains(&(item_obj.as_ptr() as *const ())) {
+                        return Err(ParseError::UnresolvedAlias);
+                    }
                     self.merge(item_obj.properties.slice(), budget)?;
                 }
                 Ok(())
             }
-            _ => self.append(G::Property {
+            _ => Ok(self.append(G::Property {
                 key: Some(key),
                 value: Some(value),
                 ..Default::default()
-            }),
+            })?),
         }
     }
 
@@ -3418,6 +3451,12 @@ impl<Enc: Encoding> Default for NodeProperties<Enc> {
 pub struct ImplicitKeyAnchors {
     pub key_anchor: Option<StringRange>,
     pub mapping_anchor: Option<StringRange>,
+}
+
+#[derive(Clone, Copy)]
+pub enum AnchorPlaceholder {
+    Array,
+    Object,
 }
 
 impl<Enc: Encoding> NodeProperties<Enc> {
@@ -3812,14 +3851,20 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
     /// Register `anchor` with an empty collection node before parsing the
     /// body so a self-referential alias inside the body resolves to it.
     /// Returns the placeholder; the caller passes it to
-    /// `adopt_preregistered` once the body is parsed.
+    /// `adopt_preregistered` once the body is parsed. The placeholder is
+    /// only allocated when `anchor` is `Some`.
     fn preregister_collection_anchor(
         &mut self,
         anchor: Option<StringRange>,
-        placeholder: Expr,
+        kind: AnchorPlaceholder,
+        loc: Loc,
     ) -> Result<Option<Expr>, ParseError> {
         let Some(anchor) = anchor else {
             return Ok(None);
+        };
+        let placeholder = match kind {
+            AnchorPlaceholder::Array => Expr::init(E::Array::default(), loc),
+            AnchorPlaceholder::Object => Expr::init(E::Object::default(), loc),
         };
         self.anchors
             .put(Enc::key_bytes(anchor.slice(self.input)), placeholder)?;
@@ -4033,9 +4078,16 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     let sequence_indent = self.token.indent;
                     let sequence_line = self.token.line;
                     let sequence_tab_after_indent = self.tab_after_indent;
+                    // A prior-line anchor may belong to the enclosing block
+                    // mapping (implicit_key_anchors decides after the body is
+                    // parsed); only a same-line anchor is guaranteed to anchor
+                    // this flow sequence itself.
                     let preregistered = self.preregister_collection_anchor(
-                        node_props.anchor(),
-                        Expr::init(E::Array::default(), sequence_start.loc()),
+                        node_props
+                            .anchor()
+                            .filter(|_| node_props.anchor_line() == Some(sequence_line)),
+                        AnchorPlaceholder::Array,
+                        sequence_start.loc(),
                     )?;
                     let json_key = self.maybe_set_json_key(opts.flow_pair_allowed)?;
                     let seq = self.parse_flow_sequence();
@@ -4083,6 +4135,11 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                                 .put(Enc::key_bytes(key_anchor.slice(self.input)), seq)?;
                         }
 
+                        let preregistered_map = self.preregister_collection_anchor(
+                            implicit_key_anchors.mapping_anchor,
+                            AnchorPlaceholder::Object,
+                            sequence_start.loc(),
+                        )?;
                         let map = self.parse_block_mapping(
                             seq,
                             sequence_start,
@@ -4090,6 +4147,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                             sequence_line,
                             opts.flow_pair_allowed,
                         )?;
+                        let map = self.adopt_preregistered(preregistered_map, map);
 
                         if let Some(mapping_anchor) = implicit_key_anchors.mapping_anchor {
                             self.anchors
@@ -4122,7 +4180,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     }
                     let preregistered = self.preregister_collection_anchor(
                         node_props.anchor(),
-                        Expr::init(E::Array::default(), self.token.start.loc()),
+                        AnchorPlaceholder::Array,
+                        self.token.start.loc(),
                     )?;
                     let seq = self.parse_block_sequence()?;
                     break 'node self.adopt_preregistered(preregistered, seq);
@@ -4134,9 +4193,14 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     let mapping_line = self.token.line;
                     let mapping_tab_after_indent = self.tab_after_indent;
 
+                    // Same-line only; a prior-line anchor may belong to the
+                    // enclosing block mapping (see SequenceStart above).
                     let preregistered = self.preregister_collection_anchor(
-                        node_props.anchor(),
-                        Expr::init(E::Object::default(), mapping_start.loc()),
+                        node_props
+                            .anchor()
+                            .filter(|_| node_props.anchor_line() == Some(mapping_line)),
+                        AnchorPlaceholder::Object,
+                        mapping_start.loc(),
                     )?;
                     let json_key = self.maybe_set_json_key(opts.flow_pair_allowed)?;
                     let map = self.parse_flow_mapping();
@@ -4183,6 +4247,11 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                                 .put(Enc::key_bytes(key_anchor.slice(self.input)), map)?;
                         }
 
+                        let preregistered_parent = self.preregister_collection_anchor(
+                            implicit_key_anchors.mapping_anchor,
+                            AnchorPlaceholder::Object,
+                            mapping_start.loc(),
+                        )?;
                         let parent_map = self.parse_block_mapping(
                             map,
                             mapping_start,
@@ -4190,6 +4259,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                             mapping_line,
                             opts.flow_pair_allowed,
                         )?;
+                        let parent_map = self.adopt_preregistered(preregistered_parent, parent_map);
 
                         if let Some(mapping_anchor) = implicit_key_anchors.mapping_anchor {
                             self.anchors.put(
@@ -4245,7 +4315,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
                     let preregistered = self.preregister_collection_anchor(
                         node_props.anchor(),
-                        Expr::init(E::Object::default(), mapping_start.loc()),
+                        AnchorPlaceholder::Object,
+                        mapping_start.loc(),
                     )?;
                     let mapping = self.parse_block_mapping(
                         key,
@@ -4290,7 +4361,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
                     let preregistered = self.preregister_collection_anchor(
                         implicit_key_anchors.mapping_anchor,
-                        Expr::init(E::Object::default(), self.token.start.loc()),
+                        AnchorPlaceholder::Object,
+                        self.token.start.loc(),
                     )?;
                     let mapping = self.parse_block_mapping(
                         first_key,
@@ -4415,7 +4487,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
                         let preregistered = self.preregister_collection_anchor(
                             implicit_key_anchors.mapping_anchor,
-                            Expr::init(E::Object::default(), scalar_start.loc()),
+                            AnchorPlaceholder::Object,
+                            scalar_start.loc(),
                         )?;
                         let mapping = self.parse_block_mapping(
                             implicit_key,

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -23,10 +23,9 @@ use bun_core::{self, StackCheck};
 pub struct YAML;
 
 impl YAML {
-    /// Parse a YAML document. Self-referential anchors (`&a {self: *a}`) are
-    /// rejected with `Unresolved alias` so the returned `Expr` graph is
-    /// acyclic; callers that walk it without a seen-set (bundler printer,
-    /// `Expr::deep_clone`) stay safe.
+    /// Parse a YAML document. Self-referential anchors are rejected so the
+    /// returned `Expr` graph is acyclic and safe for callers that walk it
+    /// without a seen-set (bundler printer, `Expr::deep_clone`).
     pub fn parse(
         source: &bun_ast::Source,
         log: &mut bun_ast::Log,
@@ -36,9 +35,8 @@ impl YAML {
     }
 
     /// Parse a YAML document with self-referential anchors resolved. The
-    /// returned `Expr` graph may contain cycles; the caller must be able to
-    /// walk a cyclic graph (as `Bun.YAML.parse`'s `to_js` does via
-    /// `seen_objects`).
+    /// returned `Expr` graph may contain cycles; the caller must walk it with
+    /// a seen-set (as `Bun.YAML.parse`'s `to_js` does via `seen_objects`).
     pub fn parse_allowing_self_references(
         source: &bun_ast::Source,
         log: &mut bun_ast::Log,
@@ -2384,14 +2382,12 @@ pub struct Parser<'i, Enc: Encoding> {
     /// `UnresolvedAlias`, guaranteeing an acyclic `Expr` graph.
     pub allow_self_referential_aliases: bool,
     /// Collection nodes whose anchor is registered but whose body is still
-    /// being parsed. An alias that resolves to one of these is a
-    /// self-reference (`&a {self: *a}`). A merge key that resolves to one is
-    /// rejected because the placeholder is still empty at merge time.
+    /// being parsed. An alias resolving to one is a self-reference; a merge
+    /// key resolving to one is rejected (the placeholder is still empty).
     pub open_anchors: Vec<*const ()>,
-    /// Collection nodes known to be on a cycle. `charge_alias_expansion`
-    /// must not descend into these. O(1) membership keeps the per-node work
-    /// in `charge_alias_expansion` constant regardless of how many
-    /// self-referential anchors the document declares.
+    /// Collection nodes known to be on a cycle; `charge_alias_expansion`
+    /// must not descend into these. O(1) membership keeps the per-node cost
+    /// constant regardless of how many self-referential anchors exist.
     pub self_referential: HashMap<*const (), ()>,
 }
 
@@ -3882,10 +3878,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
     }
 
     /// Register `anchor` with an empty collection node before parsing the
-    /// body so a self-referential alias inside the body resolves to it.
-    /// Returns the placeholder; the caller passes it to
-    /// `adopt_preregistered` once the body is parsed. The placeholder is
-    /// only allocated when `anchor` is `Some`.
+    /// body so a self-referential alias inside resolves to it. The caller
+    /// passes the returned placeholder to `adopt_preregistered` afterwards.
     fn preregister_collection_anchor(
         &mut self,
         anchor: Option<StringRange>,
@@ -3900,10 +3894,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         };
         let name = Enc::key_bytes(anchor.slice(self.input));
         if self.anchors.get(name).is_some() {
-            // Redefinition: an alias inside this body should keep resolving
-            // to the previous definition (matching the pre-self-reference
-            // behaviour). The post-body put still overwrites for later
-            // aliases.
+            // Redefinition: an alias inside this body keeps resolving to the
+            // previous definition; the post-body put overwrites afterwards.
             return Ok(None);
         }
         let placeholder = match kind {
@@ -4050,10 +4042,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
                     if let Some(ptr) = Self::collection_ptr(&copy) {
                         if self.open_anchors.contains(&ptr) {
-                            // Self-reference: the anchored node is still being
-                            // parsed. Mark it so later alias charges don't walk
-                            // the cycle; the placeholder is empty here so there
-                            // is nothing to charge for its body yet.
+                            // Self-reference to a node still being parsed:
+                            // mark it so later alias charges skip the cycle.
                             self.self_referential.put(ptr, ())?;
                         }
                     }
@@ -4119,10 +4109,9 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     let sequence_indent = self.token.indent;
                     let sequence_line = self.token.line;
                     let sequence_tab_after_indent = self.tab_after_indent;
-                    // A prior-line anchor may belong to the enclosing block
-                    // mapping (implicit_key_anchors decides after the body is
-                    // parsed); only a same-line anchor is guaranteed to anchor
-                    // this flow sequence itself.
+                    // Only a same-line anchor definitely anchors this flow
+                    // sequence; a prior-line one may be the enclosing block
+                    // mapping's (implicit_key_anchors decides afterwards).
                     let preregistered = self.preregister_collection_anchor(
                         node_props
                             .anchor()

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -2352,6 +2352,14 @@ pub struct Parser<'i, Enc: Encoding> {
 
     pub merge_props_budget: usize,
     pub alias_expansion_budget: usize,
+
+    /// Collection nodes whose anchor is registered but whose body is still
+    /// being parsed. An alias that resolves to one of these is a
+    /// self-reference (`&a {self: *a}`).
+    pub open_anchors: Vec<*const ()>,
+    /// Collection nodes known to be on a cycle. `charge_alias_expansion`
+    /// must not descend into these.
+    pub self_referential: Vec<*const ()>,
 }
 
 impl<'i, Enc: Encoding> Parser<'i, Enc> {
@@ -2388,6 +2396,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             stack_check: StackCheck::init(),
             merge_props_budget: MappingProps::MAX_MERGED_PROPERTIES,
             alias_expansion_budget: Self::MAX_ALIAS_EXPANSION,
+            open_anchors: Vec::new(),
+            self_referential: Vec::new(),
         }
     }
 
@@ -2580,6 +2590,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
         self.anchors.clear();
         self.tag_handles.clear();
+        self.open_anchors.clear();
+        self.self_referential.clear();
 
         let mut has_yaml_directive = false;
 
@@ -3789,6 +3801,65 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         Ok(e_node)
     }
 
+    fn collection_ptr(expr: &Expr) -> Option<*const ()> {
+        match &expr.data {
+            ast::ExprData::EArray(arr) => Some(arr.as_ptr() as *const ()),
+            ast::ExprData::EObject(obj) => Some(obj.as_ptr() as *const ()),
+            _ => None,
+        }
+    }
+
+    /// Register `anchor` with an empty collection node before parsing the
+    /// body so a self-referential alias inside the body resolves to it.
+    /// Returns the placeholder; the caller passes it to
+    /// `adopt_preregistered` once the body is parsed.
+    fn preregister_collection_anchor(
+        &mut self,
+        anchor: Option<StringRange>,
+        placeholder: Expr,
+    ) -> Result<Option<Expr>, ParseError> {
+        let Some(anchor) = anchor else {
+            return Ok(None);
+        };
+        self.anchors
+            .put(Enc::key_bytes(anchor.slice(self.input)), placeholder)?;
+        if let Some(ptr) = Self::collection_ptr(&placeholder) {
+            self.open_anchors.push(ptr);
+        }
+        Ok(Some(placeholder))
+    }
+
+    /// Move the parsed collection's contents into the pre-registered
+    /// placeholder so every alias that resolved to the placeholder during
+    /// parsing now sees the final contents through the same arena pointer.
+    fn adopt_preregistered(&mut self, placeholder: Option<Expr>, parsed: Expr) -> Expr {
+        let Some(placeholder) = placeholder else {
+            return parsed;
+        };
+        if let Some(ptr) = Self::collection_ptr(&placeholder) {
+            if let Some(pos) = self.open_anchors.iter().rposition(|p| *p == ptr) {
+                self.open_anchors.remove(pos);
+            }
+        }
+        match (placeholder.data, parsed.data) {
+            (ast::ExprData::EArray(mut ph), ast::ExprData::EArray(mut pr)) => {
+                core::mem::swap(&mut *ph, &mut *pr);
+                Expr {
+                    loc: parsed.loc,
+                    data: placeholder.data,
+                }
+            }
+            (ast::ExprData::EObject(mut ph), ast::ExprData::EObject(mut pr)) => {
+                core::mem::swap(&mut *ph, &mut *pr);
+                Expr {
+                    loc: parsed.loc,
+                    data: placeholder.data,
+                }
+            }
+            _ => parsed,
+        }
+    }
+
     fn charge_alias_expansion(&mut self, root: Expr) -> Result<(), ParseError> {
         let mut stack: Vec<Expr> = vec![root];
         while let Some(node) = stack.pop() {
@@ -3798,9 +3869,15 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 .ok_or(ParseError::ExcessiveAliasing)?;
             match &node.data {
                 ast::ExprData::EArray(arr) => {
+                    if self.self_referential.contains(&(arr.as_ptr() as *const ())) {
+                        continue;
+                    }
                     stack.extend_from_slice(arr.items.slice());
                 }
                 ast::ExprData::EObject(obj) => {
+                    if self.self_referential.contains(&(obj.as_ptr() as *const ())) {
+                        continue;
+                    }
                     for prop in obj.properties.slice() {
                         if let Some(key) = prop.key {
                             stack.push(key);
@@ -3879,12 +3956,21 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     let mut copy = match self.anchors.get(Enc::key_bytes(alias.slice(self.input))) {
                         Some(e) => *e,
                         None => {
-                            // we failed to find the alias, but it might be cyclic and
-                            // available later.
                             return Err(ParseError::UnresolvedAlias);
                         }
                     };
 
+                    if let Some(ptr) = Self::collection_ptr(&copy) {
+                        if self.open_anchors.contains(&ptr) {
+                            // Self-reference: the anchored node is still being
+                            // parsed. Mark it so later alias charges don't walk
+                            // the cycle; the placeholder is empty here so there
+                            // is nothing to charge for its body yet.
+                            if !self.self_referential.contains(&ptr) {
+                                self.self_referential.push(ptr);
+                            }
+                        }
+                    }
                     self.charge_alias_expansion(copy)?;
 
                     // update position from the anchor node to the alias node.
@@ -3947,10 +4033,14 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     let sequence_indent = self.token.indent;
                     let sequence_line = self.token.line;
                     let sequence_tab_after_indent = self.tab_after_indent;
+                    let preregistered = self.preregister_collection_anchor(
+                        node_props.anchor(),
+                        Expr::init(E::Array::default(), sequence_start.loc()),
+                    )?;
                     let json_key = self.maybe_set_json_key(opts.flow_pair_allowed)?;
                     let seq = self.parse_flow_sequence();
                     self.unset_json_key(json_key);
-                    let seq = seq?;
+                    let seq = self.adopt_preregistered(preregistered, seq?);
 
                     if matches!(self.token.data, TokenData::MappingValue) {
                         if self.token.indent.is_less_than(sequence_indent)
@@ -4030,7 +4120,12 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                             return Err(Self::unexpected_token());
                         }
                     }
-                    break 'node self.parse_block_sequence()?;
+                    let preregistered = self.preregister_collection_anchor(
+                        node_props.anchor(),
+                        Expr::init(E::Array::default(), self.token.start.loc()),
+                    )?;
+                    let seq = self.parse_block_sequence()?;
+                    break 'node self.adopt_preregistered(preregistered, seq);
                 }
 
                 TokenData::MappingStart => {
@@ -4039,10 +4134,14 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     let mapping_line = self.token.line;
                     let mapping_tab_after_indent = self.tab_after_indent;
 
+                    let preregistered = self.preregister_collection_anchor(
+                        node_props.anchor(),
+                        Expr::init(E::Object::default(), mapping_start.loc()),
+                    )?;
                     let json_key = self.maybe_set_json_key(opts.flow_pair_allowed)?;
                     let map = self.parse_flow_mapping();
                     self.unset_json_key(json_key);
-                    let map = map?;
+                    let map = self.adopt_preregistered(preregistered, map?);
 
                     if matches!(self.token.data, TokenData::MappingValue) {
                         if self.token.indent.is_less_than(mapping_indent)
@@ -4144,13 +4243,18 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         }
                     }
 
-                    break 'node self.parse_block_mapping(
+                    let preregistered = self.preregister_collection_anchor(
+                        node_props.anchor(),
+                        Expr::init(E::Object::default(), mapping_start.loc()),
+                    )?;
+                    let mapping = self.parse_block_mapping(
                         key,
                         mapping_start,
                         mapping_indent,
                         mapping_line,
                         opts.flow_pair_allowed,
                     )?;
+                    break 'node self.adopt_preregistered(preregistered, mapping);
                 }
 
                 TokenData::MappingValue => {
@@ -4184,6 +4288,10 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                             .put(Enc::key_bytes(key_anchor.slice(self.input)), first_key)?;
                     }
 
+                    let preregistered = self.preregister_collection_anchor(
+                        implicit_key_anchors.mapping_anchor,
+                        Expr::init(E::Object::default(), self.token.start.loc()),
+                    )?;
                     let mapping = self.parse_block_mapping(
                         first_key,
                         self.token.start,
@@ -4191,6 +4299,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         colon_line,
                         opts.flow_pair_allowed,
                     )?;
+                    let mapping = self.adopt_preregistered(preregistered, mapping);
 
                     if let Some(mapping_anchor) = implicit_key_anchors.mapping_anchor {
                         self.anchors
@@ -4304,6 +4413,10 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                                 .put(Enc::key_bytes(key_anchor.slice(self.input)), implicit_key)?;
                         }
 
+                        let preregistered = self.preregister_collection_anchor(
+                            implicit_key_anchors.mapping_anchor,
+                            Expr::init(E::Object::default(), scalar_start.loc()),
+                        )?;
                         let mapping = self.parse_block_mapping(
                             implicit_key,
                             scalar_start,
@@ -4311,6 +4424,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                             scalar_line,
                             opts.flow_pair_allowed,
                         )?;
+                        let mapping = self.adopt_preregistered(preregistered, mapping);
 
                         if let Some(mapping_anchor) = implicit_key_anchors.mapping_anchor {
                             self.anchors

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -3898,12 +3898,19 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         let Some(anchor) = anchor else {
             return Ok(None);
         };
+        let name = Enc::key_bytes(anchor.slice(self.input));
+        if self.anchors.get(name).is_some() {
+            // Redefinition: an alias inside this body should keep resolving
+            // to the previous definition (matching the pre-self-reference
+            // behaviour). The post-body put still overwrites for later
+            // aliases.
+            return Ok(None);
+        }
         let placeholder = match kind {
             AnchorPlaceholder::Array => Expr::init(E::Array::default(), loc),
             AnchorPlaceholder::Object => Expr::init(E::Object::default(), loc),
         };
-        self.anchors
-            .put(Enc::key_bytes(anchor.slice(self.input)), placeholder)?;
+        self.anchors.put(name, placeholder)?;
         if let Some(ptr) = Self::collection_ptr(&placeholder) {
             self.open_anchors.push(ptr);
         }

--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -1037,7 +1037,7 @@ pub fn parse(global: &JSGlobalObject, call_frame: &CallFrame) -> JsResult<JSValu
         true,
         false,
         |arena, log, source| {
-            let root = match YAML::parse(source, log, arena) {
+            let root = match YAML::parse_allowing_self_references(source, log, arena) {
                 Ok(root) => root,
                 Err(YamlParseError::OutOfMemory) => return Err(JsError::OutOfMemory),
                 Err(YamlParseError::StackOverflow) => return Err(global.throw_stack_overflow()),

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -626,6 +626,26 @@ parent: &ref
         expect(result.b.k).toBe(1);
         expect(result.b.extra).toBe(2);
       });
+
+      test("the yaml module loader still rejects self-referential anchors", async () => {
+        // Only Bun.YAML.parse opts into cyclic Expr graphs; the bundler's yaml
+        // loader and pnpm-lock migration walk the Expr tree without a seen-set
+        // and must keep seeing a diagnosable parse error.
+        using dir = tempDir("yaml-cyclic-loader", {
+          "cycle.yaml": "&a\nself: *a\n",
+          "index.ts": `import data from "./cycle.yaml"; console.log(data);`,
+        });
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "index.ts"],
+          env: bunEnv,
+          cwd: String(dir),
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toContain("Unresolved alias");
+        expect(stdout).toBe("");
+        expect(exitCode).toBe(1);
+      });
     });
 
     test("handles multiple documents", () => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -619,6 +619,19 @@ parent: &ref
         );
       });
 
+      test("an alias inside a redefined anchor's body resolves to the previous definition", () => {
+        // Pre-registration would clobber the previous &shared before the body
+        // runs; skipping pre-registration on redefinition preserves the
+        // existing resolution order.
+        const result = YAML.parse("base: &shared\n  x: 1\noverride: &shared\n  <<: *shared\n  y: 2\n");
+        expect(result).toEqual({ base: { x: 1 }, override: { x: 1, y: 2 } });
+
+        const result2 = YAML.parse("a: &x {v: 1}\nb: &x {ref: *x}\nc: *x\n");
+        expect(result2.b.ref).toEqual({ v: 1 });
+        expect(result2.b.ref).toBe(result2.a);
+        expect(result2.c).toBe(result2.b);
+      });
+
       test("a merge key can alias a fully-parsed cyclic mapping", () => {
         const result = YAML.parse("a: &a\n  self: *a\n  k: 1\nb:\n  <<: *a\n  extra: 2\n");
         expect(Object.keys(result.b).sort()).toEqual(["extra", "k", "self"]);

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -496,7 +496,7 @@ database:
       });
     });
 
-    test.todo("handles circular references with anchors and aliases", () => {
+    test("handles circular references with anchors and aliases", () => {
       const yaml = `
 parent: &ref
   name: parent
@@ -508,6 +508,97 @@ parent: &ref
       expect(result.parent.name).toBe("parent");
       expect(result.parent.child.name).toBe("child");
       expect(result.parent.child.parent).toBe(result.parent);
+    });
+
+    describe("self-referential anchors", () => {
+      test("flow mapping: &a {self: *a}", () => {
+        const result = YAML.parse("&a {name: root, self: *a}");
+        expect(result.name).toBe("root");
+        expect(result.self).toBe(result);
+      });
+
+      test("flow sequence: &a [*a]", () => {
+        const result = YAML.parse("- &a [1, *a, 2]");
+        expect(result).toHaveLength(1);
+        expect(result[0][0]).toBe(1);
+        expect(result[0][1]).toBe(result[0]);
+        expect(result[0][2]).toBe(2);
+      });
+
+      test("block mapping", () => {
+        const result = YAML.parse("&a\nname: root\nself: *a\n");
+        expect(result.name).toBe("root");
+        expect(result.self).toBe(result);
+      });
+
+      test("block sequence", () => {
+        const result = YAML.parse("&a\n- first\n- *a\n");
+        expect(result[0]).toBe("first");
+        expect(result[1]).toBe(result);
+      });
+
+      test("block mapping with explicit key", () => {
+        const result = YAML.parse("&a\n? k\n: *a\n");
+        expect(result.k).toBe(result);
+      });
+
+      test("alias to cyclic node from outside the cycle", () => {
+        const result = YAML.parse("first: &a {name: x, self: *a}\nsecond: *a\n");
+        expect(result.first.self).toBe(result.first);
+        expect(result.second).toBe(result.first);
+      });
+
+      test("indirect cycle through two anchors", () => {
+        const result = YAML.parse("&a\nchild: &b\n  parent: *a\nalso: *b\n");
+        expect(result.child.parent).toBe(result);
+        expect(result.also).toBe(result.child);
+      });
+
+      test.each([undefined, 2])("stringify round-trips a cyclic object (space=%p)", space => {
+        const obj: any = { name: "root" };
+        obj.self = obj;
+        const parsed = YAML.parse(YAML.stringify(obj, null, space));
+        expect(parsed.name).toBe("root");
+        expect(parsed.self).toBe(parsed);
+      });
+
+      test.each([undefined, 2])("stringify round-trips a cyclic array (space=%p)", space => {
+        const arr: any[] = ["first"];
+        arr.push(arr);
+        const parsed = YAML.parse(YAML.stringify(arr, null, space));
+        expect(parsed[0]).toBe("first");
+        expect(parsed[1]).toBe(parsed);
+      });
+
+      test.each([undefined, 2])("stringify round-trips a nested cycle (space=%p)", space => {
+        const inner: any = { x: 1 };
+        const outer: any = { inner };
+        inner.parent = outer;
+        const parsed = YAML.parse(YAML.stringify(outer, null, space));
+        expect(parsed.inner.x).toBe(1);
+        expect(parsed.inner.parent).toBe(parsed);
+      });
+
+      test.each([undefined, 2])("stringify round-trips a cycle plus an external alias (space=%p)", space => {
+        const c: any = { name: "c" };
+        c.self = c;
+        const parsed = YAML.parse(YAML.stringify({ first: c, second: c }, null, space));
+        expect(parsed.first.name).toBe("c");
+        expect(parsed.first.self).toBe(parsed.first);
+        expect(parsed.second).toBe(parsed.first);
+      });
+
+      test("anchored non-cyclic collections still charge the alias-expansion budget", () => {
+        // Every &ai below is a pre-registered collection anchor but not
+        // self-referential; each *a(i-1) must still walk the prior subtree so
+        // the billion-laughs guard fires.
+        const lines = ["a0: &a0 [1,2,3,4,5,6,7,8,9,10]"];
+        for (let i = 1; i <= 25; i++) {
+          const prev = `*a${i - 1}`;
+          lines.push(`a${i}: &a${i} [${Array(10).fill(prev).join(",")}]`);
+        }
+        expect(() => YAML.parse(lines.join("\n"))).toThrow("Excessive aliasing");
+      });
     });
 
     test("handles multiple documents", () => {
@@ -2941,9 +3032,8 @@ config:
         expect(parsed.shared.host).toBe("localhost");
       });
 
-      test.todo("handles self-referencing objects", () => {
-        // Skipping as this causes build issues with circular references
-        const obj = { name: "root" };
+      test("handles self-referencing objects", () => {
+        const obj: any = { name: "root" };
         obj.self = obj;
 
         const yaml = YAML.stringify(obj);
@@ -3958,9 +4048,9 @@ refs:
         expect(parsed.level2.nested.deep.data.id).toBe(4);
       });
 
-      test.todo("handles root level anchors correctly", () => {
+      test("handles root level anchors correctly", () => {
         // When the root itself is referenced
-        const obj = { name: "root" };
+        const obj: any = { name: "root" };
         obj.self = obj;
 
         const yaml = YAML.stringify(obj);
@@ -4098,7 +4188,7 @@ refs:
         expect(yaml2).toBe("counter: 4");
       });
 
-      test.todo("handles circular getters", () => {
+      test("handles circular getters", () => {
         const obj = {
           get self() {
             return obj;

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -2510,32 +2510,36 @@ my_config:
       expect(YAML.parse(input2)).toMatchSnapshot();
     });
 
-    test("handles YAML bombs", () => {
-      function buildTest(depth) {
-        const lines: string[] = [];
-        lines.push(`a0: &a0\n  k0: 0`);
-        for (let i = 1; i <= depth; i++) {
-          const refs = Array.from({ length: i }, (_, j) => `*a${j}`).join(", ");
-          lines.push(`a${i}: &a${i}\n  <<: [${refs}]\n  k${i}: ${i}`);
+    test(
+      "handles YAML bombs",
+      () => {
+        function buildTest(depth) {
+          const lines: string[] = [];
+          lines.push(`a0: &a0\n  k0: 0`);
+          for (let i = 1; i <= depth; i++) {
+            const refs = Array.from({ length: i }, (_, j) => `*a${j}`).join(", ");
+            lines.push(`a${i}: &a${i}\n  <<: [${refs}]\n  k${i}: ${i}`);
+          }
+          lines.push(`root:\n  <<: *a${depth}`);
+          const input = lines.join("\n");
+
+          const expected: any = {};
+          for (let i = 0; i <= depth; i++) {
+            const record = {};
+            for (let j = 0; j <= i; j++) record[`k${j}`] = j;
+            expected[`a${i}`] = record;
+          }
+          expected.root = { ...expected[`a${depth}`] };
+
+          return { input, expected };
         }
-        lines.push(`root:\n  <<: *a${depth}`);
-        const input = lines.join("\n");
 
-        const expected: any = {};
-        for (let i = 0; i <= depth; i++) {
-          const record = {};
-          for (let j = 0; j <= i; j++) record[`k${j}`] = j;
-          expected[`a${i}`] = record;
-        }
-        expected.root = { ...expected[`a${depth}`] };
+        const { input, expected } = buildTest(24);
 
-        return { input, expected };
-      }
-
-      const { input, expected } = buildTest(24);
-
-      expect(YAML.parse(input)).toEqual(expected);
-    }, (isDebug || isASAN ? 10 : 1) * 100);
+        expect(YAML.parse(input)).toEqual(expected);
+      },
+      (isDebug || isASAN ? 10 : 1) * 100,
+    );
 
     describe("merge keys", () => {
       test("merge overrides", () => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -614,7 +614,9 @@ parent: &ref
 
       test("a merge key cannot alias a mapping whose body is still being parsed", () => {
         expect(() => YAML.parse("&outer\nname: root\ninner:\n  <<: *outer\n  extra: 1\n")).toThrow("Unresolved alias");
-        expect(() => YAML.parse("&outer\nname: root\ninner:\n  <<: [*outer]\n  extra: 1\n")).toThrow("Unresolved alias");
+        expect(() => YAML.parse("&outer\nname: root\ninner:\n  <<: [*outer]\n  extra: 1\n")).toThrow(
+          "Unresolved alias",
+        );
       });
 
       test("a merge key can alias a fully-parsed cyclic mapping", () => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -599,6 +599,31 @@ parent: &ref
         }
         expect(() => YAML.parse(lines.join("\n"))).toThrow("Excessive aliasing");
       });
+
+      test("prior-line anchor on a flow-sequence implicit key anchors the outer mapping", () => {
+        const result = YAML.parse("&a\n[1, 2]: *a\n");
+        expect(Object.keys(result)).toEqual(["1,2"]);
+        expect(result["1,2"]).toBe(result);
+      });
+
+      test("prior-line anchor on a flow-mapping implicit key anchors the outer mapping", () => {
+        const result = YAML.parse("&a\n{k: 1}: *a\n");
+        const [key] = Object.keys(result);
+        expect(result[key]).toBe(result);
+      });
+
+      test("a merge key cannot alias a mapping whose body is still being parsed", () => {
+        expect(() => YAML.parse("&outer\nname: root\ninner:\n  <<: *outer\n  extra: 1\n")).toThrow("Unresolved alias");
+        expect(() => YAML.parse("&outer\nname: root\ninner:\n  <<: [*outer]\n  extra: 1\n")).toThrow("Unresolved alias");
+      });
+
+      test("a merge key can alias a fully-parsed cyclic mapping", () => {
+        const result = YAML.parse("a: &a\n  self: *a\n  k: 1\nb:\n  <<: *a\n  extra: 2\n");
+        expect(Object.keys(result.b).sort()).toEqual(["extra", "k", "self"]);
+        expect(result.b.self).toBe(result.a);
+        expect(result.b.k).toBe(1);
+        expect(result.b.extra).toBe(2);
+      });
     });
 
     test("handles multiple documents", () => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -632,6 +632,12 @@ parent: &ref
         expect(result2.c).toBe(result2.b);
       });
 
+      test("a nested anchor redefinition shadows the still-open ancestor", () => {
+        const result = YAML.parse("&x\nchild: &x\n  ref: *x\nlater: *x\n");
+        expect(result.child.ref).toBe(result.child);
+        expect(result.later).toBe(result.child);
+      });
+
       test("a merge key can alias a fully-parsed cyclic mapping", () => {
         const result = YAML.parse("a: &a\n  self: *a\n  k: 1\nb:\n  <<: *a\n  extra: 2\n");
         expect(Object.keys(result.b).sort()).toEqual(["extra", "k", "self"]);

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -2535,7 +2535,7 @@ my_config:
       const { input, expected } = buildTest(24);
 
       expect(YAML.parse(input)).toEqual(expected);
-    }, 100);
+    }, (isDebug || isASAN ? 10 : 1) * 100);
 
     describe("merge keys", () => {
       test("merge overrides", () => {


### PR DESCRIPTION
## What does this PR do?

`Bun.YAML.stringify` already emits anchors and aliases for cyclic objects, but `Bun.YAML.parse` rejected that output with `SyntaxError: YAML Parse error: Unresolved alias`, so cyclic graphs could not round-trip between the two halves of `Bun.YAML`.

```js
const o = { name: "root" };
o.self = o;
const s = Bun.YAML.stringify(o);  // "&root {name: root,self: *root}"
Bun.YAML.parse(s);                // threw "Unresolved alias", now returns {name:"root", self:[Circular]}
```

The parser also could not build any self-referential alias graph written by hand, for example `- &a [*a]` or
```yaml
parent: &ref
  name: parent
  child:
    parent: *ref
```

### Cause

`parse_node` registered an anchor in `self.anchors` only after the anchored node's body was fully parsed, so an alias inside the body looked up a name that was not in the map yet.

### Fix

When `parse_node` is about to descend into a collection (flow/block mapping or sequence) that carries an anchor, it now pre-allocates an empty `E::Array` / `E::Object`, registers it in `self.anchors`, parses the body, then swaps the parsed contents into the pre-allocated arena slot. Every `*name` that resolved during body parsing already holds the same `StoreRef` pointer, so it sees the final contents.

The Expr -> JSValue converter in `YAMLObject.rs` already caches by arena pointer via `seen_objects`, so it reconstructs the JS-side cycle with no changes.

`charge_alias_expansion` gains a small `self_referential` set so a later `*name` pointing at a known-cyclic node does not walk the cycle and exhaust the budget. Only anchors that were actually aliased while their body was still open are marked, so acyclic anchored chains (including the billion-laughs guard) charge exactly as before; a regression test covers this.

### How did you verify your code works?

- `bun bd test test/js/bun/yaml/yaml.test.ts` passes (629 existing + 20 new/un-todo'd tests).
- `bun bd test test/js/bun/yaml/yaml-test-suite.test.ts test/js/bun/yaml/yaml-block-scalar-matrix.test.ts` passes (1486 tests).
- The new `self-referential anchors` describe block and the four formerly-`.todo` circular-reference tests fail with `Unresolved alias` on the released bun and pass on this branch.

Fixes #22769

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 23 failed, 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/yaml/yaml.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (3d922e934)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [5.65ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [4.41ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [5.25ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [3.41ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [5.56ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [4.19ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [5.61ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [5.94ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [5.40ms]
(pass) Bun.YAML > parse > input types > parses fro
... (truncated)

release without fix: 1 failed, 18 skipped
bun test v1.4.0-canary.1 (0c57816fd)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [0.10ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [0.04ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [0.05ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [0.05ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [0.04ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [0.06ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [0.04ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [0.05ms]
(pass) Bun.YAML > parse > input types > parses from Float32Array [0.05ms]
(pass) Bun.YAML > parse > input types > parses from Float64Array [0.04ms]
(pass) Bun.YAML > parse > input types > parses from BigInt64Array [0.06ms]
(pass) Bun.YAML > parse > input types > parses from BigUint64Array [0.04ms]
(pass) Bun.YAML > parse > input types > parses from DataView [0.04ms]
(pass) Bun.YAML > parse > input types > parses from Blob [0.24ms]
(pass) Bun.YAML > parse > i
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/yaml/yaml.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (3d922e934)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [3.68ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [2.83ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [3.57ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [2.55ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [3.50ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [3.89ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [5.62ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [5.55ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [5.05ms]
(pass) Bun.YAML > parse > input types > parses fro
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 809ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[2/23] gen cpp.rs (cppbind)
[3/23] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[4/23] gen JS modules (bundle-modules)
Preprocess modules (7899ms)
Bundle modules (36ms)
Postprocesss modules (182ms)
Bundle Functions (781ms)
Generate Code (105ms)

[9.02s] Bundled "src/js" for production
  2039 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[4/10] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/parsers/yaml.rs           | 254 +++++++++++++++++++++++++++++++++++++++---
 src/runtime/api/YAMLObject.rs |   2 +-
 test/js/bun/yaml/yaml.test.ts | 220 +++++++++++++++++++++++++++++++-----
 3 files changed, 428 insertions(+), 48 deletions(-)
```

</details>

**gate history** · 5 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/parsers/yaml.rs               16     36      0
src/runtime/api/YAMLObject.rs      4      1      0
test/js/bun/yaml/yaml.test.ts      6      7      0
```

</details>

<!-- robobun:evidence:end -->