### PR TITLE
bun test: drain the event loop for script files with no test() registrations

### DIFF
--- a/docs/test/runtime-behavior.mdx
+++ b/docs/test/runtime-behavior.mdx
@@ -127,6 +127,23 @@ test("test 1", () => {
 Promise.reject(new Error("Unhandled rejection"));
 ```
 
+### Files without tests
+
+A file that registers no tests, `describe` blocks, or lifecycle hooks runs as a script. After evaluating the file, `bun test` keeps running its timers and I/O until they finish, for at most the test timeout (`--timeout`). An error thrown or a promise rejected while it waits fails the run:
+
+```ts title="script.test.ts" icon="/icons/typescript.svg"
+import assert from "node:assert";
+import { readFile } from "node:fs/promises";
+
+// No test() calls. bun test waits for this function to finish.
+(async () => {
+  const source = await readFile(import.meta.path, "utf8");
+  assert.ok(source.includes("assert")); // A failed assertion here fails the run
+})();
+```
+
+`bun test` skips this wait when a preload script registers hooks, or when an earlier file or preload script left a timer or connection open.
+
 ### Custom Error Handling
 
 You can set up custom error handlers in your test setup:

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1211,18 +1211,11 @@ impl VirtualMachine {
 
     pub fn is_event_loop_alive_excluding_immediates(&self) -> bool {
         let el = self.event_loop_shared();
-        let active = self
-            .platform_loop_opt()
-            .map(|h| h.is_active())
-            .unwrap_or(false);
         self.unhandled_error_counter == 0
-            && ((active as usize)
-                + self.active_tasks
-                + el.tasks.readable_length()
-                + el.yield_tasks.len()
-                + (el.has_concurrent_tasks() as usize)
-                + (el.has_pending_refs() as usize)
-                > 0)
+            && (self.has_keep_alives()
+                || el.tasks.readable_length() > 0
+                || !el.yield_tasks.is_empty()
+                || el.has_concurrent_tasks())
     }
 
     pub fn is_event_loop_alive(&self) -> bool {
@@ -1230,6 +1223,13 @@ impl VirtualMachine {
         self.is_event_loop_alive_excluding_immediates()
             || !el.immediate_tasks.is_empty()
             || !el.next_immediate_tasks.is_empty()
+    }
+
+    /// The ref'd-handle terms of `is_event_loop_alive()`, without its task queues or error gate.
+    pub fn has_keep_alives(&self) -> bool {
+        self.platform_loop_opt().is_some_and(|h| h.is_active())
+            || self.active_tasks > 0
+            || self.event_loop_shared().has_pending_refs()
     }
 
     pub fn wakeup(&mut self) {
@@ -4864,6 +4864,7 @@ impl VirtualMachine {
     pub(crate) fn reload_entry_point_for_test_runner(
         &mut self,
         entry_path: &[u8],
+        after_preloads: impl FnOnce(&Self),
     ) -> crate::CrateResult<*mut JSInternalPromise> {
         self.has_loaded = false;
         self.set_main(entry_path);
@@ -4889,6 +4890,8 @@ impl VirtualMachine {
                 }
             }
         }
+
+        after_preloads(self);
 
         // Note: reshaped for borrowck.
         let global = self.global;
@@ -4922,11 +4925,13 @@ impl VirtualMachine {
     }
 
     /// Loads a test-file entry point and waits for the load promise to settle.
+    /// `after_preloads` runs once preloads have finished, before the file is evaluated.
     pub fn load_entry_point_for_test_runner(
         &mut self,
         entry_path: &[u8],
+        after_preloads: impl FnOnce(&Self),
     ) -> crate::CrateResult<*mut JSInternalPromise> {
-        let promise = self.reload_entry_point_for_test_runner(entry_path)?;
+        let promise = self.reload_entry_point_for_test_runner(entry_path, after_preloads)?;
 
         // pending_internal_promise can change if hot module reloading is enabled
         if self.is_watcher_enabled() {

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -921,6 +921,37 @@ fn should_drain_event_loop() -> bool {
     env_var::BUN_TEST_DRAIN_EVENT_LOOP.get().unwrap_or(false)
 }
 
+/// Runs a bare file's timers and I/O like `bun <file>` until they finish, throw, or the test timeout passes.
+fn drain_script_file(
+    reporter: &CommandLineReporter,
+    buntest: &bun_test::BunTestPtr,
+    vm: &mut VirtualMachine,
+) {
+    let errors_before = vm.unhandled_error_counter;
+    let timeout_ms = match reporter.jest.default_timeout_override {
+        u32::MAX => reporter.jest.default_timeout_ms,
+        override_ms => override_ms,
+    };
+    let deadline = (timeout_ms != 0).then(|| {
+        bun::Timespec::now(bun::TimespecMockMode::ForceRealTime).add_ms(i64::from(timeout_ms))
+    });
+    if let Some(deadline) = &deadline {
+        // So the poll below wakes at the deadline rather than at the next unrelated timer.
+        buntest.get().update_min_timeout(vm.global(), deadline);
+    }
+    while vm.unhandled_error_counter == errors_before
+        && (vm.has_keep_alives() || vm.event_loop_shared().has_pending_tasks())
+        && deadline.is_none_or(|deadline| {
+            bun::Timespec::now(bun::TimespecMockMode::ForceRealTime)
+                .order(&deadline)
+                .is_lt()
+        })
+    {
+        vm.event_loop_ref().auto_tick();
+        vm.event_loop_ref().tick();
+    }
+}
+
 /// jest and vitest never run a test file's `process.on('exit')` listeners; node's test harness asserts from them.
 pub(crate) fn skip_exit_listeners(reporter: &CommandLineReporter) -> bool {
     !(reporter.jest.node_test_used || should_drain_event_loop())
@@ -3262,7 +3293,11 @@ impl TestCommand {
             }
             // need to wake up so autoTick() doesn't wait for 16-100ms after loading the entrypoint
             vm.wakeup();
-            let promise = vm.load_entry_point_for_test_runner(file_path)?;
+            // When nothing was alive here, whatever drain_script_file() waits on is this file's.
+            let mut idle_after_preloads = false;
+            let promise = vm.load_entry_point_for_test_runner(file_path, |vm| {
+                idle_after_preloads = !vm.has_keep_alives();
+            })?;
             // Only count the file once, not once per repeat
             if repeat_index == 0 {
                 reporter.summary().files += 1;
@@ -3364,6 +3399,11 @@ impl TestCommand {
                 // here since such a file already failed. Opt-in; one file per process.
                 if should_drain_event_loop() {
                     vm.on_before_exit();
+                } else if idle_after_preloads
+                    && buntest.collection.root_scope.is_bare()
+                    && buntest.bun_test_root.get().hook_scope.is_bare()
+                {
+                    drain_script_file(reporter, &buntest_strong, vm);
                 }
                 drop(buntest_strong);
             }

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -976,7 +976,8 @@ impl BunTest {
         Ok(())
     }
 
-    fn update_min_timeout(&mut self, global_this: &JSGlobalObject, min_timeout: &Timespec) {
+    /// Arms `self.timer` for `min_timeout` unless a sooner deadline is armed; a fire in `Phase::Done` only wakes the loop.
+    pub(crate) fn update_min_timeout(&mut self, global_this: &JSGlobalObject, min_timeout: &Timespec) {
         let _g = group_begin!();
         let _ = global_this;
         // only set the timer if the new timeout is sooner than the current timeout. this unfortunately means that we can't unset an unnecessary timer.
@@ -1763,6 +1764,15 @@ pub struct DescribeScope {
 }
 
 impl DescribeScope {
+    /// True iff no test(), describe() or lifecycle hook was registered here.
+    pub(crate) fn is_bare(&self) -> bool {
+        self.entries.is_empty()
+            && self.before_all.is_empty()
+            && self.before_each.is_empty()
+            && self.after_each.is_empty()
+            && self.after_all.is_empty()
+    }
+
     pub(crate) fn create(base: BaseScope) -> Box<DescribeScope> {
         Box::new(DescribeScope {
             base,

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1812,6 +1812,203 @@ describe("bun test", () => {
   });
 });
 
+// https://github.com/oven-sh/bun/issues/34859
+describe.concurrent("script files with no test() registrations", () => {
+  async function runScripts(files: Record<string, string>, args: string[] = Object.keys(files), env = bunEnv) {
+    using dir = tempDir("bun-test-script-file", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", ...args],
+      env,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  const rejectsAfterTimer = (message: string) => `
+    (async () => {
+      await new Promise(resolve => setTimeout(resolve, 20));
+      throw new Error(${JSON.stringify(message)});
+    })();
+  `;
+
+  test("fails on a rejection that happens after a timer", async () => {
+    const { stderr, exitCode } = await runScripts({ "script.test.js": rejectsAfterTimer("rejected after a timer") });
+    expect(stderr).toContain("Unhandled error between tests");
+    expect(stderr).toContain("rejected after a timer");
+    expect(stderr).toContain("1 error");
+    expect(exitCode).toBe(1);
+  });
+
+  test("fails on an exception thrown from a timer callback", async () => {
+    const { stderr, exitCode } = await runScripts({
+      "script.test.js": `setTimeout(() => { throw new Error("thrown from a timer"); }, 20);`,
+    });
+    expect(stderr).toContain("Unhandled error between tests");
+    expect(stderr).toContain("thrown from a timer");
+    expect(exitCode).toBe(1);
+  });
+
+  test("fails on a timer armed by a setImmediate callback", async () => {
+    const { stderr, exitCode } = await runScripts({
+      "script.test.js": `setImmediate(() => setTimeout(() => { throw new Error("thrown after an immediate"); }, 20));`,
+    });
+    expect(stderr).toContain("Unhandled error between tests");
+    expect(stderr).toContain("thrown after an immediate");
+    expect(exitCode).toBe(1);
+  });
+
+  // The shape of the vendored node tests from the issue: a check made after a child process replies.
+  test("fails on an error thrown after a child process replies", async () => {
+    const { stderr, exitCode } = await runScripts({
+      "script.test.js": `
+        const { spawn } = require("node:child_process");
+        const { once } = require("node:events");
+        (async () => {
+          const child = spawn(process.execPath, ["-e", "process.send(1, () => process.disconnect())"], {
+            stdio: ["ignore", "ignore", "ignore", "ipc"],
+          });
+          const [received] = await once(child, "message");
+          if (received !== 2) throw new Error("child replied with " + received);
+        })();
+      `,
+    });
+    expect(stderr).toContain("Unhandled error between tests");
+    expect(stderr).toContain("child replied with 1");
+    expect(exitCode).toBe(1);
+  });
+
+  test("lets the file's async work finish before moving on", async () => {
+    const { stdout, stderr, exitCode } = await runScripts({
+      "script.test.js": `
+        (async () => {
+          await new Promise(resolve => setTimeout(resolve, 20));
+          await Bun.file(__filename).text();
+          console.log("async work finished");
+        })();
+      `,
+    });
+    expect(stdout).toContain("async work finished");
+    expect(stderr).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("still fails on a rejection that is pending when the module finishes evaluating", async () => {
+    const { stderr, exitCode } = await runScripts({
+      "script.test.js": `(async () => { throw new Error("rejected during evaluation"); })();`,
+    });
+    expect(stderr).toContain("Unhandled error between tests");
+    expect(stderr).toContain("rejected during evaluation");
+    expect(exitCode).toBe(1);
+  });
+
+  test("drains each script file separately", async () => {
+    const { stderr, exitCode } = await runScripts({
+      "a.test.js": rejectsAfterTimer("file A rejected"),
+      "b.test.js": rejectsAfterTimer("file B rejected"),
+    });
+    expect(stderr).toContain("file A rejected");
+    expect(stderr).toContain("file B rejected");
+    expect(stderr).toContain("2 errors");
+    expect(exitCode).toBe(1);
+  });
+
+  test("drains with --timeout=0", async () => {
+    const { stderr, exitCode } = await runScripts({ "script.test.js": rejectsAfterTimer("rejected after a timer") }, [
+      "--timeout=0",
+      "script.test.js",
+    ]);
+    expect(stderr).toContain("rejected after a timer");
+    expect(exitCode).toBe(1);
+  });
+
+  test("gives up after the test timeout on work the file never finishes", async () => {
+    const { stdout, stderr, exitCode } = await runScripts(
+      {
+        "script.test.js": `
+          setTimeout(() => console.log("timer ran"), 20);
+          setInterval(() => {}, 60_000);
+        `,
+      },
+      ["--timeout=200", "script.test.js"],
+    );
+    expect(stdout).toContain("timer ran");
+    expect(stderr).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("fails the same way under BUN_TEST_DRAIN_EVENT_LOOP", async () => {
+    const { stderr, exitCode } = await runScripts(
+      { "script.test.js": rejectsAfterTimer("rejected after a timer") },
+      ["script.test.js"],
+      { ...bunEnv, BUN_TEST_DRAIN_EVENT_LOOP: "1" },
+    );
+    expect(stderr).toContain("Unhandled error between tests");
+    expect(stderr).toContain("rejected after a timer");
+    expect(exitCode).toBe(1);
+  });
+
+  // Only the drain runs timers once a file is done, so a run that correctly skips
+  // it exits without printing this. The script files below load nothing, so the
+  // timer cannot fire while one of them is still being loaded either.
+  const lateTimer = `setTimeout(() => console.log("late timer ran"), 2_000);`;
+  const scriptFile = `globalThis.loaded = true;`;
+
+  test("does not wait on a file that registered a test()", async () => {
+    const { stdout, stderr, exitCode } = await runScripts({
+      "with.test.js": `
+        const { test } = require("bun:test");
+        test("leaves a timer behind", () => { ${lateTimer} });
+      `,
+    });
+    expect(stdout).not.toContain("late timer ran");
+    expect(stderr).toContain("1 pass");
+    expect(exitCode).toBe(0);
+  });
+
+  test("does not wait when a prior file left a ref'd handle", async () => {
+    const { stdout, stderr, exitCode } = await runScripts({
+      "a.test.js": `
+        const { test } = require("bun:test");
+        test("leaves a timer behind", () => { ${lateTimer} });
+      `,
+      "b.test.js": scriptFile,
+    });
+    expect(stdout).not.toContain("late timer ran");
+    expect(stderr).toContain("1 pass");
+    expect(stderr).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("does not wait when a preload left a ref'd handle", async () => {
+    const { stdout, stderr, exitCode } = await runScripts({ "setup.js": lateTimer, "script.test.js": scriptFile }, [
+      "--preload",
+      "./setup.js",
+      "script.test.js",
+    ]);
+    expect(stdout).not.toContain("late timer ran");
+    expect(stderr).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("does not wait when a preload registered hooks", async () => {
+    const { stdout, stderr, exitCode } = await runScripts(
+      {
+        "setup.js": `
+          import { beforeAll } from "bun:test";
+          beforeAll(() => { ${lateTimer} });
+        `,
+        "script.test.js": scriptFile,
+      },
+      ["--preload", "./setup.js", "script.test.js"],
+    );
+    expect(stdout).not.toContain("late timer ran");
+    expect(stderr).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+});
+
 function createTest(input?: string | (string | { filename: string; contents: string })[], filename?: string): string {
   const cwd = tmpdirSync();
   const inputs = Array.isArray(input) ? input : [input ?? ""];


### PR DESCRIPTION
### Problem
- A file passed to `bun test` that registers nothing (no `test()`, `describe()` or hook) and fails later, after a timer or I/O callback, passes with exit 0 and `Ran 0 tests across 1 file`. #34859's case is a vendored node test whose async IIFE asserts after a child process replies.
- Cause: `TestCommand::run` (`src/runtime/cli/test_command.rs`) only polls the event loop inside `while buntest.phase != Done`. A file with nothing registered is already `Done` when that loop is reached, so the file's timers and sockets never fire before the runner moves on. The ticks that do happen afterwards drain microtasks and immediates only, which is why a rejection that is already pending when the module finishes evaluating is reported today and one that needs the event loop is not.
- `BUN_TEST_DRAIN_EVENT_LOOP=1` (#34444, merged after this PR was opened) drains every file unconditionally and is what the vendored node test runner sets. Default `bun test` still has the bug.

Fixes #34859.

### Fix
- After a file's tests finish (none, here), when the file and the preload hook scope are both bare (`DescribeScope::is_bare()`) and nothing was keeping the loop alive before the file's top level ran (`idle_after_preloads`, sampled in the new `after_preloads` callback of `load_entry_point_for_test_runner`), `drain_script_file()` ticks the loop until nothing is left, or until `vm.unhandled_error_counter` moves. This is the fixing change; the error itself is reported by the existing "Unhandled error between tests" path, which already sets exit code 1.
- The idle gate is what makes this safe to do by default: when it holds, every keep-alive seen during the drain was created by this file. A handle leaked by an earlier file or a preload, or hooks registered by a preload, skip the drain and the file behaves exactly as today.
- The drain is bounded by the effective test timeout (`setDefaultTimeout()` override, else `--timeout`; 0 means unbounded, as in `bun <file>`), so a script that leaks a server or interval delays the run by at most one timeout instead of hanging it. The file's own `BunTest` timer is armed at that deadline so the poll wakes up on time instead of overshooting until the next unrelated timer.
- `VirtualMachine::has_keep_alives()` is the liveness test the drain and the gate share: the platform loop's ref count (which JS timers, subprocesses and sockets all fold into), `active_tasks`, and queued keep-alive deltas. `is_event_loop_alive_excluding_immediates()` is rewritten on top of it with no behavior change, so the two cannot drift apart.
- When `BUN_TEST_DRAIN_EVENT_LOOP=1` is set, the existing unconditional drain runs instead, so the env var stays the single authority for that mode.
- Files that register anything are untouched: the new code is behind `is_bare()`.
- Verified with `test/cli/test/bun-test.test.ts`, describe block "script files with no test() registrations". On the unfixed build the cases "after a timer", "timer callback", "setImmediate", "child process replies", "async work finish", "separately", "--timeout=0" and "gives up after the test timeout" fail (exit 0 or missing output); the remaining cases pin the gate (a run that wrongly drains prints `late timer ran`) and the already-working microtask shape. With the change, the rest of `bun-test.test.ts` and `pass-with-no-tests`, `isolation`, `test-timeout-behavior`, `rerun-each` and `test-shard` pass locally; two scheduling-sensitive `parallel.test.ts` cases flaked on the loaded machine used, with fixtures that all register tests and so never reach the new branch.
- Docs: a "Files without tests" paragraph in `docs/test/runtime-behavior.mdx`.

#38898 proposed reporting the rejection in `on_unhandled_rejection`'s fallback branch instead. That branch is only reached when no file is active, which never happens while a test file runs (`enter_file()` precedes loading the file and `exit_file()` follows the drain), and the microtask shape it tested already fails the run on main; its test case is covered here as "rejection that is pending when the module finishes evaluating".

### Related open PRs (same block of `test_command.rs`, different triggers)
- This PR only changes files that registered nothing. The other open changes to what `bun test` does once a file reaches `Phase::Done` are: #35896 and #35891 (a file with tests whose last test leaves work behind that fails after it ends; those two overlap each other), #35401 (replace `BUN_TEST_DRAIN_EVENT_LOOP` with node:test detection; `process.on('exit')` half of that landed as #38442) and #35137 (node:test registrations made from a macrotask). All four are currently conflicting with main. They could be merged independently of this one or folded into a single post-file policy; that is a maintainer call, and this PR is written so `is_bare()`, `has_keep_alives()` and the `BunTest` timer deadline are reusable by either outcome. #35896 edits the same `is_event_loop_alive_excluding_immediates()` body, so whichever lands second needs a small rebase.
- Interaction with #35137's case: a node:test file whose only registrations come from a macrotask is bare when it reaches `Done`, so with this PR the late `test()` call runs during the drain and throws `Cannot call test() after the test run has completed`, failing the file (today it passes silently). #35137 would make it run instead; it is not blocked by this PR.

### Background
- **Keep-alive / ref'd handle**: anything that tells the event loop "do not exit yet": a pending `setTimeout`, a listening server, a live child process, an in-flight fetch. `bun <file>` exits when the count drops to zero. In Bun these all end up as a count on the platform loop (`uws` on POSIX, libuv on Windows) plus two VM-side counters; `has_keep_alives()` reads all of them.
- **Bare scope**: a `DescribeScope` with no tests, no nested describes and no hooks. Each file gets a root scope; `--preload` scripts register hooks into a separate `hook_scope` shared by every file, which is why both are checked.
- **`unhandled_error_counter`**: bumped by the VM every time an uncaught exception or unhandled rejection is handed to the test runner. The runner attributes it to the running test, or to "between tests" when none is running, and counts the latter in `unhandled_errors_between_tests`, which forces exit code 1. The drain only watches the counter to know when to stop.
- **`BunTest` timer**: the per-file `EventLoopTimer` the runner already uses for test timeouts. Firing after the file is `Done` is a no-op apart from waking the loop, and `BunTest`'s `Drop` removes it, which is what makes it usable as the drain's alarm clock.

<details>
<summary>Before / after</summary>

```js
// delayed.test.js
(async () => {
  await new Promise(r => setTimeout(r, 20));
  throw new Error("delayed rejection should fail the test run");
})();
```

Before:

```
$ bun test ./delayed.test.js
 0 pass
 0 fail
Ran 0 tests across 1 file.
(exit 0)
```

After:

```
$ bun test ./delayed.test.js
# Unhandled error between tests
-------------------------------
error: delayed rejection should fail the test run
-------------------------------
 0 pass
 0 fail
 1 error
Ran 0 tests across 1 file.
(exit 1)
```

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/test/bun-test.test.ts

<!-- robobun:evidence:end -->