### PR TITLE
bundler: route pre-call exceptions through addError in JSBundlerPlugin match hooks

### DIFF
--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -529,13 +529,14 @@ extern "C" void JSBundlerPlugin__matchOnLoad(Bun::JSBundlerPlugin* plugin, BunSt
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(WRAP_BUNDLER_PLUGIN(context));
     arguments.append(path->transferToJS(globalObject));
-    RETURN_IF_EXCEPTION(scope, void());
-    arguments.append(namespaceString->transferToJS(globalObject));
-    RETURN_IF_EXCEPTION(scope, void());
-    arguments.append(JSC::jsNumber(defaultLoaderId));
-    arguments.append(JSC::jsBoolean(isServerSide));
+    if (!scope.exception()) [[likely]]
+        arguments.append(namespaceString->transferToJS(globalObject));
+    if (!scope.exception()) [[likely]] {
+        arguments.append(JSC::jsNumber(defaultLoaderId));
+        arguments.append(JSC::jsBoolean(isServerSide));
 
-    call(globalObject, function, callData, plugin, arguments);
+        call(globalObject, function, callData, plugin, arguments);
+    }
 
     if (scope.exception()) [[unlikely]] {
         auto exception = scope.exception();
@@ -567,15 +568,16 @@ extern "C" void JSBundlerPlugin__matchOnResolve(Bun::JSBundlerPlugin* plugin, Bu
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(plugin->vm());
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(path->transferToJS(globalObject));
-    RETURN_IF_EXCEPTION(scope, void());
-    arguments.append(namespaceString->transferToJS(globalObject));
-    RETURN_IF_EXCEPTION(scope, void());
-    arguments.append(importer->transferToJS(globalObject));
-    RETURN_IF_EXCEPTION(scope, void());
-    arguments.append(WRAP_BUNDLER_PLUGIN(context));
-    arguments.append(JSC::jsNumber(kindId));
+    if (!scope.exception()) [[likely]]
+        arguments.append(namespaceString->transferToJS(globalObject));
+    if (!scope.exception()) [[likely]]
+        arguments.append(importer->transferToJS(globalObject));
+    if (!scope.exception()) [[likely]] {
+        arguments.append(WRAP_BUNDLER_PLUGIN(context));
+        arguments.append(JSC::jsNumber(kindId));
 
-    call(globalObject, function, callData, plugin, arguments);
+        call(globalObject, function, callData, plugin, arguments);
+    }
 
     if (scope.exception()) [[unlikely]] {
         auto exception = JSValue(scope.exception());


### PR DESCRIPTION
## What

`JSBundlerPlugin__matchOnLoad` and `JSBundlerPlugin__matchOnResolve` build a `MarkedArgumentBuffer` via `BunString::transferToJS()` before calling the plugin's `onLoad`/`onResolve` handler. Each `transferToJS()` call was followed by `RETURN_IF_EXCEPTION(scope, void())`, which returns to Rust with the exception still pending on the VM and the `Load`/`Resolve` context never resolved.

This replaces those early returns with guards that fall through to the existing `if (scope.exception()) { ... plugin.addError(...) }` block, so an exception raised while marshalling arguments is cleared and reported to the bundler the same way a throw from the handler itself is.

## Why

These two functions are dispatched through the `task_tag::AnyTask` arm of the event loop (`src/runtime/dispatch.rs:254`), which does not open an exception scope around the callback. That is why they declare `DECLARE_TOP_EXCEPTION_SCOPE`: they are the top of the stack for exception purposes and their only failure channel is `plugin.addError()`, which sets `LoadValue::Err` / `ResolveValue::Err` on the context and hands it back to the bundler. Returning early without calling `addError` leaves that context orphaned.

`transferToJS()` throws `ERR_STRING_TOO_LONG` when the incoming `BunString` has tag `Dead`, i.e. when `bun_core::String::clone_utf8` failed to allocate a `WTF::StringImpl`. For bundler paths and namespaces this is effectively an OOM edge, but the code should still handle it correctly rather than leak the exception into the next microtask drain.

### Why not `DECLARE_THROW_SCOPE`

Swapping the scope to `DECLARE_THROW_SCOPE` was the first thing I tried. It makes things worse: `ThrowScope::~ThrowScope` calls `simulateThrow()`, and because the `AnyTask` arm has no outer scope the next `drainMicrotasks` scope asserts on **every** plugin dispatch:

```
ERROR: Unchecked JS exception:
    This scope can throw a JS exception: JSBundlerPlugin__matchOnResolve @ JSBundlerPlugin.cpp:567
    But the exception was unchecked as of this scope: drainMicrotasks @ ZigGlobalObject.cpp:3202
```

(Compare `JSBundlerPlugin__drainDeferred`, which *does* use `DECLARE_THROW_SCOPE`; its dispatch arm is wrapped in `call_check_slow` for exactly this reason, per the comment at `dispatch.rs:444`.)

## Verification

```
BUN_JSC_validateExceptionChecks=1 BUN_JSC_dumpSimulatedThrows=1 \
  bun bd test test/bundler/bundler_plugin.test.ts   # 52 pass
BUN_JSC_validateExceptionChecks=1 \
  bun bd test test/bundler/bundler_defer.test.ts    # 10 pass
```

The throwing path itself requires `clone_utf8` to fail (string too long or OOM), which is not reproducible without fault injection in `src/`; there is no fail-before test for this reason.