### PR TITLE
util/types: fix isBigIntObject/isSymbolObject/isBoxedPrimitive for modified objects

### DIFF
--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -154,30 +154,6 @@ const isAsyncFunction = v =>
 const isGeneratorFunction = v =>
   typeof v === "function" && StringPrototypeMatch(FunctionPrototypeToString(v), /^(async\s+)?function *\*/);
 
-function vmSafeInstanceof(val, ctor) {
-  if (val instanceof ctor) return true;
-  // instanceof doesn't work across vm boundaries, so check the whole inheritance chain
-  while (val) {
-    if (typeof val !== "object") return false;
-    if (ctor.name === internalGetConstructorName(val)) return true;
-    val = ObjectGetPrototypeOf(val);
-  }
-  return false;
-}
-function checkBox(ctor) {
-  return val => {
-    if (!vmSafeInstanceof(val, ctor)) return false;
-    try {
-      ctor.prototype.valueOf.$call(val);
-    } catch {
-      return false;
-    }
-    return true;
-  };
-}
-const isBigIntObject = checkBox(BigInt);
-const isSymbolObject = checkBox(Symbol);
-
 const {
   //! The native versions of the commented out functions are currently buggy, so we use the polyfills above for now.
   //isAsyncFunction,
@@ -185,28 +161,26 @@ const {
   isAnyArrayBuffer,
   isArrayBuffer,
   isArgumentsObject,
-  isBoxedPrimitive: _native_isBoxedPrimitive,
+  isBigIntObject,
+  isBooleanObject,
+  isBoxedPrimitive,
   isDataView,
   isExternal,
   isMap,
   isMapIterator,
   isModuleNamespaceObject,
   isNativeError,
+  isNumberObject,
   isPromise,
   isSet,
   isSetIterator,
+  isStringObject,
   isWeakMap,
   isWeakSet,
   isRegExp,
   isDate,
   isTypedArray,
-  isStringObject,
-  isNumberObject,
-  isBooleanObject,
 } = require("node:util/types");
-
-//! temp workaround to apply is{BigInt,Symbol}Object fix
-const isBoxedPrimitive = val => isBigIntObject(val) || isSymbolObject(val) || _native_isBoxedPrimitive(val);
 
 // We need this duplicate here to avoid a circular dependency between node:assert and node:util.
 class AssertionError extends Error {

--- a/src/jsc/modules/NodeUtilTypesModule.cpp
+++ b/src/jsc/modules/NodeUtilTypesModule.cpp
@@ -9,12 +9,14 @@
 #include "webcrypto/JSJsonWebKey.h"
 #include <JavaScriptCore/AggregateError.h>
 #include <JavaScriptCore/AsyncFunctionPrototype.h>
+#include <JavaScriptCore/BigIntObject.h>
 #include <JavaScriptCore/CallFrame.h>
 #include <JavaScriptCore/CallFrameInlines.h>
 #include <JavaScriptCore/ErrorPrototype.h>
 #include <JavaScriptCore/GeneratorFunctionPrototype.h>
 #include <JavaScriptCore/JSArrayBuffer.h>
 #include <JavaScriptCore/ObjectConstructor.h>
+#include <JavaScriptCore/SymbolObject.h>
 #include "ZigGeneratedClasses.h"
 #include "JSKeyObject.h"
 
@@ -72,8 +74,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionIsBigIntObject,
         JSC::CallFrame* callframe))
 {
     GET_FIRST_CELL
-    return JSValue::encode(
-        jsBoolean(globalObject->bigIntObjectStructure() == cell->structure()));
+    return JSValue::encode(jsBoolean(cell->inherits<JSC::BigIntObject>()));
 }
 JSC_DEFINE_HOST_FUNCTION(jsFunctionIsBooleanObject,
     (JSC::JSGlobalObject * globalObject,
@@ -104,9 +105,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionIsSymbolObject,
         JSC::CallFrame* callframe))
 {
     GET_FIRST_CELL
-
-    return JSValue::encode(
-        jsBoolean(globalObject->symbolObjectStructure() == cell->structure()));
+    return JSValue::encode(jsBoolean(cell->inherits<JSC::SymbolObject>()));
 }
 JSC_DEFINE_HOST_FUNCTION(jsFunctionIsError,
     (JSC::JSGlobalObject * globalObject,
@@ -329,16 +328,9 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionIsBoxedPrimitive,
     case JSC::DerivedStringObjectType:
         return JSValue::encode(jsBoolean(true));
 
-    default: {
-        if (cell->structure() == globalObject->symbolObjectStructure())
-            return JSValue::encode(jsBoolean(true));
-
-        if (cell->structure() == globalObject->bigIntObjectStructure())
-            return JSValue::encode(jsBoolean(true));
+    default:
+        return JSValue::encode(jsBoolean(cell->inherits<JSC::SymbolObject>() || cell->inherits<JSC::BigIntObject>()));
     }
-    }
-
-    return JSValue::encode(jsBoolean(false));
 }
 JSC_DEFINE_HOST_FUNCTION(jsFunctionIsArrayBufferView,
     (JSC::JSGlobalObject * globalObject,

--- a/test/js/node/util/node-inspect-tests/internal-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/internal-inspect.test.js
@@ -25,6 +25,14 @@ test("no assertion failures", () => {
   assert.match(util.inspect(e2), /\[cause\]: Error: cause\n/);
 });
 
+test("boxed BigInt/Symbol with no prototype are still formatted as boxed primitives", () => {
+  assert.strictEqual(util.inspect(Object.setPrototypeOf(Object(55n), null)), "[BigInt (null prototype): 55n]");
+  assert.strictEqual(
+    util.inspect(Object.setPrototypeOf(Object(Symbol("x")), null)),
+    "[Symbol (null prototype): Symbol(x)]",
+  );
+});
+
 //! non-standard property, should this be kept?
 test.skip("util.stylizeWithHTML", () => {
   assert.strictEqual(

--- a/test/js/node/util/test-util-types.test.js
+++ b/test/js/node/util/test-util-types.test.js
@@ -80,6 +80,51 @@ test("isBoxedPrimitive", () => {
   );
 });
 
+test("isBigIntObject/isSymbolObject/isBoxedPrimitive survive structure and prototype changes", () => {
+  const cases = [
+    ["isBigIntObject", () => Object(1n)],
+    ["isSymbolObject", () => Object(Symbol())],
+  ];
+  for (const [method, make] of cases) {
+    const withProp = make();
+    withProp.foo = "bar";
+    const nullProto = Object.setPrototypeOf(make(), null);
+    const arrayProto = Object.setPrototypeOf(make(), Array.prototype);
+
+    expect({
+      [method]: {
+        plain: types[method](make()),
+        withProp: types[method](withProp),
+        nullProto: types[method](nullProto),
+        arrayProto: types[method](arrayProto),
+        primitive: types[method](make().valueOf()),
+        plainObject: types[method]({}),
+      },
+      isBoxedPrimitive: {
+        plain: types.isBoxedPrimitive(make()),
+        withProp: types.isBoxedPrimitive(withProp),
+        nullProto: types.isBoxedPrimitive(nullProto),
+        arrayProto: types.isBoxedPrimitive(arrayProto),
+      },
+    }).toEqual({
+      [method]: {
+        plain: true,
+        withProp: true,
+        nullProto: true,
+        arrayProto: true,
+        primitive: false,
+        plainObject: false,
+      },
+      isBoxedPrimitive: {
+        plain: true,
+        withProp: true,
+        nullProto: true,
+        arrayProto: true,
+      },
+    });
+  }
+});
+
 {
   const primitive = true;
   const arrayBuffer = new ArrayBuffer();


### PR DESCRIPTION
## What does this PR do?

`util.types.isBigIntObject`, `util.types.isSymbolObject`, and `util.types.isBoxedPrimitive` currently return `false` for boxed BigInt/Symbol objects once a property has been added or the prototype has been changed:

```js
const types = require("node:util/types");
const b = Object(1n);
b.foo = "bar";
types.isBigIntObject(b);       // bun: false, node: true
types.isBoxedPrimitive(b);     // bun: false, node: true

Object.setPrototypeOf(b, null);
types.isBigIntObject(b);       // bun: false, node: true
```

Downstream this also broke `util.inspect` for null-prototype boxed primitives:

```js
util.inspect(Object.setPrototypeOf(Object(55n), null));
// bun:  "[Object: null prototype] {}"
// node: "[BigInt (null prototype): 55n]"
```

### Cause

`jsFunctionIsBigIntObject` / `jsFunctionIsSymbolObject` / `jsFunctionIsBoxedPrimitive` in `NodeUtilTypesModule.cpp` compared `cell->structure()` against `globalObject->bigIntObjectStructure()` / `symbolObjectStructure()`. That only matches the initial structure; adding a property or changing the prototype transitions to a new structure and the comparison fails. Node checks the internal slot, which survives both.

### Fix

Use `cell->inherits<JSC::BigIntObject>()` / `cell->inherits<JSC::SymbolObject>()`, which checks the ClassInfo chain and matches regardless of structure transitions. This is the same pattern already used in `src/jsc/bindings/bindings.cpp` for `BigIntObject`.

With the native check fixed, the `//! temp workaround` shim in `src/js/internal/util/inspect.js` (and its `vmSafeInstanceof` / `checkBox` helpers) are no longer needed. They are removed in favor of importing `isBigIntObject`, `isSymbolObject` (implicitly, no longer needed), and `isBoxedPrimitive` directly from `node:util/types`.

### Verification

New test in `test/js/node/util/test-util-types.test.js` covers `isBigIntObject`, `isSymbolObject`, and `isBoxedPrimitive` against:
- plain `Object(1n)` / `Object(Symbol())`
- same with a property added
- same with prototype set to `null`
- same with prototype set to `Array.prototype`
- negative cases (the unwrapped primitive, a plain `{}`)

Fails before: `USE_SYSTEM_BUN=1 bun test test/js/node/util/test-util-types.test.js -t "survive structure"`
Passes after: `bun bd test test/js/node/util/test-util-types.test.js`

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/node-inspect-tests/internal-inspect.test.js test/js/node/util/test-util-types.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b75c40034)

test/js/node/util/test-util-types.test.js:
(pass) isDate [67.52ms]
(pass) isArgumentsObject [32.10ms]
(pass) isBooleanObject [32.02ms]
(pass) isNumberObject [30.85ms]
(pass) isStringObject [26.88ms]
(pass) isSymbolObject [28.37ms]
(pass) isBigIntObject [27.66ms]
(pass) isNativeError [29.00ms]
(pass) isRegExp [27.98ms]
(pass) isGeneratorObject [27.34ms]
(pass) isGeneratorObject [26.89ms]
(pass) isPromise [27.20ms]
(pass) isMap [27.11ms]
(pass) isSet [26.88ms]
(pass) isMapIterator [26.01ms]
(pass) isSetIterator [27.16ms]
(pass) isWeakMap [27.11ms]
(pass) isWeakSet [26.38ms]
(pass) isArrayBuffer [20.17ms]
(pass) isUint8Array [19.80ms]
(pass) isUint8Clampe
... (truncated)

release without fix: 2 failed, 1 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/util/test-util-types.test.js:
(pass) isDate [1.33ms]
(pass) isArgumentsObject [0.10ms]
(pass) isBooleanObject [0.13ms]
(pass) isNumberObject [0.10ms]
(pass) isStringObject [0.12ms]
(pass) isSymbolObject [0.11ms]
(pass) isBigIntObject [0.09ms]
(pass) isNativeError [0.23ms]
(pass) isRegExp [0.07ms]
(pass) isGeneratorObject [0.07ms]
(pass) isGeneratorObject [0.06ms]
(pass) isPromise [0.06ms]
(pass) isMap [0.05ms]
(pass) isSet [0.05ms]
(pass) isMapIterator [0.09ms]
(pass) isSetIterator [0.05ms]
(pass) isWeakMap [0.20ms]
(pass) isWeakSet [0.15ms]
(pass) isArrayBuffer [0.06ms]
(pass) isUint8Array [0.05ms]
(pass) isUint8ClampedArray [0.05ms]
(pass) isUint16Array [0.05ms]
(pass) isUint32Array [0.06ms]
(pass) isInt8Array [0.04ms]
(pass) isInt16Array [0.06ms]
(pass) isInt32Array [0.04ms]
(pass) isFloat32Array [0.04ms]
(pass) isFloat64Array [0.05ms]
(pass) isBigInt64Array [0.05ms]
(pass) isBigUint64Array [0.04ms]
(pass) isDataView [0.04ms]
(pass) isSharedArrayBuffer [0.06ms]
(pass) isProxy [0.06ms]
(pass) isEventTarget [0.06ms]
(pass) isBoxedPrimitive [0.09ms]
104 |         plain: types.isBoxedPrimitive(make()),
105 |         
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/node-inspect-tests/internal-inspect.test.js test/js/node/util/test-util-types.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b75c40034)

test/js/node/util/test-util-types.test.js:
(pass) isDate [69.13ms]
(pass) isArgumentsObject [32.07ms]
(pass) isBooleanObject [31.90ms]
(pass) isNumberObject [30.76ms]
(pass) isStringObject [27.60ms]
(pass) isSymbolObject [27.67ms]
(pass) isBigIntObject [27.44ms]
(pass) isNativeError [28.65ms]
(pass) isRegExp [27.39ms]
(pass) isGeneratorObject [26.94ms]
(pass) isGeneratorObject [26.88ms]
(pass) isPromise [27.84ms]
(pass) isMap [26.50ms]
(pass) isSet [26.99ms]
(pass) isMapIterator [26.59ms]
(pass) isSetIterator [26.65ms]
(pass) isWeakMap [26.71ms]
(pass) isWeakSet [26.37ms]
(pass) isArrayBuffer [20.30ms]
(pass) isUint8Array [20.21ms]
(pass) isUint8Clampe
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     b75c40034a
  features     (none)

22 deps, 106 codegen, 1169 objects in 912ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1232] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [21.00ms]
[2/1232] gen bindgenv2
[3/1232] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1232] gen ErrorCode+*.h
[5/1232] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [10.00ms]
[6/1232] gen .bind.ts → GeneratedBindings.cpp
[7/1232] fetch tinycc
[tinycc] up to date
[8/1232] fetch libjpeg-t
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/util/inspect.js                    | 36 +++--------------
 src/jsc/modules/NodeUtilTypesModule.cpp            | 20 +++-------
 .../node-inspect-tests/internal-inspect.test.js    |  8 ++++
 test/js/node/util/test-util-types.test.js          | 45 ++++++++++++++++++++++
 4 files changed, 64 insertions(+), 45 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/internal/util/inspect.js                               3      1      0
src/jsc/modules/NodeUtilTypesModule.cpp                       1      5      0
…s/node/util/node-inspect-tests/internal-inspect.test.js      1      1      0
test/js/node/util/test-util-types.test.js                     2      1      0
```

</details>

<!-- robobun:evidence:end -->