### PR TITLE
test: compile -t filter regex after JSC options are finalized

### DIFF
--- a/src/jsc/bindings/RegularExpression.cpp
+++ b/src/jsc/bindings/RegularExpression.cpp
@@ -1,18 +1,12 @@
 #include "root.h"
 #include "headers-handwritten.h"
 #include <JavaScriptCore/RegularExpression.h>
-#include <JavaScriptCore/Options.h>
 
 using namespace JSC;
 using namespace JSC::Yarr;
 
 extern "C" RegularExpression* Yarr__RegularExpression__init(BunString pattern, uint16_t flags)
 {
-    // TODO: Remove this, we technically are accessing options before we finalize them.
-    // This means you cannot use BUN_JSC_dumpCompiledRegExpPatterns on the flag passed to `bun test -t`
-    // NOLINTBEGIN
-    Options::AllowUnfinalizedAccessScope scope {};
-    // NOLINTEND
     return new RegularExpression(pattern.toWTFString(BunString::ZeroCopy), OptionSet<Flags>(static_cast<Flags>(flags)));
 }
 extern "C" void Yarr__RegularExpression__deinit(RegularExpression* re)

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -410,13 +410,6 @@ pub struct TestOptions {
     pub path_ignore_patterns: Vec<Box<[u8]>>,
     pub path_ignore_patterns_from_cli: bool,
     pub test_filter_pattern: Option<Box<[u8]>>,
-    /// `?*bun.jsc.RegularExpression` — typed as opaque to keep this file free
-    /// of `jsc/` references. Read via `test_filter_regex()`.
-    // FORWARD_DECL(b0): erased bun_jsc::RegularExpression to break the T3→T6
-    // back-edge. High tier owns construction/destruction; this field only
-    // stores the pointer. LIFETIMES.tsv says OWNED, so the high-tier setter is
-    // responsible for freeing any previous value.
-    pub test_filter_regex: Option<core::ptr::NonNull<()>>, // SAFETY: erased *mut bun_jsc::RegularExpression
     pub max_concurrency: u32,
     /// `bun test --isolate`: run each test file in a fresh global object on
     /// the same VM, force-closing leaked handles between files.
@@ -458,16 +451,6 @@ pub struct Reporters {
     pub junit: bool,
 }
 
-impl TestOptions {
-    /// Returns the erased `*mut bun_jsc::RegularExpression`. Caller (high tier)
-    /// casts back: `unsafe { &*ptr.cast::<bun_jsc::RegularExpression>() }`.
-    #[inline]
-    pub fn test_filter_regex(&self) -> Option<core::ptr::NonNull<()>> {
-        // SAFETY: erased bun_jsc::RegularExpression — see field decl.
-        self.test_filter_regex
-    }
-}
-
 impl Default for TestOptions {
     // See `ContextData::default` — folded into the single startup call site.
     #[inline(always)]
@@ -490,7 +473,6 @@ impl Default for TestOptions {
             path_ignore_patterns: Vec::new(),
             path_ignore_patterns_from_cli: false,
             test_filter_pattern: None,
-            test_filter_regex: None,
             // Under ASAN every spawned `bun` child is several-× heavier in
             // RSS and ~2× slower to start, so `describe.concurrent` test
             // files that spawn one child per test (e.g. process-stdio,

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -15,8 +15,6 @@ use bun_core::ZStr;
 use bun_core::env::OperatingSystem;
 use bun_core::strings;
 use bun_core::{self, FeatureFlags, Global, Output, env_var};
-use bun_jsc::RegularExpression;
-use bun_jsc::regular_expression::Flags as RegexFlags;
 use bun_options_types::code_coverage_options::Reporters as CoverageReporters;
 use bun_options_types::context::{Debugger, DebuggerEnable, HotReload, MacroOptions, Shard};
 use bun_options_types::schema::api;
@@ -1713,24 +1711,9 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
         Global::exit(1);
     }
     if let Some(name_pattern) = args.option(b"--test-name-pattern") {
+        // The Yarr regex is compiled in `TestCommand::exec` after
+        // `jsc::initialize()` so JSC Options are finalized first.
         ctx.test_options.test_filter_pattern = Some(name_pattern.into());
-        let regex = match RegularExpression::init(
-            bun_core::String::from_bytes(name_pattern),
-            RegexFlags::None,
-        ) {
-            Ok(r) => r,
-            Err(_) => {
-                bun_core::pretty_errorln!(
-                    "<r><red>error<r>: --test-name-pattern expects a valid regular expression but received {}",
-                    bun_core::fmt::QuotedFormatter { text: name_pattern },
-                );
-                Global::exit(1);
-            }
-        };
-        // The compiled regex lives in `bun_jsc::RegularExpression` (T6); the
-        // T3 `TestOptions` field is type-erased to `NonNull<()>` to break the
-        // back-edge. High tier owns construction/destruction.
-        ctx.test_options.test_filter_regex = core::ptr::NonNull::new(regex.cast::<()>());
     }
     if let Some(since) = args.option(b"--changed") {
         ctx.test_options.changed = Some(since.into());

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1997,22 +1997,25 @@ impl TestCommand {
 
         // Compile the `-t` / `--test-name-pattern` regex now that JSC Options
         // are finalized (so e.g. BUN_JSC_dumpCompiledRegExpPatterns applies).
-        if let Some(pattern) = ctx.test_options.test_filter_pattern.as_deref() {
-            let regex = match jsc::RegularExpression::init(
-                bun_core::String::from_bytes(pattern),
-                jsc::regular_expression::Flags::None,
-            ) {
-                Ok(r) => r,
-                Err(_) => {
-                    bun_core::pretty_errorln!(
-                        "<r><red>error<r>: --test-name-pattern expects a valid regular expression but received {}",
-                        bun_fmt::quote(pattern),
-                    );
-                    Global::exit(1);
+        let filter_regex: Option<core::ptr::NonNull<jsc::RegularExpression>> = ctx
+            .test_options
+            .test_filter_pattern
+            .as_deref()
+            .map(|pattern| {
+                match jsc::RegularExpression::init(
+                    bun_core::String::from_bytes(pattern),
+                    jsc::regular_expression::Flags::None,
+                ) {
+                    Ok(r) => core::ptr::NonNull::new(r).unwrap(),
+                    Err(_) => {
+                        bun_core::pretty_errorln!(
+                            "<r><red>error<r>: --test-name-pattern expects a valid regular expression but received {}",
+                            bun_fmt::quote(pattern),
+                        );
+                        Global::exit(1);
+                    }
                 }
-            };
-            ctx.test_options.test_filter_regex = core::ptr::NonNull::new(regex.cast::<()>());
-        }
+            });
 
         let enable_random = ctx.test_options.randomize;
         let seed: u32 = if enable_random {
@@ -2089,14 +2092,7 @@ impl TestCommand {
                 only: ctx.test_options.only,
                 bail: ctx.test_options.bail,
                 max_concurrency: ctx.test_options.max_concurrency,
-                // `test_filter_regex` is an erased `*mut RegularExpression` (see
-                // options_types::context); cast back to a typed `NonNull` —
-                // kept raw so `matches()` can write through it without
-                // laundering shared-ref provenance.
-                filter_regex: ctx
-                    .test_options
-                    .test_filter_regex()
-                    .map(|p| p.cast::<jsc::RegularExpression>()),
+                filter_regex,
                 snapshots: Snapshots {
                     update_snapshots: ctx.test_options.update_snapshots,
                     total: 0,

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1995,6 +1995,25 @@ impl TestCommand {
         jsc::initialize(false);
         bun_http::http_thread::init(&Default::default());
 
+        // Compile the `-t` / `--test-name-pattern` regex now that JSC Options
+        // are finalized (so e.g. BUN_JSC_dumpCompiledRegExpPatterns applies).
+        if let Some(pattern) = ctx.test_options.test_filter_pattern.as_deref() {
+            let regex = match jsc::RegularExpression::init(
+                bun_core::String::from_bytes(pattern),
+                jsc::regular_expression::Flags::None,
+            ) {
+                Ok(r) => r,
+                Err(_) => {
+                    bun_core::pretty_errorln!(
+                        "<r><red>error<r>: --test-name-pattern expects a valid regular expression but received {}",
+                        bun_fmt::quote(pattern),
+                    );
+                    Global::exit(1);
+                }
+            };
+            ctx.test_options.test_filter_regex = core::ptr::NonNull::new(regex.cast::<()>());
+        }
+
         let enable_random = ctx.test_options.randomize;
         let seed: u32 = if enable_random {
             ctx.test_options

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1268,9 +1268,6 @@ describe("bun test", () => {
   });
 
   test("-t filter regex is compiled after JSC options are finalized", () => {
-    // The `-t` regex used to be compiled during CLI arg parsing, before JSC
-    // Options were read from the environment, so BUN_JSC_* regex options
-    // didn't apply to it. It's now compiled after jsc::initialize().
     const stderr = runTest({
       args: ["-t", "zzFilterMarkerzz"],
       env: { BUN_JSC_dumpCompiledRegExpPatterns: "1" },
@@ -1280,6 +1277,7 @@ describe("bun test", () => {
           expect(1).toBe(1);
         });
       `,
+      expectExitCode: 0,
     });
     expect(stderr).toContain("RegExp pattern for /zzFilterMarkerzz/");
     expect(stderr).toContain("(pass) zzFilterMarkerzz");

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1267,6 +1267,37 @@ describe("bun test", () => {
     expect(stderr).toContain("index.ts");
   });
 
+  test("-t filter regex is compiled after JSC options are finalized", () => {
+    // The `-t` regex used to be compiled during CLI arg parsing, before JSC
+    // Options were read from the environment, so BUN_JSC_* regex options
+    // didn't apply to it. It's now compiled after jsc::initialize().
+    const stderr = runTest({
+      args: ["-t", "zzFilterMarkerzz"],
+      env: { BUN_JSC_dumpCompiledRegExpPatterns: "1" },
+      input: `
+        import { test, expect } from "bun:test";
+        test("zzFilterMarkerzz", () => {
+          expect(1).toBe(1);
+        });
+      `,
+    });
+    expect(stderr).toContain("RegExp pattern for /zzFilterMarkerzz/");
+    expect(stderr).toContain("(pass) zzFilterMarkerzz");
+  });
+
+  test("-t filter rejects invalid regex", () => {
+    const stderr = runTest({
+      args: ["-t", "[invalid("],
+      input: `
+        import { test } from "bun:test";
+        test("a", () => {});
+      `,
+      expectExitCode: 1,
+    });
+    expect(stderr).toContain("--test-name-pattern expects a valid regular expression");
+    expect(stderr).toContain(`"[invalid("`);
+  });
+
   test("Skipped and todo tests are filtered out when not matching -t filter", () => {
     const stderr = runTest({
       args: ["-t", "should match"],


### PR DESCRIPTION
## Problem

`Yarr__RegularExpression__init` in `src/jsc/bindings/RegularExpression.cpp` wrapped the Yarr `RegularExpression` constructor in a `JSC::Options::AllowUnfinalizedAccessScope` because its only pre-init caller, the `bun test -t <pattern>` CLI parser, compiled the filter regex during argument parsing, before `JSC::initialize()` reads `BUN_JSC_*` environment variables and finalizes Options.

With the scope in place the unfinalized-access assertion is suppressed, but the option values read by Yarr are the defaults, so for example `BUN_JSC_dumpCompiledRegExpPatterns=1 bun test -t foo` dumps every regex except the filter pattern itself:

```
$ BUN_JSC_dumpCompiledRegExpPatterns=1 bun test -t zzFilterMarkerzz dummy.test.ts 2>&1 | grep "RegExp pattern"
RegExp pattern for /jsRegexInBody/:
# no entry for /zzFilterMarkerzz/
```

## Fix

Move the regex compilation from `parse_test_command_options` in `Arguments.rs` to `TestCommand::exec` in `test_command.rs`, immediately after `jsc::initialize(false)`. The pattern string was already being stored in `ctx.test_options.test_filter_pattern` (used by the `--parallel` argv forwarder), so arg parsing now only records the string and `exec()` compiles it once JSC Options are finalized. The `AllowUnfinalizedAccessScope` and the `Options.h` include are removed from `RegularExpression.cpp`.

The other caller, `__bun_regex_compile` (used by `install` / pnpm matchers), already calls `jsc::initialize(false)` before compiling, so the scope was only covering the `-t` path.

The only behavioural change beyond the dump fix is that an invalid `-t` pattern now errors after the `bun test vX.Y.Z` header instead of before it; the message and exit code are unchanged.

## Verification

```
$ BUN_JSC_dumpCompiledRegExpPatterns=1 bun-debug test -t zzFilterMarkerzz dummy.test.ts 2>&1 | grep "RegExp pattern"
RegExp pattern for /zzFilterMarkerzz/:
```

Added two tests to `test/cli/test/bun-test.test.ts`: one that asserts the `-t` pattern appears in the Yarr dump when `BUN_JSC_dumpCompiledRegExpPatterns=1` is set (fails before this change), and one that asserts an invalid `-t` pattern still produces the existing error message and exit code 1.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/test/bun-test.test.ts

<!-- robobun:evidence:end -->