### PR TITLE
shell(windows): document why IOWriter.winbuf is required

### DIFF
--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -637,9 +637,9 @@ impl IOWriter {
             debug_assert!(writer.len != writer.written);
             writer.len - writer.written
         };
-        // `state()` already ties `s` to `&self`, so a plain slice borrow has
-        // the right lifetime. `buf` is not reallocated until after the
-        // caller's write syscall completes.
+        // Slice stays valid for the caller's synchronous use: POSIX drains
+        // it before returning; Windows copies it into `winbuf` before any
+        // async boundary (`buf` itself may reallocate under a pending write).
         let start = s.total_bytes_written;
         &s.buf[start..start + remaining]
     }

--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -209,7 +209,9 @@ struct State {
     fd: Fd,
     writers: Writers,
     buf: Vec<u8>,
-    /// quick hack to get windows working; ideally this should be removed.
+    /// Stable copy of the in-flight chunk for libuv: `uv_write`/`uv_fs_write`
+    /// hold the `uv_buf_t` pointer until completion, but `enqueue()` may grow
+    /// (reallocate) `buf` meanwhile. POSIX drains synchronously so reads `buf`.
     #[cfg(windows)]
     winbuf: Vec<u8>,
     writer_idx: usize,
@@ -602,11 +604,11 @@ impl IOWriter {
         let result = self.get_buffer_impl();
         #[cfg(windows)]
         {
+            // Copy into the stable side-buffer libuv will point into across the
+            // async write; `buf` may reallocate before completion (see `winbuf`).
             let s = self.state();
             s.winbuf.clear();
             s.winbuf.extend_from_slice(result);
-            // `state()` ties `s` to `&self`, so the slice borrow already has
-            // the `'self` lifetime the signature wants — no raw-parts needed.
             return s.winbuf.as_slice();
         }
         #[cfg(not(windows))]


### PR DESCRIPTION
## What

Replaces the misleading `/// quick hack to get windows working; ideally this should be removed` comment on `State::winbuf` in `src/runtime/shell/IOWriter.rs` with the actual invariant the field upholds.

## Why this is not removable

`WindowsBufferedWriter::write()` hands libuv a `uv_buf_t` that points into the slice returned by `IOWriter::get_buffer()`. `uv_write` / `uv_fs_write` are asynchronous and hold that pointer until the completion callback fires (see `src/io/PipeWriter.rs:1666`, comment at line 1732: "the buffered version should always have a stable ptr").

While that write is in flight (`is_writing == true`), other event-loop callbacks can call `IOWriter::enqueue()` on the same writer, which unconditionally does `s.buf.extend_from_slice(buf)` (line 1041) before the `is_writing` check. That append can reallocate `buf`. If `get_buffer()` returned a slice into `buf` directly, libuv's stored pointer would dangle.

Concrete paths that enqueue while a write is pending:

- `subproc::CapturedWriter::do_write` (every read-chunk from a child process)
- `cat::on_io_reader_chunk` (explicit `chunks_queued`/`chunks_done` multi-in-flight counters)
- `rm`/`mkdir`/`ls`/`touch`/`cp` parallel-task fan-in to stdout/stderr
- pipeline children sharing the same `Arc<IOWriter>` for stderr (`Pipeline.rs:216`)

`winbuf` is the stable copy libuv points into; only `get_buffer()` touches it, and `write()` short-circuits on `is_writing` so it is never rewritten mid-flight. The POSIX path drains synchronously inside the write call, so it can read `buf` directly.

## Verification

Comment-only change (no runtime behavior delta). `bun bd` builds and `cargo check -p bun_runtime --target x86_64-pc-windows-msvc` passes.

There is no fail-before/pass-after test for a comment change; the value is preventing a future refactor from removing a load-bearing buffer based on a comment that says it should be removed.