### PR TITLE
test(shell): align brace.test.ts nested-empty-variant cases with bash-5.2 literal `{}`

### DIFF
--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -68,10 +68,6 @@ describe("$.braces", () => {
       ["{x,{a,,b}}", ["x", "a", "", "b"]],
       ["{x,{a,b,}}", ["x", "a", "b", ""]],
       ["{{a,},x}", ["a", "", "x"]],
-      // The outer `{...}` has no top-level comma, so its braces are literal
-      // (bash 5.2); the inner `{a,}`/`{b,}` still exercise the trailing-empty
-      // variant path this block covers.
-      ["{{a,}{b,}}", ["{ab}", "{a}", "{b}", "{}"]],
       ["p{q,{r,}{s,}}t", ["pqt", "prst", "prt", "pst", "pt"]],
     ])("%s", (pattern, expected) => {
       expect($.braces(pattern)).toEqual(expected);
@@ -219,6 +215,7 @@ describe("comma-less brace group is literal (bash 5.2)", () => {
     // `{foo}` with no comma is literal at any depth.
     ["{a,{b}}", ["a", "{b}"]],
     ["{a{b,c}}", ["{ab}", "{ac}"]],
+    ["{{a,}{b,}}", ["{ab}", "{a}", "{b}", "{}"]],
     // A comma outside every `{...}` does not make one expand.
     ["{foo},x", ["{foo},x"]],
     ["{a},{b}", ["{a},{b}"]],

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -68,14 +68,11 @@ describe("$.braces", () => {
       ["{x,{a,,b}}", ["x", "a", "", "b"]],
       ["{x,{a,b,}}", ["x", "a", "b", ""]],
       ["{{a,},x}", ["a", "", "x"]],
-      ["{{a,}{b,}}", ["ab", "a", "b", ""]],
+      // The outer `{...}` has no top-level comma, so its braces are literal
+      // (bash 5.2); the inner `{a,}`/`{b,}` still exercise the trailing-empty
+      // variant path this block covers.
+      ["{{a,}{b,}}", ["{ab}", "{a}", "{b}", "{}"]],
       ["p{q,{r,}{s,}}t", ["pqt", "prst", "prt", "pst", "pt"]],
-      // A nested comma-free `{}` previously parsed to 0 variants, which made
-      // expand_nested return early and drop the text after it. It is now 1
-      // empty variant, matching calculate_expanded_amount and expand_flat.
-      ["{x,a{}b}", ["x", "ab"]],
-      ["{a,b{}}c", ["ac", "bc"]],
-      ["{x,{}y}", ["x", "y"]],
     ])("%s", (pattern, expected) => {
       expect($.braces(pattern)).toEqual(expected);
     });


### PR DESCRIPTION
Fixes `test/js/bun/shell/brace.test.ts` which is red on main (four hard failures on every lane, e.g. [build 76627](https://buildkite.com/bun/bun/builds/76627)).

## Cause

#34856 and #34865 were developed in parallel and merged three minutes apart. #34856 changed the brace lexer so a `{...}` group with no top-level comma is demoted to literal text (bash 5.2 semantics) before the parser sees it. #34865 added a `nested with empty variant` `test.each` block whose last four entries still expect the pre-#34856 behaviour. #34865's own commit message notes #34856 was addressing the literal-`{}` question separately; the rebase was textually clean so neither PR's CI caught the semantic overlap.

```
$.braces > nested with empty variant > {{a,}{b,}}   expected ["ab","a","b",""]   got ["{ab}","{a}","{b}","{}"]
$.braces > nested with empty variant > {x,a{}b}     expected ["x","ab"]          got ["x","a{}b"]
$.braces > nested with empty variant > {a,b{}}c     expected ["ac","bc"]         got ["ac","b{}c"]
$.braces > nested with empty variant > {x,{}y}      expected ["x","y"]           got ["x","{}y"]
```

bash 5.2.37 agrees with the new output in every case:

```
$ bash -c 'printf "[%s] " {{a,}{b,}}'   # [{ab}] [{a}] [{b}] [{}]
$ bash -c 'printf "[%s] " {x,a{}b}'     # [x] [a{}b]
$ bash -c 'printf "[%s] " {a,b{}}c'     # [ac] [b{}c]
$ bash -c 'printf "[%s] " {x,{}y}'      # [x] [{}y]
```

## Fix

All four entries are removed from the `nested with empty variant` block: after #34856 none of them reach the `parse_expansion`/`expand_nested` path that block guards, because the lexer demotes their comma-less group to text first. The remaining ten entries in that block (notably `p{q,{r,}{s,}}t`, which still routes through `expand_nested` with sibling trailing-empty groups) continue to cover #34865's fix.

- `{{a,}{b,}}` is moved to the `comma-less brace group is literal (bash 5.2)` block with the bash-correct expectation `["{ab}","{a}","{b}","{}"]`. That block also runs each case through the actual shell in a subprocess, so the pattern now gets both `$.braces()` and end-to-end shell coverage.
- `{x,a{}b}`, `{a,b{}}c`, `{x,{}y}` are dropped together with their now-inaccurate comment (which describes a 0-variant `{}` reaching the parser, a state that no longer exists). Their literal-`{}` behaviour is already asserted by `p{q{},r}s` / `{a,b{}}z` / `{a,{}}z` in that same block.

No `src/` change: the runtime behaviour is correct (matches bash); only the stale expectations are realigned.

## Verification

```
bun bd test test/js/bun/shell/brace.test.ts
# before: 39 pass, 4 fail
# after:  40 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/shell/brace.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/shell/brace.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (0ecd8eb85)

test/js/bun/shell/brace.test.ts:
(pass) $.braces > no-op [1.89ms]
(pass) $.braces > 2 [1.81ms]
(pass) $.braces > 3 [1.77ms]
(pass) $.braces > nested [1.63ms]
(pass) $.braces > nested 2 [2.01ms]
(pass) $.braces > nested sibling product [1.71ms]
(pass) $.braces > nested sibling product with surrounding text [1.44ms]
(pass) $.braces > nested sibling product mixed with variants [1.97ms]
(pass) $.braces > nested sibling product triple [2.04ms]
(pass) $.braces > nested with empty variant > {x,a{,}b} [1.46ms]
(pass) $.braces > nested with empty variant > {x,{a,}}z [0.65ms]
(pass) $.braces > nested with empty variant > {x,{,a}}z [0.48ms]
(pass) $.braces > nested with empty variant > {x,{,}}z [0.47ms]
(pass) $.braces > nested with empty variant > a{b,c{d,}}e [0.52ms]
(pass) $.braces > nested with empty variant > a{b,c{,d}}e [0.48ms]
(pass) $.braces > nested with empty variant > {x,{a,,b}} [0.74ms]
(pass) $.braces > nested with empty variant > {x,{a,b,}} [0.47ms]
(pass) $.braces > nested with empty variant > {{a,},x} [0.49ms]
(pass) $.braces > nested with empty variant > p{q,{r,}{s,}}t [0.51ms]
(pass) $.braces > very deeply nested [2.81ms]
(pass) $.braces > empty string [2.88ms]
(pass) $.braces > unicode [2.43ms]
(pass) brace + glob composition > src/*.{ts,tsx} globs after brace expansion [62.79ms]
(pass) brace + glob composition > {src,lib}/*.ts composes a brace prefix with a glob [27.96ms]
(pass) brace + glob composition > an interpolated comma inside a brace group is one literal branch [22.66ms]
(pass) $.braces input bounds > rejects a word with an excessive number of br
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/shell/brace.test.ts | 8 +-------
 1 file changed, 1 insertion(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                             reads  edits  tests
test/js/bun/shell/brace.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->