### PR TITLE
Bun.spawnSync: write stdout/stderr into a caller-provided Uint8Array

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6826,7 +6826,7 @@ declare module "bun" {
        * - `"pipe"`, `undefined`: The process has a {@link ReadableStream} for standard output/error
        * - `"ignore"`, `null`: The process has no standard output/error
        * - `"inherit"`: The process inherits the standard output/error of the current process
-       * - `ArrayBufferView`: The process writes to the preallocated buffer. Not implemented.
+       * - `ArrayBufferView`: `spawnSync` only. The process writes to the preallocated buffer and the result's `stdout`/`stderr` is a `Uint8Array` subarray over the bytes written.
        * - `number`: The process writes to the file descriptor
        *
        * At indices >= 3, `"socket-fd"` (POSIX only) is also accepted:
@@ -6859,7 +6859,7 @@ declare module "bun" {
        * - `"pipe"`, `undefined`: The process has a {@link ReadableStream} for standard output/error
        * - `"ignore"`, `null`: The process has no standard output/error
        * - `"inherit"`: The process inherits the standard output/error of the current process
-       * - `ArrayBufferView`: The process writes to the preallocated buffer. Not implemented.
+       * - `ArrayBufferView`: `spawnSync` only. The process writes to the preallocated buffer and `stdout` is a `Uint8Array` subarray over the bytes written.
        * - `number`: The process writes to the file descriptor
        *
        * @default "pipe"
@@ -6871,7 +6871,7 @@ declare module "bun" {
        * - `"pipe"`, `undefined`: The process has a {@link ReadableStream} for standard output/error
        * - `"ignore"`, `null`: The process has no standard output/error
        * - `"inherit"`: The process inherits the standard output/error of the current process
-       * - `ArrayBufferView`: The process writes to the preallocated buffer. Not implemented.
+       * - `ArrayBufferView`: `spawnSync` only. The process writes to the preallocated buffer and `stderr` is a `Uint8Array` subarray over the bytes written.
        * - `number`: The process writes to the file descriptor
        *
        * @default "inherit" for `spawn`
@@ -7142,7 +7142,11 @@ declare module "bun" {
         ? number
         : undefined;
 
-    type ReadableToSyncIO<X extends Readable> = X extends "pipe" | undefined ? Buffer : undefined;
+    type ReadableToSyncIO<X extends Readable> = X extends "pipe" | undefined
+      ? Buffer
+      : X extends ArrayBufferView
+        ? Uint8Array
+        : undefined;
 
     type WritableIO = FileSink | number | undefined;
 

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -343,7 +343,11 @@ impl ArrayBuffer {
     /// prototype method: a fresh `Uint8Array` over the same backing store,
     /// length clamped to `view.byteLength`. Returns `view` itself when no
     /// narrowing is needed.
-    pub fn create_subarray(global: &JSGlobalObject, view: JSValue, length: usize) -> JsResult<JSValue> {
+    pub fn create_subarray(
+        global: &JSGlobalObject,
+        view: JSValue,
+        length: usize,
+    ) -> JsResult<JSValue> {
         crate::host_fn::from_js_host_call(global, || {
             Bun__createUint8ArraySubarray(global, view, length)
         })

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -91,6 +91,13 @@ unsafe extern "C" {
         len: usize,
         buffer: bool,
     ) -> JSValue;
+    // safe: `JSGlobalObject` is an opaque `UnsafeCell`-backed ZST handle; `view`
+    // and `length` are by-value. Returns `undefined` for non-view input.
+    safe fn Bun__createUint8ArraySubarray(
+        global: &JSGlobalObject,
+        view: JSValue,
+        length: usize,
+    ) -> JSValue;
     fn Bun__createArrayBufferForCopy(
         global: *const JSGlobalObject,
         ptr: *const c_void,
@@ -330,6 +337,16 @@ impl ArrayBuffer {
             }),
             _ => panic!("ArrayBuffer::create: KIND not implemented"),
         }
+    }
+
+    /// `view.subarray(0, length)` without going through the (overridable) JS
+    /// prototype method: a fresh `Uint8Array` over the same backing store,
+    /// length clamped to `view.byteLength`. Returns `view` itself when no
+    /// narrowing is needed.
+    pub fn create_subarray(global: &JSGlobalObject, view: JSValue, length: usize) -> JsResult<JSValue> {
+        crate::host_fn::from_js_host_call(global, || {
+            Bun__createUint8ArraySubarray(global, view, length)
+        })
     }
 
     pub fn create_empty<const KIND: JSType>(global: &JSGlobalObject) -> JsResult<JSValue> {

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1484,6 +1484,40 @@ extern "C" JSC::EncodedJSValue Bun__createUint8ArrayForCopy(JSC::JSGlobalObject*
     RELEASE_AND_RETURN(scope, JSValue::encode(array));
 }
 
+// Returns a new Uint8Array view over the first `length` bytes of `encodedView`
+// (an ArrayBufferView or ArrayBuffer), sharing its backing store; a view's
+// byteOffset is preserved. If `length` covers the whole view and it is already
+// a Uint8Array, the original value is returned unchanged.
+extern "C" JSC::EncodedJSValue Bun__createUint8ArraySubarray(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue encodedView, size_t length)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSC::JSValue value = JSC::JSValue::decode(encodedView);
+    RefPtr<JSC::ArrayBuffer> buffer;
+    size_t byteOffset = 0;
+    size_t byteLength = 0;
+    if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(value)) {
+        byteOffset = view->byteOffset();
+        byteLength = view->byteLength();
+        if (length >= byteLength && view->type() == JSC::JSType::Uint8ArrayType)
+            return encodedView;
+        buffer = view->possiblySharedBuffer();
+    } else if (auto* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(value)) {
+        buffer = jsBuffer->impl();
+        byteLength = buffer ? buffer->byteLength() : 0;
+    }
+    if (!buffer) [[unlikely]]
+        return JSValue::encode(jsUndefined());
+
+    if (length > byteLength)
+        length = byteLength;
+    auto* structure = globalObject->typedArrayStructure(JSC::TypeUint8, buffer->isResizableOrGrowableShared());
+    auto* result = JSC::JSUint8Array::create(globalObject, structure, WTF::move(buffer), byteOffset, length);
+    RETURN_IF_EXCEPTION(scope, {});
+    RELEASE_AND_RETURN(scope, JSValue::encode(result));
+}
+
 extern "C" JSC::EncodedJSValue Bun__makeArrayBufferWithBytesNoCopy(JSC::JSGlobalObject* globalObject, const void* ptr, size_t len, JSTypedArrayBytesDeallocator deallocator, void* deallocatorContext)
 {
     auto& vm = JSC::getVM(globalObject);

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -934,7 +934,7 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
     let _ = &inherited_env_storage;
 
     for fd_index in 0..stdio.len() {
-        if stdio[fd_index].can_use_memfd() {
+        if stdio[fd_index].can_use_memfd(fd_index as u32) {
             if stdio[fd_index].use_memfd(fd_index as u32) {
                 jsc_vm.counters.mark(jsc::counters::Field::SpawnMemfd);
             }

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -556,13 +556,12 @@ impl Stdio {
         }
 
         if let Some(array_buffer) = value.as_array_buffer(global) {
-            // Change in Bun v1.0.34: don't throw for empty ArrayBuffer
-            if array_buffer.byte_slice().is_empty() {
-                *out_stdio = Stdio::Ignore;
-                return Ok(());
-            }
-
             if i == 0 {
+                // Change in Bun v1.0.34: don't throw for empty ArrayBuffer
+                if array_buffer.byte_slice().is_empty() {
+                    *out_stdio = Stdio::Ignore;
+                    return Ok(());
+                }
                 // stdin: copy now so later mutation of the caller's buffer
                 // cannot change what the child reads.
                 let copied_value = jsc::array_buffer::ArrayBuffer::create_buffer(

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -114,16 +114,20 @@ impl Stdio {
         }
     }
 
-    pub fn can_use_memfd(&self) -> bool {
+    pub fn can_use_memfd(&self, index: u32) -> bool {
         #[cfg(not(any(target_os = "linux", target_os = "android")))]
         {
+            let _ = index;
             return false;
         }
 
         #[cfg(any(target_os = "linux", target_os = "android"))]
         match self {
             Self::Blob(blob) => !blob.needs_to_read_file(),
-            Self::Memfd(_) | Self::ArrayBuffer(_) => true,
+            Self::Memfd(_) => true,
+            // ArrayBuffer as stdin is input data we can pre-write to a memfd.
+            // As stdout/stderr it is the caller's sink: a pipe writes into it.
+            Self::ArrayBuffer(_) => index == 0,
             // `Self::Pipe` is never memfd: a memfd has no EOF signal, so a
             // grandchild still writing after the child exits would be lost.
             _ => false,
@@ -558,15 +562,28 @@ impl Stdio {
                 return Ok(());
             }
 
-            let copied_value =
-                jsc::array_buffer::ArrayBuffer::create_buffer(global, array_buffer.byte_slice())?;
-            let copied = copied_value
-                .as_array_buffer(global)
-                .expect("create_buffer returns a Uint8Array");
-            *out_stdio = Stdio::ArrayBuffer(jsc::array_buffer::ArrayBufferStrong {
-                array_buffer: copied,
-                held: jsc::StrongOptional::create(copied.value, global),
-            });
+            if i == 0 {
+                // stdin: copy now so later mutation of the caller's buffer
+                // cannot change what the child reads.
+                let copied_value = jsc::array_buffer::ArrayBuffer::create_buffer(
+                    global,
+                    array_buffer.byte_slice(),
+                )?;
+                let copied = copied_value
+                    .as_array_buffer(global)
+                    .expect("create_buffer returns a Uint8Array");
+                *out_stdio = Stdio::ArrayBuffer(jsc::array_buffer::ArrayBufferStrong {
+                    array_buffer: copied,
+                    held: jsc::StrongOptional::create(copied.value, global),
+                });
+            } else {
+                // stdout/stderr: hold the caller's own view so the child's
+                // output can be written into it.
+                *out_stdio = Stdio::ArrayBuffer(jsc::array_buffer::ArrayBufferStrong {
+                    array_buffer,
+                    held: jsc::StrongOptional::create(value, global),
+                });
+            }
             return Ok(());
         }
 

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -576,13 +576,27 @@ impl Stdio {
                     array_buffer: copied,
                     held: jsc::StrongOptional::create(copied.value, global),
                 });
-            } else {
+            } else if is_sync && (i == 1 || i == 2) {
                 // stdout/stderr: hold the caller's own view so the child's
                 // output can be written into it.
                 *out_stdio = Stdio::ArrayBuffer(jsc::array_buffer::ArrayBufferStrong {
                     array_buffer,
                     held: jsc::StrongOptional::create(value, global),
                 });
+            } else {
+                let name: &[u8] = match i {
+                    1 => b"stdout",
+                    2 => b"stderr",
+                    _ => {
+                        return Err(global.throw_invalid_arguments(format_args!(
+                            "ArrayBufferView cannot be used for stdio[{i}] yet"
+                        )));
+                    }
+                };
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "'{}' ArrayBufferView is only supported with Bun.spawnSync",
+                    bstr::BStr::new(name),
+                )));
             }
             return Ok(());
         }

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -500,17 +500,25 @@ impl Subprocess<'_> {
                     let Readable::Pipe(pipe) = out.replace(Readable::Ignore) else {
                         unreachable!()
                     };
-                    let pipe_state = &mut Readable::pipe_reader_mut(&pipe).state;
-                    if let PipeReader::State::Done(done) = pipe_state {
-                        let taken = core::mem::take(done);
-                        out.set(Readable::Buffer(readable::CowString::init_owned(
-                            taken.into_boxed_slice(),
-                        )));
-                        // pipe.state was emptied via take()
+                    let reader = Readable::pipe_reader_mut(&pipe);
+                    if reader.sink.is_some() {
+                        // A caller-provided Uint8Array sink: keep the pipe so
+                        // `to_buffered_value` can copy into it and return a
+                        // subarray. The `Readable::Pipe` ref we just moved out
+                        // is put back, so no `deref()` here.
+                        out.set(Readable::Pipe(pipe));
+                    } else {
+                        if let PipeReader::State::Done(done) = &mut reader.state {
+                            let taken = core::mem::take(done);
+                            out.set(Readable::Buffer(readable::CowString::init_owned(
+                                taken.into_boxed_slice(),
+                            )));
+                            // pipe.state was emptied via take()
+                        }
+                        // else: *out stays Readable::Ignore (set by replace above).
+                        // RefPtr has no Drop — release the ref this Readable held.
+                        pipe.deref();
                     }
-                    // else: *out stays Readable::Ignore (set by replace above).
-                    // RefPtr has no Drop — release the ref this Readable held.
-                    pipe.deref();
                 }
             }
         }

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -501,11 +501,13 @@ impl Subprocess<'_> {
                         unreachable!()
                     };
                     let reader = Readable::pipe_reader_mut(&pipe);
-                    if reader.sink.is_some() {
+                    if reader.sink.is_some() && matches!(reader.state, PipeReader::State::Done(_)) {
                         // A caller-provided Uint8Array sink: keep the pipe so
                         // `to_buffered_value` can copy into it and return a
                         // subarray. The `Readable::Pipe` ref we just moved out
-                        // is put back, so no `deref()` here.
+                        // is put back, so no `deref()` here. `State::Err` falls
+                        // through to `Readable::Ignore` + `deref()` below so a
+                        // POSIX read error cannot re-fire on a ref=1 pipe.
                         out.set(Readable::Pipe(pipe));
                     } else {
                         if let PipeReader::State::Done(done) = &mut reader.state {

--- a/src/runtime/api/bun/subprocess/Readable.rs
+++ b/src/runtime/api/bun/subprocess/Readable.rs
@@ -303,7 +303,7 @@ impl Readable {
                 };
                 let result = Self::pipe_reader_mut(&pipe).to_buffer(global);
                 Self::pipe_detach(&pipe);
-                Ok(result)
+                result
             }
             Readable::Buffer(_) => {
                 let Readable::Buffer(mut buf) = mem::replace(self, Readable::Closed) else {

--- a/src/runtime/api/bun/subprocess/Readable.rs
+++ b/src/runtime/api/bun/subprocess/Readable.rs
@@ -118,16 +118,16 @@ impl Readable {
         // *transferred* into the returned `Readable`. `Stdio` has a `Drop` impl that
         // would close the memfd, so suppress it here to avoid a double-close
         // (EBADF) when the Readable later closes the same fd.
-        let stdio = mem::ManuallyDrop::new(stdio);
+        let mut stdio = mem::ManuallyDrop::new(stdio);
 
         #[cfg(unix)]
         {
-            if matches!(*stdio, Stdio::Pipe) {
+            if matches!(*stdio, Stdio::Pipe | Stdio::ArrayBuffer(..)) {
                 let _ = bun_sys::set_nonblocking(result.unwrap());
             }
         }
 
-        match &*stdio {
+        match &mut *stdio {
             Stdio::Inherit => Readable::Inherit,
             Stdio::Ignore | Stdio::Ipc | Stdio::Path(..) => Readable::Ignore,
             Stdio::Fd(fd) => {
@@ -166,8 +166,13 @@ impl Readable {
             Stdio::Pipe => {
                 Readable::Pipe(PipeReader::create(event_loop, process, result, max_size))
             }
-            Stdio::ArrayBuffer(..) | Stdio::Blob(..) => {
-                panic!("TODO: implement ArrayBuffer & Blob support in Stdio readable")
+            Stdio::ArrayBuffer(ab) => {
+                let pipe = PipeReader::create(event_loop, process, result, max_size);
+                Self::pipe_reader_mut(&pipe).sink = Some(core::mem::take(ab));
+                Readable::Pipe(pipe)
+            }
+            Stdio::Blob(..) => {
+                panic!("Blob stdout/stderr is rejected in Stdio::extract_blob")
             }
             Stdio::Capture(..) => panic!("TODO: implement capture support in Stdio readable"),
             // ReadableStream is handled separately

--- a/src/runtime/api/bun/subprocess/SubprocessPipeReader.rs
+++ b/src/runtime/api/bun/subprocess/SubprocessPipeReader.rs
@@ -50,6 +50,10 @@ pub struct PipeReader {
     pub ref_count: RefCount<PipeReader>,
     pub state: State,
     pub stdio_result: StdioResult,
+    /// Caller-provided stdout/stderr `Uint8Array` (`Bun.spawnSync` only). When
+    /// set, `to_buffer` copies the collected bytes into it and returns a
+    /// subarray instead of a fresh Buffer.
+    pub sink: Option<jsc::array_buffer::ArrayBufferStrong>,
 }
 
 // `pub const ref/deref = RefCount.ref/deref` — thin forwarders so existing call
@@ -117,6 +121,7 @@ impl PipeReader {
             event_loop_handle: bun_jsc::EventLoopHandle::init(event_loop.as_ptr().cast::<()>()),
             stdio_result: result,
             state: State::Pending,
+            sink: None,
         });
         MaxBuf::add_to_pipereader(limit, &mut this.reader.maxbuf);
         #[cfg(windows)]
@@ -275,6 +280,11 @@ impl PipeReader {
             unsafe { PipeReader::detach(this_ptr) };
         }
 
+        if let Some(result) = self.fill_sink(global_object) {
+            self.state = State::Done(Vec::new());
+            return Ok(result);
+        }
+
         match &self.state {
             State::Pending => {
                 // `_parent` is unused in `from_pipe`; pass the raw ptr instead
@@ -304,7 +314,37 @@ impl PipeReader {
         }
     }
 
+    /// If a caller-provided `Uint8Array` sink is attached and the pipe has
+    /// finished, copy the collected output into it and return a `Uint8Array`
+    /// subarray over the bytes that were written. Returns `None` when no sink
+    /// is attached (the normal case), the pipe is still pending, or the sink
+    /// can no longer be resolved.
+    fn fill_sink(&mut self, global_this: &JSGlobalObject) -> Option<JSValue> {
+        if !matches!(self.state, State::Done(_)) {
+            return None;
+        }
+        let sink = self.sink.take()?;
+        let value = sink.held.get()?;
+        // Refetch the backing slice now: the `ArrayBuffer` view cached at
+        // `extract()` time may be stale if GC moved a FastTypedArray while the
+        // child ran.
+        let mut ab = value.as_array_buffer(global_this)?;
+        let dst = ab.byte_slice_mut();
+        let State::Done(done) = &self.state else {
+            unreachable!()
+        };
+        let n = done.len().min(dst.len());
+        dst[..n].copy_from_slice(&done[..n]);
+        Some(
+            jsc::array_buffer::ArrayBuffer::create_subarray(global_this, value, n)
+                .unwrap_or(JSValue::UNDEFINED),
+        )
+    }
+
     pub(crate) fn to_buffer(&mut self, global_this: &JSGlobalObject) -> JSValue {
+        if let Some(result) = self.fill_sink(global_this) {
+            return result;
+        }
         match &mut self.state {
             State::Done(bytes) => {
                 let bytes = core::mem::take(bytes);

--- a/src/runtime/api/bun/subprocess/SubprocessPipeReader.rs
+++ b/src/runtime/api/bun/subprocess/SubprocessPipeReader.rs
@@ -350,8 +350,10 @@ impl PipeReader {
                 // boxed slice so JS becomes the owner — same pattern as
                 // `MarkedArrayBuffer::from_string`.
                 let slice: &'static mut [u8] = Box::leak(bytes.into_boxed_slice());
-                Ok(MarkedArrayBuffer::from_bytes(slice, jsc::JSType::Uint8Array)
-                    .to_node_buffer(global_this))
+                Ok(
+                    MarkedArrayBuffer::from_bytes(slice, jsc::JSType::Uint8Array)
+                        .to_node_buffer(global_this),
+                )
             }
             _ => Ok(JSValue::UNDEFINED),
         }

--- a/src/runtime/api/bun/subprocess/SubprocessPipeReader.rs
+++ b/src/runtime/api/bun/subprocess/SubprocessPipeReader.rs
@@ -280,11 +280,6 @@ impl PipeReader {
             unsafe { PipeReader::detach(this_ptr) };
         }
 
-        if let Some(result) = self.fill_sink(global_object) {
-            self.state = State::Done(Vec::new());
-            return Ok(result);
-        }
-
         match &self.state {
             State::Pending => {
                 // `_parent` is unused in `from_pipe`; pass the raw ptr instead
@@ -319,7 +314,7 @@ impl PipeReader {
     /// subarray over the bytes that were written. Returns `None` when no sink
     /// is attached (the normal case), the pipe is still pending, or the sink
     /// can no longer be resolved.
-    fn fill_sink(&mut self, global_this: &JSGlobalObject) -> Option<JSValue> {
+    fn fill_sink(&mut self, global_this: &JSGlobalObject) -> Option<JsResult<JSValue>> {
         if !matches!(self.state, State::Done(_)) {
             return None;
         }
@@ -335,13 +330,14 @@ impl PipeReader {
         };
         let n = done.len().min(dst.len());
         dst[..n].copy_from_slice(&done[..n]);
-        Some(
-            jsc::array_buffer::ArrayBuffer::create_subarray(global_this, value, n)
-                .unwrap_or(JSValue::UNDEFINED),
-        )
+        Some(jsc::array_buffer::ArrayBuffer::create_subarray(
+            global_this,
+            value,
+            n,
+        ))
     }
 
-    pub(crate) fn to_buffer(&mut self, global_this: &JSGlobalObject) -> JSValue {
+    pub(crate) fn to_buffer(&mut self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
         if let Some(result) = self.fill_sink(global_this) {
             return result;
         }
@@ -354,10 +350,10 @@ impl PipeReader {
                 // boxed slice so JS becomes the owner — same pattern as
                 // `MarkedArrayBuffer::from_string`.
                 let slice: &'static mut [u8] = Box::leak(bytes.into_boxed_slice());
-                MarkedArrayBuffer::from_bytes(slice, jsc::JSType::Uint8Array)
-                    .to_node_buffer(global_this)
+                Ok(MarkedArrayBuffer::from_bytes(slice, jsc::JSType::Uint8Array)
+                    .to_node_buffer(global_this))
             }
-            _ => JSValue::UNDEFINED,
+            _ => Ok(JSValue::UNDEFINED),
         }
     }
 

--- a/test/integration/bun-types/fixture/spawn.ts
+++ b/test/integration/bun-types/fixture/spawn.ts
@@ -188,6 +188,15 @@ tsd.expectAssignable<NullSubprocess>(Bun.spawn([], { stdio: [null, null, null] }
 
 tsd.expectAssignable<SyncSubprocess<Bun.SpawnOptions.Readable, Bun.SpawnOptions.Readable>>(Bun.spawnSync([], {}));
 
+{
+  const { stdout, stderr } = Bun.spawnSync(["echo", "hi"], {
+    stdout: new Uint8Array(16),
+    stderr: new Uint8Array(16),
+  });
+  tsd.expectType(stdout).is<Uint8Array>();
+  tsd.expectType(stderr).is<Uint8Array>();
+}
+
 // Lazy option types (async only)
 {
   // valid: lazy usable with async spawn

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -298,6 +298,17 @@ for (let [gcTick, label] of [
         gcTick();
       });
 
+      it("Uint8Array as stdout/stderr is rejected for async spawn", () => {
+        gcTick();
+        expect(() => spawn([bunExe(), "-e", "1"], { stdout: new Uint8Array(8) })).toThrow(
+          "'stdout' ArrayBufferView is only supported with Bun.spawnSync",
+        );
+        expect(() => spawn([bunExe(), "-e", "1"], { stderr: new Uint8Array(8) })).toThrow(
+          "'stderr' ArrayBufferView is only supported with Bun.spawnSync",
+        );
+        gcTick();
+      });
+
       it("Blob works as stdin", async () => {
         const stdinPath = join(tmpdirSync(), "stdin.txt");
         gcTick();

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -214,14 +214,14 @@ for (let [gcTick, label] of [
         }
       }, 60_000_0);
 
-      // FIXME: fix the assertion failure
-      it.skip("Uint8Array works as stdout", () => {
+      it("Uint8Array works as stdout", () => {
         gcTick();
         const stdout_buffer = new Uint8Array(11);
-        const { stdout } = spawnSync(["node", "-e", "console.log('hello world')"], {
+        const { stdout } = spawnSync([bunExe(), "-e", "console.log('hello world')"], {
           stdout: stdout_buffer,
           stderr: null,
           stdin: null,
+          env: bunEnv,
         });
         gcTick();
         const text = new TextDecoder().decode(stdout);
@@ -231,13 +231,14 @@ for (let [gcTick, label] of [
         gcTick();
       });
 
-      it.skip("Uint8Array works as stdout when is smaller than output", () => {
+      it("Uint8Array works as stdout when is smaller than output", () => {
         gcTick();
         const stdout_buffer = new Uint8Array(5);
-        const { stdout } = spawnSync(["node", "-e", "console.log('hello world')"], {
+        const { stdout } = spawnSync([bunExe(), "-e", "console.log('hello world')"], {
           stdout: stdout_buffer,
           stderr: null,
           stdin: null,
+          env: bunEnv,
         });
         gcTick();
         const text = new TextDecoder().decode(stdout);
@@ -247,13 +248,14 @@ for (let [gcTick, label] of [
         gcTick();
       });
 
-      it.skip("Uint8Array works as stdout when is the exactly size than output", () => {
+      it("Uint8Array works as stdout when is the exactly size than output", () => {
         gcTick();
         const stdout_buffer = new Uint8Array(12);
-        const { stdout } = spawnSync(["node", "-e", "console.log('hello world')"], {
+        const { stdout } = spawnSync([bunExe(), "-e", "console.log('hello world')"], {
           stdout: stdout_buffer,
           stderr: null,
           stdin: null,
+          env: bunEnv,
         });
         gcTick();
         const text = new TextDecoder().decode(stdout);
@@ -263,19 +265,36 @@ for (let [gcTick, label] of [
         gcTick();
       });
 
-      it.skip("Uint8Array works as stdout when is larger than output", () => {
+      it("Uint8Array works as stdout when is larger than output", () => {
         gcTick();
         const stdout_buffer = new Uint8Array(15);
-        const { stdout } = spawnSync(["node", "-e", "console.log('hello world')"], {
+        const { stdout } = spawnSync([bunExe(), "-e", "console.log('hello world')"], {
           stdout: stdout_buffer,
           stderr: null,
           stdin: null,
+          env: bunEnv,
         });
         gcTick();
         const text = new TextDecoder().decode(stdout);
         const text2 = new TextDecoder().decode(stdout_buffer);
         expect(text).toBe("hello world\n");
         expect(text2).toBe("hello world\n\u0000\u0000\u0000");
+        expect((stdout as Uint8Array).buffer).toBe(stdout_buffer.buffer);
+        gcTick();
+      });
+
+      it("Uint8Array works as stderr", () => {
+        gcTick();
+        const stderr_buffer = new Uint8Array(15);
+        const { stderr } = spawnSync([bunExe(), "-e", "console.error('hello world')"], {
+          stdout: null,
+          stderr: stderr_buffer,
+          stdin: null,
+          env: bunEnv,
+        });
+        gcTick();
+        expect(new TextDecoder().decode(stderr)).toBe("hello world\n");
+        expect(new TextDecoder().decode(stderr_buffer)).toBe("hello world\n\u0000\u0000\u0000");
         gcTick();
       });
 

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -279,7 +279,7 @@ for (let [gcTick, label] of [
         const text2 = new TextDecoder().decode(stdout_buffer);
         expect(text).toBe("hello world\n");
         expect(text2).toBe("hello world\n\u0000\u0000\u0000");
-        expect((stdout as Uint8Array).buffer).toBe(stdout_buffer.buffer);
+        expect(stdout.buffer).toBe(stdout_buffer.buffer);
         gcTick();
       });
 

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -248,6 +248,21 @@ for (let [gcTick, label] of [
         gcTick();
       });
 
+      it("Uint8Array works as stdout when it is empty", () => {
+        gcTick();
+        const stdout_buffer = new Uint8Array(0);
+        const { stdout } = spawnSync([bunExe(), "-e", "console.log('hello world')"], {
+          stdout: stdout_buffer,
+          stderr: null,
+          stdin: null,
+          env: bunEnv,
+        });
+        gcTick();
+        expect(stdout).toBeInstanceOf(Uint8Array);
+        expect(stdout.byteLength).toBe(0);
+        gcTick();
+      });
+
       it("Uint8Array works as stdout when is the exactly size than output", () => {
         gcTick();
         const stdout_buffer = new Uint8Array(12);


### PR DESCRIPTION
Closes #2678.

## Reproduction

```js
for (const size of [5, 12, 15]) {
  const buf = new Uint8Array(size);
  const { stdout } = Bun.spawnSync(["echo", "hello world"], { stdout: buf });
  console.log(size, JSON.stringify(new TextDecoder().decode(stdout)), JSON.stringify(new TextDecoder().decode(buf)));
}
// before:
// 5  "hello world\n"          "\0\0\0\0\0"
// 12 "hello world\n"          "\0\0\0\0\0\0\0\0\0\0\0\0"
// 15 "hello world\n\0\0\0"  "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
```

The caller's buffer was never written to, and when the buffer was larger than the output `.stdout` was NUL-padded to the buffer's length. On macOS and Windows the same input reached `panic!("TODO: implement ArrayBuffer & Blob support in Stdio readable")`.

## Cause

`Stdio::extract` treated an ArrayBuffer at stdout/stderr exactly like stdin: it copied the bytes and (on Linux) `use_memfd` wrote those bytes to a memfd as input data. The caller's view was never touched, and the returned buffer was the full memfd contents (`fstat.st_size`), which is the pre-truncated buffer length when the child wrote less.

## Fix

For stdout/stderr, keep a Strong reference to the caller's view instead of copying, and skip the input-only memfd path (`can_use_memfd` now returns false for `ArrayBuffer` at index > 0). The child is drained through the existing `PipeReader`; when the pipe completes, the collected bytes are copied into the caller's buffer (clamped to its capacity) and `.stdout`/`.stderr` is returned as a `Uint8Array` subarray over the same backing store with length equal to the bytes actually written. A small C++ helper (`Bun__createUint8ArraySubarray`) constructs the subarray directly so it does not depend on the overridable `%TypedArray%.prototype.subarray`.

## Verification

```js
// after:
// 5  "hello"         "hello"
// 12 "hello world\n" "hello world\n"
// 15 "hello world\n" "hello world\n\0\0\0"   (stdout.buffer === buf.buffer)
```

Unskipped the four "Uint8Array works as stdout" cases in `test/js/bun/spawn/spawn.test.ts` (disabled since 2023) and added a stderr case; all five fail on main and pass with this change. The full `spawn.test.ts` suite passes and `rust:check-all` is green across the target matrix.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/spawn.test.ts

<!-- robobun:evidence:end -->