### PR TITLE
install: fix streaming tarball extraction failing when first HTTP chunk is tiny

### DIFF
--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -600,12 +600,22 @@ impl TarballStream {
         if unsafe { lib::archive_read_append_filter(archive, 1) } != 0 {
             return Err(crate::Error::Fail);
         }
+        // Register tar before read_set_options so the option has a format slot
+        // to apply to. archive_read_set_format would register it too, but
+        // libarchive's archive_set_format_option() overwrites `a->format` with
+        // each slot while dispatching and then writes NULL, so calling
+        // read_set_options after archive_read_set_format throws the selected
+        // format away and archive_read_open1() falls back to bidding. Bidding
+        // reads ahead 512 decompressed bytes and fails with "Unrecognized
+        // archive format" when the first HTTP chunk is too small for that.
+        // SAFETY: archive is a valid handle.
+        let _ = unsafe { (*archive).read_support_format_tar() };
+        // SAFETY: archive is a valid handle.
+        let _ = unsafe { (*archive).read_set_options(c"read_concatenated_archives") };
         // SAFETY: archive is a valid non-null handle from read_new(); FFI call has no other preconditions.
         if unsafe { lib::archive_read_set_format(archive, 0x30000) } != 0 {
             return Err(crate::Error::Fail);
         }
-        // SAFETY: archive is a valid handle.
-        let _ = unsafe { (*archive).read_set_options(c"read_concatenated_archives") };
 
         // SAFETY: archive is a valid handle; `this` outlives the archive
         // (freed only in `Drop` after `read_free`). See fn-level # Safety

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -269,6 +269,83 @@ describe("streaming tarball extraction", () => {
     expect(exitCode).toBe(0);
   });
 
+  // Regression: archive_read_set_options() clobbered the a->format set by
+  // archive_read_set_format(), so archive_read_open1() fell back to format
+  // bidding. The tar bidder needs 512 decompressed bytes up front; when the
+  // first HTTP chunk is smaller than the 10-byte gzip header, the gzip
+  // filter returns ARCHIVE_RETRY, which the bidder (called with avail=NULL)
+  // treats as "no data" and bids 0, yielding "Unrecognized archive format"
+  // and a user-facing "Fail extracting tarball". Observed in CI on macOS
+  // (where kqueue tends to surface a tiny first chunk) for large packages
+  // such as aws-cdk-lib and next.
+  test("streaming extract succeeds when the first chunk is smaller than the gzip header", async () => {
+    let tarballHits = 0;
+    const server: Server = createServer((req, res) => {
+      const url = new URL(req.url!, "http://x");
+      if (url.pathname.endsWith("/stream-pkg")) {
+        const body = JSON.stringify({
+          name: "stream-pkg",
+          "dist-tags": { latest: "1.0.0" },
+          versions: {
+            "1.0.0": {
+              name: "stream-pkg",
+              version: "1.0.0",
+              dist: { shasum, integrity, tarball: `http://127.0.0.1:${port}/stream-pkg/-/stream-pkg-1.0.0.tgz` },
+            },
+          },
+        });
+        res.setHeader("content-type", "application/json");
+        res.end(body);
+        return;
+      }
+      if (url.pathname.endsWith("/stream-pkg-1.0.0.tgz")) {
+        tarballHits++;
+        res.setHeader("content-type", "application/octet-stream");
+        res.setHeader("content-length", String(tgz.length));
+        req.socket.setNoDelay(true);
+        // First chunk: only the gzip magic bytes. gzip's header is 10 bytes,
+        // so the filter cannot even finish consume_header() and must return
+        // ARCHIVE_RETRY the first time the streaming extractor calls it.
+        res.write(tgz.subarray(0, 2));
+        // Give the client long enough to receive the 2 bytes, schedule its
+        // drain task, and run open_archive() before any further body arrives.
+        // This is shaping the input, not waiting on a condition in the test.
+        setTimeout(() => res.end(tgz.subarray(2)), 100);
+        return;
+      }
+      res.statusCode = 404;
+      res.end("not found");
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as { port: number }).port;
+
+    try {
+      using dir = tempDir("streaming-extract-tiny-first-chunk", {
+        "package.json": JSON.stringify({
+          name: "app",
+          version: "1.0.0",
+          dependencies: { "stream-pkg": "1.0.0" },
+        }),
+        "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:${port}/"\n`,
+      });
+
+      const { stderr, exitCode } = await runInstall(String(dir));
+      expect(stderr).not.toContain("Fail extracting tarball");
+      expect(stderr).not.toContain("error:");
+      expect(stderr).toContain("Streamed ");
+      expect(tarballHits).toBe(1);
+
+      const pkgRoot = join(String(dir), "node_modules", "stream-pkg");
+      for (const { path, body } of entries) {
+        const got = readFileSync(join(pkgRoot, path));
+        expect([path, got.equals(body)]).toEqual([path, true]);
+      }
+      expect(exitCode).toBe(0);
+    } finally {
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  });
+
   test("tarballs below BUN_INSTALL_STREAMING_MIN_SIZE take the buffered path", async () => {
     // Reuse the same large tarball but raise the threshold above it.
     // The server sends Content-Length, so `notify()` sees a body_size


### PR DESCRIPTION
## Problem

`bun install` intermittently fails on large packages (>2 MB compressed, which use the streaming extractor) with:

```
error: Fail extracting tarball for "aws-cdk-lib"
error: failed to download aws-cdk-lib@2.148.0: Fail
```

Seen in macOS CI for `test/package.json` (aws-cdk-lib), `next-auth.test.ts` (next), and `next-build.test.ts`. Reproduced at ~20% on an idle M2 Ultra with a 4-dependency package.json and a fresh cache; never fails with `BUN_INSTALL_STREAMING_MIN_SIZE` set above the tarball size.

dtrace of `archive_set_error` on a failing run shows:

```
archive_set_error: errno=92 fmt=Unrecognized archive format
    archive_read_open1+0x6a8
    ...TarballStream drain_callback...
```

## Cause

`TarballStream::open_archive` does:

```rust
archive_read_append_filter(archive, 1);              // gzip
archive_read_set_format(archive, 0x30000);           // tar: sets a->format
read_set_options(c"read_concatenated_archives");     // clobbers a->format = NULL
archive_read_open(...);
```

libarchive's `archive_set_format_option` iterates registered format slots and writes `a->format = NULL` after dispatching to each, so the format selected by `archive_read_set_format` is lost. `archive_read_open1` then sees `!a->format` and runs `choose_format()`, whose tar bidder calls `__archive_read_ahead(a, 512, NULL)`. When the first HTTP chunk is smaller than the 10-byte gzip header, the gzip filter returns `ARCHIVE_RETRY`; with `avail == NULL` that surfaces as plain `NULL`, the tar bidder returns bid 0, and `choose_format()` fails with "Unrecognized archive format".

This is timing-dependent: it only fires when the drain worker runs `open_archive()` before enough body bytes have arrived to inflate 512 bytes of tar. macOS kqueue tends to surface a small first body chunk, so it hits there far more often than on Linux.

## Fix

Call `read_support_format_tar()` before `read_set_options()` so the option has a format slot to apply to, then call `archive_read_set_format()` last so `a->format` is set when `archive_read_open()` runs and bidding is skipped as the comment intended.

## Verification

New test in `bun-install-streaming-extract.test.ts` serves a tarball whose first body write is just the 2-byte gzip magic followed by a 100 ms pause, forcing `open_archive()` to run with insufficient data for bidding. Fails deterministically on Linux before this change, passes after:

```
$ git stash push -- src/ && bun bd test ... -t "first chunk is smaller"
(fail) streaming extract succeeds when the first chunk is smaller than the gzip header
  Expected to not contain: "Fail extracting tarball"

$ git stash pop && bun bd test ... -t "first chunk is smaller"
(pass) streaming extract succeeds when the first chunk is smaller than the gzip header
```

On macOS (darwin-sourdough-arm64, release build from main @ b18d5df35), the real-world repro against registry.npmjs.org:

| config | pass/fail (n=30-40) |
|---|---|
| streaming enabled (default) | 24/30, 35/40 |
| `BUN_INSTALL_STREAMING_MIN_SIZE=999999999999` | 30/30 |


Fixes #34821

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-streaming-extract.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b0be45939)

test/cli/install/bun-install-streaming-extract.test.ts:
(pass) streaming tarball extraction > extracts a drip-fed tarball correctly (streaming) [1847.63ms]
(pass) streaming tarball extraction > extracts a drip-fed tarball correctly (buffered) [855.37ms]
328 |         }),
329 |         "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:${port}/"\n`,
330 |       });
331 | 
332 |       const { stderr, exitCode } = await runInstall(String(dir));
333 |       expect(stderr).not.toContain("Fail extracting tarball");
                               ^
error: expect(received).not.toContain(expected)

Expected to not contain: "Fail extracting tarball"
Received: "Enqueue package manifest for download: stream
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/cli/install/bun-install-streaming-extract.test.ts:
(pass) streaming tarball extraction > extracts a drip-fed tarball correctly (streaming) [58.17ms]
(pass) streaming tarball extraction > extracts a drip-fed tarball correctly (buffered) [39.15ms]
328 |         }),
329 |         "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:${port}/"\n`,
330 |       });
331 | 
332 |       const { stderr, exitCode } = await runInstall(String(dir));
333 |       expect(stderr).not.toContain("Fail extracting tarball");
                               ^
error: expect(received).not.toContain(expected)

Expected to not contain: "Fail extracting tarball"
Received: "Enqueue package manifest for download: stream-pkg\nResolving dependencies\n HTTP/1.1 GET http://127.0.0.1:42815/stream-pkg\n Accept: application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*\n Connection: keep-alive\n User-Agent: Bun/1.4.0\n Host: 127.0.0.1:42815\n Accept-Encoding: gzip, deflate, br, zstd\n

      at <anonymous> (/workspace/bun/test/cli/install/bun-install-streaming-extract.test.ts:333:26)
(fail) streaming tarball extraction > streaming extract succ
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-streaming-extract.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b0be45939)

test/cli/install/bun-install-streaming-extract.test.ts:
(pass) streaming tarball extraction > extracts a drip-fed tarball correctly (streaming) [1930.19ms]
(pass) streaming tarball extraction > extracts a drip-fed tarball correctly (buffered) [864.71ms]
(pass) streaming tarball extraction > streaming extract succeeds when the first chunk is smaller than the gzip header [554.47ms]
(pass) streaming tarball extraction > tarballs below BUN_INSTALL_STREAMING_MIN_SIZE take the buffered path [806.72ms]
(pass) streaming tarball extraction > streaming rejects a tarball whose integrity does not match [587.56ms]
(pass) buffered extract: damaged-block retry resets header state (upstream semantics) [217.22ms]
(pa
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 911ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
ninja: no work to do.
[build] done
bun test v1.4.0-canary.1 (b0be45939)

test/cli/install/bun-install-streaming-extract.test.ts:
(pass) streaming tarball extraction > extracts a drip-fed tarball correctly (streaming) [48.88ms]
(pass) streaming tarball extraction > extracts a drip-fed tarball correctly (buffered) [31.57ms]
(pass) streaming tarball extraction > streaming extract succeeds when the first chunk is smaller than the gzip header [136.00ms]
(pass) streaming tarball extraction > tarballs below BUN_INSTALL_STREAMING_MIN_SIZE take the buffered path [39.54ms]
(pass) streaming tarball extraction > streaming rejects a tarball whose integrity does not match [19.53ms]
(pass) buffered extract: damaged-block retry resets header state (upstream semantics) 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/TarballStream.rs                       | 14 +++-
 .../install/bun-install-streaming-extract.test.ts  | 77 ++++++++++++++++++++++
 2 files changed, 89 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/install/TarballStream.rs                                6      1      0
test/cli/install/bun-install-streaming-extract.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->