### PR TITLE
Remove dead code from bun_sourcemap

### DIFF
--- a/src/sourcemap/Chunk.rs
+++ b/src/sourcemap/Chunk.rs
@@ -426,8 +426,6 @@ impl Drop for OwnedLineOffsetTables {
     }
 }
 
-pub type SourceMapper<T> = SourceMapFormat<T>;
-
 // PERF(codegen): the hot-path methods below are implemented on the *concrete*
 // `NewBuilder<VLQSourceMap>` (the only instantiation — see `Builder` alias
 // below) rather than on `impl<T: SourceMapFormatCtx> NewBuilder<T>`. When these

--- a/src/sourcemap/InternalSourceMap.rs
+++ b/src/sourcemap/InternalSourceMap.rs
@@ -627,15 +627,6 @@ pub struct FindCache {
 impl FindCache {
     pub const SLOT_COUNT: usize = 16;
 
-    pub fn invalidate(&mut self, data: *const u8) {
-        for (k, s) in self.keys.iter_mut().zip(self.slots.iter_mut()) {
-            if k.data == data {
-                k.data = ptr::null();
-                s.data = ptr::null();
-            }
-        }
-    }
-
     pub fn invalidate_all(&mut self) {
         for (k, s) in self.keys.iter_mut().zip(self.slots.iter_mut()) {
             k.data = ptr::null();


### PR DESCRIPTION
Removes two unreferenced public items from `src/sourcemap/` (net -11 lines).

### Removed

- **`SourceMapper<T>`** (Chunk.rs): type alias for `SourceMapFormat<T>`. Carried over from the Zig port; never referenced in Rust.
- **`FindCache::invalidate`** (InternalSourceMap.rs): per-blob invalidation. Only `invalidate_all` is called (from `SavedSourceMap::put_value`).

Two other items (`Chunk::print_source_map_contents` and `append_source_mapping_url_remote`) are also dead but already removed by #32000, so they are left out of this PR to avoid a conflict.

### Verification

- `rg` for each symbol across `src/`, `build/debug/codegen/`, `*.classes.ts`, and `packages/`: zero hits outside the definition for both.
- No `#[no_mangle]` / `extern "C"` exports touched.
- `bun bd` builds clean.
- `bun run rust:check-all` passes on all 10 targets.
- `bun bd test test/js/bun/sourcemap/`: all pass.

### Followup (not in this PR)

`InternalSourceMap::find_with_cache` and the `FindCache` struct itself appear to be write-only: `SavedSourceMap` allocates a ~21KB `FindCache` and calls `invalidate_all()` on it in `put_value`, but nothing ever calls `find_with_cache` to populate or read it; stack remapping goes through the uncached `find()`. Removing that would also touch `SavedSourceMap`'s layout and a test that references FindCache by name, so I've left it for a separate pass.