### PR TITLE
ci(verify-baseline): parse //@ JSC flags, skip v128 wasm fixtures on x64, re-enable --jit-stress on WebKit changes

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -759,7 +759,11 @@ function getVerifyBaselineStep(platform, options) {
   const targetKey = getTargetKey(platform);
   const triplet = getTargetTriplet(platform);
   const emulator = getEmulatorBinary(platform);
-  const jitStressFlag = hasWebKitChanges(options) ? " --jit-stress" : "";
+  // Windows SDE (Pin) pays ~45s startup per fixture; 80+ serial fixtures would
+  // take ~1h. qemu-Nehalem on Linux already verifies the same x64-no-AVX JIT
+  // output at ~1s/fixture, so Windows keeps only the static scan + SIMD test.
+  const wantJitStress = hasWebKitChanges(options) && os !== "windows";
+  const jitStressFlag = wantJitStress ? " --jit-stress" : "";
   // Android binaries need /system/bin/linker64 + a bionic sysroot, neither of which exist on the
   // build host, so qemu-user cannot load them; only the static instruction scan is meaningful.
   const skipEmulationFlag = abi === "android" ? " --skip-emulation" : "";
@@ -814,7 +818,7 @@ function getVerifyBaselineStep(platform, options) {
     agents,
     retry: getRetry(),
     cancel_on_build_failing: isMergeQueue(),
-    timeout_in_minutes: hasWebKitChanges(options) ? 30 : 10,
+    timeout_in_minutes: wantJitStress ? 30 : 10,
     command: [
       ...setupCommands,
       `cargo build --release --manifest-path scripts/verify-baseline-static/Cargo.toml${os === "windows" ? " || exit /b 1" : ""}`,

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -747,7 +747,7 @@ function getEmulatorBinary(platform) {
 function hasWebKitChanges(options) {
   const { changedFiles = [] } = options;
   // vendor/WebKit is gitignored; WebKit version bumps land here.
-  return changedFiles.some(file => file.includes("scripts/build/deps/webkit.ts"));
+  return changedFiles.some(file => file === "scripts/build/deps/webkit.ts");
 }
 
 /**
@@ -760,14 +760,15 @@ function getVerifyBaselineStep(platform, options) {
   const targetKey = getTargetKey(platform);
   const triplet = getTargetTriplet(platform);
   const emulator = getEmulatorBinary(platform);
+  // Android binaries need /system/bin/linker64 + a bionic sysroot, neither of which exist on the
+  // build host, so qemu-user cannot load them; only the static instruction scan is meaningful.
+  const skipEmulation = abi === "android";
+  const skipEmulationFlag = skipEmulation ? " --skip-emulation" : "";
   // Windows SDE (Pin) pays ~45s startup per fixture; 80+ serial fixtures would
   // take ~1h. qemu-Nehalem on Linux already verifies the same x64-no-AVX JIT
   // output at ~1s/fixture, so Windows keeps only the static scan + SIMD test.
-  const wantJitStress = hasWebKitChanges(options) && os !== "windows";
+  const wantJitStress = hasWebKitChanges(options) && os !== "windows" && !skipEmulation;
   const jitStressFlag = wantJitStress ? " --jit-stress" : "";
-  // Android binaries need /system/bin/linker64 + a bionic sysroot, neither of which exist on the
-  // build host, so qemu-user cannot load them; only the static instruction scan is meaningful.
-  const skipEmulationFlag = abi === "android" ? " --skip-emulation" : "";
 
   // Scan bun-profile, not bun. The stripped binary has no .symtab (ELF) and
   // no companion .pdb (PE) — the static scanner would emit <no-symbol@addr>

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -746,7 +746,7 @@ function getEmulatorBinary(platform) {
  */
 function hasWebKitChanges(options) {
   const { changedFiles = [] } = options;
-  return changedFiles.some(file => file.includes("SetupWebKit.cmake"));
+  return changedFiles.some(file => file.includes("scripts/build/deps/webkit.ts") || file.startsWith("vendor/WebKit/"));
 }
 
 /**

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -746,7 +746,8 @@ function getEmulatorBinary(platform) {
  */
 function hasWebKitChanges(options) {
   const { changedFiles = [] } = options;
-  return changedFiles.some(file => file.includes("scripts/build/deps/webkit.ts") || file.startsWith("vendor/WebKit/"));
+  // vendor/WebKit is gitignored; WebKit version bumps land here.
+  return changedFiles.some(file => file.includes("scripts/build/deps/webkit.ts"));
 }
 
 /**

--- a/scripts/verify-baseline.ts
+++ b/scripts/verify-baseline.ts
@@ -98,13 +98,15 @@ const failedTests: string[] = [];
 
 // Mirrors the relevant bits of test/harness.ts's bunEnv so fixtures behave the
 // same here as under jsc-stress.test.ts.
-const fixtureBaseEnv = {
+const fixtureBaseEnv: Record<string, string | undefined> = {
   ...process.env,
   BUN_DEBUG_QUIET_LOGS: "1",
   NO_COLOR: "1",
   BUN_GARBAGE_COLLECTOR_LEVEL: process.env.BUN_GARBAGE_COLLECTOR_LEVEL || "0",
   BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1",
 };
+// harness.ts strips this ad-hoc agent override so it can't leak into fixtures.
+delete fixtureBaseEnv.JSC_useJIT;
 
 interface RunTestOptions {
   cwd?: string;

--- a/scripts/verify-baseline.ts
+++ b/scripts/verify-baseline.ts
@@ -11,6 +11,7 @@
 
 import { readdirSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
+import { parseJSCFlags, wasmSIMDFixtures } from "../test/js/bun/jsc-stress/jsc-flags";
 // @ts-ignore — utils.mjs has JSDoc types but no .d.ts
 import { markBuildkiteStepReported } from "./utils.mjs";
 
@@ -92,12 +93,25 @@ console.log();
 let instructionFailures = 0;
 let otherFailures = 0;
 let passed = 0;
+let skipped = 0;
 const failedTests: string[] = [];
+
+// Mirrors the relevant bits of test/harness.ts's bunEnv so fixtures behave the
+// same here as under jsc-stress.test.ts.
+const fixtureBaseEnv = {
+  ...process.env,
+  BUN_DEBUG_QUIET_LOGS: "1",
+  NO_COLOR: "1",
+  BUN_GARBAGE_COLLECTOR_LEVEL: process.env.BUN_GARBAGE_COLLECTOR_LEVEL || "0",
+  BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1",
+};
 
 interface RunTestOptions {
   cwd?: string;
   /** Tee output live to the console while still capturing it for analysis */
   live?: boolean;
+  /** Extra environment (e.g. parsed `//@` JSC flags) for the spawned binary */
+  env?: Record<string, string>;
 }
 
 /** Read a stream, write each chunk to a writable, and return the full text. */
@@ -118,6 +132,7 @@ async function runTest(label: string, binaryArgs: string[], options?: RunTestOpt
   const proc = Bun.spawn([...config.runnerCmd, binary, ...binaryArgs], {
     // config.cwd takes priority — SDE on Windows must run from its own directory for Pin DLL resolution
     cwd: config.cwd ?? options?.cwd,
+    env: { ...fixtureBaseEnv, ...(options?.env ?? {}) },
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -241,7 +256,10 @@ if (values["skip-emulation"]) {
   console.log(`--- JS fixtures (DFG/FTL) — ${jsFixtures.length} tests`);
   for (let i = 0; i < jsFixtures.length; i++) {
     const fixture = jsFixtures[i];
-    await runTest(`[${i + 1}/${jsFixtures.length}] ${fixture}`, ["--preload", preloadPath, join(fixturesDir, fixture)]);
+    const fixturePath = join(fixturesDir, fixture);
+    await runTest(`[${i + 1}/${jsFixtures.length}] ${fixture}`, ["--preload", preloadPath, fixturePath], {
+      env: parseJSCFlags(fixturePath),
+    });
   }
 
   const wasmFixtures = readdirSync(wasmFixturesDir)
@@ -251,11 +269,20 @@ if (values["skip-emulation"]) {
   console.log(`--- Wasm fixtures (BBQ/OMG) — ${wasmFixtures.length} tests`);
   for (let i = 0; i < wasmFixtures.length; i++) {
     const fixture = wasmFixtures[i];
-    await runTest(
-      `[${i + 1}/${wasmFixtures.length}] ${fixture}`,
-      ["--preload", preloadPath, join(wasmFixturesDir, fixture)],
-      { cwd: wasmFixturesDir },
-    );
+    const fixturePath = join(wasmFixturesDir, fixture);
+    // Nehalem has no AVX; JSC's recomputeDependentOptions() force-disables
+    // useWasmSIMD there, so v128-typed modules fail to parse. A real baseline
+    // CPU never runs the wasm-SIMD JIT path, so there is nothing to verify.
+    if (!isAarch64 && wasmSIMDFixtures.has(fixture)) {
+      console.log(`--- [${i + 1}/${wasmFixtures.length}] ${fixture}`);
+      console.log("    SKIP (uses wasm v128; JSC disables wasm SIMD on x64 without AVX)");
+      skipped++;
+      continue;
+    }
+    await runTest(`[${i + 1}/${wasmFixtures.length}] ${fixture}`, ["--preload", preloadPath, fixturePath], {
+      cwd: wasmFixturesDir,
+      env: parseJSCFlags(fixturePath),
+    });
   }
 } else {
   console.log();
@@ -266,6 +293,7 @@ if (values["skip-emulation"]) {
 console.log();
 console.log("--- Summary");
 console.log(`    Passed: ${passed}`);
+if (skipped) console.log(`    Skipped: ${skipped}`);
 console.log(`    Instruction failures: ${instructionFailures}`);
 console.log(`    Other failures: ${otherFailures} (not CPU instruction issues)`);
 console.log();

--- a/test/js/bun/jsc-stress/jsc-flags.test.ts
+++ b/test/js/bun/jsc-stress/jsc-flags.test.ts
@@ -1,8 +1,5 @@
-// Covers the shared helper that both jsc-stress.test.ts and
-// scripts/verify-baseline.ts use to spawn JSC stress fixtures. Keeps
-// verify-baseline's Nehalem skip list in sync with the fixtures: if a new
-// wasm fixture starts using v128 and isn't listed, or a listed one stops,
-// this test fails.
+// Covers the helper shared by jsc-stress.test.ts and scripts/verify-baseline.ts
+// and keeps verify-baseline's Nehalem skip list in sync with the wasm fixtures.
 
 import { describe, expect, test } from "bun:test";
 import { readdirSync } from "fs";
@@ -43,11 +40,9 @@ describe("parseJSCFlags", () => {
   });
 });
 
-// verify-baseline.ts emulates a Nehalem CPU (no AVX) on x64. JSC's
-// recomputeDependentOptions() sets `useWasmSIMD = false` there, which makes
-// v128 an invalid type and any module declaring one fail to parse. Assert
-// wasmSIMDFixtures lists exactly those fixtures, so the verify-baseline
-// skip list stays correct as fixtures are added or changed.
+// Nehalem has no AVX so JSC disables useWasmSIMD there, making v128 an invalid
+// wasm type. Assert wasmSIMDFixtures lists exactly the fixtures that fail to
+// parse without SIMD so verify-baseline's skip list stays correct.
 describe.concurrent("wasmSIMDFixtures matches fixtures that require wasm SIMD", () => {
   const allWasmFixtures = readdirSync(wasmFixturesDir)
     .filter(f => f.endsWith(".js"))

--- a/test/js/bun/jsc-stress/jsc-flags.test.ts
+++ b/test/js/bun/jsc-stress/jsc-flags.test.ts
@@ -55,7 +55,7 @@ describe.concurrent("wasmSIMDFixtures matches fixtures that require wasm SIMD", 
 
   test("every listed fixture exists on disk", () => {
     const onDisk = new Set(allWasmFixtures);
-    for (const f of wasmSIMDFixtures) expect(onDisk.has(f)).toBe(true);
+    expect([...wasmSIMDFixtures].filter(f => !onDisk.has(f))).toEqual([]);
   });
 
   for (const fixture of allWasmFixtures) {

--- a/test/js/bun/jsc-stress/jsc-flags.test.ts
+++ b/test/js/bun/jsc-stress/jsc-flags.test.ts
@@ -1,0 +1,94 @@
+// Covers the shared helper that both jsc-stress.test.ts and
+// scripts/verify-baseline.ts use to spawn JSC stress fixtures. Keeps
+// verify-baseline's Nehalem skip list in sync with the fixtures: if a new
+// wasm fixture starts using v128 and isn't listed, or a listed one stops,
+// this test fails.
+
+import { describe, expect, test } from "bun:test";
+import { readdirSync } from "fs";
+import { bunEnv, bunExe, isDebug } from "harness";
+import path from "path";
+import { parseJSCFlags, wasmSIMDFixtures } from "./jsc-flags";
+
+const fixturesDir = path.join(import.meta.dir, "fixtures");
+const wasmFixturesDir = path.join(fixturesDir, "wasm");
+const preloadPath = path.join(import.meta.dir, "preload.js");
+// Same headroom jsc-stress.test.ts gives debug builds for JIT tier-up loops.
+const fixtureTimeout = isDebug ? 180_000 : undefined;
+
+describe("parseJSCFlags", () => {
+  test("runDefaultWasm", () => {
+    expect(parseJSCFlags(path.join(wasmFixturesDir, "bbq-osr-with-exceptions.js"))).toEqual({
+      BUN_JSC_useDollarVM: "1",
+      BUN_JSC_jitPolicyScale: "0.1",
+    });
+  });
+
+  test("runDefault", () => {
+    expect(parseJSCFlags(path.join(wasmFixturesDir, "omg-tail-call-clobber-scratch-register.js"))).toEqual({
+      BUN_JSC_jitPolicyScale: "0",
+    });
+  });
+
+  test("runFTLNoCJIT implies useFTLJIT / !useConcurrentJIT", () => {
+    expect(parseJSCFlags(path.join(fixturesDir, "licm-no-pre-header.js"))).toEqual({
+      BUN_JSC_useFTLJIT: "true",
+      BUN_JSC_useConcurrentJIT: "false",
+      BUN_JSC_createPreHeaders: "false",
+    });
+  });
+
+  test("no directive", () => {
+    expect(parseJSCFlags(path.join(wasmFixturesDir, "ipint-bbq-osr-with-try2.js"))).toEqual({});
+  });
+});
+
+// verify-baseline.ts emulates a Nehalem CPU (no AVX) on x64. JSC's
+// recomputeDependentOptions() sets `useWasmSIMD = false` there, which makes
+// v128 an invalid type and any module declaring one fail to parse. Assert
+// wasmSIMDFixtures lists exactly those fixtures, so the verify-baseline
+// skip list stays correct as fixtures are added or changed.
+describe.concurrent("wasmSIMDFixtures matches fixtures that require wasm SIMD", () => {
+  const allWasmFixtures = readdirSync(wasmFixturesDir)
+    .filter(f => f.endsWith(".js"))
+    .sort();
+
+  test("every listed fixture exists on disk", () => {
+    const onDisk = new Set(allWasmFixtures);
+    for (const f of wasmSIMDFixtures) expect(onDisk.has(f)).toBe(true);
+  });
+
+  for (const fixture of allWasmFixtures) {
+    test(
+      fixture,
+      async () => {
+        const fixturePath = path.join(wasmFixturesDir, fixture);
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "--preload", preloadPath, fixturePath],
+          // Simulate the Nehalem path: no AVX => JSC disables wasm SIMD.
+          env: { ...bunEnv, ...parseJSCFlags(fixturePath), BUN_JSC_useWasmSIMD: "false" },
+          cwd: wasmFixturesDir,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+        if (wasmSIMDFixtures.has(fixture)) {
+          // Must fail to parse with the characteristic error; if it passes, it
+          // no longer needs SIMD and should be removed from wasmSIMDFixtures.
+          expect(stderr).toContain("WebAssembly.Module doesn't parse");
+          expect(exitCode).not.toBe(0);
+        } else {
+          // Must pass without SIMD; if it fails with a parse error, add it to
+          // wasmSIMDFixtures so verify-baseline skips it under Nehalem.
+          if (exitCode !== 0) {
+            console.log("stdout:", stdout);
+            console.log("stderr:", stderr);
+          }
+          expect(exitCode).toBe(0);
+        }
+      },
+      fixtureTimeout,
+    );
+  }
+});

--- a/test/js/bun/jsc-stress/jsc-flags.ts
+++ b/test/js/bun/jsc-stress/jsc-flags.ts
@@ -42,12 +42,7 @@ export function parseJSCFlags(filePath: string): Record<string, string> {
   return env;
 }
 
-/**
- * Wasm fixtures whose modules declare v128 (0x7B) types. JSC force-disables
- * `useWasmSIMD` on x86_64 without AVX (Options.cpp: `isX86_64() && !isX86_64_AVX()`),
- * so under Nehalem emulation these fail to parse with
- * `CompileError: WebAssembly.Module doesn't parse ... can't get ... Type`.
- * verify-baseline.ts skips them on x64 since a real Nehalem CPU could never
- * run the wasm-SIMD JIT path anyway.
- */
+// Wasm fixtures whose modules declare v128 (0x7B). JSC's Options.cpp disables
+// useWasmSIMD on x86_64 without AVX, so these fail to parse under Nehalem
+// emulation; verify-baseline.ts skips them on x64.
 export const wasmSIMDFixtures = new Set(["bbq-osr-with-exceptions.js", "omg-tail-call-clobber-scratch-register.js"]);

--- a/test/js/bun/jsc-stress/jsc-flags.ts
+++ b/test/js/bun/jsc-stress/jsc-flags.ts
@@ -1,0 +1,53 @@
+// Shared between jsc-stress.test.ts and scripts/verify-baseline.ts so both
+// spawn fixtures with the same JSC options.
+
+import fs from "fs";
+
+/**
+ * Parse JSC option flags from //@ directives at the top of a test file.
+ * Converts --flag=value to BUN_JSC_flag=value environment variables.
+ *
+ * Supported directives:
+ *   //@ runDefault("--flag=value", ...)
+ *   //@ runFTLNoCJIT("--flag=value", ...)
+ *   //@ runDefaultWasm("--flag=value", ...)
+ */
+export function parseJSCFlags(filePath: string): Record<string, string> {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const env: Record<string, string> = {};
+
+  for (const line of content.split("\n")) {
+    if (line === "// @bun" || line.trim() === "") continue;
+    if (!line.startsWith("//@")) break;
+
+    const match = line.match(/^\/\/@ (runDefault|runFTLNoCJIT|runDefaultWasm)\((.*)\)/);
+    if (!match) continue;
+
+    const [, mode, argsStr] = match;
+
+    // runFTLNoCJIT implies these flags (from WebKit's run-jsc-stress-tests)
+    if (mode === "runFTLNoCJIT") {
+      env["BUN_JSC_useFTLJIT"] = "true";
+      env["BUN_JSC_useConcurrentJIT"] = "false";
+    }
+
+    // Parse explicit flags: "--key=value"
+    const flagPattern = /"--(\w+)=([^"]+)"/g;
+    let flagMatch;
+    while ((flagMatch = flagPattern.exec(argsStr)) !== null) {
+      env[`BUN_JSC_${flagMatch[1]}`] = flagMatch[2];
+    }
+  }
+
+  return env;
+}
+
+/**
+ * Wasm fixtures whose modules declare v128 (0x7B) types. JSC force-disables
+ * `useWasmSIMD` on x86_64 without AVX (Options.cpp: `isX86_64() && !isX86_64_AVX()`),
+ * so under Nehalem emulation these fail to parse with
+ * `CompileError: WebAssembly.Module doesn't parse ... can't get ... Type`.
+ * verify-baseline.ts skips them on x64 since a real Nehalem CPU could never
+ * run the wasm-SIMD JIT path anyway.
+ */
+export const wasmSIMDFixtures = new Set(["bbq-osr-with-exceptions.js", "omg-tail-call-clobber-scratch-register.js"]);

--- a/test/js/bun/jsc-stress/jsc-stress.test.ts
+++ b/test/js/bun/jsc-stress/jsc-stress.test.ts
@@ -1,49 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import fs from "fs";
 import { bunEnv, bunExe, isDebug } from "harness";
 import path from "path";
+import { parseJSCFlags } from "./jsc-flags";
 
 const fixturesDir = path.join(import.meta.dir, "fixtures");
 const wasmFixturesDir = path.join(fixturesDir, "wasm");
-
-/**
- * Parse JSC option flags from //@ directives at the top of a test file.
- * Converts --flag=value to BUN_JSC_flag=value environment variables.
- *
- * Supported directives:
- *   //@ runDefault("--flag=value", ...)
- *   //@ runFTLNoCJIT("--flag=value", ...)
- *   //@ runDefaultWasm("--flag=value", ...)
- */
-function parseJSCFlags(filePath: string): Record<string, string> {
-  const content = fs.readFileSync(filePath, "utf-8");
-  const env: Record<string, string> = {};
-
-  for (const line of content.split("\n")) {
-    if (line === "// @bun" || line.trim() === "") continue;
-    if (!line.startsWith("//@")) break;
-
-    const match = line.match(/^\/\/@ (runDefault|runFTLNoCJIT|runDefaultWasm)\((.*)\)/);
-    if (!match) continue;
-
-    const [, mode, argsStr] = match;
-
-    // runFTLNoCJIT implies these flags (from WebKit's run-jsc-stress-tests)
-    if (mode === "runFTLNoCJIT") {
-      env["BUN_JSC_useFTLJIT"] = "true";
-      env["BUN_JSC_useConcurrentJIT"] = "false";
-    }
-
-    // Parse explicit flags: "--key=value"
-    const flagPattern = /"--(\w+)=([^"]+)"/g;
-    let flagMatch;
-    while ((flagMatch = flagPattern.exec(argsStr)) !== null) {
-      env[`BUN_JSC_${flagMatch[1]}`] = flagMatch[2];
-    }
-  }
-
-  return env;
-}
 
 const jsFixtures = [
   // FTL - Math intrinsics


### PR DESCRIPTION
## What

`hasWebKitChanges()` in `.buildkite/ci.mjs` was still checking for `cmake/targets/SetupWebKit.cmake`, a file removed when the build moved off cmake (#27973), so `verify-baseline --jit-stress` has not run since. Re-pointing it at `scripts/build/deps/webkit.ts` surfaces two problems in the `--jit-stress` phase (seen on build 76600 while #34782 briefly re-enabled it):

```
CompileError: WebAssembly.Module doesn't parse at byte 19: can't get 1th argument Type
CompileError: WebAssembly.Module doesn't parse at byte 3: can't get Function local's type in group 0
```

### Root cause

`bbq-osr-with-exceptions.js` and `omg-tail-call-clobber-scratch-register.js` encode `v128` (`0x7B`) types in their wasm modules. Under Nehalem emulation (no AVX), JSC's `recomputeDependentOptions()` does:

```cpp
if (isX86_64() && !isX86_64_AVX())
    Options::useWasmSIMD() = false;
```

which makes `v128` an invalid wasm type and the module fails to parse. aarch64 is unaffected (NEON is always available), which is why only the Linux x64 lanes failed.

Separately, `verify-baseline.ts` spawned fixtures with the bare process env, so each fixture's `//@ runDefault(...)` / `runFTLNoCJIT(...)` / `runDefaultWasm(...)` directive (`jitPolicyScale`, `useJSPI`, `useDollarVM`, `createPreHeaders`, ...) was ignored and the bunEnv test-harness knobs (`BUN_DEBUG_QUIET_LOGS`, `BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING`) were not set, unlike `jsc-stress.test.ts`.

### Fix

* Extract `parseJSCFlags` to `test/js/bun/jsc-stress/jsc-flags.ts` and import it from both `jsc-stress.test.ts` and `scripts/verify-baseline.ts`. `runTest()` now spawns with a bunEnv-equivalent base env plus the parsed `//@` flags.
* Skip the two v128-using wasm fixtures on x64. A real baseline CPU can never reach the wasm-SIMD JIT path, so there is nothing to verify there. aarch64 keeps running them.
* Point `hasWebKitChanges()` at `scripts/build/deps/webkit.ts` so `--jit-stress` actually runs on WebKit bumps again.
* Skip `--jit-stress` on the Windows SDE lane: Pin instrumentation costs ~45s per process (measured on build 76600), so 80+ serial fixtures would take roughly an hour against the 30-minute step timeout. qemu-Nehalem on Linux verifies the same x64-no-AVX JIT output at ~1s/fixture.

### Tests

`test/js/bun/jsc-stress/jsc-flags.test.ts` unit-tests `parseJSCFlags` and, more importantly, runs every wasm fixture under `BUN_JSC_useWasmSIMD=false` to assert `wasmSIMDFixtures` lists exactly the ones that fail to parse without SIMD. If a new fixture starts (or an existing one stops) requiring v128, this test fails before the verify-baseline lane does.

This is a CI-tooling change (no `src/` edits); the fail-before-fix gate that stashes `src/` is not meaningful here.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 5 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc-stress/jsc-flags.test.ts' 'test/js/bun/jsc-stress/jsc-stress.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/jsc-stress/jsc-flags.test.ts test/js/bun/jsc-stress/jsc-stress.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (326d4983b)

test/js/bun/jsc-stress/jsc-stress.test.ts:
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithsin.js [482.23ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithcos.js [460.46ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithsqrt.js [461.42ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithtan.js [469.88ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-string-equality.js [481.88ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-string-strict-equality.js [473.77ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-library-substring.js [463.96ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-string-ident-equality.js [479.16ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-regexp-test.js [495.93ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-regexp-exec.js [589.75ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-getmyargumentslength.js [458.03ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-getmyargumentslength-inline.js [454.64ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-get-my-argument-by-val.js [482.34ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-get-my-argument-by-val-inlined.js [496.93ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-get-my-argument-by-val-inlined-and-not-inlined.js [521.50ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-call-exception-no-catch.js [491.98ms]
(pass) JSC JIT Stress Tests > 
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.buildkite/ci.mjs                         | 14 +++--
 scripts/verify-baseline.ts                | 42 ++++++++++++---
 test/js/bun/jsc-stress/jsc-flags.test.ts  | 89 +++++++++++++++++++++++++++++++
 test/js/bun/jsc-stress/jsc-flags.ts       | 48 +++++++++++++++++
 test/js/bun/jsc-stress/jsc-stress.test.ts | 41 +-------------
 5 files changed, 184 insertions(+), 50 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
.buildkite/ci.mjs                              2      6      0
scripts/verify-baseline.ts                     3      8      0
test/js/bun/jsc-stress/jsc-flags.test.ts       1      6      0
test/js/bun/jsc-stress/jsc-flags.ts            1      2      0
test/js/bun/jsc-stress/jsc-stress.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->